### PR TITLE
fix(suite): preserve static part of bluetooth manufacturerData

### DIFF
--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -120,6 +120,18 @@ export const initBluetoothThunk = createThunk<void, void, void>(
 
         bluetoothIpc.on('device-update', async (deviceIpc: BluetoothDevice) => {
             const device = fromBluetoothDevice(deviceIpc);
+            const knownDevice = selectKnownDevices<DesktopBluetoothDevice>(getState()).find(
+                d => d.id === device.id,
+            );
+
+            if (knownDevice) {
+                // preserve static part of manufacturerData (model, color)
+                // incoming data may be empty on linux (after adapter restart)
+                device.manufacturerData = {
+                    ...knownDevice.manufacturerData,
+                    filterPolicy: device.manufacturerData?.filterPolicy,
+                };
+            }
 
             dispatch(bluetoothActions.deviceUpdateAction({ device }));
             await attemptDeviceConnect({ device });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Do not override static part of bluetooth manufacturerData after "device-update" event.

On linux after successful pairing and setup if BT adapter gets disconnected and connected again device.manufacturerData are empty this will override knownDevice .manufacturerData leading to model => UNKNOWN.



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-manufacturer-data&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-manufacturer-data&lookback=7)