### PR TITLE
fix(suite-native): select Bluetooth characteristics based on their UUID

### DIFF
--- a/packages/transport-native-bluetooth/src/api/bluetoothManager.ts
+++ b/packages/transport-native-bluetooth/src/api/bluetoothManager.ts
@@ -32,6 +32,8 @@ const eventNames = {
 
 // UUID of the Bluetooth service used to identify a BLE device as Trezor.
 const SERVICE_UUID = '8c000001-a59b-4d58-a9ad-073df69fa1b1';
+const WRITE_CHARACTERISTIC_UUID = '8c000002-a59b-4d58-a9ad-073df69fa1b1';
+const NOTIFY_CHARACTERISTIC_UUID = '8c000003-a59b-4d58-a9ad-073df69fa1b1';
 
 const DEBUG_LOGS = false;
 
@@ -310,10 +312,10 @@ class BluetoothManager {
         let writeCharacteristic: Characteristic | undefined;
         let notifyCharacteristic: Characteristic | undefined;
         for (const characteristic of characteristics) {
-            if (characteristic.isWritableWithoutResponse) {
+            if (characteristic.uuid === WRITE_CHARACTERISTIC_UUID) {
                 debugLog('Found write characteristic: ', characteristic.uuid);
                 writeCharacteristic = characteristic;
-            } else if (characteristic.isNotifiable) {
+            } else if (characteristic.uuid === NOTIFY_CHARACTERISTIC_UUID) {
                 debugLog('Found notify characteristic: ', characteristic.uuid);
                 notifyCharacteristic = characteristic;
             } else {


### PR DESCRIPTION
Previously, only two Bluetooth characteristics were available – one writable and one notifiable. However, starting with FW 2.9.2.4, there are multiple characteristics with overlapping capabilities. That's the reason why the mobile app doesn't work after upgrading FW to 2.9.2.4.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/bluetooth-characteristics-uuid&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/bluetooth-characteristics-uuid&lookback=7)