### PR TITLE
`readWithExpectedHeaders` not graceful in node-bridge

### DIFF
--- a/packages/transport/src/thp/call.ts
+++ b/packages/transport/src/thp/call.ts
@@ -7,6 +7,7 @@ export const callThpMessage = async ({
     apiWrite,
     apiRead,
     signal,
+    graceful,
     logger,
 }: SendThpMessageProps) => {
     // send and wait for ThpAck
@@ -16,6 +17,7 @@ export const callThpMessage = async ({
         apiWrite,
         apiRead,
         signal,
+        graceful,
         logger,
     });
     if (!sendResult.success) {
@@ -28,6 +30,7 @@ export const callThpMessage = async ({
         apiWrite,
         apiRead,
         signal,
+        graceful,
         logger,
     });
 

--- a/packages/transport/src/thp/receive.ts
+++ b/packages/transport/src/thp/receive.ts
@@ -15,6 +15,7 @@ export type ReceiveThpMessageProps = {
     thpState?: protocolThp.ThpState;
     skipAck?: boolean;
     signal?: AbortSignal;
+    graceful?: boolean;
     logger?: Logger;
 };
 
@@ -24,6 +25,7 @@ export const receiveThpMessage = async ({
     apiRead,
     apiWrite,
     signal,
+    graceful,
     logger,
 }: ReceiveThpMessageProps) => {
     if (!thpState) {
@@ -33,7 +35,11 @@ export const receiveThpMessage = async ({
     logger?.debug(`receiveThpMessage start ${thpState.expectedResponses}`);
 
     try {
-        const apiReadWithExpectedHeaders = readWithExpectedHeaders(apiRead, { signal, logger });
+        const apiReadWithExpectedHeaders = readWithExpectedHeaders(apiRead, {
+            signal,
+            graceful,
+            logger,
+        });
         const expectedHeaders = protocolThp.getExpectedHeaders(thpState);
         const message = await receive(
             () => apiReadWithExpectedHeaders(expectedHeaders),

--- a/packages/transport/src/thp/send.ts
+++ b/packages/transport/src/thp/send.ts
@@ -20,6 +20,7 @@ export const sendThpMessage = async ({
     apiWrite,
     apiRead,
     signal,
+    graceful,
     logger,
 }: SendThpMessageProps) => {
     if (!thpState) {
@@ -45,7 +46,7 @@ export const sendThpMessage = async ({
 
     let attempt = 0;
 
-    const apiReadWithExpectedHeaders = readWithExpectedHeaders(apiRead, { signal });
+    const apiReadWithExpectedHeaders = readWithExpectedHeaders(apiRead, { signal, graceful });
 
     // create sequence of scheduled actions controlled by one AbortSignal (from Transport call/send)
     // 1. send message

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -227,6 +227,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                         apiWrite,
                         apiRead,
                         signal,
+                        graceful: true,
                         logger: this.logger,
                     });
                     if (!callResult.success) {
@@ -318,6 +319,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                         apiWrite,
                         apiRead: attemptSignal => this.api.read(path, attemptSignal || signal),
                         signal,
+                        graceful: true,
                         logger: this.logger,
                     });
                     thpState?.sync('send', name);
@@ -366,6 +368,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                             this.api.write(path, chunk, attemptSignal || signal),
                         apiRead,
                         signal,
+                        graceful: true,
                     });
 
                     if (!decoded.success) {

--- a/packages/transport/src/utils/readWithExpectedHeaders.ts
+++ b/packages/transport/src/utils/readWithExpectedHeaders.ts
@@ -11,6 +11,7 @@ type Options = {
     attempts?: number;
     timeout?: number;
     logger?: Logger;
+    graceful?: boolean;
 };
 
 const ATTEMPT_ERROR = 'Unexpected chunk';
@@ -72,7 +73,7 @@ export function readWithExpectedHeaders<T extends Receiver>(receiver: T, options
                 readAndAssert(receiver, expectedHeaders, { ...options, signal: attemptSignal }),
             {
                 signal: options?.signal,
-                graceful: true,
+                graceful: options?.graceful,
                 attempts: options?.attempts || Infinity,
                 timeout: options?.timeout,
                 attemptFailureHandler: error => {

--- a/packages/transport/tests/readWithExpectedHeaders.test.ts
+++ b/packages/transport/tests/readWithExpectedHeaders.test.ts
@@ -32,6 +32,7 @@ describe('readWithExpectedHeaders', () => {
         const abortController = new AbortController();
         const read = readWithExpectedHeaders(apiRead, {
             signal: abortController.signal,
+            graceful: true,
         });
 
         const resultPromise = read([Buffer.alloc(3)]);

--- a/packages/transport/tests/thp.test.ts
+++ b/packages/transport/tests/thp.test.ts
@@ -53,6 +53,7 @@ describe('thp', () => {
                 apiRead,
                 apiWrite,
                 signal: abortController.signal,
+                graceful: true,
             });
 
             expect(apiRead).toHaveBeenCalledTimes(5);


### PR DESCRIPTION
## Description

Fixed a bug introduced in bd9a178e5a3487c1b407a38b06eed2496175fe83 where `graceful` param made THP pairing over node-bridge impossible. It should be used only in `abstractApi` transport.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-pairing-node-bridge&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-pairing-node-bridge&lookback=7)