### PR TITLE
Don't stop BT scanning on web... again

### DIFF
--- a/packages/suite/src/components/connection/hook/useBluetoothScanning.ts
+++ b/packages/suite/src/components/connection/hook/useBluetoothScanning.ts
@@ -45,11 +45,13 @@ export const useBluetoothScanning = ({
 
     // starts to scan for devices when connection mode is bluetooth
     useEffect(() => {
-        if (bluetoothMode) dispatch(bluetoothStartScanningThunk());
+        if (bluetoothMode) {
+            dispatch(bluetoothStartScanningThunk());
 
-        return () => {
-            dispatch(bluetoothStopScanningThunk());
-        };
+            return () => {
+                dispatch(bluetoothStopScanningThunk());
+            };
+        }
     }, [dispatch, bluetoothMode]);
 
     // stop scanning after 15s


### PR DESCRIPTION
## Description

Fixing bug fixed in #22017 and reintroduced in #21928.

<img width="867" height="183" alt="Snímek obrazovky z 2025-10-01 16-04-38" src="https://github.com/user-attachments/assets/0c1f085c-9510-4498-9043-431d4528d920" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-stop-scan-web-again&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-stop-scan-web-again&lookback=7)