### PR TITLE
feat(suite-native): show DEX as rate if swap dex quote is selected

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2121,6 +2121,7 @@ export const messages = {
         selectRate: {
             fixed: 'Fixed',
             floating: 'Floating',
+            dex: 'DEX',
         },
         fiatCurrencySheet: {
             title: 'Currency',

--- a/suite-native/module-trading/src/components/exchange/ExchangeRatePicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeRatePicker.tsx
@@ -23,7 +23,7 @@ export type ExchangeRatePickerProps = ExchangeRatePickerRightProps & {
 
 const ExchangeRatePickerRight = ({ isLoading, selectedValue }: ExchangeRatePickerRightProps) => {
     const { translate } = useTranslate();
-    const { isFixedRate } = (useSelector((state: CommonTradingRootState) =>
+    const { isFixedRate, isDex } = (useSelector((state: CommonTradingRootState) =>
         selectTradingProviderByNameAndTradeType(state, selectedValue?.exchange, 'exchange'),
     ) ?? {}) as ExchangeProviderInfo;
 
@@ -31,9 +31,10 @@ const ExchangeRatePickerRight = ({ isLoading, selectedValue }: ExchangeRatePicke
         return <OverviewValueSkeleton />;
     }
 
-    const rate = isFixedRate
+    let rate = isFixedRate
         ? translate('moduleTrading.selectRate.fixed')
         : translate('moduleTrading.selectRate.floating');
+    rate = isDex ? translate('moduleTrading.selectRate.dex') : rate;
 
     return (
         <HStack>

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRatePicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRatePicker.comp.test.tsx
@@ -55,4 +55,12 @@ describe('ExchangeRatePicker', () => {
 
         expect(getByText('Floating')).toBeOnTheScreen();
     });
+
+    it('should render correct value for dex quote', async () => {
+        const { getByText } = await renderExchangeRatePicker({
+            selectedValue: exchangeQuotes[3],
+        });
+
+        expect(getByText('DEX')).toBeOnTheScreen();
+    });
 });


### PR DESCRIPTION
Show DEX as a rate for dex quotes

## Related Issue

Resolve #19530

## Screenshots:
<img width="259"  src="https://github.com/user-attachments/assets/d0ad50b6-2a38-4bb0-b46e-50094fa14825" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19530-mobile-swap-fixed-or-floating-rate-picker&lookback=7)