### PR TITLE
fix(suite-native): add missing migration for device authenticityChecks

### DIFF
--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -38,6 +38,7 @@ import { localePersistWhitelist, localeReducer } from '@suite-native/intl';
 import { tradingSlice } from '@suite-native/module-trading';
 import { appSettingsPersistWhitelist, appSettingsReducer } from '@suite-native/settings';
 import {
+    backfillDeviceAuthenticityChecks,
     bluetoothPersistTransform,
     deriveAccountTypeFromPaymentType,
     devicePersistTransform,
@@ -194,7 +195,7 @@ export const prepareRootReducers = async () => {
         reducer: deviceReducer,
         persistedKeys: ['devices', 'isDeviceAutoEjectEnabled'],
         key: 'devices',
-        version: 2,
+        version: 3,
         transforms: [devicePersistTransform],
         migrations: {
             2: oldState => {
@@ -205,6 +206,12 @@ export const prepareRootReducers = async () => {
                 const migratedState = { ...oldState, devices: migratedDevices };
 
                 return migratedState;
+            },
+            3: oldState => {
+                if (!oldState.devices) return oldState;
+                const migratedDevices = backfillDeviceAuthenticityChecks(oldState.devices);
+
+                return { ...oldState, devices: migratedDevices };
             },
         },
     });

--- a/suite-native/storage/src/index.ts
+++ b/suite-native/storage/src/index.ts
@@ -7,6 +7,7 @@ export * from './atomWithUnecryptedStorage';
 export * from './migrations/account/v2';
 export * from './migrations/account/v3';
 export * from './migrations/device/v2';
+export * from './migrations/device/v3';
 export * from './migrations/wallet/transactions/v2';
 export * from './migrations/wallet/accounts/v2';
 export * from './migrations/wallet/accounts/v3';

--- a/suite-native/storage/src/migrations/device/v3.ts
+++ b/suite-native/storage/src/migrations/device/v3.ts
@@ -1,0 +1,15 @@
+import { TrezorDevice } from '@suite-common/suite-types';
+import { isDeviceAcquired } from '@suite-common/suite-utils';
+
+export const backfillDeviceAuthenticityChecks = (devices: TrezorDevice[]): TrezorDevice[] =>
+    devices.map(device => {
+        if (isDeviceAcquired(device) && !!device.authenticityChecks) return device;
+
+        return {
+            ...device,
+            authenticityChecks: {
+                firmwareRevision: null,
+                firmwareHash: null,
+            },
+        };
+    });


### PR DESCRIPTION
## Description

Add missing migration tu suite native, similar to the one added in #20406

It only adds `authenticityChecks` if not present on device, which is relevant for portfolio tracker devices.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/backfill-native-migration&lookback=7)