### PR TITLE
Feat/bt open device characteristic

### DIFF
--- a/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
+++ b/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
@@ -5,6 +5,7 @@ import {
     BluetoothDevice,
     BluetoothInfo,
     Logger,
+    NotificationCharacteristic,
     NotificationEvent,
     TrezorBluetoothSettings,
 } from './types';
@@ -30,10 +31,12 @@ type ForgetDeviceParams = {
 
 type OpenDeviceParams = {
     id: string;
+    characteristic?: NotificationCharacteristic;
 };
 
 type CloseDeviceParams = {
     id: string;
+    characteristic?: NotificationCharacteristic;
 };
 
 type WriteParams = {

--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -46,6 +46,8 @@ export interface BluetoothDevice {
 
 export type BluetoothAdapterState = 'enabled' | 'disabled' | 'permission-denied';
 
+export type NotificationCharacteristic = 'read' | 'push-notification';
+
 export interface NotificationEvent {
     adapter_state_changed: { state: BluetoothAdapterState };
     device_discovered: { id: string; devices: BluetoothDevice[] };
@@ -53,7 +55,7 @@ export interface NotificationEvent {
     device_connected: { id: string; devices: BluetoothDevice[] };
     device_connection_status: { device: BluetoothDevice };
     device_disconnected: { id: string; devices: BluetoothDevice[] };
-    device_read: { id: string; data: number[] };
+    device_read: { id: string; characteristic: NotificationCharacteristic; data: number[] };
     device_settings_ui: undefined; // dispatched by linux pairing process
     device_removed: { id: string };
 }

--- a/packages/transport-bluetooth/src/server/device.rs
+++ b/packages/transport-bluetooth/src/server/device.rs
@@ -116,6 +116,7 @@ const MANUFACTURER_DATA: u16 = 3881; // trezor-firmware CONFIG_BT_COMPANY_ID=0x0
 pub const SERVICE_UUID: Uuid = uuid!("8c000001-a59b-4d58-a9ad-073df69fa1b1"); // trezor-firmware BT_UUID_TRZ_VAL
 pub const CHARACTERISTIC_RX: Uuid = uuid!("8c000002-a59b-4d58-a9ad-073df69fa1b1"); // trezor-firmware BT_UUID_TRZ_TX_VAL
 pub const CHARACTERISTIC_TX: Uuid = uuid!("8c000003-a59b-4d58-a9ad-073df69fa1b1"); // trezor-firmware BT_UUID_TRZ_RX_VAL
+pub const CHARACTERISTIC_PUSH_NOTIFICATION: Uuid = uuid!("8c000004-a59b-4d58-a9ad-073df69fa1b1"); // trezor-firmware BT_UUID_TRZ_NOTIFY_VAL
 
 impl TrezorDevice {
     pub async fn new(peripheral: Peripheral, is_known: bool) -> Result<Self, Box<dyn Error>> {

--- a/packages/transport-bluetooth/src/server/message_handler.rs
+++ b/packages/transport-bluetooth/src/server/message_handler.rs
@@ -61,7 +61,7 @@ pub async fn handle_message(
             return Some(Message::text(json_error.to_string()));
         }
     };
-    info!("Method: {:?}", request.method);
+    info!("Method: {:?}", request.method.as_string());
 
     let payload = match request.method.clone() {
         WsRequestMethod::GetInfo => methods::get_info(manager).await,

--- a/packages/transport-bluetooth/src/server/methods/close_device.rs
+++ b/packages/transport-bluetooth/src/server/methods/close_device.rs
@@ -14,7 +14,10 @@ pub async fn close_device(
     let id = params.id;
     info!("close_device {id}");
 
-    broadcast.send(ChannelMessage::Abort(AbortProcess::Read(id)));
+    broadcast.send(ChannelMessage::Abort(AbortProcess::NotificationStream(
+        id,
+        params.characteristic,
+    )));
 
     Ok(WsResponsePayload::Success { success: true })
 }

--- a/packages/transport-bluetooth/src/server/methods/open_device.rs
+++ b/packages/transport-bluetooth/src/server/methods/open_device.rs
@@ -5,10 +5,10 @@ use tokio::time::{sleep, Duration};
 
 use crate::server::{
     adapter_manager::{AdapterError, AdapterManager},
-    device::CHARACTERISTIC_TX,
+    device::{CHARACTERISTIC_PUSH_NOTIFICATION, CHARACTERISTIC_TX},
     types::{
-        AbortProcess, ChannelMessage, MethodError, MethodResult, NotificationEvent,
-        OpenDeviceParams, WsResponsePayload,
+        AbortProcess, ChannelMessage, MethodError, MethodResult, NotificationCharacteristic,
+        NotificationEvent, OpenDeviceParams, WsResponsePayload,
     },
     ConnectionBroadcast,
 };
@@ -19,7 +19,8 @@ pub async fn open_device(
     params: OpenDeviceParams,
 ) -> MethodResult {
     let id = params.id;
-    info!("open_device {id}");
+    let characteristic = params.characteristic;
+    info!("open_device {id} characteristic {characteristic:?}");
 
     manager.get_powered_adapter_or_die().await?;
     let peripheral = manager.get_peripheral_or_die(&id).await?;
@@ -28,8 +29,17 @@ pub async fn open_device(
         return Err(MethodError::Adapter(AdapterError::PeripheralNotConnected));
     }
 
+    let characteristic = characteristic.unwrap_or(NotificationCharacteristic::Read);
+    let characteristic_uuid = match characteristic {
+        NotificationCharacteristic::Read => CHARACTERISTIC_TX,
+        NotificationCharacteristic::PushNotification => CHARACTERISTIC_PUSH_NOTIFICATION,
+    };
+
     // try to terminate/abort previous read (if any)
-    broadcast.send(ChannelMessage::Abort(AbortProcess::Read(id.clone())));
+    broadcast.send(ChannelMessage::Abort(AbortProcess::NotificationStream(
+        id.clone(),
+        Some(characteristic.clone()),
+    )));
     sleep(Duration::from_millis(5)).await;
 
     if peripheral.services().is_empty() {
@@ -38,10 +48,10 @@ pub async fn open_device(
         peripheral.discover_services().await?;
     }
 
-    let characteristics = peripheral.characteristics();
-    let Some(tx) = characteristics
+    let Some(tx) = peripheral
+        .characteristics()
         .into_iter()
-        .find(|c| c.uuid == CHARACTERISTIC_TX && c.properties.contains(CharPropFlags::NOTIFY))
+        .find(|c| c.uuid == characteristic_uuid && c.properties.contains(CharPropFlags::NOTIFY))
     else {
         return Err(MethodError::Adapter(
             AdapterError::PeripheralCharacteristicNotFound,
@@ -53,38 +63,61 @@ pub async fn open_device(
     let notification_sender = broadcast.get_sender();
     let mut notification_stream = peripheral.notifications().await?;
     let device_id = id.clone();
+    let current_ch = characteristic.clone();
+    let current_uuid = characteristic_uuid.clone();
     let stream_task = tokio::spawn(async move {
-        info!("{device_id} start notification_stream");
+        info!("{device_id} start {current_ch:?} stream");
         while let Some(data) = notification_stream.next().await {
-            info!("{device_id} recv data");
-            if let Err(err) = notification_sender.send(ChannelMessage::Notification(
-                NotificationEvent::DeviceRead {
-                    id: device_id.clone(),
-                    data: data.value,
-                },
-            )) {
-                info!("{device_id} error in notification_stream {err}");
+            if data.uuid != current_uuid {
+                continue;
+            }
+            info!("{device_id} {current_ch:?} data");
+
+            let msg = ChannelMessage::Notification(NotificationEvent::DeviceRead {
+                id: device_id.clone(),
+                characteristic: current_ch.clone(),
+                data: data.value,
+            });
+
+            if let Err(err) = notification_sender.send(msg) {
+                info!("{device_id} error in {current_ch:?} stream {err}");
             }
         }
-        info!("{device_id} notification_stream terminated");
     });
 
+    let manager_ref = manager.clone();
     let current_id = id.clone();
+    let current_ch = characteristic.clone();
     let mut receiver = broadcast.subscribe();
     tokio::spawn(async move {
         while let Ok(event) = receiver.recv().await {
             // TODO: if websocket client connection is related to this device
             // AbortProcess::ClientDisconnected
-            if let ChannelMessage::Abort(
-                AbortProcess::Read(id) | AbortProcess::DeviceDisconnected(id),
-            ) = event
-            {
-                if current_id == id {
+            if let ChannelMessage::Abort(AbortProcess::ClientDisconnected(_client)) = event {
+                if manager_ref.is_listeners_empty().await {
                     stream_task.abort();
                     let _ = peripheral.unsubscribe(&tx).await;
-                    info!("{id} abort stream terminated");
-                    break;
+                    info!("All clients disconnected, {id} {current_ch:?} stream terminated");
                 }
+                break;
+            }
+
+            // check if id should be disconnected
+            let maybe_id = match event {
+                ChannelMessage::Abort(AbortProcess::NotificationStream(id, maybe_ch)) => {
+                    let matches_ch = maybe_ch.map_or(true, |ch| ch == current_ch);
+                    matches_ch.then_some(id)
+                }
+                ChannelMessage::Abort(AbortProcess::DeviceDisconnected(id)) => Some(id),
+                _ => None,
+            };
+
+            // check current_id == maybe_id
+            if let Some(id) = maybe_id.filter(|id| id == &current_id) {
+                stream_task.abort();
+                let _ = peripheral.unsubscribe(&tx).await;
+                info!("{id} {current_ch:?} stream terminated");
+                break;
             }
         }
     });

--- a/packages/transport-bluetooth/src/server/types.rs
+++ b/packages/transport-bluetooth/src/server/types.rs
@@ -93,6 +93,27 @@ pub enum WsRequestMethod {
     Read(ReadParams),
 }
 
+impl WsRequestMethod {
+    pub fn as_string(&self) -> String {
+        match self {
+            WsRequestMethod::GetInfo => "GetInfo".to_string(),
+            WsRequestMethod::Enumerate => "Enumerate".to_string(),
+            WsRequestMethod::StartScan => "StartScan".to_string(),
+            WsRequestMethod::StopScan => "StopScan".to_string(),
+            WsRequestMethod::SetState(_) => "SetState".to_string(),
+            WsRequestMethod::ConnectDevice(params) => format!("ConnectDevice({})", params.id),
+            WsRequestMethod::DisconnectDevice(params) => {
+                format!("DisconnectDevice({})", params.id)
+            }
+            WsRequestMethod::ForgetDevice(params) => format!("ForgetDevice({})", params.id),
+            WsRequestMethod::OpenDevice(params) => format!("OpenDevice({})", params.id),
+            WsRequestMethod::CloseDevice(params) => format!("CloseDevice({})", params.id),
+            WsRequestMethod::Write(params) => format!("Write({})", params.id),
+            WsRequestMethod::Read(params) => format!("Read({})", params.id),
+        }
+    }
+}
+
 #[derive(serde::Deserialize, Debug)]
 pub struct WsRequest {
     pub id: String,

--- a/packages/transport-bluetooth/src/server/types.rs
+++ b/packages/transport-bluetooth/src/server/types.rs
@@ -5,7 +5,7 @@ use btleplug::api::CentralState;
 pub enum AbortProcess {
     ClientDisconnected(String), // websocket client disconnected
     DeviceDisconnected(String), // device disconnected
-    Read(String),               // device closed/disconnected
+    NotificationStream(String, Option<NotificationCharacteristic>), // device closed/disconnected
     Scan,                       // stop scan
 }
 
@@ -44,14 +44,23 @@ pub struct ForgetDeviceParams {
     pub id: String,
 }
 
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum NotificationCharacteristic {
+    Read,
+    PushNotification,
+}
+
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct OpenDeviceParams {
     pub id: String,
+    pub characteristic: Option<NotificationCharacteristic>,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct CloseDeviceParams {
     pub id: String,
+    pub characteristic: Option<NotificationCharacteristic>,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
@@ -177,6 +186,7 @@ pub enum NotificationEvent {
     DeviceSettingsUi, // only on linux
     DeviceRead {
         id: String,
+        characteristic: NotificationCharacteristic,
         data: Vec<u8>,
     },
 }

--- a/packages/transport-bluetooth/src/ui/app.tsx
+++ b/packages/transport-bluetooth/src/ui/app.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 
 import { TrezorBluetooth } from '../client/trezor-bluetooth';
-import { BluetoothDevice, NotificationEvent } from '../client/types';
+import { BluetoothDevice, NotificationCharacteristic, NotificationEvent } from '../client/types';
 
 // Inline CSS (simplified, readable)
 const INLINE_CSS = `
@@ -54,6 +54,9 @@ export const App: React.FC = () => {
     const [deviceId, setDeviceId] = useState('');
     const [messageInput, setMessageInput] = useState('{}');
     const [connected, setConnected] = useState(false);
+    const selectRef = useRef<(HTMLSelectElement & { value?: NotificationCharacteristic }) | null>(
+        null,
+    );
 
     const writeOutput = (message: unknown) => {
         try {
@@ -79,6 +82,10 @@ export const App: React.FC = () => {
             setDevices(prev => prev.map(d => (d.id === device.id ? device : d)));
         };
 
+        const onDeviceRead = (e: NotificationEvent['device_read']) => {
+            writeOutput(`${e.characteristic} at ${e.id} ${e.data.toString()}`);
+        };
+
         api.on('disconnected', onDisconnected);
         api.on('adapter_state_changed', onAdapterState);
         api.on('device_discovered', onDevices);
@@ -86,6 +93,8 @@ export const App: React.FC = () => {
         api.on('device_connected', onDevices);
         api.on('device_disconnected', onDevices);
         api.on('device_connection_status', onDeviceConnectionStatus);
+        api.on('device_read', onDeviceRead);
+
         (async () => {
             try {
                 await api.connect();
@@ -178,7 +187,10 @@ export const App: React.FC = () => {
 
     const openDevice = async () => {
         try {
-            const r = await api().send('open_device', { id: deviceId });
+            const r = await api().send('open_device', {
+                id: deviceId,
+                characteristic: selectRef.current?.value || undefined,
+            });
             writeOutput(r);
         } catch (e: any) {
             writeOutput({ error: e.message });
@@ -187,7 +199,10 @@ export const App: React.FC = () => {
 
     const closeDevice = async () => {
         try {
-            const r = await api().send('close_device', { id: deviceId });
+            const r = await api().send('close_device', {
+                id: deviceId,
+                characteristic: selectRef.current?.value || undefined,
+            });
             writeOutput(r);
         } catch (e: any) {
             writeOutput({ error: e.message });
@@ -370,6 +385,15 @@ export const App: React.FC = () => {
                                         >
                                             Forget
                                         </button>
+                                        <select ref={selectRef}>
+                                            <option value="">Select characteristic</option>
+                                            <option value="read" selected>
+                                                READ
+                                            </option>
+                                            <option value="push-notification">
+                                                PUSH_NOTIFICATION
+                                            </option>
+                                        </select>
                                         <button
                                             id="open_device"
                                             style={{ margin: '0 4px' }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

trezor-bluetooth api `open_device` and `close_device` with optional param `characteristic` :  'read' | 'push-notification'

this allows us to read from the device using different channels

- `read` - default if not provided in param - channel for normal workflows: openDevice -> write -> read -> closeDevice

- `push-notification` - read only channel to get state change events from the device - meant to be opened all the time after successful connection


addtionaly im changing noisy log (method+all params -> method+id) 

picked from: https://github.com/trezor/trezor-suite/pull/21577

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bt-open-device-characteristic&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bt-open-device-characteristic&lookback=7)