### PR TITLE
fix(suite): show correct signValue prefix for cardano deposit amount

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -51,6 +51,19 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
     const isStakeType = isStakeTypeTx(txSignature) || tx?.solanaSpecific?.stakeOperation?.type; // ethereum or solana staking tx
     const isStakeTypeTxNoAmount = isStakeType && amount.eq(0);
 
+    const getCardanoStakingSignValue = () => {
+        const subtype = tx.cardanoSpecific?.subtype;
+
+        switch (subtype) {
+            case 'stake_registration':
+                return 'negative';
+            case 'stake_deregistration':
+                return 'positive';
+        }
+
+        return 'positive';
+    };
+
     const getAmountSignValue = () => {
         const txOp = getTxOperation(tx.type, true);
 
@@ -288,7 +301,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 <FormattedCryptoAmount
                                     value={cardanoDeposit}
                                     symbol={tx.symbol}
-                                    signValue="positive"
+                                    signValue={getCardanoStakingSignValue()}
                                 />
                             </Text>
                         </Table.Cell>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve #21965

## Screenshots:

Stake registration:
<img width="770" height="480" alt="image" src="https://github.com/user-attachments/assets/aaeefac6-f798-49a2-82d2-b4d4feabc6f3" />

Stake deregistration:
<img width="770" height="480" alt="image" src="https://github.com/user-attachments/assets/922d49a8-ef8e-4ce8-9ab1-04094bf12b5b" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/cardano-stake-deposit-value&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/cardano-stake-deposit-value&lookback=7)