### PR TITLE
Fix/system language

### DIFF
--- a/packages/suite/src/actions/settings/languageActions.ts
+++ b/packages/suite/src/actions/settings/languageActions.ts
@@ -2,9 +2,8 @@ import type { Locale } from '@suite-common/suite-types';
 
 import { SUITE } from 'src/actions/suite/constants';
 import type { SuiteAction } from 'src/actions/suite/suiteActions';
-import { ensureLocale } from 'src/utils/suite/l10n';
 
 export const setLanguage = (locale: Locale): SuiteAction => ({
     type: SUITE.SET_LANGUAGE,
-    locale: ensureLocale(locale),
+    locale,
 });

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -15,7 +15,6 @@ import { ExperimentalFeature } from 'src/constants/suite/experimental';
 import { SIDEBAR_WIDTH_NUMERIC } from 'src/constants/suite/layout';
 import { Action, TorBootstrap, TorStatus } from 'src/types/suite';
 import type { OAuthServerEnvironment } from 'src/types/suite/metadata';
-import { ensureLocale } from 'src/utils/suite/l10n';
 
 import { setLocalFirstStorageRelayAction } from '../../actions/settings/settingsActions';
 
@@ -191,7 +190,7 @@ const initialState: SuiteState = {
         theme: {
             variant: 'light',
         },
-        language: ensureLocale('en-US'),
+        language: 'en-US',
         torOnionLinks: isWeb(),
         isCoinjoinReceiveWarningHidden: false,
         isDesktopSuitePromoHidden: false,

--- a/packages/suite/src/utils/suite/__tests__/l10n.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/l10n.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_LOCALE, getOsLocale } from '../l10n';
+import { getOsLocale } from '../l10n';
 
 describe('utils/suite/l10n', () => {
     describe(getOsLocale.name, () => {
@@ -9,15 +9,21 @@ describe('utils/suite/l10n', () => {
 
         it('selects the first supported locale', () => {
             languagesGetter.mockReturnValue(['xx-XX', 'en-US', 'de-AT']);
-            expect(getOsLocale()).toBe('en-US');
+            expect(getOsLocale('cs-CZ')).toBe('en-US');
+        });
+        it('selects locale whose name is different in OS than in Suite', () => {
+            languagesGetter.mockReturnValue(['zh-Hant-HK', 'zh-Hans-CN']);
+            expect(getOsLocale('cs-CZ')).toBe('zh-TW');
+            languagesGetter.mockReturnValue(['zh-Hans-CN', 'zh-Hant-HK']);
+            expect(getOsLocale('cs-CZ')).toBe('zh-CN');
         });
         it('falls back to a language variant if the exact match is not found', () => {
             languagesGetter.mockReturnValue(['en-GB', 'es-ES']);
-            expect(getOsLocale()).toBe('en-US');
+            expect(getOsLocale('cs-CZ')).toBe('en-US');
         });
-        it('falls back to default locale if no match is found', () => {
+        it('falls back to provided default  if no match is found', () => {
             languagesGetter.mockReturnValue(['aa', 'xx-XX']);
-            expect(getOsLocale()).toBe(DEFAULT_LOCALE);
+            expect(getOsLocale('cs-CZ')).toBe('cs-CZ');
         });
     });
 });

--- a/packages/suite/src/utils/suite/__tests__/l10n.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/l10n.test.ts
@@ -23,8 +23,6 @@ describe('utils/suite/l10n', () => {
     it('identifying locale', () => {
         expect(utils.isLocale('en-US')).toBe(true);
         expect(utils.isLocale('xx')).toBe(false);
-        expect(utils.isCompletedLocale('en-US')).toBe(true);
-        expect(utils.isCompletedLocale('xx')).toBe(false);
     });
 
     describe('ensureLocale', () => {

--- a/packages/suite/src/utils/suite/__tests__/l10n.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/l10n.test.ts
@@ -24,12 +24,4 @@ describe('utils/suite/l10n', () => {
         expect(utils.isLocale('en-US')).toBe(true);
         expect(utils.isLocale('xx')).toBe(false);
     });
-
-    describe('ensureLocale', () => {
-        it('ensure if locale is valid or return default', () => {
-            expect(utils.ensureLocale('en-US')).toBe('en-US');
-            expect(utils.ensureLocale('cs-CZ')).toBe('cs-CZ');
-            expect(utils.ensureLocale('xx')).toBe('en-US');
-        });
-    });
 });

--- a/packages/suite/src/utils/suite/__tests__/l10n.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/l10n.test.ts
@@ -1,27 +1,23 @@
-import * as utils from '../l10n';
+import { DEFAULT_LOCALE, getOsLocale } from '../l10n';
 
 describe('utils/suite/l10n', () => {
-    describe('getOsLocale', () => {
+    describe(getOsLocale.name, () => {
         let languagesGetter: any;
         beforeEach(() => {
             languagesGetter = jest.spyOn(window.navigator, 'languages', 'get');
         });
-        it('default lang', () => {
-            expect(utils.getOsLocale()).toBe('en-US');
-            expect(utils.getOsLocale('en-US')).toBe('en-US');
-        });
-        it('browser locales', () => {
-            languagesGetter.mockReturnValue(['es-ES', 'de-AT', 'en']);
-            expect(utils.getOsLocale('cs-CZ')).toBe('es-ES');
-            languagesGetter.mockReturnValue(['xx-XX', 'en-US', 'es']);
-            expect(utils.getOsLocale('cs-CZ')).toBe('en-US');
-            languagesGetter.mockReturnValue(['aa', 'xx-XX']);
-            expect(utils.getOsLocale('cs-CZ')).toBe('cs-CZ');
-        });
-    });
 
-    it('identifying locale', () => {
-        expect(utils.isLocale('en-US')).toBe(true);
-        expect(utils.isLocale('xx')).toBe(false);
+        it('selects the first supported locale', () => {
+            languagesGetter.mockReturnValue(['xx-XX', 'en-US', 'de-AT']);
+            expect(getOsLocale()).toBe('en-US');
+        });
+        it('falls back to a language variant if the exact match is not found', () => {
+            languagesGetter.mockReturnValue(['en-GB', 'es-ES']);
+            expect(getOsLocale()).toBe('en-US');
+        });
+        it('falls back to default locale if no match is found', () => {
+            languagesGetter.mockReturnValue(['aa', 'xx-XX']);
+            expect(getOsLocale()).toBe(DEFAULT_LOCALE);
+        });
     });
 });

--- a/packages/suite/src/utils/suite/l10n.ts
+++ b/packages/suite/src/utils/suite/l10n.ts
@@ -5,9 +5,6 @@ const DEFAULT_LOCALE = 'en-US';
 
 export const isLocale = (lang: string): lang is Locale => lang in LANGUAGES;
 
-export const isCompletedLocale = (lang: string): lang is Locale =>
-    isLocale(lang) && !!LANGUAGES[lang].type;
-
 /**
  * Finds and returns first of languages preferred by user's environment
  * which is implemented and completed in Suite, or defaultLocale.
@@ -15,7 +12,7 @@ export const isCompletedLocale = (lang: string): lang is Locale =>
 export const getOsLocale = (defaultLocale: Locale = DEFAULT_LOCALE): Locale => {
     const languages = getPlatformLanguages() || [];
 
-    return languages.find(isCompletedLocale) || defaultLocale;
+    return languages.find(isLocale) || defaultLocale;
 };
 
 export const watchOsLocale = (callback: (loc: Locale) => void) => {

--- a/packages/suite/src/utils/suite/l10n.ts
+++ b/packages/suite/src/utils/suite/l10n.ts
@@ -1,23 +1,38 @@
 import { LANGUAGES, Locale } from '@suite-common/suite-types';
 import { getPlatformLanguages } from '@trezor/env-utils';
 
-export const DEFAULT_LOCALE = 'en-US';
+const DEFAULT_LOCALE = 'en-US';
 
 /**
  * Finds and returns first of languages preferred by user's environment
  * which is implemented and completed in Suite, or defaultLocale.
  */
-export const getOsLocale = (): Locale => {
+export const getOsLocale = (defaultLocale: Locale = DEFAULT_LOCALE): Locale => {
     const platformLanguages = getPlatformLanguages() || [];
 
     const isLocale = (lang: string): lang is Locale => lang in LANGUAGES;
 
+    const suiteLanguageCodes = Object.keys(LANGUAGES) as Locale[];
     for (const platformLanguage of platformLanguages) {
         if (isLocale(platformLanguage)) {
             return platformLanguage;
         }
+
+        // Some languages may have different name in OS than in Suite (e.g. Taiwanese Mandarin is zh-Hant-TW)
+        const languageUnderDifferentNameInOs = suiteLanguageCodes.find(language => {
+            const languageInfo = LANGUAGES[language];
+
+            return (
+                'nameInOsStartsWith' in languageInfo &&
+                platformLanguage.startsWith(languageInfo.nameInOsStartsWith)
+            );
+        });
+        if (languageUnderDifferentNameInOs) {
+            return languageUnderDifferentNameInOs;
+        }
+
         // If your locale variant (e.g. en-GB) is not available, try to find a variant of your locale that is supported (e.g. en-US)
-        const languageVariant = (Object.keys(LANGUAGES) as Locale[]).find(
+        const languageVariant = suiteLanguageCodes.find(
             language => language.slice(0, 2) === platformLanguage.slice(0, 2),
         );
         if (languageVariant) {
@@ -25,7 +40,7 @@ export const getOsLocale = (): Locale => {
         }
     }
 
-    return DEFAULT_LOCALE;
+    return defaultLocale;
 };
 
 export const watchOsLocale = (callback: (loc: Locale) => void) => {

--- a/packages/suite/src/utils/suite/l10n.ts
+++ b/packages/suite/src/utils/suite/l10n.ts
@@ -21,8 +21,3 @@ export const watchOsLocale = (callback: (loc: Locale) => void) => {
 
     return () => window.removeEventListener('languagechange', onLanguageChange);
 };
-
-/**
- * Ensure locale is valid and return it, otherwise return defaultLocale.
- */
-export const ensureLocale = (loc: string): Locale => (isLocale(loc) ? loc : DEFAULT_LOCALE);

--- a/packages/suite/src/utils/suite/l10n.ts
+++ b/packages/suite/src/utils/suite/l10n.ts
@@ -1,18 +1,31 @@
 import { LANGUAGES, Locale } from '@suite-common/suite-types';
 import { getPlatformLanguages } from '@trezor/env-utils';
 
-const DEFAULT_LOCALE = 'en-US';
-
-export const isLocale = (lang: string): lang is Locale => lang in LANGUAGES;
+export const DEFAULT_LOCALE = 'en-US';
 
 /**
  * Finds and returns first of languages preferred by user's environment
  * which is implemented and completed in Suite, or defaultLocale.
  */
-export const getOsLocale = (defaultLocale: Locale = DEFAULT_LOCALE): Locale => {
-    const languages = getPlatformLanguages() || [];
+export const getOsLocale = (): Locale => {
+    const platformLanguages = getPlatformLanguages() || [];
 
-    return languages.find(isLocale) || defaultLocale;
+    const isLocale = (lang: string): lang is Locale => lang in LANGUAGES;
+
+    for (const platformLanguage of platformLanguages) {
+        if (isLocale(platformLanguage)) {
+            return platformLanguage;
+        }
+        // If your locale variant (e.g. en-GB) is not available, try to find a variant of your locale that is supported (e.g. en-US)
+        const languageVariant = (Object.keys(LANGUAGES) as Locale[]).find(
+            language => language.slice(0, 2) === platformLanguage.slice(0, 2),
+        );
+        if (languageVariant) {
+            return languageVariant;
+        }
+    }
+
+    return DEFAULT_LOCALE;
 };
 
 export const watchOsLocale = (callback: (loc: Locale) => void) => {

--- a/suite-common/suite-types/src/languages.ts
+++ b/suite-common/suite-types/src/languages.ts
@@ -1,7 +1,7 @@
 export type LocaleInfo = {
     name: string;
     en: string;
-    type?: 'official' | 'community';
+    type: 'official' | 'community';
 };
 
 // If you are adding language, add it to suite/package.json translations:download script too

--- a/suite-common/suite-types/src/languages.ts
+++ b/suite-common/suite-types/src/languages.ts
@@ -2,6 +2,7 @@ export type LocaleInfo = {
     name: string;
     en: string;
     type: 'official' | 'community';
+    nameInOsStartsWith?: string;
 };
 
 // If you are adding language, add it to suite/package.json translations:download script too
@@ -18,8 +19,18 @@ export const LANGUAGES = {
     'ru-RU': { name: 'Русский', en: 'Russian', type: 'community' },
     'tr-TR': { name: 'Türkçe', en: 'Turkish', type: 'community' },
     'uk-UA': { name: 'Українська', en: 'Ukrainian', type: 'community' },
-    'zh-CN': { name: '中文(简体)', en: 'Chinese Simplified', type: 'community' },
-    'zh-TW': { name: '中文(繁體)', en: 'Chinese Traditional', type: 'community' },
+    'zh-CN': {
+        name: '中文(简体)',
+        en: 'Chinese Simplified',
+        type: 'community',
+        nameInOsStartsWith: 'zh-Hans',
+    },
+    'zh-TW': {
+        name: '中文(繁體)',
+        en: 'Chinese Traditional',
+        type: 'community',
+        nameInOsStartsWith: 'zh-Hant',
+    },
 } as const satisfies Record<string, LocaleInfo>;
 
 export type Locale = keyof typeof LANGUAGES;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I noticed an unexpected change that originated from https://github.com/trezor/trezor-suite/pull/20238. My system languages are: `en-GB` primary, `cs-CZ` secondary. So, I would expect Suite to use English by default. However, because `en-GB` is different from `en-US` locale supported by Suite, it picked the secondary language and my Suite was in Czech. I think this is not intuitive, so this PR goes back to the original behaviour.

The last commit deals specifically with Chinese whose name reported by OS differs from the codes used by Suite (tested on Mac). It also deals with the fact that Chinese language can be used in other locales than `zh-CN` or `zh-TW`. We want traditional characters for users in Hong Kong and Macao, but simplified characters for users in Singapore.

Also some minor cleanup.

**QA:** Please test the following scenario, among others. On Windows, set system language to Chinese (Hong Kong). Open Suite and set Suite language to SYSTEM. It should give you `zh-TW`, i.e. traditional Chinese, not simplified. Then, close Suite and set system language to Chinese (Singapore). Reopen Suite your language should be simplified Chinese (`zh-CN`). If not, try setting some other language and then SYSTEM again.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/system-language&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/system-language&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/system-language&lookback=7)