### PR TITLE
Mobile-Trade: refactor receiveAddress to string

### DIFF
--- a/suite-native/module-trading/src/__fixtures__/account.ts
+++ b/suite-native/module-trading/src/__fixtures__/account.ts
@@ -1,6 +1,6 @@
 import { Account } from '@suite-common/wallet-types';
 
-export const getBtcAccount = (key = 'btc-account-1') =>
+export const getBtcAccount = (key = 'btc-account-1', overrides: Partial<Account> = {}) =>
     ({
         key,
         symbol: 'btc',
@@ -24,6 +24,7 @@ export const getBtcAccount = (key = 'btc-account-1') =>
             change: [],
             unused: [],
         },
+        ...overrides,
     }) as unknown as Account;
 
 export const getEthAccount = (key = 'eth-account-1') =>

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.comp.test.tsx
@@ -32,7 +32,7 @@ const getTradingState = (selectedReceiveAccount: ReceiveAccount | undefined) => 
             ...initialState,
             buy: {
                 ...initialState.buy,
-                receiveAddress: selectedReceiveAccount?.address,
+                receiveAddress: selectedReceiveAccount?.address?.address,
                 tradingAccountKey: selectedReceiveAccount?.account.key,
             },
         },

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.comp.test.tsx
@@ -32,7 +32,7 @@ const getExchangeState = (selectedReceiveAccount: ReceiveAccount | undefined) =>
             ...initialState,
             exchange: {
                 ...initialState.exchange,
-                receiveAddress: selectedReceiveAccount?.address,
+                receiveAddress: selectedReceiveAccount?.address?.address,
                 receiveAccountKey: selectedReceiveAccount?.account.key,
             },
         },

--- a/suite-native/module-trading/src/components/general/AccountList/AccountList.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountList.tsx
@@ -89,8 +89,8 @@ export const AccountList = ({
                 : tradingExchangeActions.setReceiveAccountKey(receiveAccount.account.key);
         const addressAction =
             tradingType === 'buy'
-                ? buyActions.setReceiveAddress(receiveAccount.address)
-                : exchangeActions.setReceiveAddress(receiveAccount.address);
+                ? buyActions.setReceiveAddress(receiveAccount.address?.address)
+                : exchangeActions.setReceiveAddress(receiveAccount.address?.address);
         dispatch(accountAction);
         dispatch(addressAction);
         const hasAddresses = receiveAccount.account.addresses;

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.comp.test.tsx
@@ -40,7 +40,7 @@ const getStateMockupBuy = (selectedAccount: ReceiveAccount) => ({
             ...initialState,
             buy: {
                 ...initialState.buy,
-                receiveAddress: selectedAccount?.address,
+                receiveAddress: selectedAccount?.address?.address,
                 tradingAccountKey: selectedAccount.account.key,
             },
         },
@@ -55,7 +55,7 @@ const getStateMockupExchange = (selectedAccount: ReceiveAccount) => ({
             ...initialState,
             exchange: {
                 ...initialState.exchange,
-                receiveAddress: selectedAccount?.address,
+                receiveAddress: selectedAccount?.address?.address,
                 receiveAccountKey: selectedAccount.account.key,
             },
         },

--- a/suite-native/module-trading/src/reducers/__tests__/buySlice.test.ts
+++ b/suite-native/module-trading/src/reducers/__tests__/buySlice.test.ts
@@ -1,14 +1,12 @@
 import { BuyTrade, CryptoId } from 'invity-api';
 
-import { Address } from '@trezor/blockchain-link-types';
-
 import quotes from '../../__fixtures__/buyQuotes.json';
 import { TradingBuyState, buyActions, buyInitialState, buyReducer } from '../buySlice';
 
 describe('buySlice', () => {
     describe('setReceiveAddress', () => {
         it('should set buy receive address', () => {
-            const address = { address: 'bc1qxyz' } as Address;
+            const address = 'bc1qxyz';
             const state = buyReducer(undefined, buyActions.setReceiveAddress(address));
 
             expect(state.receiveAddress).toEqual(address);
@@ -26,9 +24,7 @@ describe('buySlice', () => {
             const prevState: TradingBuyState = {
                 ...buyInitialState,
                 tradingAccountKey: 'account-key',
-                receiveAddress: {
-                    address: 'bc1qxyz',
-                } as Address,
+                receiveAddress: 'bc1qxyz',
                 quotesRequest: {
                     wantCrypto: true,
                     receiveCurrency: 'btc' as CryptoId,
@@ -78,9 +74,7 @@ describe('buySlice', () => {
             const prevState: TradingBuyState = {
                 ...buyInitialState,
                 tradingAccountKey: 'account-key',
-                receiveAddress: {
-                    address: 'bc1qxyz',
-                } as Address,
+                receiveAddress: 'bc1qxyz',
             };
 
             const state = buyReducer(prevState, buyActions.assetChanged());

--- a/suite-native/module-trading/src/reducers/__tests__/exchangeSlice.test.ts
+++ b/suite-native/module-trading/src/reducers/__tests__/exchangeSlice.test.ts
@@ -1,7 +1,5 @@
 import { CryptoId } from 'invity-api';
 
-import { Address } from '@trezor/blockchain-link-types';
-
 import { exchangeQuotes } from '../../__fixtures__/exchangeQuotes';
 import {
     TradingExchangeState,
@@ -24,7 +22,7 @@ describe('exchangeSlice', () => {
 
     describe('setReceiveAddress', () => {
         it('should set buy receive address', () => {
-            const address = { address: 'bc1qxyz' } as Address;
+            const address = 'bc1qxyz';
             const state = exchangeReducer(undefined, exchangeActions.setReceiveAddress(address));
 
             expect(state.receiveAddress).toEqual(address);
@@ -41,7 +39,7 @@ describe('exchangeSlice', () => {
         it('should clear exchange state', () => {
             const prevState: TradingExchangeState = {
                 ...exchangeInitialState,
-                receiveAddress: { address: 'bc1qxyz' } as Address,
+                receiveAddress: 'bc1qxyz',
                 tradingAccountKey: 'account-key1',
                 receiveAccountKey: 'account-key2',
                 quotesRequest: {
@@ -122,7 +120,7 @@ describe('exchangeSlice', () => {
                     receive: 'ethereum' as CryptoId,
                 },
                 receiveAccountKey: 'account-key1',
-                receiveAddress: { address: 'bc1qxyz' } as Address,
+                receiveAddress: 'bc1qxyz',
             };
 
             const state = exchangeReducer(prevState, exchangeActions.receiveAssetChanged());

--- a/suite-native/module-trading/src/reducers/__tests__/exchangeSlice.test.ts
+++ b/suite-native/module-trading/src/reducers/__tests__/exchangeSlice.test.ts
@@ -21,14 +21,14 @@ describe('exchangeSlice', () => {
     });
 
     describe('setReceiveAddress', () => {
-        it('should set buy receive address', () => {
+        it('should set exchange receive address', () => {
             const address = 'bc1qxyz';
             const state = exchangeReducer(undefined, exchangeActions.setReceiveAddress(address));
 
             expect(state.receiveAddress).toEqual(address);
         });
 
-        it('should set buy receive address to undefined', () => {
+        it('should set exchange receive address to undefined', () => {
             const state = exchangeReducer(undefined, exchangeActions.setReceiveAddress(undefined));
 
             expect(state.receiveAddress).toBeUndefined();

--- a/suite-native/module-trading/src/reducers/__tests__/tradingSlice.test.ts
+++ b/suite-native/module-trading/src/reducers/__tests__/tradingSlice.test.ts
@@ -8,7 +8,6 @@ import {
     tradingSellActions,
 } from '@suite-common/trading';
 import { deviceActions } from '@suite-common/wallet-core';
-import { Address } from '@trezor/blockchain-link-types';
 
 import quotes from '../../__fixtures__/buyQuotes.json';
 import { exchangeQuotes } from '../../__fixtures__/exchangeQuotes';
@@ -119,9 +118,7 @@ describe('tradingSlice', () => {
                 buy: {
                     ...buyInitialState,
                     tradingAccountKey: 'account-key',
-                    receiveAddress: {
-                        address: 'bc1qxyz',
-                    } as Address,
+                    receiveAddress: 'bc1qxyz',
                     quotesRequest: {
                         wantCrypto: true,
                         receiveCurrency: 'btc' as CryptoId,
@@ -325,11 +322,11 @@ describe('tradingSlice', () => {
                 ...initialState,
                 buy: {
                     ...initialState.buy,
-                    receiveAddress: { address: 'address' } as Address,
+                    receiveAddress: 'address',
                 },
                 exchange: {
                     ...initialState.exchange,
-                    receiveAddress: { address: 'address' } as Address,
+                    receiveAddress: 'address',
                 },
             };
 

--- a/suite-native/module-trading/src/reducers/buySlice.ts
+++ b/suite-native/module-trading/src/reducers/buySlice.ts
@@ -1,10 +1,9 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { TradingBuyState as CommonTradingBuyState, initialState } from '@suite-common/trading';
-import { Address } from '@trezor/blockchain-link-types';
 
 export interface TradingBuyState extends CommonTradingBuyState {
-    receiveAddress: Address | undefined;
+    receiveAddress: string | undefined;
 }
 
 export const buyInitialState: TradingBuyState = {
@@ -18,7 +17,7 @@ const buySlice = createSlice({
     name: TRADING_BUY,
     initialState: buyInitialState,
     reducers: {
-        setReceiveAddress: (state, { payload }: PayloadAction<Address | undefined>) => {
+        setReceiveAddress: (state, { payload }: PayloadAction<string | undefined>) => {
             state.receiveAddress = payload;
         },
         clearState: state => {

--- a/suite-native/module-trading/src/reducers/exchangeSlice.ts
+++ b/suite-native/module-trading/src/reducers/exchangeSlice.ts
@@ -4,10 +4,9 @@ import {
     TradingExchangeState as CommonTradingExchangeState,
     initialState,
 } from '@suite-common/trading';
-import { Address } from '@trezor/blockchain-link-types';
 
 export interface TradingExchangeState extends CommonTradingExchangeState {
-    receiveAddress: Address | undefined;
+    receiveAddress: string | undefined;
 }
 
 export const exchangeInitialState: TradingExchangeState = {
@@ -21,7 +20,7 @@ const exchangeSlice = createSlice({
     name: TRADING_EXCHANGE,
     initialState: exchangeInitialState,
     reducers: {
-        setReceiveAddress: (state, { payload }: PayloadAction<Address | undefined>) => {
+        setReceiveAddress: (state, { payload }: PayloadAction<string | undefined>) => {
             state.receiveAddress = payload;
         },
         clearState: state => {

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
@@ -48,7 +48,7 @@ describe('TradingExchangePreviewScreen', () => {
             quotes: exchangeQuotes,
             tradingAccountKey: 'eth-account-1',
             receiveAccountKey: 'btc-account-1',
-            receiveAddress: getBtcAccount().addresses?.used[0],
+            receiveAddress: getBtcAccount().addresses?.used[0].address,
             selectedQuote: exchangeQuotes[0],
         };
 

--- a/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
@@ -46,7 +46,7 @@ describe('buySelectors', () => {
         beforeEach(() => {
             account = getBtcAccount();
             state.wallet.trading.buy.tradingAccountKey = account.key;
-            state.wallet.trading.buy.receiveAddress = account.addresses?.used[0];
+            state.wallet.trading.buy.receiveAddress = account.addresses?.used[0].address;
         });
 
         it('should be undefined when no tradingAccountKey is defined', () => {

--- a/suite-native/module-trading/src/selectors/__tests__/exchangeSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/exchangeSelectors.test.ts
@@ -67,7 +67,7 @@ describe('exchangeSelectors', () => {
         beforeEach(() => {
             account = getBtcAccount();
             state.wallet.trading.exchange.receiveAccountKey = account.key;
-            state.wallet.trading.exchange.receiveAddress = account.addresses?.used[0];
+            state.wallet.trading.exchange.receiveAddress = account.addresses?.used[0].address;
         });
 
         it('should be undefined when no receiveAccountKey is defined', () => {

--- a/suite-native/module-trading/src/selectors/buySelectors.ts
+++ b/suite-native/module-trading/src/selectors/buySelectors.ts
@@ -22,8 +22,9 @@ import {
     createMemoizedSelectorWithAccounts,
 } from '../reducers';
 import { BuyFormValues } from '../types/buy';
-import { FiatCurrencyItem, ReceiveAccount } from '../types/general';
+import { FiatCurrencyItem } from '../types/general';
 import { getCurrencyLabel } from '../utils/general/currencyUtils';
+import { getReceiveAccountFromAccountAndAddressString } from '../utils/general/receiveAccountUtils';
 import {
     coinInfoToTradeableAsset,
     tradeableAssetSortingComparator,
@@ -35,7 +36,7 @@ export const selectTradingBuy = (state: TradingRootState) => state.wallet.tradin
 
 export const selectBuySelectedReceiveAccount = createMemoizedSelectorWithAccounts(
     [state => state, selectTradingBuy],
-    (state, { receiveAddress: address, tradingAccountKey }) => {
+    (state, { receiveAddress, tradingAccountKey }) => {
         if (!tradingAccountKey) {
             return undefined;
         }
@@ -43,7 +44,7 @@ export const selectBuySelectedReceiveAccount = createMemoizedSelectorWithAccount
         const account = selectAccountByKey(state, tradingAccountKey);
         invariant(account, `Unknown tradingAccountKey: [${tradingAccountKey}]`);
 
-        return { account, address } as ReceiveAccount;
+        return getReceiveAccountFromAccountAndAddressString(account, receiveAddress);
     },
 );
 

--- a/suite-native/module-trading/src/selectors/exchangeSelectors.ts
+++ b/suite-native/module-trading/src/selectors/exchangeSelectors.ts
@@ -11,7 +11,7 @@ import {
     createMemoizedSelector,
     createMemoizedSelectorWithAccounts,
 } from '../reducers';
-import { ReceiveAccount } from '../types/general';
+import { getReceiveAccountFromAccountAndAddressString } from '../utils/general/receiveAccountUtils';
 import {
     coinInfoToTradeableAsset,
     tradeableAssetSortingComparator,
@@ -26,10 +26,12 @@ export const selectExchangeSelectedSendAccount = createMemoizedSelectorWithAccou
 
 export const selectExchangeSelectedReceiveAccount = createMemoizedSelectorWithAccounts(
     [state => state, selectTradingExchange],
-    (state, { receiveAddress: address, receiveAccountKey }) => {
+    (state, { receiveAddress, receiveAccountKey }) => {
         const account = selectAccountByKey(state, receiveAccountKey);
 
-        return account ? ({ account, address } as ReceiveAccount) : undefined;
+        return account
+            ? getReceiveAccountFromAccountAndAddressString(account, receiveAddress)
+            : undefined;
     },
 );
 

--- a/suite-native/module-trading/src/utils/general/__tests__/receiveAccountUtils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/receiveAccountUtils.test.ts
@@ -1,8 +1,10 @@
+import type { Account } from '@suite-common/wallet-types';
 import type { Address } from '@trezor/blockchain-link-types';
 
 import { getBtcAccount, getEthAccount } from '../../../__fixtures__/account';
 import {
     getReceiveAccountAddressText,
+    getReceiveAccountFromAccountAndAddressString,
     isFullySelectedReceiveAccount,
 } from '../receiveAccountUtils';
 
@@ -71,6 +73,92 @@ describe('receiveAccountUtils', () => {
                     address: { address: 'should_be_ignored' } as Address,
                 }),
             ).toBe('descriptor-eth-account-1');
+        });
+    });
+
+    describe('getReceiveAccountFromAccountAndAddressString', () => {
+        let account: Account;
+
+        beforeEach(() => {
+            account = getBtcAccount('btc-account-2', {
+                addresses: {
+                    used: [
+                        {
+                            address: 'USED1',
+                            path: 'm/84/0/0',
+                            transfers: 0,
+                            balance: '0',
+                            sent: '0',
+                            received: '0',
+                        },
+                    ],
+                    change: [
+                        {
+                            address: 'CHANGE',
+                            path: 'm/84/0/3',
+                            transfers: 0,
+                            balance: '0',
+                            sent: '0',
+                            received: '0',
+                        },
+                    ],
+                    unused: [
+                        {
+                            address: 'UNUSED1',
+                            path: 'm/84/0/1',
+                            transfers: 0,
+                            balance: '0',
+                            sent: '0',
+                            received: '0',
+                        },
+                        {
+                            address: 'UNUSED2',
+                            path: 'm/84/0/2',
+                            transfers: 0,
+                            balance: '0',
+                            sent: '0',
+                            received: '0',
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('should return account when no address is specified', () => {
+            expect(getReceiveAccountFromAccountAndAddressString(account)).toEqual({ account });
+        });
+
+        it('should return account and address when used address is specified', () => {
+            expect(getReceiveAccountFromAccountAndAddressString(account, 'USED1')).toEqual({
+                account,
+                address: account.addresses!.used[0],
+            });
+        });
+
+        it('should return account and address when unused address is specified', () => {
+            expect(getReceiveAccountFromAccountAndAddressString(account, 'UNUSED2')).toEqual({
+                account,
+                address: account.addresses!.unused[1],
+            });
+        });
+
+        it('should return account and address when change address is specified', () => {
+            expect(getReceiveAccountFromAccountAndAddressString(account, 'CHANGE')).toEqual({
+                account,
+                address: account.addresses!.change[0],
+            });
+        });
+
+        it('should throw when invalid address string is specified', () => {
+            expect(() =>
+                getReceiveAccountFromAccountAndAddressString(account, 'NONEXISTING'),
+            ).toThrow('Address NONEXISTING not found in the account btc-account-2');
+        });
+
+        it('should throw when address is specified for account without addresses', () => {
+            expect(() =>
+                getReceiveAccountFromAccountAndAddressString(getEthAccount(), 'ANYADDRESS'),
+            ).toThrow('Account eth-account-1 has no addresses');
         });
     });
 });

--- a/suite-native/module-trading/src/utils/general/receiveAccountUtils.ts
+++ b/suite-native/module-trading/src/utils/general/receiveAccountUtils.ts
@@ -1,3 +1,5 @@
+import { invariant } from '@suite-common/suite-utils';
+
 import { ReceiveAccount } from '../../types/general';
 
 export const isFullySelectedReceiveAccount = (
@@ -20,4 +22,26 @@ export const getReceiveAccountAddressText = (receiveAccount: ReceiveAccount | un
     const { account, address } = receiveAccount;
 
     return account.addresses ? address?.address : account.descriptor;
+};
+
+export const getReceiveAccountFromAccountAndAddressString = (
+    account: ReceiveAccount['account'],
+    receiveAddress?: string,
+): ReceiveAccount => {
+    if (!receiveAddress) {
+        return { account };
+    }
+
+    invariant(account.addresses, `Account ${account.key} has no addresses`);
+
+    const addressPredicate = ({ address }: NonNullable<ReceiveAccount['address']>) =>
+        address === receiveAddress;
+    const { used, unused, change } = account.addresses;
+    const address =
+        used.find(addressPredicate) ??
+        unused.find(addressPredicate) ??
+        change.find(addressPredicate);
+    invariant(address, `Address ${receiveAddress} not found in the account ${account.key}`);
+
+    return { account, address };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactor mobile treding reducers to use receiveAddress as string instead of Address object.



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor-receive-address&lookback=7)