### PR TITLE
fix(suite-desktop): set descriptor.sessionOwner correctly to Trezor S…

### DIFF
--- a/packages/connect/src/device/TransportList.ts
+++ b/packages/connect/src/device/TransportList.ts
@@ -48,6 +48,7 @@ const getOrCreateTransport = (
             return tryGetTransport(transports, transportInstance.name) ?? transportInstance;
         }
     } else if (isTransportInstance(transportType)) {
+        // TODO can be improved by calling transportType.setOwner(params.id)
         const existing = tryGetTransport(transports, transportType.name);
         if (existing) {
             return existing;

--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from 'electron';
 
+import { Manifest } from '@trezor/connect';
 import { isMacOs } from '@trezor/env-utils';
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { getFreePort } from '@trezor/node-utils';
@@ -14,7 +15,7 @@ export const SERVICE_NAME = '@trezor/transport-bluetooth';
 // Export module state and use it trezor-connect module to override init + setTransports params
 // getTransport function is reassigned in onLoad, onQuit
 type BluetoothModuleState = {
-    getTransport: () => BluetoothTransport | undefined;
+    getTransport: (manifest?: Manifest) => BluetoothTransport | undefined;
 };
 
 export const bluetoothModuleState: BluetoothModuleState = {
@@ -61,10 +62,10 @@ export const init: ModuleInit = () => {
         });
     };
 
-    const getBluetoothTransport = () =>
+    const getBluetoothTransport = (manifest?: Manifest) =>
         bluetoothProcess
             ? new BluetoothTransport({
-                  id: 'BluetoothTransport',
+                  id: manifest?.appName || manifest?.appUrl || 'unknown app',
                   url: bluetoothProcess.getUrl(),
                   logger: desktopLogger,
                   messages: {}, // will be added by @trezor/connect transport initialization

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -82,6 +82,7 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
         onCreateInstance: () => ({
             onRequest: async (method, params) => {
                 logger.debug(SERVICE_NAME, `call ${method}`);
+                // TODO can be improved e.g. by implementing transport.setOwner()
                 let settingsCache: InitFullSettings<Record<string, any>> | undefined;
                 if (method === 'init') {
                     logger.info(SERVICE_NAME, `Retrieving stored firmwares`);

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron';
 
 import TrezorConnect, { ConnectSettings, LocalFirmwares, UI, UI_EVENT } from '@trezor/connect';
+import { InitFullSettings } from '@trezor/connect/src/types/api/init';
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { parseElectrumUrl } from '@trezor/utils';
 
@@ -45,10 +46,14 @@ const emitOnSetCustomBackendToMainThreadToAllowDomains = ({
 
 // override TrezorConnect.init and TrezorConnect.setTransports params
 // add BluetoothTransport if bluetooth module is enabled
-const getTransportsParam = (
-    transports?: ConnectSettings['transports'],
-): ConnectSettings['transports'] => {
-    const bluetooth = bluetoothModuleState.getTransport();
+const getTransportsParam = ({
+    transports,
+    manifest,
+}: {
+    transports: ConnectSettings['transports'];
+    manifest?: ConnectSettings['manifest'];
+}): ConnectSettings['transports'] => {
+    const bluetooth = bluetoothModuleState.getTransport(manifest);
     if (!bluetooth) return transports;
 
     if (transports && transports.length > 0) {
@@ -77,6 +82,7 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
         onCreateInstance: () => ({
             onRequest: async (method, params) => {
                 logger.debug(SERVICE_NAME, `call ${method}`);
+                let settingsCache: InitFullSettings<Record<string, any>> | undefined;
                 if (method === 'init') {
                     logger.info(SERVICE_NAME, `Retrieving stored firmwares`);
                     const [settings] = params;
@@ -89,10 +95,15 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
                     if (localFirmwares.success) {
                         settings.localFirmwares = localFirmwares.payload;
                     }
-                    settings.transports = getTransportsParam(settings.transports);
+                    settings.transports = getTransportsParam({
+                        transports: settings.transports,
+                        manifest: settings.manifest,
+                    });
 
                     const response = await TrezorConnect.init(settings);
                     await setProxy();
+
+                    settingsCache = settings;
 
                     return response;
                 }
@@ -111,7 +122,10 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
                 }
 
                 if (method === 'setTransports') {
-                    params[0].transports = getTransportsParam(params[0].transports);
+                    params[0].transports = getTransportsParam({
+                        transports: params[0].transports,
+                        manifest: settingsCache?.manifest,
+                    });
                 }
 
                 return (TrezorConnect[method] as any)(...params);


### PR DESCRIPTION
…uite desktop

This is probably not a major issue, but I felt we should maintain consistency with other transports that are created directly by [trezor-connect](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/device/DeviceList.ts#L140). 

Bluetooth descriptors would now report sessionOwner set to `BluetoothTransport` while usb reports `Trezor Suite desktop`. This PR unifies both bluetooth and usb to `Trezor Suite desktop`.

before: 

<img width="674" height="157" alt="image" src="https://github.com/user-attachments/assets/83f5c917-82d9-4a6d-812d-d24c7f7198f6" />

after: 

<img width="723" height="175" alt="image" src="https://github.com/user-attachments/assets/c133e948-6b89-41f3-b3e4-3b1b265d7def" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-descriptor-session-owner&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-descriptor-session-owner&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-descriptor-session-owner&lookback=7)