### PR TITLE
fix(suite-native): add ContinueOnTrezor screen autoconnect

### DIFF
--- a/suite-common/thp/src/startThpAutoconnectThunk.ts
+++ b/suite-common/thp/src/startThpAutoconnectThunk.ts
@@ -12,16 +12,21 @@ type StartThpAutoconnectThunkParam = {
 
 export const startThpAutoconnectThunk = createThunk<void, StartThpAutoconnectThunkParam, void>(
     `${THP_PREFIX}/startThpAutoconnectThunk`,
-    async ({ device }, { dispatch }) => {
+    async ({ device }, { dispatch, rejectWithValue }) => {
         const response = await TrezorConnect.thpGetCredentials({ device });
 
         if (response.success) {
             dispatch(thpActions.addCredential({ credential: response.payload }));
+            dispatch(finishThpAutoconnectThunk());
+
+            return;
         } else {
             dispatch(
                 notificationsActions.addToast({ type: 'error', error: response.payload.error }),
             );
+            dispatch(finishThpAutoconnectThunk());
+
+            return rejectWithValue(response.payload.error);
         }
-        dispatch(finishThpAutoconnectThunk());
     },
 );

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -832,14 +832,15 @@ export const messages = {
         autoconnect: {
             enable: {
                 title: 'Turn on Auto-connect',
-                subtitle: 'Confirm every connection on Trezor',
+                subtitle: 'Allow Trezor to connect automatically',
                 description:
                     'Trezor will connect automatically to Trezor Suite. No need to confirm each time.',
                 turnOnButton: 'Turn on Auto-connect',
+                error: 'Turning on auto-connect failed.',
             },
             disable: {
                 title: 'Turn off Auto-connect',
-                subtitle: 'Allow Trezor to connect automatically',
+                subtitle: 'Confirm every connection on Trezor',
                 description:
                     'Trezor will no longer connect automatically to Trezor Suite. You’ll confirm each connection on your device.',
                 turnOnButton: 'Turn off Auto-connect',

--- a/suite-native/thp/package.json
+++ b/suite-native/thp/package.json
@@ -10,12 +10,14 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@react-navigation/native": "7.1.17",
         "@reduxjs/toolkit": "2.8.2",
         "@suite-common/thp": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/alerts": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/intl": "workspace:*",
+        "@suite-native/navigation": "workspace:*",
         "@suite-native/toasts": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/styles": "workspace:*",

--- a/suite-native/thp/src/hooks/useThpAutoconnectAlerts.tsx
+++ b/suite-native/thp/src/hooks/useThpAutoconnectAlerts.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { useNavigation } from '@react-navigation/native';
 import { isRejected } from '@reduxjs/toolkit';
 
 import { removeThpAutoconnectThunk, startThpAutoconnectThunk, thpActions } from '@suite-common/thp';
@@ -10,21 +11,45 @@ import {
 } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { Translation } from '@suite-native/intl';
+import {
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes,
+    StackNavigationProps,
+} from '@suite-native/navigation';
 import { useToast } from '@suite-native/toasts';
+import TrezorConnect from '@trezor/connect';
+
+type NavigationProp = StackNavigationProps<
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes.DeviceSettings
+>;
 
 export const useThpAutoconnectAlerts = () => {
     const dispatch = useDispatch();
     const { showAlert } = useAlert();
     const { showToast } = useToast();
 
+    const navigation = useNavigation<NavigationProp>();
+
     const autoconnectCredentials = useSelector(selectDeviceAutoconnectCredentials);
     const device = useSelector(selectSelectedDevice);
 
-    const turnOnAutoconnect = useCallback(() => {
-        if (device !== undefined) {
-            dispatch(startThpAutoconnectThunk({ device }));
+    const turnOnAutoconnect = useCallback(async () => {
+        if (!device) return;
+
+        navigation.navigate(DeviceSettingsStackRoutes.ContinueOnTrezor);
+
+        const response = await dispatch(startThpAutoconnectThunk({ device }));
+
+        if (isRejected(response)) {
+            TrezorConnect.cancel();
+            showToast({
+                variant: 'error',
+                message: <Translation id="moduleDeviceSettings.autoconnect.enable.error" />,
+            });
         }
-    }, [dispatch, device]);
+        navigation.goBack();
+    }, [dispatch, navigation, showToast, device]);
 
     const turnOffAutoconnect = useCallback(async () => {
         const result = await dispatch(

--- a/suite-native/thp/tsconfig.json
+++ b/suite-native/thp/tsconfig.json
@@ -9,6 +9,7 @@
         { "path": "../alerts" },
         { "path": "../atoms" },
         { "path": "../intl" },
+        { "path": "../navigation" },
         { "path": "../toasts" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/styles" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12632,12 +12632,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/thp@workspace:suite-native/thp"
   dependencies:
+    "@react-navigation/native": "npm:7.1.17"
     "@reduxjs/toolkit": "npm:2.8.2"
     "@suite-common/thp": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-native/alerts": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/intl": "workspace:*"
+    "@suite-native/navigation": "workspace:*"
     "@suite-native/toasts": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/styles": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- improve response from start auto connect thunk
- improve navigation of auto connect so it's more consistent with rest of device settings
- fix incorrect copy of autoconnect card

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21620

## Screenshots:
- tested turn off autoconnect, cancel in app, cancel on trezor, success on trezor

https://github.com/user-attachments/assets/d86d0085-4851-4b2b-94e9-ff700da73ef2



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/autoconnect-settings-ux&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/autoconnect-settings-ux&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/autoconnect-settings-ux&lookback=7)