### PR TITLE
feat(suite-native): show scanning loader on the Turn on & unlock screen

### DIFF
--- a/suite-native/bluetooth/src/hooks/useBluetoothManager.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothManager.ts
@@ -14,6 +14,7 @@ export const useBluetoothManager = () => {
 
     const bluetoothPermissionStatus = useSelector(selectBluetoothPermissionStatus);
     const bluetoothAdapterStatus = useSelector(selectBluetoothAdapterStatus);
+    const isScanningInProgress = bluetoothAdapterStatus === 'enabled';
 
     const [hasPermissionBeenRequested, setHasPermissionBeenRequested] = useState(false);
 
@@ -55,12 +56,16 @@ export const useBluetoothManager = () => {
     }, [showOrHideBluetoothAlert]);
 
     useEffect(() => {
-        if (bluetoothAdapterStatus === 'enabled') {
+        if (isScanningInProgress) {
             bluetoothManager.startDeviceScan(scanErrorHandler);
 
             return () => {
                 bluetoothManager.stopDeviceScan();
             };
         }
-    }, [bluetoothAdapterStatus, scanErrorHandler]);
+    }, [isScanningInProgress, scanErrorHandler]);
+
+    return {
+        isScanningInProgress,
+    };
 };

--- a/suite-native/device/src/components/TurnOnAndUnlockDeviceScreenContent.tsx
+++ b/suite-native/device/src/components/TurnOnAndUnlockDeviceScreenContent.tsx
@@ -1,4 +1,4 @@
-import { Button, Text, VStack } from '@suite-native/atoms';
+import { HStack, Loader, Text, VStack, buttonSizeToDimensionsMap } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { getScreenHeight } from '@trezor/env-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -8,8 +8,16 @@ import { TurnOnDeviceAnimation } from './TurnOnDeviceAnimation';
 const ANIMATION_HEIGHT = getScreenHeight() * 0.6;
 
 type TurnOnAndUnlockDeviceScreenContentProps = {
-    onConnectViaCable?: () => void;
+    isScanningInProgress: boolean;
 };
+
+const loaderStyle = prepareNativeStyle(
+    (_, { isScanningInProgress }: { isScanningInProgress: boolean }) => ({
+        height: buttonSizeToDimensionsMap.medium.minHeight,
+        alignItems: 'center',
+        opacity: isScanningInProgress ? 1 : 0, // use opacity to prevent layout shifts
+    }),
+);
 
 const animationStyle = prepareNativeStyle(() => ({
     // Both height and width has to be set https://github.com/lottie-react-native/lottie-react-native/blob/master/MIGRATION-5-TO-6.md#updating-the-style-props
@@ -18,7 +26,7 @@ const animationStyle = prepareNativeStyle(() => ({
 }));
 
 export const TurnOnAndUnlockDeviceScreenContent = ({
-    onConnectViaCable,
+    isScanningInProgress,
 }: TurnOnAndUnlockDeviceScreenContentProps) => {
     const { applyStyle } = useNativeStyles();
 
@@ -28,16 +36,12 @@ export const TurnOnAndUnlockDeviceScreenContent = ({
                 <Text variant="titleMedium" textAlign="center">
                     <Translation id="moduleConnectDevice.turnOnAndUnlockScreen.title" />
                 </Text>
-                {onConnectViaCable && (
-                    <Button
-                        size="medium"
-                        colorScheme="tertiaryElevation0"
-                        viewLeft="cableUsbC"
-                        onPress={onConnectViaCable}
-                    >
-                        <Translation id="moduleConnectDevice.turnOnAndUnlockScreen.connectViaCableButton" />
-                    </Button>
-                )}
+                <HStack style={applyStyle(loaderStyle, { isScanningInProgress })}>
+                    <Loader color="iconAlertBlue" />
+                    <Text variant="body" color="textAlertBlue">
+                        <Translation id="moduleConnectDevice.turnOnAndUnlockScreen.scanningLoader" />
+                    </Text>
+                </HStack>
             </VStack>
             <TurnOnDeviceAnimation style={applyStyle(animationStyle)} />
         </VStack>

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -452,7 +452,7 @@ export const messages = {
         },
         turnOnAndUnlockScreen: {
             title: 'Turn on & unlock\nyour Trezor',
-            connectViaCableButton: 'Connect via cable',
+            scanningLoader: 'Scanning for nearby Trezors',
         },
         pinScreen: {
             title: 'Enter PIN\non your Trezor',

--- a/suite-native/module-authorize-device/src/screens/connect/TurnOnAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/TurnOnAndUnlockDeviceScreen.tsx
@@ -18,7 +18,6 @@ import {
     Screen,
     StackNavigationProps,
 } from '@suite-native/navigation';
-import { isAndroid } from '@trezor/env-utils';
 import { TimerId } from '@trezor/type-utils';
 
 import { BluetoothPairingHelpButton } from '../../components/connect/BluetoothPairingHelpButton';
@@ -38,10 +37,6 @@ export const TurnOnAndUnlockDeviceScreen = () => {
     const bluetoothAdapterStatus = useSelector(selectBluetoothAdapterStatus);
     const hasKnownBluetoothDevices = useSelector(selectHasKnownBluetoothDevices);
     const nearbyPairableBluetoothDevices = useSelector(selectNearbyPairableBluetoothDevices);
-
-    const navigateToConnectAndUnlockDeviceScreen = () => {
-        navigation.replace(AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice);
-    };
 
     const navigateToRemoveBluetoothDeviceScreen = useCallback(() => {
         navigation.replace(AuthorizeDeviceStackRoutes.RemoveBluetoothDevice);
@@ -97,7 +92,7 @@ export const TurnOnAndUnlockDeviceScreen = () => {
         }
     }, [nearbyPairableBluetoothDevices, hideAlert, navigation]);
 
-    useBluetoothManager();
+    const { isScanningInProgress } = useBluetoothManager();
 
     return (
         <Screen
@@ -116,9 +111,7 @@ export const TurnOnAndUnlockDeviceScreen = () => {
             hasBottomInset={false}
             isScrollable={false}
         >
-            <TurnOnAndUnlockDeviceScreenContent
-                onConnectViaCable={isAndroid() ? navigateToConnectAndUnlockDeviceScreen : undefined}
-            />
+            <TurnOnAndUnlockDeviceScreenContent isScanningInProgress={isScanningInProgress} />
         </Screen>
     );
 };


### PR DESCRIPTION
## Related Issue

Resolve #21764

## Recordings:

### iOS
https://github.com/user-attachments/assets/3bcc0702-73d9-44be-aa50-846784114b04

### Android
https://github.com/user-attachments/assets/0894880c-b5bf-4211-9147-45cb287ca5d5


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/turn-on-and-unlock-enhancements&lookback=7)