### PR TITLE
fix(suite): dont show useless bridge toggle troubleshooting tip when …

### DIFF
--- a/packages/suite/src/components/connection/CantSeeTrezorModal.tsx
+++ b/packages/suite/src/components/connection/CantSeeTrezorModal.tsx
@@ -21,7 +21,10 @@ import {
 } from 'src/components/suite/troubleshooting/tips';
 import { useSelector } from 'src/hooks/suite';
 import { useBridgeDesktopApi } from 'src/hooks/suite/useBridgeDesktopApi';
-import { selectHasTransportOfType } from 'src/selectors/suite/suiteSelectors';
+import {
+    selectHasTransportOfType,
+    selectTransportOfType,
+} from 'src/selectors/suite/suiteSelectors';
 
 type DontSeeYourTrezorModalProps = {
     isBluetoothMode: boolean;
@@ -47,6 +50,7 @@ export const CantSeeTrezorModal = ({
     const nearbyDevices = useSelector(selectNearbyDevices);
     const knownDevices = useSelector(selectKnownDevices);
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
+    const bridge = useSelector(selectTransportOfType('BridgeTransport'));
 
     const bridgeDesktopApi = useBridgeDesktopApi();
 
@@ -66,14 +70,14 @@ export const CantSeeTrezorModal = ({
                   TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER,
               ];
 
-        if (bridgeDesktopApi?.bridgeProcess?.process) {
+        if (bridgeDesktopApi?.bridgeProcess?.process && bridge) {
             items.push(TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE);
         } else {
             // TODO: here we are going to put instruction to uninstall standalone bridge
         }
 
         return items;
-    }, [isWebUsbTransport, bridgeDesktopApi]);
+    }, [isWebUsbTransport, bridgeDesktopApi, bridge]);
 
     const tipItems = useMemo(() => {
         if (isBluetoothMode && isDesktop()) {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
@@ -12,6 +12,8 @@ import {
     TROUBLESHOOTING_TIP_UNREADABLE_HID,
 } from 'src/components/suite/troubleshooting/tips';
 import { useSelector } from 'src/hooks/suite';
+import { useBridgeDesktopApi } from 'src/hooks/suite/useBridgeDesktopApi';
+import { selectTransportOfType } from 'src/selectors/suite/suiteSelectors';
 
 /**
  * Device was detected but @trezor/connect was not able to communicate with it. Reasons could be:
@@ -21,7 +23,8 @@ import { useSelector } from 'src/hooks/suite';
  */
 export const DeviceUnreadable = () => {
     const selectedDevice = useSelector(selectSelectedDevice);
-
+    const bridge = useSelector(selectTransportOfType('BridgeTransport'));
+    const bridgeDesktopApi = useBridgeDesktopApi();
     // generic troubleshooting tips
     const items = [];
 
@@ -41,7 +44,9 @@ export const DeviceUnreadable = () => {
         items.push(TROUBLESHOOTING_TIP_SUITE_DESKTOP);
         // you might have a very old device which is no longer supported current bridge
         // if on desktop - try toggling between the 2 bridges we have available
-        items.push(TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE);
+        if (bridgeDesktopApi?.bridgeProcess?.process && bridge) {
+            items.push(TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE);
+        }
     } else {
         // it might also be unreadable because device was acquired on transport layer by another app and never released.
         // this should be rather exceptional case that happens only when sessions synchronization is broken or other app


### PR DESCRIPTION
…not running bridge transport

Fixes #21608


<img width="1298" height="635" alt="image" src="https://github.com/user-attachments/assets/40d63817-fa40-4182-8bda-6e884a1fe3d2" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bridge-troubleshooting-tpi&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bridge-troubleshooting-tpi&lookback=7)