### PR TITLE
fix(suite-native): fix navigating from device settings for remembered wallet

### DIFF
--- a/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
@@ -11,7 +11,7 @@ import {
 } from '@suite-common/wallet-core';
 import { TitledSection, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
-import { Screen, ScreenHeader } from '@suite-native/navigation';
+import { Screen, ScreenHeader, useNavigateToInitialScreen } from '@suite-native/navigation';
 
 import { DeviceAuthenticityCard } from '../components/DeviceAuthenticityCard';
 import { DeviceBluetoothCard } from '../components/DeviceBluetoothCard';
@@ -28,6 +28,7 @@ export const DeviceSettingsModalScreen = () => {
     const deviceModel = useSelector(selectDeviceModel);
     const deviceName = useSelector(selectDeviceName);
     const deviceLabel = useSelector(selectDeviceLabel);
+    const navigateToInitialScreen = useNavigateToInitialScreen();
     const isBluetoothDevice = useSelector(selectIsBluetoothDevice);
     const isDeviceBackupUnfinished = useSelector(selectIsDeviceBackupUnfinished);
     const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
@@ -38,7 +39,9 @@ export const DeviceSettingsModalScreen = () => {
     }
 
     return (
-        <Screen header={<ScreenHeader closeActionType="close" />}>
+        <Screen
+            header={<ScreenHeader closeActionType="close" closeAction={navigateToInitialScreen} />}
+        >
             <VStack spacing="sp40">
                 <DeviceInfo deviceName={deviceLabel || deviceName} deviceModel={deviceModel} />
                 <TitledSection


### PR DESCRIPTION
## Description

Fix navigation from device settings when device is rememered wallet.

## Related issues

Resolve #21430

## Screenshots

before

[mobile device settings before.webm](https://github.com/user-attachments/assets/f3941f19-55f6-4020-8635-f8800a3c1f11)

after

[mobile device settings after.webm](https://github.com/user-attachments/assets/af3ff739-e5f5-4259-9ee7-c6903de48515)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/device-settings-navigation-remembered&lookback=7)