### PR TITLE
Mobile Trade: sort receive accounts

### DIFF
--- a/suite-native/module-trading/src/hooks/general/useReceiveAccountsListData.ts
+++ b/suite-native/module-trading/src/hooks/general/useReceiveAccountsListData.ts
@@ -2,15 +2,12 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import {
-    AccountsRootState,
-    DeviceRootState,
-    selectVisibleDeviceAccountsByNetworkSymbol,
-} from '@suite-common/wallet-core';
+import { AccountsRootState, DeviceRootState } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { useTranslate } from '@suite-native/intl';
 
 import { SectionListData } from './useSectionList';
+import { selectVisibleDeviceAccountsByNetworkSymbolSorted } from '../../selectors/commonSelectors';
 import { ReceiveAccount } from '../../types/general';
 
 export type ReceiveAccountsListMode = 'account' | 'address';
@@ -29,7 +26,7 @@ export const useReceiveAccountsListData = ({
     const { translate } = useTranslate();
 
     const accounts = useSelector((state: AccountsRootState & DeviceRootState) =>
-        selectVisibleDeviceAccountsByNetworkSymbol(state, symbol),
+        selectVisibleDeviceAccountsByNetworkSymbolSorted(state, symbol),
     );
 
     return useMemo<SectionListData<ReceiveAccount>>(() => {

--- a/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
@@ -3,7 +3,11 @@ import {
     InvityServerEnvironment,
     TradingRootStateWithDeviceAndAccounts,
 } from '@suite-common/trading';
-import { AccountsRootState, deviceInitialState } from '@suite-common/wallet-core';
+import {
+    AccountsRootState,
+    DeviceReducerState,
+    deviceInitialState,
+} from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
 import { BigNumber } from '@trezor/utils';
@@ -29,6 +33,7 @@ import {
     selectTradeToBeOpened,
     selectTradesToWatchByAccount,
     selectTradingEnvironment,
+    selectVisibleDeviceAccountsByNetworkSymbolSorted,
 } from '../commonSelectors';
 
 const actionId = 'ActionId_1';
@@ -979,6 +984,60 @@ describe('commonSelectors', () => {
 
             // Trades without account keys should not be grouped
             expect(result.tradesByAccount).toHaveLength(0);
+        });
+    });
+
+    describe('selectVisibleDeviceAccountsByNetworkSymbolSorted', () => {
+        const getStateWithAccounts = () => ({
+            wallet: {
+                ...getWalletState({ tradeType: 'exchange' }),
+                accounts: [
+                    getEthAccount('eth1'),
+                    getBtcAccount('btc0', { deviceState: 'other-device@test:123' }),
+                    getBtcAccount('btc1', { accountType: 'ledger' }),
+                    getBtcAccount('btc2', { accountType: 'normal' }),
+                    getBtcAccount('btc3', { accountType: 'segwit' }),
+                ],
+            },
+            device: {
+                ...deviceInitialState,
+                selectedDevice: {
+                    state: {
+                        staticSessionId:
+                            'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@448CCE89D32A733A1632F345:0',
+                    },
+                },
+            } as unknown as DeviceReducerState,
+        });
+
+        it('should sort accounts by type', () => {
+            const result = selectVisibleDeviceAccountsByNetworkSymbolSorted(
+                getStateWithAccounts(),
+                'btc',
+            );
+
+            expect(result).toEqual([
+                expect.objectContaining({ key: 'btc2' }), // normal
+                expect.objectContaining({ key: 'btc3' }), // segwit
+                expect.objectContaining({ key: 'btc1' }), // ledger
+            ]);
+        });
+
+        it('should be stable', () => {
+            const preloadedState = getStateWithAccounts();
+
+            expect(selectVisibleDeviceAccountsByNetworkSymbolSorted(preloadedState, 'btc')).toBe(
+                selectVisibleDeviceAccountsByNetworkSymbolSorted(preloadedState, 'btc'),
+            );
+        });
+
+        it('should be stable even for empty result', () => {
+            const preloadedState = getStateWithAccounts();
+            preloadedState.wallet.accounts = [];
+
+            expect(selectVisibleDeviceAccountsByNetworkSymbolSorted(preloadedState, 'btc')).toBe(
+                selectVisibleDeviceAccountsByNetworkSymbolSorted(preloadedState, 'btc'),
+            );
         });
     });
 });

--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -32,6 +32,7 @@ import {
     selectBaseCurrency,
     selectCurrentFiatRates,
     selectVisibleDeviceAccounts,
+    selectVisibleDeviceAccountsByNetworkSymbol,
     selectVisibleDeviceAccountsMap,
 } from '@suite-common/wallet-core';
 import { Account, TokenAddress, TokenSymbol } from '@suite-common/wallet-types';
@@ -319,3 +320,13 @@ export const selectTradesToWatchByAccount = createTradingWithDeviceAndAccountsMe
         };
     },
 );
+
+export const selectVisibleDeviceAccountsByNetworkSymbolSorted =
+    createTradingWithDeviceAndAccountsMemoizedSelector(
+        [selectVisibleDeviceAccountsByNetworkSymbol],
+        accounts => {
+            const sortedAccounts = sortAccountsByNetworksAndAccountTypes(accounts);
+
+            return returnStableArrayIfEmpty(sortedAccounts);
+        },
+    );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Sort receive accounts by type.

## Related Issue

Resolve [#22019](https://github.com/trezor/trezor-suite/issues/22019)

## Screenshots:

### Before
<img width="300" alt="Simulator Screenshot" src="https://github.com/user-attachments/assets/ad004843-896d-456c-b1b4-4a0618b0e767" />

### After
<img width="300" alt="Simulator Screenshot " src="https://github.com/user-attachments/assets/0a2117ac-b6eb-4eaf-a2a1-1b16e0e4ca08" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22019-mobile-swap-sort-accounts&lookback=7)