### PR TITLE
fix(suite): staking and unstaking times

### DIFF
--- a/packages/suite/src/components/suite/StakingProcess/StakingInfo.tsx
+++ b/packages/suite/src/components/suite/StakingProcess/StakingInfo.tsx
@@ -1,7 +1,6 @@
 import React, { JSX } from 'react';
-import { useSelector } from 'react-redux';
 
-import { getDaysToAddToPool } from '@suite-common/staking';
+import { getDaysToAddToPoolInitial } from '@suite-common/staking';
 import { NetworkSymbol, NetworkType, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     CARDANO_ACTIVATION_PERIOD_DAYS,
@@ -9,17 +8,15 @@ import {
     SOLANA_EPOCH_DAYS,
 } from '@suite-common/wallet-constants';
 import {
-    AccountsRootState,
     StakeRootState,
-    TransactionsRootState,
-    selectAccountStakeTransactions,
     selectPoolStatsApyData,
-    selectValidatorsQueue,
+    selectValidatorsQueueData,
 } from '@suite-common/wallet-core';
 import { BulletList } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
 import { CoinjoinRootState } from 'src/reducers/wallet/coinjoinReducer';
 
 import { InfoRow } from './InfoRow';
@@ -102,12 +99,7 @@ interface StakingInfoProps {
 export const StakingInfo = ({ isExpanded }: StakingInfoProps) => {
     const { account } = useSelector((state: CoinjoinRootState) => state.wallet.selectedAccount);
 
-    const { data } =
-        useSelector((state: StakeRootState) => selectValidatorsQueue(state, account?.symbol)) || {};
-
-    const stakeTxs = useSelector((state: TransactionsRootState & AccountsRootState) =>
-        selectAccountStakeTransactions(state, account?.key ?? ''),
-    );
+    const validatorsQueue = useSelector(state => selectValidatorsQueueData(state, account?.symbol));
 
     const apy = useSelector((state: StakeRootState) =>
         selectPoolStatsApyData(state, account?.symbol),
@@ -115,8 +107,12 @@ export const StakingInfo = ({ isExpanded }: StakingInfoProps) => {
 
     if (!account) return null;
 
-    const daysToAddToPool = getDaysToAddToPool(stakeTxs, data);
-    const infoRowsData = getInfoRowsData(account.networkType, account.symbol, daysToAddToPool);
+    const daysToAddToPoolInitial = getDaysToAddToPoolInitial(validatorsQueue);
+    const infoRowsData = getInfoRowsData(
+        account.networkType,
+        account.symbol,
+        daysToAddToPoolInitial,
+    );
 
     const infoRows = [
         {

--- a/packages/suite/src/components/suite/StakingProcess/UnstakingInfo.tsx
+++ b/packages/suite/src/components/suite/StakingProcess/UnstakingInfo.tsx
@@ -28,7 +28,7 @@ const getInfoRowsData = (
         case 'ethereum':
             return {
                 readyForClaimDays: (
-                    <Translation id="TR_STAKE_DAYS" values={{ count: daysToUnstake }} />
+                    <Translation id="TR_STAKE_APPROXIMATE_DAYS" values={{ count: daysToUnstake }} />
                 ),
                 deactivatePeriodHeading: <Translation id="TR_STAKE_LEAVE_STAKING_POOL" />,
                 deactivatePeriodSubheading: (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeForm.tsx
@@ -1,6 +1,5 @@
 import { getDisplaySymbol } from '@suite-common/wallet-config';
-import { selectValidatorsQueueData } from '@suite-common/wallet-core';
-import { getStakingDataForNetwork, getUnstakingPeriodInDays } from '@suite-common/wallet-utils';
+import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
 import { Banner, Column, InfoItem, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -36,12 +35,6 @@ export const UnstakeForm = () => {
         trigger,
     } = useUnstakeFormContext();
 
-    const { symbol, networkType } = account;
-
-    const { validatorWithdrawTime } = useSelector(state =>
-        selectValidatorsQueueData(state, account?.symbol),
-    );
-    const unstakingPeriod = getUnstakingPeriodInDays({ networkType, validatorWithdrawTime });
     const {
         autocompoundBalance = '0',
         canClaim = false,
@@ -63,7 +56,7 @@ export const UnstakeForm = () => {
                                 id="TR_STAKE_CAN_CLAIM_WARNING"
                                 values={{
                                     amount: claimableAmount,
-                                    symbol: getDisplaySymbol(symbol),
+                                    symbol: getDisplaySymbol(account.symbol),
                                     br: <br />,
                                 }}
                             />
@@ -76,7 +69,10 @@ export const UnstakeForm = () => {
                     />
                 </Column>
 
-                <StakeAvailableBalance formattedBalance={autocompoundBalance} symbol={symbol} />
+                <StakeAvailableBalance
+                    formattedBalance={autocompoundBalance}
+                    symbol={account.symbol}
+                />
 
                 <Column gap={spacings.lg}>
                     <UnstakeInputs />
@@ -97,19 +93,6 @@ export const UnstakeForm = () => {
                     trigger={trigger}
                 />
 
-                <InfoItem
-                    label={<Translation id="TR_STAKE_UNSTAKING_PERIOD" />}
-                    typographyStyle="body"
-                    direction="row"
-                >
-                    <Translation
-                        id="TR_UP_TO_DAYS"
-                        values={{
-                            count: unstakingPeriod,
-                        }}
-                    />
-                </InfoItem>
-
                 {shouldShowInstantUnstakeEthAmount && (
                     <InfoItem
                         label={
@@ -123,7 +106,7 @@ export const UnstakeForm = () => {
                                 <Translation
                                     id="TR_STAKE_UNSTAKING_APPROXIMATE"
                                     values={{
-                                        symbol: getDisplaySymbol(symbol),
+                                        symbol: getDisplaySymbol(account.symbol),
                                     }}
                                 />
                             </Tooltip>
@@ -133,7 +116,7 @@ export const UnstakeForm = () => {
                     >
                         <ApproximateInstantEthAmount
                             value={approximatedInstantEthAmount}
-                            symbol={symbol}
+                            symbol={account.symbol}
                         />
                     </InfoItem>
                 )}

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/hooks/useProgressLabelsData.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/hooks/useProgressLabelsData.tsx
@@ -55,9 +55,8 @@ export const useProgressLabelsData = ({
                         <Translation id="TR_STAKE_ADDING_TO_POOL" />
                         {isDaysToAddToPoolShown && (
                             <Paragraph typographyStyle="label" variant="tertiary">
-                                ~
                                 <Translation
-                                    id="TR_STAKE_DAYS"
+                                    id="TR_STAKE_APPROXIMATE_DAYS"
                                     values={{
                                         count: daysToAddToPool,
                                     }}

--- a/suite-common/staking/src/__fixtures__/ethereumStaking.ts
+++ b/suite-common/staking/src/__fixtures__/ethereumStaking.ts
@@ -535,12 +535,12 @@ export const getDaysToAddToPoolFixture = [
         result: undefined,
     },
     {
-        description: 'should return 1 if blockTime is undefined',
+        description: 'should return 2 if blockTime is undefined',
         args: {
             stakeTxs: [{}], // blockTime is undefined
             validatorsQueue: { validatorAddingDelay: 86400, validatorActivationTime: 86400 },
         },
-        result: 1,
+        result: 2,
     },
     {
         description: 'should return the number of days to wait',

--- a/suite-common/staking/src/utils/ethereumStaking.ts
+++ b/suite-common/staking/src/utils/ethereumStaking.ts
@@ -553,13 +553,11 @@ export const getDaysToAddToPool = (
         return undefined;
     }
 
-    const lastTx = stakeTxs[0];
-
-    if (!lastTx?.blockTime) return 1;
-
     const now = Math.floor(Date.now() / 1000);
+    const lastTxBlockTime = stakeTxs[0]?.blockTime || now;
+
     const secondsToWait =
-        lastTx.blockTime +
+        lastTxBlockTime +
         validatorsQueue.validatorAddingDelay +
         validatorsQueue.validatorActivationTime -
         now;
@@ -576,12 +574,14 @@ export const getDaysToUnstake = (
         return undefined;
     }
 
-    const lastTx = unstakeTxs[0];
-
-    if (!lastTx?.blockTime) return 1;
-
     const now = Math.floor(Date.now() / 1000);
-    const secondsToWait = lastTx.blockTime + validatorsQueue.validatorWithdrawTime - now;
+    const lastTxBlockTime = unstakeTxs[0]?.blockTime || now;
+
+    const secondsToWait =
+        lastTxBlockTime +
+        validatorsQueue.validatorWithdrawTime +
+        (validatorsQueue?.validatorExitTime || 0) -
+        now;
     const daysToWait = secondsToDays(secondsToWait);
 
     return daysToWait <= 0 ? 1 : daysToWait;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- unstake form now does not show unstaking period twice
- staking modal info does not consider previous staking txs
- unstaking info now includes `~`
- staking and unstaking calculation methods now use current timestamp in case tx is not available. To avoid returning hardcoded `1 day`
- unstaking period calculation now also includes `validatorExitTime`

## Related Issue

Resolve https://satoshilabs.slack.com/archives/C05KVPV16SV/p1757925504664089

Waiting for https://satoshilabs.slack.com/archives/C0543DJBK0C/p1757930937071919

## Screenshots:

The selected text is removed. Doesnt make sense imo
<img width="1357" height="1025" alt="Screenshot 2025-09-15 at 12 57 11" src="https://github.com/user-attachments/assets/d11e0207-4230-40c9-b88e-8552fdc84bd6" />

This should be fixed. No idea why exit time was not included in calculations
Before
<img width="460" height="242" alt="Screenshot 2025-09-15 at 12 27 30" src="https://github.com/user-attachments/assets/4236344b-b00d-4fee-adbe-9209431c1ed5" />
After
<img width="247" height="146" alt="Screenshot 2025-09-15 at 12 58 00" src="https://github.com/user-attachments/assets/918e2b73-3e20-4474-adb4-d02cb52f660e" />

Fixed to ignore previous staking txs
<img width="533" height="382" alt="Screenshot 2025-09-15 at 12 58 24" src="https://github.com/user-attachments/assets/d5400004-e45a-47c0-b7c4-9aa97bd46dc5" />

Added ~
<img width="471" height="812" alt="Screenshot 2025-09-15 at 12 59 32" src="https://github.com/user-attachments/assets/c6d47e83-dde2-456d-9a18-c6d4f193f745" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/staking-times&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/staking-times&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/staking-times&lookback=7)