### PR TITLE
Bluetooth adapter disabled happy path

### DIFF
--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -50,8 +50,11 @@ export const initBluetoothThunk = createThunk<void, void, void>(
         // NOTE: getInfo when adapter is disabled adapter may return different result in adapter_info field
         const apiInfo = await bluetoothIpc.getInfo();
         if (apiInfo.success) {
-            // TODO: validate apiInfo.payload.adapter_info string
-            // and store data in redux
+            dispatch(
+                bluetoothActions.adapterEventAction({
+                    status: apiInfo.payload.state,
+                }),
+            );
         }
 
         // If we already have some paired devices, we assume user will have a BT device,

--- a/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
@@ -91,7 +91,23 @@ export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements Bl
                     devices: this.state.knownDevices,
                 });
 
-                const { devices: scanResult } = await this.api.send('start_scan');
+                const { devices: scanResult } = await this.api
+                    .send('start_scan')
+                    .then(res => res)
+                    // todo: bluetooth-ipc-main.init is called in inInitBluetoothThunk. If it returns an error there, thunk does not proceed and listeners are not registered.
+                    // This is a hotfix, I believe, that initBluetoothThunks call to bluetoothIpc.init should only check that ipc channel is established, nothing more.
+                    .catch(error => {
+                        console.warn('Initial start_scan error', error);
+                        if (
+                            error.message.includes('Adapter disabled') || // <-- when bluetooth is off
+                            error.message.includes('Adapter missing') // <-- when app permissions removed
+                        ) {
+                            this.emit('adapter-event', 'disabled');
+
+                            return { devices: [] };
+                        }
+                        throw error;
+                    });
                 if (scanResult.length === 0) {
                     // wait. devices may not be returned immediately
                     await resolveAfter(1000);


### PR DESCRIPTION
This is the easiest way to fix the following issue. We might iterate and make it nicer

Repro steps:
1. have Suite with some `knownDevices` from a previous run
2. turn off bluetooth in system settings or remove blueooth app permissions 
3. Start suite
4. You get endless scanning but it finds nothing obviously
<img width="470" height="488" alt="image" src="https://github.com/user-attachments/assets/c5eb9107-1621-42c5-bbe6-8f4380fd5b0f" />

tested on Mac

and your state.bluetooth.adapter status is still uknown although we already do know that adapter is disabled.

<img width="484" height="247" alt="image" src="https://github.com/user-attachments/assets/143b5dc3-bd7d-4ad3-9f3a-f1e6002af0c4" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bluetooth-adapter-disabled-happy-path&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bluetooth-adapter-disabled-happy-path&lookback=7)