### PR TITLE
Device busy state

### DIFF
--- a/packages/product-components/src/components/RotateDeviceImage/RotateDeviceImage.tsx
+++ b/packages/product-components/src/components/RotateDeviceImage/RotateDeviceImage.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
+import { Icon } from '@trezor/components';
 import { DeviceModelInternal, normalizeDeviceColorVariant } from '@trezor/device-utils';
 
+import { mapTrezorModelToIcon } from '../../utils/mapTrezorModelToIcon';
 import { DeviceAnimation } from '../DeviceAnimation/DeviceAnimation';
 
 export type RotateDeviceImageProps = {
@@ -23,6 +25,10 @@ export const RotateDeviceImage = ({
 }: RotateDeviceImageProps) => {
     if (!deviceModel) {
         return null;
+    }
+
+    if (deviceModel === DeviceModelInternal.UNKNOWN) {
+        return <Icon name={mapTrezorModelToIcon[DeviceModelInternal.T3T1]} size="extraLarge" />;
     }
 
     return (

--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -60,14 +60,28 @@ const getWarningMessage = ({
 }: {
     deviceStatus: ConnectedDeviceStatus | null;
     showWarning: boolean;
-}) => {
+}): {
+    heading: TranslationKey;
+    description?: TranslationKey;
+} => {
     switch (deviceStatus) {
         case 'bootloader':
-            return 'TR_DEVICE_CONNECTED_NEW_DEVICE_STATE';
+            return {
+                heading: 'TR_DEVICE_CONNECTED_NEW_DEVICE_STATE',
+            };
+        case 'device-busy':
+            return {
+                heading: 'TR_DEVICE_CONNECTED_BUSY_BOOTLOADER',
+                description: 'TR_DEVICE_CONNECTED_BUSY_BOOTLOADER_DESCRIPTION',
+            };
         case 'initialize':
-            return 'TR_DEVICE_CONNECTED_INITIAL_DEVICE_STATE';
+            return {
+                heading: 'TR_DEVICE_CONNECTED_INITIAL_DEVICE_STATE',
+            };
         default:
-            return showWarning ? 'TR_DEVICE_CONNECTED' : 'TR_DEVICE_CONNECTED_WRONG_STATE';
+            return {
+                heading: showWarning ? 'TR_DEVICE_CONNECTED' : 'TR_DEVICE_CONNECTED_WRONG_STATE',
+            };
     }
 };
 
@@ -92,9 +106,7 @@ const getMessageId = ({
         description?: TranslationKey;
     } => {
         if (connected) {
-            return {
-                heading: getWarningMessage({ deviceStatus, showWarning }),
-            };
+            return getWarningMessage({ deviceStatus, showWarning });
         }
 
         return {
@@ -132,6 +144,7 @@ const getMessageId = ({
             heading: 'TR_NEEDS_TREZOR_HOST_PROTOCOL_PAIRING',
         },
 
+        'device-busy': defaultKey,
         'device-disconnect-required': defaultKey,
         'device-disconnected': defaultKey,
         'device-initialize': defaultKey,

--- a/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
@@ -58,6 +58,7 @@ export const PrerequisitesGuide = ({ allowSwitchDevice }: PrerequisitesGuideProp
                 case 'device-disconnected':
                     return <DeviceConnect />;
                 case 'device-unacquired':
+                case 'device-busy':
                     return <DeviceAcquire />;
                 case 'device-unacquired-requires-thp':
                     return <DeviceTrezorHostProtocolPair />;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2285,6 +2285,14 @@ export default defineMessages({
         defaultMessage: 'Failed to communicate with your Trezor',
         id: 'TR_NEEDS_ATTENTION_UNABLE_TO_CONNECT',
     },
+    TR_DEVICE_CONNECTED_BUSY_BOOTLOADER: {
+        defaultMessage: 'Trezor is busy, it cannot communicate',
+        id: 'TR_DEVICE_CONNECTED_BUSY_BOOTLOADER',
+    },
+    TR_DEVICE_CONNECTED_BUSY_BOOTLOADER_DESCRIPTION: {
+        defaultMessage: 'Device may be in the bootloader mode, restart the device and try again.',
+        id: 'TR_DEVICE_CONNECTED_BUSY_BOOTLOADER_DESCRIPTION',
+    },
     TR_NEEDS_TREZOR_HOST_PROTOCOL_PAIRING: {
         defaultMessage: 'Trezor Safe 7 detected',
         id: 'TR_NEEDS_TREZOR_HOST_PROTOCOL_PAIRING',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2285,6 +2285,10 @@ export default defineMessages({
         defaultMessage: 'Failed to communicate with your Trezor',
         id: 'TR_NEEDS_ATTENTION_UNABLE_TO_CONNECT',
     },
+    TR_NEEDS_ATTENTION_DEVICE_BUSY: {
+        defaultMessage: 'Trezor detected in incorrect state. Restart it to reconnect.',
+        id: 'TR_NEEDS_ATTENTION_DEVICE_BUSY',
+    },
     TR_DEVICE_CONNECTED_BUSY_BOOTLOADER: {
         defaultMessage: 'Trezor is busy, it cannot communicate',
         id: 'TR_DEVICE_CONNECTED_BUSY_BOOTLOADER',

--- a/packages/suite/src/utils/suite/prerequisites.ts
+++ b/packages/suite/src/utils/suite/prerequisites.ts
@@ -28,7 +28,8 @@ export type PrerequisiteType =
     | 'device-initialize'
     | 'device-bootloader'
     | 'firmware-missing'
-    | 'firmware-required';
+    | 'firmware-required'
+    | 'device-busy';
 
 export const getPrerequisiteName = ({
     router,
@@ -48,6 +49,8 @@ export const getPrerequisiteName = ({
 
     if (device.type === 'unacquired' && device?.transportSessionOwner)
         return 'device-used-elsewhere';
+
+    if (device.status === 'busy') return 'device-busy';
 
     // Unacquired device with Trezor Host Protocol properties means
     // that the user must perform the Trezor Host Protocol paring

--- a/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
@@ -55,6 +55,8 @@ const getDeviceNeedsAttentionMessage = (
             return 'TR_NEEDS_ATTENTION_UNREADABLE';
         case 'unacquired-thp-required':
             return 'TR_NEEDS_ATTENTION_UNACQUIRED_THP_REQUIRED';
+        case 'device-busy':
+            return 'TR_NEEDS_ATTENTION_DEVICE_BUSY';
 
         case 'connected':
         case 'disconnected':
@@ -122,15 +124,16 @@ export const NeedsAttentionBanner = ({
         onCancel?.(false);
     };
 
-    const onSolveIssueClick = (): void => {
+    const createOnIssueClickHandler = (): (() => void) | null => {
         switch (deviceStatus) {
             // If onboarding is pending, then it should pass through Manual Device Check.
             case 'initialize': // Wiped device with firmware present.
             case 'bootloader': // Fresh or factory-reset device? Can also be initalized device manually put into BL,
                 // but we cannot tell (device.features.initialized is null)
-                selectDevice();
-                dispatch(goto('suite-start'));
-                break;
+                return () => {
+                    selectDevice();
+                    dispatch(goto('suite-start'));
+                };
 
             case 'seedless':
             case 'firmware-required':
@@ -140,35 +143,41 @@ export const NeedsAttentionBanner = ({
             case 'disconnected':
             case 'firmware-recommended':
             case 'unknown':
-                selectDevice();
-                break;
+                return () => selectDevice();
 
             case 'used-in-other-window':
             case 'was-used-in-other-window':
             case 'unacquired':
-                dispatch(acquireDevice({ requestedDevice: device }));
-                break;
+                return () => dispatch(acquireDevice({ requestedDevice: device }));
             case 'unacquired-thp-required':
-                onCancel?.(false);
-                dispatch(acquireDevice({ requestedDevice: device }));
-                break;
+                return () => {
+                    onCancel?.(false);
+                    dispatch(acquireDevice({ requestedDevice: device }));
+                };
+
+            case 'device-busy':
+                return null;
 
             default:
                 return exhaustive(deviceStatus);
         }
     };
 
+    const onIssueClick = createOnIssueClickHandler();
+
     return (
         <Banner
             variant={deviceStatusBannerVariant}
             rightContent={
-                <Banner.Button
-                    onClick={onSolveIssueClick}
-                    data-testid="@switch-device/solve-issue-button"
-                    isDisabled={isLocked}
-                >
-                    <Translation id={deviceResolveIssueCTAMessage} />
-                </Banner.Button>
+                onIssueClick && (
+                    <Banner.Button
+                        onClick={onIssueClick}
+                        data-testid="@switch-device/solve-issue-button"
+                        isDisabled={isLocked}
+                    >
+                        <Translation id={deviceResolveIssueCTAMessage} />
+                    </Banner.Button>
+                )
             }
         >
             {deviceStatusMessage && (

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -69,6 +69,10 @@ export const getStatus = (device: TrezorDevice) => {
         return 'connected';
     }
 
+    if (device.type === 'unacquired' && device.status === 'busy') {
+        return 'device-busy';
+    }
+
     if (device.type === 'unacquired' && device.thp?.properties !== undefined) {
         return 'unacquired-thp-required';
     }
@@ -107,6 +111,7 @@ export const deviceNeedsAttention = (deviceStatus: ConnectedDeviceStatus): boole
         case 'unacquired':
         case 'firmware-required':
         case 'unreadable':
+        case 'device-busy':
         case 'unacquired-thp-required':
             return true;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Handles a new THP device state - when the device is in bootloader mode is connected but can't communicate. Leverages a new flag to determine this state.

This commits are from  https://github.com/trezor/trezor-suite/pull/20941

These are unrelated to the other tasks done there

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/20942#issuecomment-3265957804

resolve https://github.com/trezor/trezor-suite/issues/21391

design: https://www.figma.com/design/yl2g0XLU9iIgJsrxSOqkS9/Bluetooth---THP--Final-?node-id=3232-2328&t=8bsf90G2C9EhFmtM-0


## Screenshots:

<img width="478" height="109" alt="Screenshot 2025-09-23 at 11 28 30 AM" src="https://github.com/user-attachments/assets/75317921-81f9-474e-b37b-7e23aa6809bd" />

<img width="893" height="482" alt="Screenshot 2025-09-23 at 11 24 12 AM" src="https://github.com/user-attachments/assets/40e9f785-ebdf-4f44-ba68-26aff48ffd69" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=device-busy-state&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=device-busy-state&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=device-busy-state&lookback=7)