### PR TITLE
chore: remove translation import over barrel index.ts file

### DIFF
--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Downloading.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Downloading.tsx
@@ -5,7 +5,7 @@ import { UpdateProgress } from '@trezor/suite-desktop-api';
 import { spacings } from '@trezor/theme';
 import { bytesToHumanReadable } from '@trezor/utils';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 interface DownloadingProps {
     hideWindow: () => void;

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Ready.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Ready.tsx
@@ -2,7 +2,7 @@ import { Column, H3, Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { installUpdate } from 'src/actions/suite/desktopUpdateActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 
 interface ReadyProps {

--- a/packages/suite/src/components/firmware/Buttons/FirmwareCloseButton.tsx
+++ b/packages/suite/src/components/firmware/Buttons/FirmwareCloseButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Button, ButtonProps } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 export const FirmwareCloseButton = (props: Omit<ButtonProps, 'children'>) => (
     <Button {...props}>

--- a/packages/suite/src/components/firmware/Buttons/FirmwareContinueButton.tsx
+++ b/packages/suite/src/components/firmware/Buttons/FirmwareContinueButton.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { Button, ButtonProps } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 // eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`

--- a/packages/suite/src/components/firmware/Buttons/FirmwareInstallButton.tsx
+++ b/packages/suite/src/components/firmware/Buttons/FirmwareInstallButton.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonProps, Tooltip } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useTranslation } from 'src/hooks/suite';
 
 const InstallButtonCommon = (

--- a/packages/suite/src/components/firmware/Buttons/FirmwareRetryButton.tsx
+++ b/packages/suite/src/components/firmware/Buttons/FirmwareRetryButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Button, ButtonProps } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 export const FirmwareRetryButton = (props: Omit<ButtonProps, 'children'>) => (
     <Button {...props} data-testid="@firmware/retry-button">

--- a/packages/suite/src/components/firmware/CheckSeedStep/FirmwareInstallationBackupButton.tsx
+++ b/packages/suite/src/components/firmware/CheckSeedStep/FirmwareInstallationBackupButton.tsx
@@ -2,7 +2,7 @@ import { useFirmwareInstallation } from '@suite-common/firmware';
 import { Button } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 
 type FirmwareInstallationBackupButtonProps = {

--- a/packages/suite/src/components/firmware/FirmwareInstallationStandalone.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallationStandalone.tsx
@@ -10,7 +10,7 @@ import {
     ReconnectDevicePrompt,
     RotatingPhrases,
 } from 'src/components/firmware';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectHasTransportOfType } from 'src/selectors/suite/suiteSelectors';
 

--- a/packages/suite/src/components/firmware/RotatingPhrases.tsx
+++ b/packages/suite/src/components/firmware/RotatingPhrases.tsx
@@ -5,7 +5,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { TranslationKey } from '@suite-common/intl-types';
 import { Card, H4, Paragraph, motionEasing } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 const PHRASES: TranslationKey[] = [
     'TR_DYK_ITEM_1',

--- a/packages/suite/src/components/guide/Feedback.tsx
+++ b/packages/suite/src/components/guide/Feedback.tsx
@@ -15,7 +15,7 @@ import { spacingsPx } from '@trezor/theme';
 
 import { setView } from 'src/actions/suite/guideActions';
 import { GuideContent, GuideHeader, GuideViewWrapper } from 'src/components/guide';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 
 import { EmojiRatingSelector } from '../suite/EmojiRatingSelector';

--- a/packages/suite/src/components/guide/Guide.tsx
+++ b/packages/suite/src/components/guide/Guide.tsx
@@ -14,7 +14,7 @@ import {
     GuideSearch,
     GuideViewWrapper,
 } from 'src/components/guide';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 const FeedbackLinkWrapper = styled.div`

--- a/packages/suite/src/components/guide/GuideArticle.tsx
+++ b/packages/suite/src/components/guide/GuideArticle.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { spacingsPx } from '@trezor/theme';
 
 import { GuideContent, GuideHeader, GuideMarkdown, GuideViewWrapper } from 'src/components/guide';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useGuideLoadArticle } from 'src/hooks/guide';
 import { useSelector } from 'src/hooks/suite';
 import { selectLanguage } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/components/guide/GuideCategory.tsx
+++ b/packages/suite/src/components/guide/GuideCategory.tsx
@@ -10,7 +10,7 @@ import {
     GuideNode,
     GuideViewWrapper,
 } from 'src/components/guide';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { getNodeTitle } from 'src/utils/suite/guide';

--- a/packages/suite/src/components/guide/GuideSearch.tsx
+++ b/packages/suite/src/components/guide/GuideSearch.tsx
@@ -7,7 +7,7 @@ import { Icon, Input, Spinner, variables } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
 import { GuideNode } from 'src/components/guide';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useGuideSearch } from 'src/hooks/guide';
 import { useTranslation } from 'src/hooks/suite';
 

--- a/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
+++ b/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
@@ -6,7 +6,7 @@ import { variables } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { openNode, setView } from 'src/actions/suite/guideActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 // importing directly, otherwise unit tests fail, seems to be a styled-components issue
 import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { useDispatch, useSelector } from 'src/hooks/suite';

--- a/packages/suite/src/components/guide/OpenGuideFromTooltip.tsx
+++ b/packages/suite/src/components/guide/OpenGuideFromTooltip.tsx
@@ -6,7 +6,7 @@ import styled, { useTheme } from 'styled-components';
 import { Icon } from '@trezor/components';
 import { borders, spacingsPx, typography } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useGuideOpenNode } from 'src/hooks/guide';
 
 const OpenGuideLink = styled.span`

--- a/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
+++ b/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
@@ -11,7 +11,7 @@ import { TREZOR_FORUM_URL, TREZOR_SUPPORT_URL } from '@trezor/urls';
 
 import { setView } from 'src/actions/suite/guideActions';
 import { GuideContent, GuideHeader, GuideViewWrapper } from 'src/components/guide';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { UpdateState } from 'src/reducers/suite/desktopUpdateReducer';
 

--- a/packages/suite/src/components/onboarding/Buttons/OnboardingButtonBack.tsx
+++ b/packages/suite/src/components/onboarding/Buttons/OnboardingButtonBack.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonProps } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 export const OnboardingButtonBack = (props: Omit<ButtonProps, 'children'>) => (
     <Button

--- a/packages/suite/src/components/onboarding/OnboardingLayout.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingLayout.tsx
@@ -10,7 +10,7 @@ import { TREZOR_SUPPORT_URL } from '@trezor/urls';
 import { MODAL } from 'src/actions/suite/constants';
 import { GuideButton, GuideRouter } from 'src/components/guide';
 import { OnboardingProgressBar } from 'src/components/onboarding';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { SuiteBanners } from 'src/components/suite/banners';
 import { ReduxModal } from 'src/components/suite/modals/ReduxModal/ReduxModal';
 import { MAX_ONBOARDING_WIDTH } from 'src/constants/suite/layout';

--- a/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
@@ -9,7 +9,7 @@ import TrezorConnect from '@trezor/connect';
 import { ConfirmOnDevice } from '@trezor/product-components';
 import { spacingsPx, zIndices } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import messages from 'src/support/messages';
 
 import {

--- a/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
+++ b/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 
 import { Modal } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import * as STEP from 'src/constants/onboarding/steps';
 import { useOnboarding } from 'src/hooks/suite';
 import { AnyStepId } from 'src/types/onboarding';

--- a/packages/suite/src/components/recovery/SelectRecoveryType.tsx
+++ b/packages/suite/src/components/recovery/SelectRecoveryType.tsx
@@ -1,5 +1,5 @@
 import { OnboardingOption, OptionsDivider, OptionsWrapper } from 'src/components/onboarding';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 interface SelectRecoveryTypeProps {
     onSelect: (type: 'standard' | 'advanced') => void;

--- a/packages/suite/src/components/recovery/SelectWordCount.tsx
+++ b/packages/suite/src/components/recovery/SelectWordCount.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { OnboardingOption, OptionsDivider, OptionsWrapper } from 'src/components/onboarding';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { WordCount } from 'src/types/recovery';
 
 const StyledOption = styled(OnboardingOption)`

--- a/packages/suite/src/components/settings/SettingsLayout.tsx
+++ b/packages/suite/src/components/settings/SettingsLayout.tsx
@@ -4,7 +4,7 @@ import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import {
     NavigationItem,
     PageHeader,

--- a/packages/suite/src/components/suite/AppNavigation/AppNavigationTooltip.tsx
+++ b/packages/suite/src/components/suite/AppNavigation/AppNavigationTooltip.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 
 import { Tooltip } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 
 interface AppNavigationTooltipProps {

--- a/packages/suite/src/components/suite/BioAuthGuard/BioAuthGuard.tsx
+++ b/packages/suite/src/components/suite/BioAuthGuard/BioAuthGuard.tsx
@@ -20,7 +20,7 @@ import {
     requestBioAuthValidationThunk,
     requestOnceBioAuthValidationThunk,
 } from 'src/actions/suite/bioAuthThunks';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import {
     Body,
     Columns,

--- a/packages/suite/src/components/suite/ChangeDeviceLabelForm.tsx
+++ b/packages/suite/src/components/suite/ChangeDeviceLabelForm.tsx
@@ -7,7 +7,7 @@ import { Button, Input, Tooltip } from '@trezor/components';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { spacingsPx } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 
 const Container = styled.form<{ $isVertical?: boolean }>`

--- a/packages/suite/src/components/suite/CoinGroup/CoinGroupHeader.tsx
+++ b/packages/suite/src/components/suite/CoinGroup/CoinGroupHeader.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { IconButton, Paragraph, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 const Wrapper = styled.div`
     @media (hover: hover) {

--- a/packages/suite/src/components/suite/CoinList/Coin.tsx
+++ b/packages/suite/src/components/suite/CoinList/Coin.tsx
@@ -10,7 +10,7 @@ import { focusStyleTransition, getFocusShadowStyle } from '@trezor/components/sr
 import { CoinLogo } from '@trezor/product-components';
 import { typography } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 const SettingsWrapper = styled.div<{
     $toggled: boolean;

--- a/packages/suite/src/components/suite/CoinList/CoinList.tsx
+++ b/packages/suite/src/components/suite/CoinList/CoinList.tsx
@@ -5,7 +5,7 @@ import { getFirmwareVersion, isDeviceInBootloaderMode } from '@trezor/device-uti
 import { spacings } from '@trezor/theme';
 import { versionUtils } from '@trezor/utils';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useDiscovery, useSelector } from 'src/hooks/suite';
 import { getCoinLabel } from 'src/utils/suite/getCoinLabel';
 

--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -21,7 +21,7 @@ import { isDesktop } from '@trezor/env-utils';
 import { DeviceWithScene } from '@trezor/product-components';
 import { Elevation, spacings, spacingsPx, typography } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import type { PrerequisiteType } from 'src/types/suite';
 
 import { TranslationKey } from './Translation';

--- a/packages/suite/src/components/suite/DeviceAuthenticationExplainer.tsx
+++ b/packages/suite/src/components/suite/DeviceAuthenticationExplainer.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { TranslationKey } from '@suite-common/intl-types';
 import { Icon, IconName, variables } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 const Item = styled.div`
     display: flex;

--- a/packages/suite/src/components/suite/DropZone.tsx
+++ b/packages/suite/src/components/suite/DropZone.tsx
@@ -12,7 +12,7 @@ import {
     spacings,
 } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 type DropZoneProps = {
     accept?: string;

--- a/packages/suite/src/components/suite/LearnMoreButton.tsx
+++ b/packages/suite/src/components/suite/LearnMoreButton.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import { Button, ButtonProps } from '@trezor/components';
 import { Url } from '@trezor/urls';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { useExternalLink } from '../../hooks/suite';
 

--- a/packages/suite/src/components/suite/PinMatrix/PinMatrix.tsx
+++ b/packages/suite/src/components/suite/PinMatrix/PinMatrix.tsx
@@ -16,7 +16,7 @@ import {
 import { spacings } from '@trezor/theme';
 import { HELP_CENTER_PIN_URL } from '@trezor/urls';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useExternalLink } from 'src/hooks/suite';
 
 type PinMatrixProps = {

--- a/packages/suite/src/components/suite/Preloader/DatabaseCorruptedModal.tsx
+++ b/packages/suite/src/components/suite/Preloader/DatabaseCorruptedModal.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { H3, Modal } from '@trezor/components';
 
 import { resetSuiteAppThunk } from 'src/actions/suite/suiteThunks';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 
 export const DatabaseCorruptedModal = () => {

--- a/packages/suite/src/components/suite/Preloader/DatabaseUpgradeModal.tsx
+++ b/packages/suite/src/components/suite/Preloader/DatabaseUpgradeModal.tsx
@@ -1,6 +1,6 @@
 import { H3, Modal, Paragraph } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 type DatabaseUpgradeModalProps = {
     variant: 'blocking' | 'blocked';

--- a/packages/suite/src/components/suite/QuestionTooltip.tsx
+++ b/packages/suite/src/components/suite/QuestionTooltip.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { H3, Tooltip } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { ExtendedMessageDescriptor } from 'src/types/suite';
 
 const Wrapper = styled.div`

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -4,7 +4,7 @@ import { TranslationKey } from '@suite-common/intl-types';
 import { Column, Divider, H2, Paragraph, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { SecurityChecklist } from 'src/views/onboarding/steps/SecurityCheck/SecurityChecklist';
 import { SecurityChecklistItem } from 'src/views/onboarding/steps/SecurityCheck/types';
 

--- a/packages/suite/src/components/suite/SecurityCheck/deviceCompromisedCtas.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/deviceCompromisedCtas.tsx
@@ -7,7 +7,7 @@ import {
     Url,
 } from '@trezor/urls';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { useDevice, useDispatch } from '../../../hooks/suite';
 

--- a/packages/suite/src/components/suite/StakingProcess/StakingInfo.tsx
+++ b/packages/suite/src/components/suite/StakingProcess/StakingInfo.tsx
@@ -15,7 +15,7 @@ import {
 import { BulletList } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { CoinjoinRootState } from 'src/reducers/wallet/coinjoinReducer';
 

--- a/packages/suite/src/components/suite/StakingProcess/UnstakingInfo.tsx
+++ b/packages/suite/src/components/suite/StakingProcess/UnstakingInfo.tsx
@@ -8,7 +8,7 @@ import { getUnstakingPeriodInDays } from '@suite-common/wallet-utils';
 import { BulletList } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { CoinjoinRootState } from 'src/reducers/wallet/coinjoinReducer';
 
 import { InfoRow } from './InfoRow';

--- a/packages/suite/src/components/suite/Ticker/LastUpdateTooltip.tsx
+++ b/packages/suite/src/components/suite/Ticker/LastUpdateTooltip.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 import { Tooltip } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 const LastUpdate = styled.div`
     text-transform: none;

--- a/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
+++ b/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
@@ -14,7 +14,7 @@ import {
 import { spacings } from '@trezor/theme';
 
 import { toggleTor, updateTorStatus } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectModalType } from 'src/reducers/suite/modalReducer';
 import { selectTorState } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/components/suite/WordInputAdvanced.tsx
+++ b/packages/suite/src/components/suite/WordInputAdvanced.tsx
@@ -15,7 +15,7 @@ import { spacings } from '@trezor/theme';
 import { HELP_CENTER_ADVANCED_RECOVERY_URL } from '@trezor/urls';
 import { resolveAfter } from '@trezor/utils';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useExternalLink } from 'src/hooks/suite';
 
 type WordInputAdvancedProps = {

--- a/packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.tsx
@@ -1,7 +1,7 @@
 import { Banner } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 
 export const BridgeDeprecated = () => {

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FailedBackupBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FailedBackupBanner.tsx
@@ -1,7 +1,7 @@
 import { Banner } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch } from 'src/hooks/suite';
 

--- a/packages/suite/src/components/suite/banners/SuiteBanners/NoBackupBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/NoBackupBanner.tsx
@@ -1,7 +1,7 @@
 import { Banner } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useTranslation } from 'src/hooks/suite';
 
 export const NoBackup = () => {

--- a/packages/suite/src/components/suite/banners/SuiteBanners/NoConnectionBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/NoConnectionBanner.tsx
@@ -1,6 +1,6 @@
 import { Banner } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 export const NoConnectionBanner = () => (
     <Banner icon variant="destructive">

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx
@@ -1,7 +1,7 @@
 import { Banner, Row, Banner as WarningComponent } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch } from 'src/hooks/suite';
 

--- a/packages/suite/src/components/suite/bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal.tsx
+++ b/packages/suite/src/components/suite/bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal.tsx
@@ -5,7 +5,7 @@ import { desktopApi } from '@trezor/suite-desktop-api';
 import { spacings } from '@trezor/theme';
 
 import { toggleConnectionModal } from 'src/actions/device/deviceSlice';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { setBluetoothDeviceNeedsManualOsRemoval } from '../../../actions/bluetooth/desktopBluetoothReducer';
 import {

--- a/packages/suite/src/components/suite/graph/GraphRangeSelector.tsx
+++ b/packages/suite/src/components/suite/graph/GraphRangeSelector.tsx
@@ -20,7 +20,7 @@ import {
     variables,
 } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useGraph, useLocales } from 'src/hooks/suite';
 import { GraphRange } from 'src/types/wallet/graph';
 

--- a/packages/suite/src/components/suite/graph/GraphScaleDropdownItem.tsx
+++ b/packages/suite/src/components/suite/graph/GraphScaleDropdownItem.tsx
@@ -1,6 +1,6 @@
 import { SelectBar, SelectBarProps } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useGraph } from 'src/hooks/suite';
 import { GraphScale } from 'src/types/wallet/graph';
 

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -9,7 +9,7 @@ import { spacingsPx } from '@trezor/theme';
 import { TimerId } from '@trezor/type-utils';
 
 import { addMetadata, init, setEditing } from 'src/actions/suite/metadataLabelingActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
 import {
     selectIsLabelingAvailableForEntity,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/MobileMenu/MobileMenuActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/MobileMenu/MobileMenuActions.tsx
@@ -6,7 +6,7 @@ import type { Route } from '@suite-common/suite-types';
 import { selectIsDiscreteModeActive, setDiscreetMode } from '@suite-common/wallet-core';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useGuide } from 'src/hooks/guide/useGuide';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectRouteName } from 'src/reducers/suite/routerReducer';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/MobileMenu/MobileNavigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/MobileMenu/MobileNavigation.tsx
@@ -5,7 +5,7 @@ import { variables } from '@trezor/components';
 import { typography } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { MAIN_MENU_ITEMS } from 'src/constants/suite/menu';
 import { useAccountSearch, useDispatch, useSelector } from 'src/hooks/suite';
 import { findRouteByName } from 'src/utils/suite/router';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/BasicName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/BasicName.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { TranslationKey } from '@suite-common/intl-types';
 import { H2 } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 // eslint-disable-next-line local-rules/no-override-ds-component
 export const HeaderHeading = styled(H2)`

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/SettingsName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/SettingsName.tsx
@@ -6,7 +6,7 @@ import { desktopApi } from '@trezor/suite-desktop-api';
 import { spacingsPx } from '@trezor/theme';
 
 import { setDebugMode } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/NavBackends.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/NavBackends.tsx
@@ -6,7 +6,7 @@ import { CoinLogo } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import type { CustomBackend } from 'src/types/wallet';
 

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/NavSettings.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/NavSettings.tsx
@@ -1,7 +1,7 @@
 import { IconButton } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 
 export const NavSettings = () => {

--- a/packages/suite/src/components/suite/modals/ConfirmEvmExplanationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ConfirmEvmExplanationModal.tsx
@@ -8,8 +8,7 @@ import { spacings } from '@trezor/theme';
 
 import { SUITE } from 'src/actions/suite/constants';
 import { onCancel } from 'src/actions/suite/modalActions';
-import { Translation } from 'src/components/suite';
-import { TranslationKey } from 'src/components/suite/Translation';
+import { Translation, TranslationKey } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 const ImageWrapper = styled.div`

--- a/packages/suite/src/components/suite/modals/ModalSwitcher/DiscoveryLoader.tsx
+++ b/packages/suite/src/components/suite/modals/ModalSwitcher/DiscoveryLoader.tsx
@@ -2,7 +2,7 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Column, H3, Spinner } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { CardWithDevice } from 'src/views/suite/SwitchDevice/CardWithDevice';
 import { SwitchDeviceModal } from 'src/views/suite/SwitchDevice/SwitchDeviceModal';

--- a/packages/suite/src/components/suite/modals/ReduxModal/CardanoWithdrawModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/CardanoWithdrawModal.tsx
@@ -2,7 +2,7 @@ import { getNetworkName } from '@suite-common/wallet-utils';
 import { Card, Column, Icon, Link, Modal, Paragraph, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { useCardanoStaking } from 'src/hooks/wallet/useCardanoStaking';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -12,7 +12,7 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 
 import { showAddress } from 'src/actions/wallet/receiveActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import {
     ConfirmValueModal,
     ConfirmValueModalProps,

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
@@ -3,7 +3,7 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { convertTaprootXpub } from '@trezor/utils';
 
 import { showXpub } from 'src/actions/wallet/publicKeyActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx
@@ -7,7 +7,7 @@ import { copyToClipboard } from '@trezor/dom-utils';
 import { spacings } from '@trezor/theme';
 
 import { setFlag } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 
 const getAddressTypeText = (addressType: AddressType) => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/NoBackupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/NoBackupModal.tsx
@@ -3,7 +3,7 @@ import { spacings } from '@trezor/theme';
 
 import { onReceiveConfirmation } from 'src/actions/suite/modalActions';
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmFingerprintModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmFingerprintModal.tsx
@@ -4,7 +4,7 @@ import { getDeviceColorVariant } from '@trezor/device-utils';
 import { ConfirmOnDevice } from '@trezor/product-components';
 
 import { Fingerprint } from 'src/components/firmware';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TrezorDevice } from 'src/types/suite';
 
 type ConfirmFingerprintProps = {

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseInputCard.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseInputCard.tsx
@@ -24,7 +24,7 @@ import { spacings } from '@trezor/theme';
 import { countBytesInString, getNonAsciiChars } from '@trezor/utils';
 
 import { CONTEXT_DEVICE } from 'src/actions/suite/constants/modalConstants';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 
 type PassphraseInputCardProps = {

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewDetails.tsx
@@ -4,7 +4,7 @@ import { GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { Card, Column, InfoItem, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 const Pre = styled.pre`
     text-align: left;

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -15,7 +15,7 @@ import {
 import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TransactionReviewOutputAssets } from 'src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { TranslationFunction } from 'src/hooks/suite/useTranslation';

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -13,7 +13,7 @@ import { findAccountsByAddress, getEvmTransactionTextSignature } from '@suite-co
 import { Column, H4 } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import type { Account } from 'src/types/wallet';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UnhideTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UnhideTokenModal.tsx
@@ -9,7 +9,7 @@ import { Card, Checkbox, H2, Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { setFlag } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
@@ -9,8 +9,8 @@ import { getAccountTypeDesc, getAccountTypeUrl } from '@suite-common/wallet-util
 import { Column, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
+import { Translation } from 'src/components/suite/Translation';
 
 interface AccountTypeDescriptionProps {
     bip43Path: Bip43PathTemplate;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
@@ -5,7 +5,7 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { UnavailableCapability } from '@trezor/connect';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useAccountSearch, useSelector } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddButton.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import { Network } from '@suite-common/wallet-config';
 import { ButtonProps, Modal, Tooltip } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 interface AddButtonProps extends Omit<ButtonProps, 'children'> {
     disabledMessage: ReactNode;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
@@ -11,7 +11,7 @@ import { resolveAfter } from '@trezor/utils';
 import { openDeferredModal, openModal } from 'src/actions/suite/modalActions';
 import { toggleTor } from 'src/actions/suite/suiteActions';
 import { createCoinjoinAccount } from 'src/actions/wallet/coinjoinAccountActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectModalType } from 'src/reducers/suite/modalReducer';
 import { selectTorState } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
@@ -17,7 +17,7 @@ import {
 import { spacings } from '@trezor/theme';
 
 import { toggleTor } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useBackendsForm, useDefaultUrls } from 'src/hooks/settings/backends';
 import { useExplorerForm } from 'src/hooks/settings/useExplorerForm';
 import { useDispatch, useSelector } from 'src/hooks/suite';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
@@ -6,7 +6,7 @@ import { Network } from '@suite-common/wallet-config';
 import { Select } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import type { BackendOption } from 'src/hooks/settings/backends';
 
 const Capitalize = styled.span`

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/TorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/TorModal.tsx
@@ -1,7 +1,7 @@
 import { H3, Modal, Paragraph } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { getIsTorLoading } from 'src/utils/suite/tor';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/ExplorerConfigForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/ExplorerConfigForm.tsx
@@ -5,7 +5,7 @@ import { Explorer } from '@suite-common/wallet-config';
 import { Button, Column, InfoItem, Input, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useExplorerForm } from 'src/hooks/settings/useExplorerForm';
 
 type InputRowProps = {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
@@ -16,7 +16,7 @@ import {
 } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { usePrintableLog } from 'src/utils/suite/logsUtils';
 
 const ScrollContainer = styled.div`

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceModal.tsx
@@ -6,7 +6,7 @@ import { Icon, IconName, List, Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { onCancel, openModal } from 'src/actions/suite/modalActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CancelCoinjoinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CancelCoinjoinModal.tsx
@@ -2,7 +2,7 @@ import { Column, H3, Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { stopCoinjoinSession } from 'src/actions/wallet/coinjoinClientActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CoinjoinSuccessModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CoinjoinSuccessModal.tsx
@@ -5,7 +5,7 @@ import { spacings } from '@trezor/theme';
 
 import { onCancel as closeModal } from 'src/actions/suite/modalActions';
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectRouterParams } from 'src/reducers/suite/routerReducer';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
@@ -5,8 +5,7 @@ import { Button, H3, Modal, Paragraph, Tooltip } from '@trezor/components';
 
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { onCancel } from 'src/actions/suite/modalActions';
-import { Translation } from 'src/components/suite';
-import { TranslationKey } from 'src/components/suite/Translation';
+import { Translation, TranslationKey } from 'src/components/suite/Translation';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { Dispatch, GetState } from 'src/types/suite';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
@@ -7,10 +7,10 @@ import { ERRORS } from '@trezor/connect';
 import { EventTypeShared, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
 import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';
 import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { ConnectProcessLabel } from 'src/components/suite/ConnectProcessLabel';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { getPermissionText } from 'src/views/settings/SettingsConnectedApps/ConnectPermissions';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/AutoStopButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/AutoStopButton.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, Text } from '@trezor/components';
 
 import { toggleAutostopCoinjoin } from 'src/actions/wallet/coinjoinAccountActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectIsSessionAutostopped } from 'src/reducers/wallet/coinjoinReducer';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/CriticalCoinjoinPhaseModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/CriticalCoinjoinPhaseModal.tsx
@@ -1,7 +1,7 @@
 import { Banner, Card, Column, Divider, LoadingContent, Modal } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { SESSION_PHASE_MESSAGES } from 'src/constants/suite/coinjoin';
 import { useCoinjoinSessionPhase } from 'src/hooks/coinjoin';
 import { useSelector } from 'src/hooks/suite';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
@@ -7,7 +7,7 @@ import { Banner, Button, Card, Column, H3, Modal, Paragraph, Row } from '@trezor
 import { CoinLogo } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { AdvancedCoinSettingsModal } from 'src/components/suite/modals';
 import { useCustomBackends } from 'src/hooks/settings/backends';
 import { useDispatch } from 'src/hooks/suite';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorStopCoinjoinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorStopCoinjoinModal.tsx
@@ -2,7 +2,7 @@ import { UserContextPayload } from '@suite-common/suite-types';
 import { Banner, Column, Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 type DisableTorStopCoinjoinModalProps = {
     decision: Extract<UserContextPayload, { type: 'disable-tor-stop-coinjoin' }>['decision'];

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/DelimiterForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/DelimiterForm.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Input, Row, SelectBar } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 type DelimiterFormProps = {
     value?: string;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/ImportTransactionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/ImportTransactionModal.tsx
@@ -7,8 +7,8 @@ import { parseCSV } from '@suite-common/wallet-utils';
 import { Card, CollapsibleBox, Column, Modal, Tabs, Text, Textarea } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
 import { DropZone } from 'src/components/suite/DropZone';
+import { Translation } from 'src/components/suite/Translation';
 
 import { DelimiterForm } from './DelimiterForm';
 import { useExampleCSV } from './useExampleCSV';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MetadataProviderModal/MetadataProviderModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MetadataProviderModal/MetadataProviderModal.tsx
@@ -6,7 +6,7 @@ import { spacings } from '@trezor/theme';
 import type { Deferred } from '@trezor/utils';
 
 import { connectProvider } from 'src/actions/suite/metadataProviderActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 import { MetadataProviderType } from 'src/types/suite/metadata';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MoreRoundsNeededModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MoreRoundsNeededModal.tsx
@@ -2,7 +2,7 @@ import { Column, H3, Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { onCancel as closeModal } from 'src/actions/suite/modalActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 
 export const MoreRoundsNeededModal = () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx
@@ -11,8 +11,8 @@ import {
     TREZOR_SUPPORT_RECOVERY_ISSUES_URL,
 } from '@trezor/urls';
 
-import { Translation } from 'src/components/suite';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 
 import { MultiShareBackupStep1 } from './MultiShareBackupStep1';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep1.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep1.tsx
@@ -3,7 +3,7 @@ import { Dispatch, SetStateAction } from 'react';
 import { Card, Checkbox, Column, H4, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 type MultiShareBackupStep1Props = {
     isChecked1: boolean;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep5.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep5.tsx
@@ -12,7 +12,7 @@ import {
 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 type CalloutProps = {
     title: TranslationKey;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseDuplicateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseDuplicateModal.tsx
@@ -8,7 +8,7 @@ import { DiscoveryStatus } from '@suite-common/wallet-types';
 import { Button, Column, H3, Text, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 import { TrezorDevice } from 'src/types/suite';
 import { CardWithDevice } from 'src/views/suite/SwitchDevice/CardWithDevice';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PinMismatchModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PinMismatchModal.tsx
@@ -1,7 +1,7 @@
 import { H3, Modal } from '@trezor/components';
 
 import { changePin } from 'src/actions/settings/deviceSettingsActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 
 export const PinMismatchModal = () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/QrScannerModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/QrScannerModal.tsx
@@ -8,8 +8,8 @@ import { Card, Column, Icon, Modal, ModalProps, Paragraph, Row } from '@trezor/c
 import { borders, spacings } from '@trezor/theme';
 import { HELP_CENTER_QR_CODE_URL } from '@trezor/urls';
 
-import { Translation } from 'src/components/suite';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
+import { Translation } from 'src/components/suite/Translation';
 
 const ContentWrapper = styled.div`
     height: 380px;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RequestEnableTorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RequestEnableTorModal.tsx
@@ -5,7 +5,7 @@ import { UserContextPayload } from '@suite-common/suite-types';
 import { Banner, Modal } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SafetyChecksModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SafetyChecksModal.tsx
@@ -13,7 +13,7 @@ import {
 import { spacings } from '@trezor/theme';
 
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 
 /**

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SolanaStakingLimitBanner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SolanaStakingLimitBanner.tsx
@@ -15,7 +15,7 @@ import { StakeState } from '@trezor/blockchain-link-types/src/solana';
 import { Banner } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 interface SolanaStakingLimitBannerProps {
     account: Account;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeInANutshellModal/StakeInANutshellModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeInANutshellModal/StakeInANutshellModal.tsx
@@ -21,9 +21,9 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
-import { Translation } from 'src/components/suite';
 import { StakingInfo } from 'src/components/suite/StakingProcess/StakingInfo';
 import { UnstakingInfo } from 'src/components/suite/StakingProcess/UnstakingInfo';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/ConfirmStakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/ConfirmStakeModal.tsx
@@ -10,7 +10,7 @@ import { spacings } from '@trezor/theme';
 import { HELP_CENTER_ETH_STAKING, HELP_CENTER_SOL_STAKING } from '@trezor/urls';
 
 import { openModal } from 'src/actions/suite/modalActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeButton.tsx
@@ -3,7 +3,7 @@ import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Modal, Tooltip } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import { useStakeFormContext } from 'src/hooks/wallet/useStakeForm';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
@@ -4,7 +4,7 @@ import { Grid, Modal } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useLayoutSize, useSelector } from 'src/hooks/suite';
 import { StakeFormContext, useStakeForm } from 'src/hooks/wallet/useStakeForm';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TradingTermsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TradingTermsModal.tsx
@@ -19,7 +19,7 @@ import { spacings } from '@trezor/theme';
 import type { Deferred } from '@trezor/utils';
 
 import { setDismissedTradingTerms } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 
 const getTradingType = (modalType: TradingTermsModalProps['type']): TradingType => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/AffectedTransactions.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/AffectedTransactions.tsx
@@ -2,7 +2,7 @@ import { ChainedTransactions } from '@suite-common/wallet-types';
 import { Banner, Card, Column, Link, Row, Table, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { AffectedTransactionItem } from './AffectedTransactionItem';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionButton.tsx
@@ -2,7 +2,7 @@ import { DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
 import { Account, FormState } from '@suite-common/wallet-types';
 import { Modal } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 
 import { signAndPushSendFormTransactionThunk } from '../../../../../../../actions/wallet/send/sendFormThunks';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
@@ -1,7 +1,7 @@
 import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import { Modal } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useSelector } from 'src/hooks/suite';
 import { useRbfContext } from 'src/hooks/wallet/useRbfForm';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AdvancedTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AdvancedTxDetails.tsx
@@ -6,7 +6,7 @@ import { isTestnet } from '@suite-common/wallet-utils';
 import { Card, Tabs } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { AmountDetails } from './AmountDetails';
 import { Data } from './Data';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/Data.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/Data.tsx
@@ -5,7 +5,7 @@ import { WalletAccountTransaction } from '@suite-common/wallet-types';
 import { Column, InfoItem, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 const ParagraphWrapper = styled.div`
     white-space: pre-wrap;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/AnalyzeInExplorerBanner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/AnalyzeInExplorerBanner.tsx
@@ -3,7 +3,7 @@ import { getExplorerUrl } from '@suite-common/wallet-config/src/getExplorerUrls'
 import { selectExplorer } from '@suite-common/wallet-core';
 import { Banner, Column, H4, Paragraph } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useExternalLink, useSelector } from 'src/hooks/suite';
 
 type AnalyzeInExplorerBannerProps = {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -2,7 +2,7 @@ import { WalletAccountTransaction } from '@suite-common/wallet-types';
 import { Column, Divider } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite/useSelector';
 
 import { AnalyzeInExplorerBanner } from './AnalyzeInExplorerBanner';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
@@ -11,7 +11,7 @@ import { WalletAccountTransactionWithRequiredRbfParams } from '@suite-common/wal
 import { findChainedTransactions, getAccountKey, isPending } from '@suite-common/wallet-utils';
 import { Modal } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { Account, WalletAccountTransaction } from 'src/types/wallet';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/EverstakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/EverstakeModal.tsx
@@ -6,7 +6,7 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeButton.tsx
@@ -3,7 +3,7 @@ import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Modal, Tooltip } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import { useUnstakeFormContext } from 'src/hooks/wallet/useUnstakeForm';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeForm.tsx
@@ -4,7 +4,7 @@ import { Banner, Column, InfoItem, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useSelector } from 'src/hooks/suite';
 import { useUnstakeFormContext } from 'src/hooks/wallet/useUnstakeForm';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeModal.tsx
@@ -4,8 +4,8 @@ import { CollapsibleBox, Column, Grid, H3, Modal } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
 import { UnstakingInfo } from 'src/components/suite/StakingProcess/UnstakingInfo';
+import { Translation } from 'src/components/suite/Translation';
 import { useLayoutSize, useSelector } from 'src/hooks/suite';
 import { UnstakeFormContext, useUnstakeForm } from 'src/hooks/wallet/useUnstakeForm';
 

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
@@ -8,8 +8,8 @@ import { CoinLogo } from '@trezor/product-components';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import { fillSendForm, resetProtocol } from 'src/actions/suite/protocolActions';
-import { Translation } from 'src/components/suite';
 import type { NotificationRendererProps } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { ConditionalActionRenderer } from './ConditionalActionRenderer';

--- a/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationGroup.tsx
+++ b/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationGroup.tsx
@@ -1,7 +1,7 @@
 import { Column, H4, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { AppState } from 'src/types/suite';
 import { getSeenAndUnseenNotifications } from 'src/utils/suite/notification';
 

--- a/packages/suite/src/components/suite/notifications/Notifications/Notifications.tsx
+++ b/packages/suite/src/components/suite/notifications/Notifications/Notifications.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Divider, IconButton, Row, Tabs } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { SETTINGS } from 'src/config/suite';
 import { useSelector } from 'src/hooks/suite';
 

--- a/packages/suite/src/components/wallet/CoinjoinAccountDiscoveryProgress/CoinjoinAccountDiscoveryProgress.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinAccountDiscoveryProgress/CoinjoinAccountDiscoveryProgress.tsx
@@ -14,7 +14,7 @@ import {
 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useCoinjoinAccountLoadingProgress } from 'src/hooks/coinjoin';
 import { useSelector } from 'src/hooks/suite';
 import { selectLanguage } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/components/wallet/Fees/CustomFee/CurrentFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CurrentFee.tsx
@@ -5,7 +5,7 @@ import { Icon, Row, Text } from '@trezor/components';
 import { FeeRate } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 type CurrentFeeProps = {
     networkType: NetworkType;

--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeEthereum.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeEthereum.tsx
@@ -8,7 +8,7 @@ import { Text } from '@trezor/components';
 import { NumberInput } from '@trezor/product-components';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { InputError } from 'src/components/wallet';
 import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { validateDecimals } from 'src/utils/suite/validation';

--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeTooLowBanner.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeTooLowBanner.tsx
@@ -4,8 +4,8 @@ import { Banner, Collapsible } from '@trezor/components';
 import { HELP_CENTER_TRANSACTION_FEES_URL } from '@trezor/urls';
 import { BigNumber } from '@trezor/utils';
 
-import { Translation } from 'src/components/suite';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
+import { Translation } from 'src/components/suite/Translation';
 
 type CustomFeeTooLowBannerProps = {
     feePerUnitValue: string;

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -28,7 +28,7 @@ import { HELP_CENTER_TRANSACTION_FEES_URL } from '@trezor/urls';
 
 import { MODAL } from 'src/actions/suite/constants';
 import { REFETCH_FEES_EXCLUDED_MODAL_WINDOW_TYPES } from 'src/actions/suite/constants/modalConstants';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
 

--- a/packages/suite/src/components/wallet/Fees/StandardFee/BitcoinFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/StandardFee/BitcoinFeeCards.tsx
@@ -3,8 +3,8 @@ import { selectAreFeesLoading, useDisplayBaseCurrency } from '@suite-common/wall
 import { getFeeUnits } from '@suite-common/wallet-utils';
 import { FeeRate } from '@trezor/product-components';
 
-import { Translation } from 'src/components/suite';
 import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { Translation } from 'src/components/suite/Translation';
 import { useLocales, useSelector } from 'src/hooks/suite';
 
 import { FeeCard } from './FeeCard';

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -9,7 +9,7 @@ import { Row } from '@trezor/components';
 import { AccountTransaction } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { UnstakingTxAmount } from 'src/components/suite/UnstakingTxAmount';
 import { useTranslation } from 'src/hooks/suite';
 import { WalletAccountTransaction } from 'src/types/wallet';

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -12,7 +12,7 @@ import { HELP_CENTER_REPLACE_BY_FEE_ETHEREUM } from '@trezor/urls';
 
 import { openModal } from 'src/actions/suite/modalActions';
 import { OutlineHighlight } from 'src/components/OutlineHighlight';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TransactionTimestamp } from 'src/components/wallet/TransactionTimestamp';
 import { AccountTransactionBaseAnchor } from 'src/constants/suite/anchors';
 import { SUBPAGE_NAV_HEIGHT } from 'src/constants/suite/layout';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountImported.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountImported.tsx
@@ -1,6 +1,6 @@
 import { Banner } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import type { Account } from 'src/types/wallet/index';
 
 type AccountImportedProps = {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountOutOfSync.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountOutOfSync.tsx
@@ -1,6 +1,6 @@
 import { Banner } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import type { Account } from 'src/types/wallet/index';
 
 type AccountOutOfSyncProps = {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/BackendDisconnected.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/BackendDisconnected.tsx
@@ -2,7 +2,7 @@ import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { isTrezorConnectBackendType, tryGetAccountIdentity } from '@suite-common/wallet-utils';
 import { Banner } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useBackendReconnection } from 'src/hooks/settings/backends';
 import { useSelector } from 'src/hooks/suite';
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/CloseableBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/CloseableBanner.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import { Banner, BannerProps, Column, Margin, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme/src';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 interface Props {
     onClose: () => void;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/DeviceUnavailable.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/DeviceUnavailable.tsx
@@ -1,7 +1,7 @@
 import { Banner } from '@trezor/components';
 
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 
 export const DeviceUnavailable = () => {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/EvmExplanationBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/EvmExplanationBanner.tsx
@@ -1,7 +1,7 @@
 import { networks } from '@suite-common/wallet-config';
 
 import { SUITE } from 'src/actions/suite/constants';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { Account } from 'src/types/wallet';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ReserveBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ReserveBanner.tsx
@@ -4,7 +4,7 @@ import { Banner } from '@trezor/components';
 import { HELP_CENTER_XLM_URL, HELP_CENTER_XRP_URL } from '@trezor/urls';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import type { Account } from 'src/types/wallet/index';
 
 interface ReserveBannerProps {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/SolanaLimitedHistoryBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/SolanaLimitedHistoryBanner.tsx
@@ -1,5 +1,5 @@
 import { setFlag } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -29,7 +29,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { setFlag } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StellarLimitedHistoryBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StellarLimitedHistoryBanner.tsx
@@ -1,5 +1,5 @@
 import { setFlag } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TaprootBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TaprootBanner.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { getBip43Type } from '@suite-common/wallet-utils';
 
 import { setFlag } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TorDisconnected.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TorDisconnected.tsx
@@ -1,7 +1,7 @@
 import { Banner } from '@trezor/components';
 
 import { toggleTor } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectModalType } from 'src/reducers/suite/modalReducer';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotEnabled.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotEnabled.tsx
@@ -1,7 +1,7 @@
 import { Network } from '@suite-common/wallet-config';
 import { changeCoinVisibility } from '@suite-common/wallet-core';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { AccountExceptionLayout } from 'src/components/wallet';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotExists.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotExists.tsx
@@ -1,4 +1,4 @@
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { AccountExceptionLayout } from 'src/components/wallet';
 
 /**

--- a/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotLoaded.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotLoaded.tsx
@@ -1,6 +1,6 @@
 import { startOrRestartDiscoveryThunk } from '@suite-common/wallet-core';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { AccountExceptionLayout } from 'src/components/wallet';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountException/DiscoveryEmpty.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountException/DiscoveryEmpty.tsx
@@ -1,5 +1,5 @@
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { AccountExceptionLayout } from 'src/components/wallet';
 import { useDispatch } from 'src/hooks/suite';
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountException/DiscoveryFailed.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountException/DiscoveryFailed.tsx
@@ -1,6 +1,6 @@
 import { startOrRestartDiscoveryThunk } from '@suite-common/wallet-core';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { AccountExceptionLayout } from 'src/components/wallet';
 import { useDiscovery, useDispatch } from 'src/hooks/suite';
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Box, Column, Icon, Row, Text, useElevation } from '@trezor/components';
 import { Elevation, mapElevationToBackground, spacings, spacingsPx } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { Account } from 'src/types/wallet';
 
 import { AnimationWrapper } from '../../AnimationWrapper';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -7,7 +7,7 @@ import { Column } from '@trezor/components';
 import type { StaticSessionId } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useAccountSearch, useDefaultAccountLabel, useSelector } from 'src/hooks/suite';
 import { selectAccountLabels as selectAccountLabelsOld } from 'src/reducers/suite/metadataReducer';
 import { AccountItemType } from 'src/types/wallet';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { useScrollShadow } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { ReduxAccountSearchProvider } from 'src/hooks/suite/useAccountSearch';
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonProps, TOOLTIP_DELAY_NORMAL, TextButton, Tooltip } from '
 import { spacings } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDiscovery, useDispatch } from 'src/hooks/suite';
 import { TrezorDevice } from 'src/types/suite';
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/MobileAccountsMenu.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/MobileAccountsMenu.tsx
@@ -6,7 +6,7 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { H2, Icon, variables } from '@trezor/components';
 import { spacingsPx, zIndices } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDiscovery, useSelector } from 'src/hooks/suite';
 
 import { AccountSearchBox } from './AccountSearchBox';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
@@ -11,7 +11,7 @@ import {
 import { Button, IconButton, Row, Tooltip, motionEasing } from '@trezor/components';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { AccountsMenuNotice } from './AccountsMenuNotice';

--- a/packages/suite/src/hooks/suite/useReceiveDisabled.tsx
+++ b/packages/suite/src/hooks/suite/useReceiveDisabled.tsx
@@ -3,7 +3,7 @@ import { FC, PropsWithChildren, ReactNode } from 'react';
 import { selectIsDeviceBackupUnfinished } from '@suite-common/wallet-core';
 import { Tooltip } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 
 import { useSelector } from './useSelector';

--- a/packages/suite/src/views/backup/BackupStep1Initial.tsx
+++ b/packages/suite/src/views/backup/BackupStep1Initial.tsx
@@ -4,7 +4,7 @@ import { spacings } from '@trezor/theme';
 
 import { ConfirmKey, backupDevice } from 'src/actions/backup/backupActions';
 import { PreBackupCheckboxes } from 'src/components/backup';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsDeviceLocked } from 'src/selectors/suite/suiteSelectors';
 

--- a/packages/suite/src/views/backup/BackupStep3Finished.tsx
+++ b/packages/suite/src/views/backup/BackupStep3Finished.tsx
@@ -1,7 +1,7 @@
 import { Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { canContinue } from 'src/utils/backup';
 
 import { BackupStepDescription } from './BackupStepDescription';

--- a/packages/suite/src/views/backup/BackupStepError.tsx
+++ b/packages/suite/src/views/backup/BackupStepError.tsx
@@ -1,6 +1,6 @@
 import { Modal, Paragraph } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { BackupState } from '../../reducers/backup/backupReducer';
 

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTable.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTable.tsx
@@ -4,7 +4,7 @@ import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { Table } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { AssetData } from '../AssetsView';
 import { AssetRow } from './AssetRow';

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -36,7 +36,7 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { goto } from 'src/actions/suite/routerActions';
 import { setFlag } from 'src/actions/suite/suiteActions';
 import { DashboardSection } from 'src/components/dashboard';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDiscovery, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';

--- a/packages/suite/src/views/dashboard/DashboardPassphraseBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPassphraseBanner.tsx
@@ -10,7 +10,7 @@ import { spacingsPx } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { setFlag } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
@@ -4,7 +4,7 @@ import { CoinLogo } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -8,8 +8,7 @@ import { spacings } from '@trezor/theme';
 
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
-import { TranslationKey } from 'src/components/suite/Translation';
+import { Translation, TranslationKey } from 'src/components/suite/Translation';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 import { DiscoveryStatusType } from 'src/types/wallet';
 

--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboard.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboard.tsx
@@ -17,7 +17,7 @@ import { BigNumber, arrayPartition } from '@trezor/utils';
 
 import { setStakingDashboardCollapsed } from 'src/actions/suite/suiteActions';
 import { DashboardSection } from 'src/components/dashboard';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 

--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardAccountRow.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardAccountRow.tsx
@@ -14,7 +14,7 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { BigNumber } from '@trezor/utils';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { StakingDashboardAccountCell } from './StakingDashboardAccountCell';

--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardActivateRow.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardActivateRow.tsx
@@ -4,7 +4,7 @@ import { getStakingLimitsByNetworkSymbol } from '@suite-common/wallet-utils';
 import { Button, Paragraph, Table } from '@trezor/components';
 
 import { openModal } from 'src/actions/suite/modalActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 
 import { StakingDashboardAccountCell } from './StakingDashboardAccountCell';

--- a/packages/suite/src/views/firmware/FirmwareCustom.tsx
+++ b/packages/suite/src/views/firmware/FirmwareCustom.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useFirmwareInstallation } from '@suite-common/firmware';
 
 import { SelectCustomFirmware } from 'src/components/firmware';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { FirmwareModal } from './FirmwareModal';
 

--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -12,7 +12,7 @@ import { ConfirmOnDevice } from '@trezor/product-components';
 import { exhaustive } from '@trezor/type-utils';
 
 import { closeModalApp } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useFirmwareInstallationProgressCheck, useSelector } from 'src/hooks/suite';
 import messages from 'src/support/messages';
 

--- a/packages/suite/src/views/firmware/FirmwareUpdate.tsx
+++ b/packages/suite/src/views/firmware/FirmwareUpdate.tsx
@@ -2,7 +2,7 @@ import { useFirmwareInstallation } from '@suite-common/firmware';
 import { FirmwareType } from '@trezor/connect';
 
 import { FirmwareInitialStandalone } from 'src/components/firmware';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { FirmwareModal } from './FirmwareModal';
 

--- a/packages/suite/src/views/onboarding/UnexpectedState/DeviceDifferent.tsx
+++ b/packages/suite/src/views/onboarding/UnexpectedState/DeviceDifferent.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@trezor/components';
 
 import { OnboardingStepBox } from 'src/components/onboarding';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useOnboarding } from 'src/hooks/suite';
 
 export const DeviceDifferent = () => {

--- a/packages/suite/src/views/onboarding/steps/Backup.tsx
+++ b/packages/suite/src/views/onboarding/steps/Backup.tsx
@@ -17,7 +17,7 @@ import {
     OptionsWrapper,
     SkipStepConfirmation,
 } from 'src/components/onboarding';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectBackup, selectBackupStatus } from 'src/reducers/backup/backupReducer';

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/AdvancedSetup.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/AdvancedSetup.tsx
@@ -6,7 +6,7 @@ import { Icon } from '@trezor/components';
 import { isDesktop, isWeb } from '@trezor/env-utils';
 
 import { CollapsibleOnboardingCard } from 'src/components/onboarding/CollapsibleOnboardingCard';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { getIsTorEnabled } from 'src/utils/suite/tor';
 

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/TorSection.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/TorSection.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Switch, variables } from '@trezor/components';
 
 import { toggleTor } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectModalType } from 'src/reducers/suite/modalReducer';
 import { TorStatus } from 'src/types/suite';

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/index.tsx
@@ -1,7 +1,7 @@
 import { selectEnabledNetworks } from '@suite-common/wallet-core';
 
 import { OnboardingButtonCta } from 'src/components/onboarding';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useOnboarding, useSelector } from 'src/hooks/suite';
 import { getIsTorLoading } from 'src/utils/suite/tor';
 

--- a/packages/suite/src/views/onboarding/steps/CreateOrRecover.tsx
+++ b/packages/suite/src/views/onboarding/steps/CreateOrRecover.tsx
@@ -4,7 +4,7 @@ import {
     OptionsDivider,
     OptionsWrapper,
 } from 'src/components/onboarding';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import * as STEP from 'src/constants/onboarding/steps';
 import { useOnboarding } from 'src/hooks/suite';
 

--- a/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
@@ -7,7 +7,7 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 import { goToNextStep, updateAnalytics } from 'src/actions/onboarding/onboardingActions';
 import { OnboardingButtonCta } from 'src/components/onboarding';
 import { SelectRecoveryType, SelectRecoveryWord, SelectWordCount } from 'src/components/recovery';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useRecovery, useSelector } from 'src/hooks/suite';
 import { selectIsActionAbortable } from 'src/selectors/suite/suiteSelectors';
 import { pickByDeviceModel } from 'src/utils/device/modelUtils';

--- a/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
+++ b/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
@@ -9,7 +9,7 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { resetDevice } from 'src/actions/settings/deviceSettingsActions';
 import { OnboardingButtonBack, OnboardingStepBox, OptionsWrapper } from 'src/components/onboarding';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import * as STEP from 'src/constants/onboarding/steps';
 import { useDevice, useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
 import { selectIsActionAbortable } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/views/onboarding/steps/Security.tsx
+++ b/packages/suite/src/views/onboarding/steps/Security.tsx
@@ -6,7 +6,7 @@ import {
     OnboardingStepBox,
     SkipStepConfirmation,
 } from 'src/components/onboarding';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useOnboarding } from 'src/hooks/suite';
 
 const SecurityStep = () => {

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/DefaultTag.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/DefaultTag.tsx
@@ -1,7 +1,7 @@
 import { Badge, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useLayoutSize } from 'src/hooks/suite';
 
 export const DefaultTag = () => {

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/LegacyOptions.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/LegacyOptions.tsx
@@ -1,7 +1,7 @@
 import { BackupType } from '@suite-common/suite-types';
 import { Tooltip } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { DefaultTag } from './DefaultTag';
 import { OptionWithContent } from './OptionWithContent';

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx
@@ -12,7 +12,7 @@ import {
     spacingsPx,
 } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useLayoutSize } from 'src/hooks/suite';
 
 import { typesToLabelMap } from './typesToLabelMap';

--- a/packages/suite/src/views/onboarding/steps/ThpPairingFailedStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/ThpPairingFailedStep.tsx
@@ -4,7 +4,7 @@ import { Button, Column, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { OnboardingStepBox } from 'src/components/onboarding';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { startThpSessionThunk } from '../../../actions/thp/startThpSessionThunk';
 import { ThpPairingFailedForFirmwareInstallation } from '../../../components/connection/thp/ThpPairingFailedForFirmwareInstallation';

--- a/packages/suite/src/views/onboarding/steps/ThpPairingStartStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/ThpPairingStartStep.tsx
@@ -1,5 +1,5 @@
 import { OnboardingStepBox } from 'src/components/onboarding';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { ThpPairingStart } from '../../../components/connection/thp/ThpPairingStart';
 

--- a/packages/suite/src/views/onboarding/steps/ThpPairingStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/ThpPairingStep.tsx
@@ -6,7 +6,7 @@ import TrezorConnect from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
 import { OnboardingStepBox } from 'src/components/onboarding';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { ThpPairingCodeEntry } from '../../../components/connection/thp/ThpPairingCodeEntry';
 import messages from '../../../support/messages';

--- a/packages/suite/src/views/password-manager/PasswordManager/PasswordEntry.tsx
+++ b/packages/suite/src/views/password-manager/PasswordManager/PasswordEntry.tsx
@@ -7,7 +7,7 @@ import TrezorConnect, { DeviceUniquePath } from '@trezor/connect';
 import { spacings, spacingsPx } from '@trezor/theme';
 
 import { PATH } from 'src/actions/suite/constants/metadataPasswordsConstants';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { usePasswords } from 'src/hooks/suite';
 import type { PasswordEntry as PasswordEntryType } from 'src/types/suite/metadata';
 import * as metadataUtils from 'src/utils/suite/metadata';

--- a/packages/suite/src/views/recovery/steps/EnterOnDeviceStep.tsx
+++ b/packages/suite/src/views/recovery/steps/EnterOnDeviceStep.tsx
@@ -3,7 +3,7 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 import { mapTrezorModelToIcon } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 export const EnterOnDeviceStep = ({
     deviceModelInternal,

--- a/packages/suite/src/views/recovery/steps/RequestConfirmationStep.tsx
+++ b/packages/suite/src/views/recovery/steps/RequestConfirmationStep.tsx
@@ -1,6 +1,6 @@
 import { Paragraph } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 export const RequestConfirmationStep = () => (
     <Paragraph>

--- a/packages/suite/src/views/recovery/steps/SelectRecoveryTypeStep.tsx
+++ b/packages/suite/src/views/recovery/steps/SelectRecoveryTypeStep.tsx
@@ -1,7 +1,7 @@
 import { Card, Column, Grid, H4, Icon, Paragraph, RadioCard, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { RecoveryType, recoveryTypes } from 'src/types/recovery';
 
 type SelectRecoveryTypeStepProps = {

--- a/packages/suite/src/views/recovery/steps/SelectWordCountStep.tsx
+++ b/packages/suite/src/views/recovery/steps/SelectWordCountStep.tsx
@@ -1,7 +1,7 @@
 import { Card, Column, Grid, H4, Paragraph, RadioCard } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { WordCount, wordCounts } from 'src/types/recovery';
 
 type SelectWordCountStepProps = {

--- a/packages/suite/src/views/settings/SettingsCoins/FirmwareTypeSuggestion.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/FirmwareTypeSuggestion.tsx
@@ -6,7 +6,7 @@ import { typography } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { setFlag } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 

--- a/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
@@ -4,9 +4,9 @@ import { connectPopupActions, selectConnectAppPermissions } from '@suite-common/
 import { Card, Column, Dropdown, H3, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
 import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';
 import { ConnectProcessLabel } from 'src/components/suite/ConnectProcessLabel';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 const PermissionsList = styled.ul`

--- a/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
@@ -5,7 +5,7 @@ import { isDesktop } from '@trezor/env-utils';
 import { spacings } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 
 import { ConnectPermissions } from './ConnectPermissions';

--- a/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectButton.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectButton.tsx
@@ -4,7 +4,7 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { walletConnectPairThunk } from '@suite-common/walletconnect';
 import { Button, Input, Modal } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useTranslation } from 'src/hooks/suite';
 
 interface WalletConnectButtonProps {

--- a/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectList.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectList.tsx
@@ -7,8 +7,8 @@ import { Badge, Card, Column, Dropdown, H3, Row, Text } from '@trezor/components
 import { spacings } from '@trezor/theme';
 
 import * as modalActions from 'src/actions/suite/modalActions';
-import { Translation } from 'src/components/suite';
 import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const WalletConnectList = () => {

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -3,7 +3,7 @@ import { isDesktop } from '@trezor/env-utils';
 
 import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { SettingsSection } from 'src/components/settings/SettingsSection';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useSelector } from 'src/hooks/suite';
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen/ChangeHomescreenButtons.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen/ChangeHomescreenButtons.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonGroup, Tooltip } from '@trezor/components';
 import { DeviceModelInternal, hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 
 import { openModal } from 'src/actions/suite/modalActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 
 import { getHomescreens } from '../../../../constants/suite/homescreens';

--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -7,7 +7,7 @@ import { isBitcoinOnlyDevice } from '@trezor/device-utils';
 import { DeviceBanner } from 'src/components/settings/DeviceBanner';
 import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { SettingsSection } from 'src/components/settings/SettingsSection';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useDevice, useSelector } from 'src/hooks/suite';
 import { selectHasActiveTransport, selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
@@ -10,7 +10,7 @@ import { spacings, spacingsPx } from '@trezor/theme';
 import { SUITE_URL } from '@trezor/urls';
 
 import { setFlag } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 
 import { useExternalLink } from '../../../hooks/suite';

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -8,7 +8,7 @@ import { isDesktop, isLinux, isWeb } from '@trezor/env-utils';
 
 import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { SettingsSection } from 'src/components/settings/SettingsSection';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useLayoutSize, useSelector } from 'src/hooks/suite';
 import { selectSelectedProviderForLabels } from 'src/reducers/suite/metadataReducer';

--- a/packages/suite/src/views/settings/SettingsLoader.tsx
+++ b/packages/suite/src/views/settings/SettingsLoader.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { H3, Spinner, motionEasing } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 const Container = styled(motion.div)`
     background-color: ${({ theme }) => theme.backgroundTertiaryDefaultOnElevation0};

--- a/packages/suite/src/views/suite/ErrorPage.tsx
+++ b/packages/suite/src/views/suite/ErrorPage.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { Button, H2, Image, Link, Paragraph } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 const Wrapper = styled.div`
     display: flex;

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -19,7 +19,7 @@ import { CardButton } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
 import { closeModalApp, goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { selectIsDeviceOrUiLocked } from 'src/selectors/suite/suiteSelectors';
 import { AcquiredDevice, ForegroundAppProps, TrezorDevice } from 'src/types/suite';

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -23,7 +23,7 @@ import {
     setFlag,
     setRecentlyDisconnectedDevice,
 } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import type { AcquiredDevice, ForegroundAppProps, TrezorDevice } from 'src/types/suite';

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
@@ -5,7 +5,7 @@ import { TrezorDevice } from '@suite-common/suite-types';
 import * as deviceUtils from '@suite-common/suite-utils';
 import { TOOLTIP_DELAY_LONG, TruncateWithTooltip } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useWalletLabeling } from 'src/components/suite/labeling/WalletLabeling';
 import { useSelector } from 'src/hooks/suite';
 import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectAllConfirmation.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectAllConfirmation.tsx
@@ -4,7 +4,7 @@ import { Button, Card, Column, H3, Paragraph, Row } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 
 type EjectAllConfirmationProps = {

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectConfirmation.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectConfirmation.tsx
@@ -6,7 +6,7 @@ import { Box, Button, H4, Paragraph, Row } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 
 type EjectConfirmationProps = {

--- a/packages/suite/src/views/suite/udev/index.tsx
+++ b/packages/suite/src/views/suite/udev/index.tsx
@@ -4,7 +4,7 @@ import { Column, Modal, Paragraph, Select, Spinner } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { DATA_URL, HELP_CENTER_UDEV_URL } from '@trezor/urls';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useExternalLink, useSelector } from 'src/hooks/suite';
 import { selectUdevInstaller } from 'src/selectors/suite/suiteSelectors';
 import type { ForegroundAppProps } from 'src/types/suite';

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
@@ -7,8 +7,8 @@ import { Button, Card, H3, Note, Paragraph, Tooltip, variables } from '@trezor/c
 import { spacingsPx } from '@trezor/theme';
 
 import { startCoinjoinSession } from 'src/actions/wallet/coinjoinAccountActions';
-import { Translation } from 'src/components/suite';
 import { Error } from 'src/components/suite/Error';
+import { Translation } from 'src/components/suite/Translation';
 import { useCoinjoinSessionBlockers } from 'src/hooks/coinjoin/useCoinjoinSessionBlockers';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import {

--- a/packages/suite/src/views/wallet/details/CoinjoinSetup/AnonymityLevelSetup.tsx
+++ b/packages/suite/src/views/wallet/details/CoinjoinSetup/AnonymityLevelSetup.tsx
@@ -6,7 +6,7 @@ import styled, { useTheme } from 'styled-components';
 import { Banner, Icon, motionEasing } from '@trezor/components';
 
 import { coinjoinAccountUpdateAnonymity } from 'src/actions/wallet/coinjoinAccountActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { AnonymityStatus } from 'src/constants/suite/coinjoin';
 import { useAnonymityStatus, useDispatch } from 'src/hooks/suite';
 

--- a/packages/suite/src/views/wallet/details/CoinjoinSetup/CoinjoinSetup.tsx
+++ b/packages/suite/src/views/wallet/details/CoinjoinSetup/CoinjoinSetup.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { Banner, Card, Radio, motionAnimation, motionEasing } from '@trezor/components';
 
 import { coinjoinAccountUpdateSetupOption } from 'src/actions/wallet/coinjoinAccountActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectCoinjoinAccountByKey } from 'src/reducers/wallet/coinjoinReducer';
 

--- a/packages/suite/src/views/wallet/details/CoinjoinSetup/MaxMiningFeeSetup.tsx
+++ b/packages/suite/src/views/wallet/details/CoinjoinSetup/MaxMiningFeeSetup.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from 'styled-components';
 
 import { coinjoinAccountUpdateMaxMiningFee } from 'src/actions/wallet/coinjoinAccountActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import {
     selectDefaultMaxMiningFeeByAccountKey,

--- a/packages/suite/src/views/wallet/details/CoinjoinSetup/SkipRoundsSetup.tsx
+++ b/packages/suite/src/views/wallet/details/CoinjoinSetup/SkipRoundsSetup.tsx
@@ -6,7 +6,7 @@ import { H3, Paragraph, Switch, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { coinjoinAccountToggleSkipRounds } from 'src/actions/wallet/coinjoinAccountActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectCurrentCoinjoinSession } from 'src/reducers/wallet/coinjoinReducer';
 

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -8,10 +8,9 @@ import { spacings } from '@trezor/theme';
 import { HELP_CENTER_BIP32_URL, HELP_CENTER_XPUB_URL, Url } from '@trezor/urls';
 
 import { showXpub } from 'src/actions/wallet/publicKeyActions';
-import { Translation } from 'src/components/suite';
 import { AccountTypeBadge } from 'src/components/suite/AccountTypeBadge';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
-import { TranslationKey } from 'src/components/suite/Translation';
+import { Translation, TranslationKey } from 'src/components/suite/Translation';
 import { AccountTypeDescription } from 'src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription';
 import { WalletLayout } from 'src/components/wallet';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';

--- a/packages/suite/src/views/wallet/nfts/NftsTablesSection.tsx
+++ b/packages/suite/src/views/wallet/nfts/NftsTablesSection.tsx
@@ -3,7 +3,7 @@ import { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Banner, Column, H3 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { getTokens } from 'src/utils/wallet/tokenUtils';
 

--- a/packages/suite/src/views/wallet/receive/components/CoinjoinReceiveWarning.tsx
+++ b/packages/suite/src/views/wallet/receive/components/CoinjoinReceiveWarning.tsx
@@ -1,7 +1,7 @@
 import { Banner, Column, H4 } from '@trezor/components';
 
 import { hideCoinjoinReceiveWarning } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 

--- a/packages/suite/src/views/wallet/receive/components/ConnectDevicePromo.tsx
+++ b/packages/suite/src/views/wallet/receive/components/ConnectDevicePromo.tsx
@@ -5,7 +5,7 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Banner, H4, Paragraph } from '@trezor/components';
 import { mapTrezorModelToIcon } from '@trezor/product-components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { useSelector } from '../../../../hooks/suite';
 

--- a/packages/suite/src/views/wallet/receive/components/Header.tsx
+++ b/packages/suite/src/views/wallet/receive/components/Header.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { H2, Paragraph } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { Account } from 'src/types/wallet';
 
 const Content = styled.div`

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/BitcoinOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/BitcoinOptions.tsx
@@ -6,7 +6,7 @@ import { Button, Tooltip, variables } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
 import { OpenGuideFromTooltip } from 'src/components/guide';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSendFormContext } from 'src/hooks/wallet';
 
 import { OnOffSwitcher } from '../OnOffSwitcher';

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSortingSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSortingSelect.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import { UtxoSorting } from '@suite-common/wallet-types';
 import { Option, Select } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSendFormContext } from 'src/hooks/wallet';
 
 const sortingOptions: { value: UtxoSorting; label: ReactNode }[] = [

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/LocktimeBlockHeight.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/LocktimeBlockHeight.tsx
@@ -7,7 +7,7 @@ import { Row, Text } from '@trezor/components';
 import { NumberInput } from '@trezor/product-components';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 import { selectLanguage } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/LocktimeDatetime.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/LocktimeDatetime.tsx
@@ -7,7 +7,7 @@ import { BTC_LOCKTIME_VALUE } from '@suite-common/wallet-constants';
 import { getInputState } from '@suite-common/wallet-utils';
 import { Input, Row, Text } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useTranslation } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 

--- a/packages/suite/src/views/wallet/send/Options/CardanoOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/CardanoOptions.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Button, variables } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSendFormContext } from 'src/hooks/wallet';
 
 const Wrapper = styled.div`

--- a/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumData.tsx
+++ b/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumData.tsx
@@ -7,7 +7,7 @@ import { getInputState, isHexValid } from '@suite-common/wallet-utils';
 import { Icon, Textarea } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useTranslation } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 

--- a/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumOptions.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { FormOptions } from '@suite-common/wallet-types';
 import { Button, Tooltip } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSendFormContext } from 'src/hooks/wallet';
 
 import { EthereumData } from './EthereumData';

--- a/packages/suite/src/views/wallet/send/Options/MiscNetworkOptions/DestinationTag.tsx
+++ b/packages/suite/src/views/wallet/send/Options/MiscNetworkOptions/DestinationTag.tsx
@@ -6,7 +6,7 @@ import { Banner, Button, Column, Input, Note, Row, Switch } from '@trezor/compon
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useGuideOpenNode } from 'src/hooks/guide';
 import { useTranslation } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';

--- a/packages/suite/src/views/wallet/send/Options/MiscNetworkOptions/MiscNetworkOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/MiscNetworkOptions/MiscNetworkOptions.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { Button, Tooltip } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSendFormContext } from 'src/hooks/wallet';
 
 import { OnOffSwitcher } from '../OnOffSwitcher';

--- a/packages/suite/src/views/wallet/send/Options/OnOffSwitcher.tsx
+++ b/packages/suite/src/views/wallet/send/Options/OnOffSwitcher.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 const Wrapper = styled.div`
     display: flex;

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/SendMaxSwitch.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/SendMaxSwitch.tsx
@@ -1,6 +1,6 @@
 import { Switch } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 type SendMaxSwitchProps = {
     isSendMaxActive: boolean;

--- a/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
@@ -8,7 +8,7 @@ import { IconButton, Row, Textarea, Tooltip, variables } from '@trezor/component
 import { spacingsPx } from '@trezor/theme';
 
 import { OpenGuideFromTooltip } from 'src/components/guide';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useTranslation } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 

--- a/packages/suite/src/views/wallet/send/SendHeader.tsx
+++ b/packages/suite/src/views/wallet/send/SendHeader.tsx
@@ -6,7 +6,7 @@ import { sendFormActions } from '@suite-common/wallet-core';
 import { Button, Dropdown, DropdownMenuItemProps, Switch, Text } from '@trezor/components';
 import { FADE_IN } from '@trezor/components/src/config/animations';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { WalletSubpageHeading } from 'src/components/wallet';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';

--- a/packages/suite/src/views/wallet/send/SendRaw.tsx
+++ b/packages/suite/src/views/wallet/send/SendRaw.tsx
@@ -7,7 +7,7 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { OpenGuideFromTooltip } from 'src/components/guide';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useTranslation } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
 

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -6,7 +6,7 @@ import { Banner, Column } from '@trezor/components';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { spacings, spacingsPx } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { ConfirmEvmExplanationModal } from 'src/components/suite/modals';
 import { WalletLayout } from 'src/components/wallet';
 import { useSelector } from 'src/hooks/suite';

--- a/packages/suite/src/views/wallet/sign-verify/index.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/index.tsx
@@ -19,8 +19,7 @@ import { copyToClipboard } from '@trezor/dom-utils';
 import { spacings } from '@trezor/theme';
 
 import { isVerifySupported, sign, verify } from 'src/actions/wallet/signVerifyActions';
-import { Translation } from 'src/components/suite';
-import { TranslationKey } from 'src/components/suite/Translation';
+import { Translation, TranslationKey } from 'src/components/suite/Translation';
 import { WalletLayout, WalletSubpageHeading } from 'src/components/wallet';
 import { useDevice, useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { useCopySignedMessage } from 'src/hooks/wallet/sign-verify/useCopySignedMessage';

--- a/packages/suite/src/views/wallet/staking/WalletStaking.tsx
+++ b/packages/suite/src/views/wallet/staking/WalletStaking.tsx
@@ -1,6 +1,6 @@
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { AccountExceptionLayout, WalletLayout } from 'src/components/wallet';
 import { useSelector } from 'src/hooks/suite';
 import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EthStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EthStakingDashboard.tsx
@@ -18,7 +18,7 @@ import { Column, Flex, Grid } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { DashboardSection } from 'src/components/dashboard';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/InstantStakeBanner.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/InstantStakeBanner.tsx
@@ -8,7 +8,7 @@ import { Banner, Column, H3, Paragraph } from '@trezor/components';
 import { InternalTransfer } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
@@ -12,7 +12,7 @@ import { Column, Flex, Grid } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { DashboardSection } from 'src/components/dashboard';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/components/Rewards/RewardsEmpty.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/components/Rewards/RewardsEmpty.tsx
@@ -1,6 +1,6 @@
 import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { AccountExceptionLayout } from 'src/components/wallet';
 
 export const RewardsEmpty = () => (

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ApyCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ApyCard.tsx
@@ -1,7 +1,7 @@
 import { Card, Column, Icon, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 interface ApyCardProps {
     apy: number;

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/DiscoveryWarning.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/DiscoveryWarning.tsx
@@ -1,6 +1,6 @@
 import { Banner, H4, Paragraph } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 export const DiscoveryWarning = () => (
     <Banner

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
@@ -26,7 +26,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { openModal } from 'src/actions/suite/modalActions';
 import { DashboardSection } from 'src/components/dashboard';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useDevice, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EverstakeFooter.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EverstakeFooter.tsx
@@ -6,8 +6,8 @@ import { Icon } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 import { HELP_CENTER_ETH_STAKING, HELP_CENTER_SOL_STAKING } from '@trezor/urls';
 
-import { Translation } from 'src/components/suite';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/PayoutCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/PayoutCard.tsx
@@ -6,7 +6,7 @@ import { Card, Column, Icon, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/hooks/useProgressLabelsData.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/hooks/useProgressLabelsData.tsx
@@ -4,7 +4,7 @@ import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
 import { Account } from '@suite-common/wallet-types';
 import { Column, Paragraph } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { ProgressLabelData } from '../components/ProgressLabels/types';
 

--- a/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
+++ b/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
@@ -9,7 +9,7 @@ import { spacings } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { selectRouteName } from 'src/reducers/suite/routerReducer';
 import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/views/wallet/tokens/coins/CoinsTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/coins/CoinsTable.tsx
@@ -3,7 +3,7 @@ import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet
 import { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { isTestnet } from '@suite-common/wallet-utils';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import {
     enhanceTokensWithRates,

--- a/packages/suite/src/views/wallet/tokens/common/BlurUrls.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/BlurUrls.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Tooltip } from '@trezor/components';
 import { extractUrlsFromText } from '@trezor/utils';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { BlurWrapper } from 'src/components/wallet/TransactionItem/TransactionItemBlurWrapper';
 
 // eslint-disable-next-line local-rules/no-override-ds-component

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
@@ -7,7 +7,7 @@ import { Account } from '@suite-common/wallet-types';
 import { Card, Paragraph, Table } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 
 import { TokenRow } from './TokenRow';

--- a/packages/suite/src/views/wallet/tokens/hidden-tokens/HiddenTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/hidden-tokens/HiddenTokensTable.tsx
@@ -4,7 +4,7 @@ import { isTestnet } from '@suite-common/wallet-utils';
 import { Banner, Column, H3 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { getTokens } from 'src/utils/wallet/tokenUtils';
 

--- a/packages/suite/src/views/wallet/trading/common/ConfirmedOnTrezor.tsx
+++ b/packages/suite/src/views/wallet/trading/common/ConfirmedOnTrezor.tsx
@@ -7,7 +7,7 @@ import { variables } from '@trezor/components';
 import { RotateDeviceImage } from '@trezor/product-components';
 import { borders } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 const Confirmed = styled.div`
     display: flex;

--- a/packages/suite/src/views/wallet/trading/common/TradingAddressOptions.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingAddressOptions.tsx
@@ -10,7 +10,7 @@ import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 import { Column, InfoSegments, Select } from '@trezor/components';
 import type { AccountAddress } from '@trezor/connect';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useAccountAddressDictionary } from 'src/hooks/wallet/useAccounts';

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentSuccessful.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentSuccessful.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Button, Image, variables } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
 

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -15,7 +15,7 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TxAddress } from 'src/components/suite/copy/TxAddress';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingDetailContext } from 'src/hooks/wallet/trading/useTradingDetail';

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentSuccessful.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentSuccessful.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Button, Image, variables } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
 

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback.tsx
@@ -13,9 +13,9 @@ import { TradingType } from '@suite-common/trading';
 import { Button, Card, Column, IconCircle, Row, Text, Textarea } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
 import { EmojiRatingSelector } from 'src/components/suite/EmojiRatingSelector';
 import { ExperimentWrapper } from 'src/components/suite/Experiment/ExperimentWrapper';
+import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 import { TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
 

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentSuccessful.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentSuccessful.tsx
@@ -4,7 +4,7 @@ import { Button, Image, variables } from '@trezor/components';
 import { borders } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
 

--- a/packages/suite/src/views/wallet/trading/common/TradingDisabled.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDisabled.tsx
@@ -4,7 +4,7 @@ import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { TradingType } from '@suite-common/trading';
 import { Banner } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useTranslation } from 'src/hooks/suite';
 
 const typeLabels: Record<TradingDisabledProps['type'], ExtendedMessageDescriptor['id']> = {

--- a/packages/suite/src/views/wallet/trading/common/TradingFeaturedOffers/TradingFeaturedOffersItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFeaturedOffers/TradingFeaturedOffersItem.tsx
@@ -11,7 +11,7 @@ import { Badge, Button, Card, Text } from '@trezor/components';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { spacings, spacingsPx } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TradingTradeDetailBuySellType } from 'src/types/trading/trading';
 import { TradingFormContextValues } from 'src/types/trading/tradingForm';
 import {

--- a/packages/suite/src/views/wallet/trading/common/TradingFeaturedOffers/TradingFeaturedOffersPaymentInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFeaturedOffers/TradingFeaturedOffersPaymentInfo.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import type { TradingType } from '@suite-common/trading';
 import { spacingsPx } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TradingTradeBuySellType, TradingTradeDetailBuySellType } from 'src/types/trading/trading';
 import { TradingPaymentPlainType } from 'src/views/wallet/trading/common/TradingPaymentPlainType';
 

--- a/packages/suite/src/views/wallet/trading/common/TradingFooter/TradingFooter.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFooter/TradingFooter.tsx
@@ -7,7 +7,7 @@ import { useOnClickOutside } from '@trezor/react-utils';
 import { borders, spacingsPx, typography, zIndices } from '@trezor/theme';
 import { DATA_TOS_INVITY_URL, INVITY_URL } from '@trezor/urls';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TradingFooterLogoWrapper } from 'src/views/wallet/trading';
 import { TradingProvidedByInvity } from 'src/views/wallet/trading/common/TradingFooter/TradingProvidedByInvity';
 

--- a/packages/suite/src/views/wallet/trading/common/TradingFooter/TradingProvidedByInvity.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFooter/TradingProvidedByInvity.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Image, Link, variables } from '@trezor/components';
 import { INVITY_URL } from '@trezor/urls';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TradingFooterLogoWrapper } from 'src/views/wallet/trading';
 
 const Wrapper = styled.div`

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -9,7 +9,7 @@ import { Banner, Button, Column, Icon, Paragraph, Row } from '@trezor/components
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TxAddress } from 'src/components/suite/copy/TxAddress';
 import { useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormFeeDisclamer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormFeeDisclamer.tsx
@@ -2,7 +2,7 @@ import { Button, Flex, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { INVITY_SCHEDULE_OF_FEES } from '@trezor/urls';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 export const TradingFormFeesDisclamer = () => (
     <Flex gap={spacings.sm}>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAccount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAccount.tsx
@@ -11,8 +11,8 @@ import {
 import { Row, Select, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
 import { AccountTypeBadge } from 'src/components/suite/AccountTypeBadge';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { useTradingBuildAccountGroups } from 'src/hooks/wallet/trading/form/common/useTradingBuildAccountGroups';
 import { useTradingFiatValues } from 'src/hooks/wallet/trading/form/common/useTradingFiatValues';

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry.tsx
@@ -4,7 +4,7 @@ import { TRADING_FORM_COUNTRY_SELECT, TradingCountryOption, regional } from '@su
 import { Flag, Row, Select } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingTradeBuySellType } from 'src/types/trading/trading';
 import {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect.tsx
@@ -30,7 +30,7 @@ import {
 } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiatCrypto.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiatCrypto.tsx
@@ -6,7 +6,7 @@ import {
 } from '@suite-common/trading';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingFormInputFiatCryptoWrapProps } from 'src/types/trading/tradingForm';
 import { tradingGetAmountLabels } from 'src/utils/wallet/trading/tradingUtils';

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod.tsx
@@ -6,7 +6,7 @@ import {
 } from '@suite-common/trading';
 import { Select } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingTradeBuySellType } from 'src/types/trading/trading';
 import {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormSwitcherCryptoFiat.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormSwitcherCryptoFiat.tsx
@@ -1,6 +1,6 @@
 import { TextButton } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 interface TradingFormSwitcherCryptoFiatProps {
     // displaySymbol or fiat currency

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormSwitcherExchangeRates.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormSwitcherExchangeRates.tsx
@@ -10,8 +10,7 @@ import {
 import { Column, Grid, Paragraph, RadioCard } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
-import { TranslationKey } from 'src/components/suite/Translation';
+import { Translation, TranslationKey } from 'src/components/suite/Translation';
 
 type ItemProps = {
     isSelected: boolean;

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInputs.tsx
@@ -19,8 +19,8 @@ import { Column, FractionButton, FractionButtonProps, Row } from '@trezor/compon
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils/src/firmwareUtils';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
 import { ExperimentWrapper } from 'src/components/suite/Experiment/ExperimentWrapper';
+import { Translation } from 'src/components/suite/Translation';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -21,8 +21,8 @@ import { Button, Column, Paragraph, Row, TextButton, Tooltip } from '@trezor/com
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { Translation } from 'src/components/suite';
 import { ExperimentWrapper } from 'src/components/suite/Experiment/ExperimentWrapper';
+import { Translation } from 'src/components/suite/Translation';
 import { ApproveModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal';
 import { RevokeModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal';
 import { useDispatch, useSelector } from 'src/hooks/suite';

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferItem.tsx
@@ -2,7 +2,7 @@ import type { TradingTradeType, TradingUtilsProvidersProps } from '@suite-common
 import { Card, Paragraph, Row, Spinner } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TradingUtilsProvider } from 'src/views/wallet/trading/common/TradingUtils/TradingUtilsProvider';
 
 interface TradingFormOfferItemProps {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffersSwitcher.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffersSwitcher.tsx
@@ -9,7 +9,7 @@ import {
 import { Card, Column, Paragraph, Row, Spinner } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TradingExchangeFormContextProps } from 'src/types/trading/tradingForm';
 import { TradingFormOffersSwitcherItem } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffersSwitcherItem';
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffersSwitcherItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffersSwitcherItem.tsx
@@ -10,7 +10,7 @@ import {
 import { Badge, Radio, Row, Text, Tooltip, useElevation } from '@trezor/components';
 import { Elevation, borders, mapElevationToBackground, spacings, spacingsPx } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TradingUtilsProvider } from 'src/views/wallet/trading/common/TradingUtils/TradingUtilsProvider';
 
 const Offer = styled.div<{ $isSelected: boolean; $elevation: Elevation }>`

--- a/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeader.tsx
@@ -5,7 +5,7 @@ import { H2 } from '@trezor/components';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { spacingsPx } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { ExtendedMessageDescriptor } from 'src/types/suite';
 import {

--- a/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingOffersExchangeFiltersPanel.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingOffersExchangeFiltersPanel.tsx
@@ -14,7 +14,7 @@ import {
 import { Row, Select } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 
 const SelectWrapper = styled.div`

--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersEmpty.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersEmpty.tsx
@@ -1,7 +1,7 @@
 import { Card, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 export const TradingOffersEmpty = () => (
     <Card margin={{ top: spacings.md }}>

--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersItem.tsx
@@ -11,7 +11,7 @@ import { Badge, Button, Card, Row, Text } from '@trezor/components';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { spacings, spacingsPx } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 import { useTradingDeviceDisconnected } from 'src/hooks/wallet/trading/form/common/useTradingDeviceDisconnected';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';

--- a/packages/suite/src/views/wallet/trading/common/TradingPaymentPlainType.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingPaymentPlainType.tsx
@@ -4,7 +4,7 @@ import {
 } from '@suite-common/trading';
 import { Text } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 interface TradingPaymentTypeProps {
     method?: TradingPaymentMethodType;

--- a/packages/suite/src/views/wallet/trading/common/TradingProviderInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingProviderInfo.tsx
@@ -2,7 +2,7 @@ import { invityAPI } from '@suite-common/trading';
 import { Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TradingIcon } from 'src/views/wallet/trading/common/TradingIcon';
 
 export interface TradingProviderInfoProps {

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoExchangeType.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoExchangeType.tsx
@@ -3,7 +3,7 @@ import { ExchangeTrade } from 'invity-api';
 import type { TradingTradeType } from '@suite-common/trading';
 import { InfoItem, Text, Tooltip } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TradingExchangeProvidersInfoProps } from 'src/types/trading/trading';
 
 interface TradingInfoExchangeTypeProps {

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoHeader.tsx
@@ -5,7 +5,7 @@ import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';
 
 interface TradingInfoHeaderProps {

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoPaymentMethod.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoPaymentMethod.tsx
@@ -1,7 +1,7 @@
 import type { TradingPaymentMethodType } from '@suite-common/trading';
 import { InfoItem } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TradingPaymentType } from 'src/views/wallet/trading/common/TradingPaymentType';
 
 interface TradingInfoPaymentMethodProps {

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoProvider.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoProvider.tsx
@@ -1,6 +1,6 @@
 import { InfoItem } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TradingGetProvidersInfoProps } from 'src/types/trading/trading';
 import { TradingProviderInfo } from 'src/views/wallet/trading/common/TradingProviderInfo';
 

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferStepper.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferStepper.tsx
@@ -3,7 +3,7 @@ import { Fragment, JSX } from 'react';
 import { Icon, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { ExtendedMessageDescriptor } from 'src/types/suite';
 
 export interface TradingSelectedOfferStepperItemProps {

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
@@ -6,7 +6,7 @@ import addressValidator from '@trezor/address-validator';
 import { Column, Input, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useTranslation } from 'src/hooks/suite';
 import { useTradingReceiveAddress } from 'src/hooks/wallet/trading/form/useTradingReceiveAddress';
 

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerifyDestinationTag.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerifyDestinationTag.tsx
@@ -5,7 +5,7 @@ import { ExchangeTrade } from 'invity-api';
 import { Button, Column, Row, Switch } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useGuideOpenNode } from 'src/hooks/guide';
 import { DESTINATION_TAG_GUIDE_PATH } from 'src/views/wallet/send/Options/MiscNetworkOptions/DestinationTag';
 

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerifyOptions.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerifyOptions.tsx
@@ -2,7 +2,7 @@ import { parseCryptoId, useTradingInfo } from '@suite-common/trading';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { Select } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import {
     TradingVerifyFormAccountOptionProps,
     TradingVerifyOptionsProps,

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactionId.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactionId.tsx
@@ -3,7 +3,7 @@ import { Button, Row, Text } from '@trezor/components';
 import { copyToClipboard } from '@trezor/dom-utils';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 
 interface TradingTransactionIdProps {

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionId.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionId.tsx
@@ -1,7 +1,7 @@
 import { Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 interface TradingTransactionIdProps {
     transactionId: string;

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionStatus.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionStatus.tsx
@@ -4,7 +4,7 @@ import { DefaultTheme, useTheme } from 'styled-components';
 import { type TradingTransaction, exchangeUtils, sellUtils } from '@suite-common/trading';
 import { Icon, Row, Text } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { getStatusMessage as getBuyStatusMessage } from 'src/utils/wallet/trading/buyUtils';
 
 const getBuyTradeData = (status: BuyTradeStatus, theme: DefaultTheme) => {

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionExchange.tsx
@@ -5,7 +5,7 @@ import { tradingExchangeActions } from '@suite-common/trading';
 import { Button } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 import { useTradingWatchTrade } from 'src/hooks/wallet/trading/useTradingWatchTrade';
 import { Account } from 'src/types/wallet';

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsBuy.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsBuy.tsx
@@ -6,7 +6,7 @@ import {
 } from '@suite-common/trading';
 import { Button } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 import { useTradingWatchTrade } from 'src/hooks/wallet/trading/useTradingWatchTrade';
 import { useTradingNavigation } from 'src/hooks/wallet/useTradingNavigation';

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.tsx
@@ -12,7 +12,7 @@ import {
 import { H3, Paragraph, variables } from '@trezor/components';
 import { spacingsPx, typography } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { TradingTransactionExchange } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransactionExchange';
 import { TradingTransactionBuy } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransactionsBuy';

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsSell.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsSell.tsx
@@ -9,7 +9,7 @@ import {
 import { Button } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingWatchTrade } from 'src/hooks/wallet/trading/useTradingWatchTrade';
 import { Account } from 'src/types/wallet';

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc.tsx
@@ -3,7 +3,7 @@ import { useTheme } from 'styled-components';
 
 import { Banner, Icon, Tooltip } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import {
     KYC_DEX,
     KYC_NO_KYC,

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsProvider.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsProvider.tsx
@@ -4,7 +4,7 @@ import { type TradingUtilsProvidersProps, invityAPI } from '@suite-common/tradin
 import { Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 const Icon = styled.img`
     flex: none;

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsTooltip.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsTooltip.tsx
@@ -2,7 +2,7 @@ import { useTheme } from 'styled-components';
 
 import { Icon, Tooltip } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useTranslation } from 'src/hooks/suite';
 import { TooltipIcon, TooltipText, TooltipWrap } from 'src/views/wallet/trading';
 import { TradingOffersItemProps } from 'src/views/wallet/trading/common/TradingOffers/TradingOffersItem';

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsTooltipFee.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsTooltipFee.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { typography } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { TradingOffersItemProps } from 'src/views/wallet/trading/common/TradingOffers/TradingOffersItem';
 
 const TooltipRow = styled.div`

--- a/packages/suite/src/views/wallet/trading/redirect/TradingRedirect.tsx
+++ b/packages/suite/src/views/wallet/trading/redirect/TradingRedirect.tsx
@@ -7,7 +7,7 @@ import { updateFeeInfoThunk } from '@suite-common/wallet-core';
 import { variables } from '@trezor/components';
 import { FeeLevel } from '@trezor/connect';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingRedirect } from 'src/hooks/wallet/useTradingRedirect';
 import { Account } from 'src/types/wallet';

--- a/packages/suite/src/views/wallet/transactions/CoinjoinExplanation/CoinjoinExplanation.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinExplanation/CoinjoinExplanation.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Card, Icon, variables } from '@trezor/components';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 import { CoinjoinProcessStep, CoinjoinProcessStepProps } from './CoinjoinProcessStep';
 

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinStatusWheel.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinStatusWheel.tsx
@@ -4,7 +4,7 @@ import { Button, Card } from '@trezor/components';
 import { typography } from '@trezor/theme';
 
 import { stopCoinjoinSession } from 'src/actions/wallet/coinjoinClientActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectCurrentCoinjoinWheelStates } from 'src/reducers/wallet/coinjoinReducer';

--- a/packages/suite/src/views/wallet/transactions/TransactionList/NoSearchResults.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/NoSearchResults.tsx
@@ -4,7 +4,7 @@ import { Card, Column, H4, Paragraph, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { getWeakRandomInt } from '@trezor/utils';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 const getTip = (num: number) => {
     switch (num) {

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -12,7 +12,7 @@ import { SkeletonStack } from '@trezor/components';
 import { arrayPartition } from '@trezor/utils';
 
 import { DashboardSection } from 'src/components/dashboard';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { Pagination } from 'src/components/wallet';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectLabelingDataForAccount } from 'src/reducers/suite/metadataReducer';

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
@@ -10,7 +10,7 @@ import { Dropdown, Note, Text } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { exportTransactionsThunk } from 'src/actions/wallet/exportTransactionsActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { useTranslation } from 'src/hooks/suite/useTranslation';

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
@@ -20,7 +20,7 @@ import {
 import { spacings } from '@trezor/theme';
 
 import { setFlag } from 'src/actions/suite/suiteActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 const options = [

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/PendingGroupHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/PendingGroupHeader.tsx
@@ -1,6 +1,6 @@
 import { InfoSegments, Text } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 
 type PendingGroupHeaderProps = { txsCount: number };
 

--- a/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
@@ -7,7 +7,7 @@ import {
 } from '@suite-common/wallet-core';
 import { Card, Column, Text } from '@trezor/components';
 
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { Account, WalletAccountTransaction } from 'src/types/wallet';
 

--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
@@ -6,7 +6,7 @@ import {
 import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
 import { AccountExceptionLayout } from 'src/components/wallet';
 import { useDispatch } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';


### PR DESCRIPTION
This is a simple 
<img width="972" height="232" alt="image" src="https://github.com/user-attachments/assets/255360c6-cdc3-4196-84ed-a3f39f46cd98" />


To reduce the number of changes needed for future destruction of that `index.ts` file

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-unnecessara-index-file&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-unnecessara-index-file&lookback=7)