### PR TITLE
chore(suite-native): Fix autoconnect alert on confirmation screen

### DIFF
--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
+import { selectIsThpInProgress } from '@suite-common/thp';
 import {
     acquireDevice,
     deviceActions,
@@ -70,6 +71,7 @@ export const useDetectDeviceError = () => {
     const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
     const shouldShowAutoEjectAlert = useSelector(selectShouldShowAutoEjectAlert);
     const shouldShowSystemUnpairingAlert = useSelector(selectShouldShowSystemUnpairingAlert);
+    const isThpInProgress = useSelector(selectIsThpInProgress);
 
     const isDeviceFirmwareSupported = useSelector(selectIsDeviceFirmwareSupported);
     const deviceError = useSelector(selectDeviceError);
@@ -113,7 +115,7 @@ export const useDetectDeviceError = () => {
                 },
                 testID: '@device/errors/alert/unacquired-device',
             });
-        } else {
+        } else if (!isThpInProgress) {
             hideAlert();
         }
     }, [
@@ -124,6 +126,7 @@ export const useDetectDeviceError = () => {
         dispatch,
         hideAlert,
         showAlert,
+        isThpInProgress,
     ]);
 
     useEffect(() => {

--- a/suite-native/module-accounts-management/src/components/AccountSettingsRemoveCoinButton.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountSettingsRemoveCoinButton.tsx
@@ -48,7 +48,7 @@ export const AccountSettingsRemoveCoinButton = ({
             onPressPrimaryButton: handleRemoveAccount,
             secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
             secondaryButtonVariant: 'redElevation0',
-            onPressSecondaryButton: () => hideAlert(),
+            onPressSecondaryButton: hideAlert,
         });
     };
 

--- a/suite-native/module-authorize-device/src/screens/thp/ThpConfirmationScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/thp/ThpConfirmationScreen.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { selectThpStep } from '@suite-common/thp';
-import { selectIsDeviceThpRequired } from '@suite-common/wallet-core';
 import { ContinueOnTrezorScreenContent } from '@suite-native/device';
 import {
     AuthorizeDeviceStackParamList,
@@ -24,24 +23,17 @@ export const ThpConfirmationScreen = ({
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const { showThpAutoconnectEnableAlert } = useThpAutoconnectAlerts();
 
-    const isDeviceThpRequired = useSelector(selectIsDeviceThpRequired);
     const thpStep = useSelector(selectThpStep);
 
     useEffect(() => {
-        if (isDeviceThpRequired && thpStep === null) {
-            navigateToInitialScreen();
-        } else if (thpStep === 'CodeEntry') {
+        if (thpStep === 'CodeEntry') {
             navigation.navigate(AuthorizeDeviceStackRoutes.ThpCodeEntry);
         } else if (thpStep === 'AutoconnectInfo') {
             showThpAutoconnectEnableAlert();
+        } else if (thpStep === null) {
+            navigateToInitialScreen();
         }
-    }, [
-        isDeviceThpRequired,
-        thpStep,
-        navigateToInitialScreen,
-        navigation,
-        showThpAutoconnectEnableAlert,
-    ]);
+    }, [thpStep, navigateToInitialScreen, navigation, showThpAutoconnectEnableAlert]);
 
     return (
         <Screen

--- a/suite-native/module-home/src/screens/HomeScreen/useShowAutoEjectAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/useShowAutoEjectAlert.tsx
@@ -1,5 +1,7 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+
+import { useFocusEffect } from '@react-navigation/native';
 
 import { toggleAutoEjectThunk } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
@@ -37,60 +39,62 @@ export const useShowAutoEjectAlert = () => {
         [],
     );
 
-    useEffect(() => {
-        if (shouldShowSystemUnpairingAlert) {
-            // The alert regarding system unpairing has a higher priority.
-            return;
-        }
-        if (!hasAutoEjectAlertBeenDisplayed && shouldShowAutoEjectAlert) {
-            showAlert({
-                appendix: (
-                    <VStack alignItems="center" spacing="sp24" testID="@home/alert/view-only">
-                        <AutoEjectAnimation />
-                        <CenteredTitleHeader
-                            title={
-                                <Translation id="moduleSettings.viewOnly.autoEject.alert.title" />
-                            }
-                            subtitle={
-                                <Translation id="moduleSettings.viewOnly.autoEject.alert.subtitle" />
-                            }
-                        />
-                    </VStack>
-                ),
-                primaryButtonTitle: (
-                    <Translation id="moduleSettings.viewOnly.autoEject.alert.primaryButtonTitle" />
-                ),
-                onPressPrimaryButton: () => {
-                    reportAutoEjectToAnalytics('skip');
-                    dispatch(setHasAutoEjectAlertBeenDisplayed(true));
-                },
-                secondaryButtonTitle: (
-                    <Translation id="moduleSettings.viewOnly.autoEject.alert.secondaryButtonTitle" />
-                ),
-                onPressSecondaryButton: () => {
-                    dispatch(setHasAutoEjectAlertBeenDisplayed(true));
-                    dispatch(toggleAutoEjectThunk());
-                    reportAutoEjectToAnalytics('enable');
-                    showToast({
-                        message: (
-                            <Translation id="moduleSettings.viewOnly.autoEject.alert.successToast" />
-                        ),
-                        variant: 'default',
-                    });
-                },
-            });
-        }
-        if (!shouldShowAutoEjectAlert) {
-            hideAlert();
-        }
-    }, [
-        dispatch,
-        hasAutoEjectAlertBeenDisplayed,
-        hideAlert,
-        reportAutoEjectToAnalytics,
-        shouldShowAutoEjectAlert,
-        shouldShowSystemUnpairingAlert,
-        showAlert,
-        showToast,
-    ]);
+    useFocusEffect(
+        useCallback(() => {
+            if (shouldShowSystemUnpairingAlert) {
+                // The alert regarding system unpairing has a higher priority.
+                return;
+            }
+            if (!hasAutoEjectAlertBeenDisplayed && shouldShowAutoEjectAlert) {
+                showAlert({
+                    appendix: (
+                        <VStack alignItems="center" spacing="sp24" testID="@home/alert/view-only">
+                            <AutoEjectAnimation />
+                            <CenteredTitleHeader
+                                title={
+                                    <Translation id="moduleSettings.viewOnly.autoEject.alert.title" />
+                                }
+                                subtitle={
+                                    <Translation id="moduleSettings.viewOnly.autoEject.alert.subtitle" />
+                                }
+                            />
+                        </VStack>
+                    ),
+                    primaryButtonTitle: (
+                        <Translation id="moduleSettings.viewOnly.autoEject.alert.primaryButtonTitle" />
+                    ),
+                    onPressPrimaryButton: () => {
+                        reportAutoEjectToAnalytics('skip');
+                        dispatch(setHasAutoEjectAlertBeenDisplayed(true));
+                    },
+                    secondaryButtonTitle: (
+                        <Translation id="moduleSettings.viewOnly.autoEject.alert.secondaryButtonTitle" />
+                    ),
+                    onPressSecondaryButton: () => {
+                        dispatch(setHasAutoEjectAlertBeenDisplayed(true));
+                        dispatch(toggleAutoEjectThunk());
+                        reportAutoEjectToAnalytics('enable');
+                        showToast({
+                            message: (
+                                <Translation id="moduleSettings.viewOnly.autoEject.alert.successToast" />
+                            ),
+                            variant: 'default',
+                        });
+                    },
+                });
+            }
+            if (!shouldShowAutoEjectAlert) {
+                hideAlert();
+            }
+        }, [
+            dispatch,
+            hasAutoEjectAlertBeenDisplayed,
+            hideAlert,
+            reportAutoEjectToAnalytics,
+            shouldShowAutoEjectAlert,
+            shouldShowSystemUnpairingAlert,
+            showAlert,
+            showToast,
+        ]),
+    );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Autoconnect alert on 3rd connection was broken. This PR fixes it and it should now behave correctly.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/autoconnect&lookback=7)