### PR TITLE
fix(transport-bluetooth): linux connection status after unsuccessful connection

### DIFF
--- a/packages/transport-bluetooth/src/server/platform/linux.rs
+++ b/packages/transport-bluetooth/src/server/platform/linux.rs
@@ -212,6 +212,8 @@ async fn connect_with_timeout(ctx: ConnectDeviceContext) -> Result<(), PlatformE
 
     // check the result
     if let Err(err) = result {
+        dispatch_status(manager, device, DeviceConnectionStatus::Disconnected).await;
+
         info!("connect_with_timeout error: {err}");
         return Err(err)?;
     }

--- a/packages/transport-bluetooth/src/ui/app.tsx
+++ b/packages/transport-bluetooth/src/ui/app.tsx
@@ -158,7 +158,7 @@ export const App: React.FC = () => {
     const connectDevice = async (id?: string) => {
         const idToUse = id || deviceId;
         try {
-            const r = await api().send('connect_device', { id: idToUse, timeout: 30000 });
+            const r = await api().send('connect_device', { id: idToUse, timeout: 10000 });
             writeOutput(r);
             setDeviceId(idToUse);
         } catch (e: any) {
@@ -371,12 +371,14 @@ export const App: React.FC = () => {
                                         <button
                                             style={{ margin: '0 4px' }}
                                             onClick={() =>
-                                                d.connected
+                                                d.connectionStatus.type !== 'disconnected'
                                                     ? disconnectDevice(d.id)
                                                     : connectDevice(d.id)
                                             }
                                         >
-                                            {d.connected ? 'Disconnect' : 'Connect'}
+                                            {d.connectionStatus.type !== 'disconnected'
+                                                ? 'Disconnect'
+                                                : 'Connect'}
                                         </button>
                                         <button
                                             id="forget_device"


### PR DESCRIPTION

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-connection-status&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-connection-status&lookback=7)