### PR TITLE
Do not allow to click on a loading button

### DIFF
--- a/suite-native/atoms/src/Button/Button.tsx
+++ b/suite-native/atoms/src/Button/Button.tsx
@@ -350,7 +350,7 @@ export const Button = ({
 
     return (
         <AnimatedPressable
-            disabled={isDisabled}
+            disabled={isDisabled || isLoading}
             onPressIn={handlePressIn}
             onPressOut={handlePressOut}
             {...pressableProps}

--- a/suite-native/atoms/src/Button/IconButton.tsx
+++ b/suite-native/atoms/src/Button/IconButton.tsx
@@ -78,7 +78,7 @@ export const IconButton = ({
         <AnimatedPressable
             onPressIn={handlePressIn}
             onPressOut={handlePressOut}
-            disabled={isDisabled}
+            disabled={isDisabled || isLoading}
             {...pressableProps}
             style={[
                 animatedPressStyle,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- I just went trhroug all the cases and I believe that no button in our app should proceed the onPress action while loading, it should always be disabled.

Places where `isDisabled` was missing for `isLoading==true`
- Send transaction button at the end of Send form
- Edit device name in Device settings
- Add account on My accounts
- ReviewOutputsFooter in trading module
- MaxSlippageForm in trading module


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/loading-button-disabled&lookback=7)