### PR TITLE
chore(suite-native): unpair trezor screen

### DIFF
--- a/suite-common/suite-utils/src/__fixtures__/device.ts
+++ b/suite-common/suite-utils/src/__fixtures__/device.ts
@@ -1,6 +1,5 @@
 import type { TrezorDevice } from '@suite-common/suite-types';
 import { testMocks } from '@suite-common/test-utils';
-import { asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import * as URLS from '@trezor/urls';
 
@@ -64,27 +63,22 @@ const getIsDeviceConnectedViaBluetooth = [
     {
         description: 'device is connected via bluetooth',
         device: getSuiteDevice({
-            bluetoothProps: { id: asBluetoothDeviceId('21') },
+            descriptor: { apiType: 'bluetooth' },
             connected: true,
-        }),
+        }) as TrezorDevice,
         result: true,
     },
     {
-        description: 'device is not connected but bluetooth props are present',
+        description: 'device is not connected and api type is bluetooth',
         device: getSuiteDevice({
-            bluetoothProps: { id: asBluetoothDeviceId('21') },
+            descriptor: { apiType: 'bluetooth' },
             connected: false,
-        }),
+        }) as TrezorDevice,
         result: false,
     },
     {
-        description: 'device is not connected via bluetooth',
-        device: SUITE_DEVICE,
-        result: false,
-    },
-    {
-        description: "device is connected but doesn't have bluetooth props",
-        device: getSuiteDevice({ connected: true }),
+        description: 'device is connected via usb',
+        device: { ...SUITE_DEVICE, descriptor: { apiType: 'usb' } } as TrezorDevice,
         result: false,
     },
     {

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -165,9 +165,6 @@ export const shouldDisplayInitialWarningIcon = (deviceStatus: ConnectedDeviceSta
 
 export const isDeviceRemembered = (device?: TrezorDevice): boolean => !!device?.remember;
 
-export const getIsDeviceConnectedViaBluetooth = (device?: TrezorDevice): boolean =>
-    !!device?.connected && !!device?.bluetoothProps;
-
 export const isDeviceAcquired = (device?: TrezorDevice): device is AcquiredDevice =>
     !!device?.features;
 
@@ -513,5 +510,8 @@ export const getIsDeviceConnectedAndAuthorized = ({
     deviceFeatures?: PROTO.Features;
 }) => !!deviceState && !!deviceFeatures;
 
-export const getIsDeviceDescriptorApiTypeBluetooth = (device: Device) =>
+export const getIsDeviceDescriptorApiTypeBluetooth = (device: Device | TrezorDevice) =>
     device.descriptor.apiType === 'bluetooth';
+
+export const getIsDeviceConnectedViaBluetooth = (device?: TrezorDevice): boolean =>
+    !!device?.connected && getIsDeviceDescriptorApiTypeBluetooth(device);

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -493,7 +493,7 @@ export const getDeviceInternalModel = (
     (device?.thp?.properties?.internal_model as DeviceModelInternal) ??
     DeviceModelInternal.UNKNOWN;
 
-export const isThpDevice = <T extends Device | TrezorDevice>(
+export const getIsThpDevice = <T extends Device | TrezorDevice>(
     device: T,
 ): device is T & { thp: ThpStateSerialized } => device.thp !== undefined;
 

--- a/suite-common/thp/src/autoInitThpAfterDeviceConnectionThunk.ts
+++ b/suite-common/thp/src/autoInitThpAfterDeviceConnectionThunk.ts
@@ -1,6 +1,6 @@
 import { selectIsFirmwareInstallationRunning } from '@suite-common/firmware/src/firmwareReducer';
 import { createThunk } from '@suite-common/redux-utils';
-import { isThpDevice } from '@suite-common/suite-utils';
+import { getIsThpDevice } from '@suite-common/suite-utils';
 import { acquireDevice, selectDevices } from '@suite-common/wallet-core';
 import { Device } from '@trezor/connect';
 
@@ -15,7 +15,7 @@ export const autoInitThpAfterDeviceConnectionThunk = createThunk<
     AutoInitThpAfterDeviceConnectionThunkParams,
     void
 >(`${THP_PREFIX}/autoInitThpAfterDeviceConnectionThunk`, ({ device }, { dispatch, getState }) => {
-    if (!isThpDevice(device)) return;
+    if (!getIsThpDevice(device)) return;
 
     // This needs to be re-selected to convert Device to TrezorDevice.
     // This TrezorDevice will be there ready after the reducer fills data in.

--- a/suite-common/thp/src/removeThpAutoconnectThunk.ts
+++ b/suite-common/thp/src/removeThpAutoconnectThunk.ts
@@ -1,5 +1,5 @@
 import { createThunk } from '@suite-common/redux-utils/';
-import { isThpDevice } from '@suite-common/suite-utils';
+import { getIsThpDevice } from '@suite-common/suite-utils';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 
@@ -27,7 +27,7 @@ export const removeThpAutoconnectThunk = createThunk<
     ): Promise<RemoveThpAutoconnectThunkResult> => {
         const device = selectSelectedDevice(getState());
 
-        if (device === undefined || !isThpDevice(device)) {
+        if (device === undefined || !getIsThpDevice(device)) {
             return fulfillWithValue(undefined);
         }
 

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -10,6 +10,7 @@ import {
     getIsDeviceConnectedAndAuthorized,
     getIsDeviceConnectedViaBluetooth,
     getIsDeviceInitialized,
+    getIsThpDevice,
     getStatus,
 } from '@suite-common/suite-utils';
 import { networkSymbolCollection } from '@suite-common/wallet-config';
@@ -176,6 +177,11 @@ export const selectIsDeviceConnected = createMemoizedSelector(
 export const selectIsDeviceConnectedViaBluetooth = createMemoizedSelector(
     [selectSelectedDevice],
     device => getIsDeviceConnectedViaBluetooth(device),
+);
+
+export const selectIsThpDevice = createMemoizedSelector(
+    [selectSelectedDevice],
+    device => device && getIsThpDevice(device),
 );
 
 export const selectIsDeviceConnectedViaBluetoothLowOnBattery = createMemoizedSelector(

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -4,8 +4,8 @@ import { AcquiredDevice, TrezorDevice } from '@suite-common/suite-types';
 import {
     getDeviceInstances,
     getFirstDeviceInstance,
+    getIsThpDevice,
     getSelectedDevice,
-    isThpDevice,
     sortByTimestamp,
 } from '@suite-common/suite-utils';
 import {
@@ -372,7 +372,7 @@ export const deviceConnectThunks = createThunk<void, DeviceConnectThunksParams, 
     async ({ type, device }, { dispatch }) => {
         switch (type) {
             case DEVICE.CONNECT:
-                if (isThpDevice(device)) {
+                if (getIsThpDevice(device)) {
                     // awaited so that discoveryMiddleware knows what state THP is when processing deviceActions.connectDevice
                     await dispatch(connectThpDeviceThunk({ device }));
                 }

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -829,11 +829,8 @@ export const messages = {
             title: 'Unpair Trezor',
             content: 'Unpair your Trezor from this device',
             unpairTrezorButton: 'Unpair',
-            info: {
-                title: 'Unpair Trezor',
-                description:
-                    'This removes your Trezor from the list of paired devices in Trezor Suite.',
-            },
+            description:
+                'This removes your Trezor from the list of paired devices in Trezor Suite.',
             successMessage: 'Trezor has been unpaired.',
         },
         autoconnect: {

--- a/suite-native/module-device-settings/package.json
+++ b/suite-native/module-device-settings/package.json
@@ -18,7 +18,6 @@
         "@suite-common/thp": "workspace:*",
         "@suite-common/validators": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
-        "@suite-native/alerts": "workspace:*",
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/bluetooth": "workspace:*",

--- a/suite-native/module-device-settings/src/components/UnpairBluetoothDeviceCard.tsx
+++ b/suite-native/module-device-settings/src/components/UnpairBluetoothDeviceCard.tsx
@@ -1,0 +1,31 @@
+import { useNavigation } from '@react-navigation/native';
+
+import { CompactCardWithIconLayout } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import {
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes,
+    StackNavigationProps,
+} from '@suite-native/navigation';
+
+type NavigationProp = StackNavigationProps<
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes.DeviceSettings
+>;
+
+export const UnpairBluetoothDeviceCard = () => {
+    const navigation = useNavigation<NavigationProp>();
+
+    const navigateToUnpairScreen = () => {
+        navigation.navigate(DeviceSettingsStackRoutes.UnpairBluetoothDevice);
+    };
+
+    return (
+        <CompactCardWithIconLayout
+            title={<Translation id="moduleDeviceSettings.bluetooth.title" />}
+            subtitle={<Translation id="moduleDeviceSettings.bluetooth.content" />}
+            icon="bluetoothSlash"
+            onPress={navigateToUnpairScreen}
+        />
+    );
+};

--- a/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
@@ -19,6 +19,7 @@ import { ContinueOnTrezorScreen } from '../screens/ContinueOnTrezorScreen';
 import { DeviceAuthenticityScreen } from '../screens/DeviceAuthenticityScreen';
 import { DeviceSettingsModalScreen } from '../screens/DeviceSettingsModalScreen';
 import { PinProtectionScreen } from '../screens/PinProtectionScreen';
+import { UnpairBluetoothDeviceScreen } from '../screens/UnpairBluetoothDeviceScreen';
 
 const DeviceSettingsStack = createNativeStackNavigator<DeviceSettingsStackParamList>();
 
@@ -66,6 +67,10 @@ export const DeviceSettingsStackNavigator = () => (
         <DeviceSettingsStack.Screen
             name={DeviceSettingsStackRoutes.DeviceCheckBackupStack}
             component={DeviceCheckBackupStackNavigator}
+        />
+        <DeviceSettingsStack.Screen
+            name={DeviceSettingsStackRoutes.UnpairBluetoothDevice}
+            component={UnpairBluetoothDeviceScreen}
         />
         <DeviceSettingsStack.Screen
             name={DeviceSettingsStackRoutes.AutoConnectSettings}

--- a/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
@@ -8,6 +8,7 @@ import {
     selectIsDeviceBackupUnfinished,
     selectIsDeviceConnectedViaBluetooth,
     selectIsDeviceInitialized,
+    selectIsThpDevice,
 } from '@suite-common/wallet-core';
 import { TitledSection, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -33,6 +34,7 @@ export const DeviceSettingsModalScreen = () => {
     const isDeviceConnectedViaBluetooth = useSelector(selectIsDeviceConnectedViaBluetooth);
     const isDeviceBackupUnfinished = useSelector(selectIsDeviceBackupUnfinished);
     const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
+    const isThpDevice = useSelector(selectIsThpDevice);
     const isCheckBackupAvailable = isDeviceInitialized && !isDeviceBackupUnfinished;
 
     if (!deviceModel || !deviceName) {
@@ -50,8 +52,8 @@ export const DeviceSettingsModalScreen = () => {
                 >
                     {isDeviceInitialized && <DevicePinProtectionCard />}
                     <DeviceFirmwareCard />
+                    {isThpDevice && <DeviceAutoConnectCard />}
                     {isDeviceConnectedViaBluetooth && <UnpairBluetoothDeviceCard />}
-                    {isDeviceConnectedViaBluetooth && <DeviceAutoConnectCard />}
                 </TitledSection>
                 <TitledSection
                     title={<Translation id="moduleDeviceSettings.sectionTitles.security" />}

--- a/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
@@ -15,11 +15,11 @@ import { Screen, ScreenHeader, useNavigateToInitialScreen } from '@suite-native/
 
 import { DeviceAuthenticityCard } from '../components/DeviceAuthenticityCard';
 import { DeviceAutoConnectCard } from '../components/DeviceAutoConnectCard';
-import { DeviceBluetoothCard } from '../components/DeviceBluetoothCard';
 import { DeviceCheckBackupCard } from '../components/DeviceCheckBackupCard';
 import { DeviceFirmwareCard } from '../components/DeviceFirmwareCard';
 import { DeviceInfo } from '../components/DeviceInfo';
 import { DevicePinProtectionCard } from '../components/DevicePinProtectionCard';
+import { UnpairBluetoothDeviceCard } from '../components/UnpairBluetoothDeviceCard';
 import { WipeDeviceCard } from '../components/WipeDeviceCard';
 import { useDeviceChangedCheck } from '../hooks/useDeviceChangedCheck';
 
@@ -50,7 +50,7 @@ export const DeviceSettingsModalScreen = () => {
                 >
                     {isDeviceInitialized && <DevicePinProtectionCard />}
                     <DeviceFirmwareCard />
-                    {isDeviceConnectedViaBluetooth && <DeviceBluetoothCard />}
+                    {isDeviceConnectedViaBluetooth && <UnpairBluetoothDeviceCard />}
                     {isDeviceConnectedViaBluetooth && <DeviceAutoConnectCard />}
                 </TitledSection>
                 <TitledSection

--- a/suite-native/module-device-settings/src/screens/UnpairBluetoothDeviceScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/UnpairBluetoothDeviceScreen.tsx
@@ -1,12 +1,14 @@
 import { useNavigation } from '@react-navigation/native';
 
-import { useAlert } from '@suite-native/alerts';
-import { CompactCardWithIconLayout } from '@suite-native/atoms';
+import { Button, VStack } from '@suite-native/atoms';
 import { useBluetoothDevice } from '@suite-native/bluetooth';
+import { useDeviceConnectionGuard } from '@suite-native/device-authorization';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
     DeviceSettingsStackRoutes,
+    DynamicScreenHeader,
+    Screen,
     StackNavigationProps,
 } from '@suite-native/navigation';
 import { useToast } from '@suite-native/toasts';
@@ -16,14 +18,15 @@ type NavigationProp = StackNavigationProps<
     DeviceSettingsStackRoutes.DeviceSettings
 >;
 
-export const DeviceBluetoothCard = () => {
-    const { showAlert } = useAlert();
+export const UnpairBluetoothDeviceScreen = () => {
     const { showToast } = useToast();
     const navigation = useNavigation<NavigationProp>();
 
     const { unpairBluetoothDevice } = useBluetoothDevice();
 
-    const unpairTrezor = async () => {
+    useDeviceConnectionGuard();
+
+    const handleUnpairTrezor = async () => {
         navigation.navigate(DeviceSettingsStackRoutes.ContinueOnTrezor);
         await unpairBluetoothDevice({
             onSuccess: () => {
@@ -37,24 +40,20 @@ export const DeviceBluetoothCard = () => {
         });
     };
 
-    const showInfoAlert = () => {
-        showAlert({
-            title: <Translation id="moduleDeviceSettings.bluetooth.info.title" />,
-            description: <Translation id="moduleDeviceSettings.bluetooth.info.description" />,
-            primaryButtonTitle: (
-                <Translation id="moduleDeviceSettings.bluetooth.unpairTrezorButton" />
-            ),
-            secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
-            onPressPrimaryButton: unpairTrezor,
-        });
-    };
-
     return (
-        <CompactCardWithIconLayout
-            title={<Translation id="moduleDeviceSettings.bluetooth.title" />}
-            subtitle={<Translation id="moduleDeviceSettings.bluetooth.content" />}
-            icon="bluetoothSlash"
-            onPress={showInfoAlert}
-        />
+        <Screen
+            header={
+                <DynamicScreenHeader
+                    title={<Translation id="moduleDeviceSettings.bluetooth.title" />}
+                    subtitle={<Translation id="moduleDeviceSettings.bluetooth.description" />}
+                />
+            }
+        >
+            <VStack justifyContent="flex-end" flex={1}>
+                <Button onPress={handleUnpairTrezor}>
+                    <Translation id="moduleDeviceSettings.bluetooth.unpairTrezorButton" />
+                </Button>
+            </VStack>
+        </Screen>
     );
 };

--- a/suite-native/module-device-settings/src/screens/UnpairBluetoothDeviceScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/UnpairBluetoothDeviceScreen.tsx
@@ -46,6 +46,7 @@ export const UnpairBluetoothDeviceScreen = () => {
                 <DynamicScreenHeader
                     title={<Translation id="moduleDeviceSettings.bluetooth.title" />}
                     subtitle={<Translation id="moduleDeviceSettings.bluetooth.description" />}
+                    closeActionType="close"
                 />
             }
         >

--- a/suite-native/module-device-settings/tsconfig.json
+++ b/suite-native/module-device-settings/tsconfig.json
@@ -12,7 +12,6 @@
         {
             "path": "../../suite-common/wallet-core"
         },
-        { "path": "../alerts" },
         { "path": "../analytics" },
         { "path": "../atoms" },
         { "path": "../bluetooth" },

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -221,6 +221,7 @@ export type DeviceSettingsStackParamList = {
     [DeviceSettingsStackRoutes.PinProtection]: undefined;
     [DeviceSettingsStackRoutes.AutoConnectSettings]: undefined;
     [DeviceSettingsStackRoutes.DeviceCheckBackupStack]: NavigatorScreenParams<DeviceCheckBackupStackParamList>;
+    [DeviceSettingsStackRoutes.UnpairBluetoothDevice]: undefined;
 };
 
 export type DevicePinProtectionStackParamList = {

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -83,6 +83,7 @@ export enum DeviceSettingsStackRoutes {
     WipeDeviceStack = 'WipeDeviceStack',
     DeviceNameStack = 'DeviceNameStack',
     DeviceCheckBackupStack = 'DeviceCheckBackupStack',
+    UnpairBluetoothDevice = 'UnpairBluetoothDevice',
     AutoConnectSettings = 'AutoConnectSettings',
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12037,7 +12037,6 @@ __metadata:
     "@suite-common/thp": "workspace:*"
     "@suite-common/validators": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
-    "@suite-native/alerts": "workspace:*"
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/bluetooth": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change unpair UX so it works with `useDeviceConnectionGuard` and create a screen for this behavior instead of it being triggered from an alert on the root device settings screen.

https://github.com/trezor/trezor-suite/issues/22125

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/unpair-bluetooth-device&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/unpair-bluetooth-device&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/unpair-bluetooth-device&lookback=7)