### PR TITLE
feat(ci): add action to easily sync develop from public to private repo

### DIFF
--- a/.github/workflows/bot-sync-develop.yml
+++ b/.github/workflows/bot-sync-develop.yml
@@ -1,0 +1,43 @@
+name: "[Bot] Sync develop branch"
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  sync-develop:
+    if: github.repository == 'trezor/trezor-suite-private'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: trezor-bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TREZOR_BOT_APP_ID }}
+          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ steps.trezor-bot-token.outputs.token }}
+
+      - name: Configure git user
+        run: |
+          git config user.name "trezor-ci"
+          git config user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
+
+      - name: Fetch develop from public repository
+        run: git fetch https://github.com/trezor/trezor-suite.git develop
+
+      - name: Sync develop branch
+        run: |
+          git checkout develop
+          git reset --hard FETCH_HEAD
+          git push origin develop --force-with-lease
+        env:
+          GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Simplify the process of synchronization develop from public to private. Now it is a manual work, because we don't have the permission to push to protected branch.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/sync-private-repo&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/sync-private-repo&lookback=7)