### PR TITLE
fix(suite): prevent default value overwriting user amount input

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormRedirectValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormRedirectValues.ts
@@ -15,19 +15,22 @@ export const useTradingBuyFormRedirectValues = (
 ): TradingBuyFormProps | null => {
     const { buildDefaultCryptoOption } = useTradingInfo();
 
-    return isFromRedirect && quotesRequest
-        ? {
-              amountInCrypto: quotesRequest.wantCrypto,
-              cryptoSelect: buildDefaultCryptoOption(quotesRequest.receiveCurrency),
-              currencySelect: buildTradingFiatOption(
-                  quotesRequest.fiatCurrency as FiatCurrencyCode,
-              ),
-              countrySelect: getDefaultCountry(quotesRequest.country as TradingCountryCode),
-              cryptoInput: quotesRequest.cryptoStringAmount,
-              paymentMethod: quotesRequest.paymentMethod && {
-                  value: quotesRequest.paymentMethod,
-                  label: quotesRequest.paymentMethod,
-              },
-          }
-        : null;
+    if (!isFromRedirect || !quotesRequest) return null;
+
+    return {
+        amountInCrypto: quotesRequest.wantCrypto,
+        cryptoSelect: buildDefaultCryptoOption(quotesRequest.receiveCurrency),
+        currencySelect: buildTradingFiatOption(quotesRequest.fiatCurrency as FiatCurrencyCode),
+        countrySelect: getDefaultCountry(quotesRequest.country as TradingCountryCode),
+
+        // fill the input that corresponds to the entered amount type
+        ...(quotesRequest.wantCrypto
+            ? { cryptoInput: quotesRequest.cryptoStringAmount }
+            : { fiatInput: quotesRequest.fiatStringAmount }),
+
+        paymentMethod: quotesRequest.paymentMethod && {
+            value: quotesRequest.paymentMethod,
+            label: quotesRequest.paymentMethod,
+        },
+    };
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { Control, Controller } from 'react-hook-form';
 
 import {
@@ -64,17 +64,6 @@ export const TradingFormInputCurrency = ({
             context.refreshQuotes();
         }
     };
-
-    // update defaultCurrency in select only on mount
-    useEffect(() => {
-        if (isTradingBuyContext(context)) {
-            context.setValue(TRADING_FORM_FIAT_CURRENCY_SELECT, defaultCurrency);
-            context.setValue(
-                TRADING_FORM_FIAT_INPUT,
-                fiatCurrencies?.defaultAmountsOfFiatCurrencies?.get(defaultCurrency.value) ?? '',
-            );
-        }
-    }, [fiatCurrencies?.defaultAmountsOfFiatCurrencies]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
         <Controller


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prevent default value overwriting user amount input.

## Related Issue

Resolve #21013

## Screenshots:

https://github.com/user-attachments/assets/1b93a4bb-1b3c-4df6-8391-228ba1155539




🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/21013-compare-offers-fiat&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/21013-compare-offers-fiat&lookback=7)