### PR TITLE
Feat: decode trezor push notification in connect

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -987,6 +987,16 @@ const initDeviceList = (context: CoreContext) => {
         sendCoreMessage(createDeviceMessage(DEVICE.CHANGED, device.toMessageObject()));
     });
 
+    deviceList.on(DEVICE.TREZOR_PUSH_NOTIFICATION, payload => {
+        sendCoreMessage(
+            createDeviceMessage(DEVICE.TREZOR_PUSH_NOTIFICATION, {
+                device: payload.device.toMessageObject(),
+                mode: payload.mode,
+                type: payload.type,
+            }),
+        );
+    });
+
     deviceList.on(TRANSPORT.START, transport =>
         sendCoreMessage(createTransportMessage(TRANSPORT.START, transport)),
     );

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -1,10 +1,12 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/Device.js
 import { DeviceModelInternal, FirmwareRelease, models } from '@trezor/device-utils';
 import {
+    type DecodedTrezorPushNotification,
     TransportProtocol,
     thp as protocolThp,
     v1 as protocolV1,
     v2 as protocolV2,
+    tpn,
 } from '@trezor/protocol';
 import { Session, TRANSPORT, TRANSPORT_ERROR } from '@trezor/transport';
 import { type Descriptor, type Transport } from '@trezor/transport';
@@ -94,6 +96,10 @@ export interface DeviceEvents {
     [DEVICE.PASSPHRASE_ON_DEVICE]: void;
     [DEVICE.BUTTON]: { device: Device; payload: DeviceButtonRequestPayload };
     [DEVICE.FIRMWARE_VERSION_CHANGED]: DeviceVersionChanged['payload'];
+    [DEVICE.TREZOR_PUSH_NOTIFICATION]: {
+        device: DeviceTyped;
+        payload: DecodedTrezorPushNotification;
+    };
     [DEVICE.THP_PAIRING]: {
         payload: DeviceThpPairingPayload;
         callback: (response: Result<UiResponseThpPairingTag['payload']>) => void;
@@ -106,6 +112,7 @@ interface DeviceLifecycleEvents {
     [DEVICE.CONNECT_UNACQUIRED]: void;
     [DEVICE.CHANGED]: void;
     [DEVICE.DISCONNECT]: void;
+    [DEVICE.TREZOR_PUSH_NOTIFICATION]: DecodedTrezorPushNotification;
 }
 
 type DeviceParams = {
@@ -322,6 +329,12 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return this.acquirePromise;
     }
 
+    trezorPushNotificationHandler(message: number[]) {
+        // TODO: now we are just emitting event, other logic will be implemented for some notifications.
+        const decoded: DecodedTrezorPushNotification = tpn.decode(message);
+        this.lifecycle.emit(DEVICE.TREZOR_PUSH_NOTIFICATION, decoded);
+    }
+
     subscribe() {
         const { bluetoothProps } = this;
         if (bluetoothProps?.id) {
@@ -340,6 +353,13 @@ export class Device extends TypedEmitter<DeviceEvents> {
                         this.transport.on('battery-level', event => {
                             this._updateFeature('soc', event.data[0]);
                             this.lifecycle.emit(DEVICE.CHANGED);
+                        });
+                    }
+                    if (this.bluetoothProps?.channels?.['trezor-push-notification']) {
+                        this.transport.on('trezor-push-notification', ({ id, data }) => {
+                            if (id === bluetoothProps.id) {
+                                this.trezorPushNotificationHandler(data);
+                            }
                         });
                     }
                 });

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -14,7 +14,7 @@ import {
 } from '@trezor/utils';
 
 import { ERRORS } from '../constants';
-import { DEVICE, TransportError, TransportInfo } from '../events';
+import { DEVICE, DecodedTrezorPushNotification, TransportError, TransportInfo } from '../events';
 import { Device } from './Device';
 import { ConnectSettings, DeviceUniquePath, StaticSessionId } from '../types';
 import { createTransportList } from './TransportList';
@@ -61,6 +61,7 @@ interface DeviceListEvents {
     [TRANSPORT.ERROR]: TransportError;
     [DEVICE.CONNECT]: Device;
     [DEVICE.CONNECT_UNACQUIRED]: Device;
+    [DEVICE.TREZOR_PUSH_NOTIFICATION]: DecodedTrezorPushNotification & { device: Device };
     [DEVICE.DISCONNECT]: Device;
     [DEVICE.CHANGED]: Device;
 }
@@ -161,6 +162,12 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         device.lifecycle.on(DEVICE.CONNECT_UNACQUIRED, () =>
             this.emit(DEVICE.CONNECT_UNACQUIRED, device),
         );
+        device.lifecycle.on(DEVICE.TREZOR_PUSH_NOTIFICATION, payload => {
+            this.emit(DEVICE.TREZOR_PUSH_NOTIFICATION, {
+                device,
+                ...payload,
+            });
+        });
         device.lifecycle.on(DEVICE.DISCONNECT, () => {
             device.lifecycle.removeAllListeners();
             this.authPenaltyManager.remove(device);

--- a/packages/connect/src/events/device.ts
+++ b/packages/connect/src/events/device.ts
@@ -1,9 +1,15 @@
 import type { VersionArray } from '@trezor/device-utils';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
-import type { ThpCredentials, ThpPairingMethod } from '@trezor/protocol';
+import type {
+    DecodedTrezorPushNotification,
+    ThpCredentials,
+    ThpPairingMethod,
+} from '@trezor/protocol';
 
 import type { Device } from '../types/device';
 import type { MessageFactoryFn } from '../types/utils';
+
+export { type DecodedTrezorPushNotification } from '@trezor/protocol';
 
 export const DEVICE_EVENT = 'DEVICE_EVENT';
 export const DEVICE = {
@@ -13,6 +19,7 @@ export const DEVICE = {
     DISCONNECT: 'device-disconnect',
     CHANGED: 'device-changed',
     FIRMWARE_VERSION_CHANGED: 'device-firmware_version_changed',
+    TREZOR_PUSH_NOTIFICATION: 'device-trezor_push_notification',
 
     // This event is triggered every time, the device provides the THP credentials to the Suite.
     // This happens on two occasions:
@@ -66,6 +73,13 @@ export interface DeviceThpCredentialsChanged {
     };
 }
 
+export interface DeviceTrezorPushNotification {
+    type: typeof DEVICE.TREZOR_PUSH_NOTIFICATION;
+    payload: DecodedTrezorPushNotification & {
+        device: Device;
+    };
+}
+
 export type DeviceEvent =
     | {
           type:
@@ -77,7 +91,8 @@ export type DeviceEvent =
       }
     | DeviceButtonRequest
     | DeviceThpCredentialsChanged
-    | DeviceVersionChanged;
+    | DeviceVersionChanged
+    | DeviceTrezorPushNotification;
 
 export type DeviceEventMessage = DeviceEvent & { event: typeof DEVICE_EVENT };
 

--- a/packages/connect/src/types/api/__tests__/events.ts
+++ b/packages/connect/src/types/api/__tests__/events.ts
@@ -40,6 +40,9 @@ export const events = (api: TrezorConnect) => {
 
             return;
         }
+        if (event.type === 'device-trezor_push_notification') {
+            return;
+        }
         const { payload } = event;
         payload.path.toLowerCase();
         if (payload.type === 'acquired') {

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -28,3 +28,9 @@ export interface TransportProtocol {
     decode: TransportProtocolDecode;
     getHeaders: (data: Buffer) => [header: Buffer, chunkHeader: Buffer];
 }
+
+export {
+    TrezorPushNotificationType,
+    TrezorPushNotificationMode,
+    type DecodedTrezorPushNotification,
+} from './protocol-tpn/index';

--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -69,8 +69,6 @@ export class BluetoothApi extends AbstractApi {
         });
         api.on('device_read', ({ id, data, characteristic }) => {
             if (characteristic === 'trezor-push-notification') {
-                // TODO: we should create a protocol decode that passes some type that is more humanfriendly to be emmited.
-                // @ts-expect-error data is number[] but we are emitting it as NotificationData.
                 this.emit('trezor-push-notification', { id, data });
             } else if (characteristic === 'battery-level') {
                 this.emit('battery-level', { id, data });

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -7,7 +7,6 @@ import type {
     AsyncResultWithTypedError,
     DescriptorApiLevel,
     Logger,
-    NotificationData,
     PathInternal,
     Success,
 } from '../types';
@@ -33,7 +32,7 @@ type AccessLock = {
 export abstract class AbstractApi extends TypedEmitter<{
     'transport-interface-change': DescriptorApiLevel[];
     'transport-interface-error': { error: typeof ERRORS.API_DISCONNECTED };
-    [TRANSPORT.TREZOR_PUSH_NOTIFICATION]: { id: string; data: NotificationData };
+    [TRANSPORT.TREZOR_PUSH_NOTIFICATION]: { id: string; data: number[] };
     [TRANSPORT.BATTERY_LEVEL]: { id: string; data: number[] };
 }> {
     protected logger?: Logger;

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -13,7 +13,6 @@ import {
     Descriptor,
     Logger,
     MessageResponse,
-    NotificationData,
     PathPublic,
     ResultWithTypedError,
     Session,
@@ -80,7 +79,7 @@ type TransportEvents = {
     [TRANSPORT.ERROR]: BridgeCommonErrors | typeof ERRORS.API_DISCONNECTED; // BluetoothApi disconnected
     [TRANSPORT.STOPPED]: void;
     [TRANSPORT.SEND_MESSAGE_PROGRESS]: number;
-    [TRANSPORT.TREZOR_PUSH_NOTIFICATION]: { id: string; data: NotificationData };
+    [TRANSPORT.TREZOR_PUSH_NOTIFICATION]: { id: string; data: number[] };
     [TRANSPORT.BATTERY_LEVEL]: { id: string; data: number[] };
 };
 

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -34,20 +34,6 @@ export type Descriptor = Omit<DescriptorApiLevel, 'path'> & {
     id?: string;
 };
 
-/** Device boot/startup notification */
-type NotifyBoot = 0;
-/** Device unlocked and ready to accept messages */
-type NotifyUnlock = 1;
-/** Device hard-locked and won't accept messages */
-type NotifyLock = 2;
-type NormalMode = 0;
-type BootloaderMode = 1;
-export type NotificationData = [
-    1,
-    NotifyBoot | NotifyUnlock | NotifyLock,
-    NormalMode | BootloaderMode,
-];
-
 export interface Logger {
     info(...args: any): void;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Using tpn (trezor-push-notification) decode in Connect so it can emit new event `DEVICE.TREZOR_PUSH_NOTIFICATION` for Suite to react on those notifications.

For some of those notifications we will have to implement some type of logic in Connect.

There is no usage of this new event in Suite yet, but it is received from `DEVICE_EVENT` and since it is inclulded in action there is action type that is triggered from it as well, it does nothing yet but it is ready to be used.


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/decode-trezor-push-notification-in-connect&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/decode-trezor-push-notification-in-connect&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/decode-trezor-push-notification-in-connect&lookback=7)