### PR TITLE
Fix: delay discovery during THP autoconnect modal

### DIFF
--- a/packages/suite/src/components/connection/thp/ThpAutoconnectInfoModal.tsx
+++ b/packages/suite/src/components/connection/thp/ThpAutoconnectInfoModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { startThpAutoconnectThunk, thpActions } from '@suite-common/thp';
+import { finishThpAutoconnectThunk, startThpAutoconnectThunk } from '@suite-common/thp';
 import { Column, H3, Modal, Paragraph } from '@trezor/components';
 
 import { useDevice, useDispatch } from '../../../hooks/suite';
@@ -18,7 +18,7 @@ export const ThpAutoconnectInfoModal = () => {
     };
 
     const onCancel = () => {
-        dispatch(thpActions.finishThpFlow());
+        dispatch(finishThpAutoconnectThunk());
     };
 
     return (

--- a/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotLoaded.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotLoaded.tsx
@@ -1,4 +1,4 @@
-import { restartDiscoveryThunk } from '@suite-common/wallet-core';
+import { startOrRestartDiscoveryThunk } from '@suite-common/wallet-core';
 
 import { Translation } from 'src/components/suite';
 import { AccountExceptionLayout } from 'src/components/wallet';
@@ -14,7 +14,7 @@ export const AccountNotLoaded = () => {
     const dispatch = useDispatch();
     const { isLocked } = useDevice();
 
-    const handleClick = () => dispatch(restartDiscoveryThunk());
+    const handleClick = () => dispatch(startOrRestartDiscoveryThunk());
 
     return (
         <AccountExceptionLayout

--- a/packages/suite/src/components/wallet/WalletLayout/AccountException/DiscoveryFailed.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountException/DiscoveryFailed.tsx
@@ -1,4 +1,4 @@
-import { restartDiscoveryThunk } from '@suite-common/wallet-core';
+import { startOrRestartDiscoveryThunk } from '@suite-common/wallet-core';
 
 import { Translation } from 'src/components/suite';
 import { AccountExceptionLayout } from 'src/components/wallet';
@@ -14,7 +14,7 @@ export const DiscoveryFailed = () => {
     const description =
         discovery !== undefined && discovery.status === 'failed' ? discovery.error : undefined;
 
-    const handleClick = () => dispatch(restartDiscoveryThunk());
+    const handleClick = () => dispatch(startOrRestartDiscoveryThunk());
 
     return (
         <AccountExceptionLayout

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
@@ -4,9 +4,9 @@ import { AnimatePresence, MotionProps, motion } from 'framer-motion';
 import styled from 'styled-components';
 
 import {
-    restartDiscoveryThunk,
     selectSelectedDevice,
     selectShowRediscoverButton,
+    startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
 import { Button, IconButton, Row, Tooltip, motionEasing } from '@trezor/components';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
@@ -55,7 +55,7 @@ export const RefreshAfterDiscoveryNeeded = () => {
         return null;
     }
 
-    const restartDiscovery = () => dispatch(restartDiscoveryThunk());
+    const restartDiscovery = () => dispatch(startOrRestartDiscoveryThunk());
 
     return (
         <AnimatePresence>

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -9,7 +9,7 @@ import {
     forgetDisconnectedDevices,
     handleDeviceDisconnect,
     observeSelectedDevice,
-    restartDiscoveryThunk,
+    startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 
@@ -112,7 +112,7 @@ const suite =
             case SUITE.ONLINE_STATUS:
                 // Restart discovery to reconnect to backends when user goes offline -> online.
                 if (action.payload === true) {
-                    api.dispatch(restartDiscoveryThunk());
+                    api.dispatch(startOrRestartDiscoveryThunk());
                 }
                 break;
 

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -1,6 +1,7 @@
 import { connectPopupCallThunkInner } from '@suite-common/connect-popup';
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
+import { selectThpStep } from '@suite-common/thp';
 import {
     accountsActions,
     changeNetworks,
@@ -49,6 +50,11 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         const isDeviceReady =
             device?.connected && isDeviceAcquired(device) && (!isDeviceLocked || becomesAcquired);
 
+        // delay discovery if THP Autoconnect modal is open (discovery executed by the modal), as it is the only
+        // THP step that takes place *after* device acquisition, and also needs device interaction to complete.
+        const isTHPAutoconnectModal = selectThpStep(getState()) === 'AutoconnectInfo';
+        const isUIReady = !isTHPAutoconnectModal;
+
         if (
             becomesAcquired ||
             becomesConnected ||
@@ -58,7 +64,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             changeNetworks.match(action) ||
             accountsActions.changeAccountVisibility.match(action)
         ) {
-            if (isDeviceReady) {
+            if (isDeviceReady && isUIReady) {
                 const shouldRediscover = selectShouldRediscover(getState(), device);
                 const noDiscoveryYet = device?.state?.staticSessionId === undefined;
                 if (noDiscoveryYet || shouldRediscover) {

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -5,10 +5,9 @@ import {
     accountsActions,
     changeNetworks,
     deviceActions,
-    runAdditionalDiscoveryThunk,
     selectSelectedDevice,
     selectShouldRediscover,
-    startDiscoveryThunk,
+    startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
 
 import { SUITE } from 'src/actions/suite/constants';
@@ -16,7 +15,7 @@ import { selectIsDeviceLocked } from 'src/selectors/suite/suiteSelectors';
 
 // todo: this is crazy. needs some consideration
 export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
-    async (action, { dispatch, next, getState, extra }) => {
+    async (action, { dispatch, next, getState }) => {
         const prevState = getState();
 
         // Pass action to next middleware, meaning that the code below runs *only after* the action has been completely processed in Redux.
@@ -60,25 +59,10 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             accountsActions.changeAccountVisibility.match(action)
         ) {
             if (isDeviceReady) {
-                if (!device?.state) {
-                    // note: currently this is only used in Suite. If a Suite Lite implementation is needed,
-                    // refactor this to a parameter because suiteSettings is a suite-only reducer.
-                    const isAddingHiddenWalletWithRespectToSettings =
-                        extra.selectors.selectSuiteSettings(getState()).defaultWalletLoading ===
-                        'passphrase';
-
-                    dispatch(
-                        startDiscoveryThunk({
-                            device,
-                            isAddingHiddenWalletWithRespectToSettings,
-                            isAddingExistingWallet: true,
-                            isAddingHiddenWallet: isAddingHiddenWalletWithRespectToSettings,
-                        }),
-                    );
-                } else if (device.state.staticSessionId) {
-                    if (selectShouldRediscover(getState(), device)) {
-                        dispatch(runAdditionalDiscoveryThunk(device.state.staticSessionId));
-                    }
+                const shouldRediscover = selectShouldRediscover(getState(), device);
+                const noDiscoveryYet = device?.state?.staticSessionId === undefined;
+                if (noDiscoveryYet || shouldRediscover) {
+                    dispatch(startOrRestartDiscoveryThunk());
                 }
             }
         }

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -1,7 +1,7 @@
 import { ComponentProps, JSX } from 'react';
 
 import { NetworkType, getNetwork } from '@suite-common/wallet-config';
-import { restartDiscoveryThunk } from '@suite-common/wallet-core';
+import { startOrRestartDiscoveryThunk } from '@suite-common/wallet-core';
 import { DiscoveryStatus, FailedAccount } from '@suite-common/wallet-types';
 import { Button, Column, H3, IconCircle, IconName, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
@@ -147,7 +147,7 @@ export const PortfolioCardException = ({
                             values={{ details: discoveryFailedMessage(discovery, failed) }}
                         />
                     }
-                    cta={{ action: () => dispatch(restartDiscoveryThunk()), icon: 'repeat' }}
+                    cta={{ action: () => dispatch(startOrRestartDiscoveryThunk()), icon: 'repeat' }}
                     dataTestBase={exception.type}
                 />
             );
@@ -167,7 +167,7 @@ export const PortfolioCardException = ({
                             const result = await dispatch(applySettings({ use_passphrase: true }));
                             if (!result || !result.success) return;
                             // restart discovery
-                            dispatch(restartDiscoveryThunk());
+                            dispatch(startOrRestartDiscoveryThunk());
                         },
                         label: 'TR_ACCOUNT_ENABLE_PASSPHRASE',
                     }}

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -3,10 +3,10 @@ import styled from 'styled-components';
 
 import { Context } from '@suite-common/message-system';
 import {
-    restartDiscoveryThunk,
     selectDeviceSupportedNetworks,
     selectEnabledNetworks,
     selectShowRediscoverButton,
+    startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
 import { Button, Tooltip, motionEasing } from '@trezor/components';
 import { hasBitcoinOnlyFirmware, isBitcoinOnlyDevice } from '@trezor/device-utils';
@@ -106,7 +106,7 @@ export const SettingsCoins = () => {
         (bitcoinOnlyFirmware || (!bitcoinOnlyFirmware && onlyBitcoinNetworksEnabled));
 
     const startDiscovery = () => {
-        dispatch(restartDiscoveryThunk());
+        dispatch(startOrRestartDiscoveryThunk());
     };
 
     const animation = getDiscoveryButtonAnimationConfig(!!isDiscoveryRunning);

--- a/suite-common/thp/src/finishThpAutoconnectThunk.ts
+++ b/suite-common/thp/src/finishThpAutoconnectThunk.ts
@@ -1,0 +1,17 @@
+import { createThunk } from '@suite-common/redux-utils/';
+import { startOrRestartDiscoveryThunk } from '@suite-common/wallet-core';
+
+import { THP_PREFIX, thpActions } from './thpActions';
+
+/**
+ * Finish THP Autoconnect flow and start discovery.
+ * Discovery middleware delays discovery until THP AutoConnect modal is closed.
+ * TODO: implementation on mobile?
+ */
+export const finishThpAutoconnectThunk = createThunk<void, void, void>(
+    `${THP_PREFIX}/finishThpAutoconnectThunk`,
+    (_, { dispatch }) => {
+        dispatch(thpActions.finishThpFlow());
+        dispatch(startOrRestartDiscoveryThunk());
+    },
+);

--- a/suite-common/thp/src/index.ts
+++ b/suite-common/thp/src/index.ts
@@ -4,5 +4,6 @@ export { selectIsThpInProgress, selectThpStep, selectThpCredentials } from './th
 export { thpActions } from './thpActions';
 export * from './thpUtils';
 export { connectThpDeviceThunk } from './connectThpDeviceThunk';
+export { finishThpAutoconnectThunk } from './finishThpAutoconnectThunk';
 export { startThpAutoconnectThunk } from './startThpAutoconnectThunk';
 export { autoInitThpAfterDeviceConnectionThunk } from './autoInitThpAfterDeviceConnectionThunk';

--- a/suite-common/thp/src/startThpAutoconnectThunk.ts
+++ b/suite-common/thp/src/startThpAutoconnectThunk.ts
@@ -3,6 +3,7 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 
+import { finishThpAutoconnectThunk } from './finishThpAutoconnectThunk';
 import { THP_PREFIX, thpActions } from './thpActions';
 
 export const startThpAutoconnectThunk = createThunk<void, void, void>(
@@ -23,6 +24,6 @@ export const startThpAutoconnectThunk = createThunk<void, void, void>(
                 notificationsActions.addToast({ type: 'error', error: response.payload.error }),
             );
         }
-        dispatch(thpActions.finishThpFlow());
+        dispatch(finishThpAutoconnectThunk());
     },
 );

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -410,13 +410,14 @@ type DeviceConnectThunksParams = {
 
 export const deviceConnectThunks = createThunk<void, DeviceConnectThunksParams, void>(
     `${DEVICE_MODULE_PREFIX}/deviceConnectThunk`,
-    ({ type, device }, { dispatch }) => {
+    async ({ type, device }, { dispatch }) => {
         switch (type) {
             case DEVICE.CONNECT:
-                dispatch(deviceActions.connectDevice({ device }));
                 if (isThpDevice(device)) {
-                    dispatch(connectThpDeviceThunk({ device }));
+                    // awaited so that discoveryMiddleware knows what state THP is when processing deviceActions.connectDevice
+                    await dispatch(connectThpDeviceThunk({ device }));
                 }
+                dispatch(deviceActions.connectDevice({ device }));
                 break;
             case DEVICE.CONNECT_UNACQUIRED:
                 dispatch(

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -768,19 +768,33 @@ export const cancelDiscoveryThunk = createThunk(
 /**
  * Helper to restart discovery for currently selected device
  */
-export const restartDiscoveryThunk = createThunk(
+export const startOrRestartDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/restart`,
-    (_, { dispatch, getState }) => {
+    (_, { dispatch, getState, extra }) => {
         const device = selectSelectedDevice(getState());
         if (!device) return;
         const staticSessionId = device.state?.staticSessionId;
         if (staticSessionId) {
             // we already have staticSessionId (=passphrase state), we probably failed during blockchain discovery
             dispatch(runAdditionalDiscoveryThunk(staticSessionId));
-        } else {
-            // if no staticSessionId available yet it means we failed sooner, for example during pin input
-            dispatch(startDiscoveryThunk({ device }));
+
+            return;
         }
+
+        // Note: currently used only in Suite. If a Suite Lite implementation is needed, create a new extra selector
+        // for this particular setting, and provide it for Suite Lite.
+        const isAddingHiddenWallet =
+            extra.selectors.selectSuiteSettings(getState()).defaultWalletLoading === 'passphrase';
+
+        // if no staticSessionId available yet it means we failed sooner, for example during pin input
+        dispatch(
+            startDiscoveryThunk({
+                device,
+                isAddingExistingWallet: true,
+                isAddingHiddenWallet,
+                isAddingHiddenWalletWithRespectToSettings: isAddingHiddenWallet,
+            }),
+        );
     },
 );
 

--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -7,10 +7,9 @@ import {
     changeNetworks,
     deviceActions,
     discoveryActions,
-    restartDiscoveryThunk,
     selectSelectedDevice,
     selectShouldRediscover,
-    startDiscoveryThunk,
+    startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
 import {
     createAndBackupWalletThunk,
@@ -72,12 +71,10 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
                 device.connected &&
                 isDeviceAcquired(device)
             ) {
-                if (!device.state) {
-                    dispatch(startDiscoveryThunk({}));
-                } else if (device.state.staticSessionId) {
-                    if (selectShouldRediscover(getState(), device)) {
-                        dispatch(restartDiscoveryThunk());
-                    }
+                const shouldRediscover = selectShouldRediscover(getState(), device);
+                const noDiscoveryYet = device?.state?.staticSessionId === undefined;
+                if (noDiscoveryYet || shouldRediscover) {
+                    dispatch(startOrRestartDiscoveryThunk());
                 }
             }
         }


### PR DESCRIPTION
## Description

CR commit by commit recommended:

- slight refactoring in discovery to unify some common default functionality to `restartDiscoveryThunk`, now renamed to `startOrRestartDiscoveryThunk`
- defer discovery when THP Autoconnect Modal 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20957

## Screenshots:

Discovery starts after:
- [succesful THP Autoconnect](https://github.com/user-attachments/assets/24a30d2f-84a4-4604-a610-e9b69c85d3c8)
- [THP Autoconnect cancelled on-device](https://github.com/user-attachments/assets/fe093e2e-c64a-4150-a668-2d8073202a9f)
- [canceled modal](https://github.com/user-attachments/assets/c2aa73ac-d015-4bb0-b0f4-ff1179a695f1)

Note: I tried playing around, if I can fire autoconnect during discovery. But the request gets in queue and again, [you just have a loader on the autoconnect modal](https://github.com/user-attachments/assets/9740a85e-d6f4-41ab-93fc-b8105f80b0dc), and it actually calls after discovery is finished (locks are released). So no.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/autoconnect-modal-during-discovery&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/autoconnect-modal-during-discovery&lookback=7)