### PR TITLE
feat: try to forget BT in OS when wiping or forgetting device

### DIFF
--- a/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
@@ -24,8 +24,8 @@ export const forgetBluetoothDeviceThunk = createThunk<void, ForgetBluetoothDevic
         dispatch(setIsUnpairingDevice({ isUnpairing: false }));
         if (!resultForget.success) {
             dispatch(setBluetoothDeviceNeedsManualOsRemoval({ needsManualRemoval: true }));
-            dispatch(bluetoothActions.removeKnownDeviceAction({ id: bluetoothId }));
         }
+        dispatch(bluetoothActions.removeKnownDeviceAction({ id: bluetoothId }));
     },
 );
 

--- a/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
@@ -80,6 +80,10 @@ const fixture: Feature[] = [
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
+                    type: deviceActions.forgetDevicePersistentData.type,
+                    payload: { deviceId: 'device-id' },
+                },
+                {
                     type: notificationsActions.addToast.type,
                     payload: { type: 'device-wiped', context: 'toast', id: expect.any(Number) },
                 } satisfies ReturnType<typeof notificationsActions.addToast>,
@@ -211,6 +215,10 @@ const fixture: Feature[] = [
                         },
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
+                {
+                    type: deviceActions.forgetDevicePersistentData.type,
+                    payload: { deviceId: 'device-id' },
+                },
                 {
                     type: notificationsActions.addToast.type,
                     payload: { type: 'device-wiped', context: 'toast', id: expect.any(Number) },

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -1,4 +1,4 @@
-import { bluetoothActions } from '@suite-common/bluetooth';
+import { bluetoothActions, selectKnownDevices } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 import { AcquiredDevice, TrezorDevice } from '@suite-common/suite-types';
 import {
@@ -425,12 +425,14 @@ type ForgetAllDeviceDataThunkParams = {
  */
 export const forgetSingleDevicePersistentDataThunk = createThunk(
     `${DEVICE_MODULE_PREFIX}/forgetSingleDevicePersistentDataThunk`,
-    ({ device }: ForgetAllDeviceDataThunkParams, { dispatch }) => {
+    ({ device }: ForgetAllDeviceDataThunkParams, { dispatch, extra }) => {
         if (typeof device.id === 'string') {
             dispatch(deviceActions.forgetDevicePersistentData({ deviceId: device.id }));
         }
         if (device.bluetoothProps !== undefined) {
             dispatch(bluetoothActions.removeKnownDeviceAction({ id: device.bluetoothProps.id }));
+            // try to remove OS-level Bluetooth bonds, if supported by the platform
+            dispatch(extra.thunks.forgetBluetoothDevice({ bluetoothId: device.bluetoothProps.id }));
         }
         if (isThpDevice(device)) {
             dispatch(thpActions.removeCredentials({ credentials: device.thp.credentials }));
@@ -439,22 +441,26 @@ export const forgetSingleDevicePersistentDataThunk = createThunk(
 );
 
 /**
- * Helper thunk to do the same as `forgetSingleDevicePersistentDataThunk`, but for all devices.
- * Rather than iterating through the devices, this thunk removes all data in a single swoop.
- * This is also fully reliable for removing THP data, unlike the single device function.
+ * Helper thunk to do the same as `forgetSingleDevicePersistentDataThunk`, but for all devices as well as orphaned data.
+ * Note that if you eject wallets, but BT, THP and persistentDeviceData are stil remembered, than they cannot be matched
+ * by iterating through `devices`. So this thunk removes all data in a single swoop.
  */
 export const forgetAllDevicesPersistentDataThunk = createThunk(
     `${DEVICE_MODULE_PREFIX}/forgetAllDevicesPersistentDataThunk`,
-    (_, { dispatch }) => {
+    (_, { dispatch, getState, extra }) => {
         dispatch(deviceActions.forgetAllDevicesPersistentData());
         dispatch(thpActions.removeAllCredentials());
         dispatch(bluetoothActions.knownDevicesUpdateAction({ knownDevices: [] }));
+        // try to remove OS-level Bluetooth bonds for each device, if supported by the platform
+        selectKnownDevices(getState()).forEach(knownDevice => {
+            dispatch(extra.thunks.forgetBluetoothDevice({ bluetoothId: knownDevice.id }));
+        });
     },
 );
 
 export const wipeDeviceThunk = createThunk(
     `${DEVICE_MODULE_PREFIX}/wipeDevice`,
-    async (_, { dispatch, getState, extra, rejectWithValue }) => {
+    async (_, { dispatch, getState, rejectWithValue }) => {
         const device = selectSelectedDevice(getState());
         if (!device) return;
         const isBootloaderMode = device.mode === 'bootloader';
@@ -480,14 +486,6 @@ export const wipeDeviceThunk = createThunk(
             // Accounts data are related to the old device.id; to properly clear reducers and indexed db,
             // we need to retrieve device objects BEFORE and AFTER the wipe process.
             // And call SUITE.FORGET_DEVICE on ALL devices (with old and new device.id)
-            if (device.bluetoothProps !== undefined) {
-                dispatch(
-                    bluetoothActions.removeKnownDeviceAction({ id: device.bluetoothProps.id }),
-                );
-                dispatch(
-                    extra.thunks.forgetBluetoothDevice({ bluetoothId: device.bluetoothProps.id }),
-                );
-            }
             const newDevice = selectSelectedDevice(getState());
             const newDevices = selectDevices(getState());
 
@@ -495,6 +493,11 @@ export const wipeDeviceThunk = createThunk(
             deviceInstances.forEach(d => {
                 dispatch(deviceActions.forgetDevice({ device: d }));
             });
+
+            // Wiping a device changes bluetoothId and THP static key, so wipe BT known device & THP credentials
+            // (and persistent device data as well, because device.id changed).
+            dispatch(forgetSingleDevicePersistentDataThunk({ device }));
+
             dispatch(notificationsActions.addToast({ type: 'device-wiped' }));
 
             // Special case with webusb: Device after wipe changes device_id. With webusb transport, device_id is used as a path

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -393,6 +393,65 @@ export const deviceConnectThunks = createThunk<void, DeviceConnectThunksParams, 
     },
 );
 
+// Note: currently used only by mobile, see `forgetAllDisconnectedDevices` for a simpler thunk
+export const toggleAutoEjectThunk = createThunk(
+    `${DEVICE_MODULE_PREFIX}/toggleAutoEjectThunk`,
+    (_, { dispatch, getState }) => {
+        const physicalDevices = selectPhysicalDevices(getState());
+        dispatch(deviceActions.toggleIsDeviceAutoEjectEnabled());
+
+        physicalDevices.forEach(wallet => {
+            if (!wallet.connected && wallet.remember) {
+                dispatch(deviceActions.forgetDevice({ device: wallet }));
+            } else {
+                // TODO investigate why do we need to consider wallet.remember at all, when we are ejecting all wallets.
+                dispatch(
+                    deviceActions.rememberDevice({
+                        device: wallet,
+                        remember: !wallet.remember,
+                    }),
+                );
+            }
+        });
+    },
+);
+
+type ForgetAllDeviceDataThunkParams = {
+    device: TrezorDevice;
+};
+
+/**
+ * This thunk is the central place to remove all persistent data related to a device.
+ */
+export const forgetSingleDevicePersistentDataThunk = createThunk(
+    `${DEVICE_MODULE_PREFIX}/forgetSingleDevicePersistentDataThunk`,
+    ({ device }: ForgetAllDeviceDataThunkParams, { dispatch }) => {
+        if (typeof device.id === 'string') {
+            dispatch(deviceActions.forgetDevicePersistentData({ deviceId: device.id }));
+        }
+        if (device.bluetoothProps !== undefined) {
+            dispatch(bluetoothActions.removeKnownDeviceAction({ id: device.bluetoothProps.id }));
+        }
+        if (isThpDevice(device)) {
+            dispatch(thpActions.removeCredentials({ credentials: device.thp.credentials }));
+        }
+    },
+);
+
+/**
+ * Helper thunk to do the same as `forgetSingleDevicePersistentDataThunk`, but for all devices.
+ * Rather than iterating through the devices, this thunk removes all data in a single swoop.
+ * This is also fully reliable for removing THP data, unlike the single device function.
+ */
+export const forgetAllDevicesPersistentDataThunk = createThunk(
+    `${DEVICE_MODULE_PREFIX}/forgetAllDevicesPersistentDataThunk`,
+    (_, { dispatch }) => {
+        dispatch(deviceActions.forgetAllDevicesPersistentData());
+        dispatch(thpActions.removeAllCredentials());
+        dispatch(bluetoothActions.knownDevicesUpdateAction({ knownDevices: [] }));
+    },
+);
+
 export const wipeDeviceThunk = createThunk(
     `${DEVICE_MODULE_PREFIX}/wipeDevice`,
     async (_, { dispatch, getState, extra, rejectWithValue }) => {
@@ -451,65 +510,6 @@ export const wipeDeviceThunk = createThunk(
 
             return rejectWithValue(result.payload.error);
         }
-    },
-);
-
-// Note: currently used only by mobile, see `forgetAllDisconnectedDevices` for a simpler thunk
-export const toggleAutoEjectThunk = createThunk(
-    `${DEVICE_MODULE_PREFIX}/toggleAutoEjectThunk`,
-    (_, { dispatch, getState }) => {
-        const physicalDevices = selectPhysicalDevices(getState());
-        dispatch(deviceActions.toggleIsDeviceAutoEjectEnabled());
-
-        physicalDevices.forEach(wallet => {
-            if (!wallet.connected && wallet.remember) {
-                dispatch(deviceActions.forgetDevice({ device: wallet }));
-            } else {
-                // TODO investigate why do we need to consider wallet.remember at all, when we are ejecting all wallets.
-                dispatch(
-                    deviceActions.rememberDevice({
-                        device: wallet,
-                        remember: !wallet.remember,
-                    }),
-                );
-            }
-        });
-    },
-);
-
-type ForgetAllDeviceDataThunkParams = {
-    device: TrezorDevice;
-};
-
-/**
- * This thunk is the central place to remove all persistent data related to a device.
- */
-export const forgetSingleDevicePersistentDataThunk = createThunk(
-    `${DEVICE_MODULE_PREFIX}/forgetSingleDevicePersistentDataThunk`,
-    ({ device }: ForgetAllDeviceDataThunkParams, { dispatch }) => {
-        if (typeof device.id === 'string') {
-            dispatch(deviceActions.forgetDevicePersistentData({ deviceId: device.id }));
-        }
-        if (device.bluetoothProps !== undefined) {
-            dispatch(bluetoothActions.removeKnownDeviceAction({ id: device.bluetoothProps.id }));
-        }
-        if (isThpDevice(device)) {
-            dispatch(thpActions.removeCredentials({ credentials: device.thp.credentials }));
-        }
-    },
-);
-
-/**
- * Helper thunk to do the same as `forgetSingleDevicePersistentDataThunk`, but for all devices.
- * Rather than iterating through the devices, this thunk removes all data in a single swoop.
- * This is also fully reliable for removing THP data, unlike the single device function.
- */
-export const forgetAllDevicesPersistentDataThunk = createThunk(
-    `${DEVICE_MODULE_PREFIX}/forgetAllDevicesPersistentDataThunk`,
-    (_, { dispatch }) => {
-        dispatch(deviceActions.forgetAllDevicesPersistentData());
-        dispatch(thpActions.removeAllCredentials());
-        dispatch(bluetoothActions.knownDevicesUpdateAction({ knownDevices: [] }));
     },
 );
 


### PR DESCRIPTION
## Description

CR commit by commit recommended:

- move code within file for `no-use-before-define`, I extracted a commit for transparency of the next one: 
- try to remove BT device from OS when `forgetSingleDevicePersistentDataThunk`
  - this really works only on Windows but on macOS | Linux it will at least yield the Manual Device Removal modal
  - and call `forgetSingleDevicePersistentDataThunk` when wiping device
    - BTW this also removes THP credentials and device persistent data, which was omitted before 

## Related Issue

Resolve #21395
Resolve #21387

## Screenshots:

Wiping device on Linux. The Bluetooth removal works the same for forgetting a device.
→ leads to the Manual Device Removal modal on next pairing (AFAIK needed only on macOS | Linux, while Windows is the only platform where we can successfully unpair device in OS, and do not need this modal)  

[Screencast from 2025-09-10 19-03-19.webm](https://github.com/user-attachments/assets/66c2547a-07b0-4965-8519-b8f843b6560c)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/forget-bt-also-in-os-also-on-wipe&lookback=7)