### PR TITLE
fix(suite-native): send: fix broken navigation

### DIFF
--- a/suite-native/module-send/src/screens/SendAddressReviewScreen.tsx
+++ b/suite-native/module-send/src/screens/SendAddressReviewScreen.tsx
@@ -1,5 +1,7 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+
+import { useFocusEffect } from '@react-navigation/native';
 
 import { AccountsRootState, DeviceRootState, SendRootState } from '@suite-common/wallet-core';
 import { Box, Text, VStack } from '@suite-native/atoms';
@@ -35,16 +37,18 @@ export const SendAddressReviewScreen = ({
             selectIsTransactionReviewInProgress(state, accountKey, tokenContract),
     );
 
-    useEffect(() => {
-        if (isAddressConfirmed) {
-            navigation.navigate(SendStackRoutes.SendOutputsReview, {
-                accountKey,
-                tokenContract,
-                prevHeaderHeight: currentHeaderHeight,
-                initialSnapIndex: currentHeaderHeight ? 1 : undefined,
-            });
-        }
-    }, [isAddressConfirmed, accountKey, navigation, tokenContract, currentHeaderHeight]);
+    useFocusEffect(
+        useCallback(() => {
+            if (isAddressConfirmed) {
+                navigation.navigate(SendStackRoutes.SendOutputsReview, {
+                    accountKey,
+                    tokenContract,
+                    prevHeaderHeight: currentHeaderHeight,
+                    initialSnapIndex: currentHeaderHeight ? 1 : undefined,
+                });
+            }
+        }, [accountKey, currentHeaderHeight, isAddressConfirmed, navigation, tokenContract]),
+    );
 
     useEffect(() => {
         if (isTransactionReviewInProgress) {

--- a/suite-native/module-send/src/screens/SendDestinationTagReviewScreen.tsx
+++ b/suite-native/module-send/src/screens/SendDestinationTagReviewScreen.tsx
@@ -1,11 +1,11 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useFocusEffect } from '@react-navigation/native';
 
 import { AccountsRootState, DeviceRootState, SendRootState } from '@suite-common/wallet-core';
 import { Text, VStack } from '@suite-native/atoms';
-import { ConfirmOnTrezorWrapper } from '@suite-native/device';
+import { ConfirmOnTrezorWrapper, useConfirmOnTrezorController } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import { SendStackParamList, SendStackRoutes, StackProps } from '@suite-native/navigation';
 
@@ -22,6 +22,8 @@ export const SendDestinationTagReviewScreen = ({
 }: StackProps<SendStackParamList, SendStackRoutes.SendDestinationTagReview>) => {
     const { accountKey, tokenContract, destinationTag, transaction } = route.params;
     const [hasReviewAlreadyStarted, setHasReviewAlreadyStarted] = useState(false);
+
+    const { confirmOnTrezorRef, currentHeaderHeight } = useConfirmOnTrezorController();
 
     const isTransactionReviewInProgress = useSelector(
         (state: AccountsRootState & DeviceRootState & SendRootState) =>
@@ -51,18 +53,32 @@ export const SendDestinationTagReviewScreen = ({
         ]),
     );
 
-    useEffect(() => {
-        if (isDestinationTagConfirmed) {
-            navigation.navigate(SendStackRoutes.SendAddressReview, {
-                accountKey,
-                tokenContract,
-                transaction,
-            });
-        }
-    }, [isDestinationTagConfirmed, accountKey, navigation, tokenContract, transaction]);
+    useFocusEffect(
+        useCallback(() => {
+            if (isDestinationTagConfirmed) {
+                navigation.navigate(SendStackRoutes.SendAddressReview, {
+                    accountKey,
+                    tokenContract,
+                    transaction,
+                    prevHeaderHeight: currentHeaderHeight,
+                    initialSnapIndex: currentHeaderHeight ? 1 : undefined,
+                });
+            }
+        }, [
+            accountKey,
+            currentHeaderHeight,
+            isDestinationTagConfirmed,
+            navigation,
+            tokenContract,
+            transaction,
+        ]),
+    );
 
     return (
-        <ConfirmOnTrezorWrapper closeActionType={isTransactionReviewInProgress ? 'close' : 'back'}>
+        <ConfirmOnTrezorWrapper
+            controlRef={confirmOnTrezorRef}
+            closeActionType={isTransactionReviewInProgress ? 'close' : 'back'}
+        >
             <VStack flex={1} spacing="sp24" marginTop="sp16">
                 <Text variant="titleSmall">
                     <Translation id="moduleSend.review.destinationTagTitle" />

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -109,6 +109,8 @@ export type SendStackParamList = {
         transaction: GeneralPrecomposedTransactionFinal;
         accountKey: AccountKey;
         tokenContract?: TokenAddress;
+        prevHeaderHeight?: number;
+        initialSnapIndex?: number;
     };
     [SendStackRoutes.SendOutputsReview]: {
         accountKey: AccountKey;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

useEffect hooks inside `SendAddressReview` and `SendDestinationTagReview` screens were still triggered even after navigating away. Since React Navigation keeps screens mounted in the stack, those effects continued to listen to Redux state updates and fired unintended navigation actions.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21815

## Screenshots:

https://github.com/user-attachments/assets/dc9edb94-ec61-4c0f-81f7-fd5e09b49f51



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/xrp-send-fix&lookback=7)