### PR TITLE
fix(suite-native): non closable device onboarding screen

### DIFF
--- a/suite-native/module-device-onboarding/src/components/NonClosableDeviceOnboardingScreen.tsx
+++ b/suite-native/module-device-onboarding/src/components/NonClosableDeviceOnboardingScreen.tsx
@@ -1,0 +1,33 @@
+import React, { ReactNode } from 'react';
+
+import { Box } from '@suite-native/atoms';
+import {
+    Screen,
+    ScreenHeader,
+    ScreenProps,
+    useOverrideBackNavigation,
+} from '@suite-native/navigation';
+
+type NonClosableDeviceOnboardingScreenProps = {
+    screenHeaderRightIcon?: ReactNode;
+} & ScreenProps;
+
+export const NonClosableDeviceOnboardingScreen = ({
+    children,
+    screenHeaderRightIcon,
+    ...screenProps
+}: NonClosableDeviceOnboardingScreenProps) => {
+    useOverrideBackNavigation();
+
+    return (
+        <Screen
+            {...screenProps}
+            header={<ScreenHeader leftIcon={null} rightIcon={screenHeaderRightIcon} />}
+            isScrollable={false}
+        >
+            <Box flex={1} marginTop="sp16">
+                {children}
+            </Box>
+        </Screen>
+    );
+};

--- a/suite-native/module-device-onboarding/src/screens/ThpCodeEntryScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ThpCodeEntryScreen.tsx
@@ -9,7 +9,7 @@ import {
 } from '@suite-native/navigation';
 import { ThpCodeEntryScreenContent } from '@suite-native/thp';
 
-import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
+import { NonClosableDeviceOnboardingScreen } from '../components/NonClosableDeviceOnboardingScreen';
 import { useInitiateThpConnection } from '../hooks/useInitiateThpConnection';
 
 export const ThpCodeEntryScreen = ({
@@ -26,8 +26,8 @@ export const ThpCodeEntryScreen = ({
     }, [thpStep, navigation]);
 
     return (
-        <DeviceOnboardingScreenWithExitButton>
+        <NonClosableDeviceOnboardingScreen>
             <ThpCodeEntryScreenContent onRetry={initiateThpConnection} />
-        </DeviceOnboardingScreenWithExitButton>
+        </NonClosableDeviceOnboardingScreen>
     );
 };

--- a/suite-native/module-device-onboarding/src/screens/ThpConfirmationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ThpConfirmationScreen.tsx
@@ -9,7 +9,7 @@ import {
     StackProps,
 } from '@suite-native/navigation';
 
-import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
+import { NonClosableDeviceOnboardingScreen } from '../components/NonClosableDeviceOnboardingScreen';
 
 export const ThpConfirmationScreen = ({
     navigation,
@@ -27,12 +27,8 @@ export const ThpConfirmationScreen = ({
     }, [thpStep, navigation]);
 
     return (
-        <DeviceOnboardingScreenWithExitButton
-            isScrollable={false}
-            noBottomPadding={true}
-            hasBottomInset={false}
-        >
+        <NonClosableDeviceOnboardingScreen noBottomPadding={true} hasBottomInset={false}>
             <ContinueOnTrezorScreenContent />
-        </DeviceOnboardingScreenWithExitButton>
+        </NonClosableDeviceOnboardingScreen>
     );
 };

--- a/suite-native/module-device-onboarding/src/screens/ThpPairingInfoScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ThpPairingInfoScreen.tsx
@@ -1,14 +1,14 @@
 import { ThpPairingInfoHelpButton, ThpPairingInfoScreenContent } from '@suite-native/thp';
 
-import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
+import { NonClosableDeviceOnboardingScreen } from '../components/NonClosableDeviceOnboardingScreen';
 import { useInitiateThpConnection } from '../hooks/useInitiateThpConnection';
 
 export const ThpPairingInfoScreen = () => {
     const { initiateThpConnection } = useInitiateThpConnection();
 
     return (
-        <DeviceOnboardingScreenWithExitButton screenHeaderRightIcon={<ThpPairingInfoHelpButton />}>
+        <NonClosableDeviceOnboardingScreen screenHeaderRightIcon={<ThpPairingInfoHelpButton />}>
             <ThpPairingInfoScreenContent onContinue={initiateThpConnection} />
-        </DeviceOnboardingScreenWithExitButton>
+        </NonClosableDeviceOnboardingScreen>
     );
 };

--- a/suite-native/module-device-onboarding/src/screens/ThpPairingSuccessScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ThpPairingSuccessScreen.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { nativeFirmwareActions } from '@suite-native/firmware';
 import { ThpPairingSuccessScreenContent } from '@suite-native/thp';
 
-import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
+import { NonClosableDeviceOnboardingScreen } from '../components/NonClosableDeviceOnboardingScreen';
 import { useNavigateToNextScreenAfterFirmwareInstallation } from '../hooks/useNavigateToNextScreenAfterFirmwareInstallation';
 
 export const ThpPairingSuccessScreen = () => {
@@ -17,8 +17,8 @@ export const ThpPairingSuccessScreen = () => {
     };
 
     return (
-        <DeviceOnboardingScreenWithExitButton>
+        <NonClosableDeviceOnboardingScreen>
             <ThpPairingSuccessScreenContent onContinue={onContinue} />
-        </DeviceOnboardingScreenWithExitButton>
+        </NonClosableDeviceOnboardingScreen>
     );
 };

--- a/suite-native/thp/src/components/ThpCodeEntryScreenContent.tsx
+++ b/suite-native/thp/src/components/ThpCodeEntryScreenContent.tsx
@@ -44,7 +44,7 @@ export const ThpCodeEntryScreenContent = ({ onRetry }: ThpCodeEntryScreenContent
     }, [thpStep, showAlert, onRetry]);
 
     return (
-        <VStack marginTop="sp16" spacing="sp32">
+        <VStack marginTop="sp16" spacing="sp32" flex={1}>
             <CenteredTitleHeader
                 title={<Translation id="thp.codeEntry.title" />}
                 titleVariant="titleMedium"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21780

## Screenshots:

https://github.com/user-attachments/assets/f52e4095-261e-4167-ad93-e14897920fdb



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/disable-closing-fw-install-in-onboarding&lookback=7)