### PR TITLE
feat(suite): track dashboard global Send/Receive entry clicks

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal.tsx
@@ -1,54 +1,61 @@
 import { useState } from 'react';
 
 import { Account } from '@suite-common/wallet-types';
+import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { GlobalSendReceiveModalBase } from './GlobalSendReceiveModalBase';
-import { useDevice } from '../../../../../../hooks/suite';
-import { LocalAccountSearchProvider } from '../../../../../../hooks/suite/useAccountSearch';
+import { useAccountSearch, useDevice } from '../../../../../../hooks/suite';
 import { AccountItemType } from '../../../../../../types/wallet';
 import { AddAccountButton } from '../../../../../wallet/WalletLayout/AccountsMenu/AddAccountButton';
 import { Translation } from '../../../../Translation';
 import { AddAccountModal } from '../../../../modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal';
 
 type GlobalReceiveModalProps = {
-    onCancel: () => void;
-    onSubmit: (account: Account, type: AccountItemType) => void;
+    onCancel: (filledSearch: boolean) => void;
+    onSubmit: (account: Account, type: AccountItemType, filledSearch: boolean) => void;
 };
 
 export const GlobalReceiveModal = ({ onCancel, onSubmit }: GlobalReceiveModalProps) => {
+    const { searchString } = useAccountSearch();
     const { device } = useDevice();
     const [addAccountModalOpen, setAddAccountModalOpen] = useState(false);
 
     return (
-        <LocalAccountSearchProvider>
-            <>
-                <GlobalSendReceiveModalBase
-                    heading={<Translation id="TR_RECEIVE" />}
-                    onCancel={onCancel}
-                    onSubmit={onSubmit}
-                    additionalAction={
-                        <AddAccountButton
-                            data-testid="@global-send-receive/add-account"
-                            device={device}
-                            customModalOpen={() => {
-                                setAddAccountModalOpen(true);
-                            }}
-                            isFullWidth={false}
-                            isIconOnly={false}
-                        />
-                    }
-                />
-                {addAccountModalOpen && device && (
-                    <AddAccountModal
-                        noRedirect
+        <>
+            <GlobalSendReceiveModalBase
+                heading={<Translation id="TR_RECEIVE" />}
+                onCancel={onCancel}
+                onSubmit={onSubmit}
+                additionalAction={
+                    <AddAccountButton
+                        data-testid="@global-send-receive/add-account"
                         device={device}
-                        onCancel={() => setAddAccountModalOpen(false)}
-                        onAddAccount={account => {
-                            onSubmit(account, 'coin');
+                        customModalOpen={() => {
+                            setAddAccountModalOpen(true);
+
+                            analytics.report({
+                                type: EventType.DashboardReceiveModalOptions,
+                                payload: {
+                                    option: 'addAccount',
+                                    filledSearch: !!searchString,
+                                },
+                            });
                         }}
+                        isFullWidth={false}
+                        isIconOnly={false}
                     />
-                )}
-            </>
-        </LocalAccountSearchProvider>
+                }
+            />
+            {addAccountModalOpen && device && (
+                <AddAccountModal
+                    noRedirect
+                    device={device}
+                    onCancel={() => setAddAccountModalOpen(false)}
+                    onAddAccount={account => {
+                        onSubmit(account, 'coin', !!searchString);
+                    }}
+                />
+            )}
+        </>
     );
 };

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal.tsx
@@ -1,21 +1,18 @@
 import { Account } from '@suite-common/wallet-types';
 
 import { GlobalSendReceiveModalBase } from './GlobalSendReceiveModalBase';
-import { LocalAccountSearchProvider } from '../../../../../../hooks/suite/useAccountSearch';
 import { AccountItemType } from '../../../../../../types/wallet';
 import { Translation } from '../../../../Translation';
 
 type GlobalSendModalProps = {
-    onCancel: () => void;
-    onSubmit: (account: Account, type: AccountItemType) => void;
+    onCancel: (filledSearch: boolean) => void;
+    onSubmit: (account: Account, type: AccountItemType, filledSearch: boolean) => void;
 };
 
 export const GlobalSendModal = ({ onCancel, onSubmit }: GlobalSendModalProps) => (
-    <LocalAccountSearchProvider>
-        <GlobalSendReceiveModalBase
-            heading={<Translation id="SEND_TRANSACTION" />}
-            onCancel={onCancel}
-            onSubmit={onSubmit}
-        />
-    </LocalAccountSearchProvider>
+    <GlobalSendReceiveModalBase
+        heading={<Translation id="SEND_TRANSACTION" />}
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+    />
 );

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx
@@ -1,7 +1,12 @@
 import { useState } from 'react';
 
+import { Account } from '@suite-common/wallet-types';
+import { EventType, analytics } from '@trezor/suite-analytics';
+
 import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
 import { useDevice } from 'src/hooks/suite';
+import { LocalAccountSearchProvider } from 'src/hooks/suite/useAccountSearch';
+import { AccountItemType } from 'src/types/wallet';
 
 import { useGoToWithAnalytics } from '../useGoToWithAnalytics';
 import { GlobalReceiveModal } from './GlobalReceiveModal';
@@ -10,10 +15,79 @@ import { GlobalSendReceiveButtons } from './GlobalSendReceiveButtons';
 
 export const GlobalSendReceive = () => {
     const { device } = useDevice();
+
     const goToWithAnalytics = useGoToWithAnalytics();
     const buttonVariant = device?.connected && device?.available ? 'primary' : 'tertiary';
     const [isSendModalOpen, setIsSendModalOpen] = useState(false);
     const [isReceiveModalOpen, setIsReceiveModalOpen] = useState(false);
+
+    const handleSendCancel = (filledSearch: boolean) => {
+        setIsSendModalOpen(false);
+
+        analytics.report({
+            type: EventType.DashboardSendModalOptions,
+            payload: {
+                option: 'close',
+                filledSearch,
+            },
+        });
+    };
+
+    const handleSendSubmit = (account: Account, type: AccountItemType, filledSearch: boolean) => {
+        setIsSendModalOpen(false);
+
+        analytics.report({
+            type: EventType.DashboardSendModalOptions,
+            payload: {
+                option: 'account',
+                filledSearch,
+            },
+        });
+
+        goToWithAnalytics(type === 'tokens' ? 'wallet-tokens' : 'wallet-send', {
+            params: {
+                symbol: account.symbol,
+                accountIndex: account.index,
+                accountType: account.accountType,
+            },
+        });
+    };
+
+    const handleReceiveCancel = (filledSearch: boolean) => {
+        setIsReceiveModalOpen(false);
+
+        analytics.report({
+            type: EventType.DashboardReceiveModalOptions,
+            payload: {
+                option: 'close',
+                filledSearch,
+            },
+        });
+    };
+
+    const handleReceiveSubmit = (
+        account: Account,
+        type: AccountItemType,
+        filledSearch: boolean,
+    ) => {
+        setIsReceiveModalOpen(false);
+
+        analytics.report({
+            type: EventType.DashboardReceiveModalOptions,
+            payload: {
+                option: 'account',
+                filledSearch,
+            },
+        });
+
+        goToWithAnalytics(type === 'tokens' ? 'wallet-tokens' : 'wallet-receive', {
+            params: {
+                symbol: account.symbol,
+                accountIndex: account.index,
+                accountType: account.accountType,
+            },
+        });
+    };
 
     return (
         <AppNavigationTooltip>
@@ -23,36 +97,17 @@ export const GlobalSendReceive = () => {
                 variant={buttonVariant}
             />
             {isSendModalOpen && (
-                <GlobalSendModal
-                    onCancel={() => setIsSendModalOpen(false)}
-                    onSubmit={(account, type) => {
-                        setIsSendModalOpen(false);
-
-                        goToWithAnalytics(type === 'tokens' ? 'wallet-tokens' : 'wallet-send', {
-                            params: {
-                                symbol: account.symbol,
-                                accountIndex: account.index,
-                                accountType: account.accountType,
-                            },
-                        });
-                    }}
-                />
+                <LocalAccountSearchProvider>
+                    <GlobalSendModal onCancel={handleSendCancel} onSubmit={handleSendSubmit} />
+                </LocalAccountSearchProvider>
             )}
             {isReceiveModalOpen && (
-                <GlobalReceiveModal
-                    onCancel={() => setIsReceiveModalOpen(false)}
-                    onSubmit={(account, type) => {
-                        setIsReceiveModalOpen(false);
-
-                        goToWithAnalytics(type === 'tokens' ? 'wallet-tokens' : 'wallet-receive', {
-                            params: {
-                                symbol: account.symbol,
-                                accountIndex: account.index,
-                                accountType: account.accountType,
-                            },
-                        });
-                    }}
-                />
+                <LocalAccountSearchProvider>
+                    <GlobalReceiveModal
+                        onCancel={handleReceiveCancel}
+                        onSubmit={handleReceiveSubmit}
+                    />
+                </LocalAccountSearchProvider>
             )}
         </AppNavigationTooltip>
     );

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { selectHasBitcoinOnlyFirmware } from '@suite-common/wallet-core';
 import { ButtonGroup, ButtonVariant } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { ExperimentalFeatureFlag } from 'src/support/suite/ExperimentalFeatureFlag';
 
@@ -28,6 +29,8 @@ export const GlobalSendReceiveButtons = ({
                     icon="arrowUp"
                     onClick={() => {
                         setIsSendModalOpen(true);
+
+                        analytics.report({ type: EventType.DashboardSendModal });
                     }}
                     data-testid="@wallet/menu/wallet-global-send"
                     variant={variant}
@@ -40,6 +43,8 @@ export const GlobalSendReceiveButtons = ({
                     icon="arrowDown"
                     onClick={() => {
                         setIsReceiveModalOpen(true);
+
+                        analytics.report({ type: EventType.DashboardReceiveModal });
                     }}
                     data-testid="@wallet/menu/wallet-global-receive"
                     variant={variant}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveModalBase.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveModalBase.tsx
@@ -8,8 +8,8 @@ import { AccountItemType } from '../../../../../../types/wallet';
 
 type GlobalSendReceiveModalBaseProps = {
     heading?: React.ReactNode;
-    onCancel: () => void;
-    onSubmit: (account: Account, type: AccountItemType) => void;
+    onCancel: (filledSearch: boolean) => void;
+    onSubmit: (account: Account, type: AccountItemType, filledSearch: boolean) => void;
     additionalAction?: React.ReactNode;
 };
 
@@ -23,21 +23,24 @@ export const GlobalSendReceiveModalBase = ({
     const { translationString } = useTranslation();
 
     return (
-        <Modal heading={heading} onCancel={onCancel} size="small">
+        <Modal heading={heading} onCancel={() => onCancel(!!searchString)} size="small">
             <Column height={500} gap={spacings.sm}>
                 <Row gap={spacings.xs}>
                     <Box flex="1">
                         <Input
                             placeholder={translationString('TR_SEARCH')}
                             size="small"
-                            value={searchString}
+                            value={searchString ?? ''}
                             onChange={event => setSearchString(event.target.value)}
                         />
                     </Box>
                     {additionalAction}
                 </Row>
                 <ElevationContext baseElevation={-1}>
-                    <AccountList hideStaking onSubmit={onSubmit} />
+                    <AccountList
+                        hideStaking
+                        onSubmit={(account, type) => onSubmit(account, type, !!searchString)}
+                    />
                 </ElevationContext>
             </Column>
         </Modal>

--- a/suite-common/analytics/src/events/suite/constants.ts
+++ b/suite-common/analytics/src/events/suite/constants.ts
@@ -17,6 +17,10 @@ export enum EventType {
     AppUriHandler = 'app/uri-handler',
 
     DashboardActions = 'dashboard/actions',
+    DashboardSendModal = 'dashboard/send-modal',
+    DashboardSendModalOptions = 'dashboard/send-modal/options',
+    DashboardReceiveModal = 'dashboard/receive-modal',
+    DashboardReceiveModalOptions = 'dashboard/receive-modal/options',
 
     DeviceConnect = 'device-connect',
     DeviceDisconnect = 'device-disconnect',

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -88,6 +88,26 @@ export type SuiteAnalyticsEvent =
           };
       }
     | {
+          type: EventType.DashboardSendModal;
+      }
+    | {
+          type: EventType.DashboardSendModalOptions;
+          payload: {
+              option: 'account' | 'close';
+              filledSearch: boolean;
+          };
+      }
+    | {
+          type: EventType.DashboardReceiveModal;
+      }
+    | {
+          type: EventType.DashboardReceiveModalOptions;
+          payload: {
+              option: 'account' | 'close' | 'addAccount';
+              filledSearch: boolean;
+          };
+      }
+    | {
           type: EventType.DeviceConnect;
           payload: {
               mode: 'normal' | 'bootloader' | 'initialize' | 'seedless';


### PR DESCRIPTION
## Description

Adds analytics tracking for Dashboard Send / Receive buttons and user actions inside the modals.

### Events

- **dashboard/send-modal**: user clicks Send
- **dashboard/receive-modal**: user clicks Receive
- **dashboard/send-modal/options**: user selects account / closes modal (option: 'account' | 'close', filledSearch: bool)
- **dashboard/receive-modal/options**: user selects account / closes / adds account (option: 'account' | 'close' | 'addAccount', filledSearch: bool)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21995


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/analytics-global-send-receive&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/analytics-global-send-receive&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/analytics-global-send-receive&lookback=7)