### PR TITLE
feat(suite-native): show correct screen when device is disconnected during onboarding

### DIFF
--- a/suite-common/suite-utils/src/__fixtures__/device.ts
+++ b/suite-common/suite-utils/src/__fixtures__/device.ts
@@ -59,6 +59,19 @@ const getStatus: Array<{ device: TrezorDevice; status: string }> = [
     },
 ];
 
+const isDeviceConnectedViaBluetooth = [
+    {
+        description: 'device is connected via bluetooth',
+        device: getSuiteDevice({ bluetoothProps: { id: '21' } }),
+        result: true,
+    },
+    {
+        description: 'device is not connected via bluetooth',
+        device: SUITE_DEVICE,
+        result: false,
+    },
+];
+
 const isSelectedDevice = [
     {
         description: `Device is selected`,
@@ -554,6 +567,7 @@ const getFirmwareDowngradeUrl = [
 
 export default {
     getStatus,
+    isDeviceConnectedViaBluetooth,
     isSelectedDevice,
     isSelectedInstance,
     getNewInstanceNumber,

--- a/suite-common/suite-utils/src/__tests__/device.test.ts
+++ b/suite-common/suite-utils/src/__tests__/device.test.ts
@@ -13,6 +13,14 @@ describe('getStatus', () => {
     });
 });
 
+describe('isDeviceConnectedViaBluetooth', () => {
+    fixtures.isDeviceConnectedViaBluetooth.forEach(f => {
+        it(f.description, () => {
+            expect(utils.isDeviceConnectedViaBluetooth(f.device)).toEqual(f.result);
+        });
+    });
+});
+
 describe('isSelectedDevice', () => {
     fixtures.isSelectedDevice.forEach(f => {
         it(f.description, () => {

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -139,6 +139,9 @@ export const shouldDisplayInitialWarningIcon = (deviceStatus: ConnectedDeviceSta
 
 export const isDeviceRemembered = (device?: TrezorDevice): boolean => !!device?.remember;
 
+export const isDeviceConnectedViaBluetooth = (device?: TrezorDevice): boolean =>
+    !!device?.bluetoothProps;
+
 export const isDeviceAcquired = (device?: TrezorDevice): device is AcquiredDevice =>
     !!device?.features;
 

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -10,6 +10,7 @@ import {
     getIsDeviceConnectedAndAuthorized,
     getIsDeviceInitialized,
     getStatus,
+    isDeviceConnectedViaBluetooth,
 } from '@suite-common/suite-utils';
 import { networkSymbolCollection } from '@suite-common/wallet-config';
 import { Device, DeviceState, StaticSessionId } from '@trezor/connect';
@@ -148,7 +149,7 @@ export const selectIsDeviceConnected = createMemoizedSelector(
 
 export const selectIsDeviceConnectedViaBluetooth = createMemoizedSelector(
     [selectSelectedDevice],
-    device => !!device?.bluetoothProps,
+    device => isDeviceConnectedViaBluetooth(device),
 );
 
 export const selectDeviceBluetoothId = createMemoizedSelector(

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -10,6 +10,7 @@ import {
     getDeviceInternalModel,
     getIsDeviceConnectedAndAuthorized,
     getIsDeviceInitialized,
+    isDeviceConnectedViaBluetooth,
     isThpDevice,
 } from '@suite-common/suite-utils';
 import { isThpPairingUIRequestButtonAction } from '@suite-common/thp';
@@ -176,10 +177,15 @@ deviceConnectionMiddleware.startListening({
 
 deviceConnectionMiddleware.startListening({
     predicate: action => deviceActions.deviceDisconnect.match(action),
-    effect: (_action: UnknownAction, { getState }) => {
+    effect: (action: UnknownAction, { getState }) => {
+        if (!deviceActions.deviceDisconnect.match(action)) {
+            throw new Error('This listener only handles deviceDisconnect action');
+        }
+
         const isDeviceRemembered = selectIsDeviceRemembered(getState());
         const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(getState());
         const isFirmwareInstallationRunning = selectIsFirmwareInstallationRunning(getState());
+        const wasDeviceConnectedViaBluetooth = isDeviceConnectedViaBluetooth(action.payload);
 
         if (
             checkIsActiveRouteAnyOf(
@@ -191,7 +197,8 @@ deviceConnectionMiddleware.startListening({
 
         if (checkIsDeviceOnboardingFocused()) {
             navigationContainerRef.navigate(RootStackRoutes.DeviceOnboardingStack, {
-                screen: DeviceOnboardingStackRoutes.ConnectAndUnlockDevice,
+                screen: DeviceOnboardingStackRoutes.DeviceDisconnected,
+                params: { wasDeviceConnectedViaBluetooth },
             });
         } else {
             if (!checkIsHomeStackFocused()) {

--- a/suite-native/module-device-onboarding/src/navigation/DeviceOnboardingStackNavigator.tsx
+++ b/suite-native/module-device-onboarding/src/navigation/DeviceOnboardingStackNavigator.tsx
@@ -7,12 +7,12 @@ import {
 } from '@suite-native/navigation';
 
 import { ConfirmFirmwareUpdateScreen } from '../screens/ConfirmFirmwareUpdateScreen';
-import { ConnectAndUnlockDeviceScreen } from '../screens/ConnectAndUnlockDeviceScreen';
 import { CreateOrRecoverCrossroadsScreen } from '../screens/CreateOrRecoverCrossroadsScreen';
 import { CreatePinScreen } from '../screens/CreatePinScreen';
 import { CreateWalletLoadingScreen } from '../screens/CreateWalletLoadingScreen';
 import { DeviceAuthenticityScreen } from '../screens/DeviceAuthenticityScreen';
 import { DeviceAuthenticitySuccessScreen } from '../screens/DeviceAuthenticitySuccessScreen';
+import { DeviceDisconnectedScreen } from '../screens/DeviceDisconnectedScreen';
 import { DeviceTutorialScreen } from '../screens/DeviceTutorialScreen';
 import { FirmwareInstallationScreen } from '../screens/FirmwareInstallationScreen';
 import { RecoveryInstructionsScreen } from '../screens/RecoveryInstructionsScreen';
@@ -38,8 +38,8 @@ export const DeviceOnboardingStackNavigator = () => (
         screenOptions={stackNavigationOptionsConfig}
     >
         <DeviceOnboardingStack.Screen
-            name={DeviceOnboardingStackRoutes.ConnectAndUnlockDevice}
-            component={ConnectAndUnlockDeviceScreen}
+            name={DeviceOnboardingStackRoutes.DeviceDisconnected}
+            component={DeviceDisconnectedScreen}
             options={{
                 gestureEnabled: false,
                 animation: 'slide_from_bottom',

--- a/suite-native/module-device-onboarding/src/screens/DeviceDisconnectedScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/DeviceDisconnectedScreen.tsx
@@ -1,37 +1,40 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/core';
-
 import { useAlert } from '@suite-native/alerts';
-import { ConnectAndUnlockDeviceScreenContent } from '@suite-native/device';
+import {
+    ConnectAndUnlockDeviceScreenContent,
+    TurnOnAndUnlockDeviceScreenContent,
+} from '@suite-native/device';
 import { setWasDeviceOnboardingCancelled } from '@suite-native/device-onboarding';
 import { useTranslate } from '@suite-native/intl';
 import {
     AppTabsRoutes,
     DeviceOnboardingStackParamList,
+    DeviceOnboardingStackRoutes,
     HomeStackRoutes,
     RootStackParamList,
     RootStackRoutes,
     Screen,
     ScreenHeader,
-    StackToStackCompositeNavigationProps,
+    StackToStackCompositeScreenProps,
 } from '@suite-native/navigation';
 
-type NavigationProp = StackToStackCompositeNavigationProps<
+export const DeviceDisconnectedScreen = ({
+    route,
+    navigation,
+}: StackToStackCompositeScreenProps<
     DeviceOnboardingStackParamList,
-    RootStackRoutes.DeviceOnboardingStack,
+    DeviceOnboardingStackRoutes.DeviceDisconnected,
     RootStackParamList
->;
+>) => {
+    const { wasDeviceConnectedViaBluetooth } = route.params;
 
-export const ConnectAndUnlockDeviceScreen = () => {
     const dispatch = useDispatch();
-
     const { showAlert } = useAlert();
-
     const { translate } = useTranslate();
 
-    const navigation = useNavigation<NavigationProp>();
+    const [isAlertDismissed, setIsAlertDismissed] = useState(false);
 
     const navigateToHome = () =>
         navigation.popTo(RootStackRoutes.AppTabs, {
@@ -52,6 +55,7 @@ export const ConnectAndUnlockDeviceScreen = () => {
             ),
             pictogramVariant: 'critical',
             primaryButtonVariant: 'redBold',
+            onPressPrimaryButton: () => setIsAlertDismissed(true),
             secondaryButtonTitle: translate('generic.buttons.cancel'),
             secondaryButtonVariant: 'redElevation0',
             onPressSecondaryButton: () => {
@@ -77,12 +81,17 @@ export const ConnectAndUnlockDeviceScreen = () => {
 
     return (
         <Screen
+            header={<ScreenHeader closeAction={navigateToHome} closeActionType="close" />}
             noHorizontalPadding
+            noBottomPadding
             hasBottomInset={false}
             isScrollable={false}
-            header={<ScreenHeader closeAction={navigateToHome} closeActionType="close" />}
         >
-            <ConnectAndUnlockDeviceScreenContent />
+            {wasDeviceConnectedViaBluetooth ? (
+                <TurnOnAndUnlockDeviceScreenContent isScanningInProgress={isAlertDismissed} />
+            ) : (
+                <ConnectAndUnlockDeviceScreenContent />
+            )}
         </Screen>
     );
 };

--- a/suite-native/navigation/src/__tests__/routeUtils.test.ts
+++ b/suite-native/navigation/src/__tests__/routeUtils.test.ts
@@ -73,17 +73,17 @@ describe('Navigation Utils', () => {
                 type: 'stack',
                 key: 'stack-test4',
                 index: 0,
-                routeNames: [DeviceOnboardingStackRoutes.ConnectAndUnlockDevice],
+                routeNames: [DeviceOnboardingStackRoutes.DeviceDisconnected],
                 routes: [
                     {
-                        name: DeviceOnboardingStackRoutes.ConnectAndUnlockDevice,
+                        name: DeviceOnboardingStackRoutes.DeviceDisconnected,
                         key: 'ConnectAndUnlockDevice-test4',
                     },
                 ],
             });
 
             const routeList = [
-                DeviceOnboardingStackRoutes.ConnectAndUnlockDevice,
+                DeviceOnboardingStackRoutes.DeviceDisconnected,
                 DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
             ];
             const result = checkIsActiveRouteAnyOf(routeList);

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -132,7 +132,9 @@ export type OnboardingStackParamList = {
 };
 
 export type DeviceOnboardingStackParamList = {
-    [DeviceOnboardingStackRoutes.ConnectAndUnlockDevice]: undefined;
+    [DeviceOnboardingStackRoutes.DeviceDisconnected]: {
+        wasDeviceConnectedViaBluetooth: boolean;
+    };
     [DeviceOnboardingStackRoutes.UninitializedDeviceLanding]: undefined;
     [DeviceOnboardingStackRoutes.SuspiciousDevice]: {
         suspicionCause: DeviceSuspicionCause;

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -39,7 +39,7 @@ export enum OnboardingStackRoutes {
 }
 
 export enum DeviceOnboardingStackRoutes {
-    ConnectAndUnlockDevice = 'ConnectAndUnlockDevice',
+    DeviceDisconnected = 'DeviceDisconnected',
     UninitializedDeviceLanding = 'UninitializedDeviceLanding',
     SuspiciousDevice = 'SuspiciousDevice',
     SecurityCheck = 'SecurityCheck',


### PR DESCRIPTION
## Related Issue

Resolve #21045


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/device-disconnected-during-onboarding&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/device-disconnected-during-onboarding&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/device-disconnected-during-onboarding&lookback=7)