### PR TITLE
Remove initial cancel call for BT devices

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -197,6 +197,12 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return (this.descriptorType ?? 0) <= 2;
     }
 
+    public get isProtocolV2Device() {
+        // TODO currently only DEVICE_TYPE.TypeBluetooth is detected;
+        // in the future we can also check productName === "Trezor Safe 7" for usb transports
+        return this.descriptorType === 6;
+    }
+
     private name = 'Trezor';
 
     private color?: string;

--- a/packages/connect/src/device/workflow/handshake.ts
+++ b/packages/connect/src/device/workflow/handshake.ts
@@ -33,6 +33,12 @@ export const handshakeCancel = async ({ device, logger, signal }: Context) => {
         return;
     }
 
+    if (device.isProtocolV2Device) {
+        await device.setupThp();
+
+        return;
+    }
+
     logger?.debug('handshake Cancel start');
 
     // send could fail on T1 bootloader when device has erase/wipe button request displayed


### PR DESCRIPTION
## Description

When connected over BT, we don't need to call `Cancel` first in order to detect v2 protocol as it's always v2. This resolves some issues, e.g. when the device is suspended so the Cancel call times out which kinda breaks the handshake.

## Related issues
At least in some cases resolves #21820

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/initial-cancel-wake&lookback=7)