### PR TITLE
feat(suite-native): show error on invalid balance for swap fees

### DIFF
--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -61,6 +61,7 @@ import {
     selectTradingPlatformByCryptoId,
     selectTradingPrefilledFromAccount,
     selectTradingProviderByNameAndTradeType,
+    selectTradingSellAccountKey,
     selectTradingSellFormStep,
     selectTradingSellInfo,
     selectTradingSellLoadingTimestampAndStatus,
@@ -989,6 +990,22 @@ describe('tradingSelectors', () => {
 
     it('selectTradingModalAccountKey should return stable modalAccountKey', () => {
         expect(selectTradingModalAccountKey(state)).toEqual('modalAccountKey');
+    });
+    it('selectTradingSellAccountKey should return undefined when tradingAccountKey is not set', () => {
+        state.wallet.trading.sell.tradingAccountKey = undefined;
+
+        expect(selectTradingSellAccountKey(state)).toBeUndefined();
+    });
+
+    it('selectTradingSellAccountKey should return the correct account key when set', () => {
+        const testAccountKey = 'test-account-key-123';
+        state.wallet.trading.sell.tradingAccountKey = testAccountKey;
+
+        expect(selectTradingSellAccountKey(state)).toBe(testAccountKey);
+    });
+
+    it('selectTradingSellAccountKey should be stable', () => {
+        expect(selectTradingSellAccountKey(state)).toBe(selectTradingSellAccountKey(state));
     });
 
     it('selectTradingPrefilledFromAccount should return stable prefilledFromAccount ', () => {

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -585,6 +585,9 @@ export const selectTradingExchangeAccountKey = (state: TradingRootState) =>
 export const selectTradingExchangeReceiveAccountKey = (state: TradingRootState) =>
     state.wallet.trading.exchange.receiveAccountKey;
 
+export const selectTradingSellAccountKey = (state: TradingRootState) =>
+    state.wallet.trading.sell.tradingAccountKey;
+
 export const selectTradingModalAccountKey = (state: TradingRootState) =>
     state.wallet.trading.modalAccountKey;
 

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2649,6 +2649,20 @@ export const messages = {
                 continueButton: 'Continue editing',
             },
         },
+        precomposedTransaction: {
+            errors: {
+                amountNotEnoughCurrencyFee:
+                    'Insufficient {networkDisplaySymbol} to cover the transaction fee',
+                amountIsNotEnough: "You don't have enough funds.",
+                amountIsTooLow: 'Amount is too low',
+                amountIsLessThanReserve: 'Recipient account requires minimum reserve to activate',
+                stakeNotEnoughFunds: 'Insufficient funds for staking',
+                remainingBalanceLessThanRent:
+                    'After sending this amount, your account will have SOL remaining lower than the rent.',
+                amountNotEnoughCurrencyFeeWithEthAmount:
+                    'Insufficient {networkDisplaySymbol} to cover the transaction fee.',
+            },
+        },
     },
     navigation: {
         tabs: {

--- a/suite-native/module-send/src/hooks/useSendForm.ts
+++ b/suite-native/module-send/src/hooks/useSendForm.ts
@@ -34,7 +34,7 @@ import { TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
 import {
     FeeLevelsMaxAmount,
     calculateFeeLevelsMaxAmountThunk,
-    storeFeeLevels,
+    transactionManagementActions,
     useSubscribeForSolanaBlockUpdates,
 } from '@suite-native/transaction-management';
 import { useDebounce } from '@trezor/react-utils';
@@ -267,7 +267,7 @@ export const useSendForm = (accountKey: string, tokenContract?: TokenAddress) =>
         );
 
         if (isFulfilled(response)) {
-            dispatch(storeFeeLevels({ feeLevels: response.payload }));
+            dispatch(transactionManagementActions.storeFeeLevels({ feeLevels: response.payload }));
             navigation.navigate(SendStackRoutes.SendFees, {
                 accountKey,
                 tokenContract,

--- a/suite-native/module-trading/src/__fixtures__/account.ts
+++ b/suite-native/module-trading/src/__fixtures__/account.ts
@@ -149,3 +149,41 @@ export const getCardanoAccount = (key = 'ada-account-1') =>
         visible: true,
         deviceState: 'test-device',
     }) as unknown as Account;
+
+export const getSolAccount = (key = 'sol-account-1', overrides: Partial<Account> = {}) =>
+    ({
+        key,
+        deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@448CCE89D32A733A1632F345:0',
+        accountLabel: 'Solana #1',
+        index: 0,
+        path: "m/44'/501'/0'/0'",
+        descriptor: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+        accountType: 'normal',
+        symbol: 'sol',
+        empty: false,
+        visible: true,
+        balance: '10000000000', // 10 SOL
+        availableBalance: '10000000000', // 10 SOL
+        formattedBalance: '10.000000000',
+        tokens: [],
+        addresses: undefined,
+        utxo: [],
+        history: {
+            total: 25,
+            unconfirmed: 0,
+        },
+        metadata: {
+            key: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+        },
+        ts: 1750315199039,
+        networkType: 'solana',
+        misc: {
+            rent: 10,
+        },
+        page: {
+            index: 1,
+            size: 25,
+            total: 3,
+        },
+        ...overrides,
+    }) as Account;

--- a/suite-native/module-trading/src/__fixtures__/walletState.ts
+++ b/suite-native/module-trading/src/__fixtures__/walletState.ts
@@ -3,7 +3,7 @@ import { FiatRatesState } from '@suite-common/wallet-core';
 import { Account, RatesByKey, type WalletSettings } from '@suite-common/wallet-types';
 import { PROTO } from '@trezor/connect';
 
-import { getBaseAccount, getBtcAccount, getEthAccount } from './account';
+import { getBaseAccount, getBtcAccount, getEthAccount, getSolAccount } from './account';
 import { getInitializedTradingState } from './tradingState';
 
 type GetWalletStateParams = {
@@ -41,5 +41,6 @@ export const getWalletState = ({
         { ...getBtcAccount('btc-account-2'), ...(deviceState && { deviceState }) },
         { ...getEthAccount(), ...(deviceState && { deviceState }) },
         { ...getBaseAccount(), ...(deviceState && { deviceState }) },
+        { ...getSolAccount(), ...(deviceState && { deviceState }) },
     ] as Account[],
 });

--- a/suite-native/module-trading/src/components/fees/FeePicker.tsx
+++ b/suite-native/module-trading/src/components/fees/FeePicker.tsx
@@ -15,7 +15,7 @@ type FeePickerProps = {
 
 export const FEE_PICKER_TEST_ID = '@trading/fees/fee-picker';
 
-export const FeePicker = ({ fee, symbol, onPress, isLoading }: FeePickerProps) => (
+export const FeePicker = ({ fee, symbol, onPress, isLoading = false }: FeePickerProps) => (
     <TradeInfoRow onPress={onPress} testID={FEE_PICKER_TEST_ID}>
         <Text variant="hint">
             <Translation id="moduleTrading.tradingExchangePreviewScreen.feeLabel" />

--- a/suite-native/module-trading/src/components/fees/FeePickerCard.tsx
+++ b/suite-native/module-trading/src/components/fees/FeePickerCard.tsx
@@ -32,16 +32,18 @@ export const FeePickerCard = ({ trade, accountKey, symbol, tradingType }: FeePic
         >();
     const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
 
+    const actualFee = composedTransactionInfo?.composed?.fee;
+    const fee = actualFee ?? '0';
+
     const handleFeesPressed = () => {
+        if (actualFee === undefined) {
+            return;
+        }
         navigation.navigate(TradingStackRoutes.TradingFees, {
             accountKey,
             tradingType,
         });
     };
-
-    const actualFee = composedTransactionInfo?.composed?.fee;
-    const fee = actualFee ?? '0';
-    const isLoading = actualFee === undefined;
 
     return (
         <AnimatedCard noPadding>
@@ -53,7 +55,7 @@ export const FeePickerCard = ({ trade, accountKey, symbol, tradingType }: FeePic
                 fee={fee}
                 symbol={symbol}
                 onPress={handleFeesPressed}
-                isLoading={isLoading}
+                isLoading={actualFee === undefined}
             />
         </AnimatedCard>
     );

--- a/suite-native/module-trading/src/components/fees/__tests__/FeePickerCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/fees/__tests__/FeePickerCard.comp.test.tsx
@@ -107,4 +107,12 @@ describe('FeePickerCard', () => {
             tradingType: 'buy',
         });
     });
+
+    it('should not navigate when actualFee is undefined', async () => {
+        const { getByText } = await renderFeePickerCard({}, {});
+
+        await userEvent.press(getByText('Fee'));
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
 });

--- a/suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx
@@ -6,8 +6,11 @@ import { ExchangeTrade, SellFiatTrade } from 'invity-api';
 import {
     TradingRootState,
     isExchangeTrade,
+    selectTradingExchangeAccountKey,
     selectTradingProviderByNameAndTradeType,
+    selectTradingSellAccountKey,
 } from '@suite-common/trading';
+import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { Text, VStack } from '@suite-native/atoms';
 import { splitAddressToChunks } from '@suite-native/helpers';
 import { Translation, useTranslate } from '@suite-native/intl';
@@ -19,6 +22,15 @@ export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellF
     const tradeType = isExchangeTrade(trade) ? 'exchange' : 'sell';
     const providerInfo = useSelector((state: TradingRootState) =>
         selectTradingProviderByNameAndTradeType(state, trade.exchange, tradeType),
+    );
+    const sendAccountKey = useSelector((state: TradingRootState) =>
+        isExchangeTrade(trade)
+            ? selectTradingExchangeAccountKey(state)
+            : selectTradingSellAccountKey(state),
+    );
+
+    const networkSymbol = useSelector((state: AccountsRootState) =>
+        sendAccountKey ? selectAccountNetworkSymbol(state, sendAccountKey) : null,
     );
 
     const providerName =
@@ -34,6 +46,11 @@ export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellF
         return null;
     }
 
+    const addressText =
+        networkSymbol === 'sol'
+            ? receiveAddress
+            : splitAddressToChunks(receiveAddress ?? '').join(' ');
+
     return (
         <Animated.View entering={FadeIn}>
             <TradeInfoRow>
@@ -45,7 +62,7 @@ export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellF
                         />
                     </Text>
                     <Text variant="hint" color="textSubdued">
-                        {splitAddressToChunks(receiveAddress ?? '').join(' ')}
+                        {addressText}
                     </Text>
                 </VStack>
             </TradeInfoRow>

--- a/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.comp.test.tsx
@@ -2,28 +2,14 @@ import React from 'react';
 
 import { ExchangeTrade, SellFiatTrade } from 'invity-api';
 
-import { isExchangeTrade, selectTradingProviderByNameAndTradeType } from '@suite-common/trading';
 import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import { exchangeMercuryo } from '../../../__fixtures__/exchangeProviders';
 import { exchangeQuotes } from '../../../__fixtures__/exchangeQuotes';
-import { sellMoonpay } from '../../../__fixtures__/sellProviders';
+import { sellBanxa } from '../../../__fixtures__/sellProviders';
 import { sellQuotes } from '../../../__fixtures__/sellQuotes';
+import { getWalletState } from '../../../__fixtures__/walletState';
 import { ProviderReceiveAddress } from '../ProviderReceiveAddress';
-
-// Mock the trading selector to return provider info
-jest.mock('@suite-common/trading', () => ({
-    ...jest.requireActual('@suite-common/trading'),
-    selectTradingProviderByNameAndTradeType: jest.fn(),
-    isExchangeTrade: jest.fn(),
-}));
-
-const mockSelectTradingProviderByNameAndTradeType =
-    selectTradingProviderByNameAndTradeType as jest.MockedFunction<
-        typeof selectTradingProviderByNameAndTradeType
-    >;
-
-const mockIsExchangeTrade = isExchangeTrade as jest.MockedFunction<typeof isExchangeTrade>;
 
 describe('ProviderReceiveAddress', () => {
     // Use real fixtures for more realistic test data
@@ -37,19 +23,39 @@ describe('ProviderReceiveAddress', () => {
         destinationAddress: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2', // Add destination address
     };
 
-    const renderProviderReceiveAddress = async (trade: ExchangeTrade | SellFiatTrade) =>
-        await renderWithStoreProviderAsync(<ProviderReceiveAddress trade={trade} />);
+    const renderProviderReceiveAddress = async (
+        trade: ExchangeTrade | SellFiatTrade,
+        tradeType: 'exchange' | 'sell' = 'exchange',
+        accountKey: string = 'btc-account-1',
+    ) => {
+        const walletState = getWalletState({ tradeType });
+
+        // Set up provider info in the trading state
+        if (tradeType === 'exchange') {
+            walletState.trading.exchange.exchangeInfo!.providerInfos = {
+                mercuryo: exchangeMercuryo,
+            };
+            // Set trading account key so selectTradingExchangeAccountKey returns a value
+            walletState.trading.exchange.tradingAccountKey = accountKey;
+        } else {
+            walletState.trading.sell.sellInfo!.providerInfos = {
+                'banxa-sell': sellBanxa, // Use banxa-sell to match the trade fixture
+            };
+            // Set trading account key so selectTradingSellAccountKey returns a value
+            walletState.trading.sell.tradingAccountKey = accountKey;
+        }
+
+        return await renderWithStoreProviderAsync(<ProviderReceiveAddress trade={trade} />, {
+            preloadedState: { wallet: walletState },
+        });
+    };
 
     beforeEach(() => {
         jest.clearAllMocks();
-        // Mock isExchangeTrade to return true for ExchangeTrade and false for SellFiatTrade
-        mockIsExchangeTrade.mockImplementation((trade: any) => 'sendAddress' in trade);
     });
 
     it('should display provider name and receive address for exchange trade', async () => {
-        mockSelectTradingProviderByNameAndTradeType.mockReturnValue(exchangeMercuryo);
-
-        const { getByText } = await renderProviderReceiveAddress(mockExchangeTrade);
+        const { getByText } = await renderProviderReceiveAddress(mockExchangeTrade, 'exchange');
 
         // User should see the provider name in the label
         expect(getByText("Mercuryo's receive address")).toBeTruthy();
@@ -58,29 +64,37 @@ describe('ProviderReceiveAddress', () => {
     });
 
     it('should display provider name and destination address for sell fiat trade', async () => {
-        mockSelectTradingProviderByNameAndTradeType.mockReturnValue(sellMoonpay);
-
-        const { getByText } = await renderProviderReceiveAddress(mockSellFiatTrade);
+        const { getByText } = await renderProviderReceiveAddress(mockSellFiatTrade, 'sell');
 
         // User should see the provider name in the label
-        expect(getByText("MoonPay's receive address")).toBeTruthy();
+        expect(getByText("Banxa's receive address")).toBeTruthy();
         // User should see the address split into readable chunks
         expect(getByText('1BvB MSEY stWe tqTF n5Au 4m4G Fg7x JaNV N2')).toBeTruthy();
     });
 
     it('should show fallback text when provider info is not available', async () => {
-        mockSelectTradingProviderByNameAndTradeType.mockReturnValue(undefined);
+        const walletState = getWalletState({ tradeType: 'exchange' });
+        // Don't set provider info to simulate missing provider
+        walletState.trading.exchange.exchangeInfo!.providerInfos = {};
 
-        const { getByText } = await renderProviderReceiveAddress(mockExchangeTrade);
+        const { getByText } = await renderWithStoreProviderAsync(
+            <ProviderReceiveAddress trade={mockExchangeTrade} />,
+            { preloadedState: { wallet: walletState } },
+        );
 
         // User should see fallback text when provider info is missing
         expect(getByText("Provider's receive address")).toBeTruthy();
     });
 
     it('should show fallback text when provider company name is not available', async () => {
-        mockSelectTradingProviderByNameAndTradeType.mockReturnValue(undefined);
+        const walletState = getWalletState({ tradeType: 'exchange' });
+        // Don't set provider info to simulate missing provider
+        walletState.trading.exchange.exchangeInfo!.providerInfos = {};
 
-        const { getByText } = await renderProviderReceiveAddress(mockExchangeTrade);
+        const { getByText } = await renderWithStoreProviderAsync(
+            <ProviderReceiveAddress trade={mockExchangeTrade} />,
+            { preloadedState: { wallet: walletState } },
+        );
 
         // User should see fallback text when company name is missing
         expect(getByText("Provider's receive address")).toBeTruthy();
@@ -89,9 +103,7 @@ describe('ProviderReceiveAddress', () => {
     it('should not render anything when receive address is missing for exchange trade', async () => {
         const tradeWithoutAddress = { ...mockExchangeTrade, sendAddress: undefined };
 
-        mockSelectTradingProviderByNameAndTradeType.mockReturnValue(exchangeMercuryo);
-
-        const { queryByText } = await renderProviderReceiveAddress(tradeWithoutAddress);
+        const { queryByText } = await renderProviderReceiveAddress(tradeWithoutAddress, 'exchange');
 
         // User should not see any address information when address is missing
         expect(queryByText("Mercuryo's receive address")).toBeFalsy();
@@ -100,11 +112,20 @@ describe('ProviderReceiveAddress', () => {
     it('should not render anything when destination address is missing for sell fiat trade', async () => {
         const tradeWithoutAddress = { ...mockSellFiatTrade, destinationAddress: undefined };
 
-        mockSelectTradingProviderByNameAndTradeType.mockReturnValue(sellMoonpay);
-
-        const { queryByText } = await renderProviderReceiveAddress(tradeWithoutAddress);
+        const { queryByText } = await renderProviderReceiveAddress(tradeWithoutAddress, 'sell');
 
         // User should not see any address information when address is missing
-        expect(queryByText("MoonPay's receive address")).toBeFalsy();
+        expect(queryByText("Banxa's receive address")).toBeFalsy();
+    });
+
+    it('should display solana address as-is without splitting', async () => {
+        const { getByText } = await renderProviderReceiveAddress(
+            mockExchangeTrade,
+            'exchange',
+            'sol-account-1',
+        );
+
+        // For Solana addresses, the address should be displayed without splitting
+        expect(getByText('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa')).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
@@ -5,14 +5,12 @@ import { useNavigation } from '@react-navigation/native';
 import { isFulfilled } from '@reduxjs/toolkit';
 import type { ExchangeTrade, FormResponse } from 'invity-api';
 
-import { invariant } from '@suite-common/suite-utils';
 import {
     TradingFulfillValue,
     TradingSendRejectedProps,
     TradingSignAndPushSendFormTransactionProps,
     cryptoIdToNetworkAndContractAddress,
     exchangeThunks,
-    selectTradingExchangeFormStep,
     selectTradingExchangeSelectedQuote,
 } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
@@ -36,7 +34,12 @@ import {
 } from '@suite-native/navigation';
 import { useToast } from '@suite-native/toasts';
 import { TokensRootState, selectAccountTokenDecimals } from '@suite-native/tokens';
-import { NativeSupportedFeeLevel } from '@suite-native/transaction-management';
+import {
+    NativeSupportedFeeLevel,
+    selectFeeLevels,
+    useFeesFetching,
+    usePrecomposedTransactionError,
+} from '@suite-native/transaction-management';
 import TrezorConnect from '@trezor/connect';
 
 import { selectExchangeSelectedSendAccount } from '../../selectors/exchangeSelectors';
@@ -79,21 +82,31 @@ export const useExchangeFlow = () => {
         selectIsAmountInSats(state, sendAccount?.symbol),
     );
 
-    const formStep = useSelector(selectTradingExchangeFormStep);
-
     const networkFeeInfo = useSelector((state: FeesRootState) =>
         selectConvertedNetworkFeeInfo(state, sendAccount?.symbol),
     );
 
     const serializedTx = useSelector(selectSendSerializedTx);
 
+    const feeLevels = useSelector(selectFeeLevels);
+
+    const selectedLevel = feeLevels[(selectedFee as NativeSupportedFeeLevel) ?? 'normal'];
+    const feeError = selectedLevel?.type === 'error' ? selectedLevel.error : null;
+
+    const txnErrorString = usePrecomposedTransactionError({
+        error: feeError,
+        context: {
+            networkSymbol: sendAccount?.symbol,
+        },
+    });
+
     const { isConsentRequested, waitForConsent, resolveConsent } = useConsent();
 
-    invariant(sendAccount, 'Send account is required');
-    invariant(selectedQuote?.send, 'Send cryptoId is required');
+    useFeesFetching({
+        accountKey: sendAccount?.key,
+        isRefetchDisabled: selectedFee === 'custom',
+    });
 
-    const network = getNetwork(sendAccount.symbol);
-    const decimals = tokenDecimals ?? network.decimals;
     // TODO: slip24 - not implemented in mobile
     const isSlip24Active = false;
 
@@ -128,8 +141,10 @@ export const useExchangeFlow = () => {
             feePerUnit?: string;
             feeLimit?: string;
         }) => {
-            if (!network || !networkFeeInfo) {
-                console.error('Network and networkFeeInfo are required for composing transaction');
+            if (!sendAccount || !networkFeeInfo) {
+                console.error(
+                    'Send account and networkFeeInfo are required for composing transaction',
+                );
 
                 return;
             }
@@ -139,7 +154,7 @@ export const useExchangeFlow = () => {
                     composeTradingTransactionThunk({
                         tradeType: 'exchange',
                         account: sendAccount,
-                        network,
+                        network: getNetwork(sendAccount.symbol),
                         feeInfo: networkFeeInfo,
                         selectedFeeLevel,
                         feePerUnit,
@@ -152,13 +167,13 @@ export const useExchangeFlow = () => {
                 console.error('Failed to compose trading transaction:', error);
             }
         },
-        [dispatch, network, networkFeeInfo, sendAccount],
+        [dispatch, networkFeeInfo, sendAccount],
     );
 
     // this is called when we want to fetch fees and compose a transaction
     const fetchFeesAndCompose = useCallback(async () => {
         if (!sendAccount) {
-            console.error('Send account is required');
+            console.error('Send account is required to fetch fees and compose transaction');
 
             return;
         }
@@ -174,6 +189,12 @@ export const useExchangeFlow = () => {
     const getCommonFunctions = useCallback(
         (trade?: ExchangeTrade) => {
             const tradeToUse = trade ?? selectedQuote;
+
+            if (!tradeToUse) {
+                console.error('Trade or selectedQuote is required to getCommonFunctions');
+
+                return null;
+            }
 
             const returnUrl = buildTradingUrl({
                 actionType: 'trade',
@@ -214,6 +235,10 @@ export const useExchangeFlow = () => {
             const commonFunctions = getCommonFunctions(trade);
 
             if (!trade || !sendAccount || !commonFunctions) {
+                console.error(
+                    'Trade, send account and common functions are required to confirm trade',
+                );
+
                 return false;
             }
 
@@ -243,8 +268,15 @@ export const useExchangeFlow = () => {
         const commonFunctions = getCommonFunctions(selectedQuote);
 
         if (!commonFunctions || !sendAccount) {
+            console.error(
+                'Common functions and send account are required to sign and send transaction',
+            );
+
             return false;
         }
+
+        const network = getNetwork(sendAccount.symbol);
+        const decimals = tokenDecimals ?? network.decimals;
 
         const { returnUrl, triggerAnalyticsTradeConfirmation, processResponseData, nextStep } =
             commonFunctions;
@@ -309,32 +341,32 @@ export const useExchangeFlow = () => {
             return false;
         }
     }, [
-        resolveConsent,
-        waitForConsent,
         dispatch,
         getCommonFunctions,
+        isSlip24Active,
+        resolveConsent,
         selectedQuote,
         sendAccount,
-        decimals,
         shouldSendInSats,
-        isSlip24Active,
         showToast,
+        tokenDecimals,
+        waitForConsent,
     ]);
 
     useEffect(() => {
-        if (selectedFee) {
+        if (selectedFee && networkFeeInfo) {
             composeRequest({
                 selectedFeeLevel: selectedFee as NativeSupportedFeeLevel,
                 feePerUnit: feePerUnitDraft,
                 feeLimit: feeLimitDraft,
             });
         }
-    }, [selectedFee, composeRequest, feePerUnitDraft, feeLimitDraft]);
+    }, [selectedFee, composeRequest, feePerUnitDraft, feeLimitDraft, networkFeeInfo]);
 
     return {
+        txnErrorString,
         confirmTrade,
         composeRequest,
-        formStep,
         fetchFeesAndCompose,
         signAndSendTransaction,
         serializedTx,

--- a/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ScrollView } from 'react-native-gesture-handler';
+import Animated from 'react-native-reanimated';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { invariant } from '@suite-common/suite-utils';
 import { parseCryptoId, selectTradingExchangeSelectedQuote } from '@suite-common/trading';
 import { TokenAddress } from '@suite-common/wallet-types';
-import { Button, Text, VStack } from '@suite-native/atoms';
+import { Button, InlineAlertBox, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     Screen,
@@ -20,11 +20,11 @@ import { ExchangeTradePreviewCard } from '../components/exchange/ExchangeTradePr
 import { FeePickerCard } from '../components/fees/FeePickerCard';
 import { useExchangeFlow } from '../hooks/exchange/useExchangeFlow';
 import { useChangeStringsExtractor } from '../hooks/history/useChangeStringsExtractor';
-import { exchangeActions } from '../reducers';
 import {
     selectExchangeSelectedReceiveAccount,
     selectExchangeSelectedSendAccount,
 } from '../selectors/exchangeSelectors';
+import { clearTradingStateThunk } from '../thunks';
 import { getReceiveAccountAddressText } from '../utils/general/receiveAccountUtils';
 
 export type TradingExchangePreviewScreenProps = StackProps<
@@ -46,27 +46,25 @@ export const TradingExchangePreviewScreen = ({ navigation }: TradingExchangePrev
     const quote = useSelector(selectTradingExchangeSelectedQuote);
     const fromAccount = useSelector(selectExchangeSelectedSendAccount);
     const toAccount = useSelector(selectExchangeSelectedReceiveAccount);
-
-    invariant(quote, 'quote must be defined');
-    invariant(fromAccount, 'fromAccount must be defined');
-    invariant(toAccount, 'toAccount must be defined');
+    const hasRequestedTradeConfirmation = useRef(false);
 
     const { fromStringValue, toStringValue } = useChangeStringsExtractor(quote);
 
+    useSubscribeForSolanaBlockUpdates(fromAccount ?? null);
+
+    const { txnErrorString, confirmTrade, fetchFeesAndCompose } = useExchangeFlow();
+
+    const [flowStep, setFlowStep] = useState<FlowStep>('confirm');
+
+    // clear trading state on unmount
     useEffect(
         () => () => {
-            dispatch(exchangeActions.clearState());
+            dispatch(clearTradingStateThunk());
         },
         [dispatch],
     );
 
-    useSubscribeForSolanaBlockUpdates(fromAccount);
-
-    const { confirmTrade, fetchFeesAndCompose } = useExchangeFlow();
-
-    const [flowStep, setFlowStep] = useState<FlowStep>('confirm');
-
-    const handleConfirmTrade = async () => {
+    const handleConfirmTrade = useCallback(async () => {
         const addressText = getReceiveAccountAddressText(toAccount);
 
         if (!addressText) {
@@ -74,20 +72,41 @@ export const TradingExchangePreviewScreen = ({ navigation }: TradingExchangePrev
 
             return;
         }
+        try {
+            const success = await confirmTrade({
+                sendAccount: fromAccount,
+                receiveAddress: addressText,
+                trade: quote,
+                approvalFlow: false,
+            });
 
-        const success = await confirmTrade({
-            sendAccount: fromAccount,
-            receiveAddress: addressText,
-            trade: quote,
-            approvalFlow: false,
-        });
-
-        if (success) {
-            await fetchFeesAndCompose();
+            if (success) {
+                await fetchFeesAndCompose();
+                setFlowStep('signTxn');
+            }
+        } catch (e) {
+            // TODO: show warning https://github.com/trezor/trezor-suite/issues/21882
+            console.error('Failed to confirm trade', e);
         }
-    };
+    }, [confirmTrade, fetchFeesAndCompose, fromAccount, quote, toAccount]);
+
+    useEffect(() => {
+        if (!hasRequestedTradeConfirmation.current) {
+            hasRequestedTradeConfirmation.current = true;
+
+            handleConfirmTrade();
+        }
+        // only run on mount
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const handleSignTransaction = () => {
+        if (!quote || !fromAccount) {
+            console.warn('quote or fromAccount is not defined', quote, fromAccount);
+
+            return;
+        }
+
         const tokenContract = quote.send
             ? (parseCryptoId(quote.send)?.contractAddress as TokenAddress)
             : undefined;
@@ -102,11 +121,8 @@ export const TradingExchangePreviewScreen = ({ navigation }: TradingExchangePrev
         });
     };
 
-    const handleTapContinue = async () => {
-        if (flowStep === 'confirm') {
-            await handleConfirmTrade();
-            setFlowStep('signTxn');
-        } else if (flowStep === 'signTxn') {
+    const handleTapContinue = () => {
+        if (flowStep === 'signTxn') {
             handleSignTransaction();
         } else {
             console.warn('Unknown flow step', flowStep);
@@ -124,31 +140,40 @@ export const TradingExchangePreviewScreen = ({ navigation }: TradingExchangePrev
         >
             <ScrollView>
                 <VStack spacing="sp20" paddingVertical="sp20">
-                    <ExchangeTradePreviewCard
-                        account={fromAccount}
-                        cryptoId={quote.send}
-                        amount={
-                            <Text variant="hint" color="textAlertRed">
-                                -{fromStringValue}
-                            </Text>
-                        }
-                        title={
-                            <Translation id="moduleTrading.tradingExchangePreviewScreen.fromAccount" />
-                        }
-                    />
-                    <ExchangeTradePreviewCard
-                        account={toAccount.account}
-                        cryptoId={quote.receive}
-                        amount={
-                            <Text variant="hint" color="textSecondaryHighlight">
-                                +{toStringValue}
-                            </Text>
-                        }
-                        title={
-                            <Translation id="moduleTrading.tradingExchangePreviewScreen.toAccount" />
-                        }
-                    />
-                    {flowStep === 'signTxn' && (
+                    {txnErrorString && (
+                        <Animated.View>
+                            <InlineAlertBox variant="critical" title={txnErrorString} />
+                        </Animated.View>
+                    )}
+                    {fromAccount && quote?.send && (
+                        <ExchangeTradePreviewCard
+                            account={fromAccount}
+                            cryptoId={quote.send}
+                            amount={
+                                <Text variant="hint" color="textAlertRed">
+                                    -{fromStringValue}
+                                </Text>
+                            }
+                            title={
+                                <Translation id="moduleTrading.tradingExchangePreviewScreen.fromAccount" />
+                            }
+                        />
+                    )}
+                    {toAccount?.account && quote?.receive && (
+                        <ExchangeTradePreviewCard
+                            account={toAccount.account}
+                            cryptoId={quote.receive}
+                            amount={
+                                <Text variant="hint" color="textSecondaryHighlight">
+                                    +{toStringValue}
+                                </Text>
+                            }
+                            title={
+                                <Translation id="moduleTrading.tradingExchangePreviewScreen.toAccount" />
+                            }
+                        />
+                    )}
+                    {fromAccount && quote?.send && !txnErrorString && (
                         <FeePickerCard
                             trade={quote}
                             symbol={fromAccount.symbol}
@@ -159,7 +184,12 @@ export const TradingExchangePreviewScreen = ({ navigation }: TradingExchangePrev
                 </VStack>
             </ScrollView>
 
-            <Button onPress={handleTapContinue}>{flowStepToButtonText[flowStep]}</Button>
+            <Button
+                onPress={handleTapContinue}
+                isDisabled={flowStep === 'confirm' || !!txnErrorString}
+            >
+                {flowStepToButtonText[flowStep]}
+            </Button>
         </Screen>
     );
 };

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
@@ -1,12 +1,7 @@
 import { RouteProp } from '@react-navigation/native';
 
 import { TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
-import {
-    TestStore,
-    initStore,
-    renderWithStoreProviderAsync,
-    userEvent,
-} from '@suite-native/test-utils';
+import { TestStore, initStore, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import { getBtcAccount } from '../../__fixtures__/account';
 import { exchangeQuotes } from '../../__fixtures__/exchangeQuotes';
@@ -25,14 +20,18 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockConfirmTrade = jest.fn().mockResolvedValue(Promise.resolve());
+const mockFetchFeesAndCompose = jest.fn();
+const mockSignAndSendTransaction = jest.fn();
+const mockResolveConsent = jest.fn();
 
 jest.mock('../../hooks/exchange/useExchangeFlow', () => ({
     useExchangeFlow: () => ({
         confirmTrade: mockConfirmTrade,
-        fetchFeesAndCompose: jest.fn(),
-        signAndSendTransaction: jest.fn(),
+        fetchFeesAndCompose: mockFetchFeesAndCompose,
+        signAndSendTransaction: mockSignAndSendTransaction,
         isConsentRequested: false,
-        resolveConsent: jest.fn(),
+        resolveConsent: mockResolveConsent,
+        txnErrorString: null,
     }),
 }));
 
@@ -76,19 +75,31 @@ describe('TradingExchangePreviewScreen', () => {
         expect(getByText('Continue')).toBeOnTheScreen();
     });
 
-    it('should call confirmTrade on Continue press', async () => {
-        const { getByText, queryByText } = await renderTradingExchangePreviewScreen();
+    it('should render screen title correctly', async () => {
+        const { getByText } = await renderTradingExchangePreviewScreen();
 
-        await userEvent.press(getByText('Continue'));
+        expect(getByText('Swap')).toBeOnTheScreen();
+    });
 
-        expect(mockConfirmTrade).toHaveBeenCalledTimes(1);
-        expect(mockConfirmTrade).toHaveBeenCalledWith({
-            sendAccount: expect.objectContaining({ key: 'eth-account-1' }),
-            receiveAddress: '1BTC',
-            trade: exchangeQuotes[0],
-            approvalFlow: false,
-        });
-        expect(queryByText('Continue')).not.toBeOnTheScreen();
-        expect(getByText('Sign and Send Transaction')).toBeOnTheScreen();
+    it('should render from and to account labels', async () => {
+        const { getByText } = await renderTradingExchangePreviewScreen();
+
+        expect(getByText('From')).toBeOnTheScreen();
+        expect(getByText('To')).toBeOnTheScreen();
+    });
+
+    it('should render transaction details section', async () => {
+        const { getByText } = await renderTradingExchangePreviewScreen();
+
+        expect(getByText('Transaction details')).toBeOnTheScreen();
+        expect(getByText('Fee')).toBeOnTheScreen();
+    });
+
+    it('should render FeePickerCard when no error and fromAccount and quote are available', async () => {
+        const { getByText } = await renderTradingExchangePreviewScreen();
+
+        // Should render the fee picker section
+        expect(getByText('Transaction details')).toBeOnTheScreen();
+        expect(getByText('Fee')).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -31,7 +31,7 @@ import {
     NativeSupportedFeeLevel,
     UpdateSelectedFeeLevelThunkParams,
     addTransactionLabelingThunk,
-    storeFeeLevels,
+    transactionManagementActions,
 } from '@suite-native/transaction-management';
 import TrezorConnect from '@trezor/connect';
 
@@ -51,6 +51,7 @@ export const clearTradingStateThunk = createThunk(
 
         // Clear send form transaction state (precomposed, signed, serialized, ...)
         dispatch(sendFormActions.dispose());
+        dispatch(transactionManagementActions.clearFeeLevels());
 
         // Clear form draft with selected fees
         dispatch(formDraftActions.removeDraft({ key: 'trading-sell' }));
@@ -163,19 +164,18 @@ export const composeTradingTransactionThunk = createThunk(
 
             if (isFulfilled(response)) {
                 const feeLevels = response.payload;
-                dispatch(storeFeeLevels({ feeLevels }));
+                dispatch(transactionManagementActions.storeFeeLevels({ feeLevels }));
 
-                const composed = (await dispatch(
-                    enhancePrecomposedTransactionThunk({
-                        transactionFormValues: formState,
-                        precomposedTransaction: feeLevels[
-                            selectedFeeLevel
-                        ] as PrecomposedTransactionFinal,
-                        selectedAccount: account,
-                    }),
-                ).unwrap()) as PrecomposedTransactionFinal;
+                const selectedLevel = feeLevels[selectedFeeLevel];
+                if (selectedLevel && selectedLevel.type === 'final') {
+                    const composed = (await dispatch(
+                        enhancePrecomposedTransactionThunk({
+                            transactionFormValues: formState,
+                            precomposedTransaction: selectedLevel as PrecomposedTransactionFinal,
+                            selectedAccount: account,
+                        }),
+                    ).unwrap()) as PrecomposedTransactionFinal;
 
-                if (composed && composed.type === 'final') {
                     dispatch(
                         tradingCommonActions.saveComposedTransactionInfo({
                             selectedFee: selectedFeeLevel,
@@ -209,7 +209,14 @@ export const composeTradingTransactionThunk = createThunk(
                 return fulfillWithValue(response.payload);
             }
 
-            return rejectWithValue(`Failed to compose transaction: ${response.error}`);
+            const errStr =
+                (response as any)?.error?.message ??
+                (typeof (response as any)?.error === 'string'
+                    ? (response as any).error
+                    : 'Unknown error');
+            console.error('Failed to compose transaction:', errStr);
+
+            return rejectWithValue(`Failed to compose transaction: ${errStr}`);
         } catch (error) {
             console.error('Compose trading transaction error:', error);
 

--- a/suite-native/transaction-management/src/__tests__/sendFormSlice.test.ts
+++ b/suite-native/transaction-management/src/__tests__/sendFormSlice.test.ts
@@ -3,7 +3,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { extraDependenciesMock } from '@suite-common/test-utils';
 import { GeneralPrecomposedLevels } from '@suite-common/wallet-types';
 
-import { initialState, sendFormSlice, storeFeeLevels } from '../sendFormSlice';
+import { sendFormSlice, transactionManagementActions } from '../sendFormSlice';
 
 describe('sendFormSlice', () => {
     // Create a test store with the prepared reducer
@@ -46,7 +46,7 @@ describe('sendFormSlice', () => {
                 } as any,
             };
 
-            store.dispatch(storeFeeLevels({ feeLevels }));
+            store.dispatch(transactionManagementActions.storeFeeLevels({ feeLevels }));
 
             expect(store.getState().send.feeLevels).toEqual(feeLevels);
         });
@@ -67,7 +67,9 @@ describe('sendFormSlice', () => {
             };
 
             // Set initial fee levels
-            store.dispatch(storeFeeLevels({ feeLevels: initialFeeLevels }));
+            store.dispatch(
+                transactionManagementActions.storeFeeLevels({ feeLevels: initialFeeLevels }),
+            );
 
             const newFeeLevels: GeneralPrecomposedLevels = {
                 custom: {
@@ -82,7 +84,9 @@ describe('sendFormSlice', () => {
                 } as any,
             };
 
-            store.dispatch(storeFeeLevels({ feeLevels: newFeeLevels }));
+            store.dispatch(
+                transactionManagementActions.storeFeeLevels({ feeLevels: newFeeLevels }),
+            );
 
             expect(store.getState().send.feeLevels).toEqual(newFeeLevels);
             expect(store.getState().send.feeLevels).not.toEqual(initialFeeLevels);
@@ -92,45 +96,17 @@ describe('sendFormSlice', () => {
             const store = createTestStore();
             const emptyFeeLevels: GeneralPrecomposedLevels = {};
 
-            store.dispatch(storeFeeLevels({ feeLevels: emptyFeeLevels }));
+            store.dispatch(
+                transactionManagementActions.storeFeeLevels({ feeLevels: emptyFeeLevels }),
+            );
 
             expect(store.getState().send.feeLevels).toEqual(emptyFeeLevels);
         });
     });
 
-    it('should return initial state when store is created', () => {
-        const store = createTestStore();
-        const state = store.getState().send;
-
-        expect(state).toEqual(initialState);
-    });
-
-    describe('action creators', () => {
-        it('should create storeFeeLevels action with correct payload', () => {
-            const feeLevels: GeneralPrecomposedLevels = {
-                normal: {
-                    type: 'final',
-                    totalSpent: '1000433210428000',
-                    fee: '433210428000',
-                    feePerByte: '1',
-                    feeLimit: '11000',
-                    bytes: 250,
-                    inputs: [],
-                    estimatedFeeLimit: '11000',
-                } as any,
-            };
-
-            const action = storeFeeLevels({ feeLevels });
-
-            expect(action.type).toBe('send/storeFeeLevels');
-            expect(action.payload).toEqual({ feeLevels });
-        });
-    });
-
-    describe('state immutability', () => {
-        it('should not mutate the original state', () => {
+    describe('clearFeeLevels', () => {
+        it('should clear fee levels when they exist', () => {
             const store = createTestStore();
-            const originalState = store.getState().send;
             const feeLevels: GeneralPrecomposedLevels = {
                 normal: {
                     type: 'final',
@@ -142,12 +118,36 @@ describe('sendFormSlice', () => {
                     inputs: [],
                     estimatedFeeLimit: '11000',
                 } as any,
+                high: {
+                    type: 'final',
+                    totalSpent: '1000433210428000',
+                    fee: '733210428000',
+                    feePerByte: '4',
+                    feeLimit: '21000',
+                    bytes: 250,
+                    inputs: [],
+                    estimatedFeeLimit: '21000',
+                } as any,
             };
 
-            store.dispatch(storeFeeLevels({ feeLevels }));
+            // First store fee levels
+            store.dispatch(transactionManagementActions.storeFeeLevels({ feeLevels }));
+            expect(store.getState().send.feeLevels).toEqual(feeLevels);
 
-            // The original state object should not be mutated
-            expect(originalState).not.toBe(store.getState().send);
+            // Then clear them
+            store.dispatch(transactionManagementActions.clearFeeLevels());
+            expect(store.getState().send.feeLevels).toEqual({});
+        });
+
+        it('should clear fee levels when they are already empty', () => {
+            const store = createTestStore();
+
+            // Verify initial state is empty
+            expect(store.getState().send.feeLevels).toEqual({});
+
+            // Clear fee levels (should remain empty)
+            store.dispatch(transactionManagementActions.clearFeeLevels());
+            expect(store.getState().send.feeLevels).toEqual({});
         });
     });
 });

--- a/suite-native/transaction-management/src/hooks/__tests__/usePrecomposedTransactionError.test.ts
+++ b/suite-native/transaction-management/src/hooks/__tests__/usePrecomposedTransactionError.test.ts
@@ -1,0 +1,88 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+
+import { usePrecomposedTransactionError } from '../usePrecomposedTransactionError';
+
+// Mock the translation function
+const mockTranslate = jest.fn();
+
+jest.mock('@suite-native/intl', () => ({
+    useTranslate: () => ({
+        translate: mockTranslate,
+    }),
+}));
+
+describe('usePrecomposedTransactionError', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const mockContext = {
+        networkSymbol: 'btc' as NetworkSymbol,
+    };
+
+    const mockContextWithoutNetwork = {};
+
+    it.each([[null], [undefined], ['INVALID_ERROR'], ['']])(
+        'should return null when error is %s',
+        error => {
+            const { result } = renderHookWithBasicProvider(() =>
+                usePrecomposedTransactionError({ error, context: mockContext }),
+            );
+
+            expect(result.current).toBeNull();
+            expect(mockTranslate).not.toHaveBeenCalled();
+        },
+    );
+
+    it('should return translated error message for valid error', () => {
+        mockTranslate.mockReturnValue('Translated error message');
+
+        const { result } = renderHookWithBasicProvider(() =>
+            usePrecomposedTransactionError({
+                error: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
+                context: mockContext,
+            }),
+        );
+
+        expect(result.current).toBe('Translated error message');
+        expect(mockTranslate).toHaveBeenCalledWith(
+            'transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFee',
+            { networkDisplaySymbol: 'BTC' },
+        );
+    });
+
+    it('should handle context without network symbol', () => {
+        mockTranslate.mockReturnValue('Translated error message');
+
+        const { result } = renderHookWithBasicProvider(() =>
+            usePrecomposedTransactionError({
+                error: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
+                context: mockContextWithoutNetwork,
+            }),
+        );
+
+        expect(result.current).toBe('Translated error message');
+        expect(mockTranslate).toHaveBeenCalledWith(
+            'transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFee',
+            { networkDisplaySymbol: '' },
+        );
+    });
+
+    it('should handle different network symbols', () => {
+        mockTranslate.mockReturnValue('Translated error message');
+
+        const { result } = renderHookWithBasicProvider(() =>
+            usePrecomposedTransactionError({
+                error: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
+                context: { networkSymbol: 'eth' as NetworkSymbol },
+            }),
+        );
+
+        expect(result.current).toBe('Translated error message');
+        expect(mockTranslate).toHaveBeenCalledWith(
+            'transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFee',
+            { networkDisplaySymbol: 'ETH' },
+        );
+    });
+});

--- a/suite-native/transaction-management/src/hooks/fees/useFeesFetching.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeesFetching.ts
@@ -11,7 +11,7 @@ import {
 import { AccountKey } from '@suite-common/wallet-types';
 
 export type UseFeesFetchingProps = {
-    accountKey: AccountKey;
+    accountKey: AccountKey | undefined;
     isRefetchDisabled?: boolean;
 };
 

--- a/suite-native/transaction-management/src/hooks/index.ts
+++ b/suite-native/transaction-management/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './useShowReviewCancellationAlert';
 export * from './useOutputsReviewBackInterceptor';
 export * from './useWaitForButtonRequest';
 export * from './fees';
+export * from './usePrecomposedTransactionError';

--- a/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.ts
+++ b/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+
+import { useTranslate } from '@suite-native/intl';
+
+import {
+    PrecomposedTransactionErrorContext,
+    getPrecomposedTransactionErrorTranslation,
+} from '../utils/precomposedTransactionErrorUtils';
+
+type UsePrecomposedTransactionErrorProps = {
+    error: string | null | undefined;
+    context: PrecomposedTransactionErrorContext;
+};
+
+/**
+ * Hook to get precomposed transaction error translation with proper values
+ */
+export const usePrecomposedTransactionError = ({
+    error,
+    context,
+}: UsePrecomposedTransactionErrorProps): string | null => {
+    const { translate } = useTranslate();
+
+    return useMemo(() => {
+        const errorData = getPrecomposedTransactionErrorTranslation(error, context);
+
+        if (!errorData) {
+            return null;
+        }
+
+        const { txKeyPath, values } = errorData;
+
+        return translate(txKeyPath, values);
+    }, [error, context, translate]);
+};

--- a/suite-native/transaction-management/src/index.ts
+++ b/suite-native/transaction-management/src/index.ts
@@ -1,6 +1,7 @@
 export * from './types';
 export * from './components';
 export * from './hooks';
+export * from './utils';
 export * from './feesFormSchema';
 export * from './selectors';
 export * from './sendFormSlice';

--- a/suite-native/transaction-management/src/sendFormSlice.ts
+++ b/suite-native/transaction-management/src/sendFormSlice.ts
@@ -33,6 +33,9 @@ export const sendFormSlice = createSliceWithExtraDeps({
     name: 'send',
     initialState,
     reducers: {
+        clearFeeLevels: state => {
+            state.feeLevels = {};
+        },
         storeFeeLevels: (
             state,
             { payload }: PayloadAction<{ feeLevels: GeneralPrecomposedLevels }>,
@@ -70,4 +73,4 @@ export const sendFormSlice = createSliceWithExtraDeps({
     },
 });
 
-export const { storeFeeLevels } = sendFormSlice.actions;
+export const transactionManagementActions = sendFormSlice.actions;

--- a/suite-native/transaction-management/src/thunks.ts
+++ b/suite-native/transaction-management/src/thunks.ts
@@ -17,7 +17,7 @@ import {
     isFinalPrecomposedTransaction,
 } from '@suite-common/wallet-types';
 
-import { storeFeeLevels } from './sendFormSlice';
+import { transactionManagementActions } from './sendFormSlice';
 import { FeeLevelsMaxAmount } from './types/fees';
 
 const TRANSACTION_MANAGEMENT_PREFIX = '@suite-native/transaction-management';
@@ -125,7 +125,7 @@ export const calculateCustomFeeLevelThunk = createThunk<
         }
 
         const feeLevels = response.payload;
-        dispatch(storeFeeLevels({ feeLevels }));
+        dispatch(transactionManagementActions.storeFeeLevels({ feeLevels }));
 
         if (!isFinalPrecomposedTransaction(feeLevels.custom)) {
             return rejectWithValue('Unable to compose custom fee level.');

--- a/suite-native/transaction-management/src/utils/__tests__/precomposedTransactionErrorUtils.test.ts
+++ b/suite-native/transaction-management/src/utils/__tests__/precomposedTransactionErrorUtils.test.ts
@@ -1,0 +1,100 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+
+import {
+    PrecomposedTransactionErrorContext,
+    getPrecomposedTransactionErrorTranslation,
+    isPrecomposedTransactionError,
+} from '../precomposedTransactionErrorUtils';
+
+describe('precomposedTransactionErrorUtils', () => {
+    describe('isPrecomposedTransactionError', () => {
+        it.each([
+            'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
+            'AMOUNT_IS_NOT_ENOUGH',
+            'AMOUNT_IS_TOO_LOW',
+            'AMOUNT_IS_LESS_THAN_RESERVE',
+            'TR_STAKE_NOT_ENOUGH_FUNDS',
+            'REMAINING_BALANCE_LESS_THAN_RENT',
+            'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
+        ])('should return true for valid precomposed transaction error: %s', error => {
+            expect(isPrecomposedTransactionError(error)).toBe(true);
+        });
+
+        it.each(['INVALID_ERROR', 'UNKNOWN_ERROR', 'NETWORK_ERROR', '', null, undefined])(
+            'should return false for invalid error: %s',
+            error => {
+                expect(isPrecomposedTransactionError(error as string)).toBe(false);
+            },
+        );
+    });
+
+    describe('getPrecomposedTransactionErrorTranslation', () => {
+        const mockContext: PrecomposedTransactionErrorContext = {
+            networkSymbol: 'btc' as NetworkSymbol,
+        };
+
+        it.each(['INVALID_ERROR', '', null, undefined])(
+            'should return null for invalid error: %s',
+            error => {
+                expect(
+                    getPrecomposedTransactionErrorTranslation(error as string, mockContext),
+                ).toBeNull();
+            },
+        );
+
+        it.each([
+            {
+                error: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
+                expectedTxKeyPath:
+                    'transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFee',
+                expectedValues: { networkDisplaySymbol: 'BTC' },
+            },
+            {
+                error: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
+                expectedTxKeyPath:
+                    'transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFeeWithEthAmount',
+                expectedValues: { networkDisplaySymbol: 'BTC' },
+            },
+            {
+                error: 'AMOUNT_IS_LESS_THAN_RESERVE',
+                expectedTxKeyPath:
+                    'transactionManagement.precomposedTransaction.errors.amountIsLessThanReserve',
+                expectedValues: {},
+            },
+            {
+                error: 'REMAINING_BALANCE_LESS_THAN_RENT',
+                expectedTxKeyPath:
+                    'transactionManagement.precomposedTransaction.errors.remainingBalanceLessThanRent',
+                expectedValues: {},
+            },
+            {
+                error: 'AMOUNT_IS_NOT_ENOUGH',
+                expectedTxKeyPath:
+                    'transactionManagement.precomposedTransaction.errors.amountIsNotEnough',
+                expectedValues: {},
+            },
+            {
+                error: 'AMOUNT_IS_TOO_LOW',
+                expectedTxKeyPath:
+                    'transactionManagement.precomposedTransaction.errors.amountIsTooLow',
+                expectedValues: {},
+            },
+            {
+                error: 'TR_STAKE_NOT_ENOUGH_FUNDS',
+                expectedTxKeyPath:
+                    'transactionManagement.precomposedTransaction.errors.stakeNotEnoughFunds',
+                expectedValues: {},
+            },
+        ])(
+            'should return correct translation data for $error',
+            ({ error, expectedTxKeyPath, expectedValues }) => {
+                const result = getPrecomposedTransactionErrorTranslation(error, mockContext);
+
+                expect(result).toEqual({
+                    txKeyPath: expectedTxKeyPath,
+                    values: expectedValues,
+                });
+            },
+        );
+    });
+});

--- a/suite-native/transaction-management/src/utils/index.ts
+++ b/suite-native/transaction-management/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './precomposedTransactionErrorUtils';

--- a/suite-native/transaction-management/src/utils/precomposedTransactionErrorUtils.ts
+++ b/suite-native/transaction-management/src/utils/precomposedTransactionErrorUtils.ts
@@ -1,0 +1,126 @@
+import { NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { PrecomposedTransactionError } from '@suite-common/wallet-types';
+import { TxKeyPath } from '@suite-native/intl';
+
+/**
+ * Values that can be provided for precomposed transaction error messages
+ */
+export type PrecomposedTransactionErrorValues = {
+    networkDisplaySymbol?: string;
+};
+
+/**
+ * Context information needed to generate error message values
+ */
+export type PrecomposedTransactionErrorContext = {
+    networkSymbol?: NetworkSymbol;
+};
+
+const VALID_PRECOMPOSED_ERRORS: PrecomposedTransactionError['error'][] = [
+    'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
+    'AMOUNT_IS_NOT_ENOUGH',
+    'AMOUNT_IS_TOO_LOW',
+    'AMOUNT_IS_LESS_THAN_RESERVE',
+    'TR_STAKE_NOT_ENOUGH_FUNDS',
+    'REMAINING_BALANCE_LESS_THAN_RENT',
+    'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
+];
+
+/**
+ * Type guard to check if an error is a precomposed transaction error
+ */
+export const isPrecomposedTransactionError = (
+    error: string,
+): error is PrecomposedTransactionError['error'] =>
+    VALID_PRECOMPOSED_ERRORS.includes(error as PrecomposedTransactionError['error']);
+
+/**
+ * Generates the translation key and values for a precomposed transaction error message
+ */
+const generateErrorData = (
+    error: string | undefined | null,
+    context: PrecomposedTransactionErrorContext,
+): {
+    txKeyPath: TxKeyPath;
+    values: PrecomposedTransactionErrorValues;
+} | null => {
+    const { networkSymbol } = context;
+
+    if (!error || !isPrecomposedTransactionError(error)) {
+        return null;
+    }
+
+    switch (error) {
+        case 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE':
+            return {
+                txKeyPath:
+                    'transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFee',
+                values: {
+                    networkDisplaySymbol: networkSymbol
+                        ? getNetworkDisplaySymbol(networkSymbol)
+                        : '',
+                },
+            };
+
+        case 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT':
+            return {
+                txKeyPath:
+                    'transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFeeWithEthAmount',
+                values: {
+                    networkDisplaySymbol: networkSymbol
+                        ? getNetworkDisplaySymbol(networkSymbol)
+                        : '',
+                },
+            };
+
+        case 'AMOUNT_IS_LESS_THAN_RESERVE':
+            return {
+                txKeyPath:
+                    'transactionManagement.precomposedTransaction.errors.amountIsLessThanReserve',
+                values: {},
+            };
+
+        case 'REMAINING_BALANCE_LESS_THAN_RENT':
+            return {
+                txKeyPath:
+                    'transactionManagement.precomposedTransaction.errors.remainingBalanceLessThanRent',
+                values: {},
+            };
+
+        case 'AMOUNT_IS_NOT_ENOUGH':
+            return {
+                txKeyPath: 'transactionManagement.precomposedTransaction.errors.amountIsNotEnough',
+                values: {},
+            };
+
+        case 'AMOUNT_IS_TOO_LOW':
+            return {
+                txKeyPath: 'transactionManagement.precomposedTransaction.errors.amountIsTooLow',
+                values: {},
+            };
+
+        case 'TR_STAKE_NOT_ENOUGH_FUNDS':
+            return {
+                txKeyPath:
+                    'transactionManagement.precomposedTransaction.errors.stakeNotEnoughFunds',
+                values: {},
+            };
+
+        default:
+            return {
+                txKeyPath: 'transactionManagement.precomposedTransaction.errors.amountIsNotEnough',
+                values: {},
+            };
+    }
+};
+
+/**
+ * Returns the translation key and values for a precomposed transaction error
+ */
+export const getPrecomposedTransactionErrorTranslation = (
+    error: string | undefined | null,
+    context: PrecomposedTransactionErrorContext,
+): {
+    txKeyPath: TxKeyPath;
+    values: PrecomposedTransactionErrorValues;
+} | null => generateErrorData(error, context);


### PR DESCRIPTION
- on going to preview screen, confirm the trade and compose fees
- on compose error, show error message
- do not chunkify solana addresses

## Related Issue

Resolve #21693
Resolve #21714

## Screenshots:

https://github.com/user-attachments/assets/986f3294-a4a3-4e49-862b-a9d2f20db934



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/trading-swap-review-validate-fees&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/trading-swap-review-validate-fees&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/trading-swap-review-validate-fees&lookback=7)