### PR TITLE
fix(suite): close dropdown after option select

### DIFF
--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -291,6 +291,7 @@ export type SelectProps = KeyPressScrollProps &
         isScrollToSelectedEnabled?: boolean;
         onChange?: (value: Option, ref?: SelectInstance<Option, boolean> | null) => void;
         'data-testid'?: string;
+        openMenuOnFocus?: boolean;
     };
 
 export const Select = ({
@@ -308,6 +309,7 @@ export const Select = ({
     isLoading = false,
     isRenderedInModal = false,
     isScrollToSelectedEnabled = true,
+    openMenuOnFocus = true,
     'data-testid': dataTest,
     ...rest
 }: SelectProps) => {
@@ -390,7 +392,7 @@ export const Select = ({
                     ref={selectRef}
                     onKeyDown={onKeyDown}
                     classNamePrefix={reactSelectClassNamePrefix}
-                    openMenuOnFocus
+                    openMenuOnFocus={openMenuOnFocus}
                     closeMenuOnScroll={closeMenuOnScroll}
                     menuPosition="fixed" // Required for closeMenuOnScroll to work properly when near page bottom
                     menuPortalTarget={menuPortalTarget}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
@@ -57,15 +57,20 @@ type BackendTypeSelectProps = {
 export const BackendTypeSelect = ({ network, value, onChange }: BackendTypeSelectProps) => {
     const backendOptions = useBackendOptions(network);
 
-    const changeType = (option: { value: BackendOption }) => onChange(option.value);
+    if (!backendOptions.length) {
+        return null;
+    }
 
-    return backendOptions.length ? (
+    return (
         <Select
             value={backendOptions.find(option => option.value === value)}
-            onChange={changeType}
+            openMenuOnFocus={false}
+            onChange={option => {
+                onChange(option.value);
+            }}
             options={backendOptions}
             data-testid="@settings/advance/select-type"
             size="small"
         />
-    ) : null;
+    );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Close dropdown after option select.

## Related Issue

Resolve #19430

## Screenshots:

https://github.com/user-attachments/assets/28acce7f-76d8-4e05-8535-2f9977b47e87




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/19430-disable-auto-opening&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/19430-disable-auto-opening&lookback=7)