### PR TITLE
fix(suite-native): use 0 decimals for sats value to fix the conversion

### DIFF
--- a/suite-native/module-send/src/components/FiatAmountInput.tsx
+++ b/suite-native/module-send/src/components/FiatAmountInput.tsx
@@ -5,7 +5,9 @@ import { getNetwork } from '@suite-common/wallet-config';
 import {
     DeviceRootState,
     TransactionsRootState,
+    WalletSettingsRootState,
     selectBaseCurrency,
+    selectIsAmountInSats,
     selectIsBaseCurrencyInSats,
 } from '@suite-common/wallet-core';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-utils';
@@ -33,12 +35,17 @@ export const FiatAmountInput = ({
     const { setValue } = useFormContext<SendOutputsFormValues>();
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const isBaseCurrencyInSats = useSelector(selectIsBaseCurrencyInSats);
+    const isAmountInSats = useSelector((state: WalletSettingsRootState) =>
+        selectIsAmountInSats(state, symbol),
+    );
     const { fiatAmountTransformer } = useAmountInputTransformers(symbol);
     const { decimals } = getNetwork(symbol);
     const tokenDecimals = useSelector(
         (state: DeviceRootState & TokenDefinitionsRootState & TransactionsRootState) =>
             selectAccountTokenDecimals(state, accountKey, tokenContract),
     );
+    // Use 0 decimals if amount is in sats, otherwise use token decimals or network decimals
+    const cryptoDecimals = isAmountInSats ? 0 : (tokenDecimals ?? decimals);
     const converters = useCryptoFiatConverters({ symbol, tokenContract });
 
     const cryptoFieldName = getOutputFieldName(recipientIndex, 'amount');
@@ -62,7 +69,6 @@ export const FiatAmountInput = ({
             asBaseCurrencyAmount(new BigNumber(transformedValue)),
         );
         if (cryptoValue) {
-            const cryptoDecimals = tokenDecimals ?? decimals;
             setValue(cryptoFieldName, cryptoValue.toFixed(cryptoDecimals), {
                 shouldValidate: true,
             });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Sats are supposed to be an integer and there is [a transformation that removes all non-digit characters](https://github.com/trezor/trezor-suite/blob/dcf3cc0cc69113c0278695d3704772ca3dda5576/suite-native/helpers/src/hooks/useAmountInputTransformers.ts#L20) so the value was correct but the decimal point was removed.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20826

## Screenshots:
<img width="381" height="283" alt="image" src="https://github.com/user-attachments/assets/76c03de7-13b3-42d6-8e6d-4192829661d4" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/sats-calculation&lookback=7)