### PR TITLE
Add `tryToUnlock` to `ThpHandshakeInitRequest`

### DIFF
--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -68,7 +68,7 @@ export const createThpChannel = async (device: Device) => {
 // State HH1 and HH2
 // TODO: link-to-public-docs
 // https://www.notion.so/satoshilabs/THP-Specification-2-1-203dc5260606804192aecaa58fb961ca
-export const thpHandshake = async (device: Device) => {
+export const thpHandshake = async (device: Device, unlockPin = false) => {
     const thpState = device.getThpState();
     if (!thpState?.handshakeCredentials) {
         throw ERRORS.TypedError('Device_ThpStateMissing');
@@ -84,6 +84,7 @@ export const thpHandshake = async (device: Device) => {
     const knownCredentials = (settings?.knownCredentials || []).sort(cre =>
         cre.autoconnect ? -1 : 1,
     );
+    const tryToUnlock = unlockPin ? 1 : 0;
 
     // 1. Generate a new ephemeral X25519 key pair (host_ephemeral_privkey, host_ephemeral_pubkey).
     const hostEphemeralKeys = protocolThp.getCurve25519KeyPair(randomBytes(32));
@@ -91,7 +92,7 @@ export const thpHandshake = async (device: Device) => {
     // 2. Send the message HandshakeInitiationReq(host_ephemeral_pubkey) to the host.
     const handshakeInit = await thpCall(device, 'ThpHandshakeInitRequest', {
         key: hostEphemeralKeys.publicKey,
-        tryToUnlock: 0,
+        tryToUnlock,
     });
 
     const { trezorEncryptedStaticPubkey } = handshakeInit.message;
@@ -103,6 +104,7 @@ export const thpHandshake = async (device: Device) => {
         hostStaticKeys,
         hostEphemeralKeys,
         knownCredentials,
+        tryToUnlock,
         protobufEncoder: (name, data) => encodeMessage(device.transport.getMessages(), name, data),
     });
 

--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -91,6 +91,7 @@ export const thpHandshake = async (device: Device) => {
     // 2. Send the message HandshakeInitiationReq(host_ephemeral_pubkey) to the host.
     const handshakeInit = await thpCall(device, 'ThpHandshakeInitRequest', {
         key: hostEphemeralKeys.publicKey,
+        tryToUnlock: 0,
     });
 
     const { trezorEncryptedStaticPubkey } = handshakeInit.message;

--- a/packages/connect/src/device/thp/index.ts
+++ b/packages/connect/src/device/thp/index.ts
@@ -12,7 +12,18 @@ export const getThpChannel = async (device: Device, withInteraction?: boolean) =
     try {
         if (thpState?.phase === 'handshake') {
             await createThpChannel(device);
-            await thpHandshake(device);
+            try {
+                await thpHandshake(device);
+            } catch (error) {
+                if (error.code === 'ThpDeviceLocked') {
+                    // Device is pin-locked, retry handshake with tryToUnlock param
+                    thpState.resetState();
+                    await createThpChannel(device);
+                    await thpHandshake(device, true);
+                } else {
+                    throw error;
+                }
+            }
         }
         if (thpState?.phase === 'pairing' && withInteraction) {
             // start pairing with UI interaction

--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -121,9 +121,7 @@ const processThpPairingResponse = (device: Device, payload: UiResponseThpPairing
 const waitForPairingCancel = (device: Device) => {
     const readAbort = new AbortController();
     device.getThpState()?.setExpectedResponses([0x04]); // expect Cancel
-    const readCancel = device.getCurrentSession().receive({
-        signal: readAbort.signal,
-    });
+    const readCancel = device.getCurrentSession().receive({ signal: readAbort.signal });
 
     return {
         readAbort,

--- a/packages/protocol/src/protocol-thp/crypto/pairing.ts
+++ b/packages/protocol/src/protocol-thp/crypto/pairing.ts
@@ -56,6 +56,7 @@ export const handleHandshakeInit = ({
     knownCredentials,
     hostStaticKeys,
     hostEphemeralKeys,
+    tryToUnlock,
     protobufEncoder,
 }: {
     handshakeInitResponse: ThpHandshakeInitResponse;
@@ -63,6 +64,7 @@ export const handleHandshakeInit = ({
     knownCredentials: ThpCredentialResponse[];
     hostEphemeralKeys: Curve25519KeyPair;
     hostStaticKeys: Curve25519KeyPair;
+    tryToUnlock: 0 | 1;
     protobufEncoder: (name: string, data: Record<string, unknown>) => { message: Buffer };
 }) => {
     if (!thpState.handshakeCredentials) {
@@ -82,8 +84,8 @@ export const handleHandshakeInit = ({
     h = handshakeHash;
     // 2. Set h = SHA-256(h || host_ephemeral_pubkey).
     h = hashOfTwo(h, hostEphemeralKeys.publicKey);
-    // 3. Set h = SHA-256(h).
-    h = hashOfTwo(h, Buffer.alloc(0));
+    // 3. Set h = SHA-256(h || try_to_unlock).
+    h = hashOfTwo(h, Buffer.from([tryToUnlock]));
     // 4. Set h = SHA-256(h || trezor_ephemeral_pubkey).
     h = hashOfTwo(h, trezorEphemeralPubkey);
     // 5. Set ck, k = HKDF(protocol_name, X25519(host_ephemeral_privkey, trezor_ephemeral_pubkey)).

--- a/packages/protocol/src/protocol-thp/encode.ts
+++ b/packages/protocol/src/protocol-thp/encode.ts
@@ -38,6 +38,9 @@ const getBytesFromField = (data: Record<string, unknown>, fieldName: string) => 
     if (typeof value === 'string') {
         return Buffer.from(value, 'hex');
     }
+    if (typeof value === 'number') {
+        return Buffer.from([value]);
+    }
     if (Buffer.isBuffer(value)) {
         return value;
     }
@@ -58,7 +61,9 @@ const handshakeInitRequestPayload = (data: Record<string, unknown>, _thpState: T
         throw new Error('ThpHandshakeInitRequest missing key field');
     }
 
-    return key;
+    const tryToUnlock = getBytesFromField(data, 'tryToUnlock') ?? Buffer.from([0]);
+
+    return Buffer.concat([key, tryToUnlock]);
 };
 
 const handshakeCompletionRequestPayload = (data: Record<string, unknown>) => {

--- a/packages/protocol/src/protocol-thp/messages/messageTypes.ts
+++ b/packages/protocol/src/protocol-thp/messages/messageTypes.ts
@@ -33,6 +33,7 @@ export type ThpCreateChannelResponse = {
 
 export type ThpHandshakeInitRequest = {
     key: Buffer;
+    tryToUnlock: 0 | 1;
 };
 
 export type ThpHandshakeInitResponse = {

--- a/packages/protocol/src/protocol-thp/utils.ts
+++ b/packages/protocol/src/protocol-thp/utils.ts
@@ -95,24 +95,18 @@ export const getExpectedResponses = (bytes: Buffer) => {
 // get expected responses from ThpState (stored as numbers)
 // and join them with the channel to receive 3 bytes header
 export const getExpectedHeaders = (state: ThpState): Buffer[] =>
-    [
-        ...state.expectedResponses,
-        THP_ERROR_HEADER_BYTE, // error could be sent any time
-    ].map(resp => {
-        let magic;
-        switch (resp) {
-            case THP_CONTINUATION_PACKET:
-                magic = Buffer.from([resp]); // THP_CONTINUATION_PACKET is not masked with sequence bit
-                break;
-            case THP_READ_ACK_HEADER_BYTE:
-                magic = addAckBit(resp, state.sendBit);
-                break;
-            default:
-                magic = addSequenceBit(resp, state.recvBit);
-        }
-
-        return Buffer.concat([magic, state.channel]);
-    });
+    [...state.expectedResponses, THP_ERROR_HEADER_BYTE] // error could be sent any time
+        .map(resp => {
+            switch (resp) {
+                case THP_CONTINUATION_PACKET:
+                    return Buffer.from([resp]); // THP_CONTINUATION_PACKET is not masked with sequence bit
+                case THP_READ_ACK_HEADER_BYTE:
+                    return addAckBit(resp, state.sendBit);
+                default:
+                    return addSequenceBit(resp, state.recvBit);
+            }
+        })
+        .map(magic => Buffer.concat([magic, state.channel]));
 
 export const isExpectedResponse = (bytes: Buffer, state: ThpState) => {
     if (bytes.length < 3) {

--- a/packages/transport/src/thp/send.ts
+++ b/packages/transport/src/thp/send.ts
@@ -46,7 +46,11 @@ export const sendThpMessage = async ({
 
     let attempt = 0;
 
-    const apiReadWithExpectedHeaders = readWithExpectedHeaders(apiRead, { signal, graceful });
+    const apiReadWithExpectedHeaders = readWithExpectedHeaders(apiRead, {
+        signal,
+        graceful,
+        logger,
+    });
 
     // create sequence of scheduled actions controlled by one AbortSignal (from Transport call/send)
     // 1. send message
@@ -72,6 +76,7 @@ export const sendThpMessage = async ({
                         ),
                     {
                         signal: attemptSignal,
+                        graceful,
                         deadline: Date.now() + THP_ACK_DEADLINE,
                     },
                 );

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -411,6 +411,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                         apiRead,
                         signal,
                         graceful: true,
+                        logger: this.logger,
                     });
 
                     if (!decoded.success) {

--- a/packages/transport/src/utils/readWithExpectedHeaders.ts
+++ b/packages/transport/src/utils/readWithExpectedHeaders.ts
@@ -36,13 +36,10 @@ async function readAndAssert<T extends Receiver>(
     }
 
     const bytes = chunk.payload;
-    const expected = expectedHeaders.find(header => {
-        if (bytes.length < header.length) {
-            return false;
-        }
-
-        return bytes.subarray(0, header.length).compare(header) === 0 ? true : false;
-    });
+    const expected = expectedHeaders.find(
+        header =>
+            header.length <= bytes.length && bytes.subarray(0, header.length).compare(header) === 0,
+    );
 
     if (expected) {
         logger?.debug('readAndAssert done');


### PR DESCRIPTION
## Description

**WARNING: DO NOT MERGE UNTIL WE HAVE FIRMWARE WITH https://github.com/trezor/trezor-firmware/pull/5922 PREPARED**

This PR changes `ThpHandshakeInitRequest` payload from 32 to 33 bytes in order to be compatible with the firmware change above. The last byte is then used to retry the handshake with pin matrix shown in case of locked device (`ThpDeviceLocked` error).

Note: As this is breaking change in THP protocol, it won't be possible NEITHER to use Suite with devices without the corresponding change NOR to use previous versions of Suite with already updated devices. Therefore, if you use Suite to update your fw, you have to do it in Suite before this PR and start to use Suite with this PR merged immediately after, as the device stops communicating after fw installation.

## Related Issue

Will adjust Suite to https://github.com/trezor/trezor-firmware/pull/5922


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/thp-handshake-pin&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/thp-handshake-pin&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/thp-handshake-pin&lookback=7)