### PR TITLE
feat(suite-native): instruct users to unpair Trezor also from OS settings

### DIFF
--- a/suite-native/bluetooth/src/__tests__/selectors.test.ts
+++ b/suite-native/bluetooth/src/__tests__/selectors.test.ts
@@ -13,6 +13,7 @@ import { BluetoothDevice } from '../types';
 const initialState: NativeBluetoothState = {
     ...prepareInitialState<BluetoothDevice>(),
     permissionStatus: 'granted',
+    shouldShowSystemUnpairingAlert: false,
 };
 
 const unknownDevice: BluetoothDevice = {

--- a/suite-native/bluetooth/src/bluetoothSlice.ts
+++ b/suite-native/bluetooth/src/bluetoothSlice.ts
@@ -13,6 +13,7 @@ import { BluetoothDevice, BluetoothPermissionStatus } from './types';
 
 export type NativeBluetoothState = BluetoothState<BluetoothDevice> & {
     permissionStatus: BluetoothPermissionStatus;
+    shouldShowSystemUnpairingAlert: boolean;
 };
 
 export type NativeBluetoothRootState = {
@@ -24,6 +25,7 @@ export const bluetoothSlice = createSliceWithExtraDeps({
     initialState: {
         ...prepareInitialState<BluetoothDevice>(),
         permissionStatus: 'unavailable',
+        shouldShowSystemUnpairingAlert: false,
     },
     reducers: {
         updatePermissionStatus: (state, { payload }: PayloadAction<BluetoothPermissionStatus>) => {
@@ -32,6 +34,9 @@ export const bluetoothSlice = createSliceWithExtraDeps({
             if (state.permissionStatus !== 'blocked' || payload !== 'denied') {
                 state.permissionStatus = payload;
             }
+        },
+        setShouldShowSystemUnpairingAlert: (state, { payload }: PayloadAction<boolean>) => {
+            state.shouldShowSystemUnpairingAlert = payload;
         },
     },
     extraReducers: (builder, extra) => {
@@ -49,4 +54,4 @@ export const bluetoothSlice = createSliceWithExtraDeps({
     },
 });
 
-export const { updatePermissionStatus } = bluetoothSlice.actions;
+export const { updatePermissionStatus, setShouldShowSystemUnpairingAlert } = bluetoothSlice.actions;

--- a/suite-native/bluetooth/src/hooks/useBluetoothAlerts.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothAlerts.ts
@@ -1,12 +1,13 @@
 import { useCallback, useState } from 'react';
 import { openSettings } from 'react-native-permissions';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
 import { useAlert } from '@suite-native/alerts';
 import { useTranslate } from '@suite-native/intl';
 
+import { setShouldShowSystemUnpairingAlert } from '../bluetoothSlice';
 import { selectBluetoothAdapterStatus, selectBluetoothPermissionStatus } from '../selectors';
 import { useBluetoothPermissions } from './useBluetoothPermissions';
 import { useBluetoothSettings } from './useBluetoothSettings';
@@ -15,6 +16,7 @@ export const useBluetoothAlerts = () => {
     const { showAlert, hideAlert } = useAlert();
     const { translate } = useTranslate();
     const navigation = useNavigation();
+    const dispatch = useDispatch();
 
     const { requestBluetoothPermission } = useBluetoothPermissions();
     const { openBluetoothSettings } = useBluetoothSettings();
@@ -83,8 +85,25 @@ export const useBluetoothAlerts = () => {
         });
     }, [showAlert, openBluetoothSettings, translate]);
 
+    const showSystemUnpairingAlert = useCallback(() => {
+        showAlert({
+            title: translate('bluetooth.alerts.systemUnpairing.title'),
+            description: translate('bluetooth.alerts.systemUnpairing.description'),
+            primaryButtonTitle: translate('bluetooth.alerts.systemUnpairing.primaryButton'),
+            onPressPrimaryButton: () => {
+                dispatch(setShouldShowSystemUnpairingAlert(false));
+                openBluetoothSettings();
+            },
+            secondaryButtonTitle: translate('bluetooth.alerts.systemUnpairing.secondaryButton'),
+            onPressSecondaryButton: () => {
+                dispatch(setShouldShowSystemUnpairingAlert(false));
+            },
+        });
+    }, [showAlert, dispatch, openBluetoothSettings, translate]);
+
     return {
         showOrHideBluetoothAlert,
         showPairingFailedAlert,
+        showSystemUnpairingAlert,
     };
 };

--- a/suite-native/bluetooth/src/hooks/useBluetoothDevice.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothDevice.ts
@@ -7,6 +7,7 @@ import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import TrezorConnect from '@trezor/connect';
 import { bluetoothManager } from '@trezor/transport-native-bluetooth';
 
+import { setShouldShowSystemUnpairingAlert } from '../bluetoothSlice';
 import { BluetoothDevice } from '../types';
 
 type UnpairDeviceProps = {
@@ -49,6 +50,7 @@ export const useBluetoothDevice = () => {
             const { success, payload } = result.payload;
             if (success || payload.code === 'Device_Disconnected') {
                 dispatch(bluetoothActions.removeKnownDeviceAction({ id: deviceBluetoothId }));
+                dispatch(setShouldShowSystemUnpairingAlert(true));
                 onSuccess();
             } else if (payload.code === 'Failure_ActionCancelled') {
                 onCancel();

--- a/suite-native/bluetooth/src/index.ts
+++ b/suite-native/bluetooth/src/index.ts
@@ -2,6 +2,7 @@ export * from './types';
 export * from './bluetoothSlice';
 export * from './selectors';
 export * from './hooks/useBluetoothAdapter';
+export * from './hooks/useBluetoothAlerts';
 export * from './hooks/useBluetoothDevice';
 export * from './hooks/useBluetoothManager';
 export * from './hooks/useBluetoothPermissions';

--- a/suite-native/bluetooth/src/selectors.ts
+++ b/suite-native/bluetooth/src/selectors.ts
@@ -12,6 +12,9 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<NativeBluetoothRo
 export const selectBluetoothPermissionStatus = (state: NativeBluetoothRootState) =>
     state.bluetooth.permissionStatus;
 
+export const selectShouldShowSystemUnpairingAlert = (state: NativeBluetoothRootState) =>
+    state.bluetooth.shouldShowSystemUnpairingAlert;
+
 export const selectBluetoothAdapterStatus = (state: NativeBluetoothRootState) =>
     selectAdapterStatus(state);
 

--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -16,6 +16,7 @@ import {
 } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { EventType, analytics } from '@suite-native/analytics';
+import { selectShouldShowSystemUnpairingAlert } from '@suite-native/bluetooth';
 import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
 import { Translation } from '@suite-native/intl';
 import { SUITE_LITE_SUPPORT_URL, useOpenLink } from '@suite-native/link';
@@ -68,6 +69,7 @@ export const useDetectDeviceError = () => {
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
     const shouldShowAutoEjectAlert = useSelector(selectShouldShowAutoEjectAlert);
+    const shouldShowSystemUnpairingAlert = useSelector(selectShouldShowSystemUnpairingAlert);
 
     const isDeviceFirmwareSupported = useSelector(selectIsDeviceFirmwareSupported);
     const deviceError = useSelector(selectDeviceError);
@@ -288,8 +290,17 @@ export const useDetectDeviceError = () => {
         // Device with error can't be view-only.
         // Edge case: If user has connected two devices simultaneously,
         // it will not hide the alert.
-        if (isNoPhysicalDeviceConnected && !shouldShowAutoEjectAlert) {
+        if (
+            isNoPhysicalDeviceConnected &&
+            !shouldShowAutoEjectAlert &&
+            !shouldShowSystemUnpairingAlert
+        ) {
             hideAlert();
         }
-    }, [isNoPhysicalDeviceConnected, hideAlert, shouldShowAutoEjectAlert]);
+    }, [
+        isNoPhysicalDeviceConnected,
+        hideAlert,
+        shouldShowAutoEjectAlert,
+        shouldShowSystemUnpairingAlert,
+    ]);
 };

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -178,6 +178,13 @@ export const messages = {
                 primaryButton: 'Open system settings',
                 secondaryButton: 'Device removed',
             },
+            systemUnpairing: {
+                title: 'Remove Trezor from system settings',
+                description:
+                    'To unpair fully, make sure you remove your Trezor from your phone’s Bluetooth settings. If not, you might have trouble pairing it again in the future.',
+                primaryButton: 'Open system settings',
+                secondaryButton: 'Device removed',
+            },
         },
         deviceList: {
             connect: {
@@ -772,11 +779,11 @@ export const messages = {
         bluetooth: {
             title: 'Unpair Trezor',
             content: 'Unpair your Trezor from this device',
-            unpairTrezorButton: 'Unpair Trezor',
+            unpairTrezorButton: 'Unpair',
             info: {
                 title: 'Unpair Trezor',
                 description:
-                    'This will remove your Trezor from the list of paired devices in Trezor Suite. You should also remove your Trezor from your phone’s Bluetooth devices.',
+                    'This removes your Trezor from the list of paired devices in Trezor Suite.',
             },
             successMessage: 'Trezor has been unpaired.',
         },

--- a/suite-native/module-device-settings/src/components/DeviceBluetoothCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceBluetoothCard.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { useAlert } from '@suite-native/alerts';
 import { CompactCardWithIconLayout } from '@suite-native/atoms';
-import { useBluetoothDevice, useBluetoothSettings } from '@suite-native/bluetooth';
+import { useBluetoothDevice } from '@suite-native/bluetooth';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
@@ -22,7 +22,6 @@ export const DeviceBluetoothCard = () => {
     const navigation = useNavigation<NavigationProp>();
 
     const { unpairBluetoothDevice } = useBluetoothDevice();
-    const { openBluetoothSettings } = useBluetoothSettings();
 
     const unpairTrezor = async () => {
         navigation.navigate(DeviceSettingsStackRoutes.ContinueOnTrezor);
@@ -33,9 +32,8 @@ export const DeviceBluetoothCard = () => {
                     variant: 'success',
                     message: <Translation id="moduleDeviceSettings.bluetooth.successMessage" />,
                 });
-                openBluetoothSettings();
             },
-            onCancel: () => navigation.goBack(),
+            onCancel: navigation.goBack,
         });
     };
 

--- a/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
@@ -1,5 +1,7 @@
-import React, { useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { useSelector } from 'react-redux';
+
+import { useFocusEffect } from '@react-navigation/native';
 
 import {
     selectIsDeviceAuthorized,
@@ -7,6 +9,7 @@ import {
     selectIsDeviceUnlocked,
     selectIsDiscoveredDeviceAccountless,
 } from '@suite-common/wallet-core';
+import { selectShouldShowSystemUnpairingAlert, useBluetoothAlerts } from '@suite-native/bluetooth';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { Screen } from '@suite-native/navigation';
 
@@ -17,10 +20,13 @@ import { useHomeRefreshControl } from './useHomeRefreshControl';
 import { useShowAutoEjectAlert } from './useShowAutoEjectAlert';
 
 export const HomeScreen = () => {
+    const { showSystemUnpairingAlert } = useBluetoothAlerts();
+
     const isDiscoveredDeviceAccountless = useSelector(selectIsDiscoveredDeviceAccountless);
     const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
     const isDeviceUnlocked = useSelector(selectIsDeviceUnlocked);
     const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
+    const shouldShowSystemUnpairingAlert = useSelector(selectShouldShowSystemUnpairingAlert);
 
     const isEmptyHomeRendererShown =
         (isDiscoveredDeviceAccountless && // There has to be no accounts and discovery not active.
@@ -33,6 +39,14 @@ export const HomeScreen = () => {
         isDiscoveredDeviceAccountless,
         portfolioContentRef,
     });
+
+    useFocusEffect(
+        useCallback(() => {
+            if (shouldShowSystemUnpairingAlert) {
+                showSystemUnpairingAlert();
+            }
+        }, [shouldShowSystemUnpairingAlert, showSystemUnpairingAlert]),
+    );
 
     useShowAutoEjectAlert();
 

--- a/suite-native/module-home/src/screens/HomeScreen/useShowAutoEjectAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/useShowAutoEjectAlert.tsx
@@ -5,6 +5,7 @@ import { toggleAutoEjectThunk } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { EventType, SuiteNativeAnalyticsEvent, analytics } from '@suite-native/analytics';
 import { CenteredTitleHeader, VStack } from '@suite-native/atoms';
+import { selectShouldShowSystemUnpairingAlert } from '@suite-native/bluetooth';
 import { Translation } from '@suite-native/intl';
 import {
     selectHasAutoEjectAlertBeenDisplayed,
@@ -23,6 +24,7 @@ export const useShowAutoEjectAlert = () => {
     const { showToast } = useToast();
 
     const shouldShowAutoEjectAlert = useSelector(selectShouldShowAutoEjectAlert);
+    const shouldShowSystemUnpairingAlert = useSelector(selectShouldShowSystemUnpairingAlert);
     const hasAutoEjectAlertBeenDisplayed = useSelector(selectHasAutoEjectAlertBeenDisplayed);
 
     const reportAutoEjectToAnalytics = useCallback(
@@ -36,6 +38,10 @@ export const useShowAutoEjectAlert = () => {
     );
 
     useEffect(() => {
+        if (shouldShowSystemUnpairingAlert) {
+            // The alert regarding system unpairing has a higher priority.
+            return;
+        }
         if (!hasAutoEjectAlertBeenDisplayed && shouldShowAutoEjectAlert) {
             showAlert({
                 appendix: (
@@ -83,6 +89,7 @@ export const useShowAutoEjectAlert = () => {
         hideAlert,
         reportAutoEjectToAnalytics,
         shouldShowAutoEjectAlert,
+        shouldShowSystemUnpairingAlert,
         showAlert,
         showToast,
     ]);


### PR DESCRIPTION
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21407



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/bluetooth-unpairing-enhancements&lookback=7)