### PR TITLE
fix(suite): Allow full scroll in onboarding when message banner is shown

### DIFF
--- a/packages/suite/src/components/onboarding/OnboardingLayout.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingLayout.tsx
@@ -33,7 +33,8 @@ const Body = styled.div`
     justify-content: center;
     display: flex;
     width: 100%;
-    height: 100%;
+    height: auto;
+    overflow: scroll;
 `;
 
 const ScrollingWrapper = styled.div`


### PR DESCRIPTION
## Description

When a message banner appeared during onboarding, scrolling was blocked until the banner was closed. Now scrolling works normally even with the banner visible.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21038

## Screenshots:

https://github.com/user-attachments/assets/98d828bd-b294-47f5-a1c1-230297cbbc02



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/onboarding-body-scrolling&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/onboarding-body-scrolling&lookback=7)