### PR TITLE
chore(suite): improve visual of bluetooth debug settings

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/ForgetBluetoothDevices.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/ForgetBluetoothDevices.tsx
@@ -1,9 +1,8 @@
 import { bluetoothActions } from '@suite-common/bluetooth';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { Button } from '@trezor/components';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
-import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
+import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
 
 export const ForgetAllDevicesButton = () => {
@@ -22,12 +21,16 @@ export const ForgetAllDevicesButton = () => {
                 description="Forgets devices persisted in Suite. In order to fully remove, go to system settings and manually remove the device there."
             />
             <ActionColumn>
-                <Button onClick={handleForgetButtonClick} size="small" variant="destructive">
+                <ActionButton onClick={handleForgetButtonClick} size="small" variant="destructive">
                     Forget in Suite
-                </Button>
-                <Button onClick={handleOpenSettingsButtonClick} size="small" variant="tertiary">
+                </ActionButton>
+                <ActionButton
+                    onClick={handleOpenSettingsButtonClick}
+                    size="small"
+                    variant="tertiary"
+                >
                     Open system settings
-                </Button>
+                </ActionButton>
             </ActionColumn>
         </SectionItem>
     );


### PR DESCRIPTION
using ActionButton istead of Button looks better and seems to follow conventions more tightly in the settings section.

before 

<img width="480" height="339" alt="image" src="https://github.com/user-attachments/assets/ffde4a70-f184-4fbd-92c4-6c5ec3378472" />

after 

<img width="476" height="322" alt="image" src="https://github.com/user-attachments/assets/2e6ea7c9-cc81-4a7a-b2bf-d5717683ba11" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bluetooth-debug-visual&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bluetooth-debug-visual&lookback=7)