### PR TITLE
chore(connect): use device.descriptor instead of device.bluetoothProps

### DIFF
--- a/packages/connect/src/api/bleUnpair.ts
+++ b/packages/connect/src/api/bleUnpair.ts
@@ -33,7 +33,7 @@ export default class BleUnpair extends AbstractMethod<'bleUnpair', PROTO.BleUnpa
             // or fails here with transport read/write error
             // in both cases Device_Disconnected error should be handled as "expected success"
             if (
-                this.device.bluetoothProps &&
+                this.device.descriptor.apiType === 'bluetooth' &&
                 error.message === TRANSPORT_ERROR.INTERFACE_DATA_TRANSFER
             ) {
                 // typed error is considered as "method failed successfully"

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -491,7 +491,7 @@ export const onCallFirmwareUpdate = async ({
             'waiting for disconnected event after rebootToBootloader...',
         );
 
-        if (device.bluetoothProps) {
+        if (device.descriptor.apiType === 'bluetooth') {
             // close device
             await device.release();
             // wait for device-change
@@ -553,7 +553,7 @@ export const onCallFirmwareUpdate = async ({
     }
 
     let method: ReconnectParams['method'] = 'wait';
-    if (device.bluetoothProps) {
+    if (device.descriptor.apiType === 'bluetooth') {
         await waitForBluetoothReboot({ device, target: 'normal', postMessage });
         method = 'auto';
     }

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -126,7 +126,7 @@ type DeviceParams = {
 export class Device extends TypedEmitter<DeviceEvents> {
     public readonly transport: Transport;
     private thp: protocolThp.ThpState | undefined;
-    private readonly descriptor: Pick<Descriptor, 'apiType' | 'id' | 'type' | 'path'>;
+    public readonly descriptor: Pick<Descriptor, 'apiType' | 'id' | 'type' | 'path'>;
     private sessionAcquired: Session | null;
 
     // protocol related
@@ -150,16 +150,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
         'battery-level': false,
         'trezor-push-notification': false,
     };
-
-    public get bluetoothProps() {
-        if (this.descriptor.id && this.descriptor.apiType === 'bluetooth') {
-            return {
-                id: asBluetoothDeviceId(this.descriptor.id),
-            };
-        }
-
-        return undefined;
-    }
 
     // @ts-expect-error: strictPropertyInitialization
     private _firmwareStatus: DeviceFirmwareStatus;
@@ -1121,6 +1111,13 @@ export class Device extends TypedEmitter<DeviceEvents> {
         const { apiType, id } = descriptor;
         const base = { path, name, descriptor: { apiType, id } };
 
+        const bluetoothProps =
+            this.descriptor.id && this.descriptor.apiType === 'bluetooth'
+                ? {
+                      id: asBluetoothDeviceId(this.descriptor.id),
+                  }
+                : undefined;
+
         if (this.unreadableError) {
             return {
                 ...base,
@@ -1139,7 +1136,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 label: 'Unacquired device',
                 name: this.name,
                 transportSessionOwner: this.sessionAcquired ? undefined : sessionOwner,
-                bluetoothProps: this.bluetoothProps,
+                bluetoothProps,
                 thp: this.thp?.serialize(),
                 status: this.busy ? this.busy : undefined,
             };
@@ -1165,7 +1162,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             unavailableCapabilities: this.unavailableCapabilities,
             availableTranslations: this.availableTranslations,
             authenticityChecks: this.authenticityChecks,
-            bluetoothProps: this.bluetoothProps,
+            bluetoothProps,
             thp: this.thp?.serialize(),
         };
     }

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -141,6 +141,7 @@ export type KnownDevice = BaseDevice & {
     };
     transportSessionOwner?: undefined;
     hid?: undefined;
+    /** @deprecated  use descriptor.id in combination with descriptor.apiType */
     bluetoothProps?: BluetoothDeviceProps;
 };
 
@@ -164,6 +165,7 @@ export type UnknownDevice = BaseDevice & {
     availableTranslations?: typeof undefined;
     transportSessionOwner?: string;
     hid?: undefined;
+    /** @deprecated  use descriptor.id in combination with descriptor.apiType */
     bluetoothProps?: BluetoothDeviceProps;
 };
 
@@ -187,6 +189,7 @@ export type UnreadableDevice = BaseDevice & {
     availableTranslations?: typeof undefined;
     transportSessionOwner?: undefined;
     hid: boolean;
+    /** @deprecated  use descriptor.id in combination with descriptor.apiType */
     bluetoothProps?: typeof undefined;
 };
 


### PR DESCRIPTION
part of #22050


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=deprecate-bluetooth-props&lookback=7)