### PR TITLE
chore(suite-native): thp confirmation redirect in middleware

### DIFF
--- a/suite-common/thp/package.json
+++ b/suite-common/thp/package.json
@@ -11,6 +11,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "2.8.2",
         "@suite-common/redux-utils": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/suite-common/thp/src/index.ts
+++ b/suite-common/thp/src/index.ts
@@ -2,6 +2,7 @@ export { prepareThpReducer, THP_BUTTON_REQUESTS_NAMES } from './thpReducer';
 export type { ThpStep } from './thpReducer';
 export { selectIsThpInProgress, selectThpStep, selectThpCredentials } from './thpSelectors';
 export { thpActions } from './thpActions';
+export * from './thpUtils';
 export { connectThpDeviceThunk } from './connectThpDeviceThunk';
 export { startThpAutoconnectThunk } from './startThpAutoconnectThunk';
 export { autoInitThpAfterDeviceConnectionThunk } from './autoInitThpAfterDeviceConnectionThunk';

--- a/suite-common/thp/src/thpUtils.ts
+++ b/suite-common/thp/src/thpUtils.ts
@@ -1,0 +1,22 @@
+import { G } from '@mobily/ts-belt';
+import { UnknownAction } from '@reduxjs/toolkit';
+
+import { UI } from '@trezor/connect';
+
+type ThpPairingRequestPayload = {
+    name: 'thp_pairing_request' | 'thp_connection_request';
+};
+
+type ThpPairingRequestAction = {
+    type: typeof UI.REQUEST_BUTTON;
+    payload: ThpPairingRequestPayload;
+};
+
+export const isThpPairingUIRequestButtonAction = (
+    action: UnknownAction,
+): action is ThpPairingRequestAction =>
+    action.type === UI.REQUEST_BUTTON &&
+    G.isNotNullable(action.payload) &&
+    'name' in action.payload &&
+    (action.payload.name === 'thp_pairing_request' ||
+        action.payload.name === 'thp_connection_request');

--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation, useNavigationState } from '@react-navigation/native';
 import { useAtomValue } from 'jotai';
 
-import { selectIsThpInProgress, selectThpStep } from '@suite-common/thp';
+import { selectIsThpInProgress } from '@suite-common/thp';
 import {
     selectIsDeviceConnected,
     selectIsDeviceInitialized,
@@ -46,7 +46,6 @@ export const useHandleDeviceConnection = () => {
     const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
     const isDeviceThpRequired = useSelector(selectIsDeviceThpRequired);
     const isThpInProgress = useSelector(selectIsThpInProgress);
-    const thpStep = useSelector(selectThpStep);
     const isFirmwareInstallationRunning = useSelector(selectIsFirmwareInstallationRunning);
     const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
     const isDeviceCompromised = useSelector(selectIsDeviceCompromised);
@@ -70,19 +69,6 @@ export const useHandleDeviceConnection = () => {
     const isOnPinMatrixBlacklistedRoute = pinMatrixBlacklistedScreens.includes(
         lastRoute as RootStackRoutes,
     );
-
-    // Nothing can be accomplished before a THP connection is established.
-    useEffect(() => {
-        if (
-            isOnboardingFinished &&
-            !isFirmwareInstallationRunning &&
-            (thpStep === 'ConfirmConnectionBeforePairing' || thpStep === 'ConfirmOnlyConnection')
-        ) {
-            navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
-                screen: AuthorizeDeviceStackRoutes.ThpConfirmation,
-            });
-        }
-    }, [isOnboardingFinished, isFirmwareInstallationRunning, thpStep, navigation]);
 
     // When is an uninitialized device model that supports device setup, navigate to device onboarding.
     useEffect(() => {

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -6,6 +6,7 @@ import {
 } from '@reduxjs/toolkit';
 
 import { isThpDevice } from '@suite-common/suite-utils';
+import { isThpPairingUIRequestButtonAction } from '@suite-common/thp';
 import {
     deviceActions,
     deviceConnectThunks,
@@ -125,5 +126,17 @@ deviceConnectionMiddleware.startListening({
                 },
             });
         }
+    },
+});
+
+deviceConnectionMiddleware.startListening({
+    predicate: (action: UnknownAction) => isThpPairingUIRequestButtonAction(action),
+    effect: (_action: UnknownAction, { getState }) => {
+        if (selectIsFirmwareInstallationRunning(getState())) return;
+
+        // Nothing can be accomplished before a THP connection is established.
+        navigationContainerRef.navigate(RootStackRoutes.AuthorizeDeviceStack, {
+            screen: AuthorizeDeviceStackRoutes.ThpConfirmation,
+        });
     },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9749,6 +9749,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/thp@workspace:suite-common/thp"
   dependencies:
+    "@mobily/ts-belt": "npm:^3.13.1"
     "@reduxjs/toolkit": "npm:2.8.2"
     "@suite-common/redux-utils": "workspace:*"
     "@trezor/connect": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- move navigation to THP device confirmation to `deviceConnectionMiddleware` in an attempt to simplify `useHandleDeviceConnection` hook.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/thp-confirmation-middleware-redirect&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/thp-confirmation-middleware-redirect&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/thp-confirmation-middleware-redirect&lookback=7)