### PR TITLE
feat(suite): display stellar token information on the transaction details page.

### DIFF
--- a/packages/blockchain-link-utils/src/stellar.ts
+++ b/packages/blockchain-link-utils/src/stellar.ts
@@ -10,12 +10,7 @@ import {
     extractBaseAddress,
 } from '@stellar/stellar-sdk';
 
-import type {
-    Target,
-    TokenDetailByMint,
-    Transaction,
-    TransactionDetail,
-} from '@trezor/blockchain-link-types';
+import type { TokenDetailByMint, Transaction } from '@trezor/blockchain-link-types';
 import { isCodesignBuild } from '@trezor/env-utils';
 import type { StellarAsset } from '@trezor/protobuf/src/messages';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -54,12 +49,13 @@ const convertMemo = (memo: Memo): string | undefined => {
 
 export const transformTransaction = (
     rawTx: Horizon.ServerApi.TransactionRecord,
-    descriptor?: string,
+    descriptor: string,
+    tokenDetailByMint: TokenDetailByMint,
 ): Transaction => {
     // In Stellar, there are many types of operations; currently, we only include limited support and will consider adding more support later.
     const parsedTx = new StellarTransaction(rawTx.envelope_xdr, Networks.PUBLIC);
 
-    const tx: Transaction = {
+    const baseTx: Transaction = {
         type: 'unknown', // default type
         txid: rawTx.hash,
         amount: '0',
@@ -85,84 +81,126 @@ export const transformTransaction = (
 
     if (!rawTx.successful) {
         // If the transaction is not successful, we can set the type to 'failed' and return early
-        return { ...tx, type: 'failed' };
+        return { ...baseTx, type: 'failed' };
     }
 
     if (parsedTx.operations.length !== 1) {
         // If the transaction has more than one operation, we consider it as a unknown type
-        return tx;
+        return baseTx;
     }
 
     const rawOp = parsedTx.operations[0];
     const opSource = rawOp.source || rawTx.source_account;
+    const fromAddress = extractBaseAddress(opSource);
 
-    const params = {
-        fromAddress: extractBaseAddress(opSource),
-        toAddress: '',
-        amount: '',
-    };
+    let toAddress: string | undefined;
+    let nativeAmount: string | undefined;
+    let isTokenTransfer = false;
+    let tokenInfo: { assetCode: string; assetIssuer: string; amount: string } | undefined;
 
     switch (rawOp.type) {
-        case 'createAccount': {
-            params.toAddress = extractBaseAddress(rawOp.destination);
-            params.amount = toStroops(rawOp.startingBalance).toString();
+        case 'createAccount':
+            toAddress = extractBaseAddress(rawOp.destination);
+            nativeAmount = toStroops(rawOp.startingBalance).toString();
             break;
-        }
-        case 'payment': {
-            if (!rawOp.asset.isNative()) {
-                // If the asset is not native (XLM), we consider it as a unknown type
-                return tx;
+        case 'payment':
+            toAddress = extractBaseAddress(rawOp.destination);
+            if (rawOp.asset.isNative()) {
+                nativeAmount = toStroops(rawOp.amount).toString();
+            } else {
+                isTokenTransfer = true;
+                tokenInfo = {
+                    assetCode: rawOp.asset.getCode(),
+                    assetIssuer: rawOp.asset.getIssuer(),
+                    amount: toStroops(rawOp.amount).toString(),
+                };
+                // For token transfers, the native amount is 0
+                nativeAmount = '0';
             }
-
-            params.toAddress = extractBaseAddress(rawOp.destination);
-            params.amount = toStroops(rawOp.amount).toString();
             break;
-        }
-        default: {
+        default:
             // We only support createAccount and payment operations for now, so we consider it as a unknown type
-            return tx;
-        }
+            return baseTx;
     }
 
-    if (descriptor !== params.fromAddress && descriptor !== params.toAddress) {
-        // If the send and receive addresses do not match the descriptor, we consider it as a unknown type
-        return tx;
+    if (!toAddress) {
+        // Should not happen if operation is supported, but as a safeguard.
+        return baseTx;
     }
 
-    const targets: Target[] = [
-        {
-            n: 0,
-            addresses: [params.toAddress],
-            isAddress: true,
-            amount: params.amount,
-        },
-    ];
+    const isFrom = descriptor === fromAddress;
+    const isTo = descriptor === toAddress;
 
-    const details: TransactionDetail = {
-        vin: [
-            {
-                n: 0,
-                addresses: [params.fromAddress],
-                isAddress: true,
-                value: params.amount,
+    if (!descriptor || (!isFrom && !isTo)) {
+        // Transaction does not involve the user's address
+        return baseTx;
+    }
+
+    const type = isFrom ? 'sent' : 'recv';
+
+    if (isTokenTransfer && tokenInfo) {
+        const { assetCode, assetIssuer, amount: tokenAmount } = tokenInfo;
+        const contract = `${assetCode}-${assetIssuer}`;
+
+        return {
+            ...baseTx,
+            type,
+            amount: '0', // No native amount for token transfers
+            tokens: [
+                {
+                    type,
+                    standard: 'STELLAR-CLASSIC',
+                    from: fromAddress,
+                    to: toAddress,
+                    contract,
+                    name: tokenDetailByMint[contract]?.name || assetCode,
+                    symbol: assetCode,
+                    decimals: STELLAR_DECIMALS,
+                    amount: tokenAmount,
+                },
+            ],
+        };
+    }
+
+    if (nativeAmount) {
+        // Native asset transfer
+        return {
+            ...baseTx,
+            type,
+            amount: nativeAmount,
+            targets: [
+                {
+                    n: 0,
+                    addresses: [toAddress],
+                    isAddress: true,
+                    amount: nativeAmount,
+                },
+            ],
+            details: {
+                vin: [
+                    {
+                        n: 0,
+                        addresses: [fromAddress],
+                        isAddress: true,
+                        value: nativeAmount,
+                    },
+                ],
+                vout: [
+                    {
+                        n: 0,
+                        addresses: [toAddress],
+                        isAddress: true,
+                        value: nativeAmount,
+                    },
+                ],
+                size: 0,
+                totalInput: nativeAmount,
+                totalOutput: nativeAmount,
             },
-        ],
-        vout: [
-            {
-                n: 0,
-                addresses: [params.toAddress],
-                isAddress: true,
-                value: params.amount,
-            },
-        ],
-        size: 0,
-        totalInput: params.amount,
-        totalOutput: params.amount,
-    };
+        };
+    }
 
-    const type = descriptor === params.fromAddress ? 'sent' : 'recv';
-
-    return { ...tx, amount: params.amount, details, targets, type };
+    return baseTx;
 };
 
 export const buildSendTransaction = (

--- a/packages/blockchain-link-utils/src/tests/fixtures/stellar.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/stellar.ts
@@ -983,7 +983,8 @@ export const fixtures = {
             },
         },
         {
-            description: 'transaction contains a payment operation, but the asset is not native',
+            description:
+                'transaction contains a payment operation, but the asset is not native, the descriptor is the sender',
             input: {
                 descriptor: 'GB635ARCRZOV7YZ5KC2BRIBFRHOCBJ5E35O76H3VUAMJP7UDTXFHG5C4',
                 tx: {
@@ -1063,9 +1064,120 @@ export const fixtures = {
                     feeSource: 'GB635ARCRZOV7YZ5KC2BRIBFRHOCBJ5E35O76H3VUAMJP7UDTXFHG5C4',
                 },
                 targets: [],
-                tokens: [],
+                tokens: [
+                    {
+                        amount: '100000',
+                        contract: 'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+                        decimals: 7,
+                        from: 'GB635ARCRZOV7YZ5KC2BRIBFRHOCBJ5E35O76H3VUAMJP7UDTXFHG5C4',
+                        name: 'USDC',
+                        standard: 'STELLAR-CLASSIC',
+                        symbol: 'USDC',
+                        to: 'GCSXD3NLEYB72P2AXPHM2ED3MD7FUSFWTBLKMYKVGJ7P4NAFRMIRA74Z',
+                        type: 'sent',
+                    },
+                ],
                 txid: '29854b425e62081bbf845c2b10e8bdb525e3a3765d8ca53bc1a0bd0c88a0f265',
-                type: 'unknown',
+                type: 'sent',
+            },
+        },
+        {
+            description:
+                'transaction contains a payment operation, but the asset is not native, the descriptor is the receiver',
+            input: {
+                descriptor: 'GCSXD3NLEYB72P2AXPHM2ED3MD7FUSFWTBLKMYKVGJ7P4NAFRMIRA74Z',
+                tx: {
+                    _links: {
+                        self: {
+                            href: 'https://horizon.stellar.org/transactions/29854b425e62081bbf845c2b10e8bdb525e3a3765d8ca53bc1a0bd0c88a0f265',
+                        },
+                        account: {
+                            href: 'https://horizon.stellar.org/accounts/GB635ARCRZOV7YZ5KC2BRIBFRHOCBJ5E35O76H3VUAMJP7UDTXFHG5C4',
+                        },
+                        ledger: {
+                            href: 'https://horizon.stellar.org/ledgers/56802308',
+                        },
+                        operations: {
+                            href: 'https://horizon.stellar.org/transactions/29854b425e62081bbf845c2b10e8bdb525e3a3765d8ca53bc1a0bd0c88a0f265/operations{?cursor,limit,order}',
+                            templated: true,
+                        },
+                        effects: {
+                            href: 'https://horizon.stellar.org/transactions/29854b425e62081bbf845c2b10e8bdb525e3a3765d8ca53bc1a0bd0c88a0f265/effects{?cursor,limit,order}',
+                            templated: true,
+                        },
+                        precedes: {
+                            href: 'https://horizon.stellar.org/transactions?order=asc\u0026cursor=243964055197659136',
+                        },
+                        succeeds: {
+                            href: 'https://horizon.stellar.org/transactions?order=desc\u0026cursor=243964055197659136',
+                        },
+                        transaction: {
+                            href: 'https://horizon.stellar.org/transactions/29854b425e62081bbf845c2b10e8bdb525e3a3765d8ca53bc1a0bd0c88a0f265',
+                        },
+                    },
+                    id: '29854b425e62081bbf845c2b10e8bdb525e3a3765d8ca53bc1a0bd0c88a0f265',
+                    paging_token: '243964055197659136',
+                    successful: true,
+                    hash: '29854b425e62081bbf845c2b10e8bdb525e3a3765d8ca53bc1a0bd0c88a0f265',
+                    ledger_attr: 56802308,
+                    created_at: '2025-04-27T02:26:45Z',
+                    source_account: 'GB635ARCRZOV7YZ5KC2BRIBFRHOCBJ5E35O76H3VUAMJP7UDTXFHG5C4',
+                    source_account_sequence: '243959279193686019',
+                    fee_account: 'GB635ARCRZOV7YZ5KC2BRIBFRHOCBJ5E35O76H3VUAMJP7UDTXFHG5C4',
+                    fee_charged: '100',
+                    max_fee: '100',
+                    operation_count: 1,
+                    envelope_xdr:
+                        'AAAAAgAAAAB9voIijl1f4z1QtBigJYncIKek313/H3WgGJf+g53KcwAAAGQDYresAAAAAwAAAAEAAAAAAAAAAAAAAABoDZcMAAAAAAAAAAEAAAAAAAAAAQAAAAClce2rJgP9P0C7zs0Qe2D+Wki2mFamYVUyfv40BYsREAAAAAFVU0RDAAAAADuZETgO/piLoKiQDrHP5E82b32+lGvtB3JA9/Yk3xXFAAAAAAABhqAAAAAAAAAAAYOdynMAAABAlHIFUVI4zaeOWaxlSnbl1pucEZ32DsAvUssdqeSEB1eb2mlHlfy2xKx9DKQ4RD8/JgjgRAsW/Xp5bRzIWBrRDg==',
+                    result_xdr: 'AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=',
+                    fee_meta_xdr:
+                        'AAAAAgAAAAMDYrv2AAAAAAAAAAB9voIijl1f4z1QtBigJYncIKek313/H3WgGJf+g53KcwAAAAABxS4QA2K3rAAAAAIAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAANiu/YAAAAAaA2VlgAAAAAAAAABA2K8BAAAAAAAAAAAfb6CIo5dX+M9ULQYoCWJ3CCnpN9d/x91oBiX/oOdynMAAAAAAcUtrANit6wAAAACAAAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAAADYrv2AAAAAGgNlZYAAAAA',
+                    memo_type: 'none',
+                    signatures: [
+                        'lHIFUVI4zaeOWaxlSnbl1pucEZ32DsAvUssdqeSEB1eb2mlHlfy2xKx9DKQ4RD8/JgjgRAsW/Xp5bRzIWBrRDg==',
+                    ],
+                    preconditions: {
+                        timebounds: {
+                            min_time: '0',
+                            max_time: '1745721100',
+                        },
+                    },
+                },
+            },
+            expectedOutput: {
+                amount: '0',
+                blockHeight: 56802308,
+                blockTime: 1745720805,
+                details: {
+                    size: 0,
+                    totalInput: '0',
+                    totalOutput: '0',
+                    vin: [],
+                    vout: [],
+                },
+                fee: '100',
+                feeRate: undefined,
+                internalTransfers: [],
+                stellarSpecific: {
+                    memo: undefined,
+                    feeSource: 'GB635ARCRZOV7YZ5KC2BRIBFRHOCBJ5E35O76H3VUAMJP7UDTXFHG5C4',
+                },
+                targets: [],
+                tokens: [
+                    {
+                        amount: '100000',
+                        contract: 'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+                        decimals: 7,
+                        from: 'GB635ARCRZOV7YZ5KC2BRIBFRHOCBJ5E35O76H3VUAMJP7UDTXFHG5C4',
+                        name: 'USDC',
+                        standard: 'STELLAR-CLASSIC',
+                        symbol: 'USDC',
+                        to: 'GCSXD3NLEYB72P2AXPHM2ED3MD7FUSFWTBLKMYKVGJ7P4NAFRMIRA74Z',
+                        type: 'recv',
+                    },
+                ],
+                txid: '29854b425e62081bbf845c2b10e8bdb525e3a3765d8ca53bc1a0bd0c88a0f265',
+                type: 'recv',
             },
         },
         {

--- a/packages/blockchain-link-utils/src/tests/stellar.test.ts
+++ b/packages/blockchain-link-utils/src/tests/stellar.test.ts
@@ -14,6 +14,7 @@ describe('stellar/utils', () => {
                     // @ts-expect-error Fixtures don't fully implement this interface.
                     input.tx as Horizon.ServerApi.TransactionRecord,
                     input.descriptor,
+                    {},
                 );
                 expect(result).toEqual(expectedOutput);
             });

--- a/packages/blockchain-link/src/workers/stellar/index.ts
+++ b/packages/blockchain-link/src/workers/stellar/index.ts
@@ -164,7 +164,7 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
 
     const cursor = transactions.records[transactions.records.length - 1]?.paging_token;
     account.history.transactions = transactions.records.map(record =>
-        utils.transformTransaction(record, payload.descriptor),
+        utils.transformTransaction(record, payload.descriptor, tokenMetadata),
     );
 
     return {

--- a/packages/blockchain-link/tests/integration/stellar.test.ts
+++ b/packages/blockchain-link/tests/integration/stellar.test.ts
@@ -137,7 +137,7 @@ describe('Stellar', () => {
 
         const expectedCursor = txRawResp.records[txRawResp.records.length - 1].paging_token;
         const expectedTxs = txRawResp.records.map(record =>
-            utils.transformTransaction(record, descriptor),
+            utils.transformTransaction(record, descriptor, {}),
         );
 
         const result = await blockchain.getAccountInfo({

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -37,7 +37,7 @@ export const IODetails = ({ tx, isPhishingTransaction }: IODetailsProps) => {
                     />
                 </>
             );
-        } else if (network?.networkType === 'solana') {
+        } else if (network?.networkType === 'solana' || network?.networkType === 'stellar') {
             return (
                 <>
                     <IOGroup

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
@@ -60,40 +60,51 @@ export const TokenSpecificBalanceDetailsRow = ({
                 </Column>
             ) : null}
 
-            {Object.entries(tokensByStandard).map(([key, tokens]) => (
-                <Column key={key} gap={spacings.xs}>
-                    <H4>
-                        <Translation
-                            id="TR_TOKEN_TRANSFERS"
-                            values={{ standard: key.toUpperCase() }}
-                        />
-                    </H4>
-                    {tokens.map((transfer, index) => {
-                        const value = isNftTokenTransfer(transfer) ? (
-                            <FormattedNftAmount
-                                transfer={transfer}
-                                isWithLink
-                                alignMultitoken="flex-start"
-                                linkTypographyStyle="label"
-                            />
-                        ) : (
-                            convertAmountSubunitsToUnits(transfer.amount, transfer.decimals)
-                        );
+            {Object.entries(tokensByStandard).map(([key, tokens]) => {
+                const getStandardDisplayName = (standard: string) => {
+                    switch (standard) {
+                        case 'STELLAR-CLASSIC':
+                            return 'Stellar';
+                        default:
+                            return standard.toUpperCase();
+                    }
+                };
 
-                        return (
-                            <IOGroup
-                                key={index}
-                                tx={{ ...tx, symbol: transfer.symbol || '' }}
-                                contractAddress={transfer.contract}
-                                inputs={[{ addresses: [transfer.from], value }] as IODetails[]}
-                                outputs={[{ addresses: [transfer.to] }] as IODetails[]}
-                                isPhishingTransaction={isPhishingTransaction}
-                                hasHeadings={false}
+                return (
+                    <Column key={key} gap={spacings.xs}>
+                        <H4>
+                            <Translation
+                                id="TR_TOKEN_TRANSFERS"
+                                values={{ standard: getStandardDisplayName(key) }}
                             />
-                        );
-                    })}
-                </Column>
-            ))}
+                        </H4>
+                        {tokens.map((transfer, index) => {
+                            const value = isNftTokenTransfer(transfer) ? (
+                                <FormattedNftAmount
+                                    transfer={transfer}
+                                    isWithLink
+                                    alignMultitoken="flex-start"
+                                    linkTypographyStyle="label"
+                                />
+                            ) : (
+                                convertAmountSubunitsToUnits(transfer.amount, transfer.decimals)
+                            );
+
+                            return (
+                                <IOGroup
+                                    key={index}
+                                    tx={{ ...tx, symbol: transfer.symbol || '' }}
+                                    contractAddress={transfer.contract}
+                                    inputs={[{ addresses: [transfer.from], value }] as IODetails[]}
+                                    outputs={[{ addresses: [transfer.to] }] as IODetails[]}
+                                    isPhishingTransaction={isPhishingTransaction}
+                                    hasHeadings={false}
+                                />
+                            );
+                        })}
+                    </Column>
+                );
+            })}
         </>
     );
 };

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailInputsSheet.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailInputsSheet.tsx
@@ -96,14 +96,18 @@ export const TransactionDetailInputsSheet = ({
 
                 <TransactionDetailInputsSheetSection
                     header={
-                        <Translation id="transactions.TransactionDetailScreen.inputsSheet.internalTransfers" />
+                        <Text variant="hint" color="textSubdued">
+                            <Translation id="transactions.TransactionDetailScreen.inputsSheet.internalTransfers" />
+                        </Text>
                     }
                     transfers={internalTransfers}
                 />
 
                 <TransactionDetailInputsSheetSection
                     header={
-                        <Translation id="transactions.TransactionDetailScreen.inputsSheet.tokenTransfers" />
+                        <Text variant="hint" color="textSubdued">
+                            <Translation id="transactions.TransactionDetailScreen.inputsSheet.tokenTransfers" />
+                        </Text>
                     }
                     transfers={tokenTransfers}
                 />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

On the historical details page, we should support displaying token sending and receiving information.


## Related Issue

Resolve #21593
Resolve #20417


## Screenshots:
<img width="2556" height="1836" alt="Screenshot From 2025-09-17 14-40-31" src="https://github.com/user-attachments/assets/8d9791d5-5de2-4dc9-8716-fdf59b9aff22" />
<img width="2556" height="1836" alt="Screenshot From 2025-09-17 14-41-21" src="https://github.com/user-attachments/assets/adc6dc4a-3e4a-4346-a48e-236c4d11d69f" />
<img width="2556" height="1836" alt="Screenshot From 2025-09-17 14-41-33" src="https://github.com/user-attachments/assets/a2119b6f-08de-4698-a0b4-e16cd741b0e9" />
<img width="1080" height="2400" alt="Screenshot_20250917-130151_Trezor_Suite_Lite_Debug" src="https://github.com/user-attachments/assets/4d821734-7cac-4f95-90eb-0bf4ebbb3b54" />
<img width="1080" height="2400" alt="Screenshot_20250917-150647_Trezor_Suite_Lite_Debug" src="https://github.com/user-attachments/assets/d79781ea-bfbb-4e63-83ca-8d11b49f01aa" />
