### PR TITLE
Fix: changelog for is required

### DIFF
--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json
@@ -1,5 +1,5 @@
 {
-    "required": false,
+    "required": true,
     "version": [1, 9, 0],
     "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.8.1-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.8.1-universal.json
@@ -1,5 +1,5 @@
 {
-    "required": false,
+    "required": true,
     "version": [1, 8, 1],
     "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.9.0-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.9.0-universal.json
@@ -1,5 +1,5 @@
 {
-    "required": false,
+    "required": true,
     "version": [1, 9, 0],
     "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.0-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.0-bitcoinonly.json
@@ -1,5 +1,5 @@
 {
-    "required": false,
+    "required": true,
     "version": [2, 3, 0],
     "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.0-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.0-universal.json
@@ -1,5 +1,5 @@
 {
-    "required": false,
+    "required": true,
     "version": [2, 1, 0],
     "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.0-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.0-universal.json
@@ -1,5 +1,5 @@
 {
-    "required": false,
+    "required": true,
     "version": [2, 3, 0],
     "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],

--- a/packages/connect/setupJest.ts
+++ b/packages/connect/setupJest.ts
@@ -1,7 +1,9 @@
 /* WARNING! This file should be imported ONLY in tests! */
 
+import { firmwareAssets } from '@trezor/connect-common';
 import { DeviceModelInternal, FirmwareRelease } from '@trezor/device-utils';
 import { AbstractApiTransport, UsbApi } from '@trezor/transport';
+import { versionUtils } from '@trezor/utils';
 
 import { type Features } from './src/types';
 
@@ -82,40 +84,13 @@ export const getDeviceFeatures = (feat?: Partial<Features>): Features => ({
     ...feat,
 });
 
-const commonReleaseData: FirmwareRelease = {
-    required: false,
-    url: '/some/path/to/firmware.bin',
-    version: [2, 8, 9],
-    min_bootloader_version: [2, 1, 6],
-    min_firmware_version: [2, 7, 2],
-    bootloader_version: [2, 1, 8],
-    translations: {
-        'cs-CZ': 'firmware/translations/t2t1/translation-T2T1-cs-CZ-2.8.9.bin',
-        'de-DE': 'firmware/translations/t2t1/translation-T2T1-de-DE-2.8.9.bin',
-        'es-ES': 'firmware/translations/t2t1/translation-T2T1-es-ES-2.8.9.bin',
-        'fr-FR': 'firmware/translations/t2t1/translation-T2T1-fr-FR-2.8.9.bin',
-        'it-IT': 'firmware/translations/t2t1/translation-T2T1-it-IT-2.8.9.bin',
-        'pt-BR': 'firmware/translations/t2t1/translation-T2T1-pt-BR-2.8.9.bin',
-    },
-    firmware_revision: 'fad9682201cf9289bba2adb66e6e07ed1cf78936',
-    fingerprint: 'ac995c394f7a7b3ea4cbd9c04977621d6d2fbef30bba856f707f585f34866ac4',
-    changelog:
-        '* Ability to cancel recovery flow on word count selection screen.\n' +
-        '* New UI for confirming long messages.\n' +
-        '* Changed "swipe to continue" to "tap to continue". Screens still respond to swipe-up, but the preferred interaction method is now tapping the lower part of the screen.',
-};
-
-const getReleaseData = (releaseInfo: Partial<FirmwareRelease> = {}): FirmwareRelease => ({
-    ...commonReleaseData,
-    ...releaseInfo,
-});
-
 declare global {
     var JestMocks: {
         getDeviceFeatures: typeof getDeviceFeatures;
         createTestTransport: typeof createTestTransport;
         createTestTransportClass: typeof createTestTransportClass;
-        getReleaseData: typeof getReleaseData;
+        releasesT1B1: FirmwareRelease[];
+        releasesT2T1: FirmwareRelease[];
     };
 
     type TestFixtures<TestedMethod extends (...args: any) => any> = {
@@ -125,9 +100,20 @@ declare global {
     }[];
 }
 
+// T1B1
+const releasesT1B1 = Object.values(firmwareAssets.t1b1.universal).sort((a, b) =>
+    versionUtils.isNewer(b.version, a.version) ? 1 : -1,
+);
+
+// T2T1
+const releasesT2T1 = Object.values(firmwareAssets.t2t1.universal).sort((a, b) =>
+    versionUtils.isNewer(b.version, a.version) ? 1 : -1,
+);
+
 global.JestMocks = {
     getDeviceFeatures,
     createTestTransport,
     createTestTransportClass,
-    getReleaseData,
+    releasesT1B1,
+    releasesT2T1,
 };

--- a/packages/connect/src/data/__tests__/getReleaseInfo.bootloader.test.ts
+++ b/packages/connect/src/data/__tests__/getReleaseInfo.bootloader.test.ts
@@ -7,18 +7,23 @@ import {
 
 import { getReleaseInfo } from '../firmwareInfo';
 
-const { getReleaseData, getDeviceFeatures } = global.JestMocks;
+const { getDeviceFeatures, releasesT1B1, releasesT2T1 } = global.JestMocks;
+
+const [latestT1B1] = releasesT1B1;
+const [latestT2T1] = releasesT2T1;
 
 const fixtures = [
     {
         desc: 'Firmware version in bootloader mode and release version is newer than firmware version',
+        releasesOfDevice: releasesT2T1,
         features: getDeviceFeatures({
             bootloader_mode: true,
+            firmware_present: true,
             fw_major: 2,
             fw_minor: 8,
             fw_patch: 7,
         }),
-        release: getReleaseData(),
+        release: latestT2T1,
         conditions: {
             environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
@@ -32,22 +37,24 @@ const fixtures = [
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
-            release: getReleaseData(),
+            release: latestT2T1,
             intermediary: undefined,
             isRequired: false,
             isNewer: true,
-            translations: getReleaseData().translations,
+            translations: latestT2T1.translations,
         },
     },
     {
-        desc: 'Firmware version in bootloader mode is smaller than min_firmware_version so it offers intermediate FW',
+        desc: 'Firmware version in firmware mode is smaller than min_firmware_version so it offers intermediate FW',
+        releasesOfDevice: releasesT1B1,
         features: getDeviceFeatures({
-            bootloader_mode: true,
-            fw_major: 2,
-            fw_minor: 6,
-            fw_patch: 0,
+            internal_model: DeviceModelInternal.T1B1,
+            firmware_present: true,
+            major_version: 1,
+            minor_version: 6,
+            patch_version: 2,
         }),
-        release: getReleaseData(),
+        release: latestT1B1,
         conditions: {
             environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
@@ -57,8 +64,6 @@ const fixtures = [
         intermediary: {
             min_firmware_version: [1, 6, 2] as VersionArray,
             min_bootloader_version: [1, 8, 0] as VersionArray,
-            firmware_revision: '592590cf66a9b62dfeee7e4d2afb6e01005e5b2c',
-            url: '/some/path.bin',
             version: 1,
         },
         result: {
@@ -67,32 +72,32 @@ const fixtures = [
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
-            release: getReleaseData(),
+            release: latestT1B1,
             intermediary: {
                 min_firmware_version: [1, 6, 2] as VersionArray,
                 min_bootloader_version: [1, 8, 0] as VersionArray,
-                firmware_revision: '592590cf66a9b62dfeee7e4d2afb6e01005e5b2c',
-                url: '/some/path.bin',
                 version: 1,
             },
-            isRequired: false,
+            isRequired: true,
             isNewer: true,
-            translations: getReleaseData().translations,
+            translations: latestT1B1.translations,
         },
     },
     {
         desc: 'Firmware version in bootloader mode is latest version',
+        releasesOfDevice: releasesT1B1,
         features: getDeviceFeatures({
             bootloader_mode: true,
+            firmware_present: true,
             internal_model: DeviceModelInternal.T1B1,
-            fw_major: 2,
-            fw_minor: 8,
-            fw_patch: 10,
-            major_version: 2,
-            minor_version: 1,
-            patch_version: 8,
+            fw_major: latestT1B1.version[0],
+            fw_minor: latestT1B1.version[1],
+            fw_patch: latestT1B1.version[2],
+            major_version: latestT1B1.bootloader_version?.[0],
+            minor_version: latestT1B1.bootloader_version?.[1],
+            patch_version: latestT1B1.bootloader_version?.[2],
         }),
-        release: getReleaseData(),
+        release: latestT1B1,
         conditions: {
             environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
@@ -106,23 +111,25 @@ const fixtures = [
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
-            release: getReleaseData(),
+            release: latestT1B1,
             intermediary: undefined,
-            isRequired: false,
+            isRequired: null,
             isNewer: false,
-            translations: getReleaseData().translations,
+            translations: latestT1B1.translations,
         },
     },
     {
         desc: 'Bootloader does not report FW version - Firmware version in bootloader mode is smaller than min_firmware_version so it offers intermediate FW',
+        releasesOfDevice: releasesT1B1,
         features: getDeviceFeatures({
             bootloader_mode: true,
+            firmware_present: true,
             internal_model: DeviceModelInternal.T1B1,
-            major_version: 2,
-            minor_version: 1,
-            patch_version: 0,
+            major_version: 1,
+            minor_version: 6,
+            patch_version: 2,
         }),
-        release: getReleaseData(),
+        release: latestT1B1,
         conditions: {
             environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
@@ -142,7 +149,7 @@ const fixtures = [
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
-            release: getReleaseData(),
+            release: latestT1B1,
             intermediary: {
                 min_firmware_version: [1, 6, 2] as VersionArray,
                 min_bootloader_version: [1, 8, 0] as VersionArray,
@@ -150,9 +157,9 @@ const fixtures = [
                 url: '/some/path.bin',
                 version: 1,
             },
-            isRequired: false,
+            isRequired: null,
             isNewer: true,
-            translations: getReleaseData().translations,
+            translations: latestT1B1.translations,
         },
     },
 ];
@@ -167,6 +174,7 @@ describe('getReleaseInfo() in bootloader', () => {
                 intermediary: f.intermediary,
                 firmwareType: f.firmwareType,
                 isBitcoinOnlyAvailable: f.isBitcoinOnlyAvailable,
+                releasesOfDevice: f.releasesOfDevice,
             });
             if (f.result) {
                 expect(result).toMatchObject(f.result);

--- a/packages/connect/src/data/__tests__/getReleaseInfo.firmware.test.ts
+++ b/packages/connect/src/data/__tests__/getReleaseInfo.firmware.test.ts
@@ -1,19 +1,28 @@
-import { FirmwareRelease, FirmwareType, VersionArray } from '@trezor/device-utils';
+import {
+    DeviceModelInternal,
+    FirmwareRelease,
+    FirmwareType,
+    VersionArray,
+} from '@trezor/device-utils';
 
 import { getReleaseInfo } from '../firmwareInfo';
 
-const { getDeviceFeatures, getReleaseData } = global.JestMocks;
+const { getDeviceFeatures, releasesT1B1, releasesT2T1 } = global.JestMocks;
+
+const [latestT1B1] = releasesT1B1;
+const [latestT2T1] = releasesT2T1;
 
 const fixtures = [
     {
         desc: 'Having newer version makes release `isNewer` and probability 100 `shouldBeOffered` true',
+        releasesOfDevice: releasesT2T1,
         features: getDeviceFeatures({
             bootloader_mode: null,
             major_version: 2,
             minor_version: 8,
             patch_version: 7,
         }),
-        release: getReleaseData(),
+        release: latestT2T1,
         conditions: {
             environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
@@ -26,22 +35,23 @@ const fixtures = [
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
-            release: getReleaseData(),
+            release: latestT2T1,
             intermediary: undefined,
             isRequired: false,
             isNewer: true,
-            translations: getReleaseData().translations,
+            translations: latestT2T1.translations,
         },
     },
     {
         desc: 'Having newer version makes release `isNewer` and probability 0 `shouldBeOffered` false',
+        releasesOfDevice: releasesT2T1,
         features: getDeviceFeatures({
             bootloader_mode: null,
             major_version: 2,
             minor_version: 8,
             patch_version: 7,
         }),
-        release: getReleaseData(),
+        release: latestT2T1,
         conditions: {
             environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 0,
@@ -54,22 +64,24 @@ const fixtures = [
                 rollout_probability: 0,
                 shouldBeOffered: false,
             },
-            release: getReleaseData(),
+            release: latestT2T1,
             intermediary: undefined,
             isRequired: false,
             isNewer: true,
-            translations: getReleaseData().translations,
+            translations: latestT2T1.translations,
         },
     },
     {
         desc: 'Having latest version makes release `isNewer` false',
+        releasesOfDevice: releasesT2T1,
         features: getDeviceFeatures({
             bootloader_mode: null,
-            major_version: 2,
-            minor_version: 8,
-            patch_version: 9,
+            firmware_present: true,
+            major_version: latestT2T1.version[0],
+            minor_version: latestT2T1.version[1],
+            patch_version: latestT2T1.version[2],
         }),
-        release: getReleaseData(),
+        release: latestT2T1,
         conditions: {
             environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
@@ -82,22 +94,25 @@ const fixtures = [
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
-            release: getReleaseData(),
+            release: latestT2T1,
             intermediary: undefined,
-            isRequired: false,
+            isRequired: null,
             isNewer: false,
-            translations: getReleaseData().translations,
+            translations: latestT2T1.translations,
         },
     },
     {
         desc: 'Having device version lower than min firmware version - requires intermediate',
+        releasesOfDevice: releasesT1B1,
         features: getDeviceFeatures({
             bootloader_mode: null,
-            major_version: 2,
+            firmware_present: true,
+            internal_model: DeviceModelInternal.T1B1,
+            major_version: 1,
             minor_version: 6,
-            patch_version: 0,
+            patch_version: 2,
         }),
-        release: getReleaseData(),
+        release: latestT1B1,
         conditions: {
             environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
@@ -105,8 +120,6 @@ const fixtures = [
         intermediary: {
             min_firmware_version: [1, 6, 2] as VersionArray,
             min_bootloader_version: [1, 8, 0] as VersionArray,
-            firmware_revision: '592590cf66a9b62dfeee7e4d2afb6e01005e5b2c',
-            url: '/some/path.bin',
             version: 1,
         },
         isBitcoinOnlyAvailable: true,
@@ -117,17 +130,15 @@ const fixtures = [
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
-            release: getReleaseData(),
+            release: latestT1B1,
             intermediary: {
                 min_firmware_version: [1, 6, 2] as VersionArray,
                 min_bootloader_version: [1, 8, 0] as VersionArray,
-                firmware_revision: '592590cf66a9b62dfeee7e4d2afb6e01005e5b2c',
-                url: '/some/path.bin',
                 version: 1,
             },
-            isRequired: false,
+            isRequired: true,
             isNewer: true,
-            translations: getReleaseData().translations,
+            translations: latestT1B1.translations,
         },
     },
 ];
@@ -142,6 +153,7 @@ describe('getReleaseInfo() in firmware mode', () => {
                 intermediary: f.intermediary,
                 firmwareType: f.firmwareType,
                 isBitcoinOnlyAvailable: f.isBitcoinOnlyAvailable,
+                releasesOfDevice: f.releasesOfDevice,
             });
             if (f.result) {
                 expect(result).toMatchObject(f.result);

--- a/packages/connect/src/data/__tests__/getReleaseInfo.fresh.test.ts
+++ b/packages/connect/src/data/__tests__/getReleaseInfo.fresh.test.ts
@@ -7,11 +7,14 @@ import {
 
 import { getReleaseInfo } from '../firmwareInfo';
 
-const { getReleaseData, getDeviceFeatures } = global.JestMocks;
+const { getDeviceFeatures, releasesT2T1 } = global.JestMocks;
+
+const [latestT2T1] = releasesT2T1;
 
 const fixtures = [
     {
         desc: 'it should respect bootloader and offer intermediary',
+        releasesOfDevice: releasesT2T1,
         features: getDeviceFeatures({
             bootloader_mode: true,
             major_version: 1,
@@ -20,7 +23,7 @@ const fixtures = [
             internal_model: DeviceModelInternal.T1B1,
             firmware_present: false,
         }),
-        release: getReleaseData(),
+        release: latestT2T1,
         conditions: {
             environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
@@ -30,8 +33,6 @@ const fixtures = [
         intermediary: {
             min_firmware_version: [1, 6, 2] as VersionArray,
             min_bootloader_version: [1, 8, 0] as VersionArray,
-            firmware_revision: '592590cf66a9b62dfeee7e4d2afb6e01005e5b2c',
-            url: '/some/path.bin',
             version: 1,
         },
         result: {
@@ -40,17 +41,15 @@ const fixtures = [
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
-            release: getReleaseData(),
+            release: latestT2T1,
             intermediary: {
                 min_firmware_version: [1, 6, 2] as VersionArray,
                 min_bootloader_version: [1, 8, 0] as VersionArray,
-                firmware_revision: '592590cf66a9b62dfeee7e4d2afb6e01005e5b2c',
-                url: '/some/path.bin',
                 version: 1,
             },
-            isRequired: false,
+            isRequired: true,
             isNewer: true,
-            translations: getReleaseData().translations,
+            translations: latestT2T1.translations,
         },
     },
 ];
@@ -65,6 +64,7 @@ describe('getReleaseInfo() for fresh device', () => {
                 intermediary: f.intermediary,
                 firmwareType: f.firmwareType,
                 isBitcoinOnlyAvailable: f.isBitcoinOnlyAvailable,
+                releasesOfDevice: f.releasesOfDevice,
             });
             if (f.result) {
                 expect(result).toMatchObject(f.result);

--- a/packages/connect/src/data/__tests__/getReleaseInfo.required.test.ts
+++ b/packages/connect/src/data/__tests__/getReleaseInfo.required.test.ts
@@ -2,18 +2,22 @@ import { FirmwareRelease, FirmwareType, VersionArray } from '@trezor/device-util
 
 import { getReleaseInfo } from '../firmwareInfo';
 
-const { getDeviceFeatures, getReleaseData } = global.JestMocks;
+const { getDeviceFeatures, releasesT1B1, releasesT2T1 } = global.JestMocks;
+
+const [latestT1B1] = releasesT1B1;
+const [latestT2T1] = releasesT2T1;
 
 const fixtures = [
     {
         desc: 'Having newer version makes release `isNewer` and probability 100 `shouldBeOffered` true',
+        releasesOfDevice: releasesT2T1,
         features: getDeviceFeatures({
             bootloader_mode: null,
             major_version: 2,
             minor_version: 8,
             patch_version: 7,
         }),
-        release: getReleaseData(),
+        release: latestT2T1,
         conditions: {
             environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
@@ -26,22 +30,23 @@ const fixtures = [
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
-            release: getReleaseData(),
+            release: latestT2T1,
             intermediary: undefined,
             isRequired: false,
             isNewer: true,
-            translations: getReleaseData().translations,
+            translations: latestT2T1.translations,
         },
     },
     {
         desc: 'Having newer version makes release `isNewer` and probability 0 `shouldBeOffered` false',
+        releasesOfDevice: releasesT2T1,
         features: getDeviceFeatures({
             bootloader_mode: null,
             major_version: 2,
             minor_version: 8,
             patch_version: 7,
         }),
-        release: getReleaseData(),
+        release: latestT2T1,
         conditions: {
             environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 0,
@@ -54,22 +59,24 @@ const fixtures = [
                 rollout_probability: 0,
                 shouldBeOffered: false,
             },
-            release: getReleaseData(),
+            release: latestT2T1,
             intermediary: undefined,
             isRequired: false,
             isNewer: true,
-            translations: getReleaseData().translations,
+            translations: latestT2T1.translations,
         },
     },
     {
         desc: 'Having latest version makes release `isNewer` false',
+        releasesOfDevice: releasesT2T1,
         features: getDeviceFeatures({
             bootloader_mode: null,
-            major_version: 2,
-            minor_version: 8,
-            patch_version: 9,
+            firmware_present: true,
+            major_version: latestT2T1.version[0],
+            minor_version: latestT2T1.version[1],
+            patch_version: latestT2T1.version[2],
         }),
-        release: getReleaseData(),
+        release: latestT2T1,
         conditions: {
             environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
@@ -82,22 +89,24 @@ const fixtures = [
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
-            release: getReleaseData(),
+            release: latestT2T1,
             intermediary: undefined,
-            isRequired: false,
+            isRequired: null,
             isNewer: false,
-            translations: getReleaseData().translations,
+            translations: latestT2T1.translations,
         },
     },
     {
         desc: 'Having device version lower than min firmware version - requires intermediate',
+        releasesOfDevice: releasesT1B1,
         features: getDeviceFeatures({
             bootloader_mode: null,
-            major_version: 2,
+            firmware_present: true,
+            major_version: 1,
             minor_version: 6,
-            patch_version: 0,
+            patch_version: 2,
         }),
-        release: getReleaseData(),
+        release: latestT1B1,
         conditions: {
             environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
@@ -105,8 +114,6 @@ const fixtures = [
         intermediary: {
             min_firmware_version: [1, 6, 2] as VersionArray,
             min_bootloader_version: [1, 8, 0] as VersionArray,
-            firmware_revision: '592590cf66a9b62dfeee7e4d2afb6e01005e5b2c',
-            url: '/some/path.bin',
             version: 1,
         },
         isBitcoinOnlyAvailable: true,
@@ -117,17 +124,15 @@ const fixtures = [
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
-            release: getReleaseData(),
+            release: latestT1B1,
             intermediary: {
                 min_firmware_version: [1, 6, 2] as VersionArray,
                 min_bootloader_version: [1, 8, 0] as VersionArray,
-                firmware_revision: '592590cf66a9b62dfeee7e4d2afb6e01005e5b2c',
-                url: '/some/path.bin',
                 version: 1,
             },
-            isRequired: false,
+            isRequired: true,
             isNewer: true,
-            translations: getReleaseData().translations,
+            translations: latestT1B1.translations,
         },
     },
 ];
@@ -142,6 +147,7 @@ describe('getReleaseInfo() in firmware mode', () => {
                 intermediary: f.intermediary,
                 firmwareType: f.firmwareType,
                 isBitcoinOnlyAvailable: f.isBitcoinOnlyAvailable,
+                releasesOfDevice: f.releasesOfDevice,
             });
             if (f.result) {
                 expect(result).toMatchObject(f.result);

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -12,7 +12,7 @@ import {
 import { getIntegerInRangeFromString, removeTrailingSlashes, versionUtils } from '@trezor/utils';
 
 import { DataManager } from './DataManager';
-import { Features } from '../types/device';
+import { Features, StrictFeatures } from '../types/device';
 import { FirmwareReleaseConfigInfo, FirmwareUpdateSource } from '../types/firmware';
 import { getReleaseAsset, getReleasesAssetByDeviceModelAndFirmwareType } from '../utils/assetUtils';
 import { httpRequest } from '../utils/assets';
@@ -466,6 +466,54 @@ const calculateShouldOfferRelease = (
     }
 };
 
+const getChangelog = (releases: FirmwareRelease[], features: StrictFeatures) => {
+    // releases are already filtered, so they can be considered "safe".
+    // so lets build changelog! It should include only those firmwares, that are
+    // newer than currently installed firmware.
+
+    if (features.bootloader_mode) {
+        // the problem with bootloader is that we see only bootloader and not firmware version
+        // and multiple releases may share same bootloader version. we really can not tell that
+        // the versions that are installable are newer. so...
+        if (features.firmware_present && features.major_version === 1) {
+            // return null signaling that we don't really know, but only if some firmware
+            // is already installed!
+            return null;
+        }
+        if (features.firmware_present && features.major_version === 2) {
+            // little different situation is with model 2, where in bootloader (and with some fw installed)
+            // we actually know the firmware version
+            return releases.filter(r =>
+                versionUtils.isNewer(r.version, [
+                    features.fw_major,
+                    features.fw_minor,
+                    features.fw_patch,
+                ]),
+            );
+        }
+
+        // for fresh devices, we can assume that all releases are actually "new"
+        return releases;
+    }
+
+    // otherwise we are in firmware mode and because each release in releases list has
+    // version higher than the previous one, we can filter out the version that is already
+    // installed and show only what's new!
+    return releases.filter(r =>
+        versionUtils.isNewer(r.version, [
+            features.major_version,
+            features.minor_version,
+            features.patch_version,
+        ]),
+    );
+};
+
+const isRequired = (changelog: ReturnType<typeof getChangelog>) => {
+    if (!changelog || !changelog.length) return null;
+
+    return changelog.some(item => item.required);
+};
+
 interface GetReleaseInfoParams {
     features: Features;
     release: FirmwareRelease;
@@ -473,6 +521,7 @@ interface GetReleaseInfoParams {
     intermediary: IntermediaryReleaseConfig | undefined;
     firmwareType: FirmwareType;
     isBitcoinOnlyAvailable: boolean;
+    releasesOfDevice: FirmwareRelease[];
 }
 
 export const getReleaseInfo = ({
@@ -482,6 +531,7 @@ export const getReleaseInfo = ({
     intermediary,
     firmwareType,
     isBitcoinOnlyAvailable,
+    releasesOfDevice,
 }: GetReleaseInfoParams): FirmwareReleaseConfigInfo => {
     if (!isStrictFeatures(features)) {
         throw new Error('Features of unexpected shape provided.');
@@ -489,7 +539,9 @@ export const getReleaseInfo = ({
     if (!isValidConditionalRelease(release)) {
         throw new Error(`Release object in unexpected shape.`);
     }
-    const { min_firmware_version, min_bootloader_version, required } = release;
+    const { min_firmware_version, min_bootloader_version } = release;
+
+    const changelog = getChangelog(releasesOfDevice, features as StrictFeatures);
 
     let isNewer = false;
     let requiresIntermediary = false;
@@ -536,7 +588,7 @@ export const getReleaseInfo = ({
         },
         release,
         intermediary: requiresIntermediary ? intermediary : undefined,
-        isRequired: required,
+        isRequired: isRequired(changelog),
         isNewer,
         translations: release.translations,
     };
@@ -566,11 +618,16 @@ export const getFirmwareReleaseConfigInfo = (features: Features, firmwareType: F
         versionContext.version &&
         versionUtils.isNewerOrEqual(versionContext.version, release[versionContext.minVersionKey]);
 
+    const releasesOfDevice = getReleasesAssetByDeviceModelAndFirmwareType(
+        features.internal_model,
+        firmwareType,
+    );
+
     let suitableRelease = release;
     if (!isCompatible) {
         // If the target isn't compatible, search for the best alternative.
         const alternativeRelease = findBestCompatibleRelease(
-            getReleasesAssetByDeviceModelAndFirmwareType(features.internal_model, firmwareType),
+            releasesOfDevice,
             currentVersion,
             versionContext.minVersionKey,
         );
@@ -590,6 +647,7 @@ export const getFirmwareReleaseConfigInfo = (features: Features, firmwareType: F
         conditions,
         intermediary,
         firmwareType: firmware_type,
+        releasesOfDevice,
     });
 };
 

--- a/packages/connect/src/utils/__tests__/firmwareUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/firmwareUtils.test.ts
@@ -17,7 +17,7 @@ describe('firmwareUtils', () => {
             it('should return undefined for an empty data object', () => {
                 expect(
                     findBestCompatibleRelease(
-                        {},
+                        [],
                         { bootloaderVersion: null, firmwareVersion: [1, 0, 0] },
                         'min_firmware_version',
                     ),
@@ -28,7 +28,7 @@ describe('firmwareUtils', () => {
         describe('with checkProperty = "min_firmware_version"', () => {
             it('should return the newest compatible release', () => {
                 const compatibleRelease = findBestCompatibleRelease(
-                    firmwareAssets.t2t1.universal,
+                    Object.values(firmwareAssets.t2t1.universal),
                     { bootloaderVersion: null, firmwareVersion: [2, 0, 7] },
                     'min_firmware_version',
                 );
@@ -38,7 +38,7 @@ describe('firmwareUtils', () => {
             it('should return undefined if no release meets the min firmware version', () => {
                 expect(
                     findBestCompatibleRelease(
-                        firmwareAssets.t1b1.universal,
+                        Object.values(firmwareAssets.t1b1.universal),
                         { bootloaderVersion: null, firmwareVersion: [0, 8, 5] },
                         'min_firmware_version',
                     ),
@@ -50,7 +50,7 @@ describe('firmwareUtils', () => {
             it('should return undefined for an empty data object', () => {
                 expect(
                     findBestCompatibleRelease(
-                        {},
+                        [],
                         { bootloaderVersion: null, firmwareVersion: [1, 0, 0] },
                         'min_bootloader_version',
                     ),
@@ -58,7 +58,7 @@ describe('firmwareUtils', () => {
             });
             it('should return the correct release based on bootloader version', () => {
                 const compatibleRelease = findBestCompatibleRelease(
-                    firmwareAssets.t1b1.universal,
+                    Object.values(firmwareAssets.t1b1.universal),
                     { bootloaderVersion: null, firmwareVersion: [1, 6, 3] },
                     'min_bootloader_version',
                 );
@@ -68,7 +68,7 @@ describe('firmwareUtils', () => {
             it('should return undefined if no release meets the min bootloader version', () => {
                 expect(
                     findBestCompatibleRelease(
-                        firmwareAssets.t1b1.universal,
+                        Object.values(firmwareAssets.t1b1.universal),
                         { bootloaderVersion: null, firmwareVersion: [0, 8, 5] },
                         'min_bootloader_version',
                     ),
@@ -94,7 +94,7 @@ describe('firmwareUtils', () => {
                         ),
                 );
                 const comptabibleRelease = findBestCompatibleRelease(
-                    firmwareAssets.t3t1.universal,
+                    Object.values(firmwareAssets.t3t1.universal),
                     {
                         bootloaderVersion:
                             firstReleaseWithBootloaderCompatibleWithLatest.bootloader_version,

--- a/packages/connect/src/utils/assetUtils.ts
+++ b/packages/connect/src/utils/assetUtils.ts
@@ -5,6 +5,7 @@ import {
     FirmwareType,
     VersionArray,
 } from '@trezor/device-utils';
+import { versionUtils } from '@trezor/utils';
 
 export class HttpRequestError extends Error {
     response: Response;
@@ -27,11 +28,18 @@ type FirmwareAssetMap = {
 export const getReleasesAssetByDeviceModelAndFirmwareType = (
     deviceModel: DeviceModelInternal,
     firmwareType: FirmwareType,
-) => {
+): FirmwareRelease[] => {
     const firmwareTypeInFileName =
         firmwareType === FirmwareType.BitcoinOnly ? 'bitcoinonly' : 'universal';
 
-    return (firmwareAssets as FirmwareAssetMap)[deviceModel.toLowerCase()][firmwareTypeInFileName];
+    const availableRelesesRecord = (firmwareAssets as FirmwareAssetMap)[deviceModel.toLowerCase()][
+        firmwareTypeInFileName
+    ];
+    const availableFirmwaresReleases = Object.values(availableRelesesRecord);
+
+    return availableFirmwaresReleases.sort((a, b) =>
+        versionUtils.isNewer(b.version, a.version) ? 1 : -1,
+    );
 };
 
 export const getReleaseAsset = (

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -17,15 +17,13 @@ type VersionCheckProperty = 'min_firmware_version' | 'min_bootloader_version';
 //  It sorts available firmwares from newest to oldest and returns the first one
 //  that meets the minimum version requirement for a given device property.
 export const findBestCompatibleRelease = (
-    releasesOfDevice: Record<string, FirmwareRelease>,
+    availableFirmwares: FirmwareRelease[],
     currentVesion: CurrentVersion,
     checkProperty: VersionCheckProperty,
 ): FirmwareRelease | undefined => {
-    if (!releasesOfDevice || Object.keys(releasesOfDevice).length === 0) {
+    if (!availableFirmwares || availableFirmwares.length === 0) {
         return;
     }
-
-    const availableFirmwares = Object.values(releasesOfDevice);
 
     const currentFirmwareVersion = currentVesion.firmwareVersion;
     const currentBootloaderVersion = currentVesion.bootloaderVersion;

--- a/packages/device-utils/src/types.ts
+++ b/packages/device-utils/src/types.ts
@@ -121,8 +121,6 @@ export interface IntermediaryReleaseConfig {
     min_firmware_version: VersionArray;
     min_bootloader_version: VersionArray;
     version: number;
-    firmware_revision: string;
-    url: string;
 }
 
 export interface FirmwareReleaseConfig {

--- a/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
@@ -16,8 +16,6 @@ const bootloaderDeviceNeedsIntermediary = {
                 intermediary: {
                     min_firmware_version: [1, 6, 2],
                     min_bootloader_version: [1, 6, 2],
-                    firmware_revision: '592590cf66a9b62dfeee7e4d2afb6e01005e5b2c',
-                    url: '/some/path.bin',
                     version: 1,
                 },
             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Adding missing `"required": true,` since when we change to the format of releases JSON, we used data.trezor.io as source of truth, but some of those `required` were only changed in the copy of those releases.json files in Suite.
* Returning `getChangelog` and `isRequired` function to firmware info so if there is `"required": true` in any release between the current one and the last one it is marked as required and therefore the Device is not allowed to be used in Suite until it is properly updated.
* I had to update the tests and I add couple of improvements as well that I could not stop my self from doing.

Resolves https://github.com/trezor/trezor-suite/issues/22028


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/changelog-for-is-required&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/changelog-for-is-required&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/changelog-for-is-required&lookback=7)