### PR TITLE
fix: wrong scroll bar in THP Pin modal

### DIFF
--- a/packages/suite/src/components/connection/thp/ThpPairingCodeEntry.tsx
+++ b/packages/suite/src/components/connection/thp/ThpPairingCodeEntry.tsx
@@ -44,6 +44,7 @@ export const ThpPairingCodeEntry = ({ disabled, lastCode }: ThpPairingPinEntryPr
                       (-(SPINNER_SIZE + 24) as SpacingValues)
                     : undefined,
             }}
+            width="fit-content" // This is important because of the above negative margin hack
         >
             <PinInput
                 length={6}


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/21664

<img width="827" height="461" alt="image" src="https://github.com/user-attachments/assets/e57b47bd-7995-4586-8778-94169c71ef93" />


<img width="827" height="461" alt="image" src="https://github.com/user-attachments/assets/d03b0c51-bd28-4d87-aaea-1f220a8eb6ce" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-loading-thp-pin-scrollbar&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-loading-thp-pin-scrollbar&lookback=7)