### PR TITLE
fix(suite-native): handle cancelling of Bluetooth pairing correctly

### DIFF
--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx
@@ -25,6 +25,7 @@ const connectionStatusMap: Record<
     'connection-error': { component: 'button', text: 'TR_BLUETOOTH_TRY_AGAIN' }, // Out-of-range, offline, in the faraday cage, ...
     pairing: { component: 'loader', text: 'TR_BLUETOOTH_PAIRING' },
     paired: null, // This shall never be shown to the user
+    'pairing-canceled': null, // This shall never be shown to the user
     'pairing-error': null, // This shall never be shown to the user
 };
 

--- a/packages/suite/src/components/suite/bluetooth/BluetoothSelectedDevice.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothSelectedDevice.tsx
@@ -18,6 +18,7 @@ const OkComponent = ({ device }: OkComponentProps) => {
         disconnected: <PairingState isLoading text="TR_BLUETOOTH_DISCONNECTED_BUT_WAITING" />,
         pairing: <PairingState isLoading text="TR_BLUETOOTH_PAIRING" />,
         paired: <PairingState text="TR_BLUETOOTH_PAIRED" />,
+        'pairing-canceled': 'Pairing canceled', // Shall not be shown in the UI
         'pairing-error': 'Pairing failed', // Shall not be shown in the UI
         connecting: <PairingState isLoading text="TR_BLUETOOTH_CONNECTING" />,
         connected: <PairingState text="TR_BLUETOOTH_CONNECTED" />,

--- a/packages/transport-native-bluetooth/src/api/bluetoothManager.ts
+++ b/packages/transport-native-bluetooth/src/api/bluetoothManager.ts
@@ -104,13 +104,19 @@ class BluetoothManager {
 
     private updateDeviceConnectionStatusChange = (event: DeviceConnectionStatusChangeEvent) => {
         const { deviceId, connectionStatus } = event;
-        this.nearbyDevices = this.nearbyDevices.map(d =>
-            // Make sure that pairing-error is the final state, reconnecting is not possible.
-            d.id === deviceId && d.connectionStatus.type !== 'pairing-error'
-                ? { ...d, lastUpdatedTimestamp: Date.now(), connectionStatus }
-                : d,
-        );
-        // TODO: Do not emit any other events when the connection status is pairing-error?
+        if (
+            connectionStatus.type === 'pairing-canceled' ||
+            connectionStatus.type === 'pairing-error'
+        ) {
+            // If pairing is canceled or fails, the device vanishes and is no longer connectable.
+            this.nearbyDevices = this.nearbyDevices.filter(d => d.id !== deviceId);
+        } else {
+            this.nearbyDevices = this.nearbyDevices.map(d =>
+                d.id === deviceId
+                    ? { ...d, lastUpdatedTimestamp: Date.now(), connectionStatus }
+                    : d,
+            );
+        }
         this.eventEmitter.emit(eventNames.deviceConnectionStatusChange, event);
         this.emitNearbyDevicesChange();
     };
@@ -173,17 +179,11 @@ class BluetoothManager {
             return;
         }
 
-        const now = Date.now();
         // Since we get frequent scan updates, we can filter disconnected devices quite aggressively.
-        const disconnectedCutoffTimestamp = now - 3_000;
-        // Pairing requests timeout after 30 seconds on both platforms.
-        const pairingErrorCutoffTimestamp = now - 30_000;
-
+        const disconnectedCutoffTimestamp = Date.now() - 3_000;
         const filteredNearbyDevices = this.nearbyDevices.filter(
             ({ lastUpdatedTimestamp, connectionStatus: { type: status } }) =>
-                (status !== 'disconnected' && status !== 'pairing-error') ||
-                (status === 'disconnected' && lastUpdatedTimestamp > disconnectedCutoffTimestamp) ||
-                (status === 'pairing-error' && lastUpdatedTimestamp > pairingErrorCutoffTimestamp),
+                status !== 'disconnected' || lastUpdatedTimestamp > disconnectedCutoffTimestamp,
         );
         if (filteredNearbyDevices.length !== this.nearbyDevices.length) {
             this.nearbyDevices = filteredNearbyDevices;
@@ -337,7 +337,7 @@ class BluetoothManager {
             debugLog(`Device ${device.id} pairing canceled`);
             this.updateDeviceConnectionStatusChange({
                 deviceId: device.id,
-                connectionStatus: { type: 'pairing-error', error: error.message },
+                connectionStatus: { type: 'pairing-canceled' },
             });
             // If a pairing request is first accepted on the device but later rejected on the host,
             // the bluetooth connection might stay open, and thus we have to cancel it explicitly.

--- a/packages/transport-native-bluetooth/src/api/types.ts
+++ b/packages/transport-native-bluetooth/src/api/types.ts
@@ -4,6 +4,7 @@ export type DeviceConnectionStatus =
     | { type: 'paired' }
     | { type: 'connecting' }
     | { type: 'connected' }
+    | { type: 'pairing-canceled' }
     | { type: 'pairing-error'; error: string }
     | { type: 'connection-error'; error: string };
 

--- a/suite-common/bluetooth/src/types.ts
+++ b/suite-common/bluetooth/src/types.ts
@@ -29,6 +29,7 @@ export type DeviceBluetoothConnectionStatus =
     | { type: 'paired' }
     | { type: 'connecting' }
     | { type: 'connected' }
+    | { type: 'pairing-canceled' }
     | {
           type: 'pairing-error'; // This device cannot be paired ever again (new macAddress, new device)
           error: string;

--- a/suite-native/bluetooth/package.json
+++ b/suite-native/bluetooth/package.json
@@ -20,6 +20,7 @@
         "@suite-native/device-mutex": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/intl": "workspace:*",
+        "@suite-native/toasts": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",

--- a/suite-native/bluetooth/src/hooks/useBluetoothAdapter.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothAdapter.ts
@@ -9,6 +9,7 @@ import {
 } from '@suite-common/bluetooth';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import { useTranslate } from '@suite-native/intl';
+import { useToast } from '@suite-native/toasts';
 import { isIOs } from '@trezor/env-utils';
 import {
     BluetoothDevice as TransportBluetoothDevice,
@@ -32,6 +33,7 @@ const toBluetoothDevice = (device: TransportBluetoothDevice) => ({
 
 export const useBluetoothAdapter = () => {
     const dispatch = useDispatch();
+    const { showToast } = useToast();
     const { translate } = useTranslate();
 
     const isBluetoothEnabled = useFeatureFlag(FeatureFlag.IsBluetoothEnabled);
@@ -85,7 +87,12 @@ export const useBluetoothAdapter = () => {
                 }),
                 bluetoothManager.onDeviceConnectionStatusChange(event => {
                     dispatch(bluetoothActions.updateDeviceConnectionStatus(event));
-                    if (event.connectionStatus.type === 'pairing-error') {
+                    if (event.connectionStatus.type === 'pairing-canceled') {
+                        showToast({
+                            message: translate('bluetooth.toasts.pairingCanceled'),
+                            variant: 'default',
+                        });
+                    } else if (event.connectionStatus.type === 'pairing-error') {
                         showPairingFailedAlert();
                     }
                 }),
@@ -95,7 +102,7 @@ export const useBluetoothAdapter = () => {
                 subscriptions.forEach(subscription => subscription.remove());
             };
         }
-    }, [bluetoothPermissionStatus, dispatch, showPairingFailedAlert, translate]);
+    }, [bluetoothPermissionStatus, dispatch, showPairingFailedAlert, showToast, translate]);
 
     useEffect(() => {
         if (bluetoothAdapterStatus === 'enabled' && knownBluetoothDevices.length > 0) {

--- a/suite-native/bluetooth/tsconfig.json
+++ b/suite-native/bluetooth/tsconfig.json
@@ -16,6 +16,7 @@
         { "path": "../device-mutex" },
         { "path": "../feature-flags" },
         { "path": "../intl" },
+        { "path": "../toasts" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -213,6 +213,9 @@ export const messages = {
                 step3: 'Tap “Forget this device”',
             },
         },
+        toasts: {
+            pairingCanceled: 'Bluetooth pairing canceled.',
+        },
         deviceList: {
             connect: {
                 title: 'Connect your Trezor',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11177,6 +11177,7 @@ __metadata:
     "@suite-native/device-mutex": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/intl": "workspace:*"
+    "@suite-native/toasts": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"


### PR DESCRIPTION
- When Bluetooth pairing is cancelled on either end, a previously removed toast message is shown.
- When Bluetooth pairing is broken (paired on host OS but unpaired on TS7) and pairing fails, show the existing alert.
- In both cases, a corresponding device is removed from `nearbyDevices` as it's no longer connectable.

## Related Issue

Resolve #21933


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/bluetooth-pairing-canceled&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/bluetooth-pairing-canceled&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/bluetooth-pairing-canceled&lookback=7)