### PR TITLE
Fix condition in `connectDevice`

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -190,7 +190,7 @@ const connectDevice = (draft: DeviceReducerState, device: Device) => {
         const changedDevices = affectedDevices.map(d => {
             // change availability according to "passphrase_protection" field
             if (
-                d.useEmptyPassphrase === true &&
+                d.useEmptyPassphrase !== true &&
                 isUnlocked(device.features) &&
                 !features.passphrase_protection
             ) {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

This condition was probably changed by mistake in https://github.com/trezor/trezor-suite/commit/799c999985a648afb04d61646f32b7424db25a5d. Changing back to original behaviour.

How to reproduce:
- Disable `passphrase-protection` via `trezorctl disable-passphrase`.
- Go to send form.
- Disconnect.
- Reconnect.

## Related Issue

Resolve [Slack issue](https://satoshilabs.slack.com/archives/CKZHV2G13/p1758706634931569)

## Screenshots:
<img width="1730" height="886" alt="Screenshot 2025-09-26 at 18 00 43" src="https://github.com/user-attachments/assets/ebeb676a-a7ba-405a-a2a2-a132be5fdd00" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/passphrase-protection&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/passphrase-protection&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/passphrase-protection&lookback=7)