### PR TITLE
fix(suite-common): disable slip24 for dex txs

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
@@ -28,7 +28,7 @@ const formattedSendAmount = `${localizeNumber(sendAmount)} SOL`;
 const formattedReceiveAmount = `${localizeNumber(swapQuotesSolanaBTC[1].receiveStringAmount)} BTC`;
 const { sendAddress, receiveAddress } = swapTradeSolanaBTC;
 const formattedSendAddress = formatAddress(sendAddress);
-const toastText = `${formattedSendAmount} sent from Solana #1`;
+const toastText = `Swap transaction of ${formattedSendAmount} (Solana #1) to ${formattedReceiveAmount} (Bitcoin #1) was broadcasted`;
 
 test.describe('Trading - Swap coins', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
@@ -127,7 +127,7 @@ test.describe('Trading - Swap coins', { tag: ['@group=trading', '@webOnly'] }, (
             await page.clock.install();
             await devicePrompt.sendButton.click();
             await expect(tradingPage.transactionDetailStatus).toHaveText('Pending');
-            await expect(page.getByTestId('@toast/tx-sent')).toContainText(toastText);
+            await expect(page.getByTestId('@toast/tx-exchange')).toContainText(toastText);
         });
 
         await test.step('Verify button opens provider support page in new tab', async () => {

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -23,6 +23,7 @@ import {
     selectTradingExchangeAccountKey,
     selectTradingExchangeInfo,
     selectTradingExchangeReceiveAccountKey,
+    selectTradingIsSlip24Allowed,
     selectTradingTrades,
     selectTradingVerifiedAddress,
     tradingActions,
@@ -94,7 +95,6 @@ export const useTradingExchangeForm = ({
         isLoading,
     } = useSelector(selectTradingExchange);
     const verifiedAddress = useSelector(selectTradingVerifiedAddress);
-    const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const exchangeInfo = useSelector(selectTradingExchangeInfo);
     const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
     const { selectedFee, composed } = composedTransactionInfo;
@@ -138,6 +138,11 @@ export const useTradingExchangeForm = ({
         navigateToExchangeOffers,
         navigateToExchangeConfirm,
     } = useTradingNavigation(account);
+
+    const isDebug = useSelector(selectIsDebugModeActive);
+    const isSlip24Active = useSelector(state =>
+        selectTradingIsSlip24Allowed(state, account, isDebug),
+    );
 
     const { symbol } = account;
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
@@ -480,7 +485,7 @@ export const useTradingExchangeForm = ({
                     decimals,
                     shouldSendInSats,
                     // TODO: slip24 - exclude from debug mode
-                    isSlip24Active: isDebugModeActive,
+                    isSlip24Active,
                     nextStep,
                     processResponseData,
                     triggerAnalyticsTradeConfirmation,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -17,6 +17,7 @@ import {
     type TradingTransactionSell,
     getTradingQuotesByPaymentMethod,
     selectTradingComposedTransactionInfo,
+    selectTradingIsSlip24Allowed,
     selectTradingPaymentMethods,
     selectTradingSell,
     selectTradingTrades,
@@ -83,7 +84,6 @@ export const useTradingSellForm = ({
         sellInfo,
         amountLimits,
     } = useSelector(selectTradingSell);
-    const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const paymentMethods = useSelector(selectTradingPaymentMethods);
 
     const isPreviousRouteFromTradeSection = useTradingPreviousRoute(type);
@@ -111,6 +111,11 @@ export const useTradingSellForm = ({
 
     const { navigateToSellForm, navigateToSellOffers, navigateToSellConfirm } =
         useTradingNavigation(account);
+
+    const isDebug = useSelector(selectIsDebugModeActive);
+    const isSlip24Active = useSelector(state =>
+        selectTradingIsSlip24Allowed(state, account, isDebug),
+    );
 
     const { symbol } = account;
     const baseCurrencyCode = useSelector(selectBaseCurrency);
@@ -473,7 +478,7 @@ export const useTradingSellForm = ({
                     decimals,
                     formValues: values as TradingSellFormProps,
                     // TODO: slip24 - exclude from debug mode
-                    isSlip24Active: isDebugModeActive,
+                    isSlip24Active,
                     nextStep,
                     signAndPushSendFormTransaction,
                 }),

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -42,7 +42,6 @@ export const sendDexTransactionThunk = createThunk<
             account,
             returnUrl,
             setMaxOutputId,
-            isSlip24Active,
             nextStep,
             processResponseData,
             triggerAnalyticsTradeConfirmation,
@@ -71,7 +70,7 @@ export const sendDexTransactionThunk = createThunk<
             activeSection: 'exchange',
             providers,
             trade: selectedQuote,
-            isSlip24Active,
+            isSlip24Active: false,
             sendAccountKey: account.key,
             receiveAccountKey,
         });

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -385,8 +385,7 @@ export const getTradingFormState = ({
                 !trade.receiveStringAmount ||
                 !trade.send ||
                 !trade.sendStringAmount ||
-                !provider?.companyName ||
-                !isSlip24Active
+                !provider?.companyName
             ) {
                 return defaultState;
             }


### PR DESCRIPTION
## Description

[This PR](https://github.com/trezor/trezor-suite/pull/20922) broke slip24 functionality and enabled it in e2e tests which caused tests to fail. Also, slip24 should not be enabled for DEX transactions.

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/slip-24-dex-fix&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/slip-24-dex-fix&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/slip-24-dex-fix&lookback=7)