### PR TITLE
fix(connect): http errors handling for suite-native

### DIFF
--- a/packages/connect/src/device/checkFirmwareRevision.ts
+++ b/packages/connect/src/device/checkFirmwareRevision.ts
@@ -5,7 +5,7 @@ import { serializeError, versionUtils } from '@trezor/utils';
 import { calculateRevisionForDevice } from './calculateRevisionForDevice';
 import { getOnlineReleaseByVersion } from '../data/firmwareInfo';
 import { FirmwareRevisionCheckError, FirmwareRevisionCheckResult } from '../types/device';
-import { HttpRequestError } from '../utils/assets-browser';
+import { HttpRequestError } from '../utils/assetUtils';
 
 const isNotFoundError = (e: unknown): boolean =>
     e instanceof HttpRequestError && e.response.status === 404;

--- a/packages/connect/src/utils/assetUtils.ts
+++ b/packages/connect/src/utils/assetUtils.ts
@@ -6,6 +6,16 @@ import {
     VersionArray,
 } from '@trezor/device-utils';
 
+export class HttpRequestError extends Error {
+    response: Response;
+
+    constructor(response: Response) {
+        const message = `${response.status} while fetching ${response.url}`;
+        super(message);
+        this.response = response;
+    }
+}
+
 type FirmwareAssetMap = {
     [device: string]: {
         [type: string]: {
@@ -43,7 +53,7 @@ export const getReleaseAsset = (
 
 export const firmwareReleaseConfigAssets = require('@trezor/connect-common/files/firmware/release/releases.v1.json');
 
-export const tryLocalAssetRequire = (url: string) => {
+export const tryLocalAssetRequire = (url: string): unknown => {
     const fileUrl = url.split('?')[0];
 
     switch (fileUrl) {

--- a/packages/connect/src/utils/assets-browser.ts
+++ b/packages/connect/src/utils/assets-browser.ts
@@ -1,17 +1,11 @@
 import fetch from 'cross-fetch';
 
+import { HttpRequestError } from './assetUtils';
 import { HttpRequestOptions, HttpRequestReturnType, HttpRequestType } from './assetsTypes';
 
-export class HttpRequestError extends Error {
-    response: Response;
-
-    constructor(response: Response) {
-        const message = `${response.status} while fetching ${response.url}`;
-        super(message);
-        this.response = response;
-    }
-}
-
+/**
+ * Http request wrapper for Suite Web & Desktop to handle various response states in a unified way.
+ */
 export const httpRequest = async <T extends HttpRequestType>(
     url: string,
     type: T = 'text' as T,

--- a/packages/connect/src/utils/assets.native.ts
+++ b/packages/connect/src/utils/assets.native.ts
@@ -1,6 +1,10 @@
-import { tryLocalAssetRequire } from './assetUtils';
+import { HttpRequestError, tryLocalAssetRequire } from './assetUtils';
 import { HttpRequestOptions, HttpRequestReturnType, HttpRequestType } from './assetsTypes';
 
+/**
+ * Http requesst wrapper for suite-native, that first tries to read files locally (unless forced to skip),
+ * then fetches from remote source and handles various response states in a unified way.
+ */
 export function httpRequest<T extends HttpRequestType>(
     url: string,
     type: T,
@@ -14,9 +18,7 @@ export function httpRequest<T extends HttpRequestType>(
         })
             .then(response => {
                 if (!response.ok) {
-                    throw new Error(
-                        `HTTP request failed with status ${response.status} ${response.statusText}`,
-                    );
+                    throw new HttpRequestError(response);
                 }
                 if (type === 'binary') {
                     return response.arrayBuffer() as unknown as HttpRequestReturnType<T>;

--- a/packages/connect/src/utils/assets.ts
+++ b/packages/connect/src/utils/assets.ts
@@ -9,6 +9,13 @@ if (global && typeof global.fetch !== 'function') {
     global.fetch = fetch;
 }
 
+/**
+ * Http request wrapper for Suite Web & Desktop, that first tries to read files locally (unless forced to skip),
+ * then fetches from remote source.
+ *
+ * ATTENTION !!! For suite-native, see assets.native.ts
+ * (automatically replaced by bundler, no explicit import)
+ */
 export function httpRequest<T extends HttpRequestType>(
     url: string,
     type: T,


### PR DESCRIPTION
## Description

- fix fetch http error handling for `suite-native`
- commentary to make it clear which function does which

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/156

## Screenshots:

See issue for before.

After:

[AFTER firmware-version-unknown.webm](https://github.com/user-attachments/assets/10398a5c-7fd0-4ef0-8ba0-35fec89e1c44)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native-revision-check-404&lookback=7)