### PR TITLE
fix: unpair BLE device when forgetting it

### DIFF
--- a/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
@@ -9,6 +9,7 @@ import {
 import TrezorConnect, { BluetoothDeviceId } from '@trezor/connect';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
+import { bluetoothDisconnectDeviceThunk } from './bluetoothDisconnectDeviceThunk';
 import {
     setBluetoothDeviceNeedsManualOsRemoval,
     setIsUnpairingDevice,
@@ -24,6 +25,7 @@ export const forgetBluetoothDeviceThunk = createThunk<void, ForgetBluetoothDevic
     `${BLUETOOTH_PREFIX}/forgetBluetoothDevice`,
     async ({ bluetoothId }, { dispatch }) => {
         dispatch(setIsUnpairingDevice({ isUnpairing: true }));
+        await dispatch(bluetoothDisconnectDeviceThunk({ id: bluetoothId }));
         const resultForget = await bluetoothIpc.forgetDevice(bluetoothId);
         dispatch(setIsUnpairingDevice({ isUnpairing: false }));
         if (!resultForget.success) {


### PR DESCRIPTION
## Description

Disconnect BLE device (on OS-level BT bonding) before forgetting it.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21387 (should fix it for good)
and that's followup to https://github.com/trezor/trezor-suite/issues/20952

## Screenshots:

Now the device BT pairing disconnects when forgetti 

[disconnect when forget.webm](https://github.com/user-attachments/assets/17606e7c-1b71-4fab-bc6b-b5c1259cba06)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/unpair-BLE-when-forgetting&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/unpair-BLE-when-forgetting&lookback=7)