### PR TITLE
Labeling fixies native

### DIFF
--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -9,7 +9,6 @@ import {
     blockchainActions,
     convertSendFormDraftsBtcAmountUnitsThunk,
     deviceActions,
-    forgetAccountsThunk,
     sendFormActions,
     setCustomBackendThunk,
     stakeActions,
@@ -37,7 +36,7 @@ const walletMiddleware =
             const accountsToRemove = api
                 .getState()
                 .wallet.accounts.filter(a => a.deviceState === deviceState);
-            api.dispatch(forgetAccountsThunk({ accountsToRemove }));
+            api.dispatch(accountsActions.removeAccount(accountsToRemove));
         }
 
         // propagate action to reducers, this needs to happen before addTransaction is dispatched because it needs to have account in redux already

--- a/suite-common/local-first-storage/src/storage/unsubscribeAndDisposeLocalFirstStorageThunk.ts
+++ b/suite-common/local-first-storage/src/storage/unsubscribeAndDisposeLocalFirstStorageThunk.ts
@@ -19,9 +19,7 @@ export const unsubscribeAndDisposeLocalFirstStorageThunk = createThunk<
     `${LOCAL_FIRST_STORAGE_PREFIX}/unsubscribeLocalFirstStorageThunk`,
     ({ device }, { rejectWithValue }) => {
         if (localFirstStorageProvider === null) {
-            throw new Error(
-                "throw Error('initLocalFirstStorageThunk() must be called before this!');",
-            );
+            throw new Error("initLocalFirstStorageThunk() must be called before this!'");
         }
 
         const deviceStaticSessionId = device.state?.staticSessionId;

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -173,14 +173,3 @@ export const fetchAndUpdateAccountThunk = createThunk(
         }
     },
 );
-
-type ForgetAccountsThunkParams = {
-    accountsToRemove: Account[];
-};
-
-export const forgetAccountsThunk = createThunk<void, ForgetAccountsThunkParams, void>(
-    `${ACCOUNTS_MODULE_PREFIX}/forgetAccountThunk`,
-    ({ accountsToRemove }, { dispatch }) => {
-        dispatch(accountsActions.removeAccount(accountsToRemove));
-    },
-);

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -180,15 +180,7 @@ type ForgetAccountsThunkParams = {
 
 export const forgetAccountsThunk = createThunk<void, ForgetAccountsThunkParams, void>(
     `${ACCOUNTS_MODULE_PREFIX}/forgetAccountThunk`,
-    ({ accountsToRemove }, { dispatch, extra, getState }) => {
-        for (const accountToRemove of accountsToRemove) {
-            const device = selectDevices(getState())?.find(
-                it => it.state?.staticSessionId === accountToRemove.deviceState,
-            );
-            if (device !== undefined) {
-                dispatch(extra.thunks.unsubscribeAndDisposeLocalFirstStorage({ device }));
-            }
-        }
+    ({ accountsToRemove }, { dispatch }) => {
         dispatch(accountsActions.removeAccount(accountsToRemove));
     },
 );

--- a/suite-common/wallet-core/src/device/initEvoluKeysThunk.ts
+++ b/suite-common/wallet-core/src/device/initEvoluKeysThunk.ts
@@ -39,39 +39,41 @@ export const initEvoluKeysThunk = createThunk<void, InitCipherKeyThunkParams, vo
             deviceActions.setLocalFirstStorageSecretRetrieving({ device, isRetrieving: true }),
         );
 
-        const result = await TrezorConnect.evoluGetNode({
-            device: {
-                path: device.path,
-                state: device.state,
-                instance: device.instance,
-            },
-            useEmptyPassphrase: device.useEmptyPassphrase,
-        });
+        try {
+            const result = await TrezorConnect.evoluGetNode({
+                device: {
+                    path: device.path,
+                    state: device.state,
+                    instance: device.instance,
+                },
+                useEmptyPassphrase: device.useEmptyPassphrase,
+            });
 
-        if (result.success) {
-            const { deriveSlip21Node, bytesToHex, hexToBytes } = await loadEvoluCommon();
+            if (result.success) {
+                const { deriveSlip21Node, bytesToHex, hexToBytes } = await loadEvoluCommon();
 
-            // Slip21 path from Trezor Device: ["TREZOR", "Evolu"]
-            const evoluNode = hexToBytes(result.payload.data);
+                // Slip21 path from Trezor Device: ["TREZOR", "Evolu"]
+                const evoluNode = hexToBytes(result.payload.data);
 
-            const evoluKeys: EvoluKeys = {
-                ownerId: asDeviceEvoluOwnerId(
-                    bytesToHex(deriveSlip21Node('Owner Id', evoluNode).slice(32, 64)),
-                ),
-                writeKey: bytesToHex(deriveSlip21Node('Write Key', evoluNode).slice(32, 64)),
-                encryptionKey: bytesToHex(
-                    deriveSlip21Node('Encryption Key', evoluNode).slice(32, 64),
-                ),
-            };
+                const evoluKeys: EvoluKeys = {
+                    ownerId: asDeviceEvoluOwnerId(
+                        bytesToHex(deriveSlip21Node('Owner Id', evoluNode).slice(32, 64)),
+                    ),
+                    writeKey: bytesToHex(deriveSlip21Node('Write Key', evoluNode).slice(32, 64)),
+                    encryptionKey: bytesToHex(
+                        deriveSlip21Node('Encryption Key', evoluNode).slice(32, 64),
+                    ),
+                };
 
-            // This also sets the `isRetrieving` flag to `false`
-            dispatch(deviceActions.setLocalFirstStorageSecret({ device, evoluKeys }));
-        } else {
+                // This also sets the `isRetrieving` flag to `false`
+                dispatch(deviceActions.setLocalFirstStorageSecret({ device, evoluKeys }));
+            } else {
+                return rejectWithValue(result.payload);
+            }
+        } finally {
             dispatch(
                 deviceActions.setLocalFirstStorageSecretRetrieving({ device, isRetrieving: false }),
             );
-
-            return rejectWithValue(result.payload);
         }
     },
 );

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -17,7 +17,6 @@ import { DiscoverAccountsProgress } from '@trezor/connect/src/types/api/discover
 import { DISCOVERY_MODULE_PREFIX, discoveryActions } from './discoveryActions';
 import { isDiscoveryInProgress, selectDiscoveryByDevicePath } from './discoverySelectors';
 import { CreateAccountActionProps, accountsActions } from '../accounts/accountsActions';
-import { forgetAccountsThunk } from '../accounts/accountsThunks';
 import { deviceActions } from '../device/deviceActions';
 import {
     selectDeviceByStaticSessionId,
@@ -624,7 +623,7 @@ export const runAdditionalDiscoveryThunk = createThunk(
 
         const accountsToRemove = selectAccountsToBeForgotten(getState());
         if (accountsToRemove.length > 0) {
-            dispatch(forgetAccountsThunk({ accountsToRemove }));
+            dispatch(accountsActions.removeAccount(accountsToRemove));
         }
 
         dispatch(

--- a/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
+++ b/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
@@ -38,10 +38,10 @@ export const selectDeviceThunk = createThunk<void, SelectDeviceThunkParams, void
         }
 
         dispatch(deviceActions.selectDevice(trezorDevice));
-        if (
-            trezorDevice?.state?.staticSessionId !== undefined &&
-            extra.selectors.selectSuiteSettings(getState()).isLocalFirstStorageEnabled
-        ) {
+
+        const { isLocalFirstStorageEnabled } = extra.selectors.selectSuiteSettings(getState());
+
+        if (trezorDevice?.state?.staticSessionId !== undefined && isLocalFirstStorageEnabled) {
             dispatch(extra.thunks.subscribeLocalFirstStorage({ device: trezorDevice }));
         }
     },

--- a/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
@@ -4,7 +4,7 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import { changeNetworks } from './walletSettingsActions';
 import { WALLET_SETTINGS } from './walletSettingsConstants';
 import { selectEnabledNetworks } from './walletSettingsReducer';
-import { forgetAccountsThunk } from '../accounts/accountsThunks';
+import { accountsActions } from '../accounts/accountsActions';
 import { selectAccountsToBeForgotten } from '../selectors';
 
 export const changeCoinVisibility = createThunk<
@@ -26,7 +26,7 @@ export const changeCoinVisibility = createThunk<
 
     const accountsToRemove = selectAccountsToBeForgotten(getState());
     if (accountsToRemove.length > 0) {
-        dispatch(forgetAccountsThunk({ accountsToRemove }));
+        dispatch(accountsActions.removeAccount(accountsToRemove));
     }
 
     // this seems to be only for analyticsMiddleware

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -42,7 +42,7 @@ const isActionDeviceRelated = (action: AnyAction): boolean => {
 };
 
 export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
-    (action, { dispatch, next, getState }) => {
+    (action, { dispatch, next, getState, extra }) => {
         const isDeviceForceRemembered = selectIsDeviceForceRemembered(getState());
 
         if (isDeviceEventAction(action, DEVICE.DISCONNECT)) {
@@ -61,12 +61,15 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
         next(action);
 
         if (deviceActions.forgetDevice.match(action)) {
+            const { device } = action.payload;
             dispatch(handleDeviceDisconnect(action.payload.device));
 
-            const deviceState = action.payload.device.state;
-            if (deviceState) {
-                const accountsToRemove = selectAccountsByDeviceState(getState(), deviceState);
+            if (device.state !== undefined) {
+                const accountsToRemove = selectAccountsByDeviceState(getState(), device.state);
                 dispatch(forgetAccountsThunk({ accountsToRemove }));
+                if (action.payload.device !== undefined) {
+                    dispatch(extra.thunks.unsubscribeAndDisposeLocalFirstStorage({ device }));
+                }
             }
         }
 

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -3,8 +3,8 @@ import { AnyAction, isAnyOf } from '@reduxjs/toolkit';
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { isAnyDeviceEventAction } from '@suite-common/suite-utils';
 import {
+    accountsActions,
     deviceActions,
-    forgetAccountsThunk,
     forgetDisconnectedDevices,
     handleDeviceDisconnect,
     observeSelectedDevice,
@@ -66,7 +66,7 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
 
             if (device.state !== undefined) {
                 const accountsToRemove = selectAccountsByDeviceState(getState(), device.state);
-                dispatch(forgetAccountsThunk({ accountsToRemove }));
+                dispatch(accountsActions.removeAccount(accountsToRemove));
                 if (action.payload.device !== undefined) {
                     dispatch(extra.thunks.unsubscribeAndDisposeLocalFirstStorage({ device }));
                 }

--- a/suite-native/module-accounts-management/src/components/AccountSettingsRemoveCoinButton.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountSettingsRemoveCoinButton.tsx
@@ -1,10 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import {
-    AccountsRootState,
-    forgetAccountsThunk,
-    selectAccountByKey,
-} from '@suite-common/wallet-core';
+import { AccountsRootState, accountsActions, selectAccountByKey } from '@suite-common/wallet-core';
 import { AccountKey } from '@suite-common/wallet-types';
 import { useAlert } from '@suite-native/alerts';
 import { Button, TrezorSuiteLiteHeader } from '@suite-native/atoms';
@@ -29,7 +25,7 @@ export const AccountSettingsRemoveCoinButton = ({
     if (!account) return null;
 
     const handleRemoveAccount = () => {
-        dispatch(forgetAccountsThunk({ accountsToRemove: [account] }));
+        dispatch(accountsActions.removeAccount([account]));
         navigateToInitialScreen();
     };
 

--- a/suite-native/module-send/src/sendFormAddLabelingThunk.ts
+++ b/suite-native/module-send/src/sendFormAddLabelingThunk.ts
@@ -3,6 +3,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { selectPrecomposedSendForm, selectSendPrecomposedTx } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { isCardanoTx } from '@suite-common/wallet-utils';
+import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 
 import { SEND_MODULE_PREFIX } from './constants';
 
@@ -17,6 +18,15 @@ type SendFormAddLabelingThunkParams = {
 export const sendFormAddLabelingThunk = createThunk<void, SendFormAddLabelingThunkParams, void>(
     `${SEND_MODULE_PREFIX}/sendTransactionThunk`,
     async ({ selectedAccount, txId }, { getState, dispatch }) => {
+        const isFeatureFlagOn = selectIsFeatureFlagEnabled(
+            getState(),
+            FeatureFlag.IsLocalFirstStorageEnabled,
+        );
+
+        if (!isFeatureFlagOn) {
+            return;
+        }
+
         const precomposedTransaction = selectSendPrecomposedTx(getState());
 
         if (precomposedTransaction) {

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -2,7 +2,10 @@ import { Platform } from 'react-native';
 
 import * as Device from 'expo-device';
 
-import { subscribeLocalFirstStorageThunk } from '@suite-common/local-first-storage';
+import {
+    subscribeLocalFirstStorageThunk,
+    unsubscribeAndDisposeLocalFirstStorageThunk,
+} from '@suite-common/local-first-storage';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { extraDependenciesMock } from '@suite-common/test-utils/src/extraDependenciesMock'; // precise import path to avoid circular dependencies
 import { selectSelectedDevice } from '@suite-common/wallet-core';
@@ -60,6 +63,7 @@ export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDepende
     } as Partial<ExtraDependencies['selectors']>,
     thunks: {
         subscribeLocalFirstStorage: subscribeLocalFirstStorageThunk,
+        unsubscribeAndDisposeLocalFirstStorage: unsubscribeAndDisposeLocalFirstStorageThunk,
     } as Partial<ExtraDependencies['thunks']>,
     actions: {} as Partial<ExtraDependencies['actions']>,
     actionTypes: {} as Partial<ExtraDependencies['actionTypes']>,


### PR DESCRIPTION
Commit by commit:
1. just add some defensive check in labeling thunk
2. Fix unsubscribe (state clear) for eject wallet in the the middleware where all the logic happens for native :iphone: 
3. revert of absolute nonsense (forgetAccountThunk) wtf I did there???

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=labeling-fixies-native&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=labeling-fixies-native&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=labeling-fixies-native&lookback=7)