### PR TITLE
fix(protocol-thp): add error to getExpectedHeaders

### DIFF
--- a/packages/protocol/src/protocol-thp/utils.ts
+++ b/packages/protocol/src/protocol-thp/utils.ts
@@ -95,7 +95,10 @@ export const getExpectedResponses = (bytes: Buffer) => {
 // get expected responses from ThpState (stored as numbers)
 // and join them with the channel to receive 3 bytes header
 export const getExpectedHeaders = (state: ThpState): Buffer[] =>
-    state.expectedResponses.map(resp => {
+    [
+        ...state.expectedResponses,
+        THP_ERROR_HEADER_BYTE, // error could be sent any time
+    ].map(resp => {
         let magic;
         switch (resp) {
             case THP_CONTINUATION_PACKET:


### PR DESCRIPTION
## Description

We found out that `THP_ERROR_HEADER_BYTE` was not handled properly by `getExpectedHeaders`. 
This means that instead of receiving the actual error message, we would only get unexpected headers. 

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-error-handling&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-error-handling&lookback=7)