### PR TITLE
chore(protocol): remove unused `ThpInvalidData` error type

### DIFF
--- a/packages/protocol/src/protocol-thp/decode.ts
+++ b/packages/protocol/src/protocol-thp/decode.ts
@@ -142,8 +142,6 @@ const decodeThpError = (payload: Buffer): ThpMessageResponse => {
                 return 'ThpUnallocatedChannel';
             case 0x03:
                 return 'ThpDecryptionFailed';
-            case 0x04:
-                return 'ThpInvalidData';
             case 0x05:
                 return 'ThpDeviceLocked';
             default:

--- a/packages/protocol/src/protocol-thp/messages/messageTypes.ts
+++ b/packages/protocol/src/protocol-thp/messages/messageTypes.ts
@@ -13,7 +13,6 @@ export type ThpError = {
         | 'ThpTransportBusy'
         | 'ThpUnallocatedChannel'
         | 'ThpDecryptionFailed'
-        | 'ThpInvalidData'
         | 'ThpDeviceLocked'
         | 'ThpUnknownError';
     message: string;


### PR DESCRIPTION
## Description

The `ThpInvalidData` error type is not used anywhere (and never has been). It can be safely removed.
<!--- Describe your changes in detail -->

## Related Issue

The error was removed from Trezor FW here: https://github.com/trezor/trezor-firmware/pull/5812

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=m1nd3r/remove-invalid-data-error&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=m1nd3r/remove-invalid-data-error&lookback=7)