### PR TITLE
refactor(suite): migrate auto eject functionality to wallet settings

### DIFF
--- a/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
+++ b/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
@@ -1,5 +1,5 @@
 import { testMocks } from '@suite-common/test-utils';
-import { deviceActions } from '@suite-common/wallet-core';
+import { deviceActions, initialWalletSettingsState } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 
 import suiteReducer from 'src/reducers/suite/suiteReducer';
@@ -23,9 +23,11 @@ const getInitialState = (state: Partial<DeviceSettingsFixtureState> = {}) => ({
     device: {
         devices: state.device?.devices ?? [DEVICE],
         selectedDevice: state.device?.selectedDevice ?? DEVICE,
-        isDeviceAutoEjectEnabled: false,
         persistentDeviceData: [],
         isConnectionModalOpen: false,
+    },
+    wallet: {
+        settings: initialWalletSettingsState,
     },
     router: {},
     messageSystem: { validMessages: { feature: [] } },

--- a/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { extraDependenciesMock, testMocks } from '@suite-common/test-utils';
-import { prepareDeviceReducer } from '@suite-common/wallet-core';
+import { initialWalletSettingsState, prepareDeviceReducer } from '@suite-common/wallet-core';
 
 import { prepareSuiteMiddleware } from 'src/middlewares/suite/suiteMiddleware';
 import metadataReducer from 'src/reducers/suite/metadataReducer';
@@ -67,7 +67,6 @@ const getInitialState = (state?: InitialState) => {
         device: {
             devices: device ? [device] : [],
             selectedDevice: device,
-            isDeviceAutoEjectEnabled: false,
             persistentDeviceData: [],
             isConnectionModalOpen: false,
         },
@@ -83,6 +82,7 @@ const getInitialState = (state?: InitialState) => {
             selectedAccount: {
                 account: accounts[0],
             },
+            settings: initialWalletSettingsState,
         },
         router: {
             app: 'fo',

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -233,7 +233,6 @@ describe('Storage actions', () => {
             getInitialState({
                 device: {
                     devices: [dev1, dev2, dev2Instance1],
-                    isDeviceAutoEjectEnabled: false,
                     persistentDeviceData: [],
                     isConnectionModalOpen: false,
                     defaultConnectionMode: 'cable',
@@ -327,7 +326,6 @@ describe('Storage actions', () => {
             getInitialState({
                 device: {
                     devices: [dev1, dev2],
-                    isDeviceAutoEjectEnabled: false,
                     persistentDeviceData: [],
                     isConnectionModalOpen: false,
                     defaultConnectionMode: 'cable',
@@ -373,7 +371,6 @@ describe('Storage actions', () => {
             getInitialState({
                 device: {
                     devices: [dev1Connected],
-                    isDeviceAutoEjectEnabled: false,
                     persistentDeviceData: [],
                     isConnectionModalOpen: false,
                     defaultConnectionMode: 'cable',
@@ -413,7 +410,6 @@ describe('Storage actions', () => {
             getInitialState({
                 device: {
                     devices: [dev1],
-                    isDeviceAutoEjectEnabled: false,
                     persistentDeviceData: [],
                     isConnectionModalOpen: false,
                     defaultConnectionMode: 'cable',

--- a/packages/suite/src/actions/suite/autoEjectThunks.ts
+++ b/packages/suite/src/actions/suite/autoEjectThunks.ts
@@ -1,40 +1,30 @@
 import { createThunk } from '@suite-common/redux-utils';
-import {
-    PORTFOLIO_TRACKER_DEVICE_ID,
-    forgetDisconnectedDevices,
-    selectDevices,
-} from '@suite-common/wallet-core';
+import { selectDevices, setDeviceAutoEjectThunk } from '@suite-common/wallet-core';
 
 import * as storageActions from 'src/actions/suite/storageActions';
 
 import { goto } from './routerActions';
-import { setAutoEject } from './suiteActions';
 
 const AUTO_EJECT_PREFIX = '@suite/autoEject';
 
-type SetAutoEjectEnabledThunkProps = { enabled: boolean };
+type SetAutoEjectEnabledThunkProps = { shouldEnable: boolean };
 
 export const setAutoEjectEnabledThunk = createThunk<void, SetAutoEjectEnabledThunkProps, void>(
     `${AUTO_EJECT_PREFIX}/enableAutoEjectThunk`,
-    ({ enabled }, { dispatch, getState }) => {
-        if (!enabled) {
-            dispatch(setAutoEject(false));
+    async ({ shouldEnable }, { dispatch, getState }) => {
+        // Disconnected devices are purged from local redux (awaited because the subsequent code may rely on updated deviceReducer state)
+        await dispatch(setDeviceAutoEjectThunk({ shouldEnable }));
 
+        if (!shouldEnable) {
             return;
         }
 
+        // All devices, even connected ones, removed from persistent storage,
+        // which means connected device are preserved in local redux.
         const allDevices = selectDevices(getState());
         allDevices.forEach(device => {
-            if (!device.connected && device.id !== PORTFOLIO_TRACKER_DEVICE_ID) {
-                // Disconnected devices are purged from local redux (awaited because the subsequent code may rely on updated deviceReducer state)
-                dispatch(forgetDisconnectedDevices({ device, forceForget: true }));
-            }
-            // All devices, even connected ones, removed from persistent storage,
-            // which means connected device are preserved in local redux.
             dispatch(storageActions.forgetDevice(device));
         });
-
-        dispatch(setAutoEject(true));
 
         const currentDevices = selectDevices(getState());
         const connectedDevices = currentDevices.filter(device => device.connected && device.state);

--- a/packages/suite/src/actions/suite/autoForgetDeviceDataThunks.ts
+++ b/packages/suite/src/actions/suite/autoForgetDeviceDataThunks.ts
@@ -1,8 +1,5 @@
 import { createThunk } from '@suite-common/redux-utils';
-import {
-    forgetAllDevicesPersistentDataThunk,
-    setAutoForgetDeviceData,
-} from '@suite-common/wallet-core';
+import { setAutoForgetDeviceDataThunk as setAutoForgetDeviceDataThunkCore } from '@suite-common/wallet-core';
 
 import * as storageActions from 'src/actions/suite/storageActions';
 
@@ -10,28 +7,20 @@ import { setAutoEjectEnabledThunk } from './autoEjectThunks';
 
 const AUTO_FORGET_PREFIX = '@suite/autoForgetDeviceData';
 
-type SetAutoForgetDeviceDataThunkProps = { enabled: boolean };
+type SetAutoForgetDeviceDataThunkProps = { shouldEnable: boolean };
 
-// TODO: move main parts of this thunk to wallet-core. The setting `autoForgetDeviceData` already lives in wallet-core.
-// But the autoEject setting lives in suiteReducer unfortunately, so that will first have to be migrated to wallet-core.
 export const setAutoForgetDeviceDataThunk = createThunk<
     void,
     SetAutoForgetDeviceDataThunkProps,
     void
->(`${AUTO_FORGET_PREFIX}/setAutoForgetDeviceDataThunk`, async ({ enabled }, { dispatch }) => {
-    if (!enabled) {
-        dispatch(setAutoForgetDeviceData(false));
+>(`${AUTO_FORGET_PREFIX}/setAutoForgetDeviceDataThunk`, async ({ shouldEnable }, { dispatch }) => {
+    await dispatch(setAutoForgetDeviceDataThunkCore({ shouldEnable }));
 
+    if (!shouldEnable) {
         return;
     }
 
-    dispatch(setAutoForgetDeviceData(true));
-    await dispatch(forgetAllDevicesPersistentDataThunk());
-
-    // When you enable autoForget, also enable autoEject, but not the other way around, because
-    // autoEject feature is a subset of autoForget feature, autoForget does not make sense without autoEject.
-    // This also takes care of forgetting wallets (as deviceReducer `devices`) from redux as well as storage.
-    await dispatch(setAutoEjectEnabledThunk({ enabled }));
+    await dispatch(setAutoEjectEnabledThunk({ shouldEnable: true }));
 
     // Finally, having purged the data in Bluetooth and THP reducers, simply sync BT and THP to persistent storage.
     dispatch(storageActions.saveKnownDevices());

--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -48,4 +48,3 @@ export const LOCK_TYPE = {
 export const SET_EXPERIMENTAL_FEATURES = '@suite/set-experimental-features';
 export const SET_SIDEBAR_WIDTH = '@suite/set-sidebar-width';
 export const SET_IS_COINS_FILTER_VISIBLE = '@suite/set-is-coins-filter-visible';
-export const SET_AUTO_EJECT = '@suite/set-auto-eject';

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -107,8 +107,7 @@ export type SuiteAction =
     | {
           type: typeof SUITE.SET_IS_COINS_FILTER_VISIBLE;
           payload: { isCoinsFilterVisible: boolean };
-      }
-    | { type: typeof SUITE.SET_AUTO_EJECT; payload: boolean };
+      };
 
 export const appChanged = createAction(SUITE.APP_CHANGED, (payload: AppState['router']['app']) => ({
     payload,
@@ -394,10 +393,5 @@ export const lockDevice = createAction(SUITE.LOCK_DEVICE, (payload: boolean) => 
  */
 export const lockRouter = (payload: boolean): SuiteAction => ({
     type: SUITE.LOCK_ROUTER,
-    payload,
-});
-
-export const setAutoEject = (payload: boolean): SuiteAction => ({
-    type: SUITE.SET_AUTO_EJECT,
     payload,
 });

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -8,6 +8,7 @@ import {
     forgetDisconnectedDevices,
     handleDeviceDisconnect,
     observeSelectedDevice,
+    selectIsDeviceAutoEjectEnabled,
     startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
@@ -53,14 +54,15 @@ export const prepareSuiteMiddleware = createMiddlewareWithExtraDeps(
         // otherwise device will not be accessible and related data will not be removed (accounts, txs...)
         if (action.type === DEVICE.DISCONNECT) {
             const state = getState();
+            const isAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(state);
             dispatch(
                 forgetDisconnectedDevices({
                     device: action.payload,
-                    forceForget: state.suite.settings.autoEject,
+                    forceForget: isAutoEjectEnabled,
                 }),
             );
 
-            if (!state.suite.settings.autoEject) {
+            if (!isAutoEjectEnabled) {
                 if (action.payload.id) {
                     dispatch(setRecentlyDisconnectedDevice(action.payload.id));
                 }

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -24,6 +24,7 @@ import {
     selectDevices,
     selectHistoricFiatRates,
     selectIsAutoForgetDeviceDataEnabled,
+    selectIsDeviceAutoEjectEnabled,
     selectSelectedDevice,
     setBaseCurrency,
     transactionsActions,
@@ -37,7 +38,6 @@ import * as metadataActions from 'src/actions/suite/metadataActions';
 import * as storageActions from 'src/actions/suite/storageActions';
 import { GRAPH } from 'src/actions/wallet/constants';
 import * as COINJOIN from 'src/actions/wallet/constants/coinjoinConstants';
-import { selectIsAutoEjectEnabled } from 'src/selectors/suite/suiteSelectors';
 import { db } from 'src/storage';
 import type { AppState, Dispatch, Action as SuiteAction } from 'src/types/suite';
 import type { WalletAction } from 'src/types/wallet';
@@ -179,7 +179,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
             }
 
             if (deviceActions.setRememberDevice.match(action)) {
-                const isAutoEjectEnabled = selectIsAutoEjectEnabled(api.getState());
+                const isAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(api.getState());
 
                 if (action.payload.remember && !isAutoEjectEnabled) {
                     api.dispatch(storageActions.rememberDevice(action.payload.device));
@@ -210,7 +210,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
             }
 
             if (deviceActions.updateSelectedDevice.match(action)) {
-                const isAutoEjectEnabled = selectIsAutoEjectEnabled(api.getState());
+                const isAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(api.getState());
 
                 if (
                     isDeviceRemembered(action.payload) &&
@@ -278,6 +278,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS:
                 case WALLET_SETTINGS.SET_MEV_PROTECTION:
                 case WALLET_SETTINGS.AUTO_FORGET_DEVICE_DATA:
+                case WALLET_SETTINGS.SET_AUTO_EJECT:
                     api.dispatch(storageActions.saveWalletSettings());
 
                     break;
@@ -298,7 +299,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case SUITE.EVM_CLOSE_EXPLANATION_BANNER:
                 case SUITE.SET_IS_COINS_FILTER_VISIBLE:
                 case SUITE.DISMISSED_TRADING_TERMS:
-                case SUITE.SET_AUTO_EJECT:
                 case SUITE.SET_LOCAL_FIRST_STORAGE_RELAY:
                     api.dispatch(storageActions.saveSuiteSettings());
                     break;

--- a/packages/suite/src/reducers/backup/__tests__/backupReducer.test.ts
+++ b/packages/suite/src/reducers/backup/__tests__/backupReducer.test.ts
@@ -1,9 +1,13 @@
+import { testMocks } from '@suite-common/test-utils';
 import { BackupAvailability } from '@trezor/protobuf/src/messages';
 
-import type { DesktopDeviceRootState } from 'src/actions/device/deviceSlice';
+import { AppState } from 'src/reducers/store';
+import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
 
+import type { BackupState } from '../backupReducer';
 import { selectBackupStatus } from '../backupReducer';
-import type { BackupRootState, BackupState } from '../backupReducer';
+
+const { getSuiteDevice } = testMocks;
 
 describe('selectBackupStatus', () => {
     const baseBackup: BackupState = {
@@ -24,20 +28,15 @@ describe('selectBackupStatus', () => {
         error: undefined,
     };
 
-    const getState = (
-        backup: BackupState,
-        backup_availability: BackupAvailability,
-    ): BackupRootState & DesktopDeviceRootState => ({
+    const getState = (backup: BackupState, backup_availability: BackupAvailability): AppState => ({
+        ...initialAppState,
         backup: { ...baseBackup, ...backup },
         device: {
             devices: [],
-            isDeviceAutoEjectEnabled: false,
             persistentDeviceData: [],
             isConnectionModalOpen: true,
             defaultConnectionMode: 'cable',
-            selectedDevice: {
-                features: { backup_availability },
-            } as any,
+            selectedDevice: getSuiteDevice({}, { backup_availability }),
         },
     });
 

--- a/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
@@ -35,6 +35,7 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
+                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -62,6 +63,7 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
+                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -95,6 +97,7 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
+                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -123,6 +126,7 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
+                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -157,6 +161,7 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
+                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -194,6 +199,7 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
+                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -216,6 +222,7 @@ const connect: Fixture<
                         type: 'unacquired',
                         path: '1',
                     }),
+                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -245,6 +252,7 @@ const connect: Fixture<
                         type: 'unacquired',
                         path: '1',
                     }),
+                    isAutoEjectEnabled: false,
                 },
             },
         ],

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -109,7 +109,6 @@ export interface SuiteSettings {
     sidebarWidth: number;
     isCoinsFilterVisible: boolean;
     localFirstStorageRelayUrl: string | null;
-    autoEject: boolean;
 }
 
 export interface TransportState extends InstallerInfo {
@@ -212,7 +211,6 @@ const initialState: SuiteState = {
         sidebarWidth: SIDEBAR_WIDTH_NUMERIC,
         isCoinsFilterVisible: false,
         localFirstStorageRelayUrl: null,
-        autoEject: false,
     },
     recentlyConnectedDeviceRef: null,
     recentlyDisconnectedDevice: null,
@@ -371,10 +369,6 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
 
             case SUITE.SET_IS_COINS_FILTER_VISIBLE:
                 draft.settings.isCoinsFilterVisible = action.payload.isCoinsFilterVisible;
-                break;
-
-            case SUITE.SET_AUTO_EJECT:
-                draft.settings.autoEject = action.payload;
                 break;
 
             case TRANSPORT.START: {

--- a/packages/suite/src/selectors/suite/suiteSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteSelectors.ts
@@ -107,7 +107,6 @@ export const selectIsFirmwareHashCheckEnabled = (state: SuiteRootState) =>
     state.suite.settings.enabledSecurityChecks.firmwareHash;
 export const selectIsFirmwareRevisionCheckEnabled = (state: SuiteRootState) =>
     state.suite.settings.enabledSecurityChecks.firmwareRevision;
-export const selectIsAutoEjectEnabled = (state: SuiteRootState) => state.suite.settings.autoEject;
 export const selectIsTradingTermsDismissed = (state: AppState, tradingType: TradingType): boolean =>
     !!state.suite.dismissedTradingTerms?.[tradingType];
 

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -223,7 +223,7 @@ export const extraDependencies: ExtraDependencies = {
             });
         },
         storageLoadWalletSettings: (state: WalletSettingsState, { payload }: StorageLoadAction) =>
-            payload.walletSettings || state,
+            payload.walletSettings ? { ...state, ...payload.walletSettings } : state,
         storageLoadBioAuth: (state: BioAuthState, { payload }: StorageLoadAction) => {
             if (!payload?.bioAuth) return state;
 

--- a/packages/suite/src/views/settings/SettingsGeneral/AutoEject.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/AutoEject.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
 
-import { selectDevices, selectIsAutoForgetDeviceDataEnabled } from '@suite-common/wallet-core';
+import {
+    selectDevices,
+    selectIsAutoForgetDeviceDataEnabled,
+    selectIsDeviceAutoEjectEnabled,
+} from '@suite-common/wallet-core';
 import { Modal, Switch, Tooltip } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
@@ -10,7 +14,6 @@ import { ActionColumn, TextColumn } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsAutoEjectEnabled } from 'src/selectors/suite/suiteSelectors';
 
 const AutoEjectConfirmationModal = ({
     onCancel,
@@ -46,7 +49,7 @@ const AutoEjectConfirmationModal = ({
 };
 
 export const AutoEject = () => {
-    const isAutoEjectEnabled = useSelector(selectIsAutoEjectEnabled);
+    const isAutoEjectEnabled = useSelector(selectIsDeviceAutoEjectEnabled);
     const isAutoForgetDeviceDataEnabled = useSelector(selectIsAutoForgetDeviceDataEnabled);
     const dispatch = useDispatch();
     const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
@@ -56,17 +59,16 @@ export const AutoEject = () => {
     const hasAnyDisconnectedWallet = devices.some(device => !device.connected && device.state);
 
     const toggleAutoEject = () => {
-        const nextIsAutoEjectedEnabled = !isAutoEjectEnabled;
         dispatch(
             setAutoEjectEnabledThunk({
-                enabled: nextIsAutoEjectedEnabled,
+                shouldEnable: !isAutoEjectEnabled,
             }),
         );
 
         analytics.report({
             type: EventType.SettingsGeneralAutoEject,
             payload: {
-                value: nextIsAutoEjectedEnabled,
+                value: !isAutoEjectEnabled,
             },
         });
     };

--- a/packages/suite/src/views/settings/SettingsGeneral/StoreDeviceData.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/StoreDeviceData.tsx
@@ -35,7 +35,7 @@ export const StoreDeviceDataModal = ({ onCancel }: ModalProps) => {
 
     const handleConfirmClick = () => {
         const shouldEnableAutoForget = !isStoreDataEnabled;
-        dispatch(setAutoForgetDeviceDataThunk({ enabled: shouldEnableAutoForget }));
+        dispatch(setAutoForgetDeviceDataThunk({ shouldEnable: shouldEnableAutoForget }));
 
         analytics.report({
             type: EventType.SettingsGeneralStoreDeviceData,

--- a/suite-common/bluetooth/tests/bluetoothReducer.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothReducer.test.ts
@@ -142,6 +142,7 @@ describe('bluetoothReducer', () => {
         store.dispatch(
             deviceActions.connectDevice({
                 device: trezorDevice as Device,
+                isAutoEjectEnabled: false,
             }),
         );
         expect(store.getState().bluetooth.knownDevices).toEqual([nearbyDevice]);

--- a/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
@@ -116,7 +116,6 @@ const mockState: AccountsRootState & DeviceRootState = {
     device: {
         devices: [BTC_DEVICE, ETH_DEVICE],
         persistentDeviceData: [],
-        isDeviceAutoEjectEnabled: true,
     },
 };
 

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -19,6 +19,7 @@ export const DEVICE_MODULE_PREFIX = '@suite/device';
 
 export type DeviceConnectActionPayload = {
     device: Device;
+    isAutoEjectEnabled: boolean;
 };
 
 const connectDevice = createAction(DEVICE.CONNECT, (payload: DeviceConnectActionPayload) => ({
@@ -32,7 +33,9 @@ const createDeviceInstance = createAction(
 
 const connectUnacquiredDevice = createAction(
     DEVICE.CONNECT_UNACQUIRED,
-    (payload: DeviceConnectActionPayload) => ({ payload }),
+    (payload: DeviceConnectActionPayload) => ({
+        payload,
+    }),
 );
 
 const deviceChanged = createAction(DEVICE.CHANGED, (payload: Device) => ({
@@ -52,6 +55,7 @@ const setDeviceState = createAction(
         device: TrezorDevice;
         state: DeviceState & { staticSessionId: StaticSessionId };
         useEmptyPassphrase: boolean;
+        isAutoEjectEnabled: boolean;
     }) => ({
         payload,
     }),
@@ -152,10 +156,6 @@ const setLocalFirstStorageSecretRetrieving = createAction(
     }),
 );
 
-const toggleIsDeviceAutoEjectEnabled = createAction(
-    `${DEVICE_MODULE_PREFIX}/toggleAutoEjectDevices`,
-);
-
 const setDiscovered = createAction(
     `${DEVICE_MODULE_PREFIX}/setDiscovered`,
     (staticSessionId: StaticSessionId, success: boolean) => ({
@@ -186,7 +186,6 @@ export const deviceActions = {
     setThpCredentials,
     setLocalFirstStorageSecret,
     setLocalFirstStorageSecretRetrieving,
-    toggleIsDeviceAutoEjectEnabled,
     setDiscovered,
     devicePushNotification,
 };

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -29,14 +29,12 @@ export type DeviceReducerState = {
         firmwareAuthenticity?: string[];
     };
     lastConnectedAuthenticityChecks?: KnownDevice['authenticityChecks'];
-    isDeviceAutoEjectEnabled: boolean; // this is currently used only on mobile
 };
 
 export const deviceInitialState: DeviceReducerState = {
     devices: [],
     persistentDeviceData: [],
     selectedDevice: undefined,
-    isDeviceAutoEjectEnabled: false,
 };
 
 export const deviceReducerInitialState = deviceInitialState;
@@ -114,7 +112,11 @@ const merge = (
  * @param {Device} device
  * @returns
  */
-const connectDevice = (draft: DeviceReducerState, device: Device) => {
+const connectDevice = (
+    draft: DeviceReducerState,
+    device: Device,
+    options: { isAutoEjectEnabled: boolean },
+) => {
     const currentTime = new Date().getTime();
 
     const deviceCommonFields = {
@@ -193,7 +195,7 @@ const connectDevice = (draft: DeviceReducerState, device: Device) => {
         state: device._state,
         useEmptyPassphrase: undefined,
         remember: shouldDeviceBeRemembered({
-            isDeviceAutoEjectEnabled: draft.isDeviceAutoEjectEnabled,
+            isDeviceAutoEjectEnabled: options.isAutoEjectEnabled,
             device,
         }),
         temporaryRemember: false,
@@ -340,6 +342,7 @@ const setDeviceState = (
     device: TrezorDevice,
     state: DeviceState,
     useEmptyPassphrase: boolean,
+    isAutoEjectEnabled: boolean,
 ) => {
     // change only acquired devices
     if (!device.features) return;
@@ -371,7 +374,7 @@ const setDeviceState = (
     delete affectedDevice[0].discovered;
 
     affectedDevice[0].remember = shouldDeviceBeRemembered({
-        isDeviceAutoEjectEnabled: draft.isDeviceAutoEjectEnabled,
+        isDeviceAutoEjectEnabled: isAutoEjectEnabled,
         device,
     });
 };
@@ -621,7 +624,13 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
                 updatePersistentDeviceData(state, payload);
             })
             .addCase(deviceActions.setDeviceState, (state, { payload }) => {
-                setDeviceState(state, payload.device, payload.state, payload.useEmptyPassphrase);
+                setDeviceState(
+                    state,
+                    payload.device,
+                    payload.state,
+                    payload.useEmptyPassphrase,
+                    payload.isAutoEjectEnabled,
+                );
             })
             .addCase(deviceActions.addAuthorizedDevice, (state, { payload }) => {
                 addAuthorizedDevice(state, payload.device);
@@ -719,9 +728,6 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
                     };
                 },
             )
-            .addCase(deviceActions.toggleIsDeviceAutoEjectEnabled, state => {
-                state.isDeviceAutoEjectEnabled = !state.isDeviceAutoEjectEnabled;
-            })
             .addCase(deviceActions.setDiscovered, (state, { payload }) => {
                 const device = state.devices.find(
                     d => d.state?.staticSessionId === payload.staticSessionId,
@@ -730,8 +736,8 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
             })
             .addMatcher(
                 isAnyOf(deviceActions.connectDevice, deviceActions.connectUnacquiredDevice),
-                (state, { payload: { device } }) => {
-                    connectDevice(state, device);
+                (state, { payload: { device, isAutoEjectEnabled } }) => {
+                    connectDevice(state, device, { isAutoEjectEnabled });
                     updatePersistentDeviceData(state, device);
                 },
             );

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -35,8 +35,6 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<DeviceRootState>(
 export const selectDevices = (state: DeviceRootState) => state.device?.devices;
 export const selectDevicesCount = (state: DeviceRootState) => state.device?.devices?.length;
 export const selectSelectedDevice = (state: DeviceRootState) => state.device.selectedDevice;
-export const selectIsDeviceAutoEjectEnabled = (state: DeviceRootState) =>
-    state.device.isDeviceAutoEjectEnabled;
 
 /**
  * @deprecated This is a HACK, and it shall be refactored. See: https://github.com/trezor/trezor-suite/issues/22022

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -20,6 +20,7 @@ import {
     getNetworkId,
     getProtocolMagic,
     getStakingPath,
+    shouldDeviceBeRemembered,
 } from '@suite-common/wallet-utils';
 import TrezorConnect, {
     Address,
@@ -46,6 +47,8 @@ import { sortDevices } from './sortDevices';
 import { selectAccountByKey } from '../accounts/accountsSelectors';
 import { startDiscoveryThunk } from '../discovery/discoveryThunks';
 import { selectDeviceThunk, selectNewlyConnectedDeviceThunk } from '../discovery/selectDeviceThunk';
+import { setAutoEjectEnabled } from '../settings/walletSettingsActions';
+import { selectIsDeviceAutoEjectEnabled } from '../settings/walletSettingsReducer';
 
 /**
  * Triggered by `@trezor/connect DEVICE_EVENT`
@@ -314,20 +317,27 @@ type DeviceConnectThunksParams = {
 
 export const deviceConnectThunks = createThunk<void, DeviceConnectThunksParams, void>(
     `${DEVICE_MODULE_PREFIX}/deviceConnectThunk`,
-    async ({ type, device }, { dispatch }) => {
+    async ({ type, device }, { dispatch, getState }) => {
+        const isAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(getState());
         switch (type) {
             case DEVICE.CONNECT:
                 if (getIsThpDevice(device)) {
                     // awaited so that discoveryMiddleware knows what state THP is when processing deviceActions.connectDevice
                     await dispatch(connectThpDeviceThunk({ device }));
                 }
-                dispatch(deviceActions.connectDevice({ device }));
+                dispatch(
+                    deviceActions.connectDevice({
+                        device,
+                        isAutoEjectEnabled,
+                    }),
+                );
                 dispatch(selectNewlyConnectedDeviceThunk({ device }));
                 break;
             case DEVICE.CONNECT_UNACQUIRED:
                 dispatch(
                     deviceActions.connectUnacquiredDevice({
                         device,
+                        isAutoEjectEnabled,
                     }),
                 );
                 dispatch(autoInitThpAfterDeviceConnectionThunk({ device }));
@@ -339,22 +349,54 @@ export const deviceConnectThunks = createThunk<void, DeviceConnectThunksParams, 
     },
 );
 
-// Note: currently used only by mobile
-export const toggleAutoEjectThunk = createThunk(
-    `${DEVICE_MODULE_PREFIX}/toggleAutoEjectThunk`,
-    (_, { dispatch, getState }) => {
-        const physicalDeviceWallets = selectPhysicalDeviceWallets(getState());
-        dispatch(deviceActions.toggleIsDeviceAutoEjectEnabled());
+type SetDeviceAutoEjectThunkParams = {
+    shouldEnable: boolean;
+};
 
-        physicalDeviceWallets.forEach(device => {
-            if (!device.connected && device.remember) {
-                dispatch(deviceActions.forgetDevice({ device }));
-            } else {
-                // TODO investigate why do we need to consider wallet.remember at all, when we are ejecting all wallets.
-                dispatch(deviceActions.setRememberDevice({ device, remember: !device.remember }));
+export const setDeviceAutoEjectThunk = createThunk(
+    `${DEVICE_MODULE_PREFIX}/setDeviceAutoEjectThunk`,
+    ({ shouldEnable }: SetDeviceAutoEjectThunkParams, { dispatch, getState }) => {
+        const isEnabled = selectIsDeviceAutoEjectEnabled(getState());
+
+        if (isEnabled === shouldEnable) {
+            return;
+        }
+
+        dispatch(setAutoEjectEnabled(shouldEnable));
+
+        const physicalDeviceWallets = selectPhysicalDeviceWallets(getState());
+        physicalDeviceWallets.forEach(wallet => {
+            const shouldRemember = shouldDeviceBeRemembered({
+                isDeviceAutoEjectEnabled: shouldEnable,
+                device: wallet,
+            });
+
+            if (wallet.remember === shouldRemember) {
+                return;
+            }
+
+            dispatch(
+                deviceActions.setRememberDevice({
+                    device: wallet,
+                    remember: shouldRemember,
+                }),
+            );
+
+            if (shouldEnable && !wallet.connected) {
+                dispatch(forgetDisconnectedDevices({ device: wallet, forceForget: true }));
             }
         });
     },
+);
+
+export const toggleAutoEjectThunk = createThunk(
+    `${DEVICE_MODULE_PREFIX}/toggleAutoEjectThunk`,
+    (_, { dispatch, getState }) =>
+        dispatch(
+            setDeviceAutoEjectThunk({
+                shouldEnable: !selectIsDeviceAutoEjectEnabled(getState()),
+            }),
+        ),
 );
 
 type ForgetAllDeviceDataThunkParams = {

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -21,12 +21,12 @@ import { deviceActions } from '../device/deviceActions';
 import {
     selectDeviceByStaticSessionId,
     selectDevices,
-    selectIsDeviceAutoEjectEnabled,
     selectSelectedDevice,
     selectStandardWalletDevice,
 } from '../device/deviceSelectors';
 import { selectAccountsToBeForgotten, selectDiscoveryAccountsParam } from '../selectors';
 import { selectDeviceThunk } from './selectDeviceThunk';
+import { selectIsDeviceAutoEjectEnabled } from '../settings/walletSettingsReducer';
 
 const USER_UI_CANCEL_CODE = 'USER_UI_CANCEL';
 const DEVICE_CANCELLATION_CODES = ['Method_Cancel', 'Failure_ActionCancelled'];
@@ -153,17 +153,18 @@ const applyDeviceStatesThunk = createThunk(
             }
 
             // now we expect that there is exactly one device without state - meaning that we want to update its state
+            const isDeviceAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(getState());
+
             if (devicesByPathWithoutState.length === 1) {
                 dispatch(
                     deviceActions.setDeviceState({
                         device,
                         state: newDeviceState,
                         useEmptyPassphrase,
+                        isAutoEjectEnabled: isDeviceAutoEjectEnabled,
                     }),
                 );
             } else {
-                const isDeviceAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(getState());
-
                 dispatch(
                     deviceActions.addAuthorizedDevice({
                         device: {
@@ -648,11 +649,13 @@ export const runAdditionalDiscoveryThunk = createThunk(
         assertStaticSessionId(deviceStateResponse.payload._state);
 
         if (device.useEmptyPassphrase) {
+            const isAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(getState());
             dispatch(
                 deviceActions.setDeviceState({
                     device,
                     state: deviceStateResponse.payload._state,
                     useEmptyPassphrase: device.useEmptyPassphrase,
+                    isAutoEjectEnabled,
                 }),
             );
         }

--- a/suite-common/wallet-core/src/settings/walletSettingsActions.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsActions.ts
@@ -39,6 +39,11 @@ export const setAutoForgetDeviceData = createAction(
     (enabled: boolean) => ({ payload: enabled }),
 );
 
+export const setAutoEjectEnabled = createAction(
+    WALLET_SETTINGS.SET_AUTO_EJECT,
+    (enabled: boolean) => ({ payload: enabled }),
+);
+
 export type ChangeCoinVisibilityAction = {
     type: typeof WALLET_SETTINGS.CHANGE_COIN_VISIBILITY;
     payload: {
@@ -67,6 +72,7 @@ export type WalletSettingsAction =
     | ReturnType<typeof setBaseCurrency>
     | ReturnType<typeof toggleHideSuspiciousTransactions>
     | ReturnType<typeof setAutoForgetDeviceData>
+    | ReturnType<typeof setAutoEjectEnabled>
     | ChangeCoinVisibilityAction
     | SetHideBalanceAction
     | SetBitcoinAmountUnitsAction

--- a/suite-common/wallet-core/src/settings/walletSettingsConstants.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsConstants.ts
@@ -8,6 +8,7 @@ const SET_DISCREET_MODE = '@wallet-settings/set-discreet-mode';
 const CHANGE_COIN_VISIBILITY = '@wallet-settings/change-coin-visibility';
 const SET_MEV_PROTECTION = '@wallet-settings/set-mev-protection';
 const AUTO_FORGET_DEVICE_DATA = '@wallet-settings/set-auto-forget-device-data';
+const SET_AUTO_EJECT = '@wallet-settings/set-auto-eject';
 
 export const WALLET_SETTINGS = {
     SET_BASE_CURRENCY,
@@ -20,4 +21,5 @@ export const WALLET_SETTINGS = {
     CHANGE_COIN_VISIBILITY,
     SET_MEV_PROTECTION,
     AUTO_FORGET_DEVICE_DATA,
+    SET_AUTO_EJECT,
 } as const;

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -47,7 +47,8 @@ const initialState: WalletSettingsState = {
     hideSuspiciousTransactions: false,
     bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
     mevProtection: true,
-    autoForgetDeviceData: false,
+    isAutoForgetDeviceDataEnabled: false,
+    isAutoEjectEnabled: false,
 };
 export const initialWalletSettingsState: WalletSettingsState = initialState;
 
@@ -58,7 +59,8 @@ export const walletSettingsPersistedWhitelist: Array<keyof WalletSettingsState> 
     'hideSuspiciousTransactions',
     'bitcoinAmountUnit',
     'mevProtection',
-    'autoForgetDeviceData',
+    'isAutoForgetDeviceDataEnabled',
+    'isAutoEjectEnabled',
 ];
 
 export const prepareWalletSettingsReducer = createReducerWithExtraDeps(
@@ -105,7 +107,13 @@ export const prepareWalletSettingsReducer = createReducerWithExtraDeps(
         builder.addCase(
             WALLET_SETTINGS.AUTO_FORGET_DEVICE_DATA,
             (state, action: ReturnType<typeof walletSettingsActions.setAutoForgetDeviceData>) => {
-                state.autoForgetDeviceData = action.payload;
+                state.isAutoForgetDeviceDataEnabled = action.payload;
+            },
+        );
+        builder.addCase(
+            WALLET_SETTINGS.SET_AUTO_EJECT,
+            (state, action: ReturnType<typeof walletSettingsActions.setAutoEjectEnabled>) => {
+                state.isAutoEjectEnabled = action.payload;
             },
         );
     },
@@ -122,7 +130,9 @@ export const selectIsHideSuspiciousTransactions = (state: WalletSettingsRootStat
 export const selectBitcoinAmountUnit = (state: WalletSettingsRootState) =>
     state.wallet.settings.bitcoinAmountUnit;
 export const selectIsAutoForgetDeviceDataEnabled = (state: WalletSettingsRootState) =>
-    state.wallet.settings.autoForgetDeviceData;
+    state.wallet.settings.isAutoForgetDeviceDataEnabled;
+export const selectIsDeviceAutoEjectEnabled = (state: WalletSettingsRootState) =>
+    state.wallet.settings.isAutoEjectEnabled;
 
 export const selectIsAnyNetworkEnabled = (state: WalletSettingsRootState) =>
     A.isNotEmpty(selectEnabledNetworks(state));

--- a/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
@@ -1,10 +1,14 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
-import { changeNetworks } from './walletSettingsActions';
+import { changeNetworks, setAutoForgetDeviceData } from './walletSettingsActions';
 import { WALLET_SETTINGS } from './walletSettingsConstants';
 import { selectEnabledNetworks } from './walletSettingsReducer';
 import { accountsActions } from '../accounts/accountsActions';
+import {
+    forgetAllDevicesPersistentDataThunk,
+    setDeviceAutoEjectThunk,
+} from '../device/deviceThunks';
 import { selectAccountsToBeForgotten } from '../selectors';
 
 export const changeCoinVisibility = createThunk<
@@ -36,3 +40,26 @@ export const changeCoinVisibility = createThunk<
         payload: { symbol, shouldBeVisible },
     });
 });
+
+type SetAutoForgetDeviceDataThunkParams = {
+    shouldEnable: boolean;
+};
+
+export const setAutoForgetDeviceDataThunk = createThunk<
+    void,
+    SetAutoForgetDeviceDataThunkParams,
+    void
+>(
+    `${WALLET_SETTINGS.AUTO_FORGET_DEVICE_DATA}/setAutoForgetDeviceDataThunk`,
+    async ({ shouldEnable }, { dispatch }) => {
+        if (!shouldEnable) {
+            dispatch(setAutoForgetDeviceData(false));
+
+            return;
+        }
+
+        dispatch(setAutoForgetDeviceData(true));
+        await dispatch(forgetAllDevicesPersistentDataThunk());
+        await dispatch(setDeviceAutoEjectThunk({ shouldEnable: true }));
+    },
+);

--- a/suite-common/wallet-types/src/settings.ts
+++ b/suite-common/wallet-types/src/settings.ts
@@ -24,5 +24,6 @@ export interface WalletSettings {
     hideSuspiciousTransactions: boolean;
     bitcoinAmountUnit: PROTO.AmountUnit;
     mevProtection: boolean;
-    autoForgetDeviceData: boolean;
+    isAutoForgetDeviceDataEnabled: boolean;
+    isAutoEjectEnabled: boolean;
 }

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -28,7 +28,6 @@
         "@trezor/blockchain-link-utils": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
-        "@trezor/env-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/suite-common/wallet-utils/src/deviceUtils.ts
+++ b/suite-common/wallet-utils/src/deviceUtils.ts
@@ -1,7 +1,6 @@
 import { TrezorDevice } from '@suite-common/suite-types';
 import { asWalletDescriptor } from '@suite-common/wallet-types';
 import { Device, StaticSessionId } from '@trezor/connect';
-import { isNative } from '@trezor/env-utils';
 
 export const parseDeviceStaticSessionId = (deviceStaticSessionId: StaticSessionId) => {
     const [walletDescriptor, deviceId] = deviceStaticSessionId.split('@');
@@ -19,8 +18,6 @@ export const shouldDeviceBeRemembered = ({
     device: TrezorDevice | Device;
     isDeviceAutoEjectEnabled?: boolean;
 }) => {
-    if (!isNative()) return true;
-
     if (device.mode !== 'normal') return false;
 
     if (device.type !== 'acquired') return false;

--- a/suite-common/wallet-utils/tsconfig.json
+++ b/suite-common/wallet-utils/tsconfig.json
@@ -27,7 +27,6 @@
         },
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" },
-        { "path": "../../packages/env-utils" },
         { "path": "../../packages/type-utils" },
         { "path": "../../packages/urls" },
         { "path": "../../packages/utils" }

--- a/suite-native/app/e2e/fixtures/deviceAutoEjectState.ts
+++ b/suite-native/app/e2e/fixtures/deviceAutoEjectState.ts
@@ -3,4 +3,10 @@ import { PreloadedState } from '@suite-native/state';
 /**
  *  State fragment that ensures that the device auto eject is enabled.
  */
-export const deviceAutoEjectState: PreloadedState = { device: { isDeviceAutoEjectEnabled: true } };
+export const deviceAutoEjectState: PreloadedState = {
+    wallet: {
+        settings: {
+            isAutoEjectEnabled: true,
+        },
+    },
+};

--- a/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
+++ b/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
@@ -1,5 +1,9 @@
 import { TrezorDevice } from '@suite-common/suite-types';
-import { StakeState, stakeInitialState } from '@suite-common/wallet-core';
+import {
+    StakeState,
+    initialWalletSettingsState,
+    stakeInitialState,
+} from '@suite-common/wallet-core';
 import { Account, Timestamp } from '@suite-common/wallet-types';
 
 import {
@@ -121,6 +125,7 @@ const getTestState = ({
         accounts,
         stake: { ...stakeInitialState, data: { sol: withSolStakeData ? solStakeData : {} } },
         transactions: { transactions: {}, fetchStatusDetail: {} },
+        settings: initialWalletSettingsState,
     },
     device: {
         devices: [
@@ -137,7 +142,6 @@ const getTestState = ({
                 staticSessionId: staticStateString,
             },
         } as TrezorDevice,
-        isDeviceAutoEjectEnabled: false,
         persistentDeviceData: [],
     },
 });

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -201,7 +201,7 @@ export const prepareRootReducers = async () => {
 
     const devicePersistedReducer = await preparePersistReducer({
         reducer: deviceReducer,
-        persistedKeys: ['devices', 'isDeviceAutoEjectEnabled', 'persistentDeviceData'],
+        persistedKeys: ['devices', 'persistentDeviceData'],
         key: 'devices',
         version: 3,
         transforms: [devicePersistTransform],

--- a/yarn.lock
+++ b/yarn.lock
@@ -11013,7 +11013,6 @@ __metadata:
     "@trezor/blockchain-link-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
-    "@trezor/env-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"


### PR DESCRIPTION


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/auto-eject-and-auto-forget-settings&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/auto-eject-and-auto-forget-settings&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/auto-eject-and-auto-forget-settings&lookback=7)