### PR TITLE
Chore: autoEject settings migration

### DIFF
--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 25.11.0
+
+- move `autoEject` from `suite.settings` to `wallet.walletSettings`
+
 ## 25.10.0
 
 - create `persistentDeviceData` object store

--- a/packages/suite/src/storage/migrations/versions/25.11.0.ts
+++ b/packages/suite/src/storage/migrations/versions/25.11.0.ts
@@ -1,0 +1,41 @@
+import { createMigration } from '@suite/idb-migration-utils';
+
+import { SuiteDBSchema } from 'src/storage/definitions';
+
+import { updateAll } from '../utils';
+
+type OldSuiteSettingsType = { autoEject?: boolean };
+type OldWalletSettingsType = { autoForgetDeviceData?: boolean };
+
+export default createMigration<SuiteDBSchema>('25.11.0', async (db, tx) => {
+    const getSuiteSettings = async () => {
+        if (!db.objectStoreNames.contains('suiteSettings')) return undefined;
+        const suiteStore = tx.objectStore('suiteSettings');
+        const suite = await suiteStore.get('suite');
+
+        return suite?.settings as OldSuiteSettingsType | undefined;
+    };
+
+    const getWalletSettings = async () => {
+        if (!db.objectStoreNames.contains('walletSettings')) return undefined;
+        const walletSettingsStore = tx.objectStore('walletSettings');
+        const wallet = await walletSettingsStore.get('wallet');
+
+        return wallet as OldWalletSettingsType | undefined;
+    };
+
+    const suiteSettings = await getSuiteSettings();
+    const prevAutoEjectValue = suiteSettings?.autoEject === true;
+    const walletSettings = await getWalletSettings();
+    const prevAutoForgetValue = walletSettings?.autoForgetDeviceData === true;
+
+    await updateAll(tx, 'walletSettings', walletSettings => {
+        delete (walletSettings as OldWalletSettingsType).autoForgetDeviceData;
+
+        return {
+            ...walletSettings,
+            isAutoEjectEnabled: prevAutoEjectValue,
+            isAutoForgetDeviceDataEnabled: prevAutoForgetValue,
+        };
+    });
+});

--- a/packages/suite/src/storage/migrations/versions/__tests__/25.11.0.test.ts
+++ b/packages/suite/src/storage/migrations/versions/__tests__/25.11.0.test.ts
@@ -1,0 +1,86 @@
+import '@suite-common/test-utils/src/globalOverrides';
+import { IDBPDatabase, deleteDB, openDB } from 'idb';
+
+import { SuiteDBSchema } from '../../../definitions';
+import migration from '../25.11.0';
+
+const DB_NAME = 'suite-idb-test-25.11.0';
+const INITIAL_VERSION = 1;
+
+const runMigration = () =>
+    openDB(DB_NAME, INITIAL_VERSION + 1, {
+        upgrade(db: IDBPDatabase<SuiteDBSchema>, _oldVersion, _newVersion, tx) {
+            migration.migrate(db, tx);
+        },
+    });
+
+describe('migration 25.11.0', () => {
+    beforeEach(async () => {
+        await deleteDB(DB_NAME);
+    });
+
+    test('migrates autoEject and autoForget from suiteSettings to walletSettings', async () => {
+        const db = await openDB(DB_NAME, INITIAL_VERSION, {
+            upgrade(db) {
+                db.createObjectStore('suiteSettings');
+                db.createObjectStore('walletSettings');
+            },
+        });
+        await db.put('suiteSettings', { settings: { autoEject: true } }, 'suite');
+        await db.put(
+            'walletSettings',
+            { autoForgetDeviceData: true, isAutoEjectEnabled: false },
+            'wallet',
+        );
+        db.close();
+
+        const migratedDb = await runMigration();
+
+        const wallet = await migratedDb.get('walletSettings', 'wallet');
+        expect(wallet).toBeDefined();
+        expect(wallet?.isAutoEjectEnabled).toBe(true);
+        expect(wallet?.isAutoForgetDeviceDataEnabled).toBe(true);
+
+        migratedDb.close();
+    });
+
+    test('prefills defaults into walletSettings if original values are missing', async () => {
+        const db = await openDB(DB_NAME, INITIAL_VERSION, {
+            upgrade(db) {
+                db.createObjectStore('suiteSettings');
+                db.createObjectStore('walletSettings');
+            },
+        });
+        await db.put('suiteSettings', { settings: {} }, 'suite');
+        await db.put('walletSettings', {}, 'wallet');
+        db.close();
+
+        const migratedDb = await runMigration();
+
+        const wallet = await migratedDb.get('walletSettings', 'wallet');
+        expect(wallet).toBeDefined();
+        expect(wallet?.isAutoEjectEnabled).toBe(false);
+        expect(wallet?.isAutoForgetDeviceDataEnabled).toBe(false);
+
+        migratedDb.close();
+    });
+
+    test('prefills defaults into walletSettings if suiteSettings store is missing', async () => {
+        const db = await openDB(DB_NAME, INITIAL_VERSION, {
+            upgrade(db) {
+                db.createObjectStore('walletSettings');
+            },
+        });
+        await db.put('walletSettings', {}, 'wallet');
+        db.close();
+
+        const migratedDb = await runMigration();
+
+        const wallet = await migratedDb.get('walletSettings', 'wallet');
+        expect(wallet).toBeDefined();
+        expect(wallet?.isAutoEjectEnabled).toBe(false);
+        expect(wallet?.isAutoForgetDeviceDataEnabled).toBe(false);
+
+        migratedDb.close();
+    });
+});

--- a/packages/suite/src/storage/migrations/versions/index.ts
+++ b/packages/suite/src/storage/migrations/versions/index.ts
@@ -7,3 +7,4 @@ export { default as m25_7_0 } from './25.7.0';
 export { default as m25_8_0 } from './25.8.0';
 export { default as m25_9_2 } from './25.9.2';
 export { default as m25_10_0 } from './25.10.0';
+export { default as m25_11_0 } from './25.11.0';


### PR DESCRIPTION
## Description

Migration for #21639

## QA instructions

Web/Desktop:
- Open Suite 25.10
- Turn on AutoEject
- Open Suite 25.11 (after this migration)
- AutoEject shall be on

~Mobile:~ moved to the next PR https://github.com/trezor/trezor-suite/pull/22518
- ~Open Suite Lite before this migration~
- ~Turn on AutoEject~
- ~Open Suite Lite after this migration~
- ~AutoEject shall be on~

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/auto-eject-settings-migration&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/auto-eject-settings-migration&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/auto-eject-settings-migration&lookback=7)