### PR TITLE
feat(suite): device connection loading indicator

### DIFF
--- a/packages/components/src/components/loaders/Spinner/Spinner.tsx
+++ b/packages/components/src/components/loaders/Spinner/Spinner.tsx
@@ -28,6 +28,7 @@ const StyledLottie = styled(Lottie)<
     width: ${({ size }) => `${size}px`};
     height: ${({ size }) => `${size}px`};
     filter: ${({ $isGrey }) => ($isGrey ? 'grayscale(1) opacity(0.6)' : 'none')};
+    display: flex;
 
     ${withFrameProps}
 `;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -5,7 +5,7 @@ import styled, { css } from 'styled-components';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Box, Icon, Tooltip } from '@trezor/components';
 import { focusStyleTransition, getFocusShadowStyle } from '@trezor/components/src/utils/utils';
-import { borders, spacingsPx } from '@trezor/theme';
+import { borders, spacingsPx, zIndices } from '@trezor/theme';
 
 import { setRecentlyConnectedDevicePath } from 'src/actions/suite/suiteActions';
 import { openSwitchDeviceDialog } from 'src/actions/wallet/addWalletThunk';
@@ -100,6 +100,7 @@ export const DeviceSelector = () => {
             content={<RecentlyConnectedDeviceTooltipContent />}
             placement="right-end"
             hasArrow
+            zIndex={zIndices.popover /* to prevent it from appearing above modals */}
         >
             <Wrapper $isSidebarCollapsed={isSidebarCollapsed}>
                 <Tooltip

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10726,4 +10726,8 @@ export default defineMessages({
         id: 'TR_CONFIRM_BLUETOOTH_PAIRING',
         defaultMessage: 'Confirm the Bluetooth pairing request on your Trezor as well.',
     },
+    TR_THP_LOADING: {
+        id: 'TR_THP_LOADING',
+        defaultMessage: 'Securing connection',
+    },
 } as const);

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceConnectionText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceConnectionText.tsx
@@ -2,7 +2,7 @@ import { MouseEventHandler, ReactNode } from 'react';
 
 import styled, { css } from 'styled-components';
 
-import { Icon, IconName, IconVariant, Row, Text } from '@trezor/components';
+import { Icon, IconName, IconVariant, Row, Spinner, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 const Container = styled.span<{ $isAction?: boolean }>`
@@ -23,6 +23,7 @@ type DeviceConnectionTextProps = {
     icon: IconName;
     children: ReactNode;
     isAction?: boolean;
+    isLoading?: boolean;
 };
 
 export const DeviceConnectionText = ({
@@ -33,6 +34,7 @@ export const DeviceConnectionText = ({
     children,
     icon,
     isAction,
+    isLoading,
 }: DeviceConnectionTextProps) => (
     <Container
         $isAction={isAction}
@@ -41,7 +43,7 @@ export const DeviceConnectionText = ({
         data-testid-alt={dataTestAlt}
     >
         <Row gap={spacings.xxs}>
-            <Icon name={icon} size={12} variant={variant} />
+            {isLoading ? <Spinner size={12} /> : <Icon name={icon} size={12} variant={variant} />}
             <Text typographyStyle="label" variant={variant}>
                 {children}
             </Text>

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
@@ -1,66 +1,20 @@
 import React from 'react';
 
-import { selectWalletLabel } from '@suite-common/local-first-storage';
 import { TrezorDevice } from '@suite-common/suite-types';
 import * as deviceUtils from '@suite-common/suite-utils';
 import { acquireDevice } from '@suite-common/wallet-core';
-import { TOOLTIP_DELAY_LONG, TruncateWithTooltip } from '@trezor/components';
 
 import { Translation } from 'src/components/suite/Translation';
-import { useWalletLabeling } from 'src/components/suite/labeling/WalletLabeling';
-import { useSelector } from 'src/hooks/suite';
-import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
 
-import { DeviceConnectionText } from './DeviceConnectionText';
 import { useDispatch } from '../../../../hooks/suite';
 import { getDeviceResolveStatusCTAMessage } from '../getDeviceResolveStatusCTAMessage';
+import { DeviceConnectionText } from './DeviceConnectionText';
+import { DeviceStatusTextThp } from './DeviceStatusTextThp';
 
 type DeviceStatusTextProps = {
     onRefreshClick?: (e: React.MouseEvent) => void;
     device: TrezorDevice;
     forceConnectionInfo: boolean;
-};
-
-type DeviceStatusVisible = {
-    connected: boolean;
-    device: TrezorDevice;
-    forceConnectionInfo: boolean;
-};
-
-const DeviceStatusVisible = ({ device, connected, forceConnectionInfo }: DeviceStatusVisible) => {
-    const { walletLabel: walletLabelOld } = useSelector(state =>
-        selectLabelingDataForWallet(state, device.state),
-    );
-
-    const { defaultAccountLabelString } = useWalletLabeling();
-
-    const defaultWalletLabel =
-        device !== undefined ? defaultAccountLabelString({ device }) : undefined;
-
-    const localFirstWalletLabel = useSelector(state =>
-        selectWalletLabel({ state, deviceStaticSessionId: device?.state?.staticSessionId }),
-    );
-
-    const walletLabel = localFirstWalletLabel ?? walletLabelOld;
-    const isWalletLabelEmpty = walletLabel === undefined || walletLabel.trim() === '';
-    const walletText = isWalletLabelEmpty ? defaultWalletLabel : walletLabel;
-
-    return (
-        <DeviceConnectionText
-            variant={connected ? 'primary' : 'tertiary'}
-            icon={connected ? 'link' : 'linkBreak'}
-            data-testid={connected ? '@deviceStatus-connected' : '@deviceStatus-disconnected'}
-            data-testid-alt="@deviceStatus"
-        >
-            {walletText && !forceConnectionInfo ? (
-                <TruncateWithTooltip delayShow={TOOLTIP_DELAY_LONG}>
-                    {walletText}
-                </TruncateWithTooltip>
-            ) : (
-                <Translation id={connected ? 'TR_CONNECTED' : 'TR_DISCONNECTED'} />
-            )}
-        </DeviceConnectionText>
-    );
 };
 
 export const DeviceStatusText = ({ device, forceConnectionInfo }: DeviceStatusTextProps) => {
@@ -93,11 +47,5 @@ export const DeviceStatusText = ({ device, forceConnectionInfo }: DeviceStatusTe
         );
     }
 
-    return (
-        <DeviceStatusVisible
-            connected={connected}
-            device={device}
-            forceConnectionInfo={forceConnectionInfo}
-        />
-    );
+    return <DeviceStatusTextThp device={device} forceConnectionInfo={forceConnectionInfo} />;
 };

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusTextThp.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusTextThp.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react';
+
+import { selectKnownDeviceByDeviceId } from '@suite-common/bluetooth/src/bluetoothSelectors';
+import { TrezorDevice } from '@suite-common/suite-types';
+import { selectDevices } from '@suite-common/wallet-core';
+
+import { selectConnectingDevices } from 'src/actions/bluetooth/desktopBluetoothSelectors';
+import { Translation } from 'src/components/suite/Translation';
+import { useSelector } from 'src/hooks/suite';
+import { selectIsDeviceOrUiLocked } from 'src/selectors/suite/suiteSelectors';
+
+import { DeviceConnectionText } from './DeviceConnectionText';
+import { DeviceStatusTextVisible } from './DeviceStatusTextVisible';
+
+type DeviceStatusTextThpProps = {
+    device: TrezorDevice;
+    forceConnectionInfo: boolean;
+};
+
+export const DeviceStatusTextThp = ({ device, forceConnectionInfo }: DeviceStatusTextThpProps) => {
+    const { connected } = device;
+
+    const allDevices = useSelector(selectDevices);
+    const bluetoothConnecting = useSelector(selectConnectingDevices);
+    const bluetoothDevice = useSelector(state =>
+        selectKnownDeviceByDeviceId(state, device.id ?? undefined),
+    );
+    const isDeviceOrUiLocked = useSelector(selectIsDeviceOrUiLocked);
+    const isBtConnecting =
+        !device.connected &&
+        (bluetoothConnecting.some(btId => btId === bluetoothDevice?.id) ||
+            bluetoothDevice?.connectionStatus?.type === 'connecting');
+    const isThpAcquiring =
+        !device.connected &&
+        isDeviceOrUiLocked &&
+        allDevices.some(
+            dev =>
+                dev.bluetoothProps?.id === bluetoothDevice?.id &&
+                dev.type === 'unacquired' &&
+                dev.thp?.properties !== undefined,
+        );
+
+    const isLoading = isBtConnecting || isThpAcquiring;
+    const [showThpStatus, setShowThpStatus] = useState(false);
+    useEffect(() => {
+        if (isLoading) {
+            setShowThpStatus(true);
+        } else {
+            // keep the loading state for 3 more seconds to show "Connected" state for passphrase
+            const timeout = setTimeout(() => setShowThpStatus(false), 3000);
+
+            return () => clearTimeout(timeout);
+        }
+    }, [isLoading]);
+
+    const getTextId = () => {
+        if (device.connected) return 'TR_CONNECTED';
+        if (isThpAcquiring) return 'TR_THP_LOADING';
+
+        return 'TR_BLUETOOTH_CONNECTING';
+    };
+
+    if (showThpStatus) {
+        return (
+            <DeviceConnectionText
+                variant={connected ? 'primary' : 'tertiary'}
+                icon="check"
+                isLoading={isLoading}
+                data-testid="@deviceStatus-connecting"
+                data-testid-alt="@deviceStatus"
+            >
+                <Translation id={getTextId()} />
+            </DeviceConnectionText>
+        );
+    }
+
+    return <DeviceStatusTextVisible device={device} forceConnectionInfo={forceConnectionInfo} />;
+};

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusTextVisible.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusTextVisible.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { selectWalletLabel } from '@suite-common/local-first-storage';
+import { TrezorDevice } from '@suite-common/suite-types';
+import { TOOLTIP_DELAY_LONG, TruncateWithTooltip } from '@trezor/components';
+
+import { Translation } from 'src/components/suite/Translation';
+import { useWalletLabeling } from 'src/components/suite/labeling/WalletLabeling';
+import { useSelector } from 'src/hooks/suite';
+import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
+
+import { DeviceConnectionText } from './DeviceConnectionText';
+
+type DeviceStatusTextVisibleProps = {
+    device: TrezorDevice;
+    forceConnectionInfo: boolean;
+};
+
+export const DeviceStatusTextVisible = ({
+    device,
+    forceConnectionInfo,
+}: DeviceStatusTextVisibleProps) => {
+    const { connected } = device;
+    const { walletLabel: walletLabelOld } = useSelector(state =>
+        selectLabelingDataForWallet(state, device.state),
+    );
+
+    const { defaultAccountLabelString } = useWalletLabeling();
+
+    const defaultWalletLabel =
+        device !== undefined ? defaultAccountLabelString({ device }) : undefined;
+
+    const localFirstWalletLabel = useSelector(state =>
+        selectWalletLabel({ state, deviceStaticSessionId: device?.state?.staticSessionId }),
+    );
+
+    const walletLabel = localFirstWalletLabel ?? walletLabelOld;
+    const isWalletLabelEmpty = walletLabel === undefined || walletLabel.trim() === '';
+    const walletText = isWalletLabelEmpty ? defaultWalletLabel : walletLabel;
+
+    return (
+        <DeviceConnectionText
+            variant={connected ? 'primary' : 'tertiary'}
+            icon={connected ? 'link' : 'linkBreak'}
+            data-testid={connected ? '@deviceStatus-connected' : '@deviceStatus-disconnected'}
+            data-testid-alt="@deviceStatus"
+        >
+            {walletText && !forceConnectionInfo ? (
+                <TruncateWithTooltip delayShow={TOOLTIP_DELAY_LONG}>
+                    {walletText}
+                </TruncateWithTooltip>
+            ) : (
+                <Translation id={connected ? 'TR_CONNECTED' : 'TR_DISCONNECTED'} />
+            )}
+        </DeviceConnectionText>
+    );
+};


### PR DESCRIPTION
## Description

Add an indicator for when Bluetooth/THP is connecting for the device.
Uses some logic added in #21757, so merge after that. 

[Figma](https://www.figma.com/design/2KBt0gKsBiFylVBPEypBP6/Bluetooth---THP?node-id=7317-27640&t=K5JOq1ObWPnHvAiP-1)

## Screenshots:

https://github.com/user-attachments/assets/5d25db8e-4812-4a8f-8ab9-2be36c91c27a


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-device-connection-loading-indicator&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-device-connection-loading-indicator&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-device-connection-loading-indicator&lookback=7)