### PR TITLE
Mobile Trade: hide non-tradeable tokens

### DIFF
--- a/suite-native/formatters/src/index.ts
+++ b/suite-native/formatters/src/index.ts
@@ -16,3 +16,4 @@ export { FeeFormatter } from './components/FeeFormatter';
 export { useFiatFromCryptoValue } from './hooks/useFiatFromCryptoValue';
 export { useCryptoFiatConverters } from './hooks/useCryptoFiatConverters';
 export { useFormattersConfig } from './hooks/useFormattersConfig';
+export { formatNumberWithThousandCommas, convertTokenValueToDecimal } from './utils';

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2486,6 +2486,7 @@ export const messages = {
                 note: 'No pair',
                 toast: 'There is no pair for this asset',
             },
+            nonTradeable: '+ {count} non-tradeable {count, plural, one{token} other{tokens}}',
         },
         advancedSettings: {
             slippage: {

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.comp.test.tsx
@@ -14,17 +14,17 @@ import { BigNumber } from '@trezor/utils';
 import { getBtcAccount, getEthAccount } from '../../../../__fixtures__/account';
 import { getInitializedTradingState } from '../../../../__fixtures__/tradingState';
 import { useExchangeForm } from '../../../../hooks/exchange/useExchangeForm';
-import { selectAccountsWithTokensToSellSectionListByTradingType } from '../../../../selectors/commonSelectors';
+import { selectAccountsWithTokensToSellSectionCondensedListByTradingType } from '../../../../selectors/commonSelectors';
 import { ExchangeFormType } from '../../../../types/exchange';
-import { MyAsset } from '../../../../types/general';
+import { MyAssetTradeable } from '../../../../types/general';
 import { ExchangeSendAssetPicker } from '../ExchangeSendAssetPicker';
 
 jest.mock('../../../../selectors/commonSelectors', () => ({
     ...jest.requireActual('../../../../selectors/commonSelectors'),
-    selectAccountsWithTokensToSellSectionListByTradingType: jest.fn(),
+    selectAccountsWithTokensToSellSectionCondensedListByTradingType: jest.fn(),
 }));
 const mockedSelectAccountsWithTokensToSellSectionListByTradingType =
-    selectAccountsWithTokensToSellSectionListByTradingType as unknown as jest.Mock;
+    selectAccountsWithTokensToSellSectionCondensedListByTradingType as unknown as jest.Mock;
 
 describe('ExchangeSendAssetPicker', () => {
     let form: ExchangeFormType;
@@ -33,7 +33,7 @@ describe('ExchangeSendAssetPicker', () => {
     const btcAccount = getBtcAccount();
     const ethAccount = getEthAccount();
 
-    const defaultAssets: MyAsset[] = [
+    const defaultAssets: MyAssetTradeable[] = [
         {
             name: 'Bitcoin',
             symbol: 'btc',

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
@@ -11,10 +11,11 @@ import { ASSET_ITEM_HEIGHT, MyAssetListItem, MyAssetListItemProps } from './MyAs
 import { MyAssetListSectionHeader } from './MyAssetListSectionHeader';
 import {
     CombinedSelectorsRootState,
-    selectAccountsWithTokensToSellSectionListByTradingType,
+    selectAccountsWithTokensToSellSectionCondensedListByTradingType,
 } from '../../../selectors/commonSelectors';
-import { MyAsset, TradeableAsset } from '../../../types/general';
+import { MyAssetRow, TradeableAsset } from '../../../types/general';
 import { SimpleSheetHeader } from '../SimpleSheetHeader';
+import { MyAssetsDisabledListItem } from './MyAssetsDisabledListItem';
 
 export type MyAssetSheetProps = {
     tradingType: TradingType;
@@ -23,13 +24,19 @@ export type MyAssetSheetProps = {
     onAssetSelect: MyAssetListItemProps['onPress'];
 };
 
-const keyExtractor = (asset: MyAsset, sectionData: Account) => `${sectionData.key}_${asset.name}`;
+const keyExtractor = (asset: MyAssetRow, sectionData: Account) =>
+    `${sectionData.key}_${asset.name}`;
 
 const renderItem = (
-    asset: MyAsset,
+    asset: MyAssetRow,
     { sectionData }: { sectionData: Account },
     onAssetSelect: MyAssetListItemProps['onPress'],
-) => <MyAssetListItem asset={asset} account={sectionData} onPress={onAssetSelect} />;
+) =>
+    asset.isEnabled ? (
+        <MyAssetListItem asset={asset} account={sectionData} onPress={onAssetSelect} />
+    ) : (
+        <MyAssetsDisabledListItem count={asset.count} />
+    );
 
 export const MyAssetSheet = memo(
     ({ tradingType, isVisible, onClose, onAssetSelect }: MyAssetSheetProps) => {
@@ -39,7 +46,7 @@ export const MyAssetSheet = memo(
         };
 
         const myAssets = useSelector((state: CombinedSelectorsRootState) =>
-            selectAccountsWithTokensToSellSectionListByTradingType(state, tradingType),
+            selectAccountsWithTokensToSellSectionCondensedListByTradingType(state, tradingType),
         );
 
         const renderHandle = () => (
@@ -50,7 +57,7 @@ export const MyAssetSheet = memo(
         );
 
         return (
-            <BottomSheetSectionList<MyAsset, Account>
+            <BottomSheetSectionList<MyAssetRow, Account>
                 isVisible={isVisible}
                 onClose={onClose}
                 ListEmptyComponent={<MyAssetListEmptyComponent />}

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetsDisabledListItem.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetsDisabledListItem.tsx
@@ -1,0 +1,18 @@
+import { Box, Text } from '@suite-native/atoms';
+import { formatNumberWithThousandCommas } from '@suite-native/formatters/src/utils';
+import { Translation } from '@suite-native/intl';
+
+export type MyAssetsDisabledListItemProps = {
+    count: number;
+};
+
+export const MyAssetsDisabledListItem = ({ count }: MyAssetsDisabledListItemProps) => (
+    <Box padding="sp12" justifyContent="center" alignItems="center">
+        <Text variant="hint" color="textDefault">
+            <Translation
+                id="moduleTrading.myAssetSheet.nonTradeable"
+                values={{ count: formatNumberWithThousandCommas(count) }}
+            />
+        </Text>
+    </Box>
+);

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetsDisabledListItem.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetsDisabledListItem.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from '@suite-native/atoms';
-import { formatNumberWithThousandCommas } from '@suite-native/formatters/src/utils';
+import { formatNumberWithThousandCommas } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
 
 export type MyAssetsDisabledListItemProps = {

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.comp.test.tsx
@@ -7,14 +7,14 @@ import { BigNumber } from '@trezor/utils';
 
 import { getBtcAccount, getEthAccount } from '../../../../__fixtures__/account';
 import { getInitializedTradingState } from '../../../../__fixtures__/tradingState';
-import { selectAccountsWithTokensToSellSectionListByTradingType } from '../../../../selectors/commonSelectors';
-import { MyAsset } from '../../../../types/general';
+import { selectAccountsWithTokensToSellSectionCondensedListByTradingType } from '../../../../selectors/commonSelectors';
+import { MyAssetTradeable } from '../../../../types/general';
 import { TEST_ID_ACCOUNT_TYPE_BADGE } from '../MyAssetListSectionHeader';
 import { MyAssetSheet, MyAssetSheetProps } from '../MyAssetSheet';
 
 jest.mock('../../../../selectors/commonSelectors');
 const mockedSelectAccountsWithTokensToSellSectionListByTradingType =
-    selectAccountsWithTokensToSellSectionListByTradingType as unknown as jest.Mock;
+    selectAccountsWithTokensToSellSectionCondensedListByTradingType as unknown as jest.Mock;
 
 // Mock the selectFormattedAccountType selector
 jest.mock('@suite-common/wallet-core', () => ({
@@ -28,7 +28,7 @@ describe('MyAssetSheet', () => {
     const btcAccount = getBtcAccount();
     const ethAccount = getEthAccount();
 
-    const defaultAssets: MyAsset[] = [
+    const defaultAssets: MyAssetTradeable[] = [
         {
             name: 'Bitcoin',
             symbol: 'btc',

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetsDisabledListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetsDisabledListItem.comp.test.tsx
@@ -1,0 +1,21 @@
+import { renderWithBasicProvider } from '@suite-native/test-utils';
+
+import {
+    MyAssetsDisabledListItem,
+    MyAssetsDisabledListItemProps,
+} from '../MyAssetsDisabledListItem';
+
+describe('MyAssetsDisabledListItem', () => {
+    const renderMyAssetsDisabledListItem = (props: MyAssetsDisabledListItemProps) =>
+        renderWithBasicProvider(<MyAssetsDisabledListItem {...props} />);
+
+    it.each<[number, string]>([
+        [1, '+ 1 non-tradeable token'],
+        [2, '+ 2 non-tradeable tokens'],
+        [1000, '+ 1,000 non-tradeable tokens'],
+    ])('should render correct text for count %d', (count, expectedContent) => {
+        const { getByText } = renderMyAssetsDisabledListItem({ count });
+
+        expect(getByText(expectedContent)).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAssetPicker.test.tsx
@@ -14,17 +14,17 @@ import { BigNumber } from '@trezor/utils';
 import { getBtcAccount, getEthAccount } from '../../../../__fixtures__/account';
 import { getInitializedTradingState } from '../../../../__fixtures__/tradingState';
 import { useSellForm } from '../../../../hooks/sell/useSellForm';
-import { selectAccountsWithTokensToSellSectionListByTradingType } from '../../../../selectors/commonSelectors';
-import { MyAsset } from '../../../../types/general';
+import { selectAccountsWithTokensToSellSectionCondensedListByTradingType } from '../../../../selectors/commonSelectors';
+import { MyAssetTradeable } from '../../../../types/general';
 import { SellFormType } from '../../../../types/sell';
 import { SellSendAssetPicker } from '../SellSendAssetPicker';
 
 jest.mock('../../../../selectors/commonSelectors', () => ({
     ...jest.requireActual('../../../../selectors/commonSelectors'),
-    selectAccountsWithTokensToSellSectionListByTradingType: jest.fn(),
+    selectAccountsWithTokensToSellSectionCondensedListByTradingType: jest.fn(),
 }));
 const mockedSelectAccountsWithTokensToSellSectionListByTradingType =
-    selectAccountsWithTokensToSellSectionListByTradingType as unknown as jest.Mock;
+    selectAccountsWithTokensToSellSectionCondensedListByTradingType as unknown as jest.Mock;
 
 describe('SellSendAssetPicker', () => {
     let form: SellFormType;
@@ -33,7 +33,7 @@ describe('SellSendAssetPicker', () => {
     const btcAccount = getBtcAccount();
     const ethAccount = getEthAccount();
 
-    const defaultAssets: MyAsset[] = [
+    const defaultAssets: MyAssetTradeable[] = [
         {
             name: 'Bitcoin',
             symbol: 'btc',

--- a/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
+++ b/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
@@ -11,7 +11,7 @@ import {
 import {
     convertTokenValueToDecimal,
     formatNumberWithThousandCommas,
-} from '@suite-native/formatters/src/utils';
+} from '@suite-native/formatters';
 import { BigNumber } from '@trezor/utils';
 
 import { TradeOperationData, getTradeOperationData } from '../../utils/general/utils';

--- a/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
@@ -20,6 +20,7 @@ import { getWalletState } from '../../__fixtures__/walletState';
 import { TradingRootState, initialState } from '../../reducers';
 import { TradeableAsset } from '../../types/general';
 import {
+    selectAccountsWithTokensToSellSectionCondensedListByTradingType,
     selectAccountsWithTokensToSellSectionListByTradingType,
     selectActiveTradingType,
     selectAmountInBaseFiatCurrency,
@@ -861,6 +862,158 @@ describe('commonSelectors', () => {
             expect(result[0].data.length).toBe(2); // Account + 2 tokens with positive balance
             expect(result[0].data[1].contract).toBe('0xA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48'); // USDC
             expect(result[0].data[1].isEnabled).toBe(true);
+        });
+    });
+
+    describe('selectAccountsWithTokensToSellSectionCondensedListByTradingType', () => {
+        it('should group disabled tokens', () => {
+            const testDeviceState = 'test-device';
+            const ethAccount = {
+                ...getEthAccount(),
+                balance: '1000000000000000000', // 1 ETH
+                formattedBalance: '1',
+                visible: true,
+                deviceState: testDeviceState,
+                tokens: [
+                    {
+                        type: 'ERC20',
+                        standard: 'ERC20',
+                        name: 'USDC',
+                        contract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                        transfers: 1,
+                        symbol: 'usdc',
+                        decimals: 6,
+                        balance: '1000000', // 1 USDC
+                    },
+                    {
+                        type: 'ERC20',
+                        standard: 'ERC20',
+                        name: 'non tradeable token 1',
+                        contract: '0x12123123123123123123123123123123123123',
+                        transfers: 0,
+                        symbol: '000',
+                        decimals: 18,
+                        balance: '1000000',
+                    },
+                    {
+                        type: 'ERC20',
+                        standard: 'ERC20',
+                        name: 'non tradeable token 2',
+                        contract: '0xabcabcabcabcabcabcabcabcabcabcabcabcabca',
+                        transfers: 0,
+                        symbol: 'ABC',
+                        decimals: 18,
+                        balance: '1000000',
+                    },
+                ],
+            };
+            const cleanState = getInitializedTradingState('exchange');
+
+            const stateWithDevice = {
+                featureFlags: featureFlagsInitialState,
+                wallet: {
+                    trading: cleanState,
+                    accounts: [ethAccount],
+                    settings: { localCurrency: 'usd', enabledNetworks: ['eth'] },
+                    transactions: { transactions: {} },
+                },
+                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                tokenDefinitions: {
+                    eth: {
+                        coin: {
+                            data: [
+                                // presented in selectTradingSupportedSymbols
+                                '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                                // not presented in selectTradingSupportedSymbols
+                                '0x12123123123123123123123123123123123123',
+                                '0xabcabcabcabcabcabcabcabcabcabcabcabcabca',
+                            ],
+                            error: false,
+                            isLoading: false,
+                            hide: [],
+                            show: [],
+                        },
+                    },
+                },
+                fiat: { rates: {}, current: 'usd' },
+            } as any;
+
+            const result = selectAccountsWithTokensToSellSectionCondensedListByTradingType(
+                stateWithDevice,
+                'exchange',
+            );
+
+            expect(result.length).toBe(1);
+            expect(result[0].data).toEqual([
+                expect.objectContaining({ name: 'Ethereum', isEnabled: true }),
+                expect.objectContaining({ name: 'USDC', isEnabled: true }),
+                {
+                    count: 2,
+                    name: 'non-tradeable-assets',
+                    isEnabled: false,
+                },
+            ]);
+        });
+
+        it('should not display empty disabled section', () => {
+            const testDeviceState = 'test-device';
+            const ethAccount = {
+                ...getEthAccount(),
+                balance: '1000000000000000000', // 1 ETH
+                formattedBalance: '1',
+                visible: true,
+                deviceState: testDeviceState,
+                tokens: [
+                    {
+                        type: 'ERC20',
+                        standard: 'ERC20',
+                        name: 'USDC',
+                        contract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                        transfers: 1,
+                        symbol: 'usdc',
+                        decimals: 6,
+                        balance: '1000000', // 1 USDC
+                    },
+                ],
+            };
+            const cleanState = getInitializedTradingState('exchange');
+
+            const stateWithDevice = {
+                featureFlags: featureFlagsInitialState,
+                wallet: {
+                    trading: cleanState,
+                    accounts: [ethAccount],
+                    settings: { localCurrency: 'usd', enabledNetworks: ['eth'] },
+                    transactions: { transactions: {} },
+                },
+                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                tokenDefinitions: {
+                    eth: {
+                        coin: {
+                            data: [
+                                // presented in selectTradingSupportedSymbols
+                                '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                            ],
+                            error: false,
+                            isLoading: false,
+                            hide: [],
+                            show: [],
+                        },
+                    },
+                },
+                fiat: { rates: {}, current: 'usd' },
+            } as any;
+
+            const result = selectAccountsWithTokensToSellSectionCondensedListByTradingType(
+                stateWithDevice,
+                'exchange',
+            );
+
+            expect(result.length).toBe(1);
+            expect(result[0].data).toEqual([
+                expect.objectContaining({ name: 'Ethereum', isEnabled: true }),
+                expect.objectContaining({ name: 'USDC', isEnabled: true }),
+            ]);
         });
     });
 

--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -47,7 +47,7 @@ import { TokensRootState } from '@suite-native/tokens';
 
 import { SectionListData } from '../hooks/general/useSectionList';
 import { TradingRootState } from '../reducers';
-import { MyAsset, TradeableAsset } from '../types/general';
+import { MyAsset, MyAssetRow, TradeableAsset } from '../types/general';
 import { getSymbolFromTradeableAsset } from '../utils/general/tradeableAssetUtils';
 import { toCaseAwareCryptoId } from '../utils/general/utils';
 
@@ -287,6 +287,26 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
                 })
                 .filter(section => section.data.length > 0);
         },
+    );
+
+export const selectAccountsWithTokensToSellSectionCondensedListByTradingType =
+    createCombinedMemoizedSelector(
+        [selectAccountsWithTokensToSellSectionListByTradingType],
+        sectionListData =>
+            sectionListData.map(section => {
+                const data = section.data.filter(({ isEnabled }) => isEnabled) as MyAssetRow[];
+
+                const nonTradeableAssetsCount = section.data.length - data.length;
+                if (nonTradeableAssetsCount > 0) {
+                    data.push({
+                        count: nonTradeableAssetsCount,
+                        name: 'non-tradeable-assets',
+                        isEnabled: false,
+                    });
+                }
+
+                return { ...section, data };
+            }),
     );
 
 export const selectTradesToWatchByAccount = createTradingWithDeviceAndAccountsMemoizedSelector(

--- a/suite-native/module-trading/src/types/general.ts
+++ b/suite-native/module-trading/src/types/general.ts
@@ -32,6 +32,14 @@ export type MyAsset = {
     isEnabled: boolean;
 };
 
+export type MyAssetTradeable = Omit<MyAsset, 'isEnabled'> & { isEnabled: true };
+export type MyAssetsDisabled = {
+    count: number;
+    name: 'non-tradeable-assets';
+    isEnabled: false;
+};
+export type MyAssetRow = MyAssetTradeable | MyAssetsDisabled;
+
 export type ReceiveAccount = {
     account: Account;
     address?: Address;


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Display disabled tokens in single row with text "+ X non-tradeable tokens"
- Fixes exports from suite-native/formatters

## Related Issue

Resolve [#22036](https://github.com/trezor/trezor-suite/issues/22036)

## Screenshots:
<img width="300" alt="Simulator Screenshot" src="https://github.com/user-attachments/assets/ab396edc-20ee-4ac5-a696-80a5b9ce8824" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22036-mobile-trade-hide-non-tradeable-tokens&lookback=7)