### PR TITLE
Mobile Trade: do not show slippage button when DEX is disabled by FF

### DIFF
--- a/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
+++ b/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { TradingType } from '@suite-common/trading';
 import { HStack, IconButton, useBottomSheetModal } from '@suite-native/atoms';
+import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 import { IconName } from '@suite-native/icons';
 import { useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -14,6 +15,7 @@ import {
     selectActiveTradingType,
     selectIsTradingSellEnabled,
 } from '../../../selectors/commonSelectors';
+import { TradingWithFeatureFlagsRootState } from '../../../selectors/exchangeSelectors';
 import { AdvancedSettingsSheet } from '../../settings/AdvancedSettingsSheet';
 
 const useSelectedTab = () => {
@@ -68,6 +70,9 @@ export const HeaderTabs = () => {
     const data = useTabsData();
     const { translate } = useTranslate();
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
+    const areTradingExchangeDexesEnabled = useSelector((state: TradingWithFeatureFlagsRootState) =>
+        selectIsFeatureFlagEnabled(state, FeatureFlag.AreTradingExchangeDexesEnabled),
+    );
 
     return (
         <>
@@ -89,13 +94,15 @@ export const HeaderTabs = () => {
                     data={data}
                     extraData={activeTab}
                 />
-                <IconButton
-                    iconName="gear"
-                    size="small"
-                    colorScheme="tertiaryElevation0"
-                    accessibilityLabel={translate('moduleTrading.tradingScreen.tabs.settings')}
-                    onPress={() => openModal()}
-                />
+                {areTradingExchangeDexesEnabled && (
+                    <IconButton
+                        iconName="gear"
+                        size="small"
+                        colorScheme="tertiaryElevation0"
+                        accessibilityLabel={translate('moduleTrading.tradingScreen.tabs.settings')}
+                        onPress={() => openModal()}
+                    />
+                )}
             </HStack>
             <AdvancedSettingsSheet ref={bottomSheetRef} closeModal={closeModal} />
         </>

--- a/suite-native/module-trading/src/components/general/Header/__tests__/Header.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/Header/__tests__/Header.comp.test.tsx
@@ -14,16 +14,19 @@ describe('Header', () => {
         buyEnabled = false,
         sellEnabled = false,
         exchangeEnabled = false,
+        areTradingExchangeDexesEnabled = true,
     }: {
         buyEnabled?: boolean;
         sellEnabled?: boolean;
         exchangeEnabled?: boolean;
+        areTradingExchangeDexesEnabled?: boolean;
     }) => ({
         featureFlags: {
             ...featureFlagsInitialState,
             [FeatureFlag.IsTradingBuyEnabled]: buyEnabled,
             [FeatureFlag.IsTradingExchangeEnabled]: exchangeEnabled,
             [FeatureFlag.IsTradingSellEnabled]: sellEnabled,
+            [FeatureFlag.AreTradingExchangeDexesEnabled]: areTradingExchangeDexesEnabled,
         },
     });
 
@@ -31,15 +34,22 @@ describe('Header', () => {
         buyEnabled = false,
         sellEnabled = false,
         exchangeEnabled = false,
+        areTradingExchangeDexesEnabled = true,
         tradingPreloadedState = undefined,
     }: {
         buyEnabled?: boolean;
         sellEnabled?: boolean;
         exchangeEnabled?: boolean;
+        areTradingExchangeDexesEnabled?: boolean;
         tradingPreloadedState?: TradingRootState | undefined;
     }) => {
         const preloadedState: PreloadedState = {
-            ...getFFPreloadedState({ buyEnabled, sellEnabled, exchangeEnabled }),
+            ...getFFPreloadedState({
+                buyEnabled,
+                sellEnabled,
+                exchangeEnabled,
+                areTradingExchangeDexesEnabled,
+            }),
 
             messageSystem: {
                 validMessages: {
@@ -184,5 +194,15 @@ describe('Header', () => {
         });
 
         expect(getByLabelText('Advanced settings')).toBeOnTheScreen();
+    });
+
+    it('should not display settings wheel when AreTradingExchangeDexesEnabled is disabled', async () => {
+        const { queryByLabelText } = await renderHeader({
+            buyEnabled: true,
+            exchangeEnabled: true,
+            areTradingExchangeDexesEnabled: false,
+        });
+
+        expect(queryByLabelText('Advanced settings')).toBeNull();
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Show advanced settings in trade only when DEX is enabled

## Related Issue

Resolve [#22020](https://github.com/trezor/trezor-suite/issues/22020)

## Screenshots:

### DEX enabled
<img width="300" alt="Simulator Screenshot - iPhone 16 Plus - 2025-10-02 at 09 24 44" src="https://github.com/user-attachments/assets/bcc51d8f-d90e-4bd5-a41d-0d85b0ce44f8" />


### DEX disabled
<img width="300" alt="Simulator Screenshot - iPhone 16 Plus - 2025-10-02 at 09 24 30" src="https://github.com/user-attachments/assets/df8e66b1-6ada-432b-95a7-add939820b11" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22020-Mobile-swap-slippage-button-shown-for-CEX&lookback=7)