### PR TITLE
suite-native: iOS e2e tests revival

### DIFF
--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -3,10 +3,9 @@ name: "[Test] suite-native iOS E2E"
 on:
   schedule:
     - cron: "0 0 * * *"
-  # FIXME:Disabled for now, iOS tests are failing
-  # push:
-  #   branches:
-  #     - release-native/*
+  push:
+    branches:
+      - release-native/*
   workflow_dispatch:
     inputs:
       publish_results_to_github:
@@ -64,18 +63,18 @@ jobs:
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16.1.0
+          xcode-version: "26.0.1"
 
       - name: Build a Detox test app
         working-directory: ./suite-native/app
-        run: $DETOX_BINARY_PATH build  --configuration ios.sim.release
+        run: npx detox build --configuration ios.sim.release
 
       - name: Store build artifact
         uses: actions/upload-artifact@v4
         with:
           name: ios-test-build
           path: |
-            suite-native/app/ios/build/Build/Products/Release-iphonesimulator/TrezorSuiteLiteDebug.app
+            suite-native/app/ios/build/Build/Products/Release-iphonesimulator/TrezorSuiteDebug.app
 
   run_ios_e2e_tests:
     runs-on: macos-latest
@@ -131,7 +130,7 @@ jobs:
         with:
           name: ios-test-build
           path: |
-            suite-native/app/ios/build/Build/Products/Release-iphonesimulator/TrezorSuiteLiteDebug.app
+            suite-native/app/ios/build/Build/Products/Release-iphonesimulator/TrezorSuiteDebug.app
 
       - name: Prepare iPhone 11 Simulator
         run: xcrun simctl create "iPhone 11"  com.apple.CoreSimulator.SimDeviceType.iPhone-11
@@ -144,7 +143,7 @@ jobs:
           GITHUB_REPORTER_VERBOSE: false
           RELEASE_BUILD: ${{ env.release_build }}
         run: |
-          $DETOX_BINARY_PATH clean-framework-cache && $DETOX_BINARY_PATH build-framework-cache
+          npx detox clean-framework-cache && npx detox build-framework-cache
           yarn test:e2e ios.sim.release --headless --take-screenshots failing --record-videos failing
 
       - name: Upload results to Currents.dev
@@ -168,3 +167,12 @@ jobs:
         with:
           name: failed-ios-tests
           path: suite-native/app/artifacts
+
+  notify_scheduled_failure_to_slack:
+    runs-on: ubuntu-latest
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    needs: run_ios_e2e_tests
+    steps:
+      - name: Notify scheduled job failure to Slack
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"Nightly iOS :ios: E2E tests failed :7952-pepeyikes: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} "}' "${{ secrets.SLACK_MOBILE_E2E_WEBHOOK }}"

--- a/suite-native/accounts/src/components/AddAccountsButton.tsx
+++ b/suite-native/accounts/src/components/AddAccountsButton.tsx
@@ -63,7 +63,7 @@ export const AddAccountButton = ({ flowType, testID }: AddAccountButtonProps) =>
             size="medium"
             isLoading={hasDeviceDiscovery}
             isDisabled={hasDeviceDiscovery}
-            testID={testID}
+            testID={`${testID}/${isSelectedDevicePortfolioTracker ? 'import' : 'add'}`}
         />
     );
 };

--- a/suite-native/app/e2e/README.md
+++ b/suite-native/app/e2e/README.md
@@ -10,7 +10,10 @@ If you need to determine if the JS code is running within a test build, you can 
 
 To run the tests locally, you need to have the following installed:
 
-- for **iOS** build: Installed Xcode with iPhone 11 simulator created
+- for **iOS** build:
+    - Installed Xcode with iPhone 11 simulator created
+    - Installed applesimutils with `brew tap wix/brew && brew install applesimutils`
+
 - for **Android** build: Installed Android Studio with existing emulator device named `Pixel_3a_API_31`. You can do it via Android Studio UI. If you want to do it via the command line, please follow [this guide](https://wix.github.io/Detox/docs/guide/android-dev-env#heres-how-to-install-them-using-the-command-line). You can also use another emulator device, but you have to map its name to the `devices.emulator.device.avdName` value in the `.detoxrc.js` config file.
 
 ### Debug build

--- a/suite-native/app/e2e/pageObjects/accountDetailSettingsActions.ts
+++ b/suite-native/app/e2e/pageObjects/accountDetailSettingsActions.ts
@@ -1,9 +1,11 @@
 class AccountDetailSettingsActions {
     async renameAccount({ newAccountName }: { newAccountName: string }) {
         await element(by.id('@account-detail/settings/edit-button')).tap();
-        await element(by.id('@account-detail/settings/account-rename/input')).replaceText(
-            newAccountName,
-        );
+
+        const accountNameInput = element(by.id('@account-detail/settings/account-rename/input'));
+        await accountNameInput.clearText();
+        await accountNameInput.typeText(newAccountName);
+
         await element(by.id('@account-detail/settings/account-rename/confirm-button')).tap();
     }
 

--- a/suite-native/app/e2e/pageObjects/accountImportActions.ts
+++ b/suite-native/app/e2e/pageObjects/accountImportActions.ts
@@ -1,6 +1,6 @@
 import { expect as detoxExpect } from 'detox';
 
-import { scrollUntilVisible } from '../utils';
+import { inputTextToElement, scrollUntilVisible } from '../utils';
 import { onTabBar } from './tabBarActions';
 
 class AccountImportActions {
@@ -34,16 +34,11 @@ class AccountImportActions {
     }
 
     async submitXpub({ xpub, isValid }: { xpub: string; isValid: boolean }) {
-        await element(by.id('@accounts-import/sync-coins/xpub-input')).replaceText(xpub);
+        const xpubInput = element(by.id('@accounts-import/sync-coins/xpub-input'));
+        await inputTextToElement(xpubInput, xpub);
 
         const xpubSubmitButton = element(by.id('@accounts-import/sync-coins/xpub-submit'));
-
-        // Submit button is not visible without scrolling
-        await waitFor(xpubSubmitButton)
-            .toBeVisible()
-            .whileElement(by.id('@screen/mainScrollView'))
-            .scroll(50, 'down');
-
+        await scrollUntilVisible(xpubSubmitButton);
         await xpubSubmitButton.tap();
 
         if (isValid) {
@@ -54,13 +49,15 @@ class AccountImportActions {
     }
 
     async setAccountName({ accountName }: { accountName: string }) {
-        await element(by.id('@account-import/coin-synced/label-input')).replaceText(accountName);
+        const accountNameInput = element(by.id('@account-import/coin-synced/label-input'));
+        await accountNameInput.clearText();
+        await accountNameInput.typeText(accountName);
     }
 
     async confirmAddAccount() {
-        // confirm button is not visible for some coins e.g. eth
-        await element(by.id('@screen/mainScrollView')).scrollTo('bottom');
-        await element(by.id('@account-import/coin-synced/confirm-button')).tap();
+        const confirmButton = element(by.id('@account-import/coin-synced/confirm-button'));
+        await scrollUntilVisible(confirmButton);
+        await confirmButton.tap();
 
         await detoxExpect(element(by.id('@screen/Home')));
     }

--- a/suite-native/app/e2e/pageObjects/homeActions.ts
+++ b/suite-native/app/e2e/pageObjects/homeActions.ts
@@ -1,5 +1,7 @@
 import { expect as detoxExpect } from 'detox';
 
+import { waitForElementByIdToBeVisible } from '../utils';
+
 const graphHeaderDiscreetTextElement = element(
     by.id('@screen/Home').withDescendant(by.id('discreet-text')),
 );
@@ -9,6 +11,10 @@ class HomeActions {
         await waitFor(element(by.id('@screen/Home')))
             .toBeVisible()
             .withTimeout(10000);
+    }
+
+    async assertIsPortfolioGraphVisible() {
+        await waitForElementByIdToBeVisible('@home/portfolio/graph');
     }
 
     async tapSyncCoinsButton() {

--- a/suite-native/app/e2e/pageObjects/myAssetsActions.ts
+++ b/suite-native/app/e2e/pageObjects/myAssetsActions.ts
@@ -1,5 +1,7 @@
 import { expect as detoxExpect } from 'detox';
 
+import { waitForElementByIdToBeVisible } from '../utils';
+
 class MyAssetsActions {
     async waitForScreen() {
         await waitFor(element(by.id('@screen/MyAssets')))
@@ -9,9 +11,13 @@ class MyAssetsActions {
 
     async addAccount() {
         await element(by.id('@screen/mainScrollView')).scrollTo('top');
-        await element(by.id('@myAssets/addAccountButton')).tap();
+        const addAccountButtonId = '@myAssets/addAccountButton/import';
+        await waitForElementByIdToBeVisible(addAccountButtonId);
+        await element(by.id(addAccountButtonId)).tap();
 
-        await detoxExpect(element(by.id('@screen/SelectNetwork'))).toBeVisible();
+        await waitFor(element(by.id('@screen/SelectNetwork')))
+            .toBeVisible()
+            .withTimeout(5000);
     }
 
     async openAccountDetail({ accountName }: { accountName: string }) {

--- a/suite-native/app/e2e/pageObjects/settingsActions.ts
+++ b/suite-native/app/e2e/pageObjects/settingsActions.ts
@@ -1,7 +1,7 @@
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { PROTO } from '@trezor/connect';
 
-import { scrollUntilVisible } from '../utils';
+import { scrollUntilVisible, wait } from '../utils';
 
 class SettingsActions {
     async tapPreferences() {
@@ -45,10 +45,13 @@ class SettingsActions {
         await waitFor(currencySelectorTriggerElement).toBeVisible().withTimeout(10000);
         await currencySelectorTriggerElement.tap();
 
+        await wait(1000); // wait for the currency selector to open
+
         const currencySelectorItemElement = element(by.id(`@select/item/${currencyCode}`));
         await scrollUntilVisible(currencySelectorItemElement, '@bottom-sheet/scroll-view');
 
         await currencySelectorItemElement.tap();
+        await wait(1000); // wait for the currency selector to close
     }
 
     async changeBitcoinUnits(unit: PROTO.AmountUnit) {
@@ -61,6 +64,7 @@ class SettingsActions {
         const currencySelectorItemElement = element(by.id(`@select/item/${unit}/content`));
         await scrollUntilVisible(currencySelectorItemElement, '@bottom-sheet/scroll-view');
         await currencySelectorItemElement.tap();
+        await wait(1000); // wait for the bitcoin units selector to close
     }
 
     async toggleAutoEject() {

--- a/suite-native/app/e2e/pageObjects/tabBarActions.ts
+++ b/suite-native/app/e2e/pageObjects/tabBarActions.ts
@@ -25,7 +25,7 @@ class TabBarActions {
     }
 
     async tapBackButton() {
-        const backButton = element(by.id('@screen/sub-header/icon-left'));
+        const backButton = element(by.id('@screen/sub-header/go-back-button'));
         await waitFor(backButton).toBeVisible().withTimeout(10000);
         await backButton.tap();
     }

--- a/suite-native/app/e2e/pageObjects/tradingBuyActions.ts
+++ b/suite-native/app/e2e/pageObjects/tradingBuyActions.ts
@@ -1,15 +1,10 @@
 import { expect as detoxExpect } from 'detox';
 
-import {
-    scrollUntilVisible,
-    wait,
-    waitForElementByIdToBeVisible,
-    waitForElementByTextToBeVisible,
-} from '../utils';
+import { wait, waitForElementByIdToBeVisible, waitForElementByTextToBeVisible } from '../utils';
 
 const LONG_TIMEOUT = 30000;
 const SHORT_TIMEOUT = 5000;
-const ANIMATION_TIMEOUT = 1000;
+const BOTTOM_SHEET_ANIMATION_DURATION = 1000;
 
 class TradingBuyActions {
     getAmountEditingDoneButton() {
@@ -38,14 +33,14 @@ class TradingBuyActions {
     async selectAsset(asset: string) {
         await element(by.id('@trading/buy/asset-button')).tap();
         await this.expectSheetHeaderTitle('Assets');
-        await wait(ANIMATION_TIMEOUT); // wait for bottom sheet to open
+        await wait(BOTTOM_SHEET_ANIMATION_DURATION);
 
         const searchCryptoElement = element(by.id('@trading/buy/assets-search-input'));
 
         await searchCryptoElement.replaceText(asset.slice(0, -1));
-        await wait(ANIMATION_TIMEOUT); // wait for filtering to take place
+        await wait(BOTTOM_SHEET_ANIMATION_DURATION);
         await element(by.text(asset)).tap();
-        await wait(ANIMATION_TIMEOUT); //wait for bottom sheet to close
+        await wait(BOTTOM_SHEET_ANIMATION_DURATION);
 
         await waitFor(element(by.id(`@trading/buy/asset-button/symbol`))).toHaveText(asset);
     }
@@ -57,23 +52,22 @@ class TradingBuyActions {
 
         await searchFiatElement.replaceText(fiatCurrency.slice(0, -1));
 
-        await wait(ANIMATION_TIMEOUT); // wait for filtering to take place
+        await wait(BOTTOM_SHEET_ANIMATION_DURATION);
         await element(by.text(fiatCurrency)).tap();
-        await wait(ANIMATION_TIMEOUT); //wait for bottom sheet to close
+        await wait(BOTTOM_SHEET_ANIMATION_DURATION);
 
         await waitFor(element(by.id(`@trading/buy/fiat-button/ticker`))).toHaveText(fiatCurrency);
     }
 
     async selectCountry(countrySearch: string, country: string) {
         await element(by.id('@trading/buy/country')).tap();
+        await wait(BOTTOM_SHEET_ANIMATION_DURATION);
         await this.expectSheetHeaderTitle('Country of residence');
 
         const searchCountryElement = element(by.id('@trading/buy/country-search-input'));
         await searchCountryElement.replaceText(countrySearch);
-        await wait(ANIMATION_TIMEOUT); // wait for filtering to take place
         await element(by.text(country)).tap();
-        await wait(ANIMATION_TIMEOUT); //wait for bottom sheet to close
-
+        await wait(BOTTOM_SHEET_ANIMATION_DURATION);
         await detoxExpect(element(by.id('@trading/buy/country/value'))).toHaveText(country);
     }
 
@@ -95,10 +89,11 @@ class TradingBuyActions {
         const paymentMethodPickerId = '@trading/buy/payment-method-picker';
 
         await element(by.id(paymentMethodPickerId)).tap();
+        await wait(BOTTOM_SHEET_ANIMATION_DURATION);
         await this.expectSheetHeaderTitle('Payment method');
         await element(by.label('Close')).tap();
+        await wait(BOTTOM_SHEET_ANIMATION_DURATION);
         await waitForElementByIdToBeVisible(paymentMethodPickerId, SHORT_TIMEOUT);
-        await wait(ANIMATION_TIMEOUT); // wait for bottom sheet to close
     }
 
     async viewProviders() {
@@ -106,9 +101,10 @@ class TradingBuyActions {
 
         await element(by.id(providerPickerId)).tap();
         await this.expectSheetHeaderTitle('Providers');
+        await wait(BOTTOM_SHEET_ANIMATION_DURATION);
         await element(by.label('Close')).tap();
         await waitForElementByIdToBeVisible(providerPickerId, SHORT_TIMEOUT);
-        await wait(ANIMATION_TIMEOUT); // wait for bottom sheet to close
+        await wait(BOTTOM_SHEET_ANIMATION_DURATION);
     }
 
     async setFiatAmount(amount: string) {
@@ -132,10 +128,11 @@ class TradingBuyActions {
 
     async confirmBuyForm() {
         await element(by.id('@trading/buy/continue-button')).tap();
+        const bottomSheetScrollView = element(by.id('@bottom-sheet/scroll-view'));
+        await bottomSheetScrollView.scrollTo('bottom', 0.5, 0.5);
         const confirmButton = element(by.id('@trading/buy/confirm-button'));
-        await scrollUntilVisible(confirmButton, '@bottom-sheet/scroll-view');
         await confirmButton.tap();
-        await wait(ANIMATION_TIMEOUT); // wait for bottom sheet to close
+        await wait(BOTTOM_SHEET_ANIMATION_DURATION);
     }
 
     async closePaymentWebview() {

--- a/suite-native/app/e2e/pageObjects/tradingBuyActions.ts
+++ b/suite-native/app/e2e/pageObjects/tradingBuyActions.ts
@@ -1,28 +1,17 @@
 import { expect as detoxExpect } from 'detox';
 
-import { wait, waitForElementByIdToBeVisible, waitForElementByTextToBeVisible } from '../utils';
+import {
+    scrollUntilVisible,
+    wait,
+    waitForElementByIdToBeVisible,
+    waitForElementByTextToBeVisible,
+} from '../utils';
 
 const LONG_TIMEOUT = 30000;
 const SHORT_TIMEOUT = 5000;
-const SEARCH_AND_ANIMATION_TIMEOUT = 1000;
+const ANIMATION_TIMEOUT = 1000;
 
 class TradingBuyActions {
-    getSearchCrytoElement() {
-        return element(by.label('Search tokens or address'));
-    }
-
-    getSearchFiatElement() {
-        return element(by.label('Search country or ticker'));
-    }
-
-    getSearchCountryElement() {
-        return element(by.label('Search country'));
-    }
-
-    getFiatAmountElement() {
-        return element(by.id('@trading/buy/fiat-amount-input'));
-    }
-
     getAmountEditingDoneButton() {
         return element(by.id('@trading/buy/amount-editing-done-button'));
     }
@@ -38,7 +27,7 @@ class TradingBuyActions {
     }
 
     async scrollScreenToBottom() {
-        await element(by.id('@screen/Trading')).swipe('up');
+        await element(by.id('@screen/mainScrollView')).scrollTo('bottom');
     }
 
     async waitForQuotesToLoad() {
@@ -49,34 +38,41 @@ class TradingBuyActions {
     async selectAsset(asset: string) {
         await element(by.id('@trading/buy/asset-button')).tap();
         await this.expectSheetHeaderTitle('Assets');
-        await this.getSearchCrytoElement().tap();
-        await this.getSearchCrytoElement().replaceText(asset.slice(0, -1));
-        await wait(SEARCH_AND_ANIMATION_TIMEOUT);
-        await element(by.text(asset)).tap();
+        await wait(ANIMATION_TIMEOUT); // wait for bottom sheet to open
 
-        await detoxExpect(element(by.id('@trading/buy/asset-button/symbol'))).toHaveText(asset);
+        const searchCryptoElement = element(by.id('@trading/buy/assets-search-input'));
+
+        await searchCryptoElement.replaceText(asset.slice(0, -1));
+        await wait(ANIMATION_TIMEOUT); // wait for filtering to take place
+        await element(by.text(asset)).tap();
+        await wait(ANIMATION_TIMEOUT); //wait for bottom sheet to close
+
+        await waitFor(element(by.id(`@trading/buy/asset-button/symbol`))).toHaveText(asset);
     }
 
     async selectFiatCurrency(fiatCurrency: string) {
         await element(by.id('@trading/buy/fiat-button')).tap();
         await this.expectSheetHeaderTitle('Currency');
-        await this.getSearchFiatElement().tap();
-        await this.getSearchFiatElement().replaceText(fiatCurrency.slice(0, -1));
-        await wait(SEARCH_AND_ANIMATION_TIMEOUT);
-        await element(by.label(fiatCurrency)).tap();
+        const searchFiatElement = element(by.id('@trading/buy/fiat-search-input'));
 
-        await detoxExpect(element(by.id('@trading/buy/fiat-button/ticker'))).toHaveText(
-            fiatCurrency,
-        );
+        await searchFiatElement.replaceText(fiatCurrency.slice(0, -1));
+
+        await wait(ANIMATION_TIMEOUT); // wait for filtering to take place
+        await element(by.text(fiatCurrency)).tap();
+        await wait(ANIMATION_TIMEOUT); //wait for bottom sheet to close
+
+        await waitFor(element(by.id(`@trading/buy/fiat-button/ticker`))).toHaveText(fiatCurrency);
     }
 
     async selectCountry(countrySearch: string, country: string) {
         await element(by.id('@trading/buy/country')).tap();
         await this.expectSheetHeaderTitle('Country of residence');
-        await this.getSearchCountryElement().tap();
-        await this.getSearchCountryElement().replaceText(countrySearch);
-        await wait(SEARCH_AND_ANIMATION_TIMEOUT);
+
+        const searchCountryElement = element(by.id('@trading/buy/country-search-input'));
+        await searchCountryElement.replaceText(countrySearch);
+        await wait(ANIMATION_TIMEOUT); // wait for filtering to take place
         await element(by.text(country)).tap();
+        await wait(ANIMATION_TIMEOUT); //wait for bottom sheet to close
 
         await detoxExpect(element(by.id('@trading/buy/country/value'))).toHaveText(country);
     }
@@ -96,25 +92,30 @@ class TradingBuyActions {
     }
 
     async viewPaymentMethods() {
-        await element(by.id('@trading/buy/payment-method-picker')).tap();
+        const paymentMethodPickerId = '@trading/buy/payment-method-picker';
+
+        await element(by.id(paymentMethodPickerId)).tap();
         await this.expectSheetHeaderTitle('Payment method');
         await element(by.label('Close')).tap();
-        await waitForElementByIdToBeVisible('@trading/buy/payment-method-picker', SHORT_TIMEOUT);
+        await waitForElementByIdToBeVisible(paymentMethodPickerId, SHORT_TIMEOUT);
+        await wait(ANIMATION_TIMEOUT); // wait for bottom sheet to close
     }
 
     async viewProviders() {
-        await element(by.id('@trading/buy/provider-picker')).tap();
+        const providerPickerId = '@trading/buy/provider-picker';
+
+        await element(by.id(providerPickerId)).tap();
         await this.expectSheetHeaderTitle('Providers');
         await element(by.label('Close')).tap();
-        await waitForElementByIdToBeVisible('@trading/buy/provider-picker', SHORT_TIMEOUT);
+        await waitForElementByIdToBeVisible(providerPickerId, SHORT_TIMEOUT);
+        await wait(ANIMATION_TIMEOUT); // wait for bottom sheet to close
     }
 
     async setFiatAmount(amount: string) {
-        await this.getFiatAmountElement().tap();
-        await this.getFiatAmountElement().replaceText(amount);
-        await this.getFiatAmountElement().typeText('\n'); // Simulate pressing 'Enter' to submit the input
+        const fiatAmountElement = element(by.id('@trading/buy/fiat-amount-input'));
+        await fiatAmountElement.replaceText(amount);
+        await fiatAmountElement.tapReturnKey();
         await this.waitForQuotesToLoad();
-        await this.scrollScreenToBottom();
     }
 
     async expectReceiveAccountBalance(expectedValue: string) {
@@ -132,9 +133,9 @@ class TradingBuyActions {
     async confirmBuyForm() {
         await element(by.id('@trading/buy/continue-button')).tap();
         const confirmButton = element(by.id('@trading/buy/confirm-button'));
-        const bottomSheetScrollView = element(by.id('@bottom-sheet/scroll-view'));
-        await bottomSheetScrollView.scrollTo('bottom');
+        await scrollUntilVisible(confirmButton, '@bottom-sheet/scroll-view');
         await confirmButton.tap();
+        await wait(ANIMATION_TIMEOUT); // wait for bottom sheet to close
     }
 
     async closePaymentWebview() {

--- a/suite-native/app/e2e/tests/accountManagement.test.ts
+++ b/suite-native/app/e2e/tests/accountManagement.test.ts
@@ -9,9 +9,9 @@ import { onAccountDetail } from '../pageObjects/accountDetailActions';
 import { onAccountDetailSettings } from '../pageObjects/accountDetailSettingsActions';
 import { onMyAssets } from '../pageObjects/myAssetsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
-import { appIsFullyLoaded, mergePreloadedReduxState, openApp, wipeAppData } from '../utils';
+import { appIsFullyLoaded, openApp, preparePreloadedReduxState, wipeAppData } from '../utils';
 
-const preloadedState = mergePreloadedReduxState(
+const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
     portfolioTrackerBtcAccountState,
 );

--- a/suite-native/app/e2e/tests/accountManagement.test.ts
+++ b/suite-native/app/e2e/tests/accountManagement.test.ts
@@ -7,9 +7,10 @@ import {
 } from '../fixtures/portfolioTrackerBtcAccountState';
 import { onAccountDetail } from '../pageObjects/accountDetailActions';
 import { onAccountDetailSettings } from '../pageObjects/accountDetailSettingsActions';
+import { onHome } from '../pageObjects/homeActions';
 import { onMyAssets } from '../pageObjects/myAssetsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
-import { appIsFullyLoaded, openApp, preparePreloadedReduxState, wipeAppData } from '../utils';
+import { openApp, preparePreloadedReduxState, wipeAppData } from '../utils';
 
 const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
@@ -22,7 +23,7 @@ describe('Account management', () => {
             newInstance: true,
             args: { preloadedState },
         });
-        await appIsFullyLoaded();
+        await onHome.assertIsPortfolioGraphVisible();
     });
 
     afterEach(async () => {

--- a/suite-native/app/e2e/tests/appSettings.test.ts
+++ b/suite-native/app/e2e/tests/appSettings.test.ts
@@ -5,9 +5,9 @@ import { portfolioTrackerBtcAccountState } from '../fixtures/portfolioTrackerBtc
 import { onHome } from '../pageObjects/homeActions';
 import { onSettings } from '../pageObjects/settingsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
-import { appIsFullyLoaded, mergePreloadedReduxState, openApp, restartApp } from '../utils';
+import { appIsFullyLoaded, openApp, preparePreloadedReduxState, restartApp } from '../utils';
 
-const preloadedState = mergePreloadedReduxState(
+const preloadedState = preparePreloadedReduxState(
     portfolioTrackerBtcAccountState,
     onboardingCompletedState,
 );
@@ -21,7 +21,7 @@ describe('App Settings - without device interactions', () => {
     });
 
     beforeEach(async () => {
-        await restartApp();
+        await restartApp({ args: { preloadedState } });
         await appIsFullyLoaded();
     });
 
@@ -37,7 +37,7 @@ describe('App Settings - without device interactions', () => {
         await onTabBar.navigateToSettings();
         await onSettings.tapPreferences();
         await onSettings.changeLocalizationCurrency('czk');
-        await device.pressBack();
+        await onTabBar.tapBackButton();
         await onTabBar.navigateToHome();
 
         await waitFor(element(by.text(/^.*CZK.*$/i)))
@@ -53,7 +53,7 @@ describe('App Settings - without device interactions', () => {
         await onTabBar.navigateToSettings();
         await onSettings.tapPreferences();
         await onSettings.changeBitcoinUnits(PROTO.AmountUnit.SATOSHI);
-        await device.pressBack();
+        await onTabBar.tapBackButton();
         await onTabBar.navigateToHome();
 
         await waitFor(element(by.text('0 sat')))
@@ -67,7 +67,7 @@ describe('App Settings - without device interactions', () => {
         await onTabBar.navigateToSettings();
         await onSettings.tapPrivacyAndSecurity();
         await onSettings.toggleDiscreetMode();
-        await device.pressBack();
+        await onTabBar.tapBackButton();
         await onTabBar.navigateToHome();
 
         await onHome.assertIsDiscreetModeEnabled();

--- a/suite-native/app/e2e/tests/appSettings.test.ts
+++ b/suite-native/app/e2e/tests/appSettings.test.ts
@@ -5,7 +5,7 @@ import { portfolioTrackerBtcAccountState } from '../fixtures/portfolioTrackerBtc
 import { onHome } from '../pageObjects/homeActions';
 import { onSettings } from '../pageObjects/settingsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
-import { appIsFullyLoaded, openApp, preparePreloadedReduxState, restartApp } from '../utils';
+import { openApp, preparePreloadedReduxState, wipeAppData } from '../utils';
 
 const preloadedState = preparePreloadedReduxState(
     portfolioTrackerBtcAccountState,
@@ -13,16 +13,16 @@ const preloadedState = preparePreloadedReduxState(
 );
 
 describe('App Settings - without device interactions', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await openApp({
             newInstance: true,
             args: { preloadedState },
         });
+        await onHome.assertIsPortfolioGraphVisible();
     });
 
-    beforeEach(async () => {
-        await restartApp({ args: { preloadedState } });
-        await appIsFullyLoaded();
+    afterEach(async () => {
+        await wipeAppData();
     });
 
     afterAll(async () => {

--- a/suite-native/app/e2e/tests/bitcoinAccountsImport.test.ts
+++ b/suite-native/app/e2e/tests/bitcoinAccountsImport.test.ts
@@ -3,11 +3,16 @@ import { xpubs } from '../fixtures/xpubs';
 import { onAccountImport } from '../pageObjects/accountImportActions';
 import { onMyAssets } from '../pageObjects/myAssetsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
-import { openApp } from '../utils';
+import { openApp, preparePreloadedReduxState } from '../utils';
 
 describe('Import Bitcoin network accounts.', () => {
     beforeAll(async () => {
-        await openApp({ newInstance: true, args: { preloadedState: onboardingCompletedState } });
+        await openApp({
+            newInstance: true,
+            args: {
+                preloadedState: preparePreloadedReduxState(onboardingCompletedState),
+            },
+        });
         await onTabBar.navigateToMyAssets();
     });
 

--- a/suite-native/app/e2e/tests/coinEnabling.test.ts
+++ b/suite-native/app/e2e/tests/coinEnabling.test.ts
@@ -6,12 +6,22 @@ import { onDeviceConnecting } from '../pageObjects/deviceConnectingActions';
 import { onHome } from '../pageObjects/homeActions';
 import { onSettings } from '../pageObjects/settingsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
-import { disconnectTrezorUserEnv, openApp, prepareTrezorEmulator } from '../utils';
+import {
+    disconnectTrezorUserEnv,
+    openApp,
+    preparePreloadedReduxState,
+    prepareTrezorEmulator,
+} from '../utils';
 
 conditionalDescribe(device.getPlatform() === 'android', 'Coin enabling', () => {
     beforeAll(async () => {
         await prepareTrezorEmulator();
-        await openApp({ newInstance: true, args: { preloadedState: onboardingCompletedState } });
+        await openApp({
+            newInstance: true,
+            args: {
+                preloadedState: preparePreloadedReduxState(onboardingCompletedState),
+            },
+        });
     });
 
     afterAll(async () => {

--- a/suite-native/app/e2e/tests/deeplinkPopup.test.ts
+++ b/suite-native/app/e2e/tests/deeplinkPopup.test.ts
@@ -12,8 +12,8 @@ import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
 import {
     appIsFullyLoaded,
     disconnectTrezorUserEnv,
-    mergePreloadedReduxState,
     openApp,
+    preparePreloadedReduxState,
     prepareTrezorEmulator,
     restartApp,
 } from '../utils';
@@ -38,7 +38,7 @@ const openUriScheme = (url: string, platformToOpen: 'android') => {
     });
 };
 
-const preloadedState = mergePreloadedReduxState(
+const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
     btcDiscoveryFinishedState,
     deviceAutoEjectState,

--- a/suite-native/app/e2e/tests/deviceOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/deviceOnboarding.test.ts
@@ -8,8 +8,8 @@ import { onDeviceOnboarding } from '../pageObjects/deviceOnboardingActions';
 import { onHome } from '../pageObjects/homeActions';
 import {
     disconnectTrezorUserEnv,
-    mergePreloadedReduxState,
     openApp,
+    preparePreloadedReduxState,
     prepareTrezorEmulator,
     wait,
     wipeAppData,
@@ -40,7 +40,7 @@ const finishOnboardingFlow = async () => {
     await onHome.waitForScreen();
 };
 
-const preloadedState = mergePreloadedReduxState(
+const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
     deviceChecksEnabledState,
     btcCoinEnabled,

--- a/suite-native/app/e2e/tests/deviceSettings.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettings.test.ts
@@ -11,14 +11,14 @@ import { onDeviceSettings } from '../pageObjects/deviceSettingsActions';
 import {
     appIsFullyLoaded,
     disconnectTrezorUserEnv,
-    mergePreloadedReduxState,
     openApp,
+    preparePreloadedReduxState,
     prepareTrezorEmulator,
     restartApp,
     wipeAppData,
 } from '../utils';
 
-const preloadedStateT3T1 = mergePreloadedReduxState(
+const preloadedStateT3T1 = preparePreloadedReduxState(
     onboardingCompletedState,
     regtestDiscoveryFinishedStateT3T1,
 );
@@ -144,7 +144,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
     });
 });
 
-const preloadedStateT1B1 = mergePreloadedReduxState(
+const preloadedStateT1B1 = preparePreloadedReduxState(
     onboardingCompletedState,
     regtestDiscoveryFinishedStateT1B1,
 );

--- a/suite-native/app/e2e/tests/ejectWallets.test.ts
+++ b/suite-native/app/e2e/tests/ejectWallets.test.ts
@@ -10,14 +10,14 @@ import { onTabBar } from '../pageObjects/tabBarActions';
 import {
     appIsFullyLoaded,
     disconnectTrezorUserEnv,
-    mergePreloadedReduxState,
     openApp,
+    preparePreloadedReduxState,
     prepareTrezorEmulator,
     restartApp,
     wipeAppData,
 } from '../utils';
 
-const preloadedState = mergePreloadedReduxState(
+const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
     regtestDiscoveryFinishedStateT3T1,
 );

--- a/suite-native/app/e2e/tests/invalidAccountsImport.test.ts
+++ b/suite-native/app/e2e/tests/invalidAccountsImport.test.ts
@@ -13,18 +13,20 @@ const goToBtcImportXpubScreen = async () => {
     await onAccountImport.selectCoin({ networkSymbol: 'btc' });
 };
 
+const preloadedState = preparePreloadedReduxState(onboardingCompletedState);
+
 describe('Import invalid accounts', () => {
     beforeAll(async () => {
         await openApp({
             newInstance: true,
             args: {
-                preloadedState: preparePreloadedReduxState(onboardingCompletedState),
+                preloadedState,
             },
         });
     });
 
     beforeEach(async () => {
-        await restartApp();
+        await restartApp({ args: { preloadedState } });
         await appIsFullyLoaded();
         await goToBtcImportXpubScreen();
     });

--- a/suite-native/app/e2e/tests/invalidAccountsImport.test.ts
+++ b/suite-native/app/e2e/tests/invalidAccountsImport.test.ts
@@ -5,7 +5,7 @@ import { xpubs } from '../fixtures/xpubs';
 import { onAccountImport } from '../pageObjects/accountImportActions';
 import { onMyAssets } from '../pageObjects/myAssetsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
-import { appIsFullyLoaded, openApp, restartApp } from '../utils';
+import { appIsFullyLoaded, openApp, preparePreloadedReduxState, restartApp } from '../utils';
 
 const goToBtcImportXpubScreen = async () => {
     await onTabBar.navigateToMyAssets();
@@ -15,7 +15,12 @@ const goToBtcImportXpubScreen = async () => {
 
 describe('Import invalid accounts', () => {
     beforeAll(async () => {
-        await openApp({ newInstance: true, args: { preloadedState: onboardingCompletedState } });
+        await openApp({
+            newInstance: true,
+            args: {
+                preloadedState: preparePreloadedReduxState(onboardingCompletedState),
+            },
+        });
     });
 
     beforeEach(async () => {

--- a/suite-native/app/e2e/tests/invalidAccountsImport.test.ts
+++ b/suite-native/app/e2e/tests/invalidAccountsImport.test.ts
@@ -5,7 +5,7 @@ import { xpubs } from '../fixtures/xpubs';
 import { onAccountImport } from '../pageObjects/accountImportActions';
 import { onMyAssets } from '../pageObjects/myAssetsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
-import { appIsFullyLoaded, openApp, preparePreloadedReduxState, restartApp } from '../utils';
+import { openApp, preparePreloadedReduxState, wipeAppData } from '../utils';
 
 const goToBtcImportXpubScreen = async () => {
     await onTabBar.navigateToMyAssets();
@@ -16,19 +16,18 @@ const goToBtcImportXpubScreen = async () => {
 const preloadedState = preparePreloadedReduxState(onboardingCompletedState);
 
 describe('Import invalid accounts', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await openApp({
             newInstance: true,
             args: {
                 preloadedState,
             },
         });
+        await goToBtcImportXpubScreen();
     });
 
-    beforeEach(async () => {
-        await restartApp({ args: { preloadedState } });
-        await appIsFullyLoaded();
-        await goToBtcImportXpubScreen();
+    afterEach(async () => {
+        await wipeAppData();
     });
 
     it('Import an already imported XPUB', async () => {

--- a/suite-native/app/e2e/tests/othersAccountsImport.test.ts
+++ b/suite-native/app/e2e/tests/othersAccountsImport.test.ts
@@ -3,11 +3,16 @@ import { xpubs } from '../fixtures/xpubs';
 import { onAccountImport } from '../pageObjects/accountImportActions';
 import { onMyAssets } from '../pageObjects/myAssetsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
-import { openApp } from '../utils';
+import { openApp, preparePreloadedReduxState } from '../utils';
 
 describe('Import accounts of other networks.', () => {
     beforeAll(async () => {
-        await openApp({ newInstance: true, args: { preloadedState: onboardingCompletedState } });
+        await openApp({
+            newInstance: true,
+            args: {
+                preloadedState: preparePreloadedReduxState(onboardingCompletedState),
+            },
+        });
         await onTabBar.navigateToMyAssets();
     });
 

--- a/suite-native/app/e2e/tests/passphraseFlow.test.ts
+++ b/suite-native/app/e2e/tests/passphraseFlow.test.ts
@@ -10,8 +10,8 @@ import { onPassphrase } from '../pageObjects/passphraseModule';
 import {
     appIsFullyLoaded,
     disconnectTrezorUserEnv,
-    mergePreloadedReduxState,
     openApp,
+    preparePreloadedReduxState,
     prepareTrezorEmulator,
     restartApp,
     wait,
@@ -55,7 +55,7 @@ const expectNonEmptyWallet = async () => {
     jestExpect(text).toMatch(/[0-9.]+ BTC REGTEST/);
 };
 
-const preloadedState = mergePreloadedReduxState(
+const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
     regtestDiscoveryFinishedStateT3T1,
 );

--- a/suite-native/app/e2e/tests/passphraseFlow.test.ts
+++ b/suite-native/app/e2e/tests/passphraseFlow.test.ts
@@ -6,6 +6,7 @@ import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
 import { regtestDiscoveryFinishedStateT3T1 } from '../fixtures/regtestDiscoveryFinishedStateT3T1';
+import { onDeviceManager } from '../pageObjects/deviceManagerActions';
 import { onPassphrase } from '../pageObjects/passphraseModule';
 import {
     appIsFullyLoaded,
@@ -94,6 +95,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'passphrase flow', () =>
             await prepareTrezorEmulator();
             await restartApp();
             await appIsFullyLoaded();
+            await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
         });
 
         it('Open empty passphrase wallet', async () => {

--- a/suite-native/app/e2e/tests/receive.test.ts
+++ b/suite-native/app/e2e/tests/receive.test.ts
@@ -10,13 +10,13 @@ import { onMyAssets } from '../pageObjects/myAssetsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
 import {
     disconnectTrezorUserEnv,
-    mergePreloadedReduxState,
     openApp,
+    preparePreloadedReduxState,
     prepareTrezorEmulator,
     restartApp,
 } from '../utils';
 
-const preloadedState = mergePreloadedReduxState(
+const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
     btcDiscoveryFinishedState,
 );

--- a/suite-native/app/e2e/tests/send.test.ts
+++ b/suite-native/app/e2e/tests/send.test.ts
@@ -14,8 +14,8 @@ import { onTabBar } from '../pageObjects/tabBarActions';
 import {
     appIsFullyLoaded,
     disconnectTrezorUserEnv,
-    mergePreloadedReduxState,
     openApp,
+    preparePreloadedReduxState,
     prepareTrezorEmulator,
     restartApp,
 } from '../utils';
@@ -64,7 +64,7 @@ const signTransactionAndSendIt = async () => {
     await onSendOutputsReview.clickSendTransaction();
 };
 
-const preloadedState = mergePreloadedReduxState(
+const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
     regtestDiscoveryFinishedStateT3T1,
 );

--- a/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
@@ -3,9 +3,9 @@ import { portfolioTrackerBtcAccountState } from '../fixtures/portfolioTrackerBtc
 import { onTabBar } from '../pageObjects/tabBarActions';
 import { tradingBuyActions } from '../pageObjects/tradingBuyActions';
 import { tradingHistoryActions } from '../pageObjects/tradingHistoryActions';
-import { appIsFullyLoaded, mergePreloadedReduxState, openApp, restartApp } from '../utils';
+import { appIsFullyLoaded, openApp, preparePreloadedReduxState, restartApp } from '../utils';
 
-const preloadedState = mergePreloadedReduxState(
+const preloadedState = preparePreloadedReduxState(
     portfolioTrackerBtcAccountState,
     onboardingCompletedState,
 );

--- a/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
@@ -25,7 +25,7 @@ describe('Trade Buy', () => {
     });
 
     beforeEach(async () => {
-        await restartApp();
+        await restartApp({ args: { preloadedState } });
         await appIsFullyLoaded();
         await onTabBar.navigateToTrade();
         await tradingBuyActions.waitForTradeDataToLoad();

--- a/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
@@ -1,9 +1,10 @@
 import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
 import { portfolioTrackerBtcAccountState } from '../fixtures/portfolioTrackerBtcAccountState';
+import { onHome } from '../pageObjects/homeActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
 import { tradingBuyActions } from '../pageObjects/tradingBuyActions';
 import { tradingHistoryActions } from '../pageObjects/tradingHistoryActions';
-import { appIsFullyLoaded, openApp, preparePreloadedReduxState, restartApp } from '../utils';
+import { openApp, preparePreloadedReduxState } from '../utils';
 
 const preloadedState = preparePreloadedReduxState(
     portfolioTrackerBtcAccountState,
@@ -18,17 +19,13 @@ describe('Trade Buy', () => {
                 preloadedState,
             },
         });
+        await onHome.assertIsPortfolioGraphVisible();
+        await onTabBar.navigateToTrade();
+        await tradingBuyActions.waitForTradeDataToLoad();
     });
 
     afterAll(async () => {
         await device.terminateApp();
-    });
-
-    beforeEach(async () => {
-        await restartApp({ args: { preloadedState } });
-        await appIsFullyLoaded();
-        await onTabBar.navigateToTrade();
-        await tradingBuyActions.waitForTradeDataToLoad();
     });
 
     it('Basic buy for 100 PLN flow', async () => {

--- a/suite-native/app/e2e/utils.ts
+++ b/suite-native/app/e2e/utils.ts
@@ -8,6 +8,10 @@ import { mergeDeepObject } from '@trezor/utils';
 
 const platform = device.getPlatform();
 
+// There is inconsistency between platforms. Android needs to have 100% of an element visible to be able to interact with it.
+// On the other hand, if we are trying to scroll to 100% visibility on iOS, it causes scrolling more than height of the screen and it makes Detox crash.
+const SCROLL_VISIBILITY_THRESHOLD = platform === 'android' ? 100 : undefined;
+
 const INITIAL_LAUNCH_ARGS: LaunchArguments = {
     // Do not synchronize communication with the trezor bridge and metro server running on localhost. Since the trezor
     // bridge is exchanging messages with the app all the time, the test runner would wait forever otherwise.
@@ -25,6 +29,12 @@ const TREZOR_E2E_DEVICE_LABEL = 'Trezor T - Tester';
 
 export const wait = async (ms: number) => {
     await new Promise(resolve => setTimeout(resolve, ms));
+};
+
+export const appIsFullyLoaded = async () => {
+    await waitFor(element(by.id('@screen/mainScrollView')))
+        .toBeVisible()
+        .withTimeout(35000);
 };
 
 const getExpoDeepLinkUrl = () => {
@@ -92,6 +102,11 @@ export const openApp = async ({
             launchArgs,
         });
     }
+
+    if (launchArgs.preloadedState) {
+        // wait for preloaded state to be applied
+        await appIsFullyLoaded();
+    }
 };
 
 type RestartAppProps = {
@@ -117,26 +132,20 @@ export const scrollUntilVisible = async (
 ) => {
     try {
         // Try to confirm that the element is visible without scrolling.
-        await detoxExpect(target).toBeVisible();
+        await detoxExpect(target).toBeVisible(SCROLL_VISIBILITY_THRESHOLD);
     } catch {
         // If the element is not visible, then use the scroll to find it.
-        await waitFor(target)
-            .toBeVisible(100)
-            .whileElement(by.id(scrollViewTestId))
-            .scroll(300, 'down');
+        const scrollViewElement = element(by.id(scrollViewTestId));
+        await waitFor(scrollViewElement).toBeVisible().withTimeout(5000);
 
-        // add extra scroll in case that the element is still not fully visible.
-        await element(by.id(scrollViewTestId)).scroll(150, 'down');
+        await waitFor(target)
+            .toBeVisible(SCROLL_VISIBILITY_THRESHOLD)
+            .whileElement(by.id(scrollViewTestId))
+            .scroll(300, 'down', 0.5, 0.5);
 
         // wait for scroll animation to finish before performing next action
         await wait(1000);
     }
-};
-
-export const appIsFullyLoaded = async () => {
-    await waitFor(element(by.id('@screen/mainScrollView')))
-        .toBeVisible()
-        .withTimeout(35000);
 };
 
 function getModelFromEnv(): Model {
@@ -199,14 +208,24 @@ export const waitForElementByIdToBeVisible = (testId: string, timeout = 30000) =
         .withTimeout(timeout);
 
 /**
- * Merges multiple preloaded state fragments into a single preloaded state. Be mindful about the
- * order of the fragments, as the later fragments will always override the earlier ones!
+ * Merges multiple preloaded state fragments into a single preloaded state and serializes the result.
+ * Be mindful about the order of the fragments, as the later fragments will always override the earlier ones!
  */
-export const mergeAndSerializePreloadedReduxState = (
-    ...stateFragments: PreloadedState[]
-): string => {
+export const preparePreloadedReduxState = (...stateFragments: PreloadedState[]): string => {
     const definedFragments = stateFragments.filter(fragment => fragment !== undefined);
     const mergedState = mergeDeepObject(...definedFragments);
 
     return JSON.stringify(mergedState);
+};
+
+export const inputTextToElement = async (element: Detox.IndexableNativeElement, text: string) => {
+    // on Android it is very slow to type text symbol by symbol, for performance reasons `replaceText` is used instead.
+    if (platform === 'android') {
+        await element.replaceText(text);
+    } else {
+        // on iOS the replaceText do not trigger input events (focus, blur, etc.) so we need can not paste text there as for Android.
+        // the typeText method is way faster than for Android, so there is not performance drawback.
+        await element.tap();
+        await element.typeText(text);
+    }
 };

--- a/suite-native/app/e2e/utils.ts
+++ b/suite-native/app/e2e/utils.ts
@@ -8,11 +8,7 @@ import { mergeDeepObject } from '@trezor/utils';
 
 const platform = device.getPlatform();
 
-type LaunchArgumentsWithPreloadedState = Omit<LaunchArguments, 'preloadedState'> & {
-    preloadedState?: PreloadedState;
-};
-
-const INITIAL_LAUNCH_ARGS: LaunchArgumentsWithPreloadedState = {
+const INITIAL_LAUNCH_ARGS: LaunchArguments = {
     // Do not synchronize communication with the trezor bridge and metro server running on localhost. Since the trezor
     // bridge is exchanging messages with the app all the time, the test runner would wait forever otherwise.
     detoxURLBlacklistRegex: '\\("^.*127.0.0.1.*",".*localhost.*","^*clients3\\.google\\.com*"\\)',
@@ -44,7 +40,7 @@ const openExpoDevClientApp = async ({
     launchArgs,
 }: {
     newInstance: boolean;
-    launchArgs: LaunchArgumentsWithPreloadedState;
+    launchArgs: LaunchArguments;
 }) => {
     const deepLinkUrl = getExpoDeepLinkUrl();
 
@@ -81,7 +77,7 @@ export const openApp = async ({
     args = {},
 }: {
     newInstance: boolean;
-    args?: LaunchArgumentsWithPreloadedState;
+    args?: LaunchArguments;
 }) => {
     const launchArgs = {
         ...INITIAL_LAUNCH_ARGS,
@@ -99,7 +95,7 @@ export const openApp = async ({
 };
 
 type RestartAppProps = {
-    args?: LaunchArgumentsWithPreloadedState;
+    args?: LaunchArguments;
 };
 
 export const restartApp = async ({ args = {} }: RestartAppProps = {}) => {
@@ -121,7 +117,7 @@ export const scrollUntilVisible = async (
 ) => {
     try {
         // Try to confirm that the element is visible without scrolling.
-        await detoxExpect(target).toBeVisible(100);
+        await detoxExpect(target).toBeVisible();
     } catch {
         // If the element is not visible, then use the scroll to find it.
         await waitFor(target)
@@ -206,8 +202,11 @@ export const waitForElementByIdToBeVisible = (testId: string, timeout = 30000) =
  * Merges multiple preloaded state fragments into a single preloaded state. Be mindful about the
  * order of the fragments, as the later fragments will always override the earlier ones!
  */
-export const mergePreloadedReduxState = (...stateFragments: PreloadedState[]): PreloadedState => {
+export const mergeAndSerializePreloadedReduxState = (
+    ...stateFragments: PreloadedState[]
+): string => {
     const definedFragments = stateFragments.filter(fragment => fragment !== undefined);
+    const mergedState = mergeDeepObject(...definedFragments);
 
-    return mergeDeepObject(...definedFragments);
+    return JSON.stringify(mergedState);
 };

--- a/suite-native/atoms/src/Input/BottomSheetSearchInput.tsx
+++ b/suite-native/atoms/src/Input/BottomSheetSearchInput.tsx
@@ -16,6 +16,7 @@ import { useSearchInputCallbacks } from './useSearchInputCallbacks';
 export type BottomSheetSearchInputProps = {
     onChange: (value: string) => void;
     placeholder?: string;
+    testId?: string;
     isDisabled?: boolean;
     maxLength?: number;
     elevation?: SurfaceElevation;
@@ -44,6 +45,7 @@ export const BottomSheetSearchInput = forwardRef<
             onBlur = noOp,
             value,
             autoCorrect,
+            testId,
         },
         ref,
     ) => {
@@ -85,6 +87,7 @@ export const BottomSheetSearchInput = forwardRef<
                         maxLength={maxLength}
                         value={value}
                         autoCorrect={autoCorrect}
+                        testID={testId}
                     />
                     <SearchInputClearButton
                         onPress={handleClear}

--- a/suite-native/config/src/launch-arguments.ts
+++ b/suite-native/config/src/launch-arguments.ts
@@ -11,7 +11,7 @@ export type LaunchArguments = {
     isTradingSellEnabled?: boolean;
     isDeviceConnectEnabled?: boolean;
     areDebugOnlyNetworksEnabled?: boolean;
-    preloadedState?: Record<string, unknown>;
+    preloadedState?: string; // stringified object
     isFirmwareUpdateEnabled?: boolean;
     isLocalizationEnabled?: boolean;
     isLocalFirstStorageEnabled?: boolean;

--- a/suite-native/module-trading/src/components/general/BottomSheetSearchInputWithCancel.tsx
+++ b/suite-native/module-trading/src/components/general/BottomSheetSearchInputWithCancel.tsx
@@ -2,13 +2,12 @@ import { useRef } from 'react';
 
 import {
     BottomSheetSearchInput,
+    BottomSheetSearchInputProps,
     BottomSheetSearchInputRef,
     SearchInputWithCancel,
 } from '@suite-native/atoms';
 
 const noOp = () => {};
-
-export type BottomSheetSearchInputProps = React.ComponentProps<typeof BottomSheetSearchInput>;
 
 export const BottomSheetSearchInputWithCancel = ({
     onFocus = noOp,

--- a/suite-native/module-trading/src/components/general/CountrySheet/CountrySheet.tsx
+++ b/suite-native/module-trading/src/components/general/CountrySheet/CountrySheet.tsx
@@ -31,6 +31,7 @@ export const CountrySheet = memo(
                     onClose={onClose}
                     title={<Translation id="moduleTrading.countrySheet.title" />}
                     onFilterChange={setFilterValue}
+                    searchInputTestId="@trading/buy/country-search-input"
                     searchInputPlaceholder={translate(
                         'moduleTrading.countrySheet.searchInputPlaceholder',
                     )}

--- a/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencySheet.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencySheet.tsx
@@ -37,6 +37,7 @@ export const FiatCurrencySheet = memo(
                     searchInputPlaceholder={translate(
                         'moduleTrading.fiatCurrencySheet.searchInputPlaceholder',
                     )}
+                    searchInputTestId="@trading/buy/fiat-search-input"
                 />
             ),
             [onClose, setFilterValue, translate],

--- a/suite-native/module-trading/src/components/general/SearchableSheetHeader.tsx
+++ b/suite-native/module-trading/src/components/general/SearchableSheetHeader.tsx
@@ -20,6 +20,7 @@ export type SearchableSheetHeaderProps = {
     onFilterChange?: (value: string) => void;
     filterValue?: string;
     searchInputPlaceholder?: string;
+    searchInputTestId?: string;
 };
 
 export const SEARCHABLE_SHEET_HEADER_DEFAULT_HEIGHT = 160 as const;
@@ -42,6 +43,7 @@ export const SearchableSheetHeader = ({
     rightButtonA11yLabel,
     onFilterChange = noOp,
     filterValue,
+    searchInputTestId,
     searchInputPlaceholder,
 }: SearchableSheetHeaderProps) => {
     const { applyStyle } = useNativeStyles();
@@ -85,6 +87,7 @@ export const SearchableSheetHeader = ({
                     onBlur={() => changeFilterFocus(false)}
                     value={filterValue}
                     placeholder={searchInputPlaceholder}
+                    testId={searchInputTestId}
                 />
             </Animated.View>
             {children}

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheetHeader.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheetHeader.tsx
@@ -39,6 +39,7 @@ export const TradeableAssetSheetHeader = ({
             onFilterFocusChange={setIsFilterActive}
             onFilterChange={onFilterChange}
             style={applyStyle(wrapperStyle)}
+            searchInputTestId="@trading/buy/assets-search-input"
             searchInputPlaceholder={translate(
                 'moduleTrading.tradeableAssetsSheet.searchInputPlaceholder',
             )}

--- a/suite-native/module-trading/src/components/general/__tests__/BottomSheetSearchInputWithCancel.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/BottomSheetSearchInputWithCancel.comp.test.tsx
@@ -1,9 +1,7 @@
+import { BottomSheetSearchInputProps } from '@suite-native/atoms';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
-import {
-    BottomSheetSearchInputProps,
-    BottomSheetSearchInputWithCancel,
-} from '../BottomSheetSearchInputWithCancel';
+import { BottomSheetSearchInputWithCancel } from '../BottomSheetSearchInputWithCancel';
 
 jest.mock('@trezor/react-utils', () => {
     const originalModule = jest.requireActual('@trezor/react-utils');

--- a/suite-native/navigation/src/components/GoBackIcon.tsx
+++ b/suite-native/navigation/src/components/GoBackIcon.tsx
@@ -9,9 +9,10 @@ import { CloseActionType } from '../navigators';
 type GoBackIconProps = {
     closeActionType?: CloseActionType;
     closeAction?: () => void;
+    testID?: string;
 };
 
-export const GoBackIcon = ({ closeActionType = 'back', closeAction }: GoBackIconProps) => {
+export const GoBackIcon = ({ closeActionType = 'back', closeAction, testID }: GoBackIconProps) => {
     const navigation = useNavigation();
 
     const handleGoBack = useCallback(() => {
@@ -24,6 +25,7 @@ export const GoBackIcon = ({ closeActionType = 'back', closeAction }: GoBackIcon
 
     return (
         <IconButton
+            testID={testID}
             iconName={closeActionType === 'back' ? 'caretLeft' : 'x'}
             size="medium"
             colorScheme="tertiaryElevation0"

--- a/suite-native/navigation/src/components/ScreenHeader.tsx
+++ b/suite-native/navigation/src/components/ScreenHeader.tsx
@@ -56,7 +56,11 @@ export const ScreenHeader = ({
                 {leftIcon !== undefined ? (
                     leftIcon
                 ) : (
-                    <GoBackIcon closeActionType={closeActionType} closeAction={closeAction} />
+                    <GoBackIcon
+                        closeActionType={closeActionType}
+                        closeAction={closeAction}
+                        testID="@screen/sub-header/go-back-button"
+                    />
                 )}
             </Box>
             <ScreenHeaderContent title={title} customContent={customContent} />

--- a/suite-native/state/src/StoreProvider.e2e.tsx
+++ b/suite-native/state/src/StoreProvider.e2e.tsx
@@ -1,11 +1,18 @@
 import { launchArguments } from '@suite-native/config';
 
 import { BaseStoreProvider, BaseStoreProviderProps } from './BaseStoreProvider';
+import { PreloadedState } from './store';
 
 type StoreProviderProps = BaseStoreProviderProps;
 
 export const StoreProvider = ({ children }: StoreProviderProps) => {
     const { preloadedState } = launchArguments;
 
-    return <BaseStoreProvider preloadedState={preloadedState}>{children}</BaseStoreProvider>;
+    return (
+        // preloadedState has to be cast to PreloadedState type because it is passed from Detox as `string` (serialized object)
+        // but the `react-native-launch-arguments` library does converts it to JavaScript object in the background.
+        <BaseStoreProvider preloadedState={preloadedState as PreloadedState}>
+            {children}
+        </BaseStoreProvider>
+    );
 };


### PR DESCRIPTION
<img width="700" height="700" alt="Gemini_Generated_Image_pj6r83pj6r83pj6r" src="https://github.com/user-attachments/assets/edd7ae14-e826-436e-8977-f62b0c16fac3" />

## Description
- redux preloadedState needs to be serialized for iOS before passing as a launch argument
- trading e2e test refactored to use testID instead of text matching where possible
- some problems with text inputs resolved (on iOS, the `replaceText`method behaves differently than on Android, etc.)
- the pipeline is run nightly and reported to the Slack channel on failure
- Xcode version used in CI bumped to 26.0.1
- link to passing CI: https://github.com/trezor/trezor-suite/actions/runs/18345181905
- **THIS PR IS NOT ENABLING iOS TESTS INTERACTING WITH TREZOR-USER-ENV (YET).**

## Related Issue

Resolve #20624 

## Screenshots:
<img width="785" height="573" alt="Screenshot 2025-10-09 at 7 23 50 AM" src="https://github.com/user-attachments/assets/f448e289-7ee2-4b79-a270-f486d995e447" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/native/ios-e2e-tests-revival&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/native/ios-e2e-tests-revival&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native/ios-e2e-tests-revival&lookback=7)