### PR TITLE
feat(suite-native): in app rating

### DIFF
--- a/scripts/list-outdated-dependencies/mobile-dependencies.txt
+++ b/scripts/list-outdated-dependencies/mobile-dependencies.txt
@@ -59,6 +59,7 @@ expo-splash-screen
 expo-sqlite
 expo-status-bar
 expo-system-ui
+expo-store-review
 expo-updates
 expo-video
 fantasticon

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -50,8 +50,7 @@ export const Feature = {
 
     entropyCheck: 'security.entropyCheck',
     entropyCheckMobile: 'security.entropyCheck.mobile',
-    // FW update feature flag implemented only for mobile app
-    firmwareUpdate: 'device.firmware.update',
+
     trading: {
         buy: 'trading.buy',
         sell: 'trading.sell',
@@ -62,6 +61,10 @@ export const Feature = {
     },
     dashboardPromoBanner: 'dashboard.promoBanner',
     mevProtection: 'settings.mevProtection',
+
+    // Feature flags implemented only for mobile app
+    firmwareUpdate: 'device.firmware.update',
+    inAppRating: 'inAppRating',
 } as const;
 
 type ExtractFeatureValues<T> =

--- a/suite-native/in-app-rating/package.json
+++ b/suite-native/in-app-rating/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@suite-native/in-app-rating",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@reduxjs/toolkit": "2.8.2",
+        "@suite-common/message-system": "workspace:*",
+        "expo-store-review": "~8.1.5",
+        "react-redux": "9.2.0"
+    }
+}

--- a/suite-native/in-app-rating/redux.d.ts
+++ b/suite-native/in-app-rating/redux.d.ts
@@ -1,0 +1,7 @@
+import { AsyncThunkAction } from '@reduxjs/toolkit';
+
+declare module 'redux' {
+    export interface Dispatch {
+        <TThunk extends AsyncThunkAction<any, any, any>>(thunk: TThunk): ReturnType<TThunk>;
+    }
+}

--- a/suite-native/in-app-rating/src/hooks/useInAppRating.ts
+++ b/suite-native/in-app-rating/src/hooks/useInAppRating.ts
@@ -1,0 +1,33 @@
+import * as StoreReview from 'expo-store-review';
+
+import { useIsInAppRatingEnabled } from './useIsInAppRatingEnabled';
+
+export const useInAppRating = () => {
+    const isAppRatingEnabled = useIsInAppRatingEnabled();
+
+    const askForRating = async () => {
+        if (!isAppRatingEnabled) return;
+
+        try {
+            const canReview = await StoreReview.hasAction();
+
+            if (!canReview) {
+                console.warn('In-app review not allowed on this device');
+
+                return;
+            }
+
+            // Adding a small delay to ensure the prompt is shown at an appropriate time
+            await new Promise(resolve => {
+                setTimeout(async () => {
+                    await StoreReview.requestReview();
+                    resolve(undefined);
+                }, 1000);
+            });
+        } catch (error) {
+            console.warn('In-app review error:', error);
+        }
+    };
+
+    return { askForRating };
+};

--- a/suite-native/in-app-rating/src/hooks/useIsInAppRatingEnabled.ts
+++ b/suite-native/in-app-rating/src/hooks/useIsInAppRatingEnabled.ts
@@ -1,0 +1,15 @@
+import { useSelector } from 'react-redux';
+
+import {
+    Feature,
+    MessageSystemRootState,
+    selectIsFeatureEnabled,
+} from '@suite-common/message-system';
+
+export const useIsInAppRatingEnabled = () => {
+    const isInAppRatingEnabled = useSelector((state: MessageSystemRootState) =>
+        selectIsFeatureEnabled(state, Feature.inAppRating, true),
+    );
+
+    return isInAppRatingEnabled;
+};

--- a/suite-native/in-app-rating/src/index.ts
+++ b/suite-native/in-app-rating/src/index.ts
@@ -1,0 +1,2 @@
+export * from './hooks/useIsInAppRatingEnabled';
+export * from './hooks/useInAppRating';

--- a/suite-native/in-app-rating/tsconfig.json
+++ b/suite-native/in-app-rating/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        {
+            "path": "../../suite-common/message-system"
+        }
+    ]
+}

--- a/suite-native/module-send/src/components/OutputsReviewFooter.tsx
+++ b/suite-native/module-send/src/components/OutputsReviewFooter.tsx
@@ -69,6 +69,7 @@ const navigateOutOfSendFlowAction = ({
                 tokenContract,
                 txid,
                 closeActionType: 'close',
+                source: 'send',
             },
         });
     }

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -302,6 +302,7 @@ export type RootStackParamList = {
         accountKey: AccountKey;
         closeActionType?: CloseActionType;
         tokenContract?: TokenAddress;
+        source?: 'send';
     };
     [RootStackRoutes.DevUtilsStack]: undefined;
     [RootStackRoutes.AccountDetail]: AccountDetailParams;

--- a/suite-native/receive/package.json
+++ b/suite-native/receive/package.json
@@ -26,6 +26,7 @@
         "@suite-native/device-mutex": "workspace:*",
         "@suite-native/helpers": "workspace:*",
         "@suite-native/icons": "workspace:*",
+        "@suite-native/in-app-rating": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/link": "workspace:*",
         "@suite-native/module-device-onboarding": "workspace:*",

--- a/suite-native/receive/src/components/ReceiveScreenHeader.tsx
+++ b/suite-native/receive/src/components/ReceiveScreenHeader.tsx
@@ -1,7 +1,6 @@
-import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, usePreventRemove } from '@react-navigation/native';
 
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
@@ -24,12 +23,14 @@ type ReceiveScreenHeaderProps = {
     accountKey?: AccountKey;
     tokenContract?: TokenAddress;
     closeActionType: CloseActionType;
+    onLeave?: () => void;
 };
 
 export const ReceiveScreenHeader = ({
     accountKey,
     tokenContract,
     closeActionType,
+    onLeave,
 }: ReceiveScreenHeaderProps) => {
     const navigation = useNavigation();
     const navigateToInitialScreen = useNavigateToInitialScreen();
@@ -44,14 +45,13 @@ export const ReceiveScreenHeader = ({
         selectAccountTokenSymbol(state, accountKey, tokenContract),
     );
 
-    useEffect(() => {
-        const unsubscribe = navigation.addListener('beforeRemove', () => {
-            // When leaving the screen, cancel the request for address on trezor device
-            TrezorConnect.cancel();
-        });
+    usePreventRemove(true, ({ data }) => {
+        TrezorConnect.cancel();
 
-        return unsubscribe;
-    }, [navigation]);
+        navigation.dispatch(data.action);
+
+        onLeave?.();
+    });
 
     return (
         <ScreenHeader

--- a/suite-native/receive/src/screens/ReceiveAddressScreen.tsx
+++ b/suite-native/receive/src/screens/ReceiveAddressScreen.tsx
@@ -25,10 +25,11 @@ import {
     selectHasFirmwareAuthenticityCheckHardFailed,
     useConfirmOnTrezorController,
 } from '@suite-native/device';
+import { useInAppRating } from '@suite-native/in-app-rating';
 import { Translation } from '@suite-native/intl';
 import { Link } from '@suite-native/link';
 import { WalletBackupNotSetWarningBottomSheet } from '@suite-native/module-device-onboarding';
-import { CloseActionType, useNavigateToInitialScreen } from '@suite-native/navigation';
+import { CloseActionType } from '@suite-native/navigation';
 import TrezorConnect from '@trezor/connect';
 import { HELP_CENTER_OTHER_CRYPTOCURRENCIES_DESTINATION_TAGS_URL } from '@trezor/urls';
 
@@ -49,10 +50,10 @@ export const ReceiveAddressScreen = ({
     tokenContract,
     closeActionType,
 }: ReceiveAddressScreenProps) => {
+    const { askForRating } = useInAppRating();
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
-    const navigateToInitialScreen = useNavigateToInitialScreen();
     const isDeviceBackupRequired = useSelector(selectIsDeviceBackupRequired);
 
     const { revealConfirmOnTrezorSheet, confirmOnTrezorRef, closeSheet } =
@@ -113,13 +114,14 @@ export const ReceiveAddressScreen = ({
         <ConfirmOnTrezorWrapper
             isManualControlEnabled
             controlRef={confirmOnTrezorRef}
-            closeActionType={isReceiveApproved ? 'close' : closeActionType}
-            closeAction={isReceiveApproved ? navigateToInitialScreen : onCancel}
+            closeActionType={closeActionType}
+            closeAction={onCancel}
             defaultHeader={
                 <ReceiveScreenHeader
                     accountKey={accountKey}
                     tokenContract={tokenContract}
                     closeActionType={isReceiveApproved ? 'close' : closeActionType}
+                    onLeave={isReceiveApproved ? askForRating : undefined}
                 />
             }
         >

--- a/suite-native/receive/tsconfig.json
+++ b/suite-native/receive/tsconfig.json
@@ -19,6 +19,7 @@
         { "path": "../device-mutex" },
         { "path": "../helpers" },
         { "path": "../icons" },
+        { "path": "../in-app-rating" },
         { "path": "../intl" },
         { "path": "../link" },
         { "path": "../module-device-onboarding" },

--- a/suite-native/transactions/package.json
+++ b/suite-native/transactions/package.json
@@ -31,6 +31,7 @@
         "@suite-native/formatters": "workspace:*",
         "@suite-native/helpers": "workspace:*",
         "@suite-native/icons": "workspace:*",
+        "@suite-native/in-app-rating": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/labeling": "workspace:*",
         "@suite-native/link": "workspace:*",

--- a/suite-native/transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/transactions/src/screens/TransactionDetailScreen.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
+import { useNavigation, usePreventRemove } from '@react-navigation/native';
+
 import {
     BlockchainRootState,
     TransactionsRootState,
@@ -11,6 +13,7 @@ import {
 import { TokenAddress, TokenSymbol } from '@suite-common/wallet-types';
 import { EventType, analytics } from '@suite-native/analytics';
 import { Button, VStack } from '@suite-native/atoms';
+import { useInAppRating } from '@suite-native/in-app-rating';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
 import {
@@ -29,7 +32,10 @@ import { TransactionName } from '../components/TransactionName';
 export const TransactionDetailScreen = ({
     route,
 }: StackProps<RootStackParamList, RootStackRoutes.TransactionDetail>) => {
-    const { txid, accountKey, tokenContract, closeActionType = 'back' } = route.params;
+    const { askForRating } = useInAppRating();
+    const navigation = useNavigation();
+
+    const { txid, accountKey, tokenContract, closeActionType = 'back', source } = route.params;
     const openLink = useOpenLink();
     const transaction = useSelector((state: TransactionsRootState) =>
         selectTransactionByAccountKeyAndTxid(state, accountKey, txid),
@@ -42,6 +48,11 @@ export const TransactionDetailScreen = ({
     );
 
     const tokenTransfer = transaction?.tokens.find(token => token.contract === tokenContract);
+
+    usePreventRemove(source === 'send', ({ data }) => {
+        navigation.dispatch(data.action);
+        askForRating();
+    });
 
     useEffect(() => {
         if (transaction) {

--- a/suite-native/transactions/tsconfig.json
+++ b/suite-native/transactions/tsconfig.json
@@ -36,6 +36,7 @@
         { "path": "../formatters" },
         { "path": "../helpers" },
         { "path": "../icons" },
+        { "path": "../in-app-rating" },
         { "path": "../intl" },
         { "path": "../labeling" },
         { "path": "../link" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11576,6 +11576,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite-native/in-app-rating@workspace:*, @suite-native/in-app-rating@workspace:suite-native/in-app-rating":
+  version: 0.0.0-use.local
+  resolution: "@suite-native/in-app-rating@workspace:suite-native/in-app-rating"
+  dependencies:
+    "@reduxjs/toolkit": "npm:2.8.2"
+    "@suite-common/message-system": "workspace:*"
+    expo-store-review: "npm:~8.1.5"
+    react-redux: "npm:9.2.0"
+  languageName: unknown
+  linkType: soft
+
 "@suite-native/intl@workspace:*, @suite-native/intl@workspace:^, @suite-native/intl@workspace:suite-native/intl":
   version: 0.0.0-use.local
   resolution: "@suite-native/intl@workspace:suite-native/intl"
@@ -12437,6 +12448,7 @@ __metadata:
     "@suite-native/device-mutex": "workspace:*"
     "@suite-native/helpers": "workspace:*"
     "@suite-native/icons": "workspace:*"
+    "@suite-native/in-app-rating": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/link": "workspace:*"
     "@suite-native/module-device-onboarding": "workspace:*"
@@ -12731,6 +12743,7 @@ __metadata:
     "@suite-native/formatters": "workspace:*"
     "@suite-native/helpers": "workspace:*"
     "@suite-native/icons": "workspace:*"
+    "@suite-native/in-app-rating": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/labeling": "workspace:*"
     "@suite-native/link": "workspace:*"
@@ -24890,6 +24903,16 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/d82e4155f7a549bbb010e7b5c13386fd8b5b513c6e219823ab99633a942bb88192cb4a3db6e3f0f1eddb3ce891439ada79a1ff03073e219041bfcaa67e69c1ef
+  languageName: node
+  linkType: hard
+
+"expo-store-review@npm:~8.1.5":
+  version: 8.1.5
+  resolution: "expo-store-review@npm:8.1.5"
+  peerDependencies:
+    expo: "*"
+    react-native: "*"
+  checksum: 10/8740804f795c9e7a26e6a59551fe0865ffb2064fce32cba52f038b2d77176de3db5f261efa66de8e4abb54386977f2f5a379c0947de862efe7993b426c303849
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

 •Implemented In-App Rating
• Rating is triggered in these two scenarios:
```
 Receive: After closing the receive address confirmation screen  
Send: After closing the transaction details progress screen  
```

• Added In-App Rating Feature Flag

**Note**: There’s no reliable way to test this besides on an iOS device/simulator in debug mode, since the actual display of the prompt is fully controlled by the platform. For more details, see the [iOS](https://developer.apple.com/design/human-interface-guidelines/ratings-and-reviews) and [Android](https://developer.android.com/guide/playcore/in-app-review#when-to-request) guidelines.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20925

## Screenshots:

https://github.com/user-attachments/assets/0fc42c0a-037c-4505-a41c-119d7246c441

https://github.com/user-attachments/assets/39376dda-7887-4cd1-bd56-6bdb4022e5cf




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/in-app-review&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/in-app-review&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/in-app-review&lookback=7)