### PR TITLE
chore(suite-native): autoconnect settings

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -837,20 +837,27 @@ export const messages = {
             successMessage: 'Trezor has been unpaired.',
         },
         autoconnect: {
-            enable: {
-                title: 'Turn on Auto-connect',
-                subtitle: 'Allow Trezor to connect automatically',
-                description:
-                    'Trezor will connect automatically to Trezor Suite. No need to confirm each time.',
-                turnOnButton: 'Turn on Auto-connect',
-                error: 'Turning on auto-connect failed.',
+            settingsCard: {
+                title: 'Auto connect',
+                description: 'Toggle auto connect settings',
             },
-            disable: {
-                title: 'Turn off Auto-connect',
-                subtitle: 'Confirm every connection on Trezor',
+            screen: {
+                subtitle:
+                    'With auto connect, Trezor will connect automatically without having to confirm every connection.',
+            },
+            enable: {
+                pictogramTitle: 'Auto connect enabled',
                 description:
                     'Trezor will no longer connect automatically to Trezor Suite. You’ll confirm each connection on your device.',
-                turnOnButton: 'Turn off Auto-connect',
+                turnOffButton: 'Turn off',
+                error: 'Turning on auto-connect failed.',
+                successToast: 'Auto-connect turned on',
+            },
+            disable: {
+                pictogramTitle: 'Auto connect disabled',
+                description:
+                    'Trezor will connect automatically to Trezor Suite. No need to confirm each time.',
+                turnOnButton: 'Turn on',
             },
         },
     },

--- a/suite-native/module-device-settings/src/components/DeviceAutoConnectCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceAutoConnectCard.tsx
@@ -1,22 +1,12 @@
-import { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-
 import { useNavigation } from '@react-navigation/native';
-import { isRejected } from '@reduxjs/toolkit';
 
-import { removeThpAutoconnectThunk } from '@suite-common/thp';
-import { selectDeviceAutoconnectCredentials } from '@suite-common/wallet-core';
-import { useAlert } from '@suite-native/alerts';
 import { CompactCardWithIconLayout } from '@suite-native/atoms';
-import { Translation, useTranslate } from '@suite-native/intl';
+import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
     DeviceSettingsStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
-import { useThpAutoconnectActions } from '@suite-native/thp';
-import { useToast } from '@suite-native/toasts';
-import TrezorConnect from '@trezor/connect';
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,
@@ -24,92 +14,19 @@ type NavigationProp = StackNavigationProps<
 >;
 
 export const DeviceAutoConnectCard = () => {
-    const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProp>();
 
-    const { translate } = useTranslate();
-    const { showAlert } = useAlert();
-    const { showToast } = useToast();
-    const { startThpAutoconnect } = useThpAutoconnectActions();
-
-    const autoconnectCredentials = useSelector(selectDeviceAutoconnectCredentials);
-
-    const title =
-        autoconnectCredentials.length > 0
-            ? translate('moduleDeviceSettings.autoconnect.disable.title')
-            : translate('moduleDeviceSettings.autoconnect.enable.title');
-    const subtitle =
-        autoconnectCredentials.length > 0
-            ? translate('moduleDeviceSettings.autoconnect.disable.subtitle')
-            : translate('moduleDeviceSettings.autoconnect.enable.subtitle');
-
-    const onAutoconnectTurnOff = useCallback(async () => {
-        const result = await dispatch(
-            removeThpAutoconnectThunk({
-                credentials: autoconnectCredentials,
-            }),
-        ).unwrap();
-
-        if (isRejected(result)) {
-            showToast({
-                variant: 'error',
-                message: result.error.message,
-            });
-        }
-    }, [dispatch, showToast, autoconnectCredentials]);
-
-    const handleTurnOffAutoconnect = useCallback(() => {
-        showAlert({
-            title: <Translation id="moduleDeviceSettings.autoconnect.disable.title" />,
-            description: <Translation id="moduleDeviceSettings.autoconnect.disable.description" />,
-            primaryButtonTitle: (
-                <Translation id="moduleDeviceSettings.autoconnect.disable.turnOnButton" />
-            ),
-            onPressPrimaryButton: onAutoconnectTurnOff,
-            secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
-        });
-    }, [showAlert, onAutoconnectTurnOff]);
-
-    const onAutoconnectTurnOn = useCallback(async () => {
-        navigation.navigate(DeviceSettingsStackRoutes.ContinueOnTrezor);
-
-        const result = await startThpAutoconnect();
-
-        if (result && isRejected(result)) {
-            TrezorConnect.cancel();
-            showToast({
-                variant: 'error',
-                message: <Translation id="moduleDeviceSettings.autoconnect.enable.error" />,
-            });
-        }
-        navigation.goBack();
-    }, [navigation, startThpAutoconnect, showToast]);
-
-    const handleTurnOnAutoconnect = useCallback(() => {
-        showAlert({
-            title: <Translation id="moduleDeviceSettings.autoconnect.enable.title" />,
-            description: <Translation id="moduleDeviceSettings.autoconnect.enable.description" />,
-            primaryButtonTitle: (
-                <Translation id="moduleDeviceSettings.autoconnect.enable.turnOnButton" />
-            ),
-            onPressPrimaryButton: onAutoconnectTurnOn,
-            secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
-        });
-    }, [showAlert, onAutoconnectTurnOn]);
-
-    const onPress = useCallback(() => {
-        if (autoconnectCredentials.length > 0) {
-            handleTurnOffAutoconnect();
-        } else {
-            handleTurnOnAutoconnect();
-        }
-    }, [autoconnectCredentials.length, handleTurnOnAutoconnect, handleTurnOffAutoconnect]);
+    const onPress = () => {
+        navigation.navigate(DeviceSettingsStackRoutes.AutoConnectSettings);
+    };
 
     return (
         <CompactCardWithIconLayout
             icon="trezorSafe5"
-            title={title}
-            subtitle={subtitle}
+            title={<Translation id="moduleDeviceSettings.autoconnect.settingsCard.title" />}
+            subtitle={
+                <Translation id="moduleDeviceSettings.autoconnect.settingsCard.description" />
+            }
             onPress={onPress}
         />
     );

--- a/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
@@ -14,6 +14,7 @@ import { DeviceNameStackNavigator } from './DeviceNameStackNavigator';
 import { DevicePinProtectionStackNavigator } from './DevicePinProtectionStackNavigator';
 import { FirmwareUpdateStackNavigator } from './FirmwareUpdateStackNavigator';
 import { WipeDeviceStackNavigator } from './WipeDeviceStackNavigator';
+import { AutoConnectSettingsScreen } from '../screens/AutoConnectSettingsScreen';
 import { ContinueOnTrezorScreen } from '../screens/ContinueOnTrezorScreen';
 import { DeviceAuthenticityScreen } from '../screens/DeviceAuthenticityScreen';
 import { DeviceSettingsModalScreen } from '../screens/DeviceSettingsModalScreen';
@@ -65,6 +66,10 @@ export const DeviceSettingsStackNavigator = () => (
         <DeviceSettingsStack.Screen
             name={DeviceSettingsStackRoutes.DeviceCheckBackupStack}
             component={DeviceCheckBackupStackNavigator}
+        />
+        <DeviceSettingsStack.Screen
+            name={DeviceSettingsStackRoutes.AutoConnectSettings}
+            component={AutoConnectSettingsScreen}
         />
     </DeviceSettingsStack.Navigator>
 );

--- a/suite-native/module-device-settings/src/screens/AutoConnectSettingsScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/AutoConnectSettingsScreen.tsx
@@ -1,0 +1,128 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+import { isRejected } from '@reduxjs/toolkit';
+
+import { removeThpAutoconnectThunk } from '@suite-common/thp';
+import { selectDeviceAutoconnectCredentials } from '@suite-common/wallet-core';
+import { Button, Card, PictogramTitleHeader, VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import {
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes,
+    DynamicScreenHeader,
+    Screen,
+    StackNavigationProps,
+} from '@suite-native/navigation';
+import { useThpAutoconnectActions } from '@suite-native/thp';
+import { useToast } from '@suite-native/toasts';
+import TrezorConnect from '@trezor/connect';
+
+import { useDeviceConnectionGuard } from '../hooks/useDeviceConnectionGuard';
+
+type NavigationProp = StackNavigationProps<
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes.DeviceSettings
+>;
+
+export const AutoConnectSettingsScreen = () => {
+    const { isDeviceConnected } = useDeviceConnectionGuard();
+
+    const dispatch = useDispatch();
+    const navigation = useNavigation<NavigationProp>();
+
+    const { showToast } = useToast();
+    const { startThpAutoconnect } = useThpAutoconnectActions();
+
+    const autoconnectCredentials = useSelector(selectDeviceAutoconnectCredentials);
+
+    const isAutoconnectEnabled = autoconnectCredentials.length > 0;
+
+    const onAutoconnectTurnOff = useCallback(async () => {
+        const result = await dispatch(
+            removeThpAutoconnectThunk({
+                credentials: autoconnectCredentials,
+            }),
+        ).unwrap();
+
+        if (isRejected(result)) {
+            showToast({
+                variant: 'error',
+                message: result.error.message,
+            });
+        }
+    }, [dispatch, showToast, autoconnectCredentials]);
+
+    const onAutoconnectTurnOn = useCallback(async () => {
+        navigation.navigate(DeviceSettingsStackRoutes.ContinueOnTrezor);
+
+        const result = await startThpAutoconnect();
+
+        if (result && isRejected(result)) {
+            TrezorConnect.cancel();
+            showToast({
+                variant: 'error',
+                message: <Translation id="moduleDeviceSettings.autoconnect.enable.error" />,
+            });
+        } else {
+            showToast({
+                variant: 'success',
+                message: <Translation id="moduleDeviceSettings.autoconnect.enable.successToast" />,
+            });
+        }
+        navigation.goBack();
+    }, [navigation, startThpAutoconnect, showToast]);
+
+    const onPress = () => {
+        if (isAutoconnectEnabled) {
+            onAutoconnectTurnOff();
+        } else {
+            onAutoconnectTurnOn();
+        }
+    };
+
+    if (!isDeviceConnected) return null;
+
+    return (
+        <Screen
+            header={
+                <DynamicScreenHeader
+                    title={<Translation id="moduleDeviceSettings.autoconnect.settingsCard.title" />}
+                    subtitle={<Translation id="moduleDeviceSettings.autoconnect.screen.subtitle" />}
+                    closeActionType="close"
+                />
+            }
+        >
+            <Card>
+                <VStack spacing="sp32">
+                    <PictogramTitleHeader
+                        variant={isAutoconnectEnabled ? 'success' : 'info'}
+                        icon={isAutoconnectEnabled ? 'check' : 'x'}
+                        title={
+                            isAutoconnectEnabled ? (
+                                <Translation id="moduleDeviceSettings.autoconnect.enable.pictogramTitle" />
+                            ) : (
+                                <Translation id="moduleDeviceSettings.autoconnect.disable.pictogramTitle" />
+                            )
+                        }
+                        subtitle={
+                            isAutoconnectEnabled ? (
+                                <Translation id="moduleDeviceSettings.autoconnect.disable.description" />
+                            ) : (
+                                <Translation id="moduleDeviceSettings.autoconnect.enable.description" />
+                            )
+                        }
+                    />
+                    <Button onPress={onPress} colorScheme="primary" size="medium">
+                        {isAutoconnectEnabled ? (
+                            <Translation id="moduleDeviceSettings.autoconnect.enable.turnOffButton" />
+                        ) : (
+                            <Translation id="moduleDeviceSettings.autoconnect.disable.turnOnButton" />
+                        )}
+                    </Button>
+                </VStack>
+            </Card>
+        </Screen>
+    );
+};

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -218,6 +218,7 @@ export type DeviceSettingsStackParamList = {
     [DeviceSettingsStackRoutes.DeviceNameStack]: NavigatorScreenParams<DeviceNameStackParamList>;
     [DeviceSettingsStackRoutes.WipeDeviceStack]: NavigatorScreenParams<WipeDeviceStackParamList>;
     [DeviceSettingsStackRoutes.PinProtection]: undefined;
+    [DeviceSettingsStackRoutes.AutoConnectSettings]: undefined;
     [DeviceSettingsStackRoutes.DeviceCheckBackupStack]: NavigatorScreenParams<DeviceCheckBackupStackParamList>;
 };
 

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -82,6 +82,7 @@ export enum DeviceSettingsStackRoutes {
     WipeDeviceStack = 'WipeDeviceStack',
     DeviceNameStack = 'DeviceNameStack',
     DeviceCheckBackupStack = 'DeviceCheckBackupStack',
+    AutoConnectSettings = 'AutoConnectSettings',
 }
 
 export enum DevicePinProtectionStackRoutes {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- create autoconnect settings screen to keep UI and UX consistent and protect it by `useDeviceConnectionGuard`

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="1179" height="2556" alt="IMG_2990" src="https://github.com/user-attachments/assets/fb18bbae-7d84-4dfd-a180-71795ae34a29" />
<img width="1179" height="2556" alt="IMG_2991" src="https://github.com/user-attachments/assets/ccd18449-50d4-4077-8f66-67098a2da194" />
<img width="1179" height="2556" alt="IMG_2992" src="https://github.com/user-attachments/assets/fae69350-fb9c-49aa-93b5-1398732a1aeb" />

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-settings-remembered&lookback=7)