### PR TITLE
fix(suite): do not show connection hint when already connected

### DIFF
--- a/packages/suite/src/components/suite/bluetooth/BluetoothSelectedDevice.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothSelectedDevice.tsx
@@ -50,15 +50,30 @@ export type BluetoothSelectedDeviceProps = {
     onReScanClick: () => void;
 };
 
-export const BluetoothSelectedDevice = ({ device, onReScanClick }: BluetoothSelectedDeviceProps) =>
-    device.connectionStatus.type === 'connection-error' ||
-    device.connectionStatus.type === 'pairing-error' ? (
-        <ErrorComponent onReScanClick={onReScanClick} device={device} />
-    ) : (
+export const BluetoothSelectedDevice = ({
+    device,
+    onReScanClick,
+}: BluetoothSelectedDeviceProps) => {
+    const isError =
+        device.connectionStatus.type === 'connection-error' ||
+        device.connectionStatus.type === 'pairing-error';
+
+    if (isError) {
+        return <ErrorComponent onReScanClick={onReScanClick} device={device} />;
+    }
+
+    const showHint = ['disconnected', 'connecting', 'pairing'].includes(
+        device.connectionStatus.type,
+    );
+
+    return (
         <Card>
             <OkComponent device={device} />
-            <Banner variant="info" icon="info" margin={{ top: 16 }}>
-                <Translation id="TR_CONFIRM_BLUETOOTH_PAIRING" />
-            </Banner>
+            {showHint && (
+                <Banner variant="info" icon="info" margin={{ top: 16 }}>
+                    <Translation id="TR_CONFIRM_BLUETOOTH_PAIRING" />
+                </Banner>
+            )}
         </Card>
     );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously, the blue hint would be shown even after the pairing was finished (0:12 of the video), which was unnecessary.

## Related Issue

Improvement on https://github.com/trezor/trezor-suite/pull/21810

## Screenshots:
After the fix:

https://github.com/user-attachments/assets/5f509bda-0f8a-4342-a7bd-b2745af54459




🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connection-hint&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connection-hint&lookback=7)