### PR TITLE
Refactor: move BT & THP to devicePersistentData

### DIFF
--- a/packages/suite/src/utils/suite/storage.ts
+++ b/packages/suite/src/utils/suite/storage.ts
@@ -20,6 +20,9 @@ export const serializeDevice = (
         connected: false,
         buttonRequests: [],
         authenticityChecks: filterInconclusiveAuthenticityChecks(device.authenticityChecks),
+        // instead persisted on `persistentDeviceData` as part of the effort to unlink device from wallet
+        thp: undefined,
+        bluetoothProps: undefined,
     };
     if (forceRemember) sd.forceRemember = true;
 

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/TemporaryForgetDeviceButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/TemporaryForgetDeviceButton.tsx
@@ -1,4 +1,5 @@
 import type { AcquiredDevice, TrezorDevice } from '@suite-common/suite-types';
+import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { deviceActions, forgetSingleDevicePersistentDataThunk } from '@suite-common/wallet-core';
 import { IconButton, Paragraph, Tooltip } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
@@ -23,8 +24,10 @@ export const TemporaryForgetDeviceButton = ({
     const isDebug = useSelector(selectIsDebugModeActive);
     if (!isDebug) return null;
 
+    if (!isDeviceAcquired(device)) return null;
+
     const handleClick = () => {
-        dispatch(forgetSingleDevicePersistentDataThunk({ device }));
+        dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: device.id }));
 
         instances.forEach(instance => {
             dispatch(deviceActions.forgetDevice({ device: instance }));

--- a/suite-common/bluetooth/src/support/mocks.ts
+++ b/suite-common/bluetooth/src/support/mocks.ts
@@ -1,0 +1,23 @@
+import { DeviceModelInternal } from '@trezor/device-utils';
+
+import { BluetoothDeviceCommon } from '../types';
+
+// This file is intentionally not reexported in index.ts, so that bundler won't have to import.
+
+/**
+ * Generate a mock bluetooth known or nearby device.
+ */
+export const createBluetoothDevice = (
+    partialBluetoothDevice?: Partial<BluetoothDeviceCommon>,
+): BluetoothDeviceCommon => ({
+    id: 'bt-device-1',
+    name: 'Mock Trezor bt-device-1',
+    manufacturerData: {
+        deviceModel: DeviceModelInternal.T3W1,
+        deviceColor: 0,
+        filterPolicy: undefined,
+    },
+    lastUpdatedTimestamp: 1,
+    connectionStatus: { type: 'connected' },
+    ...partialBluetoothDevice,
+});

--- a/suite-common/bluetooth/src/types.ts
+++ b/suite-common/bluetooth/src/types.ts
@@ -38,6 +38,7 @@ export type DeviceBluetoothConnectionStatus =
 
 // Do not export this outside of this suite-common package, Suite uses ist own type
 // from the '@trezor/transport-bluetooth' and mobile (native) have its own type as well.
+// It's acceptable to use in @suite-common, where the code is still platform-agnostic, e.g. in unit tests.
 export type BluetoothDeviceCommon = {
     id: string;
     name: string;

--- a/suite-common/bluetooth/tests/filterOutOldDuplicatesByName.test.ts
+++ b/suite-common/bluetooth/tests/filterOutOldDuplicatesByName.test.ts
@@ -1,42 +1,13 @@
-import { DeviceModelInternal } from '@trezor/device-utils';
-
 import { filterOutOldDuplicatesByName } from '../src/filterOutOldDuplicatesByName';
+import { createBluetoothDevice } from '../src/support/mocks';
 import { BluetoothDeviceCommon } from '../src/types';
-
-const defaultDeviceAdditionalParams: Pick<
-    BluetoothDeviceCommon,
-    'connectionStatus' | 'manufacturerData'
-> = {
-    connectionStatus: {
-        type: 'disconnected',
-    },
-    manufacturerData: {
-        deviceColor: 1,
-        deviceModel: DeviceModelInternal.T3W1,
-    },
-};
 
 describe(filterOutOldDuplicatesByName.name, () => {
     it('returns all devices if names are unique', () => {
         const devices: BluetoothDeviceCommon[] = [
-            {
-                id: '1',
-                name: 'DeviceA',
-                lastUpdatedTimestamp: 100,
-                ...defaultDeviceAdditionalParams,
-            },
-            {
-                id: '2',
-                name: 'DeviceB',
-                lastUpdatedTimestamp: 200,
-                ...defaultDeviceAdditionalParams,
-            },
-            {
-                id: '3',
-                name: 'DeviceC',
-                lastUpdatedTimestamp: 300,
-                ...defaultDeviceAdditionalParams,
-            },
+            createBluetoothDevice({ id: '1', name: 'DeviceA', lastUpdatedTimestamp: 100 }),
+            createBluetoothDevice({ id: '2', name: 'DeviceB', lastUpdatedTimestamp: 200 }),
+            createBluetoothDevice({ id: '3', name: 'DeviceC', lastUpdatedTimestamp: 300 }),
         ];
         const result = filterOutOldDuplicatesByName(devices);
         expect(result).toHaveLength(3);
@@ -45,97 +16,32 @@ describe(filterOutOldDuplicatesByName.name, () => {
 
     it('keeps only the latest device for duplicate names', () => {
         const devices: BluetoothDeviceCommon[] = [
-            {
-                id: '1',
-                name: 'DeviceA',
-                lastUpdatedTimestamp: 100,
-                ...defaultDeviceAdditionalParams,
-            },
-            {
-                id: '2',
-                name: 'DeviceA',
-                lastUpdatedTimestamp: 200,
-                ...defaultDeviceAdditionalParams,
-            },
-            {
-                id: '3',
-                name: 'DeviceB',
-                lastUpdatedTimestamp: 150,
-                ...defaultDeviceAdditionalParams,
-            },
+            createBluetoothDevice({ id: '1', name: 'DeviceA', lastUpdatedTimestamp: 100 }),
+            createBluetoothDevice({ id: '2', name: 'DeviceA', lastUpdatedTimestamp: 200 }),
+            createBluetoothDevice({ id: '3', name: 'DeviceB', lastUpdatedTimestamp: 150 }),
         ];
         const result = filterOutOldDuplicatesByName(devices);
         expect(result).toHaveLength(2);
         expect(result).toEqual([
-            {
-                id: '2',
-                name: 'DeviceA',
-                lastUpdatedTimestamp: 200,
-                ...defaultDeviceAdditionalParams,
-            },
-            {
-                id: '3',
-                name: 'DeviceB',
-                lastUpdatedTimestamp: 150,
-                ...defaultDeviceAdditionalParams,
-            },
+            createBluetoothDevice({ id: '2', name: 'DeviceA', lastUpdatedTimestamp: 200 }),
+            createBluetoothDevice({ id: '3', name: 'DeviceB', lastUpdatedTimestamp: 150 }),
         ]);
     });
 
     it('handles multiple sets of duplicates', () => {
         const devices: BluetoothDeviceCommon[] = [
-            {
-                id: '1',
-                name: 'DeviceA',
-                lastUpdatedTimestamp: 100,
-                ...defaultDeviceAdditionalParams,
-            },
-            {
-                id: '2',
-                name: 'DeviceA',
-                lastUpdatedTimestamp: 200,
-                ...defaultDeviceAdditionalParams,
-            },
-            {
-                id: '3',
-                name: 'DeviceB',
-                lastUpdatedTimestamp: 150,
-                ...defaultDeviceAdditionalParams,
-            },
-            {
-                id: '4',
-                name: 'DeviceB',
-                lastUpdatedTimestamp: 250,
-                ...defaultDeviceAdditionalParams,
-            },
-            {
-                id: '5',
-                name: 'DeviceC',
-                lastUpdatedTimestamp: 300,
-                ...defaultDeviceAdditionalParams,
-            },
+            createBluetoothDevice({ id: '1', name: 'DeviceA', lastUpdatedTimestamp: 100 }),
+            createBluetoothDevice({ id: '2', name: 'DeviceA', lastUpdatedTimestamp: 200 }),
+            createBluetoothDevice({ id: '3', name: 'DeviceB', lastUpdatedTimestamp: 150 }),
+            createBluetoothDevice({ id: '4', name: 'DeviceB', lastUpdatedTimestamp: 250 }),
+            createBluetoothDevice({ id: '5', name: 'DeviceC', lastUpdatedTimestamp: 300 }),
         ];
         const result = filterOutOldDuplicatesByName(devices);
         expect(result).toHaveLength(3);
         expect(result).toEqual([
-            {
-                id: '2',
-                name: 'DeviceA',
-                lastUpdatedTimestamp: 200,
-                ...defaultDeviceAdditionalParams,
-            },
-            {
-                id: '4',
-                name: 'DeviceB',
-                lastUpdatedTimestamp: 250,
-                ...defaultDeviceAdditionalParams,
-            },
-            {
-                id: '5',
-                name: 'DeviceC',
-                lastUpdatedTimestamp: 300,
-                ...defaultDeviceAdditionalParams,
-            },
+            createBluetoothDevice({ id: '2', name: 'DeviceA', lastUpdatedTimestamp: 200 }),
+            createBluetoothDevice({ id: '4', name: 'DeviceB', lastUpdatedTimestamp: 250 }),
+            createBluetoothDevice({ id: '5', name: 'DeviceC', lastUpdatedTimestamp: 300 }),
         ]);
     });
 
@@ -147,27 +53,12 @@ describe(filterOutOldDuplicatesByName.name, () => {
 
     it('keeps the latest device when timestamps are equal (prefers last in array)', () => {
         const devices: BluetoothDeviceCommon[] = [
-            {
-                id: '1',
-                name: 'DeviceA',
-                lastUpdatedTimestamp: 100,
-                ...defaultDeviceAdditionalParams,
-            },
-            {
-                id: '2',
-                name: 'DeviceA',
-                lastUpdatedTimestamp: 100,
-                ...defaultDeviceAdditionalParams,
-            },
+            createBluetoothDevice({ id: '1', name: 'DeviceA', lastUpdatedTimestamp: 100 }),
+            createBluetoothDevice({ id: '2', name: 'DeviceA', lastUpdatedTimestamp: 100 }),
         ];
         const result = filterOutOldDuplicatesByName(devices);
         expect(result).toEqual([
-            {
-                id: '2',
-                name: 'DeviceA',
-                lastUpdatedTimestamp: 100,
-                ...defaultDeviceAdditionalParams,
-            },
+            createBluetoothDevice({ id: '2', name: 'DeviceA', lastUpdatedTimestamp: 100 }),
         ]);
     });
 });

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -85,6 +85,7 @@ export type AuthorizedDevice = AcquiredDevice & {
  */
 export type DeviceWithEmptyPath = Omit<AcquiredDevice, 'path'> & { path: '' };
 
+type PersistedDeviceKey = UnionSubset<keyof AcquiredDevice, 'thp' | 'bluetoothProps'>;
 type PersistedFeatureKey = UnionSubset<
     keyof Features,
     | 'device_id'
@@ -95,9 +96,10 @@ type PersistedFeatureKey = UnionSubset<
     | 'label'
     | 'initialized'
 >;
-export type PersistentDeviceData = Pick<Features, PersistedFeatureKey> & {
-    firmwareVersion: VersionArray | null;
-    lastConnectedBy: 'bluetooth' | 'usb' | null;
-    // TODO move devicesWithFailedEntropyCheck to this object, including persistence & migration
-    // TODO move deviceAuthenticity to this object and newly introduce persistence
-};
+export type PersistentDeviceData = Pick<AcquiredDevice, PersistedDeviceKey> &
+    Pick<Features, PersistedFeatureKey> & {
+        firmwareVersion: VersionArray | null;
+        lastConnectedBy: 'bluetooth' | 'usb' | null;
+        // TODO move devicesWithFailedEntropyCheck to this object, including persistence & migration
+        // TODO move deviceAuthenticity to this object and newly introduce persistence
+    };

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -3,12 +3,14 @@ import {
     DeviceButtonRequest,
     DeviceEvent,
     DeviceState,
+    Features,
     KnownDevice,
     PROTO,
     UnknownDevice as UnknownDeviceBase,
     UnreadableDevice as UnreadableDeviceBase,
 } from '@trezor/connect';
-import { Branded } from '@trezor/type-utils';
+import { VersionArray } from '@trezor/device-utils';
+import { Branded, UnionSubset } from '@trezor/type-utils';
 
 // Extend original ButtonRequestMessage from @trezor/connect
 // suite (deviceReducer) stores them in slightly different shape:
@@ -82,3 +84,20 @@ export type AuthorizedDevice = AcquiredDevice & {
  * used when saving device to storage
  */
 export type DeviceWithEmptyPath = Omit<AcquiredDevice, 'path'> & { path: '' };
+
+type PersistedFeatureKey = UnionSubset<
+    keyof Features,
+    | 'device_id'
+    | 'internal_model'
+    | 'fw_vendor'
+    | 'revision'
+    | 'unit_color'
+    | 'label'
+    | 'initialized'
+>;
+export type PersistentDeviceData = Pick<Features, PersistedFeatureKey> & {
+    firmwareVersion: VersionArray | null;
+    lastConnectedBy: 'bluetooth' | 'usb' | null;
+    // TODO move devicesWithFailedEntropyCheck to this object, including persistence & migration
+    // TODO move deviceAuthenticity to this object and newly introduce persistence
+};

--- a/suite-common/thp/src/index.ts
+++ b/suite-common/thp/src/index.ts
@@ -1,5 +1,5 @@
-export { prepareThpReducer, THP_BUTTON_REQUESTS_NAMES } from './thpReducer';
-export type { ThpStep } from './thpReducer';
+export { prepareThpReducer, initialThpState, THP_BUTTON_REQUESTS_NAMES } from './thpReducer';
+export type { ThpStep, ThpState } from './thpReducer';
 export { selectIsThpInProgress, selectThpStep, selectThpCredentials } from './thpSelectors';
 export { thpActions } from './thpActions';
 export * from './thpUtils';

--- a/suite-common/thp/src/support/mocks.ts
+++ b/suite-common/thp/src/support/mocks.ts
@@ -1,0 +1,41 @@
+import type { ThpSuiteCredentials } from '@suite-common/suite-types';
+import { DeviceModelInternal } from '@trezor/device-utils';
+import type { ThpStateSerialized } from '@trezor/protocol';
+
+// This file is intentionally not reexported in index.ts, so that bundler won't have to import.
+
+/**
+ * Generate a mock THP credential.
+ */
+export const createCredential = (
+    partialCredential?: Partial<ThpSuiteCredentials>,
+): ThpSuiteCredentials => ({
+    credential: 'default-credential',
+    trezor_static_public_key: 'random-static-public-key',
+    connectionCounter: 0,
+    autoconnect: false,
+    ...partialCredential,
+});
+
+/**
+ * Generate a mock device.thp properties as they are on a readable device
+ */
+export const createDeviceThp = (
+    partialDeviceThp?: Partial<ThpStateSerialized>,
+): ThpStateSerialized => ({
+    properties: {
+        internal_model: DeviceModelInternal.T3W1,
+        model_variant: 0,
+        protocol_version_major: 2,
+        protocol_version_minor: 0,
+        pairing_methods: [],
+    },
+    channel: 'channel-id',
+    sendBit: 0,
+    recvBit: 0,
+    sendNonce: 1,
+    recvNonce: 2,
+    expectedResponses: [1],
+    credentials: [createCredential()],
+    ...partialDeviceThp,
+});

--- a/suite-common/thp/src/thpReducer.ts
+++ b/suite-common/thp/src/thpReducer.ts
@@ -45,14 +45,14 @@ export type ThpState = {
     staticKey?: string;
 };
 
-const initialState: ThpState = {
+export const initialThpState: ThpState = {
     step: null,
     lastThpCode: undefined,
     credentials: [] as ThpSuiteCredentials[],
 };
 
 export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
-    initialState,
+    initialThpState,
     (builder, extra) =>
         builder
             .addCase(thpActions.invalidCode, state => {

--- a/suite-common/thp/tests/autoInitThpAfterDeviceConnectionThunk.test.ts
+++ b/suite-common/thp/tests/autoInitThpAfterDeviceConnectionThunk.test.ts
@@ -6,23 +6,16 @@ import { acquireDevice, prepareDeviceReducer } from '@suite-common/wallet-core';
 import { Device } from '@trezor/connect';
 
 import { autoInitThpAfterDeviceConnectionThunk } from '../src/autoInitThpAfterDeviceConnectionThunk';
+import { createDeviceThp } from '../src/support/mocks';
 import { ThpState, prepareThpReducer } from '../src/thpReducer';
 
 const thpReduce = prepareThpReducer(extraDependenciesMock);
 const firmwareReduce = prepareFirmwareReducer(extraDependenciesMock);
 const deviceReduce = prepareDeviceReducer(extraDependenciesMock);
 
-const device = testMocks.getSuiteDevice({
-    thp: {
-        credentials: [],
-        channel: '',
-        sendBit: 0,
-        recvBit: 0,
-        sendNonce: 0,
-        recvNonce: 0,
-        expectedResponses: [],
-    },
-}) as Device;
+const device = testMocks.getConnectDevice({
+    thp: createDeviceThp(),
+});
 const initialThpState: ThpState = { step: null, lastThpCode: undefined, credentials: [] };
 const initialFirmwareState: FirmwareUpdateState = {
     error: '',

--- a/suite-common/thp/tests/connectThpDeviceThunk.test.ts
+++ b/suite-common/thp/tests/connectThpDeviceThunk.test.ts
@@ -1,29 +1,18 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { FirmwareUpdateState, prepareFirmwareReducer } from '@suite-common/firmware';
-import { ThpSuiteCredentials } from '@suite-common/suite-types';
 import { configureMockStore, extraDependenciesMock, testMocks } from '@suite-common/test-utils';
 import { Device } from '@trezor/connect';
 
 import { connectThpDeviceThunk } from '../src/connectThpDeviceThunk';
+import { createCredential, createDeviceThp } from '../src/support/mocks';
 import { ThpState, prepareThpReducer } from '../src/thpReducer';
 
 const thpReduce = prepareThpReducer(extraDependenciesMock);
 const firmwareReduce = prepareFirmwareReducer(extraDependenciesMock);
 
-const thpCredential1: ThpSuiteCredentials = {
-    connectionCounter: 0,
-    credential: 'credential-1',
-    autoconnect: false,
-    trezor_static_public_key: 'pubkey-1',
-};
-
-const thpCredential2: ThpSuiteCredentials = {
-    connectionCounter: 0,
-    credential: 'credential-2',
-    autoconnect: false,
-    trezor_static_public_key: 'pubkey-2',
-};
+const thpCredential1 = createCredential({ credential: 'credential-1' });
+const thpCredential2 = createCredential({ credential: 'credential-2' });
 
 const initialThpState: ThpState = {
     step: null,
@@ -42,22 +31,7 @@ const initialFirmwareState: FirmwareUpdateState = {
 };
 
 const device: Pick<Device, 'thp' | 'features'> = {
-    thp: {
-        credentials: [thpCredential1],
-        properties: {
-            internal_model: 'T3W1',
-            model_variant: 0,
-            protocol_version_major: 10,
-            protocol_version_minor: 20,
-            pairing_methods: [],
-        },
-        channel: '',
-        sendBit: 0,
-        recvBit: 0,
-        sendNonce: 0,
-        recvNonce: 0,
-        expectedResponses: [],
-    },
+    thp: { ...createDeviceThp(), credentials: [thpCredential1] },
     features: testMocks.getDeviceFeatures(),
 };
 

--- a/suite-common/thp/tests/thpReducer.test.ts
+++ b/suite-common/thp/tests/thpReducer.test.ts
@@ -1,9 +1,9 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
-import { ThpSuiteCredentials } from '@suite-common/suite-types';
 import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
 
 import { prepareThpReducer, thpActions } from '../src';
+import { createCredential } from '../src/support/mocks';
 import { ThpState } from '../src/thpReducer';
 
 const thpReduce = prepareThpReducer(extraDependenciesMock);
@@ -14,12 +14,9 @@ const initialState: ThpState = {
     credentials: [],
 };
 
-const createCredential = (credential: string): ThpSuiteCredentials => ({
-    credential,
-    connectionCounter: 0,
-    trezor_static_public_key: '',
-    autoconnect: false,
-});
+const credential1 = createCredential({ credential: '1' });
+const credential2 = createCredential({ credential: '2' });
+const credential3 = createCredential({ credential: '3' });
 
 describe('thpReducer', () => {
     it('sets the lastThpCode', () => {
@@ -41,17 +38,17 @@ describe('thpReducer', () => {
             preloadedState: {
                 thp: {
                     ...initialState,
-                    credentials: [createCredential('1'), createCredential('2')],
+                    credentials: [credential1, credential2],
                 },
             },
         });
 
         expect(store.getState().thp.credentials.map(it => it.credential)).toEqual(['1', '2']);
 
-        store.dispatch(thpActions.removeCredentials({ credentials: [createCredential('3')] }));
+        store.dispatch(thpActions.removeCredentials({ credentials: [credential3] }));
         expect(store.getState().thp.credentials.map(it => it.credential)).toEqual(['1', '2']);
 
-        store.dispatch(thpActions.removeCredentials({ credentials: [createCredential('1')] }));
+        store.dispatch(thpActions.removeCredentials({ credentials: [credential1] }));
         expect(store.getState().thp.credentials.map(it => it.credential)).toEqual(['2']);
     });
 });

--- a/suite-common/wallet-core/src/device/__fixtures__/forgetPersistentDataPreloadedState.ts
+++ b/suite-common/wallet-core/src/device/__fixtures__/forgetPersistentDataPreloadedState.ts
@@ -1,0 +1,76 @@
+import { BluetoothState, prepareInitialState } from '@suite-common/bluetooth';
+import { createBluetoothDevice } from '@suite-common/bluetooth/src/support/mocks';
+import { BluetoothDeviceCommon } from '@suite-common/bluetooth/src/types';
+import { PersistentDeviceData } from '@suite-common/suite-types';
+import { ThpState, initialThpState } from '@suite-common/thp';
+import { createCredential, createDeviceThp } from '@suite-common/thp/src/support/mocks';
+import { DeviceModelInternal } from '@trezor/device-utils';
+
+import { DeviceReducerState, deviceInitialState } from '../deviceReducer';
+
+type ForgetPersistentDataPreloadedState = {
+    device: DeviceReducerState;
+    bluetooth: BluetoothState<BluetoothDeviceCommon>;
+    thp: ThpState;
+};
+
+const BTDevice1 = createBluetoothDevice({ id: 'bt-id-1' });
+const BTDevice3 = createBluetoothDevice({ id: 'bt-id-3' });
+const orphanedBTDevice = createBluetoothDevice({ id: 'bt-id-4' });
+
+const credential1A = createCredential({ credential: '1A' });
+const credential1B = createCredential({ credential: '1B' });
+const credential1C = createCredential({ credential: '1C' });
+const credential2 = createCredential({ credential: '2' });
+const orphanedCredential = createCredential({ credential: '4' });
+
+const defaultDevicePersistentData: PersistentDeviceData = {
+    device_id: 'device-id',
+    internal_model: DeviceModelInternal.UNKNOWN,
+    fw_vendor: null,
+    revision: null,
+    label: null,
+    initialized: null,
+    firmwareVersion: null,
+    lastConnectedBy: null,
+};
+
+export const forgetPersistentDataPreloadedStateFixture: ForgetPersistentDataPreloadedState = {
+    device: {
+        ...deviceInitialState,
+        persistentDeviceData: [
+            {
+                ...defaultDevicePersistentData,
+                device_id: 'device-id-1',
+                bluetoothProps: { id: BTDevice1.id },
+                thp: {
+                    ...createDeviceThp(),
+                    credentials: [credential1A, credential1B, credential1C],
+                },
+            },
+            {
+                ...defaultDevicePersistentData,
+                device_id: 'device-id-2',
+                thp: {
+                    ...createDeviceThp(),
+                    credentials: [credential2],
+                },
+            },
+            {
+                ...defaultDevicePersistentData,
+                device_id: 'device-id-3',
+                bluetoothProps: { id: BTDevice3.id },
+            },
+        ],
+    },
+
+    bluetooth: {
+        ...prepareInitialState<BluetoothDeviceCommon>(),
+        knownDevices: [BTDevice1, orphanedBTDevice],
+    },
+
+    thp: {
+        ...initialThpState,
+        credentials: [credential1A, credential1B, credential2, orphanedCredential],
+    },
+};

--- a/suite-common/wallet-core/src/device/__tests__/deviceThunks.test.ts
+++ b/suite-common/wallet-core/src/device/__tests__/deviceThunks.test.ts
@@ -1,0 +1,91 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { prepareBluetoothReducerCreator } from '@suite-common/bluetooth';
+import { BluetoothDeviceCommon } from '@suite-common/bluetooth/src/types';
+import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
+import { prepareThpReducer } from '@suite-common/thp';
+
+import { forgetPersistentDataPreloadedStateFixture } from '../__fixtures__/forgetPersistentDataPreloadedState';
+import { prepareDeviceReducer } from '../deviceReducer';
+import {
+    forgetAllDevicesPersistentDataThunk,
+    forgetSingleDevicePersistentDataThunk,
+} from '../deviceThunks';
+
+const deviceReducer = prepareDeviceReducer(extraDependenciesMock);
+const bluetoothReducer =
+    prepareBluetoothReducerCreator<BluetoothDeviceCommon>()(extraDependenciesMock);
+const thpReducer = prepareThpReducer(extraDependenciesMock);
+
+const initStore = () =>
+    configureMockStore({
+        reducer: combineReducers({
+            bluetooth: bluetoothReducer,
+            device: deviceReducer,
+            thp: thpReducer,
+        }),
+        preloadedState: forgetPersistentDataPreloadedStateFixture,
+    });
+
+describe(forgetSingleDevicePersistentDataThunk.name, () => {
+    it('forgets a single device data with Bluetooth and THP', async () => {
+        const store = initStore();
+        await store.dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: 'device-id-1' }));
+        const state = store.getState();
+
+        // device-id-1 persistent data is removed, others remain
+        expect(state.device.persistentDeviceData.map(d => d.device_id)).toEqual([
+            'device-id-2',
+            'device-id-3',
+        ]);
+        // BT known device 'bt-id-1' is removed, others remain
+        expect(state.bluetooth.knownDevices.map(d => d.id)).toEqual(['bt-id-4']);
+        // THP credentials '1A', '1B' are removed, '1C' was not found, others remain
+        expect(state.thp.credentials.map(c => c.credential)).toEqual(['2', '4']);
+    });
+
+    it('forgets a single device data with THP, but no Bluetooth data', async () => {
+        const store = initStore();
+        await store.dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: 'device-id-2' }));
+        const state = store.getState();
+
+        expect(state.device.persistentDeviceData.map(d => d.device_id)).toEqual([
+            'device-id-1',
+            'device-id-3',
+        ]);
+        expect(state.bluetooth).toEqual(forgetPersistentDataPreloadedStateFixture.bluetooth);
+        expect(state.thp.credentials.map(c => c.credential)).toEqual(['1A', '1B', '4']);
+    });
+
+    it('forgets a single device data with pointer to non-existent data', async () => {
+        const store = initStore();
+        await store.dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: 'device-id-3' }));
+        const state = store.getState();
+
+        expect(state.device.persistentDeviceData.map(d => d.device_id)).toEqual([
+            'device-id-1',
+            'device-id-2',
+        ]);
+        expect(state.bluetooth).toEqual(forgetPersistentDataPreloadedStateFixture.bluetooth);
+        expect(state.thp).toEqual(forgetPersistentDataPreloadedStateFixture.thp);
+    });
+
+    it('does nothing for a non-existent device', async () => {
+        const store = initStore();
+        await store.dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: 'device-id-4' }));
+        const state = store.getState();
+        expect(state).toEqual(forgetPersistentDataPreloadedStateFixture);
+    });
+});
+
+describe(forgetAllDevicesPersistentDataThunk.name, () => {
+    it('forgets all data, even orphaned', async () => {
+        const store = initStore();
+        await store.dispatch(forgetAllDevicesPersistentDataThunk());
+        const state = store.getState();
+
+        expect(state.device.persistentDeviceData).toEqual([]);
+        expect(state.bluetooth.knownDevices).toEqual([]);
+        expect(state.thp.credentials).toEqual([]);
+    });
+});

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -1,6 +1,7 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import {
+    AcquiredDevice,
     ButtonRequest,
     EvoluKeys,
     ThpSuiteCredentials,
@@ -74,7 +75,7 @@ const forgetDevice = createAction(
 // Forget persistent deviceReducer data for a device. See `forgetSingleDevicePersistentDataThunk` for all device-associated data.
 const forgetDevicePersistentData = createAction(
     `${DEVICE_MODULE_PREFIX}/forgetDevicePersistentData`,
-    (payload: { deviceId: string }) => ({ payload }),
+    (payload: { deviceId: AcquiredDevice['id'] }) => ({ payload }),
 );
 
 // Forget persistent deviceReducer data for all devices. See `forgetAllDevicesPersistentDataThunk` for all device-associated data.

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -5,40 +5,20 @@ import {
     deviceAuthenticityActions,
 } from '@suite-common/device-authenticity';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
-import { AcquiredDevice, ButtonRequest, TrezorDevice } from '@suite-common/suite-types';
+import {
+    AcquiredDevice,
+    ButtonRequest,
+    PersistentDeviceData,
+    TrezorDevice,
+} from '@suite-common/suite-types';
 import * as deviceUtils from '@suite-common/suite-utils';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { shouldDeviceBeRemembered } from '@suite-common/wallet-utils';
-import {
-    Device,
-    DeviceState,
-    Features,
-    KnownDevice,
-    StaticSessionId,
-    VersionArray,
-} from '@trezor/connect';
+import { Device, DeviceState, Features, KnownDevice, StaticSessionId } from '@trezor/connect';
 import { getFirmwareVersionArray } from '@trezor/device-utils';
-import { UnionSubset } from '@trezor/type-utils';
 
 import { deviceActions } from './deviceActions';
 import { PORTFOLIO_TRACKER_DEVICE_ID } from './deviceConstants';
-
-export type PersistedFeatureKey = UnionSubset<
-    keyof Features,
-    | 'device_id'
-    | 'internal_model'
-    | 'fw_vendor'
-    | 'revision'
-    | 'unit_color'
-    | 'label'
-    | 'initialized'
->;
-export type PersistentDeviceData = Pick<Features, PersistedFeatureKey> & {
-    firmwareVersion: VersionArray | null;
-    lastConnectedBy: 'bluetooth' | 'usb' | null;
-    // TODO move devicesWithFailedEntropyCheck to this object, including persistence & migration
-    // TODO move deviceAuthenticity to this object and newly introduce persistence
-};
 
 export type DeviceReducerState = {
     devices: TrezorDevice[];

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -574,6 +574,8 @@ const updatePersistentDeviceData = (draft: DeviceReducerState, device: Device | 
         unit_color: device.features.unit_color,
         label: device.features.label,
         initialized: device.features.initialized,
+        thp: device.thp,
+        bluetoothProps: device.bluetoothProps,
         lastConnectedBy: device.bluetoothProps ? 'bluetooth' : 'usb',
         firmwareVersion: getFirmwareVersionArray(device),
     };

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -31,6 +31,9 @@ export const selectSelectedDevice = (state: DeviceRootState) => state.device.sel
 export const selectIsDeviceAutoEjectEnabled = (state: DeviceRootState) =>
     state.device.isDeviceAutoEjectEnabled;
 
+export const selectPersistentDeviceData = (state: DeviceRootState) =>
+    state.device.persistentDeviceData;
+
 // Derived selectors
 export const selectIsPendingTransportEvent = createMemoizedSelector(
     [selectDevices],

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -1,4 +1,4 @@
-import { bluetoothActions, selectKnownDevices } from '@suite-common/bluetooth';
+import { bluetoothActions } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 import { AcquiredDevice, TrezorDevice } from '@suite-common/suite-types';
 import {
@@ -39,6 +39,7 @@ import { PORTFOLIO_TRACKER_DEVICE_ID, portfolioTrackerDevice } from './deviceCon
 import {
     selectDeviceById,
     selectDevices,
+    selectPersistentDeviceData,
     selectPhysicalDeviceWallets,
     selectSelectedDevice,
 } from './deviceSelectors';
@@ -417,44 +418,53 @@ export const toggleAutoEjectThunk = createThunk(
 );
 
 type ForgetAllDeviceDataThunkParams = {
-    device: TrezorDevice;
+    deviceId: AcquiredDevice['id'];
 };
 
 /**
- * This thunk is the central place to remove all persistent data related to a device.
+ * This thunk is the central place to remove all persistent data related to a device_id.
+ * This includes wallets, `persistentDeviceData`, Bluetooth, THP.
+ * But not wallets, see `forgetDevice` (ejecting wallets & forgetting the rest are separate features).
  */
 export const forgetSingleDevicePersistentDataThunk = createThunk(
     `${DEVICE_MODULE_PREFIX}/forgetSingleDevicePersistentDataThunk`,
-    ({ device }: ForgetAllDeviceDataThunkParams, { dispatch, extra }) => {
-        if (typeof device.id === 'string') {
-            dispatch(deviceActions.forgetDevicePersistentData({ deviceId: device.id }));
-        }
-        if (device.bluetoothProps !== undefined) {
-            dispatch(bluetoothActions.removeKnownDeviceAction({ id: device.bluetoothProps.id }));
+    ({ deviceId }: ForgetAllDeviceDataThunkParams, { dispatch, extra, getState }) => {
+        const persistentDeviceData = selectPersistentDeviceData(getState());
+
+        dispatch(deviceActions.forgetDevicePersistentData({ deviceId }));
+
+        const matchingDevice = persistentDeviceData.find(d => d.device_id === deviceId);
+        if (matchingDevice === undefined) return;
+
+        const bluetoothId = matchingDevice.bluetoothProps?.id;
+        if (bluetoothId !== undefined) {
+            dispatch(bluetoothActions.removeKnownDeviceAction({ id: bluetoothId }));
             // try to remove OS-level Bluetooth bonds, if supported by the platform
-            dispatch(extra.thunks.forgetBluetoothDevice({ bluetoothId: device.bluetoothProps.id }));
+            dispatch(extra.thunks.forgetBluetoothDevice({ bluetoothId }));
         }
-        if (isThpDevice(device)) {
-            dispatch(thpActions.removeCredentials({ credentials: device.thp.credentials }));
+        const credentials = matchingDevice.thp?.credentials;
+        if (credentials !== undefined) {
+            dispatch(thpActions.removeCredentials({ credentials }));
         }
     },
 );
 
 /**
  * Helper thunk to do the same as `forgetSingleDevicePersistentDataThunk`, but for all devices as well as orphaned data.
- * Note that if you eject wallets, but BT, THP and persistentDeviceData are stil remembered, than they cannot be matched
- * by iterating through `devices`. So this thunk removes all data in a single swoop.
+ * Note that if you eject wallets, but BT, THP and persistentDeviceData are stil remembered,
+ * than they cannot be matched by iterating through `devices`, though they are in `persistentDeviceData`.
  */
 export const forgetAllDevicesPersistentDataThunk = createThunk(
     `${DEVICE_MODULE_PREFIX}/forgetAllDevicesPersistentDataThunk`,
-    (_, { dispatch, getState, extra }) => {
+    (_, { dispatch, getState }) => {
+        selectPersistentDeviceData(getState()).forEach(({ device_id }) =>
+            dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: device_id })),
+        );
+
+        // just to be extra sure that no trace of orphaned data is left:
         dispatch(deviceActions.forgetAllDevicesPersistentData());
         dispatch(thpActions.removeAllCredentials());
         dispatch(bluetoothActions.knownDevicesUpdateAction({ knownDevices: [] }));
-        // try to remove OS-level Bluetooth bonds for each device, if supported by the platform
-        selectKnownDevices(getState()).forEach(knownDevice => {
-            dispatch(extra.thunks.forgetBluetoothDevice({ bluetoothId: knownDevice.id }));
-        });
     },
 );
 
@@ -494,9 +504,11 @@ export const wipeDeviceThunk = createThunk(
                 dispatch(deviceActions.forgetDevice({ device: d }));
             });
 
-            // Wiping a device changes bluetoothId and THP static key, so wipe BT known device & THP credentials
-            // (and persistent device data as well, because device.id changed).
-            dispatch(forgetSingleDevicePersistentDataThunk({ device }));
+            if (device.id !== undefined) {
+                // Wiping a device changes bluetoothId and THP static key, so wipe BT known device & THP credentials
+                // (and persistent device data as well, because device.id changed).
+                dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: device.id }));
+            }
 
             dispatch(notificationsActions.addToast({ type: 'device-wiped' }));
 


### PR DESCRIPTION
## Description

:eyes: CR commit by commit recommended
- move types to another file
- add BT & THP data on `devicePersistantData`
- refactor both of the forget device persistent data thunks
  - this also _properly_ solves [#21395](https://github.com/trezor/trezor-suite/issues/21395) because in the previous PR I forgot forgetAll, only did forgetSingle
- thunk unit tests, the first of their kind in wallet-core :tada: 

Followup to #21435 to unlink forgetting BT & THP from `state.device.devices`, which are actually wallets – and that poses a major flaw. You can simply autoeject wallets, but keep storing device-persistent data, and then you are screwed because there is no way to forget all data related to a single device!
:point_right: the pointer to BT & THP must be on `devicePersistantData` instead.

:thought_balloon: this is actually a big tech debt that we use the same entity for device as for wallets. It should be two entities 1:n, instead we duplicate all device data with each wallet. Refactoring it now is not doable given the resources, but at least with these new features we can start _persisting_ them right. It's anyway required for proper function, see above.


## Screenshots:

I realized when recording this video that it is stupid, I should instead write unit tests... And so I did!
But you can at least see the `UnpairedBluetoothDeviceNeedsManualOsRemovalModal` because I'm on Linux (in lieu of actually unpairing the device in OS settings, which only works on windows)  

[forgor.webm](https://github.com/user-attachments/assets/74493805-8149-4379-8015-6c98f323569c)



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/move-bt-thp-to-devicePersistentData&lookback=7)