### PR TITLE
fix(suite-native): Mobile Swap: compare sell tokens case insensitive

### DIFF
--- a/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
@@ -357,7 +357,7 @@ describe('commonSelectors', () => {
             expect(result.length).toBeGreaterThan(0);
             expect(result[0]).toEqual(
                 expect.objectContaining({
-                    key: expect.stringContaining('section_'),
+                    key: 'section_btc-account-1',
                     label: expect.any(String),
                     sectionData: expect.any(Object),
                     data: expect.any(Array),
@@ -461,6 +461,7 @@ describe('commonSelectors', () => {
             expect(result[0].data.length).toBe(2); // Account + 2 tokens with positive balance
             expect(result[0].data[0].symbol).toBe('eth'); // Account asset
             expect(result[0].data[1].contract).toBe('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'); // USDC
+            expect(result[0].data[1].isEnabled).toBe(true);
         });
 
         it('should handle accounts with zero balance but tokens with positive balance', () => {
@@ -791,6 +792,63 @@ describe('commonSelectors', () => {
             const symbols = result.map(section => section.sectionData.symbol);
             expect(symbols).toContain('btc');
             expect(symbols).toContain('ada');
+        });
+
+        it('should handle contractIds as case insensitive', () => {
+            const testDeviceState = 'test-device';
+            const ethAccount = {
+                ...getEthAccount(),
+                balance: '1000000000000000000', // 1 ETH
+                formattedBalance: '1',
+                visible: true,
+                deviceState: testDeviceState,
+                tokens: [
+                    {
+                        type: 'ERC20',
+                        standard: 'ERC20',
+                        name: 'USDC',
+                        contract: '0xA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48',
+                        transfers: 1,
+                        symbol: 'usdc',
+                        decimals: 6,
+                        balance: '1000000', // 1 USDC
+                    },
+                ],
+            };
+            const cleanState = getInitializedTradingState('exchange');
+
+            const stateWithDevice = {
+                featureFlags: featureFlagsInitialState,
+                wallet: {
+                    trading: cleanState,
+                    accounts: [ethAccount],
+                    settings: { localCurrency: 'usd', enabledNetworks: ['eth'] },
+                    transactions: { transactions: {} },
+                },
+                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                tokenDefinitions: {
+                    eth: {
+                        coin: {
+                            data: ['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'],
+                            error: false,
+                            isLoading: false,
+                            hide: [],
+                            show: [],
+                        },
+                    },
+                },
+                fiat: { rates: {}, current: 'usd' },
+            } as any;
+
+            const result = selectAccountsWithTokensToSellSectionListByTradingType(
+                stateWithDevice,
+                'exchange',
+            );
+
+            expect(result.length).toBe(1);
+            expect(result[0].data.length).toBe(2); // Account + 2 tokens with positive balance
+            expect(result[0].data[1].contract).toBe('0xA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48'); // USDC
+            expect(result[0].data[1].isEnabled).toBe(true);
         });
     });
 });

--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -12,12 +12,7 @@ import {
     getSimpleCoinDefinitionsByNetwork,
     selectTokenDefinitions,
 } from '@suite-common/token-definitions';
-import {
-    TradingType,
-    selectTradingExchangeSellCryptoIds,
-    selectTradingSellSellCryptoIds,
-    toTokenCryptoId,
-} from '@suite-common/trading';
+import { TradingType, selectTradingSupportedSymbols, toTokenCryptoId } from '@suite-common/trading';
 import {
     getNetwork,
     getNetworkDisplaySymbolName,
@@ -157,8 +152,8 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
             selectTokenDefinitions,
             selectCurrentFiatRates,
             selectBaseCurrency,
-            selectTradingSellSellCryptoIds,
-            selectTradingExchangeSellCryptoIds,
+            (state: CombinedSelectorsRootState, tradingType: TradingType) =>
+                selectTradingSupportedSymbols(state, tradingType),
             (state: CombinedSelectorsRootState) =>
                 selectIsFeatureFlagEnabled(state, FeatureFlag.IsCardanoSendEnabled),
             (_state, tradingType: TradingType) => tradingType,
@@ -168,17 +163,14 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
             tokenDefinitions,
             fiatRates,
             localCurrency,
-            sellSellCryptoIds,
-            exchangeSellCryptoIds,
+            sellCryptoIds,
             isCardanoSendEnabled,
             tradingType,
         ) => {
             if (tradingType === 'buy') {
                 return returnStableArrayIfEmpty([]);
             }
-
-            const sellCryptoIds =
-                tradingType === 'sell' ? sellSellCryptoIds : exchangeSellCryptoIds;
+            const sellCryptoIdsSet = new Set(sellCryptoIds);
 
             // TODO: Remove this filter when Cardano send is implemented (#15068)
             // Currently filtering out Cardano accounts and tokens from trading until Cardano send is supported
@@ -232,7 +224,9 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
                                 tokenSymbol,
                                 contract: token.contract as TokenAddress,
                                 cryptoId,
-                                isEnabled: sellCryptoIds.includes(cryptoId),
+                                isEnabled:
+                                    sellCryptoIdsSet.has(cryptoId) ||
+                                    sellCryptoIdsSet.has(cryptoId.toLowerCase() as CryptoId),
                                 fiatRateKey,
                                 rate,
                             };
@@ -264,7 +258,9 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
                             shouldIncludeTokens: false,
                         }),
                         cryptoId,
-                        isEnabled: sellCryptoIds.includes(cryptoId),
+                        isEnabled:
+                            sellCryptoIdsSet.has(cryptoId) ||
+                            sellCryptoIdsSet.has(cryptoId.toLowerCase() as CryptoId),
                     };
 
                     const assets: MyAsset[] = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Compare token CryptoIds case-insensitive.

## Related Issue

Resolve #20544


## Screenshots:
<img width="300" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-09 at 22 41 32" src="https://github.com/user-attachments/assets/ef19c12f-d788-4c1a-9e55-90897982045f" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=20544-Mobile-Swap-tokens-not-available&lookback=7)