### PR TITLE
fix(e2e): Removed checking emulator screen content for non T3T1 models

### DIFF
--- a/packages/suite-desktop-core/e2e/support/fixtures.ts
+++ b/packages/suite-desktop-core/e2e/support/fixtures.ts
@@ -68,8 +68,8 @@ const suiteTest = suiteBaseTest.extend<Fixtures>({
     analyticsSection: async ({ page }, use) => {
         await use(new AnalyticsSection(page));
     },
-    devicePrompt: async ({ page }, use) => {
-        await use(new DevicePrompt(page));
+    devicePrompt: async ({ page, model }, use) => {
+        await use(new DevicePrompt(page, model));
     },
     recoveryModal: async ({ page }, use) => {
         await use(new RecoveryModal(page));
@@ -111,8 +111,8 @@ const suiteTest = suiteBaseTest.extend<Fixtures>({
     stakingSection: async ({ page }, use) => {
         await use(new StakingSection(page));
     },
-    suite: async ({ page, model, onboardingPage }, use) => {
-        await use(new SuiteApp(page, model, onboardingPage));
+    suite: async ({ page, model, devicePrompt }, use) => {
+        await use(new SuiteApp(page, model, devicePrompt));
     },
     model: async ({ emulatorStartConf }, use) => {
         await use(new ModelFixture(emulatorStartConf.model));

--- a/packages/suite-desktop-core/e2e/support/pageObjects/devicePrompt.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/devicePrompt.ts
@@ -1,6 +1,7 @@
 import { Locator, Page, expect } from '@playwright/test';
 
 import { TrezorUserEnvLinkProxy, analyzeObject, step } from '../common';
+import { ModelFixture } from '../modelFixture';
 
 export class DevicePrompt {
     readonly confirmOnDevicePrompt: Locator;
@@ -33,7 +34,10 @@ export class DevicePrompt {
     readonly ethereumPriorityFeeRate: Locator;
     readonly headerFeeRate: Locator;
 
-    constructor(private page: Page) {
+    constructor(
+        private page: Page,
+        private readonly model: ModelFixture,
+    ) {
         this.confirmOnDevicePrompt = page.getByTestId('@prompts/confirm-on-device');
         this.connectDevicePrompt = page.getByTestId('@connect-device-prompt');
         this.modalCloseButton = page.getByTestId('@modal/close-button');
@@ -91,6 +95,11 @@ export class DevicePrompt {
     async waitForPromptAndConfirm() {
         await this.confirmOnDevicePromptIsShown();
         await TrezorUserEnvLinkProxy.pressYes();
+    }
+
+    @step()
+    async allowConnectToTrezor() {
+        await this.waitForPromptAndConfirm();
     }
 
     @step()
@@ -220,5 +229,9 @@ export class DevicePrompt {
         }
 
         return addressRaw[0].join('').replace(/\n/g, '');
+    }
+
+    getDeviceModel() {
+        return this.model.model;
     }
 }

--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -93,11 +93,6 @@ export class OnboardingPage {
     }
 
     @step()
-    async allowConnectToTrezor() {
-        await this.devicePrompt.waitForPromptAndConfirm();
-    }
-
-    @step()
     async enterTHPPairingCode() {
         const screenContent = await TrezorUserEnvLinkProxy.getScreenContent();
         const screenContentBody = screenContent.body as string;
@@ -120,7 +115,7 @@ export class OnboardingPage {
         await this.analyticsSection.continueButton.click();
 
         if (this.model.isModelWithTHP()) {
-            await this.allowConnectToTrezor();
+            await this.devicePrompt.allowConnectToTrezor();
             await this.enterTHPPairingCode();
         }
 

--- a/packages/suite-desktop-core/e2e/support/pageObjects/suiteApp.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/suiteApp.ts
@@ -2,13 +2,13 @@ import { Page } from '@playwright/test';
 
 import { step } from '../common';
 import { ModelFixture } from '../modelFixture';
-import { OnboardingPage } from './onboarding/onboardingPage';
+import { DevicePrompt } from './devicePrompt';
 
 export class SuiteApp {
     constructor(
         private readonly page: Page,
         private readonly model: ModelFixture,
-        private readonly onboardingPage: OnboardingPage,
+        private readonly devicePrompt: DevicePrompt,
     ) {}
 
     @step()
@@ -19,6 +19,6 @@ export class SuiteApp {
             return;
         }
 
-        await this.onboardingPage.allowConnectToTrezor();
+        await this.devicePrompt.allowConnectToTrezor();
     }
 }

--- a/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
@@ -150,6 +150,9 @@ export const expect = baseExpect.extend({
             lineFormat: 'fourTetragrams',
         },
     ) {
+        if (devicePrompt.getDeviceModel() !== 'T3T1') {
+            return { pass: true, message: () => 'Test is skipped on non-T3T1 models' };
+        }
         const transformedExpectedAddress = transformAddress(expectedAddress, options.lineFormat);
 
         let expectedContent;
@@ -175,6 +178,10 @@ export const expect = baseExpect.extend({
     },
 
     async toDisplayOnEmulator(devicePrompt: DevicePrompt, expectedContent: object) {
+        if (devicePrompt.getDeviceModel() !== 'T3T1') {
+            return { pass: true, message: () => 'Test is skipped on non-T3T1 models' };
+        }
+
         return await compareDisplayContent(
             devicePrompt,
             expectedContent,

--- a/packages/suite-desktop-core/e2e/tests/analytics/events.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/analytics/events.test.ts
@@ -116,6 +116,7 @@ test.describe('Analytics Events', { tag: ['@group=suite', '@webOnly'] }, () => {
         settingsPage,
         onboardingPage,
         trezorUserEnvLink,
+        devicePrompt,
     }) => {
         await test.step('Start suite with disabled analytics', async () => {
             await onboardingPage.optionallyDismissFwHashCheckError();
@@ -133,7 +134,7 @@ test.describe('Analytics Events', { tag: ['@group=suite', '@webOnly'] }, () => {
 
             await trezorUserEnvLink.startBridge(BRIDGE_VERSION);
             if (model.isModelWithTHP()) {
-                await onboardingPage.allowConnectToTrezor();
+                await devicePrompt.allowConnectToTrezor();
                 await onboardingPage.enterTHPPairingCode();
             }
         });

--- a/packages/suite-desktop-core/e2e/tests/analytics/toggle.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/analytics/toggle.test.ts
@@ -17,6 +17,7 @@ test.describe('Analytics Toggle - Enabling and Disabling', { tag: ['@group=other
         onboardingPage,
         dashboardPage,
         settingsPage,
+        devicePrompt,
     }) => {
         await test.step('Disable analytics in onboarding', async () => {
             await expect(settingsPage.analyticsSwitchInput).toBeChecked();
@@ -42,7 +43,7 @@ test.describe('Analytics Toggle - Enabling and Disabling', { tag: ['@group=other
 
         await test.step('Finish onboarding', async () => {
             if (model.isModelWithTHP()) {
-                await onboardingPage.allowConnectToTrezor();
+                await devicePrompt.allowConnectToTrezor();
                 await onboardingPage.enterTHPPairingCode();
             }
 
@@ -112,6 +113,7 @@ test.describe('Analytics Toggle - Enabling and Disabling', { tag: ['@group=other
         analyticsSection,
         onboardingPage,
         settingsPage,
+        devicePrompt,
     }) => {
         await test.step('Pass through onboarding with enabled analytics', async () => {
             await expect(settingsPage.analyticsSwitchInput).toBeChecked();
@@ -125,7 +127,7 @@ test.describe('Analytics Toggle - Enabling and Disabling', { tag: ['@group=other
 
         await test.step('Finish onboarding', async () => {
             if (model.isModelWithTHP()) {
-                await onboardingPage.allowConnectToTrezor();
+                await devicePrompt.allowConnectToTrezor();
                 await onboardingPage.enterTHPPairingCode();
             }
             await onboardingPage.onboardingContinueButton.click();

--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge.test.ts
@@ -71,7 +71,7 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
         enhancePage(suite.window);
         await suite.window.title();
 
-        const devicePrompt = new DevicePrompt(suite.window);
+        const devicePrompt = new DevicePrompt(suite.window, model);
 
         const onboardingPage = new OnboardingPage(
             suite.window,

--- a/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
@@ -94,7 +94,7 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
             });
             await pageTwo.goto('./');
             const analyticsSectionTwo = new AnalyticsSection(pageTwo);
-            const devicePromptTwo = new DevicePrompt(pageTwo);
+            const devicePromptTwo = new DevicePrompt(pageTwo, model);
             const onboardingPageTwo = new OnboardingPage(
                 pageTwo,
                 model,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The method of checking the screen content is T3T1 specific and I feel like we can solve that later. 
I have tried and there is a lot of different problems - different data format, different screen content, different way to split lines etc.  I think it will take some time to think of nice way to do it and then some more to refactor all the code.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-t3w1-trading&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-t3w1-trading&lookback=7)