### PR TITLE
Mobile-Trade: Blacklist sanctioned countries

### DIFF
--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -110,12 +110,12 @@ export const findLatestVersionForModel = (model: Model): string => {
 };
 
 export const getCountryLabel = (country: TradingCountryCode) => {
-    const labelWithFlag = regional.countriesMap.get(country);
-    if (!labelWithFlag) {
+    const countryOption = regional.countriesOptionsMap.get(country);
+    if (!countryOption) {
         throw new Error(`Country ${country} not found in the countries map`);
     }
 
-    return labelWithFlag.substring(labelWithFlag.indexOf(' ') + 1);
+    return countryOption.label.substring(countryOption.label.indexOf(' ') + 1);
 };
 
 export const calculatePercentageOfBalance = (params: PercentageOfBalanceParams) => {

--- a/suite-common/geolocation/src/countries.ts
+++ b/suite-common/geolocation/src/countries.ts
@@ -292,6 +292,34 @@ export const EEACountryCodes = [
 
 export type EEACountryCodeType = (typeof EEACountryCodes)[number];
 
+// Sanctioned countries according to https://orpa.princeton.edu/export-controls/sanctioned-countries
+export const ComprehensivelySanctionedCountries: Readonly<string[]> = [
+    'CU', // Cuba
+    'IR', // Iran
+    'KP', // North Korea
+    'RU', // Russia
+];
+
+export const OfacSanctionedCountries: Readonly<string[]> = [
+    'AF', // Afghanistan
+    'BY', // Belarus
+    'MM', // Burma (Myanmar)
+    'CF', // Central African Republic
+    'CD', // Congo (Kinshasa)
+    'ET', // Ethiopia
+    'HK', // Hong Kong
+    'IQ', // Iraq
+    'LB', // Lebanon
+    'LY', // Libya
+    'ML', // Mali
+    'NI', // Nicaragua
+    'SO', // Somalia
+    'SS', // South Sudan
+    'SD', // Sudan
+    'VE', // Venezuela
+    'YE', // Yemen
+];
+
 // Add Cloudflare-specific codes "XX" (no country data) and "T1" (Tor network).
 // See: https://developers.cloudflare.com/fundamentals/reference/http-headers/#cf-ipcountry
 export type CountryCode = keyof typeof countries | 'XX' | 'T1';

--- a/suite-common/geolocation/src/countries.ts
+++ b/suite-common/geolocation/src/countries.ts
@@ -293,14 +293,14 @@ export const EEACountryCodes = [
 export type EEACountryCodeType = (typeof EEACountryCodes)[number];
 
 // Sanctioned countries according to https://orpa.princeton.edu/export-controls/sanctioned-countries
-export const ComprehensivelySanctionedCountries: Readonly<string[]> = [
+export const ComprehensivelySanctionedCountryCodes: Readonly<string[]> = [
     'CU', // Cuba
     'IR', // Iran
     'KP', // North Korea
     'RU', // Russia
 ];
 
-export const OfacSanctionedCountries: Readonly<string[]> = [
+export const OfacSanctionedCountryCodes: Readonly<string[]> = [
     'AF', // Afghanistan
     'BY', // Belarus
     'MM', // Burma (Myanmar)

--- a/suite-common/trading/src/__tests__/regional.test.ts
+++ b/suite-common/trading/src/__tests__/regional.test.ts
@@ -1,4 +1,4 @@
-import { regional } from '../regional';
+import { nonSanctionedRegional, regional } from '../regional';
 
 describe('Regional', () => {
     describe('isInEEA', () => {
@@ -15,33 +15,49 @@ describe('Regional', () => {
         });
     });
 
-    describe('isSanctionedCountry', () => {
+    describe('isSanctioned', () => {
         it('should be true for Comprehensively Sanctioned Countries', () => {
-            const isSanctioned = regional.isSanctionedCountry('KP');
+            const isSanctioned = regional.isSanctioned('KP');
 
             expect(isSanctioned).toBe(true);
         });
 
         it('should be true for Other Countries Subject to OFAC Sanctions', () => {
-            const isSanctioned = regional.isSanctionedCountry('SD');
+            const isSanctioned = regional.isSanctioned('SD');
 
             expect(isSanctioned).toBe(true);
         });
 
         it('should be false for non-sanctioned country', () => {
-            const isSanctioned = regional.isSanctionedCountry('DE');
+            const isSanctioned = regional.isSanctioned('DE');
 
             expect(isSanctioned).toBe(false);
         });
     });
 
-    describe('nonSanctionedCountries', () => {
+    describe('getCountryOptionWithWorldwideFallback', () => {
+        it('should return country option for existing country', () => {
+            expect(regional.getCountryOptionWithWorldwideFallback('DE')).toEqual({
+                label: '🇩🇪 Germany',
+                value: 'DE',
+            });
+        });
+
+        it('should fallback to worldwide for non-existing country', () => {
+            expect(regional.getCountryOptionWithWorldwideFallback('test')).toEqual({
+                label: '🌍 Worldwide',
+                value: 'unknown',
+            });
+        });
+    });
+
+    describe('nonSanctionedRegional', () => {
         it('should not contain sanctioned countries', () => {
-            const hasSanctionedCountries = regional.nonSanctionedCountries.some(country =>
-                regional.isSanctionedCountry(country.value),
+            const hasSanctionedCountries = nonSanctionedRegional.countriesOptions.some(
+                ({ value }) => regional.isSanctioned(value),
             );
 
-            expect(regional.nonSanctionedCountries.length).toBeGreaterThan(0);
+            expect(nonSanctionedRegional.countriesOptions.length).toBeGreaterThan(0);
             expect(hasSanctionedCountries).toBe(false);
         });
     });

--- a/suite-common/trading/src/__tests__/regional.test.ts
+++ b/suite-common/trading/src/__tests__/regional.test.ts
@@ -14,4 +14,35 @@ describe('Regional', () => {
             expect(isIn).toBe(false);
         });
     });
+
+    describe('isSanctionedCountry', () => {
+        it('should be true for Comprehensively Sanctioned Countries', () => {
+            const isSanctioned = regional.isSanctionedCountry('KP');
+
+            expect(isSanctioned).toBe(true);
+        });
+
+        it('should be true for Other Countries Subject to OFAC Sanctions', () => {
+            const isSanctioned = regional.isSanctionedCountry('SD');
+
+            expect(isSanctioned).toBe(true);
+        });
+
+        it('should be false for non-sanctioned country', () => {
+            const isSanctioned = regional.isSanctionedCountry('DE');
+
+            expect(isSanctioned).toBe(false);
+        });
+    });
+
+    describe('nonSanctionedCountries', () => {
+        it('should not contain sanctioned countries', () => {
+            const hasSanctionedCountries = regional.nonSanctionedCountries.some(country =>
+                regional.isSanctionedCountry(country.value),
+            );
+
+            expect(regional.nonSanctionedCountries.length).toBeGreaterThan(0);
+            expect(hasSanctionedCountries).toBe(false);
+        });
+    });
 });

--- a/suite-common/trading/src/regional.ts
+++ b/suite-common/trading/src/regional.ts
@@ -1,6 +1,8 @@
 import {
+    ComprehensivelySanctionedCountries,
     EEACountryCodeType,
     EEACountryCodes,
+    OfacSanctionedCountries,
     countries as countriesRecord,
 } from '@suite-common/geolocation';
 import { isArrayMember, typedObjectValues } from '@trezor/utils';
@@ -10,16 +12,21 @@ import { TradingCountryCode } from './types';
 class Regional {
     readonly UNKNOWN_COUNTRY = 'unknown' as const;
 
-    countries: [TradingCountryCode, string][] = [
+    readonly countries: [TradingCountryCode, string][] = [
         [this.UNKNOWN_COUNTRY, '🌍 Worldwide'],
         ...typedObjectValues(countriesRecord).map(
             ({ code, flag, name }) => [code, `${flag} ${name}`] as [TradingCountryCode, string],
         ),
     ];
 
-    countriesMap = new Map<TradingCountryCode, string>(this.countries);
+    readonly countriesMap = new Map<TradingCountryCode, string>(this.countries);
 
-    countriesOptions = this.countries
+    readonly sanctionedCountries = new Set([
+        ...ComprehensivelySanctionedCountries,
+        ...OfacSanctionedCountries,
+    ]);
+
+    readonly countriesOptions = this.countries
         .map(([code, name]) => ({
             label: name,
             value: code,
@@ -31,8 +38,20 @@ class Regional {
             return l1.localeCompare(l2);
         });
 
+    readonly nonSanctionedCountries: { label: string; value: TradingCountryCode }[];
+
+    constructor() {
+        this.nonSanctionedCountries = this.countriesOptions.filter(
+            ({ value }) => !this.isSanctionedCountry(value),
+        );
+    }
+
     isInEEA(country: string): country is EEACountryCodeType {
         return isArrayMember(country, EEACountryCodes);
+    }
+
+    isSanctionedCountry(country: TradingCountryCode): boolean {
+        return this.sanctionedCountries.has(country);
     }
 }
 

--- a/suite-common/trading/src/regional.ts
+++ b/suite-common/trading/src/regional.ts
@@ -1,48 +1,41 @@
 import {
-    ComprehensivelySanctionedCountries,
+    ComprehensivelySanctionedCountryCodes,
     EEACountryCodeType,
     EEACountryCodes,
-    OfacSanctionedCountries,
+    OfacSanctionedCountryCodes,
     countries as countriesRecord,
 } from '@suite-common/geolocation';
 import { isArrayMember, typedObjectValues } from '@trezor/utils';
 
-import { TradingCountryCode } from './types';
+import { TradingCountryCode, TradingCountryOption } from './types';
+
+type CountryItem = (typeof countriesRecord)[keyof typeof countriesRecord];
+
+const SANCTIONED_COUNTRIES = new Set([
+    ...ComprehensivelySanctionedCountryCodes,
+    ...OfacSanctionedCountryCodes,
+]);
 
 class Regional {
     readonly UNKNOWN_COUNTRY = 'unknown' as const;
+    readonly countriesOptions: TradingCountryOption[];
+    readonly countriesOptionsMap: Map<TradingCountryCode, TradingCountryOption>;
 
-    readonly countries: [TradingCountryCode, string][] = [
-        [this.UNKNOWN_COUNTRY, '🌍 Worldwide'],
-        ...typedObjectValues(countriesRecord).map(
-            ({ code, flag, name }) => [code, `${flag} ${name}`] as [TradingCountryCode, string],
-        ),
-    ];
-
-    readonly countriesMap = new Map<TradingCountryCode, string>(this.countries);
-
-    readonly sanctionedCountries = new Set([
-        ...ComprehensivelySanctionedCountries,
-        ...OfacSanctionedCountries,
-    ]);
-
-    readonly countriesOptions = this.countries
-        .map(([code, name]) => ({
-            label: name,
-            value: code,
-        }))
-        .sort((c1, c2) => {
+    constructor(countriesFilter: (country: CountryItem) => boolean) {
+        this.countriesOptions = [
+            { value: this.UNKNOWN_COUNTRY, label: '🌍 Worldwide' },
+            ...typedObjectValues(countriesRecord)
+                .filter(countriesFilter)
+                .map(({ code, flag, name }) => ({ value: code, label: `${flag} ${name}` })),
+        ].sort((c1, c2) => {
             const l1 = c1.label.split(' ')[1];
             const l2 = c2.label.split(' ')[1];
 
             return l1.localeCompare(l2);
         });
 
-    readonly nonSanctionedCountries: { label: string; value: TradingCountryCode }[];
-
-    constructor() {
-        this.nonSanctionedCountries = this.countriesOptions.filter(
-            ({ value }) => !this.isSanctionedCountry(value),
+        this.countriesOptionsMap = new Map(
+            this.countriesOptions.map(option => [option.value, option]),
         );
     }
 
@@ -50,9 +43,19 @@ class Regional {
         return isArrayMember(country, EEACountryCodes);
     }
 
-    isSanctionedCountry(country: TradingCountryCode): boolean {
-        return this.sanctionedCountries.has(country);
+    isSanctioned(country: string): boolean {
+        return SANCTIONED_COUNTRIES.has(country as TradingCountryCode);
+    }
+
+    getCountryOptionWithWorldwideFallback(country: string): TradingCountryOption {
+        const option = this.countriesOptionsMap.get(country as TradingCountryCode);
+        if (option) {
+            return option;
+        }
+
+        return this.countriesOptionsMap.get(this.UNKNOWN_COUNTRY)!;
     }
 }
 
-export const regional = new Regional();
+export const regional = new Regional(() => true);
+export const nonSanctionedRegional = new Regional(({ code }) => !SANCTIONED_COUNTRIES.has(code));

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -162,20 +162,8 @@ export const getTagAndInfoNote = (quote: { infoNote?: string }) => {
 export const tradingGetSuccessQuotes = <T extends TradingType>(quotes: TradingTradeMapProps[T][]) =>
     quotes.filter(quote => quote.error === undefined);
 
-export const getDefaultCountry = (country: TradingCountryCode = regional.UNKNOWN_COUNTRY) => {
-    const label = regional.countriesMap.get(country);
-
-    if (!label)
-        return {
-            label: regional.countriesMap.get(regional.UNKNOWN_COUNTRY)!,
-            value: regional.UNKNOWN_COUNTRY,
-        };
-
-    return {
-        label,
-        value: country,
-    };
-};
+export const getDefaultCountry = (country: TradingCountryCode = regional.UNKNOWN_COUNTRY) =>
+    regional.getCountryOptionWithWorldwideFallback(country);
 
 export const filterQuotesAccordingTags = <T extends TradingTradeBuySellType>(
     quotes: TradingTradeBuySellMapProps[T][],

--- a/suite-native/module-trading/src/hooks/general/__tests__/useCountryFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useCountryFilteredData.test.ts
@@ -18,6 +18,16 @@ describe('useCountryFilteredData', () => {
         );
     });
 
+    it('should not contain sanctioned countries', () => {
+        const { result } = renderUseCountryFilteredData();
+
+        expect(result.current.filteredData).toEqual(
+            expect.not.arrayContaining([
+                expect.objectContaining({ value: 'KP' }), // North Korea
+            ]),
+        );
+    });
+
     it('should filter by label case-insensitive', () => {
         const { result } = renderUseCountryFilteredData();
 

--- a/suite-native/module-trading/src/hooks/general/useCountryFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/general/useCountryFilteredData.ts
@@ -1,4 +1,4 @@
-import { TradingCountryOption, regional } from '@suite-common/trading';
+import { TradingCountryOption, nonSanctionedRegional } from '@suite-common/trading';
 
 import { useListDataFilter } from './useListDataFilter';
 
@@ -7,4 +7,4 @@ const filterCallback = ({ label, value }: TradingCountryOption, filterValue: str
     value.toLowerCase().includes(filterValue.toLowerCase());
 
 export const useCountryFilteredData = () =>
-    useListDataFilter(regional.nonSanctionedCountries, filterCallback);
+    useListDataFilter(nonSanctionedRegional.countriesOptions, filterCallback);

--- a/suite-native/module-trading/src/hooks/general/useCountryFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/general/useCountryFilteredData.ts
@@ -7,4 +7,4 @@ const filterCallback = ({ label, value }: TradingCountryOption, filterValue: str
     value.toLowerCase().includes(filterValue.toLowerCase());
 
 export const useCountryFilteredData = () =>
-    useListDataFilter(regional.countriesOptions, filterCallback);
+    useListDataFilter(regional.nonSanctionedCountries, filterCallback);

--- a/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
@@ -160,7 +160,23 @@ describe('buySelectors', () => {
 
             expect(selectBuyFormDefaultValues(state)).toEqual(
                 expect.objectContaining({
-                    country: undefined,
+                    country: {
+                        label: '🌍 Worldwide',
+                        value: 'unknown',
+                    },
+                }),
+            );
+        });
+
+        it('should not specify country if country is sanctioned', () => {
+            state.wallet.trading.buy.buyInfo!.buyInfo.country = 'KP';
+
+            expect(selectBuyFormDefaultValues(state)).toEqual(
+                expect.objectContaining({
+                    country: {
+                        label: '🌍 Worldwide',
+                        value: 'unknown',
+                    },
                 }),
             );
         });

--- a/suite-native/module-trading/src/selectors/__tests__/sellSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/sellSelectors.test.ts
@@ -188,7 +188,23 @@ describe('sellSelectors', () => {
 
             expect(selectSellFormDefaultValues(state)).toEqual(
                 expect.objectContaining({
-                    country: undefined,
+                    country: {
+                        label: '🌍 Worldwide',
+                        value: 'unknown',
+                    },
+                }),
+            );
+        });
+
+        it('should not specify country if country is sanctioned', () => {
+            state.wallet.trading.sell.sellInfo!.country = 'KP';
+
+            expect(selectSellFormDefaultValues(state)).toEqual(
+                expect.objectContaining({
+                    country: {
+                        label: '🌍 Worldwide',
+                        value: 'unknown',
+                    },
                 }),
             );
         });

--- a/suite-native/module-trading/src/selectors/buySelectors.ts
+++ b/suite-native/module-trading/src/selectors/buySelectors.ts
@@ -85,12 +85,16 @@ export const selectBuyFormDefaultValues = createMemoizedSelector(
         const country = buyInfo.buyInfo.country as TradingCountryCode;
 
         const fiatCurrency = suggestedFiatCurrency || DEFAULT_FIAT_CURRENCY_FALLBACK;
-        const countryDefaultValue = regional.countriesMap.has(country)
-            ? {
-                  value: country,
-                  label: regional.countriesMap.get(country),
-              }
-            : undefined;
+        const countryDefaultValue =
+            regional.countriesMap.has(country) && !regional.isSanctionedCountry(country)
+                ? {
+                      value: country,
+                      label: regional.countriesMap.get(country)!,
+                  }
+                : {
+                      value: regional.UNKNOWN_COUNTRY,
+                      label: regional.countriesMap.get(regional.UNKNOWN_COUNTRY)!,
+                  };
 
         return {
             fiatCurrency: fiatCurrency.toLowerCase(),

--- a/suite-native/module-trading/src/selectors/buySelectors.ts
+++ b/suite-native/module-trading/src/selectors/buySelectors.ts
@@ -9,7 +9,7 @@ import {
     TradingPaymentMethodProps,
     getBestRatedQuote,
     getTradingQuotesByPaymentMethod,
-    regional,
+    nonSanctionedRegional,
     selectTradingBuyInfo,
     selectTradingBuySupportedCryptoIds,
     selectValidTradingBuyQuotes,
@@ -86,15 +86,7 @@ export const selectBuyFormDefaultValues = createMemoizedSelector(
 
         const fiatCurrency = suggestedFiatCurrency || DEFAULT_FIAT_CURRENCY_FALLBACK;
         const countryDefaultValue =
-            regional.countriesMap.has(country) && !regional.isSanctionedCountry(country)
-                ? {
-                      value: country,
-                      label: regional.countriesMap.get(country)!,
-                  }
-                : {
-                      value: regional.UNKNOWN_COUNTRY,
-                      label: regional.countriesMap.get(regional.UNKNOWN_COUNTRY)!,
-                  };
+            nonSanctionedRegional.getCountryOptionWithWorldwideFallback(country);
 
         return {
             fiatCurrency: fiatCurrency.toLowerCase(),

--- a/suite-native/module-trading/src/selectors/sellSelectors.ts
+++ b/suite-native/module-trading/src/selectors/sellSelectors.ts
@@ -6,7 +6,7 @@ import {
     TradingPaymentMethodProps,
     getBestRatedQuote,
     getTradingQuotesByPaymentMethod,
-    regional,
+    nonSanctionedRegional,
     selectTradingSellInfo,
     selectValidTradingSellQuotes,
 } from '@suite-common/trading';
@@ -58,15 +58,7 @@ export const selectSellFormDefaultValues = createMemoizedSelector(
 
         const fiatCurrency = DEFAULT_FIAT_CURRENCY_FALLBACK;
         const countryDefaultValue =
-            regional.countriesMap.has(country) && !regional.isSanctionedCountry(country)
-                ? {
-                      value: country,
-                      label: regional.countriesMap.get(country)!,
-                  }
-                : {
-                      value: regional.UNKNOWN_COUNTRY,
-                      label: regional.countriesMap.get(regional.UNKNOWN_COUNTRY)!,
-                  };
+            nonSanctionedRegional.getCountryOptionWithWorldwideFallback(country);
 
         return {
             fiatCurrency: fiatCurrency.toLowerCase(),

--- a/suite-native/module-trading/src/selectors/sellSelectors.ts
+++ b/suite-native/module-trading/src/selectors/sellSelectors.ts
@@ -57,12 +57,16 @@ export const selectSellFormDefaultValues = createMemoizedSelector(
         const country = sellInfo.country as TradingCountryCode;
 
         const fiatCurrency = DEFAULT_FIAT_CURRENCY_FALLBACK;
-        const countryDefaultValue = regional.countriesMap.has(country)
-            ? {
-                  value: country,
-                  label: regional.countriesMap.get(country),
-              }
-            : undefined;
+        const countryDefaultValue =
+            regional.countriesMap.has(country) && !regional.isSanctionedCountry(country)
+                ? {
+                      value: country,
+                      label: regional.countriesMap.get(country)!,
+                  }
+                : {
+                      value: regional.UNKNOWN_COUNTRY,
+                      label: regional.countriesMap.get(regional.UNKNOWN_COUNTRY)!,
+                  };
 
         return {
             fiatCurrency: fiatCurrency.toLowerCase(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- introduce sanctioned countries
- do not allow to select sanctioned countries in trading

## Related Issue

Resolve #21523

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mobile-trade-countries-blacklist&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mobile-trade-countries-blacklist&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mobile-trade-countries-blacklist&lookback=7)