### PR TITLE
refactor(suite-common): tweak naming of isDeviceConnectedViaBluetooth

### DIFF
--- a/suite-common/suite-utils/src/__fixtures__/device.ts
+++ b/suite-common/suite-utils/src/__fixtures__/device.ts
@@ -60,7 +60,7 @@ const getStatus: Array<{ device: TrezorDevice; status: string }> = [
     },
 ];
 
-const isDeviceConnectedViaBluetooth = [
+const getIsDeviceConnectedViaBluetooth = [
     {
         description: 'device is connected via bluetooth',
         device: getSuiteDevice({ bluetoothProps: { id: asBluetoothDeviceId('21') } }),
@@ -568,7 +568,7 @@ const getFirmwareDowngradeUrl = [
 
 export default {
     getStatus,
-    isDeviceConnectedViaBluetooth,
+    getIsDeviceConnectedViaBluetooth,
     isSelectedDevice,
     isSelectedInstance,
     getNewInstanceNumber,

--- a/suite-common/suite-utils/src/__tests__/device.test.ts
+++ b/suite-common/suite-utils/src/__tests__/device.test.ts
@@ -13,10 +13,10 @@ describe('getStatus', () => {
     });
 });
 
-describe('isDeviceConnectedViaBluetooth', () => {
-    fixtures.isDeviceConnectedViaBluetooth.forEach(f => {
+describe('getIsDeviceConnectedViaBluetooth', () => {
+    fixtures.getIsDeviceConnectedViaBluetooth.forEach(f => {
         it(f.description, () => {
-            expect(utils.isDeviceConnectedViaBluetooth(f.device)).toEqual(f.result);
+            expect(utils.getIsDeviceConnectedViaBluetooth(f.device)).toEqual(f.result);
         });
     });
 });

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -165,7 +165,7 @@ export const shouldDisplayInitialWarningIcon = (deviceStatus: ConnectedDeviceSta
 
 export const isDeviceRemembered = (device?: TrezorDevice): boolean => !!device?.remember;
 
-export const isDeviceConnectedViaBluetooth = (device?: TrezorDevice): boolean =>
+export const getIsDeviceConnectedViaBluetooth = (device?: TrezorDevice): boolean =>
     !!device?.bluetoothProps;
 
 export const isDeviceAcquired = (device?: TrezorDevice): device is AcquiredDevice =>

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -8,9 +8,9 @@ import {
     getDeviceInternalModel,
     getFwUpdateVersion,
     getIsDeviceConnectedAndAuthorized,
+    getIsDeviceConnectedViaBluetooth,
     getIsDeviceInitialized,
     getStatus,
-    isDeviceConnectedViaBluetooth,
 } from '@suite-common/suite-utils';
 import { networkSymbolCollection } from '@suite-common/wallet-config';
 import { Device, DeviceState, StaticSessionId } from '@trezor/connect';
@@ -175,13 +175,13 @@ export const selectIsDeviceConnected = createMemoizedSelector(
 
 export const selectIsDeviceConnectedViaBluetooth = createMemoizedSelector(
     [selectSelectedDevice],
-    device => isDeviceConnectedViaBluetooth(device),
+    device => getIsDeviceConnectedViaBluetooth(device),
 );
 
 export const selectIsDeviceConnectedViaBluetoothLowOnBattery = createMemoizedSelector(
     [selectIsDeviceConnectedViaBluetooth, selectDeviceFeatures],
-    (isDeviceConnectedViaBt, features) =>
-        isDeviceConnectedViaBt &&
+    (isDeviceConnectedViaBluetooth, features) =>
+        isDeviceConnectedViaBluetooth &&
         typeof features?.soc === 'number' &&
         features.soc <= DEVICE_LOW_BATTERY_PERCENTAGE_THRESHOLD,
 );

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -7,8 +7,8 @@ import {
 
 import {
     getDeviceInternalModel,
+    getIsDeviceConnectedViaBluetooth,
     getIsDeviceInitialized,
-    isDeviceConnectedViaBluetooth,
 } from '@suite-common/suite-utils';
 import { isThpPairingUIRequestButtonAction } from '@suite-common/thp';
 import {
@@ -186,7 +186,7 @@ deviceConnectionMiddleware.startListening({
         const isDeviceRemembered = selectIsDeviceRemembered(getState());
         const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(getState());
         const isFirmwareInstallationRunning = selectIsFirmwareInstallationRunning(getState());
-        const wasDeviceConnectedViaBluetooth = isDeviceConnectedViaBluetooth(action.payload);
+        const wasDeviceConnectedViaBluetooth = getIsDeviceConnectedViaBluetooth(action.payload);
 
         if (
             checkIsActiveRouteAnyOf(


### PR DESCRIPTION


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/common/is-device-connected-via-bluetooth&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/common/is-device-connected-via-bluetooth&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/common/is-device-connected-via-bluetooth&lookback=7)