### PR TITLE
chore(suite-native): no connecting screen for remembered device

### DIFF
--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -9,7 +9,6 @@ import {
     getDeviceInternalModel,
     getIsDeviceInitialized,
     isDeviceConnectedViaBluetooth,
-    isThpDevice,
 } from '@suite-common/suite-utils';
 import { isThpPairingUIRequestButtonAction } from '@suite-common/thp';
 import {
@@ -158,10 +157,7 @@ deviceConnectionMiddleware.startListening({
         const isDeviceRemembered =
             !!device.features && selectSelectedDevice(getState())?.id === device.id;
 
-        const isNonThpRememberedDeviceConnectAction =
-            isDeviceRemembered && !isThpDevice(action.payload.device);
-
-        if (isNonThpRememberedDeviceConnectAction) return;
+        if (isDeviceRemembered) return;
 
         handleDeviceConnectNavigation({
             hasDeviceBitcoinOnlyFirmware: hasBitcoinOnlyFirmware(device),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously, we were matching connecting of THP devices by finishThp action and I believe this was a shortcut we took at cost of UX. Since it's not necessary anymore, I'm removing it to keep consistent app behavior between connection protocols. Now, same as USB devices, connecting screen will not be shown when user connects remembered device.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/remembered-thp-device-no-connecting-screen&lookback=7)