### PR TITLE
fix(suite): bluetooth handle power suspend

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -82,7 +82,7 @@ export interface RendererChannels {
 
     'app/auto-start/popup-request': void;
 
-    'power-monitor/screen-locked': void;
+    'power-monitor/suspend': void;
 }
 
 // Invocation from renderer process

--- a/packages/suite-desktop-api/src/validation.ts
+++ b/packages/suite-desktop-api/src/validation.ts
@@ -47,6 +47,6 @@ const validChannels: Array<keyof RendererChannels> = [
     'connect-popup/call',
     'connect-popup/cancel',
     'app/auto-start/popup-request',
-    'power-monitor/screen-locked',
+    'power-monitor/suspend',
 ];
 export const isValidChannel = (channel: any) => validChannels.includes(channel);

--- a/packages/suite-desktop-core/src/modules/power-monitor.ts
+++ b/packages/suite-desktop-core/src/modules/power-monitor.ts
@@ -8,7 +8,16 @@ export const init: ModuleInit = ({ mainWindowProxy }) => {
     mainWindowProxy.on('init', mainWindow => {
         powerMonitor.on('lock-screen', () => {
             logger.info('power-monitor', 'Lock screen event detected');
-            mainWindow.webContents.send('power-monitor/screen-locked');
+        });
+        powerMonitor.on('unlock-screen', () => {
+            logger.info('power-monitor', 'Unlock screen event detected');
+        });
+        powerMonitor.on('suspend', () => {
+            logger.info('power-monitor', 'Suspend event detected');
+            mainWindow.webContents.send('power-monitor/suspend');
+        });
+        powerMonitor.on('resume', () => {
+            logger.info('power-monitor', 'Resume event detected');
         });
     });
 };

--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -2,6 +2,7 @@ import {
     BLUETOOTH_PREFIX,
     bluetoothActions,
     filterOutOldDuplicatesByName,
+    selectAdapterStatus,
     selectKnownDevices,
 } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
@@ -61,7 +62,14 @@ export const initBluetoothThunk = createThunk<void, void, void>(
 
         const attemptDeviceConnect = async ({ device }: { device: DesktopBluetoothDevice }) => {
             const knownDevices = selectKnownDevices<DesktopBluetoothDevice>(getState());
-            const autoConnectingDevices = selectConnectingDevices(getState());
+            const connectingDevices = selectConnectingDevices(getState());
+            const adapterStatus = selectAdapterStatus(getState());
+
+            if (adapterStatus === 'power-suspending') {
+                // system is going to sleep
+                return;
+            }
+
             // do not hijack BT connection
             const isConnectable =
                 device.connectionStatus.type === 'disconnected' &&
@@ -71,7 +79,7 @@ export const initBluetoothThunk = createThunk<void, void, void>(
             if (
                 isConnectable &&
                 knownDevices.find(d => d.id === device.id) !== undefined &&
-                !autoConnectingDevices.includes(device.id)
+                !connectingDevices.includes(device.id)
             ) {
                 await dispatch(bluetoothConnectDeviceThunk({ deviceId: device.id }));
             }

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PowerMonitor/PowerMonitor.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PowerMonitor/PowerMonitor.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
-import { selectKnownDevices } from '@suite-common/bluetooth';
+import { bluetoothActions, selectKnownDevices } from '@suite-common/bluetooth';
+import { isMacOs } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { bluetoothDisconnectDeviceThunk } from 'src/actions/bluetooth/bluetoothDisconnectDeviceThunk';
@@ -14,15 +15,19 @@ export const PowerMonitorManager = () => {
     useEffect(() => {
         if (!isDesktopApiAvailable) return;
 
+        // This is only useful for macOS
+        if (!isMacOs()) return;
+
         const disconnectAllDevices = () => {
+            dispatch(bluetoothActions.adapterEventAction({ status: 'power-suspending' }));
             knownDevices.forEach(device => {
                 if (device.connected) dispatch(bluetoothDisconnectDeviceThunk({ id: device.id }));
             });
         };
-        desktopApi.on('power-monitor/screen-locked', disconnectAllDevices);
+        desktopApi.on('power-monitor/suspend', disconnectAllDevices);
 
         return () => {
-            desktopApi.removeAllListeners('power-monitor/screen-locked');
+            desktopApi.removeAllListeners('power-monitor/suspend');
         };
     }, [dispatch, knownDevices, isDesktopApiAvailable]);
 

--- a/suite-common/bluetooth/src/types.ts
+++ b/suite-common/bluetooth/src/types.ts
@@ -5,7 +5,8 @@ export type BluetoothAdapterStatus =
     | 'enabled'
     | 'disabled'
     | 'permission-denied'
-    | 'not-compatible';
+    | 'not-compatible'
+    | 'power-suspending';
 
 export type BluetoothScanStatus = 'idle' | 'running' | 'error';
 


### PR DESCRIPTION
## Description

### For MacOS

Previous PR #21260 seems to be a step in the right direction, but it doesn't fully work due to one thing - the disconnection happens too early and Suite actually starts connecting to the device again before the OS goes to sleep. This results in a failed connection attempt and the device thinks it's still connected, preventing it from reconnecting automatically after waking up.

This PR adds a new `power-suspending` state to the bluetooth adapter status, which is set when the OS is going to sleep based on the `suspend` event from powerMonitor in Electron. 
I changed that from the original `screen-locked` event, which happens earlier and should not affect the connection by itself. 
This state prevents Suite from attempting to connect to any devices, allowing the disconnection to complete successfully.

Once the OS wakes up, the adapter status is set back to `enabled` by an event from the adapter, and Suite can then reconnect to the devices as needed.

### For Windows

None of this seems to work on Windows - because once the `suspend` event comes, there's not enough time for us to do anything. Also the `screen-locked` event is not helpful, because that comes only after you wake it up again. 

But there is a solution - we can just do nothing. The device will stay connected and everything works correctly after waking up. Tested up to 30 mins. 

### For Linux

Also doesn't seem to help, similar situation as Windows, so we don't apply the workaround there. 

## Testing scenario

1. Open Suite with connected device
2. Lock screen and close lid on laptop
3. Wait for a minute
4. Trezor should not show any connected devices
5. Open and unlock laptop
6. Trezor should connect to Suite

## Related Issue

Resolve #21206

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-suspend-disconnect&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-suspend-disconnect&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/bt-suspend-disconnect&lookback=7)