### PR TITLE
fix(suite): restore persistentDeviceData on storage load

### DIFF
--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -194,7 +194,21 @@ export const extraDependencies: ExtraDependencies = {
         },
         storageLoadDevices: (state: DeviceReducerState, { payload }: StorageLoadAction) => {
             // @ts-expect-error loaded devices have empty path, TODO deviceReducer should have path nullable, because remembered wallets??
-            state.devices = payload.devices;
+            state.devices = payload.devices.map(device => {
+                const persistentDeviceData = payload.persistentDeviceData?.find(
+                    ({ device_id }) => device_id === device.id,
+                );
+                if (persistentDeviceData) {
+                    return {
+                        ...device,
+                        bluetoothProps: persistentDeviceData.bluetoothProps,
+                        thp: persistentDeviceData.thp,
+                    };
+                } else {
+                    return device;
+                }
+            });
+
             state.persistentDeviceData = payload.persistentDeviceData ?? [];
         },
         storageLoadFormDrafts: (state: SendState, { payload }: StorageLoadAction) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`bluetoothProps` and `thp` are not restored when storage is loaded

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-persistent-device-data&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-persistent-device-data&lookback=7)