### PR TITLE
fix(connect): change call order in solanaSignTransaction

### DIFF
--- a/packages/connect/src/api/solana/api/solanaSignTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaSignTransaction.ts
@@ -246,17 +246,16 @@ export default class SolanaSignTransaction extends AbstractMethod<'solanaSignTra
         if (this.params.serialize) {
             const tx = await createTransactionShimFromHex(this.params.serialized_tx);
 
-            const { message } = await cmd.typedCall('SolanaSignTx', 'SolanaTxSignature', {
-                ...this.params,
-                serialized_tx: tx.serializeMessage(),
-            });
-
             const addressCall = await cmd.typedCall('SolanaGetAddress', 'SolanaAddress', {
                 address_n: this.params.address_n,
                 show_display: false,
                 chunkify: false,
             });
             const { address } = addressCall.message;
+            const { message } = await cmd.typedCall('SolanaSignTx', 'SolanaTxSignature', {
+                ...this.params,
+                serialized_tx: tx.serializeMessage(),
+            });
 
             tx.addSignature(address, message.signature);
             const signedSerializedTx = tx.serialize();


### PR DESCRIPTION
## Description

Change device call order in `solanaSignTransaction`.

Calling `SolanaGetAddress` first and then `SolanaSignTx` is more optimal, because get address doesn't show any UI that would block things. 

## Related Issue

Found when investigating #21622

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-solanasigntransaction-calls-order&lookback=7)