### PR TITLE
Labeling fixies native2

### DIFF
--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -7,6 +7,7 @@ import {
     prepareMessageSystemReducer,
 } from '@suite-common/message-system';
 import { validJws } from '@suite-common/message-system/src/__fixtures__/messageSystemActions';
+import { extraDependenciesMock } from '@suite-common/test-utils';
 import {
     initTokenDefinitionsThunk,
     periodicCheckTokenDefinitionsThunk,
@@ -29,7 +30,7 @@ import { initialBreakpointFlags } from '@trezor/theme';
 
 import { ROUTER, SUITE } from 'src/actions/suite/constants';
 import { init } from 'src/actions/suite/initAction';
-import suiteMiddleware from 'src/middlewares/suite/suiteMiddleware';
+import { prepareSuiteMiddleware } from 'src/middlewares/suite/suiteMiddleware';
 import metadataReducer from 'src/reducers/suite/metadataReducer';
 import modalReducer from 'src/reducers/suite/modalReducer';
 import routerReducer from 'src/reducers/suite/routerReducer';
@@ -250,7 +251,7 @@ const fixtures: Fixture[] = [
 type State = ReturnType<typeof getInitialState>;
 
 const initStore = (state: State) => {
-    const mockStore = configureStore<State, any>([suiteMiddleware]);
+    const mockStore = configureStore<State, any>([prepareSuiteMiddleware(extraDependenciesMock)]);
     const store = mockStore(state);
     store.subscribe(() => {
         const action = store.getActions().slice(-1)[0];

--- a/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 
-import { testMocks } from '@suite-common/test-utils';
+import { extraDependenciesMock, testMocks } from '@suite-common/test-utils';
 import { prepareDeviceReducer } from '@suite-common/wallet-core';
 
-import suiteMiddleware from 'src/middlewares/suite/suiteMiddleware';
+import { prepareSuiteMiddleware } from 'src/middlewares/suite/suiteMiddleware';
 import metadataReducer from 'src/reducers/suite/metadataReducer';
 import { SuiteState } from 'src/reducers/suite/suiteReducer';
 import { accountsReducer } from 'src/reducers/wallet';
@@ -91,7 +91,7 @@ const getInitialState = (state?: InitialState) => {
 };
 
 type State = ReturnType<typeof getInitialState>;
-const mockStore = configureStore<State, any>([suiteMiddleware]);
+const mockStore = configureStore<State, any>([prepareSuiteMiddleware(extraDependenciesMock)]);
 
 const initStore = (state: State) => {
     const store = mockStore(state);

--- a/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
@@ -1,13 +1,13 @@
 import { connectInitThunk } from '@suite-common/connect-init';
 import { messageSystemInitialState } from '@suite-common/message-system';
-import { testMocks } from '@suite-common/test-utils';
+import { extraDependenciesMock, testMocks } from '@suite-common/test-utils';
 import { deviceActions } from '@suite-common/wallet-core';
 import { UI, UI_EVENT } from '@trezor/connect';
 
 import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
 import { SUITE } from 'src/actions/suite/constants';
 import buttonRequestMiddleware from 'src/middlewares/suite/buttonRequestMiddleware';
-import suiteMiddleware from 'src/middlewares/suite/suiteMiddleware';
+import { prepareSuiteMiddleware } from 'src/middlewares/suite/suiteMiddleware';
 import routerReducer from 'src/reducers/suite/routerReducer';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
 import { configureStore } from 'src/support/tests/configureStore';
@@ -38,7 +38,10 @@ const getInitialState = () => ({
 type State = ReturnType<typeof getInitialState>;
 
 const initStore = (state: State) => {
-    const mockStore = configureStore<State, Action>([suiteMiddleware, buttonRequestMiddleware]);
+    const mockStore = configureStore<State, Action>([
+        prepareSuiteMiddleware(extraDependenciesMock),
+        buttonRequestMiddleware,
+    ]);
     const store = mockStore(state);
 
     return store;

--- a/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
@@ -1,10 +1,10 @@
-import { testMocks } from '@suite-common/test-utils';
+import { extraDependenciesMock, testMocks } from '@suite-common/test-utils';
 import { deviceActions, prepareDeviceReducer } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 
 import * as routerActions from 'src/actions/suite/routerActions';
 import redirectMiddleware from 'src/middlewares/suite/redirectMiddleware';
-import suiteMiddleware from 'src/middlewares/suite/suiteMiddleware';
+import { prepareSuiteMiddleware } from 'src/middlewares/suite/suiteMiddleware';
 import modalReducer from 'src/reducers/suite/modalReducer';
 import routerReducer from 'src/reducers/suite/routerReducer';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
@@ -49,7 +49,7 @@ const getInitialState = (
 });
 
 type State = ReturnType<typeof getInitialState>;
-const middlewares = [redirectMiddleware, suiteMiddleware];
+const middlewares = [redirectMiddleware, prepareSuiteMiddleware(extraDependenciesMock)];
 
 const initStore = (state: State) => {
     const mockStore = configureStore<State, Action>(middlewares);

--- a/packages/suite/src/middlewares/suite/__tests__/suiteMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/suiteMiddleware.test.ts
@@ -1,9 +1,10 @@
 import { analyticsActions, prepareAnalyticsReducer } from '@suite-common/analytics';
+import { extraDependenciesMock } from '@suite-common/test-utils';
 import { prepareDeviceReducer } from '@suite-common/wallet-core';
 
 import { ROUTER } from 'src/actions/suite/constants';
 import { appChanged } from 'src/actions/suite/suiteActions';
-import suiteMiddleware from 'src/middlewares/suite/suiteMiddleware';
+import { prepareSuiteMiddleware } from 'src/middlewares/suite/suiteMiddleware';
 import modalReducer from 'src/reducers/suite/modalReducer';
 import routerReducer from 'src/reducers/suite/routerReducer';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
@@ -47,7 +48,9 @@ const getInitialState = (router?: RouterState, suite?: Partial<SuiteState>) => (
 type State = ReturnType<typeof getInitialState>;
 
 const initStore = (state: State) => {
-    const mockStore = configureStore<State, Action>([suiteMiddleware]);
+    const mockStore = configureStore<State, Action>([
+        prepareSuiteMiddleware(extraDependenciesMock),
+    ]);
     const store = mockStore(state);
     store.subscribe(() => {
         const action = store.getActions().pop();

--- a/packages/suite/src/middlewares/suite/index.ts
+++ b/packages/suite/src/middlewares/suite/index.ts
@@ -1,23 +1,23 @@
-/* eslint-disable import/order */
 import { logsMiddleware } from '@suite-common/logger';
 
-import log from './logsMiddleware';
-import suite from './suiteMiddleware';
-import redirect from './redirectMiddleware';
 import analytics from './analyticsMiddleware';
 import buttonRequest from './buttonRequestMiddleware';
 import events from './eventsMiddleware';
-import metadata from './metadataMiddleware';
+import log from './logsMiddleware';
 import messageSystem from './messageSystemMiddleware';
+import metadata from './metadataMiddleware';
 import protocol from './protocolMiddleware';
+import redirect from './redirectMiddleware';
 import router from './routerMiddleware';
 import sentry from './sentryMiddleware';
+import { prepareSuiteMiddleware } from './suiteMiddleware';
+import { extraDependencies } from '../../support/extraDependencies';
 
-export default [
+export const suiteMiddlewares = [
     log,
     logsMiddleware, // Common logs shared between desktop and mobile app
     redirect,
-    suite,
+    prepareSuiteMiddleware(extraDependencies),
     analytics,
     buttonRequest,
     events,

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -1,7 +1,6 @@
 import { isAnyOf } from '@reduxjs/toolkit';
-import { MiddlewareAPI } from 'redux';
 
-import { AnyAction } from '@suite-common/redux-utils';
+import { AnyAction, createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { isAnyDeviceEventAction } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
@@ -17,7 +16,6 @@ import { METADATA, ROUTER, SUITE } from 'src/actions/suite/constants';
 import { handleProtocolRequest } from 'src/actions/suite/protocolActions';
 import { goto } from 'src/actions/suite/routerActions';
 import { appChanged, setRecentlyDisconnectedDevice } from 'src/actions/suite/suiteActions';
-import { Action, AppState, Dispatch } from 'src/types/suite';
 
 const isActionDeviceRelated = (action: AnyAction): boolean => {
     if (
@@ -43,20 +41,19 @@ const isActionDeviceRelated = (action: AnyAction): boolean => {
 
     return false;
 };
-const suite =
-    (api: MiddlewareAPI<Dispatch, AppState>) =>
-    (next: Dispatch) =>
-    (action: Action): Action => {
-        const prevApp = api.getState().router.app;
+
+export const prepareSuiteMiddleware = createMiddlewareWithExtraDeps(
+    (action, { dispatch, next, getState, extra }) => {
+        const prevApp = getState().router.app;
         if (action.type === ROUTER.LOCATION_CHANGE && action.payload.app !== prevApp) {
-            api.dispatch(appChanged(action.payload.app));
+            dispatch(appChanged(action.payload.app));
         }
 
         // this action needs to be processed before propagation to deviceReducer
         // otherwise device will not be accessible and related data will not be removed (accounts, txs...)
         if (action.type === DEVICE.DISCONNECT) {
-            const state = api.getState();
-            api.dispatch(
+            const state = getState();
+            dispatch(
                 forgetDisconnectedDevices({
                     device: action.payload,
                     forceForget: state.suite.settings.autoEject,
@@ -65,7 +62,7 @@ const suite =
 
             if (!state.suite.settings.autoEject) {
                 if (action.payload.id) {
-                    api.dispatch(setRecentlyDisconnectedDevice(action.payload.id));
+                    dispatch(setRecentlyDisconnectedDevice(action.payload.id));
                 }
 
                 setTimeout(() => {
@@ -79,7 +76,7 @@ const suite =
                         state.wallet.accounts.length > 0 &&
                         !isModalActive
                     ) {
-                        api.dispatch(goto('suite-switch-device', { params: { cancelable: true } }));
+                        dispatch(goto('suite-switch-device', { params: { cancelable: true } }));
                     }
                 }, 1000);
             }
@@ -89,16 +86,19 @@ const suite =
         next(action);
 
         if (deviceActions.forgetDevice.match(action)) {
-            api.dispatch(handleDeviceDisconnect(action.payload.device));
+            const { device } = action.payload;
+
+            dispatch(handleDeviceDisconnect(device));
+            dispatch(extra.thunks.unsubscribeAndDisposeLocalFirstStorage({ device }));
         }
 
         switch (action.type) {
             case SUITE.DESKTOP_HANDSHAKE:
                 if (action.payload.protocol) {
-                    api.dispatch(handleProtocolRequest(action.payload.protocol));
+                    dispatch(handleProtocolRequest(action.payload.protocol));
                 }
                 if (action.payload.desktopUpdate?.firstRun) {
-                    api.dispatch(
+                    dispatch(
                         notificationsActions.addToast({
                             type: 'auto-updater-new-version-first-run',
                             version: action.payload.desktopUpdate.firstRun,
@@ -107,12 +107,12 @@ const suite =
                 }
                 break;
             case DEVICE.DISCONNECT:
-                api.dispatch(handleDeviceDisconnect(action.payload));
+                dispatch(handleDeviceDisconnect(action.payload));
                 break;
             case SUITE.ONLINE_STATUS:
                 // Restart discovery to reconnect to backends when user goes offline -> online.
                 if (action.payload === true) {
-                    api.dispatch(startOrRestartDiscoveryThunk());
+                    dispatch(startOrRestartDiscoveryThunk());
                 }
                 break;
 
@@ -121,10 +121,9 @@ const suite =
         }
         if (isActionDeviceRelated(action)) {
             // keep suite reducer synchronized with other reducers (selected device)
-            api.dispatch(observeSelectedDevice());
+            dispatch(observeSelectedDevice());
         }
 
         return action;
-    };
-
-export default suite;
+    },
+);

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -9,7 +9,6 @@ import {
     blockchainActions,
     convertSendFormDraftsBtcAmountUnitsThunk,
     deviceActions,
-    forgetAccountsThunk,
     sendFormActions,
     setCustomBackendThunk,
     stakeActions,
@@ -37,7 +36,7 @@ const walletMiddleware =
             const accountsToRemove = api
                 .getState()
                 .wallet.accounts.filter(a => a.deviceState === deviceState);
-            api.dispatch(forgetAccountsThunk({ accountsToRemove }));
+            api.dispatch(accountsActions.removeAccount(accountsToRemove));
         }
 
         // propagate action to reducers, this needs to happen before addTransaction is dispatched because it needs to have account in redux already

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -19,7 +19,7 @@ import { prepareThpReducer } from '@suite-common/thp';
 import { prepareLabelingReducer } from '@suite-common/local-first-storage';
 import { accountsActions } from '@suite-common/wallet-core';
 
-import suiteMiddlewares from 'src/middlewares/suite';
+import { suiteMiddlewares } from 'src/middlewares/suite';
 import walletMiddlewares from 'src/middlewares/wallet';
 import onboardingMiddlewares from 'src/middlewares/onboarding';
 import backupMiddlewares from 'src/middlewares/backup';

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -61,11 +61,14 @@ export const extraDependencies: ExtraDependencies = {
         cardanoValidatePendingTxOnBlock: cardanoStakingActions.validatePendingTxOnBlock,
         cardanoFetchTrezorData: cardanoStakingActions.fetchTrezorData,
         initMetadata: metadataLabelingActions.init,
-        subscribeLocalFirstStorage: subscribeLocalFirstStorageThunk,
-        unsubscribeAndDisposeLocalFirstStorage: unsubscribeAndDisposeLocalFirstStorageThunk,
         fetchAndSaveMetadata: metadataLabelingActions.fetchAndSaveMetadata,
         addAccountMetadata: metadataLabelingActions.addAccountMetadata,
         forgetBluetoothDevice: forgetBluetoothDeviceThunk,
+
+        // This needs to be over `extra` to prevent circular dependency,
+        // `@suite-common/local-first-storage` depends on `wallet-core`
+        subscribeLocalFirstStorage: subscribeLocalFirstStorageThunk,
+        unsubscribeAndDisposeLocalFirstStorage: unsubscribeAndDisposeLocalFirstStorageThunk,
     },
     selectors: {
         selectTokenDefinitionsEnabledNetworks: (state: AppState) =>

--- a/suite-common/local-first-storage/src/storage/unsubscribeAndDisposeLocalFirstStorageThunk.ts
+++ b/suite-common/local-first-storage/src/storage/unsubscribeAndDisposeLocalFirstStorageThunk.ts
@@ -19,9 +19,7 @@ export const unsubscribeAndDisposeLocalFirstStorageThunk = createThunk<
     `${LOCAL_FIRST_STORAGE_PREFIX}/unsubscribeLocalFirstStorageThunk`,
     ({ device }, { rejectWithValue }) => {
         if (localFirstStorageProvider === null) {
-            throw new Error(
-                "throw Error('initLocalFirstStorageThunk() must be called before this!');",
-            );
+            throw new Error("initLocalFirstStorageThunk() must be called before this!'");
         }
 
         const deviceStaticSessionId = device.state?.staticSessionId;

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -39,12 +39,14 @@ export type ExtraDependencies = {
         cardanoFetchTrezorData: SuiteCompatibleThunk<'tADA' | 'ADA'>;
         initMetadata: SuiteCompatibleThunk<boolean>;
         fetchAndSaveMetadata: SuiteCompatibleThunk<StaticSessionId>;
-        subscribeLocalFirstStorage: SuiteCompatibleThunk<{ device: TrezorDevice }>;
-        unsubscribeAndDisposeLocalFirstStorage: SuiteCompatibleThunk<{ device: TrezorDevice }>;
         addAccountMetadata: SuiteCompatibleThunk<
             Exclude<MetadataAddPayload, { type: 'walletLabel' }>
         >;
         forgetBluetoothDevice: SuiteCompatibleThunk<{ bluetoothId: string }>;
+
+        // This needs to be over `extra` to prevent circular dependency
+        subscribeLocalFirstStorage: SuiteCompatibleThunk<{ device: TrezorDevice }>;
+        unsubscribeAndDisposeLocalFirstStorage: SuiteCompatibleThunk<{ device: TrezorDevice }>;
     };
     selectors: {
         // TODO when tokens are implemented 1:1 in both apps, delete from extras

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -61,10 +61,10 @@ export const extraDependenciesMock: ExtraDependencies = {
         cardanoFetchTrezorData: mockThunk('fetchTrezorData'),
         fetchAndSaveMetadata: mockThunk('fetchAndSaveMetadata'),
         initMetadata: mockThunk('initMetadata'),
-        subscribeLocalFirstStorage: mockThunk('subscribeLocalFirstStorage'),
-        unsubscribeAndDisposeLocalFirstStorage: mockThunk('unsubscribeLocalFirstStorage'),
         addAccountMetadata: mockThunk('addAccountMetadata'),
         forgetBluetoothDevice: mockThunk('forgetBluetoothDevice'),
+        subscribeLocalFirstStorage: mockThunk('subscribeLocalFirstStorage'),
+        unsubscribeAndDisposeLocalFirstStorage: mockThunk('unsubscribeLocalFirstStorage'),
     },
     selectors: {
         selectTokenDefinitionsEnabledNetworks: mockSelector(

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -173,14 +173,3 @@ export const fetchAndUpdateAccountThunk = createThunk(
         }
     },
 );
-
-type ForgetAccountsThunkParams = {
-    accountsToRemove: Account[];
-};
-
-export const forgetAccountsThunk = createThunk<void, ForgetAccountsThunkParams, void>(
-    `${ACCOUNTS_MODULE_PREFIX}/forgetAccountThunk`,
-    ({ accountsToRemove }, { dispatch }) => {
-        dispatch(accountsActions.removeAccount(accountsToRemove));
-    },
-);

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -180,15 +180,7 @@ type ForgetAccountsThunkParams = {
 
 export const forgetAccountsThunk = createThunk<void, ForgetAccountsThunkParams, void>(
     `${ACCOUNTS_MODULE_PREFIX}/forgetAccountThunk`,
-    ({ accountsToRemove }, { dispatch, extra, getState }) => {
-        for (const accountToRemove of accountsToRemove) {
-            const device = selectDevices(getState())?.find(
-                it => it.state?.staticSessionId === accountToRemove.deviceState,
-            );
-            if (device !== undefined) {
-                dispatch(extra.thunks.unsubscribeAndDisposeLocalFirstStorage({ device }));
-            }
-        }
+    ({ accountsToRemove }, { dispatch }) => {
         dispatch(accountsActions.removeAccount(accountsToRemove));
     },
 );

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -689,7 +689,7 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
                     if (!state.devices[index]) return;
                     state.devices[index].localFirstStorageSecret = {
                         isRetrieving,
-                        evoluKeys: undefined,
+                        evoluKeys: state.devices[index].localFirstStorageSecret?.evoluKeys,
                     };
                 },
             )

--- a/suite-common/wallet-core/src/device/initEvoluKeysThunk.ts
+++ b/suite-common/wallet-core/src/device/initEvoluKeysThunk.ts
@@ -39,39 +39,41 @@ export const initEvoluKeysThunk = createThunk<void, InitCipherKeyThunkParams, vo
             deviceActions.setLocalFirstStorageSecretRetrieving({ device, isRetrieving: true }),
         );
 
-        const result = await TrezorConnect.evoluGetNode({
-            device: {
-                path: device.path,
-                state: device.state,
-                instance: device.instance,
-            },
-            useEmptyPassphrase: device.useEmptyPassphrase,
-        });
+        try {
+            const result = await TrezorConnect.evoluGetNode({
+                device: {
+                    path: device.path,
+                    state: device.state,
+                    instance: device.instance,
+                },
+                useEmptyPassphrase: device.useEmptyPassphrase,
+            });
 
-        if (result.success) {
-            const { deriveSlip21Node, bytesToHex, hexToBytes } = await loadEvoluCommon();
+            if (result.success) {
+                const { deriveSlip21Node, bytesToHex, hexToBytes } = await loadEvoluCommon();
 
-            // Slip21 path from Trezor Device: ["TREZOR", "Evolu"]
-            const evoluNode = hexToBytes(result.payload.data);
+                // Slip21 path from Trezor Device: ["TREZOR", "Evolu"]
+                const evoluNode = hexToBytes(result.payload.data);
 
-            const evoluKeys: EvoluKeys = {
-                ownerId: asDeviceEvoluOwnerId(
-                    bytesToHex(deriveSlip21Node('Owner Id', evoluNode).slice(32, 64)),
-                ),
-                writeKey: bytesToHex(deriveSlip21Node('Write Key', evoluNode).slice(32, 64)),
-                encryptionKey: bytesToHex(
-                    deriveSlip21Node('Encryption Key', evoluNode).slice(32, 64),
-                ),
-            };
+                const evoluKeys: EvoluKeys = {
+                    ownerId: asDeviceEvoluOwnerId(
+                        bytesToHex(deriveSlip21Node('Owner Id', evoluNode).slice(32, 64)),
+                    ),
+                    writeKey: bytesToHex(deriveSlip21Node('Write Key', evoluNode).slice(32, 64)),
+                    encryptionKey: bytesToHex(
+                        deriveSlip21Node('Encryption Key', evoluNode).slice(32, 64),
+                    ),
+                };
 
-            // This also sets the `isRetrieving` flag to `false`
-            dispatch(deviceActions.setLocalFirstStorageSecret({ device, evoluKeys }));
-        } else {
+                // This also sets the `isRetrieving` flag to `false`
+                dispatch(deviceActions.setLocalFirstStorageSecret({ device, evoluKeys }));
+            } else {
+                return rejectWithValue(result.payload);
+            }
+        } finally {
             dispatch(
                 deviceActions.setLocalFirstStorageSecretRetrieving({ device, isRetrieving: false }),
             );
-
-            return rejectWithValue(result.payload);
         }
     },
 );

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -17,7 +17,6 @@ import { DiscoverAccountsProgress } from '@trezor/connect/src/types/api/discover
 import { DISCOVERY_MODULE_PREFIX, discoveryActions } from './discoveryActions';
 import { isDiscoveryInProgress, selectDiscoveryByDevicePath } from './discoverySelectors';
 import { CreateAccountActionProps, accountsActions } from '../accounts/accountsActions';
-import { forgetAccountsThunk } from '../accounts/accountsThunks';
 import { deviceActions } from '../device/deviceActions';
 import {
     selectDeviceByStaticSessionId,
@@ -624,7 +623,7 @@ export const runAdditionalDiscoveryThunk = createThunk(
 
         const accountsToRemove = selectAccountsToBeForgotten(getState());
         if (accountsToRemove.length > 0) {
-            dispatch(forgetAccountsThunk({ accountsToRemove }));
+            dispatch(accountsActions.removeAccount(accountsToRemove));
         }
 
         dispatch(

--- a/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
+++ b/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
@@ -38,10 +38,10 @@ export const selectDeviceThunk = createThunk<void, SelectDeviceThunkParams, void
         }
 
         dispatch(deviceActions.selectDevice(trezorDevice));
-        if (
-            trezorDevice?.state?.staticSessionId !== undefined &&
-            extra.selectors.selectSuiteSettings(getState()).isLocalFirstStorageEnabled
-        ) {
+
+        const { isLocalFirstStorageEnabled } = extra.selectors.selectSuiteSettings(getState());
+
+        if (trezorDevice?.state?.staticSessionId !== undefined && isLocalFirstStorageEnabled) {
             dispatch(extra.thunks.subscribeLocalFirstStorage({ device: trezorDevice }));
         }
     },

--- a/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
@@ -4,7 +4,7 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import { changeNetworks } from './walletSettingsActions';
 import { WALLET_SETTINGS } from './walletSettingsConstants';
 import { selectEnabledNetworks } from './walletSettingsReducer';
-import { forgetAccountsThunk } from '../accounts/accountsThunks';
+import { accountsActions } from '../accounts/accountsActions';
 import { selectAccountsToBeForgotten } from '../selectors';
 
 export const changeCoinVisibility = createThunk<
@@ -26,7 +26,7 @@ export const changeCoinVisibility = createThunk<
 
     const accountsToRemove = selectAccountsToBeForgotten(getState());
     if (accountsToRemove.length > 0) {
-        dispatch(forgetAccountsThunk({ accountsToRemove }));
+        dispatch(accountsActions.removeAccount(accountsToRemove));
     }
 
     // this seems to be only for analyticsMiddleware

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -42,7 +42,7 @@ const isActionDeviceRelated = (action: AnyAction): boolean => {
 };
 
 export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
-    (action, { dispatch, next, getState }) => {
+    (action, { dispatch, next, getState, extra }) => {
         const isDeviceForceRemembered = selectIsDeviceForceRemembered(getState());
 
         if (isDeviceEventAction(action, DEVICE.DISCONNECT)) {
@@ -61,12 +61,15 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
         next(action);
 
         if (deviceActions.forgetDevice.match(action)) {
+            const { device } = action.payload;
             dispatch(handleDeviceDisconnect(action.payload.device));
 
-            const deviceState = action.payload.device.state;
-            if (deviceState) {
-                const accountsToRemove = selectAccountsByDeviceState(getState(), deviceState);
+            if (device.state !== undefined) {
+                const accountsToRemove = selectAccountsByDeviceState(getState(), device.state);
                 dispatch(forgetAccountsThunk({ accountsToRemove }));
+                if (action.payload.device !== undefined) {
+                    dispatch(extra.thunks.unsubscribeAndDisposeLocalFirstStorage({ device }));
+                }
             }
         }
 

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -3,8 +3,8 @@ import { AnyAction, isAnyOf } from '@reduxjs/toolkit';
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { isAnyDeviceEventAction } from '@suite-common/suite-utils';
 import {
+    accountsActions,
     deviceActions,
-    forgetAccountsThunk,
     forgetDisconnectedDevices,
     handleDeviceDisconnect,
     observeSelectedDevice,
@@ -66,7 +66,7 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
 
             if (device.state !== undefined) {
                 const accountsToRemove = selectAccountsByDeviceState(getState(), device.state);
-                dispatch(forgetAccountsThunk({ accountsToRemove }));
+                dispatch(accountsActions.removeAccount(accountsToRemove));
                 if (action.payload.device !== undefined) {
                     dispatch(extra.thunks.unsubscribeAndDisposeLocalFirstStorage({ device }));
                 }

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -67,9 +67,7 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
             if (device.state !== undefined) {
                 const accountsToRemove = selectAccountsByDeviceState(getState(), device.state);
                 dispatch(accountsActions.removeAccount(accountsToRemove));
-                if (action.payload.device !== undefined) {
-                    dispatch(extra.thunks.unsubscribeAndDisposeLocalFirstStorage({ device }));
-                }
+                dispatch(extra.thunks.unsubscribeAndDisposeLocalFirstStorage({ device }));
             }
         }
 

--- a/suite-native/module-accounts-management/src/components/AccountSettingsRemoveCoinButton.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountSettingsRemoveCoinButton.tsx
@@ -1,10 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import {
-    AccountsRootState,
-    forgetAccountsThunk,
-    selectAccountByKey,
-} from '@suite-common/wallet-core';
+import { AccountsRootState, accountsActions, selectAccountByKey } from '@suite-common/wallet-core';
 import { AccountKey } from '@suite-common/wallet-types';
 import { useAlert } from '@suite-native/alerts';
 import { Button, TrezorSuiteLiteHeader } from '@suite-native/atoms';
@@ -29,7 +25,7 @@ export const AccountSettingsRemoveCoinButton = ({
     if (!account) return null;
 
     const handleRemoveAccount = () => {
-        dispatch(forgetAccountsThunk({ accountsToRemove: [account] }));
+        dispatch(accountsActions.removeAccount([account]));
         navigateToInitialScreen();
     };
 

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -2,7 +2,10 @@ import { Platform } from 'react-native';
 
 import * as Device from 'expo-device';
 
-import { subscribeLocalFirstStorageThunk } from '@suite-common/local-first-storage';
+import {
+    subscribeLocalFirstStorageThunk,
+    unsubscribeAndDisposeLocalFirstStorageThunk,
+} from '@suite-common/local-first-storage';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { extraDependenciesMock } from '@suite-common/test-utils/src/extraDependenciesMock'; // precise import path to avoid circular dependencies
 import { selectSelectedDevice } from '@suite-common/wallet-core';
@@ -60,6 +63,7 @@ export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDepende
     } as Partial<ExtraDependencies['selectors']>,
     thunks: {
         subscribeLocalFirstStorage: subscribeLocalFirstStorageThunk,
+        unsubscribeAndDisposeLocalFirstStorage: unsubscribeAndDisposeLocalFirstStorageThunk,
     } as Partial<ExtraDependencies['thunks']>,
     actions: {} as Partial<ExtraDependencies['actions']>,
     actionTypes: {} as Partial<ExtraDependencies['actionTypes']>,

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -62,6 +62,8 @@ export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDepende
         }),
     } as Partial<ExtraDependencies['selectors']>,
     thunks: {
+        // This needs to be over `extra` to prevent circular dependency,
+        // `@suite-common/local-first-storage` depends on `wallet-core`
         subscribeLocalFirstStorage: subscribeLocalFirstStorageThunk,
         unsubscribeAndDisposeLocalFirstStorage: unsubscribeAndDisposeLocalFirstStorageThunk,
     } as Partial<ExtraDependencies['thunks']>,

--- a/suite-native/transaction-management/package.json
+++ b/suite-native/transaction-management/package.json
@@ -23,6 +23,7 @@
         "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",
+        "@suite-native/feature-flags": "workspace:*",
         "@suite-native/formatters": "workspace:*",
         "@suite-native/forms": "workspace:*",
         "@suite-native/helpers": "workspace:*",

--- a/suite-native/transaction-management/src/addTransactionLabelingThunk.ts
+++ b/suite-native/transaction-management/src/addTransactionLabelingThunk.ts
@@ -3,6 +3,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { selectPrecomposedSendForm, selectSendPrecomposedTx } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { isCardanoTx } from '@suite-common/wallet-utils';
+import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 
 const TRANSACTION_MANAGEMENT_PREFIX = '@suite-native/transaction-management';
 
@@ -21,6 +22,15 @@ export const addTransactionLabelingThunk = createThunk<
 >(
     `${TRANSACTION_MANAGEMENT_PREFIX}/sendTransactionThunk`,
     async ({ selectedAccount, txId }, { getState, dispatch }) => {
+        const isFeatureFlagOn = selectIsFeatureFlagEnabled(
+            getState(),
+            FeatureFlag.IsLocalFirstStorageEnabled,
+        );
+
+        if (!isFeatureFlagOn) {
+            return;
+        }
+
         const precomposedTransaction = selectSendPrecomposedTx(getState());
 
         if (precomposedTransaction) {

--- a/suite-native/transaction-management/tsconfig.json
+++ b/suite-native/transaction-management/tsconfig.json
@@ -25,6 +25,7 @@
         },
         { "path": "../analytics" },
         { "path": "../atoms" },
+        { "path": "../feature-flags" },
         { "path": "../formatters" },
         { "path": "../forms" },
         { "path": "../helpers" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12683,6 +12683,7 @@ __metadata:
     "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"
+    "@suite-native/feature-flags": "workspace:*"
     "@suite-native/formatters": "workspace:*"
     "@suite-native/forms": "workspace:*"
     "@suite-native/helpers": "workspace:*"


### PR DESCRIPTION
Commit by commit:
1. just add some defensive check in labeling thunk
2. Fix unsubscribe (state clear) for eject wallet in the the middleware where all the logic happens for native :iphone: 
3. revert of absolute nonsense (forgetAccountThunk) wtf I did there???
4. unsubscribe evolu (& clear state) on forgetDevice same way as in native

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=labeling-fixies-native2&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=labeling-fixies-native2&lookback=7)