### PR TITLE
fix(suite-native): fix back navigation on account import error

### DIFF
--- a/suite-native/module-accounts-import/src/useShowImportError.ts
+++ b/suite-native/module-accounts-import/src/useShowImportError.ts
@@ -66,6 +66,11 @@ export const useShowImportError = (symbol: NetworkSymbol, navigation: Navigation
                 }
             }
 
+            const handleGoBack = () =>
+                navigation.popTo(AccountsImportStackRoutes.XpubScan, {
+                    networkSymbol: symbol,
+                });
+
             const { title, description, icon } = alertErrorMap[alertError];
 
             if (onRetry) {
@@ -77,7 +82,7 @@ export const useShowImportError = (symbol: NetworkSymbol, navigation: Navigation
                     primaryButtonTitle: 'Try Again',
                     onPressPrimaryButton: onRetry,
                     secondaryButtonTitle: 'Go back',
-                    onPressSecondaryButton: navigation.goBack,
+                    onPressSecondaryButton: handleGoBack,
                 });
             } else {
                 showAlert({
@@ -86,7 +91,7 @@ export const useShowImportError = (symbol: NetworkSymbol, navigation: Navigation
                     icon,
                     pictogramVariant: 'critical',
                     primaryButtonTitle: 'Go back',
-                    onPressPrimaryButton: navigation.goBack,
+                    onPressPrimaryButton: handleGoBack,
                     testID: `@alert-sheet/error/${alertError}`,
                 });
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use correct back navigation from error state on Account Import.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21531

## Screenshots:

https://github.com/user-attachments/assets/3691d025-fe5b-4f8d-891a-ae32e5deace4



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/back-navigation-on-account-import-error&lookback=7)