### PR TITLE
perf(suite-native): asset item fiat value re-renders

### DIFF
--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -177,7 +177,7 @@ export const selectAssetFiatValue = createMemoizedSelector(
     (assets, symbol) => {
         const asset = assets.assets.find(a => a.symbol === symbol);
 
-        return asset?.fiatBalance ?? null;
+        return asset?.fiatBalance?.toString() ?? null;
     },
 );
 


### PR DESCRIPTION
## Description
This PR fixes poorly memoized selector `selectAssetFiatValue` that is used for assets in the HomeScreen. This selector returns mostly the same value, so it should be re rendered only few times. The problem was, that the selector was returning new instance of `BigNumber` object, thus the re render was triggered on every fiat rate or accounts state change.

Newly this selector returns `string` so the re-render is triggered only if the string value is different to the previous render. On all seed this saves hundreds of fiat value re-renders (see screenshots).

## Related Issue

Relates https://github.com/trezor/trezor-suite/issues/17796

## Screenshots:

|Before | After |
|----------|----------|
|  <img width="345" height="725" alt="Screenshot 2025-09-24 at 9 31 34 AM" src="https://github.com/user-attachments/assets/df36e9a4-3400-44d7-bfb6-a7f9070c66c3" />     | <img width="345" height="725" alt="Screenshot 2025-09-24 at 9 19 07 AM" src="https://github.com/user-attachments/assets/1c685d70-d6c3-4992-ba5e-066742bd1367" /> |


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=perf/native/asset-item-fiat-rerendes&lookback=7)