### PR TITLE
fix(suite-native): revert Mobile Swap: use lowercase token cryptoId

### DIFF
--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -287,12 +287,6 @@ describe('toTokenCryptoId', () => {
             'ethereum--0x1234123412341234123412341234123412341234',
         );
     });
-
-    it('should always return lowercase value', () => {
-        expect(toTokenCryptoId('eth', '0x6982508145454Ce325dDbE47a25d4ec3d2311933')).toBe(
-            'ethereum--0x6982508145454ce325ddbe47a25d4ec3d2311933',
-        );
-    });
 });
 
 describe('getDefaultCountry', () => {

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -94,7 +94,7 @@ export const cryptoIdToNetworkSymbolAndContractAddress = (cryptoId: CryptoId) =>
 };
 
 export const toTokenCryptoId = (symbol: NetworkSymbol, contractAddress: string): CryptoId =>
-    `${getCoingeckoId(symbol)}${CRYPTO_PLATFORM_SEPARATOR}${contractAddress}`.toLowerCase() as CryptoId;
+    `${getCoingeckoId(symbol)}${CRYPTO_PLATFORM_SEPARATOR}${contractAddress}` as CryptoId;
 
 /** Convert testnet cryptoId to prod cryptoId (test-bitcoin -> bitcoin) */
 export const testnetToProdCryptoId = (cryptoId: CryptoId): CryptoId => {


### PR DESCRIPTION
This reverts commit 97468d8a4054a49fe7df0576cc7f78bcb8ff38cb.



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/revert-cryptoid-lowercase&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/revert-cryptoid-lowercase&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/revert-cryptoid-lowercase&lookback=7)