### PR TITLE
chore(suite-native): move redirect to uninitialized device screen to …

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -1,6 +1,6 @@
 import { testMocks } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { deviceActions } from '@suite-common/wallet-core';
+import { deviceActions, selectNewlyConnectedDeviceThunk } from '@suite-common/wallet-core';
 import { DEVICE, Device, TRANSPORT } from '@trezor/connect';
 
 import { SUITE } from 'src/actions/suite/constants';
@@ -305,6 +305,36 @@ const selectDevice = [
     },
 ];
 
+const selectNewlyConnectedDevice = [
+    {
+        description: `select a new device`,
+        state: {
+            device: { devices: [] },
+        },
+        newlyConnectedDevice: CONNECT_DEVICE,
+        expectedNextActionType: selectNewlyConnectedDeviceThunk.fulfilled.type,
+    },
+    {
+        description:
+            'selects a newly connected physical device corresponding to selected remembered wallet',
+        state: {
+            device: { devices: [SUITE_DEVICE_REMEMBERED], selectedDevice: SUITE_DEVICE_REMEMBERED },
+            suite: {},
+        },
+        newlyConnectedDevice: CONNECT_DEVICE,
+        expectedNextActionType: selectNewlyConnectedDeviceThunk.fulfilled.type,
+    },
+    {
+        description: `doesn't select a newly connected device if it is already selected`,
+        state: {
+            device: { devices: [SUITE_DEVICE], selectedDevice: SUITE_DEVICE },
+            suite: {},
+        },
+        newlyConnectedDevice: SUITE_DEVICE_UNACQUIRED,
+        expectedNextActionType: selectNewlyConnectedDeviceThunk.rejected.type,
+    },
+];
+
 type HandleDeviceConnectFixture = {
     description: string;
     state: {
@@ -315,22 +345,7 @@ type HandleDeviceConnectFixture = {
     expectedNextActionType: string;
 };
 
-const handleDeviceConnect: HandleDeviceConnectFixture[] = [
-    {
-        description: `selects a newly connected device if there are none`,
-        state: { device: {}, suite: {} },
-        newlyConnectedDevice: CONNECT_DEVICE,
-        expectedNextActionType: deviceActions.selectDevice.type,
-    },
-    {
-        description: `selects a newly connected physical device corresponding to selected remembered wallet `,
-        state: {
-            device: { devices: [SUITE_DEVICE_REMEMBERED], selectedDevice: SUITE_DEVICE_REMEMBERED },
-            suite: {},
-        },
-        newlyConnectedDevice: CONNECT_DEVICE,
-        expectedNextActionType: deviceActions.selectDevice.type,
-    },
+const markDeviceAsRecentlyConnected: HandleDeviceConnectFixture[] = [
     {
         description: `marks device as recently connected if not seen before`,
         state: {
@@ -758,9 +773,10 @@ export default {
     reducerActions,
     initialRun,
     selectDevice,
-    handleDeviceConnect,
+    markDeviceAsRecentlyConnected,
     handleDeviceDisconnect,
     forgetDisconnectedDevices,
     observeSelectedDevice,
     acquireDevice,
+    selectNewlyConnectedDevice,
 };

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -11,10 +11,11 @@ import {
     observeSelectedDevice,
     prepareDeviceReducer,
     selectDeviceThunk,
+    selectNewlyConnectedDeviceThunk,
 } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 
-import { handleDeviceConnect } from 'src/actions/wallet/handleDeviceConnectThunk';
+import { markDeviceAsRecentlyConnectedThunk } from 'src/actions/wallet/markDeviceAsRecentlyConnectedThunk';
 import modalReducer from 'src/reducers/suite/modalReducer';
 import routerReducer from 'src/reducers/suite/routerReducer';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
@@ -145,13 +146,25 @@ describe('Suite Actions', () => {
         });
     });
 
-    fixtures.handleDeviceConnect.forEach(f => {
-        it(`handleDeviceConnect: ${f.description}`, async () => {
+    fixtures.selectNewlyConnectedDevice.forEach(f => {
+        it(`selectNewlyConnectedDevice: ${f.description}`, async () => {
+            const state = getInitialState({}, f.state.device, undefined);
+            const store = initStore(state);
+
+            const device = f.newlyConnectedDevice;
+            await store.dispatch(selectNewlyConnectedDeviceThunk({ device }));
+            // a lot of actions may get called, and the one we are interested in may not be the last one
+            expect(store.getActions().some(a => a?.type === f.expectedNextActionType)).toBe(true);
+        });
+    });
+
+    fixtures.markDeviceAsRecentlyConnected.forEach(f => {
+        it(`markDeviceAsRecentlyConnected: ${f.description}`, async () => {
             const state = getInitialState(f.state.suite, f.state.device, undefined);
             const store = initStore(state);
 
             const device = f.newlyConnectedDevice;
-            await store.dispatch(handleDeviceConnect(device));
+            await store.dispatch(markDeviceAsRecentlyConnectedThunk(device));
             // a lot of actions may get called, and the one we are interested in may not be the last one
             expect(store.getActions().some(a => a?.type === f.expectedNextActionType)).toBe(true);
         });

--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -17,7 +17,7 @@ import * as languageActions from 'src/actions/settings/languageActions';
 import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import * as modalActions from 'src/actions/suite/modalActions';
 import * as routerActions from 'src/actions/suite/routerActions';
-import { handleDeviceConnect } from 'src/actions/wallet/handleDeviceConnectThunk';
+import { markDeviceAsRecentlyConnectedThunk } from 'src/actions/wallet/markDeviceAsRecentlyConnectedThunk';
 import type { Dispatch, GetState } from 'src/types/suite';
 
 import { SUITE } from './constants';
@@ -75,10 +75,10 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
         await dispatch(
             trezorConnectActions.connectInitThunk({
                 [DEVICE.CONNECT]: device => {
-                    dispatch(handleDeviceConnect(device));
+                    dispatch(markDeviceAsRecentlyConnectedThunk(device));
                 },
                 [DEVICE.CONNECT_UNACQUIRED]: device => {
-                    dispatch(handleDeviceConnect(device));
+                    dispatch(markDeviceAsRecentlyConnectedThunk(device));
                 },
                 [UI.INVALID_PIN_ATTEMPTS_DEPLETED]: () => {
                     dispatch(

--- a/packages/suite/src/actions/wallet/markDeviceAsRecentlyConnectedThunk.ts
+++ b/packages/suite/src/actions/wallet/markDeviceAsRecentlyConnectedThunk.ts
@@ -1,9 +1,5 @@
 import { createThunk } from '@suite-common/redux-utils';
-import {
-    DEVICE_MODULE_PREFIX,
-    selectDeviceThunk,
-    selectSelectedDevice,
-} from '@suite-common/wallet-core';
+import { DEVICE_MODULE_PREFIX } from '@suite-common/wallet-core';
 import { Device } from '@trezor/connect';
 
 import { selectRecentlyConnectedDevice } from 'src/selectors/suite/suiteSelectors';
@@ -13,20 +9,9 @@ import { setRecentlyConnectedDevicePath } from '../suite/suiteActions';
 // duration to visually indicate the device as recently connected
 const RECENTLY_CONNECTED_DEVICE_TIMEOUT = 5_000;
 
-export const handleDeviceConnect = createThunk<void, Device, void>(
+export const markDeviceAsRecentlyConnectedThunk = createThunk<void, Device, void>(
     `${DEVICE_MODULE_PREFIX}/handleDeviceConnect`,
     (device, { dispatch, getState }) => {
-        const selectedDevice = selectSelectedDevice(getState());
-
-        // Select automatically when it is the first known device (none selected),
-        // or when we connected physical device corresponding to a selected remembered wallet.
-        const shouldSelectDevice = selectedDevice === undefined || device.id === selectedDevice.id;
-        if (shouldSelectDevice) {
-            dispatch(selectDeviceThunk({ device }));
-
-            return;
-        }
-
         // Set the Device as recently connected to show a notification in the UI, and schedule disappearance.
         // device.path preferred because we only care about current session (not persistent),
         // and the device may initially connect as unacquired before becoming acquired.

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -10,7 +10,7 @@ import {
     getStatus,
 } from '@suite-common/suite-utils';
 import { networkSymbolCollection } from '@suite-common/wallet-config';
-import { DeviceState, StaticSessionId } from '@trezor/connect';
+import { Device, DeviceState, StaticSessionId } from '@trezor/connect';
 import {
     DeviceModelInternal,
     getFirmwareVersion,
@@ -519,6 +519,11 @@ export const selectDeviceDefaultBackupType = createMemoizedSelector(
 
 export const selectStandardWalletDevice = createMemoizedSelector([selectDevices], devices =>
     devices.find(device => device.useEmptyPassphrase),
+);
+
+export const selectIsSameOrNewDevice = createMemoizedSelector(
+    [selectSelectedDevice, (_state, device: Device | TrezorDevice | undefined) => device],
+    (selectedDevice, device) => selectedDevice === undefined || device?.id === selectedDevice.id,
 );
 
 /**

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -30,7 +30,7 @@ import TrezorConnect, {
     Device,
 } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
-import { getEnvironment, isNative } from '@trezor/env-utils';
+import { getEnvironment } from '@trezor/env-utils';
 import { exhaustive } from '@trezor/type-utils';
 import { isChanged } from '@trezor/utils';
 
@@ -39,26 +39,12 @@ import { PORTFOLIO_TRACKER_DEVICE_ID, portfolioTrackerDevice } from './deviceCon
 import {
     selectDeviceById,
     selectDevices,
-    selectIsSameOrNewDevice,
     selectPhysicalDevices,
     selectSelectedDevice,
 } from './deviceSelectors';
 import { selectAccountByKey } from '../accounts/accountsSelectors';
 import { startDiscoveryThunk } from '../discovery/discoveryThunks';
-import { selectDeviceThunk } from '../discovery/selectDeviceThunk';
-
-export const selectNewlyConnectedDeviceThunk = createThunk<void, SelectDeviceThunkParams, void>(
-    `${DEVICE_MODULE_PREFIX}/selectNewlyConnectedDevice`,
-    ({ device }, { dispatch, getState, rejectWithValue }) => {
-        if (!isNative() && !selectIsSameOrNewDevice(getState(), device)) {
-            // Select automatically when it is the first known device (none selected),
-            // or when we connected physical device corresponding to a selected remembered wallet.
-            return rejectWithValue('no-need-to-select');
-        }
-
-        dispatch(selectDeviceThunk({ device }));
-    },
-);
+import { selectDeviceThunk, selectNewlyConnectedDeviceThunk } from '../discovery/selectDeviceThunk';
 
 /**
  * Toggles remembering the given device. I.e. if given device is not remembered it will become remembered

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -264,25 +264,22 @@ export const initDevices = createThunk(
 );
 
 export const createImportedDeviceThunk = createThunk<
-    { device: TrezorDevice },
+    void,
     undefined,
     { rejectValue: { error: 'already-created' } }
->(
-    `${DEVICE_MODULE_PREFIX}/createImportedDevice`,
-    (_, { dispatch, getState, rejectWithValue, fulfillWithValue }) => {
-        const device = selectDeviceById(getState(), PORTFOLIO_TRACKER_DEVICE_ID);
+>(`${DEVICE_MODULE_PREFIX}/createImportedDevice`, (_, { dispatch, getState, rejectWithValue }) => {
+    const device = selectDeviceById(getState(), PORTFOLIO_TRACKER_DEVICE_ID);
 
-        if (device) return rejectWithValue({ error: 'already-created' });
+    if (device) return rejectWithValue({ error: 'already-created' });
 
-        dispatch(
-            deviceActions.createDeviceInstance({
-                device: portfolioTrackerDevice,
-            }),
-        );
+    dispatch(
+        deviceActions.createDeviceInstance({
+            device: portfolioTrackerDevice,
+        }),
+    );
 
-        return fulfillWithValue({ device: portfolioTrackerDevice });
-    },
-);
+    dispatch(selectDeviceThunk({ device: portfolioTrackerDevice }));
+});
 
 type ConfirmAddressOnDeviceThunk = {
     accountKey: AccountKey;

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -30,7 +30,7 @@ import TrezorConnect, {
     Device,
 } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
-import { getEnvironment } from '@trezor/env-utils';
+import { getEnvironment, isNative } from '@trezor/env-utils';
 import { exhaustive } from '@trezor/type-utils';
 import { isChanged } from '@trezor/utils';
 
@@ -39,12 +39,26 @@ import { PORTFOLIO_TRACKER_DEVICE_ID, portfolioTrackerDevice } from './deviceCon
 import {
     selectDeviceById,
     selectDevices,
+    selectIsSameOrNewDevice,
     selectPhysicalDevices,
     selectSelectedDevice,
 } from './deviceSelectors';
 import { selectAccountByKey } from '../accounts/accountsSelectors';
 import { startDiscoveryThunk } from '../discovery/discoveryThunks';
 import { selectDeviceThunk } from '../discovery/selectDeviceThunk';
+
+export const selectNewlyConnectedDeviceThunk = createThunk<void, SelectDeviceThunkParams, void>(
+    `${DEVICE_MODULE_PREFIX}/selectNewlyConnectedDevice`,
+    ({ device }, { dispatch, getState, rejectWithValue }) => {
+        if (!isNative() && !selectIsSameOrNewDevice(getState(), device)) {
+            // Select automatically when it is the first known device (none selected),
+            // or when we connected physical device corresponding to a selected remembered wallet.
+            return rejectWithValue('no-need-to-select');
+        }
+
+        dispatch(selectDeviceThunk({ device }));
+    },
+);
 
 /**
  * Toggles remembering the given device. I.e. if given device is not remembered it will become remembered
@@ -376,6 +390,7 @@ export const deviceConnectThunks = createThunk<void, DeviceConnectThunksParams, 
                     await dispatch(connectThpDeviceThunk({ device }));
                 }
                 dispatch(deviceActions.connectDevice({ device }));
+                dispatch(selectNewlyConnectedDeviceThunk({ device }));
                 break;
             case DEVICE.CONNECT_UNACQUIRED:
                 dispatch(
@@ -384,6 +399,7 @@ export const deviceConnectThunks = createThunk<void, DeviceConnectThunksParams, 
                     }),
                 );
                 dispatch(autoInitThpAfterDeviceConnectionThunk({ device }));
+                dispatch(selectNewlyConnectedDeviceThunk({ device }));
                 break;
             default:
                 exhaustive(type);

--- a/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
+++ b/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
@@ -2,9 +2,10 @@ import { createThunk } from '@suite-common/redux-utils';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { getSelectedDevice, sortByTimestamp } from '@suite-common/suite-utils';
 import { Device } from '@trezor/connect';
+import { isNative } from '@trezor/env-utils';
 
 import { DEVICE_MODULE_PREFIX, deviceActions } from '../device/deviceActions';
-import { selectDevices } from '../device/deviceSelectors';
+import { selectDevices, selectIsSameOrNewDevice } from '../device/deviceSelectors';
 
 type SelectDeviceThunkParams = {
     device: Device | TrezorDevice | undefined;
@@ -43,5 +44,18 @@ export const selectDeviceThunk = createThunk<void, SelectDeviceThunkParams, void
         ) {
             dispatch(extra.thunks.subscribeLocalFirstStorage({ device: trezorDevice }));
         }
+    },
+);
+
+export const selectNewlyConnectedDeviceThunk = createThunk<void, SelectDeviceThunkParams, void>(
+    `${DEVICE_MODULE_PREFIX}/selectNewlyConnectedDevice`,
+    ({ device }, { dispatch, getState, rejectWithValue }) => {
+        if (!isNative() && !selectIsSameOrNewDevice(getState(), device)) {
+            // Select automatically when it is the first known device (none selected),
+            // or when we connected physical device corresponding to a selected remembered wallet.
+            return rejectWithValue('no-need-to-select');
+        }
+
+        dispatch(selectDeviceThunk({ device }));
     },
 );

--- a/suite-native/device-onboarding/package.json
+++ b/suite-native/device-onboarding/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "@suite-native/device-onboarding",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@reduxjs/toolkit": "2.8.2"
+    }
+}

--- a/suite-native/device-onboarding/src/deviceOnboardingSlice.ts
+++ b/suite-native/device-onboarding/src/deviceOnboardingSlice.ts
@@ -1,0 +1,43 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+type DeviceOnboardingSliceState = {
+    wasDeviceOnboardingCancelled: boolean;
+    isOnboardingDeviceDisconnectedAlertDisplayed: boolean;
+};
+
+export type DeviceOnboardingSliceRootState = {
+    deviceOnboarding: DeviceOnboardingSliceState;
+};
+
+const deviceOnboardingSliceInitialState: DeviceOnboardingSliceState = {
+    wasDeviceOnboardingCancelled: false,
+    isOnboardingDeviceDisconnectedAlertDisplayed: false,
+};
+
+export const deviceOnboardingSlice = createSlice({
+    name: 'deviceOnboarding',
+    initialState: deviceOnboardingSliceInitialState,
+    reducers: {
+        setWasDeviceOnboardingCancelled: (state, { payload }: PayloadAction<boolean>) => {
+            state.wasDeviceOnboardingCancelled = payload;
+        },
+        setIsOnboardingDeviceDisconnectedAlertDisplayed: (
+            state,
+            { payload }: PayloadAction<boolean>,
+        ) => {
+            state.isOnboardingDeviceDisconnectedAlertDisplayed = payload;
+        },
+    },
+});
+
+export const selectWasDeviceOnboardingCancelled = (state: DeviceOnboardingSliceRootState) =>
+    state.deviceOnboarding.wasDeviceOnboardingCancelled;
+
+export const selectIsOnboardingDeviceDisconnectedAlertDisplayed = (
+    state: DeviceOnboardingSliceRootState,
+) => state.deviceOnboarding.isOnboardingDeviceDisconnectedAlertDisplayed;
+
+export const { setWasDeviceOnboardingCancelled, setIsOnboardingDeviceDisconnectedAlertDisplayed } =
+    deviceOnboardingSlice.actions;
+
+export const deviceOnboardingReducer = deviceOnboardingSlice.reducer;

--- a/suite-native/device-onboarding/src/deviceOnboardingSlice.ts
+++ b/suite-native/device-onboarding/src/deviceOnboardingSlice.ts
@@ -2,7 +2,6 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 type DeviceOnboardingSliceState = {
     wasDeviceOnboardingCancelled: boolean;
-    isOnboardingDeviceDisconnectedAlertDisplayed: boolean;
 };
 
 export type DeviceOnboardingSliceRootState = {
@@ -11,7 +10,6 @@ export type DeviceOnboardingSliceRootState = {
 
 const deviceOnboardingSliceInitialState: DeviceOnboardingSliceState = {
     wasDeviceOnboardingCancelled: false,
-    isOnboardingDeviceDisconnectedAlertDisplayed: false,
 };
 
 export const deviceOnboardingSlice = createSlice({
@@ -21,23 +19,12 @@ export const deviceOnboardingSlice = createSlice({
         setWasDeviceOnboardingCancelled: (state, { payload }: PayloadAction<boolean>) => {
             state.wasDeviceOnboardingCancelled = payload;
         },
-        setIsOnboardingDeviceDisconnectedAlertDisplayed: (
-            state,
-            { payload }: PayloadAction<boolean>,
-        ) => {
-            state.isOnboardingDeviceDisconnectedAlertDisplayed = payload;
-        },
     },
 });
 
 export const selectWasDeviceOnboardingCancelled = (state: DeviceOnboardingSliceRootState) =>
     state.deviceOnboarding.wasDeviceOnboardingCancelled;
 
-export const selectIsOnboardingDeviceDisconnectedAlertDisplayed = (
-    state: DeviceOnboardingSliceRootState,
-) => state.deviceOnboarding.isOnboardingDeviceDisconnectedAlertDisplayed;
-
-export const { setWasDeviceOnboardingCancelled, setIsOnboardingDeviceDisconnectedAlertDisplayed } =
-    deviceOnboardingSlice.actions;
+export const { setWasDeviceOnboardingCancelled } = deviceOnboardingSlice.actions;
 
 export const deviceOnboardingReducer = deviceOnboardingSlice.reducer;

--- a/suite-native/device-onboarding/src/index.ts
+++ b/suite-native/device-onboarding/src/index.ts
@@ -1,0 +1,1 @@
+export * from './deviceOnboardingSlice';

--- a/suite-native/device-onboarding/tsconfig.json
+++ b/suite-native/device-onboarding/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": []
+}

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -22,7 +22,6 @@
         "@suite-native/alerts": "workspace:*",
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",
-        "@suite-native/biometrics": "workspace:*",
         "@suite-native/device-authorization": "workspace:*",
         "@suite-native/device-mutex": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",

--- a/suite-native/device/src/deviceAtoms.ts
+++ b/suite-native/device/src/deviceAtoms.ts
@@ -1,8 +1,5 @@
 import { atom } from 'jotai';
 
-export const wasDeviceOnboardingCancelledAtom = atom<boolean>(false);
-export const isOnboardingDeviceDisconnectedAlertDisplayedAtom = atom<boolean>(false);
-
 export type DeviceDangerBannerCause = 'device-compromised' | 'backup-needed' | 'backup-failed';
 
 type DeviceDangerBanner =

--- a/suite-native/device/src/deviceNavigationConfig.ts
+++ b/suite-native/device/src/deviceNavigationConfig.ts
@@ -1,4 +1,8 @@
-import { DeviceOnboardingStackRoutes, RootStackRoutes } from '@suite-native/navigation';
+import {
+    DeviceOnboardingStackRoutes,
+    RootStackRoutes,
+    SendStackRoutes,
+} from '@suite-native/navigation';
 
 // We encourage user to disconnect device when he is redirected to suspicious device screen.
 // We should not redirect him away so he can read the screen content and decide what to do.
@@ -7,9 +11,12 @@ export const DEVICE_DISCONNECTION_BLACKLISTED_ROUTES = [
     DeviceOnboardingStackRoutes.SuspiciousDevice,
 ];
 
+const SEND_STACK_ROUTES = [...Object.keys(SendStackRoutes), RootStackRoutes.SendStack];
+
 export const DEVICE_CONNECTION_BLACKLISTED_ROUTES = [
     RootStackRoutes.DeviceCompromisedModal,
-    RootStackRoutes.SendStack,
+    DeviceOnboardingStackRoutes.SuspiciousDevice,
+    ...SEND_STACK_ROUTES,
 ];
 
 export const buildDisconnectionBlacklist = (
@@ -21,5 +28,5 @@ export const buildDisconnectionBlacklist = (
     // however Entropy check modal should be dismissed on disconnect because you cannot exit the modal via normal means
     ...(!isEntropyCheckEnabledAndFailed ? [RootStackRoutes.DeviceCompromisedModal] : []),
     // Add SendStack only if device is remembered
-    ...(isDeviceRemembered ? [RootStackRoutes.SendStack] : []),
+    ...(isDeviceRemembered ? SEND_STACK_ROUTES : []),
 ];

--- a/suite-native/device/src/deviceNavigationConfig.ts
+++ b/suite-native/device/src/deviceNavigationConfig.ts
@@ -9,7 +9,6 @@ export const DEVICE_DISCONNECTION_BLACKLISTED_ROUTES = [
 
 export const DEVICE_CONNECTION_BLACKLISTED_ROUTES = [
     RootStackRoutes.DeviceCompromisedModal,
-    RootStackRoutes.DeviceOnboardingStack,
     RootStackRoutes.SendStack,
 ];
 

--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -4,15 +4,11 @@ import { useSelector } from 'react-redux';
 import { useNavigation, useNavigationState } from '@react-navigation/native';
 
 import { selectDeviceRequestedPin } from '@suite-native/device-authorization';
-import { selectIsOnboardingDeviceDisconnectedAlertDisplayed } from '@suite-native/device-onboarding';
 import {
     AuthorizeDeviceStackRoutes,
-    DeviceOnboardingStackRoutes,
-    HomeStackRoutes,
     RootStackParamList,
     RootStackRoutes,
     StackNavigationProps,
-    useNavigationRouteMatch,
 } from '@suite-native/navigation';
 import { selectIsOnboardingFinished } from '@suite-native/settings';
 
@@ -27,54 +23,12 @@ export const useHandleDeviceConnection = () => {
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const hasDeviceRequestedPin = useSelector(selectDeviceRequestedPin);
 
-    const isOnboardingDeviceDisconnectedAlertDisplayed = useSelector(
-        selectIsOnboardingDeviceDisconnectedAlertDisplayed,
-    );
-
     const navigation = useNavigation<NavigationProp>();
 
-    const isDeviceOnboardingConnectAndUnlockScreenFocused = useNavigationRouteMatch(
-        DeviceOnboardingStackRoutes.ConnectAndUnlockDevice,
-    );
-
     const lastRoute = useNavigationState(state => state.routes.at(-1)?.name);
-    const isDeviceOnboardingStackFocused = lastRoute === RootStackRoutes.DeviceOnboardingStack;
     const isOnPinMatrixBlacklistedRoute = pinMatrixBlacklistedScreens.includes(
         lastRoute as RootStackRoutes,
     );
-
-    // When is an uninitialized device model that supports device setup, navigate to device onboarding.
-    useEffect(() => {
-        if (
-            !isOnboardingDeviceDisconnectedAlertDisplayed &&
-            (!isDeviceOnboardingStackFocused || isDeviceOnboardingConnectAndUnlockScreenFocused)
-        ) {
-            // If THP confirmation screen was shown, we want to prevent swiping/navigating back to
-            // that THP confirmation screen. Swiping/navigating back shall lead to the Home screen.
-            navigation.reset({
-                index: 1,
-                routes: [
-                    {
-                        name: RootStackRoutes.AppTabs,
-                        params: {
-                            screen: HomeStackRoutes.Home,
-                        },
-                    },
-                    {
-                        name: RootStackRoutes.DeviceOnboardingStack,
-                        params: {
-                            screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
-                        },
-                    },
-                ],
-            });
-        }
-    }, [
-        isDeviceOnboardingConnectAndUnlockScreenFocused,
-        isDeviceOnboardingStackFocused,
-        isOnboardingDeviceDisconnectedAlertDisplayed,
-        navigation,
-    ]);
 
     // When trezor gets locked, it is necessary to display a PIN matrix for T1 so that it can be unlocked
     // and then continue with the interaction. For T2, PIN is entered on device, but the screen is still displayed.

--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -1,19 +1,10 @@
 import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { useNavigation, useNavigationState } from '@react-navigation/native';
 import { useAtomValue } from 'jotai';
 
-import { selectIsThpInProgress } from '@suite-common/thp';
-import {
-    selectIsDeviceConnected,
-    selectIsDeviceInitialized,
-    selectIsDeviceThpRequired,
-    selectIsPortfolioTrackerDevice,
-} from '@suite-common/wallet-core';
-import { useIsBiometricsOverlayVisible } from '@suite-native/biometrics';
 import { selectDeviceRequestedPin } from '@suite-native/device-authorization';
-import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
 import {
     AuthorizeDeviceStackRoutes,
     DeviceOnboardingStackRoutes,
@@ -29,7 +20,6 @@ import {
     isOnboardingDeviceDisconnectedAlertDisplayedAtom,
     wasDeviceOnboardingCancelledAtom,
 } from '../deviceAtoms';
-import { selectIsDeviceCompromised, selectIsDeviceSetupSupported } from '../selectors';
 
 type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes>;
 
@@ -39,18 +29,9 @@ const pinMatrixBlacklistedScreens = [
 ];
 
 export const useHandleDeviceConnection = () => {
-    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const hasDeviceRequestedPin = useSelector(selectDeviceRequestedPin);
-    const isDeviceConnected = useSelector(selectIsDeviceConnected);
-    const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
-    const isDeviceThpRequired = useSelector(selectIsDeviceThpRequired);
-    const isThpInProgress = useSelector(selectIsThpInProgress);
-    const isFirmwareInstallationRunning = useSelector(selectIsFirmwareInstallationRunning);
-    const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
-    const isDeviceCompromised = useSelector(selectIsDeviceCompromised);
 
-    const { isBiometricsOverlayVisible } = useIsBiometricsOverlayVisible();
     const isOnboardingDeviceDisconnectedAlertDisplayed = useAtomValue(
         isOnboardingDeviceDisconnectedAlertDisplayedAtom,
     );
@@ -58,7 +39,6 @@ export const useHandleDeviceConnection = () => {
     const wasDeviceOnboardingCancelled = useAtomValue(wasDeviceOnboardingCancelledAtom);
 
     const navigation = useNavigation<NavigationProp>();
-    const dispatch = useDispatch();
 
     const isDeviceOnboardingConnectAndUnlockScreenFocused = useNavigationRouteMatch(
         DeviceOnboardingStackRoutes.ConnectAndUnlockDevice,
@@ -73,19 +53,9 @@ export const useHandleDeviceConnection = () => {
     // When is an uninitialized device model that supports device setup, navigate to device onboarding.
     useEffect(() => {
         if (
-            isDeviceSetupSupported &&
-            isDeviceConnected &&
-            isOnboardingFinished &&
-            !isDeviceInitialized &&
-            !isDeviceThpRequired &&
-            !isThpInProgress &&
-            !isPortfolioTrackerDevice &&
-            !isBiometricsOverlayVisible &&
             !isOnboardingDeviceDisconnectedAlertDisplayed &&
-            !isFirmwareInstallationRunning &&
             (!isDeviceOnboardingStackFocused || isDeviceOnboardingConnectAndUnlockScreenFocused) &&
-            !wasDeviceOnboardingCancelled &&
-            !isDeviceCompromised
+            !wasDeviceOnboardingCancelled
         ) {
             // If THP confirmation screen was shown, we want to prevent swiping/navigating back to
             // that THP confirmation screen. Swiping/navigating back shall lead to the Home screen.
@@ -108,22 +78,11 @@ export const useHandleDeviceConnection = () => {
             });
         }
     }, [
-        dispatch,
-        isDeviceConnected,
-        isOnboardingFinished,
-        isBiometricsOverlayVisible,
-        navigation,
-        isDeviceInitialized,
-        isDeviceThpRequired,
-        isThpInProgress,
-        isPortfolioTrackerDevice,
-        isDeviceSetupSupported,
-        isDeviceOnboardingStackFocused,
-        isFirmwareInstallationRunning,
-        isOnboardingDeviceDisconnectedAlertDisplayed,
         isDeviceOnboardingConnectAndUnlockScreenFocused,
+        isDeviceOnboardingStackFocused,
+        isOnboardingDeviceDisconnectedAlertDisplayed,
+        navigation,
         wasDeviceOnboardingCancelled,
-        isDeviceCompromised,
     ]);
 
     // When trezor gets locked, it is necessary to display a PIN matrix for T1 so that it can be unlocked

--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -2,9 +2,9 @@ import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useNavigation, useNavigationState } from '@react-navigation/native';
-import { useAtomValue } from 'jotai';
 
 import { selectDeviceRequestedPin } from '@suite-native/device-authorization';
+import { selectIsOnboardingDeviceDisconnectedAlertDisplayed } from '@suite-native/device-onboarding';
 import {
     AuthorizeDeviceStackRoutes,
     DeviceOnboardingStackRoutes,
@@ -15,11 +15,6 @@ import {
     useNavigationRouteMatch,
 } from '@suite-native/navigation';
 import { selectIsOnboardingFinished } from '@suite-native/settings';
-
-import {
-    isOnboardingDeviceDisconnectedAlertDisplayedAtom,
-    wasDeviceOnboardingCancelledAtom,
-} from '../deviceAtoms';
 
 type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes>;
 
@@ -32,11 +27,9 @@ export const useHandleDeviceConnection = () => {
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const hasDeviceRequestedPin = useSelector(selectDeviceRequestedPin);
 
-    const isOnboardingDeviceDisconnectedAlertDisplayed = useAtomValue(
-        isOnboardingDeviceDisconnectedAlertDisplayedAtom,
+    const isOnboardingDeviceDisconnectedAlertDisplayed = useSelector(
+        selectIsOnboardingDeviceDisconnectedAlertDisplayed,
     );
-
-    const wasDeviceOnboardingCancelled = useAtomValue(wasDeviceOnboardingCancelledAtom);
 
     const navigation = useNavigation<NavigationProp>();
 
@@ -54,8 +47,7 @@ export const useHandleDeviceConnection = () => {
     useEffect(() => {
         if (
             !isOnboardingDeviceDisconnectedAlertDisplayed &&
-            (!isDeviceOnboardingStackFocused || isDeviceOnboardingConnectAndUnlockScreenFocused) &&
-            !wasDeviceOnboardingCancelled
+            (!isDeviceOnboardingStackFocused || isDeviceOnboardingConnectAndUnlockScreenFocused)
         ) {
             // If THP confirmation screen was shown, we want to prevent swiping/navigating back to
             // that THP confirmation screen. Swiping/navigating back shall lead to the Home screen.
@@ -82,7 +74,6 @@ export const useHandleDeviceConnection = () => {
         isDeviceOnboardingStackFocused,
         isOnboardingDeviceDisconnectedAlertDisplayed,
         navigation,
-        wasDeviceOnboardingCancelled,
     ]);
 
     // When trezor gets locked, it is necessary to display a PIN matrix for T1 so that it can be unlocked

--- a/suite-native/device/src/hooks/useWipeDevice.tsx
+++ b/suite-native/device/src/hooks/useWipeDevice.tsx
@@ -3,10 +3,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { CompositeNavigationProp, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { isFulfilled } from '@reduxjs/toolkit';
-import { useSetAtom } from 'jotai';
 
 import { selectSelectedDevice, wipeDeviceThunk } from '@suite-common/wallet-core';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
+import { setWasDeviceOnboardingCancelled } from '@suite-native/device-onboarding';
 import {
     DeviceSettingsStackParamList,
     DeviceSettingsStackRoutes,
@@ -15,8 +15,6 @@ import {
     WipeDeviceStackParamList,
     WipeDeviceStackRoutes,
 } from '@suite-native/navigation';
-
-import { wasDeviceOnboardingCancelledAtom } from '../deviceAtoms';
 
 type NavigationProps = CompositeNavigationProp<
     NativeStackNavigationProp<WipeDeviceStackParamList, WipeDeviceStackRoutes.WipeDevice>,
@@ -30,14 +28,13 @@ export const useWipeDevice = () => {
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
     const device = useSelector(selectSelectedDevice);
-    const setWasDeviceOnboardingCancelled = useSetAtom(wasDeviceOnboardingCancelledAtom);
 
     const wipeDevice = async () => {
         if (!device) return;
 
         // After wipe, device gets changed and reconnected. That would trigger redirect to device onboarding which is
         // not wanted here. We want to treat it differently since it was wiped so user goes to onboarding through homescreen.
-        setWasDeviceOnboardingCancelled(true);
+        dispatch(setWasDeviceOnboardingCancelled(true));
 
         navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
             screen: DeviceSettingsStackRoutes.WipeDeviceStack,

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -23,6 +23,8 @@ import {
     HomeStackRoutes,
     RootStackRoutes,
     checkIsActiveRouteAnyOf,
+    checkIsDeviceOnboardingFocused,
+    checkIsHomeStackFocused,
     navigationContainerRef,
 } from '@suite-native/navigation';
 import { selectIsCoinEnablingInitFinished } from '@suite-native/settings';
@@ -60,7 +62,7 @@ const handleDeviceConnectNavigation = ({
         // If user previously cancelled the onboarding, they should remaing on homescreen
         if (wasDeviceOnboardingCancelled) {
             // No need to navigate if we are already on home screen (preventing sliding to new screen)
-            if (checkIsActiveRouteAnyOf([HomeStackRoutes.Home])) return;
+            if (checkIsHomeStackFocused()) return;
 
             navigationContainerRef.reset({
                 index: 0,
@@ -169,22 +171,24 @@ deviceConnectionMiddleware.startListening({
         )
             return;
 
-        if (checkIsActiveRouteAnyOf([RootStackRoutes.DeviceOnboardingStack])) {
+        if (checkIsDeviceOnboardingFocused()) {
             navigationContainerRef.navigate(RootStackRoutes.DeviceOnboardingStack, {
                 screen: DeviceOnboardingStackRoutes.ConnectAndUnlockDevice,
             });
         } else {
-            navigationContainerRef.reset({
-                index: 0,
-                routes: [
-                    {
-                        name: RootStackRoutes.AppTabs,
-                        params: {
-                            screen: HomeStackRoutes.Home,
+            if (!checkIsHomeStackFocused()) {
+                navigationContainerRef.reset({
+                    index: 0,
+                    routes: [
+                        {
+                            name: RootStackRoutes.AppTabs,
+                            params: {
+                                screen: HomeStackRoutes.Home,
+                            },
                         },
-                    },
-                ],
-            });
+                    ],
+                });
+            }
         }
     },
 });

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -15,6 +15,7 @@ import {
     selectIsDeviceRemembered,
     selectIsDeviceUsingPassphrase,
 } from '@suite-common/wallet-core';
+import { selectWasDeviceOnboardingCancelled } from '@suite-native/device-onboarding';
 import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
 import {
     AuthorizeDeviceStackRoutes,
@@ -45,10 +46,12 @@ const handleDeviceConnectNavigation = ({
     isCoinEnablingInitFinished,
     isDeviceInitialized,
     isDeviceSetupSupported,
+    wasDeviceOnboardingCancelled,
 }: {
     isCoinEnablingInitFinished: boolean;
     isDeviceInitialized: boolean;
     isDeviceSetupSupported: boolean;
+    wasDeviceOnboardingCancelled: boolean;
 }) => {
     // If device setup is not supported, we don't want to navigate anywhere
     // We handle it separately in `useDetectDeviceError` hook
@@ -59,25 +62,29 @@ const handleDeviceConnectNavigation = ({
             screen: AuthorizeDeviceStackRoutes.ConnectingDevice,
         });
     } else if (!isDeviceInitialized) {
-        // If THP confirmation screen was shown, we want to prevent swiping/navigating back to
-        // that THP confirmation screen. Swiping/navigating back shall lead to the Home screen.
-        navigationContainerRef.reset({
-            index: 1,
-            routes: [
-                {
-                    name: RootStackRoutes.AppTabs,
-                    params: {
-                        screen: HomeStackRoutes.Home,
+        if (wasDeviceOnboardingCancelled) {
+            console.warn('navigate home');
+        } else {
+            // If THP confirmation screen was shown, we want to prevent swiping/navigating back to
+            // that THP confirmation screen. Swiping/navigating back shall lead to the Home screen.
+            navigationContainerRef.reset({
+                index: 1,
+                routes: [
+                    {
+                        name: RootStackRoutes.AppTabs,
+                        params: {
+                            screen: HomeStackRoutes.Home,
+                        },
                     },
-                },
-                {
-                    name: RootStackRoutes.DeviceOnboardingStack,
-                    params: {
-                        screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
+                    {
+                        name: RootStackRoutes.DeviceOnboardingStack,
+                        params: {
+                            screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
+                        },
                     },
-                },
-            ],
-        });
+                ],
+            });
+        }
     } else {
         navigationContainerRef.navigate(RootStackRoutes.CoinEnablingInit);
     }
@@ -123,6 +130,7 @@ deviceConnectionMiddleware.startListening({
             isCoinEnablingInitFinished: selectIsCoinEnablingInitFinished(getState()),
             isDeviceInitialized: selectIsDeviceInitialized(getState()),
             isDeviceSetupSupported: selectIsDeviceSetupSupported(getState()),
+            wasDeviceOnboardingCancelled: selectWasDeviceOnboardingCancelled(getState()),
         });
     },
 });

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -15,10 +15,7 @@ import {
     selectIsDeviceRemembered,
     selectIsDeviceUsingPassphrase,
 } from '@suite-common/wallet-core';
-import {
-    selectIsOnboardingDeviceDisconnectedAlertDisplayed,
-    selectWasDeviceOnboardingCancelled,
-} from '@suite-native/device-onboarding';
+import { selectWasDeviceOnboardingCancelled } from '@suite-native/device-onboarding';
 import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
 import {
     AuthorizeDeviceStackRoutes,
@@ -50,34 +47,37 @@ const handleDeviceConnectNavigation = ({
     isDeviceInitialized,
     isDeviceSetupSupported,
     wasDeviceOnboardingCancelled,
-    isOnboardingDeviceDisconnectedAlertDisplayed,
-    isReconnectingDeviceOnDeviceOnboarding,
 }: {
     isCoinEnablingInitFinished: boolean;
     isDeviceInitialized: boolean;
     isDeviceSetupSupported: boolean;
     wasDeviceOnboardingCancelled: boolean;
-    isOnboardingDeviceDisconnectedAlertDisplayed: boolean;
-    isReconnectingDeviceOnDeviceOnboarding: boolean;
 }) => {
-    // If device setup is not supported, we don't want to navigate anywhere
-    // We handle it separately in `useDetectDeviceError` hook
-    if (!isDeviceSetupSupported) return;
-
     if (isCoinEnablingInitFinished) {
         navigationContainerRef.navigate(RootStackRoutes.AuthorizeDeviceStack, {
             screen: AuthorizeDeviceStackRoutes.ConnectingDevice,
         });
     } else if (!isDeviceInitialized) {
-        if (
-            isOnboardingDeviceDisconnectedAlertDisplayed ||
-            isReconnectingDeviceOnDeviceOnboarding
-        ) {
-            return;
-        }
+        // If device setup is not supported, we don't want to navigate anywhere
+        // We handle it separately in `useDetectDeviceError` hook. Ideally, the alert would be triggered here (it would need to be in redux though).
+        if (!isDeviceSetupSupported) return;
 
+        // If user previously cancelled the onboarding, they should remaing on homescreen
         if (wasDeviceOnboardingCancelled) {
-            console.warn('navigate home');
+            // No need to navigate if we are already on home screen (preventing sliding to new screen)
+            if (checkIsActiveRouteAnyOf([HomeStackRoutes.Home])) return;
+
+            navigationContainerRef.reset({
+                index: 0,
+                routes: [
+                    {
+                        name: RootStackRoutes.AppTabs,
+                        params: {
+                            screen: HomeStackRoutes.Home,
+                        },
+                    },
+                ],
+            });
         } else {
             // If THP confirmation screen was shown, we want to prevent swiping/navigating back to
             // that THP confirmation screen. Swiping/navigating back shall lead to the Home screen.
@@ -145,13 +145,6 @@ deviceConnectionMiddleware.startListening({
             isDeviceInitialized: selectIsDeviceInitialized(getState()),
             isDeviceSetupSupported: selectIsDeviceSetupSupported(getState()),
             wasDeviceOnboardingCancelled: selectWasDeviceOnboardingCancelled(getState()),
-            isOnboardingDeviceDisconnectedAlertDisplayed:
-                selectIsOnboardingDeviceDisconnectedAlertDisplayed(getState()),
-            isReconnectingDeviceOnDeviceOnboarding:
-                checkIsActiveRouteAnyOf([RootStackRoutes.DeviceOnboardingStack]) &&
-                checkIsActiveRouteAnyOfBlacklisted([
-                    DeviceOnboardingStackRoutes.ConnectAndUnlockDevice,
-                ]),
         });
     },
 });

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -53,11 +53,7 @@ const handleDeviceConnectNavigation = ({
     isDeviceSetupSupported: boolean;
     wasDeviceOnboardingCancelled: boolean;
 }) => {
-    if (isCoinEnablingInitFinished) {
-        navigationContainerRef.navigate(RootStackRoutes.AuthorizeDeviceStack, {
-            screen: AuthorizeDeviceStackRoutes.ConnectingDevice,
-        });
-    } else if (!isDeviceInitialized) {
+    if (!isDeviceInitialized) {
         // If device setup is not supported, we don't want to navigate anywhere
         // We handle it separately in `useDetectDeviceError` hook. Ideally, the alert would be triggered here (it would need to be in redux though).
         if (!isDeviceSetupSupported) return;
@@ -78,6 +74,8 @@ const handleDeviceConnectNavigation = ({
                     },
                 ],
             });
+
+            return;
         } else {
             // If THP confirmation screen was shown, we want to prevent swiping/navigating back to
             // that THP confirmation screen. Swiping/navigating back shall lead to the Home screen.
@@ -98,7 +96,15 @@ const handleDeviceConnectNavigation = ({
                     },
                 ],
             });
+
+            return;
         }
+    }
+
+    if (isCoinEnablingInitFinished) {
+        navigationContainerRef.navigate(RootStackRoutes.AuthorizeDeviceStack, {
+            screen: AuthorizeDeviceStackRoutes.ConnectingDevice,
+        });
     } else {
         navigationContainerRef.navigate(RootStackRoutes.CoinEnablingInit);
     }

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -23,7 +23,6 @@ import {
     HomeStackRoutes,
     RootStackRoutes,
     checkIsActiveRouteAnyOf,
-    checkIsActiveRouteAnyOfBlacklisted,
     navigationContainerRef,
 } from '@suite-native/navigation';
 import { selectIsCoinEnablingInitFinished } from '@suite-native/settings';
@@ -118,7 +117,7 @@ deviceConnectionMiddleware.startListening({
     ) => {
         const shouldNavigateToDeviceCompromisedModal = selectIsDeviceCompromised(getState());
 
-        if (!checkIsActiveRouteAnyOfBlacklisted(DEVICE_CONNECTION_BLACKLISTED_ROUTES)) return;
+        if (checkIsActiveRouteAnyOf(DEVICE_CONNECTION_BLACKLISTED_ROUTES)) return;
 
         // During firmware installation, device restarts (disconnect + connect) and we want to ignore it.
         if (selectIsFirmwareInstallationRunning(getState())) return;
@@ -162,11 +161,13 @@ deviceConnectionMiddleware.startListening({
         const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(getState());
         const isFirmwareInstallationRunning = selectIsFirmwareInstallationRunning(getState());
 
-        const isDeviceDisconnectionNavigationAllowed = checkIsActiveRouteAnyOfBlacklisted(
-            buildDisconnectionBlacklist(isEntropyCheckEnabledAndFailed, isDeviceRemembered),
-        );
-
-        if (!isDeviceDisconnectionNavigationAllowed || isFirmwareInstallationRunning) return;
+        if (
+            checkIsActiveRouteAnyOf(
+                buildDisconnectionBlacklist(isEntropyCheckEnabledAndFailed, isDeviceRemembered),
+            ) ||
+            isFirmwareInstallationRunning
+        )
+            return;
 
         if (checkIsActiveRouteAnyOf([RootStackRoutes.DeviceOnboardingStack])) {
             navigationContainerRef.navigate(RootStackRoutes.DeviceOnboardingStack, {

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -15,7 +15,10 @@ import {
     selectIsDeviceRemembered,
     selectIsDeviceUsingPassphrase,
 } from '@suite-common/wallet-core';
-import { selectWasDeviceOnboardingCancelled } from '@suite-native/device-onboarding';
+import {
+    selectIsOnboardingDeviceDisconnectedAlertDisplayed,
+    selectWasDeviceOnboardingCancelled,
+} from '@suite-native/device-onboarding';
 import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
 import {
     AuthorizeDeviceStackRoutes,
@@ -47,11 +50,15 @@ const handleDeviceConnectNavigation = ({
     isDeviceInitialized,
     isDeviceSetupSupported,
     wasDeviceOnboardingCancelled,
+    isOnboardingDeviceDisconnectedAlertDisplayed,
+    isReconnectingDeviceOnDeviceOnboarding,
 }: {
     isCoinEnablingInitFinished: boolean;
     isDeviceInitialized: boolean;
     isDeviceSetupSupported: boolean;
     wasDeviceOnboardingCancelled: boolean;
+    isOnboardingDeviceDisconnectedAlertDisplayed: boolean;
+    isReconnectingDeviceOnDeviceOnboarding: boolean;
 }) => {
     // If device setup is not supported, we don't want to navigate anywhere
     // We handle it separately in `useDetectDeviceError` hook
@@ -62,6 +69,13 @@ const handleDeviceConnectNavigation = ({
             screen: AuthorizeDeviceStackRoutes.ConnectingDevice,
         });
     } else if (!isDeviceInitialized) {
+        if (
+            isOnboardingDeviceDisconnectedAlertDisplayed ||
+            isReconnectingDeviceOnDeviceOnboarding
+        ) {
+            return;
+        }
+
         if (wasDeviceOnboardingCancelled) {
             console.warn('navigate home');
         } else {
@@ -131,6 +145,13 @@ deviceConnectionMiddleware.startListening({
             isDeviceInitialized: selectIsDeviceInitialized(getState()),
             isDeviceSetupSupported: selectIsDeviceSetupSupported(getState()),
             wasDeviceOnboardingCancelled: selectWasDeviceOnboardingCancelled(getState()),
+            isOnboardingDeviceDisconnectedAlertDisplayed:
+                selectIsOnboardingDeviceDisconnectedAlertDisplayed(getState()),
+            isReconnectingDeviceOnDeviceOnboarding:
+                checkIsActiveRouteAnyOf([RootStackRoutes.DeviceOnboardingStack]) &&
+                checkIsActiveRouteAnyOfBlacklisted([
+                    DeviceOnboardingStackRoutes.ConnectAndUnlockDevice,
+                ]),
         });
     },
 });

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -34,6 +34,7 @@ import {
 import {
     NativeDeviceRootState,
     selectIsDeviceCompromised,
+    selectIsDeviceSetupSupported,
     selectIsEntropyCheckEnabledAndFailed,
 } from '../selectors';
 import { isDeviceConnectAction } from '../utils';
@@ -42,12 +43,40 @@ export const deviceConnectionMiddleware = createListenerMiddleware<NativeDeviceR
 
 const handleDeviceConnectNavigation = ({
     isCoinEnablingInitFinished,
+    isDeviceInitialized,
+    isDeviceSetupSupported,
 }: {
     isCoinEnablingInitFinished: boolean;
+    isDeviceInitialized: boolean;
+    isDeviceSetupSupported: boolean;
 }) => {
+    // If device setup is not supported, we don't want to navigate anywhere
+    // We handle it separately in `useDetectDeviceError` hook
+    if (!isDeviceSetupSupported) return;
+
     if (isCoinEnablingInitFinished) {
         navigationContainerRef.navigate(RootStackRoutes.AuthorizeDeviceStack, {
             screen: AuthorizeDeviceStackRoutes.ConnectingDevice,
+        });
+    } else if (!isDeviceInitialized) {
+        // If THP confirmation screen was shown, we want to prevent swiping/navigating back to
+        // that THP confirmation screen. Swiping/navigating back shall lead to the Home screen.
+        navigationContainerRef.reset({
+            index: 1,
+            routes: [
+                {
+                    name: RootStackRoutes.AppTabs,
+                    params: {
+                        screen: HomeStackRoutes.Home,
+                    },
+                },
+                {
+                    name: RootStackRoutes.DeviceOnboardingStack,
+                    params: {
+                        screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
+                    },
+                },
+            ],
         });
     } else {
         navigationContainerRef.navigate(RootStackRoutes.CoinEnablingInit);
@@ -55,18 +84,12 @@ const handleDeviceConnectNavigation = ({
 };
 
 deviceConnectionMiddleware.startListening({
-    predicate: (action, currentState) =>
-        isDeviceConnectAction(action) &&
-        // TODO this should dissappear after we merge device onboarding redirect here as well
-        // https://github.com/trezor/trezor-suite/issues/20157
-        // If device is not initialized and is compromised, we display the modal (reason why this condition is here) and then want to redirect to uninitialized device landing.
-        (selectIsDeviceInitialized(currentState) || selectIsDeviceCompromised(currentState)),
+    predicate: action => isDeviceConnectAction(action),
     effect: (
         action: UnknownAction,
         { getState }: ListenerEffectAPI<NativeDeviceRootState, Dispatch<UnknownAction>>,
     ) => {
         const shouldNavigateToDeviceCompromisedModal = selectIsDeviceCompromised(getState());
-        const isCoinEnablingInitFinished = selectIsCoinEnablingInitFinished(getState());
 
         if (!checkIsActiveRouteAnyOfBlacklisted(DEVICE_CONNECTION_BLACKLISTED_ROUTES)) return;
 
@@ -96,7 +119,11 @@ deviceConnectionMiddleware.startListening({
 
         if (isNonThpRememberedDeviceConnectAction) return;
 
-        handleDeviceConnectNavigation({ isCoinEnablingInitFinished });
+        handleDeviceConnectNavigation({
+            isCoinEnablingInitFinished: selectIsCoinEnablingInitFinished(getState()),
+            isDeviceInitialized: selectIsDeviceInitialized(getState()),
+            isDeviceSetupSupported: selectIsDeviceSetupSupported(getState()),
+        });
     },
 });
 

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -3,7 +3,6 @@ import { AnyAction, isAnyOf } from '@reduxjs/toolkit';
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { isAnyDeviceEventAction } from '@suite-common/suite-utils';
 import {
-    createImportedDeviceThunk,
     deviceActions,
     forgetAccountsThunk,
     forgetDisconnectedDevices,
@@ -62,10 +61,6 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
         /* The `next` function has to be executed here, because the further dispatched actions of this middleware
          expect that the state was already changed by the action stored in the `action` variable. */
         next(action);
-
-        if (isAnyOf(createImportedDeviceThunk.fulfilled)(action)) {
-            dispatch(selectDeviceThunk({ device: action.payload.device }));
-        }
 
         if (deviceActions.forgetDevice.match(action)) {
             dispatch(handleDeviceDisconnect(action.payload.device));

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -9,13 +9,11 @@ import {
     handleDeviceDisconnect,
     observeSelectedDevice,
     selectAccountsByDeviceState,
-    selectDeviceThunk,
     selectDiscoveryByDevicePath,
     selectIsDeviceForceRemembered,
 } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
 import { clearAndUnlockDeviceAccessQueue } from '@suite-native/device-mutex';
-import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 import { reportSecurityCheck } from '@suite-native/sentry';
 import { setShouldShowAutoEjectAlert } from '@suite-native/settings';
 import { DEVICE } from '@trezor/connect';
@@ -72,18 +70,9 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
             }
         }
 
-        const isUsbDeviceConnectFeatureEnabled = selectIsFeatureFlagEnabled(
-            getState(),
-            FeatureFlag.IsDeviceConnectEnabled,
-        );
-
         switch (action.type) {
             case DEVICE.CONNECT:
             case DEVICE.CONNECT_UNACQUIRED: {
-                if (isUsbDeviceConnectFeatureEnabled) {
-                    dispatch(selectDeviceThunk(action.payload));
-                }
-
                 const { device } = action.payload;
                 const { features, mode } = device;
 

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -46,6 +46,7 @@ import {
     asBaseCurrencyAmount,
     getAccountFiatBalance,
 } from '@suite-common/wallet-utils';
+import { DeviceOnboardingSliceRootState } from '@suite-native/device-onboarding';
 import {
     FeatureFlag,
     FeatureFlagsRootState,
@@ -70,7 +71,8 @@ export type NativeDeviceRootState = DeviceRootState &
     FiatRatesRootState &
     FeatureFlagsRootState &
     NativeFirmwareRootState &
-    MessageSystemRootState;
+    MessageSystemRootState &
+    DeviceOnboardingSliceRootState;
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<NativeDeviceRootState>();
 

--- a/suite-native/device/tsconfig.json
+++ b/suite-native/device/tsconfig.json
@@ -23,7 +23,6 @@
         { "path": "../alerts" },
         { "path": "../analytics" },
         { "path": "../atoms" },
-        { "path": "../biometrics" },
         { "path": "../device-authorization" },
         { "path": "../device-mutex" },
         { "path": "../feature-flags" },

--- a/suite-native/module-authenticity-checks/src/components/FirmwareAuthenticityCheckFailModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/FirmwareAuthenticityCheckFailModalContent.tsx
@@ -10,10 +10,12 @@ import {
 import { Button } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
+    DeviceOnboardingStackRoutes,
     RootStackParamList,
     RootStackRoutes,
     ScreenHeader,
     StackToStackCompositeNavigationProps,
+    useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 import { selectIsCoinEnablingInitFinished } from '@suite-native/settings';
 import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL } from '@trezor/urls';
@@ -28,7 +30,9 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 
 export const FirmwareAuthenticityCheckFailModalContent = () => {
     const dispatch = useDispatch();
+
     const navigation = useNavigation<NavigationProps>();
+    const navigateToInitialScreen = useNavigateToInitialScreen();
 
     const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
     const isCoinEnablingInitFinished = useSelector(selectIsCoinEnablingInitFinished);
@@ -43,10 +47,14 @@ export const FirmwareAuthenticityCheckFailModalContent = () => {
     const handleClose = () => {
         dismissCheck();
 
-        if (!isCoinEnablingInitFinished && isDeviceInitialized) {
-            navigation.navigate(RootStackRoutes.CoinEnablingInit);
+        if (!isDeviceInitialized) {
+            navigation.popTo(RootStackRoutes.DeviceOnboardingStack, {
+                screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
+            });
+        } else if (!isCoinEnablingInitFinished) {
+            navigation.popTo(RootStackRoutes.CoinEnablingInit);
         } else {
-            if (navigation.canGoBack()) navigation.goBack();
+            navigateToInitialScreen();
         }
     };
 

--- a/suite-native/module-device-onboarding/package.json
+++ b/suite-native/module-device-onboarding/package.json
@@ -19,6 +19,7 @@
         "@suite-native/atoms": "workspace:*",
         "@suite-native/device": "workspace:*",
         "@suite-native/device-authorization": "workspace:*",
+        "@suite-native/device-onboarding": "workspace:*",
         "@suite-native/helpers": "workspace:*",
         "@suite-native/icons": "workspace:*",
         "@suite-native/intl": "workspace:*",

--- a/suite-native/module-device-onboarding/src/hooks/useExitAlert.ts
+++ b/suite-native/module-device-onboarding/src/hooks/useExitAlert.ts
@@ -1,12 +1,11 @@
 import { useCallback } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/core';
-import { useSetAtom } from 'jotai';
 
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
-import { wasDeviceOnboardingCancelledAtom } from '@suite-native/device';
+import { setWasDeviceOnboardingCancelled } from '@suite-native/device-onboarding';
 import { useFirmware } from '@suite-native/firmware';
 import { useTranslate } from '@suite-native/intl';
 import {
@@ -25,11 +24,15 @@ type NavigationProps = StackToStackCompositeNavigationProps<
     RootStackParamList
 >;
 export const useExitAlert = (handleContinueButtonPress?: () => void) => {
+    const dispatch = useDispatch();
+
     const navigation = useNavigation<NavigationProps>();
+
     const { showAlert } = useAlert();
+
     const { translate } = useTranslate();
+
     const selectedDevice = useSelector(selectSelectedDevice);
-    const setWasDeviceOnboardingCancelled = useSetAtom(wasDeviceOnboardingCancelledAtom);
     const { setIsFirmwareInstallationRunning } = useFirmware();
 
     const handleExitButtonPress = useCallback(() => {
@@ -47,7 +50,7 @@ export const useExitAlert = (handleContinueButtonPress?: () => void) => {
             onPressPrimaryButton: () => {
                 if (selectedDevice) {
                     setIsFirmwareInstallationRunning(false);
-                    setWasDeviceOnboardingCancelled(true);
+                    dispatch(setWasDeviceOnboardingCancelled(true));
                     navigation.popTo(RootStackRoutes.AppTabs, {
                         screen: AppTabsRoutes.HomeStack,
                         params: {
@@ -64,13 +67,13 @@ export const useExitAlert = (handleContinueButtonPress?: () => void) => {
             },
         });
     }, [
+        dispatch,
         handleContinueButtonPress,
-        selectedDevice,
-        setWasDeviceOnboardingCancelled,
-        setIsFirmwareInstallationRunning,
-        translate,
-        showAlert,
         navigation,
+        selectedDevice,
+        setIsFirmwareInstallationRunning,
+        showAlert,
+        translate,
     ]);
 
     return { handleExitButtonPress };

--- a/suite-native/module-device-onboarding/src/screens/ConnectAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ConnectAndUnlockDeviceScreen.tsx
@@ -1,14 +1,14 @@
 import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/core';
-import { useSetAtom } from 'jotai';
 
 import { useAlert } from '@suite-native/alerts';
+import { ConnectAndUnlockDeviceScreenContent } from '@suite-native/device';
 import {
-    ConnectAndUnlockDeviceScreenContent,
-    isOnboardingDeviceDisconnectedAlertDisplayedAtom,
-    wasDeviceOnboardingCancelledAtom,
-} from '@suite-native/device';
+    setIsOnboardingDeviceDisconnectedAlertDisplayed,
+    setWasDeviceOnboardingCancelled,
+} from '@suite-native/device-onboarding';
 import { useTranslate } from '@suite-native/intl';
 import {
     AppTabsRoutes,
@@ -28,17 +28,16 @@ type NavigationProp = StackToStackCompositeNavigationProps<
 >;
 
 export const ConnectAndUnlockDeviceScreen = () => {
+    const dispatch = useDispatch();
+
     const { showAlert } = useAlert();
+
     const { translate } = useTranslate();
+
     const navigation = useNavigation<NavigationProp>();
-    const setIsOnboardingDeviceDisconnectedAlertDisplayed = useSetAtom(
-        isOnboardingDeviceDisconnectedAlertDisplayedAtom,
-    );
 
     const hideDeviceDisconnectedAlert = () =>
-        setIsOnboardingDeviceDisconnectedAlertDisplayed(false);
-
-    const setWasDeviceOnboardingCancelled = useSetAtom(wasDeviceOnboardingCancelledAtom);
+        dispatch(setIsOnboardingDeviceDisconnectedAlertDisplayed(false));
 
     const navigateToHome = () =>
         navigation.popTo(RootStackRoutes.AppTabs, {
@@ -51,8 +50,8 @@ export const ConnectAndUnlockDeviceScreen = () => {
     useEffect(() => {
         // This alert should be shown only if the device was physically disconnected from the phone.
         // In case that user "disconnects" device by cancelling the onboarding flow via the app UI, the alert is not shown!
-        setIsOnboardingDeviceDisconnectedAlertDisplayed(true);
-        setWasDeviceOnboardingCancelled(false);
+        dispatch(setIsOnboardingDeviceDisconnectedAlertDisplayed(true));
+        dispatch(setWasDeviceOnboardingCancelled(false));
 
         showAlert({
             title: translate('moduleDeviceOnboarding.deviceDisconnectedAlert.title'),

--- a/suite-native/module-device-onboarding/src/screens/ConnectAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ConnectAndUnlockDeviceScreen.tsx
@@ -5,10 +5,7 @@ import { useNavigation } from '@react-navigation/core';
 
 import { useAlert } from '@suite-native/alerts';
 import { ConnectAndUnlockDeviceScreenContent } from '@suite-native/device';
-import {
-    setIsOnboardingDeviceDisconnectedAlertDisplayed,
-    setWasDeviceOnboardingCancelled,
-} from '@suite-native/device-onboarding';
+import { setWasDeviceOnboardingCancelled } from '@suite-native/device-onboarding';
 import { useTranslate } from '@suite-native/intl';
 import {
     AppTabsRoutes,
@@ -36,9 +33,6 @@ export const ConnectAndUnlockDeviceScreen = () => {
 
     const navigation = useNavigation<NavigationProp>();
 
-    const hideDeviceDisconnectedAlert = () =>
-        dispatch(setIsOnboardingDeviceDisconnectedAlertDisplayed(false));
-
     const navigateToHome = () =>
         navigation.popTo(RootStackRoutes.AppTabs, {
             screen: AppTabsRoutes.HomeStack,
@@ -48,9 +42,6 @@ export const ConnectAndUnlockDeviceScreen = () => {
         });
 
     useEffect(() => {
-        // This alert should be shown only if the device was physically disconnected from the phone.
-        // In case that user "disconnects" device by cancelling the onboarding flow via the app UI, the alert is not shown!
-        dispatch(setIsOnboardingDeviceDisconnectedAlertDisplayed(true));
         dispatch(setWasDeviceOnboardingCancelled(false));
 
         showAlert({
@@ -63,10 +54,8 @@ export const ConnectAndUnlockDeviceScreen = () => {
             primaryButtonVariant: 'redBold',
             secondaryButtonTitle: translate('generic.buttons.cancel'),
             secondaryButtonVariant: 'redElevation0',
-            onPressPrimaryButton: hideDeviceDisconnectedAlert,
             onPressSecondaryButton: () => {
                 setWasDeviceOnboardingCancelled(true);
-                hideDeviceDisconnectedAlert();
                 navigateToHome();
             },
         });

--- a/suite-native/module-device-onboarding/tsconfig.json
+++ b/suite-native/module-device-onboarding/tsconfig.json
@@ -5,6 +5,7 @@
         { "path": "../atoms" },
         { "path": "../device" },
         { "path": "../device-authorization" },
+        { "path": "../device-onboarding" },
         { "path": "../helpers" },
         { "path": "../icons" },
         { "path": "../intl" },

--- a/suite-native/navigation/jest.config.js
+++ b/suite-native/navigation/jest.config.js
@@ -1,0 +1,5 @@
+const { ...baseConfig } = require('../../jest.config.native');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-native/navigation/package.json
+++ b/suite-native/navigation/package.json
@@ -4,10 +4,10 @@
     "private": true,
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
-    "type": "module",
     "main": "src/index",
     "scripts": {
         "depcheck": "yarn g:depcheck",
+        "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {

--- a/suite-native/navigation/src/__tests__/routeUtils.test.ts
+++ b/suite-native/navigation/src/__tests__/routeUtils.test.ts
@@ -1,0 +1,165 @@
+import { navigationContainerRef } from '../components/NavigationContainerWithAnalytics';
+import { checkIsActiveRouteAnyOf } from '../routeUtils';
+import { DeviceOnboardingStackRoutes, HomeStackRoutes, RootStackRoutes } from '../routes';
+
+jest.mock('../components/NavigationContainerWithAnalytics', () => ({
+    navigationContainerRef: {
+        getState: jest.fn(),
+    },
+}));
+
+const mockedNavigationContainerRef = navigationContainerRef as jest.Mocked<
+    typeof navigationContainerRef
+>;
+
+describe('Navigation Utils', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('checkIsActiveRouteAnyOf', () => {
+        it('should return true when active route matches one of the provided routes', () => {
+            mockedNavigationContainerRef.getState.mockReturnValue({
+                stale: false,
+                type: 'stack',
+                key: 'stack-test1',
+                index: 0,
+                routeNames: [
+                    RootStackRoutes.OnboardingStack,
+                    RootStackRoutes.AppTabs,
+                    RootStackRoutes.AccountSettings,
+                ],
+                routes: [
+                    {
+                        name: RootStackRoutes.AppTabs,
+                        params: { screen: 'Home' },
+                        key: 'AppTabs-test1',
+                    },
+                ],
+            });
+
+            const routeList = [RootStackRoutes.AppTabs, RootStackRoutes.OnboardingStack];
+            const result = checkIsActiveRouteAnyOf(routeList);
+
+            expect(result).toBe(true);
+        });
+
+        it('should return false when active route does not match any of the provided routes', () => {
+            mockedNavigationContainerRef.getState.mockReturnValue({
+                stale: false,
+                type: 'stack',
+                key: 'stack-test2',
+                index: 0,
+                routeNames: [RootStackRoutes.AppTabs, RootStackRoutes.AccountSettings],
+                routes: [
+                    {
+                        name: RootStackRoutes.AccountSettings,
+                        key: 'AccountSettings-test2',
+                    },
+                ],
+            });
+
+            const routeList = [
+                RootStackRoutes.OnboardingStack,
+                RootStackRoutes.AuthorizeDeviceStack,
+            ];
+            const result = checkIsActiveRouteAnyOf(routeList);
+
+            expect(result).toBe(false);
+        });
+
+        it('should return false when routes array is empty', () => {
+            mockedNavigationContainerRef.getState.mockReturnValue({
+                stale: false,
+                type: 'stack',
+                key: 'stack-test3',
+                index: 0,
+                routeNames: [],
+                routes: [],
+            });
+
+            const routeList = [RootStackRoutes.AppTabs];
+            const result = checkIsActiveRouteAnyOf(routeList);
+
+            expect(result).toBe(false);
+        });
+
+        it('should return true for DeviceOnboardingStackRoutes', () => {
+            mockedNavigationContainerRef.getState.mockReturnValue({
+                stale: false,
+                type: 'stack',
+                key: 'stack-test4',
+                index: 0,
+                routeNames: [DeviceOnboardingStackRoutes.ConnectAndUnlockDevice],
+                routes: [
+                    {
+                        name: DeviceOnboardingStackRoutes.ConnectAndUnlockDevice,
+                        key: 'ConnectAndUnlockDevice-test4',
+                    },
+                ],
+            });
+
+            const routeList = [
+                DeviceOnboardingStackRoutes.ConnectAndUnlockDevice,
+                DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
+            ];
+            const result = checkIsActiveRouteAnyOf(routeList);
+
+            expect(result).toBe(true);
+        });
+
+        it('should return true for HomeStackRoutes', () => {
+            mockedNavigationContainerRef.getState.mockReturnValue({
+                stale: false,
+                type: 'stack',
+                key: 'stack-test5',
+                index: 0,
+                routeNames: [HomeStackRoutes.Home],
+                routes: [
+                    {
+                        name: HomeStackRoutes.Home,
+                        key: 'Home-test5',
+                    },
+                ],
+            });
+
+            const routeList = [HomeStackRoutes.Home];
+            const result = checkIsActiveRouteAnyOf(routeList);
+
+            expect(result).toBe(true);
+        });
+
+        it('should handle multiple routes in navigation stack and check the last one', () => {
+            mockedNavigationContainerRef.getState.mockReturnValue({
+                stale: false,
+                type: 'stack',
+                key: 'stack-test6',
+                index: 2,
+                routeNames: [
+                    RootStackRoutes.AppTabs,
+                    RootStackRoutes.OnboardingStack,
+                    RootStackRoutes.AuthorizeDeviceStack,
+                ],
+                routes: [
+                    {
+                        name: RootStackRoutes.OnboardingStack,
+                        key: 'OnboardingStack-test6-2',
+                    },
+                    {
+                        name: RootStackRoutes.AuthorizeDeviceStack,
+                        key: 'AuthorizeDeviceStack-test6-3',
+                    },
+                    {
+                        name: RootStackRoutes.AppTabs,
+                        key: 'AppTabs-test6-1',
+                    },
+                ],
+            });
+
+            const routeList = [RootStackRoutes.AuthorizeDeviceStack];
+            const result = checkIsActiveRouteAnyOf(routeList);
+
+            expect(result).toBe(false);
+        });
+    });
+});

--- a/suite-native/navigation/src/__tests__/routeUtils.test.ts
+++ b/suite-native/navigation/src/__tests__/routeUtils.test.ts
@@ -1,5 +1,5 @@
 import { navigationContainerRef } from '../components/NavigationContainerWithAnalytics';
-import { checkIsActiveRouteAnyOf } from '../routeUtils';
+import { checkIsActiveRouteAnyOf, checkIsHomeStackFocused } from '../routeUtils';
 import { DeviceOnboardingStackRoutes, HomeStackRoutes, RootStackRoutes } from '../routes';
 
 jest.mock('../components/NavigationContainerWithAnalytics', () => ({
@@ -18,7 +18,7 @@ describe('Navigation Utils', () => {
     });
 
     describe('checkIsActiveRouteAnyOf', () => {
-        it('should return true when active route matches one of the provided routes', () => {
+        it('check is home stack focused', () => {
             mockedNavigationContainerRef.getState.mockReturnValue({
                 stale: false,
                 type: 'stack',
@@ -38,8 +38,7 @@ describe('Navigation Utils', () => {
                 ],
             });
 
-            const routeList = [RootStackRoutes.AppTabs, RootStackRoutes.OnboardingStack];
-            const result = checkIsActiveRouteAnyOf(routeList);
+            const result = checkIsHomeStackFocused();
 
             expect(result).toBe(true);
         });
@@ -63,22 +62,6 @@ describe('Navigation Utils', () => {
                 RootStackRoutes.OnboardingStack,
                 RootStackRoutes.AuthorizeDeviceStack,
             ];
-            const result = checkIsActiveRouteAnyOf(routeList);
-
-            expect(result).toBe(false);
-        });
-
-        it('should return false when routes array is empty', () => {
-            mockedNavigationContainerRef.getState.mockReturnValue({
-                stale: false,
-                type: 'stack',
-                key: 'stack-test3',
-                index: 0,
-                routeNames: [],
-                routes: [],
-            });
-
-            const routeList = [RootStackRoutes.AppTabs];
             const result = checkIsActiveRouteAnyOf(routeList);
 
             expect(result).toBe(false);

--- a/suite-native/navigation/src/checkIsActiveRouteAnyOfBlacklisted.ts
+++ b/suite-native/navigation/src/checkIsActiveRouteAnyOfBlacklisted.ts
@@ -1,7 +1,7 @@
 import { navigationContainerRef } from './components/NavigationContainerWithAnalytics';
-import { DeviceOnboardingStackRoutes, RootStackRoutes } from './routes';
+import { DeviceOnboardingStackRoutes, HomeStackRoutes, RootStackRoutes } from './routes';
 
-type RouteType = RootStackRoutes | DeviceOnboardingStackRoutes;
+type RouteType = RootStackRoutes | DeviceOnboardingStackRoutes | HomeStackRoutes;
 type Routes = RouteType[];
 
 const getActiveRouteName = () =>

--- a/suite-native/navigation/src/index.ts
+++ b/suite-native/navigation/src/index.ts
@@ -5,7 +5,7 @@ export * from './config';
 export * from './useHandleHardwareBackNavigation';
 export * from './useNavigateToInitialScreen';
 export * from './useScrollDivider';
-export * from './checkIsActiveRouteAnyOfBlacklisted';
+export * from './routeUtils';
 export * from './hooks/useNavigationRoute';
 export * from './hooks/useOverrideBackNavigation';
 export * from './components/TabBar';

--- a/suite-native/navigation/src/routeUtils.ts
+++ b/suite-native/navigation/src/routeUtils.ts
@@ -1,16 +1,34 @@
 import { navigationContainerRef } from './components/NavigationContainerWithAnalytics';
-import { DeviceOnboardingStackRoutes, HomeStackRoutes, RootStackRoutes } from './routes';
+import { AppNavigationState, getActiveRouteName } from './hooks/useNavigationRoute';
+import {
+    AppTabsRoutes,
+    DeviceOnboardingStackRoutes,
+    HomeStackRoutes,
+    RootStackRoutes,
+} from './routes';
 
 type RouteType = RootStackRoutes | DeviceOnboardingStackRoutes | HomeStackRoutes;
 export type Routes = RouteType[];
 
-const getActiveRouteName = () =>
-    navigationContainerRef.getState()?.routes.at(-1)?.name as RouteType;
+export const checkIsActiveRouteAnyOf = (routeList: string[]): boolean => {
+    const activeRoute = getActiveRouteName(navigationContainerRef.getState() as AppNavigationState);
 
-export const checkIsActiveRouteAnyOf = (routeList: Routes) => {
-    const activeRouteName = getActiveRouteName();
+    if (!activeRoute) return false;
 
-    if (!activeRouteName) return false;
+    return routeList.includes(activeRoute);
+};
 
-    return routeList.includes(activeRouteName);
+export const checkIsDeviceOnboardingFocused = () => {
+    const DEVICE_ONBOARDING_ROUTES = [
+        RootStackRoutes.DeviceOnboardingStack,
+        ...Object.keys(DeviceOnboardingStackRoutes),
+    ];
+
+    return checkIsActiveRouteAnyOf(DEVICE_ONBOARDING_ROUTES);
+};
+
+export const checkIsHomeStackFocused = () => {
+    const HOME_ROUTES = [HomeStackRoutes.Home, AppTabsRoutes.HomeStack];
+
+    return checkIsActiveRouteAnyOf(HOME_ROUTES);
 };

--- a/suite-native/navigation/src/routeUtils.ts
+++ b/suite-native/navigation/src/routeUtils.ts
@@ -2,7 +2,7 @@ import { navigationContainerRef } from './components/NavigationContainerWithAnal
 import { DeviceOnboardingStackRoutes, HomeStackRoutes, RootStackRoutes } from './routes';
 
 type RouteType = RootStackRoutes | DeviceOnboardingStackRoutes | HomeStackRoutes;
-type Routes = RouteType[];
+export type Routes = RouteType[];
 
 const getActiveRouteName = () =>
     navigationContainerRef.getState()?.routes.at(-1)?.name as RouteType;
@@ -14,6 +14,3 @@ export const checkIsActiveRouteAnyOf = (routeList: Routes) => {
 
     return routeList.includes(activeRouteName);
 };
-
-export const checkIsActiveRouteAnyOfBlacklisted = (blacklist: Routes) =>
-    !checkIsActiveRouteAnyOf(blacklist);

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -27,6 +27,7 @@
         "@suite-native/bluetooth": "workspace:*",
         "@suite-native/device": "workspace:*",
         "@suite-native/device-authorization": "workspace:*",
+        "@suite-native/device-onboarding": "workspace:*",
         "@suite-native/discovery": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/firmware": "workspace:*",

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -31,6 +31,7 @@ import { prepareWalletConnectReducer } from '@suite-common/walletconnect/src/wal
 import { bannerFlagsPersistWhitelist, bannerFlagsReducer } from '@suite-native/banner-flags';
 import { bluetoothSlice } from '@suite-native/bluetooth';
 import { deviceAuthorizationReducer } from '@suite-native/device-authorization';
+import { deviceOnboardingReducer } from '@suite-native/device-onboarding';
 import { featureFlagsPersistedKeys, featureFlagsReducer } from '@suite-native/feature-flags';
 import { nativeFirmwareReducer } from '@suite-native/firmware';
 import { graphPersistTransform, graphReducer } from '@suite-native/graph';
@@ -277,6 +278,7 @@ export const prepareRootReducers = async () => {
             graph: graphReducer,
             device: devicePersistedReducer,
             deviceAuthorization: deviceAuthorizationReducer,
+            deviceOnboarding: deviceOnboardingReducer,
             firmware: firmwarePersistedReducer,
             nativeFirmware: nativeFirmwareReducer,
             logs: logsSlice.reducer,

--- a/suite-native/state/tsconfig.json
+++ b/suite-native/state/tsconfig.json
@@ -34,6 +34,7 @@
         { "path": "../bluetooth" },
         { "path": "../device" },
         { "path": "../device-authorization" },
+        { "path": "../device-onboarding" },
         { "path": "../discovery" },
         { "path": "../feature-flags" },
         { "path": "../firmware" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10424,6 +10424,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite-native/device-onboarding@workspace:*, @suite-native/device-onboarding@workspace:suite-native/device-onboarding":
+  version: 0.0.0-use.local
+  resolution: "@suite-native/device-onboarding@workspace:suite-native/device-onboarding"
+  dependencies:
+    "@reduxjs/toolkit": "npm:2.8.2"
+  languageName: unknown
+  linkType: soft
+
 "@suite-native/device@workspace:*, @suite-native/device@workspace:suite-native/device":
   version: 0.0.0-use.local
   resolution: "@suite-native/device@workspace:suite-native/device"
@@ -10440,7 +10448,6 @@ __metadata:
     "@suite-native/alerts": "workspace:*"
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"
-    "@suite-native/biometrics": "workspace:*"
     "@suite-native/device-authorization": "workspace:*"
     "@suite-native/device-mutex": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"
@@ -10962,6 +10969,7 @@ __metadata:
     "@suite-native/atoms": "workspace:*"
     "@suite-native/device": "workspace:*"
     "@suite-native/device-authorization": "workspace:*"
+    "@suite-native/device-onboarding": "workspace:*"
     "@suite-native/helpers": "workspace:*"
     "@suite-native/icons": "workspace:*"
     "@suite-native/intl": "workspace:*"
@@ -11401,6 +11409,7 @@ __metadata:
     "@suite-native/bluetooth": "workspace:*"
     "@suite-native/device": "workspace:*"
     "@suite-native/device-authorization": "workspace:*"
+    "@suite-native/device-onboarding": "workspace:*"
     "@suite-native/discovery": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/firmware": "workspace:*"


### PR DESCRIPTION
…middleware

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20754

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/uninitialized-device-landing&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/uninitialized-device-landing&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/uninitialized-device-landing&lookback=7)