### PR TITLE
chore(suite-desktop): nicer Trezor Host Protocol section in debug set…

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/ResetThpCredentials.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/ResetThpCredentials.tsx
@@ -3,9 +3,8 @@ import { useState } from 'react';
 import { removeThpAutoconnectThunk } from '@suite-common/thp';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
-import { Button } from '@trezor/components';
 
-import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
+import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 
 import { useDispatch, useSelector } from '../../../hooks/suite';
 
@@ -14,11 +13,11 @@ export const ResetThpCredentials = () => {
     const dispatch = useDispatch();
     const device = useSelector(selectSelectedDevice);
 
-    if (!device) {
-        return null;
-    }
-
     const onClick = async () => {
+        if (!device) {
+            return null;
+        }
+
         setIsLoading(true);
 
         const result = await dispatch(removeThpAutoconnectThunk()).unwrap();
@@ -43,9 +42,15 @@ export const ResetThpCredentials = () => {
                 description="Delete all THP credentials stored in the Suite for the connected device."
             />
             <ActionColumn>
-                <Button onClick={onClick} isLoading={isLoading}>
+                <ActionButton
+                    isTooltipActive={!device}
+                    tooltipContent="Connect device to reset THP credentials"
+                    isDisabled={!device}
+                    onClick={onClick}
+                    isLoading={isLoading}
+                >
                     Reset
-                </Button>
+                </ActionButton>
             </ActionColumn>
         </SectionItem>
     );


### PR DESCRIPTION
…tings

before 

<img width="802" height="67" alt="image" src="https://github.com/user-attachments/assets/95da4455-1b96-49ba-8c9a-9442443a027d" />

after 

<img width="810" height="137" alt="image" src="https://github.com/user-attachments/assets/d7947d09-25be-4ef7-a1cb-a3fbbda897f3" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=debug-reset-thp-nicer&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=debug-reset-thp-nicer&lookback=7)