### PR TITLE
feat(suite-native): guide user to unpair ble from system settings on ios

### DIFF
--- a/suite-native/atoms/src/BottomSheetListItem.tsx
+++ b/suite-native/atoms/src/BottomSheetListItem.tsx
@@ -12,16 +12,21 @@ const listItemStyle = prepareNativeStyle(() => ({
 
 type BottomSheetListItemProps = OrderedListIconProps & {
     translationKey: TxKeyPath;
+    translationValues?: Record<string, string | undefined>;
 };
 
-export const BottomSheetListItem = ({ translationKey, ...props }: BottomSheetListItemProps) => {
+export const BottomSheetListItem = ({
+    translationKey,
+    translationValues,
+    ...props
+}: BottomSheetListItemProps) => {
     const { applyStyle } = useNativeStyles();
 
     return (
         <HStack spacing="sp12" alignItems="center">
             <OrderedListIcon {...props} />
             <Text style={applyStyle(listItemStyle)}>
-                <Translation id={translationKey} />
+                <Translation id={translationKey} values={translationValues} />
             </Text>
         </HStack>
     );

--- a/suite-native/bluetooth/src/components/SystemUnpairingAlertIosInstructions.tsx
+++ b/suite-native/bluetooth/src/components/SystemUnpairingAlertIosInstructions.tsx
@@ -1,0 +1,40 @@
+import { useSelector } from 'react-redux';
+
+import { selectDeviceName } from '@suite-common/wallet-core';
+import { BottomSheetListItem, Box, Text, VStack } from '@suite-native/atoms';
+import { Translation, TxKeyPath } from '@suite-native/intl';
+
+type SystemUnpairingAlertIosInstructionsProps = {
+    translationKey: TxKeyPath;
+};
+
+export const SystemUnpairingAlertIosInstructions = ({
+    translationKey,
+}: SystemUnpairingAlertIosInstructionsProps) => {
+    const deviceName = useSelector(selectDeviceName);
+
+    return (
+        <Box>
+            <Text>
+                <Translation id={translationKey} />
+            </Text>
+            <VStack paddingTop="sp24">
+                <BottomSheetListItem
+                    iconNumber={1}
+                    translationKey="bluetooth.alerts.pairingInstructions.step1"
+                />
+                <BottomSheetListItem
+                    iconNumber={2}
+                    translationKey="bluetooth.alerts.pairingInstructions.step2"
+                    translationValues={{
+                        deviceName,
+                    }}
+                />
+                <BottomSheetListItem
+                    iconNumber={3}
+                    translationKey="bluetooth.alerts.pairingInstructions.step3"
+                />
+            </VStack>
+        </Box>
+    );
+};

--- a/suite-native/bluetooth/src/hooks/useBluetoothAlerts.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothAlerts.ts
@@ -1,29 +1,29 @@
 import { useCallback, useState } from 'react';
 import { openSettings } from 'react-native-permissions';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
 import { useAlert } from '@suite-native/alerts';
 import { useTranslate } from '@suite-native/intl';
 
-import { setShouldShowSystemUnpairingAlert } from '../bluetoothSlice';
 import { selectBluetoothAdapterStatus, selectBluetoothPermissionStatus } from '../selectors';
 import { useBluetoothPermissions } from './useBluetoothPermissions';
+import { useBluetoothPlatformSpecificAlerts } from './useBluetoothPlatformSpecificAlerts';
 import { useBluetoothSettings } from './useBluetoothSettings';
 
 export const useBluetoothAlerts = () => {
     const { showAlert, hideAlert } = useAlert();
     const { translate } = useTranslate();
     const navigation = useNavigation();
-    const dispatch = useDispatch();
 
     const { requestBluetoothPermission } = useBluetoothPermissions();
-    const { openBluetoothSettings, openLocationServicesSettings } = useBluetoothSettings();
+    const { openLocationServicesSettings } = useBluetoothSettings();
+    const { showBluetoothAdapterDisabledAlert, showPairingFailedAlert, showSystemUnpairingAlert } =
+        useBluetoothPlatformSpecificAlerts();
 
     const bluetoothPermissionStatus = useSelector(selectBluetoothPermissionStatus);
     const bluetoothAdapterStatus = useSelector(selectBluetoothAdapterStatus);
-
     const [isBluetoothAlertShown, setIsBluetoothAlertShown] = useState(false);
 
     const showOrHideBluetoothAlert = useCallback(() => {
@@ -48,14 +48,7 @@ export const useBluetoothAlerts = () => {
             });
             setIsBluetoothAlertShown(true);
         } else if (bluetoothAdapterStatus === 'disabled') {
-            showAlert({
-                title: translate('bluetooth.alerts.adapterDisabled.title'),
-                description: translate('bluetooth.alerts.adapterDisabled.description'),
-                primaryButtonTitle: translate('bluetooth.alerts.adapterDisabled.primaryButton'),
-                onPressPrimaryButton: openBluetoothSettings,
-                secondaryButtonTitle: translate('generic.buttons.cancel'),
-                onPressSecondaryButton: navigation.goBack,
-            });
+            showBluetoothAdapterDisabledAlert();
             setIsBluetoothAlertShown(true);
         } else if (bluetoothAdapterStatus === 'enabled') {
             if (isBluetoothAlertShown) {
@@ -68,10 +61,10 @@ export const useBluetoothAlerts = () => {
         requestBluetoothPermission,
         bluetoothAdapterStatus,
         isBluetoothAlertShown,
-        openBluetoothSettings,
         navigation,
         translate,
         showAlert,
+        showBluetoothAdapterDisabledAlert,
         hideAlert,
     ]);
 
@@ -87,32 +80,6 @@ export const useBluetoothAlerts = () => {
             onPressSecondaryButton: navigation.goBack,
         });
     }, [showAlert, openLocationServicesSettings, translate, navigation]);
-
-    const showPairingFailedAlert = useCallback(() => {
-        showAlert({
-            title: translate('bluetooth.alerts.pairingFailed.title'),
-            description: translate('bluetooth.alerts.pairingFailed.description'),
-            primaryButtonTitle: translate('bluetooth.alerts.pairingFailed.primaryButton'),
-            onPressPrimaryButton: openBluetoothSettings,
-            secondaryButtonTitle: translate('bluetooth.alerts.pairingFailed.secondaryButton'),
-        });
-    }, [showAlert, openBluetoothSettings, translate]);
-
-    const showSystemUnpairingAlert = useCallback(() => {
-        showAlert({
-            title: translate('bluetooth.alerts.systemUnpairing.title'),
-            description: translate('bluetooth.alerts.systemUnpairing.description'),
-            primaryButtonTitle: translate('bluetooth.alerts.systemUnpairing.primaryButton'),
-            onPressPrimaryButton: () => {
-                dispatch(setShouldShowSystemUnpairingAlert(false));
-                openBluetoothSettings();
-            },
-            secondaryButtonTitle: translate('bluetooth.alerts.systemUnpairing.secondaryButton'),
-            onPressSecondaryButton: () => {
-                dispatch(setShouldShowSystemUnpairingAlert(false));
-            },
-        });
-    }, [showAlert, dispatch, openBluetoothSettings, translate]);
 
     return {
         showOrHideBluetoothAlert,

--- a/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.android.tsx
+++ b/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.android.tsx
@@ -1,0 +1,64 @@
+// This is Android version, see the file name.
+
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { useAlert } from '@suite-native/alerts';
+import { useTranslate } from '@suite-native/intl';
+
+import { setShouldShowSystemUnpairingAlert } from '../bluetoothSlice';
+import { useBluetoothSettings } from './useBluetoothSettings';
+
+export const useBluetoothPlatformSpecificAlerts = () => {
+    const { showAlert } = useAlert();
+    const { translate } = useTranslate();
+    const dispatch = useDispatch();
+    const navigation = useNavigation();
+
+    const { openBluetoothSettings } = useBluetoothSettings();
+
+    const showBluetoothAdapterDisabledAlert = useCallback(() => {
+        showAlert({
+            title: translate('bluetooth.alerts.adapterDisabled.title'),
+            description: translate('bluetooth.alerts.adapterDisabled.description.android'),
+            primaryButtonTitle: translate('bluetooth.alerts.adapterDisabled.primaryButton'),
+            onPressPrimaryButton: openBluetoothSettings,
+            secondaryButtonTitle: translate('generic.buttons.cancel'),
+            onPressSecondaryButton: navigation.goBack,
+        });
+    }, [showAlert, navigation.goBack, openBluetoothSettings, translate]);
+
+    const showPairingFailedAlert = useCallback(() => {
+        showAlert({
+            title: translate('bluetooth.alerts.pairingFailed.title'),
+            description: translate('bluetooth.alerts.pairingFailed.description'),
+            primaryButtonTitle: translate('bluetooth.alerts.pairingFailed.primaryButton'),
+            onPressPrimaryButton: openBluetoothSettings,
+            secondaryButtonTitle: translate('bluetooth.alerts.pairingFailed.secondaryButton'),
+        });
+    }, [showAlert, openBluetoothSettings, translate]);
+
+    const showSystemUnpairingAlert = useCallback(() => {
+        showAlert({
+            title: translate('bluetooth.alerts.systemUnpairing.title.android'),
+            description: translate('bluetooth.alerts.systemUnpairing.description.android'),
+            primaryButtonTitle: translate('bluetooth.alerts.systemUnpairing.primaryButton'),
+            onPressPrimaryButton: () => {
+                dispatch(setShouldShowSystemUnpairingAlert(false));
+                openBluetoothSettings();
+            },
+            secondaryButtonTitle: translate('bluetooth.alerts.systemUnpairing.secondaryButton'),
+            onPressSecondaryButton: () => {
+                dispatch(setShouldShowSystemUnpairingAlert(false));
+            },
+        });
+    }, [showAlert, dispatch, openBluetoothSettings, translate]);
+
+    return {
+        showBluetoothAdapterDisabledAlert,
+        showPairingFailedAlert,
+        showSystemUnpairingAlert,
+    };
+};

--- a/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.ios.tsx
+++ b/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.ios.tsx
@@ -1,0 +1,54 @@
+// This is iOS version, see the file name.
+
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { useAlert } from '@suite-native/alerts';
+import { useTranslate } from '@suite-native/intl';
+
+import { setShouldShowSystemUnpairingAlert } from '../bluetoothSlice';
+import { SystemUnpairingAlertIosInstructions } from '../components/SystemUnpairingAlertIosInstructions';
+
+export const useBluetoothPlatformSpecificAlerts = () => {
+    const { showAlert } = useAlert();
+    const { translate } = useTranslate();
+    const dispatch = useDispatch();
+
+    const showBluetoothAdapterDisabledAlert = useCallback(() => {
+        showAlert({
+            title: translate('bluetooth.alerts.adapterDisabled.title'),
+            description: translate('bluetooth.alerts.adapterDisabled.description.ios'),
+            primaryButtonTitle: translate('generic.buttons.gotIt'),
+        });
+    }, [showAlert, translate]);
+
+    const showPairingFailedAlert = useCallback(() => {
+        showAlert({
+            title: translate('bluetooth.alerts.pairingFailed.title'),
+            description: (
+                <SystemUnpairingAlertIosInstructions translationKey="bluetooth.alerts.pairingFailed.description" />
+            ),
+            primaryButtonTitle: translate('generic.buttons.gotIt'),
+        });
+    }, [showAlert, translate]);
+
+    const showSystemUnpairingAlert = useCallback(() => {
+        showAlert({
+            title: translate('bluetooth.alerts.systemUnpairing.title.ios'),
+            textAlign: 'left',
+            description: (
+                <SystemUnpairingAlertIosInstructions translationKey="bluetooth.alerts.systemUnpairing.description.ios" />
+            ),
+            primaryButtonTitle: translate('generic.buttons.gotIt'),
+            onPressPrimaryButton: () => {
+                dispatch(setShouldShowSystemUnpairingAlert(false));
+            },
+        });
+    }, [showAlert, dispatch, translate]);
+
+    return {
+        showBluetoothAdapterDisabledAlert,
+        showPairingFailedAlert,
+        showSystemUnpairingAlert,
+    };
+};

--- a/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.ts
@@ -1,0 +1,13 @@
+/**
+ * Platform-specific Bluetooth alerts hook
+ *
+ * This file serves as the main entry point for the platform-specific Bluetooth alerts hook.
+ * React Native's Metro bundler will automatically resolve to the appropriate platform-specific
+ * implementation (.ios.tsx for iOS, .android.tsx for Android) based on the platform.
+ */
+
+import { useBluetoothPlatformSpecificAlerts as iosImpl } from './useBluetoothPlatformSpecificAlerts.ios';
+
+// Re-export the iOS implementation as the default
+// Metro bundler will handle platform-specific resolution at build time
+export const useBluetoothPlatformSpecificAlerts = iosImpl;

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -174,8 +174,11 @@ export const messages = {
             },
             adapterDisabled: {
                 title: 'Turn on Bluetooth',
-                description:
-                    'Bluetooth is currently turned off on this phone. Go to phone settings and turn on Bluetooth.',
+                description: {
+                    android:
+                        'Bluetooth is currently turned off on this phone. Go to phone settings and turn on Bluetooth.',
+                    ios: 'Bluetooth is currently turned off on this phone. Go to Control Center and turn on Bluetooth.',
+                },
                 primaryButton: 'Open system settings',
             },
             locationServicesDisabled: {
@@ -192,11 +195,23 @@ export const messages = {
                 secondaryButton: 'Device removed',
             },
             systemUnpairing: {
-                title: 'Remove Trezor from system settings',
-                description:
-                    'To unpair fully, make sure you remove your Trezor from your phone’s Bluetooth settings. If not, you might have trouble pairing it again in the future.',
+                title: {
+                    android: 'Remove Trezor from system settings',
+                    ios: 'Remove Trezor from Bluetooth settings',
+                },
+                description: {
+                    android:
+                        'To unpair fully, make sure you remove your Trezor from your phone’s Bluetooth settings. If not, you might have trouble pairing it again in the future.',
+                    ios: 'If not, you might have trouble pairing it again in the future.',
+                },
+
                 primaryButton: 'Open system settings',
                 secondaryButton: 'Device removed',
+            },
+            pairingInstructions: {
+                step1: 'Go to Settings > Bluetooth',
+                step2: 'Find {deviceName} and tap on ⓘ',
+                step3: 'Tap “Forget this device”',
             },
         },
         deviceList: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There is no official way to guide user to specific system settings on iOS and no known way how to do it on iOS 26. 

- [x] fix all usage of `openBluetoothSettings` for ios

On Android it stayed exactly the same as it has been until now.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21688

## Screenshots:
| iOS | Android |
|-----|---------|
|  <img  height="600" alt="image" src="https://github.com/user-attachments/assets/c3dfcd8d-9ad4-4579-b82c-47f6defbff09" /> |   <img height="600"  alt="image" src="https://github.com/user-attachments/assets/f22441ce-8a14-4686-9483-74e94b86aac4" /> |
| <img height="350" alt="image" src="https://github.com/user-attachments/assets/492926a4-f805-4357-86d2-0664712180c3" /> |  <img height="350"  alt="image" src="https://github.com/user-attachments/assets/5ebc124e-9548-43ef-b2fe-fd1672536225" /> |
| <img height="350"  alt="image" src="https://github.com/user-attachments/assets/9c136003-df5f-4fe8-83aa-ff0fb15bdec5" /> | <img height="350"  alt="image" src="https://github.com/user-attachments/assets/b6fde06e-ff35-483e-b95d-1baff0879278" /> |





🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/unpair-ble-system-ios&lookback=7)