### PR TITLE
feat(connect): propagate soft lock/unlock push notifications

### DIFF
--- a/packages/connect/src/device/workflow/trezorPushNotification.ts
+++ b/packages/connect/src/device/workflow/trezorPushNotification.ts
@@ -87,6 +87,14 @@ export const trezorPushNotificationHandler = async ({ device, message }: TpnWork
         case TrezorPushNotificationType.UNLOCK:
             await setupDeviceMode(device, decoded.mode);
             break;
+        case TrezorPushNotificationType.SOFTLOCK:
+            device.setBusy('pin-locked');
+            device.lifecycle.emit(DEVICE.CHANGED);
+            break;
+        case TrezorPushNotificationType.SOFTUNLOCK:
+            device.setBusy(device.features ? undefined : 'thp-locked');
+            device.lifecycle.emit(DEVICE.CHANGED);
+            break;
         default:
             break;
     }

--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -148,7 +148,6 @@ const getMessageId = ({
         'device-rebooting': defaultKey, // TODO: device is booting to normal mode
         'device-bootloader-locked': defaultKey, // TODO: device is  a) rebooting or b) its was rebooted to bootloader
         'device-hard-locked': defaultKey, // TODO: device is hard locked and will not respond to messages, unlock it
-        'device-pin-locked': defaultKey, // TODO: unlock PIN on your device
         'device-disconnect-required': defaultKey,
         'device-disconnected': defaultKey,
         'device-initialize': defaultKey,

--- a/packages/suite/src/utils/suite/prerequisites.ts
+++ b/packages/suite/src/utils/suite/prerequisites.ts
@@ -32,8 +32,7 @@ export type PrerequisiteType =
     | 'device-busy'
     | 'device-rebooting'
     | 'device-bootloader-locked'
-    | 'device-hard-locked'
-    | 'device-pin-locked';
+    | 'device-hard-locked';
 
 export const getPrerequisiteName = ({
     router,
@@ -58,7 +57,6 @@ export const getPrerequisiteName = ({
     if (device.status === 'rebooting') return 'device-rebooting';
     if (device.status === 'bootloader-locked') return 'device-bootloader-locked';
     if (device.status === 'hard-locked') return 'device-hard-locked';
-    if (device.status === 'pin-locked') return 'device-pin-locked';
 
     // Unacquired device with Trezor Host Protocol properties means
     // that the user must perform the Trezor Host Protocol paring


### PR DESCRIPTION
Set correct status after Trezor is locked/unlocked by PIN while connected via bluetooth. This has no effect over cable, we'll need to sort it out differently. UI for the `pin-locked` state needs to be worked out, too.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/lock-unlock-push-notif&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/lock-unlock-push-notif&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/lock-unlock-push-notif&lookback=7)