### PR TITLE
feat(suite): remove switch device button

### DIFF
--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -160,14 +160,13 @@ const getMessageId = ({
     return map[prerequisite];
 };
 
-interface ConnectDevicePromptProps {
+type ConnectDevicePromptProps = {
     connected: boolean;
     showWarning?: boolean;
     showWarningIcon: boolean;
-    allowSwitchDevice?: boolean;
     prerequisite: PrerequisiteType | null;
     deviceStatus: ConnectedDeviceStatus | null;
-}
+};
 
 const ConnectImage = ({
     connected,

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -117,7 +117,7 @@ export const Preloader = ({ children }: PropsWithChildren) => {
         return (
             <WelcomeLayout showAccounts={false}>
                 <Card paddingType="large">
-                    <PrerequisitesGuide allowSwitchDevice />
+                    <PrerequisitesGuide />
                 </Card>
             </WelcomeLayout>
         );

--- a/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
@@ -8,13 +8,12 @@ import {
     getStatus,
     shouldDisplayInitialWarningIcon,
 } from '@suite-common/suite-utils';
-import { selectDevices, selectSelectedDevice } from '@suite-common/wallet-core';
-import { Button, Column, motionEasing } from '@trezor/components';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { Column, motionEasing } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { goto } from 'src/actions/suite/routerActions';
-import { ConnectDevicePrompt, Translation } from 'src/components/suite';
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { ConnectDevicePrompt } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
 import { selectPrerequisite } from 'src/selectors/suite/suiteSelectors';
 
 import { DeviceAcquire } from './DeviceAcquire';
@@ -37,15 +36,8 @@ const BottomAnimatedContainer = styled(motion.div)`
     display: flex;
 `;
 
-type PrerequisitesGuideProps = {
-    allowSwitchDevice?: boolean;
-};
-
-export const PrerequisitesGuide = ({ allowSwitchDevice }: PrerequisitesGuideProps) => {
-    const dispatch = useDispatch();
+export const PrerequisitesGuide = () => {
     const device = useSelector(selectSelectedDevice);
-    const devices = useSelector(selectDevices);
-    const connectedDevicesCount = devices.filter(d => d.connected === true).length;
     const prerequisite = useSelector(selectPrerequisite);
 
     const TipComponent = useMemo(
@@ -89,18 +81,10 @@ export const PrerequisitesGuide = ({ allowSwitchDevice }: PrerequisitesGuideProp
         [prerequisite],
     );
 
-    const handleSwitchDeviceClick = () =>
-        dispatch(goto('suite-switch-device', { params: { cancelable: true } }));
-
     const deviceStatus = (device && getStatus(device)) ?? null;
 
     return (
         <Column alignItems="center" gap={spacings.xxxl} margin={{ vertical: 40 }}>
-            {allowSwitchDevice && connectedDevicesCount > 1 && (
-                <Button variant="tertiary" onClick={handleSwitchDeviceClick} icon="trezorDevices">
-                    <Translation id="TR_SWITCH_DEVICE" />
-                </Button>
-            )}
             <ConnectDevicePrompt
                 connected={!!device}
                 deviceStatus={deviceStatus}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After wallet switcher was added to `PrerequisitesGuide` screen in https://github.com/trezor/trezor-suite/pull/21872, the button is redundant. Removing.

## Screenshots:
Before:
<img width="1091" height="1087" alt="Screenshot 2025-09-25 at 15 47 12" src="https://github.com/user-attachments/assets/01a2e83b-53a2-4197-ba94-ab9f744d8df2" />

After:
<img width="1095" height="991" alt="Screenshot 2025-09-25 at 15 46 21" src="https://github.com/user-attachments/assets/7470c27d-1b05-4ef7-82e6-234e74dc4ea9" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-device-switch&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-device-switch&lookback=7)