### PR TITLE
fix(suite): display receive address in swap instead of account label

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.styles.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.styles.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const StyledReceiveAddress = styled.span`
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 120px;
+`;

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.styles.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.styles.ts
@@ -1,8 +1,0 @@
-import styled from 'styled-components';
-
-export const StyledReceiveAddress = styled.span`
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 120px;
-`;

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -9,7 +9,7 @@ import {
 } from '@suite-common/trading';
 import { Account, TokenAddress } from '@suite-common/wallet-types';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-utils';
-import { Box, Column, InfoItem, Row, Text } from '@trezor/components';
+import { Box, Column, InfoItem, Row, Text, Tooltip } from '@trezor/components';
 import { borders, spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
@@ -21,6 +21,8 @@ import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo
 import { TradingCryptoAmount } from 'src/views/wallet/trading/common/TradingCryptoAmount';
 import { TradingFiatAmount } from 'src/views/wallet/trading/common/TradingFiatAmount';
 
+import { StyledReceiveAddress } from './TradingInfoItem.styles';
+
 interface TradingInfoItemProps {
     account?: Account;
     type: TradingType;
@@ -29,6 +31,7 @@ interface TradingInfoItemProps {
     amount?: string;
     isReceive?: boolean;
     formStep?: TradingExchangeStepType | TradingSellStepType;
+    receiveAddress?: string;
 }
 
 export const TradingInfoItem = ({
@@ -39,6 +42,7 @@ export const TradingInfoItem = ({
     currency,
     amount,
     formStep,
+    receiveAddress,
 }: TradingInfoItemProps) => {
     const { translationString } = useTranslation();
     const currencyInfo = currency && cryptoIdToNetworkSymbolAndContractAddress(currency);
@@ -59,11 +63,17 @@ export const TradingInfoItem = ({
                     <Text variant="tertiary" typographyStyle="hint" as="div">
                         <Row>
                             {accountLabelPrefix}&nbsp;
-                            <AccountLabel
-                                account={account}
-                                showAccountTypeBadge
-                                accountTypeBadgeSize="small"
-                            />
+                            {type === 'exchange' && receiveAddress ? (
+                                <Tooltip content={receiveAddress} hasArrow>
+                                    <StyledReceiveAddress>{receiveAddress}</StyledReceiveAddress>
+                                </Tooltip>
+                            ) : (
+                                <AccountLabel
+                                    account={account}
+                                    showAccountTypeBadge
+                                    accountTypeBadgeSize="small"
+                                />
+                            )}
                         </Row>
                     </Text>
                 )}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -30,7 +30,7 @@ function isFormStepWithAccountLabel({
     type,
 }: Pick<TradingInfoItemProps, 'formStep' | 'isReceive' | 'account' | 'type'>): boolean {
     return Boolean(
-        (['SEND_TRANSACTION', 'SIGN_DATA'].includes(formStep!) || !isReceive) &&
+        (['SEND_TRANSACTION', 'SIGN_DATA'].some(f => f === formStep) || !isReceive) &&
             account &&
             type !== 'sell',
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -9,19 +9,19 @@ import {
 } from '@suite-common/trading';
 import { Account, TokenAddress } from '@suite-common/wallet-types';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-utils';
-import { Box, Column, InfoItem, Row, Text, Tooltip } from '@trezor/components';
+import { Box, Column, InfoItem, Row, Text } from '@trezor/components';
 import { borders, spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
+import { copyAddressToClipboard } from 'src/actions/suite/copyAddressActions';
 import { AccountLabel, BaseCurrencyValue, Translation } from 'src/components/suite';
 import { ExperimentWrapper } from 'src/components/suite/Experiment/ExperimentWrapper';
+import { TokenAddressRow } from 'src/components/suite/copy/TokenAddressRow';
 import { useTranslation } from 'src/hooks/suite';
 import { TradingPayGetLabelType } from 'src/types/trading/trading';
 import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';
 import { TradingCryptoAmount } from 'src/views/wallet/trading/common/TradingCryptoAmount';
 import { TradingFiatAmount } from 'src/views/wallet/trading/common/TradingFiatAmount';
-
-import { StyledReceiveAddress } from './TradingInfoItem.styles';
 
 interface TradingInfoItemProps {
     account?: Account;
@@ -48,10 +48,14 @@ export const TradingInfoItem = ({
     const currencyInfo = currency && cryptoIdToNetworkSymbolAndContractAddress(currency);
     const accountLabelPrefix = translationString(isReceive ? 'TR_TO' : 'TR_FROM').toLowerCase();
 
-    const shouldShowAccountLabel =
-        ((formStep && ['SEND_TRANSACTION', 'SIGN_DATA'].includes(formStep)) || !isReceive) &&
+    const showAccountLabel =
+        (['SEND_TRANSACTION', 'SIGN_DATA'].find(f => f === formStep) || !isReceive) &&
         account &&
         type !== 'sell';
+
+    // `account` is undefined for external addresses
+    const isExternalBuyOrExchange =
+        (type === 'exchange' || type === 'buy') && !account && !!receiveAddress;
 
     return type === 'exchange' || isReceive ? (
         <Column width="100%">
@@ -59,15 +63,18 @@ export const TradingInfoItem = ({
                 <Text variant="tertiary" typographyStyle="hint">
                     <Translation id={label} />
                 </Text>
-                {shouldShowAccountLabel && (
+                {(showAccountLabel || isExternalBuyOrExchange) && (
                     <Text variant="tertiary" typographyStyle="hint" as="div">
                         <Row>
                             {accountLabelPrefix}&nbsp;
-                            {type === 'exchange' && receiveAddress ? (
-                                <Tooltip content={receiveAddress} hasArrow>
-                                    <StyledReceiveAddress>{receiveAddress}</StyledReceiveAddress>
-                                </Tooltip>
-                            ) : (
+                            {isExternalBuyOrExchange && (
+                                <TokenAddressRow
+                                    tokenContractAddress={receiveAddress}
+                                    shouldAllowCopy={true}
+                                    onCopy={() => copyAddressToClipboard(receiveAddress)}
+                                />
+                            )}
+                            {!isExternalBuyOrExchange && account && (
                                 <AccountLabel
                                     account={account}
                                     showAccountTypeBadge

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -23,6 +23,19 @@ import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo
 import { TradingCryptoAmount } from 'src/views/wallet/trading/common/TradingCryptoAmount';
 import { TradingFiatAmount } from 'src/views/wallet/trading/common/TradingFiatAmount';
 
+function isFormStepWithAccountLabel({
+    formStep,
+    isReceive,
+    account,
+    type,
+}: Pick<TradingInfoItemProps, 'formStep' | 'isReceive' | 'account' | 'type'>): boolean {
+    return Boolean(
+        (['SEND_TRANSACTION', 'SIGN_DATA'].includes(formStep!) || !isReceive) &&
+            account &&
+            type !== 'sell',
+    );
+}
+
 interface TradingInfoItemProps {
     account?: Account;
     type: TradingType;
@@ -48,10 +61,7 @@ export const TradingInfoItem = ({
     const currencyInfo = currency && cryptoIdToNetworkSymbolAndContractAddress(currency);
     const accountLabelPrefix = translationString(isReceive ? 'TR_TO' : 'TR_FROM').toLowerCase();
 
-    const showAccountLabel =
-        (['SEND_TRANSACTION', 'SIGN_DATA'].find(f => f === formStep) || !isReceive) &&
-        account &&
-        type !== 'sell';
+    const showAccountLabel = isFormStepWithAccountLabel({ formStep, isReceive, account, type });
 
     // `account` is undefined for external addresses
     const isExternalBuyOrExchange =

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo.tsx
@@ -1,5 +1,6 @@
-import { CryptoId, ExchangeTrade } from 'invity-api';
+import { BuyTrade, CryptoId, ExchangeTrade } from 'invity-api';
 
+import { TradingType } from '@suite-common/trading';
 import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -51,7 +52,9 @@ export const TradingSelectedOfferInfo = ({
             formStep={formStep}
             receiveAddress={
                 // A better solution would be to add type (e.g. `exchange` to `ExchangeTrade`) to each union item in `TradingTradeType` so it's easy to narrow down the type.
-                type === 'exchange' ? (selectedQuote as ExchangeTrade).receiveAddress : undefined
+                (['exchange', 'buy'] satisfies TradingType[]).find(t => t === type)
+                    ? (selectedQuote as ExchangeTrade | BuyTrade).receiveAddress
+                    : undefined
             }
             isReceive
         />,

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo.tsx
@@ -1,6 +1,6 @@
-import { BuyTrade, CryptoId, ExchangeTrade } from 'invity-api';
+import { type CryptoId } from 'invity-api';
 
-import { TradingType } from '@suite-common/trading';
+import { TradingTradeType, isBuyTrade, isExchangeTrade } from '@suite-common/trading';
 import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -13,6 +13,14 @@ import { TradingInfoPaymentMethod } from 'src/views/wallet/trading/common/Tradin
 import { TradingInfoProvider } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoProvider';
 import { TradingTransactionId } from 'src/views/wallet/trading/common/TradingTransactionId';
 import { TradingUtilsKyc } from 'src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc';
+
+function getReceiveAddress(selectedQuote: TradingTradeType) {
+    if (!isExchangeTrade(selectedQuote) && !isBuyTrade(selectedQuote)) {
+        return undefined;
+    }
+
+    return selectedQuote.receiveAddress;
+}
 
 export const TradingSelectedOfferInfo = ({
     account,
@@ -50,12 +58,7 @@ export const TradingSelectedOfferInfo = ({
             currency={quoteAmounts?.receiveCurrency}
             amount={quoteAmounts?.receiveAmount}
             formStep={formStep}
-            receiveAddress={
-                // A better solution would be to add type (e.g. `exchange` to `ExchangeTrade`) to each union item in `TradingTradeType` so it's easy to narrow down the type.
-                (['exchange', 'buy'] satisfies TradingType[]).find(t => t === type)
-                    ? (selectedQuote as ExchangeTrade | BuyTrade).receiveAddress
-                    : undefined
-            }
+            receiveAddress={getReceiveAddress(selectedQuote)}
             isReceive
         />,
     ];

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo.tsx
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import { CryptoId, ExchangeTrade } from 'invity-api';
 
 import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
@@ -49,6 +49,10 @@ export const TradingSelectedOfferInfo = ({
             currency={quoteAmounts?.receiveCurrency}
             amount={quoteAmounts?.receiveAmount}
             formStep={formStep}
+            receiveAddress={
+                // A better solution would be to add type (e.g. `exchange` to `ExchangeTrade`) to each union item in `TradingTradeType` so it's easy to narrow down the type.
+                type === 'exchange' ? (selectedQuote as ExchangeTrade).receiveAddress : undefined
+            }
             isReceive
         />,
     ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Display receive address (if it's external) in swap/buy instead of account label.

## Related Issue

Resolve #21681

## Screenshots:
<img width="1222" height="1014" alt="Snímek obrazovky 2025-09-29 v 9 16 33" src="https://github.com/user-attachments/assets/e8641126-6d49-474c-a2f0-395e41a0909f" />
<img width="1264" height="581" alt="Snímek obrazovky 2025-09-29 v 9 17 44" src="https://github.com/user-attachments/assets/ac7ac02d-0b3e-4ddc-a470-a185a6a2ad00" />
<img width="1234" height="1064" alt="Snímek obrazovky 2025-09-29 v 9 17 56" src="https://github.com/user-attachments/assets/83a998e4-f94b-4063-b3e9-e7754d86bada" />
<img width="1282" height="595" alt="Snímek obrazovky 2025-09-29 v 9 18 04" src="https://github.com/user-attachments/assets/7d6f46b9-56d9-4b52-a6a4-710dcf92d259" />
<img width="1263" height="975" alt="Snímek obrazovky 2025-09-29 v 9 25 29" src="https://github.com/user-attachments/assets/202d2326-f630-4d31-87f6-6c1c3b10e7ca" />




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/21681-swap-receive-address&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/21681-swap-receive-address&lookback=7)