### PR TITLE
chore(suite-native): Mobile Swap: optimize TradingExchangePreviewScreen

### DIFF
--- a/suite-native/module-trading/src/__fixtures__/walletState.ts
+++ b/suite-native/module-trading/src/__fixtures__/walletState.ts
@@ -1,5 +1,5 @@
 import { TradingType } from '@suite-common/trading';
-import { FiatRatesState } from '@suite-common/wallet-core';
+import { FiatRatesState, SendState } from '@suite-common/wallet-core';
 import { Account, RatesByKey, type WalletSettings } from '@suite-common/wallet-types';
 import { PROTO, StaticSessionId } from '@trezor/connect';
 
@@ -53,6 +53,6 @@ export const getWalletState = ({
             precomposedTx: undefined,
             serializedTx: undefined,
             signedTx: undefined,
-        },
+        } as SendState,
     };
 };

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFeePickerCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFeePickerCard.tsx
@@ -1,0 +1,28 @@
+import { useSelector } from 'react-redux';
+
+import { ExchangeTrade } from 'invity-api';
+
+import { selectExchangeSelectedSendAccount } from '../../../selectors/exchangeSelectors';
+import { FeePickerCard } from '../../fees/FeePickerCard';
+
+export type ExchangeFeePickerCardProps = {
+    quote?: ExchangeTrade;
+    isTxnError: boolean;
+};
+
+export const ExchangeFeePickerCard = ({ quote, isTxnError }: ExchangeFeePickerCardProps) => {
+    const fromAccount = useSelector(selectExchangeSelectedSendAccount);
+
+    if (!fromAccount || !quote?.send || isTxnError) {
+        return null;
+    }
+
+    return (
+        <FeePickerCard
+            trade={quote}
+            symbol={fromAccount.symbol}
+            accountKey={fromAccount.key}
+            tradingType="exchange"
+        />
+    );
+};

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.tsx
@@ -1,0 +1,38 @@
+import { useSelector } from 'react-redux';
+
+import { ExchangeTrade } from 'invity-api';
+
+import { Text } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+import { ExchangeTradePreviewCard } from './ExchangeTradePreviewCard';
+import { selectExchangeSelectedSendAccount } from '../../../selectors/exchangeSelectors';
+
+export type ExchangeFromAccountTradePreviewCardProps = {
+    quote?: ExchangeTrade;
+    fromStringValue: string | undefined;
+};
+
+export const ExchangeFromAccountTradePreviewCard = ({
+    quote,
+    fromStringValue,
+}: ExchangeFromAccountTradePreviewCardProps) => {
+    const fromAccount = useSelector(selectExchangeSelectedSendAccount);
+
+    if (!quote?.send || !fromAccount) {
+        return null;
+    }
+
+    return (
+        <ExchangeTradePreviewCard
+            account={fromAccount}
+            cryptoId={quote.send}
+            amount={
+                <Text variant="hint" color="textAlertRed">
+                    -{fromStringValue}
+                </Text>
+            }
+            title={<Translation id="moduleTrading.tradingExchangePreviewScreen.fromAccount" />}
+        />
+    );
+};

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.tsx
@@ -1,0 +1,76 @@
+import { memo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+import { ExchangeTrade } from 'invity-api';
+
+import { parseCryptoId } from '@suite-common/trading';
+import { selectSendPrecomposedTx } from '@suite-common/wallet-core';
+import { TokenAddress } from '@suite-common/wallet-types';
+import { Button } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import {
+    type AppTabsParamList,
+    type StackToTabCompositeNavigationProp,
+    type TradingStackParamList,
+    TradingStackRoutes,
+} from '@suite-native/navigation';
+
+import { selectExchangeSelectedSendAccount } from '../../../selectors/exchangeSelectors';
+
+export type ExchangePreviewContinueButtonProps = {
+    isDisabled: boolean;
+    quote?: ExchangeTrade;
+    onSignTransactionNavigation: () => void;
+};
+
+type NavigationProp = StackToTabCompositeNavigationProp<
+    TradingStackParamList,
+    TradingStackRoutes.TradingExchangePreview,
+    AppTabsParamList
+>;
+
+export const ExchangePreviewContinueButton = memo(
+    ({ isDisabled, quote, onSignTransactionNavigation }: ExchangePreviewContinueButtonProps) => {
+        const navigation = useNavigation<NavigationProp>();
+
+        const precomposedTransaction = useSelector(selectSendPrecomposedTx);
+        const fromAccount = useSelector(selectExchangeSelectedSendAccount);
+
+        if (precomposedTransaction?.type !== 'final') {
+            return null;
+        }
+
+        const handleSignTransaction = () => {
+            if (!quote || !fromAccount) {
+                console.warn('quote or fromAccount is not defined', {
+                    hasQuote: !!quote,
+                    hasFromAccount: !!fromAccount,
+                });
+
+                return;
+            }
+
+            const tokenContract = quote.send
+                ? (parseCryptoId(quote.send)?.contractAddress as TokenAddress)
+                : undefined;
+
+            navigation.navigate({
+                name: TradingStackRoutes.TradingOutputsReview,
+                params: {
+                    tradingType: 'exchange',
+                    accountKey: fromAccount.key,
+                    tokenContract,
+                    orderId: quote.orderId ?? '',
+                },
+            });
+            onSignTransactionNavigation();
+        };
+
+        return (
+            <Button onPress={handleSignTransaction} isDisabled={isDisabled}>
+                <Translation id="generic.buttons.continue" />
+            </Button>
+        );
+    },
+);

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.tsx
@@ -1,0 +1,11 @@
+import { memo } from 'react';
+
+import { Translation } from '@suite-native/intl';
+import { ScreenHeader } from '@suite-native/navigation';
+
+export const ExchangePreviewScreenHeader = memo(() => (
+    <ScreenHeader
+        title={<Translation id="moduleTrading.tradingExchangePreviewScreen.title" />}
+        closeActionType="close"
+    />
+));

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
@@ -1,0 +1,40 @@
+import { memo } from 'react';
+import { ScrollView } from 'react-native-gesture-handler';
+import Animated from 'react-native-reanimated';
+
+import { ExchangeTrade } from 'invity-api';
+
+import { InlineAlertBox, VStack } from '@suite-native/atoms';
+
+import { ExchangeFeePickerCard } from './ExchangeFeePickerCard';
+import { ExchangeFromAccountTradePreviewCard } from './ExchangeFromAccountTradePreviewCard';
+import { ExchangeToAccountTradePreviewCard } from './ExchangeToAccountTradePreviewCard';
+import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
+
+export type ExchangePreviewViewProps = {
+    quote: ExchangeTrade | undefined;
+    txnErrorString: string | null;
+};
+
+export const ExchangePreviewView = memo(({ quote, txnErrorString }: ExchangePreviewViewProps) => {
+    const { fromStringValue, toStringValue } = useChangeStringsExtractor(quote);
+    const isTxnError = !!txnErrorString;
+
+    return (
+        <ScrollView>
+            <VStack spacing="sp20" paddingVertical="sp20">
+                {isTxnError && (
+                    <Animated.View>
+                        <InlineAlertBox variant="critical" title={txnErrorString} />
+                    </Animated.View>
+                )}
+                <ExchangeFromAccountTradePreviewCard
+                    quote={quote}
+                    fromStringValue={fromStringValue}
+                />
+                <ExchangeToAccountTradePreviewCard quote={quote} toStringValue={toStringValue} />
+                <ExchangeFeePickerCard quote={quote} isTxnError={isTxnError} />
+            </VStack>
+        </ScrollView>
+    );
+});

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx
@@ -1,0 +1,38 @@
+import { useSelector } from 'react-redux';
+
+import { ExchangeTrade } from 'invity-api';
+
+import { Text } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+import { ExchangeTradePreviewCard } from './ExchangeTradePreviewCard';
+import { selectExchangeSelectedReceiveAccount } from '../../../selectors/exchangeSelectors';
+
+export type ExchangeToAccountTradePreviewCardProps = {
+    quote?: ExchangeTrade;
+    toStringValue: string | undefined;
+};
+
+export const ExchangeToAccountTradePreviewCard = ({
+    quote,
+    toStringValue,
+}: ExchangeToAccountTradePreviewCardProps) => {
+    const toAccount = useSelector(selectExchangeSelectedReceiveAccount);
+
+    if (!quote?.receive || !toAccount?.account) {
+        return null;
+    }
+
+    return (
+        <ExchangeTradePreviewCard
+            account={toAccount.account}
+            cryptoId={quote.receive}
+            amount={
+                <Text variant="hint" color="textSecondaryHighlight">
+                    +{toStringValue}
+                </Text>
+            }
+            title={<Translation id="moduleTrading.tradingExchangePreviewScreen.toAccount" />}
+        />
+    );
+};

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeTradePreviewCard.tsx
@@ -15,8 +15,8 @@ import { Card, HStack, Text, VStack } from '@suite-native/atoms';
 import { CryptoIcon, NetworkIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 
-import { TradeInfoHeader } from '../TradeInfo/TradeInfoHeader';
-import { TradeInfoRow } from '../TradeInfo/TradeInfoRow';
+import { TradeInfoHeader } from '../../TradeInfo/TradeInfoHeader';
+import { TradeInfoRow } from '../../TradeInfo/TradeInfoRow';
 
 type ExchangeTradePreviewProps = {
     account: Account;

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFeePickerCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFeePickerCard.comp.test.tsx
@@ -1,0 +1,53 @@
+import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { exchangeQuotes } from '../../../../__fixtures__/exchangeQuotes';
+import { getWalletState } from '../../../../__fixtures__/walletState';
+import { ExchangeFeePickerCard, ExchangeFeePickerCardProps } from '../ExchangeFeePickerCard';
+
+describe('ExchangeFeePickerCard', () => {
+    const renderExchangeFeePickerCard = (
+        props: Partial<ExchangeFeePickerCardProps> = {},
+        tradingAccountKey = 'btc-account-1',
+    ) => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'exchange' }),
+        };
+        preloadedState.wallet!.trading!.composedTransactionInfo = { composed: { fee: '1000' } };
+        preloadedState.wallet!.trading!.exchange!.tradingAccountKey = tradingAccountKey;
+
+        return renderWithStoreProviderAsync(
+            <ExchangeFeePickerCard isTxnError={false} {...props} />,
+            { preloadedState },
+        );
+    };
+
+    it('should render nothing when isTxnError', async () => {
+        const { toJSON } = await renderExchangeFeePickerCard({
+            quote: exchangeQuotes[0],
+            isTxnError: true,
+        });
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render nothing when there is no quote', async () => {
+        const { toJSON } = await renderExchangeFeePickerCard({});
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render nothing when account is not found', async () => {
+        const { toJSON } = await renderExchangeFeePickerCard(
+            { quote: exchangeQuotes[0] },
+            'unknown-account-key',
+        );
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render FeePickerCard otherwise', async () => {
+        const { getByText } = await renderExchangeFeePickerCard({ quote: exchangeQuotes[0] });
+
+        expect(getByText('Fee')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFromAccountTradePreviewCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFromAccountTradePreviewCard.comp.test.tsx
@@ -1,0 +1,53 @@
+import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { exchangeQuotes } from '../../../../__fixtures__/exchangeQuotes';
+import { getWalletState } from '../../../../__fixtures__/walletState';
+import {
+    ExchangeFromAccountTradePreviewCard,
+    ExchangeFromAccountTradePreviewCardProps,
+} from '../ExchangeFromAccountTradePreviewCard';
+
+describe('ExchangeFromAccountTradePreviewCard', () => {
+    const renderExchangeFromAccountTradePreviewCard = (
+        props: Partial<ExchangeFromAccountTradePreviewCardProps> = {},
+        tradingAccountKey = 'btc-account-1',
+    ) => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'exchange' }),
+        };
+        preloadedState.wallet!.trading!.composedTransactionInfo = { composed: { fee: '1000' } };
+        preloadedState.wallet!.trading!.exchange!.tradingAccountKey = tradingAccountKey;
+
+        return renderWithStoreProviderAsync(
+            <ExchangeFromAccountTradePreviewCard fromStringValue="100" {...props} />,
+            {
+                preloadedState,
+            },
+        );
+    };
+
+    it('should render nothing when there is no quote', async () => {
+        const { toJSON } = await renderExchangeFromAccountTradePreviewCard({});
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render nothing when account is not found', async () => {
+        const { toJSON } = await renderExchangeFromAccountTradePreviewCard(
+            { quote: exchangeQuotes[0] },
+            'unknown-account-key',
+        );
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should ExchangeTradePreviewCard otherwise', async () => {
+        const { getByText } = await renderExchangeFromAccountTradePreviewCard({
+            quote: exchangeQuotes[0],
+        });
+
+        expect(getByText('Account')).toBeOnTheScreen();
+        expect(getByText('BTC Account #1')).toBeOnTheScreen();
+        expect(getByText('-100')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewContinueButton.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewContinueButton.comp.test.tsx
@@ -1,0 +1,139 @@
+import { GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { PreloadedState, renderWithStoreProviderAsync, userEvent } from '@suite-native/test-utils';
+
+import { exchangeQuotes } from '../../../../__fixtures__/exchangeQuotes';
+import { getWalletState } from '../../../../__fixtures__/walletState';
+import {
+    ExchangePreviewContinueButton,
+    ExchangePreviewContinueButtonProps,
+} from '../ExchangePreviewContinueButton';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => ({
+        navigate: mockNavigate,
+    }),
+}));
+
+describe('ExchangePreviewContinueButton', () => {
+    const renderExchangePreviewContinueButton = (
+        props: Partial<ExchangePreviewContinueButtonProps> = {},
+        preloadedState: PreloadedState = {},
+    ) =>
+        renderWithStoreProviderAsync(
+            <ExchangePreviewContinueButton
+                isDisabled={false}
+                quote={exchangeQuotes[0]}
+                onSignTransactionNavigation={jest.fn()}
+                {...props}
+            />,
+            { preloadedState },
+        );
+
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    const getPreloadedState = (): PreloadedState => {
+        const preloadedState = { wallet: getWalletState({ tradeType: 'exchange' }) };
+        preloadedState.wallet!.trading!.exchange!.tradingAccountKey = 'btc-account-1';
+        preloadedState.wallet!.trading!.exchange!.receiveAccountKey = 'eth-account-1';
+        preloadedState.wallet!.send!.precomposedTx = {
+            type: 'final',
+            totalSpent: '1100',
+            fee: '1000',
+            feePerByte: '100',
+            bytes: 1,
+        } as GeneralPrecomposedTransactionFinal;
+
+        return preloadedState;
+    };
+
+    it('should render nothing when precomposed transaction is not in final state', async () => {
+        const preloadedState = getPreloadedState();
+        preloadedState!.wallet!.send!.precomposedTx = {
+            type: 'composing',
+        } as any;
+        const { toJSON } = await renderExchangePreviewContinueButton({}, preloadedState);
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render continue button', async () => {
+        const { getByText } = await renderExchangePreviewContinueButton({}, getPreloadedState());
+
+        expect(getByText('Continue')).toBeOnTheScreen();
+    });
+
+    it('should render disabled button when isDisabled prop is specified', async () => {
+        const { getByText } = await renderExchangePreviewContinueButton(
+            { isDisabled: true },
+            getPreloadedState(),
+        );
+
+        expect(getByText('Continue')).toBeDisabled();
+    });
+
+    it('should fire console.warn and do not navigate when quote is not specified', async () => {
+        const mockOnSignTransactionNavigation = jest.fn();
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const { getByText } = await renderExchangePreviewContinueButton(
+            { quote: undefined, onSignTransactionNavigation: mockOnSignTransactionNavigation },
+            getPreloadedState(),
+        );
+
+        await userEvent.press(getByText('Continue'));
+
+        expect(consoleWarnSpy).toHaveBeenCalledWith('quote or fromAccount is not defined', {
+            hasQuote: false,
+            hasFromAccount: true,
+        });
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockOnSignTransactionNavigation).not.toHaveBeenCalled();
+    });
+
+    it('should fire console.warn and do not navigate when fromAccount is not found', async () => {
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const preloadedState = getPreloadedState();
+        preloadedState!.wallet!.trading!.exchange!.tradingAccountKey = 'non-existing-key';
+        const mockOnSignTransactionNavigation = jest.fn();
+        const { getByText } = await renderExchangePreviewContinueButton(
+            { onSignTransactionNavigation: mockOnSignTransactionNavigation },
+            preloadedState,
+        );
+
+        await userEvent.press(getByText('Continue'));
+
+        expect(consoleWarnSpy).toHaveBeenCalledWith('quote or fromAccount is not defined', {
+            hasQuote: true,
+            hasFromAccount: false,
+        });
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockOnSignTransactionNavigation).not.toHaveBeenCalled();
+    });
+
+    it('should navigate to TradingOutputsReview on continue press', async () => {
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const mockOnSignTransactionNavigation = jest.fn();
+        const { getByText } = await renderExchangePreviewContinueButton(
+            { onSignTransactionNavigation: mockOnSignTransactionNavigation },
+            getPreloadedState(),
+        );
+
+        await userEvent.press(getByText('Continue'));
+
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith({
+            name: 'TradingOutputsReview',
+            params: {
+                tradingType: 'exchange',
+                accountKey: 'btc-account-1',
+                orderId: exchangeQuotes[0].orderId,
+                tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            },
+        });
+        expect(mockOnSignTransactionNavigation).toHaveBeenCalledTimes(1);
+    });
+});

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewView.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewView.comp.test.tsx
@@ -1,0 +1,40 @@
+import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { exchangeQuotes } from '../../../../__fixtures__/exchangeQuotes';
+import { getWalletState } from '../../../../__fixtures__/walletState';
+import { ExchangePreviewView, ExchangePreviewViewProps } from '../ExchangePreviewView';
+
+describe('ExchangePreviewView', () => {
+    const renderExchangePreviewView = (props: Partial<ExchangePreviewViewProps> = {}) => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'exchange' }),
+        };
+        preloadedState.wallet!.trading!.composedTransactionInfo = { composed: { fee: '1000' } };
+        preloadedState.wallet!.trading!.exchange!.tradingAccountKey = 'btc-account-1';
+        preloadedState.wallet!.trading!.exchange!.receiveAccountKey = 'eth-account-1';
+
+        return renderWithStoreProviderAsync(
+            <ExchangePreviewView quote={exchangeQuotes[0]} txnErrorString={null} {...props} />,
+            { preloadedState },
+        );
+    };
+
+    it('should render all sections except alert', async () => {
+        const { getByText } = await renderExchangePreviewView({});
+
+        expect(getByText('BTC Account #1')).toBeOnTheScreen();
+        expect(getByText('Ethereum #1')).toBeOnTheScreen();
+        expect(getByText('Fee')).toBeOnTheScreen();
+    });
+
+    it('should render txnErrorString but no fee picker when isTxnError is true', async () => {
+        const { getByText, queryByText } = await renderExchangePreviewView({
+            txnErrorString: 'txnErrorString',
+        });
+
+        expect(getByText('BTC Account #1')).toBeOnTheScreen();
+        expect(getByText('Ethereum #1')).toBeOnTheScreen();
+        expect(getByText('txnErrorString')).toBeOnTheScreen();
+        expect(queryByText('Fee')).toBeNull();
+    });
+});

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeToAccountTradePreviewCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeToAccountTradePreviewCard.comp.test.tsx
@@ -1,0 +1,51 @@
+import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { exchangeQuotes } from '../../../../__fixtures__/exchangeQuotes';
+import { getWalletState } from '../../../../__fixtures__/walletState';
+import {
+    ExchangeToAccountTradePreviewCard,
+    ExchangeToAccountTradePreviewCardProps,
+} from '../ExchangeToAccountTradePreviewCard';
+
+describe('ExchangeToAccountTradePreviewCard', () => {
+    const renderExchangeToAccountTradePreviewCard = (
+        props: Partial<ExchangeToAccountTradePreviewCardProps> = {},
+        receiveAccountKey = 'btc-account-1',
+    ) => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'exchange' }),
+        };
+        preloadedState.wallet!.trading!.composedTransactionInfo = { composed: { fee: '1000' } };
+        preloadedState.wallet!.trading!.exchange!.receiveAccountKey = receiveAccountKey;
+
+        return renderWithStoreProviderAsync(
+            <ExchangeToAccountTradePreviewCard toStringValue="100" {...props} />,
+            { preloadedState },
+        );
+    };
+
+    it('should render nothing when there is no quote', async () => {
+        const { toJSON } = await renderExchangeToAccountTradePreviewCard({});
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render nothing when account is not found', async () => {
+        const { toJSON } = await renderExchangeToAccountTradePreviewCard(
+            { quote: exchangeQuotes[0] },
+            'unknown-account-key',
+        );
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should ExchangeTradePreviewCard otherwise', async () => {
+        const { getByText } = await renderExchangeToAccountTradePreviewCard({
+            quote: exchangeQuotes[0],
+        });
+
+        expect(getByText('Account')).toBeOnTheScreen();
+        expect(getByText('BTC Account #1')).toBeOnTheScreen();
+        expect(getByText('+100')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/index.ts
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/index.ts
@@ -1,0 +1,3 @@
+export * from './ExchangePreviewContinueButton';
+export * from './ExchangePreviewView';
+export * from './ExchangePreviewScreenHeader';

--- a/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
@@ -1,20 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ScrollView } from 'react-native-gesture-handler';
-import Animated from 'react-native-reanimated';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useNetInfo } from '@react-native-community/netinfo';
 import { useFocusEffect } from '@react-navigation/native';
 
-import { parseCryptoId, selectTradingExchangeSelectedQuote } from '@suite-common/trading';
-import { selectSendPrecomposedTx } from '@suite-common/wallet-core';
-import { TokenAddress } from '@suite-common/wallet-types';
+import { selectTradingExchangeSelectedQuote } from '@suite-common/trading';
 import { useAlert } from '@suite-native/alerts';
-import { Button, InlineAlertBox, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     Screen,
-    ScreenHeader,
     StackProps,
     TradingStackParamList,
     TradingStackRoutes,
@@ -22,10 +16,12 @@ import {
 import { useSubscribeForSolanaBlockUpdates } from '@suite-native/transaction-management';
 import { useDebounce } from '@trezor/react-utils';
 
-import { ExchangeTradePreviewCard } from '../components/exchange/ExchangeTradePreviewCard';
-import { FeePickerCard } from '../components/fees/FeePickerCard';
+import {
+    ExchangePreviewContinueButton,
+    ExchangePreviewScreenHeader,
+    ExchangePreviewView,
+} from '../components/exchange/ExchangePreview';
 import { useExchangeFlow } from '../hooks/exchange/useExchangeFlow';
-import { useChangeStringsExtractor } from '../hooks/history/useChangeStringsExtractor';
 import {
     selectExchangeSelectedReceiveAccount,
     selectExchangeSelectedSendAccount,
@@ -46,9 +42,7 @@ export const TradingExchangePreviewScreen = ({ navigation }: TradingExchangePrev
     const quote = useSelector(selectTradingExchangeSelectedQuote);
     const fromAccount = useSelector(selectExchangeSelectedSendAccount);
     const toAccount = useSelector(selectExchangeSelectedReceiveAccount);
-    const precomposedTransaction = useSelector(selectSendPrecomposedTx);
     const hasRequestedTradeConfirmation = useRef(false);
-    const { fromStringValue, toStringValue } = useChangeStringsExtractor(quote);
 
     useSubscribeForSolanaBlockUpdates(fromAccount ?? null);
 
@@ -56,14 +50,6 @@ export const TradingExchangePreviewScreen = ({ navigation }: TradingExchangePrev
 
     const [isConfirmationErrorRequested, setIsConfirmationErrorRequested] =
         useState<boolean>(false);
-
-    // clear trading state on unmount
-    useEffect(
-        () => () => {
-            dispatch(clearTradingStateThunk());
-        },
-        [dispatch],
-    );
 
     const handleConfirmTrade = useCallback(async () => {
         const addressText = getReceiveAccountAddressText(toAccount);
@@ -92,6 +78,28 @@ export const TradingExchangePreviewScreen = ({ navigation }: TradingExchangePrev
             console.error('Failed to confirm trade', e);
         }
     }, [confirmTrade, debounce, fetchFeesAndCompose, quote, toAccount]);
+
+    const onSignTransactionNavigation = useCallback(() => {
+        hasRequestedTradeConfirmation.current = false;
+    }, []);
+
+    useFocusEffect(
+        useCallback(() => {
+            if (!hasRequestedTradeConfirmation.current) {
+                hasRequestedTradeConfirmation.current = true;
+
+                handleConfirmTrade();
+            }
+        }, [handleConfirmTrade]),
+    );
+
+    // clear trading state on unmount
+    useEffect(
+        () => () => {
+            dispatch(clearTradingStateThunk());
+        },
+        [dispatch],
+    );
 
     useEffect(() => {
         if (isConfirmationErrorRequested) {
@@ -124,99 +132,14 @@ export const TradingExchangePreviewScreen = ({ navigation }: TradingExchangePrev
         showAlert,
     ]);
 
-    useFocusEffect(
-        useCallback(() => {
-            if (!hasRequestedTradeConfirmation.current) {
-                hasRequestedTradeConfirmation.current = true;
-
-                handleConfirmTrade();
-            }
-        }, [handleConfirmTrade]),
-    );
-
-    const handleSignTransaction = () => {
-        if (!quote || !fromAccount) {
-            console.warn('quote or fromAccount is not defined', quote, fromAccount);
-
-            return;
-        }
-
-        const tokenContract = quote.send
-            ? (parseCryptoId(quote.send)?.contractAddress as TokenAddress)
-            : undefined;
-
-        navigation.navigate({
-            name: TradingStackRoutes.TradingOutputsReview,
-            params: {
-                tradingType: 'exchange',
-                accountKey: fromAccount.key,
-                tokenContract,
-                orderId: quote.orderId ?? '',
-            },
-        });
-        hasRequestedTradeConfirmation.current = false;
-    };
-
     return (
-        <Screen
-            header={
-                <ScreenHeader
-                    title={<Translation id="moduleTrading.tradingExchangePreviewScreen.title" />}
-                    closeActionType="close"
-                />
-            }
-        >
-            <ScrollView>
-                <VStack spacing="sp20" paddingVertical="sp20">
-                    {txnErrorString && (
-                        <Animated.View>
-                            <InlineAlertBox variant="critical" title={txnErrorString} />
-                        </Animated.View>
-                    )}
-                    {fromAccount && quote?.send && (
-                        <ExchangeTradePreviewCard
-                            account={fromAccount}
-                            cryptoId={quote.send}
-                            amount={
-                                <Text variant="hint" color="textAlertRed">
-                                    -{fromStringValue}
-                                </Text>
-                            }
-                            title={
-                                <Translation id="moduleTrading.tradingExchangePreviewScreen.fromAccount" />
-                            }
-                        />
-                    )}
-                    {toAccount?.account && quote?.receive && (
-                        <ExchangeTradePreviewCard
-                            account={toAccount.account}
-                            cryptoId={quote.receive}
-                            amount={
-                                <Text variant="hint" color="textSecondaryHighlight">
-                                    +{toStringValue}
-                                </Text>
-                            }
-                            title={
-                                <Translation id="moduleTrading.tradingExchangePreviewScreen.toAccount" />
-                            }
-                        />
-                    )}
-                    {fromAccount && quote?.send && !txnErrorString && (
-                        <FeePickerCard
-                            trade={quote}
-                            symbol={fromAccount.symbol}
-                            accountKey={fromAccount.key}
-                            tradingType="exchange"
-                        />
-                    )}
-                </VStack>
-            </ScrollView>
-
-            {precomposedTransaction?.type === 'final' && (
-                <Button onPress={handleSignTransaction} isDisabled={!!txnErrorString}>
-                    <Translation id="generic.buttons.continue" />
-                </Button>
-            )}
+        <Screen header={<ExchangePreviewScreenHeader />}>
+            <ExchangePreviewView quote={quote} txnErrorString={txnErrorString} />
+            <ExchangePreviewContinueButton
+                quote={quote}
+                isDisabled={!!txnErrorString}
+                onSignTransactionNavigation={onSignTransactionNavigation}
+            />
         </Screen>
     );
 };

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
@@ -124,16 +124,9 @@ describe('TradingExchangePreviewScreen', () => {
         expect(getByText('Fee')).toBeOnTheScreen();
     });
 
-    it('should render FeePickerCard when no error and fromAccount and quote are available', async () => {
-        const { getByText } = await renderTradingExchangePreviewScreen();
-
-        // Should render the fee picker section
-        expect(getByText('Transaction details')).toBeOnTheScreen();
-        expect(getByText('Fee')).toBeOnTheScreen();
-    });
-
     describe('Error Alert Functionality', () => {
         it('should show error alert when trade confirmation fails', async () => {
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
             // Mock confirmTrade to throw an error
             mockConfirmTrade.mockRejectedValueOnce(new Error('Trade confirmation failed'));
 
@@ -143,6 +136,10 @@ describe('TradingExchangePreviewScreen', () => {
             await waitFor(() => {
                 expect(mockShowAlert).toHaveBeenCalledTimes(1);
             });
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                'Failed to confirm trade',
+                new Error('Trade confirmation failed'),
+            );
         });
 
         it('should retry trade confirmation when retry button is pressed', async () => {

--- a/suite-native/module-trading/src/selectors/exchangeSelectors.ts
+++ b/suite-native/module-trading/src/selectors/exchangeSelectors.ts
@@ -5,7 +5,8 @@ import {
     selectTradingExchangeBuyCryptoIds,
     selectTradingExchangeProviders,
 } from '@suite-common/trading';
-import { selectAccountByKey } from '@suite-common/wallet-core';
+import { selectAccounts } from '@suite-common/wallet-core';
+import { Account } from '@suite-common/wallet-types';
 import {
     FeatureFlag,
     FeatureFlagsRootState,
@@ -30,15 +31,25 @@ const createTradingWithFeatureFlagsMemoizedSelector =
 
 export const selectTradingExchange = (state: TradingRootState) => state.wallet.trading.exchange;
 
+const findAccountByKey = (accounts: Account[], accountKey: string | undefined) => {
+    if (!accountKey) return undefined;
+
+    return accounts.find(a => a.key === accountKey);
+};
+
 export const selectExchangeSelectedSendAccount = createMemoizedSelectorWithAccounts(
-    [state => state, selectTradingExchange],
-    (state, { tradingAccountKey }) => selectAccountByKey(state, tradingAccountKey) || undefined,
+    [selectAccounts, state => selectTradingExchange(state).tradingAccountKey],
+    findAccountByKey,
 );
 
 export const selectExchangeSelectedReceiveAccount = createMemoizedSelectorWithAccounts(
-    [state => state, selectTradingExchange],
-    (state, { receiveAddress, receiveAccountKey }) => {
-        const account = selectAccountByKey(state, receiveAccountKey);
+    [
+        selectAccounts,
+        state => selectTradingExchange(state).receiveAccountKey,
+        state => selectTradingExchange(state).receiveAddress,
+    ],
+    (accounts, accountKey, receiveAddress) => {
+        const account = findAccountByKey(accounts, accountKey);
 
         return account
             ? getReceiveAccountFromAccountAndAddressString(account, receiveAddress)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

minimize rerenders on `TradingExchangePreviewScreen`

## Related Issue

Resolve [#22006](https://github.com/trezor/trezor-suite/issues/22006)

## Screenshots:

<img width="300" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-30 at 14 46 21" src="https://github.com/user-attachments/assets/4be2918a-1a51-451c-b2a8-348a26d1765f" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22006-mobile-swap-optimize-rerenders-of-TradingExchangePreviewScreen&lookback=7)