### PR TITLE
fix(suite): madge - skip type imports

### DIFF
--- a/.madgerc
+++ b/.madgerc
@@ -1,0 +1,17 @@
+{
+    "fileExtensions": [
+        "ts",
+        "tsx"
+    ],
+    "excludeRegExp": [
+        "node_modules|lib|libDev"
+    ],
+    "detectiveOptions": {
+        "ts": {
+            "skipTypeImports": true
+        },
+        "tsx": {
+            "skipTypeImports": true
+        }
+    }
+}

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -7,7 +7,7 @@ import { isErrorWithoutDeviceInteraction } from '@trezor/transport/src/errors-gr
 import { resolveAfter, scheduleAction, versionUtils } from '@trezor/utils';
 
 import { ERRORS } from '../constants';
-import { Device } from './Device';
+import type { Device } from './Device';
 import { DEVICE } from '../events';
 import { initLog } from '../utils/debug';
 

--- a/scripts/circular-dependencies/check-circular-dependencies.sh
+++ b/scripts/circular-dependencies/check-circular-dependencies.sh
@@ -8,7 +8,7 @@ SNAPSHOT_FILE="scripts/circular-dependencies/madge-snapshot.txt"
 TMP_FILE="$(mktemp)"
 
 # Run madge, allow it to fail
-if ! npx madge --circular --extensions ts,tsx --exclude "node_modules|lib|libDev" packages suite suite-native suite-common | tail -n +2 | sed 's/^[0-9][0-9]*) *//' | sort > "$TMP_FILE"; then
+if ! npx madge --circular packages suite suite-native suite-common | tail -n +2 | sed 's/^[0-9][0-9]*) *//' | sort > "$TMP_FILE"; then
   echo "⚠️ madge exited with non-zero status, continuing to compare results..."
   echo
 fi
@@ -18,7 +18,7 @@ if ! git diff --no-index --color=always "$SNAPSHOT_FILE" "$TMP_FILE"; then
   echo
   echo "❌ Circular dependency snapshot mismatch!"
   echo "Update the snapshot with:"
-  echo "  npx madge --circular --extensions ts,tsx --exclude \"node_modules|lib|libDev\" packages suite suite-native suite-common | tail -n +2 | sed 's/^[0-9][0-9]*) *//' | LC_ALL=C sort > $SNAPSHOT_FILE"
+  echo "  npx madge --circular packages suite suite-native suite-common | tail -n +2 | sed 's/^[0-9][0-9]*) *//' | LC_ALL=C sort > $SNAPSHOT_FILE"
   rm -f "$TMP_FILE"
   exit 1
 fi

--- a/scripts/circular-dependencies/madge-snapshot.txt
+++ b/scripts/circular-dependencies/madge-snapshot.txt
@@ -1,22 +1,5 @@
 
 
-packages/blockchain-link-types/src/blockbook.ts > packages/blockchain-link-types/src/common.ts
-packages/coinjoin/src/backend/CoinjoinAddressController.ts > packages/coinjoin/src/backend/backendUtils.ts > packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinMempoolController.ts
-packages/coinjoin/src/backend/backendUtils.ts > packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinBackendClient.ts
-packages/coinjoin/src/backend/backendUtils.ts > packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinBackendClient.ts > packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
-packages/coinjoin/src/backend/backendUtils.ts > packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinMempoolController.ts
-packages/coinjoin/src/client/CoinjoinClient.ts > packages/coinjoin/src/client/analyzeTransactions.ts
-packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/connectionConfirmation.ts
-packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/endedRound.ts
-packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/inputRegistration.ts
-packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/outputRegistration.ts
-packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/outputRegistration.ts > packages/coinjoin/src/client/round/outputDecomposition.ts
-packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/selectRound.ts
-packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/transactionSigning.ts
-packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinBackendClient.ts
-packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinBackendClient.ts > packages/coinjoin/src/backend/CoinjoinWebsocketController.ts > packages/coinjoin/src/types/index.ts
-packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinFilterController.ts
-packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinMempoolController.ts
 packages/components/src/components/BulletList/BulletList.tsx > packages/components/src/components/BulletList/BulletListItem.tsx
 packages/components/src/components/Collapsible/Collapsible.tsx > packages/components/src/components/Collapsible/CollapsibleContent.tsx
 packages/components/src/components/Collapsible/Collapsible.tsx > packages/components/src/components/Collapsible/CollapsibleToggle.tsx
@@ -25,31 +8,20 @@ packages/components/src/components/List/List.tsx > packages/components/src/compo
 packages/components/src/components/Table/Table.tsx > packages/components/src/components/Table/TableCell.tsx
 packages/components/src/components/Table/Table.tsx > packages/components/src/components/Table/TableCell.tsx > packages/components/src/components/Table/TableHeader.tsx
 packages/components/src/components/Table/Table.tsx > packages/components/src/components/Table/TableRow.tsx
-packages/components/src/components/form/Select/Select.tsx > packages/components/src/components/form/Select/customComponents.tsx
-packages/components/src/components/form/Select/Select.tsx > packages/components/src/components/form/Select/useOnKeyDown.ts
 packages/components/src/index.ts > packages/components/src/components/form/SelectBar/SelectBar.tsx
 packages/components/src/index.ts > packages/components/src/support/Story.tsx
-packages/components/src/utils/frameProps.tsx > packages/components/src/components/Flex/Flex.tsx
 packages/connect-explorer-theme/src/components/404.tsx > packages/connect-explorer-theme/src/components/anchor.tsx > packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts
 packages/connect-explorer-theme/src/components/anchor.tsx > packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts
 packages/connect-explorer-theme/src/components/anchor.tsx > packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/500.tsx
 packages/connect-explorer-theme/src/components/anchor.tsx > packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/breadcrumb.tsx
 packages/connect-explorer-theme/src/components/anchor.tsx > packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/flexsearch.tsx > packages/connect-explorer-theme/src/components/search.tsx
 packages/connect-explorer-theme/src/components/anchor.tsx > packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/nav-links.tsx
-packages/connect-explorer-theme/src/components/anchor.tsx > packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/nav-links.tsx > packages/connect-explorer-theme/src/index.tsx > packages/connect-explorer-theme/src/mdx-components.tsx
 packages/connect-explorer-theme/src/components/anchor.tsx > packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/navbar.tsx
 packages/connect-explorer-theme/src/components/anchor.tsx > packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/sidebar.tsx > packages/connect-explorer-theme/src/components/menu.tsx
 packages/connect-explorer-theme/src/components/anchor.tsx > packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/toc.tsx
-packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/nav-links.tsx > packages/connect-explorer-theme/src/index.tsx
-packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/nav-links.tsx > packages/connect-explorer-theme/src/index.tsx > packages/connect-explorer-theme/src/mdx-components.tsx
 packages/connect-explorer-theme/src/components/sidebar.tsx > packages/connect-explorer-theme/src/components/menu.tsx
 packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/flexsearch.tsx
-packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/flexsearch.tsx > packages/connect-explorer-theme/src/components/search.tsx > packages/connect-explorer-theme/src/types.ts
-packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/nav-links.tsx > packages/connect-explorer-theme/src/index.tsx
-packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/nav-links.tsx > packages/connect-explorer-theme/src/index.tsx > packages/connect-explorer-theme/src/mdx-components.tsx
-packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/nav-links.tsx > packages/connect-explorer-theme/src/index.tsx > packages/connect-explorer-theme/src/polyfill.ts
 packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/contexts/config.tsx
-packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/nav-links.tsx > packages/connect-explorer-theme/src/index.tsx > packages/connect-explorer-theme/src/mdx-components.tsx
 packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/500.tsx
 packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/500.tsx > packages/connect-explorer-theme/src/utils/index.ts > packages/connect-explorer-theme/src/utils/use-git-edit-url.ts
 packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/banner.tsx
@@ -58,90 +30,28 @@ packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explore
 packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/footer.tsx > packages/connect-explorer-theme/src/components/locale-switch.tsx
 packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/head.tsx
 packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/nav-links.tsx
-packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/nav-links.tsx > packages/connect-explorer-theme/src/index.tsx
-packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/nav-links.tsx > packages/connect-explorer-theme/src/index.tsx > packages/connect-explorer-theme/src/mdx-components.tsx
 packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/navbar.tsx
 packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/sidebar.tsx
 packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/sidebar.tsx > packages/connect-explorer-theme/src/components/menu.tsx
 packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/theme-switch.tsx
 packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/toc.tsx
-packages/connect-explorer/src/actions/index.ts > packages/connect-explorer/src/actions/methodActions.ts > packages/connect-explorer/src/types/index.ts > packages/connect-explorer/src/actions/trezorConnectActions.ts
-packages/connect-explorer/src/actions/index.ts > packages/connect-explorer/src/actions/methodActions.ts > packages/connect-explorer/src/types/index.ts > packages/connect-explorer/src/reducers/index.ts > packages/connect-explorer/src/reducers/trezorConnectReducer.ts
-packages/connect-explorer/src/actions/methodActions.ts > packages/connect-explorer/src/types/index.ts
-packages/connect-explorer/src/actions/methodActions.ts > packages/connect-explorer/src/types/index.ts > packages/connect-explorer/src/reducers/index.ts > packages/connect-explorer/src/reducers/methodReducer.ts
-packages/connect-explorer/src/types/index.ts > packages/connect-explorer/src/actions/trezorConnectActions.ts
-packages/connect-explorer/src/types/index.ts > packages/connect-explorer/src/reducers/index.ts > packages/connect-explorer/src/reducers/methodReducer.ts
-packages/connect-explorer/src/types/index.ts > packages/connect-explorer/src/reducers/index.ts > packages/connect-explorer/src/reducers/methodReducer.ts > packages/connect-explorer/src/reducers/methodCommon.ts
-packages/connect-explorer/src/types/index.ts > packages/connect-explorer/src/reducers/index.ts > packages/connect-explorer/src/reducers/methodReducer.ts > packages/connect-explorer/src/reducers/methodInit.ts
-packages/connect-explorer/src/types/index.ts > packages/connect-explorer/src/reducers/index.ts > packages/connect-explorer/src/reducers/trezorConnectReducer.ts
-packages/connect/src/data/firmwareInfo.ts > packages/connect/src/data/DataManager.ts
-packages/connect/src/data/firmwareInfo.ts > packages/connect/src/data/DataManager.ts > packages/connect/src/utils/firmwareReleaseConfigUtils.ts
-packages/connect/src/data/firmwareInfo.ts > packages/connect/src/utils/firmwareUtils.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/DeviceCommands.ts > packages/connect/src/device/DeviceCurrentSession.ts
+packages/connect/src/data/DataManager.ts > packages/connect/src/data/firmwareInfo.ts
+packages/connect/src/device/Device.ts > packages/connect/src/device/DeviceCurrentSession.ts
 packages/connect/src/device/Device.ts > packages/connect/src/device/StateStorage.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts > packages/connect/src/device/thp/handshake.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts > packages/connect/src/device/thp/handshake.ts > packages/connect/src/device/thp/thpCall.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts > packages/connect/src/device/thp/pairing.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts > packages/connect/src/device/thp/session.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/checkFirmwareHashWithRetries.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/checkFirmwareHashWithRetries.ts > packages/connect/src/device/workflow/checkFirmwareHash.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/checkFirmwareHashWithRetries.ts > packages/connect/src/device/workflow/checkFirmwareHash.ts > packages/connect/src/api/firmware/index.ts > packages/connect/src/api/firmware/getBinary.ts > packages/connect/src/types/index.ts > packages/connect/src/types/api/index.ts > packages/connect/src/types/api/off.ts > packages/connect/src/events/ui-request.ts > packages/connect/src/core/AbstractMethod.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/checkFirmwareHashWithRetries.ts > packages/connect/src/device/workflow/checkFirmwareHash.ts > packages/connect/src/api/firmware/index.ts > packages/connect/src/api/firmware/uploadFirmware.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/handshake.ts > packages/connect/src/types/workflow.ts
-packages/connect/src/events/index.ts > packages/connect/src/events/call.ts > packages/connect/src/device/Device.ts
-packages/connect/src/events/index.ts > packages/connect/src/events/call.ts > packages/connect/src/device/Device.ts > packages/connect/src/device/DeviceCommands.ts > packages/connect/src/device/DeviceCurrentSession.ts
-packages/connect/src/events/index.ts > packages/connect/src/events/call.ts > packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts > packages/connect/src/device/thp/handshake.ts > packages/connect/src/device/thp/thpCall.ts
-packages/connect/src/events/index.ts > packages/connect/src/events/call.ts > packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts > packages/connect/src/device/thp/pairing.ts
-packages/connect/src/events/index.ts > packages/connect/src/events/call.ts > packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/checkFirmwareHashWithRetries.ts > packages/connect/src/device/workflow/checkFirmwareHash.ts > packages/connect/src/api/firmware/index.ts > packages/connect/src/api/firmware/getBinary.ts > packages/connect/src/types/index.ts > packages/connect/src/types/api/index.ts > packages/connect/src/types/api/off.ts > packages/connect/src/events/ui-request.ts > packages/connect/src/core/AbstractMethod.ts
-packages/connect/src/events/index.ts > packages/connect/src/events/call.ts > packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/checkFirmwareHashWithRetries.ts > packages/connect/src/device/workflow/checkFirmwareHash.ts > packages/connect/src/api/firmware/index.ts > packages/connect/src/api/firmware/uploadFirmware.ts
 packages/ipc-proxy/src/proxy-handler.ts > packages/ipc-proxy/src/validateIpcMessage.ts
 packages/product-components/src/components/SelectAssetModal/SelectAssetModal.tsx > packages/product-components/src/components/SelectAssetModal/AssetItem.tsx
 packages/suite-desktop-core/e2e/support/analytics.ts > packages/suite-desktop-core/e2e/support/fixtures.ts
-packages/suite-desktop-core/src/modules/auto-start.ts > packages/suite-desktop-core/src/modules/index.ts
 packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/auto-updater.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/bluetooth.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/bridge.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/coinjoin.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/crash-recover.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/csp.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/custom-protocols.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/dev-tools.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/event-logging/app.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/event-logging/contents.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/event-logging/index.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/event-logging/process.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/external-links.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/file-protocol.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/firmware.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/http-receiver.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/menu.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/metadata.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/power-monitor.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/request-filter.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/request-interceptor.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/shortcuts.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/store.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/system-settings.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/theme.ts
 packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/tray.ts
 packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/trezor-connect.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/user-data.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/window-controls.ts
 packages/suite/src/actions/suite/metadataActions.ts > packages/suite/src/actions/suite/metadataProviderActions.ts
-packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx > packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipAccount.tsx
-packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx > packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipDashboard.tsx
 packages/suite/src/components/suite/index.tsx > packages/suite/src/components/suite/Preloader/Preloader.tsx > packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx > packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx > packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayoutWithoutModalSwitcher.tsx > packages/suite/src/components/suite/layouts/SuiteLayout/index.ts > packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx > packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx > packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal.tsx > packages/suite/src/components/suite/modals/index.tsx > packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx > packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletExistsFlow.tsx > packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/EnterPassphrase.tsx > packages/suite/src/views/suite/SwitchDevice/CardWithDevice.tsx > packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
 packages/suite/src/components/suite/index.tsx > packages/suite/src/components/suite/Preloader/Preloader.tsx > packages/suite/src/views/start/AnalyticsConsentScreen.tsx
-packages/suite/src/components/suite/modals/ReduxModal/ReduxModal.tsx > packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/DeviceConfirmationModal.tsx
-packages/suite/src/components/suite/modals/ReduxModal/ReduxModal.tsx > packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
-packages/suite/src/components/suite/modals/ReduxModal/ReduxModal.tsx > packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
 packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx > packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
 packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx > packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalExchange.tsx
 packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx > packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalSell.tsx
 packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx > packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx > packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx
 packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx > packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx > packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
-packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx > packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep2to4.tsx
 packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx > packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/CollapsibleIOSection.tsx > packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.tsx
 packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx > packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
 packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx > packages/suite/src/components/suite/troubleshooting/TroubleshootingTipsList.tsx
@@ -157,20 +67,15 @@ packages/suite/src/components/wallet/Fees/StandardFee/StandardFee.tsx > packages
 packages/suite/src/components/wallet/Fees/StandardFee/StandardFee.tsx > packages/suite/src/components/wallet/Fees/StandardFee/MiscFeeCards.tsx
 packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTargetsList.tsx > packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
 packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx > packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow.tsx
-packages/suite/src/utils/wallet/graph/utils.ts > packages/suite/src/utils/wallet/graph/utilsShared.ts > packages/suite/src/utils/wallet/graph/utilsWorker.ts
-packages/suite/src/utils/wallet/graph/utilsShared.ts > packages/suite/src/utils/wallet/graph/utilsWorker.ts
+packages/suite/src/utils/wallet/graph/utils.ts > packages/suite/src/utils/wallet/graph/utilsWorker.ts
 packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTable.tsx > packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
 packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx > packages/suite/src/views/onboarding/steps/SelectBackupType/FloatingSelections.tsx
-packages/transport/src/api/abstract.ts > packages/transport/src/types/index.ts
-packages/transport/src/transports/abstract.ts > packages/transport/src/transports/bridge.ts
 suite-common/connect-popup/src/methodHooks/index.ts > suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
 suite-common/connect-popup/src/methodHooks/index.ts > suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
 suite-common/connect-popup/src/methodHooks/index.ts > suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
 suite-common/connect-popup/src/methodHooks/index.ts > suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
 suite-common/graph/src/graphDataFetching.ts > suite-common/graph/src/graphUtils.ts
-suite-common/intl-types/src/index.ts > suite-common/intl-types/src/types.ts > packages/suite/src/components/suite/Translation.tsx
 suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts
-suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts > suite-common/trading/src/selectors/tradingSelectors.ts
 suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
 suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
 suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/common/verifyAddressThunk.ts
@@ -198,13 +103,11 @@ suite-common/trading/src/types.ts > suite-common/trading/src/reducers/tradingRed
 suite-common/trading/src/types.ts > suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts > suite-common/trading/src/selectors/tradingSelectors.ts > suite-common/trading/src/utils.ts
 suite-common/trading/src/types.ts > suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts > suite-common/trading/src/selectors/tradingSelectors.ts > suite-common/trading/src/utils.ts > suite-common/trading/src/regional.ts
 suite-common/trading/src/types.ts > suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts > suite-common/trading/src/selectors/tradingSelectors.ts > suite-common/trading/src/utils/infoUtils.ts
-suite-common/trading/src/types.ts > suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
 suite-common/trading/src/types.ts > suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts > suite-common/trading/src/utils/buy/buyUtils.ts
 suite-common/trading/src/types.ts > suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
 suite-common/trading/src/types.ts > suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts > suite-common/trading/src/thunks/common/getNonce.ts
 suite-common/trading/src/types.ts > suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts > suite-common/trading/src/thunks/common/getRefundAddress.ts
 suite-common/trading/src/types.ts > suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
-suite-common/trading/src/types.ts > suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
 suite-common/trading/src/types.ts > suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/common/watchTradeThunk.ts
 suite-common/trading/src/types.ts > suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
 suite-common/trading/src/types.ts > suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/index.ts > suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts > suite-common/trading/src/utils/exchange/exchangeUtils.ts
@@ -255,4 +158,3 @@ suite-native/device/src/index.ts > suite-native/device/src/components/Bootloader
 suite-native/device/src/index.ts > suite-native/device/src/components/BootloaderModeScreen.tsx > suite-native/device/src/selectors.ts > suite-native/firmware/src/index.ts > suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
 suite-native/navigation/src/components/ScreenHeader.tsx > suite-native/navigation/src/components/ScreenHeaderContent.tsx
 suite-native/navigation/src/index.ts > suite-native/navigation/src/useNavigateToInitialScreen.ts
-suite-native/react-native-graph/src/LineGraphProps.ts > suite-native/react-native-graph/src/CreateGraphPath.ts

--- a/scripts/circular-dependencies/madge-snapshot.txt
+++ b/scripts/circular-dependencies/madge-snapshot.txt
@@ -36,7 +36,6 @@ packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explore
 packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/theme-switch.tsx
 packages/connect-explorer-theme/src/contexts/index.ts > packages/connect-explorer-theme/src/contexts/active-anchor.tsx > packages/connect-explorer-theme/src/constants.tsx > packages/connect-explorer-theme/src/components/index.ts > packages/connect-explorer-theme/src/components/toc.tsx
 packages/connect/src/data/DataManager.ts > packages/connect/src/data/firmwareInfo.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/DeviceCurrentSession.ts
 packages/connect/src/device/Device.ts > packages/connect/src/device/StateStorage.ts
 packages/ipc-proxy/src/proxy-handler.ts > packages/ipc-proxy/src/validateIpcMessage.ts
 packages/product-components/src/components/SelectAssetModal/SelectAssetModal.tsx > packages/product-components/src/components/SelectAssetModal/AssetItem.tsx


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR removes the type imports from madge circular dependency check

### Argument for:
The circular type imports won't break builds and they still work without issuess

### Argument con:
Codewise, it is still objectively wrong to have circular imports even for the type code

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=madge-ignore-type-imports&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=madge-ignore-type-imports&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=madge-ignore-type-imports&lookback=7)