### PR TITLE
Feat: wipe device bt notification

### DIFF
--- a/packages/suite/src/middlewares/suite/index.ts
+++ b/packages/suite/src/middlewares/suite/index.ts
@@ -11,6 +11,7 @@ import redirect from './redirectMiddleware';
 import router from './routerMiddleware';
 import sentry from './sentryMiddleware';
 import { prepareSuiteMiddleware } from './suiteMiddleware';
+import trezorPushNotification from './trezorPushNotificationMiddleware';
 import { extraDependencies } from '../../support/extraDependencies';
 
 export const suiteMiddlewares = [
@@ -21,6 +22,7 @@ export const suiteMiddlewares = [
     analytics,
     buttonRequest,
     events,
+    trezorPushNotification,
     metadata,
     messageSystem,
     protocol,

--- a/packages/suite/src/middlewares/suite/trezorPushNotificationMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/trezorPushNotificationMiddleware.ts
@@ -1,0 +1,25 @@
+import { MiddlewareAPI } from 'redux';
+
+import { deviceWipedFromDeviceThunk } from '@suite-common/wallet-core/src/device/deviceThunks';
+import { DEVICE, TrezorPushNotificationType } from '@trezor/connect';
+
+import { Action, AppState, Dispatch } from 'src/types/suite';
+
+const trezorPushNotification =
+    (api: MiddlewareAPI<Dispatch, AppState>) =>
+    (next: Dispatch) =>
+    (action: Action): Action => {
+        if (action.type === DEVICE.TREZOR_PUSH_NOTIFICATION) {
+            switch (action.payload.type) {
+                case TrezorPushNotificationType.WIPE:
+                    api.dispatch(deviceWipedFromDeviceThunk());
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return next(action);
+    };
+
+export default trezorPushNotification;

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -468,6 +468,68 @@ export const forgetAllDevicesPersistentDataThunk = createThunk(
     },
 );
 
+/**
+ * Handles the necessary cleanup after a device has been wiped.
+ * This includes forgetting old/new device instances, clearing persistent data,
+ * showing a success toast, and requesting a reconnect.
+ */
+const handlePostWipeCleanupThunk = createThunk(
+    `${DEVICE_MODULE_PREFIX}/handlePostWipeCleanup`,
+    (
+        {
+            initialDevice,
+            deviceInstances,
+        }: {
+            initialDevice: TrezorDevice;
+            deviceInstances: AcquiredDevice[];
+        },
+        { dispatch, getState },
+    ) => {
+        // Wiping a device triggers device.id change, and this change is propagated to device reducer via @trezor/connect DEVICE.CHANGE event.
+        // Accounts data are related to the old device.id; to properly clear reducers and indexed db,
+        // we need to retrieve device objects BEFORE and AFTER the wipe process.
+        // And call SUITE.FORGET_DEVICE on ALL devices (with old and new device.id)
+        const newDevice = selectSelectedDevice(getState());
+        const newDevices = selectDevices(getState());
+
+        deviceInstances.push(...getDeviceInstances(newDevice!, newDevices));
+        deviceInstances.forEach(d => {
+            dispatch(deviceActions.forgetDevice({ device: d }));
+        });
+
+        if (initialDevice.id !== undefined) {
+            // Wiping a device changes bluetoothId and THP static key, so wipe BT known device & THP credentials
+            // (and persistent device data as well, because device.id changed).
+            dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: initialDevice.id }));
+        }
+
+        dispatch(notificationsActions.addToast({ type: 'device-wiped' }));
+
+        // Special case with webusb: Device after wipe changes device_id. With webusb transport, device_id is used as a path
+        // and thus as a descriptor for webusb. So, after the device is wiped, in the transport layer, the device is still paired
+        // through the old descriptor, but suite already works with a new one. It kinda works, but only until we try a new call,
+        // typically resetDevice when in onboarding - we get a device-disconnected error.
+        //
+        // Edit 1: disconnecting the device wiped from bootloader mode is also necessary.
+        // Edit 2: encountered libusb error with bridge 2.0.27. So let's enforce disconnecting for all devices.
+        dispatch(deviceActions.requestDeviceReconnect());
+    },
+);
+
+export const deviceWipedFromDeviceThunk = createThunk(
+    `${DEVICE_MODULE_PREFIX}/deviceWipedFromDeviceThunk`,
+    (_, { dispatch, getState }) => {
+        const device = selectSelectedDevice(getState());
+        if (!device) return;
+        const devices = selectDevices(getState());
+        // collect devices with old "device.id" to be removed (see description below)
+        const deviceInstances = getDeviceInstances(device, devices);
+
+        // Successful wipe happened on the device itself, so we just run the cleanup.
+        dispatch(handlePostWipeCleanupThunk({ initialDevice: device, deviceInstances }));
+    },
+);
+
 export const wipeDeviceThunk = createThunk(
     `${DEVICE_MODULE_PREFIX}/wipeDevice`,
     async (_, { dispatch, getState, rejectWithValue }) => {
@@ -492,34 +554,9 @@ export const wipeDeviceThunk = createThunk(
             // This is an expected success for Bluetooth-connected devices
             (device.bluetoothProps !== undefined && result.payload.code === 'Device_Disconnected')
         ) {
-            // Wiping a device triggers device.id change, and this change is propagated to device reducer via @trezor/connect DEVICE.CHANGE event.
-            // Accounts data are related to the old device.id; to properly clear reducers and indexed db,
-            // we need to retrieve device objects BEFORE and AFTER the wipe process.
-            // And call SUITE.FORGET_DEVICE on ALL devices (with old and new device.id)
-            const newDevice = selectSelectedDevice(getState());
-            const newDevices = selectDevices(getState());
-
-            deviceInstances.push(...getDeviceInstances(newDevice!, newDevices));
-            deviceInstances.forEach(d => {
-                dispatch(deviceActions.forgetDevice({ device: d }));
-            });
-
-            if (device.id !== undefined) {
-                // Wiping a device changes bluetoothId and THP static key, so wipe BT known device & THP credentials
-                // (and persistent device data as well, because device.id changed).
-                dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: device.id }));
-            }
-
-            dispatch(notificationsActions.addToast({ type: 'device-wiped' }));
-
-            // Special case with webusb: Device after wipe changes device_id. With webusb transport, device_id is used as a path
-            // and thus as a descriptor for webusb. So, after the device is wiped, in the transport layer, the device is still paired
-            // through the old descriptor, but suite already works with a new one. It kinda works, but only until we try a new call,
-            // typically resetDevice when in onboarding - we get a device-disconnected error.
-            //
-            // Edit 1: disconnecting the device wiped from bootloader mode is also necessary.
-            // Edit 2: encountered libusb error with bridge 2.0.27. So let's enforce disconnecting for all devices.
-            dispatch(deviceActions.requestDeviceReconnect());
+            // The wipe was successful, now run the shared cleanup logic.
+            // We pass the original `device` object to the cleanup thunk.
+            dispatch(handlePostWipeCleanupThunk({ initialDevice: device, deviceInstances }));
         } else {
             dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description

When wiping device from device menu directly there is a notification that lets Suite know that Device was wiped and so it triggers the same as when it is wiped from Suite.

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/21988

## Screenshots:

<img width="1773" height="816" alt="Screenshot from 2025-09-30 16-54-11" src="https://github.com/user-attachments/assets/0b815f71-aa3a-4265-8618-8c933adda342" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/wipe-device-bt-notification&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/wipe-device-bt-notification&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/wipe-device-bt-notification&lookback=7)