### PR TITLE
feat(suite): preserve manufacturer data on linux edge case

### DIFF
--- a/packages/suite/src/actions/bluetooth/__tests__/fixLinuxManufacturerData.test.ts
+++ b/packages/suite/src/actions/bluetooth/__tests__/fixLinuxManufacturerData.test.ts
@@ -1,0 +1,62 @@
+import type { BluetoothFilterPolicy, BluetoothManufacturerData } from '@suite-common/bluetooth';
+import { asBluetoothDeviceId } from '@trezor/connect';
+import { DeviceModelInternal } from '@trezor/device-utils';
+
+import { createMockedBluetoothDevice } from './createMockedBluetoothDevice';
+import { fixLinuxManufacturerData } from '../fixLinuxManufacturerData';
+
+const mockedFilterPolicy: BluetoothFilterPolicy = {
+    pairing: true,
+    bond_memory_full: true,
+    connected: false,
+    user_disconnected: false,
+};
+
+const mockedManufacturerData: BluetoothManufacturerData = {
+    deviceModel: DeviceModelInternal.T2T1,
+    deviceColor: 1,
+    filterPolicy: mockedFilterPolicy,
+};
+
+describe('fixLinuxManufacturerData', () => {
+    const mockKnownDevice = createMockedBluetoothDevice({
+        id: asBluetoothDeviceId('1'),
+        manufacturerData: mockedManufacturerData,
+    });
+    it('should preserve known device manufacturer data when device model is UNKNOWN', () => {
+        const deviceWithUnknownModel = createMockedBluetoothDevice({
+            ...mockKnownDevice,
+            manufacturerData: {
+                deviceModel: DeviceModelInternal.UNKNOWN,
+                deviceColor: 5,
+                filterPolicy: mockedFilterPolicy,
+            },
+        });
+
+        const result = fixLinuxManufacturerData(deviceWithUnknownModel, mockKnownDevice);
+
+        expect(result.manufacturerData).toEqual(mockedManufacturerData);
+    });
+
+    it('should return device unchanged when model is not UNKNOWN', () => {
+        const deviceWithValidModel = createMockedBluetoothDevice({
+            ...mockKnownDevice,
+            manufacturerData: {
+                deviceModel: DeviceModelInternal.T2T1,
+                deviceColor: 2,
+                filterPolicy: mockedFilterPolicy,
+            },
+        });
+
+        const result = fixLinuxManufacturerData(deviceWithValidModel, mockKnownDevice);
+
+        expect(result).toBe(deviceWithValidModel);
+    });
+
+    it('should return device unchanged when no known device exists', () => {
+        const device = mockKnownDevice;
+        const result = fixLinuxManufacturerData(device, undefined);
+
+        expect(result).toBe(device);
+    });
+});

--- a/packages/suite/src/actions/bluetooth/fixLinuxManufacturerData.ts
+++ b/packages/suite/src/actions/bluetooth/fixLinuxManufacturerData.ts
@@ -1,0 +1,24 @@
+import { DeviceModelInternal } from '@trezor/device-utils';
+
+import type { DesktopBluetoothDevice } from './DesktopBluetoothDevice';
+
+/**
+ * Fixes manufacturer data on Linux where adapter reconnection
+ * can cause device model to become UNKNOWN
+ */
+export const fixLinuxManufacturerData = (
+    device: DesktopBluetoothDevice,
+    knownDevice: DesktopBluetoothDevice | undefined,
+): DesktopBluetoothDevice => {
+    if (knownDevice && device.manufacturerData.deviceModel === DeviceModelInternal.UNKNOWN) {
+        return {
+            ...device,
+            manufacturerData: {
+                ...knownDevice.manufacturerData,
+                filterPolicy: device.manufacturerData?.filterPolicy,
+            },
+        };
+    }
+
+    return device;
+};

--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -22,6 +22,7 @@ import {
 import { bluetoothConnectDeviceThunk } from './bluetoothConnectDeviceThunk';
 import { bluetoothStartScanningThunk } from './bluetoothStartScanningThunk';
 import { selectConnectingDevices } from './desktopBluetoothSelectors';
+import { fixLinuxManufacturerData } from './fixLinuxManufacturerData';
 import { remapKnownDevicesForLinuxAndWindows } from './remapKnownDevicesForLinuxAndWindows';
 
 export const initBluetoothThunk = createThunk<void, void, void>(
@@ -148,7 +149,12 @@ export const initBluetoothThunk = createThunk<void, void, void>(
         });
 
         bluetoothIpc.on('device-update', (deviceIpc: BluetoothDevice) => {
-            const device = fromBluetoothDevice(deviceIpc);
+            let device = fromBluetoothDevice(deviceIpc);
+
+            const knownDevice = selectKnownDevices<DesktopBluetoothDevice>(getState()).find(
+                d => d.id === device.id,
+            );
+            device = fixLinuxManufacturerData(device, knownDevice);
 
             dispatch(bluetoothActions.deviceUpdateAction({ device }));
         });


### PR DESCRIPTION
based of https://github.com/trezor/trezor-suite/pull/22049 just nit polished as @szymonlesisz wanted.

> Do not override static part of bluetooth manufacturerData after "device-update" event.

> On linux after successful pairing and setup if BT adapter gets disconnected and connected again device.manufacturerData are empty this will override knownDevice .manufacturerData leading to model => UNKNOWN.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/linux-manufacturer-data&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/linux-manufacturer-data&lookback=7)