### PR TITLE
THP/BT timeouts

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -118,7 +118,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     public readonly transportPath;
     public readonly bluetoothProps;
     private thp: protocolThp.ThpState | undefined;
-    private readonly possibleHIDdevice;
+    private readonly descriptorType;
     private sessionAcquired: Session | null;
 
     // protocol related
@@ -189,6 +189,14 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return this._firmwareType;
     }
 
+    private get possibleHIDdevice() {
+        return this.descriptorType === 0 || this.descriptorType === 2;
+    }
+
+    public get possibleT1() {
+        return (this.descriptorType ?? 0) <= 2;
+    }
+
     private name = 'Trezor';
 
     private color?: string;
@@ -215,7 +223,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this.uniquePath = id;
         this.transport = transport;
         this.transportPath = descriptor.path;
-        this.possibleHIDdevice = [0, 2].includes(descriptor.type);
+        this.descriptorType = descriptor.type;
         this.bluetoothProps = descriptor.id ? { id: descriptor.id } : undefined;
 
         this.sessionAcquired = null;

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -185,7 +185,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
             // transport response is pending endlessly, calling any other message will end up with "device call in progress"
             // set the timeout for this call so whenever it happens "unacquired device" will be created instead
             // next time device should be called together with "Initialize" (calling "acquireDevice" from the UI)
-            const timeout = name === 'GetFeatures' ? 3_000 : undefined;
+            const timeout = this.device.possibleT1 && name === 'GetFeatures' ? 3_000 : undefined;
 
             const callPromise = this.call(name, data, { timeout });
 

--- a/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
+++ b/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
@@ -93,7 +93,7 @@ describe('workflow/handshake', () => {
                 new Promise(resolve => {
                     const timeout = setTimeout(
                         () => resolve({ success: true, payload: Buffer.alloc(readAttempt) }),
-                        500 * readAttempt, // increase respond time on each attempt, should timeout on 3rd
+                        1500 * readAttempt, // increase respond time on each attempt, should timeout on 3rd
                     );
                     signal.addEventListener('abort', () => {
                         abortSpy();
@@ -107,7 +107,7 @@ describe('workflow/handshake', () => {
         const { device, abortController } = await getAcquiredDevice({ read: readMock });
         const promise = handshakeCancel({ device, signal: abortController.signal });
 
-        await fastForward(2000);
+        await fastForward(6000);
         await promise;
 
         expect(readMock).toHaveBeenCalledTimes(3);
@@ -177,7 +177,7 @@ describe('workflow/handshake', () => {
         const writeMock = jest.fn(
             (_a, _b, signal) =>
                 new Promise(resolve => {
-                    const timeout = setTimeout(() => resolve({ success: false }), 2000);
+                    const timeout = setTimeout(() => resolve({ success: false }), 6000);
                     signal.addEventListener('abort', () => {
                         abortSpy();
                         clearTimeout(timeout);
@@ -193,7 +193,7 @@ describe('workflow/handshake', () => {
         });
         const promise = handshakeCancel({ device, signal: abortController.signal });
 
-        await fastForward(2000);
+        await fastForward(6000);
         await promise;
 
         expect(writeMock).toHaveBeenCalledTimes(1);

--- a/packages/connect/src/device/workflow/handshake.ts
+++ b/packages/connect/src/device/workflow/handshake.ts
@@ -6,7 +6,7 @@ import { TypedError } from '../../constants/errors';
 import { WorkflowContext } from '../../types/workflow';
 import { Log } from '../../utils/debug';
 
-const CANCEL_TIMEOUT = 1_000;
+const CANCEL_TIMEOUT = 3_000;
 const ATTEMPTS_LIMIT = 10;
 
 type Context = {

--- a/packages/transport/src/thp/send.ts
+++ b/packages/transport/src/thp/send.ts
@@ -11,7 +11,7 @@ export type SendThpMessageProps = Omit<ReceiveThpMessageProps, 'apiChunkSize'> &
 };
 
 const ATTEMPTS_LIMIT = 10;
-const THP_ACK_DEADLINE = 3000;
+const THP_ACK_DEADLINE = 30_000;
 
 export const sendThpMessage = async ({
     thpState,

--- a/packages/transport/tests/thp.test.ts
+++ b/packages/transport/tests/thp.test.ts
@@ -152,7 +152,7 @@ describe('thp', () => {
                 apiRead,
             });
 
-            await jest.advanceTimersByTimeAsync(11 * 3000); // (ATTEMPTS_LIMIT + 1) * THP_ACK_DEADLINE
+            await jest.advanceTimersByTimeAsync(11 * 30_000); // (ATTEMPTS_LIMIT + 1) * THP_ACK_DEADLINE
             const result = await sendPromise;
 
             expect(result).toMatchObject({ success: false, message: 'Aborted by deadline' });
@@ -185,7 +185,7 @@ describe('thp', () => {
                 apiRead,
             });
 
-            await jest.advanceTimersByTimeAsync(20 * 3000); // (ATTEMPTS_LIMIT + 1) * THP_ACK_DEADLINE
+            await jest.advanceTimersByTimeAsync(20 * 30_000); // (ATTEMPTS_LIMIT + 1) * THP_ACK_DEADLINE
             const result = await sendPromise;
 
             expect(result).toMatchObject({ success: false, message: 'Aborted by deadline' });
@@ -262,7 +262,7 @@ describe('thp', () => {
                 signal: abortController.signal,
             });
 
-            await jest.advanceTimersByTimeAsync(4000);
+            await jest.advanceTimersByTimeAsync(40_000);
             expect(apiWrite).toHaveBeenCalledTimes(2); // there was 1 retransmission
 
             abortController.abort();


### PR DESCRIPTION
## Description

Minor changes in timeouts which could help a bit with THP over BT.

- timeout for initial `Cancel` message increased from 1s to 3s
- deadline for awaiting thp ack increased from 3s to 30s
- general 3s timeout for `GetFeatures` message now enabled only for T1 devices (as it's a workaround for very old T1s)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-timeouts&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-timeouts&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thp-timeouts&lookback=7)