### PR TITLE
Chore/bt napi events

### DIFF
--- a/packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts
+++ b/packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts
@@ -1,6 +1,6 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
-import { BluetoothManufacturerData } from '@suite-common/bluetooth';
+import { BluetoothManufacturerData, prepareInitialState } from '@suite-common/bluetooth';
 import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
@@ -21,10 +21,7 @@ const manufacturerData: BluetoothManufacturerData = {
 const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependenciesMock);
 
 const initialState: DesktopBluetoothState = {
-    adapterStatus: 'unknown',
-    scanStatus: 'idle',
-    nearbyDevices: [] as DesktopBluetoothDevice[],
-    knownDevices: [] as DesktopBluetoothDevice[],
+    ...prepareInitialState(),
     unpairedDeviceNeedsManualOsRemoval: false,
     connectingDeviceIds: [],
     isUnpairingDevice: false,

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -25,6 +25,7 @@ export const initialAppState: AppState = {
         scanStatus: 'error',
         nearbyDevices: null,
         knownDevices: [],
+        ignoredDeviceIds: [],
     },
     thp: {
         step: null,

--- a/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
@@ -167,8 +167,15 @@ export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements Bl
                 const isPaired = devices.find(d => d.id === id)?.paired;
                 if (!isPaired) {
                     const bindings = await this.getNapiBindings();
-                    await bindings.connectDevice(id, timeout, (_err, _resp) => {
-                        // TODO: emit events from NAPI
+                    await bindings.connectDevice(id, timeout, (_err, data) => {
+                        try {
+                            const json = JSON.parse(data);
+                            if (json.event == 'device_connection_status') {
+                                this.emit('device-update', json.payload.device);
+                            }
+                        } catch {
+                            // silent
+                        }
                     });
                 }
             } catch (error) {

--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -15,6 +15,7 @@ export type BluetoothState<T extends BluetoothDeviceCommon> = {
     // This will be persisted. Those are devices we believed that are paired
     // (because we already successfully paired them in the Suite) in the Operating System
     knownDevices: T[];
+    ignoredDeviceIds: string[];
 };
 
 export const prepareInitialState = <T extends BluetoothDeviceCommon>(): BluetoothState<T> => ({
@@ -22,6 +23,7 @@ export const prepareInitialState = <T extends BluetoothDeviceCommon>(): Bluetoot
     scanStatus: 'idle',
     nearbyDevices: null,
     knownDevices: [] as T[],
+    ignoredDeviceIds: [],
 });
 
 export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>() =>
@@ -42,7 +44,9 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                         // won't be possible to connect to them ever again. User has to start pairing again,
                         // which would produce a device with new id.
                         .filter(
-                            nearbyDevice => nearbyDevice.connectionStatus?.type !== 'pairing-error',
+                            nearbyDevice =>
+                                nearbyDevice.connectionStatus?.type !== 'pairing-error' &&
+                                !state.ignoredDeviceIds.includes(nearbyDevice.id),
                         ) as Draft<T>[];
                 },
             )
@@ -65,6 +69,12 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                     state.nearbyDevices = state.nearbyDevices.map(it =>
                         it.id === device.id ? device : it,
                     ) as Draft<T>[];
+                }
+
+                // pairing error can be received from NAPI connectDevice
+                // in that case the rust server doesnt know about it
+                if (device.connectionStatus.type === 'pairing-error') {
+                    state.ignoredDeviceIds.push(device.id);
                 }
 
                 state.knownDevices = state.knownDevices.map(it =>

--- a/suite-common/bluetooth/tests/bluetoothReducer.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothReducer.test.ts
@@ -10,8 +10,8 @@ import {
     BluetoothManufacturerData,
     bluetoothActions,
     prepareBluetoothReducerCreator,
+    prepareInitialState,
 } from '../src';
-import { BluetoothState } from '../src/bluetoothReducer';
 import { BluetoothDeviceCommon } from '../src/types';
 
 const manufacturerData: BluetoothManufacturerData = {
@@ -23,12 +23,7 @@ const manufacturerData: BluetoothManufacturerData = {
 const bluetoothReducer =
     prepareBluetoothReducerCreator<BluetoothDeviceCommon>()(extraDependenciesMock);
 
-const initialState: BluetoothState<BluetoothDeviceCommon> = {
-    adapterStatus: 'unknown',
-    scanStatus: 'idle',
-    nearbyDevices: [] as BluetoothDeviceCommon[],
-    knownDevices: [] as BluetoothDeviceCommon[],
-};
+const initialState = prepareInitialState();
 
 const pairingDeviceA: BluetoothDeviceCommon = {
     id: 'A',

--- a/suite-common/bluetooth/tests/bluetoothSelectors.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothSelectors.test.ts
@@ -1,7 +1,6 @@
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { BluetoothManufacturerData, prepareSelectAllDevices } from '../src';
-import { BluetoothState } from '../src/bluetoothReducer';
+import { BluetoothManufacturerData, prepareInitialState, prepareSelectAllDevices } from '../src';
 import { WithBluetoothState } from '../src/bluetoothSelectors';
 import { BluetoothDeviceCommon } from '../src/types';
 
@@ -9,13 +8,6 @@ const manufacturerData: BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal.T3W1,
     deviceColor: 0,
     filterPolicy: undefined,
-};
-
-const initialState: BluetoothState<BluetoothDeviceCommon> = {
-    adapterStatus: 'unknown',
-    scanStatus: 'idle',
-    nearbyDevices: [],
-    knownDevices: [],
 };
 
 const pairingDeviceStateA: BluetoothDeviceCommon = {
@@ -48,7 +40,7 @@ describe('bluetoothSelectors', () => {
 
         const state: WithBluetoothState<BluetoothDeviceCommon> = {
             bluetooth: {
-                ...initialState,
+                ...prepareInitialState(),
                 knownDevices: [pairingDeviceStateA, disconnectedDeviceB],
                 nearbyDevices: [
                     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- handle events from NAPI bindings and emit event from bluetooth-ipc
- WIP store ignoredDevices in bt reducer - to discuss


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bt-napi-events&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bt-napi-events&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/bt-napi-events&lookback=7)