### PR TITLE
Disable sensitive action when device compromised

### DIFF
--- a/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
@@ -13,15 +13,18 @@ import {
 
 import { AppState } from 'src/types/suite';
 
-import { selectIsEntropyCheckEnabled } from './suiteSelectors';
+import {
+    selectIsEntropyCheckEnabled,
+    selectIsFirmwareHashCheckEnabled,
+    selectIsFirmwareRevisionCheckEnabled,
+} from './suiteSelectors';
 
 export const selectFirmwareRevisionCheckErrorIfEnabled = (state: AppState) => {
     const revisionCheckError = selectFirmwareRevisionCheckError(state);
     if (revisionCheckError === null) return null;
     if (isSkippedRevisionCheckError(revisionCheckError)) return null;
 
-    const isFirmwareRevisionCheckDisabled =
-        !state.suite.settings.enabledSecurityChecks.firmwareRevision;
+    const isFirmwareRevisionCheckDisabled = !selectIsFirmwareRevisionCheckEnabled(state);
     if (isFirmwareRevisionCheckDisabled) return null;
 
     const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.firmwareRevisionCheck);
@@ -35,7 +38,7 @@ export const selectFirmwareHashCheckErrorIfEnabled = (state: AppState) => {
     if (hashCheckError === null) return null;
     if (isSkippedHashCheckError(hashCheckError)) return null;
 
-    const isFirmwareHashCheckDisabled = !state.suite.settings.enabledSecurityChecks.firmwareHash;
+    const isFirmwareHashCheckDisabled = !selectIsFirmwareHashCheckEnabled(state);
     if (isFirmwareHashCheckDisabled) return null;
 
     const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.firmwareHashCheck);
@@ -57,6 +60,13 @@ export const selectFirmwareHashCheckErrorIfEnabled = (state: AppState) => {
 
     return hashCheckError;
 };
+
+export function selectIsDeviceCompromised(state: AppState): boolean {
+    const revisionError = selectFirmwareRevisionCheckErrorIfEnabled(state);
+    const hashError = selectFirmwareHashCheckErrorIfEnabled(state);
+
+    return revisionError !== null || hashError !== null;
+}
 
 /**
  * Determine hard failure of either of firmware authenticity checks to block access to device.

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -57,6 +57,7 @@ import {
     useLayoutSize,
     useSelector,
 } from 'src/hooks/suite';
+import { selectIsDeviceCompromised } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 import {
     selectIsCopyAddressModalShown,
     selectIsUnhideTokenModalShown,
@@ -96,6 +97,8 @@ export const TokenRow = ({
     );
     const { coins } = useSelector(selectTradingInfo);
     const isDeviceLocked = isLocked(true);
+    const isDeviceCompromised = useSelector(selectIsDeviceCompromised);
+
     const networkContractAddress = getContractAddressForNetworkSymbol(
         account.symbol,
         token.contract,
@@ -158,8 +161,6 @@ export const TokenRow = ({
         </InfoItem>
     );
 
-    const isReceiveButtonDisabled = isDeviceLocked;
-
     const contractAddress = getContractAddressForNetworkSymbol(account.symbol, token.contract);
     const tokenCryptoId = toTokenCryptoId(account.symbol, contractAddress);
     const tokenTradingOptions = coins?.[tokenCryptoId]?.services;
@@ -168,6 +169,7 @@ export const TokenRow = ({
     const canSwapToken =
         (!!tokenTradingOptions && tokenTradingOptions.exchange) || token.balance === '0';
     const canSellToken = !!tokenTradingOptions && tokenTradingOptions.sell;
+    const canReceiveToken = !isDeviceLocked && !isDeviceCompromised;
 
     const onTradeButtonClick = (type: TradingType, ...[routeName]: Parameters<typeof goto>) => {
         dispatch(
@@ -332,7 +334,7 @@ export const TokenRow = ({
                                 'data-testid': '@trading/tokens/receive-button',
                                 icon: 'arrowDown',
                                 onClick: onReceive,
-                                isDisabled: isReceiveButtonDisabled,
+                                isDisabled: !canReceiveToken,
                                 isHidden:
                                     tokenStatusType === TokenManagementAction.HIDE
                                         ? !isBelowTablet
@@ -462,11 +464,19 @@ export const TokenRow = ({
                                     }}
                                 />
                                 <IconButton
-                                    label={<Translation id="TR_NAV_RECEIVE" />}
+                                    label={
+                                        <Translation
+                                            id={
+                                                isDeviceCompromised
+                                                    ? 'TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED'
+                                                    : 'TR_NAV_RECEIVE'
+                                            }
+                                        />
+                                    }
                                     key="token-receive"
                                     variant="tertiary"
                                     icon="arrowDown"
-                                    isDisabled={isReceiveButtonDisabled}
+                                    isDisabled={!canReceiveToken}
                                     onClick={onReceive}
                                 />
                             </ButtonGroup>

--- a/packages/suite/src/views/wallet/trading/buy/TradingBuyForm.tsx
+++ b/packages/suite/src/views/wallet/trading/buy/TradingBuyForm.tsx
@@ -2,9 +2,11 @@ import { Context } from '@suite-common/message-system';
 import { TradingType } from '@suite-common/trading';
 
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
+import { useSelector } from 'src/hooks/suite';
 import { useMessageSystemTrading } from 'src/hooks/suite/useMessageSystemTrading';
 import { useTradingBuyForm } from 'src/hooks/wallet/trading/form/useTradingBuyForm';
 import { TradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { selectIsDeviceCompromised } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 import { UseTradingProps } from 'src/types/trading/trading';
 import { TradingContainer } from 'src/views/wallet/trading/common/TradingContainer';
 import { TradingFormLayout } from 'src/views/wallet/trading/common/TradingForm/TradingFormLayout';
@@ -25,11 +27,12 @@ const TradingBuyFormContent = ({ selectedAccount }: UseTradingProps) => {
 const TradingBuyFormWrapper = ({ selectedAccount }: UseTradingProps) => {
     const type: TradingType = 'buy';
     const { isDisabled, content } = useMessageSystemTrading(type);
+    const isDeviceCompromised = useSelector(selectIsDeviceCompromised);
 
     return (
         <TradingLayout>
             <ContextMessage context={Context.getTrading(type)} />
-            {isDisabled ? (
+            {isDisabled || isDeviceCompromised ? (
                 <TradingDisabled type={type} content={content} />
             ) : (
                 <TradingBuyFormContent selectedAccount={selectedAccount} />

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx
@@ -2,9 +2,11 @@ import { Context } from '@suite-common/message-system';
 import { TradingType } from '@suite-common/trading';
 
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
+import { useSelector } from 'src/hooks/suite';
 import { useMessageSystemTrading } from 'src/hooks/suite/useMessageSystemTrading';
 import { TradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingExchangeForm } from 'src/hooks/wallet/trading/form/useTradingExchangeForm';
+import { selectIsDeviceCompromised } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 import { UseTradingProps } from 'src/types/trading/trading';
 import { TradingContainer } from 'src/views/wallet/trading/common/TradingContainer';
 import { TradingFormLayout } from 'src/views/wallet/trading/common/TradingForm/TradingFormLayout';
@@ -25,11 +27,12 @@ const TradingExchangeFormContent = ({ selectedAccount }: UseTradingProps) => {
 const TradingExchangeFormWrapper = ({ selectedAccount }: UseTradingProps) => {
     const type: TradingType = 'exchange';
     const { isDisabled, content } = useMessageSystemTrading(type);
+    const isDeviceCompromised = useSelector(selectIsDeviceCompromised);
 
     return (
         <TradingLayout>
             <ContextMessage context={Context.getTrading(type)} />
-            {isDisabled ? (
+            {isDisabled || isDeviceCompromised ? (
                 <TradingDisabled type={type} content={content} />
             ) : (
                 <TradingExchangeFormContent selectedAccount={selectedAccount} />

--- a/packages/suite/src/views/wallet/trading/sell/TradingSellForm.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingSellForm.tsx
@@ -2,9 +2,11 @@ import { Context } from '@suite-common/message-system';
 import { TradingType } from '@suite-common/trading';
 
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
+import { useSelector } from 'src/hooks/suite';
 import { useMessageSystemTrading } from 'src/hooks/suite/useMessageSystemTrading';
 import { TradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingSellForm } from 'src/hooks/wallet/trading/form/useTradingSellForm';
+import { selectIsDeviceCompromised } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 import { UseTradingProps } from 'src/types/trading/trading';
 import { TradingContainer } from 'src/views/wallet/trading/common/TradingContainer';
 import { TradingFormLayout } from 'src/views/wallet/trading/common/TradingForm/TradingFormLayout';
@@ -25,11 +27,12 @@ const TradingSellFormContent = ({ selectedAccount }: UseTradingProps) => {
 const TradingSellFormWrapper = ({ selectedAccount }: UseTradingProps) => {
     const type: TradingType = 'sell';
     const { isDisabled, content } = useMessageSystemTrading(type);
+    const isDeviceCompromised = useSelector(selectIsDeviceCompromised);
 
     return (
         <TradingLayout>
             <ContextMessage context={Context.getTrading(type)} />
-            {isDisabled ? (
+            {isDisabled || isDeviceCompromised ? (
                 <TradingDisabled type={type} content={content} />
             ) : (
                 <TradingSellFormContent selectedAccount={selectedAccount} />


### PR DESCRIPTION
Disable receive button in token section when device compromised.

## Related Issue

Resolve #14943 
Resolve #14942

## Screenshots:

<img width="1217" height="731" alt="Snímek obrazovky 2025-09-22 v 15 50 55" src="https://github.com/user-attachments/assets/c7481f10-5baa-442f-8842-a60db7a5783c" />
<img width="1207" height="502" alt="Snímek obrazovky 2025-09-22 v 15 51 02" src="https://github.com/user-attachments/assets/a0648092-6c4f-4121-a59a-4e4a7fabd892" />
<img width="1229" height="752" alt="Snímek obrazovky 2025-09-22 v 15 51 12" src="https://github.com/user-attachments/assets/1a540af0-6ac4-4d32-8c0d-178d5cde5111" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/14943-receive-button&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/14943-receive-button&lookback=7)