### PR TITLE
Refactor onboarding layout

### DIFF
--- a/packages/components/src/components/BulletList/BulletList.stories.tsx
+++ b/packages/components/src/components/BulletList/BulletList.stories.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 
 import { Meta, StoryObj } from '@storybook/react';
 
-import { spacings } from '@trezor/theme';
+import { spacingsNew } from '@trezor/theme';
 
 import { BulletList as BulletListComponent, allowedBulletListFrameProps } from './BulletList';
-import { bulletSizes } from './types';
+import { bulletLineWidths, bulletListDirections, bulletSizes } from './types';
 import { getFramePropsStory } from '../../utils/frameProps';
 
 const meta: Meta = {
@@ -34,13 +34,15 @@ export const BulletList: StoryObj<typeof BulletListComponent> = {
     ),
     args: {
         ...getFramePropsStory(allowedBulletListFrameProps).args,
-        gap: spacings.xxl,
-        titleGap: spacings.xs,
-        bulletGap: spacings.xl,
+        gap: 32,
+        titleGap: 8,
+        bulletGap: 24,
         isOrdered: true,
         bulletSize: 'large',
-        width: 400,
-        margin: { vertical: spacings.lg, horizontal: 'auto' },
+        lineWidth: 2,
+        direction: 'vertical',
+        width: 600,
+        margin: { vertical: 12, horizontal: 'auto' },
     },
     argTypes: {
         isOrdered: {
@@ -49,25 +51,37 @@ export const BulletList: StoryObj<typeof BulletListComponent> = {
             },
         },
         gap: {
-            options: Object.values(spacings),
+            options: spacingsNew,
             control: {
                 type: 'select',
             },
         },
         titleGap: {
-            options: Object.values(spacings),
+            options: spacingsNew,
             control: {
                 type: 'select',
             },
         },
         bulletGap: {
-            options: Object.values(spacings),
+            options: spacingsNew,
             control: {
                 type: 'select',
             },
         },
         bulletSize: {
             options: bulletSizes,
+            control: {
+                type: 'select',
+            },
+        },
+        lineWidth: {
+            options: bulletLineWidths,
+            control: {
+                type: 'select',
+            },
+        },
+        direction: {
+            options: bulletListDirections,
             control: {
                 type: 'select',
             },

--- a/packages/components/src/components/BulletList/BulletList.tsx
+++ b/packages/components/src/components/BulletList/BulletList.tsx
@@ -2,10 +2,10 @@ import { createContext, useContext } from 'react';
 
 import styled from 'styled-components';
 
-import { SpacingValues, spacings } from '@trezor/theme';
+import { SpacingValuesNew } from '@trezor/theme';
 
 import { BulletListItem } from './BulletListItem';
-import { BulletSize } from './types';
+import { BulletLineWidth, BulletListDirection, BulletSize } from './types';
 import {
     FrameProps,
     FramePropsKeys,
@@ -24,10 +24,12 @@ export const allowedBulletListFrameProps = [
 ] as const satisfies FramePropsKeys[];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedBulletListFrameProps)[number]>;
 
-const Container = styled.ul<TransientProps<AllowedFrameProps>>`
+const Container = styled.ul<
+    TransientProps<AllowedFrameProps> & { $direction: BulletListDirection }
+>`
     display: flex;
     list-style-type: none;
-    flex-direction: column;
+    flex-direction: ${({ $direction }) => ($direction === 'vertical' ? 'column' : 'row')};
     align-items: stretch;
     counter-reset: item-counter;
 
@@ -35,37 +37,45 @@ const Container = styled.ul<TransientProps<AllowedFrameProps>>`
 `;
 
 export type BulletListProps = AllowedFrameProps & {
-    gap?: SpacingValues;
-    bulletGap?: SpacingValues;
-    titleGap?: SpacingValues;
+    gap?: SpacingValuesNew;
+    bulletGap?: SpacingValuesNew;
+    titleGap?: SpacingValuesNew;
     isOrdered?: boolean;
     bulletSize?: BulletSize;
+    lineWidth?: BulletLineWidth;
+    direction?: BulletListDirection;
     children: React.ReactNode;
     'data-testid'?: string;
 };
 
 type BulletListContextValue = {
-    itemGap: SpacingValues;
-    titleGap: SpacingValues;
-    bulletGap: SpacingValues;
+    itemGap: SpacingValuesNew;
+    titleGap: SpacingValuesNew;
+    bulletGap: SpacingValuesNew;
     bulletSize: BulletSize;
+    lineWidth: BulletLineWidth;
     isOrdered: boolean;
+    direction: BulletListDirection;
 };
 
 const BulletListContext = createContext<BulletListContextValue>({
-    itemGap: spacings.xxl,
-    titleGap: spacings.xs,
-    bulletGap: spacings.xl,
+    itemGap: 32,
+    titleGap: 8,
+    bulletGap: 24,
     bulletSize: 'large',
     isOrdered: false,
+    lineWidth: 2,
+    direction: 'vertical',
 });
 
 export const BulletList = ({
-    gap = spacings.xxl,
-    bulletGap = spacings.xl,
-    titleGap = spacings.xs,
+    gap = 32,
+    bulletGap = 24,
+    titleGap = 8,
     isOrdered = false,
     bulletSize = 'large',
+    lineWidth = 2,
+    direction = 'vertical',
     'data-testid': dataTestId,
     children,
     ...rest
@@ -74,9 +84,17 @@ export const BulletList = ({
 
     return (
         <BulletListContext.Provider
-            value={{ itemGap: gap, bulletGap, titleGap, isOrdered, bulletSize }}
+            value={{
+                itemGap: gap,
+                bulletGap,
+                titleGap,
+                isOrdered,
+                bulletSize,
+                lineWidth,
+                direction,
+            }}
         >
-            <Container data-testid={dataTestId} {...frameProps}>
+            <Container data-testid={dataTestId} {...frameProps} $direction={direction}>
                 {children}
             </Container>
         </BulletListContext.Provider>

--- a/packages/components/src/components/BulletList/BulletListItem.tsx
+++ b/packages/components/src/components/BulletList/BulletListItem.tsx
@@ -1,24 +1,49 @@
 import styled, { css, useTheme } from 'styled-components';
 
-import { SpacingValues, borders, typography } from '@trezor/theme';
+import { SpacingValuesNew, typography } from '@trezor/theme';
 
 import { useBulletList } from './BulletList';
-import { BulletListItemState, BulletSize } from './types';
+import { BulletLineWidth, BulletListDirection, BulletListItemState, BulletSize } from './types';
 import { mapSizeToDimension, mapStateToColor } from './utils';
 import { IconCircle } from '../IconCircle/IconCircle';
 import { Text } from '../typography/Text/Text';
 
-const Item = styled.li<{ $bulletGap: SpacingValues; $size: BulletSize }>`
+const Item = styled.li<{
+    $bulletGap: SpacingValuesNew;
+    $titleGap: SpacingValuesNew;
+    $size: BulletSize;
+    $direction: BulletListDirection;
+}>`
     display: grid;
-    columns: 2;
     grid-template-columns: ${mapSizeToDimension}px 1fr;
-    column-gap: ${({ $bulletGap }) => `${$bulletGap}px`};
+
+    ${({ $direction, $bulletGap, $titleGap }) =>
+        $direction === 'vertical'
+            ? css`
+                  column-gap: ${$bulletGap}px;
+              `
+            : css`
+                  flex: 1;
+                  row-gap: ${$titleGap}px;
+
+                  &:last-child {
+                      flex: 0;
+                  }
+              `}
 `;
 
-const BulletWrapper = styled.div`
+const BulletWrapper = styled.div<{ $direction: BulletListDirection }>`
     align-self: center;
     counter-increment: item-counter;
     position: relative;
+
+    ${({ $direction }) =>
+        $direction === 'horizontal' &&
+        css`
+            grid-column: 1;
+            grid-row: 1;
+            place-self: center;
+        `}
 `;
 
 const Bullet = styled.div<{
@@ -37,6 +62,14 @@ const Bullet = styled.div<{
         theme[$isDarkTheme ? 'textDefaultInverted' : 'backgroundNeutralDisabled']};
     color: ${mapStateToColor};
     ${({ $size }) => ($size === 'small' ? typography.label : typography.hint)}
+
+    ${({ $state, $isOrdered, theme }) =>
+        $state === 'default' &&
+        $isOrdered &&
+        css`
+            background-color: ${theme.textDefaultInverted};
+            box-shadow: ${theme.boxShadowBase};
+        `}
 
     &::before {
         ${({ $isOrdered, $isDarkTheme }) =>
@@ -59,22 +92,52 @@ const Bullet = styled.div<{
     }
 `;
 
-const Title = styled.div`
+const Title = styled.div<{ $direction: BulletListDirection }>`
     align-self: center;
     overflow: hidden;
+
+    ${({ $direction }) =>
+        $direction === 'horizontal' &&
+        css`
+            grid-column: 1;
+            grid-row: 2;
+            text-align: center;
+            place-self: center;
+            overflow: visible;
+        `}
 `;
 
-const Line = styled.div<{ $size: BulletSize }>`
-    place-self: stretch center;
-    border-left: ${borders.widths.large} dashed ${({ theme }) => theme.borderDashed};
-    margin: calc(${mapSizeToDimension}px * -0.5) 0;
+const Line = styled.div<{
+    $size: BulletSize;
+    $direction: BulletListDirection;
+    $bulletGap: SpacingValuesNew;
+    $lineWidth: BulletLineWidth;
+}>`
+    ${({ $direction, $bulletGap, $size, $lineWidth }) =>
+        $direction === 'horizontal'
+            ? css`
+                  grid-column: 2;
+                  grid-row: 1;
+                  margin: 0 ${$bulletGap}px;
+                  border-top: ${$lineWidth}px dashed ${({ theme }) => theme.borderDashed};
+                  place-self: center stretch;
 
-    ${Item}:last-child & {
-        opacity: 0;
-    }
+                  ${Item}:last-child & {
+                      display: none;
+                  }
+              `
+            : css`
+                  place-self: stretch center;
+                  border-left: ${$lineWidth}px dashed ${({ theme }) => theme.borderDashed};
+                  margin: calc(${mapSizeToDimension({ $size })}px * -0.5) 0;
+
+                  ${Item}:last-child & {
+                      opacity: 0;
+                  }
+              `}
 `;
 
-const Content = styled.div<{ $itemGap: SpacingValues; $titleGap: SpacingValues }>`
+const Content = styled.div<{ $itemGap: SpacingValuesNew; $titleGap: SpacingValuesNew }>`
     padding-bottom: ${({ $itemGap }) => `${$itemGap}px`};
 
     &:not(:empty) {
@@ -99,13 +162,20 @@ export const BulletListItem = ({
     'data-testid': dataTestId,
     children,
 }: BulletListItemProps) => {
-    const { itemGap, bulletGap, titleGap, bulletSize, isOrdered } = useBulletList();
+    const { itemGap, bulletGap, titleGap, bulletSize, isOrdered, direction, lineWidth } =
+        useBulletList();
     const theme = useTheme();
     const isDarkTheme = theme.variant === 'dark';
 
     return (
-        <Item $bulletGap={bulletGap} $size={bulletSize} data-testid={dataTestId}>
-            <BulletWrapper>
+        <Item
+            $bulletGap={bulletGap}
+            $titleGap={titleGap}
+            $size={bulletSize}
+            $direction={direction}
+            data-testid={dataTestId}
+        >
+            <BulletWrapper $direction={direction}>
                 {state === 'done' ? (
                     <IconCircle
                         name="check"
@@ -122,24 +192,31 @@ export const BulletListItem = ({
                     />
                 )}
             </BulletWrapper>
-            <Title>
+            <Title $direction={direction}>
                 <Text
                     as="div"
-                    typographyStyle="body"
+                    typographyStyle={direction === 'vertical' ? 'body' : 'hint'}
                     color={mapStateToColor({ $state: state, theme })}
-                    ellipsisLineCount={2}
+                    ellipsisLineCount={direction === 'vertical' ? 2 : undefined}
                 >
                     {title}
                 </Text>
             </Title>
-            <Line $size={bulletSize} />
-            <Content $itemGap={itemGap} $titleGap={titleGap}>
-                {children && (
-                    <Text as="div" typographyStyle="hint">
-                        {children}
-                    </Text>
-                )}
-            </Content>
+            <Line
+                $size={bulletSize}
+                $direction={direction}
+                $bulletGap={bulletGap}
+                $lineWidth={lineWidth}
+            />
+            {direction === 'vertical' && (
+                <Content $itemGap={itemGap} $titleGap={titleGap}>
+                    {children && (
+                        <Text as="div" typographyStyle="hint">
+                            {children}
+                        </Text>
+                    )}
+                </Content>
+            )}
         </Item>
     );
 };

--- a/packages/components/src/components/BulletList/types.ts
+++ b/packages/components/src/components/BulletList/types.ts
@@ -1,6 +1,14 @@
+import { SpacingValuesNew } from '@trezor/theme';
+
 import { UISize } from '../../config/types';
 
 export const bulletSizes = ['large', 'medium', 'small'] as const;
 export type BulletSize = Extract<UISize, (typeof bulletSizes)[number]>;
 
+export const bulletLineWidths = [0, 1, 2] as const;
+export type BulletLineWidth = Extract<SpacingValuesNew, (typeof bulletLineWidths)[number]>;
+
 export type BulletListItemState = 'default' | 'done' | 'pending';
+
+export const bulletListDirections = ['vertical', 'horizontal'] as const;
+export type BulletListDirection = (typeof bulletListDirections)[number];

--- a/packages/suite/src/components/onboarding/OnboardingLayout.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingLayout.tsx
@@ -2,9 +2,8 @@ import { ReactNode } from 'react';
 
 import styled from 'styled-components';
 
-import { Button, Flex, Row, variables } from '@trezor/components';
+import { Box, Button, Column, Row } from '@trezor/components';
 import { isDesktop, isMacOs } from '@trezor/env-utils';
-import { spacings, spacingsPx } from '@trezor/theme';
 import { TREZOR_SUPPORT_URL } from '@trezor/urls';
 
 import { MODAL } from 'src/actions/suite/constants';
@@ -25,96 +24,9 @@ import { ConnectionGlobalModalManager } from '../connection/ConnectionGlobalModa
 import { TRAFFIC_LIGHT_DEFAULT_OFFSET } from '../suite/TrafficLightOffset';
 import { DebugLegend } from '../suite/layouts/SuiteLayout/DebugLegend';
 
-const Wrapper = styled.div`
-    display: flex;
-    width: 100%;
-    height: 100%;
-    flex-direction: column;
-    align-items: center;
-`;
-
-const Body = styled.div`
-    justify-content: center;
-    display: flex;
-    width: 100%;
-    height: 100%;
-`;
-
-const ScrollingWrapper = styled.div`
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-`;
-
 const OnboardingSpacer = styled.div`
     height: ${TRAFFIC_LIGHT_DEFAULT_OFFSET}px;
     width: 100%;
-`;
-
-const ContentWrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    align-items: center;
-    overflow: auto;
-`;
-
-const Header = styled.div`
-    display: flex;
-    width: 100%;
-    padding: ${spacingsPx.sm};
-    justify-content: space-between;
-    align-items: center;
-    flex-direction: column;
-    max-width: ${MAX_ONBOARDING_WIDTH}px;
-    margin-bottom: ${spacingsPx.md};
-
-    ${variables.SCREEN_QUERY.BELOW_LAPTOP} {
-        padding: 0 ${spacingsPx.lg};
-    }
-
-    ${variables.SCREEN_QUERY.MOBILE} {
-        /* low width screen (mobile) */
-        margin-bottom: ${spacingsPx.xl};
-    }
-
-    @media all and (max-height: ${variables.SCREEN_SIZE.SM}) {
-        /* low height screen */
-        padding: 0 ${spacingsPx.lg};
-        margin-bottom: ${spacingsPx.xl};
-    }
-`;
-
-const LogoHeaderRow = styled.div`
-    display: flex;
-    width: 100%;
-    justify-content: space-between;
-    margin-top: ${spacingsPx.lg};
-    margin-bottom: ${spacingsPx.xxl};
-
-    ${variables.SCREEN_QUERY.MOBILE} {
-        display: none;
-    }
-`;
-
-const ProgressBarRow = styled.div`
-    width: 100%;
-    margin-bottom: ${spacingsPx.lg};
-
-    ${variables.SCREEN_QUERY.MOBILE} {
-        margin-bottom: 0;
-    }
-`;
-
-const Content = styled.div`
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    max-width: ${MAX_ONBOARDING_WIDTH}px;
-    width: 100%;
-    padding: 0 ${spacingsPx.lg} ${spacingsPx.xxxxl} ${spacingsPx.lg};
 `;
 
 type OnboardingContentProps = {
@@ -125,12 +37,11 @@ const OnboardingContent = ({ children }: OnboardingContentProps) => {
     const { onCancelHandler } = useOnboardingCancelButtonContext();
 
     return (
-        <ContentWrapper id="layout-scroll">
-            <Header>
-                <LogoHeaderRow>
+        <Column gap={24}>
+            <Column gap={48}>
+                <Row justifyContent="space-between">
                     <SmallDeviceItem />
-
-                    <Row gap={spacings.sm}>
+                    <Row gap={12}>
                         <Button
                             variant="tertiary"
                             icon="arrowUpRight"
@@ -152,15 +63,11 @@ const OnboardingContent = ({ children }: OnboardingContentProps) => {
                             </Button>
                         ) : null}
                     </Row>
-                </LogoHeaderRow>
-
-                <ProgressBarRow>
-                    <OnboardingProgressBar />
-                </ProgressBarRow>
-            </Header>
-
-            <Content>{children}</Content>
-        </ContentWrapper>
+                </Row>
+                <OnboardingProgressBar />
+            </Column>
+            <Box>{children}</Box>
+        </Column>
     );
 };
 
@@ -183,23 +90,23 @@ export const OnboardingLayout = ({ children }: OnboardingLayoutProps) => {
         <>
             <ConnectionGlobalModalManager />
             {allowedModal !== null ? <ReduxModal {...allowedModal} /> : null}
-
-            <Wrapper>
-                <Body data-testid="@onboarding-layout/body">
-                    <ScrollingWrapper>
-                        {isMac && isDesktopApp && <OnboardingSpacer />}
-                        <Flex direction="column" alignItems="center">
-                            <SuiteBanners isOnboarding />
-                        </Flex>
-                        <OnboardingCancelButtonContext>
-                            <OnboardingContent>{children}</OnboardingContent>
-                        </OnboardingCancelButtonContext>
-                    </ScrollingWrapper>
-
-                    <GuideButton />
-                    <GuideRouter />
-                </Body>
-            </Wrapper>
+            <Column width="100%" height="100%" overflow="auto" alignItems="center">
+                {isMac && isDesktopApp && <OnboardingSpacer />}
+                <Column
+                    data-testid="@onboarding-layout/body"
+                    gap={20}
+                    maxWidth={MAX_ONBOARDING_WIDTH}
+                    width="100%"
+                    padding={{ horizontal: 20, top: 32, bottom: 48 }}
+                >
+                    <SuiteBanners isOnboarding />
+                    <OnboardingCancelButtonContext>
+                        <OnboardingContent>{children}</OnboardingContent>
+                    </OnboardingCancelButtonContext>
+                </Column>
+            </Column>
+            <GuideButton />
+            <GuideRouter />
             {theme.variant === 'debug' && <DebugLegend layout={OnboardingLayout.name} />}
         </>
     );

--- a/packages/suite/src/components/onboarding/OnboardingProgressBar.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingProgressBar.tsx
@@ -1,9 +1,7 @@
-import { Fragment, useMemo } from 'react';
+import { useMemo } from 'react';
 
-import styled, { css, useTheme } from 'styled-components';
-
-import { Icon, variables } from '@trezor/components';
-import { spacingsPx, typography } from '@trezor/theme';
+import { TranslationKey } from '@suite-common/intl-types';
+import { BulletList, BulletListItemState, Text } from '@trezor/components';
 
 import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useOnboarding, useSelector } from 'src/hooks/suite';
@@ -38,137 +36,39 @@ const useOnboardingStepCategoriesInPath = () => {
     );
 };
 
-const ProgressBarWrapper = styled.div`
-    display: flex;
-    padding: ${spacingsPx.lg} 0;
-    width: 100%;
+const getState = (index: number, indexOfActiveStep: number): BulletListItemState => {
+    if (index < indexOfActiveStep) return 'done';
+    if (index === indexOfActiveStep) return 'default';
 
-    /* prevents jumping in completed state with check mark icon shown */
-    height: 64px;
-    justify-content: space-between;
-    align-items: flex-start;
-`;
-
-const StepWrapper = styled.div<{ $active: boolean }>`
-    display: flex;
-    flex-direction: column;
-    padding: 0 ${spacingsPx.lg};
-    align-items: center;
-    align-self: flex-start;
-    color: ${({ theme }) => theme.textSubdued};
-    ${typography.highlight};
-
-    @media all and (max-width: ${variables.SCREEN_SIZE.LG}) {
-        padding: 0;
-    }
-
-    ${({ $active, theme }) =>
-        $active &&
-        css`
-            color: ${theme.textPrimaryDefault};
-        `}
-`;
-
-const IconWrapper = styled.div<{ $stepCompleted?: boolean; $active?: boolean }>`
-    display: flex;
-    width: 32px;
-    height: 32px;
-    background: ${({ theme }) => theme.backgroundNeutralSubtleOnElevation1};
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
-    font-variant-numeric: tabular-nums;
-
-    ${props =>
-        props.$stepCompleted &&
-        css`
-            background: transparent;
-        `}
-
-    ${({ $active, theme }) =>
-        $active &&
-        css`
-            background: ${theme.backgroundSurfaceElevation1};
-            box-shadow: ${({ theme }) => theme.boxShadowBase};
-            color: ${theme.textPrimaryDefault};
-        `}
-`;
-
-const Label = styled.div`
-    text-align: center;
-    margin: 10px 0 0;
-    display: block;
-    color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
-    ${typography.label}
-
-    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
-        display: none;
-    }
-`;
-
-const Divider = styled.div`
-    flex-grow: 1;
-    border-bottom: 1px solid ${({ theme }) => theme.borderElevation1};
-    margin: ${spacingsPx.md} ${spacingsPx.lg};
-
-    @media (max-width: ${variables.SCREEN_SIZE.XL}) {
-        margin: ${spacingsPx.md};
-    }
-
-    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
-        margin: ${spacingsPx.md} ${spacingsPx.sm};
-    }
-`;
+    return 'pending';
+};
 
 export const OnboardingProgressBar = () => {
-    const theme = useTheme();
-
     const stepCategoriesInPath = useOnboardingStepCategoriesInPath();
     const { activeStepCategory } = useOnboarding();
-    const lastStepIndex = stepCategoriesInPath.length - 1;
     const indexOfActiveStep = stepCategoriesInPath.findIndex(
         ({ id }) => id === activeStepCategory?.id,
     );
 
     return (
-        <ProgressBarWrapper>
-            {stepCategoriesInPath.map(({ id, labelTranslationId }, index) => {
-                // if active step was not found (-1) because activeStepGroup is undefined, no step will be considered completed
-                const stepCompleted = indexOfActiveStep > index;
-                const stepActive = index === indexOfActiveStep;
-
-                return (
-                    <Fragment key={id}>
-                        <StepWrapper $active={stepActive}>
-                            <IconWrapper $active={stepActive} $stepCompleted={stepCompleted}>
-                                {stepCompleted ? (
-                                    <Icon name="check" color={theme.legacy.TYPE_GREEN} />
-                                ) : (
-                                    <>
-                                        {index === lastStepIndex ? (
-                                            <Icon
-                                                name="confetti"
-                                                size={20}
-                                                color={
-                                                    stepActive ? theme.legacy.TYPE_GREEN : undefined
-                                                }
-                                            />
-                                        ) : (
-                                            index + 1
-                                        )}
-                                    </>
-                                )}
-                            </IconWrapper>
-                            {labelTranslationId ? (
-                                <Label>
-                                    <Translation id={labelTranslationId} />
-                                </Label>
-                            ) : null}
-                        </StepWrapper>
-                        {index < lastStepIndex && <Divider />}
-                    </Fragment>
-                );
-            })}
-        </ProgressBarWrapper>
+        <BulletList
+            direction="horizontal"
+            isOrdered
+            bulletGap={16}
+            margin={{ horizontal: 24 }}
+            lineWidth={1}
+        >
+            {stepCategoriesInPath.map(({ id, labelTranslationId }, index) => (
+                <BulletList.Item
+                    key={id}
+                    title={
+                        <Text typographyStyle="label">
+                            <Translation id={labelTranslationId as TranslationKey} />
+                        </Text>
+                    }
+                    state={getState(index, indexOfActiveStep)}
+                />
+            ))}
+        </BulletList>
     );
 };

--- a/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
@@ -4,10 +4,10 @@ import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { TrezorDevice } from '@suite-common/suite-types';
-import { Modal } from '@trezor/components';
+import { Box, Column, Modal, Row } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
 import { ConfirmOnDevice } from '@trezor/product-components';
-import { spacingsPx, zIndices } from '@trezor/theme';
+import { zIndices } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite/Translation';
 import messages from 'src/support/messages';
@@ -17,35 +17,7 @@ import {
     CollapsibleOnboardingCardProps,
 } from './CollapsibleOnboardingCard';
 
-const WrapperWrapper = styled.div`
-    z-index: ${zIndices.modal};
-`;
-
-const ConfirmWrapper = styled.div`
-    margin-bottom: ${spacingsPx.lg};
-    height: 62px;
-`;
-
-const InnerActions = styled.div`
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin: ${spacingsPx.xxl} auto;
-`;
-
-const OuterActions = styled.div<{ $smallMargin?: boolean }>`
-    display: flex;
-    margin-top: ${({ $smallMargin }) => ($smallMargin ? '0px' : spacingsPx.lg)};
-    width: 100%;
-    justify-content: center;
-    z-index: ${zIndices.onboardingForeground};
-`;
-
-const StyledCollapsibleCard = styled(CollapsibleOnboardingCard)<{ $isBackDropVisible: boolean }>`
-    z-index: ${({ $isBackDropVisible }) => ($isBackDropVisible ? zIndices.modal : 0)};
-`;
-
-export interface OnboardingStepBoxProps extends CollapsibleOnboardingCardProps {
+export type OnboardingStepBoxProps = CollapsibleOnboardingCardProps & {
     innerActions?: ReactNode;
     outerActions?: ReactNode;
     device?: TrezorDevice;
@@ -53,7 +25,13 @@ export interface OnboardingStepBoxProps extends CollapsibleOnboardingCardProps {
     nested?: boolean;
     devicePromptTitle?: ReactNode;
     isActionAbortable?: boolean;
-}
+};
+
+const StyledCollapsibleOnboardingCard = styled(CollapsibleOnboardingCard)<{
+    $isBackDropVisible: boolean;
+}>`
+    z-index: ${({ $isBackDropVisible }) => ($isBackDropVisible ? zIndices.modal : 0)};
+`;
 
 // Legacy duplicate of CollapsibleBox !! Should not be used elsewhere
 export const OnboardingStepBox = ({
@@ -79,10 +57,22 @@ export const OnboardingStepBox = ({
     return (
         <>
             {isBackDropVisible && <Modal.Backdrop zIndex={zIndices.modal} />}
-            {!disableConfirmWrapper && (
-                <WrapperWrapper data-testid="@prompts/confirm-on-device'">
-                    {deviceModelInternal && (
-                        <ConfirmWrapper>
+            <Column alignItems="center" gap={20} padding={{ top: image ? 0 : 40 }}>
+                <StyledCollapsibleOnboardingCard
+                    image={image}
+                    heading={heading}
+                    description={description}
+                    nested={nested}
+                    $isBackDropVisible={isBackDropVisible}
+                    {...rest}
+                >
+                    {!disableConfirmWrapper && deviceModelInternal && (
+                        <Box
+                            position={{
+                                type: 'absolute',
+                                bottom: `calc(100% + ${image ? 60 : 20}px)`,
+                            }}
+                        >
                             <ConfirmOnDevice
                                 title={
                                     devicePromptTitle || <Translation id="TR_CONFIRM_ON_TREZOR" />
@@ -98,28 +88,21 @@ export const OnboardingStepBox = ({
                                         : undefined
                                 }
                             />
-                        </ConfirmWrapper>
+                        </Box>
                     )}
-                </WrapperWrapper>
-            )}
-
-            <StyledCollapsibleCard
-                image={image}
-                heading={heading}
-                description={description}
-                nested={nested}
-                $isBackDropVisible={isBackDropVisible}
-                {...rest}
-            >
-                {(children || innerActions) && (
-                    <>
-                        {children}
-                        {innerActions && <InnerActions>{innerActions}</InnerActions>}
-                    </>
-                )}
-            </StyledCollapsibleCard>
-
-            {outerActions && <OuterActions $smallMargin={nested}>{outerActions}</OuterActions>}
+                    {(children || innerActions) && (
+                        <>
+                            {children}
+                            {innerActions && (
+                                <Row justifyContent="center" margin={{ vertical: 32 }}>
+                                    {innerActions}
+                                </Row>
+                            )}
+                        </>
+                    )}
+                </StyledCollapsibleOnboardingCard>
+                {outerActions && <Box zIndex={zIndices.onboardingForeground}>{outerActions}</Box>}
+            </Column>
         </>
     );
 };

--- a/packages/suite/src/config/onboarding/steps.ts
+++ b/packages/suite/src/config/onboarding/steps.ts
@@ -119,6 +119,7 @@ export const stepCategories: StepCategory[] = [
     },
     {
         id: 'final',
+        labelTranslationId: 'TR_COMPLETE',
         steps: [
             {
                 id: STEP.ID_FINAL_STEP,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6800,6 +6800,10 @@ export default defineMessages({
         id: 'TR_PIN_HEADING_INITIAL',
         defaultMessage: 'Set a PIN',
     },
+    TR_COMPLETE: {
+        id: 'TR_COMPLETE',
+        defaultMessage: 'Complete',
+    },
     TR_COMPLETE_SETUP: {
         id: 'TR_COMPLETE_SETUP',
         defaultMessage: 'Complete setup',

--- a/packages/theme/src/spacings.ts
+++ b/packages/theme/src/spacings.ts
@@ -29,7 +29,9 @@ export const negativeSpacings = {
     xxxxxl: -60,
 } as const;
 
-export type SpacingValuesNew = 0 | 2 | 4 | 6 | 8 | 10 | 12 | 14 | 16 | 20 | 24 | 32 | 40 | 48 | 60;
+export const spacingsNew = [0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 20, 24, 32, 40, 48, 60] as const;
+
+export type SpacingValuesNew = (typeof spacingsNew)[number];
 export type SpacingValuesPxNew = `${SpacingValuesNew}px`;
 
 export type Spacings = typeof spacings;


### PR DESCRIPTION
First wave of onboarding refactoring.

- add horizontal prop to BulletList component
- general simplification of the layout
- remove custom components
- layout no longer jump when the device prompt shows up

### Before
<img width="1045" height="318" alt="Screenshot 2025-10-01 at 12 26 28" src="https://github.com/user-attachments/assets/9d30b22e-d298-4364-8824-84c443c78e37" />
<img width="1045" height="395" alt="Screenshot 2025-10-01 at 12 27 11" src="https://github.com/user-attachments/assets/f323e376-c7c1-436e-a5b4-c1eb6da01112" />

### After
<img width="1034" height="339" alt="Screenshot 2025-10-01 at 12 26 03" src="https://github.com/user-attachments/assets/5664e006-5a95-4f2f-b2d6-f5ef8514e94c" />
<img width="1045" height="341" alt="Screenshot 2025-10-01 at 12 26 47" src="https://github.com/user-attachments/assets/f5e51ba5-4875-49f0-b9c5-7294854725fd" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/add-horizontal-bullet-list&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/add-horizontal-bullet-list&lookback=7)