### PR TITLE
fix(suite): use translationString to avoid missing key warning

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -25,7 +25,7 @@ import {
     OnboardingStepBox,
     SkipStepConfirmation,
 } from 'src/components/onboarding';
-import { useDevice, useOnboarding, useSelector } from 'src/hooks/suite';
+import { useDevice, useOnboarding, useSelector, useTranslation } from 'src/hooks/suite';
 import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 
 import { PrerequisitesGuide, Translation } from '../suite';
@@ -115,12 +115,12 @@ const getNoFirmwareInstalledSubheading = (device: AcquiredDevice) => {
         : 'TR_FIRMWARE_SUBHEADING_UNKNOWN';
 };
 
-interface FirmwareInitialProps {
+type FirmwareInitialProps = {
     shouldSwitchFirmwareType?: boolean;
     // This component is shared between Onboarding flow and standalone fw update modal with few minor UI changes
     // If it is set to true, then you know it is being rendered in standalone fw update modal
     onClose?: () => void;
-}
+};
 
 export const FirmwareInitial = ({
     shouldSwitchFirmwareType = false,
@@ -132,6 +132,7 @@ export const FirmwareInitial = ({
             shouldSwitchFirmwareType,
         });
     const { isActive: isOnboarding, updateAnalytics } = useOnboarding();
+    const { translationString } = useTranslation();
     const devices = useSelector(selectDevices);
     const isDebug = useSelector(selectIsDebugModeActive);
     const isDeviceConnectedViaBluetooth = useSelector(selectIsDeviceConnectedViaBluetooth);
@@ -255,7 +256,7 @@ export const FirmwareInitial = ({
                                 {chunks}
                             </TextButton>
                         ),
-                        bitcoinOnly: <Translation id="TR_FIRMWARE_TYPE_BITCOIN_ONLY" />,
+                        bitcoinOnly: translationString('TR_FIRMWARE_TYPE_BITCOIN_ONLY'),
                     }}
                 />
             ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Nesting translations somehow triggers the missing `key` warning in console. Changing to `translationString` to get rid of the warning. No functional change.

## Screenshots:
<img width="1794" height="1110" alt="Screenshot 2025-09-26 at 14 26 18" src="https://github.com/user-attachments/assets/0be5bcd4-cc8e-4e78-97d0-f81de9a38702" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/missing-key-warning&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/missing-key-warning&lookback=7)