### PR TITLE
merge unacquired usb device when already remembered

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
@@ -61,7 +61,7 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
             });
 
             await test.step('After reloading inactive suite session does not take Bridge session back', async () => {
-                await expect(page.getByTestId('@deviceStatus-disconnected').first()).toBeVisible({
+                await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE', {
                     timeout: 30_000,
                 });
             });

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -165,7 +165,7 @@ const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Feat
 
     if (dev && typeof dev.type === 'string' && dev.type === 'unreadable') {
         return {
-            descriptor: { apiType: 'usb' },
+            descriptor: { apiType: 'usb', id: 'device-id' },
             type: 'unreadable',
             path,
             label: 'Unreadable device',
@@ -177,7 +177,7 @@ const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Feat
 
     if (dev && typeof dev.type === 'string' && dev.type === 'unacquired') {
         return {
-            descriptor: { apiType: 'usb' },
+            descriptor: { apiType: 'usb', id: 'device-id' },
             type: dev.type,
             path,
             label: 'Unacquired device',
@@ -191,7 +191,7 @@ const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Feat
     const features = getDeviceFeatures(feat);
 
     return {
-        descriptor: { apiType: 'usb' },
+        descriptor: { apiType: 'usb', id: 'device-id' },
         id: features.device_id,
         // @ts-expect-error
         path: '',
@@ -245,6 +245,7 @@ const getSuiteDevice = (
             ts: 0,
             buttonRequests: [],
             metadata: {},
+
             ...dev,
             ...device,
             state: dev?.state

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -132,14 +132,16 @@ const connectDevice = (draft: DeviceReducerState, device: Device) => {
     // connected device is unacquired/unreadable
     if (!device.features) {
         const knownDevices = draft.devices.filter(
-            ({ bluetoothProps }) =>
-                bluetoothProps && bluetoothProps?.id === device.bluetoothProps?.id,
+            ({ descriptor }) =>
+                descriptor &&
+                descriptor?.id === device.descriptor?.id &&
+                descriptor.apiType === device.descriptor?.apiType,
         );
         if (knownDevices.length > 0) {
             knownDevices.forEach(dd => {
                 dd.connected = true;
                 dd.path = device.path;
-                dd.status = device.status;
+                dd.status = 'used';
                 dd.thp = device.thp;
             });
 


### PR DESCRIPTION
unacquired device no longer appears as a duplicated device if we are able to tell that any of the remembered devices is identical with recently connected unacquried device

Before
<img width="402" height="388" alt="image" src="https://github.com/user-attachments/assets/a44513ac-f1ce-464f-9896-e47e0a60111f" />

After there is only one device


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=device-descriptor-followup&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=device-descriptor-followup&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=device-descriptor-followup&lookback=7)