### PR TITLE
feat(connect): handle channel replacement in THP pairing

### DIFF
--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -138,10 +138,11 @@ export const thpHandshake = async (device: Device, unlockPin = false) => {
         }
     }
 
-    thpState.setIsPaired(!!handshakeCompletion.message.state);
+    thpState.setIsPaired(handshakeCompletion.message.state !== 0);
     thpState.setPhase('pairing');
 
-    if (thpState.isPaired && thpState.isAutoconnectPaired) {
+    if (thpState.isAutoconnectPaired || handshakeCompletion.message.state === 2) {
+        // State HC1 -> HC2 pairing complete
         // finish pairing. device is ready to communicate without further interaction
         await thpCall(device, 'ThpEndRequest', {});
         thpState.setPhase('paired');

--- a/packages/protocol/src/protocol-thp/messages/messageTypes.ts
+++ b/packages/protocol/src/protocol-thp/messages/messageTypes.ts
@@ -47,6 +47,9 @@ export type ThpHandshakeCompletionRequest = {
     encryptedPayload: Buffer;
 };
 
+// 0 - not paired
+// 1 - paired but will require connection confirmation (thp_connection_request)
+// 2 - paired with autoconnect. no further interaction needed
 export type ThpHandshakeCompletionResponse = {
     state: 0 | 1 | 2;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
following https://github.com/trezor/trezor-firmware/pull/5901

THP flow does not expect further interaction if `handshakeCompletion` state === 2

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/thp-channel-replacement&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/thp-channel-replacement&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/thp-channel-replacement&lookback=7)