### PR TITLE
chore(connect): limit public fields on device.descriptor to only thos…

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -126,7 +126,7 @@ type DeviceParams = {
 export class Device extends TypedEmitter<DeviceEvents> {
     public readonly transport: Transport;
     private thp: protocolThp.ThpState | undefined;
-    private readonly descriptor: Descriptor;
+    private readonly descriptor: Pick<Descriptor, 'apiType' | 'id' | 'type' | 'path'>;
     private sessionAcquired: Session | null;
 
     // protocol related
@@ -245,7 +245,14 @@ export class Device extends TypedEmitter<DeviceEvents> {
         // === immutable properties
         this.uniquePath = id;
         this.transport = transport;
-        this.descriptor = descriptor;
+        this.descriptor = {
+            id: descriptor.id,
+            apiType: descriptor.apiType,
+            type: descriptor.type,
+            path: descriptor.path,
+            // session, sessionOwner are handled separately
+            // debug, debugSession are not relevant here
+        };
 
         this.sessionAcquired = null;
 
@@ -1111,7 +1118,8 @@ export class Device extends TypedEmitter<DeviceEvents> {
     // simplified object to pass via postMessage
     toMessageObject(): DeviceTyped {
         const { name, uniquePath: path, descriptor } = this;
-        const base = { path, name, descriptor };
+        const { apiType, id } = descriptor;
+        const base = { path, name, descriptor: { apiType, id } };
 
         if (this.unreadableError) {
             return {

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -106,7 +106,7 @@ export const asDeviceUniquePath = (id: string) => id as DeviceUniquePath;
 type BaseDevice = {
     path: DeviceUniquePath;
     name: string;
-    descriptor: Descriptor;
+    descriptor: Pick<Descriptor, 'apiType' | 'id'>;
 };
 
 export type BluetoothDeviceId = string & Branded<'BluetoothDeviceId'>;

--- a/suite-common/test-utils/package.json
+++ b/suite-common/test-utils/package.json
@@ -18,7 +18,6 @@
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
-        "@trezor/transport": "workspace:*",
         "@trezor/utils": "workspace:*",
         "core-js": "^3.45.1",
         "fake-indexeddb": "^6.2.2",

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -25,7 +25,6 @@ import {
     asDeviceUniquePath,
 } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
-import { PathPublic } from '@trezor/transport/src/types';
 
 /**
  * Generate wallet account
@@ -166,7 +165,7 @@ const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Feat
 
     if (dev && typeof dev.type === 'string' && dev.type === 'unreadable') {
         return {
-            descriptor: { path: PathPublic('1'), session: null, type: 1, apiType: 'usb' },
+            descriptor: { apiType: 'usb' },
             type: 'unreadable',
             path,
             label: 'Unreadable device',
@@ -178,7 +177,7 @@ const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Feat
 
     if (dev && typeof dev.type === 'string' && dev.type === 'unacquired') {
         return {
-            descriptor: { path: PathPublic('1'), session: null, type: 1, apiType: 'usb' },
+            descriptor: { apiType: 'usb' },
             type: dev.type,
             path,
             label: 'Unacquired device',
@@ -192,7 +191,7 @@ const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Feat
     const features = getDeviceFeatures(feat);
 
     return {
-        descriptor: { path: PathPublic('1'), session: null, type: 1, apiType: 'usb' },
+        descriptor: { apiType: 'usb' },
         id: features.device_id,
         // @ts-expect-error
         path: '',

--- a/suite-common/test-utils/tsconfig.json
+++ b/suite-common/test-utils/tsconfig.json
@@ -8,7 +8,6 @@
         { "path": "../wallet-types" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" },
-        { "path": "../../packages/transport" },
         { "path": "../../packages/utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10579,7 +10579,6 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
-    "@trezor/transport": "workspace:*"
     "@trezor/utils": "workspace:*"
     core-js: "npm:^3.45.1"
     fake-indexeddb: "npm:^6.2.2"


### PR DESCRIPTION
…e that are currently consumed by suite

cherry-picked from #22050

lets only expose fields that are really used to avoid possible inconsistencies

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-device-descriptor-limit&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-device-descriptor-limit&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-device-descriptor-limit&lookback=7)