### PR TITLE
fix(suite-native): continue on trezor autoconnect

### DIFF
--- a/suite-common/thp/src/removeThpAutoconnectThunk.ts
+++ b/suite-common/thp/src/removeThpAutoconnectThunk.ts
@@ -1,7 +1,7 @@
 import { createThunk } from '@suite-common/redux-utils/';
 import { isThpDevice } from '@suite-common/suite-utils';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { Unsuccessful } from '@trezor/connect';
 
 import { THP_PREFIX, thpActions } from './thpActions';
 
@@ -11,24 +11,22 @@ type RemoveThpAutoconnectThunkParams =
       }
     | undefined;
 
-type RemoveThpAutoconnectThunkResult =
-    | ReturnType<typeof TrezorConnect.thpRemoveCredentials>
-    | undefined;
+type RemoveThpAutoconnectThunkResult = ReturnType<typeof TrezorConnect.thpRemoveCredentials>;
 
 export const removeThpAutoconnectThunk = createThunk<
     RemoveThpAutoconnectThunkResult,
     RemoveThpAutoconnectThunkParams,
-    void
+    { rejectValue: Unsuccessful | 'invalid-device' }
 >(
     `${THP_PREFIX}/removeThpAutoconnectThunk`,
     async (
         params,
         { getState, dispatch, fulfillWithValue, rejectWithValue },
-    ): Promise<RemoveThpAutoconnectThunkResult> => {
+    ): Promise<RemoveThpAutoconnectThunkResult | ReturnType<typeof rejectWithValue>> => {
         const device = selectSelectedDevice(getState());
 
         if (device === undefined || !isThpDevice(device)) {
-            return fulfillWithValue(undefined);
+            return rejectWithValue('invalid-device');
         }
 
         const credentialsToRemove =
@@ -41,10 +39,11 @@ export const removeThpAutoconnectThunk = createThunk<
         if (response.success) {
             dispatch(thpActions.removeCredentials({ credentials: credentialsToRemove }));
         }
+
         dispatch(thpActions.finishThpFlow());
 
         if (!response.success) {
-            rejectWithValue(response);
+            return rejectWithValue(response);
         }
 
         return fulfillWithValue(response);

--- a/suite-common/thp/src/startThpAutoconnectThunk.ts
+++ b/suite-common/thp/src/startThpAutoconnectThunk.ts
@@ -6,24 +6,31 @@ import TrezorConnect from '@trezor/connect';
 import { finishThpAutoconnectThunk } from './finishThpAutoconnectThunk';
 import { THP_PREFIX, thpActions } from './thpActions';
 
-export const startThpAutoconnectThunk = createThunk<void, void, void>(
+export const startThpAutoconnectThunk = createThunk(
     `${THP_PREFIX}/startThpAutoconnectThunk`,
-    async (_, { getState, dispatch }) => {
+    async (_, { getState, dispatch, rejectWithValue, fulfillWithValue }) => {
         const device = selectSelectedDevice(getState());
 
         if (device === undefined) {
-            return;
+            dispatch(thpActions.cancelThpFlow());
+
+            return rejectWithValue('invalid-device');
         }
 
         const response = await TrezorConnect.thpGetCredentials({ device });
 
         if (response.success) {
             dispatch(thpActions.addCredential({ credential: response.payload }));
+            dispatch(finishThpAutoconnectThunk());
+            fulfillWithValue(response);
         } else {
             dispatch(
                 notificationsActions.addToast({ type: 'error', error: response.payload.error }),
             );
+
+            dispatch(thpActions.cancelThpFlow());
+
+            return rejectWithValue(response);
         }
-        dispatch(finishThpAutoconnectThunk());
     },
 );

--- a/suite-native/module-device-settings/src/components/DeviceAutoConnectCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceAutoConnectCard.tsx
@@ -1,13 +1,28 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
+import { useNavigation } from '@react-navigation/native';
+
 import { selectDeviceAutoconnectCredentials } from '@suite-common/wallet-core';
 import { CompactCardWithIconLayout } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
+import {
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes,
+    StackNavigationProps,
+} from '@suite-native/navigation';
 import { useThpAutoconnectAlerts } from '@suite-native/thp';
+
+type NavigationProp = StackNavigationProps<
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes.DeviceSettings
+>;
 
 export const DeviceAutoConnectCard = () => {
     const { translate } = useTranslate();
+
+    const navigation = useNavigation<NavigationProp>();
+
     const { showThpAutoconnectTurnOffAlert, showThpAutoconnectTurnOnAlert } =
         useThpAutoconnectAlerts();
 
@@ -23,12 +38,18 @@ export const DeviceAutoConnectCard = () => {
             : translate('moduleDeviceSettings.autoconnect.enable.subtitle');
 
     const onPress = useCallback(() => {
+        navigation.navigate(DeviceSettingsStackRoutes.ContinueOnTrezor);
         if (autoconnectCredentials.length > 0) {
             showThpAutoconnectTurnOffAlert();
         } else {
             showThpAutoconnectTurnOnAlert();
         }
-    }, [showThpAutoconnectTurnOffAlert, showThpAutoconnectTurnOnAlert, autoconnectCredentials]);
+    }, [
+        navigation,
+        autoconnectCredentials.length,
+        showThpAutoconnectTurnOffAlert,
+        showThpAutoconnectTurnOnAlert,
+    ]);
 
     return (
         <CompactCardWithIconLayout

--- a/suite-native/thp/package.json
+++ b/suite-native/thp/package.json
@@ -10,6 +10,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@react-navigation/native": "7.1.17",
         "@reduxjs/toolkit": "2.8.2",
         "@suite-common/thp": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",

--- a/suite-native/thp/src/hooks/useThpAutoconnectAlerts.tsx
+++ b/suite-native/thp/src/hooks/useThpAutoconnectAlerts.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { useNavigation } from '@react-navigation/native';
 import { isRejected } from '@reduxjs/toolkit';
 
 import { removeThpAutoconnectThunk, startThpAutoconnectThunk, thpActions } from '@suite-common/thp';
@@ -13,12 +14,23 @@ export const useThpAutoconnectAlerts = () => {
     const dispatch = useDispatch();
     const { showAlert } = useAlert();
     const { showToast } = useToast();
+    const navigation = useNavigation();
 
     const autoconnectCredentials = useSelector(selectDeviceAutoconnectCredentials);
 
-    const turnOnAutoconnect = useCallback(() => {
-        dispatch(startThpAutoconnectThunk());
-    }, [dispatch]);
+    const turnOnAutoconnect = useCallback(async () => {
+        const response = await dispatch(startThpAutoconnectThunk()).unwrap();
+
+        if (isRejected(response)) {
+            showToast({
+                variant: 'error',
+                message: response.error.message,
+            });
+        }
+        if (navigation.canGoBack()) {
+            navigation.goBack();
+        }
+    }, [dispatch, navigation, showToast]);
 
     const turnOffAutoconnect = useCallback(async () => {
         const result = await dispatch(
@@ -33,7 +45,10 @@ export const useThpAutoconnectAlerts = () => {
                 message: result.error.message,
             });
         }
-    }, [dispatch, showToast, autoconnectCredentials]);
+        if (navigation.canGoBack()) {
+            navigation.goBack();
+        }
+    }, [navigation, dispatch, autoconnectCredentials, showToast]);
 
     const ignoreAutoconnect = useCallback(() => {
         dispatch(thpActions.finishThpFlow());

--- a/yarn.lock
+++ b/yarn.lock
@@ -12617,6 +12617,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/thp@workspace:suite-native/thp"
   dependencies:
+    "@react-navigation/native": "npm:7.1.17"
     "@reduxjs/toolkit": "npm:2.8.2"
     "@suite-common/thp": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Redirect to Continue on Trezor when toggling auto connect in mobile app.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21620

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/continue-on-trezor&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/continue-on-trezor&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/continue-on-trezor&lookback=7)