### PR TITLE
fix(fiat-services): merge headers for native fetch

### DIFF
--- a/suite-common/fiat-services/src/fetch.native.ts
+++ b/suite-common/fiat-services/src/fetch.native.ts
@@ -5,5 +5,17 @@ export const requestInit: RequestInit = {
     },
 };
 
-export const fetchUrl = (url: string, init?: RequestInit) =>
-    fetch(url, { ...requestInit, ...init });
+export const fetchUrl = (url: string, init?: RequestInit) => {
+    const combinedHeaders = {
+        ...(requestInit.headers ?? {}),
+        ...(init?.headers ?? {}),
+    };
+
+    const newInit: RequestInit = {
+        ...requestInit,
+        ...init,
+        headers: combinedHeaders,
+    };
+
+    return fetch(url, newInit);
+};

--- a/suite-common/fiat-services/tests/fetch.native.test.ts
+++ b/suite-common/fiat-services/tests/fetch.native.test.ts
@@ -1,0 +1,126 @@
+import { fetchUrl, requestInit } from '../src/fetch.native';
+
+// Mock fetch globally
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Helper function to create RequestInit objects for testing
+const createRequestInit = (overrides: Partial<RequestInit> = {}): RequestInit => ({
+    ...requestInit,
+    ...overrides,
+});
+
+// Helper function to create custom init configurations
+const createCustomInit = (config: {
+    headers?: HeadersInit;
+    method?: string;
+    body?: string;
+}): RequestInit => ({
+    ...(config.method && { method: config.method }),
+    ...(config.body && { body: config.body }),
+    ...(config.headers && { headers: config.headers }),
+});
+
+describe('fetch.native', () => {
+    beforeEach(() => {
+        mockFetch.mockClear();
+    });
+
+    describe('fetchUrl', () => {
+        test('calls fetch with default headers when no init provided', () => {
+            const url = 'https://api.example.com/data';
+            const expectedInit = createRequestInit();
+
+            fetchUrl(url);
+
+            expect(mockFetch).toHaveBeenCalledWith(url, expectedInit);
+        });
+
+        test('merges custom headers with default headers', () => {
+            const url = 'https://api.example.com/data';
+            const customInit = createCustomInit({
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: 'Bearer token',
+                },
+            });
+            const expectedInit = createRequestInit({
+                headers: {
+                    'User-Agent': 'Trezor Suite',
+                    'Content-Type': 'application/json',
+                    Authorization: 'Bearer token',
+                },
+            });
+
+            fetchUrl(url, customInit);
+
+            expect(mockFetch).toHaveBeenCalledWith(url, expectedInit);
+        });
+
+        test('overrides default headers when custom headers have same keys', () => {
+            const url = 'https://api.example.com/data';
+            const customInit = createCustomInit({
+                headers: {
+                    'User-Agent': 'Custom Agent',
+                },
+            });
+            const expectedInit = createRequestInit({
+                headers: {
+                    'User-Agent': 'Custom Agent',
+                },
+            });
+
+            fetchUrl(url, customInit);
+
+            expect(mockFetch).toHaveBeenCalledWith(url, expectedInit);
+        });
+
+        test('preserves other init properties while merging headers', () => {
+            const url = 'https://api.example.com/data';
+            const customInit = createCustomInit({
+                method: 'POST',
+                body: JSON.stringify({ data: 'test' }),
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            });
+            const expectedInit = createRequestInit({
+                headers: {
+                    'User-Agent': 'Trezor Suite',
+                    'Content-Type': 'application/json',
+                },
+                method: 'POST',
+                body: JSON.stringify({ data: 'test' }),
+            });
+
+            fetchUrl(url, customInit);
+
+            expect(mockFetch).toHaveBeenCalledWith(url, expectedInit);
+        });
+
+        it.each([
+            ['undefined', undefined],
+            ['null', null],
+            ['empty string', ''],
+        ])('handles %s headers gracefully', (type, headersValue) => {
+            const url = 'https://api.example.com/data';
+            const customInit =
+                type === 'null'
+                    ? { method: 'GET', headers: headersValue as any }
+                    : createCustomInit({
+                          method: 'GET',
+                          headers: headersValue as unknown as HeadersInit,
+                      });
+            const expectedInit = createRequestInit({
+                headers: {
+                    'User-Agent': 'Trezor Suite',
+                },
+                method: 'GET',
+            });
+
+            fetchUrl(url, customInit);
+
+            expect(mockFetch).toHaveBeenCalledWith(url, expectedInit);
+        });
+    });
+});


### PR DESCRIPTION
`fetch.native.ts` uses default `User-Agent`, but if there are headers provided for the fetch, it is overwritten and User-Agent can be lost. In this case it is replaced by`User-Agent` added by `CFNetwork` (iOS) or `okhttp` (android). 

Such requests are then blocked by trezor Cloudflare and it leads to blocking coingecko fiat rates requests for non-blockbook networks. This happened for example in [this change](https://github.com/trezor/trezor-suite/blob/df88491cc9eef2b66c912170d88a8984b254b8c6/suite-common/fiat-services/src/coingecko.ts#L101) and resulted in `403` for XRP, XLM and SOL fiat rates requests.

This PR introduces merging of headers to prevent such situation


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/merge-fetch-headers&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/merge-fetch-headers&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/merge-fetch-headers&lookback=7)