### PR TITLE
refactor(suite-common): tweak naming of selectIsBluetoothDevice

### DIFF
--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -70,7 +70,7 @@ export const selectDeviceCapabilities = createMemoizedSelector(
     features => features?.capabilities,
 );
 
-export const selectIsBluetoothDevice = createMemoizedSelector(
+export const selectIsBluetoothSupportedByDevice = createMemoizedSelector(
     [selectDeviceCapabilities],
     capabilities => !!capabilities?.includes('Capability_BLE'),
 );

--- a/suite-native/device/src/components/ConnectorImage.tsx
+++ b/suite-native/device/src/components/ConnectorImage.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { selectIsBluetoothDevice } from '@suite-common/wallet-core';
+import { selectIsBluetoothSupportedByDevice } from '@suite-common/wallet-core';
 import { Box, Image } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
@@ -18,9 +18,9 @@ export type ConnectorImageProps = {
 export const ConnectorImage = ({ maxHeight }: ConnectorImageProps) => {
     const { applyStyle } = useNativeStyles();
 
-    const isBluetoothDevice = useSelector(selectIsBluetoothDevice);
+    const isBluetoothSupportedByDevice = useSelector(selectIsBluetoothSupportedByDevice);
 
-    if (!isBluetoothDevice) {
+    if (!isBluetoothSupportedByDevice) {
         return (
             <Image
                 source={require('../assets/connector.webp')}

--- a/suite-native/module-home/src/screens/HomeScreen/components/AutoEjectAnimation.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/AutoEjectAnimation.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { selectIsBluetoothDevice } from '@suite-common/wallet-core';
+import { selectIsBluetoothSupportedByDevice } from '@suite-common/wallet-core';
 import { LottieAnimation } from '@suite-native/atoms';
 
 import autoEjectCableLottie from '../../../assets/auto-eject-cable-lottie.json';
 import autoEjectWirelessLottie from '../../../assets/auto-eject-wireless-lottie.json';
 
 export const AutoEjectAnimation = () => {
-    const isBluetoothDevice = useSelector(selectIsBluetoothDevice);
+    const isBluetoothSupportedByDevice = useSelector(selectIsBluetoothSupportedByDevice);
 
     return (
         <LottieAnimation
-            source={isBluetoothDevice ? autoEjectWirelessLottie : autoEjectCableLottie}
+            source={isBluetoothSupportedByDevice ? autoEjectWirelessLottie : autoEjectCableLottie}
         />
     );
 };


### PR DESCRIPTION


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/common/is-bluetooth-device-selector&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/common/is-bluetooth-device-selector&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/common/is-bluetooth-device-selector&lookback=7)