### PR TITLE
fix(suite-native): localization files disabled without ff

### DIFF
--- a/suite-native/intl/src/hooks/useTranslatedMessages.ts
+++ b/suite-native/intl/src/hooks/useTranslatedMessages.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { NativeLocale } from '@suite-common/suite-types';
+import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 
 import { messages as defaultMessages } from '../messages';
 import { flatten } from '../utils';
@@ -19,12 +20,13 @@ type UseTranslatedMessagesProps = {
 
 export const useTranslatedMessages = ({ language }: UseTranslatedMessagesProps) => {
     const [messages, setMessages] = useState<{ [key: string]: string }>({});
+    const isLocalizationEnabled = useFeatureFlag(FeatureFlag.IsLocalizationEnabled);
 
     useEffect(() => {
-        const localizedMessages = LANGUAGE_TRANSLATIONS_MAP[language];
+        const localizedMessages = isLocalizationEnabled ? LANGUAGE_TRANSLATIONS_MAP[language] : {};
 
         setMessages({ ...englishFallback, ...localizedMessages });
-    }, [language]);
+    }, [language, isLocalizationEnabled]);
 
     return messages;
 };


### PR DESCRIPTION
## Description
- localization files downloaded from crowdin are used only if `Localization FF` is enabled. 


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/disable-localization-files-without-ff&lookback=7)