### PR TITLE
Fix/fee levels and min values

### DIFF
--- a/packages/connect/src/data/defaultFeeLevels.ts
+++ b/packages/connect/src/data/defaultFeeLevels.ts
@@ -10,7 +10,7 @@ const BLOCKS_FOR_FEE_LEVEL: Record<string, Record<string, number>> = {
         // blocktime ~ 600sec.
         high: 1,
         normal: 3,
-        economy: 12,
+        economy: 6,
         // low fee is offerred by Connect, though Suite only uses the first three levels (see feesThunks.ts)
         low: 36,
     },

--- a/suite-common/wallet-core/src/fees/feesUtils.ts
+++ b/suite-common/wallet-core/src/fees/feesUtils.ts
@@ -8,11 +8,13 @@ import { BigNumber } from '@trezor/utils';
 
 const NETWORK_FEE_OVERRIDES: Record<
     string,
-    { minFeePerUnit: string; overrideLevels: FeeLevel['label'][] }
+    { minFeePerUnit: Partial<Record<FeeLevel['label'], string>> }
 > = {
     bitcoin: {
-        minFeePerUnit: '1',
-        overrideLevels: ['normal', 'high'],
+        minFeePerUnit: {
+            normal: '1',
+            high: '2',
+        },
     },
 } as const;
 
@@ -91,10 +93,9 @@ export const getNewFeeInfo = async ({
     if (network.symbol === 'btc') {
         const feeOverride = NETWORK_FEE_OVERRIDES.bitcoin;
         result.payload.levels.forEach(level => {
-            if (feeOverride.overrideLevels.includes(level.label)) {
-                level.feePerUnit = new BigNumber(level.feePerUnit).lte(feeOverride.minFeePerUnit)
-                    ? feeOverride.minFeePerUnit
-                    : level.feePerUnit;
+            const minFee = feeOverride.minFeePerUnit[level.label];
+            if (minFee !== undefined && new BigNumber(level.feePerUnit).lte(minFee)) {
+                level.feePerUnit = minFee;
             }
         });
     }


### PR DESCRIPTION
## Description

**Changes**:
- calculate Economy level based of 6 latest blocks
- set min 2sat/vb for high level

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21654


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/fee-levels-and-min-values&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/fee-levels-and-min-values&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/fee-levels-and-min-values&lookback=7)