### PR TITLE
fix(suite): THP modal scrollbar

### DIFF
--- a/packages/suite/src/components/connection/thp/ThpPairingCodeEntry.tsx
+++ b/packages/suite/src/components/connection/thp/ThpPairingCodeEntry.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { thpActions } from '@suite-common/thp';
 import { PinInput, Row, Spinner } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
-import { SpacingValues } from '@trezor/theme';
 
 import { useDispatch } from '../../../hooks/suite';
 
@@ -34,17 +33,7 @@ export const ThpPairingCodeEntry = ({ disabled, lastCode }: ThpPairingPinEntryPr
     };
 
     return (
-        <Row
-            gap={24}
-            margin={{
-                right: isLoading
-                    ? // This is a bit hack, but I think it is better to make it explicitly
-                      // bound to SPINNER_SIZE+gap so it is clear why it is shifted (to prevent jumping)
-                      // This is relevant only when parent component sets margin (e.g., centering)
-                      (-(SPINNER_SIZE + 24) as SpacingValues)
-                    : undefined,
-            }}
-        >
+        <Row gap={24}>
             <PinInput
                 length={6}
                 onComplete={onCodeEntry}


### PR DESCRIPTION
## Description

Fix scrollbar by removing useless code that was taking care of proper centering, this also simplifies the code a bit :slightly_smiling_face: 

## Screenshots:

Before

<img width="623" height="219" alt="b4" src="https://github.com/user-attachments/assets/adb50076-f7ea-4c25-8d7b-1a4817600220" />


After

<img width="623" height="219" alt="after" src="https://github.com/user-attachments/assets/f0059268-d034-4ad0-b868-4213943b14e1" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-THP-scrollbar&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-THP-scrollbar&lookback=7)