### PR TITLE
feat(suite): add info banner for BT pairing

### DIFF
--- a/packages/suite/src/components/suite/bluetooth/BluetoothSelectedDevice.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothSelectedDevice.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 
 import { DeviceBluetoothConnectionStatusType } from '@suite-common/bluetooth';
-import { Card, Row } from '@trezor/components';
+import { Banner, Card, Row } from '@trezor/components';
 
 import { BluetoothDeviceComponent } from './BluetoothDeviceComponent';
 import { BluetoothTips } from './BluetoothTips';
@@ -57,5 +57,8 @@ export const BluetoothSelectedDevice = ({ device, onReScanClick }: BluetoothSele
     ) : (
         <Card>
             <OkComponent device={device} />
+            <Banner variant="info" icon="info" margin={{ top: 16 }}>
+                <Translation id="TR_CONFIRM_BLUETOOTH_PAIRING" />
+            </Banner>
         </Card>
     );

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10845,4 +10845,8 @@ export default defineMessages({
         id: 'TR_PUBLIC_KEY_COSE',
         defaultMessage: 'COSE (CIP-30)',
     },
+    TR_CONFIRM_BLUETOOTH_PAIRING: {
+        id: 'TR_CONFIRM_BLUETOOTH_PAIRING',
+        defaultMessage: 'Confirm the Bluetooth pairing request on your Trezor as well.',
+    },
 } as const);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21742

## Screenshots:
<img width="975" height="581" alt="Screenshot 2025-09-23 at 14 57 56" src="https://github.com/user-attachments/assets/81afea85-a1aa-4384-9fac-ae260d35e8e9" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/confirm-pin-on-trezor-banner&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/confirm-pin-on-trezor-banner&lookback=7)