### PR TITLE
chore(suite): hide MEV settings when no supported coins are enabled

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -2,7 +2,7 @@ import { Context } from '@suite-common/message-system';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
     selectEnabledNetworks,
-    selectIsMevProtectionFeatureEnabled,
+    selectIsMevProtectionSettingsVisible,
 } from '@suite-common/wallet-core';
 import { isDesktop, isLinux, isWeb } from '@trezor/env-utils';
 
@@ -68,7 +68,7 @@ export const SettingsGeneral = () => {
 
     const isMetadataEnabled = metadata.enabled && !metadata.initiating;
     const isProviderConnected = useSelector(selectSelectedProviderForLabels);
-    const isMevProtectionFeatureEnabled = useSelector(selectIsMevProtectionFeatureEnabled);
+    const isMevProtectionSettingsVisible = useSelector(selectIsMevProtectionSettingsVisible);
 
     return (
         <SettingsLayout data-testid="@settings/index">
@@ -120,7 +120,7 @@ export const SettingsGeneral = () => {
                 {isDesktop() && !isLinux() && <BioAuthSettings />}
             </SettingsSection>
 
-            {isMevProtectionFeatureEnabled && (
+            {isMevProtectionSettingsVisible && (
                 <SettingsSection title={<Translation id="TR_SECURITY" />} icon="shield">
                     <MevProtection />
                 </SettingsSection>

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -3,8 +3,17 @@ import {
     Feature,
     MessageSystemRootState,
 } from '@suite-common/message-system/src/messageSystemTypes';
-import { createReducerWithExtraDeps, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
-import { NetworkSymbol, getNetwork, networkSymbolCollection } from '@suite-common/wallet-config';
+import {
+    createReducerWithExtraDeps,
+    createWeakMapSelector,
+    returnStableArrayIfEmpty,
+} from '@suite-common/redux-utils';
+import {
+    NetworkSymbol,
+    getNetwork,
+    networkSymbolCollection,
+    networksCollection,
+} from '@suite-common/wallet-config';
 import type { WalletSettings } from '@suite-common/wallet-types';
 import { isBaseCurrencyWithSats } from '@suite-common/wallet-utils';
 import { PROTO } from '@trezor/connect';
@@ -20,6 +29,10 @@ export type WalletSettingsRootState = {
         settings: State;
     };
 };
+
+export const createMemoizedSelector = createWeakMapSelector.withTypes<
+    WalletSettingsRootState & MessageSystemRootState
+>();
 
 const initialState: State = {
     localCurrency: 'usd',
@@ -138,3 +151,16 @@ export const selectIsMevProtectionEnabled = (state: WalletSettingsRootState) =>
 
 export const selectIsMevProtectionFeatureEnabled = (state: MessageSystemRootState) =>
     selectIsFeatureEnabled(state, Feature.mevProtection, true);
+
+const MEV_PROTECTION_SUPPORTED_NETWORK_SYMBOLS = networksCollection
+    .filter(network => network.features.includes('mev-protection'))
+    .map(network => network.symbol);
+
+export const selectIsMevProtectionSettingsVisible = createMemoizedSelector(
+    [selectIsMevProtectionFeatureEnabled, selectEnabledNetworks],
+    (isFeatureEnabled, enabledNetworks) =>
+        isFeatureEnabled &&
+        enabledNetworks.some(enabledNetwork =>
+            MEV_PROTECTION_SUPPORTED_NETWORK_SYMBOLS.includes(enabledNetwork),
+        ),
+);

--- a/suite-native/module-settings/src/screens/SettingsDeviceChecksScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsDeviceChecksScreen.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { selectIsMevProtectionFeatureEnabled } from '@suite-common/wallet-core';
+import { selectIsMevProtectionSettingsVisible } from '@suite-common/wallet-core';
 import { Text, VStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
@@ -11,7 +11,7 @@ import { TurnOffFirmwareAuthenticityCheckCard } from '../components/TurnOffFirmw
 import { TurnOffMevProtectionCard } from '../components/TurnOffMevProtectionCard';
 
 export const SettingsDeviceChecksScreen = () => {
-    const isMevProtectionFeatureEnabled = useSelector(selectIsMevProtectionFeatureEnabled);
+    const isMevProtectionSettingsVisible = useSelector(selectIsMevProtectionSettingsVisible);
 
     return (
         <Screen
@@ -28,7 +28,7 @@ export const SettingsDeviceChecksScreen = () => {
                 </VStack>
                 <TurnOffFirmwareAuthenticityCheckCard />
                 <TurnOffDeviceAuthenticityCheckCard />
-                {isMevProtectionFeatureEnabled && <TurnOffMevProtectionCard />}
+                {isMevProtectionSettingsVisible && <TurnOffMevProtectionCard />}
             </VStack>
         </Screen>
     );


### PR DESCRIPTION
## Description

Don't show MEV protection settings when no supported network is enabled.

## Related Issue

Resolve #21475 


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/show-hide-mev&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/show-hide-mev&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/show-hide-mev&lookback=7)