### PR TITLE
fix(transport-bluetooth): server wait for missing characteristics

### DIFF
--- a/packages/transport-bluetooth/src/server/methods/open_device.rs
+++ b/packages/transport-bluetooth/src/server/methods/open_device.rs
@@ -10,7 +10,7 @@ use crate::server::{
         AbortProcess, ChannelMessage, MethodError, MethodResult, NotificationCharacteristic,
         NotificationEvent, OpenDeviceParams, WsResponsePayload,
     },
-    ConnectionBroadcast,
+    utils, ConnectionBroadcast,
 };
 
 pub async fn open_device(
@@ -43,11 +43,7 @@ pub async fn open_device(
     )));
     sleep(Duration::from_millis(5)).await;
 
-    if peripheral.services().is_empty() {
-        // services() always empty on linux macos
-        // discover_services() slows down the process on windows
-        peripheral.discover_services().await?;
-    }
+    utils::wait_for_characteristics(&peripheral).await?;
 
     let Some(tx) = peripheral
         .characteristics()

--- a/packages/transport-bluetooth/src/server/methods/write.rs
+++ b/packages/transport-bluetooth/src/server/methods/write.rs
@@ -2,6 +2,7 @@ use crate::server::{
     adapter_manager::{AdapterError, AdapterManager},
     device::CHARACTERISTIC_RX,
     types::{MethodError, MethodResult, WriteParams, WsResponsePayload},
+    utils,
 };
 use btleplug::api::{CharPropFlags, Peripheral as _, WriteType};
 use log::info;
@@ -21,12 +22,6 @@ pub async fn write(manager: AdapterManager, params: WriteParams) -> MethodResult
         return Err(MethodError::Adapter(AdapterError::PeripheralNotConnected));
     }
 
-    if peripheral.services().is_empty() {
-        // services() always empty on linux macos
-        // discover_services() slows down the process on windows
-        peripheral.discover_services().await?;
-    }
-
     // windows WithResponse takes too long. ~3000ms
     let (write_type, write_flag) = if with_response {
         (WriteType::WithResponse, CharPropFlags::WRITE)
@@ -36,6 +31,8 @@ pub async fn write(manager: AdapterManager, params: WriteParams) -> MethodResult
             CharPropFlags::WRITE_WITHOUT_RESPONSE,
         )
     };
+
+    utils::wait_for_characteristics(&peripheral).await?;
 
     let characteristics = peripheral.characteristics();
     let Some(rx) = characteristics

--- a/packages/transport-bluetooth/src/server/utils.rs
+++ b/packages/transport-bluetooth/src/server/utils.rs
@@ -54,6 +54,17 @@ pub async fn dispatch_status(
         .await
 }
 
+pub async fn wait_for_characteristics(peripheral: &Peripheral) -> Result<(), PlatformError> {
+    let mut retries = 10;
+    while retries > 0 && peripheral.characteristics().is_empty() {
+        peripheral.discover_services().await?;
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+        info!("wait_for_characteristics {retries}");
+        retries -= 1;
+    }
+    Ok(())
+}
+
 /// Common btleplug flow after successful pairing
 /// process is separated into parts:
 /// discover_services + (macos: try_to_subscribe) + verify_connection


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

characteristics are discovered with delay on linux:
1. disable BT in system settings, sleep device
1. start suite with already paired/known device
1. suite: connect device > bluetooth
1. enable BT in system
1. click on connect device
1. unlock device from sleep
1. device is connected


errors:
```
INFO  trezor_bluetooth::server::adapter_manager    > DeviceConnected: PeripheralId(DeviceId { object_path: Path("/org/bluez/hci0/dev_C4_20_57_55_C9_EA\0") }) : TrezorDevice { id: "hci0/dev_C4_20_57_55_C9_EA", props: Mutex { data: TrezorDeviceProps { name: "Trezor Safe 7", address: "C4:20:57:55:C9:EA", data: [], paired: true, connected: false, connection_status: Connecting, discovery_timestamp: 1759307310610, timestamp: 1759307319338, event_timestamp: 1759307319338, rssi: -65 }, poisoned: false, .. } }

 INFO  trezor_bluetooth::server::message_handler    > Method: "OpenDevice(hci0/dev_C4_20_57_55_C9_EA)"
 INFO  trezor_bluetooth::server::methods::open_device > open_device hci0/dev_C4_20_57_55_C9_EA characteristic Some(Read)
 INFO  trezor_bluetooth::server::connection_handler   > ChannelMessage listener Abort(NotificationStream("hci0/dev_C4_20_57_55_C9_EA", Some(Read)))
 INFO  trezor_bluetooth::server::message_handler      > WsError Adapter(PeripheralCharacteristicNotFound)
Device device.run error.message: Unable to open device, code: undefined
 INFO  trezor_bluetooth::server::message_handler      > Method: "OpenDevice(hci0/dev_C4_20_57_55_C9_EA)"
 INFO  trezor_bluetooth::server::methods::open_device > open_device hci0/dev_C4_20_57_55_C9_EA characteristic Some(BatteryLevel)
 INFO  trezor_bluetooth::server::message_handler      > Method: "OpenDevice(hci0/dev_C4_20_57_55_C9_EA)"
 INFO  trezor_bluetooth::server::methods::open_device > open_device hci0/dev_C4_20_57_55_C9_EA characteristic Some(TrezorPushNotification)
@trezor/connect handleMessage device-connect_unacquired
 INFO  trezor_bluetooth::server::connection_handler   > ChannelMessage listener Abort(NotificationStream("hci0/dev_C4_20_57_55_C9_EA", Some(BatteryLevel)))
 INFO  trezor_bluetooth::server::connection_handler   > ChannelMessage listener Abort(NotificationStream("hci0/dev_C4_20_57_55_C9_EA", Some(TrezorPushNotification)))
 INFO  trezor_bluetooth::server::message_handler      > WsError Adapter(PeripheralCharacteristicNotFound)
 INFO  trezor_bluetooth::server::message_handler      > WsError Adapter(PeripheralCharacteristicNotFound)
@trezor/connect handleMessage device-changed
```


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-missing-characteristic&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-missing-characteristic&lookback=7)