### PR TITLE
fix(e2e-suite): stabilize flaky discovery tests

### DIFF
--- a/docs/tests/e2e-playwright-suite.md
+++ b/docs/tests/e2e-playwright-suite.md
@@ -154,6 +154,14 @@ To open last HTML report run:
 
 ## Results
 
+Results contains traces, metadata, logs, screenshots, videos and various useful information for debugging.
+Traces contain electron logs of our desktop suit app. Both in CI, currents and local env (`packages/suite-desktop-core/e2e/test-results`).
+CI runs have artifact with logs from `trezor-user-env`. They exist per group. Log are separated by Log entry `- - - STARTING TEST trading/swap-tokens.test.ts` and `- - - FINISHING TEST trading/swap-tokens.test.ts`
+
+- electrum-regtest.txt
+- trezor-user-env-debugging.log
+- tenv-emulator-bridge-debugging.log
+
 ### Currents.dev
 
 Test reports are uploaded to [currents.dev](https://app.currents.dev/)

--- a/packages/suite-desktop-core/e2e/tests/wallet/discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/discovery.test.ts
@@ -46,11 +46,14 @@ test.describe('Discovery', { tag: ['@group=wallet'] }, () => {
         // end up in some de-synced state. if this test becomes flaky, this reload might be the reason.
         await page.reload();
 
-        await expect(page.getByTestId('@deviceStatus-connected')).toBeVisible({ timeout: 10000 });
-        await expect(dashboardPage.loading).toBeVisible({ timeout: 10000 });
-        await dashboardPage.loading.waitFor({ state: 'detached', timeout: DISCOVERY_LIMIT });
-        for (const symbol of ['btc', ...coinsToActivate] as NetworkSymbol[]) {
-            await expect(walletPage.balanceOfAccount(symbol).first()).toBeVisible();
+        await expect(page.getByTestId('@deviceStatus-connected')).toBeVisible({ timeout: 10_000 });
+        // Discovery bar does not have to be shown at all if discovery finished before reload, so we build verification on accounts' visibility
+        await expect(dashboardPage.loading).toBeHidden({ timeout: DISCOVERY_LIMIT });
+        const expectedAccounts = ['btc', ...coinsToActivate] as NetworkSymbol[];
+        for (const symbol of expectedAccounts) {
+            await expect.soft(walletPage.balanceOfAccount(symbol).first()).toBeVisible({
+                timeout: DISCOVERY_LIMIT,
+            });
         }
     });
 });


### PR DESCRIPTION
Latest refactoring and fixes caused that discovery loading bar might not be shown after the reload if all coins were already discovered.
So we are changing our assert to mainly verify visibility of expected accounts.

Also enhances doc on test result artifacts

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-flaky-tests&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-flaky-tests&lookback=7)