### PR TITLE
fix(suite-native): turn on and unlock

### DIFF
--- a/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenHeader.tsx
+++ b/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenHeader.tsx
@@ -17,7 +17,7 @@ import {
     NavigateParameters,
     RootStackParamList,
     StackToStackCompositeNavigationProps,
-    useOverrideBackNavigation,
+    useHandleHardwareBackNavigation,
 } from '@suite-native/navigation';
 import TrezorConnect from '@trezor/connect';
 
@@ -91,7 +91,7 @@ export const ConnectDeviceScreenHeader = ({
         navigation,
     ]);
 
-    useOverrideBackNavigation({ onNavigateBack: handleCancel });
+    useHandleHardwareBackNavigation(handleCancel);
 
     // Hide alert when navigating away from the PIN entry screen (PIN entered or canceled on device)
     // eslint-disable-next-line arrow-body-style


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
https://github.com/trezor/trezor-suite/pull/21197/files this refactor broke navigation on this screen and @BrantalikP will create a follow up PR with proper navigation handling of these hooks. Meanwhile, I'm reverting this change to fix the issue short term.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21891

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/turn-on-and-unlock&lookback=7)