### PR TITLE
feat(suite-native): hide swap dex quotes behind feature flag

### DIFF
--- a/suite-native/config/src/launch-arguments.ts
+++ b/suite-native/config/src/launch-arguments.ts
@@ -17,6 +17,7 @@ export type LaunchArguments = {
     isFirmwareUpdateEnabled?: boolean;
     isLocalizationEnabled?: boolean;
     isLocalFirstStorageEnabled?: boolean;
+    areTradingExchangeDexesEnabled?: boolean;
 };
 
 export const launchArguments = LaunchArguments.value<LaunchArguments>();

--- a/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
@@ -27,6 +27,7 @@ describe('featureFlagsSlice', () => {
                 isTradingBuyEnabled: false,
                 isTradingExchangeEnabled: false,
                 isTradingSellEnabled: false,
+                areTradingExchangeDexesEnabled: false,
                 isLocalizationEnabled: false,
             });
         });
@@ -53,6 +54,7 @@ describe('featureFlagsSlice', () => {
                 isTradingBuyEnabled: false,
                 isTradingExchangeEnabled: false,
                 isTradingSellEnabled: false,
+                areTradingExchangeDexesEnabled: false,
                 isLocalizationEnabled: false,
             });
         });

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -13,6 +13,7 @@ export const FeatureFlag = {
     IsTradingBuyEnabled: 'isTradingBuyEnabled',
     IsTradingExchangeEnabled: 'isTradingExchangeEnabled',
     IsTradingSellEnabled: 'isTradingSellEnabled',
+    AreTradingExchangeDexesEnabled: 'areTradingExchangeDexesEnabled',
     IsLocalizationEnabled: 'isLocalizationEnabled',
     IsLocalFirstStorageEnabled: 'isLocalFirstStorageEnabled',
 } as const;
@@ -46,6 +47,8 @@ export const featureFlagsInitialState: FeatureFlagsState = {
         process.env.EXPO_PUBLIC_FF_IS_TRADING_SWAP_ENABLED === 'true',
     [FeatureFlag.IsTradingSellEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_TRADING_SELL_ENABLED === 'true',
+    [FeatureFlag.AreTradingExchangeDexesEnabled]:
+        process.env.EXPO_PUBLIC_FF_ARE_TRADING_EXCHANGE_DEXES_ENABLED === 'true',
     [FeatureFlag.IsLocalizationEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_LOCALIZATION_ENABLED === 'true',
     [FeatureFlag.IsLocalFirstStorageEnabled]:
@@ -62,6 +65,7 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsTradingBuyEnabled,
     FeatureFlag.IsTradingExchangeEnabled,
     FeatureFlag.IsTradingSellEnabled,
+    FeatureFlag.AreTradingExchangeDexesEnabled,
     FeatureFlag.IsLocalFirstStorageEnabled,
     FeatureFlag.IsLocalizationEnabled,
 ];

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -23,6 +23,7 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsTradingBuyEnabled]: '💰 Trading Buy',
     [FeatureFlagEnum.IsTradingExchangeEnabled]: '💰 Trading Swap',
     [FeatureFlagEnum.IsTradingSellEnabled]: '💰 Trading Sell',
+    [FeatureFlagEnum.AreTradingExchangeDexesEnabled]: '💰 Trading Exchange Dexes Enabled',
     [FeatureFlagEnum.IsLocalizationEnabled]: '🌍 Localization',
     [FeatureFlagEnum.IsLocalFirstStorageEnabled]: 'Local First Storage (Labels)',
 } as const satisfies Record<FeatureFlagEnum, string>;

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -2,6 +2,7 @@ import { ExchangeTrade } from 'invity-api';
 
 import { tradingExchangeActions } from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';
+import { FeatureFlag, FeatureFlagsRootState } from '@suite-native/feature-flags';
 import {
     PreloadedState,
     TestStore,
@@ -31,6 +32,9 @@ describe('useExchangeForm', () => {
                 tradeType: 'exchange',
                 bitcoinAmountUnit,
             }),
+            featureFlags: {
+                [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
+            } as FeatureFlagsRootState['featureFlags'],
         };
 
         return await initStore(preloadedState);

--- a/suite-native/module-trading/src/selectors/__tests__/exchangeSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/exchangeSelectors.test.ts
@@ -2,6 +2,7 @@ import { CryptoId } from 'invity-api';
 
 import { AccountsRootState } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
+import { FeatureFlag, FeatureFlagsRootState } from '@suite-native/feature-flags';
 
 import { getBtcAccount } from '../../__fixtures__/account';
 import { exchangeQuotes } from '../../__fixtures__/exchangeQuotes';
@@ -18,11 +19,14 @@ import {
 } from '../exchangeSelectors';
 
 describe('exchangeSelectors', () => {
-    let state: TradingRootState & AccountsRootState;
+    let state: TradingRootState & AccountsRootState & FeatureFlagsRootState;
 
     beforeEach(() => {
         state = {
             wallet: getWalletState({ tradeType: 'exchange' }),
+            featureFlags: {
+                [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
+            } as FeatureFlagsRootState['featureFlags'],
         };
     });
 
@@ -160,7 +164,7 @@ describe('exchangeSelectors', () => {
             });
         });
 
-        it('should group quotes by fixed/float/dex', () => {
+        it('should group quotes by fixed/float/dex when DEX feature flag is enabled', () => {
             state.wallet.trading.exchange.quotes = exchangeQuotes;
 
             const groupedQuotes = selectGroupedExchangeQuotes(state);
@@ -188,6 +192,29 @@ describe('exchangeSelectors', () => {
                     }),
                 ],
             });
+        });
+
+        it('should exclude DEX quotes when DEX feature flag is disabled', () => {
+            state.wallet.trading.exchange.quotes = exchangeQuotes;
+            state.featureFlags[FeatureFlag.AreTradingExchangeDexesEnabled] = false;
+
+            const groupedQuotes = selectGroupedExchangeQuotes(state);
+
+            expect(groupedQuotes.dex).toEqual([]);
+        });
+
+        it('should sort quotes by rate within each group (highest rate first)', () => {
+            state.wallet.trading.exchange.quotes = exchangeQuotes;
+
+            const groupedQuotes = selectGroupedExchangeQuotes(state);
+
+            // Fixed quotes should be sorted by rate (highest first)
+            expect(groupedQuotes.fixed[0].rate ?? 0).toBeGreaterThan(
+                groupedQuotes.fixed[1].rate ?? 0,
+            );
+
+            // DEX quotes should be sorted by rate (highest first)
+            expect(groupedQuotes.dex[0].rate ?? 0).toBeGreaterThan(groupedQuotes.dex[1].rate ?? 0);
         });
 
         it('should be stable', () => {

--- a/suite-native/module-trading/src/selectors/exchangeSelectors.ts
+++ b/suite-native/module-trading/src/selectors/exchangeSelectors.ts
@@ -1,10 +1,16 @@
 import { ExchangeTrade } from 'invity-api';
 
+import { createWeakMapSelector } from '@suite-common/redux-utils';
 import {
     selectTradingExchangeBuyCryptoIds,
     selectTradingExchangeProviders,
 } from '@suite-common/trading';
 import { selectAccountByKey } from '@suite-common/wallet-core';
+import {
+    FeatureFlag,
+    FeatureFlagsRootState,
+    selectIsFeatureFlagEnabled,
+} from '@suite-native/feature-flags';
 
 import {
     TradingRootState,
@@ -16,6 +22,11 @@ import {
     coinInfoToTradeableAsset,
     tradeableAssetSortingComparator,
 } from '../utils/general/tradeableAssetUtils';
+
+export type TradingWithFeatureFlagsRootState = TradingRootState & FeatureFlagsRootState;
+
+const createTradingWithFeatureFlagsMemoizedSelector =
+    createWeakMapSelector.withTypes<TradingWithFeatureFlagsRootState>();
 
 export const selectTradingExchange = (state: TradingRootState) => state.wallet.trading.exchange;
 
@@ -61,14 +72,16 @@ const ratingSortingComparator = (
     b: { rate?: number | undefined },
 ) => (b.rate ?? 0) - (a.rate ?? 0);
 
-export const selectGroupedExchangeQuotes = createMemoizedSelector(
+export const selectGroupedExchangeQuotes = createTradingWithFeatureFlagsMemoizedSelector(
     [
         selectExchangeQuotes,
         selectTradingExchangeProviders as unknown as (
             state: TradingRootState,
         ) => ReturnType<typeof selectTradingExchangeProviders>,
+        (state: TradingWithFeatureFlagsRootState) =>
+            selectIsFeatureFlagEnabled(state, FeatureFlag.AreTradingExchangeDexesEnabled),
     ],
-    (quotes, providers = {}) => {
+    (quotes, providers = {}, areTradingExchangeDexesEnabled) => {
         const groups = {
             fixed: [] as ExchangeTrade[],
             float: [] as ExchangeTrade[],
@@ -80,6 +93,9 @@ export const selectGroupedExchangeQuotes = createMemoizedSelector(
             const { isFixedRate } = providers[exchange] || {};
 
             if (isDex) {
+                if (!areTradingExchangeDexesEnabled) {
+                    return;
+                }
                 groups.dex.push(quote);
             } else if (isFixedRate) {
                 groups.fixed.push(quote);


### PR DESCRIPTION
We will support only CEX Swaps in the beginning. This PR hides DEX quotes behind `AreTradingExchangeDexesEnabled` feature flag.

## Related Issue

Resolve #21696

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=21696-mobile-swap-disable-dex-quotes-via-featureflag&lookback=7)