### PR TITLE
refactor(suite): add graph feature based on backend type to each network

### DIFF
--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -3,13 +3,14 @@ import { selectBaseCurrency, selectIsElectrumBackendSelected } from '@suite-comm
 import { isTrezorConnectBackendType, tryGetAccountIdentity } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
 
-import { Dispatch, GetState } from 'src/types/suite';
-import { Account } from 'src/types/wallet';
-import { GraphData, GraphRange, GraphScale } from 'src/types/wallet/graph';
+import { type Dispatch, type GetState } from 'src/types/suite';
+import { type Account } from 'src/types/wallet';
+import { type GraphData, type GraphRange, type GraphScale } from 'src/types/wallet/graph';
 import {
-    accountGraphDataFilterFn,
     enhanceBlockchainAccountHistory,
     ensureHistoryRates,
+    getPristineAccounts,
+    isNetworkWithGraphFeature,
 } from 'src/utils/wallet/graph';
 
 import {
@@ -160,13 +161,14 @@ export const updateGraphData = createThunk<
 
         // TODO: default behaviour should be fetch only new data (since last timestamp)
         // exclude accounts with unsupported backend type
-        let filteredAccounts = accounts.filter(a => isTrezorConnectBackendType(a.backendType));
+        let filteredAccounts = accounts
+            .filter(account => isTrezorConnectBackendType(account.backendType))
+            .filter(account => isNetworkWithGraphFeature(account.symbol));
+
         if (newAccountsOnly) {
-            // add only accounts for which we don't have any data for given interval
-            filteredAccounts = filteredAccounts.filter(
-                account => !graph.data.find(d => accountGraphDataFilterFn(d, account)),
-            );
+            filteredAccounts = getPristineAccounts(graph, accounts);
         }
+
         if (filteredAccounts.length === 0) {
             return;
         }
@@ -185,16 +187,12 @@ export const updateGraphData = createThunk<
             dispatch({
                 type: AGGREGATED_GRAPH_SUCCESS,
             });
-
-            return;
         } catch (error) {
             if (error.name === 'AbortError') {
                 dispatch({
                     type: AGGREGATED_GRAPH_SUCCESS,
                 });
             }
-
-            return;
         }
     },
 );

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -2,7 +2,7 @@ import { differenceInMonths, fromUnixTime, isWithinInterval } from 'date-fns';
 
 import { getFiatRatesForTimestamps } from '@suite-common/fiat-services';
 import { resetTime } from '@suite-common/suite-utils';
-import { type NetworkSymbol, getNetwork, networks } from '@suite-common/wallet-config';
+import { type NetworkSymbol, getNetwork, getNetworkFeatures } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
@@ -66,7 +66,7 @@ export function getPristineAccounts(graph: AppState['wallet']['graph'], accounts
  * Does given network has backend type with support for retrieving transactions history, e.g. for showing graph?
  */
 export function isNetworkWithGraphFeature(symbol: NetworkSymbol) {
-    return networks[symbol].features.find(feature => feature === 'graph');
+    return getNetworkFeatures(symbol).includes('graph');
 }
 
 export const enhanceBlockchainAccountHistory = (

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -2,13 +2,14 @@ import { differenceInMonths, fromUnixTime, isWithinInterval } from 'date-fns';
 
 import { getFiatRatesForTimestamps } from '@suite-common/fiat-services';
 import { resetTime } from '@suite-common/suite-utils';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol, getNetwork, networks } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import type { BlockchainAccountBalanceHistory, StaticSessionId } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
+import { type AppState } from 'src/reducers/store';
 import { State as GraphState } from 'src/reducers/wallet/graphReducer';
 import { CommonAggregatedHistory, GraphData, GraphRange, GraphScale } from 'src/types/wallet/graph';
 
@@ -53,6 +54,20 @@ export const accountGraphDataFilterFn = (d: GraphData, account: Account) =>
     d.account.descriptor === account.descriptor &&
     d.account.symbol === account.symbol &&
     d.account.deviceState === account.deviceState;
+
+/**
+ * Extract only accounts for which we don't have any data for given interval
+ */
+export function getPristineAccounts(graph: AppState['wallet']['graph'], accounts: Account[]) {
+    return accounts.filter(account => !graph.data.find(d => accountGraphDataFilterFn(d, account)));
+}
+
+/**
+ * Does given network has backend type with support for retrieving transactions history, e.g. for showing graph?
+ */
+export function isNetworkWithGraphFeature(symbol: NetworkSymbol) {
+    return networks[symbol].features.find(feature => feature === 'graph');
+}
 
 export const enhanceBlockchainAccountHistory = (
     data: BlockchainAccountBalanceHistory[],

--- a/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
@@ -3,10 +3,14 @@ import { getNetworkFeatures } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import { Text } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
+import { capitalizeFirstLetter, union } from '@trezor/utils';
+
+import { isNetworkWithGraphFeature } from 'src/utils/wallet/graph';
 
 import { Translation } from '../../../components/suite';
 
-const UNSUPPORTED_NETWORKS = ['ripple', 'solana', 'stellar'];
+const hasAnyAccountWithTokens = (accounts: Account[]): boolean =>
+    accounts.some(account => getNetworkFeatures(account.symbol).includes('tokens'));
 
 export const useUnsupportedNetworkMessage = ({
     showGraphControls,
@@ -17,25 +21,16 @@ export const useUnsupportedNetworkMessage = ({
     device?: TrezorDevice;
     accounts: Account[];
 }) => {
-    const hasAnyAccountWithTokens = (accounts: Account[]): boolean =>
-        accounts.some(account => {
-            const features = getNetworkFeatures(account.symbol);
-
-            return features?.includes('tokens') ?? false;
-        });
-
     const affectedAccounts =
-        showGraphControls &&
-        !hasBitcoinOnlyFirmware(device) &&
-        accounts
-            .filter(
-                account => account.history && UNSUPPORTED_NETWORKS.includes(account.networkType),
-            )
-            .map(({ networkType }) => networkType);
+        showGraphControls && !hasBitcoinOnlyFirmware(device)
+            ? accounts
+                  .filter(account => account.history && !isNetworkWithGraphFeature(account.symbol))
+                  .map(({ networkType }) => networkType)
+            : [];
 
-    const affectedNetworks = [...new Set(affectedAccounts || [])];
+    const affectedNetworks = union(affectedAccounts);
     const hasTokens = hasAnyAccountWithTokens(accounts);
-    const showMissingDataTooltip = affectedNetworks.length > 0 || hasTokens;
+    const showMissingDataTooltip = affectedNetworks.length > 0 || hasAnyAccountWithTokens(accounts);
 
     return { affectedNetworks, showMissingDataTooltip, hasTokens };
 };
@@ -44,8 +39,6 @@ type MessageProps = {
     affectedNetworks: string[];
     hasTokens: boolean;
 };
-
-const capitalizeFirstLetter = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
 
 const Message = ({ affectedNetworks, hasTokens }: MessageProps) => {
     const hasNetworks = affectedNetworks.length > 0;

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
@@ -49,14 +49,14 @@ export const TransactionSummary = ({ account }: TransactionSummaryProps) => {
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const dispatch = useDispatch();
 
+    if (account.networkType === 'ripple' || account.networkType === 'stellar') {
+        return null;
+    }
+
     const intervalGraphData = getGraphDataForInterval({ account, graph });
     const data = intervalGraphData[0]?.data
         ? aggregateBalanceHistory(intervalGraphData, selectedRange.groupBy, 'account')
         : [];
-
-    if (account.networkType === 'ripple' || account.networkType === 'stellar') {
-        return null;
-    }
 
     const error = intervalGraphData[0]?.error ?? false;
     const isLoading = intervalGraphData[0]?.isLoading ?? false;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -61,3 +61,4 @@ export * from './zip';
 export * from './removeTrailingSlashes';
 export * from './getIntegerInRangeFromString';
 export * from './safeBigIntStringify';
+export * from './union';

--- a/packages/utils/src/union.ts
+++ b/packages/utils/src/union.ts
@@ -1,0 +1,3 @@
+export function union<T extends string | number>(data: T[]) {
+    return [...new Set(data)];
+}

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -294,7 +294,7 @@ export const networks = {
         bip43Path: "m/1852'/1815'/i'",
         decimals: 6,
         testnet: false,
-        features: ['tokens', 'staking', 'coin-definitions', 'sign-verify'],
+        features: ['tokens', 'staking', 'coin-definitions', 'sign-verify', 'graph'],
         explorer: getExplorerUrls('https://cexplorer.io', 'cardano'),
         support: {
             [DeviceModelInternal.T2T1]: '2.4.3',
@@ -584,7 +584,7 @@ export const networks = {
         bip43Path: "m/1852'/1815'/i'",
         decimals: 6,
         testnet: true,
-        features: ['tokens', 'staking'],
+        features: ['tokens', 'staking', 'graph'],
         explorer: getExplorerUrls('https://preview.cexplorer.io', 'cardano'),
         support: {
             [DeviceModelInternal.T2T1]: '2.4.3',

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -13,7 +13,7 @@ export const networks = {
         decimals: 8,
         testnet: false,
         explorer: getExplorerUrls('https://btc1.trezor.io', 'bitcoin'),
-        features: ['rbf', 'sign-verify', 'amount-unit'],
+        features: ['rbf', 'sign-verify', 'amount-unit', 'graph'],
         backendTypes: ['blockbook', 'electrum'],
         accountTypes: {
             coinjoin: {
@@ -60,6 +60,7 @@ export const networks = {
             'staking',
             'eip1559',
             'mev-protection',
+            'graph',
         ],
         backendTypes: ['blockbook'],
         accountTypes: {
@@ -99,6 +100,7 @@ export const networks = {
             'coin-definitions',
             'nft-definitions',
             'eip1559',
+            'graph',
         ],
         backendTypes: ['blockbook'],
         accountTypes: {
@@ -132,6 +134,7 @@ export const networks = {
             'coin-definitions',
             'nft-definitions',
             'mev-protection',
+            'graph',
         ],
         backendTypes: ['blockbook'],
         accountTypes: {
@@ -166,6 +169,7 @@ export const networks = {
             'coin-definitions',
             'nft-definitions',
             'eip1559',
+            'graph',
         ],
         backendTypes: ['blockbook'],
         accountTypes: {
@@ -201,6 +205,7 @@ export const networks = {
             'nft-definitions',
             'eip1559',
             'mev-protection',
+            'graph',
         ],
         backendTypes: ['blockbook'],
         accountTypes: {
@@ -235,6 +240,7 @@ export const networks = {
             'coin-definitions',
             'nft-definitions',
             'eip1559',
+            'graph',
         ],
         backendTypes: ['blockbook'],
         accountTypes: {
@@ -325,7 +331,7 @@ export const networks = {
         decimals: 18,
         testnet: false,
         explorer: getExplorerUrls('https://etc1.trezor.io', 'ethereum'),
-        features: ['sign-verify', 'tokens', 'coin-definitions'],
+        features: ['sign-verify', 'tokens', 'coin-definitions', 'graph'],
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'ethereum-classic',
@@ -370,7 +376,7 @@ export const networks = {
         decimals: 8,
         testnet: false,
         explorer: getExplorerUrls('https://ltc1.trezor.io', 'bitcoin'),
-        features: ['sign-verify'],
+        features: ['sign-verify', 'graph'],
         backendTypes: ['blockbook'],
         accountTypes: {
             segwit: {
@@ -395,7 +401,7 @@ export const networks = {
         decimals: 8,
         testnet: false,
         explorer: getExplorerUrls('https://bch1.trezor.io', 'bitcoin'),
-        features: ['sign-verify'],
+        features: ['sign-verify', 'graph'],
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'bitcoin-cash',
@@ -410,7 +416,7 @@ export const networks = {
         decimals: 8,
         testnet: false,
         explorer: getExplorerUrls('https://doge1.trezor.io', 'bitcoin'),
-        features: ['sign-verify'],
+        features: ['sign-verify', 'graph'],
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'dogecoin',
@@ -426,7 +432,7 @@ export const networks = {
         decimals: 8,
         testnet: false,
         explorer: getExplorerUrls('https://zec1.trezor.io', 'bitcoin'),
-        features: ['sign-verify'],
+        features: ['sign-verify', 'graph'],
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'zcash',
@@ -442,7 +448,7 @@ export const networks = {
         decimals: 8,
         testnet: true,
         explorer: getExplorerUrls('https://tbtc4-1.trezor.io', 'bitcoin'),
-        features: ['rbf', 'sign-verify', 'amount-unit'],
+        features: ['rbf', 'sign-verify', 'amount-unit', 'graph'],
         backendTypes: ['blockbook', 'electrum'],
         accountTypes: {
             coinjoin: {
@@ -478,7 +484,7 @@ export const networks = {
         decimals: 8,
         testnet: true,
         explorer: getExplorerUrls('http://localhost:19121', 'bitcoin'),
-        features: ['rbf', 'sign-verify', 'amount-unit'],
+        features: ['rbf', 'sign-verify', 'amount-unit', 'graph'],
         backendTypes: ['blockbook', 'electrum'],
         accountTypes: {
             coinjoin: {
@@ -515,7 +521,7 @@ export const networks = {
         decimals: 18,
         testnet: true,
         explorer: getExplorerUrls('https://sepolia.etherscan.io', 'ethereum'),
-        features: ['rbf', 'sign-verify', 'tokens', 'nfts', 'nft-definitions', 'eip1559'],
+        features: ['rbf', 'sign-verify', 'tokens', 'nfts', 'nft-definitions', 'eip1559', 'graph'],
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'sepolia-test-ethereum', // fake, coingecko does not have testnets
@@ -531,7 +537,16 @@ export const networks = {
         decimals: 18,
         testnet: true,
         explorer: getExplorerUrls('https://holesky.etherscan.io', 'ethereum'),
-        features: ['rbf', 'sign-verify', 'tokens', 'staking', 'nfts', 'nft-definitions', 'eip1559'],
+        features: [
+            'rbf',
+            'sign-verify',
+            'tokens',
+            'staking',
+            'nfts',
+            'nft-definitions',
+            'eip1559',
+            'graph',
+        ],
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'holesky-test-ethereum', // fake, coingecko does not have testnets

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -68,7 +68,8 @@ export type NetworkFeature =
     | 'coin-definitions'
     | 'nft-definitions'
     | 'eip1559'
-    | 'mev-protection';
+    | 'mev-protection'
+    | 'graph';
 
 type Level = `/${number}'`;
 type MaybeApostrophe = `'` | '';

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -1,4 +1,5 @@
 import { testMocks } from '@suite-common/test-utils';
+import { NetworkFeature } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
@@ -234,7 +235,12 @@ describe('account utils', () => {
         const ethAcc = getWalletAccount();
         const coinjoinAcc = getWalletAccount({ symbol: 'regtest', accountType: 'coinjoin' });
 
-        expect(getNetworkAccountFeatures(btcAcc)).toEqual(['rbf', 'sign-verify', 'amount-unit']);
+        expect(getNetworkAccountFeatures(btcAcc)).toEqual([
+            'rbf',
+            'sign-verify',
+            'amount-unit',
+            'graph',
+        ] satisfies NetworkFeature[]);
         expect(getNetworkAccountFeatures(btcTaprootAcc)).toEqual(['rbf', 'amount-unit']);
         expect(getNetworkAccountFeatures(ethAcc)).toEqual([
             'rbf',
@@ -246,6 +252,7 @@ describe('account utils', () => {
             'staking',
             'eip1559',
             'mev-protection',
+            'graph',
         ]);
         expect(getNetworkAccountFeatures(coinjoinAcc)).toEqual(['rbf', 'amount-unit']);
         // when account does not have features defined, take them from root network object


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Update wallet graph data only for networks with graph feature (i.e. with blockbook backend type).

## Related Issue

Resolve #17980 

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/17980-fetch-graph-data&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/17980-fetch-graph-data&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/17980-fetch-graph-data&lookback=7)