### PR TITLE
fix(suite-native): navigation reactivity on entropy check failure

### DIFF
--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -9,6 +9,7 @@ import {
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
+import { RootStackRoutes, navigationContainerRef } from '@suite-native/navigation';
 import TrezorConnect, { PROTO } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -129,6 +130,7 @@ export const createAndBackupWalletThunk = createThunk(
             result.payload.code === 'Failure_EntropyCheck'
         ) {
             dispatch(failEntropyCheckThunk({ device, error: result.payload }));
+            navigationContainerRef.navigate(RootStackRoutes.DeviceCompromisedModal);
         }
 
         return result;


### PR DESCRIPTION
## Description

Fix after https://github.com/trezor/trezor-suite/commit/84a04cb13ee90bacaca06cb3a1583483a991f59e. Before that refactoring,[useHandleDeviceConnection](https://github.com/trezor/trezor-suite/blob/1d667e500e04b58f3e04be5772883a024d5438ae/suite-native/device/src/hooks/useHandleDeviceConnection.ts#L202-L220) was reactive on `shouldNavigateToDeviceCompromisedModal`, which is reactive on `device.devicesWithFailedEntropyCheck` → navigates to `DeviceCompromisedModal`

Now, [deviceConnectionMiddleware](https://github.com/trezor/trezor-suite/blob/786977de79989874451761012f6cd1367976d6fb/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts#L115-L130) is reactive only on `DEVICE.CONNECT`, and will not fire on `deviceActions.setEntropyCheckFail`

## Screenshots:

BEFORE:
[entropy check hangs.webm](https://github.com/user-attachments/assets/dac51270-1432-4d2a-a4a1-272932511e19) → hangs indefinitely.

AFTER:
[mobile entropy check fixed.webm](https://github.com/user-attachments/assets/5acf3d29-16a4-4e02-8637-d71bd7e9a6d6) → :ghost: :heavy_check_mark: 


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-entropy-check&lookback=7)