### PR TITLE
fix(connect): entering passphrase with locked thp device

### DIFF
--- a/packages/connect/src/device/thp/session.ts
+++ b/packages/connect/src/device/thp/session.ts
@@ -5,7 +5,7 @@ import { thpCall } from './thpCall';
 
 export const createThpSession = async (device: Device, deriveCardano: boolean) => {
     let passphrase: protocolThp.ThpCreateNewSession;
-    if (!device.features.passphrase_protection) {
+    if (device.features.passphrase_protection === false) {
         passphrase = { passphrase: '' };
     } else {
         // same flow as DeviceCurrentSession PassphraseRequest


### PR DESCRIPTION
## Description

In locked state, the device features have `passphrase_protection: null`
That means in `createThpSession` it sets an empty passphrase and doesn't prompt, I changed it, so it must be explicitly false. 

## Related Issue

Resolve #21911


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thp-device-locked-entering-passphrase&lookback=7)