### PR TITLE
feat(suite-native): add labeling also to sent trade txns

### DIFF
--- a/suite-native/module-send/package.json
+++ b/suite-native/module-send/package.json
@@ -18,7 +18,6 @@
         "@reduxjs/toolkit": "2.8.2",
         "@shopify/flash-list": "1.7.6",
         "@suite-common/formatters": "workspace:*",
-        "@suite-common/local-first-storage": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/token-definitions": "workspace:*",
         "@suite-common/validators": "workspace:*",

--- a/suite-native/module-send/src/sendFormThunks.ts
+++ b/suite-native/module-send/src/sendFormThunks.ts
@@ -26,12 +26,14 @@ import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { EventType, analytics } from '@suite-native/analytics';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { selectAccountTokenSymbol } from '@suite-native/tokens';
-import { UpdateSelectedFeeLevelThunkParams } from '@suite-native/transaction-management';
+import {
+    UpdateSelectedFeeLevelThunkParams,
+    addTransactionLabelingThunk,
+} from '@suite-native/transaction-management';
 import { BlockbookTransaction } from '@trezor/blockchain-link-types';
 import { Success } from '@trezor/connect';
 
 import { SEND_MODULE_PREFIX } from './constants';
-import { sendFormAddLabelingThunk } from './sendFormAddLabelingThunk';
 
 export const signTransactionNativeThunk = createThunk<
     BlockbookTransaction | undefined,
@@ -195,7 +197,7 @@ export const sendTransactionThunk = createThunk<
 
         if (formValues !== null) {
             await dispatch(
-                sendFormAddLabelingThunk({
+                addTransactionLabelingThunk({
                     txId: sendResponse.payload.payload.txid,
                     selectedAccount,
                 }),

--- a/suite-native/module-send/tsconfig.json
+++ b/suite-native/module-send/tsconfig.json
@@ -6,9 +6,6 @@
             "path": "../../suite-common/formatters"
         },
         {
-            "path": "../../suite-common/local-first-storage"
-        },
-        {
             "path": "../../suite-common/redux-utils"
         },
         {

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -30,6 +30,7 @@ import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import {
     NativeSupportedFeeLevel,
     UpdateSelectedFeeLevelThunkParams,
+    addTransactionLabelingThunk,
     storeFeeLevels,
 } from '@suite-native/transaction-management';
 import TrezorConnect from '@trezor/connect';
@@ -301,7 +302,13 @@ export const signAndPushSendFormTransactionThunk = createThunk(
             return rejectWithValue(pushResult.error);
         }
 
-        // Return the expected TradingFulfillValue format
+        dispatch(
+            addTransactionLabelingThunk({
+                txId: pushResult.payload.payload.txid,
+                selectedAccount,
+            }),
+        );
+
         return fulfillWithValue({
             success: true,
             payload: pushResult.payload,

--- a/suite-native/transaction-management/package.json
+++ b/suite-native/transaction-management/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "2.8.2",
+        "@suite-common/local-first-storage": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/validators": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite-native/transaction-management/src/addTransactionLabelingThunk.ts
+++ b/suite-native/transaction-management/src/addTransactionLabelingThunk.ts
@@ -4,9 +4,9 @@ import { selectPrecomposedSendForm, selectSendPrecomposedTx } from '@suite-commo
 import { Account } from '@suite-common/wallet-types';
 import { isCardanoTx } from '@suite-common/wallet-utils';
 
-import { SEND_MODULE_PREFIX } from './constants';
+const TRANSACTION_MANAGEMENT_PREFIX = '@suite-native/transaction-management';
 
-type SendFormAddLabelingThunkParams = {
+type AddTransactionLabelingThunkParams = {
     selectedAccount: Account;
     txId: string;
 };
@@ -14,8 +14,12 @@ type SendFormAddLabelingThunkParams = {
 // Todo: This code below is kinda copy-paste from `applySendFormMetadataLabelsThunk` in Desktop.
 //       However, desktop code is polluted by Legacy Labeling (Metadata) so it cannot be easily reused.
 //       After we get rid of old Labeling, this shall be unified and move to the wallet-core.
-export const sendFormAddLabelingThunk = createThunk<void, SendFormAddLabelingThunkParams, void>(
-    `${SEND_MODULE_PREFIX}/sendTransactionThunk`,
+export const addTransactionLabelingThunk = createThunk<
+    void,
+    AddTransactionLabelingThunkParams,
+    void
+>(
+    `${TRANSACTION_MANAGEMENT_PREFIX}/sendTransactionThunk`,
     async ({ selectedAccount, txId }, { getState, dispatch }) => {
         const precomposedTransaction = selectSendPrecomposedTx(getState());
 

--- a/suite-native/transaction-management/src/index.ts
+++ b/suite-native/transaction-management/src/index.ts
@@ -7,3 +7,4 @@ export * from './feesFormSchema';
 export * from './selectors';
 export * from './sendFormSlice';
 export * from './thunks';
+export * from './addTransactionLabelingThunk';

--- a/suite-native/transaction-management/tsconfig.json
+++ b/suite-native/transaction-management/tsconfig.json
@@ -3,6 +3,9 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
+            "path": "../../suite-common/local-first-storage"
+        },
+        {
             "path": "../../suite-common/redux-utils"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11280,7 +11280,6 @@ __metadata:
     "@reduxjs/toolkit": "npm:2.8.2"
     "@shopify/flash-list": "npm:1.7.6"
     "@suite-common/formatters": "workspace:*"
-    "@suite-common/local-first-storage": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/token-definitions": "workspace:*"
     "@suite-common/validators": "workspace:*"
@@ -11823,6 +11822,7 @@ __metadata:
   dependencies:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@reduxjs/toolkit": "npm:2.8.2"
+    "@suite-common/local-first-storage": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/validators": "workspace:*"


### PR DESCRIPTION
Move txn labeling thunk to transaction-management and add it also to sent trade transactions.



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/add-labeling-to-mobile&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/add-labeling-to-mobile&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/add-labeling-to-mobile&lookback=7)