### PR TITLE
feat(e2e-suite): Adds customMatcher support for asserting translations

### DIFF
--- a/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
@@ -1,6 +1,10 @@
+/* eslint-disable playwright/no-standalone-expect */
 import { Locator, Request, expect as baseExpect, test } from '@playwright/test';
 import { diff } from 'jest-diff';
 import { isEqual } from 'lodash';
+
+import { TranslationKey } from '@trezor/suite/src/components/suite/Translation';
+import messages from '@trezor/suite/src/support/messages';
 
 import { formatAddress, isEqualWithOmit, normalizeWhitespace } from '../common';
 import { DevicePrompt } from '../pageObjects/devicePrompt';
@@ -85,6 +89,18 @@ export const splitStringByDisplayLimit = (text: string) => {
     // Add a newline item into array after each item except the last one
     return splitLines.flatMap((line, index) =>
         index < splitLines.length - 1 ? [line.trim(), '\n'] : [line.trim()],
+    );
+};
+
+const applyPlaceholderValues = (
+    template: string,
+    placeholderValues: string[] | undefined,
+): string => {
+    if (!placeholderValues || placeholderValues.length === 0) return template;
+    let i = 0;
+
+    return template.replace(/\{[^}]+\}/g, () =>
+        i < placeholderValues.length ? placeholderValues[i++] : '',
     );
 };
 
@@ -194,6 +210,61 @@ export const expect = baseExpect.extend({
             pass: baseExpect.objectContaining(subObject).asymmetricMatch(superObject),
             message: () =>
                 `expected superObject to have subObject. Diff:\n${diff(subObject, superObject)}`,
+        };
+    },
+
+    async toHaveTranslation(
+        locator: Locator,
+        translationKey: TranslationKey,
+        // Some translations have placeholders like 'Maximum {decimals} decimals allowed'
+        options?: { isValue?: boolean; placeholderValues?: string[]; timeout?: number },
+    ) {
+        const expectedTranslation = applyPlaceholderValues(
+            messages[translationKey].defaultMessage,
+            options?.placeholderValues,
+        );
+
+        if (options?.isValue) {
+            await baseExpect(locator).toHaveValue(expectedTranslation, {
+                timeout: options?.timeout,
+            });
+        } else {
+            await baseExpect(locator).toHaveText(expectedTranslation, {
+                timeout: options?.timeout,
+            });
+        }
+
+        return {
+            pass: true,
+            message: () => 'errors are handled in expects above',
+        };
+    },
+
+    async toContainTranslation(
+        locator: Locator,
+        translationKey: TranslationKey,
+        // Some translations have placeholders like 'Maximum {decimals} decimals allowed'
+        options?: { isValue?: boolean; placeholderValues?: string[]; timeout?: number },
+    ) {
+        const expectedTranslation = applyPlaceholderValues(
+            messages[translationKey].defaultMessage,
+            options?.placeholderValues,
+        );
+        if (options?.isValue) {
+            await baseExpect
+                .poll(async () => await locator.inputValue(), {
+                    timeout: options?.timeout,
+                })
+                .toContain(expectedTranslation);
+        } else {
+            await baseExpect(locator).toContainText(expectedTranslation, {
+                timeout: options?.timeout,
+            });
+        }
+
+        return {
+            pass: true,
+            message: () => 'errors are handled in expects above',
         };
     },
 });

--- a/packages/suite-desktop-core/e2e/support/testExtends/enhancePage.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/enhancePage.ts
@@ -40,8 +40,8 @@ export const enhancePage = (page: Page): Page => {
     //Retry mechanism for settings dropdowns which tend to be flaky in automation
     page.selectDropdownOptionWithRetry = async function (dropdown: Locator, option: Locator) {
         await test.step('Select dropdown option with RETRY', async () => {
-            await dropdown.scrollIntoViewIfNeeded();
             await expect(async () => {
+                await dropdown.scrollIntoViewIfNeeded();
                 if (!(await option.isVisible())) {
                     await dropdown.click({ timeout: 2000 });
                 }

--- a/packages/suite-desktop-core/e2e/tests/backup/t2t1-fail.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/backup/t2t1-fail.test.ts
@@ -1,6 +1,5 @@
 import { escapeRegExp } from 'lodash';
 
-import messages from '@trezor/suite/src/support/messages';
 import { EventType } from '@trezor/suite-analytics';
 import { HELP_CENTER_RECOVERY_ISSUES_URL } from '@trezor/urls';
 
@@ -50,16 +49,16 @@ test.describe('Backup fail', { tag: ['@group=device-management', '@specificModel
 
         await test.step('Check dashboard notification error banner', async () => {
             await expect(onboardingPage.backup.errorBanner).toBeVisible({ timeout: 30_000 });
-            await expect(onboardingPage.backup.errorBanner).toContainText(
-                messages['TR_FAILED_BACKUP'].defaultMessage,
+            await expect(onboardingPage.backup.errorBanner).toContainTranslation(
+                'TR_FAILED_BACKUP',
             );
         });
 
         await test.step('Check backup failed setting in device settings', async () => {
             await onboardingPage.backup.errorBannerContinueButton.click();
             await expect(onboardingPage.backup.failedBackupSetting).toBeVisible();
-            await expect(onboardingPage.backup.failedBackupSetting).toContainText(
-                messages['TR_BACKUP_RECOVERY_SEED_FAILED_DESC'].defaultMessage,
+            await expect(onboardingPage.backup.failedBackupSetting).toContainTranslation(
+                'TR_BACKUP_RECOVERY_SEED_FAILED_DESC',
             );
             // removes URL query params .../recovery-issues?utm_medium=desktop|web|???
             const urlBase = HELP_CENTER_RECOVERY_ISSUES_URL.split('?')[0];

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-duplicate.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-duplicate.test.ts
@@ -1,5 +1,3 @@
-import messages from '@trezor/suite/src/support/messages';
-
 import { expect, test } from '../../support/fixtures';
 
 test.describe('Passphrase duplicate', { tag: ['@group=passphrase'] }, () => {
@@ -24,11 +22,11 @@ test.describe('Passphrase duplicate', { tag: ['@group=passphrase'] }, () => {
             await dashboardPage.openDeviceSwitcher();
             await dashboardPage.addHiddenWallet(passphraseToType, { skipDiscovery: true });
             await expect(page.getByTestId('@passphrase-duplicate-header')).toBeVisible();
-            await expect(page.getByTestId('@passphrase-duplicate-header')).toHaveText(
-                messages['TR_WALLET_DUPLICATE_TITLE'].defaultMessage,
+            await expect(page.getByTestId('@passphrase-duplicate-header')).toHaveTranslation(
+                'TR_WALLET_DUPLICATE_TITLE',
             );
-            await expect(page.getByTestId('@passphrase-duplicate-description')).toHaveText(
-                messages['TR_WALLET_DUPLICATE_DESC'].defaultMessage,
+            await expect(page.getByTestId('@passphrase-duplicate-description')).toHaveTranslation(
+                'TR_WALLET_DUPLICATE_DESC',
             );
         });
     });

--- a/packages/suite-desktop-core/e2e/tests/staking/staking-form.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/staking-form.test.ts
@@ -1,6 +1,5 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
-import messages from '@trezor/suite/src/support/messages';
 import { BigNumber } from '@trezor/utils';
 
 import { calculatePercentageOfBalance } from '../../support/common';
@@ -75,7 +74,7 @@ test.describe('ETH staking form', { tag: ['@group=staking'] }, () => {
                     await stakingSection.cryptoInput.fill('4000');
                     await expect
                         .soft(stakingSection.cryptoInputBottomText)
-                        .toHaveText(messages['AMOUNT_IS_NOT_ENOUGH'].defaultMessage, {
+                        .toHaveTranslation('AMOUNT_IS_NOT_ENOUGH', {
                             timeout: 15_000,
                         });
                 });
@@ -84,7 +83,7 @@ test.describe('ETH staking form', { tag: ['@group=staking'] }, () => {
                     await stakingSection.cryptoInput.clear();
                     await expect
                         .soft(stakingSection.cryptoInputBottomText)
-                        .toHaveText(messages['AMOUNT_IS_NOT_SET'].defaultMessage, {
+                        .toHaveTranslation('AMOUNT_IS_NOT_SET', {
                             timeout: 15_000,
                         });
 

--- a/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
@@ -38,9 +38,11 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
             await onboardingPage.completeOnboarding();
             await test.step('Bridge session taken by another suite session', async () => {
                 await stealBridgeSession();
-                await expect(dashboardPage.deviceStatus).toHaveText('Refresh');
+                await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE');
                 await dashboardPage.deviceSwitchingOpenButton.click();
-                await expect(dashboardPage.deviceStatusOnSwitchDevice).toHaveText('Refresh');
+                await expect(dashboardPage.deviceStatusOnSwitchDevice).toHaveTranslation(
+                    'TR_USE_HERE',
+                );
                 await expect(dashboardPage.walletAtIndex(0)).toBeHidden();
             });
 
@@ -54,9 +56,7 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
 
             await test.step('Reload inactive suite session', async () => {
                 await stealBridgeSession();
-                await expect(dashboardPage.deviceStatus).toHaveText('Refresh');
-                // In this case we don't use suiteApp.reloadApp() because this reload doesn't lose the THP session
-                // It was kept active by the stolen session
+                await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE');
                 await page.reload();
             });
 
@@ -108,7 +108,7 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
             await onboardingPageTwo.completeOnboarding();
             const dashboardPageTwo = new DashboardPage(pageTwo, devicePromptTwo);
             await expect(dashboardPageTwo.deviceStatus).toHaveText('Connected');
-            await expect(dashboardPage.deviceStatus).toHaveText('Refresh');
+            await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE');
 
             await pageTwo.close();
         },

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
@@ -1,5 +1,4 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
-import messages from '@trezor/suite/src/support/messages';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import {
@@ -142,8 +141,8 @@ test.describe('Trading - Buy BTC', { tag: ['@group=trading', '@webOnly'] }, () =
         await test.step('Wait 30s for watch refresh and status change to Approved', async () => {
             await tradingMock.changeBuyWatchResponseTo('SUCCESS');
             await page.clock.fastForward(tradingMock.watchPeriod);
-            await expect(tradingPage.transactionDetailStatus).toHaveText(
-                messages['TR_BUY_DETAIL_SUCCESS_TITLE'].defaultMessage,
+            await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                'TR_BUY_DETAIL_SUCCESS_TITLE',
             );
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
             await expect(tradingPage.confirmationCryptoAmount).toHaveText(bestBuyCryptoAmount);

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-ethereum.test.ts
@@ -1,5 +1,4 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
-import messages from '@trezor/suite/src/support/messages';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import { buyQuotesEthereum, buyTradeEthereum, invityEndpoint } from '../../fixtures/invity';
@@ -71,8 +70,8 @@ test.describe('Trading - Buy Ethereum', { tag: ['@group=trading', '@webOnly'] },
         await tradingPage.waitForRedirectCompletion();
 
         await test.step('Verify transaction detail', async () => {
-            await expect(tradingPage.transactionDetailStatus).toHaveText(
-                messages['TR_BUY_DETAIL_SUCCESS_TITLE'].defaultMessage,
+            await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                'TR_BUY_DETAIL_SUCCESS_TITLE',
             );
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
             await expect(tradingPage.confirmationCryptoAmount).toHaveText(formattedCryptoAmount);

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
@@ -1,5 +1,4 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
-import messages from '@trezor/suite/src/support/messages';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import {
@@ -64,8 +63,8 @@ test.describe('Trading - Buy Solana', { tag: ['@group=trading', '@webOnly'] }, (
         await tradingPage.waitForRedirectCompletion();
 
         await test.step('Verify transaction detail', async () => {
-            await expect(tradingPage.transactionDetailStatus).toHaveText(
-                messages['TR_BUY_DETAIL_SUCCESS_TITLE'].defaultMessage,
+            await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                'TR_BUY_DETAIL_SUCCESS_TITLE',
             );
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
             await expect(tradingPage.confirmationCryptoAmount).toHaveText(formattedCryptoAmount);

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
@@ -1,5 +1,4 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
-import messages from '@trezor/suite/src/support/messages';
 
 import { expect, test } from '../../support/fixtures';
 
@@ -42,16 +41,17 @@ test.describe('Trading - Sell inputs', { tag: ['@group=trading', '@webOnly'] }, 
                 await tradingPage.youPayCryptoInput.fill('0.000000001');
                 await expect
                     .soft(tradingPage.cryptoInputBottomText)
-                    .toHaveText('Maximum 8 decimals allowed', { timeout: 15_000 });
+                    .toHaveTranslation('AMOUNT_IS_NOT_IN_RANGE_DECIMALS', {
+                        placeholderValues: ['8'],
+                        timeout: 15_000,
+                    });
             });
 
             await test.step('Not enough funds', async () => {
                 await tradingPage.youPayCryptoInput.fill('10');
                 await expect
                     .soft(tradingPage.cryptoInputBottomText)
-                    .toHaveText(messages['AMOUNT_IS_NOT_ENOUGH'].defaultMessage, {
-                        timeout: 15_000,
-                    });
+                    .toHaveTranslation('AMOUNT_IS_NOT_ENOUGH', { timeout: 15_000 });
             });
 
             await tradingPage.youPayCryptoInput.clear();

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -1,5 +1,4 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
-import messages from '@trezor/suite/src/support/messages';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import {
@@ -124,8 +123,8 @@ test.describe(
                     await route.fulfill({ json: { status: 'SUCCESS' } });
                 });
                 await page.clock.fastForward(tradingMock.watchPeriod);
-                await expect(tradingPage.transactionDetailStatus).toHaveText(
-                    messages['TR_SELL_DETAIL_SUCCESS_TITLE'].defaultMessage,
+                await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                    'TR_SELL_DETAIL_SUCCESS_TITLE',
                 );
                 await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
                 await expect(tradingPage.confirmationCryptoAmount).toHaveText(

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -1,5 +1,4 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
-import messages from '@trezor/suite/src/support/messages';
 
 import {
     getCompanyNameFromList,
@@ -76,8 +75,8 @@ test.describe('Trading - Swap coin to token', { tag: ['@group=trading', '@webOnl
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
             await expect(page.getByTestId('@toast/tx-exchange')).toContainText(toastText);
-            await expect(tradingPage.transactionDetailStatus).toHaveText(
-                messages['TR_EXCHANGE_DETAIL_SUCCESS_TITLE'].defaultMessage,
+            await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
             );
             await expect(tradingPage.confirmationCryptoAmount.first()).toHaveText(
                 formattedSendAmount,

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -1,5 +1,4 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
-import messages from '@trezor/suite/src/support/messages';
 
 import {
     getCompanyNameFromList,
@@ -73,8 +72,8 @@ test.describe('Trading - Swap token to coin', { tag: ['@group=trading', '@webOnl
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
             await expect(page.getByTestId('@toast/tx-exchange')).toContainText(toastText);
-            await expect(tradingPage.transactionDetailStatus).toHaveText(
-                messages['TR_EXCHANGE_DETAIL_SUCCESS_TITLE'].defaultMessage,
+            await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
             );
             await expect(tradingPage.confirmationCryptoAmount.first()).toHaveText(
                 formattedSendAmount,

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
@@ -1,5 +1,4 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
-import messages from '@trezor/suite/src/support/messages';
 
 import {
     getCompanyNameFromList,
@@ -73,8 +72,8 @@ test.describe('Trading - Swap tokens', { tag: ['@group=trading', '@webOnly'] }, 
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
             await expect(page.getByTestId('@toast/tx-exchange')).toContainText(toastText);
-            await expect(tradingPage.transactionDetailStatus).toHaveText(
-                messages['TR_EXCHANGE_DETAIL_SUCCESS_TITLE'].defaultMessage,
+            await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
             );
             await expect(tradingPage.confirmationCryptoAmount.first()).toHaveText(
                 formattedSendAmount,


### PR DESCRIPTION
micro refactoring to stabilize sell solana test - moves scroll into retry block. The test is flaky. I did 30 runs in CI with this improvement and all passed without a hiccup. So I hope this solves it and there is no interaction with some problems on Solana network. I will monitor it.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-sell-solana-flaky&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-sell-solana-flaky&lookback=7)