### PR TITLE
Chore/25.9.2 migration

### DIFF
--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -93,7 +93,7 @@ export const resetDevice =
     (params: Parameters<typeof TrezorConnect.resetDevice>[0] = {}) =>
     async (dispatch: Dispatch, getState: GetState) => {
         const device = selectSelectedDevice(getState());
-        const isEntropyCheckEnabled = selectIsEntropyCheckEnabled(getState());
+        const isEntropyCheckEnabledInSettings = selectIsEntropyCheckEnabled(getState());
         const isEntropyCheckDisabledByMessageSystem = selectIsFeatureDisabled(
             getState(),
             Feature.entropyCheck,
@@ -143,16 +143,19 @@ export const resetDevice =
             passphrase_protection: DEVICE.DEFAULT_PASSPHRASE_PROTECTION,
         };
 
+        const isEntropyCheckEnabled =
+            isEntropyCheckEnabledInSettings && !isEntropyCheckDisabledByMessageSystem;
+
         const result = await TrezorConnect.resetDevice({
             ...defaults,
             ...params,
             device: {
                 path: device.path,
             },
-            entropy_check: isEntropyCheckEnabled && !isEntropyCheckDisabledByMessageSystem,
+            entropy_check: isEntropyCheckEnabled,
         });
 
-        if (!result.success) {
+        if (isEntropyCheckEnabled && !result.success) {
             dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
             if (result.payload.code === 'Failure_EntropyCheck') {
                 dispatch(failEntropyCheckThunk({ device, error: result.payload }));

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 25.9.2
+
+- clear `security.devicesWithFailedEntropyCheck` because of false positives in 25.8
+
 ## 25.9.0
 
 - persist `suite.stakingDashboardCollapsed` in `suiteSettings`

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -4,11 +4,6 @@
 
 - clear `security.devicesWithFailedEntropyCheck` because of false positives in 25.8
 
-## 25.9.0
-
-- persist `suite.stakingDashboardCollapsed` in `suiteSettings`
-- persist `wallet.settings.mevProtection` in `walletSettings`
-
 ## 25.8.0
 
 - make `device.authenticityChecks` non-nullable

--- a/packages/suite/src/storage/migrations/versions/25.9.2.ts
+++ b/packages/suite/src/storage/migrations/versions/25.9.2.ts
@@ -1,0 +1,15 @@
+import { createMigration } from '@suite/idb-migration-utils';
+
+import { SuiteDBSchema } from 'src/storage/definitions';
+
+export default createMigration<SuiteDBSchema>('25.9.2', async (db, tx) => {
+    if (!db.objectStoreNames.contains('security')) return;
+
+    const store = tx.objectStore('security');
+    const security = await store.get('security');
+
+    if (security && 'devicesWithFailedEntropyCheck' in security) {
+        delete security.devicesWithFailedEntropyCheck;
+        await store.put(security, 'security');
+    }
+});

--- a/packages/suite/src/storage/migrations/versions/index.ts
+++ b/packages/suite/src/storage/migrations/versions/index.ts
@@ -5,3 +5,4 @@
 
 export { default as m25_7_0 } from './25.7.0';
 export { default as m25_8_0 } from './25.8.0';
+export { default as m25_9_2 } from './25.9.2';

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -123,7 +123,11 @@ export const createAndBackupWalletThunk = createThunk(
         }
 
         const result = deviceResponse.payload;
-        if (!result.success && result.payload.code === 'Failure_EntropyCheck') {
+        if (
+            isEntropyCheckEnabled &&
+            !result.success &&
+            result.payload.code === 'Failure_EntropyCheck'
+        ) {
             dispatch(failEntropyCheckThunk({ device, error: result.payload }));
         }
 


### PR DESCRIPTION
Due to a [bug](https://github.com/trezor/trezor-suite/pull/21325) in 25.8, some unrelated errors during wallet creation led to an entropy check failure. Even after entropy check was disabled via message system, device IDs kept being stored locally, so after re-enabling the check in 25.9.1, users could see the entropy check failure screen.

This PR adds a migration to clear `devicesWithFailedEntropyCheck` field in the DB.
It also adds a failsafe mechanism not to trigger `failEntropyCheckThunk` when entropy check is disabled.

Entropy check has been [re-re-enabled](https://github.com/trezor/trezor-suite/pull/21480/files) from 25.9.2 onwards.

How to test:
- Using a fake device, fail entropy check on 25.7 or older (where it is not disabled).
- Reopen Suite, reconnect device - you SHOULD see the Ghost modal.
- Upgrade to 25.9.2 - you should NOT see the Ghost modal.
- Fail entropy check again, reopen Suite, reconnect device - you SHOULD see the Ghost modal.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/25.9.2-migration&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/25.9.2-migration&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/25.9.2-migration&lookback=7)