### PR TITLE
chore(suite): implement fiat values in offer comparison

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersItem.tsx
@@ -24,7 +24,6 @@ import {
     isTradingSellContext,
 } from 'src/utils/wallet/trading/tradingTypingUtils';
 import { TradingTestWrapper } from 'src/views/wallet/trading';
-import { TradingUtilsKyc } from 'src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc';
 import { TradingUtilsPrice } from 'src/views/wallet/trading/common/TradingUtils/TradingUtilsPrice';
 import { TradingUtilsProvider } from 'src/views/wallet/trading/common/TradingUtils/TradingUtilsProvider';
 
@@ -166,16 +165,8 @@ export const TradingOffersItem = ({ quote }: TradingOffersItemProps) => {
                         />
                     </ExchangeNameOfferColumn>
                     <AmountOfferColumn>
-                        <Row alignItems="flex-end" data-testid="@trading/offer/amount">
-                            <TradingUtilsPrice {...cryptoAmountProps} />
-
-                            {isTradingExchangeContext(context) && (
-                                <TradingUtilsKyc
-                                    exchange={exchange}
-                                    providers={context.exchangeInfo?.providerInfos}
-                                    isForComparator
-                                />
-                            )}
+                        <Row alignItems="flex-start" data-testid="@trading/offer/amount">
+                            <TradingUtilsPrice {...cryptoAmountProps} quote={quote} />
                         </Row>
                     </AmountOfferColumn>
                     <ActionsOfferColumn>

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsPrice.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsPrice.tsx
@@ -1,19 +1,31 @@
 import { CryptoId } from 'invity-api';
 import styled from 'styled-components';
 
+import { ExperimentId } from '@suite-common/message-system';
+import {
+    TradingTradeMapProps,
+    cryptoIdToNetworkSymbolAndContractAddress,
+} from '@suite-common/trading';
+import { TokenAddress } from '@suite-common/wallet-types';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-utils';
-import { Tooltip } from '@trezor/components';
+import { Column, Row, Text, Tooltip } from '@trezor/components';
 import { FONT_SIZE, SCREEN_QUERY } from '@trezor/components/src/config/variables';
-import { spacingsPx, typography } from '@trezor/theme';
+import { spacings, spacingsPx, typography } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { Translation } from 'src/components/suite';
+import { BaseCurrencyValue, Translation } from 'src/components/suite';
+import { ExperimentWrapper } from 'src/components/suite/Experiment/ExperimentWrapper';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingCryptoAmountProps } from 'src/types/trading/trading';
-import { isTradingSellContext } from 'src/utils/wallet/trading/tradingTypingUtils';
+import {
+    isTradingExchangeContext,
+    isTradingSellContext,
+} from 'src/utils/wallet/trading/tradingTypingUtils';
 import { tradingGetAmountLabels } from 'src/utils/wallet/trading/tradingUtils';
 import { TradingCryptoAmount } from 'src/views/wallet/trading/common/TradingCryptoAmount';
 import { TradingFiatAmount } from 'src/views/wallet/trading/common/TradingFiatAmount';
+
+import { TradingUtilsKyc } from './TradingUtilsKyc';
 
 const PriceWrap = styled.div``;
 
@@ -39,13 +51,17 @@ const PriceValue = styled.div`
     }
 `;
 
+interface TradingUtilsPriceProps extends TradingCryptoAmountProps {
+    quote: TradingTradeMapProps[keyof TradingTradeMapProps];
+}
 export const TradingUtilsPrice = ({
     amountInCrypto,
     sendAmount,
     sendCurrency,
     receiveAmount,
     receiveCurrency,
-}: TradingCryptoAmountProps) => {
+    quote,
+}: TradingUtilsPriceProps) => {
     const context = useTradingFormContext();
     const { type } = context;
 
@@ -56,6 +72,10 @@ export const TradingUtilsPrice = ({
         !new BigNumber(receiveAmount).isEqualTo(
             new BigNumber(context.quotesRequest?.cryptoStringAmount),
         );
+
+    const { symbol, contractAddress } = receiveCurrency
+        ? cryptoIdToNetworkSymbolAndContractAddress(receiveCurrency)
+        : {};
 
     return (
         <PriceWrap>
@@ -99,29 +119,74 @@ export const TradingUtilsPrice = ({
                 )}
             </PriceTitle>
             <PriceValueWrap data-testid="@trading/offers/quote/amount">
-                <PriceValue>
-                    {amountInCrypto ? (
-                        <TradingFiatAmount
-                            amount={
-                                sendAmount !== undefined
-                                    ? asBaseCurrencyAmount(new BigNumber(sendAmount))
-                                    : undefined
-                            }
-                            currency={sendCurrency}
-                        />
-                    ) : (
-                        <>
-                            {receiveCurrency && (
-                                <TradingCryptoAmount
-                                    amount={receiveAmount}
-                                    cryptoId={receiveCurrency}
-                                    displayLogo
-                                />
+                <Column>
+                    <Row alignItems="flex-start">
+                        <PriceValue>
+                            {amountInCrypto ? (
+                                <>
+                                    <TradingFiatAmount
+                                        amount={
+                                            sendAmount !== undefined
+                                                ? asBaseCurrencyAmount(new BigNumber(sendAmount))
+                                                : undefined
+                                        }
+                                        currency={sendCurrency}
+                                    />
+                                </>
+                            ) : (
+                                <Column>
+                                    {receiveCurrency && (
+                                        <TradingCryptoAmount
+                                            amount={receiveAmount}
+                                            cryptoId={receiveCurrency}
+                                            displayLogo
+                                        />
+                                    )}
+                                    <ExperimentWrapper
+                                        id={ExperimentId.tradingFiatValues}
+                                        components={[
+                                            { variant: 'A', element: <></> },
+                                            {
+                                                variant: 'B',
+                                                element:
+                                                    symbol && receiveAmount ? (
+                                                        <Text
+                                                            variant="tertiary"
+                                                            typographyStyle="hint"
+                                                            margin={{ left: spacings.xxl }}
+                                                        >
+                                                            <BaseCurrencyValue
+                                                                amount={receiveAmount.toString()}
+                                                                symbol={symbol}
+                                                                rateType="current"
+                                                                tokenAddress={
+                                                                    contractAddress as
+                                                                        | TokenAddress
+                                                                        | undefined
+                                                                }
+                                                                showApproximationIndicator
+                                                            />
+                                                        </Text>
+                                                    ) : (
+                                                        <></>
+                                                    ),
+                                            },
+                                        ]}
+                                    />
+                                </Column>
                             )}
-                        </>
-                    )}
-                </PriceValue>
-                {/*<TradingUtilsTooltip quote={quote} />*/}
+                        </PriceValue>
+                        {isTradingExchangeContext(context) && (
+                            <Row margin={{ top: spacings.xs }}>
+                                <TradingUtilsKyc
+                                    exchange={quote.exchange}
+                                    providers={context.exchangeInfo?.providerInfos}
+                                    isForComparator
+                                />
+                            </Row>
+                        )}
+                    </Row>
+                </Column>
             </PriceValueWrap>
         </PriceWrap>
     );


### PR DESCRIPTION
## Description

This PR adds fiat rates to the offer comparison page. Displaying fiat rates is currently gated behind an experiment, so to test it you’ll need to follow the steps outlined in [this PR](https://github.com/trezor/trezor-suite/pull/21114).

Additionally, I moved `TradingUtilsKyc` into `TradingUtilsPrice` to ensure the UI is properly aligned both with and without fiat values.

## Related Issue

Resolve #21517

## Screenshots:

### Exchange
<img width="1206" height="1444" alt="image" src="https://github.com/user-attachments/assets/5100fdd4-1162-4f1f-9be0-e617d1ddec44" />

### Buy
<img width="1218" height="1446" alt="image" src="https://github.com/user-attachments/assets/2cdeccc9-ba92-4628-9714-ead21492a69b" />

### Sell - amount in fiat
<img width="1214" height="562" alt="image" src="https://github.com/user-attachments/assets/0d4ca8b4-5244-44eb-b8e5-369ead4855c8" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/compare-offers-fiat-rates&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/compare-offers-fiat-rates&lookback=7)