### PR TITLE
Fix for THP re-pairing modal

### DIFF
--- a/packages/suite/src/components/connection/thp/ThpConnectionModal.tsx
+++ b/packages/suite/src/components/connection/thp/ThpConnectionModal.tsx
@@ -1,6 +1,5 @@
 import { TrezorDevice } from '@suite-common/suite-types';
 import { thpActions } from '@suite-common/thp';
-import TrezorConnect from '@trezor/connect';
 
 import { useDispatch } from 'src/hooks/suite';
 
@@ -14,7 +13,6 @@ export const ThpConnectionModal = ({ device }: ThpConnectionModalProps) => {
     const dispatch = useDispatch();
 
     const onCancel = () => {
-        TrezorConnect.cancel();
         dispatch(thpActions.finishThpFlow());
     };
 


### PR DESCRIPTION
This PR removes a duplicated Trezor cancel call that causes THP pairing issue.

**Changes**:
- removed duplicated `TrezorConnect.cancel()` call

NOTE: this fixes it in BT mode, I'm still working on fix for devices connected via cable

## Related Issue

Resolves https://github.com/trezor/trezor-suite/issues/21374 & https://github.com/trezor/trezor-suite/issues/21375

## Screenshots:

https://github.com/user-attachments/assets/719541a0-6d29-45c1-b99d-dfbf8014581c



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-endless-loading&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-endless-loading&lookback=7)