### PR TITLE
feat(transport): open/close with params (channel)

### DIFF
--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -2,6 +2,7 @@ import {
     AbstractApi,
     AbstractApiConstructorParams,
     DEVICE_TYPE,
+    OpenDeviceChannel,
 } from '@trezor/transport/src/api/abstract';
 import * as ERRORS from '@trezor/transport/src/errors';
 import { PathInternal } from '@trezor/transport/src/types';
@@ -64,8 +65,14 @@ export class BluetoothApi extends AbstractApi {
             this.readBuffer.cancelRead(event.id);
             transportApiEvent(event);
         });
-        api.on('device_read', ({ id, data }) => {
-            this.readBuffer.onMessage(id, Buffer.from(data));
+        api.on('device_read', ({ id, data, characteristic }) => {
+            if (characteristic === 'push-notification') {
+                this.emit('trezor-push-notification', { id, data });
+            } else if (characteristic === 'battery-level') {
+                this.emit('battery-level', { id, data });
+            } else {
+                this.readBuffer.onMessage(id, Buffer.from(data));
+            }
         });
         api.on('adapter_state_changed', ({ state }) => {
             if (state !== 'enabled') {
@@ -97,20 +104,20 @@ export class BluetoothApi extends AbstractApi {
             .catch(e => this.error({ error: ERRORS.INTERFACE_DATA_TRANSFER, message: e.message }));
     }
 
-    openDevice(path: string) {
+    openDevice(path: string, options?: { channel?: OpenDeviceChannel }) {
         return this.api
-            .send('open_device', { id: path })
+            .send('open_device', { id: path, characteristic: options?.channel })
             .then(() => this.success(undefined))
             .catch(e =>
                 this.error({ error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE, message: e.message }),
             );
     }
 
-    closeDevice(path: string) {
+    closeDevice(path: string, options?: { channel?: OpenDeviceChannel }) {
         this.readBuffer.cancelRead(path);
 
         return this.api
-            .send('close_device', { id: path })
+            .send('close_device', { id: path, characteristic: options?.channel })
             .then(() => this.success(undefined))
             .catch(e =>
                 this.error({ error: ERRORS.INTERFACE_UNABLE_TO_CLOSE_DEVICE, message: e.message }),

--- a/packages/transport-bluetooth/src/client/transport.ts
+++ b/packages/transport-bluetooth/src/client/transport.ts
@@ -20,6 +20,12 @@ export class BluetoothTransport extends AbstractApiTransport {
         api.on('transport-interface-error', ({ error }) => {
             this.emit('transport-error', error);
         });
+        api.on('trezor-push-notification', event => {
+            this.emit('trezor-push-notification', event);
+        });
+        api.on('battery-level', event => {
+            this.emit('battery-level', event);
+        });
 
         super({
             api,

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -142,11 +142,10 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
             return acquireIntentResult;
         }
 
-        const openDeviceResult = await api.openDevice(
-            acquireIntentResult.payload.path,
-            acquireInput.previous !== 'null',
-            acquireInput.signal,
-        );
+        const openDeviceResult = await api.openDevice(acquireIntentResult.payload.path, {
+            reset: acquireInput.previous !== 'null',
+            signal: acquireInput.signal,
+        });
         logger?.debug(`core: openDevice: result: ${JSON.stringify(openDeviceResult)}`);
 
         if (!openDeviceResult.success) {

--- a/packages/transport-native-bluetooth/src/api/BluetoothApi.ts
+++ b/packages/transport-native-bluetooth/src/api/BluetoothApi.ts
@@ -108,7 +108,7 @@ export class BluetoothApi extends AbstractApi {
         }
     }
 
-    public async openDevice(path: string, _first: boolean) {
+    public async openDevice(path: string) {
         this.logger?.debug('openDevice', path);
 
         // BT does not need to be opened, it is opened when connected

--- a/packages/transport-test/e2e/api/api.test.ts
+++ b/packages/transport-test/e2e/api/api.test.ts
@@ -62,7 +62,7 @@ const runTests = async () => {
         };
 
         const pingPong = async () => {
-            await api.openDevice(path, true);
+            await api.openDevice(path, { reset: true });
             const writeResponse = await api.write(path, buildMessage('PING'));
             debug('writeResponse', writeResponse);
             assertSuccess(writeResponse);
@@ -102,7 +102,7 @@ const runTests = async () => {
 
         await sharedTest('read-abort-write', async () => {
             debug('open device');
-            await api.openDevice(path, true);
+            await api.openDevice(path, { reset: true });
 
             const abortController = new AbortController();
             debug('read with abort signal');

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -1,5 +1,6 @@
 import { TypedEmitter, getSynchronize } from '@trezor/utils';
 
+import { TRANSPORT } from '../constants';
 import * as ERRORS from '../errors';
 import type {
     AnyError,
@@ -26,6 +27,8 @@ export enum DEVICE_TYPE {
     TypeBluetooth = 6,
 }
 
+export type OpenDeviceChannel = 'read' | 'push-notification' | 'battery-level';
+
 type AccessLock = {
     read: boolean;
     write: boolean;
@@ -40,6 +43,8 @@ type AccessLock = {
 export abstract class AbstractApi extends TypedEmitter<{
     'transport-interface-change': DescriptorApiLevel[];
     'transport-interface-error': { error: typeof ERRORS.API_DISCONNECTED };
+    [TRANSPORT.TREZOR_PUSH_NOTIFICATION]: { id: string; data: number[] };
+    [TRANSPORT.BATTERY_LEVEL]: { id: string; data: number[] };
 }> {
     protected logger?: Logger;
     protected listening: boolean = false;
@@ -106,8 +111,11 @@ export abstract class AbstractApi extends TypedEmitter<{
      */
     abstract openDevice(
         path: PathInternal,
-        reset: boolean,
-        signal?: AbortSignal,
+        options?: {
+            reset: boolean;
+            signal?: AbortSignal;
+            channel?: OpenDeviceChannel;
+        },
     ): AsyncResultWithTypedError<
         undefined,
         | typeof ERRORS.DEVICE_NOT_FOUND
@@ -123,6 +131,9 @@ export abstract class AbstractApi extends TypedEmitter<{
      */
     abstract closeDevice(
         path: PathInternal,
+        options?: {
+            channel?: OpenDeviceChannel;
+        },
     ): AsyncResultWithTypedError<
         undefined,
         | typeof ERRORS.DEVICE_NOT_FOUND

--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -191,7 +191,7 @@ export class UdpApi extends AbstractApi {
         }
     }
 
-    public openDevice(_path: string, _first: boolean, _signal?: AbortSignal) {
+    public openDevice(_path: string) {
         // todo: maybe ping?
         return Promise.resolve(this.success(undefined));
     }

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -271,7 +271,7 @@ export class UsbApi extends AbstractApi {
         }
     }
 
-    public async openDevice(path: string, reset: boolean, signal?: AbortSignal) {
+    public async openDevice(path: string, options: { reset: boolean; signal?: AbortSignal }) {
         // note: multiple retries to open device. reason:  when another window acquires device, changed session
         // is broadcasted to other clients. they are responsible for releasing interface, which takes some time.
         // if there is only one client working with device, this will succeed using only one attempt.
@@ -280,18 +280,21 @@ export class UsbApi extends AbstractApi {
         // I would need to throw artificially which is not nice.
         for (let i = 0; i < 5; i++) {
             this.logger?.debug(`usb: openDevice attempt ${i}`);
-            const res = await this.openInternal(path, reset, signal);
-            if (res.success || signal?.aborted) {
+            const res = await this.openInternal(path, options);
+            if (res.success || options.signal?.aborted) {
                 return res;
             }
 
             await resolveAfter(100 * i);
         }
 
-        return this.openInternal(path, reset, signal);
+        return this.openInternal(path, options);
     }
 
-    private async openInternal(path: string, reset: boolean, signal?: AbortSignal) {
+    private async openInternal(
+        path: string,
+        { reset, signal }: { reset: boolean; signal?: AbortSignal },
+    ) {
         const device = this.findDevice(path);
         if (!device) {
             return this.error({ error: ERRORS.DEVICE_NOT_FOUND });

--- a/packages/transport/src/constants.ts
+++ b/packages/transport/src/constants.ts
@@ -35,6 +35,8 @@ export const TRANSPORT = {
     DEVICE_SESSION_CHANGED: 'transport-device_session_changed',
     DEVICE_REQUEST_RELEASE: 'transport-device_request_release',
     SEND_MESSAGE_PROGRESS: 'transport-send_message_progress',
+    TREZOR_PUSH_NOTIFICATION: 'trezor-push-notification',
+    BATTERY_LEVEL: 'battery-level',
     /* messages */
     DISABLE_WEBUSB: 'transport-disable_webusb',
     REQUEST_DEVICE: 'transport-request_device',

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -78,6 +78,8 @@ type TransportEvents = {
     [TRANSPORT.ERROR]: BridgeCommonErrors | typeof ERRORS.API_DISCONNECTED; // BluetoothApi disconnected
     [TRANSPORT.STOPPED]: void;
     [TRANSPORT.SEND_MESSAGE_PROGRESS]: number;
+    [TRANSPORT.TREZOR_PUSH_NOTIFICATION]: { id: string; data: number[] };
+    [TRANSPORT.BATTERY_LEVEL]: { id: string; data: number[] };
 };
 
 export type TransportDeviceEvent =

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -119,8 +119,11 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 const reset = !!input.previous;
                 const openDeviceResult = await this.api.openDevice(
                     acquireIntentResponse.payload.path,
-                    reset,
-                    signal,
+                    {
+                        reset,
+                        signal,
+                        channel: 'read',
+                    },
                 );
 
                 if (!openDeviceResult.success) {
@@ -147,7 +150,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     return this.error({ error: releaseIntentResponse.error });
                 }
 
-                await this.api.closeDevice(releaseIntentResponse.payload.path);
+                await this.api.closeDevice(releaseIntentResponse.payload.path, { channel: 'read' });
 
                 await this.sessionsClient.releaseDone({
                     path: releaseIntentResponse.payload.path,
@@ -162,7 +165,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
     public releaseSync(session: Session) {
         // Obviously not sync as was advertised. Also looks a bit weird but should be the same as before.
         this.sessionsClient.releaseIntent({ session }).then(res => {
-            if (res.success) this.api.closeDevice(res.payload.path);
+            if (res.success) this.api.closeDevice(res.payload.path, { channel: 'read' });
         });
     }
 
@@ -405,7 +408,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
             })
             .then(response => {
                 if (response.success) {
-                    return this.api.closeDevice(response.payload.path);
+                    return this.api.closeDevice(response.payload.path, { channel: 'read' });
                 }
 
                 return this.success(undefined);

--- a/packages/transport/tests/apiUsb.test.ts
+++ b/packages/transport/tests/apiUsb.test.ts
@@ -123,7 +123,7 @@ describe('api/usb', () => {
 
         const abortController = new AbortController();
         await api.enumerate(abortController.signal);
-        const promise = api.openDevice('123', true, abortController.signal);
+        const promise = api.openDevice('123', { reset: true, signal: abortController.signal });
         abortController.abort();
 
         const result = await promise;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Picked from https://github.com/trezor/trezor-suite/pull/21577

add `options` to transport openDevice/closeDevice methods.

`options.channel` is used to determine which characteristic to read in bluetooth transport ('read' | 'push-notification' | 'battery-life')

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/transport-push-notifications&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/transport-push-notifications&lookback=7)