### PR TITLE
THP pairing cancel workflow failing tests

### DIFF
--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -1,6 +1,6 @@
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b2f872bcb7f007fe18a5a7db7f7ed45d4fa47342
+    image: ghcr.io/trezor/trezor-user-env:af3bcc4e3657c3b02584af8ddb3f674facf15dc5
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp


### PR DESCRIPTION
## Description

Seems to pass if I use Trezor-user-env proxy from @mroz22: https://github.com/trezor/trezor-user-env/pull/322
But it could also be some kind of Trezor-user-env regression

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-thp-cancel-workflow-test&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-thp-cancel-workflow-test&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-thp-cancel-workflow-test&lookback=7)