### PR TITLE
feat(suite-native): respect Bluetooth auto-connect policy on mobile

### DIFF
--- a/suite-native/bluetooth/src/__tests__/selectors.test.ts
+++ b/suite-native/bluetooth/src/__tests__/selectors.test.ts
@@ -13,6 +13,9 @@ import { BluetoothDevice } from '../types';
 
 const initialState: NativeBluetoothState = {
     ...prepareInitialState<BluetoothDevice>(),
+    autoConnectPolicy: {
+        '1ec77690-be29-43c6-8859-dfeca15c7c0f': { type: 'autoconnect-disabled' },
+    },
     permissionStatus: 'granted',
     shouldShowSystemUnpairingAlert: false,
 };
@@ -44,12 +47,18 @@ const knownDevice: BluetoothDevice = {
         },
     },
 };
+const knownAutoConnectDisabledDevice: BluetoothDevice = {
+    ...knownDevice,
+    id: asBluetoothDeviceId('1ec77690-be29-43c6-8859-dfeca15c7c0f'),
+};
 const knownConnectingDevice: BluetoothDevice = {
     ...knownDevice,
+    id: asBluetoothDeviceId('2d000bf2-b8b7-4920-b907-540507c4562e'),
     connectionStatus: { type: 'connecting' },
 };
 const knownPairableDevice: BluetoothDevice = {
     ...knownDevice,
+    id: asBluetoothDeviceId('32ca56ec-9835-4ffd-a191-c11c43199abe'),
     manufacturerData: {
         ...knownDevice.manufacturerData,
         filterPolicy: {
@@ -57,6 +66,19 @@ const knownPairableDevice: BluetoothDevice = {
             connected: false,
             bond_memory_full: false,
             user_disconnected: false,
+        },
+    },
+};
+const knownUserDisconnectedDevice: BluetoothDevice = {
+    ...knownDevice,
+    id: asBluetoothDeviceId('703c0b54-6b17-423a-9221-04353ceec796'),
+    manufacturerData: {
+        ...knownDevice.manufacturerData,
+        filterPolicy: {
+            pairing: false,
+            connected: false,
+            bond_memory_full: false,
+            user_disconnected: true,
         },
     },
 };
@@ -143,9 +165,22 @@ describe('selectKnownConnectableBluetoothDevices', () => {
         ['empty nearby devices', [], [knownDevice], []],
         ['no known devices', [knownDevice], [], []],
         [
-            'one known device',
-            [pairableDevice, knownDevice, knownConnectingDevice, knownPairableDevice],
-            [knownDevice],
+            'some known devices',
+            [
+                pairableDevice,
+                knownDevice,
+                knownAutoConnectDisabledDevice,
+                knownConnectingDevice,
+                knownPairableDevice,
+                knownUserDisconnectedDevice,
+            ],
+            [
+                knownDevice,
+                knownAutoConnectDisabledDevice,
+                knownConnectingDevice,
+                knownPairableDevice,
+                knownUserDisconnectedDevice,
+            ],
             [knownDevice],
         ],
     ])('returns correct value for %s', (_, nearbyDevices, knownDevices, expectedDevices) => {

--- a/suite-native/bluetooth/src/selectors.ts
+++ b/suite-native/bluetooth/src/selectors.ts
@@ -1,5 +1,6 @@
 import {
     selectAdapterStatus,
+    selectAutoConnectPolicy,
     selectKnownDevices,
     selectNearbyDevices,
 } from '@suite-common/bluetooth';
@@ -8,6 +9,9 @@ import { createWeakMapSelector } from '@suite-common/redux-utils';
 import { NativeBluetoothRootState } from './bluetoothSlice';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<NativeBluetoothRootState>();
+
+export const selectBluetoothAutoConnectPolicy = (state: NativeBluetoothRootState) =>
+    selectAutoConnectPolicy(state);
 
 export const selectBluetoothPermissionStatus = (state: NativeBluetoothRootState) =>
     state.bluetooth.permissionStatus;
@@ -42,11 +46,12 @@ export const selectNearbyPairableBluetoothDevices = createMemoizedSelector(
 );
 
 export const selectKnownConnectableBluetoothDevices = createMemoizedSelector(
-    [selectNearbyBluetoothDevices, selectKnownBluetoothDevices],
-    (nearbyBluetoothDevices, knownBluetoothDevices) =>
+    [selectNearbyBluetoothDevices, selectKnownBluetoothDevices, selectBluetoothAutoConnectPolicy],
+    (nearbyBluetoothDevices, knownBluetoothDevices, autoConnectPolicy) =>
         nearbyBluetoothDevices.filter(
             ({ id, manufacturerData, connectionStatus }) =>
                 knownBluetoothDevices.some(knownDevice => knownDevice.id === id) &&
+                autoConnectPolicy[id]?.type !== 'autoconnect-disabled' &&
                 manufacturerData.filterPolicy?.pairing !== true &&
                 manufacturerData.filterPolicy?.user_disconnected !== true &&
                 connectionStatus.type === 'disconnected',


### PR DESCRIPTION
## Related Issue

Resolve #22034


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/bluetooth-auto-connect-policy&lookback=7)