### PR TITLE
fix(suite-native): use device connection guard for wipe device

### DIFF
--- a/suite-native/module-device-settings/src/navigation/WipeDeviceStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/WipeDeviceStackNavigator.tsx
@@ -1,14 +1,12 @@
-import { useSelector } from 'react-redux';
-
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-import { selectIsDeviceConnected } from '@suite-common/wallet-core';
 import {
     WipeDeviceStackParamList,
     WipeDeviceStackRoutes,
     stackNavigationOptionsConfig,
 } from '@suite-native/navigation';
 
+import { useDeviceConnectionGuard } from '../hooks/useDeviceConnectionGuard';
 import { FactoryResetScreen } from '../screens/FactoryResetScreen';
 import { WipeDeviceContinueOnTrezorScreen } from '../screens/WipeDeviceContinueOnTrezorScreen';
 import { WipeDeviceLoadingScreen } from '../screens/WipeDeviceLoadingScreen';
@@ -17,7 +15,7 @@ import { WipeDeviceScreen } from '../screens/WipeDeviceScreen';
 const WipeDeviceStack = createNativeStackNavigator<WipeDeviceStackParamList>();
 
 export const WipeDeviceStackNavigator = () => {
-    const isDeviceConnected = useSelector(selectIsDeviceConnected);
+    const { isDeviceConnected } = useDeviceConnectionGuard();
 
     if (!isDeviceConnected) return;
 


### PR DESCRIPTION


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/wipe-device-connection-guard&lookback=7)