### PR TITLE
feat(suite): show bluetooth status and status page url in debug settings

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -129,6 +129,8 @@ export interface InvokeChannels {
               success: false;
               message: string;
           };
+    //   todo:
+    'bluetooth/get-status': () => InvokeResult<any>;
 }
 
 type DesktopApiListener = ListenerMethod<RendererChannels>;
@@ -202,4 +204,6 @@ export type DesktopApi = {
     // bioAuth
     isBioAuthAvailable: DesktopApiInvoke<'bio-auth/is-bio-auth-available'>;
     validateBioAuth: DesktopApiInvoke<'bio-auth/validate-bio-auth'>;
+    // Bluetooth
+    getBluetoothStatus: DesktopApiInvoke<'bluetooth/get-status'>;
 };

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -197,5 +197,6 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
         openSystemSettings: settings => ipcRenderer.invoke('system/open-settings', settings),
         validateBioAuth: payload => ipcRenderer.invoke('bio-auth/validate-bio-auth', payload),
         isBioAuthAvailable: () => ipcRenderer.invoke('bio-auth/is-bio-auth-available'),
+        getBluetoothStatus: () => ipcRenderer.invoke('bluetooth/get-status'),
     };
 };

--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -142,8 +142,11 @@ export const init: ModuleInit = () => {
         validateIpcMessage(ipcEvent);
 
         try {
-            const url = bluetoothProcess?.getUrl();
-            const status = await bluetoothProcess?.status();
+            await getBluetoothProcess();
+            if (!bluetoothProcess)
+                return { success: false, error: 'unable to load bluetooth process' };
+            const url = bluetoothProcess.getUrl();
+            const status = await bluetoothProcess.status();
 
             return { success: true, payload: { url, ...status } };
         } catch (error) {

--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -1,7 +1,11 @@
 import { ipcMain } from 'electron';
 
 import { isMacOs } from '@trezor/env-utils';
-import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
+import {
+    IpcProxyHandlerOptions,
+    createIpcProxyHandler,
+    validateIpcMessage,
+} from '@trezor/ipc-proxy';
 import { getFreePort } from '@trezor/node-utils';
 import { BluetoothIpc, BluetoothIpcApi, BluetoothTransport } from '@trezor/transport-bluetooth';
 
@@ -133,6 +137,19 @@ export const init: ModuleInit = () => {
         killBluetoothProcess();
         bluetoothModuleState.getTransport = () => undefined;
     };
+
+    ipcMain.handle('bluetooth/get-status', async ipcEvent => {
+        validateIpcMessage(ipcEvent);
+
+        try {
+            const url = bluetoothProcess?.getUrl();
+            const status = await bluetoothProcess?.status();
+
+            return { success: true, payload: { url, ...status } };
+        } catch (error) {
+            return { success: false, error };
+        }
+    });
 
     return { onLoad, onQuit };
 };

--- a/packages/suite/src/views/settings/SettingsDebug/BluetoothServerStatus.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/BluetoothServerStatus.tsx
@@ -1,17 +1,15 @@
 import { useEffect, useState } from 'react';
 
-import { DotIndicator } from '@trezor/components';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { Url } from '@trezor/urls';
 
-import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
+import { SectionItem, TextColumn } from 'src/components/suite';
 
 export const BluetoothServerStatus = () => {
     const [status, setStatus] = useState<
         | { type: 'unknown' }
         | {
               type: 'success';
-              // process and service not used now
               process: boolean;
               service: boolean;
               url: string;
@@ -30,11 +28,12 @@ export const BluetoothServerStatus = () => {
         });
     }, []);
 
-    if (status.type === 'unknown' || status.type === 'error') {
+    if (status.type === 'unknown' || status.type === 'error' || !status.process) {
+        // loading, or failed to load, or process reported as false - there might be case when
+        // server is not owned by suite-desktop, running on another port, possibly the default one (21327)
+        // this case is not handled and we display nothing
         return null;
     }
-
-    console.log(status);
 
     return (
         <SectionItem>
@@ -44,18 +43,6 @@ export const BluetoothServerStatus = () => {
                 buttonTitle="Status page"
                 buttonLink={status.url as Url}
             />
-            <ActionColumn>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <DotIndicator isActive={status.process} />
-                        <span>Process</span>
-                    </div>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <DotIndicator isActive={status.service} />
-                        <span>Service</span>
-                    </div>
-                </div>
-            </ActionColumn>
         </SectionItem>
     );
 };

--- a/packages/suite/src/views/settings/SettingsDebug/BluetoothServerStatus.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/BluetoothServerStatus.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+
+import { DotIndicator } from '@trezor/components';
+import { desktopApi } from '@trezor/suite-desktop-api';
+import { Url } from '@trezor/urls';
+
+import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
+
+export const BluetoothServerStatus = () => {
+    const [status, setStatus] = useState<
+        | { type: 'unknown' }
+        | {
+              type: 'success';
+              // process and service not used now
+              process: boolean;
+              service: boolean;
+              url: string;
+          }
+        | { type: 'error'; error: string }
+    >({ type: 'unknown' });
+
+    useEffect(() => {
+        desktopApi.getBluetoothStatus().then(result => {
+            console.log(result);
+            if (result.success) {
+                setStatus({ type: 'success', ...result.payload });
+            } else {
+                setStatus({ type: 'error', error: result.error });
+            }
+        });
+    }, []);
+
+    if (status.type === 'unknown' || status.type === 'error') {
+        return null;
+    }
+
+    console.log(status);
+
+    return (
+        <SectionItem>
+            <TextColumn
+                title="Bluetooth status page"
+                description="Bluetooth debugging tool available only in dev builds."
+                buttonTitle="Status page"
+                buttonLink={status.url as Url}
+            />
+            <ActionColumn>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                        <DotIndicator isActive={status.process} />
+                        <span>Process</span>
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                        <DotIndicator isActive={status.service} />
+                        <span>Service</span>
+                    </div>
+                </div>
+            </ActionColumn>
+        </SectionItem>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -9,6 +9,7 @@ import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { Backends } from './Backends';
 import { BluetoothEnabledCheckbox } from './BluetoothEnabledCheckbox';
+import { BluetoothServerStatus } from './BluetoothServerStatus';
 import { CheckFirmwareAuthenticity } from './CheckFirmwareAuthenticity';
 import { CoinjoinApi } from './CoinjoinApi';
 import { ConnectPopup } from './ConnectPopup';
@@ -95,6 +96,7 @@ export const SettingsDebug = () => {
                 <SettingsSection title={<Translation id="TR_BLUETOOTH" />}>
                     <BluetoothEnabledCheckbox />
                     <ShowBluetoothDebugInfo />
+                    <BluetoothServerStatus />
                     <ForgetAllDevicesButton />
                 </SettingsSection>
             )}


### PR DESCRIPTION
there is a nice bluetooth playground UI that is getting some love in #21455

and since bl server starts on a random port, it is useful to tunnel this infomation into UI. I also added standard process status information.

note: it probably needs another update of bt binary to take effect

<img width="940" height="438" alt="image" src="https://github.com/user-attachments/assets/1ae77557-7dc7-4888-a9e9-9c087ed4ba3d" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bl-status-page-in-settings&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bl-status-page-in-settings&lookback=7)