### PR TITLE
fix(suite-native): fix warning unstable selector in tests

### DIFF
--- a/suite-native/module-trading/src/components/fees/__tests__/FeePicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/fees/__tests__/FeePicker.comp.test.tsx
@@ -5,11 +5,13 @@ import { renderWithStoreProviderAsync, userEvent } from '@suite-native/test-util
 
 import { FEE_PICKER_TEST_ID, FeePicker } from '../FeePicker';
 
+const rateObject = { rate: 50000, error: null };
+
 // Mock the selectors used by CryptoToFiatAmountFormatter
 jest.mock('@suite-common/wallet-core', () => ({
     ...jest.requireActual('@suite-common/wallet-core'),
     selectBaseCurrency: jest.fn(() => 'usd'),
-    selectFiatRatesByFiatRateKey: jest.fn(() => ({ rate: 50000, error: null })),
+    selectFiatRatesByFiatRateKey: jest.fn(() => rateObject),
 }));
 
 describe('FeePicker', () => {

--- a/suite-native/module-trading/src/components/fees/__tests__/FeePickerCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/fees/__tests__/FeePickerCard.comp.test.tsx
@@ -7,11 +7,13 @@ import { renderWithStoreProviderAsync, userEvent } from '@suite-native/test-util
 
 import { FeePickerCard } from '../FeePickerCard';
 
+const rateObject = { rate: 50000, error: null };
+
 // Mock the selectors used by CryptoToFiatAmountFormatter
 jest.mock('@suite-common/wallet-core', () => ({
     ...jest.requireActual('@suite-common/wallet-core'),
     selectBaseCurrency: jest.fn(() => 'usd'),
-    selectFiatRatesByFiatRateKey: jest.fn(() => ({ rate: 50000, error: null })),
+    selectFiatRatesByFiatRateKey: jest.fn(() => rateObject),
 }));
 
 // Mock navigation


### PR DESCRIPTION
fix tests not to show unstable selector warning

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/tests-unstable-selectors-v2&lookback=7)