### PR TITLE
fix(suite): handle loading missing stores gracefully

### DIFF
--- a/packages/suite/src/actions/suite/constants/storageConstants.ts
+++ b/packages/suite/src/actions/suite/constants/storageConstants.ts
@@ -1,6 +1,7 @@
 // actions
 export const LOAD = '@storage/load' as const;
 export const ERROR = '@storage/error' as const;
+export const CORRUPTED = '@storage/corrupted' as const;
 
 // prefix for thunks
 export const MODULE_PREFIX = '@suite/storage' as const;

--- a/packages/suite/src/components/suite/Preloader/DatabaseCorruptedModal.tsx
+++ b/packages/suite/src/components/suite/Preloader/DatabaseCorruptedModal.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+import { Button, H3, Modal, Paragraph } from '@trezor/components';
+
+import { resetSuiteAppThunk } from 'src/actions/suite/suiteThunks';
+import { Translation } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite';
+
+export const DatabaseCorruptedModal = () => {
+    const dispatch = useDispatch();
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleClick = () => {
+        setIsLoading(true);
+        dispatch(resetSuiteAppThunk());
+    };
+
+    return (
+        <Modal iconName="database" variant="destructive">
+            <H3>
+                <Translation id="TR_DATABASE_CORRUPTED" />
+            </H3>
+            <Paragraph variant="tertiary">
+                <Button onClick={handleClick} isLoading={isLoading}>
+                    <Translation id="TR_CLEAR_STORAGE" />
+                </Button>
+            </Paragraph>
+        </Modal>
+    );
+};

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -19,6 +19,7 @@ import { Onboarding } from 'src/views/onboarding';
 import { SuiteStart } from 'src/views/start/SuiteStart';
 import { ErrorPage } from 'src/views/suite/ErrorPage';
 
+import { DatabaseCorruptedModal } from './DatabaseCorruptedModal';
 import { DatabaseUpgradeModal } from './DatabaseUpgradeModal';
 import { InitialLoading } from './InitialLoading';
 import { selectShouldDisplayDeviceCompromised } from './selectShouldDisplayDeviceCompromised';
@@ -83,6 +84,9 @@ export const Preloader = ({ children }: PropsWithChildren) => {
     }
     if (lifecycle.status === 'db-error') {
         return <DatabaseUpgradeModal variant={lifecycle.error} />;
+    }
+    if (lifecycle.status === 'db-corrupted') {
+        return <DatabaseCorruptedModal />;
     }
 
     // @trezor/connect was initialized, but didn't emit "TRANSPORT" event yet (it could take a while)

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -1,3 +1,5 @@
+import '@suite-common/test-utils/src/globalOverrides';
+
 import { fireEvent, screen } from '@testing-library/react';
 
 import { AnalyticsState } from '@suite-common/analytics';

--- a/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
@@ -1,3 +1,5 @@
+import '@suite-common/test-utils/src/globalOverrides';
+
 import { AcquiredDevice } from '@suite-common/suite-types';
 import { testMocks } from '@suite-common/test-utils';
 import { DeviceReducerState, deviceInitialState } from '@suite-common/wallet-core';

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -1,3 +1,5 @@
+import '@suite-common/test-utils/src/globalOverrides';
+
 import { screen } from '@testing-library/react';
 
 import { configureMockStore, initPreloadedState } from '@suite-common/test-utils';

--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -1,3 +1,5 @@
+import '@suite-common/test-utils/src/globalOverrides';
+
 import { useEffect, useState } from 'react';
 import { DeepPartial } from 'react-hook-form';
 

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -45,7 +45,9 @@ export type SuiteLifecycle =
     | { status: 'error'; error: string }
     // blocked if the instance cannot upgrade due to older version running,
     // blocking in case instance is running older version thus blocking other instance
-    | { status: 'db-error'; error: 'blocking' | 'blocked' };
+    | { status: 'db-error'; error: 'blocking' | 'blocked' }
+    // inconsistent IDB state detected, need to reset storage
+    | { status: 'db-corrupted'; error: unknown };
 
 export interface Flags {
     initialRun: boolean; // true on very first launch of Suite, will switch to false after completing onboarding process
@@ -268,6 +270,9 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                 break;
             case STORAGE.ERROR:
                 draft.lifecycle = { status: 'db-error', error: action.payload };
+                break;
+            case STORAGE.CORRUPTED:
+                draft.lifecycle = { status: 'db-corrupted', error: action.payload };
                 break;
             case SUITE.INIT:
                 draft.lifecycle = { status: 'loading' };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7260,6 +7260,10 @@ export default defineMessages({
         id: 'TR_THIS_INSTANCE_IS_BLOCKING',
         defaultMessage: 'This instance is blocking a database upgrade',
     },
+    TR_DATABASE_CORRUPTED: {
+        id: 'TR_DATABASE_CORRUPTED',
+        defaultMessage: 'Database is corrupted',
+    },
     TR_RUNNING_MULTIPLE_INSTANCES: {
         id: 'TR_RUNNING_MULTIPLE_INSTANCES',
         defaultMessage:

--- a/packages/suite/src/support/suite/preloadStore.ts
+++ b/packages/suite/src/support/suite/preloadStore.ts
@@ -4,7 +4,7 @@ import { db } from 'src/storage';
 // This function should be called before first render
 // PreloadedState will be used in redux store creation
 export const preloadStore = async () => {
-    if (!(await db.isSupported())) return;
+    if (!db.isSupported()) return;
 
     // check if db is blocked/blocking before preloading start
     const dbError = await new Promise<'blocked' | 'blocking' | undefined>(resolve => {
@@ -24,88 +24,97 @@ export const preloadStore = async () => {
         } as const;
     }
 
-    // Load state from database in parallel using Promise.all
-    const [
-        suiteSettings,
-        devices,
-        thp,
-        bluetooth,
-        accounts,
-        walletSettings,
-        tradingTrades,
-        historicRates,
-        graph,
-        analytics,
-        metadata,
-        txs,
-        messageSystem,
-        backendSettings,
-        sendFormDrafts,
-        formDrafts,
-        coinjoinAccounts,
-        coinjoinDebugSettings,
-        tokenManagement,
-        persistentDeviceData,
-        connect,
-        explorer,
-        bioAuth,
-        firmware,
-    ] = await Promise.all([
-        db.getItemByPK('suiteSettings', 'suite'),
-        db.getItemsExtended('devices'),
-        db.getItemByPK('thp', 'value'),
-        db.getItemByPK('bluetooth', 'value'),
-        db.getItemsExtended('accounts'),
-        db.getItemByPK('walletSettings', 'wallet'),
-        db.getItemsExtended('tradingTrades'),
-        db.getItemsWithKeys('historicRates'),
-        db.getItemsExtended('graph'),
-        db.getItemByPK('analytics', 'suite'),
-        db.getItemByPK('metadata', 'state'),
-        db.getItemsExtended('txs', 'order'),
-        db.getItemByPK('messageSystem', 'suite'),
-        db.getItemsWithKeys('backendSettings'),
-        db.getItemsWithKeys('sendFormDrafts'),
-        db.getItemsWithKeys('formDrafts'),
-        db.getItemsExtended('coinjoinAccounts'),
-        db.getItemByPK('coinjoinDebugSettings', 'debug'),
-        db.getItemsWithKeys('tokenManagement'),
-        db.getItemByPK('persistentDeviceData', 'persistentDeviceData'),
-        db.getItemByPK('connect', 'connect'),
-        db.getItemsExtended('explorer'),
-        db.getItemByPK('bioAuth', 'bioAuth'),
-        db.getItemByPK('firmware', 'firmware'),
-    ]);
-
-    return {
-        type: STORAGE.LOAD,
-        payload: {
+    try {
+        // Load state from database in parallel using Promise.all
+        const [
             suiteSettings,
-            walletSettings,
             devices,
             thp,
             bluetooth,
             accounts,
-            txs,
-            graph,
+            walletSettings,
             tradingTrades,
             historicRates,
-            sendFormDrafts,
-            formDrafts,
+            graph,
             analytics,
             metadata,
+            txs,
             messageSystem,
             backendSettings,
+            sendFormDrafts,
+            formDrafts,
             coinjoinAccounts,
             coinjoinDebugSettings,
             tokenManagement,
             persistentDeviceData,
-            bioAuth,
             connect,
             explorer,
+            bioAuth,
             firmware,
-        },
-    } as const;
+        ] = await Promise.all([
+            db.getItemByPK('suiteSettings', 'suite'),
+            db.getItemsExtended('devices'),
+            db.getItemByPK('thp', 'value'),
+            db.getItemByPK('bluetooth', 'value'),
+            db.getItemsExtended('accounts'),
+            db.getItemByPK('walletSettings', 'wallet'),
+            db.getItemsExtended('tradingTrades'),
+            db.getItemsWithKeys('historicRates'),
+            db.getItemsExtended('graph'),
+            db.getItemByPK('analytics', 'suite'),
+            db.getItemByPK('metadata', 'state'),
+            db.getItemsExtended('txs', 'order'),
+            db.getItemByPK('messageSystem', 'suite'),
+            db.getItemsWithKeys('backendSettings'),
+            db.getItemsWithKeys('sendFormDrafts'),
+            db.getItemsWithKeys('formDrafts'),
+            db.getItemsExtended('coinjoinAccounts'),
+            db.getItemByPK('coinjoinDebugSettings', 'debug'),
+            db.getItemsWithKeys('tokenManagement'),
+            db.getItemByPK('persistentDeviceData', 'persistentDeviceData'),
+            db.getItemByPK('connect', 'connect'),
+            db.getItemsExtended('explorer'),
+            db.getItemByPK('bioAuth', 'bioAuth'),
+            db.getItemByPK('firmware', 'firmware'),
+        ]);
+
+        return {
+            type: STORAGE.LOAD,
+            payload: {
+                suiteSettings,
+                walletSettings,
+                devices,
+                thp,
+                bluetooth,
+                accounts,
+                txs,
+                graph,
+                tradingTrades,
+                historicRates,
+                sendFormDrafts,
+                formDrafts,
+                analytics,
+                metadata,
+                messageSystem,
+                backendSettings,
+                coinjoinAccounts,
+                coinjoinDebugSettings,
+                tokenManagement,
+                persistentDeviceData,
+                bioAuth,
+                connect,
+                explorer,
+                firmware,
+            },
+        } as const;
+    } catch (error) {
+        console.error(error); // Report the error to sentry instead of silently failing
+
+        return {
+            type: STORAGE.CORRUPTED,
+            payload: error,
+        } as const;
+    }
 };
 
 export type PreloadStoreAction = Awaited<ReturnType<typeof preloadStore>>;


### PR DESCRIPTION
## Description

Handle errors during `preloadStore` → display a modal to let you reset suite.

IMO it's better than resetting it right away, because the user would be confused (why is my data missing), this lets you know there is a problem and you're control of the solution (well, you have no other option than to accept, because Suite is broken at this point, no way to continue gracefully without resetting). 

The UI is not beautiful but this is an rare edge case, mostly for internal Trezor people, see the Issue.

## Related Issue

Resolve #21782

## Screenshots:

[database corrupted.webm](https://github.com/user-attachments/assets/1cae3639-edfd-453c-b6fe-13ef59d454d4)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/preload-missing-stores&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/preload-missing-stores&lookback=7)