### PR TITLE
feat(suite-native): display connecting after coin enabling

### DIFF
--- a/suite-native/app/e2e/pageObjects/coinEnablingActions.ts
+++ b/suite-native/app/e2e/pageObjects/coinEnablingActions.ts
@@ -1,4 +1,6 @@
 import { scrollUntilVisible } from '../utils';
+import { onDeviceConnecting } from './deviceConnectingActions';
+import { onHome } from './homeActions';
 
 class CoinEnablingActions {
     async waitForInitScreen() {
@@ -15,6 +17,16 @@ class CoinEnablingActions {
 
     async clickOnConfirmButton() {
         await element(by.id('@coin-enabling/button-save')).tap();
+    }
+
+    async handleCoinEnablingInit(coins = ['btc']) {
+        await this.waitForInitScreen();
+        for (const coin of coins) {
+            await this.toggleNetwork(coin);
+        }
+        await this.clickOnConfirmButton();
+        await onDeviceConnecting.waitForDeviceConnectingScreen();
+        await onHome.waitForScreen();
     }
 }
 

--- a/suite-native/app/e2e/pageObjects/deviceConnectingActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceConnectingActions.ts
@@ -1,0 +1,9 @@
+class DeviceConnectingActions {
+    async waitForDeviceConnectingScreen() {
+        await waitFor(element(by.id('@screen/ConnectingDevice')))
+            .toBeVisible()
+            .withTimeout(10000);
+    }
+}
+
+export const onDeviceConnecting = new DeviceConnectingActions();

--- a/suite-native/app/e2e/tests/coinEnabling.test.ts
+++ b/suite-native/app/e2e/tests/coinEnabling.test.ts
@@ -2,6 +2,8 @@ import { conditionalDescribe } from '@suite-common/test-utils';
 
 import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
 import { onCoinEnabling } from '../pageObjects/coinEnablingActions';
+import { onDeviceConnecting } from '../pageObjects/deviceConnectingActions';
+import { onHome } from '../pageObjects/homeActions';
 import { onSettings } from '../pageObjects/settingsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
 import { disconnectTrezorUserEnv, openApp, prepareTrezorEmulator } from '../utils';
@@ -21,6 +23,9 @@ conditionalDescribe(device.getPlatform() === 'android', 'Coin enabling', () => {
         await onCoinEnabling.waitForInitScreen();
         await onCoinEnabling.toggleNetwork('btc');
         await onCoinEnabling.clickOnConfirmButton();
+
+        await onDeviceConnecting.waitForDeviceConnectingScreen();
+        await onHome.waitForScreen();
 
         const bitcoinTextElement = element(by.text('Bitcoin'));
 

--- a/suite-native/app/e2e/tests/onboardAndConnect.test.ts
+++ b/suite-native/app/e2e/tests/onboardAndConnect.test.ts
@@ -1,6 +1,3 @@
-// `expect` keyword is already used by jest.
-import { expect as detoxExpect } from 'detox';
-
 import { conditionalDescribe } from '@suite-common/test-utils';
 
 import { onCoinEnabling } from '../pageObjects/coinEnablingActions';
@@ -29,14 +26,7 @@ conditionalDescribe(
                 .toBeVisible()
                 .withTimeout(10000);
 
-            await onCoinEnabling.waitForInitScreen();
-
-            await onCoinEnabling.toggleNetwork('btc');
-            await onCoinEnabling.toggleNetwork('eth');
-
-            await onCoinEnabling.clickOnConfirmButton();
-
-            await detoxExpect(element(by.id('@home/portfolio/header')));
+            await onCoinEnabling.handleCoinEnablingInit(['btc', 'eth']);
         });
     },
 );

--- a/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
+++ b/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
@@ -10,10 +10,8 @@ import { selectDiscoveryNetworkSymbols } from '@suite-native/discovery';
 import { Form, useForm } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import {
-    AppTabsRoutes,
     AuthorizeDeviceStackParamList,
     AuthorizeDeviceStackRoutes,
-    HomeStackRoutes,
     RootStackParamList,
     RootStackRoutes,
     Screen,
@@ -61,11 +59,8 @@ export const CoinEnablingInitScreen = () => {
             payload: { enabledNetworks: values.enabledCoins },
         });
 
-        navigation.popTo(RootStackRoutes.AppTabs, {
-            screen: AppTabsRoutes.HomeStack,
-            params: {
-                screen: HomeStackRoutes.Home,
-            },
+        navigation.popTo(RootStackRoutes.AuthorizeDeviceStack, {
+            screen: AuthorizeDeviceStackRoutes.ConnectingDevice,
         });
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Coin enabling screen redirects straight to dashboard where you're waiting for discovery. It used to be that on device connection, we were displaying connecting screen so that at least something was loaded already in dashboard when we redirect there. For consistency, connecting screen should be displayed after coin enabling init as well. 

Notes for QA: Now when you open the app with no coins enabled and you connect device, after coin enabling, you should be redirected to connecting screen and then to dashboard.

https://github.com/user-attachments/assets/1692821b-bbcc-44bd-b53d-b2cd0046f27d


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/connecting-screen-after-coin-enabling&lookback=7)