### PR TITLE
fix(transport): fix broken usb synchronziation after page reload

### DIFF
--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -461,7 +461,9 @@ export abstract class AbstractApiTransport extends AbstractTransport {
             });
         }
         super.stop();
-        this.sessionsClient.dispose();
+        // note:
+        // not disposing sessionClient on purpose. on window reload, transport.stop is called. we do not want to clear sessions background data in this case because
+        // there might be another client connected to it. When the last client disconnects, the background disposes itself.
         this.api.dispose();
     }
 }


### PR DESCRIPTION
1. open suite in window A. click get address (do not approve on device)
2. open suite in window B.  device appears as used elsewhere correctly
3. reload window B
4. device descriptors are wiped in sessions background, window B tries to grab device. synchronization breaks.

this PR fixes it

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-webusb-broken-synchronization&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-webusb-broken-synchronization&lookback=7)