### PR TITLE
fix(urls): remove dependency on env-utils from @trezor/urls

### DIFF
--- a/packages/suite/src/utils/suite/__tests__/tor.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/tor.test.ts
@@ -3,10 +3,6 @@ import { withPlatformUtm } from '@trezor/urls/src/platform-utm';
 
 import { getIsTorDomain, getTorUrlIfAvailable, isOnionUrl } from 'src/utils/suite/tor';
 
-jest.mock('@trezor/env-utils', () => ({
-    getEnvironment: jest.fn(() => 'web'),
-}));
-
 describe('tor', () => {
     beforeAll(() => {
         jest.spyOn(console, 'warn').mockImplementation();
@@ -17,6 +13,9 @@ describe('tor', () => {
     });
 
     describe('getTorUrlIfAvailable', () => {
+        const defaultSuiteTypeValue = process.env.SUITE_TYPE;
+        process.env.SUITE_TYPE = 'web';
+
         const fixtures = [
             {
                 desc: 'simple domain',
@@ -60,6 +59,8 @@ describe('tor', () => {
                 expect(getTorUrlIfAvailable(f.in)).toEqual(f.out);
             });
         });
+
+        process.env.SUITE_TYPE = defaultSuiteTypeValue;
     });
 
     describe('getIsTorDomain', () => {

--- a/packages/urls/package.json
+++ b/packages/urls/package.json
@@ -10,8 +10,5 @@
         "type-check": "yarn g:tsc --build",
         "test:e2e": "yarn g:jest -c ../../jest.config.base.js",
         "test:unit": "yarn g:jest"
-    },
-    "dependencies": {
-        "@trezor/env-utils": "workspace:*"
     }
 }

--- a/packages/urls/src/platform-utm.ts
+++ b/packages/urls/src/platform-utm.ts
@@ -1,8 +1,25 @@
-import { getEnvironment } from '@trezor/env-utils';
-
 import { type Url } from './types';
 
 type TrezorUrlWithoutUTM = `${string}trezor.io${string}`;
+
+const resolveUtmMedium = () => {
+    try {
+        if (process.env.SUITE_TYPE === 'web') {
+            return 'web';
+        } else if (process.env.SUITE_TYPE === 'desktop') {
+            return 'desktop';
+        } else if (
+            process.env.EXPO_PUBLIC_ENVIRONMENT &&
+            process.env.EXPO_PUBLIC_ENVIRONMENT !== 'undefined'
+        ) {
+            return 'mobile';
+        }
+
+        return undefined;
+    } catch {
+        return undefined;
+    }
+};
 
 export const withPlatformUtm = (url: TrezorUrlWithoutUTM): Url => {
     if (!url.includes('trezor.io')) {
@@ -13,7 +30,10 @@ export const withPlatformUtm = (url: TrezorUrlWithoutUTM): Url => {
         throw new Error(`URL must not include utm_medium: ${url}`);
     }
 
-    const utmMedium = getEnvironment();
+    const utmMedium = resolveUtmMedium();
+
+    if (!utmMedium) return url as Url;
+
     const separator = url.includes('?') ? '&' : '?';
 
     const cleanUrl = url.endsWith('/') ? url.slice(0, -1) : url;

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -175,10 +175,10 @@ export const HELP_CENTER_TOR_URL: Url = withPlatformUtm(
     'https://trezor.io/guides/trezor-suite/trezor-suite-desktop/tor-in-trezor-suite',
 );
 export const HELP_CENTER_FW_DOWNGRADE_T1B1_URL: Url = withPlatformUtm(
-    'https://trezor.io/guides/trezor-suite/trezor-suite-desktop/downgrade-firmware-model-one',
+    'https://trezor.io/support/troubleshooting/device-issues/downgrade-firmware-model-one',
 );
 export const HELP_CENTER_FW_DOWNGRADE_T2T1_URL: Url = withPlatformUtm(
-    'https://trezor.io/guides/trezor-suite/trezor-suite-desktop/downgrade-firmware-model-t',
+    'https://trezor.io/support/troubleshooting/device-issues/downgrade-firmware-model-t',
 );
 export const HELP_CENTER_FW_DOWNGRADE_T3B1_URL: Url = withPlatformUtm(
     'https://trezor.io/guides/trezor-suite/trezor-suite-desktop/downgrade-firmware-trezor-safe-3',

--- a/packages/urls/tests/urls.test.ts
+++ b/packages/urls/tests/urls.test.ts
@@ -18,7 +18,7 @@ const excluded = [
     URLS.IMAGE_PROXY_API_URL, // returns 'unauthorized'
 ];
 
-describe.skip('Test that all external links are alive', () => {
+describe('Test that all external links are alive', () => {
     beforeEach(() => {
         jest.setTimeout(30000);
     });

--- a/packages/urls/tests/utm.test.ts
+++ b/packages/urls/tests/utm.test.ts
@@ -1,19 +1,10 @@
-import { getEnvironment } from '@trezor/env-utils';
-
 import { withPlatformUtm } from '../src/platform-utm';
 
-jest.mock('@trezor/env-utils', () => ({
-    getEnvironment: jest.fn(() => 'mobile'),
-}));
-
-const mGetEnvironment = getEnvironment as jest.MockedFunction<typeof getEnvironment>;
-
 describe('withUtm', () => {
-    afterEach(() => {
-        jest.restoreAllMocks();
-    });
-
     test('adds utm_medium=mobile for trezor.io urls', () => {
+        const defaultValue = process.env.EXPO_PUBLIC_ENVIRONMENT;
+        process.env.EXPO_PUBLIC_ENVIRONMENT = 'mobile';
+
         expect(
             withPlatformUtm(
                 'https://trezor.io/support/troubleshooting/device-issues/how-to-reset-your-pin',
@@ -35,10 +26,12 @@ describe('withUtm', () => {
         expect(withPlatformUtm('https://suite.trezor.io/web/firmware')).toBe(
             `https://suite.trezor.io/web/firmware?utm_medium=mobile`,
         );
+        process.env.EXPO_PUBLIC_ENVIRONMENT = defaultValue;
     });
 
     test('adds utm_medium=desktop for trezor.io urls', () => {
-        mGetEnvironment.mockReturnValue('desktop');
+        const defaultValue = process.env.SUITE_TYPE;
+        process.env.SUITE_TYPE = 'desktop';
 
         expect(
             withPlatformUtm(
@@ -61,10 +54,13 @@ describe('withUtm', () => {
         expect(withPlatformUtm('https://suite.trezor.io/web/firmware')).toBe(
             `https://suite.trezor.io/web/firmware?utm_medium=desktop`,
         );
+
+        process.env.SUITE_TYPE = defaultValue;
     });
 
     test('adds utm_medium=web for trezor.io urls', () => {
-        mGetEnvironment.mockReturnValue('web');
+        const defaultValue = process.env.SUITE_TYPE;
+        process.env.SUITE_TYPE = 'web';
 
         expect(
             withPlatformUtm(
@@ -87,6 +83,7 @@ describe('withUtm', () => {
         expect(withPlatformUtm('https://suite.trezor.io/web/firmware')).toBe(
             `https://suite.trezor.io/web/firmware?utm_medium=web`,
         );
+        process.env.SUITE_TYPE = defaultValue;
     });
 
     test('throws error for invalid domains', () => {
@@ -121,7 +118,8 @@ describe('withUtm', () => {
     });
 
     test('appends platform utm with & if query params already exist', () => {
-        mGetEnvironment.mockReturnValue('web');
+        const defaultValue = process.env.SUITE_TYPE;
+        process.env.SUITE_TYPE = 'web';
 
         expect(withPlatformUtm('https://trezor.io/support?foo=bar')).toBe(
             'https://trezor.io/support?foo=bar&utm_medium=web',
@@ -134,5 +132,6 @@ describe('withUtm', () => {
         expect(withPlatformUtm('https://suite.trezor.io/web/firmware?existing=true')).toBe(
             'https://suite.trezor.io/web/firmware?existing=true&utm_medium=web',
         );
+        process.env.SUITE_TYPE = defaultValue;
     });
 });

--- a/packages/urls/tsconfig.json
+++ b/packages/urls/tsconfig.json
@@ -1,5 +1,5 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": [{ "path": "../env-utils" }]
+    "references": []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13159,8 +13159,6 @@ __metadata:
 "@trezor/urls@workspace:*, @trezor/urls@workspace:packages/urls":
   version: 0.0.0-use.local
   resolution: "@trezor/urls@workspace:packages/urls"
-  dependencies:
-    "@trezor/env-utils": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Move logic for UTM by environment inside @trezor/urls to make it work everywhere and remove dependency on env-utils.
- Keep it in urls package to prevent lot of boilerplate from creating suite-urls packages.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21515



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/urls-environment&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/urls-environment&lookback=7)