### PR TITLE
feat: rework of state for THP pairing so it is saved per-device to avoid device mish-mash

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -289,6 +289,7 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
                 enhanceMessageWithAnalytics(
                     createUiMessage(UI.REQUEST_CONFIRMATION, {
                         view: 'no-backup',
+                        device: device.toMessageObject(),
                     }),
                     { device: device.toMessageObject() },
                 ),

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -121,6 +121,7 @@ const waitForReconnectedDevice = async (
                 postMessage(
                     createUiMessage(UI.REQUEST_CONFIRMATION, {
                         view: thpPairingError ? 'thp-pairing-failed' : 'thp-pairing-start',
+                        device: device.toMessageObject(),
                     }),
                 );
                 const uiResp = await uiPromise.promise;

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -203,6 +203,7 @@ export interface UiRequestPermission {
 export interface UiRequestConfirmation {
     type: typeof UI_REQUEST.REQUEST_CONFIRMATION;
     payload: {
+        device: Device;
         view:
             | 'thp-pairing-start'
             | 'thp-pairing-failed'

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -77,6 +77,13 @@ export type FirmwareHashCheckResult =
           errorPayload?: unknown;
       };
 
+/**
+ * The Unique Device Identifier per Suite run & Connected Device.
+ * When Suite is restarted or the Device is reconnected this will change.
+ *
+ * The main reason for this identifier is to reference device which is unacquired
+ * and therefore has no `id` yet. Typical use case is THP pairing
+ */
 export type DeviceUniquePath = string & Branded<'DeviceUniquePath'>;
 export const DeviceUniquePath = (id: string) => id as DeviceUniquePath;
 

--- a/packages/suite/src/components/connection/ConnectionGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectionGlobalModal.tsx
@@ -22,15 +22,17 @@ export const ConnectionGlobalModal = ({ showThpModals = true }: ConnectionGlobal
     const dispatch = useDispatch();
     const isConnectDeviceModalOpen = useSelector(selectIsConnectionModalOpen);
     const device = useSelector(selectSelectedDevice);
-    const thpStep = useSelector(selectThpStep);
+    const thpStepState = useSelector(selectThpStep);
 
     const closeConnectionModal = () => {
         dispatch(setConnectionModal(false));
     };
 
+    const thpStep = device !== undefined ? thpStepState[device.path] : null;
+
     // handle THP modals first if we have a device and thpStep
     if (device !== undefined && thpStep !== null && showThpModals) {
-        switch (thpStep) {
+        switch (thpStep.step) {
             case 'BeforeConnectionInfo':
                 return null;
             case 'ConfirmConnectionBeforePairing':
@@ -38,15 +40,15 @@ export const ConnectionGlobalModal = ({ showThpModals = true }: ConnectionGlobal
             case 'ConfirmOnlyConnection':
                 return <ThpConnectionModal device={device} />;
             case 'CodeEntry':
-                return <ThpPairingPinEntryModal />;
+                return <ThpPairingPinEntryModal device={device} />;
             case 'CodeInvalid':
-                return <ThpPairingFailedModal />;
+                return <ThpPairingFailedModal device={device} />;
             case 'AutoconnectInfo':
-                return <ThpAutoconnectInfoModal />;
+                return <ThpAutoconnectInfoModal device={device} />;
             case 'Autoconnect':
                 return <ThpAutoconnectionModal device={device} />;
             default:
-                return exhaustive(thpStep);
+                return exhaustive(thpStep.step);
         }
     }
 

--- a/packages/suite/src/components/connection/thp/ThpAutoconnectInfoModal.tsx
+++ b/packages/suite/src/components/connection/thp/ThpAutoconnectInfoModal.tsx
@@ -1,12 +1,17 @@
 import { useState } from 'react';
 
+import { TrezorDevice } from '@suite-common/suite-types';
 import { finishThpAutoconnectThunk, startThpAutoconnectThunk } from '@suite-common/thp';
 import { Column, H3, Modal, Paragraph } from '@trezor/components';
 
 import { useDevice, useDispatch } from '../../../hooks/suite';
 import { Translation } from '../../suite/Translation';
 
-export const ThpAutoconnectInfoModal = () => {
+type ThpAutoconnectInfoModalParams = {
+    device: TrezorDevice;
+};
+
+export const ThpAutoconnectInfoModal = ({ device }: ThpAutoconnectInfoModalParams) => {
     const [isLoading, setIsLoading] = useState(false);
     const { isLocked } = useDevice();
     const dispatch = useDispatch();
@@ -14,11 +19,11 @@ export const ThpAutoconnectInfoModal = () => {
 
     const onTurnOn = () => {
         setIsLoading(true);
-        dispatch(startThpAutoconnectThunk());
+        dispatch(startThpAutoconnectThunk({ device }));
     };
 
     const onCancel = () => {
-        dispatch(finishThpAutoconnectThunk());
+        dispatch(finishThpAutoconnectThunk({ path: device.path }));
     };
 
     return (

--- a/packages/suite/src/components/connection/thp/ThpAutoconnectionModal.tsx
+++ b/packages/suite/src/components/connection/thp/ThpAutoconnectionModal.tsx
@@ -12,7 +12,7 @@ export const ThpAutoconnectionModal = ({ device }: ThpAutoconnectionModalProps) 
     const dispatch = useDispatch();
 
     const onCancel = () => {
-        dispatch(thpActions.finishThpFlow());
+        dispatch(thpActions.finishThpFlow({ path: device.path }));
     };
 
     return (

--- a/packages/suite/src/components/connection/thp/ThpPairingFailedModal.tsx
+++ b/packages/suite/src/components/connection/thp/ThpPairingFailedModal.tsx
@@ -1,16 +1,20 @@
 import { useState } from 'react';
 
+import { TrezorDevice } from '@suite-common/suite-types';
 import { thpActions } from '@suite-common/thp';
 import { acquireDevice } from '@suite-common/wallet-core';
 import { Column, Modal, Paragraph } from '@trezor/components';
 
 import { ThpPairingCodeEntry } from './ThpPairingCodeEntry';
-import { useDevice, useDispatch, useSelector } from '../../../hooks/suite';
+import { useDispatch, useSelector } from '../../../hooks/suite';
 import { Translation } from '../../suite/Translation';
 
-export const ThpPairingFailedModal = () => {
+type ThpPairingFailedModalParams = {
+    device: TrezorDevice;
+};
+
+export const ThpPairingFailedModal = ({ device }: ThpPairingFailedModalParams) => {
     const [isLoading, setIsLoading] = useState(false);
-    const { device } = useDevice();
     const dispatch = useDispatch();
     const lastThpCode = useSelector(state => state.thp.lastThpCode);
 
@@ -21,7 +25,7 @@ export const ThpPairingFailedModal = () => {
     };
 
     const onCancel = () => {
-        dispatch(thpActions.finishThpFlow());
+        dispatch(thpActions.finishThpFlow({ path: device.path }));
     };
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ThpPairingPinEntryModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ThpPairingPinEntryModal.tsx
@@ -1,5 +1,6 @@
 import { useIntl } from 'react-intl';
 
+import { TrezorDevice } from '@suite-common/suite-types';
 import { thpActions } from '@suite-common/thp';
 import { Box, Modal } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
@@ -9,13 +10,17 @@ import messages from '../../../../../support/messages';
 import { ThpPairingCodeEntry } from '../../../../connection/thp/ThpPairingCodeEntry';
 import { Translation } from '../../../Translation';
 
-export const ThpPairingPinEntryModal = () => {
+type ThpPairingPinEntryModalParams = {
+    device: TrezorDevice;
+};
+
+export const ThpPairingPinEntryModal = ({ device }: ThpPairingPinEntryModalParams) => {
     const intl = useIntl();
     const dispatch = useDispatch();
 
     const onCancel = () => {
         TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
-        dispatch(thpActions.finishThpFlow());
+        dispatch(thpActions.finishThpFlow({ path: device.path }));
     };
 
     return (

--- a/suite-common/thp/src/connectThpDeviceThunk.ts
+++ b/suite-common/thp/src/connectThpDeviceThunk.ts
@@ -8,7 +8,7 @@ import { selectThpCredentials } from './thpSelectors';
 const NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT = 3;
 
 type ConnectThpDeviceThinkParams = {
-    device: Pick<Device, 'thp'>;
+    device: Pick<Device, 'thp' | 'path'>;
 };
 
 export const connectThpDeviceThunk = createThunk<void, ConnectThpDeviceThinkParams, void>(
@@ -42,11 +42,11 @@ export const connectThpDeviceThunk = createThunk<void, ConnectThpDeviceThinkPara
 
             dispatch(
                 shallShowAutoConnectDialog
-                    ? thpActions.showAutoconnectInfo()
-                    : thpActions.finishThpFlow(),
+                    ? thpActions.showAutoconnectInfo({ path: device.path })
+                    : thpActions.finishThpFlow({ path: device.path }),
             );
         } else {
-            dispatch(thpActions.finishThpFlow());
+            dispatch(thpActions.finishThpFlow({ path: device.path }));
         }
     },
 );

--- a/suite-common/thp/src/finishThpAutoconnectThunk.ts
+++ b/suite-common/thp/src/finishThpAutoconnectThunk.ts
@@ -1,17 +1,22 @@
 import { createThunk } from '@suite-common/redux-utils/';
 import { startOrRestartDiscoveryThunk } from '@suite-common/wallet-core';
+import { DeviceUniquePath } from '@trezor/connect';
 
 import { THP_PREFIX, thpActions } from './thpActions';
+
+type FinishThpAutoconnectThunkParams = {
+    path: DeviceUniquePath;
+};
 
 /**
  * Finish THP Autoconnect flow and start discovery.
  * Discovery middleware delays discovery until THP AutoConnect modal is closed.
  * TODO: implementation on mobile?
  */
-export const finishThpAutoconnectThunk = createThunk<void, void, void>(
+export const finishThpAutoconnectThunk = createThunk<void, FinishThpAutoconnectThunkParams, void>(
     `${THP_PREFIX}/finishThpAutoconnectThunk`,
-    (_, { dispatch }) => {
-        dispatch(thpActions.finishThpFlow());
+    ({ path }, { dispatch }) => {
+        dispatch(thpActions.finishThpFlow({ path }));
         dispatch(startOrRestartDiscoveryThunk());
     },
 );

--- a/suite-common/thp/src/startThpAutoconnectThunk.ts
+++ b/suite-common/thp/src/startThpAutoconnectThunk.ts
@@ -1,20 +1,18 @@
 import { createThunk } from '@suite-common/redux-utils/';
+import { TrezorDevice } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 
 import { finishThpAutoconnectThunk } from './finishThpAutoconnectThunk';
 import { THP_PREFIX, thpActions } from './thpActions';
 
-export const startThpAutoconnectThunk = createThunk<void, void, void>(
+type StartThpAutoconnectThunkParam = {
+    device: TrezorDevice;
+};
+
+export const startThpAutoconnectThunk = createThunk<void, StartThpAutoconnectThunkParam, void>(
     `${THP_PREFIX}/startThpAutoconnectThunk`,
-    async (_, { getState, dispatch }) => {
-        const device = selectSelectedDevice(getState());
-
-        if (device === undefined) {
-            return;
-        }
-
+    async ({ device }, { dispatch }) => {
         const response = await TrezorConnect.thpGetCredentials({ device });
 
         if (response.success) {
@@ -24,6 +22,6 @@ export const startThpAutoconnectThunk = createThunk<void, void, void>(
                 notificationsActions.addToast({ type: 'error', error: response.payload.error }),
             );
         }
-        dispatch(finishThpAutoconnectThunk());
+        dispatch(finishThpAutoconnectThunk({ path: device.path }));
     },
 );

--- a/suite-common/thp/src/thpActions.ts
+++ b/suite-common/thp/src/thpActions.ts
@@ -1,44 +1,49 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import { ThpSuiteCredentials } from '@suite-common/suite-types';
+import { DeviceUniquePath } from '@trezor/connect';
 import { ThpCredentials } from '@trezor/protocol';
 
 export const THP_PREFIX = '@suite/thp';
 
-const invalidCode = createAction(`${THP_PREFIX}/invalid-pin-action`);
+const invalidCode = createAction(
+    `${THP_PREFIX}/invalid-pin-action`,
+    (payload: { path: DeviceUniquePath }) => ({ payload }),
+);
 
-const finishThpFlow = createAction(`${THP_PREFIX}/finish-thp-flow`);
+const finishThpFlow = createAction(
+    `${THP_PREFIX}/finish-thp-flow`,
+    (payload: { path: DeviceUniquePath }) => ({ payload }),
+);
 
-const cancelThpFlow = createAction(`${THP_PREFIX}/cancel-thp-flow`);
+const cancelThpFlow = createAction(
+    `${THP_PREFIX}/cancel-thp-flow`,
+    (payload: { path: DeviceUniquePath }) => ({ payload }),
+);
 
-export const showAutoconnectInfo = createAction(`${THP_PREFIX}/showAutoconnectInfo`);
+export const showAutoconnectInfo = createAction(
+    `${THP_PREFIX}/showAutoconnectInfo`,
+    (payload: { path: DeviceUniquePath }) => ({ payload }),
+);
 
 export const setLastThpCode = createAction(
     `${THP_PREFIX}/set-last-thp-code`,
-    (payload: { code: string }) => ({
-        payload,
-    }),
+    (payload: { code: string; path: DeviceUniquePath }) => ({ payload }),
 );
 
 export const incrementCredentialConnectionCounter = createAction(
     `${THP_PREFIX}/increment-credential-connection-counter`,
-    (payload: { credential: ThpSuiteCredentials }) => ({
-        payload,
-    }),
+    (payload: { credential: ThpSuiteCredentials }) => ({ payload }),
 );
 
 export const addCredential = createAction(
     `${THP_PREFIX}/add-credential`,
-    (payload: { credential: ThpCredentials }) => ({
-        payload,
-    }),
+    (payload: { credential: ThpCredentials }) => ({ payload }),
 );
 
 export const removeCredentials = createAction(
     `${THP_PREFIX}/removeCredentials`,
-    (payload: { credentials: ThpCredentials[] }) => ({
-        payload,
-    }),
+    (payload: { credentials: ThpCredentials[] }) => ({ payload }),
 );
 
 export const removeAllCredentials = createAction(`${THP_PREFIX}/removeAllCredentials`);

--- a/suite-common/thp/src/thpReducer.ts
+++ b/suite-common/thp/src/thpReducer.ts
@@ -6,7 +6,9 @@ import {
     DEVICE,
     DeviceButtonRequest,
     DeviceThpCredentialsChanged,
+    DeviceUniquePath,
     UI,
+    UiRequestButton,
     UiRequestConfirmation,
     UiRequestThpPairing,
 } from '@trezor/connect';
@@ -33,11 +35,10 @@ export type ThpStep =
     | 'AutoconnectInfo'
     | 'Autoconnect'
     // Currently relevant only for Firmware Update / Custom Firmware & Onboarding Firmware
-    | 'BeforeConnectionInfo'
-    | null;
+    | 'BeforeConnectionInfo';
 
 export type ThpState = {
-    step: ThpStep;
+    step: Record<DeviceUniquePath, { step: ThpStep } | null>;
     lastThpCode?: string;
     credentials: ThpSuiteCredentials[];
     // staticKey for the application.
@@ -46,7 +47,7 @@ export type ThpState = {
 };
 
 export const initialThpState: ThpState = {
-    step: null,
+    step: {},
     lastThpCode: undefined,
     credentials: [] as ThpSuiteCredentials[],
 };
@@ -55,14 +56,14 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
     initialThpState,
     (builder, extra) =>
         builder
-            .addCase(thpActions.invalidCode, state => {
-                state.step = 'CodeInvalid';
+            .addCase(thpActions.invalidCode, (state, { payload }) => {
+                state.step[payload.path] = { step: 'CodeInvalid' };
             })
             .addCase(thpActions.setLastThpCode, (state, { payload }) => {
                 state.lastThpCode = payload.code;
             })
-            .addCase(thpActions.showAutoconnectInfo, state => {
-                state.step = 'AutoconnectInfo';
+            .addCase(thpActions.showAutoconnectInfo, (state, { payload }) => {
+                state.step[payload.path] = { step: 'AutoconnectInfo' };
             })
             .addCase(thpActions.incrementCredentialConnectionCounter, (state, { payload }) => {
                 const credentialToUpdate = state.credentials.find(
@@ -88,13 +89,16 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
             .addCase(thpActions.removeAllCredentials, state => {
                 state.credentials = [];
             })
-            .addMatcher(isAnyOf(thpActions.finishThpFlow, thpActions.cancelThpFlow), state => {
-                state.step = null;
-            })
+            .addMatcher(
+                isAnyOf(thpActions.finishThpFlow, thpActions.cancelThpFlow),
+                (state, { payload }) => {
+                    state.step[payload.path] = null;
+                },
+            )
             .addMatcher(
                 action => action.type === UI.REQUEST_THP_PAIRING,
-                state => {
-                    state.step = 'CodeEntry';
+                (state, { payload }: UiRequestThpPairing) => {
+                    state.step[payload.device.path] = { step: 'CodeEntry' };
                 },
             )
             .addMatcher(
@@ -111,17 +115,18 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
             )
             .addMatcher(
                 action => action.type === UI.REQUEST_BUTTON,
-                (state, action: AnyAction) => {
-                    const actionName: THPButtonRequestName = action.payload.name;
+                (state, action: UiRequestButton) => {
+                    const devicePath = action.payload.device.path;
+                    const actionName = action.payload.name as THPButtonRequestName;
                     switch (actionName) {
                         case 'thp_pairing_request':
-                            state.step = 'ConfirmConnectionBeforePairing';
+                            state.step[devicePath] = { step: 'ConfirmConnectionBeforePairing' };
                             break;
                         case 'thp_connection_request':
-                            state.step = 'ConfirmOnlyConnection';
+                            state.step[devicePath] = { step: 'ConfirmOnlyConnection' };
                             break;
                         case 'thp_autoconnect_credential_request':
-                            state.step = 'Autoconnect';
+                            state.step[devicePath] = { step: 'Autoconnect' };
                             break;
                     }
                 },
@@ -130,26 +135,28 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
             .addMatcher<DeviceButtonRequest | UiRequestThpPairing | UiRequestConfirmation>(
                 action => action.type === UI.REQUEST_CONFIRMATION || action.type === DEVICE.BUTTON,
                 (state, action) => {
+                    const devicePath = action.payload.device.path;
+
                     // The THP device is ready for pairing, wait for user action
                     if (action.type === UI.REQUEST_CONFIRMATION) {
                         if (action.payload.view === 'thp-pairing-start') {
-                            state.step = 'BeforeConnectionInfo';
+                            state.step[devicePath] = { step: 'BeforeConnectionInfo' };
                         }
                         if (action.payload.view === 'thp-pairing-failed') {
-                            state.step = 'CodeInvalid';
+                            state.step[devicePath] = { step: 'CodeInvalid' };
                         }
                     }
 
                     // Handle button requests in the THP pairing
                     if (action.type === DEVICE.BUTTON) {
                         if (action.payload.name === 'thp_pairing_request') {
-                            state.step = 'ConfirmConnectionBeforePairing';
+                            state.step[devicePath] = { step: 'ConfirmConnectionBeforePairing' };
                         }
                         if (action.payload.name === 'thp_connection_request') {
-                            state.step = 'ConfirmOnlyConnection';
+                            state.step[devicePath] = { step: 'ConfirmOnlyConnection' };
                         }
                         if (action.payload.name === 'thp_autoconnect_credential_request') {
-                            state.step = 'Autoconnect';
+                            state.step[devicePath] = { step: 'Autoconnect' };
                         }
                     }
                 },

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -205,7 +205,7 @@ export const acquireDevice = createThunk(
 
         if (!response.success) {
             if (response.payload.code === 'Device_ThpPairingTagInvalid') {
-                dispatch(thpActions.invalidCode());
+                dispatch(thpActions.invalidCode({ path: device.path }));
             } else {
                 dispatch(
                     notificationsActions.addToast({
@@ -215,7 +215,7 @@ export const acquireDevice = createThunk(
                     }),
                 );
                 if (device?.thp !== undefined) {
-                    dispatch(thpActions.cancelThpFlow());
+                    dispatch(thpActions.cancelThpFlow({ path: device.path }));
                 }
             }
         } else if (startDiscovery) {


### PR DESCRIPTION
Resolves https://github.com/trezor/trezor-suite/issues/21818

HUGE WIP

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=thp-steps-use-correct-thp-device&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=thp-steps-use-correct-thp-device&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=thp-steps-use-correct-thp-device&lookback=7)