### PR TITLE
fix(suite-native): delay finishing FW installation until user interaction

### DIFF
--- a/suite-native/module-device-onboarding/src/screens/ThpPairingSuccessScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ThpPairingSuccessScreen.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { nativeFirmwareActions } from '@suite-native/firmware';
@@ -12,15 +11,14 @@ export const ThpPairingSuccessScreen = () => {
     const { navigateToNextScreenAfterFirmwareInstallation } =
         useNavigateToNextScreenAfterFirmwareInstallation();
 
-    useEffect(() => {
+    const onContinue = () => {
         dispatch(nativeFirmwareActions.setIsFirmwareInstallationRunning(false));
-    }, [dispatch]);
+        navigateToNextScreenAfterFirmwareInstallation();
+    };
 
     return (
         <DeviceOnboardingScreenWithExitButton>
-            <ThpPairingSuccessScreenContent
-                onContinue={navigateToNextScreenAfterFirmwareInstallation}
-            />
+            <ThpPairingSuccessScreenContent onContinue={onContinue} />
         </DeviceOnboardingScreenWithExitButton>
     );
 };


### PR DESCRIPTION
It seems that moving some logic from `useHandleDeviceConnection` to `deviceConnectionMiddleware` changed the order of execution and the effect on `ThpPairingSuccessScreen` is triggered sooner than expected. That leads to device onboarding being re-entered after FW installation and successful THP pairing. Instead, user is expected to be taken to the THP success screen and then continue in the device onboarding flow.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-onboarding-fw-thp&lookback=7)