### PR TITLE
refactor(suite): increase EVM data size to 16kB (hex)

### DIFF
--- a/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumData.tsx
+++ b/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumData.tsx
@@ -88,8 +88,8 @@ export const EthereumData = ({ close }: EthereumDataProps) => {
             if (value && !isHexValid(value, '0x')) {
                 return translationString('DATA_NOT_VALID_HEX');
             }
-            if (value && value.length > 8192 * 2) {
-                return translationString('DATA_HEX_TOO_BIG'); // 8192 bytes limit for protobuf single message encoding in FW
+            if (value && value.length > formInputsMaxLength.ethData * 2) {
+                return translationString('DATA_HEX_TOO_BIG');
             }
         },
     });
@@ -113,6 +113,10 @@ export const EthereumData = ({ close }: EthereumDataProps) => {
                 label={<Translation id="DATA_ETH" />}
                 innerRef={asciiRef}
                 {...asciiField}
+                characterCount={{
+                    current: asciiValue?.length,
+                    max: formInputsMaxLength.ethData,
+                }}
             />
             <Space> = </Space>
             <Textarea
@@ -131,6 +135,10 @@ export const EthereumData = ({ close }: EthereumDataProps) => {
                 }
                 innerRef={hexRef}
                 {...hexField}
+                characterCount={{
+                    current: hexValue?.length,
+                    max: formInputsMaxLength.ethData * 2,
+                }}
             />
         </Wrapper>
     );

--- a/suite-common/validators/src/inputsLengthConfig.ts
+++ b/suite-common/validators/src/inputsLengthConfig.ts
@@ -7,7 +7,13 @@ export const formInputsMaxLength = {
     amount: 255,
     fiat: 255,
     opReturn: 255,
-    ethData: 255,
+
+    /**
+     * - Hex data field has 16kB limit for protobuf single message encoding in firmware
+     * - For UTF-16 encoding: 16384 B / 2 = 8192 B
+     */
+    ethData: 8192,
+
     btcLocktime: 10, // max: 4294967294
     xrpDestinationTag: 10, // max: 4294967295
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## TODO

- [x] test it on T1

## Description

Increase EVM data size to 16kB (hex)

## Related Issue

Resolve #21198

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/21198-evm-data-length&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/21198-evm-data-length&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/21198-evm-data-length&lookback=7)