### PR TITLE
fix(suite-native): Mobile Swap: use lowercase token cryptoId

### DIFF
--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -287,6 +287,12 @@ describe('toTokenCryptoId', () => {
             'ethereum--0x1234123412341234123412341234123412341234',
         );
     });
+
+    it('should always return lowercase value', () => {
+        expect(toTokenCryptoId('eth', '0x6982508145454Ce325dDbE47a25d4ec3d2311933')).toBe(
+            'ethereum--0x6982508145454ce325ddbe47a25d4ec3d2311933',
+        );
+    });
 });
 
 describe('getDefaultCountry', () => {

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -94,7 +94,7 @@ export const cryptoIdToNetworkSymbolAndContractAddress = (cryptoId: CryptoId) =>
 };
 
 export const toTokenCryptoId = (symbol: NetworkSymbol, contractAddress: string): CryptoId =>
-    `${getCoingeckoId(symbol)}${CRYPTO_PLATFORM_SEPARATOR}${contractAddress}` as CryptoId;
+    `${getCoingeckoId(symbol)}${CRYPTO_PLATFORM_SEPARATOR}${contractAddress}`.toLowerCase() as CryptoId;
 
 /** Convert testnet cryptoId to prod cryptoId (test-bitcoin -> bitcoin) */
 export const testnetToProdCryptoId = (cryptoId: CryptoId): CryptoId => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Convert `contractAddress` to lowercase for better matching.

<!--- Describe your changes in detail -->

## Related Issue

Resolve [#20544](https://github.com/trezor/trezor-suite/issues/20544)

## Screenshots:

<img width="300" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-09 at 22 41 32" src="https://github.com/user-attachments/assets/a6181473-efcf-4c61-9f8e-655fc46c5f18" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=20544-Mobile-Swap-tokens-not-available&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=20544-Mobile-Swap-tokens-not-available&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=20544-Mobile-Swap-tokens-not-available&lookback=7)