### PR TITLE
Fix/thp abort workflow

### DIFF
--- a/packages/connect/e2e/tests/device/thpPairing.test.ts
+++ b/packages/connect/e2e/tests/device/thpPairing.test.ts
@@ -14,7 +14,6 @@ describe('THP pairing', () => {
 
     const waitForDevice = async (settings: Partial<ConnectSettings['thp']>) => {
         await initTrezorConnect(controller, {
-            debug: true,
             pendingTransportEvent: false,
             thp: {
                 appName: 'TrezorConnect',
@@ -170,22 +169,35 @@ describe('THP pairing', () => {
         expect(address).toMatchObject({ success: true });
     });
 
-    it('ThpPairing cancelled', async () => {
+    const ERR = new Error('Unexpected success');
+    const CANCEL_ERR = 'Custom cancel';
+    const FW_CANCEL_ERR = 'Cancelled';
+    const cancelOnHost = async () => {
+        // events are emitted before ButtonAck is sent to device
+        await new Promise(resolve => setTimeout(resolve, 10));
+        TrezorConnect.cancel(CANCEL_ERR);
+    };
+    const buttonRequestHandler = (msg?: string) => (br: { name?: string }) => {
+        if (msg && msg === br.name) {
+            controller.send({ type: 'emulator-press-no' });
+        } else {
+            controller.send({ type: 'emulator-press-yes' });
+        }
+    };
+
+    it('ThpPairing cancel workflow', async () => {
         const device = await waitForDevice({
             pairingMethods: ['CodeEntry'],
             knownCredentials: [],
         });
 
-        const ERR = new Error('Unexpected success');
         let result;
 
         // 1. reject pairing tag request from host
-        TrezorConnect.on('ui-request_thp_pairing', () => {
-            TrezorConnect.cancel('Custom cancel');
-        });
+        TrezorConnect.on('ui-request_thp_pairing', cancelOnHost);
         result = await TrezorConnect.getFeatures({ device });
         if (result.success) throw ERR;
-        expect(result.payload.error).toMatch('Custom cancel');
+        expect(result.payload.error).toMatch(CANCEL_ERR);
 
         // 2. reject pairing tag request from Trezor
         TrezorConnect.removeAllListeners('ui-request_thp_pairing');
@@ -194,7 +206,7 @@ describe('THP pairing', () => {
         });
         result = await TrezorConnect.getFeatures({ device });
         if (result.success) throw ERR;
-        expect(result.payload.error).toMatch('Cancelled');
+        expect(result.payload.error).toMatch(FW_CANCEL_ERR);
 
         // 3. reject pairing confirmation from Trezor
         TrezorConnect.removeAllListeners('ui-button');
@@ -203,23 +215,19 @@ describe('THP pairing', () => {
         });
         result = await TrezorConnect.getFeatures({ device });
         if (result.success) throw ERR;
-        expect(result.payload.error).toMatch('Cancelled');
+        expect(result.payload.error).toMatch(FW_CANCEL_ERR);
 
         // 3. reject pairing confirmation from host
         TrezorConnect.removeAllListeners('ui-button');
-        TrezorConnect.on('ui-button', () => {
-            TrezorConnect.cancel('Custom canceled');
-        });
+        TrezorConnect.on('ui-button', cancelOnHost);
         result = await TrezorConnect.getFeatures({ device });
         if (result.success) throw ERR;
-        expect(result.payload.error).toMatch('Custom canceled');
+        expect(result.payload.error).toMatch(FW_CANCEL_ERR); // canceled gracefully on Trezor
 
         // check if pairing is still responsive
         TrezorConnect.removeAllListeners('ui-button');
         TrezorConnect.removeAllListeners('ui-request_thp_pairing');
-        TrezorConnect.on('ui-button', () => {
-            controller.send({ type: 'emulator-press-yes' });
-        });
+        TrezorConnect.on('ui-button', buttonRequestHandler());
         TrezorConnect.on('ui-request_thp_pairing', async ({ nfcData, ...rest }) => {
             const state = await controller.getPairingInfo(rest.device.thp!.channel, nfcData);
             TrezorConnect.uiResponse({
@@ -229,19 +237,43 @@ describe('THP pairing', () => {
         });
         result = await TrezorConnect.getFeatures({ device });
         expect(result).toMatchObject({ success: true });
+    });
+
+    it('ThpState cancel workflow', async () => {
+        // enable passphrase
+        await setup(controller, { mnemonic: 'mnemonic_all', passphrase_protection: true });
+
+        const device = await waitForDevice({ pairingMethods: ['SkipPairing'] });
+
+        const passphraseHandler = (value: string) => () => {
+            TrezorConnect.uiResponse({
+                type: 'ui-receive_passphrase',
+                payload: {
+                    passphraseOnDevice: false,
+                    value,
+                },
+            });
+            TrezorConnect.removeAllListeners('ui-request_passphrase');
+        };
+
+        let result;
+
+        // pair
+        result = await TrezorConnect.getFeatures({ device });
+        expect(result).toMatchObject({ success: true });
+
+        TrezorConnect.on('ui-request_passphrase', passphraseHandler(''));
 
         // 4. reject ButtonRequest from host
         TrezorConnect.removeAllListeners('ui-button');
-        TrezorConnect.on('ui-button', () => {
-            TrezorConnect.cancel('Custom canceled');
-        });
+        TrezorConnect.on('ui-button', cancelOnHost);
         result = await TrezorConnect.getAddress({
             device,
             path: "m/44'/0'/0'/1/1",
             showOnTrezor: true,
         });
         if (result.success) throw ERR;
-        expect(result.payload.error).toMatch('Custom canceled');
+        expect(result.payload.error).toMatch(CANCEL_ERR);
 
         // 4. reject ButtonRequest from Trezor
         TrezorConnect.removeAllListeners('ui-button');
@@ -254,18 +286,60 @@ describe('THP pairing', () => {
             showOnTrezor: true,
         });
         if (result.success) throw ERR;
-        expect(result.payload.error).toMatch('Cancelled');
+        expect(result.payload.error).toMatch(FW_CANCEL_ERR);
 
-        // and finally check if device is still responsive
+        // 5. reject passphrase from host
+        TrezorConnect.removeAllListeners('ui-request_passphrase');
         TrezorConnect.removeAllListeners('ui-button');
-        TrezorConnect.on('ui-button', () => {
-            controller.send({ type: 'emulator-press-yes' });
-        });
+        TrezorConnect.on('ui-button', buttonRequestHandler());
+        TrezorConnect.on('ui-request_passphrase', cancelOnHost);
         result = await TrezorConnect.getAddress({
-            device,
+            device: {
+                ...device,
+                instance: 1,
+            },
             path: "m/44'/0'/0'/1/1",
             showOnTrezor: true,
         });
-        expect(result).toMatchObject({ success: true });
+        if (result.success) throw ERR;
+        expect(result.payload.error).toMatch(CANCEL_ERR);
+
+        // 6. reject passphrase from Trezor
+        TrezorConnect.removeAllListeners('ui-request_passphrase');
+        TrezorConnect.removeAllListeners('ui-button');
+        TrezorConnect.on('ui-request_passphrase', passphraseHandler('a'));
+        TrezorConnect.on('ui-button', buttonRequestHandler('passphrase_host1')); // NOTE: .name may be changed in the future
+        result = await TrezorConnect.getAddress({
+            device: {
+                ...device,
+                instance: 1,
+            },
+            path: "m/44'/0'/0'/1/1",
+            showOnTrezor: true,
+        });
+        if (result.success) throw ERR;
+        expect(result.payload.error).toMatch(FW_CANCEL_ERR);
+
+        // and finally check if device is still responsive
+        TrezorConnect.removeAllListeners('ui-button');
+        TrezorConnect.removeAllListeners('ui-request_passphrase');
+        TrezorConnect.on('ui-request_passphrase', passphraseHandler('a'));
+        TrezorConnect.on('ui-button', buttonRequestHandler());
+        result = await TrezorConnect.getAddress({
+            device: {
+                ...device,
+                state: 'ms1TJk4b4s7aisyL3jfrkCqwznttWwiS4r@448CCE89D32A733A1632F345:1',
+                instance: 1,
+            },
+            path: "m/44'/0'/0'/1/1",
+            showOnTrezor: true,
+        });
+        expect(result).toMatchObject({
+            success: true,
+            payload: { address: '17vNxNJDg2djoFntLUhY6BbdovTnZ9YYhn' },
+        });
+
+        // disable passphrase
+        await setup(controller, { mnemonic: 'mnemonic_all' });
     });
 });

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -444,7 +444,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     async interrupt(reason: Error) {
-        await abortThpWorkflow(this, () => this.runAbort?.abort(reason));
+        await abortThpWorkflow(this);
         await this.currentSession?.abort(reason);
 
         // reject inner defer

--- a/packages/connect/src/device/thp/thpCall.ts
+++ b/packages/connect/src/device/thp/thpCall.ts
@@ -88,7 +88,7 @@ export const thpCall = async <T extends MessageKey>(
     return result.payload as ThpCallResponse[T];
 };
 
-export const abortThpWorkflow = async (device: Device, abort?: () => any) => {
+export const abortThpWorkflow = async (device: Device) => {
     const thpState = device.getThpState();
     if (!thpState || !device.currentRun) {
         return Promise.resolve(); // not a THP device
@@ -106,10 +106,6 @@ export const abortThpWorkflow = async (device: Device, abort?: () => any) => {
     } else if (thpState.cancelablePromise) {
         thpState.sync('send', 'Cancel');
         await device.getCurrentSession().send('Cancel', {});
-        // abort current run and wait for the result
-        if (abort) {
-            abort();
-        }
         await device.currentRun;
     }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Partial revert of https://github.com/trezor/trezor-suite/commit/0789c968622dcc14171e480018a198b189e7f28b

Bug discovered while investigating [this issue](https://github.com/trezor/trezor-suite/issues/21374)

Turns out i was wrong [here](https://github.com/trezor/trezor-suite/pull/20951)

> while doing the tests i also noticed that abortThpWorkflow didnt reject/abort pending device.currentRun promise and hungs forever.

This claim is (was) true only in the tests because `ui-event-*` is dispatched before `ButtonAck` message is actually sent to the device, thats why abort was effective - but not exactly correct.

communication workflow should be:

1. Host: -> GetAddress
1. Trezor: <- ThpAck
1. Trezor: <- ButtonRequest
1. Host: -> ThpAck
1. Host:  -> ButtonAck + emit ui-event at the same time
1. Trezor: <- ThpAck
1. Host: in read state ....
1. Host: -> `Cancel`
1. Trezor: <- `Cancelled`
1. Host: -> `ThpAck`

currently last 2 points are not done in connect because `device.currentRun` is aborted, so Trezor is leaved in retransmission state (sends Cancelled until receives ThpAck)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thp-abort-workflow&lookback=7)