### PR TITLE
fix(suite-native): propagate battery-level notifications to transport

### DIFF
--- a/packages/transport-native-bluetooth/src/transport.ts
+++ b/packages/transport-native-bluetooth/src/transport.ts
@@ -17,6 +17,9 @@ export class NativeBluetoothTransport extends AbstractApiTransport {
         api.on('trezor-push-notification', event => {
             this.emit('trezor-push-notification', event);
         });
+        api.on('battery-level', event => {
+            this.emit('battery-level', event);
+        });
 
         super({ api, ...rest });
     }

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -183,7 +183,7 @@ export const selectIsDeviceConnectedViaBluetoothLowOnBattery = createMemoizedSel
     (isDeviceConnectedViaBluetooth, features) =>
         isDeviceConnectedViaBluetooth &&
         typeof features?.soc === 'number' &&
-        features.soc <= DEVICE_LOW_BATTERY_PERCENTAGE_THRESHOLD,
+        features.soc < DEVICE_LOW_BATTERY_PERCENTAGE_THRESHOLD,
 );
 
 export const selectDeviceBluetoothId = createMemoizedSelector(


### PR DESCRIPTION
- batter-level notification notifications propagated to transport layer
- selectIsDeviceConnectedViaBluetoothLowOnBattery fixed to correspond to alert wording

## Related Issue

Resolve #22098


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/battery-level-notification&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/battery-level-notification&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/battery-level-notification&lookback=7)