### PR TITLE
tests: refactor test serial mode

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
@@ -9,7 +9,7 @@ import { expect, test } from '../../support/fixtures';
 
 test.use({ exceptionLogger: skipFixture });
 test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
-    test.describe.configure({ mode: 'serial' })
+    test.describe.configure({ mode: 'serial' });
 
     test.beforeAll(async ({ trezorUserEnvLink }) => {
         // Ensure bridge is stopped so we properly test the electron app starting node-bridge module.

--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
@@ -8,7 +8,9 @@ import { launchSuite, launchSuiteElectronApp } from '../../support/electron';
 import { expect, test } from '../../support/fixtures';
 
 test.use({ exceptionLogger: skipFixture });
-test.describe.serial('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
+test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
+    test.describe.configure({ mode: 'serial' })
+
     test.beforeAll(async ({ trezorUserEnvLink }) => {
         // Ensure bridge is stopped so we properly test the electron app starting node-bridge module.
         await trezorUserEnvLink.connect();

--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge.test.ts
@@ -16,7 +16,9 @@ import { enhancePage } from '../../support/testExtends/enhancePage';
 const NODE_BRIDGE_VERSION = '3.1.0';
 
 test.use({ exceptionLogger: skipFixture });
-test.describe.serial('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
+test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
+    test.describe.configure({ mode: 'serial' })
+
     test.beforeEach(async ({ trezorUserEnvLink }) => {
         //Ensure bridge is stopped so we properly test the electron app starting node-bridge module.
         await trezorUserEnvLink.connect();

--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge.test.ts
@@ -17,7 +17,7 @@ const NODE_BRIDGE_VERSION = '3.1.0';
 
 test.use({ exceptionLogger: skipFixture });
 test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
-    test.describe.configure({ mode: 'serial' })
+    test.describe.configure({ mode: 'serial' });
 
     test.beforeEach(async ({ trezorUserEnvLink }) => {
         //Ensure bridge is stopped so we properly test the electron app starting node-bridge module.

--- a/packages/suite-desktop-core/e2e/tests/settings/autodetect.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/autodetect.test.ts
@@ -35,7 +35,7 @@ const testCases = [
 
 test.use({ startEmulator: false });
 testCases.forEach(({ testName, userPreferences, text, textColor, bodyBackgroundColor }) => {
-    test.describe.serial('Language and theme detection', { tag: ['@group=settings'] }, () => {
+    test.describe('Language and theme detection', { tag: ['@group=settings'] }, () => {
         test.use(userPreferences);
         test(
             testName,
@@ -54,5 +54,5 @@ testCases.forEach(({ testName, userPreferences, text, textColor, bodyBackgroundC
                 );
             },
         );
-    });
+    })
 });

--- a/packages/suite-desktop-core/e2e/tests/settings/autodetect.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/autodetect.test.ts
@@ -54,5 +54,5 @@ testCases.forEach(({ testName, userPreferences, text, textColor, bodyBackgroundC
                 );
             },
         );
-    })
+    });
 });

--- a/packages/suite-desktop-core/e2e/tests/settings/t3b1-device-settings.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/t3b1-device-settings.test.ts
@@ -8,10 +8,12 @@ import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
-test.describe.serial(
+test.describe(
     'T3B1 - Device settings',
     { tag: ['@group=settings', '@specificModel'] },
     () => {
+        test.describe.configure({ mode: 'serial' });
+
         test.use({
             emulatorStartConf: { model: 'T3B1', wipe: true },
         });

--- a/packages/suite-desktop-core/e2e/tests/settings/t3b1-device-settings.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/t3b1-device-settings.test.ts
@@ -8,53 +8,49 @@ import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
-test.describe(
-    'T3B1 - Device settings',
-    { tag: ['@group=settings', '@specificModel'] },
-    () => {
-        test.describe.configure({ mode: 'serial' });
+test.describe('T3B1 - Device settings', { tag: ['@group=settings', '@specificModel'] }, () => {
+    test.describe.configure({ mode: 'serial' });
 
-        test.use({
-            emulatorStartConf: { model: 'T3B1', wipe: true },
-        });
+    test.use({
+        emulatorStartConf: { model: 'T3B1', wipe: true },
+    });
 
-        test.beforeEach(async ({ onboardingPage, settingsPage }) => {
-            await onboardingPage.completeOnboarding();
-            await settingsPage.navigateTo('device');
-        });
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
+        await onboardingPage.completeOnboarding();
+        await settingsPage.navigateTo('device');
+    });
 
-        test(
-            'change all possible device settings',
-            {
-                annotation: createTestAnnotation({
-                    testCase: 'Verifies that a user can change all possible device settings.',
-                    category: TestCategory.Settings,
-                    priority: TestPriority.Medium,
-                }),
-            },
-            async ({ settingsPage, page }) => {
-                await test.step('Verify firmware modal', async () => {
-                    await page.getByTestId('@settings/device/update-button').click();
-                    await page.getByTestId('@modal/close-button').click();
-                });
+    test(
+        'change all possible device settings',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can change all possible device settings.',
+                category: TestCategory.Settings,
+                priority: TestPriority.Medium,
+            }),
+        },
+        async ({ settingsPage, page }) => {
+            await test.step('Verify firmware modal', async () => {
+                await page.getByTestId('@settings/device/update-button').click();
+                await page.getByTestId('@modal/close-button').click();
+            });
 
-                await test.step("Change and verify device's name", async () => {
-                    const newDeviceName = 'TREVOR!';
-                    await settingsPage.changeDeviceName(newDeviceName);
-                    await expect(page.getByTestId('@menu/device/label')).toHaveText(newDeviceName);
-                });
+            await test.step("Change and verify device's name", async () => {
+                const newDeviceName = 'TREVOR!';
+                await settingsPage.changeDeviceName(newDeviceName);
+                await expect(page.getByTestId('@menu/device/label')).toHaveText(newDeviceName);
+            });
 
-                await settingsPage.changeDeviceBackground('circleweb');
-            },
-        );
+            await settingsPage.changeDeviceBackground('circleweb');
+        },
+    );
 
-        test('Device Wipe', async ({ page, trezorUserEnvLink }) => {
-            await page.getByTestId('@settings/device/open-wipe-modal-button').click();
-            await page.getByTestId('@wipe/checkbox-1').click();
-            await page.getByTestId('@wipe/checkbox-2').click();
-            await page.getByTestId('@wipe/wipe-button').click();
-            await trezorUserEnvLink.pressYes();
-            //TODO: Verification?
-        });
-    },
-);
+    test('Device Wipe', async ({ page, trezorUserEnvLink }) => {
+        await page.getByTestId('@settings/device/open-wipe-modal-button').click();
+        await page.getByTestId('@wipe/checkbox-1').click();
+        await page.getByTestId('@wipe/checkbox-2').click();
+        await page.getByTestId('@wipe/wipe-button').click();
+        await trezorUserEnvLink.pressYes();
+        //TODO: Verification?
+    });
+});


### PR DESCRIPTION
## Description

Using `test.describe.configure({ mode: 'serial' })` is better practice, as it's consistent with other configuration options.

`autodetect.test.ts` is already perfectly isolated, no need to run the tests in serial mode.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/refactor-test-serial-mode&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/refactor-test-serial-mode&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/refactor-test-serial-mode&lookback=7)