### PR TITLE
Mobile Trade: Trade history detail shows correct token icon

### DIFF
--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailTransactionInfo.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailTransactionInfo.tsx
@@ -5,6 +5,7 @@ import { CryptoId } from 'invity-api';
 import {
     TradingRootState,
     cryptoIdToNetworkAndContractAddress,
+    isCryptoIdForNativeToken,
     selectTradingTradeByOrderId,
 } from '@suite-common/trading';
 import { NetworkDisplaySymbol } from '@suite-common/wallet-config';
@@ -25,22 +26,15 @@ type CryptoIdIconProps = { cryptoId: CryptoId | undefined };
 const TRADE_DETAIL_TEST_ID = '@trading/history/detail';
 
 const CryptoIdIcon = ({ cryptoId }: CryptoIdIconProps) => {
-    if (!cryptoId) {
-        return null;
-    }
-
     const { network, contractAddress } = cryptoIdToNetworkAndContractAddress(cryptoId);
-
-    if (!network) {
+    if (!network || !cryptoId) {
         return null;
     }
 
-    return (
-        <CryptoIcon
-            symbol={network.displaySymbol as NetworkDisplaySymbol}
-            contractAddress={contractAddress}
-            size="tiny"
-        />
+    return isCryptoIdForNativeToken(cryptoId) ? (
+        <CryptoIcon symbol={network.displaySymbol as NetworkDisplaySymbol} size="tiny" />
+    ) : (
+        <CryptoIcon symbol={network.symbol} contractAddress={contractAddress} size="tiny" />
     );
 };
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Show correct icon in Trade history

## Related Issue

Resolve #22128

## Screenshots:
<img width="300" alt="Simulator Screenshot" src="https://github.com/user-attachments/assets/1aee05be-d597-4597-8199-aef8b0ccad1f" />
<img width="300" alt="Simulator Screenshot" src="https://github.com/user-attachments/assets/f0cdbffa-d7a2-4e6f-8ac0-ed0454e73972" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22128-Mobile-Trade-Trade-history-detail-icon&lookback=7)