### PR TITLE
fix(suite): show BluetoothConnectionModal while connecting

### DIFF
--- a/packages/suite/src/components/connection/BluetoothConnectionModal.tsx
+++ b/packages/suite/src/components/connection/BluetoothConnectionModal.tsx
@@ -1,9 +1,11 @@
 import { Modal } from '@trezor/components';
 
 import { DesktopBluetoothDevice } from 'src/actions/bluetooth/DesktopBluetoothDevice';
+import { selectConnectingDevices } from 'src/actions/bluetooth/desktopBluetoothSelectors';
 import { BluetoothPairingPin } from 'src/components/suite/bluetooth/BluetoothPairingPin';
 import { BluetoothScanningList } from 'src/components/suite/bluetooth/BluetoothScanningList';
 import { BluetoothSelectedDevice } from 'src/components/suite/bluetooth/BluetoothSelectedDevice';
+import { useSelector } from 'src/hooks/suite';
 
 import { Translation } from '../suite';
 import { BluetoothDeviceList } from '../suite/bluetooth/BluetoothDeviceList';
@@ -34,6 +36,8 @@ export const BluetoothConnectionModal = ({
     onCancel,
     onClose,
 }: BluetoothConnectionModalProps) => {
+    const connectingDevices = useSelector(selectConnectingDevices);
+
     if (
         selectedDevice !== undefined &&
         selectedDevice !== null &&
@@ -56,7 +60,8 @@ export const BluetoothConnectionModal = ({
 
     if (
         selectedDevice !== undefined &&
-        selectedDeviceConnectionTypes.includes(selectedDevice.connectionStatus.type)
+        (selectedDeviceConnectionTypes.includes(selectedDevice.connectionStatus.type) ||
+            connectingDevices.includes(selectedDevice.id))
     ) {
         return (
             <Modal


### PR DESCRIPTION
## Description

Currently there is an issue with the BluetoothConnectionModal disappearing while pairing on Mac. 

This is because `connectionStatus` doesn't get updated initially from NAPI. 
We will add events for that later, but we should also check if it's in `connectingDevices`.


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bluetooth-connect-modal-during-connection&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bluetooth-connect-modal-during-connection&lookback=7)