### PR TITLE
Feat: server bluetooth push notifications

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -323,19 +323,20 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     subscribe() {
-        if (this.bluetoothProps?.id) {
+        const { bluetoothProps } = this;
+        if (bluetoothProps?.id) {
             this.transport
                 .subscribe({
-                    path: this.bluetoothProps.id,
-                    channels: ['battery-level'],
+                    path: bluetoothProps.id,
+                    channels: ['battery-level', 'trezor-push-notification'],
                 })
                 .then(result => {
-                    if (result.success && this.bluetoothProps) {
-                        this.bluetoothProps.channels = result.payload;
+                    if (result.success && bluetoothProps) {
+                        bluetoothProps.channels = result.payload;
                         this.lifecycle.emit(DEVICE.CHANGED);
                     }
 
-                    if (this.bluetoothProps?.channels?.['battery-level']) {
+                    if (bluetoothProps.channels?.['battery-level']) {
                         this.transport.on('battery-level', event => {
                             this._updateFeature('soc', event.data[0]);
                             this.lifecycle.emit(DEVICE.CHANGED);
@@ -423,6 +424,9 @@ export class Device extends TypedEmitter<DeviceEvents> {
             }
         }
 
+        // We subscribe now that we have completed handshake with device.
+        this.subscribe();
+
         return true;
     }
 
@@ -480,10 +484,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
             .then(() => {
                 if (wasUnacquired && !this.isUnacquired()) {
                     this.lifecycle.emit(DEVICE.CONNECT);
-                    // If device has `Capability_BLE` we assume it can do PUSH notifications so we subscribe.
-                    if (this.features.capabilities.includes('Capability_BLE')) {
-                        this.subscribe();
-                    }
                 }
             });
 

--- a/packages/transport-bluetooth/CHANGELOG.md
+++ b/packages/transport-bluetooth/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 0.4.2
+
+- added open_device/close_device characteristics param
+- dispatching notifications from requested characteristics
+- removed NAPI bindings
+- fix: get_info method
+- fix: linux connectionsStatus after unsuccessful connection
+
 ### 0.4.1
 
 - breaking change in websocket api parameters, responses and notifications

--- a/packages/transport-bluetooth/Cargo.lock
+++ b/packages/transport-bluetooth/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "trezor-bluetooth"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bluez-async",
  "btleplug",

--- a/packages/transport-bluetooth/Cargo.toml
+++ b/packages/transport-bluetooth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trezor-bluetooth"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [profile.release]

--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -68,7 +68,9 @@ export class BluetoothApi extends AbstractApi {
             transportApiEvent(event);
         });
         api.on('device_read', ({ id, data, characteristic }) => {
-            if (characteristic === 'push-notification') {
+            if (characteristic === 'trezor-push-notification') {
+                // TODO: we should create a protocol decode that passes some type that is more humanfriendly to be emmited.
+                // @ts-expect-error data is number[] but we are emitting it as NotificationData.
                 this.emit('trezor-push-notification', { id, data });
             } else if (characteristic === 'battery-level') {
                 this.emit('battery-level', { id, data });

--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -1,3 +1,4 @@
+import { NotificationData } from '@trezor/transport/src/transports/abstract';
 import type { Logger } from '@trezor/transport/src/types';
 import type { TypedEmitter } from '@trezor/utils';
 
@@ -55,7 +56,10 @@ export interface NotificationEvent {
     device_connected: { id: string; devices: BluetoothDevice[] };
     device_connection_status: { device: BluetoothDevice };
     device_disconnected: { id: string; devices: BluetoothDevice[] };
-    device_read: { id: string; characteristic: NotificationCharacteristic; data: number[] };
+    device_read:
+        | { id: string; characteristic: 'battery-level' | 'read'; data: number[] }
+        | { id: string; characteristic: 'trezor-push-notification'; data: NotificationData };
+
     device_settings_ui: undefined; // dispatched by linux pairing process
     device_removed: { id: string };
 }

--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -1,4 +1,3 @@
-import { NotificationData } from '@trezor/transport/src/transports/abstract';
 import type { Logger } from '@trezor/transport/src/types';
 import type { TypedEmitter } from '@trezor/utils';
 
@@ -47,7 +46,7 @@ export interface BluetoothDevice {
 
 export type BluetoothAdapterState = 'enabled' | 'disabled' | 'permission-denied';
 
-export type NotificationCharacteristic = 'read' | 'push-notification' | 'battery-level';
+export type NotificationCharacteristic = 'read' | 'trezor-push-notification' | 'battery-level';
 
 export interface NotificationEvent {
     adapter_state_changed: { state: BluetoothAdapterState };
@@ -56,9 +55,7 @@ export interface NotificationEvent {
     device_connected: { id: string; devices: BluetoothDevice[] };
     device_connection_status: { device: BluetoothDevice };
     device_disconnected: { id: string; devices: BluetoothDevice[] };
-    device_read:
-        | { id: string; characteristic: 'battery-level' | 'read'; data: number[] }
-        | { id: string; characteristic: 'trezor-push-notification'; data: NotificationData };
+    device_read: { id: string; characteristic: NotificationCharacteristic; data: number[] };
 
     device_settings_ui: undefined; // dispatched by linux pairing process
     device_removed: { id: string };

--- a/packages/transport-bluetooth/src/server/methods/open_device.rs
+++ b/packages/transport-bluetooth/src/server/methods/open_device.rs
@@ -32,7 +32,7 @@ pub async fn open_device(
     let characteristic = characteristic.unwrap_or(NotificationCharacteristic::Read);
     let characteristic_uuid = match characteristic {
         NotificationCharacteristic::Read => CHARACTERISTIC_TX,
-        NotificationCharacteristic::PushNotification => CHARACTERISTIC_PUSH_NOTIFICATION,
+        NotificationCharacteristic::TrezorPushNotification => CHARACTERISTIC_PUSH_NOTIFICATION,
         NotificationCharacteristic::BatteryLevel => CHARACTERISTIC_BATTERY_LEVEL,
     };
 

--- a/packages/transport-bluetooth/src/server/types.rs
+++ b/packages/transport-bluetooth/src/server/types.rs
@@ -48,7 +48,7 @@ pub struct ForgetDeviceParams {
 #[serde(rename_all = "kebab-case")]
 pub enum NotificationCharacteristic {
     Read,
-    PushNotification,
+    TrezorPushNotification,
     BatteryLevel,
 }
 

--- a/packages/transport-bluetooth/src/ui/app.tsx
+++ b/packages/transport-bluetooth/src/ui/app.tsx
@@ -390,8 +390,8 @@ export const App: React.FC = () => {
                                         <select ref={selectRef}>
                                             <option value="">Select characteristic</option>
                                             <option value="read">READ</option>
-                                            <option value="push-notification">
-                                                PUSH_NOTIFICATION
+                                            <option value="trezor-push-notification">
+                                                TREZOR_PUSH_NOTIFICATION
                                             </option>
                                             <option value="battery-level">BATTERY_LEVEL</option>
                                         </select>

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -7,6 +7,7 @@ import type {
     AsyncResultWithTypedError,
     DescriptorApiLevel,
     Logger,
+    NotificationData,
     PathInternal,
     Success,
 } from '../types';
@@ -16,7 +17,7 @@ export interface AbstractApiConstructorParams {
     logger?: Logger;
 }
 
-export type OpenDeviceChannel = 'read' | 'push-notification' | 'battery-level';
+export type OpenDeviceChannel = 'read' | 'trezor-push-notification' | 'battery-level';
 
 type AccessLock = {
     read: boolean;
@@ -32,7 +33,7 @@ type AccessLock = {
 export abstract class AbstractApi extends TypedEmitter<{
     'transport-interface-change': DescriptorApiLevel[];
     'transport-interface-error': { error: typeof ERRORS.API_DISCONNECTED };
-    [TRANSPORT.TREZOR_PUSH_NOTIFICATION]: { id: string; data: number[] };
+    [TRANSPORT.TREZOR_PUSH_NOTIFICATION]: { id: string; data: NotificationData };
     [TRANSPORT.BATTERY_LEVEL]: { id: string; data: number[] };
 }> {
     protected logger?: Logger;

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -13,6 +13,7 @@ import {
     Descriptor,
     Logger,
     MessageResponse,
+    NotificationData,
     PathPublic,
     ResultWithTypedError,
     Session,
@@ -79,7 +80,7 @@ type TransportEvents = {
     [TRANSPORT.ERROR]: BridgeCommonErrors | typeof ERRORS.API_DISCONNECTED; // BluetoothApi disconnected
     [TRANSPORT.STOPPED]: void;
     [TRANSPORT.SEND_MESSAGE_PROGRESS]: number;
-    [TRANSPORT.TREZOR_PUSH_NOTIFICATION]: { id: string; data: number[] };
+    [TRANSPORT.TREZOR_PUSH_NOTIFICATION]: { id: string; data: NotificationData };
     [TRANSPORT.BATTERY_LEVEL]: { id: string; data: number[] };
 };
 

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -34,6 +34,20 @@ export type Descriptor = Omit<DescriptorApiLevel, 'path'> & {
     id?: string;
 };
 
+/** Device boot/startup notification */
+type NotifyBoot = 0;
+/** Device unlocked and ready to accept messages */
+type NotifyUnlock = 1;
+/** Device hard-locked and won't accept messages */
+type NotifyLock = 2;
+type NormalMode = 0;
+type BootloaderMode = 1;
+export type NotificationData = [
+    1,
+    NotifyBoot | NotifyUnlock | NotifyLock,
+    NormalMode | BootloaderMode,
+];
+
 export interface Logger {
     info(...args: any): void;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changing event name from transport-bluetooth to `trezor-push-notification` from `push-notification`.


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/server-bluetooth-push-notifications&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/server-bluetooth-push-notifications&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/server-bluetooth-push-notifications&lookback=7)