### PR TITLE
fix(suite-web): bundle missing polyfills

### DIFF
--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -1,5 +1,5 @@
 import { sentryWebpackPlugin } from '@sentry/webpack-plugin';
-import path from 'path';
+import path, { resolve } from 'path';
 import TerserPlugin from 'terser-webpack-plugin';
 import webpack from 'webpack';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
@@ -111,6 +111,15 @@ const config: webpack.Configuration = {
                                 },
                             ],
                             '@babel/preset-typescript',
+                            [
+                                '@babel/preset-env',
+                                {
+                                    corejs: 3,
+                                    configPath: resolve(__dirname, '../browserslist'),
+                                    shippedProposals: true,
+                                    useBuiltIns: 'usage',
+                                },
+                            ],
                         ],
                         plugins: [
                             [

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -19,6 +19,7 @@
         "@suite-common/suite-types": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/suite": "workspace:*",
+        "core-js": "^3.45.1",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-helmet-async": "^2.0.5",

--- a/packages/suite-web/src/MainWeb.tsx
+++ b/packages/suite-web/src/MainWeb.tsx
@@ -1,3 +1,6 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import 'core-js/actual';
+
 /* eslint-disable import/order */
 import { Provider as ReduxProvider } from 'react-redux';
 import { HelmetProvider } from 'react-helmet-async';

--- a/packages/suite-web/src/MainWeb.tsx
+++ b/packages/suite-web/src/MainWeb.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import 'core-js/actual';
 
 /* eslint-disable import/order */

--- a/yarn.lock
+++ b/yarn.lock
@@ -14015,6 +14015,7 @@ __metadata:
     "@trezor/suite-local-first-storage": "workspace:*"
     "@types/react": "npm:^19.0.0"
     "@types/react-dom": "npm:^19.0.0"
+    core-js: "npm:^3.45.1"
     postcss-styled-syntax: "npm:^0.7.1"
     react: "npm:19.0.0"
     react-dom: "npm:19.0.0"


### PR DESCRIPTION
## Description
- Configure the `@babel/preset-env` to add required polyfills based on current browserslist.
- Note, the `import 'core-js';` must be added to the app root, else it won't load any.

## Related Issue

Resolve #21684 

### Screenshots

<img width="502" height="149" alt="Snímek obrazovky 2025-09-22 v 16 52 37" src="https://github.com/user-attachments/assets/9807ec9c-b59d-4f09-8ac0-c9cb0f6442b4" />
<img width="1512" height="828" alt="Snímek obrazovky 2025-09-22 v 16 57 59" src="https://github.com/user-attachments/assets/294910ca-5e0a-4c78-840d-77a35a94febc" />
<img width="1512" height="803" alt="Snímek obrazovky 2025-09-22 v 17 02 13" src="https://github.com/user-attachments/assets/1b7e1329-5ff1-4a2a-8540-0febb69dc1d7" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/21684-babel-polyfills&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/21684-babel-polyfills&lookback=7)