### PR TITLE
Listeners leak not fixed

### DIFF
--- a/packages/connect/setupJest.ts
+++ b/packages/connect/setupJest.ts
@@ -18,6 +18,7 @@ const createTransportApi = (override = {}) =>
         on: () => {},
         off: () => {},
         once: () => {},
+        removeAllListeners: (_: string) => {},
         openDevice: (path: string) => Promise.resolve({ success: true, payload: [{ path }] }),
         closeDevice: () => Promise.resolve({ success: true }),
         write: () => Promise.resolve({ success: true }),

--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -45,8 +45,11 @@ const transportApiMock = (fixtures: ResponseFixture[]) => {
         throw new Error('Missing latest bundled release.');
     }
 
+    let allListenersRemoved = false;
+
     return {
         on: (evt: string, listener: any) => {
+            if (allListenersRemoved) return;
             if (evt === 'transport-interface-change') {
                 eventChangeListener = (...args: any[]) => {
                     setTimeout(() => listener(...args), 1);
@@ -54,11 +57,15 @@ const transportApiMock = (fixtures: ResponseFixture[]) => {
             }
         },
         once: (evt: string, listener: any) => {
+            if (allListenersRemoved) return;
             if (evt === 'transport-interface-change') {
                 eventChangeListener = (...args: any[]) => {
                     setTimeout(() => listener(...args), 1);
                 };
             }
+        },
+        removeAllListeners: (_: string) => {
+            allListenersRemoved = true;
         },
         emitInterfaceChange: (...args: any[]) => {
             eventChangeListener(...args);

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -416,11 +416,11 @@ export abstract class AbstractApiTransport extends AbstractTransport {
     }
 
     stop() {
-        if (this.api.rawListeners('transport-interface-change').length === 0) {
-            this.api.once('transport-interface-change', () => {
-                this.logger?.debug('device connected after transport stopped, goodbye...');
-            });
-        }
+        this.api.removeAllListeners();
+
+        this.api.once('transport-interface-change', () => {
+            this.logger?.debug('device connected after transport stopped, goodbye...');
+        });
         super.stop();
         this.sessionsClient.dispose();
         this.api.dispose();

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -416,7 +416,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
     }
 
     stop() {
-        if (!this.stopped) {
+        if (this.api.rawListeners('transport-interface-change').length === 0) {
             this.api.once('transport-interface-change', () => {
                 this.logger?.debug('device connected after transport stopped, goodbye...');
             });


### PR DESCRIPTION
turns out that #21617 was not enough to fix the listeners leak observable in case when bluetooth binary is missing and transport runs in endless init/stop loop.

1st commit - poor mans solution
2nd commit - maybe better. and maybe we should rename transport.stop to transport.dispose (as we do everywhere) and we should simply remove listeners on this.api? 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=listeners-leak-not-fixed&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=listeners-leak-not-fixed&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=listeners-leak-not-fixed&lookback=7)