### PR TITLE
fix(suite): close connection modal on cancel in BTAdapterStatus

### DIFF
--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -188,7 +188,7 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
         return (
             <BluetoothAdapterStatusModal
                 bluetoothAdapterStatus={bluetoothAdapterStatus}
-                onCancel={toggleBluetoothMode}
+                onCancel={onCancel}
             />
         );
     }


### PR DESCRIPTION
Small change, cancel in BT adapter status modal now closes the whole connection flow.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21221



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/error-message-when-starting-up-with-BT-turned-off&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/error-message-when-starting-up-with-BT-turned-off&lookback=7)