### PR TITLE
feat(suite-native): show pairing failed alert if pairing is not possible

### DIFF
--- a/suite-native/bluetooth/package.json
+++ b/suite-native/bluetooth/package.json
@@ -17,7 +17,6 @@
         "@suite-native/device-mutex": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/intl": "workspace:*",
-        "@suite-native/toasts": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/transport-native-bluetooth": "workspace:*",

--- a/suite-native/bluetooth/src/hooks/useBluetoothAdapter.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothAdapter.ts
@@ -5,7 +5,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { bluetoothActions, parseManufacturerData } from '@suite-common/bluetooth';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import { useTranslate } from '@suite-native/intl';
-import { useToast } from '@suite-native/toasts';
 import {
     BluetoothDevice as TransportBluetoothDevice,
     bluetoothManager,
@@ -17,6 +16,7 @@ import {
     selectKnownBluetoothDevices,
     selectKnownConnectableBluetoothDevices,
 } from '../selectors';
+import { useBluetoothAlerts } from './useBluetoothAlerts';
 import { useBluetoothDevice } from './useBluetoothDevice';
 import { useBluetoothPermissions } from './useBluetoothPermissions';
 
@@ -27,11 +27,11 @@ const toBluetoothDevice = (device: TransportBluetoothDevice) => ({
 
 export const useBluetoothAdapter = () => {
     const dispatch = useDispatch();
-    const { showToast } = useToast();
     const { translate } = useTranslate();
 
     const isBluetoothEnabled = useFeatureFlag(FeatureFlag.IsBluetoothEnabled);
     const { checkBluetoothPermission } = useBluetoothPermissions();
+    const { showPairingFailedAlert } = useBluetoothAlerts();
     const { connectBluetoothDevice } = useBluetoothDevice();
 
     const bluetoothPermissionStatus = useSelector(selectBluetoothPermissionStatus);
@@ -77,10 +77,7 @@ export const useBluetoothAdapter = () => {
                 bluetoothManager.onDeviceConnectionStatusChange(event => {
                     dispatch(bluetoothActions.updateDeviceConnectionStatus(event));
                     if (event.connectionStatus.type === 'pairing-error') {
-                        showToast({
-                            message: translate('bluetooth.toasts.pairingCanceled'),
-                            variant: 'default',
-                        });
+                        showPairingFailedAlert();
                     }
                 }),
             ];
@@ -89,7 +86,7 @@ export const useBluetoothAdapter = () => {
                 subscriptions.forEach(subscription => subscription.remove());
             };
         }
-    }, [bluetoothPermissionStatus, dispatch, showToast, translate]);
+    }, [bluetoothPermissionStatus, dispatch, showPairingFailedAlert, translate]);
 
     useEffect(() => {
         if (bluetoothAdapterStatus === 'enabled' && knownBluetoothDevices.length > 0) {

--- a/suite-native/bluetooth/src/hooks/useBluetoothAlerts.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothAlerts.ts
@@ -73,7 +73,18 @@ export const useBluetoothAlerts = () => {
         hideAlert,
     ]);
 
+    const showPairingFailedAlert = useCallback(() => {
+        showAlert({
+            title: translate('bluetooth.alerts.pairingFailed.title'),
+            description: translate('bluetooth.alerts.pairingFailed.description'),
+            primaryButtonTitle: translate('bluetooth.alerts.pairingFailed.primaryButton'),
+            onPressPrimaryButton: openBluetoothSettings,
+            secondaryButtonTitle: translate('bluetooth.alerts.pairingFailed.secondaryButton'),
+        });
+    }, [showAlert, openBluetoothSettings, translate]);
+
     return {
         showOrHideBluetoothAlert,
+        showPairingFailedAlert,
     };
 };

--- a/suite-native/bluetooth/tsconfig.json
+++ b/suite-native/bluetooth/tsconfig.json
@@ -9,7 +9,6 @@
         { "path": "../device-mutex" },
         { "path": "../feature-flags" },
         { "path": "../intl" },
-        { "path": "../toasts" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/styles" },
         {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -171,9 +171,13 @@ export const messages = {
                     'Bluetooth is currently turned off on this phone. Go to phone settings and turn on Bluetooth.',
                 primaryButton: 'Open system settings',
             },
-        },
-        toasts: {
-            pairingCanceled: 'Bluetooth pairing canceled.',
+            pairingFailed: {
+                title: 'Bluetooth pairing failed',
+                description:
+                    'The Trezor you’re trying to connect may still be remembered in your phone’s Bluetooth settings. Remove it and try again.',
+                primaryButton: 'Open system settings',
+                secondaryButton: 'Device removed',
+            },
         },
         deviceList: {
             connect: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10304,7 +10304,6 @@ __metadata:
     "@suite-native/device-mutex": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/intl": "workspace:*"
-    "@suite-native/toasts": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/transport-native-bluetooth": "workspace:*"


### PR DESCRIPTION
Previously, just a confusing toast message was shown:
_Bluetooth pairing canceled._

Now the message is more descriptive with an option to open Bluetooth settings.

[Figma](https://www.figma.com/design/yl2g0XLU9iIgJsrxSOqkS9/Bluetooth---THP--Final-?node-id=3056-14286&t=sn8RG0oenl2ahV5f-0)

## Screenshots:
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/41016f00-0d34-42b9-9309-a738e851455d" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/pairing-error-alert&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/pairing-error-alert&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/pairing-error-alert&lookback=7)