### PR TITLE
fix(suite): BT auto reconnection policy

### DIFF
--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -61,11 +61,13 @@ export const initBluetoothThunk = createThunk<void, void, void>(
         }
 
         const attemptDeviceConnect = async ({ device }: { device: DesktopBluetoothDevice }) => {
-            const knownDevices = selectKnownDevices<DesktopBluetoothDevice>(getState());
+            const knownDevice = selectKnownDevices<DesktopBluetoothDevice>(getState()).find(
+                d => d.id === device.id,
+            );
             const connectingDevices = selectConnectingDevices(getState());
             const adapterStatus = selectAdapterStatus(getState());
 
-            if (adapterStatus === 'power-suspending') {
+            if (!knownDevice || adapterStatus === 'power-suspending') {
                 // system is going to sleep
                 return;
             }
@@ -73,14 +75,10 @@ export const initBluetoothThunk = createThunk<void, void, void>(
             // do not hijack BT connection
             const isConnectable =
                 device.connectionStatus.type === 'disconnected' &&
-                (!device.manufacturerData.filterPolicy?.connected ||
-                    device.manufacturerData.filterPolicy.pairing);
+                !device.manufacturerData.filterPolicy?.user_disconnected &&
+                !device.manufacturerData.filterPolicy?.pairing;
 
-            if (
-                isConnectable &&
-                knownDevices.find(d => d.id === device.id) !== undefined &&
-                !connectingDevices.includes(device.id)
-            ) {
+            if (isConnectable && !connectingDevices.includes(device.id)) {
                 await dispatch(bluetoothConnectDeviceThunk({ deviceId: device.id }));
             }
         };

--- a/suite-common/bluetooth/src/manufacturerDataUtils.ts
+++ b/suite-common/bluetooth/src/manufacturerDataUtils.ts
@@ -13,6 +13,7 @@ const MODEL_BLE_CODE: Record<number, DeviceModelInternal> = {
 const ADV_FLAG_PAIRING = 0x01;
 const ADV_FLAG_BOND_MEM_FULL = 0x02;
 const ADV_FLAG_DEV_CONNECTED = 0x04;
+const ADV_FLAG_USER_DISCONNECT = 0x08;
 
 const parseDeviceModel = (bytes: number): DeviceModelInternal =>
     MODEL_BLE_CODE[bytes] ?? DeviceModelInternal.UNKNOWN;
@@ -21,6 +22,7 @@ const parseFilterPolicy = (value: number): BluetoothFilterPolicy => ({
     pairing: !!(value & ADV_FLAG_PAIRING),
     bond_memory_full: !!(value & ADV_FLAG_BOND_MEM_FULL),
     connected: !!(value & ADV_FLAG_DEV_CONNECTED),
+    user_disconnected: !!(value & ADV_FLAG_USER_DISCONNECT),
 });
 
 const serializeFilterPolicy = (policy?: BluetoothFilterPolicy) => {

--- a/suite-common/bluetooth/src/types.ts
+++ b/suite-common/bluetooth/src/types.ts
@@ -14,6 +14,7 @@ export type BluetoothFilterPolicy = {
     pairing: boolean; // accepts connections from all devices
     connected: boolean; // currently connected here or elsewhere
     bond_memory_full: boolean; // new connections cannot be established
+    user_disconnected: boolean; // manual disconnection do the device
 };
 
 export type BluetoothManufacturerData = {

--- a/suite-common/bluetooth/tests/manufacturerDataUtils.test.ts
+++ b/suite-common/bluetooth/tests/manufacturerDataUtils.test.ts
@@ -6,6 +6,7 @@ const filterPolicy = {
     pairing: false,
     connected: false,
     bond_memory_full: false,
+    user_disconnected: false,
 };
 
 describe(parseManufacturerData.name, () => {
@@ -28,6 +29,7 @@ describe(parseManufacturerData.name, () => {
                 pairing: true,
                 connected: true,
                 bond_memory_full: true,
+                user_disconnected: true,
             },
         });
     });
@@ -45,21 +47,30 @@ describe(parseManufacturerData.name, () => {
             pairing: true,
             connected: false,
             bond_memory_full: true,
+            user_disconnected: false,
         });
         expect(parseManufacturerData([5, 0, 6]).filterPolicy).toEqual({
             pairing: true,
             connected: true,
             bond_memory_full: false,
+            user_disconnected: false,
         });
         expect(parseManufacturerData([6, 0, 6]).filterPolicy).toEqual({
             pairing: false,
             connected: true,
             bond_memory_full: true,
+            user_disconnected: false,
         });
-        expect(parseManufacturerData([7, 0, 6]).filterPolicy).toEqual({
+        expect(parseManufacturerData([15, 0, 6]).filterPolicy).toEqual({
             pairing: true,
             connected: true,
             bond_memory_full: true,
+            user_disconnected: true,
+        });
+
+        expect(parseManufacturerData([8, 0, 6]).filterPolicy).toEqual({
+            ...filterPolicy,
+            user_disconnected: true,
         });
     });
 });

--- a/suite-native/bluetooth/src/__tests__/selectors.test.ts
+++ b/suite-native/bluetooth/src/__tests__/selectors.test.ts
@@ -39,6 +39,7 @@ const knownDevice: BluetoothDevice = {
             pairing: false,
             connected: false,
             bond_memory_full: false,
+            user_disconnected: false,
         },
     },
 };
@@ -54,6 +55,7 @@ const knownPairableDevice: BluetoothDevice = {
             pairing: true,
             connected: false,
             bond_memory_full: false,
+            user_disconnected: false,
         },
     },
 };
@@ -70,6 +72,7 @@ const pairableDevice: BluetoothDevice = {
             pairing: true,
             connected: false,
             bond_memory_full: false,
+            user_disconnected: false,
         },
     },
 };

--- a/suite-native/bluetooth/src/selectors.ts
+++ b/suite-native/bluetooth/src/selectors.ts
@@ -48,6 +48,7 @@ export const selectKnownConnectableBluetoothDevices = createMemoizedSelector(
             ({ id, manufacturerData, connectionStatus }) =>
                 knownBluetoothDevices.some(knownDevice => knownDevice.id === id) &&
                 manufacturerData.filterPolicy?.pairing !== true &&
+                manufacturerData.filterPolicy?.user_disconnected !== true &&
                 connectionStatus.type === 'disconnected',
         ),
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix auto reconnect condition.

device should not reconnect if:
1. is known and in pairing mode 
2. was disconnect by user (usign device menu: Pair & connect  > 00:00:00:00 > Disconnect)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21730



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-autoreconnection&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-autoreconnection&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/bt-autoreconnection&lookback=7)