### PR TITLE
feat(suite-native): reorganize contents of Bluetooth device card

### DIFF
--- a/suite-native/bluetooth/src/components/BluetoothDeviceCard.tsx
+++ b/suite-native/bluetooth/src/components/BluetoothDeviceCard.tsx
@@ -47,12 +47,13 @@ export const BluetoothDeviceCard = ({
                 <DeviceColorImage color={deviceColor} />
             </Box>
             <Box alignItems="center">
-                <Text variant="titleSmall">{modelConfig.name}</Text>
+                <Text variant="titleSmall">{device.name}</Text>
                 <Text variant="hint" color="textSubdued">
+                    {modelConfig.name}
+                    {' • '}
                     {modelConfig.colors[deviceColor] ?? (
                         <Translation id="bluetooth.deviceCard.unknownColor" />
-                    )}{' '}
-                    • {device.name}
+                    )}
                 </Text>
             </Box>
             <Button


### PR DESCRIPTION
Reorganize Bluetooth device card on mobile as described in https://github.com/trezor/trezor-suite/issues/21363.

## Screenshots:
<img width="1179" height="1037" alt="image" src="https://github.com/user-attachments/assets/430cf90d-c561-44fa-abcc-18bebb41b647" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/bluetooth-device-card&lookback=7)