### PR TITLE
fix(suite-native): send DAC failure to DeviceCompromised screen

### DIFF
--- a/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
+++ b/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
@@ -17,6 +17,11 @@ import { useToast } from '@suite-native/toasts';
 import TrezorConnect from '@trezor/connect';
 import { isArrayMember } from '@trezor/utils';
 
+type CheckDeviceAuthenticityParams = {
+    handleSuccess: () => void;
+    handleFailure: () => void;
+};
+
 export const useDeviceAuthenticityCheck = () => {
     const navigation = useNavigation();
     const dispatch = useDispatch();
@@ -140,7 +145,7 @@ export const useDeviceAuthenticityCheck = () => {
     );
 
     const checkDeviceAuthenticity = useCallback(
-        async (handleSuccess: () => void) => {
+        async ({ handleSuccess, handleFailure }: CheckDeviceAuthenticityParams) => {
             if (!device) {
                 handleDeviceAccessError('Device is not connected');
 
@@ -180,6 +185,7 @@ export const useDeviceAuthenticityCheck = () => {
             dispatch(deviceAuthenticityActions.result({ device, result: storedResult }));
 
             if (storedResult?.valid === false) {
+                handleFailure();
                 reportCheckResult('compromised', storedResult.error, storedResult);
             } else if (result.success) {
                 handleSuccess();

--- a/suite-native/module-device-onboarding/src/screens/DeviceAuthenticityScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/DeviceAuthenticityScreen.tsx
@@ -4,23 +4,32 @@ import { ContinueOnTrezorScreenContent, useDeviceAuthenticityCheck } from '@suit
 import {
     DeviceOnboardingStackParamList,
     DeviceOnboardingStackRoutes,
-    StackProps,
+    RootStackParamList,
+    RootStackRoutes,
+    StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 
 import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
 
-export const DeviceAuthenticityScreen = ({
-    navigation,
-}: StackProps<DeviceOnboardingStackParamList, DeviceOnboardingStackRoutes.DeviceAuthenticity>) => {
+type NavigationProp = StackToStackCompositeNavigationProps<
+    DeviceOnboardingStackParamList,
+    DeviceOnboardingStackRoutes.DeviceAuthenticity,
+    RootStackParamList
+>;
+
+export const DeviceAuthenticityScreen = ({ navigation }: { navigation: NavigationProp }) => {
     const { checkDeviceAuthenticity } = useDeviceAuthenticityCheck();
 
     const handleSuccess = useCallback(() => {
         navigation.navigate(DeviceOnboardingStackRoutes.DeviceAuthenticitySuccess);
     }, [navigation]);
+    const handleFailure = useCallback(() => {
+        navigation.navigate(RootStackRoutes.DeviceCompromisedModal);
+    }, [navigation]);
 
     const startCheckDeviceAuthenticity = useCallback(() => {
-        checkDeviceAuthenticity(handleSuccess);
-    }, [checkDeviceAuthenticity, handleSuccess]);
+        checkDeviceAuthenticity({ handleSuccess, handleFailure });
+    }, [checkDeviceAuthenticity, handleSuccess, handleFailure]);
 
     useEffect(() => {
         startCheckDeviceAuthenticity();

--- a/suite-native/module-device-settings/src/navigation/DeviceAuthenticityStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DeviceAuthenticityStackNavigator.tsx
@@ -39,15 +39,25 @@ export const DeviceAuthenticityStackNavigator = () => {
         });
     }, [navigation]);
 
+    const handleFailure = useCallback(() => {
+        navigation.navigate(RootStackRoutes.DeviceCompromisedModal);
+    }, [navigation]);
+
     const { checkDeviceAuthenticity } = useDeviceAuthenticityCheck();
     const { isDeviceConnected } = useDeviceConnectionGuard();
 
     useEffect(() => {
         if (isDeviceConnected && !isAuthenticityCheckStarted) {
             setIsAuthenticityCheckStarted(true);
-            checkDeviceAuthenticity(handleSuccess);
+            checkDeviceAuthenticity({ handleSuccess, handleFailure });
         }
-    }, [checkDeviceAuthenticity, handleSuccess, isAuthenticityCheckStarted, isDeviceConnected]);
+    }, [
+        checkDeviceAuthenticity,
+        handleSuccess,
+        handleFailure,
+        isAuthenticityCheckStarted,
+        isDeviceConnected,
+    ]);
 
     if (!isDeviceConnected) return;
 


### PR DESCRIPTION
## Description

Fix mobile DAC, see issue 
## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/160

## Screenshots:

Now fixed: (I am not showing success screenshot because those were working properly)

[DAC settings fixd.webm](https://github.com/user-attachments/assets/26392812-d9f4-4fde-9cf4-bb6fc6443415)

[DAC onboarding fixd.webm](https://github.com/user-attachments/assets/26573d58-921b-4519-995c-93dd83f48331)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native-DAC&lookback=7)