### PR TITLE
chore(transport-native-bluetooth): easy way to debug bluetooth native transport

### DIFF
--- a/packages/transport-native-bluetooth/src/transport.ts
+++ b/packages/transport-native-bluetooth/src/transport.ts
@@ -9,7 +9,12 @@ export class NativeBluetoothTransport extends AbstractApiTransport {
     constructor(params: ConstructorParameters<typeof AbstractTransport>[0]) {
         const { logger, ...rest } = params;
 
-        const api = new BluetoothApi({ logger });
+        const api = new BluetoothApi({
+            logger:
+                process.env.EXPO_PUBLIC_IS_NATIVE_BLUETOOTH_LOGGER_ENABLED === 'true'
+                    ? console
+                    : logger,
+        });
         api.on('trezor-push-notification', event => {
             this.emit('trezor-push-notification', event);
         });

--- a/suite-native/app/.env.development
+++ b/suite-native/app/.env.development
@@ -5,6 +5,7 @@ EXPO_PUBLIC_ENVIRONMENT=debug
 # EXPO_PUBLIC_IS_ANALYTICS_LOGGER_ENABLED=true
 # EXPO_PUBLIC_IS_SENTRY_ON_DEBUG_BUILD_ENABLED=true # always enabled outside debug build
 # EXPO_PUBLIC_IS_NATIVE_USB_LOGGER_ENABLED=true
+# EXPO_PUBLIC_IS_NATIVE_BLUETOOTH_LOGGER_ENABLED=true
 
 
 ### Initial states for Feature Flags, see suite-native/feature-flags/src/featureFlagsSlice.ts

--- a/suite-native/app/README.md
+++ b/suite-native/app/README.md
@@ -84,6 +84,7 @@ You can override ENV variables locally using `.env.development.local` (or `.env.
 - `EXPO_PUBLIC_IS_ANALYTICS_LOGGER_ENABLED=true` in `.env.development.local` to debug analytics locally,
 - `EXPO_PUBLIC_IS_SENTRY_ON_DEBUG_BUILD_ENABLED=true` to debug Sentry locally and
 - `EXPO_PUBLIC_IS_NATIVE_USB_LOGGER_ENABLED=true` to debug @trezor/transport-native-usb locally.
+- `EXPO_PUBLIC_IS_NATIVE_BLUETOOTH_LOGGER_ENABLED=true` to debug @trezor/transport-native-bluetooth locally.
 - `EXPO_PUBLIC_FF_*` overrides initial state for Feature Flags. See [.env.development](./.env.development) for examples to copy to `.env.development.local` file and [featureFlagsSlice.ts](../feature-flags/src/featureFlagsSlice.ts) for all available values.
 
 ## Native changes - bumping runtimeVersion


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Similar to native usb transport.

## Screenshots:
<img width="862" height="603" alt="image" src="https://github.com/user-attachments/assets/864e32b6-5f57-435d-9c80-e304ca0d9f27" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/easy-way-to-log-bluetooth-transport&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/easy-way-to-log-bluetooth-transport&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/easy-way-to-log-bluetooth-transport&lookback=7)