### PR TITLE
feat(suite-native): prompt users to enable Location Services on old Androids

### DIFF
--- a/packages/transport-native-bluetooth/src/api/bluetoothManager.ts
+++ b/packages/transport-native-bluetooth/src/api/bluetoothManager.ts
@@ -115,7 +115,7 @@ class BluetoothManager {
         this.emitNearbyDevicesChange();
     };
 
-    public startDeviceScan = () => {
+    public startDeviceScan = (errorHandler?: (error: BleError) => void) => {
         const options: ScanOptions = {
             allowDuplicates: true, // ensures we get frequent scan updates even on iOS
         };
@@ -123,6 +123,7 @@ class BluetoothManager {
             if (error) {
                 errorLog('Scan error', error);
                 this.stopStaleNearbyDevicesRemoval();
+                errorHandler?.(error);
             }
             if (scannedDevice) {
                 debugLog(`Scanned device ${scannedDevice}`);

--- a/packages/transport-native-bluetooth/src/index.ts
+++ b/packages/transport-native-bluetooth/src/index.ts
@@ -1,3 +1,4 @@
+export { BleError, BleErrorCode } from 'react-native-ble-plx';
 export * from './api/types';
 export * from './api/bluetoothManager';
 export * from './transport';

--- a/suite-native/bluetooth/src/hooks/useBluetoothAlerts.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothAlerts.ts
@@ -19,7 +19,7 @@ export const useBluetoothAlerts = () => {
     const dispatch = useDispatch();
 
     const { requestBluetoothPermission } = useBluetoothPermissions();
-    const { openBluetoothSettings } = useBluetoothSettings();
+    const { openBluetoothSettings, openLocationServicesSettings } = useBluetoothSettings();
 
     const bluetoothPermissionStatus = useSelector(selectBluetoothPermissionStatus);
     const bluetoothAdapterStatus = useSelector(selectBluetoothAdapterStatus);
@@ -75,6 +75,19 @@ export const useBluetoothAlerts = () => {
         hideAlert,
     ]);
 
+    const showLocationServicesDisabledAlert = useCallback(() => {
+        showAlert({
+            title: translate('bluetooth.alerts.locationServicesDisabled.title'),
+            description: translate('bluetooth.alerts.locationServicesDisabled.description'),
+            primaryButtonTitle: translate(
+                'bluetooth.alerts.locationServicesDisabled.primaryButton',
+            ),
+            onPressPrimaryButton: openLocationServicesSettings,
+            secondaryButtonTitle: translate('generic.buttons.cancel'),
+            onPressSecondaryButton: navigation.goBack,
+        });
+    }, [showAlert, openLocationServicesSettings, translate, navigation]);
+
     const showPairingFailedAlert = useCallback(() => {
         showAlert({
             title: translate('bluetooth.alerts.pairingFailed.title'),
@@ -103,6 +116,7 @@ export const useBluetoothAlerts = () => {
 
     return {
         showOrHideBluetoothAlert,
+        showLocationServicesDisabledAlert,
         showPairingFailedAlert,
         showSystemUnpairingAlert,
     };

--- a/suite-native/bluetooth/src/hooks/useBluetoothManager.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothManager.ts
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { AppState } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import { bluetoothManager } from '@trezor/transport-native-bluetooth';
+import { BleError, BleErrorCode, bluetoothManager } from '@trezor/transport-native-bluetooth';
 
 import { selectBluetoothAdapterStatus, selectBluetoothPermissionStatus } from '../selectors';
 import { useBluetoothAlerts } from './useBluetoothAlerts';
@@ -10,12 +10,21 @@ import { useBluetoothPermissions } from './useBluetoothPermissions';
 
 export const useBluetoothManager = () => {
     const { requestBluetoothPermission } = useBluetoothPermissions();
-    const { showOrHideBluetoothAlert } = useBluetoothAlerts();
+    const { showOrHideBluetoothAlert, showLocationServicesDisabledAlert } = useBluetoothAlerts();
 
     const bluetoothPermissionStatus = useSelector(selectBluetoothPermissionStatus);
     const bluetoothAdapterStatus = useSelector(selectBluetoothAdapterStatus);
 
     const [hasPermissionBeenRequested, setHasPermissionBeenRequested] = useState(false);
+
+    const scanErrorHandler = useCallback(
+        (error: BleError) => {
+            if (error.errorCode === BleErrorCode.LocationServicesDisabled) {
+                showLocationServicesDisabledAlert();
+            }
+        },
+        [showLocationServicesDisabledAlert],
+    );
 
     useEffect(() => {
         // Auto-request the permission only once when the screen is shown.
@@ -47,11 +56,11 @@ export const useBluetoothManager = () => {
 
     useEffect(() => {
         if (bluetoothAdapterStatus === 'enabled') {
-            bluetoothManager.startDeviceScan();
+            bluetoothManager.startDeviceScan(scanErrorHandler);
 
             return () => {
                 bluetoothManager.stopDeviceScan();
             };
         }
-    }, [bluetoothAdapterStatus]);
+    }, [bluetoothAdapterStatus, scanErrorHandler]);
 };

--- a/suite-native/bluetooth/src/hooks/useBluetoothSettings.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothSettings.ts
@@ -10,7 +10,14 @@ export const useBluetoothSettings = () => {
         }
     }, []);
 
+    const openLocationServicesSettings = useCallback(() => {
+        if (Platform.OS === 'android') {
+            Linking.sendIntent('android.settings.LOCATION_SOURCE_SETTINGS');
+        }
+    }, []);
+
     return {
         openBluetoothSettings,
+        openLocationServicesSettings,
     };
 };

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -175,6 +175,12 @@ export const messages = {
                     'Bluetooth is currently turned off on this phone. Go to phone settings and turn on Bluetooth.',
                 primaryButton: 'Open system settings',
             },
+            locationServicesDisabled: {
+                title: 'Enable Location Services',
+                description:
+                    'Location Services are currently disabled on this phone. Go to phone settings and enable them.',
+                primaryButton: 'Open system settings',
+            },
             pairingFailed: {
                 title: 'Bluetooth pairing failed',
                 description:


### PR DESCRIPTION
## Related Issue

Resolve #21441


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/bluetooth-location-services&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/bluetooth-location-services&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/bluetooth-location-services&lookback=7)