### PR TITLE
fix(transport-bluetooth): stop scanning when all clients disconnected

### DIFF
--- a/packages/transport-bluetooth/src/server/adapter_manager.rs
+++ b/packages/transport-bluetooth/src/server/adapter_manager.rs
@@ -632,6 +632,10 @@ impl AdapterManager {
             }
         }
     }
+    pub async fn is_listeners_empty(&self) -> bool {
+        let state = self.manager_state.lock().await;
+        state.listeners.is_empty()
+    }
 
     async fn dispatch_adapter_event(&self) {
         let state = self.adapter_state.lock().await.clone();

--- a/packages/transport-bluetooth/src/server/methods/start_scan.rs
+++ b/packages/transport-bluetooth/src/server/methods/start_scan.rs
@@ -64,6 +64,14 @@ pub async fn start_scan(manager: AdapterManager, broadcast: ConnectionBroadcast)
                     info!("Abort start_scan loop");
                     break;
                 }
+                ChannelMessage::Abort(AbortProcess::ClientDisconnected(_client)) => {
+                    if manager_ref.is_listeners_empty().await {
+                        info!("All clients disconnected, stopping scanning");
+                        stop_scanning(&adapter).await;
+                        manager_ref.set_scanning(false).await;
+                    }
+                    break;
+                }
                 ChannelMessage::Notification(NotificationEvent::AdapterStateChanged { state }) => {
                     match state {
                         AdapterState::Enabled => {


### PR DESCRIPTION
## Description

This will trigger once all WS clients are disconnected and stop any ongoing Bluetooth scanning

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/transport-bluetooth-stop-scan-client-disconnect&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/transport-bluetooth-stop-scan-client-disconnect&lookback=7)