### PR TITLE
feat(suite): persist link to THP credentials in devices

### DIFF
--- a/packages/suite/src/utils/suite/storage.ts
+++ b/packages/suite/src/utils/suite/storage.ts
@@ -44,7 +44,6 @@ export const serializeDevice = (
         connected: false,
         buttonRequests: [],
         authenticityChecks: filterInconclusiveAuthenticityChecks(device.authenticityChecks),
-        thp: undefined,
     };
     if (forceRemember) sd.forceRemember = true;
 

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -532,7 +532,6 @@ export const forgetSingleDevicePersistentDataThunk = createThunk(
         if (device.bluetoothProps !== undefined) {
             dispatch(bluetoothActions.removeKnownDeviceAction({ id: device.bluetoothProps.id }));
         }
-        // TODO: this works only for a connected device, as we intentionally do not link THP credentials in a remembered wallet.
         if (isThpDevice(device)) {
             dispatch(thpActions.removeCredentials({ credentials: device.thp.credentials }));
         }


### PR DESCRIPTION
## Description

Store link to THP credentials with each remembered wallet. This is a followup to #21160, where I wanted to do this, but removed it because of unclear product, now resolved.

THP was originally designed in a way to store credentials in a way that you cannot prove a device was connected here _unless you physically conect it_ (and see that a stored credential matches). 
But since we persist wallets & device data by default and have made it opt-out, this no longer makes sense.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-persist-thp-per-device&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-persist-thp-per-device&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-persist-thp-per-device&lookback=7)