### PR TITLE
fix(suite): Tor misbehaving -> Tor slow

### DIFF
--- a/packages/suite-desktop-api/src/enums.ts
+++ b/packages/suite-desktop-api/src/enums.ts
@@ -4,5 +4,5 @@ export enum TorStatus {
     Disabling = 'Disabling',
     Enabling = 'Enabling',
     Error = 'Error',
-    Misbehaving = 'Misbehaving',
+    Slow = 'Slow',
 }

--- a/packages/suite-desktop-core/src/modules/request-interceptor.ts
+++ b/packages/suite-desktop-core/src/modules/request-interceptor.ts
@@ -52,7 +52,7 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
             case 'NETWORK_MISBEHAVING':
                 logger.debug(SERVICE_NAME, 'networks is misbehaving');
                 mainWindowProxy.getInstance()?.webContents.send('tor/status', {
-                    type: TorStatus.Misbehaving,
+                    type: TorStatus.Slow,
                 });
 
                 return;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Tor.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Tor.tsx
@@ -27,7 +27,7 @@ const torStatusTranslationMap: Record<TorStatus, TranslationKey> = {
     [TorStatus.Disabling]: 'TR_TOR_DISABLING',
     [TorStatus.Enabling]: 'TR_TOR_ENABLING',
     [TorStatus.Error]: 'TR_TOR_ERROR',
-    [TorStatus.Misbehaving]: 'TR_TOR_MISBEHAVING',
+    [TorStatus.Slow]: 'TR_TOR_SLOW',
 };
 
 const torIconMap: Record<TorStatus, IconName> = {
@@ -36,7 +36,7 @@ const torIconMap: Record<TorStatus, IconName> = {
     [TorStatus.Disabling]: 'arrowsClockwise',
     [TorStatus.Enabling]: 'arrowsClockwise',
     [TorStatus.Error]: 'warning',
-    [TorStatus.Misbehaving]: 'warning',
+    [TorStatus.Slow]: 'info',
 };
 
 const torIconVariantMap: Record<TorStatus, IconVariant> = {
@@ -45,7 +45,7 @@ const torIconVariantMap: Record<TorStatus, IconVariant> = {
     [TorStatus.Disabling]: 'destructive',
     [TorStatus.Enabling]: 'info',
     [TorStatus.Error]: 'warning',
-    [TorStatus.Misbehaving]: 'warning',
+    [TorStatus.Slow]: 'info',
 };
 
 type TorTooltipProps = {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4309,8 +4309,8 @@ export default defineMessages({
         id: 'TR_TOR_ERROR',
         defaultMessage: 'Error',
     },
-    TR_TOR_MISBEHAVING: {
-        id: 'TR_TOR_MISBEHAVING',
+    TR_TOR_SLOW: {
+        id: 'TR_TOR_SLOW',
         defaultMessage: 'Running slow',
     },
     TR_TOR_TITLE: {

--- a/packages/suite/src/support/suite/useTor.tsx
+++ b/packages/suite/src/support/suite/useTor.tsx
@@ -30,7 +30,7 @@ export const useTor = () => {
             desktopApi.on('tor/status', (newStatus: TorStatusEvent) => {
                 const { type } = newStatus;
                 dispatch(updateTorStatus(type));
-                if (type === TorStatus.Misbehaving) {
+                if (type === TorStatus.Slow) {
                     // When network is slow for some reason but still working we display toast message
                     // to let the user know that it is going to take some time but it's working.
                     dispatch(

--- a/packages/suite/src/utils/suite/tor.ts
+++ b/packages/suite/src/utils/suite/tor.ts
@@ -19,8 +19,7 @@ export const isOnionUrl = (url: string) => {
 export const getIsTorEnabled = (torStatus: TorStatus) => {
     switch (torStatus) {
         case TorStatus.Enabled:
-        case TorStatus.Misbehaving:
-            // When Tor is in status Misbehaving means network is not behaving properly but still enabled.
+        case TorStatus.Slow:
             return true;
 
         case TorStatus.Enabling:


### PR DESCRIPTION
Instead of displaying that Tor is misbehaving, display that Tor is slow. Changed warning to info, as this can happen on just slow netowrks.

## Related Issue

Resolve #21638

## Screenshots:
<img width="370" height="184" alt="tor" src="https://github.com/user-attachments/assets/cfbbffa4-b66a-49a0-9c79-ee60610bef15" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tor-clarify-misbehaving&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tor-clarify-misbehaving&lookback=7)