### PR TITLE
feat(suite-native): process Bluetooth push notifications

### DIFF
--- a/packages/transport-native-bluetooth/src/api/BluetoothApi.ts
+++ b/packages/transport-native-bluetooth/src/api/BluetoothApi.ts
@@ -1,6 +1,10 @@
 import { Subscription } from 'react-native-ble-plx';
 
-import { AbstractApi, AbstractApiConstructorParams } from '@trezor/transport/src/api/abstract';
+import {
+    AbstractApi,
+    AbstractApiConstructorParams,
+    OpenDeviceChannel,
+} from '@trezor/transport/src/api/abstract';
 import { DEVICE_TYPE } from '@trezor/transport/src/constants';
 import * as ERRORS from '@trezor/transport/src/errors';
 import {
@@ -15,14 +19,23 @@ import { bluetoothManager } from './bluetoothManager';
 export class BluetoothApi extends AbstractApi {
     chunkSize = 244;
 
-    private subscription: Subscription;
+    private subscriptions: Subscription[];
+    private pushNotificationSubscribedDevices = new Set<string>();
 
     constructor(params: AbstractApiConstructorParams) {
         super(params);
-        this.subscription = bluetoothManager.onDeviceConnectionStatusChange(event => {
-            this.logger?.debug('onDeviceConnectionStatusChange', event);
-            this.emit('transport-interface-change', this.getDescriptors());
-        });
+        this.subscriptions = [
+            bluetoothManager.onDeviceConnectionStatusChange(event => {
+                this.logger?.debug('onDeviceConnectionStatusChange', event);
+                this.emit('transport-interface-change', this.getDescriptors());
+            }),
+            bluetoothManager.onDevicePushNotification(({ deviceId, data }) => {
+                this.logger?.debug('onDevicePushNotificationEvent', { deviceId, data });
+                if (this.pushNotificationSubscribedDevices.has(deviceId)) {
+                    this.emit('trezor-push-notification', { id: deviceId, data });
+                }
+            }),
+        ];
     }
 
     public async enumerate() {
@@ -105,23 +118,31 @@ export class BluetoothApi extends AbstractApi {
         }
     }
 
-    public async openDevice(path: string) {
-        this.logger?.debug('openDevice', path);
+    public async openDevice(path: string, options?: { channel?: OpenDeviceChannel }) {
+        this.logger?.debug('openDevice', path, options);
+
+        if (options?.channel === 'trezor-push-notification') {
+            this.pushNotificationSubscribedDevices.add(path);
+        }
 
         // BT does not need to be opened, it is opened when connected
         return this.success(undefined);
     }
 
-    public async closeDevice(path: string) {
-        this.logger?.debug('closeDevice', path);
-        bluetoothManager.cancelRead(path);
+    public async closeDevice(path: string, options?: { channel?: OpenDeviceChannel }) {
+        this.logger?.debug('closeDevice', path, options);
+
+        if (options?.channel === 'read') {
+            bluetoothManager.cancelRead(path);
+        } else if (options?.channel === 'trezor-push-notification') {
+            this.pushNotificationSubscribedDevices.delete(path);
+        }
 
         return this.success(undefined);
     }
 
     public async dispose(): Promise<void> {
         this.logger?.debug('dispose');
-        // Clean up any resources or listeners here
-        this.subscription?.remove();
+        this.subscriptions.forEach(s => s.remove());
     }
 }

--- a/packages/transport-native-bluetooth/src/api/bluetoothManager.ts
+++ b/packages/transport-native-bluetooth/src/api/bluetoothManager.ts
@@ -16,7 +16,11 @@ import { EventEmitter } from 'events';
 import { readMessageBuffer } from '@trezor/transport/src/utils/readMessageBuffer';
 import type { TimerId } from '@trezor/type-utils';
 
-import { BluetoothDevice, DeviceConnectionStatusChangeEvent } from './types';
+import {
+    BluetoothDevice,
+    DeviceConnectionStatusChangeEvent,
+    DevicePushNotificationEvent,
+} from './types';
 
 type DeviceId = string;
 
@@ -26,14 +30,16 @@ type BleDeviceWithMetadata = {
 };
 
 const eventNames = {
-    deviceConnectionStatusChange: 'deviceConnectionStatusChange',
     nearbyDevicesChange: 'nearbyDevicesChange',
-};
+    deviceConnectionStatusChange: 'deviceConnectionStatusChange',
+    devicePushNotification: 'devicePushNotification',
+} as const;
 
 // UUID of the Bluetooth service used to identify a BLE device as Trezor.
 const SERVICE_UUID = '8c000001-a59b-4d58-a9ad-073df69fa1b1';
 const WRITE_CHARACTERISTIC_UUID = '8c000002-a59b-4d58-a9ad-073df69fa1b1';
 const NOTIFY_CHARACTERISTIC_UUID = '8c000003-a59b-4d58-a9ad-073df69fa1b1';
+const PUSH_CHARACTERISTIC_UUID = '8c000004-a59b-4d58-a9ad-073df69fa1b1';
 
 const DEBUG_LOGS = false;
 
@@ -48,11 +54,13 @@ const errorLog = (...args: any[]) => {
     console.error('BluetoothManager', ...args);
 };
 
+const base64ToByteArray = (value: string) => Array.from(Buffer.from(value, 'base64'));
+
 const toBluetoothDevice = (device: Device): BluetoothDevice => ({
     id: device.id,
     name: device.name ?? 'Unknown',
     // @suite-common utils expect the Bluetooth company identifier (first two bytes) to be trimmed
-    manufacturerData: Array.from(Buffer.from(device.manufacturerData ?? '', 'base64')).slice(2),
+    manufacturerData: base64ToByteArray(device.manufacturerData ?? '').slice(2),
     lastUpdatedTimestamp: Date.now(),
     connectionStatus: { type: 'disconnected' },
 });
@@ -80,26 +88,26 @@ class BluetoothManager {
 
     public onNearbyDevicesChange = (
         listener: (nearbyDevices: BluetoothDevice[]) => void,
-    ): Subscription => {
-        this.eventEmitter.on(eventNames.nearbyDevicesChange, listener);
+    ): Subscription => this.subscribeTo(eventNames.nearbyDevicesChange, listener);
+
+    public onDeviceConnectionStatusChange = (
+        listener: (event: DeviceConnectionStatusChangeEvent) => void,
+    ): Subscription => this.subscribeTo(eventNames.deviceConnectionStatusChange, listener);
+
+    public onDevicePushNotification = (
+        listener: (event: DevicePushNotificationEvent) => void,
+    ): Subscription => this.subscribeTo(eventNames.devicePushNotification, listener);
+
+    private subscribeTo = (eventName: keyof typeof eventNames, listener: (arg: any) => void) => {
+        this.eventEmitter.on(eventName, listener);
 
         return {
-            remove: () => this.eventEmitter.off(eventNames.nearbyDevicesChange, listener),
+            remove: () => this.eventEmitter.off(eventName, listener),
         };
     };
 
     private emitNearbyDevicesChange = () => {
         this.eventEmitter.emit(eventNames.nearbyDevicesChange, this.nearbyDevices);
-    };
-
-    public onDeviceConnectionStatusChange = (
-        listener: (event: DeviceConnectionStatusChangeEvent) => void,
-    ): Subscription => {
-        this.eventEmitter.on(eventNames.deviceConnectionStatusChange, listener);
-
-        return {
-            remove: () => this.eventEmitter.off(eventNames.deviceConnectionStatusChange, listener),
-        };
     };
 
     private updateDeviceConnectionStatusChange = (event: DeviceConnectionStatusChangeEvent) => {
@@ -113,6 +121,10 @@ class BluetoothManager {
         // TODO: Do not emit any other events when the connection status is pairing-error?
         this.eventEmitter.emit(eventNames.deviceConnectionStatusChange, event);
         this.emitNearbyDevicesChange();
+    };
+
+    private emitDevicePushNotification = (event: DevicePushNotificationEvent) => {
+        this.eventEmitter.emit(eventNames.devicePushNotification, event);
     };
 
     public startDeviceScan = (errorHandler?: (error: BleError) => void) => {
@@ -302,25 +314,23 @@ class BluetoothManager {
     private discoverAndTestCharacteristics = async (device: Device) => {
         await device.discoverAllServicesAndCharacteristics();
 
-        const characteristics: Characteristic[] =
-            await device.characteristicsForService(SERVICE_UUID);
-        if (characteristics.length === 0) {
-            throw new Error(
-                'No device characteristics found. Make sure the device is connected and has the correct service UUID.',
-            );
-        }
+        const characteristics = await device.characteristicsForService(SERVICE_UUID);
 
         let writeCharacteristic: Characteristic | undefined;
         let notifyCharacteristic: Characteristic | undefined;
+        let pushCharacteristic: Characteristic | undefined;
         for (const characteristic of characteristics) {
             if (characteristic.uuid === WRITE_CHARACTERISTIC_UUID) {
-                debugLog('Found write characteristic: ', characteristic.uuid);
+                debugLog('Found write characteristic', characteristic.uuid);
                 writeCharacteristic = characteristic;
             } else if (characteristic.uuid === NOTIFY_CHARACTERISTIC_UUID) {
-                debugLog('Found notify characteristic: ', characteristic.uuid);
+                debugLog('Found notify characteristic', characteristic.uuid);
                 notifyCharacteristic = characteristic;
+            } else if (characteristic.uuid === PUSH_CHARACTERISTIC_UUID) {
+                debugLog('Found push characteristic', characteristic.uuid);
+                pushCharacteristic = characteristic;
             } else {
-                debugLog('Found other unknown characteristic: ', characteristic.uuid);
+                debugLog('Found other unknown characteristic', characteristic.uuid);
             }
         }
 
@@ -329,6 +339,9 @@ class BluetoothManager {
         }
         if (!notifyCharacteristic) {
             throw new Error('Notify characteristic not found.');
+        }
+        if (!pushCharacteristic) {
+            throw new Error('Push characteristic not found.');
         }
 
         try {
@@ -345,24 +358,15 @@ class BluetoothManager {
             throw error;
         }
 
-        device.monitorCharacteristicForService(
-            SERVICE_UUID,
-            notifyCharacteristic.uuid,
-            (error, characteristic) => {
-                if (error) {
-                    debugLog('Error monitoring characteristic', error);
-                } else if (characteristic) {
-                    const { value } = characteristic;
-                    debugLog('Received data', value);
-                    if (value) {
-                        debugLog('Processing device message', device.id, value);
-                        this.readBuffer.onMessage(device.id, Buffer.from(value, 'base64'));
-                    }
-                } else {
-                    errorLog('No characteristic received');
-                }
-            },
-        );
+        this.monitorCharacteristic(notifyCharacteristic, 'notify', (value: string) => {
+            this.readBuffer.onMessage(device.id, Buffer.from(value, 'base64'));
+        });
+        this.monitorCharacteristic(pushCharacteristic, 'push', (value: string) => {
+            this.emitDevicePushNotification({
+                deviceId: device.id,
+                data: base64ToByteArray(value),
+            });
+        });
 
         debugLog(`Adding device ${device.id} to connected devices`);
         this.connectedDevices[device.id] = {
@@ -391,6 +395,24 @@ class BluetoothManager {
             clearTimeout(timeoutId);
         }
     };
+
+    private monitorCharacteristic = (
+        characteristicToMonitor: Characteristic,
+        name: 'notify' | 'push',
+        callback: (value: string) => void,
+    ) =>
+        characteristicToMonitor.monitor((error, characteristic) => {
+            if (error) {
+                debugLog(`Error monitoring ${name} characteristic:`, error);
+            } else if (characteristic) {
+                const { deviceID, value } = characteristic;
+                debugLog(`Received ${name} characteristic data:`, value);
+                if (value) {
+                    debugLog(`Processing message for device ${deviceID}:`, value);
+                    callback(value);
+                }
+            }
+        });
 
     public disconnectDevice = ({ deviceId }: { deviceId: DeviceId }) => {
         debugLog(`Disconnecting device ${deviceId}`);

--- a/packages/transport-native-bluetooth/src/api/types.ts
+++ b/packages/transport-native-bluetooth/src/api/types.ts
@@ -12,6 +12,11 @@ export type DeviceConnectionStatusChangeEvent = {
     connectionStatus: DeviceConnectionStatus;
 };
 
+export type DevicePushNotificationEvent = {
+    deviceId: string;
+    data: number[];
+};
+
 export interface BluetoothDevice {
     id: string;
     name: string;

--- a/packages/transport-native-bluetooth/src/transport.ts
+++ b/packages/transport-native-bluetooth/src/transport.ts
@@ -9,11 +9,11 @@ export class NativeBluetoothTransport extends AbstractApiTransport {
     constructor(params: ConstructorParameters<typeof AbstractTransport>[0]) {
         const { logger, ...rest } = params;
 
-        super({
-            api: new BluetoothApi({
-                logger,
-            }),
-            ...rest,
+        const api = new BluetoothApi({ logger });
+        api.on('trezor-push-notification', event => {
+            this.emit('trezor-push-notification', event);
         });
+
+        super({ api, ...rest });
     }
 }


### PR DESCRIPTION
Bluetooth transport just passes the notification data to Connect.

## Related Issue

Resolve #21785


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/bluetooth-push-notifications&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/bluetooth-push-notifications&lookback=7)