### PR TITLE
feat: do not use cache for non-production sources to ease the development

### DIFF
--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -9,6 +9,7 @@ import {
     uploadFirmware,
 } from '../api/firmware';
 import { ERRORS, PROTO } from '../constants';
+import { DataManager } from '../data/DataManager';
 import { getFirmwareLocation, getReleaseByVersion } from '../data/firmwareInfo';
 import type { Device } from '../device/Device';
 import { DeviceList } from '../device/DeviceList';
@@ -469,16 +470,19 @@ export const onCallFirmwareUpdate = async ({
 
     // We have completed binary download and we should notify sending an event,
     // if desktop wants to store it. We only do this for final FW, not intermediaries.
-    postMessage(
-        createUiMessage(UI.FIRMWARE_DOWNLOADED, {
+    const firmwareUpdateSource = DataManager.getSettings('firmwareUpdateSource');
+    const isCacheUsed = firmwareUpdateSource === 'production';
+    if (isCacheUsed) {
+        const message = createUiMessage(UI.FIRMWARE_DOWNLOADED, {
             binary: finalBinaryInfo.binary,
             binaryVersion: finalBinaryInfo.binaryVersion,
             releaseVersion: finalBinaryInfo.releaseVersion,
             firmwareType: device.firmwareType,
             internalModel: device.features.internal_model,
             release: finalBinaryRelase,
-        }),
-    );
+        });
+        postMessage(message);
+    }
 
     const deviceInitiallyConnectedInBootloader = device.features.bootloader_mode;
 

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -9,7 +9,6 @@ import {
     uploadFirmware,
 } from '../api/firmware';
 import { ERRORS, PROTO } from '../constants';
-import { DataManager } from '../data/DataManager';
 import { getFirmwareLocation, getReleaseByVersion } from '../data/firmwareInfo';
 import type { Device } from '../device/Device';
 import { DeviceList } from '../device/DeviceList';
@@ -23,6 +22,7 @@ import {
 } from '../types';
 import { FirmwareUpdateResponse } from '../types/api/firmwareUpdate';
 import type { Log } from '../utils/debug';
+import { isFirmwareCacheUsedForSelectedSource } from '../utils/firmwareUtils';
 
 type PostMessage = (message: CoreEventMessage) => void;
 
@@ -468,11 +468,9 @@ export const onCallFirmwareUpdate = async ({
 
     const finalBinaryRelase = device?.firmwareReleaseConfigInfo?.release;
 
-    // We have completed binary download and we should notify sending an event,
+    // We have completed binary download, and we should notify sending an event,
     // if desktop wants to store it. We only do this for final FW, not intermediaries.
-    const firmwareUpdateSource = DataManager.getSettings('firmwareUpdateSource');
-    const isCacheUsed = firmwareUpdateSource === 'production';
-    if (isCacheUsed) {
+    if (isFirmwareCacheUsedForSelectedSource()) {
         const message = createUiMessage(UI.FIRMWARE_DOWNLOADED, {
             binary: finalBinaryInfo.binary,
             binaryVersion: finalBinaryInfo.binaryVersion,

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -222,8 +222,11 @@ export const getReleaseByVersion = async (
 
     const releaseName = buildLocalReleaseName(firmwareType, deviceModel, firmwareVersion);
 
+    const firmwareUpdateSource = DataManager.getSettings('firmwareUpdateSource');
+    const isCacheUsed = firmwareUpdateSource === 'production';
+
     const { firmwareDir, firmwareList } = DataManager.getLocalFirmwares();
-    if (firmwareList.includes(releaseName)) {
+    if (isCacheUsed && firmwareList.includes(releaseName)) {
         const localReleasePath = `${firmwareDir}${releaseName}`;
         const localReleaseBuffer = await httpRequest(localReleasePath, 'json');
 

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -21,6 +21,7 @@ import {
     buildLocalFirmwareFileName,
     buildLocalReleaseName,
     findBestCompatibleRelease,
+    isFirmwareCacheUsedForSelectedSource,
     isStrictFeatures,
 } from '../utils/firmwareUtils';
 
@@ -222,11 +223,8 @@ export const getReleaseByVersion = async (
 
     const releaseName = buildLocalReleaseName(firmwareType, deviceModel, firmwareVersion);
 
-    const firmwareUpdateSource = DataManager.getSettings('firmwareUpdateSource');
-    const isCacheUsed = firmwareUpdateSource === 'production';
-
     const { firmwareDir, firmwareList } = DataManager.getLocalFirmwares();
-    if (isCacheUsed && firmwareList.includes(releaseName)) {
+    if (isFirmwareCacheUsedForSelectedSource() && firmwareList.includes(releaseName)) {
         const localReleasePath = `${firmwareDir}${releaseName}`;
         const localReleaseBuffer = await httpRequest(localReleasePath, 'json');
 
@@ -662,11 +660,8 @@ export const getFirmwareLocation = ({
         };
     }
 
-    const firmwareUpdateSource = DataManager.getSettings('firmwareUpdateSource');
-    const isCacheUsed = firmwareUpdateSource === 'production';
-
     const { firmwareDir, firmwareList } = DataManager.getLocalFirmwares();
-    if (isCacheUsed && firmwareList.includes(firmwareName)) {
+    if (isFirmwareCacheUsedForSelectedSource() && firmwareList.includes(firmwareName)) {
         return {
             baseUrl: firmwareDir,
             path: firmwareName,

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -659,8 +659,11 @@ export const getFirmwareLocation = ({
         };
     }
 
+    const firmwareUpdateSource = DataManager.getSettings('firmwareUpdateSource');
+    const isCacheUsed = firmwareUpdateSource === 'production';
+
     const { firmwareDir, firmwareList } = DataManager.getLocalFirmwares();
-    if (firmwareList.includes(firmwareName)) {
+    if (isCacheUsed && firmwareList.includes(firmwareName)) {
         return {
             baseUrl: firmwareDir,
             path: firmwareName,

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -2,6 +2,7 @@ import { FirmwareType } from '@trezor/device-utils';
 import type { DeviceModelInternal, FirmwareRelease, VersionArray } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
 
+import { DataManager } from '../data/DataManager';
 import type { CurrentVersion } from '../data/firmwareInfo';
 import type { Features, StrictFeatures } from '../types/device';
 
@@ -133,3 +134,6 @@ export const getFirmwareType = (features: Features) => {
 
     return type;
 };
+
+export const isFirmwareCacheUsedForSelectedSource = () =>
+    DataManager.getSettings('firmwareUpdateSource') === 'production';

--- a/packages/suite/src/components/firmware/FirmwareOffer.tsx
+++ b/packages/suite/src/components/firmware/FirmwareOffer.tsx
@@ -67,7 +67,11 @@ export const FirmwareOffer = ({ isCustomFirmware, targetFirmwareType }: Firmware
         >
             {currentVersion &&
                 (isDebugModeActive ? (
-                    <Tooltip content={<Text variant="warning">{release.firmware_revision}</Text>}>
+                    <Tooltip
+                        content={
+                            <Text variant="warning">DEV: {originalDevice.features.revision}</Text>
+                        }
+                    >
                         <CurrentVersion />
                     </Tooltip>
                 ) : (
@@ -106,7 +110,7 @@ export const FirmwareOffer = ({ isCustomFirmware, targetFirmwareType }: Firmware
                                 </MarkdownWithComponents>
                             ) : undefined}
                             {isDebugModeActive && (
-                                <Text variant="warning">{release.firmware_revision}</Text>
+                                <Text variant="warning">DEV: {release.firmware_revision}</Text>
                             )}
                         </Column>
                     }

--- a/packages/suite/src/components/firmware/FirmwareOffer.tsx
+++ b/packages/suite/src/components/firmware/FirmwareOffer.tsx
@@ -13,6 +13,8 @@ import { MarkdownWithComponents, Translation, TrezorLink } from 'src/components/
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { getSuiteFirmwareTypeString } from 'src/utils/firmware';
 
+import { selectIsDebugModeActive } from '../../selectors/suite/suiteSelectors';
+
 type FirmwareOfferProps = {
     isCustomFirmware?: boolean;
     targetFirmwareType?: FirmwareType;
@@ -20,6 +22,7 @@ type FirmwareOfferProps = {
 
 export const FirmwareOffer = ({ isCustomFirmware, targetFirmwareType }: FirmwareOfferProps) => {
     const useDevkit = useSelector(state => state.firmware.useDevkit);
+    const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const { originalDevice } = useFirmwareInstallation();
     const { translationString } = useTranslation();
 
@@ -32,13 +35,28 @@ export const FirmwareOffer = ({ isCustomFirmware, targetFirmwareType }: Firmware
         ? translationString('TR_CUSTOM_FIRMWARE_VERSION')
         : getFwUpdateVersion(originalDevice);
 
-    const parsedChangelog = isCustomFirmware
-        ? null
-        : parseFirmwareChangelog({ release: originalDevice.firmwareReleaseConfigInfo.release });
+    const { release } = originalDevice.firmwareReleaseConfigInfo;
+
+    const parsedChangelog = isCustomFirmware ? null : parseFirmwareChangelog({ release });
     const changelogUrl = getChangelogUrl(originalDevice);
 
     const currentFirmwareType = getSuiteFirmwareTypeString(originalDevice.firmwareType);
     const futureFirmwareType = getSuiteFirmwareTypeString(targetFirmwareType);
+
+    const CurrentVersion = () => (
+        <>
+            <Column alignItems="center" gap={spacings.xxs}>
+                <Text typographyStyle="label" variant="tertiary">
+                    <Translation id="TR_ONBOARDING_CURRENT_VERSION" />
+                </Text>
+                <Text typographyStyle="hint">
+                    {currentFirmwareType ? translationString(currentFirmwareType) : ''}
+                    {currentVersion ? ` ${currentVersion}` : ''}
+                </Text>
+            </Column>
+            <Icon name="arrowRight" size={16} />
+        </>
+    );
 
     return (
         <Row
@@ -47,20 +65,14 @@ export const FirmwareOffer = ({ isCustomFirmware, targetFirmwareType }: Firmware
             width="100%"
             margin={{ vertical: spacings.md, horizontal: 'auto' }}
         >
-            {currentVersion && (
-                <>
-                    <Column alignItems="center" gap={spacings.xxs}>
-                        <Text typographyStyle="label" variant="tertiary">
-                            <Translation id="TR_ONBOARDING_CURRENT_VERSION" />
-                        </Text>
-                        <Text typographyStyle="hint">
-                            {currentFirmwareType ? translationString(currentFirmwareType) : ''}
-                            {currentVersion ? ` ${currentVersion}` : ''}
-                        </Text>
-                    </Column>
-                    <Icon name="arrowRight" size={16} />
-                </>
-            )}
+            {currentVersion &&
+                (isDebugModeActive ? (
+                    <Tooltip content={<Text variant="warning">{release.firmware_revision}</Text>}>
+                        <CurrentVersion />
+                    </Tooltip>
+                ) : (
+                    <CurrentVersion />
+                ))}
             <Column alignItems="center" gap={spacings.xxs}>
                 <Text typographyStyle="label" variant="tertiary">
                     <Translation id="TR_ONBOARDING_NEW_VERSION" />
@@ -87,11 +99,16 @@ export const FirmwareOffer = ({ isCustomFirmware, targetFirmwareType }: Firmware
                         ) : undefined
                     }
                     content={
-                        parsedChangelog ? (
-                            <MarkdownWithComponents>
-                                {parsedChangelog.changelog}
-                            </MarkdownWithComponents>
-                        ) : undefined
+                        <Column>
+                            {parsedChangelog ? (
+                                <MarkdownWithComponents>
+                                    {parsedChangelog.changelog}
+                                </MarkdownWithComponents>
+                            ) : undefined}
+                            {isDebugModeActive && (
+                                <Text variant="warning">{release.firmware_revision}</Text>
+                            )}
+                        </Column>
                     }
                     isActive={!!parsedChangelog}
                 >

--- a/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import { firmwareActions, selectFirmwareUpdateSource } from '@suite-common/firmware';
+import { Column, Text } from '@trezor/components';
 import { FirmwareUpdateSource } from '@trezor/connect/src/types/firmware';
 
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from 'src/components/suite';
@@ -32,7 +33,18 @@ export const FirmwareUpdateEnvironmentSelect = () => {
         <SectionItem>
             <TextColumn
                 title="Firmware Update Source"
-                description="Set firmware update source for testing unsigned and signed. Remember you have to reload the web app or desktop in order for it to be fully applied."
+                description={
+                    <Column gap={4}>
+                        <Text>
+                            Set firmware update source for testing unsigned and signed. Remember you
+                            have to reload the web app or desktop in order for it to be fully
+                            applied.
+                        </Text>
+                        <Text variant="info">
+                            If you select production, the binaries will be cached.
+                        </Text>
+                    </Column>
+                }
             />
             <ActionColumn>
                 <StyledActionSelect


### PR DESCRIPTION

<img width="1559" height="305" alt="image" src="https://github.com/user-attachments/assets/6f6b315d-3467-4a91-aefb-e574b57bd498" />

<img width="865" height="348" alt="image" src="https://github.com/user-attachments/assets/81a53cab-12cf-4d39-8a73-feb156eeefb9" />

<img width="865" height="348" alt="image" src="https://github.com/user-attachments/assets/e9415b86-53a9-4111-ad5e-a71fc7586a09" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=disable-cache-for-non-production-fw-builds&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=disable-cache-for-non-production-fw-builds&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=disable-cache-for-non-production-fw-builds&lookback=7)