### PR TITLE
chore: naming for asDeviceUniquePath

### DIFF
--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -16,7 +16,7 @@ import {
 import { ERRORS } from '../constants';
 import { DEVICE, DecodedTrezorPushNotification, TransportError, TransportInfo } from '../events';
 import { Device } from './Device';
-import { ConnectSettings, DeviceUniquePath, StaticSessionId } from '../types';
+import { ConnectSettings, DeviceUniquePath, StaticSessionId, asDeviceUniquePath } from '../types';
 import { createTransportList } from './TransportList';
 import { TransportManager } from './TransportManager';
 import { initLog } from '../utils/debug';
@@ -144,7 +144,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
     private async onDeviceConnected(descriptor: Descriptor, transport: Transport) {
         const id = (this.deviceCounter++).toString(16).slice(-8);
-        const device = new Device({ id: DeviceUniquePath(id), transport, descriptor });
+        const device = new Device({ id: asDeviceUniquePath(id), transport, descriptor });
 
         const penalty = this.authPenaltyManager.get();
         const stillConnected = await this.handshakeLock(() =>

--- a/packages/connect/src/types/api/__tests__/bitcoin.ts
+++ b/packages/connect/src/types/api/__tests__/bitcoin.ts
@@ -1,4 +1,4 @@
-import { DeviceUniquePath, TrezorConnect } from '../../..';
+import { TrezorConnect, asDeviceUniquePath } from '../../..';
 
 export const getAddress = async (api: TrezorConnect) => {
     // regular
@@ -29,7 +29,7 @@ export const getAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.getAddress({
         device: {
-            path: DeviceUniquePath('1'),
+            path: asDeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/api/__tests__/cardano.ts
+++ b/packages/connect/src/types/api/__tests__/cardano.ts
@@ -1,4 +1,4 @@
-import { DeviceUniquePath, PROTO, TrezorConnect } from '../../..';
+import { PROTO, TrezorConnect, asDeviceUniquePath } from '../../..';
 
 const {
     CardanoAddressType,
@@ -122,7 +122,7 @@ export const cardanoGetAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.cardanoGetAddress({
         device: {
-            path: DeviceUniquePath('1'),
+            path: asDeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/api/__tests__/ethereum.ts
+++ b/packages/connect/src/types/api/__tests__/ethereum.ts
@@ -1,4 +1,4 @@
-import { DeviceUniquePath, TrezorConnect } from '../../..';
+import { TrezorConnect, asDeviceUniquePath } from '../../..';
 
 export const ethereumGetAddress = async (api: TrezorConnect) => {
     // regular
@@ -30,7 +30,7 @@ export const ethereumGetAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.ethereumGetAddress({
         device: {
-            path: DeviceUniquePath('1'),
+            path: asDeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/api/__tests__/nem.ts
+++ b/packages/connect/src/types/api/__tests__/nem.ts
@@ -1,4 +1,4 @@
-import { DeviceUniquePath, NEM, TrezorConnect } from '../../..';
+import { NEM, TrezorConnect, asDeviceUniquePath } from '../../..';
 
 export const nemGetAddress = async (api: TrezorConnect) => {
     // regular
@@ -33,7 +33,7 @@ export const nemGetAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.nemGetAddress({
         device: {
-            path: DeviceUniquePath('1'),
+            path: asDeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/api/__tests__/ripple.ts
+++ b/packages/connect/src/types/api/__tests__/ripple.ts
@@ -1,4 +1,4 @@
-import { DeviceUniquePath, TrezorConnect } from '../../..';
+import { TrezorConnect, asDeviceUniquePath } from '../../..';
 
 export const rippleGetAddress = async (api: TrezorConnect) => {
     // regular
@@ -31,7 +31,7 @@ export const rippleGetAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.rippleGetAddress({
         device: {
-            path: DeviceUniquePath('1'),
+            path: asDeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/api/__tests__/stellar.ts
+++ b/packages/connect/src/types/api/__tests__/stellar.ts
@@ -1,4 +1,4 @@
-import { DeviceUniquePath, TrezorConnect } from '../../..';
+import { TrezorConnect, asDeviceUniquePath } from '../../..';
 
 export const stellarGetAddress = async (api: TrezorConnect) => {
     // regular
@@ -29,7 +29,7 @@ export const stellarGetAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.stellarGetAddress({
         device: {
-            path: DeviceUniquePath('1'),
+            path: asDeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/api/__tests__/tezos.ts
+++ b/packages/connect/src/types/api/__tests__/tezos.ts
@@ -1,4 +1,4 @@
-import { DeviceUniquePath, TrezorConnect } from '../../..';
+import { TrezorConnect, asDeviceUniquePath } from '../../..';
 
 export const tezosGetAddress = async (api: TrezorConnect) => {
     // regular
@@ -29,7 +29,7 @@ export const tezosGetAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.tezosGetAddress({
         device: {
-            path: DeviceUniquePath('1'),
+            path: asDeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -77,8 +77,15 @@ export type FirmwareHashCheckResult =
           errorPayload?: unknown;
       };
 
+/**
+ * The Unique Device Identifier per Suite run & Connected Device.
+ * When Suite is restarted or the Device is reconnected this will change.
+ *
+ * The main reason for this identifier is to reference device which is unacquired
+ * and therefore has no `id` yet. Typical use case is THP pairing
+ */
 export type DeviceUniquePath = string & Branded<'DeviceUniquePath'>;
-export const DeviceUniquePath = (id: string) => id as DeviceUniquePath;
+export const asDeviceUniquePath = (id: string) => id as DeviceUniquePath;
 
 type BaseDevice = {
     path: DeviceUniquePath;

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -22,6 +22,7 @@ import {
     Features,
     FirmwareType,
     TrezorConnect,
+    asDeviceUniquePath,
 } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
@@ -160,7 +161,7 @@ type StringPath<T extends { path: DeviceUniquePath }> = Omit<T, 'path'> & { path
  * @returns {Device}
  */
 const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Features>): Device => {
-    const path = DeviceUniquePath(dev?.path ?? '1');
+    const path = asDeviceUniquePath(dev?.path ?? '1');
 
     if (dev && typeof dev.type === 'string' && dev.type === 'unreadable') {
         return {


### PR DESCRIPTION
I think we shall not name the function same as type. 

1. Consistency
2. It may be confusing for some IDEs (for example Webstor does not handle refactoring/rename well).
3. It seems kinda weird, to start function with UpperCase, its breaking the convention. This is kinda nitpicking, the above (1.) is the main reason .


I have also added some better comment there. :pray: @marekrjpolak for confirmation.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chorde-DeviceUniquePath&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chorde-DeviceUniquePath&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chorde-DeviceUniquePath&lookback=7)