### PR TITLE
fix(suite): allow autoconnect for uninitialized devices

### DIFF
--- a/suite-common/thp/src/connectThpDeviceThunk.ts
+++ b/suite-common/thp/src/connectThpDeviceThunk.ts
@@ -8,7 +8,7 @@ import { selectThpCredentials } from './thpSelectors';
 const NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT = 3;
 
 type ConnectThpDeviceThinkParams = {
-    device: Pick<Device, 'thp' | 'features'>;
+    device: Pick<Device, 'thp'>;
 };
 
 export const connectThpDeviceThunk = createThunk<void, ConnectThpDeviceThinkParams, void>(
@@ -27,8 +27,7 @@ export const connectThpDeviceThunk = createThunk<void, ConnectThpDeviceThinkPara
         if (credential !== undefined) {
             // We do not want to offer Autoconnect after reconnection dues to Firmware installation.
             // Autoconnect will be offered on the next reconnection.
-            // Also, do not offer Autoconnect if reconnecting a device with Firmware, but not yet a wallet.
-            if (!isFwInstall && device.features?.initialized === true) {
+            if (!isFwInstall) {
                 dispatch(thpActions.incrementCredentialConnectionCounter({ credential }));
             }
 

--- a/suite-common/thp/tests/connectThpDeviceThunk.test.ts
+++ b/suite-common/thp/tests/connectThpDeviceThunk.test.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { FirmwareUpdateState, prepareFirmwareReducer } from '@suite-common/firmware';
-import { configureMockStore, extraDependenciesMock, testMocks } from '@suite-common/test-utils';
+import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
 import { Device } from '@trezor/connect';
 
 import { connectThpDeviceThunk } from '../src/connectThpDeviceThunk';
@@ -30,9 +30,8 @@ const initialFirmwareState: FirmwareUpdateState = {
     firmwareUpdateSource: 'production',
 };
 
-const device: Pick<Device, 'thp' | 'features'> = {
+const device: Pick<Device, 'thp'> = {
     thp: { ...createDeviceThp(), credentials: [thpCredential1] },
-    features: testMocks.getDeviceFeatures(),
 };
 
 describe(connectThpDeviceThunk.name, () => {
@@ -75,24 +74,6 @@ describe(connectThpDeviceThunk.name, () => {
         });
 
         store.dispatch(connectThpDeviceThunk({ device }));
-        expect(store.getState().thp.credentials[0].connectionCounter).toEqual(0);
-        expect(store.getState().thp.credentials[1].connectionCounter).toEqual(0);
-        expect(store.getState().thp.step).toEqual(null);
-    });
-
-    it("won't update the connection counter for credential when not initialized", () => {
-        const store = configureMockStore({
-            extra: {},
-            reducer: combineReducers({ thp: thpReduce, firmware: firmwareReduce }),
-            preloadedState: { thp: initialThpState, firmware: initialFirmwareState },
-        });
-
-        const nonInitializedDevice = {
-            ...device,
-            features: { ...testMocks.getDeviceFeatures(), initialized: false },
-        };
-
-        store.dispatch(connectThpDeviceThunk({ device: nonInitializedDevice }));
         expect(store.getState().thp.credentials[0].connectionCounter).toEqual(0);
         expect(store.getState().thp.credentials[1].connectionCounter).toEqual(0);
         expect(store.getState().thp.step).toEqual(null);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- we want to increment connection counter for all thp connections, even for uninitialized devices

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21440

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-autoconnect&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-autoconnect&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thp-autoconnect&lookback=7)