### PR TITLE
chore(suite-build): polyfill process in vite to fix jws.createVerify

### DIFF
--- a/packages/suite-build/vite.config.mts
+++ b/packages/suite-build/vite.config.mts
@@ -287,6 +287,14 @@ if (typeof window !== 'undefined' && typeof global === 'undefined') {
 if (typeof window !== 'undefined' && typeof globalThis === 'undefined') {
     window.globalThis = window;
 };
+// Polyfill process.nextTick for jws.createVerify
+if (
+    typeof window !== 'undefined' &&
+    typeof window.process !== 'undefined' &&
+    typeof window.process.nextTick === 'undefined'
+) {
+    window.process.nextTick = cb => Promise.resolve().then(cb);
+}
 
 // Export nothing - this module is only for side effects
 export {};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Trying to fix `TypeError: process.nextTick is not a function` error that happens only using vite. We have the `process` polyfilled in webpack. 

## Screenshots:
<img width="1102" height="290" alt="image (26)" src="https://github.com/user-attachments/assets/38aa37bb-897f-4208-8b6d-8d79bfe322ea" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/vite-process-polyfill&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/vite-process-polyfill&lookback=7)