### PR TITLE
chore(transport-bluetooth): unify server params and responses

### DIFF
--- a/packages/transport-bluetooth/CHANGELOG.md
+++ b/packages/transport-bluetooth/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+### 0.4.1
+
+- breaking change in websocket api parameters, responses and notifications
+- NAPI bindings used only in connectDevice flow
+- fix: stop scanning when all clients disconnected
+
 ### 0.4.0
 
 - add NAPI bindings for MacOS
+- methods: set_state, connect_device, disconnect_device, forget_device, open, close, read, write
 
 ### 0.3.0
 

--- a/packages/transport-bluetooth/Cargo.lock
+++ b/packages/transport-bluetooth/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "trezor-bluetooth"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bluez-async",
  "btleplug",

--- a/packages/transport-bluetooth/Cargo.toml
+++ b/packages/transport-bluetooth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trezor-bluetooth"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [profile.release]

--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -49,7 +49,7 @@ export class BluetoothApi extends AbstractApi {
     enumerate() {
         return this.api
             .send('enumerate')
-            .then(devices => this.success(this.devicesToDescriptors(devices)))
+            .then(({ devices }) => this.success(this.devicesToDescriptors(devices)))
             .catch(() => this.success([]));
     }
 
@@ -99,7 +99,7 @@ export class BluetoothApi extends AbstractApi {
 
     openDevice(path: string) {
         return this.api
-            .send('open_device', path)
+            .send('open_device', { id: path })
             .then(() => this.success(undefined))
             .catch(e =>
                 this.error({ error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE, message: e.message }),
@@ -110,7 +110,7 @@ export class BluetoothApi extends AbstractApi {
         this.readBuffer.cancelRead(path);
 
         return this.api
-            .send('close_device', path)
+            .send('close_device', { id: path })
             .then(() => this.success(undefined))
             .catch(e =>
                 this.error({ error: ERRORS.INTERFACE_UNABLE_TO_CLOSE_DEVICE, message: e.message }),

--- a/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
@@ -91,7 +91,7 @@ export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements Bl
                     devices: this.state.knownDevices,
                 });
 
-                const scanResult = await this.api.send('start_scan');
+                const { devices: scanResult } = await this.api.send('start_scan');
                 if (scanResult.length === 0) {
                     // wait. devices may not be returned immediately
                     await resolveAfter(1000);
@@ -116,7 +116,7 @@ export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements Bl
         }
 
         try {
-            const devices = await this.api.send('start_scan');
+            const { devices } = await this.api.send('start_scan');
             this.isScanning = true;
             this.emit('device-list-update', this.filterConnectableDevices(devices));
         } catch (error) {
@@ -149,7 +149,8 @@ export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements Bl
 
         // this is intentionally not wrapped in try/catch
         // we want to remove event listeners before error is returned
-        const emitDeviceUpdate = (device: BluetoothDevice) => this.emit('device-update', device);
+        const emitDeviceUpdate = ({ device }: { device: BluetoothDevice }) =>
+            this.emit('device-update', device);
         this.api.on('device_connection_status', emitDeviceUpdate);
         const result = await this.api
             .send('connect_device', { id, timeout: 30000 })
@@ -163,7 +164,7 @@ export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements Bl
     async disconnectDevice(id: string) {
         try {
             await this.connectApi();
-            await this.api.send('disconnect_device', id);
+            await this.api.send('disconnect_device', { id });
         } catch (error) {
             return this.result(error.message);
         }
@@ -174,7 +175,7 @@ export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements Bl
     async forgetDevice(id: string) {
         try {
             await this.connectApi();
-            await this.api.send('forget_device', id);
+            await this.api.send('forget_device', { id });
         } catch (error) {
             return this.result(error.message);
         }

--- a/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
+++ b/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
@@ -9,6 +9,8 @@ import {
     TrezorBluetoothSettings,
 } from './types';
 
+// reflection of rust params ./src/server/types.rs
+
 type SetStateParams = {
     devices: Pick<BluetoothDevice, 'id' | 'macAddress'>[];
 };
@@ -18,11 +20,34 @@ type ConnectDeviceParams = {
     timeout: number;
 };
 
+type DisconnectDeviceParams = {
+    id: string;
+};
+
+type ForgetDeviceParams = {
+    id: string;
+};
+
+type OpenDeviceParams = {
+    id: string;
+};
+
+type CloseDeviceParams = {
+    id: string;
+};
+
 type WriteParams = {
     id: string;
     data: number[];
     withResponse?: boolean;
 };
+
+type ReadParams = {
+    id: string;
+};
+
+// WsResponsePayload::Success
+type Success = { success: boolean };
 
 // Client for trezor-bluetooth rust websocket server
 export class TrezorBluetooth extends WebsocketClient<NotificationEvent> {
@@ -108,18 +133,18 @@ export class TrezorBluetooth extends WebsocketClient<NotificationEvent> {
         return this.sendMessage({ method: 'write', params: { ...params, withResponse } });
     }
 
-    send(method: 'set_state', state: SetStateParams): Promise<boolean>;
+    send(method: 'set_state', state: SetStateParams): Promise<Success>;
     send(method: 'get_info', adapter?: boolean): Promise<BluetoothInfo>;
-    send(method: 'enumerate'): Promise<BluetoothDevice[]>;
-    send(method: 'start_scan'): Promise<BluetoothDevice[]>;
-    send(method: 'stop_scan'): Promise<boolean>;
-    send(method: 'connect_device', params: ConnectDeviceParams): Promise<boolean>; // args: id, timeout
-    send(method: 'disconnect_device', id: string): Promise<boolean>;
-    send(method: 'forget_device', id: string): Promise<boolean>;
-    send(method: 'open_device', id: string): Promise<boolean>;
-    send(method: 'close_device', id: string): Promise<boolean>;
-    send(method: 'read', id: string): Promise<boolean>;
-    send(method: 'write', params: WriteParams): Promise<boolean>;
+    send(method: 'enumerate'): Promise<{ devices: BluetoothDevice[] }>;
+    send(method: 'start_scan'): Promise<{ devices: BluetoothDevice[] }>;
+    send(method: 'stop_scan'): Promise<Success>;
+    send(method: 'connect_device', params: ConnectDeviceParams): Promise<Success>;
+    send(method: 'disconnect_device', params: DisconnectDeviceParams): Promise<Success>;
+    send(method: 'forget_device', params: ForgetDeviceParams): Promise<Success>;
+    send(method: 'open_device', params: OpenDeviceParams): Promise<Success>;
+    send(method: 'close_device', params: CloseDeviceParams): Promise<Success>;
+    send(method: 'read', params: ReadParams): Promise<{ data: number[] }>;
+    send(method: 'write', params: WriteParams): Promise<Success>;
     public send(method: string, params?: any) {
         if (method === 'connect_device') {
             return this.connectDevice(params);
@@ -130,14 +155,14 @@ export class TrezorBluetooth extends WebsocketClient<NotificationEvent> {
         }
 
         if (method === 'open_device') {
-            this.writeBuffer[params] = {
+            this.writeBuffer[params.id] = {
                 bytes: 0,
                 lastWrite: 0,
             };
         }
 
         if (method === 'close_device') {
-            delete this.writeBuffer[params];
+            delete this.writeBuffer[params.id];
         }
 
         return this.sendMessage({ method, params });

--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -52,7 +52,7 @@ export interface NotificationEvent {
     device_discovered: { id: string; devices: BluetoothDevice[] };
     device_updated: { id: string; devices: BluetoothDevice[] };
     device_connected: { id: string; devices: BluetoothDevice[] };
-    device_connection_status: BluetoothDevice;
+    device_connection_status: { device: BluetoothDevice };
     device_disconnected: { id: string; devices: BluetoothDevice[] };
     device_read: { id: string; data: number[] };
     device_settings_ui: undefined; // dispatched by linux pairing process

--- a/packages/transport-bluetooth/src/server/message_handler.rs
+++ b/packages/transport-bluetooth/src/server/message_handler.rs
@@ -72,13 +72,19 @@ pub async fn handle_message(
         WsRequestMethod::ConnectDevice(params) => {
             methods::connect_device(manager, broadcast, params).await
         }
-        WsRequestMethod::DisconnectDevice(id) => {
-            methods::disconnect_device(manager, broadcast, id).await
+        WsRequestMethod::DisconnectDevice(params) => {
+            methods::disconnect_device(manager, broadcast, params).await
         }
-        WsRequestMethod::ForgetDevice(id) => methods::forget_device(manager, broadcast, id).await,
-        WsRequestMethod::OpenDevice(id) => methods::open_device(manager, broadcast, id).await,
-        WsRequestMethod::CloseDevice(id) => methods::close_device(manager, broadcast, id).await,
-        WsRequestMethod::Read(id) => methods::read(manager, id).await,
+        WsRequestMethod::ForgetDevice(params) => {
+            methods::forget_device(manager, broadcast, params).await
+        }
+        WsRequestMethod::OpenDevice(params) => {
+            methods::open_device(manager, broadcast, params).await
+        }
+        WsRequestMethod::CloseDevice(params) => {
+            methods::close_device(manager, broadcast, params).await
+        }
+        WsRequestMethod::Read(params) => methods::read(manager, params).await,
         WsRequestMethod::Write(params) => methods::write(manager, params).await,
     };
 

--- a/packages/transport-bluetooth/src/server/methods/close_device.rs
+++ b/packages/transport-bluetooth/src/server/methods/close_device.rs
@@ -1,6 +1,6 @@
 use crate::server::{
     adapter_manager::AdapterManager,
-    types::{AbortProcess, ChannelMessage, MethodResult, WsResponsePayload},
+    types::{AbortProcess, ChannelMessage, CloseDeviceParams, MethodResult, WsResponsePayload},
     ConnectionBroadcast,
 };
 
@@ -9,11 +9,12 @@ use log::info;
 pub async fn close_device(
     _manager: AdapterManager,
     broadcast: ConnectionBroadcast,
-    id: String,
+    params: CloseDeviceParams,
 ) -> MethodResult {
+    let id = params.id;
     info!("close_device {id}");
 
     broadcast.send(ChannelMessage::Abort(AbortProcess::Read(id)));
 
-    Ok(WsResponsePayload::Success(true))
+    Ok(WsResponsePayload::Success { success: true })
 }

--- a/packages/transport-bluetooth/src/server/methods/connect_device.rs
+++ b/packages/transport-bluetooth/src/server/methods/connect_device.rs
@@ -20,5 +20,5 @@ pub async fn connect_device(
 
     BluetoothDevice::connect(context).await?;
 
-    Ok(WsResponsePayload::Success(true))
+    Ok(WsResponsePayload::Success { success: true })
 }

--- a/packages/transport-bluetooth/src/server/methods/disconnect_device.rs
+++ b/packages/transport-bluetooth/src/server/methods/disconnect_device.rs
@@ -4,16 +4,19 @@ use log::info;
 use crate::server::{
     adapter_manager::AdapterManager,
     device::DeviceConnectionStatus,
-    types::{AbortProcess, ChannelMessage, MethodResult, WsResponsePayload},
+    types::{
+        AbortProcess, ChannelMessage, DisconnectDeviceParams, MethodResult, WsResponsePayload,
+    },
     ConnectionBroadcast,
 };
 
 pub async fn disconnect_device(
     manager: AdapterManager,
     broadcast: ConnectionBroadcast,
-    id: String,
+    params: DisconnectDeviceParams,
 ) -> MethodResult {
-    info!("disconnect_device {:?}", id);
+    let id = params.id;
+    info!("disconnect_device {id}");
     // notify other threads: connect_device pairing, open_device read
     broadcast.send(ChannelMessage::Abort(AbortProcess::DeviceDisconnected(
         id.clone(),
@@ -33,7 +36,7 @@ pub async fn disconnect_device(
     let peripheral = manager.get_peripheral_or_die(&id).await?;
 
     match peripheral.disconnect().await {
-        Ok(_) => Ok(WsResponsePayload::Success(true)),
+        Ok(_) => Ok(WsResponsePayload::Success { success: true }),
         Err(err) => {
             info!("disconnect_device error: {err:?}");
             Err(err.into())

--- a/packages/transport-bluetooth/src/server/methods/enumerate.rs
+++ b/packages/transport-bluetooth/src/server/methods/enumerate.rs
@@ -10,5 +10,5 @@ pub async fn enumerate(manager: AdapterManager) -> MethodResult {
 
     let devices = manager.get_devices().await;
 
-    Ok(WsResponsePayload::Peripherals(devices))
+    Ok(WsResponsePayload::Peripherals { devices })
 }

--- a/packages/transport-bluetooth/src/server/methods/forget_device.rs
+++ b/packages/transport-bluetooth/src/server/methods/forget_device.rs
@@ -3,19 +3,20 @@ use log::info;
 use crate::server::{
     adapter_manager::AdapterManager,
     platform::{BluetoothDevice, PlatformDevice},
-    types::{MethodError, MethodResult, WsResponsePayload},
+    types::{ForgetDeviceParams, MethodError, MethodResult, WsResponsePayload},
     ConnectionBroadcast,
 };
 
 pub async fn forget_device(
     _manager: AdapterManager,
     _sender: ConnectionBroadcast,
-    id: String,
+    params: ForgetDeviceParams,
 ) -> MethodResult {
-    info!("forget_device");
+    let id = params.id;
+    info!("forget_device {id}");
 
     match BluetoothDevice::forget(id).await {
-        Ok(()) => Ok(WsResponsePayload::Success(true)),
+        Ok(()) => Ok(WsResponsePayload::Success { success: true }),
         Err(err) => Err(MethodError::PlatformError(err)),
     }
 }

--- a/packages/transport-bluetooth/src/server/methods/open_device.rs
+++ b/packages/transport-bluetooth/src/server/methods/open_device.rs
@@ -8,7 +8,7 @@ use crate::server::{
     device::CHARACTERISTIC_TX,
     types::{
         AbortProcess, ChannelMessage, MethodError, MethodResult, NotificationEvent,
-        WsResponsePayload,
+        OpenDeviceParams, WsResponsePayload,
     },
     ConnectionBroadcast,
 };
@@ -16,8 +16,9 @@ use crate::server::{
 pub async fn open_device(
     manager: AdapterManager,
     broadcast: ConnectionBroadcast,
-    id: String,
+    params: OpenDeviceParams,
 ) -> MethodResult {
+    let id = params.id;
     info!("open_device {id}");
 
     manager.get_powered_adapter_or_die().await?;
@@ -88,5 +89,5 @@ pub async fn open_device(
         }
     });
 
-    Ok(WsResponsePayload::Success(true))
+    Ok(WsResponsePayload::Success { success: true })
 }

--- a/packages/transport-bluetooth/src/server/methods/read.rs
+++ b/packages/transport-bluetooth/src/server/methods/read.rs
@@ -1,13 +1,14 @@
 use crate::server::{
     adapter_manager::{AdapterError, AdapterManager},
-    types::{MethodError, MethodResult, WsResponsePayload},
+    types::{MethodError, MethodResult, ReadParams, WsResponsePayload},
 };
 use btleplug::api::Peripheral;
 use log::info;
 
 /// this method is just a placeholder to keep @trezor/transport interface
 /// read logic is done in `open_device.rs`
-pub async fn read(manager: AdapterManager, id: String) -> MethodResult {
+pub async fn read(manager: AdapterManager, params: ReadParams) -> MethodResult {
+    let id = params.id;
     info!("read: {id}");
 
     manager.get_powered_adapter_or_die().await?;
@@ -17,5 +18,5 @@ pub async fn read(manager: AdapterManager, id: String) -> MethodResult {
         return Err(MethodError::Adapter(AdapterError::PeripheralNotConnected));
     }
 
-    Ok(WsResponsePayload::Read(vec![]))
+    Ok(WsResponsePayload::Read { data: vec![] })
 }

--- a/packages/transport-bluetooth/src/server/methods/set_state.rs
+++ b/packages/transport-bluetooth/src/server/methods/set_state.rs
@@ -9,5 +9,5 @@ pub async fn set_state(manager: AdapterManager, params: SetStateParams) -> Metho
 
     manager.set_known_peripherals(params.devices).await;
 
-    Ok(WsResponsePayload::Success(true))
+    Ok(WsResponsePayload::Success { success: true })
 }

--- a/packages/transport-bluetooth/src/server/methods/start_scan.rs
+++ b/packages/transport-bluetooth/src/server/methods/start_scan.rs
@@ -38,7 +38,7 @@ pub async fn start_scan(manager: AdapterManager, broadcast: ConnectionBroadcast)
     if manager.is_scanning().await {
         info!("AdapterManager is already scanning");
         let devices = manager.get_devices().await;
-        return Ok(WsResponsePayload::Peripherals(devices));
+        return Ok(WsResponsePayload::Peripherals { devices });
     } else {
         manager.set_scanning(true).await;
     }
@@ -96,5 +96,5 @@ pub async fn start_scan(manager: AdapterManager, broadcast: ConnectionBroadcast)
     sleep(Duration::from_millis(200)).await;
 
     let devices = manager.get_devices().await;
-    Ok(WsResponsePayload::Peripherals(devices))
+    Ok(WsResponsePayload::Peripherals { devices })
 }

--- a/packages/transport-bluetooth/src/server/methods/stop_scan.rs
+++ b/packages/transport-bluetooth/src/server/methods/stop_scan.rs
@@ -15,8 +15,8 @@ pub async fn stop_scan(manager: AdapterManager, broadcast: ConnectionBroadcast) 
     if let Err(err) = adapter.stop_scan().await {
         info!("stop_scan/adapter.stop_scan error: {err}");
 
-        return Ok(WsResponsePayload::Success(false));
+        return Ok(WsResponsePayload::Success { success: false });
     }
 
-    Ok(WsResponsePayload::Success(true))
+    Ok(WsResponsePayload::Success { success: true })
 }

--- a/packages/transport-bluetooth/src/server/methods/write.rs
+++ b/packages/transport-bluetooth/src/server/methods/write.rs
@@ -57,5 +57,5 @@ pub async fn write(manager: AdapterManager, params: WriteParams) -> MethodResult
 
     peripheral.write(rx, &vec, write_type).await?;
 
-    Ok(WsResponsePayload::Success(true))
+    Ok(WsResponsePayload::Success { success: true })
 }

--- a/packages/transport-bluetooth/src/server/platform/linux.rs
+++ b/packages/transport-bluetooth/src/server/platform/linux.rs
@@ -57,11 +57,11 @@ impl PlatformDevice for LinuxDevice {
         // let res: Result<(), dbus::Error> = adapter_proxy.method_call("org.bluez.Device1", "CancelPairing", ()).await;
         // match res {
         //     Ok(()) => {
-        //         Ok(WsResponsePayload::Success(true))
+        //         Ok(WsResponsePayload::Success{ success: true })
         //     }
         //     Err(err) => {
         //         println!("Forget error {:?}", err);
-        //         Ok(WsResponsePayload::Success(false))
+        //         Ok(WsResponsePayload::Success{ success: false })
         //     }
         // }
 

--- a/packages/transport-bluetooth/src/server/types.rs
+++ b/packages/transport-bluetooth/src/server/types.rs
@@ -35,11 +35,36 @@ pub struct ConnectDeviceParams {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct DisconnectDeviceParams {
+    pub id: String,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct ForgetDeviceParams {
+    pub id: String,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct OpenDeviceParams {
+    pub id: String,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct CloseDeviceParams {
+    pub id: String,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct WriteParams {
     pub id: String,
     pub data: Vec<u8>,
     #[serde(rename = "withResponse")]
     pub with_response: bool,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct ReadParams {
+    pub id: String,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
@@ -51,12 +76,12 @@ pub enum WsRequestMethod {
     StopScan,
     SetState(SetStateParams),
     ConnectDevice(ConnectDeviceParams),
-    DisconnectDevice(String),
-    ForgetDevice(String),
-    OpenDevice(String),
-    CloseDevice(String),
+    DisconnectDevice(DisconnectDeviceParams),
+    ForgetDevice(ForgetDeviceParams),
+    OpenDevice(OpenDeviceParams),
+    CloseDevice(CloseDeviceParams),
     Write(WriteParams),
-    Read(String),
+    Read(ReadParams),
 }
 
 #[derive(serde::Deserialize, Debug)]
@@ -76,9 +101,15 @@ pub enum WsResponsePayload {
         adapter_info: String,
         adapter_version: u8,
     },
-    Peripherals(Vec<TrezorDevice>),
-    Success(bool),
-    Read(Vec<u8>),
+    Peripherals {
+        devices: Vec<TrezorDevice>,
+    },
+    Success {
+        success: bool,
+    },
+    Read {
+        data: Vec<u8>,
+    },
 }
 
 #[derive(serde::Serialize, Clone, Debug)]
@@ -140,7 +171,9 @@ pub enum NotificationEvent {
     DeviceRemoved {
         id: String,
     },
-    DeviceConnectionStatus(TrezorDevice),
+    DeviceConnectionStatus {
+        device: TrezorDevice,
+    },
     #[allow(dead_code)]
     DeviceSettingsUi, // only on linux
     DeviceRead {

--- a/packages/transport-bluetooth/src/server/utils.rs
+++ b/packages/transport-bluetooth/src/server/utils.rs
@@ -50,7 +50,7 @@ pub async fn dispatch_status(
 ) {
     device.set_connection_status(phase);
     manager
-        .dispatch_notification(NotificationEvent::DeviceConnectionStatus(device))
+        .dispatch_notification(NotificationEvent::DeviceConnectionStatus { device })
         .await
 }
 

--- a/packages/transport-bluetooth/src/ui/index.ts
+++ b/packages/transport-bluetooth/src/ui/index.ts
@@ -76,7 +76,7 @@ const createDevice = (api: TrezorBluetooth, d: BluetoothDevice) => {
                     writeOutput({ error: e.message });
                 });
         } else {
-            api.send('disconnect_device', d.id).catch(e => {
+            api.send('disconnect_device', { id: d.id }).catch(e => {
                 writeOutput({ error: e.message });
             });
         }
@@ -136,7 +136,7 @@ async function init() {
         updateDeviceList(api, event.devices);
     });
     api.on('device_connection_status', event => {
-        updateDevice(api, event);
+        updateDevice(api, event.device);
     });
 
     getElement('api_connect').onclick = () => {
@@ -159,7 +159,7 @@ async function init() {
 
     getElement('start_scan').onclick = () => {
         api.send('start_scan')
-            .then(devices => {
+            .then(({ devices }) => {
                 updateDeviceList(api, devices);
             })
             .catch(e => {
@@ -210,7 +210,7 @@ async function init() {
 
     getElement('disconnect_device').onclick = () => {
         const id = getDeviceId();
-        api.send('disconnect_device', id)
+        api.send('disconnect_device', { id })
             .then(r => {
                 writeOutput(r);
             })
@@ -221,7 +221,7 @@ async function init() {
 
     getElement('forget_device').onclick = () => {
         const id = getDeviceId();
-        api.send('forget_device', id)
+        api.send('forget_device', { id })
             .then(r => {
                 writeOutput(r);
             })
@@ -232,7 +232,7 @@ async function init() {
 
     getElement('open_device').onclick = () => {
         const id = getDeviceId();
-        api.send('open_device', id)
+        api.send('open_device', { id })
             .then(r => {
                 writeOutput(r);
             })
@@ -243,7 +243,7 @@ async function init() {
 
     getElement('close_device').onclick = () => {
         const id = getDeviceId();
-        api.send('close_device', id)
+        api.send('close_device', { id })
             .then(r => {
                 writeOutput(r);
             })
@@ -264,8 +264,8 @@ async function init() {
     };
 
     getElement('read').onclick = () => {
-        const value = getDeviceId();
-        api.send('read', value)
+        const id = getDeviceId();
+        api.send('read', { id })
             .then(r => {
                 writeOutput(r);
             })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

for easier maintenance 

all notifications are objects
all websocket responses are objects
all websocket requests are objects


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21208


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bt-unify-server-params&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bt-unify-server-params&lookback=7)