### PR TITLE
BT disconnection fixes

### DIFF
--- a/.github/workflows/build-transport-bluetooth-binary.yml
+++ b/.github/workflows/build-transport-bluetooth-binary.yml
@@ -25,6 +25,8 @@ jobs:
         working-directory: packages/transport-bluetooth
         run: |
           BUILD_VERSION_TAG="${{ github.ref_name }}:${{ github.sha }}"
+          mkdir build
+          touch build/index.html
           docker build . -f ./scripts/Dockerfile -t trezor-bluetooth-image --build-arg BUILD_VERSION_TAG=$BUILD_VERSION_TAG
           docker create --name trezor-bluetooth-container trezor-bluetooth-image
           docker cp trezor-bluetooth-container:/output/. ../suite-data/files/bin/bluetooth

--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from 'electron';
 
+import { isMacOs } from '@trezor/env-utils';
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { getFreePort } from '@trezor/node-utils';
 import { BluetoothIpc, BluetoothIpcApi, BluetoothTransport } from '@trezor/transport-bluetooth';
@@ -85,13 +86,17 @@ export const init: ModuleInit = () => {
 
                     if (!api) throw apiError;
 
-                    if (method === 'connectDevice') {
+                    if (method === 'connectDevice' && isMacOs()) {
                         // special case for macos
-                        const result = await bluetoothProcess?.connectAndSubscribeInMainThread(
-                            params[0],
-                        );
-                        if (result && !result.success) {
-                            return result;
+                        const deviceId = params[0];
+                        const devices = await api.enumerateDevices();
+                        const isPaired = devices.find(d => d.id === deviceId)?.paired;
+                        if (!isPaired) {
+                            const result =
+                                await bluetoothProcess?.connectAndSubscribeInMainThread(deviceId);
+                            if (result && !result.success) {
+                                return result;
+                            }
                         }
                     }
 

--- a/packages/transport-bluetooth/scripts/Dockerfile
+++ b/packages/transport-bluetooth/scripts/Dockerfile
@@ -15,6 +15,7 @@ COPY ./src ./src
 COPY ./Cargo.toml ./Cargo.toml
 COPY ./Cargo.lock ./Cargo.lock
 COPY ./build.rs ./build.rs
+COPY ./build/ ./build/
 
 ARG BUILD_VERSION_TAG
 ENV BUILD_VERSION_TAG=${BUILD_VERSION_TAG}

--- a/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
@@ -182,4 +182,15 @@ export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements Bl
 
         return this.result();
     }
+
+    async enumerateDevices() {
+        try {
+            await this.connectApi();
+            const { devices } = await this.api.send('enumerate');
+
+            return this.filterConnectableDevices(devices);
+        } catch {
+            return [];
+        }
+    }
 }

--- a/packages/transport-bluetooth/src/lib.rs
+++ b/packages/transport-bluetooth/src/lib.rs
@@ -4,7 +4,9 @@ use napi_derive::napi;
 
 use crate::server::{
     adapter_manager::AdapterManager, connection_broadcast::ConnectionBroadcast,
-    methods::connect_device as connect_device_method, types::ConnectDeviceParams,
+    methods::connect_device as connect_device_method,
+    methods::disconnect_device as disconnect_device_method, types::ConnectDeviceParams,
+    types::DisconnectDeviceParams,
 };
 
 use btleplug::api::Central;
@@ -42,7 +44,27 @@ pub async fn connect_device(
     tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
     let _ = adapter.stop_scan().await;
 
-    match connect_device_method(manager, broadcast, ConnectDeviceParams { id, timeout }).await {
+    match connect_device_method(
+        manager.clone(),
+        broadcast.clone(),
+        ConnectDeviceParams {
+            id: id.clone(),
+            timeout,
+        },
+    )
+    .await
+    {
+        Ok(_) => Ok::<(), napi::Error>(()),
+        Err(e) => Err(error(e.to_string()))?,
+    }?;
+
+    match disconnect_device_method(
+        manager.clone(),
+        broadcast.clone(),
+        DisconnectDeviceParams { id: id.clone() },
+    )
+    .await
+    {
         Ok(_) => Ok(()),
         Err(e) => Err(error(e.to_string()))?,
     }


### PR DESCRIPTION
## Description

Resolve the disconnection issues on Mac in 2 ways: 

1. Always disconnect from the device after pairing with NAPI. Then connect only from BT process. 
2. Don't use NAPI at all if connecting to already paired device


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-connect-fixes&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-connect-fixes&lookback=7)