### PR TITLE
feat(graph): disabling Cardano for a trend graph

### DIFF
--- a/suite-common/graph/src/constants.ts
+++ b/suite-common/graph/src/constants.ts
@@ -22,6 +22,12 @@ export const isLocalBalanceHistoryCoin = (
 
 // Some networks might be ignored by graph
 // Solana is ignored because it takes a lot of time and network resources to get all needed history data
-export const IGNORED_BALANCE_HISTORY_COINS = ['sol'] satisfies Array<NetworkSymbol>;
+// Ada is ignored because it sends a lot of requests to the blockfrost API. Therefore we have temporarily disabled it.
+export const IGNORED_BALANCE_HISTORY_COINS = [
+    'sol',
+    'dsol',
+    'ada',
+    'tada',
+] satisfies Array<NetworkSymbol>;
 export const isIgnoredBalanceHistoryCoin = (symbol: NetworkSymbol) =>
     isArrayMember(symbol, IGNORED_BALANCE_HISTORY_COINS);

--- a/suite-common/graph/src/index.ts
+++ b/suite-common/graph/src/index.ts
@@ -1,4 +1,5 @@
 export * from './hooks';
+export * from './constants';
 export type {
     FiatGraphPoint,
     FiatGraphPointWithCryptoBalance,

--- a/suite-native/graph/jest.config.js
+++ b/suite-native/graph/jest.config.js
@@ -1,0 +1,5 @@
+const { ...baseConfig } = require('../../jest.config.native');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-native/graph/package.json
+++ b/suite-native/graph/package.json
@@ -6,7 +6,7 @@
     "sideEffects": false,
     "main": "src/index",
     "scripts": {
-        "test:unit": "yarn g:jest -c ../../jest.config.base.js",
+        "test:unit": "yarn g:jest",
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build"
     },

--- a/suite-native/graph/src/selectors.ts
+++ b/suite-native/graph/src/selectors.ts
@@ -2,10 +2,12 @@ import { A } from '@mobily/ts-belt';
 
 import { AccountItem } from '@suite-common/graph';
 import { isIgnoredBalanceHistoryCoin } from '@suite-common/graph/src/constants';
+import { createWeakMapSelector } from '@suite-common/redux-utils';
 import {
     TokenDefinitionsRootState,
     selectFilterKnownTokens,
 } from '@suite-common/token-definitions';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
     AccountsRootState,
     DeviceRootState,
@@ -16,6 +18,8 @@ import { TokenAddress } from '@suite-common/wallet-types';
 import { tryGetAccountIdentity } from '@suite-common/wallet-utils';
 
 type GraphCommonRootState = DeviceRootState & AccountsRootState & TokenDefinitionsRootState;
+
+export const createMemoizedSelector = createWeakMapSelector.withTypes<GraphCommonRootState>();
 
 export const selectPortfolioGraphAccountItems = (state: GraphCommonRootState): AccountItem[] => {
     const accounts = selectDeviceMainnetAccounts(state);
@@ -36,21 +40,17 @@ export const selectPortfolioGraphAccountItems = (state: GraphCommonRootState): A
     });
 };
 
-export const selectHasDeviceHistoryEnabledAccounts = (
-    state: DeviceRootState & AccountsRootState,
-): boolean => {
-    const accounts = selectDeviceMainnetAccounts(state);
+export const selectHasDeviceHistoryEnabledAccounts = createMemoizedSelector(
+    [selectDeviceMainnetAccounts],
+    (accounts): boolean =>
+        A.isNotEmpty(accounts.filter(a => !isIgnoredBalanceHistoryCoin(a.symbol))),
+);
 
-    return A.isNotEmpty(accounts.filter(a => !isIgnoredBalanceHistoryCoin(a.symbol)));
-};
-
-export const selectHasDeviceHistoryIgnoredAccounts = (
-    state: DeviceRootState & AccountsRootState,
-): boolean => {
-    const accounts = selectDeviceMainnetAccounts(state);
-
-    return A.isNotEmpty(accounts.filter(a => isIgnoredBalanceHistoryCoin(a.symbol)));
-};
+export const selectDeviceHistoryIgnoredNetworkSymbols = createMemoizedSelector(
+    [selectDeviceMainnetAccounts],
+    (accounts): readonly NetworkSymbol[] =>
+        A.uniq(accounts.filter(a => isIgnoredBalanceHistoryCoin(a.symbol)).map(a => a.symbol)),
+);
 
 export const selectIsHistoryEnabledAccountByAccountKey = (
     state: AccountsRootState,

--- a/suite-native/graph/src/tests/selectors.test.ts
+++ b/suite-native/graph/src/tests/selectors.test.ts
@@ -1,0 +1,105 @@
+import { TokenDefinitionsRootState } from '@suite-common/token-definitions';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    AccountsRootState,
+    DeviceRootState,
+    selectDeviceMainnetAccounts,
+} from '@suite-common/wallet-core';
+import { Account } from '@suite-common/wallet-types';
+
+import { selectDeviceHistoryIgnoredNetworkSymbols } from '../selectors';
+
+// Mock the dependencies
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    selectDeviceMainnetAccounts: jest.fn(),
+}));
+
+jest.mock('@suite-common/graph/src/constants', () => ({
+    isIgnoredBalanceHistoryCoin: (symbol: NetworkSymbol) => ['sol', 'ada'].includes(symbol),
+}));
+
+const mockSelectDeviceMainnetAccounts = selectDeviceMainnetAccounts as jest.MockedFunction<
+    typeof selectDeviceMainnetAccounts
+>;
+type TestState = DeviceRootState & AccountsRootState & TokenDefinitionsRootState;
+
+describe('selectDeviceHistoryIgnoredNetworkSymbols', () => {
+    let mockState: TestState;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockState = {
+            device: {} as DeviceRootState['device'],
+            wallet: {} as AccountsRootState['wallet'],
+            tokenDefinitions: {} as TokenDefinitionsRootState['tokenDefinitions'],
+        } as TestState;
+    });
+
+    it('should return empty array when no accounts are present', () => {
+        mockSelectDeviceMainnetAccounts.mockReturnValue([]);
+
+        const result = selectDeviceHistoryIgnoredNetworkSymbols(mockState);
+
+        expect(result).toEqual([]);
+        expect(mockSelectDeviceMainnetAccounts).toHaveBeenCalledWith(mockState);
+    });
+
+    it('should return ignored network symbols', () => {
+        const accounts: Account[] = [
+            { symbol: 'btc' as NetworkSymbol } as Account,
+            { symbol: 'sol' as NetworkSymbol } as Account,
+            { symbol: 'ada' as NetworkSymbol } as Account,
+            { symbol: 'eth' as NetworkSymbol } as Account,
+        ];
+
+        mockSelectDeviceMainnetAccounts.mockReturnValue(accounts);
+
+        const result = selectDeviceHistoryIgnoredNetworkSymbols(mockState);
+
+        expect(result).toEqual(['sol', 'ada']);
+    });
+
+    it('should return unique ignored network symbols', () => {
+        const accounts: Account[] = [
+            { symbol: 'btc' as NetworkSymbol } as Account,
+            { symbol: 'sol' as NetworkSymbol } as Account,
+            { symbol: 'sol' as NetworkSymbol } as Account,
+            { symbol: 'ada' as NetworkSymbol } as Account,
+            { symbol: 'ada' as NetworkSymbol } as Account,
+        ];
+
+        mockSelectDeviceMainnetAccounts.mockReturnValue(accounts);
+
+        const result = selectDeviceHistoryIgnoredNetworkSymbols(mockState);
+
+        expect(result).toEqual(['sol', 'ada']);
+    });
+
+    it('should return empty array when accounts array is empty', () => {
+        mockSelectDeviceMainnetAccounts.mockReturnValue([]);
+
+        const result = selectDeviceHistoryIgnoredNetworkSymbols(mockState);
+
+        expect(result).toEqual([]);
+    });
+
+    it('should be stable', () => {
+        const accounts: Account[] = [
+            { symbol: 'sol' as NetworkSymbol } as Account,
+            { symbol: 'ada' as NetworkSymbol } as Account,
+            { symbol: 'btc' as NetworkSymbol } as Account,
+        ];
+
+        mockSelectDeviceMainnetAccounts.mockReturnValue(accounts);
+
+        // First call
+        const result1 = selectDeviceHistoryIgnoredNetworkSymbols(mockState);
+
+        // Second call with same state
+        const result2 = selectDeviceHistoryIgnoredNetworkSymbols(mockState);
+
+        expect(result1).toBe(result2);
+    });
+});

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -81,9 +81,9 @@ export const messages = {
         addLabel: 'Add label',
     },
     moduleHome: {
-        graphIgnoredNetworks: {
-            sol: 'Solana and all related tokens are reflected in the balance, but not in the graph.',
-        },
+        graphIgnoredNetworks:
+            '{networksString} and all related tokens are reflected in the balance, but not in the graph.',
+
         emptyState: {
             emptyDevice: {
                 title: 'Your wallet is empty',

--- a/suite-native/intl/tsconfig.json
+++ b/suite-native/intl/tsconfig.json
@@ -1,17 +1,11 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "outDir": "libDev"
-    },
+    "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
             "path": "../../suite-common/suite-types"
         },
-        {
-            "path": "../feature-flags"
-        },
-        {
-            "path": "../../packages/utils"
-        }
+        { "path": "../feature-flags" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite-native/module-home/package.json
+++ b/suite-native/module-home/package.json
@@ -15,6 +15,7 @@
         "@react-navigation/native-stack": "7.3.25",
         "@reduxjs/toolkit": "2.8.2",
         "@suite-common/graph": "workspace:*",
+        "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/accounts": "workspace:*",

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useImperativeHandle } from 'react';
 import { useSelector } from 'react-redux';
 
+import { getNetwork } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Box, Text, VStack } from '@suite-native/atoms';
 import { selectSelectedDeviceTotalFiatBalance } from '@suite-native/device';
@@ -8,8 +9,8 @@ import { useIsDiscoveryDurationTooLong } from '@suite-native/discovery';
 import {
     Graph,
     TimeSwitch,
+    selectDeviceHistoryIgnoredNetworkSymbols,
     selectHasDeviceHistoryEnabledAccounts,
-    selectHasDeviceHistoryIgnoredAccounts,
     useGraphAtoms,
     useGraphForAllDeviceAccounts,
 } from '@suite-native/graph';
@@ -23,16 +24,20 @@ export type PortfolioGraphRef = {
 };
 
 const IgnoredNetworksBanner = () => {
-    const hasDeviceHistoryIgnoredAccounts = useSelector(selectHasDeviceHistoryIgnoredAccounts);
+    const graphIgnoredNetworkSymbols = useSelector(selectDeviceHistoryIgnoredNetworkSymbols);
 
-    if (!hasDeviceHistoryIgnoredAccounts) {
+    if (!graphIgnoredNetworkSymbols.length) {
         return null;
     }
+
+    const networksString = graphIgnoredNetworkSymbols
+        .map(symbol => getNetwork(symbol).name)
+        .join(', ');
 
     return (
         <Box paddingHorizontal="sp16">
             <Text textAlign="center" variant="hint" color="textSubdued">
-                <Translation id="moduleHome.graphIgnoredNetworks.sol" />
+                <Translation id="moduleHome.graphIgnoredNetworks" values={{ networksString }} />
             </Text>
         </Box>
     );

--- a/suite-native/module-home/tsconfig.json
+++ b/suite-native/module-home/tsconfig.json
@@ -4,6 +4,9 @@
     "references": [
         { "path": "../../suite-common/graph" },
         {
+            "path": "../../suite-common/wallet-config"
+        },
+        {
             "path": "../../suite-common/wallet-core"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12056,6 +12056,7 @@ __metadata:
     "@react-navigation/native-stack": "npm:7.3.25"
     "@reduxjs/toolkit": "npm:2.8.2"
     "@suite-common/graph": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/accounts": "workspace:*"


### PR DESCRIPTION
Dont show ADA in graph temporarily

## Related Issue

Resolve #21778

## Screenshots:

https://github.com/user-attachments/assets/98894006-c68a-4570-85ad-ae202e95640c



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=21778-disable-cardano-ada-in-portfolio-and-account-graphs---mobile&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=21778-disable-cardano-ada-in-portfolio-and-account-graphs---mobile&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=21778-disable-cardano-ada-in-portfolio-and-account-graphs---mobile&lookback=7)