### PR TITLE
chore: introduce BluetoothDeviceId as branded type

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -41,6 +41,7 @@ import {
     UiResponseWord,
 } from '../events';
 import {
+    BluetoothDeviceId,
     DeviceFirmwareStatus,
     DeviceState,
     DeviceStatus,
@@ -53,6 +54,7 @@ import {
     KnownDevice,
     UnavailableCapabilities,
     VersionArray,
+    asBluetoothDeviceId,
 } from '../types';
 import { handshakeCancel } from './workflow/handshake';
 import { getReleaseAsset } from '../utils/assetUtils';
@@ -147,7 +149,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     private _bluetoothProps?: {
         channels: Record<OpenDeviceChannel, boolean> | undefined;
-        id: string;
+        id: BluetoothDeviceId;
     };
     public get bluetoothProps() {
         return this._bluetoothProps;
@@ -242,7 +244,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         if (descriptor.id) {
             this._bluetoothProps = {
-                id: descriptor.id,
+                id: asBluetoothDeviceId(descriptor.id),
                 channels: undefined,
             };
         }

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -85,8 +85,11 @@ type BaseDevice = {
     name: string;
 };
 
+export type BluetoothDeviceId = string & Branded<'BluetoothDeviceId'>;
+export const asBluetoothDeviceId = (id: string) => id as BluetoothDeviceId;
+
 export type BluetoothDeviceProps = {
-    id: string;
+    id: BluetoothDeviceId;
 };
 
 export type KnownDevice = BaseDevice & {

--- a/packages/suite/src/actions/bluetooth/DesktopBluetoothDevice.ts
+++ b/packages/suite/src/actions/bluetooth/DesktopBluetoothDevice.ts
@@ -3,10 +3,12 @@ import {
     parseManufacturerData,
     serializeManufacturerData,
 } from '@suite-common/bluetooth';
+import { BluetoothDeviceId, asBluetoothDeviceId } from '@trezor/connect';
 import { BluetoothDevice } from '@trezor/transport-bluetooth';
 
-export type DesktopBluetoothDevice = Omit<BluetoothDevice, 'data'> & {
+export type DesktopBluetoothDevice = Omit<BluetoothDevice, 'data' | 'id'> & {
     manufacturerData: BluetoothManufacturerData;
+    id: BluetoothDeviceId;
 };
 
 export const toBluetoothDevice = (device: DesktopBluetoothDevice): BluetoothDevice => ({
@@ -22,7 +24,7 @@ export const toBluetoothDevice = (device: DesktopBluetoothDevice): BluetoothDevi
 });
 
 export const fromBluetoothDevice = (device: BluetoothDevice): DesktopBluetoothDevice => ({
-    id: device.id,
+    id: asBluetoothDeviceId(device.id),
     name: device.name,
     macAddress: device.macAddress,
     manufacturerData: parseManufacturerData(device.data),

--- a/packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts
+++ b/packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts
@@ -2,6 +2,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 
 import { BluetoothManufacturerData, prepareInitialState } from '@suite-common/bluetooth';
 import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
+import { asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { DesktopBluetoothDevice } from '../DesktopBluetoothDevice';
@@ -28,9 +29,9 @@ const initialState: DesktopBluetoothState = {
 };
 
 const disconnectedDeviceB: DesktopBluetoothDevice = {
+    id: asBluetoothDeviceId('B'),
     connected: false,
     macAddress: '',
-    id: 'B',
     manufacturerData,
     name: 'Trezor B',
     lastUpdatedTimestamp: 2,

--- a/packages/suite/src/actions/bluetooth/__tests__/remapKnownDevicesForLinuxAndWindows.test.ts
+++ b/packages/suite/src/actions/bluetooth/__tests__/remapKnownDevicesForLinuxAndWindows.test.ts
@@ -1,4 +1,5 @@
 import { BluetoothManufacturerData } from '@suite-common/bluetooth';
+import { asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { DesktopBluetoothDevice } from '../DesktopBluetoothDevice';
@@ -11,7 +12,7 @@ const manufacturerData: BluetoothManufacturerData = {
 };
 
 const nearbyDeviceA: DesktopBluetoothDevice = {
-    id: 'New-Id-A',
+    id: asBluetoothDeviceId('New-Id-A'),
     manufacturerData,
     name: 'Trezor A',
     lastUpdatedTimestamp: 1,
@@ -23,7 +24,7 @@ const nearbyDeviceA: DesktopBluetoothDevice = {
 };
 
 const nearbyDeviceC: DesktopBluetoothDevice = {
-    id: 'C',
+    id: asBluetoothDeviceId('C'),
     manufacturerData,
     name: 'Trezor C',
     lastUpdatedTimestamp: 1,
@@ -35,7 +36,7 @@ const nearbyDeviceC: DesktopBluetoothDevice = {
 };
 
 const knownDeviceB: DesktopBluetoothDevice = {
-    id: 'B',
+    id: asBluetoothDeviceId('B'),
     manufacturerData,
     name: 'Trezor A',
     lastUpdatedTimestamp: 1,
@@ -47,7 +48,7 @@ const knownDeviceB: DesktopBluetoothDevice = {
 };
 
 const knownDeviceA: DesktopBluetoothDevice = {
-    id: 'Original-Id A',
+    id: asBluetoothDeviceId('Original-Id A'),
     manufacturerData,
     name: 'Trezor B',
     lastUpdatedTimestamp: 2,
@@ -69,7 +70,7 @@ describe(remapKnownDevicesForLinuxAndWindows.name, () => {
             macAddress: 'Address-Trezor-A-Staying-Same',
             connected: false,
             manufacturerData,
-            id: 'New-Id-A',
+            id: asBluetoothDeviceId('New-Id-A'),
             lastUpdatedTimestamp: 2,
             connectionStatus: {
                 type: 'pairing',

--- a/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
@@ -1,7 +1,7 @@
 import { BLUETOOTH_PREFIX, bluetoothActions } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import TrezorConnect, { Device } from '@trezor/connect';
+import TrezorConnect, { BluetoothDeviceId, Device } from '@trezor/connect';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
@@ -18,7 +18,7 @@ type BluetoothConnectDeviceThunkResult = {
 
 export const bluetoothConnectDeviceThunk = createThunk<
     BluetoothConnectDeviceThunkResult,
-    { deviceId: string },
+    { deviceId: BluetoothDeviceId },
     void
 >(
     `${BLUETOOTH_PREFIX}/bluetoothConnectDeviceThunk`,

--- a/packages/suite/src/actions/bluetooth/bluetoothDisconnectDeviceThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothDisconnectDeviceThunk.ts
@@ -1,6 +1,7 @@
 import { BLUETOOTH_PREFIX, bluetoothActions } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import { BluetoothDeviceId } from '@trezor/connect';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
 type BluetoothDisconnectDeviceThunkResult = {
@@ -9,7 +10,7 @@ type BluetoothDisconnectDeviceThunkResult = {
 
 export const bluetoothDisconnectDeviceThunk = createThunk<
     BluetoothDisconnectDeviceThunkResult,
-    { id: string },
+    { id: BluetoothDeviceId },
     void
 >(
     `${BLUETOOTH_PREFIX}/bluetoothDisconnectDeviceThunk`,

--- a/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
@@ -6,7 +6,7 @@ import {
     selectIsDeviceConnectedViaBluetooth,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { BluetoothDeviceId } from '@trezor/connect';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
 import {
@@ -17,7 +17,7 @@ import {
 type ForgetBluetoothDeviceThunkParams = {
     // This thunk must relay on `bluetoothId` directly. When this think is called,
     // the device may already be disconnected, and therefore, it cannot be selected from the state.
-    bluetoothId: string;
+    bluetoothId: BluetoothDeviceId;
 };
 
 export const forgetBluetoothDeviceThunk = createThunk<void, ForgetBluetoothDeviceThunkParams, void>(
@@ -34,7 +34,7 @@ export const forgetBluetoothDeviceThunk = createThunk<void, ForgetBluetoothDevic
 );
 
 type UnpairCurrentBondThunkParams = {
-    bluetoothId: string;
+    bluetoothId: BluetoothDeviceId;
 };
 
 const unpairCurrentBondThunk = createThunk<void, UnpairCurrentBondThunkParams, void>(

--- a/packages/suite/src/components/connection/BluetoothConnectionModal.tsx
+++ b/packages/suite/src/components/connection/BluetoothConnectionModal.tsx
@@ -1,4 +1,5 @@
 import { Modal } from '@trezor/components';
+import { BluetoothDeviceId } from '@trezor/connect';
 
 import { DesktopBluetoothDevice } from 'src/actions/bluetooth/DesktopBluetoothDevice';
 import { selectConnectingDevices } from 'src/actions/bluetooth/desktopBluetoothSelectors';
@@ -15,9 +16,9 @@ type BluetoothConnectionModalProps = {
     nearbyDevices: DesktopBluetoothDevice[] | null;
     knownDevices: DesktopBluetoothDevice[] | null;
     shouldPairAgain: boolean;
-    onPairingCancel: (deviceId: string) => Promise<void>;
+    onPairingCancel: (deviceId: BluetoothDeviceId) => Promise<void>;
     onRescanClick: () => void;
-    onConnect: (deviceId: string) => Promise<void>;
+    onConnect: (deviceId: BluetoothDeviceId) => Promise<void>;
     onCancel: () => void;
     onClose: () => void;
 };

--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -10,6 +10,7 @@ import {
     selectNearbyDevices,
 } from '@suite-common/bluetooth';
 import { Box, Button, Column, Modal, Row, Spinner, Text } from '@trezor/components';
+import { BluetoothDeviceId } from '@trezor/connect';
 import { isDesktop } from '@trezor/env-utils';
 import { borders } from '@trezor/theme';
 import { TimerId } from '@trezor/type-utils';
@@ -181,7 +182,7 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
         }, SCAN_TIMEOUT);
     };
 
-    const handlePairingCancel = async (deviceId: string) => {
+    const handlePairingCancel = async (deviceId: BluetoothDeviceId) => {
         await dispatch(bluetoothDisconnectDeviceThunk({ id: deviceId }));
         setSelectedDeviceId(null);
         onReScanClick();
@@ -193,7 +194,7 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
         toggleBluetoothMode();
     };
 
-    const onConnect = async (deviceId: string) => {
+    const onConnect = async (deviceId: BluetoothDeviceId) => {
         setSelectedDeviceId(deviceId);
         const result = await dispatch(bluetoothConnectDeviceThunk({ deviceId })).unwrap();
 

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceList.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceList.tsx
@@ -1,4 +1,5 @@
 import { Card, Column, Row, SkeletonRectangle } from '@trezor/components';
+import { BluetoothDeviceId } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
 import { BluetoothDeviceListItem } from './BluetoothDeviceListItem';
@@ -17,9 +18,9 @@ const SkeletonDevice = () => (
 
 type BluetoothDeviceListProps = {
     deviceList: DesktopBluetoothDevice[];
-    onConnect: (deviceId: string) => Promise<void>;
+    onConnect: (deviceId: BluetoothDeviceId) => Promise<void>;
     isScanning: boolean;
-    onPairAgain?: (deviceId: string) => Promise<void>;
+    onPairAgain?: (deviceId: BluetoothDeviceId) => Promise<void>;
 };
 
 export const BluetoothDeviceList = ({

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx
@@ -7,6 +7,7 @@ import {
     selectNearbyDevices,
 } from '@suite-common/bluetooth';
 import { Button, Row } from '@trezor/components';
+import { BluetoothDeviceId } from '@trezor/connect';
 
 import { BluetoothDeviceComponent } from './BluetoothDeviceComponent';
 import { DesktopBluetoothDevice } from '../../../actions/bluetooth/DesktopBluetoothDevice';
@@ -33,7 +34,7 @@ type GhostDeviceActionButtonProps = {
     device: DesktopBluetoothDevice;
     isConnectingDevice: boolean;
     isLoading: boolean;
-    onPairAgain?: (deviceId: string) => Promise<void>;
+    onPairAgain?: (deviceId: BluetoothDeviceId) => Promise<void>;
 };
 
 const GhostDeviceActionButton = ({
@@ -61,8 +62,8 @@ const GhostDeviceActionButton = ({
 type ActionButtonProps = {
     isGhostDevice: boolean;
     device: DesktopBluetoothDevice;
-    onConnect: (deviceId: string) => Promise<void>;
-    onPairAgain?: (deviceId: string) => Promise<void>;
+    onConnect: (deviceId: BluetoothDeviceId) => Promise<void>;
+    onPairAgain?: (deviceId: BluetoothDeviceId) => Promise<void>;
 };
 
 const ActionButton = ({ isGhostDevice, device, onConnect, onPairAgain }: ActionButtonProps) => {
@@ -101,8 +102,8 @@ const ActionButton = ({ isGhostDevice, device, onConnect, onPairAgain }: ActionB
 
 type BluetoothDeviceItemProps = {
     device: DesktopBluetoothDevice;
-    onConnect: (deviceId: string) => Promise<void>;
-    onPairAgain?: (deviceId: string) => Promise<void>;
+    onConnect: (deviceId: BluetoothDeviceId) => Promise<void>;
+    onPairAgain?: (deviceId: BluetoothDeviceId) => Promise<void>;
 };
 
 export const BluetoothDeviceListItem = ({

--- a/packages/suite/src/components/suite/bluetooth/BluetoothScanningList.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothScanningList.tsx
@@ -1,4 +1,5 @@
 import { selectScanStatus } from '@suite-common/bluetooth';
+import { BluetoothDeviceId } from '@trezor/connect';
 
 import { BluetoothDeviceList } from './BluetoothDeviceList';
 import { BluetoothTips } from './BluetoothTips';
@@ -8,7 +9,7 @@ import { Translation } from '../Translation';
 
 type BluetoothScanningListProps = {
     devices: DesktopBluetoothDevice[];
-    onConnect: (deviceId: string) => Promise<void>;
+    onConnect: (deviceId: BluetoothDeviceId) => Promise<void>;
     onReScanClick: () => void;
 };
 

--- a/suite-common/bluetooth/src/bluetoothActions.ts
+++ b/suite-common/bluetooth/src/bluetoothActions.ts
@@ -1,5 +1,7 @@
 import { createAction } from '@reduxjs/toolkit';
 
+import { BluetoothDeviceId } from '@trezor/connect';
+
 import {
     BluetoothAdapterStatus,
     BluetoothDeviceCommon,
@@ -38,7 +40,7 @@ const knownDevicesUpdateAction = createAction(
 
 const removeKnownDeviceAction = createAction(
     `${BLUETOOTH_PREFIX}/remove-known-device`,
-    ({ id }: { id: string }) => ({
+    ({ id }: { id: BluetoothDeviceId }) => ({
         payload: { id },
     }),
 );
@@ -56,7 +58,7 @@ const updateDeviceConnectionStatus = createAction(
         deviceId,
         connectionStatus,
     }: {
-        deviceId: string;
+        deviceId: BluetoothDeviceId;
         connectionStatus: DeviceBluetoothConnectionStatus;
     }) => ({
         payload: { deviceId, connectionStatus },

--- a/suite-common/bluetooth/src/index.ts
+++ b/suite-common/bluetooth/src/index.ts
@@ -1,11 +1,11 @@
 export type {
     BluetoothManufacturerData,
     BluetoothScanStatus,
+    BluetoothFilterPolicy,
     DeviceBluetoothConnectionStatusType,
 } from './types';
 export type { BluetoothState } from './bluetoothReducer';
 export type { WithBluetoothState } from './bluetoothSelectors';
-export type { BluetoothFilterPolicy } from './types';
 
 export { BLUETOOTH_PREFIX, bluetoothActions } from './bluetoothActions';
 export { prepareInitialState, prepareBluetoothReducerCreator } from './bluetoothReducer';

--- a/suite-common/bluetooth/src/support/mocks.ts
+++ b/suite-common/bluetooth/src/support/mocks.ts
@@ -1,3 +1,4 @@
+import { asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { BluetoothDeviceCommon } from '../types';
@@ -10,7 +11,7 @@ import { BluetoothDeviceCommon } from '../types';
 export const createBluetoothDevice = (
     partialBluetoothDevice?: Partial<BluetoothDeviceCommon>,
 ): BluetoothDeviceCommon => ({
-    id: 'bt-device-1',
+    id: asBluetoothDeviceId('bt-device-1'),
     name: 'Mock Trezor bt-device-1',
     manufacturerData: {
         deviceModel: DeviceModelInternal.T3W1,

--- a/suite-common/bluetooth/src/types.ts
+++ b/suite-common/bluetooth/src/types.ts
@@ -1,3 +1,4 @@
+import { BluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 export type BluetoothAdapterStatus =
@@ -43,7 +44,7 @@ export type DeviceBluetoothConnectionStatus =
 // from the '@trezor/transport-bluetooth' and mobile (native) have its own type as well.
 // It's acceptable to use in @suite-common, where the code is still platform-agnostic, e.g. in unit tests.
 export type BluetoothDeviceCommon = {
-    id: string;
+    id: BluetoothDeviceId;
     name: string;
     manufacturerData: BluetoothManufacturerData;
     lastUpdatedTimestamp: number;

--- a/suite-common/bluetooth/tests/bluetoothReducer.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothReducer.test.ts
@@ -3,16 +3,12 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
 import { deviceActions } from '@suite-common/wallet-core';
-import { Device } from '@trezor/connect';
+import { Device, asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import {
-    BluetoothManufacturerData,
-    bluetoothActions,
-    prepareBluetoothReducerCreator,
-    prepareInitialState,
-} from '../src';
-import { BluetoothDeviceCommon } from '../src/types';
+import { bluetoothActions } from '../src/bluetoothActions';
+import { prepareBluetoothReducerCreator, prepareInitialState } from '../src/bluetoothReducer';
+import { BluetoothDeviceCommon, BluetoothManufacturerData } from '../src/types';
 
 const manufacturerData: BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal.T3W1,
@@ -26,7 +22,7 @@ const bluetoothReducer =
 const initialState = prepareInitialState();
 
 const pairingDeviceA: BluetoothDeviceCommon = {
-    id: 'A',
+    id: asBluetoothDeviceId('A'),
     manufacturerData,
     name: 'Trezor A',
     lastUpdatedTimestamp: 1,
@@ -34,7 +30,7 @@ const pairingDeviceA: BluetoothDeviceCommon = {
 };
 
 const disconnectedDeviceB: BluetoothDeviceCommon = {
-    id: 'B',
+    id: asBluetoothDeviceId('B'),
     manufacturerData,
     name: 'Trezor B',
     lastUpdatedTimestamp: 2,
@@ -42,7 +38,7 @@ const disconnectedDeviceB: BluetoothDeviceCommon = {
 };
 
 const pairingErrorDevice: BluetoothDeviceCommon = {
-    id: 'pairing-error',
+    id: asBluetoothDeviceId('pairing-error'),
     manufacturerData,
     name: 'Trezor Pairing Error',
     lastUpdatedTimestamp: 1,
@@ -103,7 +99,7 @@ describe('bluetoothReducer', () => {
         );
         expect(store.getState().bluetooth.knownDevices).toEqual(knownDeviceToAdd);
 
-        store.dispatch(bluetoothActions.removeKnownDeviceAction({ id: 'A' }));
+        store.dispatch(bluetoothActions.removeKnownDeviceAction({ id: asBluetoothDeviceId('A') }));
 
         expect(store.getState().bluetooth.knownDevices).toEqual([disconnectedDeviceB]);
     });
@@ -118,7 +114,7 @@ describe('bluetoothReducer', () => {
         });
 
         const trezorDevice: Pick<TrezorDevice, 'bluetoothProps'> = {
-            bluetoothProps: { id: 'A' },
+            bluetoothProps: { id: asBluetoothDeviceId('A') },
         };
 
         store.dispatch(deviceActions.deviceDisconnect(trezorDevice as TrezorDevice));
@@ -140,7 +136,7 @@ describe('bluetoothReducer', () => {
         });
 
         const trezorDevice: Pick<Device, 'bluetoothProps'> = {
-            bluetoothProps: { id: 'A' },
+            bluetoothProps: { id: asBluetoothDeviceId('A') },
         };
 
         store.dispatch(

--- a/suite-common/bluetooth/tests/bluetoothSelectors.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothSelectors.test.ts
@@ -1,3 +1,4 @@
+import { asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { BluetoothManufacturerData, prepareInitialState, prepareSelectAllDevices } from '../src';
@@ -11,7 +12,7 @@ const manufacturerData: BluetoothManufacturerData = {
 };
 
 const pairingDeviceStateA: BluetoothDeviceCommon = {
-    id: 'A',
+    id: asBluetoothDeviceId('A'),
     manufacturerData,
     name: 'Trezor A',
     lastUpdatedTimestamp: 1,
@@ -19,7 +20,7 @@ const pairingDeviceStateA: BluetoothDeviceCommon = {
 };
 
 const disconnectedDeviceB: BluetoothDeviceCommon = {
-    id: 'B',
+    id: asBluetoothDeviceId('B'),
     manufacturerData,
     name: 'Trezor B',
     lastUpdatedTimestamp: 2,
@@ -27,7 +28,7 @@ const disconnectedDeviceB: BluetoothDeviceCommon = {
 };
 
 const pairingDeviceStateC: BluetoothDeviceCommon = {
-    id: 'C',
+    id: asBluetoothDeviceId('C'),
     manufacturerData,
     name: 'Trezor C',
     lastUpdatedTimestamp: 3,

--- a/suite-common/bluetooth/tests/filterOutOldDuplicatesByName.test.ts
+++ b/suite-common/bluetooth/tests/filterOutOldDuplicatesByName.test.ts
@@ -1,3 +1,5 @@
+import { asBluetoothDeviceId } from '@trezor/connect';
+
 import { filterOutOldDuplicatesByName } from '../src/filterOutOldDuplicatesByName';
 import { createBluetoothDevice } from '../src/support/mocks';
 import { BluetoothDeviceCommon } from '../src/types';
@@ -5,9 +7,21 @@ import { BluetoothDeviceCommon } from '../src/types';
 describe(filterOutOldDuplicatesByName.name, () => {
     it('returns all devices if names are unique', () => {
         const devices: BluetoothDeviceCommon[] = [
-            createBluetoothDevice({ id: '1', name: 'DeviceA', lastUpdatedTimestamp: 100 }),
-            createBluetoothDevice({ id: '2', name: 'DeviceB', lastUpdatedTimestamp: 200 }),
-            createBluetoothDevice({ id: '3', name: 'DeviceC', lastUpdatedTimestamp: 300 }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('1'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 100,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('2'),
+                name: 'DeviceB',
+                lastUpdatedTimestamp: 200,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('3'),
+                name: 'DeviceC',
+                lastUpdatedTimestamp: 300,
+            }),
         ];
         const result = filterOutOldDuplicatesByName(devices);
         expect(result).toHaveLength(3);
@@ -16,32 +30,84 @@ describe(filterOutOldDuplicatesByName.name, () => {
 
     it('keeps only the latest device for duplicate names', () => {
         const devices: BluetoothDeviceCommon[] = [
-            createBluetoothDevice({ id: '1', name: 'DeviceA', lastUpdatedTimestamp: 100 }),
-            createBluetoothDevice({ id: '2', name: 'DeviceA', lastUpdatedTimestamp: 200 }),
-            createBluetoothDevice({ id: '3', name: 'DeviceB', lastUpdatedTimestamp: 150 }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('1'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 100,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('2'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 200,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('3'),
+                name: 'DeviceB',
+                lastUpdatedTimestamp: 150,
+            }),
         ];
         const result = filterOutOldDuplicatesByName(devices);
         expect(result).toHaveLength(2);
         expect(result).toEqual([
-            createBluetoothDevice({ id: '2', name: 'DeviceA', lastUpdatedTimestamp: 200 }),
-            createBluetoothDevice({ id: '3', name: 'DeviceB', lastUpdatedTimestamp: 150 }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('2'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 200,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('3'),
+                name: 'DeviceB',
+                lastUpdatedTimestamp: 150,
+            }),
         ]);
     });
 
     it('handles multiple sets of duplicates', () => {
         const devices: BluetoothDeviceCommon[] = [
-            createBluetoothDevice({ id: '1', name: 'DeviceA', lastUpdatedTimestamp: 100 }),
-            createBluetoothDevice({ id: '2', name: 'DeviceA', lastUpdatedTimestamp: 200 }),
-            createBluetoothDevice({ id: '3', name: 'DeviceB', lastUpdatedTimestamp: 150 }),
-            createBluetoothDevice({ id: '4', name: 'DeviceB', lastUpdatedTimestamp: 250 }),
-            createBluetoothDevice({ id: '5', name: 'DeviceC', lastUpdatedTimestamp: 300 }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('1'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 100,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('2'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 200,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('3'),
+                name: 'DeviceB',
+                lastUpdatedTimestamp: 150,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('4'),
+                name: 'DeviceB',
+                lastUpdatedTimestamp: 250,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('5'),
+                name: 'DeviceC',
+                lastUpdatedTimestamp: 300,
+            }),
         ];
         const result = filterOutOldDuplicatesByName(devices);
         expect(result).toHaveLength(3);
         expect(result).toEqual([
-            createBluetoothDevice({ id: '2', name: 'DeviceA', lastUpdatedTimestamp: 200 }),
-            createBluetoothDevice({ id: '4', name: 'DeviceB', lastUpdatedTimestamp: 250 }),
-            createBluetoothDevice({ id: '5', name: 'DeviceC', lastUpdatedTimestamp: 300 }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('2'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 200,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('4'),
+                name: 'DeviceB',
+                lastUpdatedTimestamp: 250,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('5'),
+                name: 'DeviceC',
+                lastUpdatedTimestamp: 300,
+            }),
         ]);
     });
 
@@ -53,12 +119,24 @@ describe(filterOutOldDuplicatesByName.name, () => {
 
     it('keeps the latest device when timestamps are equal (prefers last in array)', () => {
         const devices: BluetoothDeviceCommon[] = [
-            createBluetoothDevice({ id: '1', name: 'DeviceA', lastUpdatedTimestamp: 100 }),
-            createBluetoothDevice({ id: '2', name: 'DeviceA', lastUpdatedTimestamp: 100 }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('1'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 100,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('2'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 100,
+            }),
         ];
         const result = filterOutOldDuplicatesByName(devices);
         expect(result).toEqual([
-            createBluetoothDevice({ id: '2', name: 'DeviceA', lastUpdatedTimestamp: 100 }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('2'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 100,
+            }),
         ]);
     });
 });

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -18,7 +18,13 @@ import {
     SelectedAccountStatus,
     WalletType,
 } from '@suite-common/wallet-types';
-import { BlockchainBlock, ConnectSettings, Manifest, StaticSessionId } from '@trezor/connect';
+import {
+    BlockchainBlock,
+    BluetoothDeviceId,
+    ConnectSettings,
+    Manifest,
+    StaticSessionId,
+} from '@trezor/connect';
 
 import { ActionType, SuiteCompatibleSelector, SuiteCompatibleThunk } from './types';
 
@@ -42,7 +48,7 @@ export type ExtraDependencies = {
         addAccountMetadata: SuiteCompatibleThunk<
             Exclude<MetadataAddPayload, { type: 'walletLabel' }>
         >;
-        forgetBluetoothDevice: SuiteCompatibleThunk<{ bluetoothId: string }>;
+        forgetBluetoothDevice: SuiteCompatibleThunk<{ bluetoothId: BluetoothDeviceId }>;
 
         // This needs to be over `extra` to prevent circular dependency
         subscribeLocalFirstStorage: SuiteCompatibleThunk<{ device: TrezorDevice }>;

--- a/suite-common/suite-utils/src/__fixtures__/device.ts
+++ b/suite-common/suite-utils/src/__fixtures__/device.ts
@@ -1,5 +1,6 @@
 import type { TrezorDevice } from '@suite-common/suite-types';
 import { testMocks } from '@suite-common/test-utils';
+import { asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import * as URLS from '@trezor/urls';
 
@@ -62,7 +63,7 @@ const getStatus: Array<{ device: TrezorDevice; status: string }> = [
 const isDeviceConnectedViaBluetooth = [
     {
         description: 'device is connected via bluetooth',
-        device: getSuiteDevice({ bluetoothProps: { id: '21' } }),
+        device: getSuiteDevice({ bluetoothProps: { id: asBluetoothDeviceId('21') } }),
         result: true,
     },
     {

--- a/suite-common/wallet-core/src/device/__fixtures__/forgetPersistentDataPreloadedState.ts
+++ b/suite-common/wallet-core/src/device/__fixtures__/forgetPersistentDataPreloadedState.ts
@@ -3,6 +3,7 @@ import { createBluetoothDevice } from '@suite-common/bluetooth/src/support/mocks
 import { BluetoothDeviceCommon } from '@suite-common/bluetooth/src/types';
 import { ThpState, initialThpState } from '@suite-common/thp';
 import { createCredential, createDeviceThp } from '@suite-common/thp/src/support/mocks';
+import { asBluetoothDeviceId } from '@trezor/connect';
 
 import { defaultDevicePersistentData } from '../../support/deviceMocks';
 import { DeviceReducerState, deviceInitialState } from '../deviceReducer';
@@ -13,9 +14,9 @@ type ForgetPersistentDataPreloadedState = {
     thp: ThpState;
 };
 
-const BTDevice1 = createBluetoothDevice({ id: 'bt-id-1' });
-const BTDevice3 = createBluetoothDevice({ id: 'bt-id-3' });
-const orphanedBTDevice = createBluetoothDevice({ id: 'bt-id-4' });
+const BTDevice1 = createBluetoothDevice({ id: asBluetoothDeviceId('bt-id-1') });
+const BTDevice3 = createBluetoothDevice({ id: asBluetoothDeviceId('bt-id-3') });
+const orphanedBTDevice = createBluetoothDevice({ id: asBluetoothDeviceId('bt-id-4') });
 
 const credential1A = createCredential({ credential: '1A' });
 const credential1B = createCredential({ credential: '1B' });

--- a/suite-native/bluetooth/src/__tests__/selectors.test.ts
+++ b/suite-native/bluetooth/src/__tests__/selectors.test.ts
@@ -1,4 +1,5 @@
 import { prepareInitialState } from '@suite-common/bluetooth';
+import { asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { NativeBluetoothState } from '../bluetoothSlice';
@@ -17,7 +18,7 @@ const initialState: NativeBluetoothState = {
 };
 
 const unknownDevice: BluetoothDevice = {
-    id: '4de11222-cef9-43fa-aee2-ffa77c697a29',
+    id: asBluetoothDeviceId('4de11222-cef9-43fa-aee2-ffa77c697a29'),
     name: 'Disconnected TS7',
     connectionStatus: { type: 'disconnected' },
     lastUpdatedTimestamp: Date.now(),
@@ -28,7 +29,7 @@ const unknownDevice: BluetoothDevice = {
 };
 
 const knownDevice: BluetoothDevice = {
-    id: '7a39820f-6387-4251-b066-46ed70d37d3f',
+    id: asBluetoothDeviceId('7a39820f-6387-4251-b066-46ed70d37d3f'),
     name: 'Disconnected TS7',
     connectionStatus: { type: 'disconnected' },
     lastUpdatedTimestamp: Date.now(),
@@ -61,7 +62,7 @@ const knownPairableDevice: BluetoothDevice = {
 };
 
 const pairableDevice: BluetoothDevice = {
-    id: '653ab4bc-d0b5-47d7-ab5d-ad834e4956f5',
+    id: asBluetoothDeviceId('653ab4bc-d0b5-47d7-ab5d-ad834e4956f5'),
     name: 'Pairable TS7',
     connectionStatus: { type: 'disconnected' },
     lastUpdatedTimestamp: Date.now(),

--- a/suite-native/bluetooth/src/hooks/useBluetoothAdapter.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothAdapter.ts
@@ -10,6 +10,7 @@ import {
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import { useTranslate } from '@suite-native/intl';
 import { useToast } from '@suite-native/toasts';
+import { asBluetoothDeviceId } from '@trezor/connect';
 import { isIOs } from '@trezor/env-utils';
 import {
     BluetoothDevice as TransportBluetoothDevice,
@@ -28,6 +29,7 @@ import { useBluetoothPermissions } from './useBluetoothPermissions';
 
 const toBluetoothDevice = (device: TransportBluetoothDevice) => ({
     ...device,
+    id: asBluetoothDeviceId(device.id),
     manufacturerData: parseManufacturerData(device.manufacturerData),
 });
 
@@ -86,7 +88,12 @@ export const useBluetoothAdapter = () => {
                     );
                 }),
                 bluetoothManager.onDeviceConnectionStatusChange(event => {
-                    dispatch(bluetoothActions.updateDeviceConnectionStatus(event));
+                    dispatch(
+                        bluetoothActions.updateDeviceConnectionStatus({
+                            ...event,
+                            deviceId: asBluetoothDeviceId(event.deviceId),
+                        }),
+                    );
                     if (event.connectionStatus.type === 'pairing-canceled') {
                         showToast({
                             message: translate('bluetooth.toasts.pairingCanceled'),

--- a/suite-native/bluetooth/src/types.ts
+++ b/suite-native/bluetooth/src/types.ts
@@ -1,4 +1,5 @@
 import { BluetoothManufacturerData } from '@suite-common/bluetooth';
+import { BluetoothDeviceId } from '@trezor/connect';
 import { BluetoothDevice as TransportBluetoothDevice } from '@trezor/transport-native-bluetooth';
 
 export type BluetoothPermissionStatus =
@@ -9,6 +10,7 @@ export type BluetoothPermissionStatus =
     | 'granted'
     | 'limited';
 
-export type BluetoothDevice = Omit<TransportBluetoothDevice, 'manufacturerData'> & {
+export type BluetoothDevice = Omit<TransportBluetoothDevice, 'manufacturerData' | 'id'> & {
+    id: BluetoothDeviceId;
     manufacturerData: BluetoothManufacturerData;
 };


### PR DESCRIPTION


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bluetooth-id-branded-type&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bluetooth-id-branded-type&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=bluetooth-id-branded-type&lookback=7)