### PR TITLE
fix(suite): update cant see trezor navigation

### DIFF
--- a/packages/suite/src/components/connection/CantSeeTrezorModal.tsx
+++ b/packages/suite/src/components/connection/CantSeeTrezorModal.tsx
@@ -28,6 +28,7 @@ type DontSeeYourTrezorModalProps = {
     onGoBack: () => void;
     onRescan: () => void;
     onStillDontWork: () => void;
+    onClose: () => void;
 };
 
 const commonCableTips = [
@@ -41,6 +42,7 @@ export const CantSeeTrezorModal = ({
     isBluetoothMode,
     onRescan,
     onStillDontWork,
+    onClose,
 }: DontSeeYourTrezorModalProps) => {
     const nearbyDevices = useSelector(selectNearbyDevices);
     const knownDevices = useSelector(selectKnownDevices);
@@ -102,6 +104,7 @@ export const CantSeeTrezorModal = ({
             onGoBack();
         } else {
             openTrezorSupport();
+            onClose();
         }
     };
 
@@ -120,7 +123,7 @@ export const CantSeeTrezorModal = ({
                 </>
             }
             heading={<Translation id="TR_STILL_DONT_SEE_YOUR_TREZOR" />}
-            onCancel={onGoBack}
+            onCancel={onClose}
         >
             <TroubleshootingTipsList items={tipItems} />
         </Modal>

--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -172,6 +172,7 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
                 isBluetoothMode={isBluetoothMode}
                 onRescan={onReScanClick}
                 onGoBack={toggleShowHints}
+                onClose={onCancel}
                 onStillDontWork={toggleShouldPairAgain}
             />
         );


### PR DESCRIPTION
For cancel and close modal -> close the whole connection modal.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21461

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/dont-see-trezor-navigation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/dont-see-trezor-navigation&lookback=7)