### PR TITLE
fix(e2e-suite): fix bakcup-fail verification and stabilize eth fee tests

### DIFF
--- a/packages/components/src/components/form/SelectBar/SelectBar.tsx
+++ b/packages/components/src/components/form/SelectBar/SelectBar.tsx
@@ -214,6 +214,7 @@ export const SelectBar = <V extends ValueTypes>({
                                         onClick={handleOptionClick(option)}
                                         $isDisabled={!!isDisabled}
                                         $isSelected={isSelected}
+                                        data-isdisabled={!!isDisabled}
                                         data-testid={`select-bar/${String(option.value)}`}
                                     >
                                         <Column

--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -210,3 +210,15 @@ export const analyzeObject = (obj: any): any => {
 
     return obj;
 };
+
+export const sanitizeAndStringifyLogFields = (fields: Record<string, unknown>) =>
+    JSON.stringify(
+        Object.fromEntries(
+            Object.entries(fields).map(([key, value]) => [
+                key,
+                typeof value === 'undefined' ? 'warning: undefined' : value,
+            ]),
+        ),
+        null,
+        2,
+    );

--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/fees.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/fees.ts
@@ -50,7 +50,7 @@ export class Fees {
             isSolanaResponse(response, 'simulateTransaction'),
         );
 
-        // Suite calls the each request twice and we have to wait for all of them
+        // Suite calls each request twice and we have to wait for all of them
         return Promise.all([
             getFeeForMessagePromise,
             getRecentPrioritizationFeesPromise,
@@ -162,5 +162,23 @@ before rounding: ${maxFeeInEthereum} ETH, after rounding: ${maxFeeRounded} ETH`;
         await TrezorUserEnvLinkProxy.clickEmu(burgerMenuCoordinates);
         const feeInfoCoordinates = { x: 125, y: 100 };
         await TrezorUserEnvLinkProxy.clickEmu(feeInfoCoordinates);
+    }
+
+    @step()
+    async switchToCustom() {
+        await expect(this.switchModeButton('custom')).toHaveAttribute('data-isdisabled', 'false');
+        await this.switchModeButton('custom').click();
+    }
+
+    @step()
+    async setEthereumCustomFees(input: {
+        gasLimit: string;
+        maxFeePerGas: string;
+        maxPriorityFeePerGas: string;
+    }) {
+        await this.switchToCustom();
+        await this.ethereumFeeLimit.fill(input.gasLimit);
+        await this.ethereumMaxFeePerGas.fill(input.maxFeePerGas);
+        await this.ethereumMaxPriorityFeePerGas.fill(input.maxPriorityFeePerGas);
     }
 }

--- a/packages/suite-desktop-core/e2e/tests/backup/t2t1-fail.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/backup/t2t1-fail.test.ts
@@ -1,3 +1,5 @@
+import { escapeRegExp } from 'lodash';
+
 import messages from '@trezor/suite/src/support/messages';
 import { EventType } from '@trezor/suite-analytics';
 import { HELP_CENTER_RECOVERY_ISSUES_URL } from '@trezor/urls';
@@ -59,9 +61,12 @@ test.describe('Backup fail', { tag: ['@group=device-management', '@specificModel
             await expect(onboardingPage.backup.failedBackupSetting).toContainText(
                 messages['TR_BACKUP_RECOVERY_SEED_FAILED_DESC'].defaultMessage,
             );
+            // removes URL query params .../recovery-issues?utm_medium=desktop|web|???
+            const urlBase = HELP_CENTER_RECOVERY_ISSUES_URL.split('?')[0];
+            const urlBaseRegexp = new RegExp(escapeRegExp(urlBase));
             await expect(onboardingPage.backup.backupFailedSettingLink).toHaveAttribute(
                 'href',
-                HELP_CENTER_RECOVERY_ISSUES_URL,
+                urlBaseRegexp,
             );
             await expect(onboardingPage.backup.backupFailedSettingButton).toBeDisabled();
         });

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
@@ -115,7 +115,7 @@ test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () 
             {
                 feeType: 'custom',
                 feeSwitchFunction: async () => {
-                    await tradingPage.fees.switchModeButton('custom').click();
+                    await tradingPage.fees.switchToCustom();
                     await tradingPage.fees.customInput.fill('10');
                 },
             },

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
@@ -67,10 +67,11 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
 
     test('Sell Ethereum', async ({ tradingPage, devicePrompt }) => {
         await test.step('Fill in a sell request', async () => {
-            await tradingPage.fees.switchModeButton('custom').click();
-            await tradingPage.fees.ethereumFeeLimit.fill(gasLimit);
-            await tradingPage.fees.ethereumMaxFeePerGas.fill(maxFeePerGas);
-            await tradingPage.fees.ethereumMaxPriorityFeePerGas.fill(maxPriorityFeePerGas);
+            await tradingPage.fees.setEthereumCustomFees({
+                gasLimit,
+                maxFeePerGas,
+                maxPriorityFeePerGas,
+            });
             await tradingPage.fillSellForm(cryptoAmount, 'ethereum');
             await expect(tradingPage.bestOfferAmount).toHaveText(fiatAmount);
             await expect(tradingPage.quoteProvider).toHaveText(capitalizeFirstLetter(provider));

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
@@ -59,7 +59,7 @@ test.describe('Trading - Sell inputs', { tag: ['@group=trading', '@webOnly'] }, 
         });
 
         await test.step('Try all % inputs for Bitcoin', async () => {
-            await tradingPage.fees.switchModeButton('custom').click();
+            await tradingPage.fees.switchToCustom();
             await tradingPage.fees.customInput.fill(customFeeRate.toString());
 
             for (const percentage of [10, 25, 50]) {

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-fees-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-fees-bitcoin.test.ts
@@ -27,7 +27,7 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@group=trading', '@webOnly
     test('Swap custom fees for Bitcoin', async ({ page, tradingPage, devicePrompt }) => {
         let feeRate: string;
         await test.step('Fill in a Swap form', async () => {
-            await tradingPage.fees.switchModeButton('custom').click();
+            await tradingPage.fees.switchToCustom();
             await tradingPage.fees.customInput.fill(customFee);
             await tradingPage.fillSwapForm({
                 amount: sendAmount,

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-fees-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-fees-ethereum.test.ts
@@ -37,10 +37,11 @@ test.describe('Trading - Swap fees', { tag: ['@group=trading', '@webOnly'] }, ()
 
     test('Swap custom fees for Ethereum', async ({ page, tradingPage, devicePrompt }) => {
         await test.step('Fill in a Swap form', async () => {
-            await tradingPage.fees.switchModeButton('custom').click();
-            await tradingPage.fees.ethereumFeeLimit.fill(gasLimit);
-            await tradingPage.fees.ethereumMaxFeePerGas.fill(maxFeePerGas);
-            await tradingPage.fees.ethereumMaxPriorityFeePerGas.fill(maxPriorityFeePerGas);
+            await tradingPage.fees.setEthereumCustomFees({
+                gasLimit,
+                maxFeePerGas,
+                maxPriorityFeePerGas,
+            });
             await tradingPage.fillSwapForm({
                 amount: sendAmount,
                 sendCurrency: 'ethereum',

--- a/packages/suite-desktop-core/e2e/tests/wallet/send-eth.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/send-eth.test.ts
@@ -47,10 +47,11 @@ test.describe('Send Eth', { tag: ['@group=wallet'] }, () => {
             await tradingPage.fees.expectEthereumFeeCalculated();
             await tradingPage.sendAddressInput.fill(sendAddress);
             await tradingPage.sendAmountInput.fill(sendAmount);
-            await tradingPage.fees.switchModeButton('custom').click();
-            await tradingPage.fees.ethereumFeeLimit.fill(gasLimit);
-            await tradingPage.fees.ethereumMaxFeePerGas.fill(maxFeePerGas);
-            await tradingPage.fees.ethereumMaxPriorityFeePerGas.fill(maxPriorityFeePerGas);
+            await tradingPage.fees.setEthereumCustomFees({
+                gasLimit,
+                maxFeePerGas,
+                maxPriorityFeePerGas,
+            });
         });
 
         const { ethereumMaximumFee, errorMessageMaxCalculation } =


### PR DESCRIPTION
backup-fail test had wrong link assert. The value is different on web and desktop -> Change to partial match

eth fee tests and other fee tests struggled with switching to custom fee. Test were able to click the button before suite was ready. I have added in product a new data-isdisabled attribute so tests are able to click only once it is ready.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-tests&lookback=7)