### PR TITLE
feat: store releases JSON once downloaded for FW installation in desktop

### DIFF
--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -465,6 +465,8 @@ export const onCallFirmwareUpdate = async ({
         }),
     );
 
+    const finalBinaryRelase = device?.firmwareReleaseConfigInfo?.release;
+
     // We have completed binary download and we should notify sending an event,
     // if desktop wants to store it. We only do this for final FW, not intermediaries.
     postMessage(
@@ -474,6 +476,7 @@ export const onCallFirmwareUpdate = async ({
             releaseVersion: finalBinaryInfo.releaseVersion,
             firmwareType: device.firmwareType,
             internalModel: device.features.internal_model,
+            release: finalBinaryRelase,
         }),
     );
 

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -17,6 +17,7 @@ import { httpRequest } from '../utils/assets';
 import {
     buildIntermediaryFirmwareFileName,
     buildLocalFirmwareFileName,
+    buildLocalReleaseName,
     findBestCompatibleRelease,
     isStrictFeatures,
 } from '../utils/firmwareUtils';
@@ -221,6 +222,16 @@ export const getReleaseByVersion = async (
     const releaseFromConfig = getReleaseConfig(features, firmwareType)?.release;
     if (releaseFromConfig && versionUtils.isEqual(firmwareVersion, releaseFromConfig.version)) {
         return releaseFromConfig;
+    }
+
+    const releaseName = buildLocalReleaseName(firmwareType, deviceModel, firmwareVersion);
+
+    const { firmwareDir, firmwareList } = DataManager.getLocalFirmwares();
+    if (firmwareList.includes(releaseName)) {
+        const localReleasePath = `${firmwareDir}${releaseName}`;
+        const localReleaseBuffer = await httpRequest(localReleasePath, 'json');
+
+        return JSON.parse(localReleaseBuffer.toString());
     }
 
     const release =

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -2,16 +2,16 @@
  * messages to UI emitted as UI_EVENT
  */
 import type { EventTypeDeviceSelected } from '@trezor/connect-analytics';
-import { DeviceModelInternal } from '@trezor/device-utils';
+import { DeviceModelInternal, FirmwareRelease } from '@trezor/device-utils';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 
 import type {
-    BinaryInfo,
     BitcoinNetworkInfo,
     CoinInfo,
     Device,
     FirmwareType,
     SelectFeeLevel,
+    VersionArray,
 } from '../types';
 import type { DeviceButtonRequest, DeviceThpPairingPayload } from './device';
 import { MethodPermission } from '../core/AbstractMethod';
@@ -232,14 +232,18 @@ export interface UiRequestSelectDevice {
     };
 }
 
+export type FirmwareStoreEvent = {
+    binary: ArrayBuffer;
+    binaryVersion: VersionArray;
+    internalModel: DeviceModelInternal;
+    release: FirmwareRelease | undefined;
+    firmwareType?: FirmwareType;
+    releaseVersion?: number[];
+};
+
 export interface UiRequestFirmwareDownloaded {
     type: typeof UI_REQUEST.FIRMWARE_DOWNLOADED;
-    payload:
-        | BinaryInfo
-        | {
-              internalModel?: DeviceModelInternal;
-              firmwareType?: FirmwareType;
-          };
+    payload: FirmwareStoreEvent;
 }
 
 export interface UiRequestUnexpectedDeviceMode {

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -61,16 +61,42 @@ export const findBestCompatibleRelease = (
     return compatibleFirmware;
 };
 
+const buildLocalFileBaseName = (
+    firmwareType: FirmwareType,
+    deviceModel: DeviceModelInternal,
+    version: VersionArray,
+): string => {
+    const firmwareSuffix = firmwareType === FirmwareType.BitcoinOnly ? '-bitcoinonly' : '';
+    const model = deviceModel.toLowerCase();
+    const versionString = version.join('.');
+
+    return `trezor-${model}-${versionString}${firmwareSuffix}`;
+};
+
+/**
+ * Builds the filename for a local release JSON file.
+ * Example: "trezor-t2t1-2.6.0-bitcoinonly.json"
+ */
+export const buildLocalReleaseName = (
+    firmwareType: FirmwareType,
+    deviceModel: DeviceModelInternal,
+    version: VersionArray,
+): string => `${buildLocalFileBaseName(firmwareType, deviceModel, version)}.json`;
+
+/**
+ * Builds the filename for a local firmware binary file.
+ * Example: "trezor-t2t1-2.6.0.bin"
+ */
 export const buildLocalFirmwareFileName = (
     firmwareType: FirmwareType,
     deviceModel: DeviceModelInternal,
     version: VersionArray,
-) => {
-    const firmwareTypeFileString = firmwareType === FirmwareType.BitcoinOnly ? '-bitcoinonly' : '';
+): string => `${buildLocalFileBaseName(firmwareType, deviceModel, version)}.bin`;
 
-    return `trezor-${deviceModel.toLowerCase()}-${version.join('.')}${firmwareTypeFileString}.bin`;
-};
-
+/**
+ * Builds the filename for an intermediary firmware file.
+ * Example: "trezor-t2b1-inter-v2.bin"
+ */
 export const buildIntermediaryFirmwareFileName = (
     internalModel: DeviceModelInternal,
     version: number,

--- a/packages/suite-desktop-core/src/modules/firmware.ts
+++ b/packages/suite-desktop-core/src/modules/firmware.ts
@@ -1,6 +1,8 @@
 import { FirmwareType } from '@trezor/connect';
-import { buildLocalFirmwareFileName } from '@trezor/connect/src/utils/firmwareUtils';
-import { DeviceModelInternal, VersionArray } from '@trezor/device-utils';
+import {
+    buildLocalFirmwareFileName,
+    buildLocalReleaseName,
+} from '@trezor/connect/src/utils/firmwareUtils';
 
 import { readDir, save } from '../libs/user-data';
 import { app } from '../typed-electron';
@@ -31,61 +33,78 @@ export const getStoredFirmwares = async () => {
 export const init: ModuleInit = ({ mainThreadEmitter }) => {
     const { logger } = global;
 
-    mainThreadEmitter.on(
-        'module/trezor-connect/firmware-store',
-        async (event: {
-            binary: ArrayBuffer;
-            binaryVersion: VersionArray;
-            releaseVersion: number[];
-            internalModel: DeviceModelInternal;
-            firmwareType: FirmwareType;
-        }) => {
-            const {
-                binary,
-                binaryVersion,
-                internalModel,
-                firmwareType = FirmwareType.Universal,
-            } = event;
+    mainThreadEmitter.on('module/trezor-connect/firmware-store', async event => {
+        const {
+            binary,
+            binaryVersion,
+            internalModel,
+            firmwareType = FirmwareType.Universal,
+            release,
+        } = event;
 
-            const firmwareBinName = buildLocalFirmwareFileName(
-                firmwareType,
-                internalModel,
-                binaryVersion,
+        const firmwareBinName = buildLocalFirmwareFileName(
+            firmwareType,
+            internalModel,
+            binaryVersion,
+        );
+
+        const { success, error, payload } = await getStoredFirmwares();
+        if (!success || !payload) {
+            logger.error(SERVICE_NAME, `Failed to read firmware directory: ${error}`);
+
+            return;
+        }
+
+        const { firmwareList } = payload;
+
+        if (!firmwareList.includes(firmwareBinName)) {
+            logger.info(
+                SERVICE_NAME,
+                `Saving new downloaded firmware: ${firmwareBinName} to ${FIRMWARE_DIR}`,
             );
 
-            const { success, error, payload } = await getStoredFirmwares();
-            if (!success || !payload) {
-                logger.error(SERVICE_NAME, `Failed to read firmware directory: ${error}`);
+            const saveFwResponse = await save(FIRMWARE_DIR, firmwareBinName, binary, 'binary');
+            if (!saveFwResponse.success) {
+                logger.error(SERVICE_NAME, `Failed to save firmware: ${saveFwResponse.error}`);
 
                 return;
             }
 
-            const { firmwareList } = payload;
-
-            if (!firmwareList.includes(firmwareBinName)) {
-                logger.info(
-                    SERVICE_NAME,
-                    `Saving new downloaded firmware: ${firmwareBinName} to ${FIRMWARE_DIR}`,
+            if (release) {
+                const releaseJsonName = buildLocalReleaseName(
+                    firmwareType,
+                    internalModel,
+                    binaryVersion,
                 );
 
-                const saveFwResponse = await save(FIRMWARE_DIR, firmwareBinName, binary, 'binary');
-                if (!saveFwResponse.success) {
-                    logger.error(SERVICE_NAME, `Failed to save firmware: ${saveFwResponse.error}`);
-
-                    return;
-                }
-
-                // Emit updated firmware list only if the firmware was saved successfully.
-                const updatedFirmwares = await getStoredFirmwares();
-                if (updatedFirmwares.payload) {
-                    mainThreadEmitter.emit('module/firmware/list', updatedFirmwares.payload);
-                }
-            } else {
                 logger.info(
                     SERVICE_NAME,
-                    `Firmware ${firmwareBinName} already exists, skipping save.`,
+                    `Saving firmware release notes: ${releaseJsonName} to ${FIRMWARE_DIR}`,
                 );
+
+                const releaseData = JSON.stringify(release, null, 4);
+
+                const saveReleaseResponse = await save(
+                    FIRMWARE_DIR,
+                    releaseJsonName,
+                    releaseData,
+                    'utf-8',
+                );
+                if (!saveReleaseResponse.success) {
+                    logger.error(
+                        SERVICE_NAME,
+                        `Failed to save firmware release notes: ${saveReleaseResponse.error}`,
+                    );
+                }
             }
-        },
-    );
+
+            // Emit updated firmware list only if the firmware was saved successfully.
+            const updatedFirmwares = await getStoredFirmwares();
+            if (updatedFirmwares.payload) {
+                mainThreadEmitter.emit('module/firmware/list', updatedFirmwares.payload);
+            }
+        } else {
+            logger.info(SERVICE_NAME, `Firmware ${firmwareBinName} already exists, skipping save.`);
+        }
+    });
 };

--- a/packages/suite-desktop-core/src/modules/index.ts
+++ b/packages/suite-desktop-core/src/modules/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { isDevEnv } from '@suite-common/suite-utils';
-import type { DeviceEvent, LocalFirmwares } from '@trezor/connect';
+import type { DeviceEvent, FirmwareStoreEvent, LocalFirmwares } from '@trezor/connect';
 import { InterceptedEvent } from '@trezor/request-manager';
 import type { HandshakeClient, TorStatus } from '@trezor/suite-desktop-api';
 import { TypedEmitter, isNotUndefined } from '@trezor/utils';
@@ -86,7 +86,7 @@ interface MainThreadMessages {
         service: boolean;
         process: boolean;
     };
-    'module/trezor-connect/firmware-store': any;
+    'module/trezor-connect/firmware-store': FirmwareStoreEvent;
     'module/firmware/list': LocalFirmwares;
     'app/fully-quit': void;
     'app/show': void;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding improvement to the stored downloaded FW in desktop. It will also store the releases JSON when storing the FW binary so in following uses of it, it can use the downloaded one and don't download it again.

## Related Issue
Related https://github.com/trezor/trezor-suite/issues/19763

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/store-also-jsons-of-downloaded-bins&lookback=7)