### PR TITLE
fix(suite-native): remove unused intl provider that needs store

### DIFF
--- a/suite-native/graph/src/components/GraphContextProvider.tsx
+++ b/suite-native/graph/src/components/GraphContextProvider.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from 'react';
 
-import { IntlProvider } from '@suite-native/intl';
 import { useActiveColorScheme } from '@suite-native/theme';
 import { StylesProvider, createRenderer } from '@trezor/styles';
 import { prepareNativeTheme } from '@trezor/theme';
@@ -19,10 +18,8 @@ export const GraphContextProvider = ({ children }: ProviderProps) => {
     const theme = prepareNativeTheme({ colorVariant });
 
     return (
-        <IntlProvider>
-            <StylesProvider theme={theme} renderer={renderer}>
-                {children}
-            </StylesProvider>
-        </IntlProvider>
+        <StylesProvider theme={theme} renderer={renderer}>
+            {children}
+        </StylesProvider>
     );
 };


### PR DESCRIPTION


## Description

- The Intl provider was missing the Store provider in the TransactionEvent, but it wasn’t used anyway. Because the store provider was missing, the graph wasn’t rendered at all.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21519

## Screenshots:

<img width="375" height="217" alt="image" src="https://github.com/user-attachments/assets/9fd065ac-9274-493d-a688-b9755bcbeed1" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/account-detail-graph&lookback=7)