### PR TITLE
feat(suite): kill searchpartyuseragent on mac bt pairing

### DIFF
--- a/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
@@ -1,8 +1,5 @@
-import path from 'path';
-
 import { isDevEnv } from '@suite-common/suite-utils';
 import { isWindows } from '@trezor/env-utils';
-import { BluetoothNapiBindings } from '@trezor/transport-bluetooth';
 
 import { BaseProcess, Status } from './BaseProcess';
 import { getSwitchValue } from '../process-switches';
@@ -79,14 +76,5 @@ export class BluetoothProcess extends BaseProcess {
         }
 
         return super.start();
-    }
-
-    async getNapiBindings() {
-        const processPath = path.join(super.getProcessDir(), `index.js`);
-        this.logger.info(this.logTopic, `Loading bluetooth native module from ${processPath}`);
-
-        const bindings: BluetoothNapiBindings = await import(/*webpackIgnore: true */ processPath);
-
-        return bindings;
     }
 }

--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -1,6 +1,5 @@
 import { ipcMain } from 'electron';
 
-import { isMacOs } from '@trezor/env-utils';
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { getFreePort } from '@trezor/node-utils';
 import { BluetoothIpc, BluetoothIpcApi, BluetoothTransport } from '@trezor/transport-bluetooth';
@@ -57,7 +56,6 @@ export const init: ModuleInit = () => {
         return new BluetoothIpc({
             url: btProcess.getUrl(),
             logger: desktopLogger,
-            napiBindings: isMacOs() ? () => btProcess.getNapiBindings() : undefined,
         });
     };
 

--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -1,7 +1,10 @@
+import { exec } from 'child_process';
 import { ipcMain } from 'electron';
 
+import { isMacOs } from '@trezor/env-utils';
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { getFreePort } from '@trezor/node-utils';
+import { InvokeResult } from '@trezor/suite-desktop-api';
 import { BluetoothIpc, BluetoothIpcApi, BluetoothTransport } from '@trezor/transport-bluetooth';
 
 import { BluetoothProcess } from '../libs/processes/BluetoothProcess';
@@ -87,6 +90,32 @@ export const init: ModuleInit = () => {
 
                     if (method === 'dispose') {
                         killBluetoothProcess();
+                    }
+
+                    // Workaround for MacOS pairing flow:
+                    // Unfortunately the "searchpartyuseragent" process interferes with the pairing PIN dialog and causes it to not show up.
+                    // This is related to Apple's Find My feature and happens to users with Bluetooth devices such as AirPods paired to their Mac.
+                    // We previously tried using NAPI to execute pairing inside the foreground Electron app process to handle MacOS security restrictions,
+                    // but it still did not work in 100% of cases. So now we simply kill the process before attempting to connect to a device.
+                    // The process will be automatically restarted by MacOS if needed and doesn't seem to cause any issues with Find My functionality.
+                    if (method === 'connectDevice' && isMacOs()) {
+                        try {
+                            const devices = await api.enumerateDevices();
+                            const isPaired = devices.find(d => d.id === params[0])?.paired;
+                            if (!isPaired) {
+                                await new Promise<InvokeResult>(resolve => {
+                                    exec('pkill searchpartyuseragent', {}, error => {
+                                        if (error) {
+                                            resolve({ success: false, error: error.toString() });
+                                        } else {
+                                            resolve({ success: true });
+                                        }
+                                    });
+                                });
+                            }
+                        } catch (error) {
+                            logger.warn(SERVICE_NAME, `macos pairing workaround failed: ${error}`);
+                        }
                     }
 
                     return (api[method] as any)(...params);

--- a/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
@@ -7,7 +7,6 @@ import type {
     BluetoothIpcApi,
     BluetoothIpcEvents,
     BluetoothIpcState,
-    BluetoothNapiBindings,
     IpcResponse,
     TrezorBluetoothSettings,
 } from './types';
@@ -20,15 +19,10 @@ export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements Bl
     private api: TrezorBluetooth;
     private state: BluetoothIpcState = { knownDevices: [] };
     private isScanning = false;
-    private readonly getNapiBindings: (() => Promise<BluetoothNapiBindings>) | undefined;
 
-    constructor({
-        napiBindings,
-        ...settings
-    }: TrezorBluetoothSettings & { napiBindings: BluetoothIpc['getNapiBindings'] }) {
+    constructor(settings: TrezorBluetoothSettings) {
         super();
         this.api = new TrezorBluetooth(settings);
-        this.getNapiBindings = napiBindings;
     }
 
     // 1. suite knows the device but system may not. device could be removed manually from the system UI
@@ -159,29 +153,6 @@ export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements Bl
 
     async connectDevice(id: string) {
         const timeout = 30000;
-
-        // macos: pair in the main thread then disconnect and pickup connection again in the background
-        if (this.getNapiBindings) {
-            try {
-                const devices = await this.enumerateDevices();
-                const isPaired = devices.find(d => d.id === id)?.paired;
-                if (!isPaired) {
-                    const bindings = await this.getNapiBindings();
-                    await bindings.connectDevice(id, timeout, (_err, data) => {
-                        try {
-                            const json = JSON.parse(data);
-                            if (json.event == 'device_connection_status') {
-                                this.emit('device-update', json.payload.device);
-                            }
-                        } catch {
-                            // silent
-                        }
-                    });
-                }
-            } catch (error) {
-                return this.result(error.message);
-            }
-        }
 
         try {
             await this.connectApi();

--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -109,11 +109,3 @@ export interface BluetoothIpcApi {
     off: TypedManagerEvents['off'];
     removeAllListeners: TypedManagerEvents['removeAllListeners'];
 }
-
-export type BluetoothNapiBindings = {
-    connectDevice: (
-        id: string,
-        timeout: number,
-        callback: (err: Error | null, json: string) => any,
-    ) => Promise<void>;
-};


### PR DESCRIPTION
## Description

Unfortunately the `searchpartyuseragent` process interferes with the pairing PIN dialog and causes it to not show up.
This is related to Apple's Find My feature and happens to users with Bluetooth devices such as AirPods paired to their Mac.

We previously tried using NAPI to execute pairing inside the foreground Electron app process to handle MacOS security restrictions, but it still did not work in 100% of cases. So now we simply kill the process before attempting to connect to a device.
The process will be automatically restarted by MacOS if needed and doesn't seem to cause any issues with Find My functionality.

Desktop builds: https://github.com/trezor/trezor-suite/actions/runs/17922205467

---

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/pkill-searchpartyuseragent&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/pkill-searchpartyuseragent&lookback=7)