### PR TITLE
fix(suite): do not show THP modals in onboarding

### DIFF
--- a/packages/suite/src/components/connection/ConnectionGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectionGlobalModal.tsx
@@ -13,7 +13,12 @@ import { ThpConnectionModal } from './thp/ThpConnectionModal';
 import { ThpPairingFailedModal } from './thp/ThpPairingFailedModal';
 import { ThpPairingPinEntryModal } from '../suite/modals/ReduxModal/DeviceContextModal/ThpPairingPinEntryModal';
 
-export const ConnectionGlobalModal = () => {
+type ConnectionGlobalModalProps = {
+    /** @deprecated Should be removed once we get rid of onboarding fullscreen app logic. */
+    showThpModals?: boolean;
+};
+
+export const ConnectionGlobalModal = ({ showThpModals = true }: ConnectionGlobalModalProps) => {
     const dispatch = useDispatch();
     const isConnectDeviceModalOpen = useSelector(selectIsConnectionModalOpen);
     const device = useSelector(selectSelectedDevice);
@@ -24,7 +29,7 @@ export const ConnectionGlobalModal = () => {
     };
 
     // handle THP modals first if we have a device and thpStep
-    if (device !== undefined && thpStep !== null) {
+    if (device !== undefined && thpStep !== null && showThpModals) {
         switch (thpStep) {
             case 'BeforeConnectionInfo':
                 return null;

--- a/packages/suite/src/components/onboarding/OnboardingLayout.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingLayout.tsx
@@ -184,7 +184,7 @@ export const OnboardingLayout = ({ children }: OnboardingLayoutProps) => {
 
     return (
         <>
-            <ConnectionGlobalModal />
+            <ConnectionGlobalModal showThpModals={false} />
             {allowedModal !== null ? <ReduxModal {...allowedModal} /> : null}
 
             <Wrapper>

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -1,10 +1,13 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
+import { selectThpStep } from '@suite-common/thp';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { exhaustive } from '@trezor/type-utils';
 
+import { goto } from 'src/actions/suite/routerActions';
 import { OnboardingLayout } from 'src/components/onboarding';
 import * as STEP from 'src/constants/onboarding/steps';
-import { useOnboarding } from 'src/hooks/suite';
+import { useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
 import { UnexpectedState } from 'src/views/onboarding/UnexpectedState';
 import { BackupStep } from 'src/views/onboarding/steps/Backup';
 import BasicSettingsStep from 'src/views/onboarding/steps/BasicSettings';
@@ -20,7 +23,19 @@ import { DeviceTutorial } from './steps/DeviceTutorial';
 import { DeviceAuthenticity } from './steps/SecurityCheck/DeviceAuthenticity';
 
 export const Onboarding = () => {
+    const dispatch = useDispatch();
+
     const { activeStepId, goToNextStep } = useOnboarding();
+    const device = useSelector(selectSelectedDevice);
+    const thpStep = useSelector(selectThpStep);
+
+    // This is a temporary hack until we refactor onboarding
+    // we cant include THP modals in the onboarding flow, so in a this specific edge we redirect user to the dashboard where onboarding starts over and picks up where it ended
+    useEffect(() => {
+        if (activeStepId !== STEP.ID_FIRMWARE_STEP && thpStep === 'ConfirmOnlyConnection') {
+            dispatch(goto('suite-index'));
+        }
+    }, [device, thpStep, activeStepId, dispatch]);
 
     const StepComponent = useMemo(() => {
         switch (activeStepId) {


### PR DESCRIPTION
Onboarding had a duplicated THP flow modals, this PR adds a prop to not have them duplicated.

**Changes**:
- added `showThpModals` prop tot `ConnectionGlobalModal`
  - passed false in onboarding flow

Resolve https://github.com/trezor/trezor-suite/issues/21379

## Screenshots:
**BEFORE:**
<img width="1124" height="682" alt="487835954-39ebfab7-e430-40f4-a620-7982c480e442" src="https://github.com/user-attachments/assets/001ce61b-be33-47c0-9d20-354d2ea80253" />

**AFTER:**
<img width="1117" height="1095" alt="Screenshot 2025-09-12 at 14 31 32" src="https://github.com/user-attachments/assets/7bace307-a2d4-4ef8-83bb-03da45c0ccd6" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/onboarding-thp-autofocus&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/onboarding-thp-autofocus&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/onboarding-thp-autofocus&lookback=7)