### PR TITLE
fix(suite-native): FW: fix device navigation handling

### DIFF
--- a/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
+++ b/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
@@ -135,10 +135,8 @@ export const FirmwareInstallationScreenContent = ({
     }, [operation, onFirmwareInstallationSuccess, setIsFirmwareInstallationRunning]);
 
     const handleCancel = useCallback(() => {
-        setIsFirmwareInstallationRunning(false);
-        TrezorConnect.cancel();
         navigation.goBack();
-    }, [navigation, setIsFirmwareInstallationRunning]);
+    }, [navigation]);
 
     const startFirmwareUpdate = useCallback(async () => {
         setIsFirmwareInstallationRunning(true);

--- a/suite-native/module-device-settings/src/screens/FirmwareInstallationScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/FirmwareInstallationScreen.tsx
@@ -35,7 +35,7 @@ export const FirmwareInstallationScreen = () => {
     }, [thpStep, initiateThpConnection, navigateToInitialScreen]);
 
     const handleFirmwareInstallationFailure = useCallback(() => {
-        navigation.navigate(FirmwareUpdateStackRoutes.ConfirmFirmwareUpdate);
+        navigation.popTo(FirmwareUpdateStackRoutes.ConfirmFirmwareUpdate);
     }, [navigation]);
 
     return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix navigation action when the firmware installation is canceled on the device.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
### Before

https://github.com/user-attachments/assets/12b6dee3-cfae-46c3-bbed-7ff1b8026522


### After

https://github.com/user-attachments/assets/b43715c6-73ee-4837-8579-0a31446f3be8



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/fw-device-navigation&lookback=7)