### PR TITLE
fix(suite-common): when renderer desktop ignore fw downloaded event

### DIFF
--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -82,7 +82,7 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
                 );
             }
 
-            if (action.type === UI_REQUEST.FIRMWARE_DOWNLOADED && !isDesktop()) {
+            if (action.type === UI_REQUEST.FIRMWARE_DOWNLOADED) {
                 // We are in web therefore we ignore `FIRMWARE_DOWNLOADED` action.
                 return;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When we are in renderer in desktop we should also ignore `ui-firmware_downloaded` event.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ignore-in-web-when-desktop-fw-downloaded-event&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ignore-in-web-when-desktop-fw-downloaded-event&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/ignore-in-web-when-desktop-fw-downloaded-event&lookback=7)