### PR TITLE
refactor(e2e-suite): Disable debug mode in tests after onboarding

### DIFF
--- a/packages/suite-desktop-core/e2e/support/electron.ts
+++ b/packages/suite-desktop-core/e2e/support/electron.ts
@@ -13,10 +13,12 @@ const disableFirmwareRevisionChecksPatch =
     '--state.suite.settings.enabledSecurityChecks.firmwareRevision=false';
 const showDebugMenuStatePatch = '--state.suite.settings.debug.showDebugMenu=true';
 const disableDisconnectPromptPatch = '--state.suite.flags.hasSeenDisconnectTooltip=true';
+const showConnectLogsArgument = '--state.suite.settings.debug.showConnectLogs=true';
 // #15670 Bug in desktop app that loglevel is ignored
 const logLevelArgument = `--log-level=${process.env.LOGLEVEL ?? 'debug'}`;
 const disableHWAccelerationArgument = '--disable-gpu'; // to fix chromium error GetVSyncParametersIfAvailable()
 const removeUserDataArgument = '--remove-user-data-on-start';
+const exposeStoreArgument = '--expose-store';
 
 export type LaunchSuiteParams = {
     keepUserData?: boolean;
@@ -46,6 +48,7 @@ const formatErrorLogMessage = (data: string) => {
 const buildArgs = (params: LaunchSuiteParams) => {
     const args = [
         path.join(appDir, './dist/app.js'),
+        exposeStoreArgument,
         `--width=${params.viewport.width}`,
         `--height=${params.viewport.height}`,
         logLevelArgument,
@@ -53,7 +56,7 @@ const buildArgs = (params: LaunchSuiteParams) => {
         disableHashChecksPatch,
         showDebugMenuStatePatch,
         disableDisconnectPromptPatch,
-        '--state.suite.settings.debug.showConnectLogs=true',
+        showConnectLogsArgument,
     ];
 
     if (params.bridgeDaemon) {

--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -93,7 +93,7 @@ export class OnboardingPage {
     }
 
     @step()
-    async completeOnboarding() {
+    async completeOnboarding(options?: { keepDebugModeEnabled?: boolean }) {
         await this.disableNecessaryFirmwareChecks();
         await this.disableDisconnectPrompt();
         await this.optionallyDismissFwHashCheckError();
@@ -101,6 +101,11 @@ export class OnboardingPage {
         await this.onboardingContinueButton.click();
         if (this.isModelWithSecureElement()) {
             await this.passThroughAuthenticityCheck();
+        }
+        // Enabled debug mode is needed for passing firmware checks but it also enables several hidden features
+        // that differs from production version, so we disable it again after onboarding is done
+        if (!options?.keepDebugModeEnabled) {
+            await this.disableDebugMode();
         }
         await this.page.discoveryShouldFinish();
     }
@@ -147,6 +152,17 @@ export class OnboardingPage {
             window.store.dispatch({
                 type: SuiteActions.SET_DEBUG_MODE,
                 payload: { showDebugMenu: true },
+            });
+        }, SuiteActions);
+    }
+
+    @step()
+    async disableDebugMode() {
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        await this.page.evaluate(SuiteActions => {
+            window.store.dispatch({
+                type: SuiteActions.SET_DEBUG_MODE,
+                payload: { showDebugMenu: false },
             });
         }, SuiteActions);
     }

--- a/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
@@ -9,7 +9,7 @@ test.describe(
     { tag: ['@group=settings', '@desktopOnly'] },
     () => {
         test.beforeEach(async ({ onboardingPage }) => {
-            await onboardingPage.completeOnboarding();
+            await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
         });
 
         test(

--- a/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
@@ -8,7 +8,7 @@ test.describe('Coin balance', { tag: ['@group=wallet'] }, () => {
     const address = 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v';
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
     test.beforeEach(async ({ onboardingPage }) => {
-        await onboardingPage.completeOnboarding();
+        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
     });
 
     test(

--- a/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
@@ -38,7 +38,7 @@ test.describe(
                 await page.waitForTimeout(5_000);
             });
 
-            await onboardingPage.completeOnboarding();
+            await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
             await settingsPage.changeNetworks({
                 enableNetworks: ['regtest'],
                 disableNetworks: ['btc'],

--- a/packages/suite-desktop-core/e2e/tests/wallet/send-form-regtest.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/send-form-regtest.test.ts
@@ -11,7 +11,7 @@ test.describe('Send form for bitcoin', { tag: ['@group=wallet'] }, () => {
     });
     test.beforeEach(
         async ({ onboardingPage, dashboardPage, settingsPage, walletPage, trezorUserEnvLink }) => {
-            await onboardingPage.completeOnboarding();
+            await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
 
             await settingsPage.navigateTo('coins');
             await settingsPage.coins.enableNetwork('regtest');

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -65,6 +65,7 @@ const createMainWindow = (winBounds: WinBounds, store: Store) => {
             webSecurity: !isDevEnv,
             allowRunningInsecureContent: isDevEnv,
             preload: path.join(__dirname, 'preload.js'),
+            additionalArguments: hasSwitch('expose-store') ? ['--expose-store'] : [],
         },
         icon: path.join(global.resourcesPath, 'images', 'icons', '512x512.png'),
         backgroundColor: colorVariants[darkTheme ? 'dark' : 'standard'].backgroundSurfaceElevation0,

--- a/packages/suite-desktop-core/src/libs/process-switches.ts
+++ b/packages/suite-desktop-core/src/libs/process-switches.ts
@@ -18,6 +18,7 @@ export type SuiteSwitch =
     | 'log-no-print'
     | 'remove-user-data-on-start'
     | 'expose-connect-ws'
+    | 'expose-store'
     | 'state'; // very special handling, see `./app-utils.ts`
 
 /**

--- a/packages/suite-desktop-core/src/preload.ts
+++ b/packages/suite-desktop-core/src/preload.ts
@@ -4,6 +4,7 @@ import { exposeIpcProxy } from '@trezor/ipc-proxy';
 import { getDesktopApi } from '@trezor/suite-desktop-api';
 
 import '@sentry/electron/preload'; // With this only IPCMode.Classic is ever taken into account
+import { hasSwitch } from './libs/process-switches';
 
 contextBridge.exposeInMainWorld(
     ...exposeIpcProxy(ipcRenderer, [
@@ -16,3 +17,6 @@ contextBridge.exposeInMainWorld(
 
 const desktopApi = getDesktopApi(ipcRenderer);
 contextBridge.exposeInMainWorld('desktopApi', desktopApi);
+contextBridge.exposeInMainWorld('desktopFlags', {
+    exposeStore: hasSwitch('expose-store'),
+});

--- a/packages/suite-desktop-ui/src/MainDesktop.tsx
+++ b/packages/suite-desktop-ui/src/MainDesktop.tsx
@@ -99,6 +99,11 @@ export const init = async (container: HTMLElement) => {
     const { statePatch } = await desktopApi.handshake();
     const store = initStore(preloadAction, statePatch);
 
+    // Expose Redux store for Playwright/e2e tests
+    if (typeof window !== 'undefined' && window.desktopFlags?.exposeStore) {
+        (window as any).store = store;
+    }
+
     // start logging to file if Debug menu is active
     if (
         preloadAction?.type === STORAGE.LOAD &&

--- a/packages/suite-desktop-ui/src/global.d.ts
+++ b/packages/suite-desktop-ui/src/global.d.ts
@@ -2,4 +2,5 @@ type TrezorConnectIpcChannel = (method: string, ...params: any[]) => Promise<any
 
 interface Window {
     TrezorConnectIpcChannel?: TrezorConnectIpcChannel; // Electron API
+    desktopFlags?: { exposeStore?: boolean };
 }


### PR DESCRIPTION
Disabling debug mode will bring our tests closer to production like state. There won't be any hidden or not-finished features.

I had to introduce redux store exposing in desktop tho. Alternative we could decouple debug mode and fw / authenticity checks. But I assume that would be more work.
Please let me know any idea how to improve my suggested implementation or whether this could introduce problems or risks. 

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-e2e-tests-without-debug&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-e2e-tests-without-debug&lookback=7)