### PR TITLE
Disabled when disconnected

### DIFF
--- a/packages/suite/src/components/suite/CoinList/CoinList.tsx
+++ b/packages/suite/src/components/suite/CoinList/CoinList.tsx
@@ -29,7 +29,7 @@ export const CoinList = ({
     const { device, isLocked } = useDevice();
 
     const blockchain = useSelector(state => state.wallet.blockchain);
-    const isDeviceLocked = !!device && isLocked();
+    const isDeviceLocked = !!device && isLocked(true);
     const { isDiscoveryRunning } = useDiscovery();
     const lockedTooltip = isDeviceLocked ? 'TR_DISABLED_SWITCH_TOOLTIP' : null;
     const discoveryTooltip = isDiscoveryRunning ? 'TR_LOADING_ACCOUNTS' : null;

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -18,6 +18,7 @@ interface CTA {
     variant?: ComponentProps<typeof Button>['variant'];
     action: () => void;
     icon?: IconName;
+    isDisabled?: boolean;
 }
 
 interface ContainerProps {
@@ -53,7 +54,7 @@ const Container = ({ title, description, cta, dataTestBase }: ContainerProps) =>
                         key={a.label || 'TR_RETRY'}
                         variant={a.variant || 'warning'}
                         icon={a.icon || 'plus'}
-                        isLoading={isLocked()}
+                        isLoading={a.isDisabled ?? isLocked()}
                         onClick={a.action}
                         data-testid={`@exception/${dataTestBase}/${a.variant || 'primary'}-button`}
                     >
@@ -128,6 +129,7 @@ export const PortfolioCardException = ({
                     cta={[
                         {
                             action: () => dispatch(goto('settings-coins')),
+                            isDisabled: false,
                             icon: 'gear',
                             label: 'TR_COIN_SETTINGS',
                         },


### PR DESCRIPTION
while playing with BT device that gets disconnected quite often, I noticed that some of the buttons should not be disabled when device is disconnected. 

1. when you disable all coins + have remembered disconnected device, CTA is useless. 
<img width="842" height="895" alt="Screenshot 2025-09-09 at 18 10 46" src="https://github.com/user-attachments/assets/8b4374fa-ef0a-4f06-ad27-0943244efca8" />

2. enabling coins should do no harm, there is a 'referesh' button that remains disabled for disconnected devices.
<img width="1321" height="820" alt="Screenshot 2025-09-10 at 13 22 26" src="https://github.com/user-attachments/assets/eafddec8-7d0b-405b-8525-e1623e3d5388" />
<img width="745" height="860" alt="Screenshot 2025-09-10 at 13 38 29" src="https://github.com/user-attachments/assets/cf8451af-ba08-4032-af01-674d0d09ad4d" />

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=disabled-when-disconnected&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=disabled-when-disconnected&lookback=7)