### PR TITLE
fix(suite): use the `HiddenPlaceholder` on correct DOM level

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/dashboard/discreet-mode.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/dashboard/discreet-mode.test.ts
@@ -46,7 +46,7 @@ test.describe('Discreet Mode', { tag: ['@group=suite'] }, () => {
                 await verifyHiddenAndRevealedValue({
                     locator: walletPage.balanceOfAccount('btc'),
                     hiddenValue: '###',
-                    revealedValue: '0',
+                    revealedValue: '###',
                 });
             });
 

--- a/packages/suite/src/components/suite/FormattedNftAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedNftAmount.tsx
@@ -8,7 +8,7 @@ import { Box, Column, Row, Text } from '@trezor/components';
 import { TokenTransfer } from '@trezor/connect';
 import { TypographyStyle, spacings } from '@trezor/theme';
 
-import { HiddenPlaceholder, Sign } from 'src/components/suite';
+import { RedactNumericalValue, Sign } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 // importing directly, otherwise unit tests fail, seems to be a styled-components issue
 import { TrezorLink } from 'src/components/suite/TrezorLink';
@@ -51,84 +51,80 @@ export const FormattedNftAmount = ({
         const tokens = transfer.multiTokenValues;
 
         return (
-            <HiddenPlaceholder>
-                <Column alignItems={alignMultitoken}>
-                    {tokens?.map((token, index) => (
-                        <Row key={`${token.id}-${index}`} gap={spacings.xxs}>
-                            <Row>
-                                {signValue ? <Sign value={signValue} /> : null}
-                                {transfer.name ? (
-                                    <BlurUrls
-                                        text={translationString('TR_COLLECTION_NAME_OF_TOKEN_ID', {
-                                            tokenValue: token.value,
-                                            collectionName: transfer.name,
-                                        })}
-                                    />
-                                ) : (
-                                    <Row gap={spacings.xxs}>
-                                        <Row>{token.value}x</Row>
-                                        <Translation id="TR_TOKEN_ID_COLON" />
-                                    </Row>
-                                )}
-                            </Row>
-                            {isWithLink && network?.networkType === 'ethereum' ? (
-                                <TrezorLink
-                                    href={`${getExplorerUrl(explorer, 'nft')}/${transfer.contract}/${token.id}`}
-                                    color={theme.textSecondaryHighlight}
-                                    variant="underline"
-                                    typographyStyle={linkTypographyStyle}
-                                >
-                                    <Text maxWidth={145} ellipsisLineCount={1}>
-                                        {token.id}
-                                    </Text>
-                                </TrezorLink>
+            <Column alignItems={alignMultitoken}>
+                {tokens?.map((token, index) => (
+                    <Row key={`${token.id}-${index}`} gap={spacings.xxs}>
+                        <Row>
+                            {signValue ? <Sign value={signValue} /> : null}
+                            {transfer.name ? (
+                                <BlurUrls
+                                    text={translationString('TR_COLLECTION_NAME_OF_TOKEN_ID', {
+                                        tokenValue: token.value,
+                                        collectionName: transfer.name,
+                                    })}
+                                />
                             ) : (
+                                <Row gap={spacings.xxs}>
+                                    <Row>{token.value}x</Row>
+                                    <Translation id="TR_TOKEN_ID_COLON" />
+                                </Row>
+                            )}
+                        </Row>
+                        {isWithLink && network?.networkType === 'ethereum' ? (
+                            <TrezorLink
+                                href={`${getExplorerUrl(explorer, 'nft')}/${transfer.contract}/${token.id}`}
+                                color={theme.textSecondaryHighlight}
+                                variant="underline"
+                                typographyStyle={linkTypographyStyle}
+                            >
                                 <Text maxWidth={145} ellipsisLineCount={1}>
                                     {token.id}
                                 </Text>
-                            )}
-                        </Row>
-                    ))}
-                </Column>
-            </HiddenPlaceholder>
+                            </TrezorLink>
+                        ) : (
+                            <Text maxWidth={145} ellipsisLineCount={1}>
+                                {token.id}
+                            </Text>
+                        )}
+                    </Row>
+                ))}
+            </Column>
         );
     }
 
     return (
-        <HiddenPlaceholder>
-            <Row className={className}>
-                {signValue ? <Sign value={signValue} /> : null}
-                <Box margin={{ right: spacings.xxs }}>
-                    <Translation id="TR_TOKEN_ID_COLON" />
-                </Box>
-                {isWithLink ? (
-                    <TrezorLink
-                        href={
-                            network?.networkType === 'ethereum'
-                                ? `${getExplorerUrl(explorer, 'nft')}/${transfer.contract}/${transfer.amount}`
-                                : undefined
-                        }
-                        color={theme.textSecondaryHighlight}
-                        variant="underline"
-                        typographyStyle={linkTypographyStyle}
-                    >
-                        <Row gap={spacings.zero}>
-                            <Text maxWidth={145} ellipsisLineCount={1}>
-                                {transfer.amount}
-                            </Text>
-                            &nbsp;
-                            {symbolComponent}
-                        </Row>
-                    </TrezorLink>
-                ) : (
-                    <Row gap={spacings.xxs}>
+        <Row className={className}>
+            {signValue ? <Sign value={signValue} /> : null}
+            <Box margin={{ right: spacings.xxs }}>
+                <Translation id="TR_TOKEN_ID_COLON" />
+            </Box>
+            {isWithLink ? (
+                <TrezorLink
+                    href={
+                        network?.networkType === 'ethereum'
+                            ? `${getExplorerUrl(explorer, 'nft')}/${transfer.contract}/${transfer.amount}`
+                            : undefined
+                    }
+                    color={theme.textSecondaryHighlight}
+                    variant="underline"
+                    typographyStyle={linkTypographyStyle}
+                >
+                    <Row gap={spacings.zero}>
                         <Text maxWidth={145} ellipsisLineCount={1}>
-                            {transfer.amount}
+                            <RedactNumericalValue value={transfer.amount} />
                         </Text>
+                        &nbsp;
                         {symbolComponent}
                     </Row>
-                )}
-            </Row>
-        </HiddenPlaceholder>
+                </TrezorLink>
+            ) : (
+                <Row gap={spacings.xxs}>
+                    <Text maxWidth={145} ellipsisLineCount={1}>
+                        <RedactNumericalValue value={transfer.amount} />
+                    </Text>
+                    {symbolComponent}
+                </Row>
+            )}
+        </Row>
     );
 };

--- a/packages/suite/src/components/suite/RedactNumericalValue.tsx
+++ b/packages/suite/src/components/suite/RedactNumericalValue.tsx
@@ -1,5 +1,7 @@
 import { redactNumericalSubstring, useShouldRedactNumbers } from '@suite-common/wallet-utils';
 
+import { HiddenPlaceholder } from './HiddenPlaceholder';
+
 type RedactNumbersProps = {
     value: string | number;
 };
@@ -8,5 +10,16 @@ type RedactNumbersProps = {
  * Helper that redacts sensitive content, if it should be hidden in discreet mode.
  * It is effective only when wrapped by HiddenPlaceholder upstream.
  */
-export const RedactNumericalValue = ({ value }: RedactNumbersProps) =>
-    useShouldRedactNumbers() ? redactNumericalSubstring(value) : value;
+const RedactNumericalValueInner = ({ value }: RedactNumbersProps) => {
+    const shouldRedactNumbers = useShouldRedactNumbers();
+
+    return shouldRedactNumbers ? redactNumericalSubstring(value) : value;
+};
+
+export function RedactNumericalValue({ value }: RedactNumbersProps) {
+    return (
+        <HiddenPlaceholder>
+            <RedactNumericalValueInner value={value} />
+        </HiddenPlaceholder>
+    );
+}

--- a/packages/suite/src/components/suite/Ticker/PriceTicker.tsx
+++ b/packages/suite/src/components/suite/Ticker/PriceTicker.tsx
@@ -4,7 +4,7 @@ import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { TokenAddress } from '@suite-common/wallet-types';
 import { typography } from '@trezor/theme';
 
-import { BaseCurrencyValue } from 'src/components/suite';
+import { BaseCurrencyValue, HiddenPlaceholder } from 'src/components/suite';
 
 import { LastUpdateTooltip } from './LastUpdateTooltip';
 import { NoRatesTooltip } from './NoRatesTooltip';
@@ -37,25 +37,27 @@ export const PriceTicker = ({
     const emptyStateComponent = noEmptyStateTooltip ? <Empty>—</Empty> : <NoRatesTooltip />;
 
     return (
-        <BaseCurrencyValue
-            amount="1"
-            symbol={symbol}
-            tokenAddress={contractAddress}
-            showLoadingSkeleton={showLoadingSkeleton}
-            fiatRateFormatterOptions={{
-                minimumFractionDigits: 0,
-                maximumFractionDigits: 4,
-            }}
-        >
-            {({ rate, timestamp }) =>
-                rate && timestamp ? (
-                    <LastUpdateTooltip timestamp={timestamp}>
-                        <FiatRateWrapper>{rate}</FiatRateWrapper>
-                    </LastUpdateTooltip>
-                ) : (
-                    emptyStateComponent
-                )
-            }
-        </BaseCurrencyValue>
+        <HiddenPlaceholder>
+            <BaseCurrencyValue
+                amount="1"
+                symbol={symbol}
+                tokenAddress={contractAddress}
+                showLoadingSkeleton={showLoadingSkeleton}
+                fiatRateFormatterOptions={{
+                    minimumFractionDigits: 0,
+                    maximumFractionDigits: 4,
+                }}
+            >
+                {({ rate, timestamp }) =>
+                    rate && timestamp ? (
+                        <LastUpdateTooltip timestamp={timestamp}>
+                            <FiatRateWrapper>{rate}</FiatRateWrapper>
+                        </LastUpdateTooltip>
+                    ) : (
+                        emptyStateComponent
+                    )
+                }
+            </BaseCurrencyValue>
+        </HiddenPlaceholder>
     );
 };

--- a/packages/suite/src/components/wallet/BigAmountValue.tsx
+++ b/packages/suite/src/components/wallet/BigAmountValue.tsx
@@ -1,15 +1,12 @@
-import { PropsWithChildren } from 'react';
-
 import styled from 'styled-components';
 
 import { Locale } from '@suite-common/suite-types';
-import { useShouldRedactNumbers } from '@suite-common/wallet-utils';
+import { redactNumericalSubstring, useShouldRedactNumbers } from '@suite-common/wallet-utils';
 import { typography } from '@trezor/theme';
 
 import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 import { useSelector } from '../../hooks/suite';
-import { RedactNumericalValue } from '../suite';
 
 const ValueWrapper = styled.div`
     display: flex;
@@ -31,10 +28,6 @@ const DecimalValue = styled.div<{ $size: 'large' | 'medium' }>`
     color: ${({ theme }) => theme.textSubdued};
 `;
 
-// redacted value placeholder doesn't have to be displayed twice, display it only for whole value
-const HideRedactedValue = ({ children }: PropsWithChildren) =>
-    useShouldRedactNumbers() ? null : children;
-
 type BigAmountValueProps = {
     formattedStringAmount: string;
     'data-testid'?: string;
@@ -54,17 +47,19 @@ export const BigAmountValue = ({
         ? formattedStringAmount.split(/(\.)/)
         : formattedStringAmount.split(/(,)/);
 
+    const shouldRedactNumbers = useShouldRedactNumbers();
+
     return (
         <ValueWrapper data-testid={dataTestId}>
             <WholeValue $size={size}>
-                <RedactNumericalValue value={whole} />
+                {shouldRedactNumbers ? redactNumericalSubstring(whole) : whole}
             </WholeValue>
-            <HideRedactedValue>
+            {!shouldRedactNumbers && (
                 <DecimalValue $size={size}>
                     {separator}
                     {fractional}
                 </DecimalValue>
-            </HideRedactedValue>
+            )}
         </ValueWrapper>
     );
 };

--- a/packages/suite/src/components/wallet/FiatHeader.tsx
+++ b/packages/suite/src/components/wallet/FiatHeader.tsx
@@ -35,7 +35,7 @@ const useFiatAmount = ({ amount, symbol }: UseFiatAmountProps) => {
 /**
  * If `symbol` is not provided, `amount` is returned as is, otherwise it is converted to fiat currency.
  */
-export const FiatHeader = ({
+const FiatHeaderContent = ({
     amount,
     symbol,
     size,
@@ -53,12 +53,16 @@ export const FiatHeader = ({
     const formattedFiatAmount = formattedAmount?.props.children;
 
     return (
-        <HiddenPlaceholder enforceIntensity={10}>
-            <BigAmountValue
-                formattedStringAmount={formattedFiatAmount}
-                data-testid={dataTestId}
-                size={size}
-            />
-        </HiddenPlaceholder>
+        <BigAmountValue
+            formattedStringAmount={formattedFiatAmount}
+            data-testid={dataTestId}
+            size={size}
+        />
     );
 };
+
+export const FiatHeader = (props: FiatHeaderProps) => (
+    <HiddenPlaceholder enforceIntensity={10}>
+        <FiatHeaderContent {...props} />
+    </HiddenPlaceholder>
+);

--- a/suite-common/formatters/src/makeFormatter.tsx
+++ b/suite-common/formatters/src/makeFormatter.tsx
@@ -48,7 +48,7 @@ export const makeFormatter = <TInput, TOutput, TDataContext extends DataContext 
     displayName = 'Formatter',
 ): Formatter<TInput, TOutput, TDataContext> => {
     const FormatterComponent: Formatter<TInput, TOutput, TDataContext> = props => (
-        <>{format(props.value, props, useShouldRedactNumbers())}</>
+        <>{format(props.value, props, useShouldRedactNumbers({ strict: false }))}</>
     );
     FormatterComponent.displayName = displayName;
 

--- a/suite-common/wallet-utils/src/discreetModeUtils.ts
+++ b/suite-common/wallet-utils/src/discreetModeUtils.ts
@@ -17,9 +17,7 @@ type RedactNumbersContextData = { shouldRedactNumbers: boolean };
 /**
  * Context to inform all components in a tree below that they should redact numbers in the displayed output.
  */
-export const RedactNumbersContext = createContext<RedactNumbersContextData>({
-    shouldRedactNumbers: false,
-});
+export const RedactNumbersContext = createContext<RedactNumbersContextData | null>(null);
 
 /**
  * Determine whether we are under a component that currently requests to redact the numbers for discreet mode.
@@ -27,5 +25,15 @@ export const RedactNumbersContext = createContext<RedactNumbersContextData>({
  * See also a helper RedactNumericalValue
  * @returns shouldRedactNumbers whether numbers should be redacted in displayed output
  */
-export const useShouldRedactNumbers = () =>
-    useContext(RedactNumbersContext)?.shouldRedactNumbers ?? false;
+export const useShouldRedactNumbers = () => {
+    const ctx = useContext(RedactNumbersContext);
+
+    // Always check the context has been set before using it. Never silently fallback to false, that would produce a bug and promote incorrect usage of the hook, i.e. outside of `HiddenPlaceholder`)
+    if (!ctx) {
+        throw new Error(
+            'useShouldRedactNumbers must be used within a `HiddenPlaceholder` component',
+        );
+    }
+
+    return ctx.shouldRedactNumbers;
+};

--- a/suite-common/wallet-utils/src/discreetModeUtils.ts
+++ b/suite-common/wallet-utils/src/discreetModeUtils.ts
@@ -19,21 +19,31 @@ type RedactNumbersContextData = { shouldRedactNumbers: boolean };
  */
 export const RedactNumbersContext = createContext<RedactNumbersContextData | null>(null);
 
+export interface UseShouldRedactNumbersProps {
+    /**
+     * If true, throw an error if the context is not set.
+     * The hook is used in formatters which are also used in suite-native where isn't used this context. So it's not always possible to be in the strict mode.
+     */
+    strict?: boolean;
+}
+
 /**
  * Determine whether we are under a component that currently requests to redact the numbers for discreet mode.
  * It may only return true if the component is wrapped in HiddenPlaceholder upstream.
  * See also a helper RedactNumericalValue
  * @returns shouldRedactNumbers whether numbers should be redacted in displayed output
  */
-export const useShouldRedactNumbers = () => {
+export const useShouldRedactNumbers = ({ strict = true }: UseShouldRedactNumbersProps = {}) => {
     const ctx = useContext(RedactNumbersContext);
 
-    // Always check the context has been set before using it. Never silently fallback to false, that would produce a bug and promote incorrect usage of the hook, i.e. outside of `HiddenPlaceholder`)
-    if (!ctx) {
+    /**
+     * Check the context has been set before using it. Prevent silently failling, producing a bug or promoting incorrect usage of the hook, i.e. outside of `HiddenPlaceholder`.
+     */
+    if (!ctx && strict) {
         throw new Error(
             'useShouldRedactNumbers must be used within a `HiddenPlaceholder` component',
         );
     }
 
-    return ctx.shouldRedactNumbers;
+    return ctx?.shouldRedactNumbers ?? false;
 };


### PR DESCRIPTION
## Description

The `useShouldRedactNumbers` reads context set in the `HiddenPlaceholder` component. Therefore, the `HiddenPlaceholder` component must be always used above `useShouldRedactNumbers` hook.

The `useShouldRedactNumbers` hook silentetly failed and thus it was easy to make the mistake. Now the `useShouldRedactNumbers` throws an error if it is used outside the `HiddenPlaceholder`.

<!--- Describe your changes in detail -->

## Related Issue

Resolve #15654

## Screenshots:
<img width="1229" height="445" alt="Snímek obrazovky 2025-09-19 v 17 34 10" src="https://github.com/user-attachments/assets/adac8d6f-38dd-4c22-bf9f-930dee591a03" />

And with disabled blur filter to see those values have been correctly redacted:
<img width="1213" height="352" alt="Snímek obrazovky 2025-09-19 v 17 34 24" src="https://github.com/user-attachments/assets/c7d0b883-24c2-431f-bf7c-32d9f29b406a" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/15654-nft-values&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/15654-nft-values&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/15654-nft-values&lookback=7)