### PR TITLE
21177 mobile swap receive address

### DIFF
--- a/suite-native/module-trading/src/__fixtures__/account.ts
+++ b/suite-native/module-trading/src/__fixtures__/account.ts
@@ -33,7 +33,7 @@ export const getEthAccount = (key = 'eth-account-1') =>
         accountLabel: 'Ethereum #1',
         index: 0,
         path: "m/44'/60'/0'/0/0",
-        descriptor: '0x73d0385F4d8E00C5e6504C6030F47BF6212736A8',
+        descriptor: 'descriptor-' + key,
         accountType: 'normal',
         symbol: 'eth',
         empty: false,

--- a/suite-native/module-trading/src/components/general/AccountList/AccountList.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountList.tsx
@@ -30,6 +30,7 @@ import { buyActions, exchangeActions } from '../../../reducers';
 import { selectBuySelectedReceiveAccount } from '../../../selectors/buySelectors';
 import { selectExchangeSelectedReceiveAccount } from '../../../selectors/exchangeSelectors';
 import { ReceiveAccount } from '../../../types/general';
+import { isFullySelectedReceiveAccount } from '../../../utils/general/receiveAccountUtils';
 
 type NavigationProp = StackToStackCompositeNavigationProps<
     TradingStackParamList,
@@ -96,7 +97,7 @@ export const AccountList = ({
         if (receiveAccount.account && hasAddresses) {
             onSetPickerMode('address');
         }
-        if ((hasAddresses && receiveAccount.address) || !hasAddresses) {
+        if (isFullySelectedReceiveAccount(receiveAccount)) {
             navigation.popToTop();
         }
     };

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.tsx
@@ -15,6 +15,7 @@ import {
 import { Color } from '@trezor/theme';
 
 import { ReceiveAccount } from '../../../types/general';
+import { getReceiveAccountAddressText } from '../../../utils/general/receiveAccountUtils';
 import { AccountAddress } from '../AccountAddress';
 import { OverviewRow } from '../OverviewRow';
 
@@ -119,10 +120,7 @@ export const ReceiveAccountPicker = ({
         navigation.navigate(TradingStackRoutes.ReceiveAccounts, { symbol, tradingType });
 
     const accountLabel = receiveAccount?.account.accountLabel;
-    const addressText =
-        (receiveAccount?.account.addresses
-            ? receiveAccount?.address?.address
-            : receiveAccount?.account.descriptor) ?? '';
+    const addressText = getReceiveAccountAddressText(receiveAccount) ?? '';
 
     return (
         <OverviewRow

--- a/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { BuyTrade, BuyTradeResponse, FormResponse } from 'invity-api';
 
+import { invariant } from '@suite-common/suite-utils';
 import {
     TradingRootState,
     buyThunks,
@@ -29,6 +30,10 @@ import {
     getAnalyticsTradingBuyPayload,
     getSourceForForm,
 } from '../../utils/general/formUtils';
+import {
+    getReceiveAccountAddressText,
+    isFullySelectedReceiveAccount,
+} from '../../utils/general/receiveAccountUtils';
 import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
 import { useConsent } from '../general/useConsent';
 import { useConsentDenier } from '../general/useConsentDenier';
@@ -179,7 +184,7 @@ export const useBuyFlow = (form: BuyFormType) => {
             },
         });
 
-        if (!receiveAccount || (!!receiveAccount.account.addresses && !receiveAccount.address)) {
+        if (!isFullySelectedReceiveAccount(receiveAccount)) {
             selectReceiveAccount();
 
             analytics.report({
@@ -193,6 +198,9 @@ export const useBuyFlow = (form: BuyFormType) => {
 
             return;
         }
+
+        const addressText = getReceiveAccountAddressText(receiveAccount);
+        invariant(addressText, 'addressText is not defined');
 
         const returnUrl = buildTradingUrl({
             actionType: 'quote',
@@ -209,10 +217,7 @@ export const useBuyFlow = (form: BuyFormType) => {
                 loginRequest: formResponse => handleWebview(formResponse, returnUrl),
                 userConsent: handleConsent.request,
                 nextStep: () => {
-                    confirmTrade(
-                        candidateQuote,
-                        receiveAccount.address?.address ?? receiveAccount.account.descriptor,
-                    );
+                    confirmTrade(candidateQuote, addressText);
                 },
             }),
         );

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -1,4 +1,4 @@
-import { tradingSettingsActions } from '@suite-common/trading';
+import { tradingExchangeActions, tradingSettingsActions } from '@suite-common/trading';
 import {
     PreloadedState,
     TestStore,
@@ -9,6 +9,7 @@ import {
 
 import { getBtcAccount, getEthAccount } from '../../../__fixtures__/account';
 import { exchangeQuotes } from '../../../__fixtures__/exchangeQuotes';
+import { btcAsset } from '../../../__fixtures__/tradeableAssets';
 import { getInitializedTradingStateWithQuotes } from '../../../__fixtures__/tradingState';
 import { ExchangeFormType } from '../../../types/exchange';
 import { useExchangeForm } from '../useExchangeForm';
@@ -157,7 +158,7 @@ describe('useExchangeSelectQuote', () => {
             );
         });
 
-        it('should call selectQuoteThunk  with correct maxSlippage value', async () => {
+        it('should call selectQuoteThunk with correct maxSlippage value', async () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             act(() => {
                 store.dispatch(tradingSettingsActions.setMaxSlippagePercentage('1.5'));
@@ -177,6 +178,30 @@ describe('useExchangeSelectQuote', () => {
                     }),
                 }),
             );
+        });
+
+        it('should not call selectQuoteThunk when account is not fully selected', async () => {
+            act(() => {
+                [
+                    tradingExchangeActions.setReceiveAccountKey('btc-account-key'),
+                    tradingExchangeActions.setTradingAccountKey('eth-account-key'),
+                ].forEach(store.dispatch);
+                exchangeForm.setValue('receiveAsset', btcAsset);
+            });
+
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const { result } = await renderUseExchangeSelectQuote();
+
+            dispatchSpy.mockClear();
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            expect(dispatchSpy).not.toHaveBeenCalled();
+            expect(mockNavigation.navigate).toHaveBeenCalledWith('ReceiveAccounts', {
+                symbol: 'btc',
+                tradingType: 'exchange',
+            });
         });
 
         it('should navigate to TradingExchangePreview when nextStep callback is executed', async () => {

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
@@ -22,6 +22,7 @@ import {
     selectExchangeSelectedSendAccount,
 } from '../../selectors/exchangeSelectors';
 import { ExchangeFormType } from '../../types/exchange';
+import { isFullySelectedReceiveAccount } from '../../utils/general/receiveAccountUtils';
 import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
 import { useConsent } from '../general/useConsent';
 import { useConsentDenier } from '../general/useConsentDenier';
@@ -74,7 +75,7 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
             return;
         }
 
-        if (!receiveAccount) {
+        if (!isFullySelectedReceiveAccount(receiveAccount)) {
             selectReceiveAccount();
 
             return;

--- a/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
@@ -17,6 +17,7 @@ import {
     selectExchangeSelectedReceiveAccount,
     selectExchangeSelectedSendAccount,
 } from '../selectors/exchangeSelectors';
+import { getReceiveAccountAddressText } from '../utils/general/receiveAccountUtils';
 
 type FlowStep = 'confirm' | 'composeFeesTxn' | 'signTxn' | 'sendTxn' | 'finished';
 
@@ -54,9 +55,9 @@ export const TradingExchangePreviewScreen = () => {
     const [flowStep, setFlowStep] = useState<FlowStep>('confirm');
 
     const handleConfirmTrade = async () => {
-        const { account } = toAccount;
+        const addressText = getReceiveAccountAddressText(toAccount);
 
-        if (!account.descriptor) {
+        if (!addressText) {
             console.warn('receiveAddress is not defined', quote);
 
             return;
@@ -64,7 +65,7 @@ export const TradingExchangePreviewScreen = () => {
 
         await confirmTrade({
             sendAccount: fromAccount,
-            receiveAddress: account.descriptor,
+            receiveAddress: addressText,
             trade: quote,
             approvalFlow: false,
         });

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
@@ -1,0 +1,79 @@
+import { RouteProp } from '@react-navigation/native';
+
+import { TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
+import {
+    TestStore,
+    initStore,
+    renderWithStoreProviderAsync,
+    userEvent,
+} from '@suite-native/test-utils';
+
+import { getBtcAccount } from '../../__fixtures__/account';
+import { exchangeQuotes } from '../../__fixtures__/exchangeQuotes';
+import { getWalletState } from '../../__fixtures__/walletState';
+import { TradingExchangePreviewScreen } from '../TradingExchangePreviewScreen';
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useRoute: () =>
+        ({
+            params: undefined,
+        }) as RouteProp<TradingStackParamList, TradingStackRoutes.TradingExchangePreview>,
+}));
+
+const mockConfirmTrade = jest.fn().mockResolvedValue(Promise.resolve());
+
+jest.mock('../../hooks/exchange/useExchangeFlow', () => ({
+    useExchangeFlow: () => ({
+        confirmTrade: mockConfirmTrade,
+        fetchFeesAndCompose: jest.fn(),
+        signAndSendTransaction: jest.fn(),
+        isConsentRequested: false,
+        resolveConsent: jest.fn(),
+    }),
+}));
+
+describe('TradingExchangePreviewScreen', () => {
+    let store: TestStore;
+
+    const renderTradingExchangePreviewScreen = () =>
+        renderWithStoreProviderAsync(<TradingExchangePreviewScreen />, { store });
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+
+        const preloadedState = { wallet: getWalletState({ tradeType: 'exchange' }) };
+        preloadedState.wallet.trading.exchange = {
+            ...preloadedState.wallet.trading.exchange,
+            quotes: exchangeQuotes,
+            tradingAccountKey: 'eth-account-1',
+            receiveAccountKey: 'btc-account-1',
+            receiveAddress: getBtcAccount().addresses?.used[0],
+            selectedQuote: exchangeQuotes[0],
+        };
+
+        store = await initStore(preloadedState);
+    });
+
+    it('should render continue button', async () => {
+        const { getByText } = await renderTradingExchangePreviewScreen();
+
+        expect(getByText('Continue')).toBeOnTheScreen();
+    });
+
+    it('should call confirmTrade on Continue press', async () => {
+        const { getByText, queryByText } = await renderTradingExchangePreviewScreen();
+
+        await userEvent.press(getByText('Continue'));
+
+        expect(mockConfirmTrade).toHaveBeenCalledTimes(1);
+        expect(mockConfirmTrade).toHaveBeenCalledWith({
+            sendAccount: expect.objectContaining({ key: 'eth-account-1' }),
+            receiveAddress: '1BTC',
+            trade: exchangeQuotes[0],
+            approvalFlow: false,
+        });
+        expect(queryByText('Continue')).not.toBeOnTheScreen();
+        expect(getByText('Prepare Transaction')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/utils/general/__tests__/receiveAccountUtils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/receiveAccountUtils.test.ts
@@ -1,0 +1,76 @@
+import type { Address } from '@trezor/blockchain-link-types';
+
+import { getBtcAccount, getEthAccount } from '../../../__fixtures__/account';
+import {
+    getReceiveAccountAddressText,
+    isFullySelectedReceiveAccount,
+} from '../receiveAccountUtils';
+
+describe('receiveAccountUtils', () => {
+    describe('isFullySelectedReceiveAccount', () => {
+        it('should be false when account is not specified', () => {
+            expect(isFullySelectedReceiveAccount(undefined)).toBe(false);
+        });
+
+        it('should be false when BTC like account is selected but no receive address is specified', () => {
+            expect(isFullySelectedReceiveAccount({ account: getBtcAccount() })).toBe(false);
+        });
+
+        it('should be true when both account and address is selected', () => {
+            const btcAccount = getBtcAccount();
+
+            expect(
+                isFullySelectedReceiveAccount({
+                    account: btcAccount,
+                    address: btcAccount.addresses!.used[0],
+                }),
+            ).toBe(true);
+        });
+
+        it('should be true when ETH like account is selected', () => {
+            expect(isFullySelectedReceiveAccount({ account: getEthAccount() })).toBe(true);
+        });
+    });
+
+    describe('getReceiveAccountAddressText', () => {
+        it('should return undefined when account is not specified', () => {
+            expect(getReceiveAccountAddressText(undefined)).toBeUndefined();
+        });
+
+        it('should return undefined when only account is specified for BTC', () => {
+            expect(
+                getReceiveAccountAddressText({
+                    account: getBtcAccount(),
+                }),
+            ).toBeUndefined();
+        });
+
+        it('should return selected address', () => {
+            const btcAccount = getBtcAccount();
+
+            expect(
+                getReceiveAccountAddressText({
+                    account: btcAccount,
+                    address: btcAccount.addresses!.used[0],
+                }),
+            ).toBe('1BTC');
+        });
+
+        it('should return descriptor when ETH account is specified', () => {
+            expect(
+                getReceiveAccountAddressText({
+                    account: getEthAccount(),
+                }),
+            ).toBe('descriptor-eth-account-1');
+        });
+
+        it('should ignore specified address for ETH', () => {
+            expect(
+                getReceiveAccountAddressText({
+                    account: getEthAccount(),
+                    address: { address: 'should_be_ignored' } as Address,
+                }),
+            ).toBe('descriptor-eth-account-1');
+        });
+    });
+});

--- a/suite-native/module-trading/src/utils/general/receiveAccountUtils.ts
+++ b/suite-native/module-trading/src/utils/general/receiveAccountUtils.ts
@@ -1,0 +1,23 @@
+import { ReceiveAccount } from '../../types/general';
+
+export const isFullySelectedReceiveAccount = (
+    receiveAccount: ReceiveAccount | undefined,
+): receiveAccount is ReceiveAccount => {
+    if (!receiveAccount) {
+        return false;
+    }
+
+    const { account, address } = receiveAccount;
+
+    return !account.addresses || !!address;
+};
+
+export const getReceiveAccountAddressText = (receiveAccount: ReceiveAccount | undefined) => {
+    if (!receiveAccount) {
+        return undefined;
+    }
+
+    const { account, address } = receiveAccount;
+
+    return account.addresses ? address?.address : account.descriptor;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Make sure user has picked address as a `receiveAddress`.
- Make sure this address is used for `confirmTrade` call.

<!--- Describe your changes in detail -->

## Related Issue

Resolve #21177
Resolve #21358


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=21177-mobile-swap-receive-address&lookback=7)