### PR TITLE
Better signal propagation in `sendThpMessage`

### DIFF
--- a/packages/transport/src/thp/send.ts
+++ b/packages/transport/src/thp/send.ts
@@ -65,7 +65,11 @@ export const sendThpMessage = async ({
 
                 // read until ThpAck or ThpError
                 return scheduleAction(
-                    () => apiReadWithExpectedHeaders(protocolThp.getExpectedHeaders(thpState)),
+                    signal =>
+                        apiReadWithExpectedHeaders(
+                            protocolThp.getExpectedHeaders(thpState),
+                            signal,
+                        ),
                     {
                         signal: attemptSignal,
                         deadline: Date.now() + THP_ACK_DEADLINE,

--- a/packages/transport/src/utils/readWithExpectedHeaders.ts
+++ b/packages/transport/src/utils/readWithExpectedHeaders.ts
@@ -67,12 +67,12 @@ async function readAndAssert<T extends Receiver>(
 // returns function: (expectedHeaders: Buffer[]) => ReturnType<AbstractApi['read']>
 // read until received chunk contains expected header and ignore other chunks
 export function readWithExpectedHeaders<T extends Receiver>(receiver: T, options: Options = {}) {
-    return (expectedHeaders?: Buffer[]) =>
+    return (expectedHeaders?: Buffer[], signal?: AbortSignal) =>
         scheduleAction(
             attemptSignal =>
                 readAndAssert(receiver, expectedHeaders, { ...options, signal: attemptSignal }),
             {
-                signal: options?.signal,
+                signal: signal ?? options?.signal,
                 graceful: options?.graceful,
                 attempts: options?.attempts || Infinity,
                 timeout: options?.timeout,


### PR DESCRIPTION
## Description

Nested `scheduleAction`'s in `sendThpMessage` didn't correctly pass their signal, which sometimes causes unaborted previous iterations during the following ones.

This is the minimum fix for the known issue (see below), but a) we have to make sure that it doesn't cause new issues in another contexts and b) I'm going to polish the thp send/receive code anyway, so I hope it's very temporary.

## Related Issue

In my case resolves #21622


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-deadline-signal&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-deadline-signal&lookback=7)