### PR TITLE
Convert homescreen to valid format

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2355,18 +2355,17 @@ export default defineMessages({
         defaultMessage: 'Display rotation',
         id: 'TR_DEVICE_SETTINGS_DISPLAY_ROTATION',
     },
-    TR_DEVICE_SETTINGS_HOMESCREEN_IMAGE_SETTINGS_BW_128x64: {
-        defaultMessage:
-            'Supports PNG or JPG (128 x 64 pixels) in pure black and white (no grayscale).',
-        id: 'TR_DEVICE_SETTINGS_HOMESCREEN_IMAGE_SETTINGS_BW_128x64',
+    TR_DEVICE_SETTINGS_HOMESCREEN_IMAGE_SETTINGS: {
+        defaultMessage: 'Recommended dimensions: {width}×{height} px.',
+        id: 'TR_DEVICE_SETTINGS_HOMESCREEN_IMAGE_SETTINGS',
+    },
+    TR_DEVICE_SETTINGS_HOMESCREEN_IMAGE_SETTINGS_BW: {
+        defaultMessage: 'Image must be in pure black and white (no grayscale).',
+        id: 'TR_DEVICE_SETTINGS_HOMESCREEN_IMAGE_SETTINGS_BW',
     },
     TR_DEVICE_SETTINGS_HOMESCREEN_EDITOR: {
         defaultMessage: 'Homescreen editor',
         id: 'TR_DEVICE_SETTINGS_HOMESCREEN_EDITOR',
-    },
-    TR_DEVICE_SETTINGS_HOMESCREEN_IMAGE_SETTINGS_COLOR: {
-        defaultMessage: '{width}×{height} px, up to {maxSizeKb} KB',
-        id: 'TR_DEVICE_SETTINGS_HOMESCREEN_IMAGE_SETTINGS_COLOR',
     },
     TR_DEVICE_SETTINGS_HOMESCREEN_SELECT_FROM_GALLERY: {
         defaultMessage: 'Gallery',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2365,7 +2365,7 @@ export default defineMessages({
         id: 'TR_DEVICE_SETTINGS_HOMESCREEN_EDITOR',
     },
     TR_DEVICE_SETTINGS_HOMESCREEN_IMAGE_SETTINGS_COLOR: {
-        defaultMessage: 'Use a JPG file ({width}×{height} px, up to {maxSizeKb} KB).',
+        defaultMessage: '{width}×{height} px, up to {maxSizeKb} KB',
         id: 'TR_DEVICE_SETTINGS_HOMESCREEN_IMAGE_SETTINGS_COLOR',
     },
     TR_DEVICE_SETTINGS_HOMESCREEN_SELECT_FROM_GALLERY: {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5608,7 +5608,7 @@ export default defineMessages({
     },
     IMAGE_VALIDATION_ERROR_INVALID_SIZE_JPG: {
         id: 'IMAGE_VALIDATION_ERROR_INVALID_SIZE_JPG',
-        defaultMessage: 'Invalid size (Image must be less than 16KB)',
+        defaultMessage: 'Invalid size (Image must be less than {maxImageSize} KB)',
     },
     IMAGE_VALIDATION_ERROR_PROGRESSIVE_JPG: {
         id: 'IMAGE_VALIDATION_ERROR_PROGRESSIVE_JPG',

--- a/packages/suite/src/utils/suite/homescreen.ts
+++ b/packages/suite/src/utils/suite/homescreen.ts
@@ -311,15 +311,78 @@ export const validateImageColors = (
     return undefined;
 };
 
-type ValidateImageParam = {
+type ImageOperationParam = {
     file: File;
     deviceModelInternal: DeviceModelInternal;
+};
+
+const exportCanvas = (
+    canvas: HTMLCanvasElement,
+    filename: string,
+    filetype: 'jpeg' | 'png',
+    quality: number,
+): File | undefined => {
+    try {
+        const mimeType = `image/${filetype}`;
+        const outDataUrl = canvas.toDataURL(mimeType, quality);
+        const bin = atob(outDataUrl.split(',')[1]);
+        const arr = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+
+        return new File([arr], filename, { type: mimeType });
+    } catch {
+        return;
+    }
+};
+
+export const convertImage = async ({
+    file,
+    deviceModelInternal,
+}: ImageOperationParam): Promise<File | undefined> => {
+    // Tries converting to valid image. Best effort only.
+    const { supports, width, height, maxImageSize } = deviceModelInformation[deviceModelInternal];
+
+    const dataUrl = await fileToDataUrl(file);
+    const image = await dataUrlToImage(dataUrl);
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return undefined;
+
+    ctx.fillStyle = 'black';
+    ctx.fillRect(0, 0, width, height);
+
+    const scale = Math.min(width / image.width, height / image.height);
+    const drawWidth = image.width * scale;
+    const drawHeight = image.height * scale;
+    const offsetX = (width - drawWidth) / 2;
+    const offsetY = (height - drawHeight) / 2;
+    ctx.drawImage(image, offsetX, offsetY, drawWidth, drawHeight);
+
+    const QUALITY_DECREASE_STEP = 0.1;
+    for (const filetype of supports) {
+        let quality = 1.0;
+        while (quality > QUALITY_DECREASE_STEP) {
+            const attempt = exportCanvas(
+                canvas,
+                file.name.replace(/\.\w+$/, `.${filetype}`),
+                filetype,
+                quality,
+            );
+            if (attempt && attempt.size <= maxImageSize) return attempt;
+            quality -= QUALITY_DECREASE_STEP;
+        }
+    }
+
+    return;
 };
 
 export const validateImage = async ({
     file,
     deviceModelInternal,
-}: ValidateImageParam): Promise<ImageValidationError | undefined> => {
+}: ImageOperationParam): Promise<ImageValidationError | undefined> => {
     const dataUrl = await fileToDataUrl(file);
     const arrayBuffer = await fileToArrayBuffer(file);
     const image = await dataUrlToImage(dataUrl);

--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
@@ -17,6 +17,7 @@ import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 import {
     ImageValidationError,
+    convertImage,
     deviceModelInformation,
     fileToDataUrl,
     imagePathToHex,
@@ -72,9 +73,16 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
 
     const onUploadHomescreen = async (files: FileList | null) => {
         if (!files || !files.length) return;
-        const file = files[0];
+        let file = files[0];
 
-        const validationResult = await validateImage({ file, deviceModelInternal });
+        let validationResult = await validateImage({ file, deviceModelInternal });
+
+        // Do NOT touch the image if it's already valid
+        if (validationResult) {
+            file = (await convertImage({ file, deviceModelInternal })) ?? file;
+            validationResult = await validateImage({ file, deviceModelInternal });
+        }
+
         setValidationError(validationResult);
 
         const dataUrl = await fileToDataUrl(file);
@@ -99,7 +107,7 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
                     <HiddenInput
                         ref={fileInputElement}
                         type="file"
-                        accept={deviceModelInformation[deviceModelInternal].supports
+                        accept={['png', 'jpeg', 'gif', 'webp', 'svg+xml']
                             .map(format => `image/${format}`)
                             .join(', ')}
                         onChange={e => onUploadHomescreen(e.target.files)}

--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
@@ -98,6 +98,18 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
 
     const isSupportedHomescreen = isHomescreenSupportedOnDevice(device);
 
+    const cancelButton = (
+        <ActionButton
+            variant="tertiary"
+            onClick={resetUpload}
+            isDisabled={isDeviceLocked}
+            isTooltipActive={isDeviceLocked}
+            tooltipContent={<Translation id="TR_SETTINGS_DEVICE_BANNER_TITLE_REMEMBERED" />}
+        >
+            <Translation id="TR_CANCEL" />
+        </ActionButton>
+    );
+
     return (
         <>
             <SettingsSectionItem anchorId={SettingsAnchor.Homescreen}>
@@ -144,17 +156,7 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
                         <ActionButton onClick={onChangeHomescreen} isDisabled={isDeviceLocked}>
                             <Translation id="TR_CHANGE_HOMESCREEN" />
                         </ActionButton>
-                        <ActionButton
-                            variant="primary"
-                            onClick={resetUpload}
-                            isDisabled={isDeviceLocked}
-                            isTooltipActive={isDeviceLocked}
-                            tooltipContent={
-                                <Translation id="TR_SETTINGS_DEVICE_BANNER_TITLE_REMEMBERED" />
-                            }
-                        >
-                            <Translation id="TR_DROP_IMAGE" />
-                        </ActionButton>
+                        {cancelButton}
                     </ActionColumn>
                 </SectionItem>
             )}
@@ -191,19 +193,7 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
                             />
                         </Col>
                     )}
-                    <ActionColumn>
-                        <ActionButton
-                            variant="primary"
-                            onClick={resetUpload}
-                            isDisabled={isDeviceLocked}
-                            isTooltipActive={isDeviceLocked}
-                            tooltipContent={
-                                <Translation id="TR_SETTINGS_DEVICE_BANNER_TITLE_REMEMBERED" />
-                            }
-                        >
-                            <Translation id="TR_DROP_IMAGE" />
-                        </ActionButton>
-                    </ActionColumn>
+                    <ActionColumn>{cancelButton}</ActionColumn>
                 </SectionItem>
             )}
         </>

--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
@@ -161,6 +161,9 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
                                     values={{
                                         width: deviceModelInformation[deviceModelInternal].width,
                                         height: deviceModelInformation[deviceModelInternal].height,
+                                        maxImageSize:
+                                            deviceModelInformation[deviceModelInternal]
+                                                .maxImageSize / 1024,
                                     }}
                                 />
                             </ValidationMessage>

--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen/HomescreenSettingsTitle.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen/HomescreenSettingsTitle.tsx
@@ -3,6 +3,7 @@ import { HOMESCREEN_EDITOR_URL } from '@trezor/urls';
 
 import { TextColumn, Translation } from 'src/components/suite';
 import { HAS_MONOCHROME_SCREEN } from 'src/constants/suite/device';
+import { useTranslation } from 'src/hooks/suite';
 import { deviceModelInformation } from 'src/utils/suite/homescreen';
 
 type HomescreenSettingsTitle = {
@@ -11,12 +12,20 @@ type HomescreenSettingsTitle = {
 
 export const HomescreenSettingsTitle = ({ deviceModelInternal }: HomescreenSettingsTitle) => {
     const hasMonochromeScreen = HAS_MONOCHROME_SCREEN[deviceModelInternal];
+    const { translationString } = useTranslation();
+
+    const baseDescription = translationString('TR_DEVICE_SETTINGS_HOMESCREEN_IMAGE_SETTINGS', {
+        width: deviceModelInformation[deviceModelInternal].width,
+        height: deviceModelInformation[deviceModelInternal].height,
+    });
 
     return hasMonochromeScreen ? (
         <TextColumn
             title={<Translation id="TR_DEVICE_SETTINGS_HOMESCREEN_TITLE" />}
             description={
-                <Translation id="TR_DEVICE_SETTINGS_HOMESCREEN_IMAGE_SETTINGS_BW_128x64" />
+                baseDescription +
+                ' ' +
+                translationString('TR_DEVICE_SETTINGS_HOMESCREEN_IMAGE_SETTINGS_BW')
             }
             buttonLink={HOMESCREEN_EDITOR_URL}
             buttonTitle={<Translation id="TR_DEVICE_SETTINGS_HOMESCREEN_EDITOR" />}
@@ -24,18 +33,7 @@ export const HomescreenSettingsTitle = ({ deviceModelInternal }: HomescreenSetti
     ) : (
         <TextColumn
             title={<Translation id="TR_DEVICE_SETTINGS_HOMESCREEN_TITLE" />}
-            description={
-                <Translation
-                    id="TR_DEVICE_SETTINGS_HOMESCREEN_IMAGE_SETTINGS_COLOR"
-                    values={{
-                        width: deviceModelInformation[deviceModelInternal].width,
-                        height: deviceModelInformation[deviceModelInternal].height,
-                        maxSizeKb: Math.round(
-                            deviceModelInformation[deviceModelInternal].maxImageSize / 1024,
-                        ),
-                    }}
-                />
-            }
+            description={baseDescription}
         />
     );
 };


### PR DESCRIPTION
Try to convert homescreen to format that device accepts. Also fix some errors while we are at it.

## Related Issue

Resolve #21460 

## Screenshots:
<img width="663" height="346" alt="image" src="https://github.com/user-attachments/assets/225aeb0b-a4f3-40ce-bc24-860184c09ae0" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/homescreen-validation&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/homescreen-validation&lookback=7)