### PR TITLE
Feat/bt napi connect module

### DIFF
--- a/packages/suite-data/files/bin/bluetooth/mac-arm64/index.js
+++ b/packages/suite-data/files/bin/bluetooth/mac-arm64/index.js
@@ -1,3 +1,3 @@
 var nativeBinding = require('./trezor-bluetooth.node');
 module.exports = nativeBinding;
-module.exports.trezorBluetoothRun = nativeBinding.trezorBluetoothRun;
+module.exports.connectDevice = nativeBinding.connectDevice;

--- a/packages/suite-data/files/bin/bluetooth/mac-x64/index.js
+++ b/packages/suite-data/files/bin/bluetooth/mac-x64/index.js
@@ -1,3 +1,3 @@
 var nativeBinding = require('./trezor-bluetooth.node');
 module.exports = nativeBinding;
-module.exports.trezorBluetoothRun = nativeBinding.trezorBluetoothRun;
+module.exports.connectDevice = nativeBinding.connectDevice;

--- a/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
@@ -71,22 +71,35 @@ export class BluetoothProcess extends BaseProcess {
         };
     }
 
-    async start() {
+    start() {
         if (this.debug) {
             process.env.RUST_LOG = 'debug';
             process.env.RUST_BACKTRACE = '1';
         }
 
-        if (isMacOs()) {
+        return super.start();
+    }
+
+    // workaround for macos pairing issue
+    async connectAndSubscribeInMainThread(
+        id: string,
+    ): Promise<{ success: true } | { success: false; error: string }> {
+        if (!isMacOs()) {
+            return Promise.resolve({ success: true });
+        }
+
+        try {
             const processPath = path.join(super.getProcessDir(), `index.js`);
             this.logger.info(this.logTopic, `Loading bluetooth native module from ${processPath}`);
 
-            const { trezorBluetoothRun } = await import(/*webpackIgnore: true */ processPath);
-            trezorBluetoothRun(this.port);
+            const { connectDevice } = await import(/*webpackIgnore: true */ processPath);
+            await connectDevice(id, 30000, (...args: any[]) => {
+                console.warn('callback', args);
+            });
 
-            return;
+            return { success: true } as const;
+        } catch (error) {
+            return { success: false, error: error.message } as const;
         }
-
-        return super.start(['-p', this.port.toString()]); // TODO: remove params after next binary release
     }
 }

--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -85,6 +85,16 @@ export const init: ModuleInit = () => {
 
                     if (!api) throw apiError;
 
+                    if (method === 'connectDevice') {
+                        // special case for macos
+                        const result = await bluetoothProcess?.connectAndSubscribeInMainThread(
+                            params[0],
+                        );
+                        if (result && !result.success) {
+                            return result;
+                        }
+                    }
+
                     if (method === 'dispose') {
                         killBluetoothProcess();
                     }

--- a/packages/transport-bluetooth/scripts/Dockerfile
+++ b/packages/transport-bluetooth/scripts/Dockerfile
@@ -38,6 +38,19 @@ RUN cargo build --target x86_64-unknown-linux-gnu --release --bins && \
   cp ./target/x86_64-unknown-linux-gnu/release/trezor-bluetooth /output/linux-x64/trezor-bluetooth && \
   strip /output/linux-x64/trezor-bluetooth
 
+# Build for macOS ARM64
+RUN rustup target add aarch64-apple-darwin && \
+  cargo build --target aarch64-apple-darwin --release --bins && \
+  mkdir -p /output/mac-arm64 && \
+  cp ./target/aarch64-apple-darwin/release/trezor-bluetooth /output/mac-arm64/trezor-bluetooth && \
+  llvm-strip /output/mac-arm64/trezor-bluetooth
+
+# Build for macOS x64
+RUN cargo build --target x86_64-apple-darwin --release --bins && \
+  mkdir -p /output/mac-x64 && \
+  cp ./target/x86_64-apple-darwin/release/trezor-bluetooth /output/mac-x64/trezor-bluetooth && \
+  llvm-strip /output/mac-x64/trezor-bluetooth
+
 # Build NAPI for macOS (ARM64 and x64)
 COPY ./package.json ./package.json
 RUN yarn global add @napi-rs/cli && \

--- a/packages/transport-bluetooth/src/lib.rs
+++ b/packages/transport-bluetooth/src/lib.rs
@@ -1,20 +1,49 @@
+use napi::bindgen_prelude::*;
+use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
+
+use crate::server::{
+    adapter_manager::AdapterManager, connection_broadcast::ConnectionBroadcast,
+    methods::connect_device as connect_device_method, types::ConnectDeviceParams,
+};
+
+use btleplug::api::Central;
+use btleplug::api::ScanFilter;
 
 mod server;
 
+fn error(msg: String) -> napi::Error {
+    napi::Error::new(napi::Status::GenericFailure, msg.to_string())
+}
+
 #[napi]
-fn trezor_bluetooth_run(port: u16) {
-    pretty_env_logger::try_init();
+pub async fn connect_device(
+    id: String,
+    timeout: u32,
+    callback: ThreadsafeFunction<String>,
+) -> Result<()> {
+    let manager = match AdapterManager::new().await {
+        Ok(manager) => manager,
+        Err(e) => Err(error(e.to_string()))?,
+    };
+    let broadcast = match ConnectionBroadcast::new(id.clone()) {
+        Ok(broadcast) => broadcast,
+        Err(e) => Err(error(e.to_string()))?,
+    };
+    let adapter = match manager.get_adapter().await {
+        Ok(Some(adapter)) => adapter,
+        Ok(None) => Err(error("AdapterNotFound".to_string()))?,
+        Err(e) => Err(error(e.to_string()))?,
+    };
 
-    let addr = format!("127.0.0.1:{}", port);
+    // start scan to collect peripherals on new AdapterManager instance
+    // requested device should be already discovered by the background process
+    let _ = adapter.start_scan(ScanFilter::default()).await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+    let _ = adapter.stop_scan().await;
 
-    std::thread::spawn(move || {
-        tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(async move {
-                server::start_server(&addr).await.unwrap_or_else(|err| {
-                    log::error!("Error starting server: {}", err);
-                });
-            });
-    });
+    match connect_device_method(manager, broadcast, ConnectDeviceParams { id, timeout }).await {
+        Ok(_) => Ok(()),
+        Err(e) => Err(error(e.to_string()))?,
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Followup to https://github.com/trezor/trezor-suite/pull/20982

use NAPI bindings only to call  `connectDevice` in the main thread while the rest of the logic is running on the background in rust binary.

NAPI module contains only connect device function without all other logic and state management.

Its worth to consider rewrite other functions/methods like this

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bt-napi-connect-module&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bt-napi-connect-module&lookback=7)