### PR TITLE
fix(suite-native): curl correctly calls slack web-hook

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -170,4 +170,4 @@ jobs:
     steps:
       - name: Notify scheduled job failure to Slack
         run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"text":"Nightly Android E2E tests failed :pepe_flame: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} "}' ${{ secrets.SLACK_MOBILE_E2E_WEBHOOK }}
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"Nightly Android E2E tests failed :pepe_flame: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} "}' "${{ secrets.SLACK_MOBILE_E2E_WEBHOOK }}"


### PR DESCRIPTION
Fix of curl syntax for calling a webhook.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/ci/curl-api-webhook-call&lookback=7)