### PR TITLE
feat(suite): lower down nearby devices update to 3s from 15s, improvements

### DIFF
--- a/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.ts
+++ b/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.ts
@@ -1,0 +1,18 @@
+import type { BluetoothDeviceCommon } from '@suite-common/bluetooth/src/types';
+import { isLinux } from '@trezor/env-utils';
+
+export const NEARBY_DEVICES_LAST_UPDATED_LIMIT = 3_000;
+export const NEARBY_DEVICES_LAST_UPDATED_LIMIT_LINUX = 5_000;
+
+/**
+ * Filters out devices that have not been responsive for a certain period of time.
+ * Linux (specifically T2 linux distro for Mac) needs more than 3 secs - tested with 5 sec, due to slow drivers.
+ */
+export const filterOutNonResponsiveDevices = <T extends BluetoothDeviceCommon>(devices: T[]) => {
+    const now = Date.now();
+    const limit = isLinux()
+        ? NEARBY_DEVICES_LAST_UPDATED_LIMIT_LINUX
+        : NEARBY_DEVICES_LAST_UPDATED_LIMIT;
+
+    return devices.filter(d => d.lastUpdatedTimestamp >= now - limit);
+};

--- a/packages/suite/src/actions/bluetooth/removeNonResponsiveNearbyDevicesThunk.ts
+++ b/packages/suite/src/actions/bluetooth/removeNonResponsiveNearbyDevicesThunk.ts
@@ -1,0 +1,17 @@
+import { BLUETOOTH_PREFIX, bluetoothActions, selectNearbyDevices } from '@suite-common/bluetooth';
+import { createThunk } from '@suite-common/redux-utils';
+
+import { filterOutNonResponsiveDevices } from './filterOutNonResponsiveDevices';
+
+export const removeNonResponsiveNearbyDevicesThunk = createThunk<void, void>(
+    `${BLUETOOTH_PREFIX}/removeNonResponsiveNearbyDevicesThunk`,
+    (_, { dispatch, getState }) => {
+        const nearbyDevices = selectNearbyDevices(getState());
+
+        dispatch(
+            bluetoothActions.nearbyDevicesUpdateAction({
+                nearbyDevices: filterOutNonResponsiveDevices(nearbyDevices),
+            }),
+        );
+    },
+);

--- a/packages/suite/src/components/connection/context/ConnectionGlobalModalContext.tsx
+++ b/packages/suite/src/components/connection/context/ConnectionGlobalModalContext.tsx
@@ -1,7 +1,6 @@
-import { ReactNode, createContext, useContext, useMemo, useState } from 'react';
+import { ReactNode, createContext, useContext, useState } from 'react';
 
 import {
-    UNPAIRED_DEVICES_LAST_UPDATED_LIMIT,
     prepareSelectAllDevices,
     selectKnownDevices,
     selectNearbyDevices,
@@ -10,6 +9,7 @@ import { BluetoothDeviceId } from '@trezor/connect';
 import { isDesktop } from '@trezor/env-utils';
 
 import { DesktopBluetoothDevice } from 'src/actions/bluetooth/DesktopBluetoothDevice';
+import { NEARBY_DEVICES_LAST_UPDATED_LIMIT } from 'src/actions/bluetooth/filterOutNonResponsiveDevices';
 import { selectDeviceDefaultConnectionMode } from 'src/actions/device/deviceSelectors';
 import { setConnectionMode } from 'src/actions/device/deviceSlice';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -78,20 +78,8 @@ const useConnectionGlobalModal = () => {
 
     const defaultConnectionMode = useSelector(selectDeviceDefaultConnectionMode);
 
-    const nearbyDevicesRaw = useSelector(selectNearbyDevices);
+    const nearbyDevices = useSelector(selectNearbyDevices);
     const knownDevices = useSelector(selectKnownDevices);
-
-    const nearbyDevices = useMemo(() => {
-        const lastUpdatedBoundaryTimestamp = Date.now() - UNPAIRED_DEVICES_LAST_UPDATED_LIMIT;
-
-        return (
-            nearbyDevicesRaw?.filter(
-                device =>
-                    !device.connected &&
-                    device.lastUpdatedTimestamp >= lastUpdatedBoundaryTimestamp,
-            ) ?? []
-        );
-    }, [nearbyDevicesRaw]);
 
     const isBluetoothMode =
         defaultConnectionMode === 'bluetooth' && isBluetoothEnabled && isDesktop();
@@ -120,7 +108,7 @@ const useConnectionGlobalModal = () => {
 
     const allDevices = useSelector(selectAllDevices);
 
-    const lastUpdatedBoundaryTimestamp = Date.now() - UNPAIRED_DEVICES_LAST_UPDATED_LIMIT;
+    const lastUpdatedBoundaryTimestamp = Date.now() - NEARBY_DEVICES_LAST_UPDATED_LIMIT;
 
     const devices = allDevices.filter(it => {
         const isDeviceUnresponsiveForTooLong =

--- a/packages/suite/src/components/connection/hook/useBluetoothScanning.ts
+++ b/packages/suite/src/components/connection/hook/useBluetoothScanning.ts
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useRef } from 'react';
 
-import { SCAN_TIMEOUT, bluetoothActions } from '@suite-common/bluetooth';
+import { bluetoothActions } from '@suite-common/bluetooth';
 import { TimerId } from '@trezor/type-utils';
 
 import { DesktopBluetoothDevice } from 'src/actions/bluetooth/DesktopBluetoothDevice';
 import { bluetoothStartScanningThunk } from 'src/actions/bluetooth/bluetoothStartScanningThunk';
 import { bluetoothStopScanningThunk } from 'src/actions/bluetooth/bluetoothStopScanningThunk';
+import { removeNonResponsiveNearbyDevicesThunk } from 'src/actions/bluetooth/removeNonResponsiveNearbyDevicesThunk';
 import { useDispatch } from 'src/hooks/suite';
 
 export type UseBluetoothScanningProps = {
@@ -17,6 +18,8 @@ export type UseBluetoothScanningProps = {
 export type UseBluetoothScanningReturn = {
     onReScanClick: () => void;
 };
+
+const SCAN_TIMEOUT = 30_000;
 
 export const useBluetoothScanning = ({
     bluetoothMode,
@@ -81,6 +84,20 @@ export const useBluetoothScanning = ({
         },
         [clearScanTimer],
     );
+
+    // currently we need to check periodically for non-responsive devices and filter them out
+    // we do not get update from bluetooth adapter when device is non responsive
+    useEffect(() => {
+        function updateNonResponsiveDevices() {
+            dispatch(removeNonResponsiveNearbyDevicesThunk());
+        }
+
+        if (bluetoothMode) {
+            const interval = setInterval(updateNonResponsiveDevices, 1_000);
+
+            return () => clearInterval(interval);
+        }
+    }, [dispatch, bluetoothMode]);
 
     return {
         onReScanClick,

--- a/packages/suite/src/components/connection/thp/ThpGlobalModalManager.tsx
+++ b/packages/suite/src/components/connection/thp/ThpGlobalModalManager.tsx
@@ -17,8 +17,8 @@ export const ThpGlobalModalManager = () => {
 
     if (device !== undefined && thpStep !== null) {
         switch (thpStep) {
+            // handled in FirmwareModal and onboarding FirmwareStep
             case 'BeforeConnectionInfo':
-                // this case is not handled here since it's handles via DeviceConfirmationModal
                 return null;
             case 'ConfirmConnectionBeforePairing':
                 return <ThpConnectionModal device={device} />;

--- a/suite-common/bluetooth/src/bluetoothConstants.ts
+++ b/suite-common/bluetooth/src/bluetoothConstants.ts
@@ -1,2 +1,0 @@
-export const SCAN_TIMEOUT = 30_000;
-export const UNPAIRED_DEVICES_LAST_UPDATED_LIMIT = 15_000;

--- a/suite-common/bluetooth/src/bluetoothSelectors.ts
+++ b/suite-common/bluetooth/src/bluetoothSelectors.ts
@@ -16,7 +16,7 @@ export const selectKnownDevices = <T extends BluetoothDeviceCommon>(state: WithB
 
 export const selectNearbyDevices = <T extends BluetoothDeviceCommon>(
     state: WithBluetoothState<T>,
-) => state.bluetooth.nearbyDevices;
+) => state.bluetooth.nearbyDevices ?? [];
 
 /**
  * We need to have generic `createWeakMapSelector.withTypes` so we need to wrap it into Higher Order Function,

--- a/suite-common/bluetooth/src/index.ts
+++ b/suite-common/bluetooth/src/index.ts
@@ -22,4 +22,3 @@ export {
 export { filterOutOldDuplicates } from './filterOutOldDuplicates';
 
 export { parseManufacturerData, serializeManufacturerData } from './manufacturerDataUtils';
-export { SCAN_TIMEOUT, UNPAIRED_DEVICES_LAST_UPDATED_LIMIT } from './bluetoothConstants';


### PR DESCRIPTION
3 seconds is enough for MacOS, for T2 Linux I needed to increase to 5 seconds, but maybe someone with linux could help me test that? @Lemonexe 

**Changes**:
- deleted bluetoothConstants as they are different for desktop and native
- created and implemented `filterOutNonResponsiveDevices`
- added 3s timeout and 5s timeout for linux nearby devices

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22102



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/fix-pair-again-list&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/fix-pair-again-list&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/fix-pair-again-list&lookback=7)