### PR TITLE
BT: fix BT duplicates on Mac & iOS

### DIFF
--- a/packages/suite/src/actions/bluetooth/__tests__/remapKnownDevicesForLinuxAndWindows.test.ts
+++ b/packages/suite/src/actions/bluetooth/__tests__/remapKnownDevicesForLinuxAndWindows.test.ts
@@ -2,7 +2,7 @@ import { BluetoothManufacturerData } from '@suite-common/bluetooth';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { DesktopBluetoothDevice } from '../DesktopBluetoothDevice';
-import { remapKnownDevicesForLinux } from '../remapKnownDevicesForLinux';
+import { remapKnownDevicesForLinuxAndWindows } from '../remapKnownDevicesForLinuxAndWindows';
 
 const manufacturerData: BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal.T3W1,
@@ -58,9 +58,9 @@ const knownDeviceA: DesktopBluetoothDevice = {
     connectionStatus: { type: 'pairing' },
 };
 
-describe(remapKnownDevicesForLinux.name, () => {
+describe(remapKnownDevicesForLinuxAndWindows.name, () => {
     it('remaps the changed id of the device, while leaving the others intact', () => {
-        const result = remapKnownDevicesForLinux({
+        const result = remapKnownDevicesForLinuxAndWindows({
             nearbyDevices: [nearbyDeviceA, nearbyDeviceC],
             knownDevices: [knownDeviceA, knownDeviceB],
         });

--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -13,7 +13,7 @@ import {
 import { bluetoothConnectDeviceThunk } from './bluetoothConnectDeviceThunk';
 import { bluetoothStartScanningThunk } from './bluetoothStartScanningThunk';
 import { selectConnectingDevices } from './desktopBluetoothSelectors';
-import { remapKnownDevicesForLinux } from './remapKnownDevicesForLinux';
+import { remapKnownDevicesForLinuxAndWindows } from './remapKnownDevicesForLinuxAndWindows';
 
 export const initBluetoothThunk = createThunk<void, void, void>(
     `${BLUETOOTH_PREFIX}/initBluetoothThunk`,
@@ -73,15 +73,21 @@ export const initBluetoothThunk = createThunk<void, void, void>(
 
             const knownDevices = selectKnownDevices<DesktopBluetoothDevice>(getState());
 
-            const remappedKnownDevices = remapKnownDevicesForLinux({
+            const remappedKnownDevices = remapKnownDevicesForLinuxAndWindows({
                 knownDevices,
                 nearbyDevices,
             });
 
             dispatch(
-                bluetoothActions.knownDevicesUpdateAction({ knownDevices: remappedKnownDevices }),
+                bluetoothActions.knownDevicesUpdateAction({
+                    knownDevices: remappedKnownDevices,
+                }),
             );
-            dispatch(bluetoothActions.nearbyDevicesUpdateAction({ nearbyDevices }));
+            dispatch(
+                bluetoothActions.nearbyDevicesUpdateAction({
+                    nearbyDevices,
+                }),
+            );
         });
 
         bluetoothIpc.on('device-update', async (deviceIpc: BluetoothDevice) => {

--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -1,6 +1,12 @@
-import { BLUETOOTH_PREFIX, bluetoothActions, selectKnownDevices } from '@suite-common/bluetooth';
+import {
+    BLUETOOTH_PREFIX,
+    bluetoothActions,
+    filterOutOldDuplicatesByName,
+    selectKnownDevices,
+} from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import { isMacOs } from '@trezor/env-utils';
 import { BluetoothDevice, bluetoothIpc } from '@trezor/transport-bluetooth';
 
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
@@ -80,12 +86,16 @@ export const initBluetoothThunk = createThunk<void, void, void>(
 
             dispatch(
                 bluetoothActions.knownDevicesUpdateAction({
-                    knownDevices: remappedKnownDevices,
+                    knownDevices: isMacOs()
+                        ? filterOutOldDuplicatesByName(remappedKnownDevices)
+                        : remappedKnownDevices,
                 }),
             );
             dispatch(
                 bluetoothActions.nearbyDevicesUpdateAction({
-                    nearbyDevices,
+                    nearbyDevices: isMacOs()
+                        ? filterOutOldDuplicatesByName(nearbyDevices)
+                        : nearbyDevices,
                 }),
             );
         });

--- a/packages/suite/src/actions/bluetooth/remapKnownDevicesForLinuxAndWindows.ts
+++ b/packages/suite/src/actions/bluetooth/remapKnownDevicesForLinuxAndWindows.ts
@@ -1,20 +1,20 @@
 import { DesktopBluetoothDevice } from './DesktopBluetoothDevice';
 
-type RemapKnownDevicesForLinuxParams = {
+type RemapKnownDevicesForLinuxAndWindowsParams = {
     knownDevices: DesktopBluetoothDevice[];
     nearbyDevices: DesktopBluetoothDevice[];
 };
 
 /**
- * On linux, when bluetooth adapter is turned off/on again, the paired
+ * On linux and windows, when bluetooth adapter is turned off/on again, the paired
  * devices will get different `id`, but `address` will remain the same.
  *
  * Therefore, we have to remap the knownDevices to change the `id`.
  */
-export const remapKnownDevicesForLinux = ({
+export const remapKnownDevicesForLinuxAndWindows = ({
     knownDevices,
     nearbyDevices,
-}: RemapKnownDevicesForLinuxParams): DesktopBluetoothDevice[] =>
+}: RemapKnownDevicesForLinuxAndWindowsParams): DesktopBluetoothDevice[] =>
     knownDevices.map(knownDevice => {
         const nearbyDeviceWithSameAddress = nearbyDevices.find(
             nearbyDevice =>

--- a/suite-common/bluetooth/src/filterOutOldDuplicatesByName.ts
+++ b/suite-common/bluetooth/src/filterOutOldDuplicatesByName.ts
@@ -7,13 +7,11 @@ export const filterOutOldDuplicatesByName = <T extends BluetoothDeviceCommon>(de
     devices.filter(device => {
         const duplicates = devices.filter(d => d.name === device.name);
 
-        if (duplicates.length > 1) {
-            const latest = duplicates.reduce((a, b) =>
-                a.lastUpdatedTimestamp > b.lastUpdatedTimestamp ? a : b,
-            );
+        if (duplicates.length <= 1) return true;
 
-            return device.id === latest.id;
-        }
+        const latest = duplicates.reduce((a, b) =>
+            a.lastUpdatedTimestamp > b.lastUpdatedTimestamp ? a : b,
+        );
 
-        return true;
+        return device.id === latest.id;
     });

--- a/suite-common/bluetooth/src/filterOutOldDuplicatesByName.ts
+++ b/suite-common/bluetooth/src/filterOutOldDuplicatesByName.ts
@@ -1,0 +1,19 @@
+import { BluetoothDeviceCommon } from '@suite-common/bluetooth/src/types';
+
+// MacOS && iOS does not provide a stable device ID for Bluetooth devices. Therefore, we need to
+// remap known devices based on their name. If there are multiple devices with the same name,
+// we keep only the most recently updated one.
+export const filterOutOldDuplicatesByName = <T extends BluetoothDeviceCommon>(devices: T[]) =>
+    devices.filter(device => {
+        const duplicates = devices.filter(d => d.name === device.name);
+
+        if (duplicates.length > 1) {
+            const latest = duplicates.reduce((a, b) =>
+                a.lastUpdatedTimestamp > b.lastUpdatedTimestamp ? a : b,
+            );
+
+            return device.id === latest.id;
+        }
+
+        return true;
+    });

--- a/suite-common/bluetooth/src/index.ts
+++ b/suite-common/bluetooth/src/index.ts
@@ -17,4 +17,6 @@ export {
     selectNearbyDevices,
 } from './bluetoothSelectors';
 
+export { filterOutOldDuplicatesByName } from './filterOutOldDuplicatesByName';
+
 export { parseManufacturerData, serializeManufacturerData } from './manufacturerDataUtils';

--- a/suite-common/bluetooth/tests/filterOutOldDuplicatesByName.test.ts
+++ b/suite-common/bluetooth/tests/filterOutOldDuplicatesByName.test.ts
@@ -16,7 +16,7 @@ const defaultDeviceAdditionalParams: Pick<
     },
 };
 
-describe('filterOutOldDuplicatesByName', () => {
+describe(filterOutOldDuplicatesByName.name, () => {
     it('returns all devices if names are unique', () => {
         const devices: BluetoothDeviceCommon[] = [
             {

--- a/suite-common/bluetooth/tests/filterOutOldDuplicatesByName.test.ts
+++ b/suite-common/bluetooth/tests/filterOutOldDuplicatesByName.test.ts
@@ -1,0 +1,173 @@
+import { DeviceModelInternal } from '@trezor/device-utils';
+
+import { filterOutOldDuplicatesByName } from '../src/filterOutOldDuplicatesByName';
+import { BluetoothDeviceCommon } from '../src/types';
+
+const defaultDeviceAdditionalParams: Pick<
+    BluetoothDeviceCommon,
+    'connectionStatus' | 'manufacturerData'
+> = {
+    connectionStatus: {
+        type: 'disconnected',
+    },
+    manufacturerData: {
+        deviceColor: 1,
+        deviceModel: DeviceModelInternal.T3W1,
+    },
+};
+
+describe('filterOutOldDuplicatesByName', () => {
+    it('returns all devices if names are unique', () => {
+        const devices: BluetoothDeviceCommon[] = [
+            {
+                id: '1',
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 100,
+                ...defaultDeviceAdditionalParams,
+            },
+            {
+                id: '2',
+                name: 'DeviceB',
+                lastUpdatedTimestamp: 200,
+                ...defaultDeviceAdditionalParams,
+            },
+            {
+                id: '3',
+                name: 'DeviceC',
+                lastUpdatedTimestamp: 300,
+                ...defaultDeviceAdditionalParams,
+            },
+        ];
+        const result = filterOutOldDuplicatesByName(devices);
+        expect(result).toHaveLength(3);
+        expect(result).toEqual(devices);
+    });
+
+    it('keeps only the latest device for duplicate names', () => {
+        const devices: BluetoothDeviceCommon[] = [
+            {
+                id: '1',
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 100,
+                ...defaultDeviceAdditionalParams,
+            },
+            {
+                id: '2',
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 200,
+                ...defaultDeviceAdditionalParams,
+            },
+            {
+                id: '3',
+                name: 'DeviceB',
+                lastUpdatedTimestamp: 150,
+                ...defaultDeviceAdditionalParams,
+            },
+        ];
+        const result = filterOutOldDuplicatesByName(devices);
+        expect(result).toHaveLength(2);
+        expect(result).toEqual([
+            {
+                id: '2',
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 200,
+                ...defaultDeviceAdditionalParams,
+            },
+            {
+                id: '3',
+                name: 'DeviceB',
+                lastUpdatedTimestamp: 150,
+                ...defaultDeviceAdditionalParams,
+            },
+        ]);
+    });
+
+    it('handles multiple sets of duplicates', () => {
+        const devices: BluetoothDeviceCommon[] = [
+            {
+                id: '1',
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 100,
+                ...defaultDeviceAdditionalParams,
+            },
+            {
+                id: '2',
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 200,
+                ...defaultDeviceAdditionalParams,
+            },
+            {
+                id: '3',
+                name: 'DeviceB',
+                lastUpdatedTimestamp: 150,
+                ...defaultDeviceAdditionalParams,
+            },
+            {
+                id: '4',
+                name: 'DeviceB',
+                lastUpdatedTimestamp: 250,
+                ...defaultDeviceAdditionalParams,
+            },
+            {
+                id: '5',
+                name: 'DeviceC',
+                lastUpdatedTimestamp: 300,
+                ...defaultDeviceAdditionalParams,
+            },
+        ];
+        const result = filterOutOldDuplicatesByName(devices);
+        expect(result).toHaveLength(3);
+        expect(result).toEqual([
+            {
+                id: '2',
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 200,
+                ...defaultDeviceAdditionalParams,
+            },
+            {
+                id: '4',
+                name: 'DeviceB',
+                lastUpdatedTimestamp: 250,
+                ...defaultDeviceAdditionalParams,
+            },
+            {
+                id: '5',
+                name: 'DeviceC',
+                lastUpdatedTimestamp: 300,
+                ...defaultDeviceAdditionalParams,
+            },
+        ]);
+    });
+
+    it('returns empty array if input is empty', () => {
+        const devices: BluetoothDeviceCommon[] = [];
+        const result = filterOutOldDuplicatesByName(devices);
+        expect(result).toEqual([]);
+    });
+
+    it('keeps the latest device when timestamps are equal (prefers last in array)', () => {
+        const devices: BluetoothDeviceCommon[] = [
+            {
+                id: '1',
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 100,
+                ...defaultDeviceAdditionalParams,
+            },
+            {
+                id: '2',
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 100,
+                ...defaultDeviceAdditionalParams,
+            },
+        ];
+        const result = filterOutOldDuplicatesByName(devices);
+        expect(result).toEqual([
+            {
+                id: '2',
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 100,
+                ...defaultDeviceAdditionalParams,
+            },
+        ]);
+    });
+});

--- a/suite-native/bluetooth/package.json
+++ b/suite-native/bluetooth/package.json
@@ -18,6 +18,7 @@
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/transport-native-bluetooth": "workspace:*",
         "expo-constants": "17.1.7",

--- a/suite-native/bluetooth/src/hooks/useBluetoothAdapter.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothAdapter.ts
@@ -2,9 +2,14 @@ import { useEffect } from 'react';
 import { AppState } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { bluetoothActions, parseManufacturerData } from '@suite-common/bluetooth';
+import {
+    bluetoothActions,
+    filterOutOldDuplicatesByName,
+    parseManufacturerData,
+} from '@suite-common/bluetooth';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import { useTranslate } from '@suite-native/intl';
+import { isIOs } from '@trezor/env-utils';
 import {
     BluetoothDevice as TransportBluetoothDevice,
     bluetoothManager,
@@ -68,9 +73,13 @@ export const useBluetoothAdapter = () => {
                     dispatch(bluetoothActions.adapterEventAction({ status }));
                 }),
                 bluetoothManager.onNearbyDevicesChange(nearbyDevices => {
+                    const mappedNearbyDevices = isIOs()
+                        ? filterOutOldDuplicatesByName(nearbyDevices.map(toBluetoothDevice))
+                        : nearbyDevices.map(toBluetoothDevice);
+
                     dispatch(
                         bluetoothActions.nearbyDevicesUpdateAction({
-                            nearbyDevices: nearbyDevices.map(toBluetoothDevice),
+                            nearbyDevices: mappedNearbyDevices,
                         }),
                     );
                 }),

--- a/suite-native/bluetooth/tsconfig.json
+++ b/suite-native/bluetooth/tsconfig.json
@@ -10,6 +10,7 @@
         { "path": "../feature-flags" },
         { "path": "../intl" },
         { "path": "../../packages/connect" },
+        { "path": "../../packages/env-utils" },
         { "path": "../../packages/styles" },
         {
             "path": "../../packages/transport-native-bluetooth"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10305,6 +10305,7 @@ __metadata:
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/transport-native-bluetooth": "workspace:*"
     expo-constants: "npm:17.1.7"


### PR DESCRIPTION
Fixes MacOS & iOS related BT issue when the BT device ID given by OS is always different. (due to privacy reasons - see https://support.apple.com/guide/security/bluetooth-security-sec82597d97e/web)

This fix is filtering `nearbyDevices` and `knownDevices` based of their name and latest update timestamp, so that we always show the `real` device to the user.

**Changes**:
- renamed `remapKnownDevicesForLinux` to `remapKnownDevicesForLinuxAndWindows` as it applies for windows as well
- created `filterOutOldDuplicatesByName`
- created tests for `filterOutOldDuplicatesByName`

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21311

## Screenshots:
TBD


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-duplicates&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-duplicates&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/bt-duplicates&lookback=7)