### PR TITLE
Mitigation for crashes when send precomposed fee level is error

### DIFF
--- a/suite-native/module-send/src/components/SendFeesForm.tsx
+++ b/suite-native/module-send/src/components/SendFeesForm.tsx
@@ -91,6 +91,10 @@ export const SendFeesForm = ({ accountKey, tokenContract }: SendFormProps) => {
     });
 
     const handleNavigateToReviewScreen = handleSubmit(() => {
+        if (!selectedFeeLevelTransaction) {
+            return;
+        }
+
         if (networkType === 'ripple' && destinationTag) {
             navigation.navigate(SendStackRoutes.SendDestinationTagReview, {
                 destinationTag,
@@ -134,11 +138,13 @@ export const SendFeesForm = ({ accountKey, tokenContract }: SendFormProps) => {
             {/*// BottomSheetModalProvider must be inside FormProvider to keep context available for sheets rendered via portal*/}
             <BottomSheetModalProvider>
                 <VStack spacing="sp32" flex={1}>
-                    <RecipientsSummary
-                        accountKey={accountKey}
-                        tokenContract={tokenContract}
-                        selectedFeeLevel={selectedFeeLevelTransaction}
-                    />
+                    {!!selectedFeeLevelTransaction && (
+                        <RecipientsSummary
+                            accountKey={accountKey}
+                            tokenContract={tokenContract}
+                            selectedFeeLevel={selectedFeeLevelTransaction}
+                        />
+                    )}
                     <VStack flex={1} justifyContent="space-between" spacing="sp24">
                         <VStack spacing="sp16">
                             <VStack spacing="sp4">
@@ -166,16 +172,18 @@ export const SendFeesForm = ({ accountKey, tokenContract }: SendFormProps) => {
                                 />
                             </VStack>
                         </VStack>
-                        <FeesFooter
-                            accountKey={accountKey}
-                            isSubmittable={isSubmittable}
-                            onSubmit={handleNavigateToReviewScreen}
-                            totalAmount={totalAmount}
-                            fee={fee}
-                            symbol={symbol}
-                            tokenContract={tokenContract}
-                            withSubmitButton={true}
-                        />
+                        {!!totalAmount && !!fee && (
+                            <FeesFooter
+                                accountKey={accountKey}
+                                isSubmittable={isSubmittable}
+                                onSubmit={handleNavigateToReviewScreen}
+                                totalAmount={totalAmount}
+                                fee={fee}
+                                symbol={symbol}
+                                tokenContract={tokenContract}
+                                withSubmitButton={true}
+                            />
+                        )}
                     </VStack>
                 </VStack>
             </BottomSheetModalProvider>

--- a/suite-native/module-send/src/hooks/useHandleOnDeviceTransactionReview.tsx
+++ b/suite-native/module-send/src/hooks/useHandleOnDeviceTransactionReview.tsx
@@ -34,7 +34,7 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 type HandleOnDeviceTransactionReviewProps = {
     accountKey: string;
     tokenContract?: TokenAddress;
-    transaction: GeneralPrecomposedTransactionFinal;
+    transaction: GeneralPrecomposedTransactionFinal | null;
 };
 
 export const useHandleOnDeviceTransactionReview = ({
@@ -72,6 +72,10 @@ export const useHandleOnDeviceTransactionReview = ({
     }, [navigation, isTransactionReviewInProgress, showReviewCancellationAlert, dispatch]);
 
     const handleOnDeviceTransactionReview = useCallback(async () => {
+        if (!transaction) {
+            return;
+        }
+
         const response = await dispatch(
             signTransactionNativeThunk({
                 accountKey,

--- a/suite-native/module-trading/src/components/fees/TradingFeesForm.tsx
+++ b/suite-native/module-trading/src/components/fees/TradingFeesForm.tsx
@@ -92,15 +92,17 @@ export const TradingFeesForm = ({ accountKey, tokenContract }: TradingFeesFormPr
                             />
                         </VStack>
                     </VStack>
-                    <FeesFooter
-                        accountKey={accountKey}
-                        isSubmittable={isSubmittable}
-                        totalAmount={totalAmount}
-                        fee={fee}
-                        symbol={symbol}
-                        tokenContract={tokenContract}
-                        withSubmitButton={false}
-                    />
+                    {!!totalAmount && !!fee && (
+                        <FeesFooter
+                            accountKey={accountKey}
+                            isSubmittable={isSubmittable}
+                            totalAmount={totalAmount}
+                            fee={fee}
+                            symbol={symbol}
+                            tokenContract={tokenContract}
+                            withSubmitButton={false}
+                        />
+                    )}
                 </VStack>
             </BottomSheetModalProvider>
         </Form>

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -24,7 +24,12 @@ import {
     sendFormActions,
     signTransactionThunk,
 } from '@suite-common/wallet-core';
-import { Account, FeeInfo, PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import {
+    Account,
+    FeeInfo,
+    PrecomposedTransactionFinal,
+    isFinalPrecomposedTransaction,
+} from '@suite-common/wallet-types';
 import { getFormDraftKey, tryGetAccountIdentity } from '@suite-common/wallet-utils';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import {
@@ -168,7 +173,7 @@ export const composeTradingTransactionThunk = createThunk(
                 dispatch(transactionManagementActions.storeFeeLevels({ feeLevels }));
 
                 const selectedLevel = feeLevels[selectedFeeLevel];
-                if (selectedLevel && selectedLevel.type === 'final') {
+                if (selectedLevel && isFinalPrecomposedTransaction(selectedLevel)) {
                     const composed = (await dispatch(
                         enhancePrecomposedTransactionThunk({
                             transactionFormValues: formState,

--- a/suite-native/transaction-management/src/hooks/fees/useFeeCalculation.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeeCalculation.ts
@@ -12,6 +12,7 @@ import {
     AccountKey,
     GeneralPrecomposedTransactionFinal,
     PrecomposedTransactionFinal,
+    isFinalPrecomposedTransaction,
 } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
@@ -46,38 +47,46 @@ export const useFeeCalculation = ({
     });
 
     const selectedFeeLevel = useWatch({ control: form.control, name: 'feeLevel' });
-    const selectedFeeLevelTransaction = feeLevels[
-        selectedFeeLevel
-    ] as GeneralPrecomposedTransactionFinal;
+    const selectedFeeLevelTransaction = isFinalPrecomposedTransaction(feeLevels[selectedFeeLevel])
+        ? (feeLevels[selectedFeeLevel] as GeneralPrecomposedTransactionFinal)
+        : null;
 
     const feePerUnit = useSelector((state: FeesRootState) =>
         selectConvertedNetworkFeeLevelFeePerUnit(state, symbol, selectedFeeLevel),
     );
 
-    const normalFee = feeLevels.normal as PrecomposedTransactionFinal;
+    const normalFee = isFinalPrecomposedTransaction(feeLevels.normal)
+        ? (feeLevels.normal as PrecomposedTransactionFinal)
+        : null;
 
     const { areFeesLoading } = useFeesFetching({
         networkSymbol: symbol,
         isRefetchDisabled: selectedFeeLevel === 'custom' || selectedSetMaxOutputId !== undefined,
     });
 
-    const transactionBytes = normalFee.bytes as number;
+    const transactionBytes = normalFee?.bytes as number;
 
     // If trezor-connect was not able to compose the fee level, we have calculate total amount locally.
     const mockedFee = useMemo(
         () =>
-            BigNumber(transactionBytes)
-                .times(feePerUnit ?? normalFee.feePerByte)
-                .toString(),
-        [transactionBytes, feePerUnit, normalFee.feePerByte],
+            normalFee
+                ? BigNumber(transactionBytes)
+                      .times(feePerUnit ?? normalFee.feePerByte)
+                      .toString()
+                : null,
+
+        [transactionBytes, feePerUnit, normalFee],
     );
 
     const mockedTotalAmount = useMemo(
-        () => BigNumber(normalFee.totalSpent).minus(normalFee.fee).plus(mockedFee).toString(),
+        () =>
+            normalFee && !!mockedFee
+                ? BigNumber(normalFee.totalSpent).minus(normalFee.fee).plus(mockedFee).toString()
+                : null,
         [normalFee, mockedFee],
     );
 
-    const isSubmittable = selectedFeeLevelTransaction?.type === 'final';
+    const isSubmittable = isFinalPrecomposedTransaction(selectedFeeLevelTransaction ?? undefined);
 
     // Use actual values if available, otherwise fall back to mocked values
     const totalAmount = selectedFeeLevelTransaction?.totalSpent ?? mockedTotalAmount;

--- a/suite-native/transaction-management/src/hooks/fees/useFeesForm.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeesForm.ts
@@ -6,7 +6,11 @@ import {
     selectAccountByKey,
     selectConvertedNetworkFeeInfo,
 } from '@suite-common/wallet-core';
-import { AccountKey, PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import {
+    AccountKey,
+    PrecomposedTransactionFinal,
+    isFinalPrecomposedTransaction,
+} from '@suite-common/wallet-types';
 import { useForm } from '@suite-native/forms';
 
 import { FeesFormValues, feesFormValidationSchema } from '../../feesFormSchema';
@@ -43,7 +47,9 @@ export const useFeesForm = ({
     const minimalFeeLimit =
         'estimatedFeeLimit' in feeLevels.normal ? feeLevels.normal.estimatedFeeLimit : undefined;
 
-    const normalFee = feeLevels.normal as PrecomposedTransactionFinal; // user is not allowed to enter this screen if normal fee is not final
+    const normalFee = isFinalPrecomposedTransaction(feeLevels.normal)
+        ? (feeLevels.normal as PrecomposedTransactionFinal)
+        : undefined;
 
     return useForm<FeesFormValues>({
         validation: feesFormValidationSchema,


### PR DESCRIPTION
Somehow when sending max amount (we have easily reproduced on XRP) the app crashes on send, because app tries to compose send max txn once more, but there is no XRP left (txn sending everything out was success), and FeeFooter expects final txn level, but receives error txn level and the change propagates before FeeFooter is removed from tree.

This PR checks type of the fee level and handles error level gracefully.

## Related Issue

Resolve #22037



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/send-max-crash&lookback=7)