### PR TITLE
feat(suite-native): filterInconclusiveAuthenticityChecks also in mobile

### DIFF
--- a/packages/suite/src/utils/suite/storage.ts
+++ b/packages/suite/src/utils/suite/storage.ts
@@ -1,33 +1,9 @@
 import { connectInitThunk } from '@suite-common/connect-init';
-import {
-    hashCheckErrorScenarios,
-    revisionCheckErrorScenarios,
-} from '@suite-common/firmware-authenticity';
+import { filterInconclusiveAuthenticityChecks } from '@suite-common/firmware-authenticity';
 import { DeviceWithEmptyPath } from '@suite-common/suite-types';
 
 import { AcquiredDevice } from 'src/types/suite';
 import { CoinjoinAccount } from 'src/types/wallet/coinjoin';
-
-type AuthenticityChecks = AcquiredDevice['authenticityChecks'];
-const filterInconclusiveAuthenticityChecks = (checks: AuthenticityChecks): AuthenticityChecks => {
-    let { firmwareRevision, firmwareHash } = checks;
-    if (
-        firmwareRevision &&
-        !firmwareRevision.success &&
-        revisionCheckErrorScenarios[firmwareRevision.error].isConclusive === false
-    ) {
-        firmwareRevision = null;
-    }
-    if (
-        firmwareHash &&
-        !firmwareHash.success &&
-        hashCheckErrorScenarios[firmwareHash.error].isConclusive === false
-    ) {
-        firmwareHash = null;
-    }
-
-    return { firmwareRevision, firmwareHash };
-};
 
 /**
  * Strip fields from Device

--- a/suite-common/firmware-authenticity/src/utils.ts
+++ b/suite-common/firmware-authenticity/src/utils.ts
@@ -1,3 +1,4 @@
+import { AcquiredDevice } from '@suite-common/suite-types';
 import { FirmwareHashCheckError, FirmwareRevisionCheckError } from '@trezor/connect';
 import type { FilterPropertiesByType } from '@trezor/type-utils';
 
@@ -47,3 +48,27 @@ export const isHashCheckErrorWithNotification = (
 ): error is HashCheckErrorWithNotification =>
     // @ts-expect-error if this no longer gives error, then TODO hash check notifications must be implemented
     hashCheckErrorScenarios[error].shouldNotify === true;
+
+type AuthenticityChecks = AcquiredDevice['authenticityChecks'];
+
+export const filterInconclusiveAuthenticityChecks = (
+    checks: AuthenticityChecks,
+): AuthenticityChecks => {
+    let { firmwareRevision, firmwareHash } = checks;
+    if (
+        firmwareRevision &&
+        !firmwareRevision.success &&
+        revisionCheckErrorScenarios[firmwareRevision.error].isConclusive === false
+    ) {
+        firmwareRevision = null;
+    }
+    if (
+        firmwareHash &&
+        !firmwareHash.success &&
+        hashCheckErrorScenarios[firmwareHash.error].isConclusive === false
+    ) {
+        firmwareHash = null;
+    }
+
+    return { firmwareRevision, firmwareHash };
+};

--- a/suite-native/storage/package.json
+++ b/suite-native/storage/package.json
@@ -14,6 +14,7 @@
         "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "2.8.2",
         "@sentry/react-native": "6.20.0",
+        "@suite-common/firmware-authenticity": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "bs58": "^6.0.0",

--- a/suite-native/storage/src/transforms/deviceTransforms.ts
+++ b/suite-native/storage/src/transforms/deviceTransforms.ts
@@ -1,15 +1,18 @@
 import { A, pipe } from '@mobily/ts-belt';
 import { createTransform } from 'redux-persist';
 
-import { TrezorDevice } from '@suite-common/suite-types';
+import { filterInconclusiveAuthenticityChecks } from '@suite-common/firmware-authenticity';
+import { AcquiredDevice, TrezorDevice } from '@suite-common/suite-types';
+import { isDeviceAcquired } from '@suite-common/suite-utils';
 
-const serializeDevice = (device: TrezorDevice): Omit<TrezorDevice, 'path'> & { path: '' } => ({
+const serializeDevice = (device: AcquiredDevice): Omit<AcquiredDevice, 'path'> & { path: '' } => ({
     ...device,
     path: '',
     remember: true,
     temporaryRemember: false,
     connected: false,
     buttonRequests: [],
+    authenticityChecks: filterInconclusiveAuthenticityChecks(device.authenticityChecks),
 });
 
 export const devicePersistTransform = createTransform<
@@ -19,6 +22,8 @@ export const devicePersistTransform = createTransform<
     inboundState =>
         pipe(
             inboundState,
+            // only for type-narrowing; this is already projected into device.remember in `shouldDeviceBeRemembered`
+            A.filter(isDeviceAcquired),
             A.filter(device => !!device.remember && device.temporaryRemember !== true),
             A.map(serializeDevice),
         ),

--- a/suite-native/storage/tsconfig.json
+++ b/suite-native/storage/tsconfig.json
@@ -3,6 +3,9 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
+            "path": "../../suite-common/firmware-authenticity"
+        },
+        {
             "path": "../../suite-common/suite-types"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11443,6 +11443,7 @@ __metadata:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@reduxjs/toolkit": "npm:2.8.2"
     "@sentry/react-native": "npm:6.20.0"
+    "@suite-common/firmware-authenticity": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     bs58: "npm:^6.0.0"


### PR DESCRIPTION
## Description

- extract `filterInconclusiveAuthenticityChecks` from Suite to suite-common
- use it in Suite Lite too

## Screenshots:

Using [the testing branch](https://github.com/trezor/trezor-suite/tree/feat/suite-native-filterInconclusiveAuthenticityChecks-TESTING):

**Before & after (unchanged):** Conclusive error is still persisted (`'revision-mismatch'`):

[UNCHANGED revision mismatch.webm](https://github.com/user-attachments/assets/e8a70f04-f042-40f4-9b72-01edb99f0ecb)

**Before:** Inconclusive `'other-error'` is erroneously persisted:

[BEFORE other-error persisted.webm](https://github.com/user-attachments/assets/158eb3f4-8d7b-46e3-88cf-e866afebb863)

 **After:** remembered device is cleared of the `'other-error'`:

[AFTER other-error not persisted.webm](https://github.com/user-attachments/assets/0d9a7d35-f0af-4830-b461-0f44e88cbaba)


## QA

N/A, these cases are hard to reproduce without [the testing branch](https://github.com/trezor/trezor-suite/tree/feat/suite-native-filterInconclusiveAuthenticityChecks-TESTING)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-native-filterInconclusiveAuthenticityChecks&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-native-filterInconclusiveAuthenticityChecks&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-native-filterInconclusiveAuthenticityChecks&lookback=7)