### PR TITLE
Do not show coin enabling for BTC only FW

### DIFF
--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -119,6 +119,11 @@ export const selectBitcoinAmountUnit = (state: WalletSettingsRootState) =>
 export const selectIsAutoForgetDeviceDataEnabled = (state: WalletSettingsRootState) =>
     state.wallet.settings.autoForgetDeviceData;
 
+export const selectIsBitcoinEnabled = createMemoizedSelector(
+    [selectEnabledNetworks],
+    enabledNetworks => enabledNetworks.includes('btc'),
+);
+
 export const selectAreSatsAmountUnit = (state: WalletSettingsRootState) => {
     const bitcoinAmountUnit = selectBitcoinAmountUnit(state);
 

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -31,6 +31,7 @@ import {
     navigationContainerRef,
 } from '@suite-native/navigation';
 import { selectIsCoinEnablingInitFinished } from '@suite-native/settings';
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 
 import {
     DEVICE_CONNECTION_BLACKLISTED_ROUTES,
@@ -46,11 +47,13 @@ import { getIsDeviceSetupSupported } from '../utils';
 export const deviceConnectionMiddleware = createListenerMiddleware<NativeDeviceRootState>();
 
 const handleDeviceConnectNavigation = ({
+    hasDeviceBitcoinOnlyFirmware,
     isCoinEnablingInitFinished,
     isDeviceInitialized,
     isDeviceSetupSupported,
     wasDeviceOnboardingCancelled,
 }: {
+    hasDeviceBitcoinOnlyFirmware: boolean;
     isCoinEnablingInitFinished: boolean;
     isDeviceInitialized: boolean;
     isDeviceSetupSupported: boolean;
@@ -104,7 +107,8 @@ const handleDeviceConnectNavigation = ({
         }
     }
 
-    if (isCoinEnablingInitFinished) {
+    if (isCoinEnablingInitFinished || hasDeviceBitcoinOnlyFirmware) {
+        // Bitcoin is enabled and coin enabling finished with btc-only FW in discoverMiddleware.
         navigationContainerRef.navigate(RootStackRoutes.AuthorizeDeviceStack, {
             screen: AuthorizeDeviceStackRoutes.ConnectingDevice,
         });
@@ -160,6 +164,7 @@ deviceConnectionMiddleware.startListening({
         if (isNonThpRememberedDeviceConnectAction) return;
 
         handleDeviceConnectNavigation({
+            hasDeviceBitcoinOnlyFirmware: hasBitcoinOnlyFirmware(device),
             isCoinEnablingInitFinished: selectIsCoinEnablingInitFinished(getState()),
             isDeviceInitialized: getIsDeviceInitialized({
                 deviceMode: device.mode,

--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -7,6 +7,7 @@ import {
     changeNetworks,
     deviceActions,
     discoveryActions,
+    selectIsBitcoinEnabled,
     selectSelectedDevice,
     selectShouldRediscover,
     startOrRestartDiscoveryThunk,
@@ -38,14 +39,19 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
 
         const isDeviceFirmwareVersionSupported = selectIsDeviceFirmwareSupported(getState());
         const isCoinEnablingInitFinished = selectIsCoinEnablingInitFinished(getState());
+        const isBitcoinEnabled = selectIsBitcoinEnabled(getState());
 
         // ensure that BTC is enabled when device with BTC-only firmware is connected
         // (it could have been disabled via some other device with universal firmware)
         if (deviceActions.selectDevice.match(action)) {
             const device = action.payload;
             if (device?.connected && hasBitcoinOnlyFirmware(device)) {
-                dispatch(changeCoinVisibility({ symbol: 'btc', shouldBeVisible: true }));
-                dispatch(setIsCoinEnablingInitFinished(true));
+                if (!isBitcoinEnabled) {
+                    dispatch(changeCoinVisibility({ symbol: 'btc', shouldBeVisible: true }));
+                }
+                if (!isCoinEnablingInitFinished) {
+                    dispatch(setIsCoinEnablingInitFinished(true));
+                }
             }
         }
 


### PR DESCRIPTION


## Description

- Prevent navigating on Coin Enabling screen with BTC-only FW.
- Do not dispatch coin visibility and coin enabling finished actions if not needed to prevent extra analytics report for BTC enabling and extra discovery start for unnecessary coin enabling finished action.


## Screenshots:

Before:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/faec3d81-d560-4e4a-90e9-a2640aa85585" />


After:

https://github.com/user-attachments/assets/49379296-827c-4e05-8b7e-792f179f8387



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/btc-only-fw-connection&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/btc-only-fw-connection&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/btc-only-fw-connection&lookback=7)