### PR TITLE
refactor(suite): use getStakingLimitsByNetworkSymbol

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeInputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeInputs.tsx
@@ -2,7 +2,7 @@ import { useFormatters } from '@suite-common/formatters';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { StakeFormState } from '@suite-common/wallet-types';
-import { getInputState, getStakingLimitsByNetwork } from '@suite-common/wallet-utils';
+import { getInputState, getStakingLimitsByNetworkSymbol } from '@suite-common/wallet-utils';
 import { Banner, Column, Text } from '@trezor/components';
 import { InputWithOptions } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
@@ -47,8 +47,11 @@ export const StakeInputs = () => {
         setCurrency,
     } = useStakeFormContext();
 
-    const { MIN_FOR_WITHDRAWALS, MAX_AMOUNT_FOR_STAKING, MIN_AMOUNT_FOR_STAKING } =
-        getStakingLimitsByNetwork(account);
+    const stakingLimits = getStakingLimitsByNetworkSymbol(account.symbol);
+
+    if (!stakingLimits) {
+        return null;
+    }
 
     const cryptoError = errors.cryptoInput;
     const fiatError = errors.fiatInput;
@@ -74,7 +77,9 @@ export const StakeInputs = () => {
         required: translationString('AMOUNT_IS_NOT_SET'),
         validate: {
             min: validateMin(translationString),
-            max: validateStakingMax(translationString, { maxAmount: MAX_AMOUNT_FOR_STAKING }),
+            max: validateStakingMax(translationString, {
+                maxAmount: stakingLimits.MAX_AMOUNT_FOR_STAKING,
+            }),
             decimals: validateDecimals(translationString, { decimals: network.decimals }),
             reserveOrBalance: validateReserveOrBalance(translationString, {
                 account,
@@ -97,21 +102,21 @@ export const StakeInputs = () => {
         return new BigNumber(account.formattedBalance)
             .dividedBy(divisor)
             .decimalPlaces(network.decimals)
-            .lte(MIN_AMOUNT_FOR_STAKING);
+            .lte(stakingLimits.MIN_AMOUNT_FOR_STAKING);
     };
 
     const tooltip = (
         <Translation
             id="TR_STAKE_MIN_AMOUNT_TOOLTIP"
             values={{
-                amount: MIN_AMOUNT_FOR_STAKING.toString(),
+                amount: stakingLimits.MIN_AMOUNT_FOR_STAKING.toString(),
                 networkDisplaySymbol,
             }}
         />
     );
 
     const isBalanceBelowMinStake = new BigNumber(account.formattedBalance || '0').lt(
-        MIN_AMOUNT_FOR_STAKING,
+        stakingLimits.MIN_AMOUNT_FOR_STAKING,
     );
 
     return (
@@ -218,7 +223,7 @@ export const StakeInputs = () => {
                                 : 'TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL'
                         }
                         values={{
-                            amount: MIN_FOR_WITHDRAWALS.toString(),
+                            amount: stakingLimits.MIN_FOR_WITHDRAWALS.toString(),
                             networkDisplaySymbol,
                         }}
                     />
@@ -229,7 +234,7 @@ export const StakeInputs = () => {
                     <Translation
                         id="TR_STAKE_RECOMMENDED_AMOUNT_FOR_WITHDRAWALS"
                         values={{
-                            amount: MIN_FOR_WITHDRAWALS.toString(),
+                            amount: stakingLimits.MIN_FOR_WITHDRAWALS.toString(),
                             networkDisplaySymbol,
                         }}
                     />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
@@ -1,5 +1,6 @@
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { SelectedAccountLoaded } from '@suite-common/wallet-types';
+import { StakingLimits, getStakingLimitsByNetworkSymbol } from '@suite-common/wallet-utils';
 import { Grid, Modal } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
@@ -15,12 +16,17 @@ import { StakeInfoCards } from './StakeInfoCards/StakeInfoCards';
 interface StakeModalModalProps {
     onCancel?: () => void;
     selectedAccount: SelectedAccountLoaded;
+    stakingLimits: StakingLimits;
 }
 
-export const StakeModalLoaded = ({ onCancel, selectedAccount }: StakeModalModalProps) => {
+export const StakeModalLoaded = ({
+    onCancel,
+    selectedAccount,
+    stakingLimits,
+}: StakeModalModalProps) => {
     const { account } = selectedAccount;
 
-    const stakeContextValues = useStakeForm({ selectedAccount });
+    const stakeContextValues = useStakeForm({ selectedAccount, stakingLimits });
     const { isBelowTablet } = useLayoutSize();
 
     const onCancelClick = () => {
@@ -58,7 +64,7 @@ export const StakeModalLoaded = ({ onCancel, selectedAccount }: StakeModalModalP
     );
 };
 
-export const StakeModal = ({ onCancel }: Omit<StakeModalModalProps, 'selectedAccount'>) => {
+export const StakeModal = ({ onCancel }: Pick<StakeModalModalProps, 'onCancel'>) => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
 
     if (selectedAccount.status !== 'loaded' || !selectedAccount.account) {
@@ -67,10 +73,17 @@ export const StakeModal = ({ onCancel }: Omit<StakeModalModalProps, 'selectedAcc
         return null;
     }
 
+    const stakingLimits = getStakingLimitsByNetworkSymbol(selectedAccount.account.symbol);
+
+    if (!stakingLimits) {
+        return null;
+    }
+
     return (
         <StakeModalLoaded
             onCancel={onCancel}
             selectedAccount={selectedAccount as SelectedAccountLoaded}
+            stakingLimits={stakingLimits}
         />
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -45,7 +45,6 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
     const { route } = useSelector(state => state.router);
     const apy = useSelector(state => selectPoolStatsApyData(state, account.symbol));
     const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
-    const stakingLimits = getStakingLimitsByNetworkSymbol(account.symbol);
 
     const displaySymbol = getDisplaySymbol(account.symbol);
     const stakingData = getStakingDataForNetwork(account);
@@ -120,6 +119,7 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
     };
 
     const { isStakingBannerClosed } = getNetworkDetails(account.networkType) ?? {};
+    const stakingLimits = getStakingLimitsByNetworkSymbol(account.symbol);
 
     if (
         route?.name !== 'wallet-index' ||

--- a/packages/suite/src/hooks/wallet/useClaimForm.ts
+++ b/packages/suite/src/hooks/wallet/useClaimForm.ts
@@ -3,13 +3,13 @@ import { useForm } from 'react-hook-form';
 
 import { getStakeFormsDefaultValues, getStakingContractAddress } from '@suite-common/staking';
 import { selectBaseCurrency, selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
-import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { PrecomposedTransactionFinal, SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 
 import { signTransaction } from 'src/actions/wallet/stakeActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { ClaimContextValues, ClaimFormState } from 'src/types/wallet/claimForm';
-import { CRYPTO_INPUT, OUTPUT_AMOUNT, UseStakeFormsProps } from 'src/types/wallet/stakeForms';
+import { CRYPTO_INPUT, OUTPUT_AMOUNT } from 'src/types/wallet/stakeForms';
 
 import { useFees } from './form/useFees';
 import { useStakeCompose } from './form/useStakeCompose';
@@ -17,7 +17,11 @@ import { useStakeCompose } from './form/useStakeCompose';
 export const ClaimFormContext = createContext<ClaimContextValues | null>(null);
 ClaimFormContext.displayName = 'ClaimFormContext';
 
-export const useClaimForm = ({ selectedAccount }: UseStakeFormsProps): ClaimContextValues => {
+type UseClaimFormsProps = {
+    selectedAccount: SelectedAccountLoaded;
+};
+
+export const useClaimForm = ({ selectedAccount }: UseClaimFormsProps): ClaimContextValues => {
     const dispatch = useDispatch();
 
     const baseCurrencyCode = useSelector(selectBaseCurrency);

--- a/packages/suite/src/hooks/wallet/useStakeForm.ts
+++ b/packages/suite/src/hooks/wallet/useStakeForm.ts
@@ -12,12 +12,16 @@ import {
     selectRawNetworkFeeInfo,
     useFormDraft,
 } from '@suite-common/wallet-core';
-import { PrecomposedTransactionFinal, StakeFormState } from '@suite-common/wallet-types';
 import {
+    PrecomposedTransactionFinal,
+    SelectedAccountLoaded,
+    StakeFormState,
+} from '@suite-common/wallet-types';
+import {
+    StakingLimits,
     fromBaseCurrencyToCryptoUnit,
     getConvertedOrDefaultFeeInfo,
     getFiatRateKey,
-    getStakingLimitsByNetwork,
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
 import { isChanged } from '@trezor/utils';
@@ -25,12 +29,7 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { signTransaction } from 'src/actions/wallet/stakeActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import {
-    CRYPTO_INPUT,
-    FIAT_INPUT,
-    OUTPUT_AMOUNT,
-    UseStakeFormsProps,
-} from 'src/types/wallet/stakeForms';
+import { CRYPTO_INPUT, FIAT_INPUT, OUTPUT_AMOUNT } from 'src/types/wallet/stakeForms';
 import type { AmountLimitProps } from 'src/utils/suite/validation';
 
 import { useFees } from './form/useFees';
@@ -39,11 +38,18 @@ import { useStakeCompose } from './form/useStakeCompose';
 export const StakeFormContext = createContext<StakeContextValues | null>(null);
 StakeFormContext.displayName = 'StakeFormContext';
 
-export const useStakeForm = ({ selectedAccount }: UseStakeFormsProps): StakeContextValues => {
+type UseStakeFormsProps = {
+    selectedAccount: SelectedAccountLoaded;
+    stakingLimits: StakingLimits;
+};
+
+export const useStakeForm = ({
+    selectedAccount,
+    stakingLimits,
+}: UseStakeFormsProps): StakeContextValues => {
     const dispatch = useDispatch();
 
     const { account, network } = selectedAccount;
-    const { symbol } = account;
 
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const networkFees = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
@@ -51,19 +57,20 @@ export const useStakeForm = ({ selectedAccount }: UseStakeFormsProps): StakeCont
     const [currency, setCurrency] = useState<'crypto' | 'fiat' | undefined>(undefined);
 
     const currentRate = useSelector(state =>
-        selectFiatRatesByFiatRateKey(state, getFiatRateKey(symbol, baseCurrencyCode), 'current'),
+        selectFiatRatesByFiatRateKey(
+            state,
+            getFiatRateKey(account.symbol, baseCurrencyCode),
+            'current',
+        ),
     );
 
-    const { MIN_AMOUNT_FOR_STAKING, MIN_FOR_WITHDRAWALS, MIN_BALANCE_FOR_STAKING } =
-        getStakingLimitsByNetwork(account);
-
     const amountLimits: AmountLimitProps = {
-        currency: symbol,
-        minCrypto: MIN_AMOUNT_FOR_STAKING.toString(),
+        currency: account.symbol,
+        minCrypto: stakingLimits.MIN_AMOUNT_FOR_STAKING.toString(),
         maxCrypto: account.formattedBalance,
         minFiat:
             toFiatCurrency({
-                amount: MIN_AMOUNT_FOR_STAKING.toString(),
+                amount: stakingLimits.MIN_AMOUNT_FOR_STAKING.toString(),
                 rate: currentRate?.rate,
             })?.toFixed(2) ?? undefined,
         maxFiat:
@@ -204,14 +211,14 @@ export const useStakeForm = ({ selectedAccount }: UseStakeFormsProps): StakeCont
             const balanceMinusFee = balance.minus(composedFee);
 
             if (
-                cryptoValue.gt(balanceMinusFee.minus(MIN_FOR_WITHDRAWALS)) &&
+                cryptoValue.gt(balanceMinusFee.minus(stakingLimits.MIN_FOR_WITHDRAWALS)) &&
                 cryptoValue.lt(balanceMinusFee) &&
-                cryptoValue.gte(MIN_AMOUNT_FOR_STAKING)
+                cryptoValue.gte(stakingLimits.MIN_AMOUNT_FOR_STAKING)
             ) {
                 setIsAdviceForWithdrawalWarningShown(true);
             }
         },
-        [composedFee, MIN_FOR_WITHDRAWALS, MIN_AMOUNT_FOR_STAKING],
+        [composedFee, stakingLimits.MIN_FOR_WITHDRAWALS, stakingLimits.MIN_AMOUNT_FOR_STAKING],
     );
 
     const onCryptoAmountChange = useCallback(
@@ -303,13 +310,17 @@ export const useStakeForm = ({ selectedAccount }: UseStakeFormsProps): StakeCont
 
         const amount = new BigNumber(account.formattedBalance).toString();
 
-        if (amount < MIN_BALANCE_FOR_STAKING.toString()) {
+        if (amount < stakingLimits.MIN_BALANCE_FOR_STAKING.toString()) {
             setIsLessAmountForWithdrawalWarningShown(true);
         }
 
-        setValue(OUTPUT_AMOUNT, new BigNumber(amount).minus(MIN_FOR_WITHDRAWALS).toString() || '', {
-            shouldDirty: true,
-        });
+        setValue(
+            OUTPUT_AMOUNT,
+            new BigNumber(amount).minus(stakingLimits.MIN_FOR_WITHDRAWALS).toString() || '',
+            {
+                shouldDirty: true,
+            },
+        );
 
         await composeRequest(CRYPTO_INPUT);
         setIsAmountForWithdrawalWarningShown(true);
@@ -318,8 +329,8 @@ export const useStakeForm = ({ selectedAccount }: UseStakeFormsProps): StakeCont
         clearErrors,
         composeRequest,
         setValue,
-        MIN_BALANCE_FOR_STAKING,
-        MIN_FOR_WITHDRAWALS,
+        stakingLimits.MIN_BALANCE_FOR_STAKING,
+        stakingLimits.MIN_FOR_WITHDRAWALS,
     ]);
 
     useEffect(() => {

--- a/packages/suite/src/hooks/wallet/useUnstakeForm.ts
+++ b/packages/suite/src/hooks/wallet/useUnstakeForm.ts
@@ -16,7 +16,7 @@ import {
     selectRawNetworkFeeInfo,
     useFormDraft,
 } from '@suite-common/wallet-core';
-import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { PrecomposedTransactionFinal, SelectedAccountLoaded } from '@suite-common/wallet-types';
 import {
     fromBaseCurrencyToCryptoUnit,
     getConvertedOrDefaultFeeInfo,
@@ -28,12 +28,7 @@ import { BigNumber, isChanged } from '@trezor/utils';
 
 import { signTransaction } from 'src/actions/wallet/stakeActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import {
-    CRYPTO_INPUT,
-    FIAT_INPUT,
-    OUTPUT_AMOUNT,
-    UseStakeFormsProps,
-} from 'src/types/wallet/stakeForms';
+import { CRYPTO_INPUT, FIAT_INPUT, OUTPUT_AMOUNT } from 'src/types/wallet/stakeForms';
 import type { AmountLimitProps } from 'src/utils/suite/validation';
 
 import { useFees } from './form/useFees';
@@ -50,7 +45,11 @@ type UnstakeContextValues = UnstakeContextValuesBase & {
 export const UnstakeFormContext = createContext<UnstakeContextValues | null>(null);
 UnstakeFormContext.displayName = 'UnstakeFormContext';
 
-export const useUnstakeForm = ({ selectedAccount }: UseStakeFormsProps): UnstakeContextValues => {
+type UseUnstakeFormsProps = {
+    selectedAccount: SelectedAccountLoaded;
+};
+
+export const useUnstakeForm = ({ selectedAccount }: UseUnstakeFormsProps): UnstakeContextValues => {
     const dispatch = useDispatch();
     const [approximatedInstantEthAmount, setApproximatedInstantEthAmount] = useState<string | null>(
         null,

--- a/packages/suite/src/types/wallet/stakeForms.ts
+++ b/packages/suite/src/types/wallet/stakeForms.ts
@@ -1,7 +1,3 @@
-import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
-
 export const FIAT_INPUT = 'fiatInput';
 export const CRYPTO_INPUT = 'cryptoInput';
 export const OUTPUT_AMOUNT = 'outputs.0.amount';
-
-export type UseStakeFormsProps = { selectedAccount: SelectedAccountLoaded };

--- a/suite-common/wallet-utils/src/stakingUtils.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.ts
@@ -47,8 +47,19 @@ export const getAccountTotalStakingBalance = (account: Account) => {
 export const isSupportedStakingNetworkSymbol = (symbol: NetworkSymbol) =>
     isSupportedEthStakingNetworkSymbol(symbol) || isSupportedSolStakingNetworkSymbol(symbol);
 
-export const getStakingLimitsByNetworkSymbol = (symbol: NetworkSymbol | undefined) => {
+export type StakingLimits = {
+    MIN_AMOUNT_FOR_STAKING: BigNumber;
+    MAX_AMOUNT_FOR_STAKING: BigNumber;
+    MIN_FOR_WITHDRAWALS: BigNumber;
+    MIN_BALANCE_FOR_STAKING: BigNumber;
+};
+
+export const getStakingLimitsByNetworkSymbol = (
+    symbol: NetworkSymbol | undefined,
+): StakingLimits | null => {
     switch (symbol) {
+        case 'tsep':
+        case 'thol':
         case 'eth':
             return {
                 MIN_AMOUNT_FOR_STAKING: MIN_ETH_AMOUNT_FOR_STAKING,
@@ -56,6 +67,8 @@ export const getStakingLimitsByNetworkSymbol = (symbol: NetworkSymbol | undefine
                 MIN_FOR_WITHDRAWALS: MIN_ETH_FOR_WITHDRAWALS,
                 MIN_BALANCE_FOR_STAKING: MIN_ETH_BALANCE_FOR_STAKING,
             };
+
+        case 'dsol':
         case 'sol':
             return {
                 MIN_AMOUNT_FOR_STAKING: MIN_SOL_AMOUNT_FOR_STAKING,
@@ -63,36 +76,18 @@ export const getStakingLimitsByNetworkSymbol = (symbol: NetworkSymbol | undefine
                 MIN_FOR_WITHDRAWALS: MIN_SOL_FOR_WITHDRAWALS,
                 MIN_BALANCE_FOR_STAKING: MIN_SOL_BALANCE_FOR_STAKING,
             };
-        default:
-            return null;
-    }
-};
 
-export const getStakingLimitsByNetwork = (account: Account) => {
-    switch (account.networkType) {
-        case 'ethereum':
-            return {
-                MIN_AMOUNT_FOR_STAKING: MIN_ETH_AMOUNT_FOR_STAKING,
-                MAX_AMOUNT_FOR_STAKING: MAX_ETH_AMOUNT_FOR_STAKING,
-                MIN_FOR_WITHDRAWALS: MIN_ETH_FOR_WITHDRAWALS,
-                MIN_BALANCE_FOR_STAKING: MIN_ETH_BALANCE_FOR_STAKING,
-            };
-        case 'solana':
-            return {
-                MIN_AMOUNT_FOR_STAKING: MIN_SOL_AMOUNT_FOR_STAKING,
-                MAX_AMOUNT_FOR_STAKING: MAX_SOL_AMOUNT_FOR_STAKING,
-                MIN_FOR_WITHDRAWALS: MIN_SOL_FOR_WITHDRAWALS,
-                MIN_BALANCE_FOR_STAKING: MIN_SOL_BALANCE_FOR_STAKING,
-            };
-        case 'cardano':
+        case 'tada':
+        case 'ada':
             return {
                 MIN_AMOUNT_FOR_STAKING: MIN_CARDANO_AMOUNT_FOR_STAKING,
                 MAX_AMOUNT_FOR_STAKING: MAX_CARDANO_AMOUNT_FOR_STAKING,
                 MIN_FOR_WITHDRAWALS: MIN_CARDANO_FOR_WITHDRAWALS,
                 MIN_BALANCE_FOR_STAKING: MIN_CARDANO_BALANCE_FOR_STAKING,
             };
+
         default:
-            throw new Error(`Unsupported network type: ${account.networkType}`);
+            return null;
     }
 };
 


### PR DESCRIPTION
## Description

- Use `getStakingLimitsByNetworkSymbol` instead of `getStakingLimitsByNetwork`.
- Add test nets and ada to `getStakingLimitsByNetworkSymbol`.

## Related Issue

Resolve #21347


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/21347-staking-limits-util&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/21347-staking-limits-util&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/21347-staking-limits-util&lookback=7)