### PR TITLE
Remove automatic V2 for BT devices

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -203,12 +203,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return (this.descriptorType ?? 0) <= 2;
     }
 
-    public get isProtocolV2Device() {
-        // TODO currently only DEVICE_TYPE.TypeBluetooth is detected;
-        // in the future we can also check productName === "Trezor Safe 7" for usb transports
-        return this.descriptorType === 6;
-    }
-
     private name = 'Trezor';
 
     private color?: string;

--- a/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
+++ b/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
@@ -30,7 +30,7 @@ const getAcquiredDevice = async (apiMethods: any = {}) => {
     const device = new Device({
         id: 'ABCD' as any, // any = DeviceUniquePath
         transport,
-        descriptor: { path: '1' as any, type: 3, session: null }, // any = PathPublic
+        descriptor: { path: '1' as any, type: 1, session: null }, // any = PathPublic
     });
     await device.acquire();
 
@@ -93,7 +93,7 @@ describe('workflow/handshake', () => {
                 new Promise(resolve => {
                     const timeout = setTimeout(
                         () => resolve({ success: true, payload: Buffer.alloc(readAttempt) }),
-                        1500 * readAttempt, // increase respond time on each attempt, should timeout on 3rd
+                        500 * readAttempt, // increase respond time on each attempt, should timeout on 3rd
                     );
                     signal.addEventListener('abort', () => {
                         abortSpy();
@@ -107,7 +107,7 @@ describe('workflow/handshake', () => {
         const { device, abortController } = await getAcquiredDevice({ read: readMock });
         const promise = handshakeCancel({ device, signal: abortController.signal });
 
-        await fastForward(6000);
+        await fastForward(2000);
         await promise;
 
         expect(readMock).toHaveBeenCalledTimes(3);
@@ -177,7 +177,7 @@ describe('workflow/handshake', () => {
         const writeMock = jest.fn(
             (_a, _b, signal) =>
                 new Promise(resolve => {
-                    const timeout = setTimeout(() => resolve({ success: false }), 6000);
+                    const timeout = setTimeout(() => resolve({ success: false }), 2000);
                     signal.addEventListener('abort', () => {
                         abortSpy();
                         clearTimeout(timeout);
@@ -193,7 +193,7 @@ describe('workflow/handshake', () => {
         });
         const promise = handshakeCancel({ device, signal: abortController.signal });
 
-        await fastForward(6000);
+        await fastForward(2000);
         await promise;
 
         expect(writeMock).toHaveBeenCalledTimes(1);

--- a/packages/connect/src/device/workflow/handshake.ts
+++ b/packages/connect/src/device/workflow/handshake.ts
@@ -6,7 +6,7 @@ import { TypedError } from '../../constants/errors';
 import { WorkflowContext } from '../../types/workflow';
 import { Log } from '../../utils/debug';
 
-const CANCEL_TIMEOUT = 3_000;
+const CANCEL_TIMEOUT = 1_000;
 const ATTEMPTS_LIMIT = 10;
 
 type Context = {
@@ -33,18 +33,12 @@ export const handshakeCancel = async ({ device, logger, signal }: Context) => {
         return;
     }
 
-    if (device.isProtocolV2Device) {
-        await device.setupThp();
-
-        return;
-    }
+    const timeout = device.possibleT1 ? CANCEL_TIMEOUT : undefined;
 
     logger?.debug('handshake Cancel start');
 
     // send could fail on T1 bootloader when device has erase/wipe button request displayed
-    const send = await device
-        .getCurrentSession()
-        .send('Cancel', {}, { signal, timeout: CANCEL_TIMEOUT });
+    const send = await device.getCurrentSession().send('Cancel', {}, { signal, timeout });
 
     if (!send.success) {
         logger?.debug(`handshake Cancel send error ${send.error}`);
@@ -58,10 +52,7 @@ export const handshakeCancel = async ({ device, logger, signal }: Context) => {
     for (let attempt = 0; attempt < ATTEMPTS_LIMIT; ++attempt) {
         logger?.debug(`handshake Cancel read attempt ${attempt}`);
 
-        const result = await device.getCurrentSession().receive({
-            signal,
-            timeout: CANCEL_TIMEOUT,
-        });
+        const result = await device.getCurrentSession().receive({ signal, timeout });
 
         // Older T1 don't respond to Cancel message which seems to be recoverable only by reacquiring
         if (!result.success && result.error.message === TRANSPORT_ERROR.ABORTED_BY_TIMEOUT) {


### PR DESCRIPTION
## Description

Reverting #21862 as it didn't work for Bluetooth devices in bootloader. Instead, initial Cancel call timeout is removed for all non-T1 devices which should fix the same issue while keeping the legacy T1 support.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/cancel-timeout&lookback=7)