### PR TITLE
feat(suite-native): show Bluetooth status on the Turn on & unlock screen

### DIFF
--- a/suite-native/bluetooth/src/hooks/useBluetoothManager.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothManager.ts
@@ -14,7 +14,6 @@ export const useBluetoothManager = () => {
 
     const bluetoothPermissionStatus = useSelector(selectBluetoothPermissionStatus);
     const bluetoothAdapterStatus = useSelector(selectBluetoothAdapterStatus);
-    const isScanningInProgress = bluetoothAdapterStatus === 'enabled';
 
     const [hasPermissionBeenRequested, setHasPermissionBeenRequested] = useState(false);
 
@@ -56,16 +55,12 @@ export const useBluetoothManager = () => {
     }, [showOrHideBluetoothAlert]);
 
     useEffect(() => {
-        if (isScanningInProgress) {
+        if (bluetoothAdapterStatus === 'enabled') {
             bluetoothManager.startDeviceScan(scanErrorHandler);
 
             return () => {
                 bluetoothManager.stopDeviceScan();
             };
         }
-    }, [isScanningInProgress, scanErrorHandler]);
-
-    return {
-        isScanningInProgress,
-    };
+    }, [bluetoothAdapterStatus, scanErrorHandler]);
 };

--- a/suite-native/device/src/components/TurnOnAndUnlockDeviceScreenContent.tsx
+++ b/suite-native/device/src/components/TurnOnAndUnlockDeviceScreenContent.tsx
@@ -1,4 +1,8 @@
+import { useSelector } from 'react-redux';
+
 import { HStack, Loader, Text, VStack, buttonSizeToDimensionsMap } from '@suite-native/atoms';
+import { selectBluetoothAdapterStatus } from '@suite-native/bluetooth';
+import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { getScreenHeight } from '@trezor/env-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -8,16 +12,14 @@ import { TurnOnDeviceAnimation } from './TurnOnDeviceAnimation';
 const ANIMATION_HEIGHT = getScreenHeight() * 0.6;
 
 type TurnOnAndUnlockDeviceScreenContentProps = {
-    isScanningInProgress: boolean;
+    isStatusVisible?: boolean;
 };
 
-const loaderStyle = prepareNativeStyle(
-    (_, { isScanningInProgress }: { isScanningInProgress: boolean }) => ({
-        height: buttonSizeToDimensionsMap.medium.minHeight,
-        alignItems: 'center',
-        opacity: isScanningInProgress ? 1 : 0, // use opacity to prevent layout shifts
-    }),
-);
+const statusStyle = prepareNativeStyle((_, { isStatusVisible }: { isStatusVisible: boolean }) => ({
+    height: buttonSizeToDimensionsMap.medium.minHeight,
+    alignItems: 'center',
+    opacity: isStatusVisible ? 1 : 0, // use opacity to prevent layout shifts
+}));
 
 const animationStyle = prepareNativeStyle(() => ({
     // Both height and width has to be set https://github.com/lottie-react-native/lottie-react-native/blob/master/MIGRATION-5-TO-6.md#updating-the-style-props
@@ -26,9 +28,11 @@ const animationStyle = prepareNativeStyle(() => ({
 }));
 
 export const TurnOnAndUnlockDeviceScreenContent = ({
-    isScanningInProgress,
+    isStatusVisible = true,
 }: TurnOnAndUnlockDeviceScreenContentProps) => {
     const { applyStyle } = useNativeStyles();
+
+    const bluetoothAdapterStatus = useSelector(selectBluetoothAdapterStatus);
 
     return (
         <VStack paddingTop="sp24" flex={1} justifyContent="space-between" alignItems="center">
@@ -36,11 +40,23 @@ export const TurnOnAndUnlockDeviceScreenContent = ({
                 <Text variant="titleMedium" textAlign="center">
                     <Translation id="moduleConnectDevice.turnOnAndUnlockScreen.title" />
                 </Text>
-                <HStack style={applyStyle(loaderStyle, { isScanningInProgress })}>
-                    <Loader color="iconAlertBlue" />
-                    <Text variant="body" color="textAlertBlue">
-                        <Translation id="moduleConnectDevice.turnOnAndUnlockScreen.scanningLoader" />
-                    </Text>
+                <HStack style={applyStyle(statusStyle, { isStatusVisible })}>
+                    {bluetoothAdapterStatus === 'disabled' && (
+                        <>
+                            <Icon name="bluetoothSlash" color="iconAlertBlue" />
+                            <Text variant="body" color="textAlertBlue">
+                                <Translation id="moduleConnectDevice.turnOnAndUnlockScreen.status.adapterDisabled" />
+                            </Text>
+                        </>
+                    )}
+                    {bluetoothAdapterStatus === 'enabled' && (
+                        <>
+                            <Loader color="iconAlertBlue" />
+                            <Text variant="body" color="textAlertBlue">
+                                <Translation id="moduleConnectDevice.turnOnAndUnlockScreen.status.scanning" />
+                            </Text>
+                        </>
+                    )}
                 </HStack>
             </VStack>
             <TurnOnDeviceAnimation style={applyStyle(animationStyle)} />

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -466,7 +466,10 @@ export const messages = {
         },
         turnOnAndUnlockScreen: {
             title: 'Turn on & unlock\nyour Trezor',
-            scanningLoader: 'Scanning for nearby Trezors',
+            status: {
+                adapterDisabled: 'Bluetooth is turned off',
+                scanning: 'Scanning for nearby Trezors',
+            },
         },
         pinScreen: {
             title: 'Enter PIN\non your Trezor',

--- a/suite-native/module-authorize-device/src/screens/connect/TurnOnAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/TurnOnAndUnlockDeviceScreen.tsx
@@ -92,7 +92,7 @@ export const TurnOnAndUnlockDeviceScreen = () => {
         }
     }, [nearbyPairableBluetoothDevices, hideAlert, navigation]);
 
-    const { isScanningInProgress } = useBluetoothManager();
+    useBluetoothManager();
 
     return (
         <Screen
@@ -111,7 +111,7 @@ export const TurnOnAndUnlockDeviceScreen = () => {
             hasBottomInset={false}
             isScrollable={false}
         >
-            <TurnOnAndUnlockDeviceScreenContent isScanningInProgress={isScanningInProgress} />
+            <TurnOnAndUnlockDeviceScreenContent />
         </Screen>
     );
 };

--- a/suite-native/module-device-onboarding/src/screens/DeviceDisconnectedScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/DeviceDisconnectedScreen.tsx
@@ -79,7 +79,7 @@ export const DeviceDisconnectedScreen = ({
             isScrollable={false}
         >
             {wasDeviceConnectedViaBluetooth ? (
-                <TurnOnAndUnlockDeviceScreenContent isScanningInProgress={isAlertDismissed} />
+                <TurnOnAndUnlockDeviceScreenContent isStatusVisible={isAlertDismissed} />
             ) : (
                 <ConnectAndUnlockDeviceScreenContent />
             )}


### PR DESCRIPTION
We had to tweak Bluetooth alerts in https://github.com/trezor/trezor-suite/pull/21768 and added Bluetooth scanning loader https://github.com/trezor/trezor-suite/pull/21806. Together, these two changes introduced a new situation that was not possible before. On iOS, you may dismiss the alert on the _Turn on & unlock_ screen when Bluetooth is disabled. If you don't enable Bluetooth afterwards, you're stuck on the _Turn on & unlock_ screen and you have no idea why nothing is happening.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/turn-on-and-unlock-bt-off&lookback=7)