### PR TITLE
fix(connect): only get features after settings/pin change if device i…

### DIFF
--- a/packages/connect/src/device/workflow/trezorPushNotification.ts
+++ b/packages/connect/src/device/workflow/trezorPushNotification.ts
@@ -72,9 +72,9 @@ export const trezorPushNotificationHandler = async ({ device, message }: TpnWork
     switch (type) {
         case TrezorPushNotificationType.SETTING_CHANGE:
         case TrezorPushNotificationType.PIN_CHANGE:
-            await device.acquire();
-            await device.getFeatures();
-            await device.release();
+            if (device.isUsedHere()) {
+                await device.getFeatures();
+            }
             break;
         case TrezorPushNotificationType.LOCK:
             device.setBusy(


### PR DESCRIPTION
The notifications are triggered even if settings/PIN are changed from Suite (device settings or onboarding). If that is the case, `device-acquire` results in an error (device used elsewhere) and user may get stuck in onboarding.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/settings-notifications&lookback=7)