### PR TITLE
perf(suite-native): improve graph re-rendering

### DIFF
--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -30,6 +30,7 @@ import {
     selectDevices,
     selectFirmwareRevisionCheckError,
     selectHasDeviceFirmwareInstalled,
+    selectHasRunningDiscovery,
     selectIsConnectedDeviceUninitialized,
     selectIsDeviceConnectedAndAuthorized,
     selectIsDeviceInBootloader,
@@ -139,9 +140,12 @@ const getTotalFiatBalanceNative = ({
 };
 
 export const selectSelectedDeviceTotalFiatBalance = createMemoizedSelector(
-    [selectDeviceAccounts, selectCurrentFiatRates, selectBaseCurrency],
-    (deviceAccounts, rates, localCurrency) =>
-        getTotalFiatBalanceNative({ deviceAccounts, localCurrency, rates }),
+    [selectDeviceAccounts, selectCurrentFiatRates, selectBaseCurrency, selectHasRunningDiscovery],
+    (deviceAccounts, rates, localCurrency, hasRunningDiscovery) =>
+        // do not return any value before discovery is finished to prevent unnecessary rerenders of portfolio graph.
+        hasRunningDiscovery
+            ? undefined
+            : getTotalFiatBalanceNative({ deviceAccounts, localCurrency, rates }),
 );
 
 export const selectDeviceTotalFiatBalanceByDeviceState = createMemoizedSelector(

--- a/suite-native/graph/src/components/GraphBaseCurrencyBalance.tsx
+++ b/suite-native/graph/src/components/GraphBaseCurrencyBalance.tsx
@@ -24,7 +24,7 @@ type GraphFiatBalanceProps = BalanceProps & {
     percentageChangeAtom: Atom<number>;
     showChange?: boolean;
     isLoading?: boolean;
-    totalBaseCurrencyBalance: BaseCurrencyAmount;
+    totalBaseCurrencyBalance?: BaseCurrencyAmount;
     isHistoryEnabledAccount?: boolean;
 };
 

--- a/suite-native/graph/src/hooks.ts
+++ b/suite-native/graph/src/hooks.ts
@@ -199,7 +199,7 @@ type UseGraphAtomsParams<TGraphPoint extends FiatGraphPoint> = {
     referencePointAtom: WritableAtom<TGraphPoint | null, [TGraphPoint | null], void>;
     selectedPointAtom: WritableAtom<TGraphPoint | null, [TGraphPoint | null], void>;
     graphPoints: TGraphPoint[];
-    totalFiatBalance: BaseCurrencyAmount;
+    totalFiatBalance?: BaseCurrencyAmount;
 };
 
 export const useGraphAtoms = <TGraphPoint extends FiatGraphPoint>({

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioHeader.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioHeader.tsx
@@ -15,7 +15,7 @@ import {
 
 type PortfolioHeaderProps = {
     isLoading: boolean;
-    totalFiatBalance: BaseCurrencyAmount;
+    totalFiatBalance?: BaseCurrencyAmount;
 };
 
 export const PortfolioHeader = ({ isLoading, totalFiatBalance }: PortfolioHeaderProps) => {
@@ -36,3 +36,5 @@ export const PortfolioHeader = ({ isLoading, totalFiatBalance }: PortfolioHeader
         </Box>
     );
 };
+
+PortfolioHeader.displayName = 'PortfolioHeader';


### PR DESCRIPTION
## Description
- partial fix of extensively re-rendering graph 
- the selector `selectSelectedDeviceTotalFiatBalance` was modified so it does not return any value before the discovery finishes. Saves about 200 re-renders on all seed with all networks enabled



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=perf/native/improve-graph-total-balance-rerenders&lookback=7)