### PR TITLE
fix(suite): do not store error object in redux

### DIFF
--- a/packages/suite/src/support/suite/preloadStore.ts
+++ b/packages/suite/src/support/suite/preloadStore.ts
@@ -112,7 +112,7 @@ export const preloadStore = async () => {
 
         return {
             type: STORAGE.CORRUPTED,
-            payload: error,
+            payload: error.message,
         } as const;
     }
 };


### PR DESCRIPTION
<img width="1403" height="658" alt="image" src="https://github.com/user-attachments/assets/184ba5b5-f3bf-4666-bce4-890eaa32a701" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=object-in-redux-fix&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=object-in-redux-fix&lookback=7)