### PR TITLE
ci(suite-native): fix translations job

### DIFF
--- a/.github/workflows/bot-crowdin-sync.yml
+++ b/.github/workflows/bot-crowdin-sync.yml
@@ -96,7 +96,6 @@ jobs:
             PR_TITLE="Crowdin translations update [MOBILE]"
             PR_BODY="Automatically generated PR for updating MOBILE crowdin translations from ${{ env.SOURCE_BRANCH }} branch."
             COMMIT_SCOPE="suite-native"
-          else
           fi
 
           COMMIT_MSG="chore(${COMMIT_SCOPE}): crowdin translation update${SUFFIX}"


### PR DESCRIPTION
Fixes bash syntax error. 



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ci/translations-sync-job-syntax&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ci/translations-sync-job-syntax&lookback=7)