### PR TITLE
fix(suite-native): getIsDeviceConnectedViaBluetooth

### DIFF
--- a/suite-common/suite-utils/src/__fixtures__/device.ts
+++ b/suite-common/suite-utils/src/__fixtures__/device.ts
@@ -63,12 +63,33 @@ const getStatus: Array<{ device: TrezorDevice; status: string }> = [
 const getIsDeviceConnectedViaBluetooth = [
     {
         description: 'device is connected via bluetooth',
-        device: getSuiteDevice({ bluetoothProps: { id: asBluetoothDeviceId('21') } }),
+        device: getSuiteDevice({
+            bluetoothProps: { id: asBluetoothDeviceId('21') },
+            connected: true,
+        }),
         result: true,
+    },
+    {
+        description: 'device is not connected but bluetooth props are present',
+        device: getSuiteDevice({
+            bluetoothProps: { id: asBluetoothDeviceId('21') },
+            connected: false,
+        }),
+        result: false,
     },
     {
         description: 'device is not connected via bluetooth',
         device: SUITE_DEVICE,
+        result: false,
+    },
+    {
+        description: "device is connected but doesn't have bluetooth props",
+        device: getSuiteDevice({ connected: true }),
+        result: false,
+    },
+    {
+        description: 'device is undefined',
+        device: undefined,
         result: false,
     },
 ];

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -166,7 +166,7 @@ export const shouldDisplayInitialWarningIcon = (deviceStatus: ConnectedDeviceSta
 export const isDeviceRemembered = (device?: TrezorDevice): boolean => !!device?.remember;
 
 export const getIsDeviceConnectedViaBluetooth = (device?: TrezorDevice): boolean =>
-    !!device?.bluetoothProps;
+    !!device?.connected && !!device?.bluetoothProps;
 
 export const isDeviceAcquired = (device?: TrezorDevice): device is AcquiredDevice =>
     !!device?.features;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- fix `getIsDeviceConnectedViaBluetooth` so it takes `device.connected` into account.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/getIsDeviceConnectedViaBluetooth&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/getIsDeviceConnectedViaBluetooth&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/getIsDeviceConnectedViaBluetooth&lookback=7)