### PR TITLE
fix(translations): fix misspelled string on bt modal

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10187,7 +10187,7 @@ export default defineMessages({
     },
     TR_SCAN_TREZORS_NEARBY: {
         id: 'TR_SCAN_TREZORS_NEARBY',
-        defaultMessage: 'Scanning for neaby Trezors',
+        defaultMessage: 'Scanning for nearby Trezors',
     },
     TR_BLUETOOTH_CANNOT_OPEN_BLUETOOTH_SETTINGS_REMOVE_DEVICE: {
         id: 'TR_BLUETOOTH_CANNOT_OPEN_BLUETOOTH_SETTINGS_REMOVE_DEVICE',


### PR DESCRIPTION
We should run crowdin sync immediately afterwards, so we have this prepared for the release

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-modal-typo&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-modal-typo&lookback=7)