### PR TITLE
fix(fiat-services): fiat rates now work for disabled and token networks

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
@@ -96,6 +96,7 @@ export const useTradingFiatValues = ({
                     baseCurrencyCode: value,
                     rateType: 'current',
                     fetchAttemptTimestamp: Date.now() as Timestamp,
+                    forceFetchToken: true,
                     skipCache: true,
                 }),
             );

--- a/suite-common/fiat-services/src/coingecko.ts
+++ b/suite-common/fiat-services/src/coingecko.ts
@@ -21,9 +21,14 @@ interface FetchCurrentFiatRatesOptions {
 
 const rateLimiter = new RateLimiter(1_000, 15_000);
 
-const fetchCoinGecko = async (url: string, init?: RequestInit) => {
+const fetchCoinGecko = async (url: string, skipCache?: boolean) => {
     try {
-        const res = await rateLimiter.limit(signal => fetchUrl(url, { signal, ...init }));
+        let res: Response;
+        if (skipCache) {
+            res = await fetchUrl(url, { headers: { 'X-Bypass-Cache': '1' } });
+        } else {
+            res = await rateLimiter.limit(signal => fetchUrl(url, { signal }));
+        }
         if (!res.ok) {
             console.warn(`Coingecko: Fiat rates failed to fetch: ${res.status}`);
 
@@ -112,11 +117,9 @@ export const fetchCurrentFiatRates = async (
     const urlParams =
         'tickers=false&market_data=true&community_data=false&developer_data=false&sparkline=false&localization=false';
 
-    const headers = options?.skipCache ? { 'X-Bypass-Cache': '1' } : undefined;
-
     for (const coinUrl of coinUrls) {
         const url = `${coinUrl}?${urlParams}`;
-        const rates = await fetchCoinGecko(url, { headers });
+        const rates = await fetchCoinGecko(url, options?.skipCache);
 
         if (rates) {
             return {

--- a/suite-common/fiat-services/src/coingecko.ts
+++ b/suite-common/fiat-services/src/coingecko.ts
@@ -44,30 +44,44 @@ const fetchCoinGecko = async (url: string, init?: RequestInit) => {
  * @returns
  */
 const buildCoinUrls = (ticker: TickerId) => {
-    const { coingeckoId, settlementLayer } = getNetwork(ticker.symbol);
+    const { coingeckoId, tradeCryptoId, settlementLayer, networkType } = getNetwork(ticker.symbol);
     if (!coingeckoId) {
-        console.error('buildCoinUrls: cannot find coingecko asset platform id for ', ticker);
+        console.error('buildCoinUrls: cannot find coingeckoId for ', ticker);
 
         return null;
     }
 
-    const baseUrl = `${COINGECKO_API_BASE_URL}/coins/${coingeckoId}`;
+    let baseId = coingeckoId;
+    if (networkType === 'ethereum') {
+        if (ticker.tokenAddress) {
+            // token on network -> network coingecko id
+            baseId = coingeckoId;
+        } else if (settlementLayer) {
+            baseId = networks[settlementLayer]?.coingeckoId ?? coingeckoId;
+        } else {
+            // native token on network -> native token coingecko id
+            if (!tradeCryptoId) {
+                console.error('buildCoinUrls: cannot find tradeCryptoId for', ticker);
 
-    if (settlementLayer && !ticker.tokenAddress) {
-        return [`${COINGECKO_API_BASE_URL}/coins/${networks[settlementLayer].coingeckoId}`];
+                return null;
+            }
+            baseId = tradeCryptoId;
+        }
     }
+
+    const baseUrl = `${COINGECKO_API_BASE_URL}/coins/${baseId}`;
 
     if (!ticker.tokenAddress) {
         return [baseUrl];
     }
 
-    if (ticker.symbol === 'ada') {
+    if (networkType === 'cardano') {
         const { policyId } = parseAsset(ticker.tokenAddress || '');
 
         return [`${baseUrl}/contract/${policyId}`, `${baseUrl}/contract/${ticker.tokenAddress}`];
     }
 
-    if (ticker.symbol === 'xlm') {
+    if (networkType === 'stellar') {
         const [code, issuer] = ticker.tokenAddress.split('-');
 
         // There are currently three formats on CoinGecko, we try them in order of frequency.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- fiat rates for tokens of disabled networks were not working because of missing token definitions
- fiat rates for bnb and pol were not working because of incorrect id
- ignore rate limit when skipping cache (problem when user has a lot of solana tokens, he never gets fiat rate)

## Screenshots:

ETH to BTC (worked before)
<img width="1042" height="1077" alt="Screenshot 2025-09-16 at 13 54 23" src="https://github.com/user-attachments/assets/7b6f7f01-9166-4e06-94c6-1b5741f69d01" />

ETH to POL (did not work)
<img width="1044" height="1075" alt="Screenshot 2025-09-16 at 13 54 39" src="https://github.com/user-attachments/assets/c3c7da93-5c6b-4461-9109-ea6948fd8364" />

ETH to LINK on BSC (did not work)
<img width="1028" height="996" alt="Screenshot 2025-09-16 at 13 54 48" src="https://github.com/user-attachments/assets/63169c64-fa27-4b48-86c5-522270405d78" />

ETH to ETH on L2 (worked before)
<img width="1037" height="1115" alt="Screenshot 2025-09-16 at 13 55 01" src="https://github.com/user-attachments/assets/d84cc5ca-d41e-423c-bdfd-f8c7b913dde3" />

ETH to OP on L2 (did not work)
<img width="1046" height="897" alt="Screenshot 2025-09-16 at 13 55 10" src="https://github.com/user-attachments/assets/f0317449-2e1d-487e-8671-b71140a08d27" />

ETH to USDC on ETH (worked before
<img width="1028" height="1072" alt="Screenshot 2025-09-16 at 14 06 33" src="https://github.com/user-attachments/assets/d50b1fe3-9435-4feb-af59-b708923e29fb" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/fiat-rates-ab&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/fiat-rates-ab&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/fiat-rates-ab&lookback=7)