### PR TITLE
fix: load core-js polyfills only with webpack

### DIFF
--- a/packages/suite-build/vite.config.mts
+++ b/packages/suite-build/vite.config.mts
@@ -361,6 +361,7 @@ export default defineConfig({
         preserveSymlinks: true,
     },
     define: {
+        'process.env.VITE': true,
         'process.browser': true,
         'process.env.VERSION': JSON.stringify(suiteVersion),
         'process.env.COMMIT_HASH': JSON.stringify(commitId),

--- a/packages/suite-web/src/MainWeb.tsx
+++ b/packages/suite-web/src/MainWeb.tsx
@@ -1,4 +1,8 @@
-import 'core-js/actual';
+// Don't include core-js polyfills when using Vite instead of Webpack. Vite already handles this on its own.
+if (!process.env.VITE) {
+    // @ts-expect-error
+    await import('core-js/actual');
+}
 
 /* eslint-disable import/order */
 import { Provider as ReduxProvider } from 'react-redux';


### PR DESCRIPTION
## Description
- Vite handles polyfills on its own based on provided browsers list and throws an error when used together with `core-js`.
- So import `core-js` for non-vite tooling -> webpack.

Tested:
- Build project with webpack and successfully run it in Chromium v96
- Start dev server with webpack/vite without any errors.

## Related Issue

Relate #21684 




🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/21684-babel-polyfills-2&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/21684-babel-polyfills-2&lookback=7)