### PR TITLE
Show error alert when trade confirmation fails

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2296,6 +2296,7 @@ export const messages = {
             feeLabel: 'Fee',
             providerNamePlaceholder: 'Provider',
             providerReceiveAddressLabel: "{providerName}'s receive address",
+            confirmationAlertTitle: 'Failed to confirm offer.',
         },
         tradingExchangeApprovalScreen: {
             title: 'Set {symbol} spending',

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -32,6 +32,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/accounts": "workspace:*",
+        "@suite-native/alerts": "workspace:*",
         "@suite-native/analytics": "workspace:*",
         "@suite-native/device": "workspace:*",
         "@suite-native/device-manager": "workspace:*",

--- a/suite-native/module-trading/src/__fixtures__/account.ts
+++ b/suite-native/module-trading/src/__fixtures__/account.ts
@@ -10,6 +10,9 @@ export const getBtcAccount = (key = 'btc-account-1', overrides: Partial<Account>
         balance: '1000000',
         availableBalance: '1000000',
         formattedBalance: '0.01',
+        networkType: 'bitcoin',
+        visible: true,
+        deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@448CCE89D32A733A1632F345:0',
         addresses: {
             used: [
                 {

--- a/suite-native/module-trading/src/__fixtures__/walletState.ts
+++ b/suite-native/module-trading/src/__fixtures__/walletState.ts
@@ -48,5 +48,11 @@ export const getWalletState = ({
             getBaseAccount(undefined, accountOverrides),
             getSolAccount(undefined, accountOverrides),
         ] as Account[],
+        send: {
+            drafts: {},
+            precomposedTx: undefined,
+            serializedTx: undefined,
+            signedTx: undefined,
+        },
     };
 };

--- a/suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx
@@ -10,6 +10,7 @@ import {
     selectTradingProviderByNameAndTradeType,
     selectTradingSellAccountKey,
 } from '@suite-common/trading';
+import { getNetwork } from '@suite-common/wallet-config/src/utils';
 import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { Text, VStack } from '@suite-native/atoms';
 import { splitAddressToChunks } from '@suite-native/helpers';
@@ -42,12 +43,13 @@ export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellF
             ? (trade as ExchangeTrade).sendAddress
             : (trade as SellFiatTrade).destinationAddress;
 
-    if (!receiveAddress) {
+    if (!receiveAddress || !networkSymbol) {
         return null;
     }
 
+    const { networkType } = getNetwork(networkSymbol);
     const addressText =
-        networkSymbol === 'sol'
+        networkType === 'solana'
             ? receiveAddress
             : splitAddressToChunks(receiveAddress ?? '').join(' ');
 

--- a/suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx
@@ -10,8 +10,7 @@ import {
     selectTradingProviderByNameAndTradeType,
     selectTradingSellAccountKey,
 } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config/src/utils';
-import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
+import { AccountsRootState, selectAccountNetworkType } from '@suite-common/wallet-core';
 import { Text, VStack } from '@suite-native/atoms';
 import { splitAddressToChunks } from '@suite-native/helpers';
 import { Translation, useTranslate } from '@suite-native/intl';
@@ -30,8 +29,8 @@ export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellF
             : selectTradingSellAccountKey(state),
     );
 
-    const networkSymbol = useSelector((state: AccountsRootState) =>
-        sendAccountKey ? selectAccountNetworkSymbol(state, sendAccountKey) : null,
+    const networkType = useSelector((state: AccountsRootState) =>
+        sendAccountKey ? selectAccountNetworkType(state, sendAccountKey) : null,
     );
 
     const providerName =
@@ -43,11 +42,10 @@ export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellF
             ? (trade as ExchangeTrade).sendAddress
             : (trade as SellFiatTrade).destinationAddress;
 
-    if (!receiveAddress || !networkSymbol) {
+    if (!receiveAddress || !networkType) {
         return null;
     }
 
-    const { networkType } = getNetwork(networkSymbol);
     const addressText =
         networkType === 'solana'
             ? receiveAddress

--- a/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.comp.test.tsx
@@ -77,13 +77,13 @@ describe('ProviderReceiveAddress', () => {
         // Don't set provider info to simulate missing provider
         walletState.trading.exchange.exchangeInfo!.providerInfos = {};
 
-        const { getByText } = await renderWithStoreProviderAsync(
+        const { queryByText } = await renderWithStoreProviderAsync(
             <ProviderReceiveAddress trade={mockExchangeTrade} />,
             { preloadedState: { wallet: walletState } },
         );
 
-        // User should see fallback text when provider info is missing
-        expect(getByText("Provider's receive address")).toBeTruthy();
+        // Component should not render when provider info is missing
+        expect(queryByText("Provider's receive address")).toBeFalsy();
     });
 
     it('should show fallback text when provider company name is not available', async () => {
@@ -91,13 +91,13 @@ describe('ProviderReceiveAddress', () => {
         // Don't set provider info to simulate missing provider
         walletState.trading.exchange.exchangeInfo!.providerInfos = {};
 
-        const { getByText } = await renderWithStoreProviderAsync(
+        const { queryByText } = await renderWithStoreProviderAsync(
             <ProviderReceiveAddress trade={mockExchangeTrade} />,
             { preloadedState: { wallet: walletState } },
         );
 
-        // User should see fallback text when company name is missing
-        expect(getByText("Provider's receive address")).toBeTruthy();
+        // Component should not render when company name is missing
+        expect(queryByText("Provider's receive address")).toBeFalsy();
     });
 
     it('should not render anything when receive address is missing for exchange trade', async () => {
@@ -127,5 +127,54 @@ describe('ProviderReceiveAddress', () => {
 
         // For Solana addresses, the address should be displayed without splitting
         expect(getByText('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa')).toBeTruthy();
+    });
+
+    it('should display ethereum address with chunking for non-solana networks', async () => {
+        const { getByText } = await renderProviderReceiveAddress(
+            mockExchangeTrade,
+            'exchange',
+            'eth-account-1',
+        );
+
+        // For non-Solana addresses, the address should be displayed with chunking
+        expect(getByText('1A1z P1eP 5QGe fi2D MPTf TL5S Lmv7 Divf Na')).toBeTruthy();
+    });
+
+    it('should display bitcoin address with chunking for non-solana networks', async () => {
+        const { getByText } = await renderProviderReceiveAddress(
+            mockExchangeTrade,
+            'exchange',
+            'btc-account-1',
+        );
+
+        // For non-Solana addresses, the address should be displayed with chunking
+        expect(getByText('1A1z P1eP 5QGe fi2D MPTf TL5S Lmv7 Divf Na')).toBeTruthy();
+    });
+
+    it('should handle solana network type correctly', async () => {
+        const solanaTrade = {
+            ...mockExchangeTrade,
+            sendAddress: '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM', // Real Solana address
+        };
+
+        const { getByText } = await renderProviderReceiveAddress(
+            solanaTrade,
+            'exchange',
+            'sol-account-1',
+        );
+
+        // For Solana addresses, the address should be displayed without splitting
+        expect(getByText('9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM')).toBeTruthy();
+    });
+
+    it('should handle undefined network symbol gracefully', async () => {
+        const { queryByText } = await renderProviderReceiveAddress(
+            mockExchangeTrade,
+            'exchange',
+            'unknown-account-1',
+        );
+
+        // Should not render anything when network symbol is undefined
+        expect(queryByText('1A1z P1eP 5QGe fi2D MPTf TL5S Lmv7 Divf Na')).toBeFalsy();
     });
 });

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
@@ -287,8 +287,6 @@ export const useExchangeFlow = () => {
             selectedAccount,
             paymentRequests,
         }: TradingSignAndPushSendFormTransactionProps): Promise<TradingFulfillValue> => {
-            resolveConsent(true);
-
             const result = await dispatch(
                 signAndPushSendFormTransactionThunk({
                     formState,
@@ -344,7 +342,6 @@ export const useExchangeFlow = () => {
         dispatch,
         getCommonFunctions,
         isSlip24Active,
-        resolveConsent,
         selectedQuote,
         sendAccount,
         shouldSendInSats,

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
@@ -103,7 +103,7 @@ export const useExchangeFlow = () => {
     const { isConsentRequested, waitForConsent, resolveConsent } = useConsent();
 
     useFeesFetching({
-        accountKey: sendAccount?.key,
+        networkSymbol: sendAccount?.symbol,
         isRefetchDisabled: selectedFee === 'custom',
     });
 

--- a/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
@@ -3,8 +3,12 @@ import { ScrollView } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { useNetInfo } from '@react-native-community/netinfo';
+
 import { parseCryptoId, selectTradingExchangeSelectedQuote } from '@suite-common/trading';
+import { selectSendPrecomposedTx } from '@suite-common/wallet-core';
 import { TokenAddress } from '@suite-common/wallet-types';
+import { useAlert } from '@suite-native/alerts';
 import { Button, InlineAlertBox, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -15,6 +19,7 @@ import {
     TradingStackRoutes,
 } from '@suite-native/navigation';
 import { useSubscribeForSolanaBlockUpdates } from '@suite-native/transaction-management';
+import { useDebounce } from '@trezor/react-utils';
 
 import { ExchangeTradePreviewCard } from '../components/exchange/ExchangeTradePreviewCard';
 import { FeePickerCard } from '../components/fees/FeePickerCard';
@@ -32,29 +37,24 @@ export type TradingExchangePreviewScreenProps = StackProps<
     TradingStackRoutes.TradingExchangePreview
 >;
 
-type FlowStep = 'confirm' | 'signTxn';
-
-// TODO: this is very WIP just to be able to test the flow
-// it wont be implemented in this component this way in the end
-const flowStepToButtonText: Record<FlowStep, string> = {
-    confirm: 'Continue',
-    signTxn: 'Sign and Send Transaction',
-};
-
 export const TradingExchangePreviewScreen = ({ navigation }: TradingExchangePreviewScreenProps) => {
+    const { showAlert } = useAlert();
     const dispatch = useDispatch();
+    const debounce = useDebounce();
+    const { isInternetReachable } = useNetInfo();
     const quote = useSelector(selectTradingExchangeSelectedQuote);
     const fromAccount = useSelector(selectExchangeSelectedSendAccount);
     const toAccount = useSelector(selectExchangeSelectedReceiveAccount);
+    const precomposedTransaction = useSelector(selectSendPrecomposedTx);
     const hasRequestedTradeConfirmation = useRef(false);
-
     const { fromStringValue, toStringValue } = useChangeStringsExtractor(quote);
 
     useSubscribeForSolanaBlockUpdates(fromAccount ?? null);
 
     const { txnErrorString, confirmTrade, fetchFeesAndCompose } = useExchangeFlow();
 
-    const [flowStep, setFlowStep] = useState<FlowStep>('confirm');
+    const [isConfirmationErrorRequested, setIsConfirmationErrorRequested] =
+        useState<boolean>(false);
 
     // clear trading state on unmount
     useEffect(
@@ -82,13 +82,46 @@ export const TradingExchangePreviewScreen = ({ navigation }: TradingExchangePrev
 
             if (success) {
                 await fetchFeesAndCompose();
-                setFlowStep('signTxn');
             }
         } catch (e) {
-            // TODO: show warning https://github.com/trezor/trezor-suite/issues/21882
+            debounce(() => {
+                setIsConfirmationErrorRequested(true);
+            });
+
             console.error('Failed to confirm trade', e);
         }
-    }, [confirmTrade, fetchFeesAndCompose, fromAccount, quote, toAccount]);
+    }, [confirmTrade, debounce, fetchFeesAndCompose, fromAccount, quote, toAccount]);
+
+    useEffect(() => {
+        if (isConfirmationErrorRequested) {
+            const description =
+                isInternetReachable === false ? (
+                    <Translation id="moduleTrading.error.deviceOfflineDescription" />
+                ) : undefined;
+
+            showAlert({
+                title: (
+                    <Translation id="moduleTrading.tradingExchangePreviewScreen.confirmationAlertTitle" />
+                ),
+                description,
+                primaryButtonTitle: <Translation id="generic.buttons.tryAgain" />,
+                primaryButtonVariant: 'redBold',
+                onPressPrimaryButton: handleConfirmTrade,
+                secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
+                secondaryButtonVariant: 'redElevation0',
+                onPressSecondaryButton: () => {
+                    navigation.popToTop();
+                },
+            });
+            setIsConfirmationErrorRequested(false);
+        }
+    }, [
+        handleConfirmTrade,
+        isConfirmationErrorRequested,
+        isInternetReachable,
+        navigation,
+        showAlert,
+    ]);
 
     useEffect(() => {
         if (!hasRequestedTradeConfirmation.current) {
@@ -119,14 +152,6 @@ export const TradingExchangePreviewScreen = ({ navigation }: TradingExchangePrev
                 tokenContract,
             },
         });
-    };
-
-    const handleTapContinue = () => {
-        if (flowStep === 'signTxn') {
-            handleSignTransaction();
-        } else {
-            console.warn('Unknown flow step', flowStep);
-        }
     };
 
     return (
@@ -184,12 +209,11 @@ export const TradingExchangePreviewScreen = ({ navigation }: TradingExchangePrev
                 </VStack>
             </ScrollView>
 
-            <Button
-                onPress={handleTapContinue}
-                isDisabled={flowStep === 'confirm' || !!txnErrorString}
-            >
-                {flowStepToButtonText[flowStep]}
-            </Button>
+            {precomposedTransaction?.type === 'final' && (
+                <Button onPress={handleSignTransaction} isDisabled={!!txnErrorString}>
+                    <Translation id="generic.buttons.continue" />
+                </Button>
+            )}
         </Screen>
     );
 };

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
@@ -1,7 +1,12 @@
 import { RouteProp } from '@react-navigation/native';
 
 import { TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
-import { TestStore, initStore, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import {
+    TestStore,
+    initStore,
+    renderWithStoreProviderAsync,
+    waitFor,
+} from '@suite-native/test-utils';
 
 import { getBtcAccount } from '../../__fixtures__/account';
 import { exchangeQuotes } from '../../__fixtures__/exchangeQuotes';
@@ -35,6 +40,16 @@ jest.mock('../../hooks/exchange/useExchangeFlow', () => ({
     }),
 }));
 
+const mockShowAlert = jest.fn();
+jest.mock('@suite-native/alerts', () => ({
+    useAlert: () => ({
+        showAlert: mockShowAlert,
+    }),
+}));
+
+const mockPopToTop = jest.fn();
+const mockNavigate = jest.fn();
+
 describe('TradingExchangePreviewScreen', () => {
     let store: TestStore;
 
@@ -43,14 +58,13 @@ describe('TradingExchangePreviewScreen', () => {
             <TradingExchangePreviewScreen
                 navigation={
                     {
-                        navigate: jest.fn(),
+                        navigate: mockNavigate,
+                        popToTop: mockPopToTop,
                     } as unknown as TradingExchangePreviewScreenProps['navigation']
                 }
                 route={{} as TradingExchangePreviewScreenProps['route']}
             />,
-            {
-                store,
-            },
+            { store },
         );
 
     beforeEach(async () => {
@@ -64,6 +78,21 @@ describe('TradingExchangePreviewScreen', () => {
             receiveAccountKey: 'btc-account-1',
             receiveAddress: getBtcAccount().addresses?.used[0].address,
             selectedQuote: exchangeQuotes[0],
+        };
+
+        // Add precomposed transaction to show the Continue button
+        preloadedState.wallet = {
+            ...preloadedState.wallet,
+            send: {
+                ...preloadedState.wallet.send,
+                precomposedTx: {
+                    type: 'final',
+                    fee: '1000',
+                    feePerByte: '10',
+                    totalSpent: '100000',
+                    bytes: 100,
+                } as any,
+            },
         };
 
         store = await initStore(preloadedState);
@@ -101,5 +130,78 @@ describe('TradingExchangePreviewScreen', () => {
         // Should render the fee picker section
         expect(getByText('Transaction details')).toBeOnTheScreen();
         expect(getByText('Fee')).toBeOnTheScreen();
+    });
+
+    describe('Error Alert Functionality', () => {
+        it('should show error alert when trade confirmation fails', async () => {
+            // Mock confirmTrade to throw an error
+            mockConfirmTrade.mockRejectedValueOnce(new Error('Trade confirmation failed'));
+
+            await renderTradingExchangePreviewScreen();
+
+            // Wait for the error to be processed
+            await waitFor(() => {
+                expect(mockShowAlert).toHaveBeenCalledTimes(1);
+            });
+        });
+
+        it('should retry trade confirmation when retry button is pressed', async () => {
+            // Mock confirmTrade to throw an error first, then succeed
+            mockConfirmTrade
+                .mockRejectedValueOnce(new Error('Trade confirmation failed'))
+                .mockResolvedValueOnce(true);
+
+            await renderTradingExchangePreviewScreen();
+
+            // Wait for the error alert to be shown
+            await waitFor(() => {
+                expect(mockShowAlert).toHaveBeenCalled();
+            });
+
+            // Get the retry function from the alert call
+            const alertCall = mockShowAlert.mock.calls[0][0];
+            const retryFunction = alertCall.onPressPrimaryButton;
+
+            // Call the retry function
+            await retryFunction();
+
+            // Verify confirmTrade was called again
+            expect(mockConfirmTrade).toHaveBeenCalledTimes(2);
+        });
+
+        it('should navigate to top when cancel button is pressed', async () => {
+            // Mock confirmTrade to throw an error
+            mockConfirmTrade.mockRejectedValueOnce(new Error('Trade confirmation failed'));
+
+            await renderTradingExchangePreviewScreen();
+
+            // Wait for the error alert to be shown
+            await waitFor(() => {
+                expect(mockShowAlert).toHaveBeenCalled();
+            });
+
+            // Get the cancel function from the alert call
+            const alertCall = mockShowAlert.mock.calls[0][0];
+            const cancelFunction = alertCall.onPressSecondaryButton;
+
+            // Call the cancel function
+            cancelFunction();
+
+            // Verify navigation.popToTop was called
+            expect(mockPopToTop).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not show error alert when trade confirmation succeeds', async () => {
+            // Mock confirmTrade to succeed
+            mockConfirmTrade.mockResolvedValue(true);
+
+            await renderTradingExchangePreviewScreen();
+
+            // Wait a bit to ensure no error alert is shown
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            // Verify no error alert was shown
+            expect(mockShowAlert).not.toHaveBeenCalled();
+        });
     });
 });

--- a/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
@@ -710,7 +710,7 @@ describe('commonSelectors', () => {
                 'exchange',
             );
 
-            const accountAsset = result[1].data[0];
+            const accountAsset = result[3].data[0];
             expect(accountAsset.symbol).toBe('base');
             expect(accountAsset.name).toBe('Base Ethereum');
         });

--- a/suite-native/module-trading/tsconfig.json
+++ b/suite-native/module-trading/tsconfig.json
@@ -43,6 +43,7 @@
             "path": "../../suite-common/wallet-utils"
         },
         { "path": "../accounts" },
+        { "path": "../alerts" },
         { "path": "../analytics" },
         { "path": "../device" },
         { "path": "../device-manager" },

--- a/suite-native/transaction-management/src/hooks/fees/__tests__/useFeesFetching.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/__tests__/useFeesFetching.test.ts
@@ -1,4 +1,5 @@
-import { AccountKey, FeesStatus } from '@suite-common/wallet-types';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { FeesStatus } from '@suite-common/wallet-types';
 import {
     PreloadedState,
     TestStore,
@@ -6,7 +7,7 @@ import {
     renderHookWithStoreProviderAsync,
 } from '@suite-native/test-utils';
 
-import { getBtcAccount, getWalletState } from '../../../__fixtures__/walletState';
+import { getWalletState } from '../../../__fixtures__/walletState';
 import { useFeesFetching } from '../useFeesFetching';
 
 // Mock the fee hooks since they have side effects and we want to test the hook's logic
@@ -20,7 +21,6 @@ jest.mock('@suite-common/wallet-core', () => ({
 
 const mockUseFetchFeesOnce = jest.requireMock('@suite-common/wallet-core').useFetchFeesOnce;
 const mockUseRefetchFees = jest.requireMock('@suite-common/wallet-core').useRefetchFees;
-const mockSelectAccountByKey = jest.requireMock('@suite-common/wallet-core').selectAccountByKey;
 const mockSelectAreFeesLoading = jest.requireMock('@suite-common/wallet-core').selectAreFeesLoading;
 
 // Add fees to the wallet state for testing
@@ -44,29 +44,29 @@ describe('useFeesFetching', () => {
 
     const renderUseFeesFetching = ({
         store,
-        accountKey = 'btc-account-1',
+        networkSymbol,
         isRefetchDisabled = false,
     }: {
         store: TestStore;
-        accountKey?: AccountKey;
+        networkSymbol?: NetworkSymbol;
         isRefetchDisabled?: boolean;
     }) =>
-        renderHookWithStoreProviderAsync(() => useFeesFetching({ accountKey, isRefetchDisabled }), {
-            store,
-        });
+        renderHookWithStoreProviderAsync(
+            () => useFeesFetching({ networkSymbol, isRefetchDisabled }),
+            { store },
+        );
 
     beforeEach(() => {
         jest.clearAllMocks();
         // Default mock implementations
         mockUseFetchFeesOnce.mockImplementation(() => {});
         mockUseRefetchFees.mockImplementation(() => {});
-        mockSelectAccountByKey.mockReturnValue(getBtcAccount());
         mockSelectAreFeesLoading.mockReturnValue(false);
     });
 
     it('should select account by key from state', async () => {
         const store = await initStore(createMockState());
-        const { result } = await renderUseFeesFetching({ store });
+        const { result } = await renderUseFeesFetching({ store, networkSymbol: 'btc' });
 
         expect(result.current.areFeesLoading).toBe(false);
         expect(mockUseFetchFeesOnce).toHaveBeenCalledWith({ networkSymbol: 'btc' });
@@ -76,26 +76,10 @@ describe('useFeesFetching', () => {
         });
     });
 
-    it('should handle undefined account gracefully', async () => {
-        mockSelectAccountByKey.mockReturnValue(undefined);
-        const store = await initStore(createMockState());
-        const { result } = await renderUseFeesFetching({
-            store,
-            accountKey: 'non-existent-account' as AccountKey,
-        });
-
-        expect(result.current.areFeesLoading).toBe(false);
-        expect(mockUseFetchFeesOnce).toHaveBeenCalledWith({ networkSymbol: undefined });
-        expect(mockUseRefetchFees).toHaveBeenCalledWith({
-            networkSymbol: undefined,
-            isDisabled: false,
-        });
-    });
-
     it('should handle loading state correctly', async () => {
         mockSelectAreFeesLoading.mockReturnValue(true);
         const store = await initStore(createMockState());
-        const { result } = await renderUseFeesFetching({ store });
+        const { result } = await renderUseFeesFetching({ store, networkSymbol: 'btc' });
 
         expect(result.current.areFeesLoading).toBe(true);
         expect(mockUseFetchFeesOnce).toHaveBeenCalledWith({ networkSymbol: 'btc' });
@@ -109,6 +93,7 @@ describe('useFeesFetching', () => {
         const store = await initStore(createMockState());
         const { result } = await renderUseFeesFetching({
             store,
+            networkSymbol: 'btc',
             isRefetchDisabled: true,
         });
 
@@ -117,6 +102,21 @@ describe('useFeesFetching', () => {
         expect(mockUseRefetchFees).toHaveBeenCalledWith({
             networkSymbol: 'btc',
             isDisabled: true,
+        });
+    });
+
+    it('should handle undefined networkSymbol gracefully', async () => {
+        const store = await initStore(createMockState());
+        const { result } = await renderUseFeesFetching({
+            store,
+            networkSymbol: undefined,
+        });
+
+        expect(result.current.areFeesLoading).toBe(false);
+        expect(mockUseFetchFeesOnce).toHaveBeenCalledWith({ networkSymbol: undefined });
+        expect(mockUseRefetchFees).toHaveBeenCalledWith({
+            networkSymbol: undefined,
+            isDisabled: false,
         });
     });
 });

--- a/suite-native/transaction-management/src/hooks/fees/useFeeCalculation.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeeCalculation.ts
@@ -57,7 +57,7 @@ export const useFeeCalculation = ({
     const normalFee = feeLevels.normal as PrecomposedTransactionFinal;
 
     const { areFeesLoading } = useFeesFetching({
-        accountKey,
+        networkSymbol: symbol,
         isRefetchDisabled: selectedFeeLevel === 'custom' || selectedSetMaxOutputId !== undefined,
     });
 

--- a/suite-native/transaction-management/src/hooks/fees/useFeesFetching.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeesFetching.ts
@@ -1,37 +1,30 @@
 import { useSelector } from 'react-redux';
 
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
-    AccountsRootState,
     FeesRootState,
-    selectAccountByKey,
     selectAreFeesLoading,
     useFetchFeesOnce,
     useRefetchFees,
 } from '@suite-common/wallet-core';
-import { AccountKey } from '@suite-common/wallet-types';
 
 export type UseFeesFetchingProps = {
-    accountKey: AccountKey | undefined;
+    networkSymbol: NetworkSymbol | undefined;
     isRefetchDisabled?: boolean;
 };
 
-export const useFeesFetching = ({ accountKey, isRefetchDisabled }: UseFeesFetchingProps) => {
-    // Account and Network Data
-    const account = useSelector((state: AccountsRootState) =>
-        selectAccountByKey(state, accountKey),
-    );
-
+export const useFeesFetching = ({ networkSymbol, isRefetchDisabled }: UseFeesFetchingProps) => {
     // Fee Data
     const areFeesLoading = useSelector((state: FeesRootState) =>
-        selectAreFeesLoading(state, account?.symbol),
+        selectAreFeesLoading(state, networkSymbol),
     );
 
     // Fetch fees on mount
-    useFetchFeesOnce({ networkSymbol: account?.symbol });
+    useFetchFeesOnce({ networkSymbol });
 
     // Refetch fees when needed
     useRefetchFees({
-        networkSymbol: account?.symbol,
+        networkSymbol,
         isDisabled: isRefetchDisabled,
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12275,6 +12275,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/accounts": "workspace:*"
+    "@suite-native/alerts": "workspace:*"
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/device": "workspace:*"


### PR DESCRIPTION
- Error alert with retry button when trade confirmation fails
- Small refactor of useFeesFetching
- Solana address in trade review is not chunked


## Related Issue

Resolve #21882 

## Screenshots:

https://github.com/user-attachments/assets/f4904726-de89-4680-9504-d01baca531d2


https://github.com/user-attachments/assets/b41c9dcd-fa9b-4d4f-9e42-4ce4e1538247



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=21882-mobile-swap-improve-error-on-failed-confirmtrade&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=21882-mobile-swap-improve-error-on-failed-confirmtrade&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=21882-mobile-swap-improve-error-on-failed-confirmtrade&lookback=7)