### PR TITLE
fix(suite): Adjust labeling spacing

### DIFF
--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/withEditable.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/withEditable.tsx
@@ -9,7 +9,8 @@ import {
 
 import styled, { useTheme } from 'styled-components';
 
-import { AutoScalingInput, Icon } from '@trezor/components';
+import { AutoScalingInput, Icon, Row } from '@trezor/components';
+import { spacings } from '@trezor/theme';
 
 const IconWrapper = styled.div<{ $bgColor: string }>`
     display: flex;
@@ -23,7 +24,6 @@ const IconWrapper = styled.div<{ $bgColor: string }>`
 
 const IconListWrapper = styled.div`
     display: flex;
-    margin: 0 0 0 10px;
 `;
 
 // To inherit everything so the input looks like the text we want to edit
@@ -89,7 +89,7 @@ export const withEditable =
         }, [value, touched]);
 
         return (
-            <>
+            <Row gap={spacings.xs}>
                 <WrappedComponent {...props}>
                     <Editable
                         minWidth={20}
@@ -140,6 +140,6 @@ export const withEditable =
                         />
                     </IconWrapper>
                 </IconListWrapper>
-            </>
+            </Row>
         );
     };

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -182,31 +182,33 @@ export const ConfirmValueModal = ({
                             alignItems="stretch"
                             data-testid="@modal/output-address"
                         >
-                            <Box aspectRatio="1" width={180} height={180}>
+                            <Box aspectRatio="1" width={170} height={170}>
                                 <QrCode value={value} />
                             </Box>
                             <Column gap={spacings.lg}>
-                                {label ? (
-                                    <InfoItem label={label}>{outputValue}</InfoItem>
-                                ) : (
-                                    outputValue
-                                )}
-                                {account && (
-                                    <MetadataLabeling
-                                        variant="button"
-                                        deviceStaticSessionId={account.deviceState}
-                                        payload={{
-                                            type: 'addressLabel',
-                                            entityKey: account.key,
-                                            defaultValue: value,
-                                            value:
-                                                localFirstAddressLabels.find(
-                                                    it => it.address === value,
-                                                )?.label ?? addressLabels[value],
-                                        }}
-                                        visible
-                                    />
-                                )}
+                                <Column gap={spacings.xs}>
+                                    {label ? (
+                                        <InfoItem label={label}>{outputValue}</InfoItem>
+                                    ) : (
+                                        outputValue
+                                    )}
+                                    {account && (
+                                        <MetadataLabeling
+                                            variant="button"
+                                            deviceStaticSessionId={account.deviceState}
+                                            payload={{
+                                                type: 'addressLabel',
+                                                entityKey: account.key,
+                                                defaultValue: value,
+                                                value:
+                                                    localFirstAddressLabels.find(
+                                                        it => it.address === value,
+                                                    )?.label ?? addressLabels[value],
+                                            }}
+                                            visible
+                                        />
+                                    )}
+                                </Column>
                                 {isCopyButtonVisible && (
                                     <Button
                                         onClick={copy}

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -492,7 +492,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     )}
                     {outputsCount > 1 && (
                         <IconButton
-                            margin={{ left: spacings.xxs }}
+                            margin={{ left: spacings.md }}
                             icon="x"
                             size="tiny"
                             variant="tertiary"


### PR DESCRIPTION
## Screenshots

Before:
<img width="887" height="292" alt="send-before" src="https://github.com/user-attachments/assets/ed73e437-533d-48ea-93c0-fd45798b5007" />
After:
<img width="899" height="300" alt="send-after" src="https://github.com/user-attachments/assets/1b1ed44c-3c05-47dd-b93d-4e49b8c98499" />

----

Before:
<img width="737" height="831" alt="receive-before" src="https://github.com/user-attachments/assets/aa181565-c972-4fcc-a203-608388e62421" />
After:
<img width="744" height="822" alt="receive-after" src="https://github.com/user-attachments/assets/82e7bf85-c5f1-4732-8ffb-4d8a6be78925" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/labeling-spacing&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/labeling-spacing&lookback=7)