### PR TITLE
feat(suite-desktop): inform to open BT settings manually if unsupported

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -119,7 +119,7 @@ export interface InvokeChannels {
     'connect-popup/set-enabled': (enabled: boolean) => void;
     'connect-popup/ready': () => void;
     'connect-popup/response': (response: ConnectPopupResponse) => void;
-    'system/open-settings': (settings: string) => InvokeResult;
+    'system/open-settings': (settings: 'bluetooth' | 'bluetooth-permissions') => InvokeResult;
     'bio-auth/is-bio-auth-available': () => boolean;
     'bio-auth/validate-bio-auth': ({ message }: { message: string }) =>
         | {

--- a/packages/suite-desktop-core/src/modules/system-settings.ts
+++ b/packages/suite-desktop-core/src/modules/system-settings.ts
@@ -9,17 +9,37 @@ import type { ModuleInit } from './index';
 
 export const SERVICE_NAME = 'system-settings';
 
+const getOSErrorDescription = (reason: string) =>
+    `Cannot open system settings (${reason}). Please open the settings manually.`;
+
+// If opening system settings was attempted but failed, try to guess the reason of failure.
+const detectFailureReason = (error: Error) => {
+    const flatpakId = process.env.FLATPAK_ID ?? process.env.FLATPAK_APP_ID;
+    if (flatpakId !== undefined && flatpakId !== '') {
+        return getOSErrorDescription('running in Flatpak sandbox');
+    }
+
+    // cannot detect reason, return original error
+    return error.toString();
+};
+
 const openSettings = (cmd: string, env?: Record<string, string>) =>
     new Promise<InvokeResult>(resolve => {
         exec(cmd, { env: { ...process.env, ...env } }, error => {
             if (error) {
-                resolve({ success: false, error: error.toString() });
+                const errorMessage = detectFailureReason(error);
+                resolve({ success: false, error: errorMessage });
             } else {
                 resolve({ success: true });
             }
         });
     });
 
+/**
+ * Try to open system Bluetooth settings with respect to the operating system,
+ * or a particular desktop environment in case of Linux (Gnome or KDE supported).
+ * In case of other systems, fail right away without attempting it.
+ */
 const openBluetoothSettings = () => {
     if (isLinux()) {
         // https://github.com/electron/electron/blob/ab2a4fd836d539194bc5cde5f0d665eddeb6a134/docs/api/environment-variables.md?plain=1#L190
@@ -35,16 +55,21 @@ const openBluetoothSettings = () => {
             });
         }
     }
+
     if (isMacOs()) {
         return openSettings('open "x-apple.systempreferences:com.apple.Bluetooth"');
     }
+
     if (isWindows()) {
         return openSettings('start ms-settings:bluetooth');
     }
 
-    return { success: false, error: 'Unsupported os' };
+    return { success: false, error: getOSErrorDescription('unsupported system') };
 };
 
+/**
+ * Try to open system Bluetooth permissions settings, which is only relevant on macOS (otherwise fail right away).
+ */
 const openBluetoothPermissions = () => {
     // Settings > Privacy and security > Bluetooth
     if (isMacOs()) {
@@ -53,7 +78,7 @@ const openBluetoothPermissions = () => {
         );
     }
 
-    return { success: false, error: 'Unsupported os' };
+    return { success: false, error: getOSErrorDescription('unsupported system') };
 };
 
 export const init: ModuleInit = () => {

--- a/packages/suite/src/actions/bluetooth/openSystemSettingsThunk.ts
+++ b/packages/suite/src/actions/bluetooth/openSystemSettingsThunk.ts
@@ -1,0 +1,30 @@
+import { BLUETOOTH_PREFIX } from '@suite-common/bluetooth';
+import { createThunk } from '@suite-common/redux-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { InvokeResult, desktopApi } from '@trezor/suite-desktop-api';
+
+type OpenSystemSettingsThunkParams = {
+    type: Parameters<typeof desktopApi.openSystemSettings>[0];
+};
+
+export const openSystemSettingsThunk = createThunk<
+    InvokeResult,
+    OpenSystemSettingsThunkParams,
+    void
+>(
+    `${BLUETOOTH_PREFIX}/openSystemSettingsThunk`,
+    async ({ type }, { dispatch, fulfillWithValue }) => {
+        const result = await desktopApi.openSystemSettings(type);
+
+        if (!result.success) {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: result.error,
+                }),
+            );
+        }
+
+        return fulfillWithValue(result);
+    },
+);

--- a/packages/suite/src/components/connection/BluetoothAdapterStatusModal.tsx
+++ b/packages/suite/src/components/connection/BluetoothAdapterStatusModal.tsx
@@ -2,9 +2,10 @@ import { useState } from 'react';
 
 import { TranslationKey } from '@suite-common/intl-types';
 import { Banner, Modal, Paragraph } from '@trezor/components';
-import { desktopApi } from '@trezor/suite-desktop-api';
 
+import { openSystemSettingsThunk } from 'src/actions/bluetooth/openSystemSettingsThunk';
 import { Translation } from 'src/components/suite/Translation';
+import { useDispatch } from 'src/hooks/suite';
 
 type BluetoothAdapterStatusModalProps = {
     bluetoothAdapterStatus: 'disabled' | 'permission-denied' | 'not-compatible';
@@ -24,10 +25,12 @@ export const BluetoothAdapterStatusModal = ({
     onCancel,
 }: BluetoothAdapterStatusModalProps) => {
     const [hasDeeplinkFailed, setHasDeeplinkFailed] = useState(false);
+    const dispatch = useDispatch();
 
     const openBluetoothSettings = async (settingsPage: 'bluetooth' | 'bluetooth-permissions') => {
-        const opened = await desktopApi.openSystemSettings(settingsPage);
-        if (!opened.success) {
+        const result = await dispatch(openSystemSettingsThunk({ type: settingsPage })).unwrap();
+
+        if (!result.success) {
             setHasDeeplinkFailed(true);
         }
     };

--- a/packages/suite/src/components/suite/bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal.tsx
+++ b/packages/suite/src/components/suite/bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 
 import { Banner, Column, H3, Modal, Paragraph, Spinner } from '@trezor/components';
-import { desktopApi } from '@trezor/suite-desktop-api';
 import { spacings } from '@trezor/theme';
 
+import { openSystemSettingsThunk } from 'src/actions/bluetooth/openSystemSettingsThunk';
 import { toggleConnectionModal } from 'src/actions/device/deviceSlice';
 import { Translation } from 'src/components/suite/Translation';
 
@@ -22,9 +22,9 @@ export const UnpairedBluetoothDeviceNeedsManualOsRemovalModal = () => {
     const [hasDeeplinkFailed, setHasDeeplinkFailed] = useState(false);
 
     const handleOpenBluetoothSettings = async () => {
-        const opened = await desktopApi.openSystemSettings('bluetooth');
+        const result = await dispatch(openSystemSettingsThunk({ type: 'bluetooth' })).unwrap();
 
-        if (!opened.success) {
+        if (!result.success) {
             setHasDeeplinkFailed(true);
         }
     };

--- a/packages/suite/src/views/settings/SettingsDebug/ForgetBluetoothDevices.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/ForgetBluetoothDevices.tsx
@@ -1,7 +1,7 @@
 import { bluetoothActions } from '@suite-common/bluetooth';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { desktopApi } from '@trezor/suite-desktop-api';
 
+import { openSystemSettingsThunk } from 'src/actions/bluetooth/openSystemSettingsThunk';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
 
@@ -12,7 +12,9 @@ export const ForgetAllDevicesButton = () => {
         dispatch(bluetoothActions.knownDevicesUpdateAction({ knownDevices: [] }));
         dispatch(notificationsActions.addToast({ type: 'clear-storage' }));
     };
-    const handleOpenSettingsButtonClick = () => desktopApi.openSystemSettings('bluetooth');
+    const handleOpenSettingsButtonClick = () => {
+        dispatch(openSystemSettingsThunk({ type: 'bluetooth' }));
+    };
 
     return (
         <SectionItem>


### PR DESCRIPTION
## Description

- Notify when opening BT settings fails with a user-friendly message.
- Create a thunk for that instead of invoking `desktopApi` directly
- typescript...

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21920

## Screenshots:

I build the app with 
```
yarn workspace @trezor/suite-build run build:desktop & yarn workspace @trezor/suite-desktop build:app & wait
yarn workspace @trezor/suite-desktop-core build:app:electron --publish never --linux --x64
```

Then executed normally at Ubuntu Gnome, and with "simulated XFCE", this is easy to test because the code fails preemptively:
`./packages/suite-desktop/build-electron/Trezor-Suite-25.10.0-linux-x86_64.AppImage --no-sandbox`
[BT settings when Gnome.webm](https://github.com/user-attachments/assets/a99decee-9f27-4333-aae2-a8273f621e40)
`XDG_CURRENT_DESKTOP=XFCE ./packages/suite-desktop/build-electron/Trezor-Suite-25.10.0-linux-x86_64.AppImage --no-sandbox`
[BT settings when XFCE.webm](https://github.com/user-attachments/assets/28c981aa-4cd6-404a-b367-13921e9cdbe7)

The Flatpak error message is reactive measure; it has to fail in the first place, and from reason other than XFCE etc.
So to reproduce, either build the flatpak ([very WIP branch here](https://github.com/trezor/trezor-suite/compare/feat/bt-settings-on-other-linux-envs...flatpak)), or modify your `PATH` temporarily to create a `gnome-control-center` executable that will take preference and fail.
[BT settings when Flatpak.webm](https://github.com/user-attachments/assets/11c44d1f-7e53-47bf-a9c0-793582e88235)


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bt-settings-on-other-linux-envs&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bt-settings-on-other-linux-envs&lookback=7)