### PR TITLE
Use minimum Lamports for sol transfer fee estimation 

### DIFF
--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -73,6 +73,7 @@
     "dependencies": {
         "@solana-program/compute-budget": "^0.8.0",
         "@solana-program/stake": "^0.2.1",
+        "@solana-program/system": "^0.7.0",
         "@solana-program/token": "^0.5.1",
         "@solana-program/token-2022": "^0.4.2",
         "@solana/kit": "^2.3.0",

--- a/packages/blockchain-link/src/workers/solana/utils/fee.ts
+++ b/packages/blockchain-link/src/workers/solana/utils/fee.ts
@@ -10,6 +10,8 @@ import {
     SimulateTransactionApi,
     TransactionMessageBytes,
     TransactionMessageBytesBase64,
+    address,
+    createNoopSigner,
     getBase64Decoder,
     getCompiledTransactionMessageEncoder,
     getTransactionEncoder,
@@ -21,6 +23,12 @@ import {
     SET_COMPUTE_UNIT_LIMIT_DISCRIMINATOR,
     getSetComputeUnitLimitInstructionDataEncoder,
 } from '@solana-program/compute-budget';
+import {
+    SYSTEM_PROGRAM_ADDRESS,
+    TRANSFER_SOL_DISCRIMINATOR,
+    getTransferSolInstruction,
+    getTransferSolInstructionDataDecoder,
+} from '@solana-program/system';
 
 import { COMPUTE_BUDGET_PROGRAM_ID } from '@trezor/blockchain-link-utils/src/solana';
 import { safeBigIntStringify } from '@trezor/utils';
@@ -55,6 +63,51 @@ const bumpUnitLimitComputeBudgetInstructions = (
             });
 
             return { ...ix, data };
+        }
+
+        return ix;
+    }),
+});
+
+// If we use send max amount it might fail simulation
+// because of max budget limit from bumpUnitLimitComputeBudgetInstructions
+const useMinimalLamportForTransferSolInstruction = (
+    message: CompiledTransactionMessage,
+): CompiledTransactionMessage => ({
+    ...message,
+    instructions: message.instructions.map(ix => {
+        if (message.staticAccounts[ix.programAddressIndex] === SYSTEM_PROGRAM_ADDRESS) {
+            if (!ix.data) {
+                return ix;
+            }
+            const decoder = getTransferSolInstructionDataDecoder();
+            const decoded = decoder.decode(ix.data);
+
+            const { accountIndices } = ix;
+
+            if (
+                decoded.discriminator !== TRANSFER_SOL_DISCRIMINATOR || // it is not a transfer sol instruction
+                decoded.amount === BigInt(0) || // don't modify zero amount instruction for sure
+                !accountIndices ||
+                accountIndices.length !== 2
+            ) {
+                return ix;
+            }
+
+            const fromAddress = message.staticAccounts[accountIndices[0]]?.toString();
+            const toAddress = message.staticAccounts[accountIndices[1]]?.toString();
+
+            if (!fromAddress || !toAddress) {
+                return ix;
+            }
+
+            const newInstruction = getTransferSolInstruction({
+                amount: 89088n, // 89088 is minimal amount to cover empty SOL account rent.
+                destination: address(toAddress),
+                source: createNoopSigner(address(fromAddress)),
+            });
+
+            return { ...ix, data: newInstruction.data };
         }
 
         return ix;
@@ -98,6 +151,7 @@ export const getPriorityFee = async (
     // Reconstruct TX for simulation
     const messageBytes = pipe(
         bumpUnitLimitComputeBudgetInstructions(compiledMessage),
+        useMinimalLamportForTransferSolInstruction,
         getCompiledTransactionMessageEncoder().encode,
     ) as TransactionMessageBytes;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13048,6 +13048,7 @@ __metadata:
   dependencies:
     "@solana-program/compute-budget": "npm:^0.8.0"
     "@solana-program/stake": "npm:^0.2.1"
+    "@solana-program/system": "npm:^0.7.0"
     "@solana-program/token": "npm:^0.5.1"
     "@solana-program/token-2022": "npm:^0.4.2"
     "@solana/kit": "npm:^2.3.0"


### PR DESCRIPTION
When simulating fee for txn with max amount, simulation ended with error due to using max CU limit for simulation. This PR replaces whatever amount is used with minimum lamports for SOL transfers to make it succeed.

Previous state caused max send txns failed to send on mobile.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-fee-simulation-for-max-amount&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-fee-simulation-for-max-amount&lookback=7)