### PR TITLE
feat(suite): simplify DeviceTutorial and Pin components, removing unu…

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/pinSection.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/pinSection.ts
@@ -6,13 +6,11 @@ export class PinSection {
     readonly skipButton: Locator;
     readonly setPinButton: Locator;
     readonly skipConfirmButton: Locator;
-    readonly continueButton: Locator;
 
     constructor(private readonly page: Page) {
         this.skipButton = this.page.getByTestId('@onboarding/skip-button');
         this.setPinButton = this.page.getByTestId('@onboarding/set-pin-button');
         this.skipConfirmButton = this.page.getByTestId('@onboarding/skip-button-confirm');
-        this.continueButton = this.page.getByTestId('@onboarding/pin/continue-button');
     }
 
     @step()

--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/tutorialSection.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/tutorialSection.ts
@@ -4,16 +4,13 @@ import { step } from '../../common';
 
 export class TutorialSection {
     readonly skipTutorialButton: Locator;
-    readonly tutorialContinueButton: Locator;
 
     constructor(private readonly page: Page) {
         this.skipTutorialButton = this.page.getByTestId('@tutorial/skip-button');
-        this.tutorialContinueButton = this.page.getByTestId('@tutorial/continue-button');
     }
 
     @step()
     async skip() {
         await this.skipTutorialButton.click();
-        await this.tutorialContinueButton.click();
     }
 }

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
@@ -43,7 +43,7 @@ test.describe(
             await trezorUserEnvLink.inputEmu('12');
             await devicePrompt.confirmOnDevicePromptIsShown();
             await trezorUserEnvLink.pressYes();
-            await expect(page.getByTestId('@onboarding/pin/continue-button')).toBeVisible();
+            await expect(page.getByTestId('@onboarding/coins/continue-button')).toBeVisible();
         });
     },
 );

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
@@ -64,8 +64,6 @@ test.describe(
 
                 await devicePrompt.confirmOnDevicePromptIsShown();
                 await trezorUserEnvLink.pressYes();
-
-                await onboardingPage.pin.continueButton.click();
             },
         );
     },

--- a/packages/suite/src/actions/onboarding/constants/onboarding.ts
+++ b/packages/suite/src/actions/onboarding/constants/onboarding.ts
@@ -4,5 +4,4 @@ export const REMOVE_PATH = '@onboarding/remove-path' as const;
 export const RESET_ONBOARDING = '@onboarding/reset-onboarding' as const;
 export const ENABLE_ONBOARDING_REDUCER = '@onboarding/enable-onboarding-reducer' as const;
 export const ANALYTICS = '@onboarding/analytics' as const;
-export const SET_TUTORIAL_STATUS = '@onboarding/set-tutorial-status' as const;
 export const SELECT_BACKUP_TYPE = '@onboarding/select-backup-type' as const;

--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -6,7 +6,6 @@ import { OnboardingAnalytics } from '@trezor/suite-analytics';
 import { ONBOARDING } from 'src/actions/onboarding/constants';
 import { stepCategories } from 'src/config/onboarding/steps';
 import * as STEP from 'src/constants/onboarding/steps';
-import { DeviceTutorialStatus } from 'src/reducers/onboarding/onboardingReducer';
 import { AnyPath, AnyStepId } from 'src/types/onboarding';
 import { Dispatch, GetState } from 'src/types/suite';
 import { findNextStep, findPrevStep, isStepUsed } from 'src/utils/onboarding/steps';
@@ -34,10 +33,6 @@ export type OnboardingAction =
     | {
           type: typeof ONBOARDING.ANALYTICS;
           payload: Partial<OnboardingAnalytics>;
-      }
-    | {
-          type: typeof ONBOARDING.SET_TUTORIAL_STATUS;
-          payload: DeviceTutorialStatus;
       }
     | {
           type: typeof ONBOARDING.SELECT_BACKUP_TYPE;
@@ -122,11 +117,6 @@ const updateAnalytics = (payload: Partial<OnboardingAnalytics>): OnboardingActio
     payload,
 });
 
-const setDeviceTutorialStatus = (status: DeviceTutorialStatus): OnboardingAction => ({
-    type: ONBOARDING.SET_TUTORIAL_STATUS,
-    payload: status,
-});
-
 const updateBackupType = (payload: BackupType): OnboardingAction => ({
     type: ONBOARDING.SELECT_BACKUP_TYPE,
     payload,
@@ -136,15 +126,8 @@ const beginOnboardingTutorial = () => async (dispatch: Dispatch, getState: GetSt
     const device = selectSelectedDevice(getState());
     if (!device) return;
 
-    dispatch(setDeviceTutorialStatus('active'));
-
-    const { success } = await TrezorConnect.showDeviceTutorial({ device });
-
-    if (success) {
-        dispatch(setDeviceTutorialStatus('completed'));
-    } else {
-        dispatch(setDeviceTutorialStatus('cancelled'));
-    }
+    await TrezorConnect.showDeviceTutorial({ device });
+    dispatch(goToNextStep());
 };
 
 export {
@@ -156,7 +139,6 @@ export {
     removePath,
     resetOnboarding,
     updateAnalytics,
-    setDeviceTutorialStatus,
     beginOnboardingTutorial,
     updateBackupType,
 };

--- a/packages/suite/src/reducers/onboarding/onboardingReducer.ts
+++ b/packages/suite/src/reducers/onboarding/onboardingReducer.ts
@@ -13,8 +13,6 @@ export interface OnboardingRootState {
     onboarding: OnboardingState;
 }
 
-export type DeviceTutorialStatus = 'active' | 'completed' | 'cancelled' | null;
-
 export interface OnboardingState {
     backupType: BackupType;
     isActive: boolean;
@@ -22,7 +20,6 @@ export interface OnboardingState {
     activeStepId: AnyStepId;
     path: AnyPath[];
     onboardingAnalytics: Partial<OnboardingAnalytics>;
-    tutorialStatus: DeviceTutorialStatus;
 }
 
 const initialState: OnboardingState = {
@@ -36,7 +33,6 @@ const initialState: OnboardingState = {
     activeStepId: STEP.ID_FIRMWARE_STEP,
     path: [],
     onboardingAnalytics: {},
-    tutorialStatus: null,
     backupType: 'shamir-single',
 };
 
@@ -82,10 +78,6 @@ const onboarding = (state: OnboardingState = initialState, action: Action) => {
             case ONBOARDING.ANALYTICS:
                 draft.onboardingAnalytics = { ...state.onboardingAnalytics, ...action.payload };
                 break;
-            case ONBOARDING.SET_TUTORIAL_STATUS:
-                draft.tutorialStatus = action.payload;
-                break;
-
             case ONBOARDING.SELECT_BACKUP_TYPE:
                 draft.backupType = action.payload;
                 break;
@@ -96,9 +88,6 @@ const onboarding = (state: OnboardingState = initialState, action: Action) => {
         }
     });
 };
-
-export const selectOnboardingTutorialStatus = (state: OnboardingRootState) =>
-    state.onboarding.tutorialStatus;
 
 export const selectIsOnboardingActive = (state: OnboardingRootState) => state.onboarding.isActive;
 

--- a/packages/suite/src/views/onboarding/steps/DeviceTutorial.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceTutorial.tsx
@@ -1,131 +1,53 @@
 import { useEffect } from 'react';
 import { useIntl } from 'react-intl';
 
-import styled from 'styled-components';
-
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Button, Column } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
-import { spacingsPx } from '@trezor/theme';
 
-import {
-    beginOnboardingTutorial,
-    goToNextStep,
-    setDeviceTutorialStatus,
-} from 'src/actions/onboarding/onboardingActions';
+import { beginOnboardingTutorial } from 'src/actions/onboarding/onboardingActions';
 import { OnboardingStepBox } from 'src/components/onboarding';
 import { DeviceConfirmImage } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectOnboardingTutorialStatus } from 'src/reducers/onboarding/onboardingReducer';
 import { selectIsActionAbortable } from 'src/selectors/suite/suiteSelectors';
 import messages from 'src/support/messages';
 
-const StyledOnboardingStepBox = styled(OnboardingStepBox)`
-    padding: 40px 20px 0;
-`;
-
-const ButtonContainer = styled.div`
-    display: flex;
-    justify-content: center;
-    margin-top: ${spacingsPx.sm};
-`;
-
 export const DeviceTutorial = () => {
     const isActionAbortable = useSelector(selectIsActionAbortable);
-    const status = useSelector(selectOnboardingTutorialStatus);
     const device = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
     const intl = useIntl();
 
-    const isContinueButtonVisible = status && ['cancelled', 'completed'].includes(status);
-    const showDevicePrompt = status === 'active';
-
-    const handleContinue = () => {
-        dispatch(goToNextStep());
-        dispatch(setDeviceTutorialStatus(null));
-    };
-
     useEffect(() => {
-        if (!status) {
-            dispatch(beginOnboardingTutorial());
-        }
-    }, [dispatch, status]);
+        dispatch(beginOnboardingTutorial());
+    }, [dispatch]);
 
-    const getHeading = () => {
-        switch (status) {
-            case 'active':
-                return (
-                    <Column justifyContent="center" alignItems="center" gap={40}>
-                        <DeviceConfirmImage device={device} height={200} />
-                        <Translation id="TR_TREZOR_DEVICE_TUTORIAL_HEADING" />
-                    </Column>
-                );
-            case 'completed':
-                return <Translation id="TR_TREZOR_DEVICE_TUTORIAL_COMPLETED_HEADING" />;
-            case 'cancelled':
-                return <Translation id="TR_TREZOR_DEVICE_TUTORIAL_CANCELED_HEADING" />;
-            // no default
-        }
-    };
-    const getDescription = () => {
-        const handleSkipClick = () =>
-            TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
-
-        switch (status) {
-            case 'active':
-                return (
-                    <>
-                        <Translation id="TR_TREZOR_DEVICE_TUTORIAL_DESCRIPTION" />
-                        <ButtonContainer>
-                            {isActionAbortable && (
-                                <Button
-                                    data-testid="@tutorial/skip-button"
-                                    variant="tertiary"
-                                    size="tiny"
-                                    onClick={handleSkipClick}
-                                >
-                                    <Translation id="TR_SKIP" />
-                                </Button>
-                            )}
-                        </ButtonContainer>
-                    </>
-                );
-            case 'completed':
-            case 'cancelled':
-                return (
-                    <ButtonContainer>
-                        <Button
-                            variant="tertiary"
-                            size="tiny"
-                            onClick={() => dispatch(beginOnboardingTutorial())}
-                        >
-                            <Translation id="TR_RESTART_TREZOR_DEVICE_TUTORIAL" />
-                        </Button>
-                    </ButtonContainer>
-                );
-            // no default
-        }
-    };
+    const handleSkipClick = () => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
 
     return (
-        <StyledOnboardingStepBox
-            heading={getHeading()}
-            description={getDescription()}
+        <OnboardingStepBox
+            heading={
+                <Column justifyContent="center" alignItems="center" gap={40}>
+                    <DeviceConfirmImage device={device} height={200} />
+                    <Translation id="TR_TREZOR_DEVICE_TUTORIAL_HEADING" />
+                </Column>
+            }
+            description={<Translation id="TR_TREZOR_DEVICE_TUTORIAL_DESCRIPTION" />}
             device={device}
-            disableConfirmWrapper={!showDevicePrompt}
-            devicePromptTitle={<Translation id="TR_CONTINUE_ON_TREZOR" />}
-            outerActions={
-                isContinueButtonVisible && (
+            innerActions={
+                isActionAbortable && (
                     <Button
-                        data-testid="@tutorial/continue-button"
-                        variant="primary"
-                        onClick={handleContinue}
+                        data-testid="@tutorial/skip-button"
+                        variant="tertiary"
+                        size="small"
+                        onClick={handleSkipClick}
                     >
-                        <Translation id="TR_CONTINUE" />
+                        <Translation id="TR_SKIP" />
                     </Button>
                 )
             }
+            devicePromptTitle={<Translation id="TR_CONTINUE_ON_TREZOR" />}
         />
     );
 };

--- a/packages/suite/src/views/onboarding/steps/Pin.tsx
+++ b/packages/suite/src/views/onboarding/steps/Pin.tsx
@@ -51,6 +51,12 @@ const SetPinStep = () => {
     };
 
     useEffect(() => {
+        if (status === 'success') {
+            goToNextStep();
+        }
+    }, [status, goToNextStep]);
+
+    useEffect(() => {
         // This is where we detect requests from a device, figure out whether the PIN functionality got enabled,
         // and set a status of the setup process accordingly
         if (device?.features) {
@@ -106,22 +112,7 @@ const SetPinStep = () => {
     }
 
     if (status === 'success') {
-        // Pin successfully set up
-        return (
-            <OnboardingStepBox
-                image="PIN"
-                heading={<Translation id="TR_PIN_HEADING_SUCCESS" />}
-                description={<Translation id="TR_PIN_SET_SUCCESS" />}
-                outerActions={
-                    <OnboardingButtonCta
-                        data-testid="@onboarding/pin/continue-button"
-                        onClick={() => goToNextStep()}
-                    >
-                        <Translation id="TR_CONTINUE" />
-                    </OnboardingButtonCta>
-                }
-            />
-        );
+        return null;
     }
 
     // 'initial', 'enter-pin', 'repeat-pin' states


### PR DESCRIPTION
- Short-circuit the device tutorial so it auto-advances after the Connect flow reports completion or cancellation, and drop the redundant confirmation screen.
- Update the PIN onboarding step to progress automatically once the device confirms PIN protection, removing the extra continue CTA.
- Align Playwright helpers and onboarding E2E scenarios with the streamlined UI by deleting the obsolete continue buttons and waiting for the next step instead.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/remove-redundant-and-visually-inconsistent-screens-from-onboarding&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/remove-redundant-and-visually-inconsistent-screens-from-onboarding&lookback=7)