### PR TITLE
Revert `fix(suite): consider starting discovery same as loading`

### DIFF
--- a/packages/suite/src/utils/wallet/selectDiscoveryOverallStatus.ts
+++ b/packages/suite/src/utils/wallet/selectDiscoveryOverallStatus.ts
@@ -69,7 +69,7 @@ const getDiscoveryStatus = ({
         };
     }
 
-    if (discovery?.status === 'progress' || discovery?.status === 'starting') {
+    if (discovery?.status === 'progress') {
         return {
             status: 'loading',
             type: 'discovery',


### PR DESCRIPTION
This reverts commit 0b11461620ba99b8742027fe460953013a58ef31.

## Description

Interpreting discovery status `starting` same as `progress` sometimes causes `discovery.test.ts` failures (because of different timing), so I reverted it until we find a proper way how to adjust the test.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/discovery-e2e-fix&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/discovery-e2e-fix&lookback=7)