### PR TITLE
feat(suite-common): bluetooth autoconnect policy

### DIFF
--- a/packages/connect/src/events/device.ts
+++ b/packages/connect/src/events/device.ts
@@ -9,7 +9,11 @@ import type {
 import type { Device } from '../types/device';
 import type { MessageFactoryFn } from '../types/utils';
 
-export { type DecodedTrezorPushNotification } from '@trezor/protocol';
+export {
+    type DecodedTrezorPushNotification,
+    TrezorPushNotificationMode,
+    TrezorPushNotificationType,
+} from '@trezor/protocol/src/protocol-tpn';
 
 export const DEVICE_EVENT = 'DEVICE_EVENT';
 export const DEVICE = {

--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -3,6 +3,7 @@ import {
     bluetoothActions,
     filterOutOldDuplicatesByName,
     selectAdapterStatus,
+    selectAutoConnectPolicy,
     selectKnownDevices,
 } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
@@ -70,18 +71,37 @@ export const initBluetoothThunk = createThunk<void, void, void>(
             const connectingDevices = selectConnectingDevices(getState());
             const adapterStatus = selectAdapterStatus(getState());
 
-            if (!knownDevice || adapterStatus === 'power-suspending') {
+            if (adapterStatus === 'power-suspending') {
                 // system is going to sleep
                 return;
             }
 
+            if (!knownDevice || connectingDevices.includes(knownDevice.id)) {
+                return;
+            }
+
             // do not hijack BT connection
+            const autoConnectPolicy = selectAutoConnectPolicy(getState());
+            const devicePolicy = autoConnectPolicy[knownDevice.id];
             const isConnectable =
                 device.connectionStatus.type === 'disconnected' &&
-                !device.manufacturerData.filterPolicy?.user_disconnected &&
+                devicePolicy?.type !== 'autoconnect-disabled' &&
                 !device.manufacturerData.filterPolicy?.pairing;
 
-            if (isConnectable && !connectingDevices.includes(device.id)) {
+            // NOTE
+            // linux is caching manufacturerData
+            // they will be always received as device is in pairing mode even if it not (until adapter reconnection)
+            // manufacturerData are updates are sent properly only if there are 2 apps paired with one trezor and both are enabled (desktop + mobile)
+            // TODO: in case of complains regarding auto reconnection on linux enable timeout based on recent disconnection timestamp
+            // if (
+            //     devicePolicy?.type === 'recently-disconnected' &&
+            //     knownDevice.manufacturerData.filterPolicy?.pairing &&
+            //     Date.now() - devicePolicy.timestamp < 10000
+            // ) {
+            //     isConnectable = false;
+            // }
+
+            if (isConnectable) {
                 await dispatch(bluetoothConnectDeviceThunk({ deviceId: device.id }));
             }
         };

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -26,6 +26,7 @@ export const initialAppState: AppState = {
         nearbyDevices: null,
         knownDevices: [],
         ignoredDeviceIds: [],
+        autoConnectPolicy: {},
     },
     thp: {
         step: null,

--- a/suite-common/bluetooth/src/bluetoothActions.ts
+++ b/suite-common/bluetooth/src/bluetoothActions.ts
@@ -4,6 +4,7 @@ import { BluetoothDeviceId } from '@trezor/connect';
 
 import {
     BluetoothAdapterStatus,
+    BluetoothAutoConnectPolicy,
     BluetoothDeviceCommon,
     BluetoothScanStatus,
     DeviceBluetoothConnectionStatus,
@@ -70,6 +71,13 @@ const scanStatusAction = createAction(
     ({ status }: { status: BluetoothScanStatus }) => ({ payload: { status } }),
 );
 
+const setAutoConnectPolicyAction = createAction(
+    `${BLUETOOTH_PREFIX}/set-autoconnect-policy`,
+    ({ id, policy }: { id: string; policy: BluetoothAutoConnectPolicy }) => ({
+        payload: { id, policy },
+    }),
+);
+
 export const bluetoothActions = {
     adapterEventAction,
     nearbyDevicesUpdateAction,
@@ -78,4 +86,5 @@ export const bluetoothActions = {
     knownDevicesUpdateAction,
     removeKnownDeviceAction,
     updateDeviceConnectionStatus,
+    setAutoConnectPolicyAction,
 };

--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -2,10 +2,16 @@ import { AnyAction, Draft } from '@reduxjs/toolkit';
 
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { DeviceConnectActionPayload, deviceActions } from '@suite-common/wallet-core';
+import { TrezorPushNotificationType } from '@trezor/connect';
 
 import { bluetoothActions } from './bluetoothActions';
 import { deserializeBluetoothDeviceSerialization } from './deserializeBluetoothDeviceSerialization';
-import { BluetoothAdapterStatus, BluetoothDeviceCommon, BluetoothScanStatus } from './types';
+import {
+    BluetoothAdapterStatus,
+    BluetoothAutoConnectPolicy,
+    BluetoothDeviceCommon,
+    BluetoothScanStatus,
+} from './types';
 
 export type BluetoothState<T extends BluetoothDeviceCommon> = {
     adapterStatus: BluetoothAdapterStatus;
@@ -16,6 +22,7 @@ export type BluetoothState<T extends BluetoothDeviceCommon> = {
     // (because we already successfully paired them in the Suite) in the Operating System
     knownDevices: T[];
     ignoredDeviceIds: string[];
+    autoConnectPolicy: Record<string, BluetoothAutoConnectPolicy | undefined>;
 };
 
 export const prepareInitialState = <T extends BluetoothDeviceCommon>(): BluetoothState<T> => ({
@@ -24,6 +31,7 @@ export const prepareInitialState = <T extends BluetoothDeviceCommon>(): Bluetoot
     nearbyDevices: null,
     knownDevices: [] as T[],
     ignoredDeviceIds: [],
+    autoConnectPolicy: {},
 });
 
 export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>() =>
@@ -104,6 +112,9 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                     }
                 }
             })
+            .addCase(bluetoothActions.setAutoConnectPolicyAction, (state, { payload }) => {
+                state.autoConnectPolicy[payload.id] = payload.policy;
+            })
 
             .addMatcher(
                 action =>
@@ -131,6 +142,43 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                         );
                         if (foundKnownDevice === undefined) {
                             state.knownDevices.push(device);
+                        } else {
+                            delete state.autoConnectPolicy[bluetoothProps.id];
+                        }
+                    }
+                },
+            )
+            .addMatcher(
+                action => action.type === deviceActions.deviceDisconnect.type,
+                (state, { payload }: ReturnType<typeof deviceActions.deviceDisconnect>) => {
+                    const id = payload.bluetoothProps?.id;
+                    const affectedDevice = id && state.knownDevices.find(it => it.id === id);
+                    if (
+                        affectedDevice &&
+                        state.autoConnectPolicy[id]?.type !== 'autoconnect-disabled'
+                    ) {
+                        state.autoConnectPolicy[id] = {
+                            type: 'recently-disconnected',
+                            timestamp: Date.now(),
+                        };
+                    }
+                },
+            )
+            .addMatcher(
+                action => action.type === deviceActions.devicePushNotification.type,
+                (
+                    state,
+                    {
+                        payload: { device, type },
+                    }: ReturnType<typeof deviceActions.devicePushNotification>,
+                ) => {
+                    if (type === TrezorPushNotificationType.DISCONNECT) {
+                        const id = device.bluetoothProps?.id;
+                        const affectedDevice = id && state.knownDevices.find(it => it.id === id);
+                        if (affectedDevice) {
+                            state.autoConnectPolicy[id] = {
+                                type: 'autoconnect-disabled',
+                            };
                         }
                     }
                 },

--- a/suite-common/bluetooth/src/bluetoothSelectors.ts
+++ b/suite-common/bluetooth/src/bluetoothSelectors.ts
@@ -46,3 +46,7 @@ export const prepareSelectAllDevices = <T extends BluetoothDeviceCommon>() =>
 
 export const selectScanStatus = <T extends BluetoothDeviceCommon>(state: WithBluetoothState<T>) =>
     state.bluetooth.scanStatus;
+
+export const selectAutoConnectPolicy = <T extends BluetoothDeviceCommon>(
+    state: WithBluetoothState<T>,
+) => state.bluetooth.autoConnectPolicy;

--- a/suite-common/bluetooth/src/index.ts
+++ b/suite-common/bluetooth/src/index.ts
@@ -2,6 +2,7 @@ export type {
     BluetoothManufacturerData,
     BluetoothScanStatus,
     BluetoothFilterPolicy,
+    BluetoothAutoConnectPolicy,
     DeviceBluetoothConnectionStatusType,
 } from './types';
 export type { BluetoothState } from './bluetoothReducer';
@@ -15,6 +16,7 @@ export {
     selectAdapterStatus,
     selectScanStatus,
     selectNearbyDevices,
+    selectAutoConnectPolicy,
 } from './bluetoothSelectors';
 
 export { filterOutOldDuplicatesByName } from './filterOutOldDuplicatesByName';

--- a/suite-common/bluetooth/src/types.ts
+++ b/suite-common/bluetooth/src/types.ts
@@ -18,6 +18,10 @@ export type BluetoothFilterPolicy = {
     user_disconnected: boolean; // manual disconnection do the device
 };
 
+export type BluetoothAutoConnectPolicy =
+    | { type: 'recently-disconnected'; timestamp: number }
+    | { type: 'autoconnect-disabled' };
+
 export type BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal;
     deviceColor: number; // TODO: add proper strict type, plain number is currently used in the codebase

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -7,7 +7,13 @@ import {
     ThpSuiteCredentials,
     TrezorDevice,
 } from '@suite-common/suite-types';
-import { DEVICE, Device, DeviceState, StaticSessionId } from '@trezor/connect';
+import {
+    DEVICE,
+    DecodedTrezorPushNotification,
+    Device,
+    DeviceState,
+    StaticSessionId,
+} from '@trezor/connect';
 
 export const DEVICE_MODULE_PREFIX = '@suite/device';
 
@@ -32,6 +38,13 @@ const connectUnacquiredDevice = createAction(
 const deviceChanged = createAction(DEVICE.CHANGED, (payload: Device) => ({
     payload,
 }));
+
+const devicePushNotification = createAction(
+    DEVICE.TREZOR_PUSH_NOTIFICATION,
+    (payload: DecodedTrezorPushNotification & { device: Device }) => ({
+        payload,
+    }),
+);
 
 const setDeviceState = createAction(
     `${DEVICE_MODULE_PREFIX}/set-device-state`,
@@ -177,4 +190,5 @@ export const deviceActions = {
     setLocalFirstStorageSecretRetrieving,
     toggleIsDeviceAutoEjectEnabled,
     setDiscovered,
+    devicePushNotification,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
continuation of [419bf7e019b69fd57939851a328fe543d2415d79](https://github.com/trezor/trezor-suite/pull/21770)

related to https://github.com/trezor/trezor-suite/issues/21730 

and slack discussion:
https://satoshilabs.slack.com/archives/C082Q0Y6WP3/p1758622139661739



Each time device is disconnected from suite or mobile AutoConnectPolicy is set to  `disconnected` 

on next auto connection attempt check if AutoConnectPolicy ==  'disconnected' **and** manufacturerData filterPolicy.user_disconnected == true and set AutoConnectPolicy to `disabled`


AutoConnectPolicy is removed after successful (manual) connection



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-autoreconnection&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-autoreconnection&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/bt-autoreconnection&lookback=7)