### PR TITLE
Add EVM account if previous one is empty

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -192,8 +192,7 @@ export const AddAccountModal = ({
                 backendType: account.backendType != 'coinjoin' ? account.backendType : undefined,
                 selectedAccount,
                 accountTypes,
-                deviceState: device.state?.staticSessionId,
-                useEmptyPassphrase: device.useEmptyPassphrase,
+                device,
             });
 
             if (newAccount instanceof Error) {
@@ -240,8 +239,7 @@ export const AddAccountModal = ({
                         account.backendType != 'coinjoin' ? account.backendType : undefined,
                     selectedAccount,
                     accountTypes,
-                    deviceState: device.state?.staticSessionId,
-                    useEmptyPassphrase: device.useEmptyPassphrase,
+                    device,
                 });
 
                 if (newAccount instanceof Error) {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -196,7 +196,7 @@ export const AccountsList = ({
             <>
                 <ExpandedSidebarOnly>
                     <AccountGroup
-                        key={`${device.state}-${type}`}
+                        key={type}
                         type={type}
                         hideLabel={hideLabel}
                         hasBalance={groupHasBalance}

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -19,6 +19,7 @@ import {
     deviceActions,
     explorerActions,
     selectAccountByKey,
+    selectAccounts,
     selectDeviceByStaticSessionId,
     selectDevices,
     selectHistoricFiatRates,
@@ -57,12 +58,34 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     accountsActions.updateAccount,
                 )(action)
             ) {
-                const { payload } = action;
-                const device = findAccountDevice(payload, selectDevices(api.getState()));
+                const newAccount = action.payload;
+                const state = api.getState();
+                const device = findAccountDevice(newAccount, selectDevices(state));
+
+                // ensure index 0 gets saved once index 1+ appears, since it may be skipped during initial discovery
+                if (newAccount.index > 0) {
+                    const prevAccount = selectAccounts(state).find(
+                        account =>
+                            account.deviceState === newAccount.deviceState &&
+                            account.accountType === newAccount.accountType &&
+                            account.symbol === newAccount.symbol &&
+                            account.index === newAccount.index - 1,
+                    );
+
+                    if (
+                        prevAccount &&
+                        prevAccount.index === 0 &&
+                        prevAccount.balance === '0' &&
+                        isAccountSuccessful(prevAccount)
+                    ) {
+                        storageActions.saveAccounts([prevAccount]);
+                    }
+                }
+
                 // update only transactions for remembered device
-                if (isDeviceRemembered(device) && isAccountSuccessful(payload)) {
-                    storageActions.saveAccounts([payload]);
-                    api.dispatch(storageActions.saveCoinjoinAccount(payload.key));
+                if (isDeviceRemembered(device) && isAccountSuccessful(newAccount)) {
+                    storageActions.saveAccounts([newAccount]);
+                    api.dispatch(storageActions.saveCoinjoinAccount(newAccount.key));
                 }
             }
 

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1242,8 +1242,7 @@ export const prepareNewAccountPayload = async ({
     backendType,
     selectedAccount,
     accountTypes,
-    deviceState,
-    useEmptyPassphrase = true,
+    device,
 }: {
     accountType: AccountType;
     networkSymbol: NetworkSymbol;
@@ -1251,20 +1250,24 @@ export const prepareNewAccountPayload = async ({
     backendType?: TrezorConnectBackendType;
     selectedAccount?: NetworkAccount;
     accountTypes?: NetworkAccount[];
-    deviceState?: StaticSessionId;
-    useEmptyPassphrase?: boolean;
+    device: TrezorDevice;
 }) => {
     const networkAccount =
         selectedAccount ?? accountTypes?.find(v => v.accountType === accountType);
 
     const newPath = networkAccount?.bip43Path.replace('i', String(index));
 
-    if (!newPath || !deviceState) return new Error('Missing path');
+    if (!newPath || !device.state?.staticSessionId) return new Error('Missing path');
 
     const res = await TrezorConnect.getAccountInfo({
         path: newPath,
         coin: networkSymbol,
-        useEmptyPassphrase,
+        useEmptyPassphrase: device.useEmptyPassphrase,
+        device: {
+            path: device.path,
+            instance: device.instance,
+            state: device.state,
+        },
     });
 
     if (!res.success) return new Error(res.payload.error);
@@ -1272,7 +1275,7 @@ export const prepareNewAccountPayload = async ({
     return {
         accountInfo: res.payload,
         visible: true,
-        deviceState,
+        deviceState: device.state.staticSessionId,
         symbol: networkSymbol,
         index,
         accountType,

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1268,6 +1268,7 @@ export const prepareNewAccountPayload = async ({
             instance: device.instance,
             state: device.state,
         },
+        details: 'txs',
     });
 
     if (!res.success) return new Error(res.payload.error);

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1255,7 +1255,9 @@ export const prepareNewAccountPayload = async ({
     const networkAccount =
         selectedAccount ?? accountTypes?.find(v => v.accountType === accountType);
 
-    const newPath = networkAccount?.bip43Path.replace('i', String(index));
+    const accountIndex = index + (accountType === 'ledger' ? 1 : 0);
+
+    const newPath = networkAccount?.bip43Path.replace('i', String(accountIndex));
 
     if (!newPath || !device.state?.staticSessionId) return new Error('Missing path');
 


### PR DESCRIPTION
## Description

- Incorrect account was added in some cases (When adding a passphrase wallet, the account showed an address from the normal account instead of the correct one)
- First account missing after app refresh (After app refresh, the first account was missing because it was not saved to the store during discovery)
- BTC receive screen displayed xpub instead of derived bech32 address 
- Fixed Ledger Ethereum accounts derivation (index offset) (Ledger Ethereum accounts were duplicated due to incorrect index handling)


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15417


<img width="1268" height="1288" alt="image (1)" src="https://github.com/user-attachments/assets/9d1a6d8d-4ff7-47a4-88dc-64ab406dbc9a" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/add-account&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/add-account&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/add-account&lookback=7)