### PR TITLE
fix(blockchain-link): increase Solana ping interval to 1 hour

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -867,7 +867,9 @@ class SolanaWorker extends BaseWorker<SolanaAPI> {
         const api = {
             clusterUrl,
             rpc: throttledRpc,
-            rpcSubscriptions: createSolanaRpcSubscriptions(mainnet(url.replace('http', 'ws'))),
+            rpcSubscriptions: createSolanaRpcSubscriptions(mainnet(url.replace('http', 'ws')), {
+                intervalMs: 60 * 60 * 1000,
+            }),
         };
 
         // genesisHash is reliable identifier of the network, for mainnet the genesis hash is 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d


### PR DESCRIPTION
## Description

Raised the `intervalMs` for Solana RPC WebSocket pings to one hour to reduce unnecessary traffic and error noise from providers that don’t support the `ping` method. This change aligns the client behavior with providers like QuickNode
and dRPC, which reject unsupported pings.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19354


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-ws-ping&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-ws-ping&lookback=7)