### PR TITLE
fix(suite): dont fetch graph unless outdated

### DIFF
--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -1,15 +1,24 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { selectBaseCurrency, selectIsElectrumBackendSelected } from '@suite-common/wallet-core';
-import { isTrezorConnectBackendType, tryGetAccountIdentity } from '@suite-common/wallet-utils';
+import { AccountKey } from '@suite-common/wallet-types';
+import {
+    getAccountKey,
+    isTrezorConnectBackendType,
+    tryGetAccountIdentity,
+} from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
 
 import { type Dispatch, type GetState } from 'src/types/suite';
 import { type Account } from 'src/types/wallet';
-import { type GraphData, type GraphRange, type GraphScale } from 'src/types/wallet/graph';
+import {
+    AccountHistoryWithBalance,
+    type GraphData,
+    type GraphRange,
+    type GraphScale,
+} from 'src/types/wallet/graph';
 import {
     enhanceBlockchainAccountHistory,
     ensureHistoryRates,
-    getPristineAccounts,
     isNetworkWithGraphFeature,
 } from 'src/utils/wallet/graph';
 
@@ -143,12 +152,12 @@ export const fetchAccountGraphData =
 
 export const updateGraphData = createThunk<
     void,
-    { accounts: Account[]; newAccountsOnly?: boolean; abortSignal?: AbortSignal },
+    { accounts: Account[]; abortSignal?: AbortSignal },
     void
 >(
     'wallet/updateGraphData',
     async (
-        { accounts, newAccountsOnly, abortSignal },
+        { accounts, abortSignal },
         {
             dispatch,
             getState,
@@ -159,17 +168,32 @@ export const updateGraphData = createThunk<
     ) => {
         const { graph } = getState().wallet;
 
-        // TODO: default behaviour should be fetch only new data (since last timestamp)
-        // exclude accounts with unsupported backend type
-        let filteredAccounts = accounts
-            .filter(account => isTrezorConnectBackendType(account.backendType))
-            .filter(account => isNetworkWithGraphFeature(account.symbol));
+        const supportedAccounts = accounts.filter(
+            a => isTrezorConnectBackendType(a.backendType) && isNetworkWithGraphFeature(a.symbol),
+        );
 
-        if (newAccountsOnly) {
-            filteredAccounts = getPristineAccounts(graph, accounts);
-        }
+        const graphDataPointsByAccount = new Map<AccountKey, AccountHistoryWithBalance[]>(
+            graph.data.map(({ account, data }) => [
+                getAccountKey(account.descriptor, account.symbol, account.deviceState),
+                data,
+            ]),
+        );
 
-        if (filteredAccounts.length === 0) {
+        const graphTxCountByAccount = new Map<AccountKey, number>(
+            Array.from(graphDataPointsByAccount.entries()).map(([key, data]) => {
+                const txCount = data.reduce((acc, point) => acc + point.txs, 0);
+
+                return [key, txCount];
+            }),
+        );
+
+        const accountsToFetch = supportedAccounts.filter(account => {
+            const txCount = graphTxCountByAccount.get(account.key) ?? 0;
+
+            return txCount !== account.history.total;
+        });
+
+        if (accountsToFetch.length === 0) {
             return;
         }
 
@@ -177,8 +201,12 @@ export const updateGraphData = createThunk<
             dispatch({
                 type: AGGREGATED_GRAPH_START,
             });
-            const promises = filteredAccounts.map(
-                a => dispatch(fetchAccountGraphData(a, { abortSignal })), // fetch for all range
+            const promises = accountsToFetch.map(a =>
+                dispatch(
+                    fetchAccountGraphData(a, {
+                        abortSignal,
+                    }),
+                ),
             );
             await Promise.all(promises);
 

--- a/packages/suite/src/hooks/suite/useGraph.ts
+++ b/packages/suite/src/hooks/suite/useGraph.ts
@@ -16,12 +16,8 @@ export const useGraph = () => {
         () => ({
             setSelectedRange: (range: GraphRange) => dispatch(graphActions.setSelectedRange(range)),
             setSelectedView: (view: GraphScale) => dispatch(graphActions.setSelectedView(view)),
-            updateGraphData: (
-                accounts: Account[],
-                options?: {
-                    newAccountsOnly?: boolean;
-                },
-            ) => dispatch(graphActions.updateGraphData({ accounts, ...options })),
+            updateGraphData: (accounts: Account[]) =>
+                dispatch(graphActions.updateGraphData({ accounts })),
         }),
         [dispatch],
     );

--- a/packages/suite/src/middlewares/wallet/graphMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/graphMiddleware.ts
@@ -18,7 +18,6 @@ const graphMiddleware =
                 api.dispatch(
                     graphActions.updateGraphData({
                         accounts: [action.payload.account],
-                        newAccountsOnly: true,
                     }),
                 );
             }
@@ -31,7 +30,6 @@ const graphMiddleware =
             api.dispatch(
                 graphActions.updateGraphData({
                     accounts: currentAccounts,
-                    newAccountsOnly: true,
                 }),
             );
         }

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
@@ -38,7 +38,7 @@ export const PortfolioCardHeader = ({
 
     const onSelectedRange = useCallback(
         (_range: GraphRange) => {
-            updateGraphData({ accounts, newAccountsOnly: true });
+            updateGraphData({ accounts });
         },
         [accounts],
     );

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
@@ -93,7 +93,6 @@ export const TransactionSummary = ({ account }: TransactionSummaryProps) => {
         dispatch(
             updateGraphData({
                 accounts: [account],
-                newAccountsOnly: true,
             }),
         );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I changed the logic for selecting accounts that trigger a graph refetch. Graph transactions are now compared against total account transactions and only if there's a difference, graph is refetched. This also works for new accounts thus `newAccountsOnly` parameter doesn't make sense anymore.

## Related Issue

Resolve #21188

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/graph-refetching&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/graph-refetching&lookback=7)