### PR TITLE
fix(suite): the device-busy state can be there in both cases - when d…

### DIFF
--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -37,6 +37,10 @@ export const getConnectedDeviceStatus = (device: TrezorDevice | undefined) => {
 };
 
 export const getStatus = (device: TrezorDevice) => {
+    if (device.status === 'busy') {
+        return 'device-busy';
+    }
+
     if (device.type === 'acquired') {
         if (!device.connected) {
             return 'disconnected';
@@ -67,10 +71,6 @@ export const getStatus = (device: TrezorDevice) => {
         }
 
         return 'connected';
-    }
-
-    if (device.status === 'busy') {
-        return 'device-busy';
     }
 
     if (device.status === 'rebooting') {


### PR DESCRIPTION
…evice is acquired or not

<!--- Provide a general summary of your changes in the Title above -->

## Description

- the `device-busy` wasn't reflected in the Suite UI when you switched in thp device in device->power to bootloader
- the problem was that `device-busy` was only detected for the unacquired devices
- now it the UI should reflect the device-busy state even when you go to bootloader from thp device settings

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=device-busy-status-acquired&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=device-busy-status-acquired&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=device-busy-status-acquired&lookback=7)