### PR TITLE
Don't stop BT scanning on web

### DIFF
--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -139,11 +139,13 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
 
     // starts to scan for devices when connection mode is bluetooth
     useEffect(() => {
-        if (isBluetoothMode) dispatch(bluetoothStartScanningThunk());
+        if (isBluetoothMode) {
+            dispatch(bluetoothStartScanningThunk());
 
-        return () => {
-            dispatch(bluetoothStopScanningThunk());
-        };
+            return () => {
+                dispatch(bluetoothStopScanningThunk());
+            };
+        }
     }, [dispatch, isBluetoothMode]);
 
     const clearScanTimer = useCallback(() => {


### PR DESCRIPTION
## Description

In web's connection modal, BT scanning is correctly not started, but it's trying to be stopped anyway, which results in console/sentry errors. This should fix it.


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-stop-scan-web&lookback=7)