### PR TITLE
chore(transport): add missing native Bluetooth transport name

### DIFF
--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -22,7 +22,10 @@ export type Proxy = BlockchainSettings['proxy'];
 export type LocalFirmwares = { firmwareDir: string; firmwareList: string[] };
 
 // omit transports which are not implemented in @trezor/connect
-type KnownTransport = Exclude<Transport['name'], 'NativeUsbTransport' | 'BluetoothTransport'>;
+type KnownTransport = Exclude<
+    Transport['name'],
+    'NativeUsbTransport' | 'BluetoothTransport' | 'NativeBluetoothTransport'
+>;
 export type ThpSettings = {
     hostName?: string; // displayed on Trezor during pairing process.
     appName?: string; // displayed on Trezor during pairing process. fallbacks to Manifest['appName']

--- a/packages/transport-native-bluetooth/src/transport.ts
+++ b/packages/transport-native-bluetooth/src/transport.ts
@@ -3,7 +3,7 @@ import { AbstractApiTransport, Transport as AbstractTransport } from '@trezor/tr
 import { BluetoothApi } from './api/BluetoothApi';
 
 export class NativeBluetoothTransport extends AbstractApiTransport {
-    public name = 'NativeBluetoothTransport' as any;
+    public name = 'NativeBluetoothTransport' as const;
     public apiType = 'bluetooth' as const;
 
     constructor(params: ConstructorParameters<typeof AbstractTransport>[0]) {

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -97,7 +97,8 @@ export abstract class AbstractTransport extends TypedEmitter<TransportEvents> {
         | 'WebUsbTransport'
         | 'UdpTransport'
         | 'NativeUsbTransport' // implementation in @trezor/transport-native
-        | 'BluetoothTransport'; // implementation in @trezor/transport-bluetooth
+        | 'BluetoothTransport' // implementation in @trezor/transport-bluetooth
+        | 'NativeBluetoothTransport'; // implementation in @trezor/transport-native-bluetooth
 
     public abstract readonly apiType: TransportApiType;
     /**


### PR DESCRIPTION
Most likely an omission.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/transport/native-bluetooth-transport&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/transport/native-bluetooth-transport&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/transport/native-bluetooth-transport&lookback=7)