### PR TITLE
Mobile Swap: Trades with eth token do not get quotes

### DIFF
--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -49,6 +49,7 @@ import { SectionListData } from '../hooks/general/useSectionList';
 import { TradingRootState } from '../reducers';
 import { MyAsset, TradeableAsset } from '../types/general';
 import { getSymbolFromTradeableAsset } from '../utils/general/tradeableAssetUtils';
+import { toCaseAwareCryptoId } from '../utils/general/utils';
 
 export type CombinedSelectorsRootState = TradingRootStateWithDeviceAndAccounts &
     TokenDefinitionsRootState &
@@ -223,7 +224,9 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
 
                             const tokenSymbol =
                                 (token.symbol?.toUpperCase() as TokenSymbol) ?? null;
-                            const cryptoId = toTokenCryptoId(account.symbol, token.contract);
+                            const cryptoId = toCaseAwareCryptoId(
+                                toTokenCryptoId(account.symbol, token.contract),
+                            );
 
                             return {
                                 symbol: account.symbol,
@@ -233,9 +236,7 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
                                 tokenSymbol,
                                 contract: token.contract as TokenAddress,
                                 cryptoId,
-                                isEnabled:
-                                    sellCryptoIdsSet.has(cryptoId) ||
-                                    sellCryptoIdsSet.has(cryptoId.toLowerCase() as CryptoId),
+                                isEnabled: sellCryptoIdsSet.has(cryptoId),
                                 fiatRateKey,
                                 rate,
                             };
@@ -253,7 +254,9 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
                             return bFiatBalance - aFiatBalance;
                         });
 
-                    const cryptoId = getNetwork(account.symbol).tradeCryptoId as CryptoId;
+                    const cryptoId = toCaseAwareCryptoId(
+                        getNetwork(account.symbol).tradeCryptoId as CryptoId,
+                    );
 
                     const accountAsset = {
                         symbol: account.symbol,
@@ -267,9 +270,7 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
                             shouldIncludeTokens: false,
                         }),
                         cryptoId,
-                        isEnabled:
-                            sellCryptoIdsSet.has(cryptoId) ||
-                            sellCryptoIdsSet.has(cryptoId.toLowerCase() as CryptoId),
+                        isEnabled: sellCryptoIdsSet.has(cryptoId),
                     };
 
                     const assets: MyAsset[] = [

--- a/suite-native/module-trading/src/utils/exchange/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/exchange/__tests__/quotesUtils.test.ts
@@ -1,8 +1,17 @@
 import { act } from 'react';
 
+import { CryptoId } from 'invity-api';
+
+import type { TokenAddress } from '@suite-common/wallet-types';
 import { renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
 
-import { btcAsset, ethAsset } from '../../../__fixtures__/tradeableAssets';
+import {
+    btcAsset,
+    ethAsset,
+    jitoOnSolanaAsset,
+    jupOnSolanaAsset,
+    usdcAsset,
+} from '../../../__fixtures__/tradeableAssets';
 import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
 import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
 import { ExchangeFormType } from '../../../types/exchange';
@@ -59,6 +68,44 @@ describe('quotesUtils', () => {
             expect(tradingExchangeFormToTradingExchangeFormProps(form.getValues)).toEqual({
                 sendCryptoSelect: { value: 'bitcoin' },
                 receiveCryptoSelect: { value: 'ethereum' },
+                outputs: [{ amount: '1' }],
+            });
+        });
+
+        it('should make address lower case for eth based assets', () => {
+            const alteredUsdcAsset = {
+                ...usdcAsset,
+                cryptoId: 'ethereum--0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48' as CryptoId,
+                contractAddress: usdcAsset.contractAddress!.toUpperCase() as TokenAddress,
+            };
+
+            act(() => {
+                form.setValue('sendAsset', alteredUsdcAsset);
+                form.setValue('receiveAsset', alteredUsdcAsset);
+                form.setValue('sendCryptoAmount', '1');
+            });
+
+            expect(tradingExchangeFormToTradingExchangeFormProps(form.getValues)).toEqual({
+                sendCryptoSelect: { value: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' },
+                receiveCryptoSelect: {
+                    value: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                },
+                outputs: [{ amount: '1' }],
+            });
+        });
+
+        it('should not make address lower case for SOL based assets', () => {
+            act(() => {
+                form.setValue('sendAsset', jupOnSolanaAsset);
+                form.setValue('receiveAsset', jitoOnSolanaAsset);
+                form.setValue('sendCryptoAmount', '1');
+            });
+
+            expect(tradingExchangeFormToTradingExchangeFormProps(form.getValues)).toEqual({
+                sendCryptoSelect: { value: 'solana--JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN' },
+                receiveCryptoSelect: {
+                    value: 'solana--jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL',
+                },
                 outputs: [{ amount: '1' }],
             });
         });

--- a/suite-native/module-trading/src/utils/exchange/quotesUtils.ts
+++ b/suite-native/module-trading/src/utils/exchange/quotesUtils.ts
@@ -2,6 +2,7 @@ import { invariant } from '@suite-common/suite-utils';
 import { MinimalExchangeFormProps } from '@suite-common/trading';
 
 import { ExchangeFormType } from '../../types/exchange';
+import { toCaseAwareCryptoId } from '../general/utils';
 
 export const tradingExchangeFormToTradingExchangeFormProps = (
     getValues: ExchangeFormType['getValues'],
@@ -17,8 +18,8 @@ export const tradingExchangeFormToTradingExchangeFormProps = (
     invariant(sendCryptoAmount, 'sendCryptoAmount is required');
 
     return {
-        sendCryptoSelect: { value: sendAsset.cryptoId },
-        receiveCryptoSelect: { value: receiveAsset.cryptoId },
+        sendCryptoSelect: { value: toCaseAwareCryptoId(sendAsset.cryptoId) },
+        receiveCryptoSelect: { value: toCaseAwareCryptoId(receiveAsset.cryptoId) },
         outputs: [{ amount: sendCryptoAmount }],
     };
 };

--- a/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { BuyTradeStatus, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
+import { BuyTradeStatus, CryptoId, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
 
 import type { TradingTransaction, TradingType } from '@suite-common/trading';
 import { FormDraftKeyPrefix } from '@suite-common/wallet-types';
@@ -14,17 +14,8 @@ import {
     getTradeOperationData,
     getTradeStatusStep,
     getTradeTitle,
+    toCaseAwareCryptoId,
 } from '../utils';
-
-jest.mock('@suite-common/trading', () => {
-    const actual = jest.requireActual('@suite-common/trading');
-
-    return {
-        ...actual,
-        cryptoIdToNetworkAndContractAddress: jest.fn(),
-        isCryptoIdForNativeToken: jest.fn(),
-    };
-});
 
 describe('utils', () => {
     describe('getTradeOperationData', () => {
@@ -189,6 +180,27 @@ describe('utils', () => {
             ['exchange', 'trading-exchange'],
         ])('should return correct prefix for %s', (tradingType, expectedPrefix) => {
             expect(getFormDraftKeyPrefixFromTradingType(tradingType)).toBe(expectedPrefix);
+        });
+    });
+
+    describe('toCaseAwareCryptoId', () => {
+        it.each<[string, CryptoId]>([
+            ['bitcoin', 'bitcoin' as CryptoId],
+            ['ethereum', 'ethereum' as CryptoId],
+            [
+                'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                'ethereum--0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48' as CryptoId,
+            ],
+            [
+                'base--0x0000000000000000000000000000000000000000',
+                'base--0x0000000000000000000000000000000000000000' as CryptoId,
+            ],
+            [
+                'solana--JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN',
+                'solana--JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN' as CryptoId,
+            ],
+        ])('should return %s for %s', (expectedValue, cryptoId) => {
+            expect(toCaseAwareCryptoId(cryptoId)).toBe(expectedValue);
         });
     });
 });

--- a/suite-native/module-trading/src/utils/general/utils.ts
+++ b/suite-native/module-trading/src/utils/general/utils.ts
@@ -4,12 +4,16 @@ import {
     TradingTradeType,
     TradingTransaction,
     TradingType,
+    cryptoIdToNetworkSymbolAndContractAddress,
     isBuyTrade,
+    isCryptoIdForNativeToken,
     isExchangeTrade,
     isSellFiatTrade,
+    toTokenCryptoId,
     tradeFinalStatuses,
 } from '@suite-common/trading';
 import type { FormDraftKeyPrefix } from '@suite-common/wallet-types';
+import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils/';
 import type { Translate } from '@suite-native/intl';
 import { exhaustive } from '@trezor/type-utils';
 import { getWeakRandomId } from '@trezor/utils';
@@ -208,3 +212,18 @@ export const getTradeTitle = (trade: TradingTransaction, translate: Translate) =
 
 export const getFormDraftKeyPrefixFromTradingType = (tradingType: TradingType) =>
     `trading-${tradingType}` as const satisfies FormDraftKeyPrefix;
+
+export const toCaseAwareCryptoId = (cryptoId: CryptoId): CryptoId => {
+    if (isCryptoIdForNativeToken(cryptoId)) {
+        return cryptoId;
+    }
+
+    const { symbol, contractAddress } = cryptoIdToNetworkSymbolAndContractAddress(cryptoId);
+    if (!contractAddress) {
+        return cryptoId;
+    }
+
+    const adjustedContractAddress = getContractAddressForNetworkSymbol(symbol, contractAddress);
+
+    return toTokenCryptoId(symbol, adjustedContractAddress);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes text case of CryptoId in tokens.

## Related Issue

Resolve [#22018](https://github.com/trezor/trezor-suite/issues/22018)

## Screenshots:
<img width="300" alt="Simulator Screenshot " src="https://github.com/user-attachments/assets/b2ee5ba3-9217-4a4a-9acc-2f664d69b7f2" />

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22018-trades-with-ETH-token-do-not-get-quotes&lookback=7)