### PR TITLE
Fix suite fallback path ts7

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -873,6 +873,11 @@ export class Device extends TypedEmitter<DeviceEvents> {
         };
 
         this.name = deviceInfo.name;
+        // NOTE: TS7 test devices do not have color specified, they are all defined unit_color=0
+        // fallback this color the existing ones to 1
+        if (feat?.internal_model === DeviceModelInternal.T3W1 && (feat?.unit_color ?? 0) === 0) {
+            feat.unit_color = 1;
+        }
 
         // todo: move to 553
         if (feat?.unit_color) {

--- a/packages/product-components/src/utils/getModelFrontColor.tsx
+++ b/packages/product-components/src/utils/getModelFrontColor.tsx
@@ -4,12 +4,16 @@ import { DeviceModelInternal, models } from '@trezor/device-utils';
 export const getModelFrontColor = (
     deviceModelInternal?: DeviceModelInternal,
     deviceUnitColor?: number,
-) => (deviceModelInternal && models[deviceModelInternal].frontColors?.[`${deviceUnitColor}`]) ?? 1;
+): number =>
+    Number(
+        (deviceModelInternal && models[deviceModelInternal].frontColors?.[`${deviceUnitColor}`]) ??
+            1,
+    );
 
 export const getLargeModelImagePath = (
     deviceModelInternal?: DeviceModelInternal,
     deviceUnitColor?: number,
-) => {
+): ImageKey => {
     const frontColor = getModelFrontColor(deviceModelInternal, deviceUnitColor);
     const deviceName =
         deviceModelInternal === DeviceModelInternal.T2B1 ? 'T3B1' : deviceModelInternal;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add fallback for the unit color. @marekrjpolak has said that it is okay

## Related Issue

https://github.com/trezor/trezor-suite/issues/21394

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-suite-fallback-path-ts7&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-suite-fallback-path-ts7&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-suite-fallback-path-ts7&lookback=7)