### PR TITLE
feat(suite): add survey banner in trading via message system

### DIFF
--- a/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
+++ b/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
@@ -4,10 +4,10 @@ import { messageSystemActions, resolveMessageContent } from '@suite-common/messa
 import { Message } from '@suite-common/suite-types';
 import { Banner, BannerProps, Row, Banner as WarningComponent } from '@trezor/components';
 
-import { goto } from 'src/actions/suite/routerActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectLanguage, selectTorState } from 'src/selectors/suite/suiteSelectors';
-import { getTorUrlIfAvailable } from 'src/utils/suite/tor';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
+
+import { MessageSystemButton } from './MessageSystemButton';
 
 type MessageSystemBannerProps = {
     message: Message;
@@ -16,36 +16,11 @@ type MessageSystemBannerProps = {
 };
 
 export const MessageSystemBanner = ({ message, margin, width }: MessageSystemBannerProps) => {
-    const { cta, variant, id, content, dismissible } = message;
+    const { variant, id, content, dismissible, cta } = message;
 
-    const { isTorEnabled } = useSelector(selectTorState);
     const language = useSelector(selectLanguage);
-    const torOnionLinks = useSelector(state => state.suite.settings.torOnionLinks);
+
     const dispatch = useDispatch();
-
-    const actionConfig = useMemo(() => {
-        if (!cta) return undefined;
-
-        const { action, label, link, anchor } = cta;
-
-        let onClick: () => Window | Promise<void> | null;
-        if (action === 'internal-link') {
-            // @ts-expect-error: impossible to add all href options to the message system config json schema
-            onClick = () => dispatch(goto(link, { anchor, preserveParams: true }));
-        } else if (action === 'external-link') {
-            onClick = () =>
-                window.open(
-                    isTorEnabled && torOnionLinks ? getTorUrlIfAvailable(link) : link,
-                    '_blank',
-                );
-        }
-
-        return {
-            label: resolveMessageContent(label, language) || label.en,
-            onClick: onClick!,
-            'data-testid': `@message-system/${id}/cta`,
-        };
-    }, [id, cta, dispatch, language, isTorEnabled, torOnionLinks]);
 
     const dismissalConfig = useMemo(() => {
         if (!dismissible) return undefined;
@@ -63,14 +38,7 @@ export const MessageSystemBanner = ({ message, margin, width }: MessageSystemBan
             variant={variant === 'critical' ? 'destructive' : variant}
             rightContent={
                 <Row gap={8}>
-                    {actionConfig && (
-                        <Banner.Button
-                            onClick={actionConfig.onClick}
-                            data-testid={actionConfig['data-testid']}
-                        >
-                            {actionConfig.label}
-                        </Banner.Button>
-                    )}
+                    <MessageSystemButton cta={cta} id={id} />
                     {dismissalConfig && (
                         <WarningComponent.IconButton
                             icon="x"

--- a/packages/suite/src/components/suite/banners/MessageSystemButton.tsx
+++ b/packages/suite/src/components/suite/banners/MessageSystemButton.tsx
@@ -1,0 +1,55 @@
+import { resolveMessageContent } from '@suite-common/message-system';
+import { Message } from '@suite-common/suite-types';
+import { Banner, ButtonProps } from '@trezor/components';
+
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import {
+    selectLanguage,
+    selectTorOnionLinks,
+    selectTorState,
+} from 'src/selectors/suite/suiteSelectors';
+import { getTorUrlIfAvailable } from 'src/utils/suite/tor';
+
+type MessageSystemButtonProps = {
+    cta?: Message['cta'];
+    id?: Message['id'];
+} & Pick<ButtonProps, 'icon' | 'iconAlignment' | 'iconSize' | 'size'>;
+
+export const MessageSystemButton = ({ cta, id, ...props }: MessageSystemButtonProps) => {
+    const { isTorEnabled } = useSelector(selectTorState);
+    const language = useSelector(selectLanguage);
+    const torOnionLinks = useSelector(selectTorOnionLinks);
+    const dispatch = useDispatch();
+
+    if (!cta) return null;
+
+    const { action, label, link, anchor } = cta;
+
+    const onClick = () => {
+        switch (action) {
+            case 'internal-link':
+                // @ts-expect-error: impossible to add all href options to the message system config json schema
+                dispatch(goto(link as Route['name'], { anchor, preserveParams: true }));
+                break;
+            case 'external-link':
+                window.open(
+                    isTorEnabled && torOnionLinks ? getTorUrlIfAvailable(link) : link,
+                    '_blank',
+                );
+                break;
+        }
+    };
+
+    const resolvedLabel = resolveMessageContent(label, language) || label.en;
+
+    return (
+        <Banner.Button
+            onClick={onClick!}
+            {...(id ? { 'data-testid': `@message-system/${id}/cta` } : {})}
+            {...props}
+        >
+            {resolvedLabel}
+        </Banner.Button>
+    );
+};

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx
@@ -9,7 +9,11 @@ import { Banner, Row } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectLanguage, selectTorState } from 'src/selectors/suite/suiteSelectors';
+import {
+    selectLanguage,
+    selectTorOnionLinks,
+    selectTorState,
+} from 'src/selectors/suite/suiteSelectors';
 import { getTorUrlIfAvailable } from 'src/utils/suite/tor';
 
 type ContextMessageProps = {
@@ -20,7 +24,7 @@ export const ContextMessage = ({ context }: ContextMessageProps) => {
     const language = useSelector(selectLanguage);
     const message = useSelector(state => selectContextMessageContent(state, context, language));
     const { isTorEnabled } = useSelector(selectTorState);
-    const torOnionLinks = useSelector(state => state.suite.settings.torOnionLinks);
+    const torOnionLinks = useSelector(selectTorOnionLinks);
     const dispatch = useDispatch();
 
     const dismissalConfig = useMemo(() => {

--- a/packages/suite/src/hooks/suite/useExternalLink.ts
+++ b/packages/suite/src/hooks/suite/useExternalLink.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { useSelector } from 'src/hooks/suite';
-import { selectTorState } from 'src/selectors/suite/suiteSelectors';
+import { selectTorOnionLinks, selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { getTorUrlIfAvailable } from 'src/utils/suite/tor';
 
 /**
@@ -9,7 +9,7 @@ import { getTorUrlIfAvailable } from 'src/utils/suite/tor';
  */
 export const useExternalLink = (originalUrl?: string) => {
     const { isTorEnabled } = useSelector(selectTorState);
-    const torOnionLinks = useSelector(state => state.suite.settings.torOnionLinks);
+    const torOnionLinks = useSelector(selectTorOnionLinks);
 
     const url = useMemo(() => {
         if (originalUrl && isTorEnabled && torOnionLinks) {

--- a/packages/suite/src/selectors/suite/suiteSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteSelectors.ts
@@ -26,6 +26,8 @@ export const selectTorState = (state: SuiteRootState) => {
     };
 };
 
+export const selectTorOnionLinks = (state: SuiteRootState) => state.suite.settings.torOnionLinks;
+
 export const selectLocalFirstStorageRelayUrl = (state: SuiteRootState) =>
     state.suite.settings.localFirstStorageRelayUrl;
 

--- a/packages/suite/src/views/settings/SettingsGeneral/TorOnionLinks.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/TorOnionLinks.tsx
@@ -7,11 +7,12 @@ import { ActionColumn, TextColumn } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectTorOnionLinks } from 'src/selectors/suite/suiteSelectors';
 
 /* keep torOnionLinks value as it is but hide this section when tor is off.
    when tor is off this value has no effect anyway (handled by ExternalLink hook) */
 export const TorOnionLinks = () => {
-    const torOnionLinks = useSelector(state => state.suite.settings.torOnionLinks);
+    const torOnionLinks = useSelector(selectTorOnionLinks);
     const dispatch = useDispatch();
 
     const handleChange = () => {

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -4,6 +4,7 @@ import { usePrevious } from 'react-use';
 import { ExchangeTradeStatus } from 'invity-api';
 import styled from 'styled-components';
 
+import { Feature, selectFeatureConfig } from '@suite-common/message-system';
 import {
     type TradingExchangeType,
     selectTradingComposedTransactionInfo,
@@ -29,6 +30,8 @@ import { TradingDetailExchangePaymentSuccessful } from 'src/views/wallet/trading
 import { TradingDetailFeedback } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback';
 import { TradingSelectedOfferInfo } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo';
 import { TradingWrapper } from 'src/views/wallet/trading/common/TradingWrapper';
+
+import { TradingDetailSurvey } from '../TradingDetailSurvey';
 
 const Wrapper = styled.div`
     ${TradingWrapper}
@@ -57,6 +60,9 @@ const getTradeStatusStep = (tradeStatus: ExchangeTradeStatus) => {
 export const TradingDetailExchange = () => {
     const accounts = useSelector(selectAccounts);
     const { account, trade, info } = useTradingDetailContext<TradingExchangeType>();
+    const tradingSurveyFeature = useSelector(state =>
+        selectFeatureConfig(state, Feature.trading.survey),
+    );
     const dispatch = useDispatch();
 
     const tradeStatus = trade?.data?.status || 'CONFIRMING';
@@ -151,13 +157,17 @@ export const TradingDetailExchange = () => {
                         <TradingDetailExchangePaymentSending supportUrl={supportUrl} />
                     )}
                 </Card>
-                <TradingDetailFeedback
-                    status={tradeStatus}
-                    type={trade.tradeType}
-                    provider={provider?.name}
-                    id={trade.data.id}
-                    quoteAmounts={quoteAmounts}
-                />
+                {tradingSurveyFeature ? (
+                    <TradingDetailSurvey />
+                ) : (
+                    <TradingDetailFeedback
+                        status={tradeStatus}
+                        type={trade.tradeType}
+                        provider={provider?.name}
+                        id={trade.data.id}
+                        quoteAmounts={quoteAmounts}
+                    />
+                )}
             </Column>
             <Card>
                 <TradingSelectedOfferInfo

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSurvey.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSurvey.tsx
@@ -1,0 +1,52 @@
+import {
+    Feature,
+    TradingSurveyPayload,
+    resolveMessageContent,
+    selectFeatureConfig,
+    validateTradingSurvey,
+} from '@suite-common/message-system';
+import { Card, Column, Paragraph, Text } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+import { MessageSystemButton } from 'src/components/suite/banners/MessageSystemButton';
+import { useSelector } from 'src/hooks/suite';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
+
+const safeValidateTradingSurvey = (data: unknown): TradingSurveyPayload | null => {
+    try {
+        return validateTradingSurvey(data);
+    } catch (error) {
+        console.error('Invalid trading.survey payload', error);
+
+        return null;
+    }
+};
+
+export const TradingDetailSurvey = () => {
+    const surveyRaw = useSelector(state => selectFeatureConfig(state, Feature.trading.survey));
+    const language = useSelector(selectLanguage);
+
+    const survey = surveyRaw?.payload ? safeValidateTradingSurvey(surveyRaw.payload) : null;
+
+    if (!survey) {
+        console.error('TradingDetailSurvey: survey is not available');
+
+        return null;
+    }
+
+    const title = survey?.title && resolveMessageContent(survey.title, language);
+
+    const description = survey?.description && resolveMessageContent(survey.description, language);
+
+    return (
+        <Card>
+            <Column gap={spacings.lg}>
+                <Column gap={spacings.xs}>
+                    <Text typographyStyle="titleSmall">{title}</Text>
+                    <Paragraph maxWidth={400}>{description}</Paragraph>
+                </Column>
+                <MessageSystemButton cta={survey.cta} icon="arrowSquareOut" iconAlignment="end" />
+            </Column>
+        </Card>
+    );
+};

--- a/suite-common/message-system/schema/config.schema.v1.json
+++ b/suite-common/message-system/schema/config.schema.v1.json
@@ -132,11 +132,49 @@
                                         "flag": {
                                             "type": "boolean"
                                         },
+                                        "payload": {
+                                            "type": "object",
+                                            "description": "Optional payload with arbitrary properties",
+                                            "additionalProperties": true
+                                        },
                                         "visibleBanner": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "description": "Legacy field for 'dashboard.promoBanner'"
+                                        },
+                                        "timeoutThresholdsPerModel": {
+                                            "type": ["object", "null"],
+                                            "description": "Legacy field for 'security.firmware.hashCheck.timeout'"
+                                        },
+                                        "averageAnonymityGainPerRound": {
+                                            "type": "number",
+                                            "description": "Legacy field for 'coinjoin'"
+                                        },
+                                        "roundsFailRateBuffer": {
+                                            "type": "number",
+                                            "description": "Legacy field for 'coinjoin'"
+                                        },
+                                        "roundsDurationInHours": {
+                                            "type": "number",
+                                            "description": "Legacy field for 'coinjoin'"
+                                        },
+                                        "maxMiningFeeModifier": {
+                                            "type": "number",
+                                            "description": "Legacy field for 'coinjoin'"
+                                        },
+                                        "maxFeePerVbyte": {
+                                            "type": "number",
+                                            "description": "Legacy field for 'coinjoin'"
+                                        },
+                                        "legalDocumentsVersion": {
+                                            "type": "number",
+                                            "description": "Legacy field for 'coinjoin'"
+                                        },
+                                        "isPublic": {
+                                            "type": "boolean",
+                                            "description": "Legacy field for 'coinjoin'"
                                         }
                                     },
-                                    "additionalProperties": true
+                                    "additionalProperties": false
                                 }
                             },
                             "context": {

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -58,6 +58,7 @@ export const Feature = {
         restrictions: {
             blacklist: 'trading.restrictions.blacklist',
         },
+        survey: 'trading.survey',
     },
     dashboardPromoBanner: 'dashboard.promoBanner',
     mevProtection: 'settings.mevProtection',

--- a/suite-common/message-system/src/messageSystemValidation.ts
+++ b/suite-common/message-system/src/messageSystemValidation.ts
@@ -21,6 +21,22 @@ import {
     VENDOR_ENUM,
 } from './messageSystemConstants';
 
+const onlyForDomain = <T extends yup.Schema<any>>(
+    allowed: string | string[],
+    schema: T,
+    fieldLabel: string,
+) =>
+    yup.mixed().when('domain', {
+        is: (d: string) => (Array.isArray(allowed) ? allowed.includes(d) : d === allowed),
+        then: () => schema,
+        otherwise: s =>
+            s.test({
+                name: 'forbidden-field',
+                message: `${fieldLabel} is only allowed when domain is ${Array.isArray(allowed) ? allowed.join(' | ') : allowed}.`,
+                test: v => v === undefined,
+            }),
+    }) as unknown as T;
+
 export type ValidateError = { field?: string; message: string };
 
 export const stripFieldFromMessage = (errors: ValidateError[]) =>
@@ -63,6 +79,22 @@ const modalSchema = yup
     })
     .noUnknown(true);
 
+const surveyPayloadSchema = yup
+    .object({
+        title: localizationSchema.required(),
+        description: localizationSchema.required(),
+        cta: ctaSchema.required(),
+    })
+    .noUnknown(false);
+
+export type TradingSurveyPayload = yup.InferType<typeof surveyPayloadSchema>;
+
+export const validateTradingSurvey = (parsed: unknown) =>
+    surveyPayloadSchema.validateSync(parsed, {
+        abortEarly: false,
+        strict: true,
+    });
+
 const featureItemSchema = yup
     .object({
         domain: yup
@@ -70,7 +102,54 @@ const featureItemSchema = yup
             .oneOf(FEATURE_LIST, 'Select a valid feature from the list.')
             .required(),
         flag: yup.boolean().required(),
-        visibleBanner: yup.string().optional(),
+        payload: yup.lazy((_value, { parent }) => {
+            if (parent.domain === 'trading.survey') {
+                return surveyPayloadSchema;
+            }
+
+            return yup.object().optional().noUnknown(false);
+        }),
+
+        // legacy fields
+        visibleBanner: onlyForDomain(
+            'dashboard.promoBanner',
+            yup.string().optional(),
+            'visibleBanner',
+        ),
+
+        timeoutThresholdsPerModel: onlyForDomain(
+            'security.firmware.hashCheck.timeout',
+            yup.object().nullable().optional().noUnknown(false),
+            'timeoutThresholdsPerModel',
+        ),
+
+        averageAnonymityGainPerRound: onlyForDomain(
+            'coinjoin',
+            yup.number().optional(),
+            'averageAnonymityGainPerRound',
+        ),
+        roundsFailRateBuffer: onlyForDomain(
+            'coinjoin',
+            yup.number().optional(),
+            'roundsFailRateBuffer',
+        ),
+        roundsDurationInHours: onlyForDomain(
+            'coinjoin',
+            yup.number().optional(),
+            'roundsDurationInHours',
+        ),
+        maxMiningFeeModifier: onlyForDomain(
+            'coinjoin',
+            yup.number().optional(),
+            'maxMiningFeeModifier',
+        ),
+        maxFeePerVbyte: onlyForDomain('coinjoin', yup.number().optional(), 'maxFeePerVbyte'),
+        legalDocumentsVersion: onlyForDomain(
+            'coinjoin',
+            yup.number().optional(),
+            'legalDocumentsVersion',
+        ),
+        isPublic: onlyForDomain('coinjoin', yup.number().optional(), 'isPublic'),
     })
     .noUnknown(true);
 

--- a/suite-common/suite-types/src/messageSystem.ts
+++ b/suite-common/suite-types/src/messageSystem.ts
@@ -405,8 +405,50 @@ export interface Modal {
 export interface Feature {
     domain: string;
     flag: boolean;
+    /**
+     * Optional payload with arbitrary properties
+     */
+    payload?: {
+        [k: string]: unknown;
+    };
+    /**
+     * Legacy field for 'dashboard.promoBanner'
+     */
     visibleBanner?: string;
-    [k: string]: unknown;
+    /**
+     * Legacy field for 'security.firmware.hashCheck.timeout'
+     */
+    timeoutThresholdsPerModel?: {
+        [k: string]: unknown;
+    } | null;
+    /**
+     * Legacy field for 'coinjoin'
+     */
+    averageAnonymityGainPerRound?: number;
+    /**
+     * Legacy field for 'coinjoin'
+     */
+    roundsFailRateBuffer?: number;
+    /**
+     * Legacy field for 'coinjoin'
+     */
+    roundsDurationInHours?: number;
+    /**
+     * Legacy field for 'coinjoin'
+     */
+    maxMiningFeeModifier?: number;
+    /**
+     * Legacy field for 'coinjoin'
+     */
+    maxFeePerVbyte?: number;
+    /**
+     * Legacy field for 'coinjoin'
+     */
+    legalDocumentsVersion?: number;
+    /**
+     * Legacy field for 'coinjoin'
+     */
+    isPublic?: boolean;
 }
 /**
  * Only used for 'context' category.


### PR DESCRIPTION
## Description

Implements a survey banner on the trade confirmation screen, enabled by the `trading.survey` flag. The banner is delivered through the message system and allows dynamic configuration of texts and CTA, replacing the default feedback banner when active.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21905

## Screenshots:

<img width="1179" height="777" alt="image" src="https://github.com/user-attachments/assets/964d1b77-31d5-442a-b60d-c7960256cc94" />

## Test message

```
{
            "conditions": [
                {
                    "environment": {
                        "desktop": "*",
                        "mobile": "*",
                        "web": "*"
                    }
                }
            ],
            "message": {
                "id": "6976247d-c709-43c5-9dcc-1568e73ebc2e",
                "priority": 1,
                "dismissible": true,
                "variant": "info",
                "category": "feature",
                "content": {
                    "en-GB": "Placeholder",
                    "en": "Placeholder",
                    "es": "Placeholder",
                    "cs": "Placeholder",
                    "de": "Placeholder",
                    "fr": "Placeholder",
                    "it": "Placeholder",
                    "pt": "Placeholder",
                    "tr": "Placeholder",
                    "ru": "Placeholder",
                    "ja": "Placeholder",
                    "uk": "Placeholder",
                    "hu": "Placeholder"
                },
                "feature": [
                    {
                        "domain": "trading.survey",
                        "flag": true,
                        "payload": {
                            "title": {
                                "en": "What was your trade like? Tell us, get $50",
                                "es": "",
                                "cs": "",
                                "de": "",
                                "fr": "",
                                "pt": ""
                            },
                            "description": {
                                "en": "Answer a short survey to see if you qualify for a 30-minute interview and get a $50 Amazon gift card.",
                                "es": "",
                                "cs": "",
                                "de": "",
                                "fr": "",
                                "pt": ""
                            },
                            "cta": {
                                "action": "external-link",
                                "link": "https://trezor.io",
                                "label": {
                                    "en": "Take the survey",
                                    "es": "",
                                    "cs": "",
                                    "de": "",
                                    "fr": "",
                                    "pt": ""
                                }
                            }
                        }
                    }
                ]
            }
        }
```

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-survey-banner&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-survey-banner&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/trading-survey-banner&lookback=7)