### PR TITLE
fix(suite-native): disconnect device on cancel during FW Install

### DIFF
--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -1,4 +1,4 @@
-import { A, pipe } from '@mobily/ts-belt';
+import { A, G, pipe } from '@mobily/ts-belt';
 
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { BackupType, TrezorDevice } from '@suite-common/suite-types';
@@ -565,3 +565,8 @@ export const selectFirmwareHashCheckError = (state: DeviceRootState) => {
 
     return checkResult.error;
 };
+
+export const selectIsThpDevice = createMemoizedSelector(
+    [selectSelectedDevice],
+    device => G.isNotNullable(device) && deviceUtils.isThpDevice(device),
+);

--- a/suite-native/module-device-onboarding/src/hooks/useExitAlert.ts
+++ b/suite-native/module-device-onboarding/src/hooks/useExitAlert.ts
@@ -3,10 +3,10 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/core';
 
-import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { deviceActions, selectIsThpDevice, selectSelectedDevice } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { setWasDeviceOnboardingCancelled } from '@suite-native/device-onboarding';
-import { useFirmware } from '@suite-native/firmware';
+import { selectIsFirmwareInstallationRunning, useFirmware } from '@suite-native/firmware';
 import { useTranslate } from '@suite-native/intl';
 import {
     AppTabsRoutes,
@@ -33,7 +33,10 @@ export const useExitAlert = (handleContinueButtonPress?: () => void) => {
     const { translate } = useTranslate();
 
     const selectedDevice = useSelector(selectSelectedDevice);
+    const isThpDevice = useSelector(selectIsThpDevice);
     const { setIsFirmwareInstallationRunning } = useFirmware();
+
+    const isFirmwareInstallationRunning = useSelector(selectIsFirmwareInstallationRunning);
 
     const handleExitButtonPress = useCallback(() => {
         showAlert({
@@ -49,6 +52,12 @@ export const useExitAlert = (handleContinueButtonPress?: () => void) => {
             secondaryButtonVariant: 'redElevation0',
             onPressPrimaryButton: () => {
                 if (selectedDevice) {
+                    TrezorConnect.cancel();
+
+                    if (isThpDevice && isFirmwareInstallationRunning) {
+                        dispatch(deviceActions.deviceDisconnect(selectedDevice));
+                    }
+
                     setIsFirmwareInstallationRunning(false);
                     dispatch(setWasDeviceOnboardingCancelled(true));
                     navigation.popTo(RootStackRoutes.AppTabs, {
@@ -57,7 +66,6 @@ export const useExitAlert = (handleContinueButtonPress?: () => void) => {
                             screen: HomeStackRoutes.Home,
                         },
                     });
-                    TrezorConnect.cancel();
                 }
             },
             onPressSecondaryButton: () => {
@@ -69,6 +77,8 @@ export const useExitAlert = (handleContinueButtonPress?: () => void) => {
     }, [
         dispatch,
         handleContinueButtonPress,
+        isFirmwareInstallationRunning,
+        isThpDevice,
         navigation,
         selectedDevice,
         setIsFirmwareInstallationRunning,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/disconnect-thp-device-during-fw-install&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/disconnect-thp-device-during-fw-install&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/disconnect-thp-device-during-fw-install&lookback=7)