### PR TITLE
feat(suite): reorder BluetoothDeviceComponent

### DIFF
--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceComponent.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceComponent.tsx
@@ -36,11 +36,11 @@ export const BluetoothDeviceComponent = ({ device }: BluetoothDeviceProps) => {
                 />
             </Column>
             <Column justifyContent="start" alignItems="start" flex="1">
-                <Text typographyStyle="body">{modelName}</Text>
+                <Text typographyStyle="body">{device.name}</Text>
                 {showBluetoothDebugInfo && <BluetoothDebugInfo device={device} />}
                 <InfoSegments typographyStyle="hint" variant="tertiary">
+                    <Text>{modelName}</Text>
                     {colorName && <Text>{colorName}</Text>}
-                    <Text>{device.name}</Text>
                 </InfoSegments>
             </Column>
         </Row>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Reordering to make device name more prominent. Mobile part was done in https://github.com/trezor/trezor-suite/pull/21385.

## Related Issue

Resolve [#21363](https://github.com/trezor/trezor-suite/issues/21363)

## Screenshots:
<img width="621" height="252" alt="Screenshot 2025-09-16 at 14 15 40" src="https://github.com/user-attachments/assets/9bb6743e-6793-4f95-bf10-084f1f284648" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/reorder-bluetooth-device-component&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/reorder-bluetooth-device-component&lookback=7)