### PR TITLE
fix(suite): show correct network info in receive modal heading

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -1,12 +1,6 @@
 import { useCallback } from 'react';
 
 import { selectConnectPopupCall } from '@suite-common/connect-popup';
-import {
-    cryptoIdToSymbol,
-    selectTradingModalAccountKey,
-    useTradingInfo,
-} from '@suite-common/trading';
-import { getDisplaySymbol, getNetwork } from '@suite-common/wallet-config';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config/src/utils';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
@@ -31,9 +25,6 @@ interface ConfirmAddressModalProps
 export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAddressModalProps) => {
     const device = useSelector(selectSelectedDevice);
     const account = useSelector(selectAccountIncludingChosenInTrading);
-    const isTradingFlow = useSelector(selectTradingModalAccountKey);
-    const { modalCryptoId } = useSelector(state => state.wallet.trading);
-    const { cryptoIdToSymbolAndContractAddress } = useTradingInfo();
     const isConnectPopup = useSelector(
         state => selectConnectPopupCall(state)?.state === 'address-confirmation',
     );
@@ -48,36 +39,6 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
     if (!device) return null;
 
     const getHeading = () => {
-        if (modalCryptoId) {
-            const symbol = cryptoIdToSymbol(modalCryptoId);
-            const { coinSymbol, contractAddress } =
-                cryptoIdToSymbolAndContractAddress(modalCryptoId);
-            const networkCurrencyName = coinSymbol && getDisplaySymbol(coinSymbol, contractAddress);
-
-            if (contractAddress) {
-                const networkName = symbol ? getNetwork(symbol).name : coinSymbol?.toUpperCase();
-
-                return (
-                    <Translation
-                        id="TR_ADDRESS_MODAL_TITLE_EXCHANGE"
-                        values={{
-                            networkName,
-                            networkCurrencyName,
-                        }}
-                    />
-                );
-            }
-
-            return (
-                <Translation
-                    id="TR_ADDRESS_MODAL_TITLE"
-                    values={{
-                        networkName: networkCurrencyName,
-                    }}
-                />
-            );
-        }
-
         if (!account) {
             return <Translation id="TR_RECEIVE" />;
         }
@@ -110,8 +71,6 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
             heading={getHeading()}
             label={<Translation id="TR_ADDRESS" />}
             validateOnDevice={validateAddress}
-            areStepsVisible={!isTradingFlow}
-            isCopyButtonVisible={!isTradingFlow}
             value={value}
             data-testid="@metadata/copy-address-button"
             {...props}

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -43,9 +43,7 @@ export type ConfirmValueModalProps = Pick<ModalProps, 'onCancel' | 'heading'> & 
     account?: Account;
     'data-testid'?: string;
     isConfirmed?: boolean;
-    areStepsVisible?: boolean;
     isValueChunked?: boolean;
-    isCopyButtonVisible?: boolean;
     label?: ReactNode;
     validateOnDevice: () => ThunkAction;
     value: string;
@@ -58,8 +56,6 @@ export const ConfirmValueModal = ({
     label,
     isConfirmed,
     isValueChunked,
-    isCopyButtonVisible,
-    areStepsVisible,
     onCancel,
     validateOnDevice,
     value,
@@ -210,77 +206,74 @@ export const ConfirmValueModal = ({
                                         />
                                     )}
                                 </Column>
-                                {isCopyButtonVisible && (
-                                    <Button
-                                        onClick={copy}
-                                        variant="tertiary"
-                                        data-testid={copyButtonDataTest}
-                                        size="small"
-                                        textWrap={false}
-                                        icon={isCopied ? 'check' : 'copy'}
-                                    >
-                                        <Translation
-                                            id={
-                                                isCopied
-                                                    ? 'TR_COPIED_TO_CLIPBOARD'
-                                                    : 'TR_COPY_TO_CLIPBOARD'
-                                            }
-                                        />
-                                    </Button>
-                                )}
+
+                                <Button
+                                    onClick={copy}
+                                    variant="tertiary"
+                                    data-testid={copyButtonDataTest}
+                                    size="small"
+                                    textWrap={false}
+                                    icon={isCopied ? 'check' : 'copy'}
+                                >
+                                    <Translation
+                                        id={
+                                            isCopied
+                                                ? 'TR_COPIED_TO_CLIPBOARD'
+                                                : 'TR_COPY_TO_CLIPBOARD'
+                                        }
+                                    />
+                                </Button>
                             </Column>
                         </Row>
                     </Card>
-                    {areStepsVisible && (
-                        <Card>
-                            <Row gap={spacings.lg}>
-                                <IconCircle
-                                    hasBorder={false}
-                                    variant="info"
-                                    size={32}
-                                    name="warningFilled"
-                                />
-                                <H3>
-                                    <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_HEADING" />
-                                </H3>
-                            </Row>
-                            <BulletList
-                                isOrdered
-                                margin={{ top: spacings.xxxl }}
-                                gap={spacings.xl}
-                                titleGap={spacings.zero}
-                                bulletGap={spacings.lg}
+                    <Card>
+                        <Row gap={spacings.lg}>
+                            <IconCircle
+                                hasBorder={false}
+                                variant="info"
+                                size={32}
+                                name="warningFilled"
+                            />
+                            <H3>
+                                <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_HEADING" />
+                            </H3>
+                        </Row>
+                        <BulletList
+                            isOrdered
+                            margin={{ top: spacings.xxxl }}
+                            gap={spacings.xl}
+                            titleGap={spacings.zero}
+                            bulletGap={spacings.lg}
+                        >
+                            <BulletList.Item
+                                title={
+                                    <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_1_HEADING" />
+                                }
                             >
-                                <BulletList.Item
-                                    title={
-                                        <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_1_HEADING" />
-                                    }
-                                >
-                                    <Paragraph variant="tertiary" textWrap="pretty">
-                                        <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_1_DESCRIPTION" />
-                                    </Paragraph>
-                                </BulletList.Item>
-                                <BulletList.Item
-                                    title={
-                                        <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_2_HEADING" />
-                                    }
-                                >
-                                    <Paragraph variant="tertiary" textWrap="pretty">
-                                        <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_2_DESCRIPTION" />
-                                    </Paragraph>
-                                </BulletList.Item>
-                                <BulletList.Item
-                                    title={
-                                        <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_3_HEADING" />
-                                    }
-                                >
-                                    <Paragraph variant="tertiary" textWrap="pretty">
-                                        <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_3_DESCRIPTION" />
-                                    </Paragraph>
-                                </BulletList.Item>
-                            </BulletList>
-                        </Card>
-                    )}
+                                <Paragraph variant="tertiary" textWrap="pretty">
+                                    <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_1_DESCRIPTION" />
+                                </Paragraph>
+                            </BulletList.Item>
+                            <BulletList.Item
+                                title={
+                                    <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_2_HEADING" />
+                                }
+                            >
+                                <Paragraph variant="tertiary" textWrap="pretty">
+                                    <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_2_DESCRIPTION" />
+                                </Paragraph>
+                            </BulletList.Item>
+                            <BulletList.Item
+                                title={
+                                    <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_3_HEADING" />
+                                }
+                            >
+                                <Paragraph variant="tertiary" textWrap="pretty">
+                                    <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_3_DESCRIPTION" />
+                                </Paragraph>
+                            </BulletList.Item>
+                        </BulletList>
+                    </Card>
                 </Column>
             </Modal.ModalBase>
         </Modal.Backdrop>

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
@@ -45,7 +45,6 @@ export const ConfirmXpubModal = (
             account={account}
             heading={<Translation id="TR_XPUB" />}
             validateOnDevice={showXpub}
-            isCopyButtonVisible={true}
             value={xpubWithReplacedApostropheWithH ?? xpub}
             isValueChunked={false}
             data-testid="@metadata/copy-xpub-button"

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1553,10 +1553,6 @@ export default defineMessages({
         defaultMessage: '{networkName} network receive address',
         id: 'TR_ADDRESS_MODAL_TITLE',
     },
-    TR_ADDRESS_MODAL_TITLE_EXCHANGE: {
-        defaultMessage: '{networkCurrencyName} receive address on {networkName} network',
-        id: 'TR_ADDRESS_MODAL_TITLE_EXCHANGE',
-    },
     TR_IMPORT_CSV_MODAL_TITLE: {
         defaultMessage: 'Import addresses from CSV',
         id: 'TR_IMPORT_CSV_MODAL_TITLE',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes an issue where heading in the receive modal would show incorrect network.

## Screenshots

before:

https://github.com/user-attachments/assets/3bb2cb9b-aab7-4650-bbd0-5197e5c9aa52

after:

https://github.com/user-attachments/assets/87055391-0d23-48d0-a21a-468f9a94b225

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/receive-modal-heading&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/receive-modal-heading&lookback=7)