### PR TITLE
refactor(suite-common): use better naming for Bluetooth selectors

### DIFF
--- a/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
@@ -1,7 +1,11 @@
 import { BLUETOOTH_PREFIX, bluetoothActions } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { selectSelectedDevice } from '@suite-common/wallet-core';
+import {
+    selectDeviceBluetoothId,
+    selectIsDeviceConnectedViaBluetooth,
+    selectSelectedDevice,
+} from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
@@ -56,14 +60,10 @@ const unpairCurrentBondThunk = createThunk<void, UnpairCurrentBondThunkParams, v
 export const bluetoothEraseBondsThunk = createThunk(
     `${BLUETOOTH_PREFIX}/bluetoothEraseBondsThunk`,
     async (_, { dispatch, getState }) => {
-        const device = selectSelectedDevice(getState());
-        if (!device || !device.features?.capabilities.includes('Capability_BLE')) {
-            return;
-        }
+        const isDeviceConnectedViaBluetooth = selectIsDeviceConnectedViaBluetooth(getState());
+        const bluetoothId = selectDeviceBluetoothId(getState());
 
-        const bluetoothId = device.bluetoothProps?.id;
-
-        if (bluetoothId !== undefined) {
+        if (isDeviceConnectedViaBluetooth && bluetoothId) {
             await dispatch(unpairCurrentBondThunk({ bluetoothId }));
         }
     },

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -8,7 +8,7 @@ import { AcquiredDevice } from '@suite-common/suite-types';
 import {
     DEVICE_LOW_BATTERY_PERCENTAGE_THRESHOLD,
     selectDevices,
-    selectIsBluetoothDevice,
+    selectIsDeviceConnectedViaBluetooth,
 } from '@suite-common/wallet-core';
 import { Column, Note, variables } from '@trezor/components';
 import { FirmwareType } from '@trezor/connect';
@@ -28,9 +28,9 @@ import {
 import { useDevice, useOnboarding, useSelector } from 'src/hooks/suite';
 import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 
-import { FirmwareLowBatteryModal } from './FirmwareLowBatteryModal';
 import { PrerequisitesGuide, Translation } from '../suite';
 import { FirmwareButtonsRow } from './Buttons/FirmwareButtonsRow';
+import { FirmwareLowBatteryModal } from './FirmwareLowBatteryModal';
 import { FirmwareSwitchWarning } from './FirmwareSwitchWarning';
 
 const Description = styled.div`
@@ -134,7 +134,7 @@ export const FirmwareInitial = ({
     const { isActive: isOnboarding, updateAnalytics } = useOnboarding();
     const devices = useSelector(selectDevices);
     const isDebug = useSelector(selectIsDebugModeActive);
-    const isBluetoothDevice = useSelector(selectIsBluetoothDevice);
+    const isDeviceConnectedViaBluetooth = useSelector(selectIsDeviceConnectedViaBluetooth);
 
     const [bitcoinOnlyOffer, setBitcoinOnlyOffer] = useState(false);
     const [showSkipConfirmation, setShowSkipConfirmation] = useState(false);
@@ -167,7 +167,7 @@ export const FirmwareInitial = ({
 
     const installFirmware = (firmwareType: FirmwareType) => {
         if (
-            isBluetoothDevice &&
+            isDeviceConnectedViaBluetooth &&
             device.features.soc &&
             device?.features.soc <= DEVICE_LOW_BATTERY_PERCENTAGE_THRESHOLD
         ) {

--- a/packages/suite/src/views/settings/SettingsDevice/FirmwareVersion.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/FirmwareVersion.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { getChangelogUrl } from '@suite-common/suite-utils';
 import {
     DEVICE_LOW_BATTERY_PERCENTAGE_THRESHOLD,
-    selectIsBluetoothDevice,
+    selectIsDeviceConnectedViaBluetooth,
 } from '@suite-common/wallet-core';
 import { Button, Tooltip } from '@trezor/components';
 import { getFirmwareVersion } from '@trezor/device-utils';
@@ -64,7 +64,7 @@ export const FirmwareVersion = ({ isDeviceLocked }: FirmwareVersionProps) => {
     const [lowBatteryWarning, setLowBatteryWarning] = useState(false);
     const dispatch = useDispatch();
     const { device } = useDevice();
-    const isBluetoothDevice = useSelector(selectIsBluetoothDevice);
+    const isDeviceConnectedViaBluetooth = useSelector(selectIsDeviceConnectedViaBluetooth);
 
     if (!device?.features) {
         return null;
@@ -77,7 +77,7 @@ export const FirmwareVersion = ({ isDeviceLocked }: FirmwareVersionProps) => {
 
     const handleUpdate = () => {
         if (
-            isBluetoothDevice &&
+            isDeviceConnectedViaBluetooth &&
             device.features?.soc &&
             device.features?.soc < DEVICE_LOW_BATTERY_PERCENTAGE_THRESHOLD
         ) {

--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -1,6 +1,7 @@
 import { Context } from '@suite-common/message-system';
 import { SUPPORTS_DEVICE_AUTHENTICITY_CHECK } from '@suite-common/suite-constants';
 import { isDeviceRemembered, isDeviceWithButtons } from '@suite-common/suite-utils';
+import { selectIsDeviceConnectedViaBluetooth } from '@suite-common/wallet-core';
 import { DeviceModelInternal, isBitcoinOnlyDevice } from '@trezor/device-utils';
 
 import { DeviceBanner, SettingsLayout, SettingsSection } from 'src/components/settings';
@@ -57,6 +58,7 @@ export const SettingsDevice = () => {
     const initializeMode = device?.mode === 'initialize';
     const isNormalMode = !bootloaderMode && !initializeMode;
     const deviceRemembered = isDeviceRemembered(device) && !device?.connected;
+    const isDeviceConnectedViaBluetooth = useSelector(selectIsDeviceConnectedViaBluetooth);
     const bitcoinOnlyDevice = isBitcoinOnlyDevice(device);
     const isPassphraseProtectionOn = Boolean(device?.features?.passphrase_protection);
     const flags = useSelector(selectSuiteFlags);
@@ -93,9 +95,6 @@ export const SettingsDevice = () => {
     const deviceModelInternal = device.features.internal_model;
 
     const supportsDeviceAuthentication = SUPPORTS_DEVICE_AUTHENTICITY_CHECK[deviceModelInternal];
-
-    const isBluetoothDevice = device.features?.capabilities.includes('Capability_BLE');
-    const isBluetoothConnectedDevice = device?.bluetoothProps?.id !== undefined;
 
     const isThpDevice = device?.thp !== undefined;
 
@@ -192,7 +191,7 @@ export const SettingsDevice = () => {
                 <FirmwareAuthenticityChecks />
             </SettingsSection>
 
-            {flags.isBluetoothEnabled && isBluetoothDevice && isBluetoothConnectedDevice && (
+            {flags.isBluetoothEnabled && isDeviceConnectedViaBluetooth && (
                 <SettingsSection title={<Translation id="TR_BLUETOOTH" />}>
                     <BluetoothEraseBonds isDeviceLocked={isDeviceLocked} />
                 </SettingsSection>

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -65,6 +65,16 @@ export const selectDeviceFeatures = createMemoizedSelector(
     device => device?.features,
 );
 
+export const selectDeviceCapabilities = createMemoizedSelector(
+    [selectDeviceFeatures],
+    features => features?.capabilities,
+);
+
+export const selectIsBluetoothDevice = createMemoizedSelector(
+    [selectDeviceCapabilities],
+    capabilities => !!capabilities?.includes('Capability_BLE'),
+);
+
 export const selectIsDeviceProtectedByPin = createMemoizedSelector(
     [selectDeviceFeatures],
     features => !!features?.pin_protection,
@@ -138,7 +148,7 @@ export const selectIsDeviceConnected = createMemoizedSelector(
     device => !!device?.connected,
 );
 
-export const selectIsBluetoothDevice = createMemoizedSelector(
+export const selectIsDeviceConnectedViaBluetooth = createMemoizedSelector(
     [selectSelectedDevice],
     device => !!device?.bluetoothProps,
 );
@@ -193,11 +203,6 @@ export const selectDeviceByBaseStaticSessionId = createMemoizedSelector(
 export const selectDeviceUnavailableCapabilities = createMemoizedSelector(
     [selectSelectedDevice],
     device => device?.unavailableCapabilities,
-);
-
-export const selectDeviceCapabilities = createMemoizedSelector(
-    [selectDeviceFeatures],
-    features => features?.capabilities,
 );
 
 export const selectHasDevicePassphraseEntryCapability = createMemoizedSelector(

--- a/suite-native/device/src/hooks/useWipeDevice.tsx
+++ b/suite-native/device/src/hooks/useWipeDevice.tsx
@@ -5,7 +5,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { isFulfilled } from '@reduxjs/toolkit';
 
 import {
-    selectIsBluetoothDevice,
+    selectIsDeviceConnectedViaBluetooth,
     selectSelectedDevice,
     wipeDeviceThunk,
 } from '@suite-common/wallet-core';
@@ -34,7 +34,7 @@ export const useWipeDevice = () => {
     const navigation = useNavigation<NavigationProps>();
 
     const device = useSelector(selectSelectedDevice);
-    const isBluetoothDevice = useSelector(selectIsBluetoothDevice);
+    const isDeviceConnectedViaBluetooth = useSelector(selectIsDeviceConnectedViaBluetooth);
 
     const wipeDevice = async () => {
         if (!device) return;
@@ -55,7 +55,7 @@ export const useWipeDevice = () => {
         });
 
         if (response.success && isFulfilled(response.payload)) {
-            if (isBluetoothDevice) {
+            if (isDeviceConnectedViaBluetooth) {
                 dispatch(setShouldShowSystemUnpairingAlert(true));
             }
             navigation.navigate(RootStackRoutes.DeviceSettingsStack, {

--- a/suite-native/firmware/src/hooks/useFirmware.tsx
+++ b/suite-native/firmware/src/hooks/useFirmware.tsx
@@ -6,7 +6,7 @@ import {
     UseFirmwareInstallationParams,
     useFirmwareInstallation,
 } from '@suite-common/firmware';
-import { selectIsBluetoothDevice } from '@suite-common/wallet-core';
+import { selectIsDeviceConnectedViaBluetooth } from '@suite-common/wallet-core';
 import { TxKeyPath, useTranslate } from '@suite-native/intl';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { setPriorityMode } from '@trezor/react-native-usb';
@@ -45,7 +45,9 @@ export const useFirmware = (
 
     // When the device is restarted after FW installation via Bluetooth, this flag changes to false
     // for a moment which triggers firmwareUpdate again. => Use ref to prevent this.
-    const isBluetoothDeviceRef = useRef(useSelector(selectIsBluetoothDevice));
+    const isDeviceConnectedViaBluetoothRef = useRef(
+        useSelector(selectIsDeviceConnectedViaBluetooth),
+    );
 
     const setIsFirmwareInstallationRunning = useCallback(
         (isRunning: boolean) => {
@@ -80,7 +82,7 @@ export const useFirmware = (
     }, [progress, status, setMayBeStuckedTimeout, resetMayBeStuckedTimeout]);
 
     const firmwareUpdate = useCallback(async () => {
-        if (!isBluetoothDeviceRef.current) {
+        if (!isDeviceConnectedViaBluetoothRef.current) {
             setPriorityMode(true);
         }
         const result = await firmwareUpdateCommon({ ignoreBaseUrl: true })
@@ -94,7 +96,7 @@ export const useFirmware = (
             })
             .then(({ connectResponse }) => connectResponse)
             .finally(() => {
-                if (!isBluetoothDeviceRef.current) {
+                if (!isDeviceConnectedViaBluetoothRef.current) {
                     setPriorityMode(false);
                 }
                 resetMayBeStuckedTimeout();

--- a/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
@@ -5,8 +5,8 @@ import {
     selectDeviceLabel,
     selectDeviceModel,
     selectDeviceName,
-    selectIsBluetoothDevice,
     selectIsDeviceBackupUnfinished,
+    selectIsDeviceConnectedViaBluetooth,
     selectIsDeviceInitialized,
 } from '@suite-common/wallet-core';
 import { TitledSection, VStack } from '@suite-native/atoms';
@@ -30,7 +30,7 @@ export const DeviceSettingsModalScreen = () => {
     const deviceName = useSelector(selectDeviceName);
     const deviceLabel = useSelector(selectDeviceLabel);
     const navigateToInitialScreen = useNavigateToInitialScreen();
-    const isBluetoothDevice = useSelector(selectIsBluetoothDevice);
+    const isDeviceConnectedViaBluetooth = useSelector(selectIsDeviceConnectedViaBluetooth);
     const isDeviceBackupUnfinished = useSelector(selectIsDeviceBackupUnfinished);
     const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
     const isCheckBackupAvailable = isDeviceInitialized && !isDeviceBackupUnfinished;
@@ -50,8 +50,8 @@ export const DeviceSettingsModalScreen = () => {
                 >
                     {isDeviceInitialized && <DevicePinProtectionCard />}
                     <DeviceFirmwareCard />
-                    {isBluetoothDevice && <DeviceBluetoothCard />}
-                    {isBluetoothDevice && <DeviceAutoConnectCard />}
+                    {isDeviceConnectedViaBluetooth && <DeviceBluetoothCard />}
+                    {isDeviceConnectedViaBluetooth && <DeviceAutoConnectCard />}
                 </TitledSection>
                 <TitledSection
                     title={<Translation id="moduleDeviceSettings.sectionTitles.security" />}


### PR DESCRIPTION
Align with desktop usage, see e.g. `SettingsDevice`.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/common/select-is-bluetooth-device&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/common/select-is-bluetooth-device&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/common/select-is-bluetooth-device&lookback=7)