### PR TITLE
Do not use name of selected device for pairing failed dialog

### DIFF
--- a/suite-native/bluetooth/src/components/SystemUnpairingAlertIosInstructions.tsx
+++ b/suite-native/bluetooth/src/components/SystemUnpairingAlertIosInstructions.tsx
@@ -1,17 +1,16 @@
-import { useSelector } from 'react-redux';
-
-import { selectDeviceName } from '@suite-common/wallet-core';
 import { BottomSheetListItem, Box, Text, VStack } from '@suite-native/atoms';
-import { Translation, TxKeyPath } from '@suite-native/intl';
+import { Translation, TxKeyPath, useTranslate } from '@suite-native/intl';
 
 type SystemUnpairingAlertIosInstructionsProps = {
     translationKey: TxKeyPath;
+    deviceName?: string;
 };
 
 export const SystemUnpairingAlertIosInstructions = ({
     translationKey,
+    deviceName,
 }: SystemUnpairingAlertIosInstructionsProps) => {
-    const deviceName = useSelector(selectDeviceName);
+    const { translate } = useTranslate();
 
     return (
         <Box>
@@ -27,7 +26,9 @@ export const SystemUnpairingAlertIosInstructions = ({
                     iconNumber={2}
                     translationKey="bluetooth.alerts.pairingInstructions.step2"
                     translationValues={{
-                        deviceName,
+                        deviceName:
+                            deviceName ??
+                            translate('bluetooth.alerts.pairingFailed.deviceNamePlaceholder'),
                     }}
                 />
                 <BottomSheetListItem

--- a/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.ios.tsx
+++ b/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.ios.tsx
@@ -1,8 +1,9 @@
 // This is iOS version, see the file name.
 
 import { useCallback } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
+import { selectDeviceName } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { useTranslate } from '@suite-native/intl';
 
@@ -13,6 +14,7 @@ export const useBluetoothPlatformSpecificAlerts = () => {
     const { showAlert } = useAlert();
     const { translate } = useTranslate();
     const dispatch = useDispatch();
+    const deviceName = useSelector(selectDeviceName);
 
     const showBluetoothAdapterDisabledAlert = useCallback(() => {
         showAlert({
@@ -37,14 +39,17 @@ export const useBluetoothPlatformSpecificAlerts = () => {
             title: translate('bluetooth.alerts.systemUnpairing.title.ios'),
             textAlign: 'left',
             description: (
-                <SystemUnpairingAlertIosInstructions translationKey="bluetooth.alerts.systemUnpairing.description.ios" />
+                <SystemUnpairingAlertIosInstructions
+                    translationKey="bluetooth.alerts.systemUnpairing.description.ios"
+                    deviceName={deviceName}
+                />
             ),
             primaryButtonTitle: translate('generic.buttons.gotIt'),
             onPressPrimaryButton: () => {
                 dispatch(setShouldShowSystemUnpairingAlert(false));
             },
         });
-    }, [showAlert, dispatch, translate]);
+    }, [showAlert, dispatch, translate, deviceName]);
 
     return {
         showBluetoothAdapterDisabledAlert,

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -191,6 +191,7 @@ export const messages = {
                     'The Trezor you’re trying to connect may still be remembered in your phone’s Bluetooth settings. Remove it and try again.',
                 primaryButton: 'Open system settings',
                 secondaryButton: 'Device removed',
+                deviceNamePlaceholder: 'your Trezor',
             },
             systemUnpairing: {
                 title: {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

For the pairing failed dialog we can't use name of selected device. It is either different device, that is remembered or "Portfolio tracker". We can't even use `BluetoothDevice` because once the pairing fails, the device is no longer in `nearbyDevices`. That is why general placeholder is used. Also applied as a backup for unpairing alert just for sure.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21889

## Screenshots:
<img width="391" height="424" alt="image" src="https://github.com/user-attachments/assets/12a53482-304e-418d-af91-0de1b1339f68" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/pairing-failed-device-name&lookback=7)