### PR TITLE
feat(suite): prioritize usb transport above bluetooth

### DIFF
--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -284,8 +284,17 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         return this.devices.length;
     }
 
+    getPrioritizedDevices() {
+        return [...this.devices].sort(
+            (a, b) =>
+                // USB transport is prioritized over Bluetooth
+                (a.descriptor.apiType === 'bluetooth' ? 1 : 0) -
+                (b.descriptor.apiType === 'bluetooth' ? 1 : 0),
+        );
+    }
+
     getAllDevices() {
-        return this.devices as readonly Device[];
+        return this.getPrioritizedDevices() as readonly Device[];
     }
 
     getOnlyDevice(): Device | undefined {
@@ -293,13 +302,13 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
     }
 
     getDeviceByPath(path: DeviceUniquePath): Device | undefined {
-        return this.devices.find(d => d.getUniquePath() === path);
+        return this.getPrioritizedDevices().find(d => d.getUniquePath() === path);
     }
 
     getDeviceByStaticState(state: StaticSessionId): Device | undefined {
         const deviceId = state.split('@')[1].split(':')[0];
 
-        return this.devices.find(d => d.features?.device_id === deviceId);
+        return this.getPrioritizedDevices().find(d => d.features?.device_id === deviceId);
     }
 
     async dispose() {

--- a/packages/suite/src/actions/bluetooth/DesktopBluetoothDevice.ts
+++ b/packages/suite/src/actions/bluetooth/DesktopBluetoothDevice.ts
@@ -9,6 +9,7 @@ import { BluetoothDevice } from '@trezor/transport-bluetooth';
 export type DesktopBluetoothDevice = Omit<BluetoothDevice, 'data' | 'id'> & {
     manufacturerData: BluetoothManufacturerData;
     id: BluetoothDeviceId;
+    deviceId?: string; // Trezor device id (not known for unacquired devices)
 };
 
 export const toBluetoothDevice = (device: DesktopBluetoothDevice): BluetoothDevice => ({

--- a/packages/suite/src/actions/bluetooth/bluetoothDisconnectDeviceThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothDisconnectDeviceThunk.ts
@@ -4,6 +4,8 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { BluetoothDeviceId } from '@trezor/connect';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
+import { stopConnectingBluetoothDevice } from './desktopBluetoothReducer';
+
 type BluetoothDisconnectDeviceThunkResult = {
     success: boolean;
 };
@@ -32,6 +34,9 @@ export const bluetoothDisconnectDeviceThunk = createThunk<
                 }),
             );
         }
+
+        // just in case if we were in the process of connecting this device
+        dispatch(stopConnectingBluetoothDevice({ deviceId: id }));
 
         return fulfillWithValue({ success: result.success });
     },

--- a/packages/suite/src/actions/bluetooth/bluetoothOnDeviceConnectedThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothOnDeviceConnectedThunk.ts
@@ -1,0 +1,29 @@
+import { BLUETOOTH_PREFIX } from '@suite-common/bluetooth';
+import { selectKnownDeviceByDeviceId } from '@suite-common/bluetooth/src/bluetoothSelectors';
+import { createThunk } from '@suite-common/redux-utils';
+import { Device } from '@trezor/connect';
+
+import { bluetoothDisconnectDeviceThunk } from './bluetoothDisconnectDeviceThunk';
+
+// called on DEVICE.CONNECT event
+export const bluetoothOnDeviceConnectedThunk = createThunk<void, Device, void>(
+    `${BLUETOOTH_PREFIX}/bluetoothOnDeviceConnectedThunk`,
+    (device, { dispatch, getState }) => {
+        const knownDevice = selectKnownDeviceByDeviceId(getState(), device.id ?? undefined);
+
+        // device is re-connected over USB, but the same device is already connected over BT
+        // -> disconnect the BT connection
+        if (
+            !device.bluetoothProps &&
+            (knownDevice?.connectionStatus.type === 'connected' ||
+                knownDevice?.connectionStatus.type === 'connecting')
+        ) {
+            console.warn('Disconnecting BT device because the same device was connected over USB');
+            dispatch(
+                bluetoothDisconnectDeviceThunk({
+                    id: knownDevice.id,
+                }),
+            );
+        }
+    },
+);

--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -8,7 +8,9 @@ import {
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { selectDevices } from '@suite-common/wallet-core';
+import TrezorConnect from '@trezor/connect';
 import { BluetoothDevice, bluetoothIpc } from '@trezor/transport-bluetooth';
+import { resolveAfter } from '@trezor/utils';
 
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
@@ -55,12 +57,6 @@ export const initBluetoothThunk = createThunk<void, void, void>(
                     status: apiInfo.payload.state,
                 }),
             );
-        }
-
-        // If we already have some paired devices, we assume user will have a BT device,
-        // and therefore we start looking for it.
-        if (knownDevices.length > 0) {
-            dispatch(bluetoothStartScanningThunk());
         }
 
         const attemptDeviceConnect = async ({ device }: { device: DesktopBluetoothDevice }) => {
@@ -149,11 +145,36 @@ export const initBluetoothThunk = createThunk<void, void, void>(
             );
         });
 
-        bluetoothIpc.on('device-update', async (deviceIpc: BluetoothDevice) => {
+        bluetoothIpc.on('device-update', (deviceIpc: BluetoothDevice) => {
             const device = fromBluetoothDevice(deviceIpc);
 
             dispatch(bluetoothActions.deviceUpdateAction({ device }));
-            await attemptDeviceConnect({ device });
+        });
+
+        // Wait for 3 seconds or earlier if a connected device is detected.
+        // The delay shouldn't be too perceptible, since other things are also loading at app start.
+        // If user connects a device via USB, we don't start the BT connection,
+        // this avoids clashes where both USB and BT try to connect at the same time.
+        const waitForDevice = new Promise<void>(resolve => {
+            const cleanup = () => {
+                TrezorConnect.off('device-connect', cleanup);
+                resolve();
+            };
+
+            TrezorConnect.on('device-connect', cleanup);
+        });
+        Promise.race([waitForDevice, resolveAfter(3000)]).then(() => {
+            // Start attempting to connect to known BT devices
+            bluetoothIpc.on('device-update', async (deviceIpc: BluetoothDevice) => {
+                const device = fromBluetoothDevice(deviceIpc);
+                await attemptDeviceConnect({ device });
+            });
+
+            // If we already have some paired devices, we assume user will have a BT device,
+            // and therefore we start looking for it.
+            if (knownDevices.length > 0) {
+                dispatch(bluetoothStartScanningThunk());
+            }
         });
     },
 );

--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -5,6 +5,7 @@ import {
     selectAutoConnectPolicy,
     selectKnownDevices,
 } from '@suite-common/bluetooth';
+import { selectFirmware } from '@suite-common/firmware';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { selectDevices } from '@suite-common/wallet-core';
@@ -66,6 +67,7 @@ export const initBluetoothThunk = createThunk<void, void, void>(
             const connectingDevices = selectConnectingDevices(getState());
             const adapterStatus = selectAdapterStatus(getState());
             const suiteDevices = selectDevices(getState());
+            const firmwareStatus = selectFirmware(getState());
 
             if (adapterStatus === 'power-suspending') {
                 // system is going to sleep
@@ -86,8 +88,12 @@ export const initBluetoothThunk = createThunk<void, void, void>(
                     !d.bluetoothProps &&
                     d.connected,
             );
+            // if FW update is in progress, only connect if it's the same device
+            const fwUpdatingDifferentDevice =
+                firmwareStatus.status === 'started' &&
+                firmwareStatus.cachedDevice?.bluetoothProps?.id !== device.id;
 
-            if (hasUnacquiredDevice || hasSameUsbDevice) {
+            if (hasUnacquiredDevice || hasSameUsbDevice || fwUpdatingDifferentDevice) {
                 return;
             }
 

--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -7,6 +7,7 @@ import {
 } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import { selectDevices } from '@suite-common/wallet-core';
 import { BluetoothDevice, bluetoothIpc } from '@trezor/transport-bluetooth';
 
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
@@ -68,6 +69,7 @@ export const initBluetoothThunk = createThunk<void, void, void>(
             );
             const connectingDevices = selectConnectingDevices(getState());
             const adapterStatus = selectAdapterStatus(getState());
+            const suiteDevices = selectDevices(getState());
 
             if (adapterStatus === 'power-suspending') {
                 // system is going to sleep
@@ -75,6 +77,21 @@ export const initBluetoothThunk = createThunk<void, void, void>(
             }
 
             if (!knownDevice || connectingDevices.includes(knownDevice.id)) {
+                return;
+            }
+
+            // wait to acquire existing devices before connecting to the new one
+            const hasUnacquiredDevice = suiteDevices.some(d => d.type === 'unacquired');
+            // prioritize USB if already connected
+            const hasSameUsbDevice = suiteDevices.find(
+                d =>
+                    knownDevice?.deviceId &&
+                    d.id === knownDevice.deviceId &&
+                    !d.bluetoothProps &&
+                    d.connected,
+            );
+
+            if (hasUnacquiredDevice || hasSameUsbDevice) {
                 return;
             }
 

--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -13,6 +13,7 @@ import { DEVICE, UI } from '@trezor/connect';
 import { isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
+import { bluetoothOnDeviceConnectedThunk } from 'src/actions/bluetooth/bluetoothOnDeviceConnectedThunk';
 import * as languageActions from 'src/actions/settings/languageActions';
 import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import * as modalActions from 'src/actions/suite/modalActions';
@@ -76,6 +77,7 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
             trezorConnectActions.connectInitThunk({
                 [DEVICE.CONNECT]: device => {
                     dispatch(markDeviceAsRecentlyConnectedThunk(device));
+                    dispatch(bluetoothOnDeviceConnectedThunk(device));
                 },
                 [DEVICE.CONNECT_UNACQUIRED]: device => {
                     dispatch(markDeviceAsRecentlyConnectedThunk(device));

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -146,6 +146,7 @@ export const saveKnownDevices = () => (_dispatch: Dispatch, getState: GetState) 
                     lastUpdatedTimestamp: it.lastUpdatedTimestamp,
                     paired: it.paired,
                     rssi: it.rssi,
+                    deviceId: it.deviceId,
 
                     // Those fields are reset to prevent some state-inconsistency and UI flickering
                     connected: false,

--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -89,7 +89,7 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                 }
 
                 state.knownDevices = state.knownDevices.map(it =>
-                    it.id === device.id ? device : it,
+                    it.id === device.id ? { deviceId: it.deviceId, ...device } : it,
                 ) as Draft<T>[];
             })
             .addCase(
@@ -127,7 +127,7 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                     state,
                     {
                         payload: {
-                            device: { bluetoothProps },
+                            device: { bluetoothProps, id: deviceId },
                         },
                     }: { payload: DeviceConnectActionPayload },
                 ) => {
@@ -144,9 +144,13 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                             it => it.id === bluetoothProps.id,
                         );
                         if (foundKnownDevice === undefined) {
-                            state.knownDevices.push(device);
+                            state.knownDevices.push({ ...device, deviceId });
                         } else {
                             delete state.autoConnectPolicy[bluetoothProps.id];
+                            // update deviceId in case it was missing
+                            if (deviceId && foundKnownDevice.deviceId !== deviceId) {
+                                foundKnownDevice.deviceId = deviceId;
+                            }
                         }
                     }
                 },

--- a/suite-common/bluetooth/src/bluetoothSelectors.ts
+++ b/suite-common/bluetooth/src/bluetoothSelectors.ts
@@ -50,3 +50,13 @@ export const selectScanStatus = <T extends BluetoothDeviceCommon>(state: WithBlu
 export const selectAutoConnectPolicy = <T extends BluetoothDeviceCommon>(
     state: WithBluetoothState<T>,
 ) => state.bluetooth.autoConnectPolicy;
+
+export const selectKnownDeviceByDeviceId = <T extends BluetoothDeviceCommon>(
+    state: WithBluetoothState<T>,
+    deviceId?: string,
+) => {
+    if (!deviceId) return undefined;
+    const knownDevices = selectKnownDevices(state);
+
+    return knownDevices.find(device => device.deviceId === deviceId);
+};

--- a/suite-common/bluetooth/src/types.ts
+++ b/suite-common/bluetooth/src/types.ts
@@ -53,6 +53,7 @@ export type BluetoothDeviceCommon = {
     manufacturerData: BluetoothManufacturerData;
     lastUpdatedTimestamp: number;
     connectionStatus: DeviceBluetoothConnectionStatus;
+    deviceId?: string;
 };
 
 export type DeviceBluetoothConnectionStatusType = DeviceBluetoothConnectionStatus['type'];

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -203,6 +203,11 @@ const connectDevice = (draft: DeviceReducerState, device: Device) => {
     // update affected devices
     if (affectedDevices.length > 0) {
         const changedDevices = affectedDevices.map(d => {
+            // new connection is over bluetooth, existing one is usb. prioritize usb.
+            if (!d.bluetoothProps && d.connected && device.bluetoothProps) {
+                return merge(d, { connected: true, available: true });
+            }
+
             // change availability according to "passphrase_protection" field
             if (
                 d.useEmptyPassphrase !== true &&
@@ -293,6 +298,10 @@ const changeDevice = (
         const isDeviceUnlocked = isUnlocked(device.features);
         // merge incoming device with State
         const changedDevices = affectedDevices.map(d => {
+            // new connection is over bluetooth, existing one is usb. prioritize usb.
+            if (!d.bluetoothProps && d.connected && device.bluetoothProps) {
+                return d;
+            }
             if (d.state && isDeviceUnlocked) {
                 // if device is unlocked and authorized (with state) check availability.
                 // if it was created with passphrase (useEmptyPassphrase = false) then availability depends on current settings

--- a/suite-native/bluetooth/src/types.ts
+++ b/suite-native/bluetooth/src/types.ts
@@ -13,4 +13,5 @@ export type BluetoothPermissionStatus =
 export type BluetoothDevice = Omit<TransportBluetoothDevice, 'manufacturerData' | 'id'> & {
     id: BluetoothDeviceId;
     manufacturerData: BluetoothManufacturerData;
+    deviceId?: string; // Trezor device id (not known for unacquired devices)
 };


### PR DESCRIPTION
## Description

1. Prioritize USB transport above Bluetooth in DeviceList
2. Prioritize USB connection above Bluetooth when merging duplicate devices in `deviceReducer`.
3. Remember `deviceId` in Bluetooth `knownDevices`, so we can compare ID across connections.
4. Don't attempt new Bluetooth connection if we already have USB connection for the same device or if there is any unacquired device (to avoid conflicts).
5. Handle race conditions during init between USB and BT by delaying BT scan/connections by 3 seconds on start. 
6. Disconnect Bluetooth device from Suite once the same device is connected via USB

Test cases: 
1. Suite startup when connected over USB and Bluetooth adapter is on -> USB device is prioritized, BT connection not attempted
2. USB disconnected -> reconnects over Bluetooth automatically
3. USB reconnected -> switches back to USB automatically
4. FW update via USB while BT is also enabled

## Related Issue

Resolve #21745 , resolve #21700

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-usb-switching-same-device&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-usb-switching-same-device&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/bt-usb-switching-same-device&lookback=7)