### PR TITLE
fix(suite): disabled the darkening filter on the device images

### DIFF
--- a/packages/components/src/components/Image/Image.tsx
+++ b/packages/components/src/components/Image/Image.tsx
@@ -94,7 +94,7 @@ const getImageHTMLProps = (
         {},
     );
 
-export const Image = ({ image, imageSrc, isFilterActive = true, ...rest }: ImageProps) => {
+export const Image = ({ image, imageSrc, isFilterActive = false, ...rest }: ImageProps) => {
     const frameProps = pickAndPrepareFrameProps(rest, allowedImageFrameProps);
     const imageHTMLProps = getImageHTMLProps(rest);
     const sourceProps = image ? getSourceProps(image) : { src: imageSrc };

--- a/packages/suite/src/views/wallet/trading/DCA/TradingDCALanding.tsx
+++ b/packages/suite/src/views/wallet/trading/DCA/TradingDCALanding.tsx
@@ -103,17 +103,17 @@ const GetAppCard = ({ isLightTheme }: GetAppCardProps) => (
     <Card>
         <Row gap={spacings.lg} alignItems="stretch">
             <TrezorLink href={TRADING_DOWNLOAD_INVITY_APP_URL}>
-                <Image image="TRADING_DCA_INVITY_APP_QR" width={100} height={100} />
+                <Image isFilterActive image="TRADING_DCA_INVITY_APP_QR" width={100} height={100} />
             </TrezorLink>
             <Column justifyContent="center" gap={spacings.xxs}>
                 <TrezorLink href={TRADING_DOWNLOAD_INVITY_APP_URL}>
                     <StoreBadge $isLight={isLightTheme}>
-                        <Image image="PLAY_STORE_BADGE" height={32} />
+                        <Image isFilterActive image="PLAY_STORE_BADGE" height={32} />
                     </StoreBadge>
                 </TrezorLink>
                 <TrezorLink href={TRADING_DOWNLOAD_INVITY_APP_URL}>
                     <StoreBadge $isLight={isLightTheme}>
-                        <Image image="APP_STORE_BADGE" height={32} />
+                        <Image isFilterActive image="APP_STORE_BADGE" height={32} />
                     </StoreBadge>
                 </TrezorLink>
             </Column>
@@ -234,7 +234,6 @@ const DCALanding = () => {
                                     ? 'TRADING_DCA_INVITY_APP'
                                     : 'TRADING_DCA_INVITY_APP_DARK'
                             }
-                            isFilterActive={false}
                         />
                     </Column>
                 </ColumnsWrapper>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve (internal discussion, problem presetned here) https://github.com/trezor/trezor-suite/pull/17880#discussion_r2394084022

This basically reverts the changes from the PR discussed here: https://github.com/trezor/trezor-suite/pull/17880#discussion_r2394095577

## Screenshots:
BFR:

<img width="525" height="651" alt="Screenshot 2025-10-01 at 11 57 15 AM" src="https://github.com/user-attachments/assets/71979c74-21ff-4c9e-bc9f-b76275d21817" />


After (this was the original state before the mentioned pr above):
<img width="526" height="705" alt="Screenshot 2025-10-01 at 12 14 55 PM" src="https://github.com/user-attachments/assets/c7d9fbfd-4ef0-45cc-9d44-2997aa6cc028" />




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=confirm-modal-renders&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=confirm-modal-renders&lookback=7)