### PR TITLE
fix(suite-native): e2e websocket hanging test

### DIFF
--- a/suite-native/app/e2e/tests/deviceOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/deviceOnboarding.test.ts
@@ -60,11 +60,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device onboarding', () 
 
     afterEach(async () => {
         await wipeAppData();
-    });
-
-    afterAll(async () => {
         await disconnectTrezorUserEnv();
-        await device.terminateApp();
     });
 
     it('Create Wallet', async () => {


### PR DESCRIPTION
There was a failing nightly device onboarding test due to hanging trezor-user-env websocket:  https://app.currents.dev/run/5db355fa73fa3f14?machineId=xkFySdFuA183&groupId=jest+tests&m_tab=machine

Probably caused by not restarting the trezor-user-env bridge after each test. Now the trezor-user-env is always in the same state for every executed test and should behave consistently.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native/e2e-fix-hanging-nightly&lookback=7)