### PR TITLE
chore(suite-native): reset device connection routes

### DIFF
--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -26,6 +26,7 @@ import {
     RootStackParamList,
     RootStackRoutes,
     StackToStackCompositeNavigationProps,
+    navigationContainerRef,
 } from '@suite-native/navigation';
 import { captureSentryException } from '@suite-native/sentry';
 import { selectIsOnboardingFinished, selectShouldShowAutoEjectAlert } from '@suite-native/settings';
@@ -233,7 +234,10 @@ export const useDetectDeviceError = () => {
             !wasDeviceEjectedByUser &&
             isOnboardingFinished
         ) {
-            navigation.navigate(RootStackRoutes.BootloaderMode);
+            navigationContainerRef.reset({
+                index: 0,
+                routes: [{ name: RootStackRoutes.BootloaderMode }],
+            });
         }
     }, [
         shouldFactoryResetBeVisible,

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -17,7 +17,6 @@ import {
 } from '@suite-common/wallet-core';
 import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
 import {
-    AppTabsRoutes,
     AuthorizeDeviceStackRoutes,
     DeviceOnboardingStackRoutes,
     HomeStackRoutes,
@@ -122,9 +121,8 @@ deviceConnectionMiddleware.startListening({
             navigationContainerRef.reset({
                 index: 0,
                 routes: [
-                    RootStackRoutes.AppTabs,
                     {
-                        screen: AppTabsRoutes.HomeStack,
+                        name: RootStackRoutes.AppTabs,
                         params: {
                             screen: HomeStackRoutes.Home,
                         },

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -119,11 +119,17 @@ deviceConnectionMiddleware.startListening({
                 screen: DeviceOnboardingStackRoutes.ConnectAndUnlockDevice,
             });
         } else {
-            navigationContainerRef.navigate(RootStackRoutes.AppTabs, {
-                screen: AppTabsRoutes.HomeStack,
-                params: {
-                    screen: HomeStackRoutes.Home,
-                },
+            navigationContainerRef.reset({
+                index: 0,
+                routes: [
+                    RootStackRoutes.AppTabs,
+                    {
+                        screen: AppTabsRoutes.HomeStack,
+                        params: {
+                            screen: HomeStackRoutes.Home,
+                        },
+                    },
+                ],
             });
         }
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- reset used instead of redirect for Home (when disconnecting device) and bootloader screen (when connecting device in bootloader) so that user cannot swipe back on 🍎 

<img width="332" height="720" alt="image" src="https://github.com/user-attachments/assets/b3f11f19-60fc-4885-8981-0d2a69dfff9c" />


## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/reset-device-connection-routes&lookback=7)