### PR TITLE
feat(suite-native): show correct screen content when connected device is required

### DIFF
--- a/suite-native/device-authorization/src/hooks/useDeviceConnectionGuard.ts
+++ b/suite-native/device-authorization/src/hooks/useDeviceConnectionGuard.ts
@@ -26,7 +26,7 @@ export const useDeviceConnectionGuard = () => {
 
     const redirectToConnectAndUnlockScreen = useCallback(() => {
         navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
-            screen: AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
+            screen: AuthorizeDeviceStackRoutes.DeviceConnectionGuard,
             params: {
                 onCancelNavigationTarget: {
                     name: RootStackRoutes.DeviceSettingsStack,

--- a/suite-native/module-authorize-device/src/navigation/AuthorizeDeviceStackNavigator.tsx
+++ b/suite-native/module-authorize-device/src/navigation/AuthorizeDeviceStackNavigator.tsx
@@ -15,6 +15,7 @@ import { PassphraseStackNavigator } from './PassphraseStackNavigator';
 import { ConnectAndUnlockDeviceScreen } from '../screens/connect/ConnectAndUnlockDeviceScreen';
 import { ConnectBluetoothDeviceScreen } from '../screens/connect/ConnectBluetoothDeviceScreen';
 import { ConnectingDeviceScreen } from '../screens/connect/ConnectingDeviceScreen';
+import { DeviceConnectionGuardScreen } from '../screens/connect/DeviceConnectionGuardScreen';
 import { PinScreen } from '../screens/connect/PinScreen';
 import { RemoveBluetoothDeviceScreen } from '../screens/connect/RemoveBluetoothDeviceScreen';
 import { TurnOnAndUnlockDeviceScreen } from '../screens/connect/TurnOnAndUnlockDeviceScreen';
@@ -50,6 +51,10 @@ export const AuthorizeDeviceStackNavigator = () => {
                         <AuthorizeDeviceStack.Screen
                             name={AuthorizeDeviceStackRoutes.ConnectingDevice}
                             component={ConnectingDeviceScreen}
+                        />
+                        <AuthorizeDeviceStack.Screen
+                            name={AuthorizeDeviceStackRoutes.DeviceConnectionGuard}
+                            component={DeviceConnectionGuardScreen}
                         />
                         <AuthorizeDeviceStack.Screen
                             name={AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice}

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectAndUnlockDeviceScreen.tsx
@@ -21,7 +21,6 @@ import {
 import { ConnectDeviceScreenHeader } from '../../components/connect/ConnectDeviceScreenHeader';
 
 export const ConnectAndUnlockDeviceScreen = ({
-    route: { params },
     navigation,
 }: StackToStackCompositeScreenProps<
     AuthorizeDeviceStackParamList,
@@ -65,11 +64,7 @@ export const ConnectAndUnlockDeviceScreen = ({
 
     return (
         <Screen
-            header={
-                <ConnectDeviceScreenHeader
-                    onCancelNavigationTarget={params?.onCancelNavigationTarget}
-                />
-            }
+            header={<ConnectDeviceScreenHeader />}
             noHorizontalPadding
             noBottomPadding
             hasBottomInset={false}

--- a/suite-native/module-authorize-device/src/screens/connect/DeviceConnectionGuardScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/DeviceConnectionGuardScreen.tsx
@@ -1,0 +1,75 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useFocusEffect } from '@react-navigation/native';
+
+import {
+    selectIsBluetoothSupportedByDevice,
+    selectIsDeviceAuthorized,
+    selectIsDeviceConnected,
+} from '@suite-common/wallet-core';
+import { selectBluetoothPermissionStatus } from '@suite-native/bluetooth';
+import {
+    ConnectAndUnlockDeviceScreenContent,
+    TurnOnAndUnlockDeviceScreenContent,
+} from '@suite-native/device';
+import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
+import {
+    AuthorizeDeviceStackParamList,
+    AuthorizeDeviceStackRoutes,
+    RootStackParamList,
+    Screen,
+    StackToStackCompositeScreenProps,
+} from '@suite-native/navigation';
+
+import { ConnectDeviceScreenHeader } from '../../components/connect/ConnectDeviceScreenHeader';
+
+export const DeviceConnectionGuardScreen = ({
+    navigation,
+    route: { params },
+}: StackToStackCompositeScreenProps<
+    AuthorizeDeviceStackParamList,
+    AuthorizeDeviceStackRoutes.DeviceConnectionGuard,
+    RootStackParamList
+>) => {
+    const isDeviceConnected = useSelector(selectIsDeviceConnected);
+    const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
+
+    const isBluetoothEnabled = useFeatureFlag(FeatureFlag.IsBluetoothEnabled);
+    const bluetoothPermissionStatus = useSelector(selectBluetoothPermissionStatus);
+    const isBluetoothSupportedByDevice = useSelector(selectIsBluetoothSupportedByDevice);
+
+    const isBluetoothVariantVisible =
+        isBluetoothEnabled &&
+        bluetoothPermissionStatus === 'granted' &&
+        isBluetoothSupportedByDevice;
+
+    useFocusEffect(
+        useCallback(() => {
+            if (isDeviceConnected && isDeviceAuthorized) {
+                navigation.goBack();
+            }
+        }, [isDeviceConnected, isDeviceAuthorized, navigation]),
+    );
+
+    return (
+        <Screen
+            header={
+                <ConnectDeviceScreenHeader
+                    onCancelNavigationTarget={params?.onCancelNavigationTarget}
+                    helpButton={null}
+                />
+            }
+            noHorizontalPadding
+            noBottomPadding
+            hasBottomInset={false}
+            isScrollable={false}
+        >
+            {isBluetoothVariantVisible ? (
+                <TurnOnAndUnlockDeviceScreenContent />
+            ) : (
+                <ConnectAndUnlockDeviceScreenContent />
+            )}
+        </Screen>
+    );
+};

--- a/suite-native/module-send/src/components/SendFeesForm.tsx
+++ b/suite-native/module-send/src/components/SendFeesForm.tsx
@@ -113,7 +113,7 @@ export const SendFeesForm = ({ accountKey, tokenContract }: SendFormProps) => {
 
         // In case that view only device is not connected, show connect screen first.
         navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
-            screen: AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
+            screen: AuthorizeDeviceStackRoutes.DeviceConnectionGuard,
             params: {
                 // If user cancels, navigate back to the send fees screen.
                 onCancelNavigationTarget: {

--- a/suite-native/module-send/src/hooks/useShowDeviceDisconnectedAlert.tsx
+++ b/suite-native/module-send/src/hooks/useShowDeviceDisconnectedAlert.tsx
@@ -25,7 +25,7 @@ export const useShowDeviceDisconnectedAlert = () => {
 
     const handleReconnect = () => {
         navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
-            screen: AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
+            screen: AuthorizeDeviceStackRoutes.DeviceConnectionGuard,
             params: {
                 // If user cancels the re-connecting process, redirect him to the Home screen.
                 onCancelNavigationTarget: {

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -265,9 +265,10 @@ export type DeviceAuthenticityStackParamList = {
 };
 
 export type AuthorizeDeviceStackParamList = {
-    [AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice]:
+    [AuthorizeDeviceStackRoutes.DeviceConnectionGuard]:
         | { onCancelNavigationTarget: NavigateParameters<RootStackParamList> }
         | undefined;
+    [AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice]: undefined;
     [AuthorizeDeviceStackRoutes.TurnOnAndUnlockDevice]: undefined;
     [AuthorizeDeviceStackRoutes.ConnectBluetoothDevice]: undefined;
     [AuthorizeDeviceStackRoutes.RemoveBluetoothDevice]: undefined;

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -126,6 +126,7 @@ export enum DeviceNameStackRoutes {
 }
 
 export enum AuthorizeDeviceStackRoutes {
+    DeviceConnectionGuard = 'DeviceConnectionGuard',
     ConnectAndUnlockDevice = 'ConnectAndUnlockDevice',
     TurnOnAndUnlockDevice = 'TurnOnAndUnlockDevice',
     ConnectBluetoothDevice = 'ConnectBluetoothDevice',


### PR DESCRIPTION
If a connected and unlocked device is required for any action in Device settings, we have to show correct screen content based on the device. I.e. show the _Turn on & unlock_ screen content for BT devices and _Connect & unlock_ for ordinary devices.

Resolve https://github.com/trezor/trezor-suite/issues/20871

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/device-required-screen&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/device-required-screen&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/device-required-screen&lookback=7)