### PR TITLE
fix(suite): do not show THP modals in onboarding

### DIFF
--- a/packages/suite/src/components/connection/ConnectionGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectionGlobalModal.tsx
@@ -13,7 +13,11 @@ import { ThpConnectionModal } from './thp/ThpConnectionModal';
 import { ThpPairingFailedModal } from './thp/ThpPairingFailedModal';
 import { ThpPairingPinEntryModal } from '../suite/modals/ReduxModal/DeviceContextModal/ThpPairingPinEntryModal';
 
-export const ConnectionGlobalModal = () => {
+type ConnectionGlobalModalProps = {
+    showThpModals?: boolean;
+};
+
+export const ConnectionGlobalModal = ({ showThpModals = true }: ConnectionGlobalModalProps) => {
     const dispatch = useDispatch();
     const isConnectDeviceModalOpen = useSelector(selectIsConnectionModalOpen);
     const device = useSelector(selectSelectedDevice);
@@ -24,7 +28,7 @@ export const ConnectionGlobalModal = () => {
     };
 
     // handle THP modals first if we have a device and thpStep
-    if (device !== undefined && thpStep !== null) {
+    if (device !== undefined && thpStep !== null && showThpModals) {
         switch (thpStep) {
             case 'BeforeConnectionInfo':
                 return null;

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -72,7 +72,7 @@ export const Onboarding = () => {
     return (
         <OnboardingLayout>
             {allowedModal && <ReduxModal {...allowedModal} />}
-            <ConnectionGlobalModal />
+            <ConnectionGlobalModal showThpModals={false} />
 
             <UnexpectedState>
                 <StepComponent />


### PR DESCRIPTION
Onboarding had a duplicated THP flow modals, this PR adds a prop to not have them duplicated.

**Changes**:
- added `showThpModals` prop tot `ConnectionGlobalModal`
  - passed false in onboarding flow

Resolve https://github.com/trezor/trezor-suite/issues/21379

## Screenshots:
**BEFORE:**
<img width="1124" height="682" alt="487835954-39ebfab7-e430-40f4-a620-7982c480e442" src="https://github.com/user-attachments/assets/001ce61b-be33-47c0-9d20-354d2ea80253" />

**AFTER:**
<img width="1117" height="1095" alt="Screenshot 2025-09-12 at 14 31 32" src="https://github.com/user-attachments/assets/7bace307-a2d4-4ef8-83bb-03da45c0ccd6" />
