### PR TITLE
feat(suite): Add labeling to receive modal

### DIFF
--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -17,7 +17,7 @@ import {
 } from 'src/reducers/suite/metadataReducer';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
 
-import { ExtendedProps, Props } from './definitions';
+import { LabelContentProps, LabelingVariant, MetadataProps, PrimitiveProps } from './definitions';
 import { withDropdown } from './withDropdown';
 import { withEditable } from './withEditable';
 import { useLabelingCombined } from '../../../../hooks/suite/useLabelingCombined';
@@ -130,10 +130,11 @@ const ButtonLikeLabel = ({
     payload,
     defaultEditableValue,
     defaultVisibleValue,
+    onClick,
     onSubmit,
     onBlur,
     'data-testid': dataTest,
-}: ExtendedProps) => {
+}: PrimitiveProps) => {
     const EditableButton = useMemo(() => withEditable(RelativeButton), []);
 
     if (editActive) {
@@ -153,7 +154,13 @@ const ButtonLikeLabel = ({
 
     if (payload.value) {
         return (
-            <LabelButton variant="tertiary" icon="tag" data-testid={dataTest} size="tiny">
+            <LabelButton
+                variant="tertiary"
+                icon="tag"
+                data-testid={dataTest}
+                size="tiny"
+                onClick={onClick}
+            >
                 <Inline>
                     <LabelValue>{payload.value} </LabelValue>
                     {/* This is the defaultVisibleValue which shows up after you hover over the label name: */}
@@ -180,7 +187,7 @@ const TextLikeLabel = ({
     onSubmit,
     onBlur,
     updateFlag,
-}: ExtendedProps) => {
+}: PrimitiveProps) => {
     const EditableLabel = useMemo(() => withEditable(RelativeLabel), []);
 
     const isAccountLabel = payload.type === 'accountLabel';
@@ -267,6 +274,81 @@ const getLocalizedActions = (type: MetadataAddPayload['type']) => {
     }
 };
 
+const LabelContent = ({
+    variant,
+    editActive,
+    onClick,
+    onSubmit,
+    onBlur,
+    accountType,
+    'data-testid': dataTestBase,
+    payload,
+    networkType,
+    path,
+    defaultEditableValue,
+    defaultVisibleValue,
+    updateFlag,
+    dropdownOptions,
+    deviceStaticSessionId,
+}: LabelContentProps) => {
+    const ButtonLikeLabelWithDropdown = useMemo(() => {
+        if (payload.value && !editActive) {
+            return withDropdown(ButtonLikeLabel);
+        }
+
+        return ButtonLikeLabel;
+    }, [payload.value, editActive]);
+
+    if (variant === 'button' && dropdownOptions) {
+        return (
+            <ButtonLikeLabelWithDropdown
+                editActive={editActive}
+                onSubmit={onSubmit}
+                onBlur={onBlur}
+                data-testid={dataTestBase}
+                payload={payload}
+                defaultEditableValue={defaultEditableValue}
+                defaultVisibleValue={defaultVisibleValue}
+                dropdownOptions={dropdownOptions}
+                deviceStaticSessionId={deviceStaticSessionId}
+            />
+        );
+    } else if (variant === 'button') {
+        return (
+            <ButtonLikeLabel
+                onClick={onClick}
+                editActive={editActive}
+                onSubmit={onSubmit}
+                onBlur={onBlur}
+                data-testid={dataTestBase}
+                payload={payload}
+                defaultEditableValue={defaultEditableValue}
+                defaultVisibleValue={defaultVisibleValue}
+                deviceStaticSessionId={deviceStaticSessionId}
+            />
+        );
+    } else {
+        return (
+            <TextLikeLabel
+                editActive={editActive}
+                accountType={accountType}
+                onSubmit={onSubmit}
+                onBlur={onBlur}
+                data-testid={dataTestBase}
+                payload={payload}
+                networkType={networkType}
+                path={path}
+                defaultEditableValue={defaultEditableValue}
+                defaultVisibleValue={defaultVisibleValue}
+                updateFlag={updateFlag}
+                deviceStaticSessionId={deviceStaticSessionId}
+            />
+        );
+    }
+};
+
+const showEditOption = (variant: LabelingVariant) => variant === 'text';
+
 /**
  * User defined labeling component.
  * - This component shows defaultVisibleValue and "Add label" button if no metadata is present.
@@ -274,6 +356,7 @@ const getLocalizedActions = (type: MetadataAddPayload['type']) => {
  */
 export const MetadataLabeling = ({
     payload,
+    variant,
     accountType,
     networkType,
     path,
@@ -285,7 +368,7 @@ export const MetadataLabeling = ({
     visible,
     updateFlag,
     deviceStaticSessionId,
-}: Props) => {
+}: MetadataProps) => {
     const dispatch = useDispatch();
     const { isDiscoveryRunning } = useDiscovery();
     const [showSuccess, setShowSuccess] = useState(false);
@@ -392,14 +475,6 @@ export const MetadataLabeling = ({
         }
     };
 
-    const ButtonLikeLabelWithDropdown = useMemo(() => {
-        if (payload.value && !editActive) {
-            return withDropdown(ButtonLikeLabel);
-        }
-
-        return ButtonLikeLabel;
-    }, [payload.value, editActive]);
-
     const labelContainerDataTest = `${dataTestBase}/hover-container`;
 
     const isEvoluLabeling =
@@ -425,12 +500,7 @@ export const MetadataLabeling = ({
             </LabelContainer>
         );
 
-    // should "add label"/"edit label" button for output label be visible
-    // special case here. It should not be visible if metadata label already exists (payload.value) because
-    // this type of labels has dropdown menu instead of "add/edit label button".
-    // but we still want to show pending and success status after editing the label.
-    const showOutputLabelActionButton =
-        showActionButton && (!payload.value || (payload.value && pending));
+    const showEdit = showEditOption(variant);
 
     return (
         <Tooltip
@@ -447,79 +517,43 @@ export const MetadataLabeling = ({
                 data-testid={labelContainerDataTest}
                 onClick={e => payload.value && !editActive && e.stopPropagation()}
             >
-                {payload.type === 'outputLabel' ? (
-                    <>
-                        <ButtonLikeLabelWithDropdown
-                            editActive={editActive}
-                            onSubmit={onSubmit || defaultOnSubmit}
-                            onBlur={handleBlur}
-                            data-testid={dataTestBase}
-                            payload={payload}
-                            defaultEditableValue={defaultEditableValue}
-                            defaultVisibleValue={defaultVisibleValue}
-                            dropdownOptions={dropdownItems}
-                            deviceStaticSessionId={deviceStaticSessionId}
-                        />
-                        {showOutputLabelActionButton && (
-                            <ActionButton
-                                data-testid={`${dataTestBase}/add-label-button`}
-                                variant="tertiary"
-                                icon={!actionButtonsDisabled ? 'tag' : undefined}
-                                isLoading={actionButtonsDisabled}
-                                isDisabled={actionButtonsDisabled}
-                                $isVisible={isVisible}
-                                size="tiny"
-                                onClick={e => {
-                                    e.stopPropagation();
-                                    // By clicking on add label button, metadata.editing field is set
-                                    // to default value of whatever may be labeled (address, etc..)
-                                    // this way we ensure that only one field may be active at time.
-                                    activateEdit();
-                                }}
-                            >
-                                {l10nLabelling.add}
-                            </ActionButton>
-                        )}
-                    </>
-                ) : (
-                    <>
-                        <TextLikeLabel
-                            editActive={editActive}
-                            accountType={accountType}
-                            onSubmit={onSubmit || defaultOnSubmit}
-                            onBlur={handleBlur}
-                            data-testid={dataTestBase}
-                            payload={payload}
-                            networkType={networkType}
-                            path={path}
-                            defaultEditableValue={defaultEditableValue}
-                            defaultVisibleValue={defaultVisibleValue}
-                            updateFlag={updateFlag}
-                            deviceStaticSessionId={deviceStaticSessionId}
-                        />
-
-                        {showActionButton && (
-                            <ActionButton
-                                data-testid={
-                                    payload.value
-                                        ? `${dataTestBase}/edit-label-button`
-                                        : `${dataTestBase}/add-label-button`
-                                }
-                                variant="tertiary"
-                                icon={!actionButtonsDisabled ? 'tag' : undefined}
-                                isLoading={actionButtonsDisabled}
-                                isDisabled={actionButtonsDisabled}
-                                $isVisible={isVisible}
-                                size="tiny"
-                                onClick={e => {
-                                    e.stopPropagation();
-                                    activateEdit();
-                                }}
-                            >
-                                {payload.value ? l10nLabelling.edit : l10nLabelling.add}
-                            </ActionButton>
-                        )}
-                    </>
+                <LabelContent
+                    variant={variant}
+                    editActive={editActive}
+                    accountType={accountType}
+                    onClick={() => activateEdit()}
+                    onSubmit={onSubmit || defaultOnSubmit}
+                    onBlur={handleBlur}
+                    data-testid={dataTestBase}
+                    payload={payload}
+                    networkType={networkType}
+                    path={path}
+                    defaultEditableValue={defaultEditableValue}
+                    defaultVisibleValue={defaultVisibleValue}
+                    updateFlag={updateFlag}
+                    dropdownOptions={dropdownItems}
+                    deviceStaticSessionId={deviceStaticSessionId}
+                />
+                {showActionButton && (showEdit || !payload.value || (payload.value && pending)) && (
+                    <ActionButton
+                        data-testid={
+                            payload.value && showEdit
+                                ? `${dataTestBase}/edit-label-button`
+                                : `${dataTestBase}/add-label-button`
+                        }
+                        variant="tertiary"
+                        icon={!actionButtonsDisabled ? 'tag' : undefined}
+                        isLoading={actionButtonsDisabled}
+                        isDisabled={actionButtonsDisabled}
+                        $isVisible={isVisible}
+                        size="tiny"
+                        onClick={e => {
+                            e.stopPropagation();
+                            activateEdit();
+                        }}
+                    >
+                        {payload.value && showEdit ? l10nLabelling.edit : l10nLabelling.add}
+                    </ActionButton>
                 )}
 
                 {showSuccess && !editActive && (

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
@@ -6,7 +6,9 @@ import type { StaticSessionId } from '@trezor/connect';
 
 import { MetadataAddPayload } from 'src/types/suite/metadata';
 
-export interface Props {
+export type LabelingVariant = 'button' | 'text';
+
+interface BaseProps {
     accountType?: AccountType;
     networkType?: NetworkType;
     path?: Bip43Path;
@@ -24,9 +26,18 @@ export interface Props {
     deviceStaticSessionId: StaticSessionId;
 }
 
-export interface ExtendedProps extends Props {
+export interface MetadataProps extends BaseProps {
+    variant: LabelingVariant;
+}
+
+export interface PrimitiveProps extends BaseProps {
     editActive: boolean;
     onSubmit: (value: string | undefined) => void;
+    onClick?: () => void | undefined;
     onBlur: () => void;
     'data-testid': string;
+}
+
+export interface LabelContentProps extends PrimitiveProps {
+    variant: LabelingVariant;
 }

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/withDropdown.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/withDropdown.tsx
@@ -3,15 +3,15 @@ import { FC, useRef } from 'react';
 import { Menu, Popover, PopoverRef } from '@trezor/components';
 import { RequiredKey } from '@trezor/type-utils';
 
-import { ExtendedProps } from './definitions';
+import { PrimitiveProps } from './definitions';
 
-type Props = RequiredKey<ExtendedProps, 'dropdownOptions'>;
+type Props = RequiredKey<PrimitiveProps, 'dropdownOptions'>;
 
 /**
  * Returns component wrapped into Dropdown.
  * ONLY for the MetadataLabeling component.
  */
-export const withDropdown = (WrappedComponent: FC<ExtendedProps>) => (props: Props) => {
+export const withDropdown = (WrappedComponent: FC<PrimitiveProps>) => (props: Props) => {
     const popoverRef = useRef<PopoverRef>(null);
 
     return (

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
@@ -131,6 +131,7 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
             <div>
                 <AccountHeading $isBalanceShown={isBalanceShown}>
                     <MetadataLabeling
+                        variant="text"
                         accountType={accountType}
                         networkType={selectedAccount.networkType}
                         path={path}

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect, useState } from 'react';
 
+import { selectAddressLabels } from '@suite-common/local-first-storage';
 import { getDeviceInternalModel } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
@@ -28,7 +29,7 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { MODAL } from 'src/actions/suite/constants';
-import { AccountLabel, Address, Translation } from 'src/components/suite';
+import { AccountLabel, Address, MetadataLabeling, Translation } from 'src/components/suite';
 import { QrCode } from 'src/components/suite/QrCode';
 import { useGuideOpenNode } from 'src/hooks/guide';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -70,6 +71,11 @@ export const ConfirmValueModal = ({
     const { accountLabel } = useSelector(selectLabelingDataForSelectedAccount);
     const dispatch = useDispatch();
     const { openNodeById } = useGuideOpenNode();
+
+    const { addressLabels } = useSelector(selectLabelingDataForSelectedAccount);
+    const localFirstAddressLabels = useSelector(state =>
+        selectAddressLabels({ state, deviceStaticSessionId: account!.deviceState }),
+    );
 
     const canConfirmOnDevice = !!(device?.connected && device?.available);
     const isCancelable = isActionAbortable || isConfirmed;
@@ -176,7 +182,7 @@ export const ConfirmValueModal = ({
                             alignItems="stretch"
                             data-testid="@modal/output-address"
                         >
-                            <Box aspectRatio="1" flex="1 0 auto" minWidth={120}>
+                            <Box aspectRatio="1" width={180} height={180}>
                                 <QrCode value={value} />
                             </Box>
                             <Column gap={spacings.lg}>
@@ -185,6 +191,19 @@ export const ConfirmValueModal = ({
                                 ) : (
                                     outputValue
                                 )}
+                                <MetadataLabeling
+                                    variant="button"
+                                    deviceStaticSessionId={account!.deviceState}
+                                    payload={{
+                                        type: 'addressLabel',
+                                        entityKey: value,
+                                        defaultValue: value,
+                                        value:
+                                            localFirstAddressLabels.find(it => it.address === value)
+                                                ?.label ?? addressLabels[value],
+                                    }}
+                                    visible
+                                />
                                 {isCopyButtonVisible && (
                                     <Button
                                         onClick={copy}

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -207,6 +207,7 @@ export const TransactionTarget = ({
             useHiddenPlaceholder={!isBeingEdited}
             addressLabel={
                 <MetadataLabeling
+                    variant="button"
                     deviceStaticSessionId={transaction.deviceState}
                     isDisabled={isActionDisabled}
                     defaultVisibleValue={label}

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -162,6 +162,7 @@ export const WalletInstance = ({
                                     {instance.state?.staticSessionId ? (
                                         <Column>
                                             <MetadataLabeling
+                                                variant="text"
                                                 deviceStaticSessionId={
                                                     instance.state.staticSessionId
                                                 }

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -56,6 +56,7 @@ const Item = ({ account, addr, locked, symbol, onClick, metadataPayload, index }
             <Table.Cell>
                 <Text typographyStyle="hint" data-testid={`@wallet/receive/used-address/${index}`}>
                     <MetadataLabeling
+                        variant="text"
                         deviceStaticSessionId={account.deviceState}
                         payload={{
                             ...metadataPayload,

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -267,6 +267,7 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                     )}
                     <Text typographyStyle="hint">
                         <MetadataLabeling
+                            variant="text"
                             deviceStaticSessionId={account.deviceState}
                             payload={{
                                 type: 'addressLabel',
@@ -310,6 +311,7 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                         <LabelPart>
                             <span>•</span>
                             <MetadataLabeling
+                                variant="button"
                                 deviceStaticSessionId={account.deviceState}
                                 visible
                                 payload={{

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -456,6 +456,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                 metadataEnabled && broadcastEnabled ? (
                     <Box maxWidth={200}>
                         <MetadataLabeling
+                            variant="button"
                             deviceStaticSessionId={device.state.staticSessionId}
                             defaultVisibleValue=""
                             payload={{


### PR DESCRIPTION
Added a third style how to display labels that displays labels **in addition** to the labeled thing. This is then used for labeling the receive address.

Also don't show dropdown menu if there is only edit option

## Related Issue

Resolve #21426

## Screenshots:
<img width="806" height="967" alt="image" src="https://github.com/user-attachments/assets/547f55b6-60fd-4a7e-93a6-513d1d1e4015" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/add-receive-labeling&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/add-receive-labeling&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/add-receive-labeling&lookback=7)