### PR TITLE
Feat: battery level notification

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -8,6 +8,7 @@ import {
 } from '@trezor/protocol';
 import { Session, TRANSPORT, TRANSPORT_ERROR } from '@trezor/transport';
 import { type Descriptor, type Transport } from '@trezor/transport';
+import { OpenDeviceChannel } from '@trezor/transport/src/api/abstract';
 import { TransportDeviceEvent } from '@trezor/transport/src/transports/abstract';
 import { Deferred, TypedEmitter, createDeferred, isArrayMember, versionUtils } from '@trezor/utils';
 
@@ -116,7 +117,12 @@ type DeviceParams = {
 export class Device extends TypedEmitter<DeviceEvents> {
     public readonly transport: Transport;
     public readonly transportPath;
-    public readonly bluetoothProps;
+    public readonly bluetoothProps:
+        | {
+              channels: Record<OpenDeviceChannel, boolean> | undefined;
+              id: string;
+          }
+        | undefined;
     private thp: protocolThp.ThpState | undefined;
     private readonly descriptorType;
     private sessionAcquired: Session | null;
@@ -224,7 +230,13 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this.transport = transport;
         this.transportPath = descriptor.path;
         this.descriptorType = descriptor.type;
-        this.bluetoothProps = descriptor.id ? { id: descriptor.id } : undefined;
+
+        if (descriptor.id) {
+            this.bluetoothProps = {
+                id: descriptor.id,
+                channels: undefined,
+            };
+        }
 
         this.sessionAcquired = null;
 
@@ -308,6 +320,29 @@ export class Device extends TypedEmitter<DeviceEvents> {
             });
 
         return this.acquirePromise;
+    }
+
+    subscribe() {
+        if (this.bluetoothProps?.id) {
+            this.transport
+                .subscribe({
+                    path: this.bluetoothProps.id,
+                    channels: ['battery-level'],
+                })
+                .then(result => {
+                    if (result.success && this.bluetoothProps) {
+                        this.bluetoothProps.channels = result.payload;
+                        this.lifecycle.emit(DEVICE.CHANGED);
+                    }
+
+                    if (this.bluetoothProps?.channels?.['battery-level']) {
+                        this.transport.on('battery-level', event => {
+                            this._updateFeature('soc', event.data[0]);
+                            this.lifecycle.emit(DEVICE.CHANGED);
+                        });
+                    }
+                });
+        }
     }
 
     release() {
@@ -445,6 +480,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
             .then(() => {
                 if (wasUnacquired && !this.isUnacquired()) {
                     this.lifecycle.emit(DEVICE.CONNECT);
+                    // If device has `Capability_BLE` we assume it can do PUSH notifications so we subscribe.
+                    if (this.features.capabilities.includes('Capability_BLE')) {
+                        this.subscribe();
+                    }
                 }
             });
 
@@ -890,6 +929,13 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 this.color = (deviceInfo.colors as Record<string, string>)[deviceUnitColor];
             }
         }
+    }
+
+    private _updateFeature<K extends keyof Features>(key: K, value: Features[K]) {
+        this._features = {
+            ...this._features,
+            [key]: value,
+        };
     }
 
     prompt<

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -168,15 +168,14 @@ export const FirmwareInitial = ({
     const installFirmware = (firmwareType: FirmwareType) => {
         if (
             isDeviceConnectedViaBluetooth &&
-            device.features.soc &&
-            device?.features.soc <= DEVICE_LOW_BATTERY_PERCENTAGE_THRESHOLD
+            typeof device?.features.soc === 'number' &&
+            device.features.soc <= DEVICE_LOW_BATTERY_PERCENTAGE_THRESHOLD
         ) {
             setShowLowBatteryWarning(true);
 
             return;
         }
 
-        console.log('installFirmware');
         firmwareUpdate({ firmwareType });
         updateAnalytics({ firmware: 'install' });
     };

--- a/packages/suite/src/components/suite/modals/LowBatteryModal.tsx
+++ b/packages/suite/src/components/suite/modals/LowBatteryModal.tsx
@@ -30,12 +30,14 @@ const LowBatteryModalHeading = ({ batteryLevel }: LowBatteryModalHeadingProps) =
 );
 
 export const LowBatteryModal = ({ onClose, children }: LowBatteryModalProps) => {
-    const device = useDevice();
-    if (!device?.device) return null;
+    const { device } = useDevice();
+    if (!device) return null;
+
+    const bateryLevel = typeof device?.features?.soc === 'number' ? device?.features.soc : 0;
 
     return (
         <Modal
-            heading={<LowBatteryModalHeading batteryLevel={device?.device.features?.soc || 0} />}
+            heading={<LowBatteryModalHeading batteryLevel={bateryLevel} />}
             onCancel={onClose}
             bottomContent={
                 <Button variant="destructive" onClick={onClose}>

--- a/packages/suite/src/views/settings/SettingsDevice/FirmwareVersion.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/FirmwareVersion.tsx
@@ -78,8 +78,8 @@ export const FirmwareVersion = ({ isDeviceLocked }: FirmwareVersionProps) => {
     const handleUpdate = () => {
         if (
             isDeviceConnectedViaBluetooth &&
-            device.features?.soc &&
-            device.features?.soc < DEVICE_LOW_BATTERY_PERCENTAGE_THRESHOLD
+            typeof device?.features.soc === 'number' &&
+            device.features.soc < DEVICE_LOW_BATTERY_PERCENTAGE_THRESHOLD
         ) {
             setLowBatteryWarning(true);
 

--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -60,7 +60,9 @@ export class BluetoothApi extends AbstractApi {
         const transportApiEvent = ({ devices }: { devices: BluetoothDevice[] }) => {
             this.emit('transport-interface-change', this.devicesToDescriptors(devices));
         };
-        api.on('device_connected', transportApiEvent);
+        api.on('device_connected', event => {
+            transportApiEvent(event);
+        });
         api.on('device_disconnected', event => {
             this.readBuffer.cancelRead(event.id);
             transportApiEvent(event);

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -3,6 +3,7 @@ import { PROTOCOL_MALFORMED, ThpState, TransportProtocol } from '@trezor/protoco
 import { ScheduleActionParams, ScheduledAction, TypedEmitter, scheduleAction } from '@trezor/utils';
 
 import type { BridgeCommonErrors } from './bridge';
+import { OpenDeviceChannel } from '../api/abstract';
 import { ACTION_TIMEOUT, TRANSPORT } from '../constants';
 import * as ERRORS from '../errors';
 import {
@@ -285,6 +286,18 @@ export abstract class AbstractTransport extends TypedEmitter<TransportEvents> {
             thpState?: ThpState;
         } & AbortableParam,
     ): AsyncResultWithTypedError<MessageResponse, ReadWriteError>;
+
+    /**
+     * Subscribe to push notification
+     */
+    subscribe(_params: {
+        path: any;
+        channels: OpenDeviceChannel[];
+        signal?: AbortSignal;
+    }): AsyncResultWithTypedError<Record<OpenDeviceChannel, boolean>, ReadWriteError> {
+        // Return a rejected promise to indicate this feature is not supported by this transport by default.
+        return Promise.reject(new Error(`${this.name} does not support the 'subscribe' method.`));
+    }
 
     /**
      * Stop transport = remove all listeners + try to release session + cancel all requests

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -5,7 +5,7 @@ import {
     AbstractTransportMethodParams,
     AbstractTransportParams,
 } from './abstract';
-import { AbstractApi } from '../api/abstract';
+import { AbstractApi, OpenDeviceChannel } from '../api/abstract';
 import { TRANSPORT } from '../constants';
 import * as ERRORS from '../errors';
 import { SessionsBackground } from '../sessions/background';
@@ -136,6 +136,41 @@ export abstract class AbstractApiTransport extends AbstractTransport {
             },
             { signal },
             [ERRORS.DEVICE_DISCONNECTED_DURING_ACTION, ERRORS.SESSION_WRONG_PREVIOUS],
+        );
+    }
+
+    public subscribe({
+        path,
+        channels,
+        signal,
+    }: {
+        path: any;
+        channels: OpenDeviceChannel[];
+        signal?: AbortSignal;
+    }) {
+        return this.scheduleAction(
+            async signal => {
+                const entries = await Promise.all(
+                    channels.map(async channel => {
+                        try {
+                            const res = await this.api.openDevice(path, {
+                                reset: false,
+                                signal,
+                                channel,
+                            });
+
+                            return [channel, res.success];
+                        } catch {
+                            return [channel, false];
+                        }
+                    }),
+                );
+
+                const map = Object.fromEntries(entries);
+
+                return this.success(map as Record<OpenDeviceChannel, boolean>);
+            },
+            { signal },
         );
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Separating battery level updates from the rest in https://github.com/trezor/trezor-suite/pull/21625/files

This should add the functionality where when device updates the State of Charge it notifies to Suite about it and then Suite knows what is the current SoC so it can use it for example to let the user know that it is required more than 50% to update FW.

Resolves https://github.com/trezor/trezor-suite/issues/21370




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/battery-level-notification&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/battery-level-notification&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/battery-level-notification&lookback=7)