### PR TITLE
fix(suite): Gallery button size

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen/ChangeHomescreenButtons.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen/ChangeHomescreenButtons.tsx
@@ -33,6 +33,7 @@ export const ChangeHomescreenButtons = ({
                 onClick={onImageUploadClick}
                 isDisabled={isDeviceLocked || !isSupportedHomescreen}
                 variant="primary"
+                size="small"
                 data-testid="@settings/device/homescreen-upload"
                 key="@settings/device/homescreen-upload"
             >
@@ -52,6 +53,7 @@ export const ChangeHomescreenButtons = ({
                 data-testid="@settings/device/homescreen-gallery"
                 key="@settings/device/homescreen-gallery"
                 variant="primary"
+                size="small"
             >
                 <Translation id="TR_DEVICE_SETTINGS_HOMESCREEN_SELECT_FROM_GALLERY" />
             </Button>


### PR DESCRIPTION
## Description
Gallery has 16px instead of 14px used in other buttons in settings

## Screenshots:

| Before | After |
| --- | --- |
| <img width="331" height="541" alt="Screenshot 2025-09-26 at 11 06 17" src="https://github.com/user-attachments/assets/bb71a07f-25dc-41a1-b0fd-a5c01a93f762" /> | <img width="346" height="534" alt="Screenshot 2025-09-26 at 11 04 40" src="https://github.com/user-attachments/assets/cc197c42-0da5-458c-8f90-9c65b2c78daf" /> |

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/gallery-button-size&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/gallery-button-size&lookback=7)