### PR TITLE
fix(e2e): remove tada out of coins.test.ts

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/settings/coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/coins.test.ts
@@ -39,7 +39,6 @@ test.describe('Coin Settings', { tag: ['@group=settings'] }, () => {
                 'thol',
                 'txrp',
                 // 'txlm', add when removed from experimental features
-                'tada',
                 'dsol',
             ];
 


### PR DESCRIPTION
After https://github.com/trezor/trezor-suite/pull/21535

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tada-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tada-tests&lookback=7)