### PR TITLE
Trading: Apply minimum validation to fiat input

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher.ts
@@ -4,17 +4,23 @@ import {
     TRADING_FORM_CRYPTO_INPUT,
     TRADING_FORM_FIAT_INPUT,
     TRADING_FORM_OUTPUT_AMOUNT,
+    TRADING_FORM_OUTPUT_CURRENCY,
     TRADING_FORM_OUTPUT_FIAT,
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
 } from '@suite-common/trading';
 import { Network } from '@suite-common/wallet-config';
+import { selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import {
     convertAmountSubunitsToUnits,
     convertAmountUnitsToSubunits,
+    fromBaseCurrencyToCryptoUnit,
+    getFiatRateKey,
 } from '@suite-common/wallet-utils';
 import { useDidUpdate } from '@trezor/react-utils';
 
+import { useSelector } from 'src/hooks/suite';
+import { useFiatFromCryptoValue } from 'src/hooks/suite/useFiatFromCryptoValue';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { TradingAllFormProps, TradingSellExchangeFormProps } from 'src/types/trading/tradingForm';
 import { SendContextValues } from 'src/types/wallet/sendForm';
@@ -23,11 +29,11 @@ import {
     tradingGetRoundedFiatAmount,
 } from 'src/utils/wallet/trading/tradingUtils';
 
+const DEFAULT_FIAT_RATE_FALLBACK = 'usd';
+
 interface TradingUseCurrencySwitcherProps<T extends TradingAllFormProps> {
     account: Account;
     methods: UseFormReturn<T>;
-    quoteCryptoAmount: string | undefined;
-    quoteFiatAmount: string | undefined;
     network: Network | null;
     inputNames: {
         cryptoInput: typeof TRADING_FORM_CRYPTO_INPUT | typeof TRADING_FORM_OUTPUT_AMOUNT;
@@ -42,33 +48,50 @@ interface TradingUseCurrencySwitcherProps<T extends TradingAllFormProps> {
 export const useTradingCurrencySwitcher = <T extends TradingAllFormProps>({
     account,
     methods,
-    quoteCryptoAmount,
-    quoteFiatAmount,
     network,
     inputNames,
     composeRequest,
 }: TradingUseCurrencySwitcherProps<T>) => {
     const { setValue, getValues, control } =
         methods as unknown as UseFormReturn<TradingAllFormProps>;
+    const rates = useSelector(selectCurrentFiatRates);
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const cryptoInputValue = useWatch({ control, name: inputNames.cryptoInput });
+    const fiatInputValue = useWatch({ control, name: inputNames.fiatInput });
     const sendCryptoSelect = getValues(TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT);
+    const currencySelect = getValues(TRADING_FORM_OUTPUT_CURRENCY);
     const networkDecimals = getTradingNetworkDecimals({
         sendCryptoSelect,
         network,
     });
+    const fiatRateKey = getFiatRateKey(
+        account.symbol,
+        currencySelect?.value ? currencySelect.value : DEFAULT_FIAT_RATE_FALLBACK,
+    );
+    const rate = rates && rates[fiatRateKey] ? rates[fiatRateKey].rate : undefined;
+    const { fiatAmount } = useFiatFromCryptoValue({
+        amount: cryptoInputValue ?? '',
+        symbol: account.symbol,
+    });
+
+    const cryptoAmount = fiatInputValue
+        ? fromBaseCurrencyToCryptoUnit({
+              fiatAmount: fiatInputValue,
+              rate,
+          })
+        : undefined;
 
     const toggleAmountInCrypto = () => {
         const { amountInCrypto } = getValues();
 
         if (!amountInCrypto) {
-            const amount = shouldSendInSats
-                ? convertAmountUnitsToSubunits(quoteCryptoAmount ?? '', networkDecimals)
-                : quoteCryptoAmount;
-
-            setValue(inputNames.cryptoInput, amount === '-1' ? '' : amount);
+            if (cryptoAmount) {
+                setValue(inputNames.cryptoInput, cryptoAmount.toFixed(networkDecimals));
+            }
         } else {
-            setValue(inputNames.fiatInput, tradingGetRoundedFiatAmount(quoteFiatAmount));
+            if (fiatAmount) {
+                setValue(inputNames.fiatInput, tradingGetRoundedFiatAmount(fiatAmount.toString()));
+            }
         }
 
         setValue('amountInCrypto', !amountInCrypto);

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
@@ -101,9 +101,19 @@ export const useTradingFiatValues = ({
                 }),
             );
 
-            if (updateFiatRatesResult.meta.requestStatus !== 'fulfilled') return null;
+            if (updateFiatRatesResult.meta.requestStatus === 'fulfilled') {
+                const fiatRates =
+                    updateFiatRatesResult.payload as PromiseSettledResult<FiatRatesResult>[];
 
-            return updateFiatRatesResult.payload as FiatRatesResult;
+                const successfulResult = fiatRates.find(
+                    (result): result is PromiseFulfilledResult<FiatRatesResult> =>
+                        result.status === 'fulfilled',
+                );
+
+                return successfulResult?.value ?? null;
+            }
+
+            return null;
         },
         [contractAddress, dispatch, symbol, isNativeToken],
     );

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -169,8 +169,6 @@ export const useTradingBuyForm = ({
     const { toggleAmountInCrypto } = useTradingCurrencySwitcher({
         account,
         methods,
-        quoteCryptoAmount: quotesByPaymentMethod?.[0]?.receiveStringAmount,
-        quoteFiatAmount: quotesByPaymentMethod?.[0]?.fiatStringAmount,
         network,
         inputNames: {
             cryptoInput: TRADING_FORM_CRYPTO_INPUT,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -42,7 +42,6 @@ import {
     useFormDraft,
 } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
-import { toFiatCurrency } from '@suite-common/wallet-utils';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { openDeferredModal } from 'src/actions/suite/modalActions';
@@ -194,12 +193,6 @@ export const useTradingExchangeForm = ({
     const output = values.outputs?.[0];
     const outputAddress = output?.address;
 
-    const fiatValues = useTradingFiatValues({
-        cryptoId: sendCryptoSelect?.value,
-        amount: sendCryptoSelect?.balance,
-        fiatCurrency: output?.currency?.value as FiatCurrencyCode,
-    });
-
     const receiveCryptoId = receiveCryptoSelect?.value;
 
     const tradingReceiveAddress = useTradingReceiveAddress({
@@ -218,13 +211,6 @@ export const useTradingExchangeForm = ({
         amount: receiveCryptoSelect?.balance,
         fiatCurrency: output?.currency?.value as FiatCurrencyCode,
     });
-
-    const fiatOfBestScoredQuote = quotes?.[0]?.sendStringAmount
-        ? (toFiatCurrency({
-              amount: quotes?.[0]?.sendStringAmount,
-              rate: fiatValues?.fiatRate?.rate,
-          })?.toFixed(2) ?? null)
-        : null;
 
     const formIsValid = Object.keys(formState.errors).length === 0;
     const hasValues = !!output?.amount && !!values.receiveCryptoSelect;
@@ -266,8 +252,6 @@ export const useTradingExchangeForm = ({
         account,
         methods,
         network,
-        quoteCryptoAmount: quotes?.[0]?.sendStringAmount,
-        quoteFiatAmount: fiatOfBestScoredQuote ?? '',
         inputNames: {
             cryptoInput: TRADING_FORM_OUTPUT_AMOUNT,
             fiatInput: TRADING_FORM_OUTPUT_FIAT,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -204,8 +204,6 @@ export const useTradingSellForm = ({
         account,
         methods,
         network,
-        quoteCryptoAmount: quotesByPaymentMethod?.[0]?.cryptoStringAmount,
-        quoteFiatAmount: quotesByPaymentMethod?.[0]?.fiatStringAmount,
         inputNames: {
             cryptoInput: TRADING_FORM_OUTPUT_AMOUNT,
             fiatInput: TRADING_FORM_OUTPUT_FIAT,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
@@ -7,7 +7,7 @@ import {
     TRADING_FORM_OUTPUT_CURRENCY,
     TradingFiatCurrencyOption,
 } from '@suite-common/trading';
-import { buildCurrencyOptions } from '@suite-common/wallet-utils';
+import { buildCurrencyOptions, buildCurrencyShortOption } from '@suite-common/wallet-utils';
 import { Select } from '@trezor/components';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
@@ -72,7 +72,10 @@ export const TradingFormInputCurrency = ({
             control={control as Control<TradingAllFormProps>}
             render={({ field: { onChange, value } }) => (
                 <Select
-                    value={value}
+                    value={buildCurrencyShortOption({
+                        currency: value.value,
+                        areSatsDisplayed: false,
+                    })}
                     onChange={(selected: TradingFiatCurrencyOption) => {
                         onChange(selected);
                         setAmountLimits(undefined);

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
@@ -1,18 +1,27 @@
-import { FieldErrors, UseControllerProps } from 'react-hook-form';
+import { FieldErrors, UseControllerProps, UseFormReturn } from 'react-hook-form';
 
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
+    TRADING_FORM_OUTPUT_CURRENCY,
     TRADING_FORM_OUTPUT_FIAT,
     TradingBuyFormProps,
 } from '@suite-common/trading';
 import { formInputsMaxLength } from '@suite-common/validators';
-import { getInputState } from '@suite-common/wallet-utils';
+import { selectCurrentFiatRates } from '@suite-common/wallet-core';
+import { TokenAddress } from '@suite-common/wallet-types';
+import {
+    buildCurrencyShortOption,
+    getFiatRateKey,
+    getInputState,
+    toFiatCurrency,
+} from '@suite-common/wallet-utils';
 import { NumberInput } from '@trezor/product-components';
 import { useDidUpdate } from '@trezor/react-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import {
     TradingAllFormProps,
@@ -24,6 +33,7 @@ import {
     isTradingExchangeContext,
     isTradingSellContext,
 } from 'src/utils/wallet/trading/tradingTypingUtils';
+import { tradingGetRoundedFiatAmount } from 'src/utils/wallet/trading/tradingUtils';
 import { TradingFormInputCurrency } from 'src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency';
 
 export const TradingFormInputFiat = <TFieldValues extends TradingAllFormProps>({
@@ -37,16 +47,26 @@ export const TradingFormInputFiat = <TFieldValues extends TradingAllFormProps>({
     const locale = useSelector(selectLanguage);
 
     const context = useTradingFormContext();
-    const { amountLimits } = context;
+    const { account, amountLimits, network } = context;
     const {
         control,
         formState: { errors },
         trigger,
         clearErrors,
-    } = methods;
+        getValues,
+    } = methods as unknown as UseFormReturn<TradingAllFormProps>;
+
+    const tokenAddress = getValues('sendCryptoSelect')?.contractAddress as TokenAddress | undefined;
+
+    const { areSatsDisplayed } = useBitcoinAmountUnit(network.symbol);
+
+    const rates = useSelector(selectCurrentFiatRates);
+    const currencySelect = getValues(TRADING_FORM_OUTPUT_CURRENCY);
+
+    const cryptoAmount = getValues(cryptoInputName) as string;
 
     const fiatInputError =
-        cryptoInputName === TRADING_FORM_OUTPUT_FIAT
+        fiatInputName === TRADING_FORM_OUTPUT_FIAT
             ? (errors as FieldErrors<TradingSellExchangeFormProps>)?.outputs?.[0]?.fiat
             : (errors as FieldErrors<TradingBuyFormProps>).fiatInput;
     const cryptoInputError =
@@ -60,6 +80,42 @@ export const TradingFormInputFiat = <TFieldValues extends TradingAllFormProps>({
                   validate: {
                       min: validateMin(translationString),
                       decimals: validateDecimals(translationString, { decimals: 2 }),
+                      minFiat: () => {
+                          if (
+                              cryptoAmount &&
+                              context.amountLimits?.minCrypto &&
+                              new BigNumber(cryptoAmount).isLessThan(
+                                  new BigNumber(context.amountLimits.minCrypto),
+                              )
+                          ) {
+                              const fiatRateKey = getFiatRateKey(
+                                  account.symbol,
+                                  currencySelect?.value ? currencySelect.value : 'usd',
+                                  tokenAddress,
+                              );
+                              const rate =
+                                  rates && rates[fiatRateKey] ? rates[fiatRateKey].rate : undefined;
+                              const minFiat = toFiatCurrency({
+                                  amount: context.amountLimits.minCrypto,
+                                  rate,
+                              })?.toString();
+
+                              if (minFiat) {
+                                  return translationString('TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT', {
+                                      minimum: tradingGetRoundedFiatAmount(minFiat),
+                                      currency: buildCurrencyShortOption({
+                                          currency: currencySelect.value,
+                                          areSatsDisplayed,
+                                      }).label,
+                                  });
+                              } else {
+                                  return translationString('TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT', {
+                                      minimum: context.amountLimits.minCrypto,
+                                      currency: context.amountLimits.currency,
+                                  });
+                              }
+                          }
+                      },
                   },
               }
             : {


### PR DESCRIPTION
## Description

- Added minimum amount validation for fiat input and display of errors in selected fiat currencies
- Synced fiat and crypto amounts: when a value is entered in one input, it’s recalculated for the other when switching

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14822

## Screenshots:

<img width="1251" height="940" alt="image" src="https://github.com/user-attachments/assets/020443bd-f501-4811-874f-0c7a0f17a5b8" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-fiat-minimum-validation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-fiat-minimum-validation&lookback=7)