### PR TITLE
feat(transport-bluetooth): server add battery-level characteristic

### DIFF
--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -46,7 +46,7 @@ export interface BluetoothDevice {
 
 export type BluetoothAdapterState = 'enabled' | 'disabled' | 'permission-denied';
 
-export type NotificationCharacteristic = 'read' | 'push-notification';
+export type NotificationCharacteristic = 'read' | 'push-notification' | 'battery-level';
 
 export interface NotificationEvent {
     adapter_state_changed: { state: BluetoothAdapterState };

--- a/packages/transport-bluetooth/src/server/device.rs
+++ b/packages/transport-bluetooth/src/server/device.rs
@@ -117,6 +117,7 @@ pub const SERVICE_UUID: Uuid = uuid!("8c000001-a59b-4d58-a9ad-073df69fa1b1"); //
 pub const CHARACTERISTIC_RX: Uuid = uuid!("8c000002-a59b-4d58-a9ad-073df69fa1b1"); // trezor-firmware BT_UUID_TRZ_TX_VAL
 pub const CHARACTERISTIC_TX: Uuid = uuid!("8c000003-a59b-4d58-a9ad-073df69fa1b1"); // trezor-firmware BT_UUID_TRZ_RX_VAL
 pub const CHARACTERISTIC_PUSH_NOTIFICATION: Uuid = uuid!("8c000004-a59b-4d58-a9ad-073df69fa1b1"); // trezor-firmware BT_UUID_TRZ_NOTIFY_VAL
+pub const CHARACTERISTIC_BATTERY_LEVEL: Uuid = uuid!("00002a19-0000-1000-8000-00805f9b34fb"); // characteristic of battery service 0000180f-0000-1000-8000-00805f9b34fb
 
 impl TrezorDevice {
     pub async fn new(peripheral: Peripheral, is_known: bool) -> Result<Self, Box<dyn Error>> {

--- a/packages/transport-bluetooth/src/server/methods/open_device.rs
+++ b/packages/transport-bluetooth/src/server/methods/open_device.rs
@@ -5,7 +5,7 @@ use tokio::time::{sleep, Duration};
 
 use crate::server::{
     adapter_manager::{AdapterError, AdapterManager},
-    device::{CHARACTERISTIC_PUSH_NOTIFICATION, CHARACTERISTIC_TX},
+    device::{CHARACTERISTIC_BATTERY_LEVEL, CHARACTERISTIC_PUSH_NOTIFICATION, CHARACTERISTIC_TX},
     types::{
         AbortProcess, ChannelMessage, MethodError, MethodResult, NotificationCharacteristic,
         NotificationEvent, OpenDeviceParams, WsResponsePayload,
@@ -33,6 +33,7 @@ pub async fn open_device(
     let characteristic_uuid = match characteristic {
         NotificationCharacteristic::Read => CHARACTERISTIC_TX,
         NotificationCharacteristic::PushNotification => CHARACTERISTIC_PUSH_NOTIFICATION,
+        NotificationCharacteristic::BatteryLevel => CHARACTERISTIC_BATTERY_LEVEL,
     };
 
     // try to terminate/abort previous read (if any)

--- a/packages/transport-bluetooth/src/server/types.rs
+++ b/packages/transport-bluetooth/src/server/types.rs
@@ -49,6 +49,7 @@ pub struct ForgetDeviceParams {
 pub enum NotificationCharacteristic {
     Read,
     PushNotification,
+    BatteryLevel,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]

--- a/packages/transport-bluetooth/src/ui/app.tsx
+++ b/packages/transport-bluetooth/src/ui/app.tsx
@@ -387,12 +387,11 @@ export const App: React.FC = () => {
                                         </button>
                                         <select ref={selectRef}>
                                             <option value="">Select characteristic</option>
-                                            <option value="read" selected>
-                                                READ
-                                            </option>
+                                            <option value="read">READ</option>
                                             <option value="push-notification">
                                                 PUSH_NOTIFICATION
                                             </option>
+                                            <option value="battery-level">BATTERY_LEVEL</option>
                                         </select>
                                         <button
                                             id="open_device"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
follow up for https://github.com/trezor/trezor-suite/pull/21606
and https://github.com/trezor/trezor-firmware/pull/5768

adding `battery-level` characteristic 

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bt-battery-service&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bt-battery-service&lookback=7)