### PR TITLE
fix(suite-native): prevent swiping back in device onboarding where appropriate

### DIFF
--- a/suite-native/module-device-onboarding/src/hooks/useInitiateThpConnection.ts
+++ b/suite-native/module-device-onboarding/src/hooks/useInitiateThpConnection.ts
@@ -30,7 +30,7 @@ export const useInitiateThpConnection = () => {
 
     useEffect(() => {
         if (thpStep === 'ConfirmConnectionBeforePairing' || thpStep === 'ConfirmOnlyConnection') {
-            navigation.navigate(DeviceOnboardingStackRoutes.ThpConfirmation);
+            navigation.replace(DeviceOnboardingStackRoutes.ThpConfirmation);
         }
     }, [thpStep, navigation]);
 

--- a/suite-native/module-device-onboarding/src/hooks/useNavigateToNextScreenAfterFirmwareInstallation.ts
+++ b/suite-native/module-device-onboarding/src/hooks/useNavigateToNextScreenAfterFirmwareInstallation.ts
@@ -35,15 +35,15 @@ export const useNavigateToNextScreenAfterFirmwareInstallation = () => {
 
     const navigateToNextScreenAfterFirmwareInstallation = () => {
         if (thpStep === 'BeforeConnectionInfo') {
-            navigation.navigate(DeviceOnboardingStackRoutes.ThpPairingInfo);
+            navigation.replace(DeviceOnboardingStackRoutes.ThpPairingInfo);
         } else if (isDeviceTutorialSupported) {
-            navigation.navigate(
+            navigation.replace(
                 shouldAuthenticateSelectedDevice
                     ? DeviceOnboardingStackRoutes.DeviceAuthenticity
                     : DeviceOnboardingStackRoutes.DeviceTutorial,
             );
         } else {
-            navigation.navigate(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
+            navigation.replace(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
         }
     };
 

--- a/suite-native/module-device-onboarding/src/screens/ConfirmFirmwareUpdateScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ConfirmFirmwareUpdateScreen.tsx
@@ -42,7 +42,7 @@ export const ConfirmFirmwareUpdateScreen = ({
         updateOnboardingAnalytics({
             firmware: hasDeviceFirmwareInstalled ? 'update' : 'install',
         });
-        navigation.navigate(DeviceOnboardingStackRoutes.FirmwareInstallation);
+        navigation.replace(DeviceOnboardingStackRoutes.FirmwareInstallation);
     };
 
     const handleSkipUpdate = () => {

--- a/suite-native/module-device-onboarding/src/screens/CreatePinScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/CreatePinScreen.tsx
@@ -104,7 +104,7 @@ export const CreatePinScreen = () => {
 
     return (
         <Screen
-            header={<ScreenHeader closeAction={onCancel} />}
+            header={<ScreenHeader closeActionType="close" closeAction={onCancel} />}
             isScrollable={false}
             noBottomPadding={true}
             hasBottomInset={false}

--- a/suite-native/module-device-onboarding/src/screens/DeviceTutorialScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/DeviceTutorialScreen.tsx
@@ -26,7 +26,7 @@ export const DeviceTutorialScreen = ({
                 await requestPrioritizedDeviceAccess({
                     deviceCallback: () => TrezorConnect.showDeviceTutorial({ device }),
                 });
-                navigation.navigate(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
+                navigation.replace(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
             };
             showTutorial();
 

--- a/suite-native/module-device-onboarding/src/screens/FirmwareInstallationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/FirmwareInstallationScreen.tsx
@@ -1,4 +1,5 @@
 import { FirmwareInstallationScreenContent } from '@suite-native/firmware';
+import { useOverrideBackNavigation } from '@suite-native/navigation';
 
 import { DeviceOnboardingExitButtonScreenHeader } from '../components/DeviceOnboardingScreenWithExitButton';
 import { useExitAlert } from '../hooks/useExitAlert';
@@ -8,6 +9,7 @@ export const FirmwareInstallationScreen = () => {
     const { handleExitButtonPress } = useExitAlert();
     const { navigateToNextScreenAfterFirmwareInstallation } =
         useNavigateToNextScreenAfterFirmwareInstallation();
+    useOverrideBackNavigation();
 
     return (
         <FirmwareInstallationScreenContent

--- a/suite-native/module-device-onboarding/src/screens/SecurityCheckScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/SecurityCheckScreen.tsx
@@ -70,7 +70,7 @@ export const SecurityCheckScreen = ({
             return;
         }
 
-        navigation.navigate(DeviceOnboardingStackRoutes.FirmwareInstallation);
+        navigation.replace(DeviceOnboardingStackRoutes.FirmwareInstallation);
     };
 
     const handlePressSecondaryButton = (id?: DeviceSuspicionCause) => {

--- a/suite-native/module-device-onboarding/src/screens/ThpCodeEntryScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ThpCodeEntryScreen.tsx
@@ -21,7 +21,7 @@ export const ThpCodeEntryScreen = ({
 
     useEffect(() => {
         if (thpStep === null) {
-            navigation.navigate(DeviceOnboardingStackRoutes.ThpPairingSuccess);
+            navigation.replace(DeviceOnboardingStackRoutes.ThpPairingSuccess);
         }
     }, [thpStep, navigation]);
 

--- a/suite-native/module-device-onboarding/src/screens/ThpConfirmationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ThpConfirmationScreen.tsx
@@ -18,11 +18,11 @@ export const ThpConfirmationScreen = ({
 
     useEffect(() => {
         if (thpStep === 'BeforeConnectionInfo') {
-            navigation.navigate(DeviceOnboardingStackRoutes.ThpPairingInfo);
+            navigation.replace(DeviceOnboardingStackRoutes.ThpPairingInfo);
         } else if (thpStep === 'CodeEntry') {
-            navigation.navigate(DeviceOnboardingStackRoutes.ThpCodeEntry);
+            navigation.replace(DeviceOnboardingStackRoutes.ThpCodeEntry);
         } else if (thpStep === null) {
-            navigation.navigate(DeviceOnboardingStackRoutes.ThpPairingSuccess);
+            navigation.replace(DeviceOnboardingStackRoutes.ThpPairingSuccess);
         }
     }, [thpStep, navigation]);
 

--- a/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
@@ -83,7 +83,7 @@ export const UninitializedDeviceLandingScreen = ({
     const handleConfirmButtonPress = () => {
         if (hasDeviceFirmwareInstalled) {
             if (shouldOfferUpdateFirmware) {
-                navigation.navigate(DeviceOnboardingStackRoutes.ConfirmFirmwareUpdate);
+                navigation.replace(DeviceOnboardingStackRoutes.ConfirmFirmwareUpdate);
             } else {
                 // If user already has the latest firmware installed, skip this update screen and navigate to device auth-check directly.
                 updateOnboardingAnalytics({
@@ -94,7 +94,7 @@ export const UninitializedDeviceLandingScreen = ({
             }
         } else {
             // Security check is relevant for brand new devices without FW only.
-            navigation.navigate(DeviceOnboardingStackRoutes.SecurityCheck);
+            navigation.replace(DeviceOnboardingStackRoutes.SecurityCheck);
         }
     };
 


### PR DESCRIPTION
This prevents swiping back on iOS.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-onboarding-navigation&lookback=7)