### PR TITLE
chore(token-definitions): use simple json instead of jws for definitions

### DIFF
--- a/suite-common/token-definitions/package.json
+++ b/suite-common/token-definitions/package.json
@@ -16,7 +16,6 @@
         "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "2.8.2",
         "@suite-common/redux-utils": "workspace:*",
-        "@suite-common/suite-utils": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",

--- a/suite-common/token-definitions/scripts/utils/sign.ts
+++ b/suite-common/token-definitions/scripts/utils/sign.ts
@@ -2,8 +2,9 @@
 
 import * as jws from 'jws';
 
-import { JWS_SIGN_ALGORITHM } from '../../src/tokenDefinitionsConstants';
 import { TokenStructure } from '../../src/tokenDefinitionsTypes';
+
+const JWS_SIGN_ALGORITHM = 'ES256';
 
 // There must be no extra spaces at the beginning of the line.
 const devPrivateKey = `-----BEGIN EC PRIVATE KEY-----

--- a/suite-common/token-definitions/src/tokenDefinitionsConstants.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsConstants.ts
@@ -1,5 +1,4 @@
 export const VERSION = 1;
-export const JWS_SIGN_ALGORITHM = 'ES256';
 
 export const TOKEN_DEFINITIONS_PREFIX_URL = 'https://data.trezor.io/suite/definitions';
-export const TOKEN_DEFINITIONS_SUFFIX_URL = `definitions.v${VERSION}.jws`;
+export const TOKEN_DEFINITIONS_SUFFIX_URL = `definitions.v${VERSION}.json`;

--- a/suite-common/token-definitions/src/tokenDefinitionsUtils.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsUtils.ts
@@ -1,11 +1,9 @@
-import { decodeJws, verifyJws } from '@suite-common/suite-utils';
 import { NetworkSymbol, getCoingeckoId, getNetworkFeatures } from '@suite-common/wallet-config';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { TokenInfo } from '@trezor/connect';
 import { isCodesignBuild } from '@trezor/env-utils';
 
 import {
-    JWS_SIGN_ALGORITHM,
     TOKEN_DEFINITIONS_PREFIX_URL,
     TOKEN_DEFINITIONS_SUFFIX_URL,
 } from './tokenDefinitionsConstants';
@@ -103,10 +101,6 @@ export const buildTokenDefinitionsFromStorage = (
     return tokenDefinitions;
 };
 
-// Currently, due to some limitations on the node side, the project has not used jws
-// in some places but instead used json. We hope to have the opportunity to
-// use this function in the future.
-// https://github.com/trezor/trezor-suite/pull/20662#discussion_r2262890493
 export const fetchTokenDefinitions = async (
     symbol: NetworkSymbol,
     type: DefinitionType,
@@ -128,26 +122,7 @@ export const fetchTokenDefinitions = async (
         throw Error(response.statusText);
     }
 
-    const jws = await response.text();
-
-    const decodedJws = decodeJws(jws);
-
-    if (!decodedJws) {
-        throw Error('Decoding of config failed');
-    }
-
-    const algorithmInHeader = decodedJws?.header.alg;
-    if (algorithmInHeader !== JWS_SIGN_ALGORITHM) {
-        throw Error(`Wrong algorithm in JWS config header: ${algorithmInHeader}`);
-    }
-
-    const isAuthenticityValid = await verifyJws(jws, JWS_SIGN_ALGORITHM);
-
-    if (!isAuthenticityValid) {
-        throw Error('Config authenticity is invalid');
-    }
-
-    const data = JSON.parse(decodedJws.payload);
+    const data = await response.json();
 
     return data;
 };

--- a/suite-common/token-definitions/tsconfig.json
+++ b/suite-common/token-definitions/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../redux-utils" },
-        { "path": "../suite-utils" },
         { "path": "../wallet-config" },
         { "path": "../wallet-types" },
         { "path": "../wallet-utils" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10627,7 +10627,6 @@ __metadata:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@reduxjs/toolkit": "npm:2.8.2"
     "@suite-common/redux-utils": "workspace:*"
-    "@suite-common/suite-utils": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- The extra verification of jws signing is not needed and it adds a huge overhead especially on mobile (verification of jws is painfully slow there).

## Related Issue

Depends on https://github.com/trezor/trezor-suite/pull/21802

## Screenshot

JWS on left, JSON on right.

Enabled coins: BTC, ETH, POL, BNB, ARB, BASE, OPT, SOL, XRP, XML (tokens only on ETH)

On debug build to see the FPS, so it's not a real release build. 

The recording starts at the moment the dashboard appeared when the application launched.
It ends when the graph finishes loading.
When I saw in the console that the token definitions were starting to download, I clicked on Settings and then immediately back to Home.


https://github.com/user-attachments/assets/064e67a3-7605-4f3a-ab08-68f5d1f05462




🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/token-definitions-json&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/token-definitions-json&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/token-definitions-json&lookback=7)