### PR TITLE
fix(token-definitions): fix file names for token definitions

### DIFF
--- a/suite-common/token-definitions/scripts/index.ts
+++ b/suite-common/token-definitions/scripts/index.ts
@@ -60,8 +60,8 @@ const main = async () => {
     fs.mkdirSync(FILES_PATH, { recursive: true });
 
     const signedData = signData(data);
-    fs.writeFileSync(join(FILES_PATH, fileName, '.jws'), signedData);
-    fs.writeFileSync(join(FILES_PATH, fileName, '.json'), JSON.stringify(data));
+    fs.writeFileSync(join(FILES_PATH, `${fileName}.jws`), signedData);
+    fs.writeFileSync(join(FILES_PATH, `${fileName}.json`), JSON.stringify(data));
 
     console.log('JSON definitions saved to ', join(FILES_PATH, fileName, '.[jws,json]'));
 };


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- join is adding / between each part so it creates something like `ethereum.simple.nft.definitions.v1/.jws`

See the failure https://github.com/trezor/trezor-suite/actions/runs/17949438690/job/51044320140#step:4:907


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/token-definitions-script&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/token-definitions-script&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/token-definitions-script&lookback=7)