### PR TITLE
Fix/bt napi events and scan loader

### DIFF
--- a/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
@@ -1,7 +1,8 @@
 import path from 'path';
 
 import { isDevEnv } from '@suite-common/suite-utils';
-import { isMacOs, isWindows } from '@trezor/env-utils';
+import { isWindows } from '@trezor/env-utils';
+import { BluetoothNapiBindings } from '@trezor/transport-bluetooth';
 
 import { BaseProcess, Status } from './BaseProcess';
 import { getSwitchValue } from '../process-switches';
@@ -80,26 +81,12 @@ export class BluetoothProcess extends BaseProcess {
         return super.start();
     }
 
-    // workaround for macos pairing issue
-    async connectAndSubscribeInMainThread(
-        id: string,
-    ): Promise<{ success: true } | { success: false; error: string }> {
-        if (!isMacOs()) {
-            return Promise.resolve({ success: true });
-        }
+    async getNapiBindings() {
+        const processPath = path.join(super.getProcessDir(), `index.js`);
+        this.logger.info(this.logTopic, `Loading bluetooth native module from ${processPath}`);
 
-        try {
-            const processPath = path.join(super.getProcessDir(), `index.js`);
-            this.logger.info(this.logTopic, `Loading bluetooth native module from ${processPath}`);
+        const bindings: BluetoothNapiBindings = await import(/*webpackIgnore: true */ processPath);
 
-            const { connectDevice } = await import(/*webpackIgnore: true */ processPath);
-            await connectDevice(id, 30000, (...args: any[]) => {
-                console.warn('callback', args);
-            });
-
-            return { success: true } as const;
-        } catch (error) {
-            return { success: false, error: error.message } as const;
-        }
+        return bindings;
     }
 }

--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -57,6 +57,7 @@ export const init: ModuleInit = () => {
         return new BluetoothIpc({
             url: btProcess.getUrl(),
             logger: desktopLogger,
+            napiBindings: isMacOs() ? () => btProcess.getNapiBindings() : undefined,
         });
     };
 
@@ -85,20 +86,6 @@ export const init: ModuleInit = () => {
                     }
 
                     if (!api) throw apiError;
-
-                    if (method === 'connectDevice' && isMacOs()) {
-                        // special case for macos
-                        const deviceId = params[0];
-                        const devices = await api.enumerateDevices();
-                        const isPaired = devices.find(d => d.id === deviceId)?.paired;
-                        if (!isPaired) {
-                            const result =
-                                await bluetoothProcess?.connectAndSubscribeInMainThread(deviceId);
-                            if (result && !result.success) {
-                                return result;
-                            }
-                        }
-                    }
 
                     if (method === 'dispose') {
                         killBluetoothProcess();

--- a/packages/transport-bluetooth/.gitignore
+++ b/packages/transport-bluetooth/.gitignore
@@ -1,1 +1,2 @@
 target
+napi

--- a/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
@@ -7,6 +7,7 @@ import type {
     BluetoothIpcApi,
     BluetoothIpcEvents,
     BluetoothIpcState,
+    BluetoothNapiBindings,
     IpcResponse,
     TrezorBluetoothSettings,
 } from './types';
@@ -19,10 +20,15 @@ export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements Bl
     private api: TrezorBluetooth;
     private state: BluetoothIpcState = { knownDevices: [] };
     private isScanning = false;
+    private readonly getNapiBindings: (() => Promise<BluetoothNapiBindings>) | undefined;
 
-    constructor(settings: TrezorBluetoothSettings) {
+    constructor({
+        napiBindings,
+        ...settings
+    }: TrezorBluetoothSettings & { napiBindings: BluetoothIpc['getNapiBindings'] }) {
         super();
         this.api = new TrezorBluetooth(settings);
+        this.getNapiBindings = napiBindings;
     }
 
     // 1. suite knows the device but system may not. device could be removed manually from the system UI
@@ -141,6 +147,24 @@ export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements Bl
     }
 
     async connectDevice(id: string) {
+        const timeout = 30000;
+
+        // macos: pair in the main thread then disconnect and pickup connection again in the background
+        if (this.getNapiBindings) {
+            try {
+                const devices = await this.enumerateDevices();
+                const isPaired = devices.find(d => d.id === id)?.paired;
+                if (!isPaired) {
+                    const bindings = await this.getNapiBindings();
+                    await bindings.connectDevice(id, timeout, (_err, _resp) => {
+                        // TODO: emit events from NAPI
+                    });
+                }
+            } catch (error) {
+                return this.result(error.message);
+            }
+        }
+
         try {
             await this.connectApi();
         } catch (error) {
@@ -153,7 +177,7 @@ export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements Bl
             this.emit('device-update', device);
         this.api.on('device_connection_status', emitDeviceUpdate);
         const result = await this.api
-            .send('connect_device', { id, timeout: 30000 })
+            .send('connect_device', { id, timeout })
             .then(() => this.result())
             .catch(error => this.result(error.message));
         this.api.off('device_connection_status', emitDeviceUpdate);

--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -108,3 +108,11 @@ export interface BluetoothIpcApi {
     off: TypedManagerEvents['off'];
     removeAllListeners: TypedManagerEvents['removeAllListeners'];
 }
+
+export type BluetoothNapiBindings = {
+    connectDevice: (
+        id: string,
+        timeout: number,
+        callback: (err: Error | null, json: string) => any,
+    ) => Promise<void>;
+};

--- a/packages/transport-bluetooth/src/lib.rs
+++ b/packages/transport-bluetooth/src/lib.rs
@@ -1,18 +1,100 @@
+use btleplug::api::{Central, ScanFilter};
+use btleplug::platform::Adapter;
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
 
 use crate::server::{
-    adapter_manager::AdapterManager, connection_broadcast::ConnectionBroadcast,
-    methods::connect_device as connect_device_method,
-    methods::disconnect_device as disconnect_device_method, types::ConnectDeviceParams,
-    types::DisconnectDeviceParams,
+    adapter_manager::AdapterManager,
+    connection_broadcast::ConnectionBroadcast,
+    methods::{
+        connect_device as connect_device_method, disconnect_device as disconnect_device_method,
+    },
+    types::{ChannelMessage, ConnectDeviceParams, DisconnectDeviceParams, NotificationEvent},
 };
 
-use btleplug::api::Central;
-use btleplug::api::ScanFilter;
-
 mod server;
+
+async fn init_adapter(target_id: String) -> Result<(AdapterManager, ConnectionBroadcast, Adapter)> {
+    let manager = match AdapterManager::new().await {
+        Ok(manager) => manager,
+        Err(e) => Err(error(e.to_string()))?,
+    };
+
+    let broadcast = match ConnectionBroadcast::new(target_id.clone()) {
+        Ok(broadcast) => broadcast,
+        Err(e) => Err(error(e.to_string()))?,
+    };
+
+    manager.add_listener(broadcast.clone()).await;
+
+    let adapter = match manager.get_adapter().await {
+        Ok(Some(adapter)) => adapter,
+        Ok(None) => Err(error("AdapterNotFound".to_string()))?,
+        Err(e) => Err(error(e.to_string()))?,
+    };
+
+    Ok((manager, broadcast, adapter))
+}
+
+fn start_event_emitter(
+    broadcast: ConnectionBroadcast,
+    callback: ThreadsafeFunction<String>,
+) -> tokio::task::JoinHandle<()> {
+    let mut receiver = broadcast.subscribe();
+
+    tokio::spawn(async move {
+        while let Ok(ChannelMessage::Notification(event)) = receiver.recv().await {
+            let json = match serde_json::to_string(&event) {
+                Ok(json) => json,
+                Err(err) => {
+                    println!("Error serialize notification {err:?}");
+                    return;
+                }
+            };
+            callback.call(Ok(json), ThreadsafeFunctionCallMode::NonBlocking);
+        }
+    })
+}
+
+// start scan to collect peripherals on new AdapterManager instance
+// requested device should be already discovered by the background process
+async fn wait_for_device(
+    adapter: Adapter,
+    broadcast: ConnectionBroadcast,
+    target_id: String,
+) -> Result<()> {
+    let mut receiver = broadcast.subscribe();
+    let mut event_listener = tokio::spawn(async move {
+        while let Ok(ChannelMessage::Notification(NotificationEvent::DeviceDiscovered {
+            id, ..
+        })) = receiver.recv().await
+        {
+            if id == target_id {
+                break;
+            }
+        }
+    });
+
+    let _ = adapter.start_scan(ScanFilter::default()).await;
+
+    let timeout = tokio::time::sleep(tokio::time::Duration::from_secs(2));
+    tokio::pin!(timeout);
+    loop {
+        tokio::select! {
+            _ = &mut event_listener => {
+                break;
+            }
+            _ = &mut timeout => {
+                break;
+            }
+        }
+    }
+
+    let _ = adapter.stop_scan().await;
+
+    Ok(())
+}
 
 fn error(msg: String) -> napi::Error {
     napi::Error::new(napi::Status::GenericFailure, msg.to_string())
@@ -24,25 +106,9 @@ pub async fn connect_device(
     timeout: u32,
     callback: ThreadsafeFunction<String>,
 ) -> Result<()> {
-    let manager = match AdapterManager::new().await {
-        Ok(manager) => manager,
-        Err(e) => Err(error(e.to_string()))?,
-    };
-    let broadcast = match ConnectionBroadcast::new(id.clone()) {
-        Ok(broadcast) => broadcast,
-        Err(e) => Err(error(e.to_string()))?,
-    };
-    let adapter = match manager.get_adapter().await {
-        Ok(Some(adapter)) => adapter,
-        Ok(None) => Err(error("AdapterNotFound".to_string()))?,
-        Err(e) => Err(error(e.to_string()))?,
-    };
-
-    // start scan to collect peripherals on new AdapterManager instance
-    // requested device should be already discovered by the background process
-    let _ = adapter.start_scan(ScanFilter::default()).await;
-    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
-    let _ = adapter.stop_scan().await;
+    let (manager, broadcast, adapter) = init_adapter(id.clone()).await?;
+    let _ = start_event_emitter(broadcast.clone(), callback);
+    let _ = wait_for_device(adapter, broadcast.clone(), id.clone()).await;
 
     match connect_device_method(
         manager.clone(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

original changes (disconnect_device) will not be implemented but it would be a waste to throw some of the changes.

- add "wait_for_device" loader - waint until device is discovered instead of hardcoded timeout
- add "event_listener" - function to listen and emit notifications from the process
- move macos custom "napi" logic to `bluetooth-ipc` 


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-napi-disconnect&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-napi-disconnect&lookback=7)