### PR TITLE
Refactor: device authenticity check with Tropic

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -204,7 +204,7 @@ const handleResponseEvent = (data: MethodResponseMessage) => {
                     type: 'error',
                     code,
                     detail: 'response-event-error',
-                    message: ('error' in data.payload && data.payload.error) || 'Unknown error',
+                    message: 'error' in data.payload ? String(data.payload.error) : 'Unknown error',
                 });
                 analytics.report({
                     type: EventType.ViewChangeError,

--- a/packages/connect/e2e/tests/device/authenticateDevice.test.ts
+++ b/packages/connect/e2e/tests/device/authenticateDevice.test.ts
@@ -21,22 +21,23 @@ describe('TrezorConnect.authenticateDevice', () => {
     });
 
     // NOTE: emulator uses different provisioning keys than production FW (different than ./data/deviceAuthenticityConfig)
-    const config = {
+    const config: DeviceAuthenticityConfig = {
         ...deviceAuthenticityConfig,
         ...Object.fromEntries(
             Object.entries(deviceAuthenticityConfig)
+                // if debug property is available, replace the normal keys with debug keys, so that we can test them as if they were prod keys
                 .filter(
                     ([_, value]) => typeof value === 'object' && value !== null && 'debug' in value,
                 )
                 .map(([key, value]: [string, any]) => [
                     key,
                     {
-                        rootPubKeys: value.debug.rootPubKeys,
-                        caPubKeys: value.debug.caPubKeys,
+                        rootPubKeysOptiga: value.debug.rootPubKeysOptiga,
+                        rootPubKeysTropic: value.debug.rootPubKeysTropic,
                     },
                 ]),
         ),
-    } as DeviceAuthenticityConfig;
+    };
 
     conditionalTest(['!T2T1', '!T1B1'], 'validation successful', async () => {
         const result = await TrezorConnect.authenticateDevice({
@@ -45,7 +46,11 @@ describe('TrezorConnect.authenticateDevice', () => {
 
         expect(result).toMatchObject({
             success: true,
-            payload: { valid: true },
+            payload: {
+                optigaResult: { valid: true },
+                // trezor-user-env T3W1 has no tropic debug keys provisioned. This test will fail if that changes in future.
+                tropicResult: null,
+            },
         });
     });
 
@@ -63,11 +68,11 @@ describe('TrezorConnect.authenticateDevice', () => {
                                     key as DeviceModelInternal,
                                 ),
                             )
-                            .map(([key, value]) => [
+                            .map(([key, _]) => [
                                 key,
                                 {
-                                    ...value,
-                                    rootPubKeys: [],
+                                    rootPubKeysOptiga: [],
+                                    rootPubKeysTropic: [],
                                 },
                             ]),
                     ),
@@ -76,7 +81,10 @@ describe('TrezorConnect.authenticateDevice', () => {
 
             expect(result).toMatchObject({
                 success: true,
-                payload: { valid: false, error: 'ROOT_PUBKEY_NOT_FOUND' },
+                payload: {
+                    optigaResult: { valid: false, error: 'ROOT_PUBKEY_NOT_FOUND' },
+                    tropicResult: null,
+                },
             });
         },
     );
@@ -86,23 +94,7 @@ describe('TrezorConnect.authenticateDevice', () => {
         'sanity check unsuccessful (caPubkey is on blacklist)',
         async () => {
             const result = await TrezorConnect.authenticateDevice({
-                config: {
-                    ...config,
-                    ...Object.fromEntries(
-                        Object.entries(config)
-                            .filter(([key, _]) =>
-                                Object.values(DeviceModelInternal).includes(
-                                    key as DeviceModelInternal,
-                                ),
-                            )
-                            .map(([key, value]) => [
-                                key,
-                                {
-                                    ...value,
-                                },
-                            ]),
-                    ),
-                },
+                config,
                 blacklistConfig: {
                     version: 1,
                     blacklistedCaPubKeys: [
@@ -116,7 +108,10 @@ describe('TrezorConnect.authenticateDevice', () => {
 
             expect(result).toMatchObject({
                 success: true,
-                payload: { valid: false, error: 'CA_PUBKEY_BLACKLISTED' },
+                payload: {
+                    optigaResult: { valid: false, error: 'CA_PUBKEY_BLACKLISTED' },
+                    tropicResult: null,
+                },
             });
         },
     );

--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -5,8 +5,9 @@ import { deviceAuthenticityBlacklist } from '../data/deviceAuthenticityBlacklist
 import { UI } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';
 import { deviceAuthenticityConfig } from '../data/deviceAuthenticityConfig';
-import { getRandomChallenge, verifyAuthenticityProof } from './firmware/verifyAuthenticityProof';
+import { verifyAuthenticityProof } from './firmware/verifyAuthenticityProof';
 import { AuthenticateDeviceParams } from '../types/api/authenticateDevice';
+import { getRandomChallenge } from './firmware/verifyAuthenticity/utils';
 
 export default class AuthenticateDevice extends AbstractMethod<
     'authenticateDevice',
@@ -42,15 +43,34 @@ export default class AuthenticateDevice extends AbstractMethod<
 
         const config = this.params.config || deviceAuthenticityConfig;
         const blacklistConfig = this.params.blacklistConfig || deviceAuthenticityBlacklist;
-        const valid = await verifyAuthenticityProof({
-            ...message,
+        const commonParams = {
             challenge,
+            deviceModel: this.device.features.internal_model,
+            allowDebugKeys: this.params.allowDebugKeys,
             config,
             blacklistConfig,
-            allowDebugKeys: this.params.allowDebugKeys,
-            deviceModel: this.device.features.internal_model,
+        } as const;
+
+        // when this method is called, optiga is currently always expected to be there
+        const optigaResult = await verifyAuthenticityProof({
+            ...commonParams,
+            certificates: message.optiga_certificates,
+            signature: message.optiga_signature,
         });
 
-        return valid;
+        // Tropic check is still is optional = not enforced
+        // TODO make it compulsory for T3W1 which is expected to have it https://github.com/trezor/trezor-suite/issues/22448
+        const { tropic_signature } = message;
+        const isTropicAvailable =
+            tropic_signature !== undefined && message.tropic_certificates.length > 0;
+        const tropicResult = isTropicAvailable
+            ? await verifyAuthenticityProof({
+                  ...commonParams,
+                  certificates: message.tropic_certificates,
+                  signature: tropic_signature,
+              })
+            : null;
+
+        return { optigaResult, tropicResult };
     }
 }

--- a/packages/connect/src/api/firmware/__tests__/verifyAuthenticityProof.test.ts
+++ b/packages/connect/src/api/firmware/__tests__/verifyAuthenticityProof.test.ts
@@ -2,11 +2,11 @@ import { DeviceAuthenticityBlacklistConfig } from '../../../data/deviceAuthentic
 import { DeviceAuthenticityConfig } from '../../../data/deviceAuthenticityConfigTypes';
 import { verifyAuthenticityProof } from '../verifyAuthenticityProof';
 
-const CA_CERT =
+const CA_CERT_OPTIGA =
     '308201df30820184a00302010202040a001ab3300a06082a8648ce3d0403023054310b300906035504061302435a311e301c060355040a0c155472657a6f7220436f6d70616e7920732e722e6f2e3125302306035504030c1c5472657a6f72204d616e75666163747572696e6720526f6f742043413020170d3233303130313030303030305a180f32303533303130313030303030305a304f310b300906035504061302435a311e301c060355040a0c155472657a6f7220436f6d70616e7920732e722e6f2e3120301e06035504030c175472657a6f72204d616e75666163747572696e672043413059301306072a8648ce3d020106082a8648ce3d030107034200041b36cc98d5e3d1a20677aaf26254ef3756f27c9d63080c93ad3e7d39d3ad23bf00497b924789bc8e3f87834994e16780ad4eae7e75db1f03835ca64363e980b4a3473045300e0603551d0f0101ff04040302020430120603551d130101ff040830060101ff020100301f0603551d2304183016801428b202f8f9c78a74e8c152bbfb433d99d0ca03ef300a06082a8648ce3d0403020349003046022100dfe2f837f3644c1f0250d37cd0f7d1e4e9b8cfc4820d7f5a623a8cb69df99f6c02210089148848c5fc597df4b8545d9b19d1cc15abe0e1252fa2938a4cf01ae835c563';
-const DEVICE_CERT =
+const DEVICE_CERT_OPTIGA =
     '3082019e30820145a00302010202044ee2a50f300a06082a8648ce3d040302304f310b300906035504061302435a311e301c060355040a0c155472657a6f7220436f6d70616e7920732e722e6f2e3120301e06035504030c175472657a6f72204d616e75666163747572696e67204341301e170d3232303433303134313630315a170d3432303433303134313630315a301d311b301906035504030c1254324231205472657a6f72205361666520333059301306072a8648ce3d020106082a8648ce3d030107034200049bbf06dad9ab5905e05471ce16d5222c89c2caa39f26267ac0747129885fbd441bcc7fa84de120a36755daf30a6f47e8c0d4bddc15036ed2a3447dfa7a1d3e88a341303f300e0603551d0f0101ff040403020080300c0603551d130101ff04023000301f0603551d23041830168014176d8b9a403574f6a2b9ac353ef578682201a21a300a06082a8648ce3d04030203470030440220747c545e112df816173d3071f1ab25d399d8108550764ce1a3a428f1f18b506902200cda822c75b3da6e44e098014452f3fc324f29a79204c3fb4d5815afafc04b17';
-const SIGNATURE =
+const SIGNATURE_OPTIGA =
     '3045022100c01793ffbe4f16d4efc84a4533d9bbfbbf1baa5349346678e07fdb6d848cca7902200df11b9d2850173d9c93993fca983c6d2a3f31ea69a0e19b69e18cc3b78424fe';
 const CHALLENGE = '29d0be0f3cb191c80d108359c64d22984a77ad8b99433814be31db0b6e9e7920';
 const CONFIG: DeviceAuthenticityConfig = {
@@ -27,8 +27,8 @@ const CONFIG: DeviceAuthenticityConfig = {
         ],
     },
     T3W1: {
-        rootPubKeysOptiga: ['you shall not pass'], // TODO T3W1
-        rootPubKeysTropic: ['you shall not pass'], // TODO T3W1
+        rootPubKeysOptiga: ['you shall not pass'], // TODO get T3W1 debug keys
+        rootPubKeysTropic: ['you shall not pass'], // TODO get T3W1 debug keys, currently the function always succeeds anyway
     },
 };
 
@@ -40,13 +40,11 @@ const BLACKLIST_CONFIG: DeviceAuthenticityBlacklistConfig = {
     },
 };
 
-describe('firmware/verifyAuthenticityProof', () => {
-    it('verify success (with prod keys)', async () => {
+describe(`firmware/${verifyAuthenticityProof.name}`, () => {
+    it('verify success for optiga (with prod keys)', async () => {
         const verify = await verifyAuthenticityProof({
-            optiga_certificates: [DEVICE_CERT, CA_CERT],
-            optiga_signature: SIGNATURE,
-            tropic_certificates: [],
-            tropic_signature: 'TODO',
+            certificates: [DEVICE_CERT_OPTIGA, CA_CERT_OPTIGA],
+            signature: SIGNATURE_OPTIGA,
             challenge: Buffer.from(CHALLENGE, 'hex'),
             deviceModel: 'T2B1',
             config: CONFIG,
@@ -54,16 +52,13 @@ describe('firmware/verifyAuthenticityProof', () => {
         });
 
         expect(verify.valid).toBe(true);
-        expect(verify.debugKey).toBe(undefined);
         expect(verify.caPubKey).toEqual(expect.any(String));
     });
 
-    it('verify success (with debug keys)', async () => {
+    it('verify success for optiga (with debug keys)', async () => {
         const verify = await verifyAuthenticityProof({
-            optiga_certificates: [DEVICE_CERT, CA_CERT],
-            optiga_signature: SIGNATURE,
-            tropic_certificates: [],
-            tropic_signature: 'TODO',
+            certificates: [DEVICE_CERT_OPTIGA, CA_CERT_OPTIGA],
+            signature: SIGNATURE_OPTIGA,
             challenge: Buffer.from(CHALLENGE, 'hex'),
             deviceModel: 'T2B1',
             config: {
@@ -82,18 +77,15 @@ describe('firmware/verifyAuthenticityProof', () => {
         });
 
         expect(verify.valid).toBe(true);
-        expect(verify.debugKey).toBe(true);
         expect(verify.caPubKey).toEqual(expect.any(String));
     });
 
-    it('verify failed (signature missmatch)', async () => {
+    it('verify failed for optiga (signature missmatch)', async () => {
         const verify = await verifyAuthenticityProof({
-            optiga_certificates: [DEVICE_CERT, CA_CERT],
-            optiga_signature:
+            certificates: [DEVICE_CERT_OPTIGA, CA_CERT_OPTIGA],
+            signature:
                 // invalid 2nd byte of signature
                 '3044022100c01793ffbe4f16d4efc84a4533d9bbfbbf1baa5349346678e07fdb6d848cca7902200df11b9d2850173d9c93993fca983c6d2a3f31ea69a0e19b69e18cc3b78424fe',
-            tropic_certificates: [],
-            tropic_signature: 'TODO',
             challenge: Buffer.from(CHALLENGE, 'hex'),
             deviceModel: 'T2B1',
             config: CONFIG,
@@ -104,12 +96,10 @@ describe('firmware/verifyAuthenticityProof', () => {
         expect(verify.error).toBe('INVALID_DEVICE_SIGNATURE');
     });
 
-    it('verify failed (missing rootPubKey)', async () => {
+    it('verify failed for optiga (missing rootPubKey)', async () => {
         const verify = await verifyAuthenticityProof({
-            optiga_certificates: [DEVICE_CERT, CA_CERT],
-            optiga_signature: SIGNATURE,
-            tropic_certificates: [],
-            tropic_signature: 'TODO',
+            certificates: [DEVICE_CERT_OPTIGA, CA_CERT_OPTIGA],
+            signature: SIGNATURE_OPTIGA,
             challenge: Buffer.from(CHALLENGE, 'hex'),
             deviceModel: 'T2B1',
             config: {
@@ -129,15 +119,13 @@ describe('firmware/verifyAuthenticityProof', () => {
         expect(verify.error).toBe('ROOT_PUBKEY_NOT_FOUND');
     });
 
-    it('verify failed (device model mismatch)', async () => {
+    it('verify failed for optiga (device model mismatch)', async () => {
         const verify = await verifyAuthenticityProof({
-            optiga_certificates: [
+            certificates: [
                 '3082019e30820145a00302010202044ee2a50f300a06082a8648ce3d040302304f310b300906035504061302435a311e301c060355040a0c155472657a6f7220436f6d70616e7920732e722e6f2e3120301e06035504030c175472657a6f72204d616e75666163747572696e67204341301e170d3232303433303134313630315a170d3432303433303134313630315a301d311b301906035504030c1254324232205472657a6f72205361666520333059301306072a8648ce3d020106082a8648ce3d030107034200049bbf06dad9ab5905e05471ce16d5222c89c2caa39f26267ac0747129885fbd441bcc7fa84de120a36755daf30a6f47e8c0d4bddc15036ed2a3447dfa7a1d3e88a341303f300e0603551d0f0101ff040403020080300c0603551d130101ff04023000301f0603551d23041830168014176d8b9a403574f6a2b9ac353ef578682201a21a300a06082a8648ce3d04030203470030440220747c545e112df816173d3071f1ab25d399d8108550764ce1a3a428f1f18b506902200cda822c75b3da6e44e098014452f3fc324f29a79204c3fb4d5815afafc04b17',
-                CA_CERT,
+                CA_CERT_OPTIGA,
             ],
-            optiga_signature: SIGNATURE,
-            tropic_certificates: [],
-            tropic_signature: 'TODO',
+            signature: SIGNATURE_OPTIGA,
             challenge: Buffer.from(CHALLENGE, 'hex'),
             deviceModel: 'T2B1',
             config: CONFIG,
@@ -148,12 +136,10 @@ describe('firmware/verifyAuthenticityProof', () => {
         expect(verify.error).toBe('INVALID_DEVICE_MODEL');
     });
 
-    it('verify failed (caPubKey on blacklist)', async () => {
+    it('verify failed for optiga (caPubKey on blacklist)', async () => {
         const verify = await verifyAuthenticityProof({
-            optiga_certificates: [DEVICE_CERT, CA_CERT],
-            optiga_signature: SIGNATURE,
-            tropic_certificates: [],
-            tropic_signature: 'TODO',
+            certificates: [DEVICE_CERT_OPTIGA, CA_CERT_OPTIGA],
+            signature: SIGNATURE_OPTIGA,
             challenge: Buffer.from(CHALLENGE, 'hex'),
             deviceModel: 'T2B1',
             config: {

--- a/packages/connect/src/api/firmware/__tests__/verifyAuthenticityProof.test.ts
+++ b/packages/connect/src/api/firmware/__tests__/verifyAuthenticityProof.test.ts
@@ -12,22 +12,23 @@ const CHALLENGE = '29d0be0f3cb191c80d108359c64d22984a77ad8b99433814be31db0b6e9e7
 const CONFIG: DeviceAuthenticityConfig = {
     version: 1,
     T3B1: {
-        rootPubKeys: [
+        rootPubKeysOptiga: [
             '045b5c3fdd01f3602092834209b86df0ca86a9faf25cac35c73bf6237d66eb21eafcec3706f1ccd5eb4cc7f2fa1751213eccb1c78389afba89a5788ff31ee46a5d',
         ],
     },
     T2B1: {
-        rootPubKeys: [
+        rootPubKeysOptiga: [
             '04626d58aca84f0fcb52ea63f0eb08de1067b8d406574a715d5e7928f4b67f113a00fb5c5918e74d2327311946c446b242c20fe7347482999bdc1e229b94e27d96',
         ],
     },
     T3T1: {
-        rootPubKeys: [
+        rootPubKeysOptiga: [
             '04626d58aca84f0fcb52ea63f0eb08de1067b8d406574a715d5e7928f4b67f113a00fb5c5918e74d2327311946c446b242c20fe7347482999bdc1e229b94e27d96',
         ],
     },
     T3W1: {
-        rootPubKeys: ['you shall not pass'], // TODO T3W1
+        rootPubKeysOptiga: ['you shall not pass'], // TODO T3W1
+        rootPubKeysTropic: ['you shall not pass'], // TODO T3W1
     },
 };
 
@@ -68,9 +69,11 @@ describe('firmware/verifyAuthenticityProof', () => {
             config: {
                 ...CONFIG,
                 T2B1: {
-                    rootPubKeys: [],
+                    rootPubKeysOptiga: [],
+                    rootPubKeysTropic: [],
                     debug: {
-                        rootPubKeys: CONFIG.T2B1.rootPubKeys,
+                        rootPubKeysOptiga: CONFIG.T2B1.rootPubKeysOptiga,
+                        rootPubKeysTropic: [],
                     },
                 },
             },
@@ -113,7 +116,7 @@ describe('firmware/verifyAuthenticityProof', () => {
                 ...CONFIG,
                 T2B1: {
                     ...CONFIG.T2B1,
-                    rootPubKeys: [
+                    rootPubKeysOptiga: [
                         // invalid root pub key
                         '0423a5c9ec44dfb96023838d958f6289fa611277ee7af60c3bcb54eff2310546d5ece48b1a507503142b122b53eda53fef3f3d3510f3b7ae2fd5f13614b025ede1',
                     ],

--- a/packages/connect/src/api/firmware/__tests__/x509.test.ts
+++ b/packages/connect/src/api/firmware/__tests__/x509.test.ts
@@ -45,7 +45,7 @@ describe('firmware/x509certificate extensions', () => {
         );
         const cert = parseCertificate(ca);
         const stateOrProvice = cert.tbsCertificate.subject[3];
-        expect(stateOrProvice.algorithm).toBe('2.5.4.8');
+        expect(stateOrProvice.algorithmOid).toBe('2.5.4.8');
         expect(stateOrProvice.parameters?.asn1.contents.toString()).toEqual('z'.repeat(128));
     });
 

--- a/packages/connect/src/api/firmware/__tests__/x509.test.ts
+++ b/packages/connect/src/api/firmware/__tests__/x509.test.ts
@@ -1,41 +1,4 @@
-import { fixSignature, parseCertificate } from '../x509certificate';
-
-// Optiga may produce a malformed signature with probability 1 in 256.
-// These test vectors verify that we are able to correctly reencode the malfomed signature into a valid DER encoding.
-describe('firmware/x509certificate', () => {
-    [
-        {
-            signature:
-                '3048022200007f0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f02220000800102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
-            result: '304502207f0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f022100800102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
-        },
-        {
-            signature:
-                '3045022100007f0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e0220800102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
-            result: '3044021f7f0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e022100800102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
-        },
-        {
-            signature:
-                '30330220007f0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e020f000000000000008001020304050607',
-            result: '302c021f7f0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e0209008001020304050607',
-        },
-        {
-            signature:
-                '303402210000800102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e020f000000000000007f01020304050607',
-            result: '302c022000800102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e02087f01020304050607',
-        },
-        {
-            signature:
-                '30440221007f0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f021f800102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e',
-            result: '304402207f0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f022000800102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e',
-        },
-    ].forEach(f => {
-        it(`fixSignature: ${f.signature.length} to ${f.result.length}`, () => {
-            const signature = fixSignature(new Uint8Array(Buffer.from(f.signature, 'hex')));
-            expect(Buffer.from(signature).toString('hex')).toEqual(f.result);
-        });
-    });
-});
+import { parseCertificate } from '../x509certificate';
 
 describe('firmware/x509certificate extensions', () => {
     it('value with length = 128 (0x80)', () => {

--- a/packages/connect/src/api/firmware/verifyAuthenticity/types.ts
+++ b/packages/connect/src/api/firmware/verifyAuthenticity/types.ts
@@ -1,0 +1,38 @@
+import { PROTO } from '../../../constants';
+import { DeviceAuthenticityBlacklistConfig } from '../../../data/deviceAuthenticityBlacklistConfig';
+import { DeviceAuthenticityConfig } from '../../../data/deviceAuthenticityConfigTypes';
+
+export type VerifySignature = (
+    rawKey: Buffer,
+    data: Uint8Array,
+    signature: Uint8Array,
+) => Promise<boolean>;
+
+export type VerifyAuthenticityProofParams = {
+    challenge: Buffer;
+    certificates: string[];
+    signature: string;
+    deviceModel: keyof typeof PROTO.DeviceModelInternal; // Device.features.internal_model
+    config: DeviceAuthenticityConfig;
+    blacklistConfig: DeviceAuthenticityBlacklistConfig;
+    allowDebugKeys?: boolean;
+};
+
+export type VerifyAuthenticityProofResult =
+    | {
+          valid: true;
+          caPubKey: string;
+          rootPubKey: string;
+          error?: typeof undefined;
+      }
+    | {
+          valid: false;
+          caPubKey: string;
+          rootPubKey?: string;
+          error:
+              | 'ROOT_PUBKEY_NOT_FOUND'
+              | 'CA_PUBKEY_BLACKLISTED'
+              | 'INVALID_DEVICE_MODEL'
+              | 'INVALID_DEVICE_CERTIFICATE'
+              | 'INVALID_DEVICE_SIGNATURE';
+      };

--- a/packages/connect/src/api/firmware/verifyAuthenticity/utils.ts
+++ b/packages/connect/src/api/firmware/verifyAuthenticity/utils.ts
@@ -1,0 +1,51 @@
+import * as crypto from 'crypto';
+
+import { PROTO } from '../../../constants';
+import { DeviceAuthenticityBlacklistConfig } from '../../../data/deviceAuthenticityBlacklistConfig';
+import { DeviceAuthenticityConfig } from '../../../data/deviceAuthenticityConfigTypes';
+
+export const getRandomChallenge = () => crypto.randomBytes(32);
+
+type GetRootPubKeyBlacklistParams = {
+    blacklistConfig: DeviceAuthenticityBlacklistConfig;
+    allowDebugKeys?: boolean;
+};
+export const getRootPubKeyBlacklist = ({
+    blacklistConfig,
+    allowDebugKeys,
+}: GetRootPubKeyBlacklistParams): string[] => {
+    const normalBlacklist = blacklistConfig.blacklistedCaPubKeys ?? [];
+    const debugBlacklist = blacklistConfig.debug?.blacklistedCaPubKeys ?? [];
+
+    return allowDebugKeys ? normalBlacklist.concat(debugBlacklist) : normalBlacklist;
+};
+
+type GetRootPubKeysParams = {
+    config: DeviceAuthenticityConfig;
+    deviceModel: keyof typeof PROTO.DeviceModelInternal;
+    allowDebugKeys?: boolean;
+};
+
+/**
+ * Select all rootPubKeys for particular model, depending if debug keys are allowed.
+ * For simplicity, keys for all curves are combined, though only some of them may pass for each respective certificate/signature.
+ */
+export const getRootPubKeys = ({
+    config,
+    deviceModel,
+    allowDebugKeys,
+}: GetRootPubKeysParams): string[] => {
+    const modelConfig = config[deviceModel];
+    if (modelConfig === undefined) {
+        throw new Error(`Pubkeys for ${deviceModel} not found in config`);
+    }
+
+    const rootPubKeysNormalOptiga = modelConfig.rootPubKeysOptiga ?? [];
+    const rootPubKeysNormalTropic = modelConfig.rootPubKeysTropic ?? [];
+    const rootPubKeysDebugOptiga = modelConfig.debug?.rootPubKeysOptiga ?? [];
+    const rootPubKeysDebugTropic = modelConfig.debug?.rootPubKeysTropic ?? [];
+    const rootPubKeysNormal = [...rootPubKeysNormalOptiga, ...rootPubKeysNormalTropic];
+    if (!allowDebugKeys) return rootPubKeysNormal;
+
+    return [...rootPubKeysNormal, ...rootPubKeysDebugOptiga, ...rootPubKeysDebugTropic];
+};

--- a/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
+++ b/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
@@ -9,7 +9,7 @@ import {
     VerifySignature,
 } from './verifyAuthenticity/types';
 import { getRootPubKeyBlacklist, getRootPubKeys } from './verifyAuthenticity/utils';
-import { AlgorithmName, fixSignature, parseCertificate } from './x509certificate';
+import { AlgorithmName, parseCertificate } from './x509certificate';
 
 // There is incomparability in results between nodejs and window SubtleCrypto api.
 // window.crypto.subtle.importKey (CryptoKey) cannot be used by `crypto-browserify`.Verify
@@ -192,7 +192,7 @@ export const verifyAuthenticityProof = async ({
     const isSignatureValid = await verifySignatureFn(
         Buffer.from(deviceCert.tbsCertificate.subjectPublicKeyInfo.bits.bytes),
         prefixedChallenge,
-        fixSignature(Buffer.from(signature, 'hex')),
+        Buffer.from(signature, 'hex'),
     );
 
     if (isDeviceCertValid && isSignatureValid) {

--- a/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
+++ b/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
@@ -99,7 +99,7 @@ export const verifyAuthenticityProof = async ({
         throw new Error(`Pubkeys for ${deviceModel} not found in config`);
     }
     const { debug } = modelConfig;
-    const { blacklistedCaPubKeys, debug: debugBlacklist } = blacklistConfig;
+    const { blacklistedCaPubKeysOptiga, debug: debugBlacklist } = blacklistConfig;
 
     // 1. parse all x509 certificates received from AuthenticityProof
     const [deviceCert, caCert] = optiga_certificates.map((c, i) => {
@@ -118,8 +118,8 @@ export const verifyAuthenticityProof = async ({
         'hex',
     );
     const rootPubKeys = allowDebugKeys
-        ? modelConfig.rootPubKeys.concat(debug?.rootPubKeys || [])
-        : modelConfig.rootPubKeys;
+        ? modelConfig.rootPubKeysOptiga.concat(debug?.rootPubKeysOptiga || [])
+        : modelConfig.rootPubKeysOptiga;
 
     const isCertSignedByRootPubkey = await Promise.all(
         rootPubKeys.map(rootPubKey =>
@@ -133,7 +133,7 @@ export const verifyAuthenticityProof = async ({
 
     const rootPubKeyIndex = isCertSignedByRootPubkey.findIndex(valid => !!valid);
     const rootPubKey = rootPubKeys[rootPubKeyIndex];
-    const isDebugRootPubKey = debug?.rootPubKeys.includes(rootPubKey);
+    const isDebugRootPubKey = debug?.rootPubKeysOptiga.includes(rootPubKey);
     const caCertValidityFrom = caCert.tbsCertificate.validity.from.getTime();
 
     if (caCertValidityFrom > new Date().getTime()) {
@@ -187,8 +187,8 @@ export const verifyAuthenticityProof = async ({
 
     if (rootPubKey && isDeviceCertValid && isSignatureValid) {
         if (
-            (!isDebugRootPubKey && blacklistedCaPubKeys.includes(caPubKey)) ||
-            (isDebugRootPubKey && debugBlacklist?.blacklistedCaPubKeys.includes(caPubKey))
+            (!isDebugRootPubKey && blacklistedCaPubKeysOptiga.includes(caPubKey)) ||
+            (isDebugRootPubKey && debugBlacklist?.blacklistedCaPubKeysOptiga.includes(caPubKey))
         ) {
             return {
                 valid: false,

--- a/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
+++ b/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
@@ -3,16 +3,18 @@ import * as crypto from 'crypto';
 import { getSubtleCrypto } from '@trezor/crypto-utils';
 import { bufferUtils } from '@trezor/utils';
 
-import { fixSignature, parseCertificate } from './x509certificate';
-import { PROTO } from '../../constants';
-import { DeviceAuthenticityBlacklistConfig } from '../../data/deviceAuthenticityBlacklistConfig';
-import { DeviceAuthenticityConfig } from '../../data/deviceAuthenticityConfigTypes';
-import { AuthenticateDeviceResult } from '../../types/api/authenticateDevice';
+import {
+    VerifyAuthenticityProofParams,
+    VerifyAuthenticityProofResult,
+    VerifySignature,
+} from './verifyAuthenticity/types';
+import { getRootPubKeyBlacklist, getRootPubKeys } from './verifyAuthenticity/utils';
+import { AlgorithmName, fixSignature, parseCertificate } from './x509certificate';
 
 // There is incomparability in results between nodejs and window SubtleCrypto api.
 // window.crypto.subtle.importKey (CryptoKey) cannot be used by `crypto-browserify`.Verify
 // The only common format of publicKey is PEM.
-const verifySignature = async (rawKey: Buffer, data: Uint8Array, signature: Uint8Array) => {
+const verifySignatureP256: VerifySignature = async (rawKey, data, signature) => {
     const signer = crypto.createVerify('sha256');
     signer.update(Buffer.from(data));
 
@@ -39,15 +41,15 @@ const verifySignature = async (rawKey: Buffer, data: Uint8Array, signature: Uint
     return signer.verify({ key }, Buffer.from(signature));
 };
 
-interface AuthenticityProofData extends PROTO.AuthenticityProof {
-    challenge: Buffer;
-    config: DeviceAuthenticityConfig;
-    blacklistConfig: DeviceAuthenticityBlacklistConfig;
-    allowDebugKeys?: boolean;
-    deviceModel: keyof typeof PROTO.DeviceModelInternal; // Device.features.internal_model
-}
+// TODO implement real function to verify TS7 tropic signature via Ed25519
+const verifySignatureEd25519: VerifySignature = (_rawKey, _data, _signature) =>
+    Promise.resolve(true); // simulate success, so it doesn't block onboarding in the meantime
 
-export const getRandomChallenge = () => crypto.randomBytes(32);
+const getVerifyFn = (algorithmName: AlgorithmName): VerifySignature => {
+    if (algorithmName === 'P-256') return verifySignatureP256;
+    if (algorithmName === 'Ed25519') return verifySignatureEd25519;
+    throw new Error(`Unsupported signature algorithm.`);
+};
 
 // Check that this certificate is a valid Trezor CA.
 // KeyUsage must be present and allow certificate signing.
@@ -86,23 +88,27 @@ const validateCaCertExtensions = (cert: ReturnType<typeof parseCertificate>, pat
 };
 
 export const verifyAuthenticityProof = async ({
-    optiga_certificates,
-    optiga_signature,
     challenge,
+    certificates,
+    signature,
+    deviceModel,
+    allowDebugKeys,
     config,
     blacklistConfig,
-    allowDebugKeys,
-    deviceModel,
-}: AuthenticityProofData): Promise<AuthenticateDeviceResult> => {
-    const modelConfig = config[deviceModel];
-    if (!modelConfig) {
-        throw new Error(`Pubkeys for ${deviceModel} not found in config`);
-    }
-    const { debug } = modelConfig;
-    const { blacklistedCaPubKeysOptiga, debug: debugBlacklist } = blacklistConfig;
+}: VerifyAuthenticityProofParams): Promise<VerifyAuthenticityProofResult> => {
+    // Parse config with given device model, type of secure element and debug mode.
+    const allRootPubKeys = getRootPubKeys({
+        config,
+        deviceModel,
+        allowDebugKeys,
+    });
+    const rootPubKeyBlacklist = getRootPubKeyBlacklist({
+        blacklistConfig,
+        allowDebugKeys,
+    });
 
     // 1. parse all x509 certificates received from AuthenticityProof
-    const [deviceCert, caCert] = optiga_certificates.map((c, i) => {
+    const [deviceCert, caCert] = certificates.map((c, i) => {
         const cert = parseCertificate(new Uint8Array(Buffer.from(c, 'hex')));
         if (i === 0) {
             // deviceCert is always at index 0
@@ -112,18 +118,21 @@ export const verifyAuthenticityProof = async ({
 
         return cert;
     });
+    const deviceCertAlgName = deviceCert.signatureAlgorithm.algorithmName;
+    const caCertAlgName = caCert.signatureAlgorithm.algorithmName;
+    if (deviceCertAlgName !== caCertAlgName) {
+        throw new Error('Mismatched signature algorithms in device and CA certificates');
+    }
+    const verifySignatureFn = getVerifyFn(deviceCertAlgName);
 
     // 2. validate that CA certificate was created using one of rootPubkeys
     const caPubKey = Buffer.from(caCert.tbsCertificate.subjectPublicKeyInfo.bits.bytes).toString(
         'hex',
     );
-    const rootPubKeys = allowDebugKeys
-        ? modelConfig.rootPubKeysOptiga.concat(debug?.rootPubKeysOptiga || [])
-        : modelConfig.rootPubKeysOptiga;
 
     const isCertSignedByRootPubkey = await Promise.all(
-        rootPubKeys.map(rootPubKey =>
-            verifySignature(
+        allRootPubKeys.map(rootPubKey =>
+            verifySignatureFn(
                 Buffer.from(rootPubKey, 'hex'),
                 caCert.tbsCertificate.asn1.raw,
                 caCert.signatureValue.bits.bytes,
@@ -132,15 +141,15 @@ export const verifyAuthenticityProof = async ({
     );
 
     const rootPubKeyIndex = isCertSignedByRootPubkey.findIndex(valid => !!valid);
-    const rootPubKey = rootPubKeys[rootPubKeyIndex];
-    const isDebugRootPubKey = debug?.rootPubKeysOptiga.includes(rootPubKey);
+    //TS evaluates string[][number] as string, but it can also be undefined (when index is -1)
+    const rootPubKeyMatch: string | undefined = allRootPubKeys[rootPubKeyIndex];
     const caCertValidityFrom = caCert.tbsCertificate.validity.from.getTime();
 
     if (caCertValidityFrom > new Date().getTime()) {
-        throw new Error(`CA validity from ${caCertValidityFrom} cant't be in the future!`);
+        throw new Error(`CA validity from ${caCertValidityFrom} can't be in the future!`);
     }
 
-    if (!rootPubKey) {
+    if (rootPubKeyMatch === undefined) {
         return {
             valid: false,
             caPubKey,
@@ -151,7 +160,7 @@ export const verifyAuthenticityProof = async ({
     // 3. validate DEVICE certificate subject (Trezor features internal_model)
     const [subject] = deviceCert.tbsCertificate.subject;
     // subject algorithm (OID) https://www.alvestrand.no/objectid/2.5.4.3.html
-    if (!subject.parameters || subject.algorithm !== '2.5.4.3') {
+    if (!subject.parameters || subject.algorithmOid !== '2.5.4.3') {
         throw new Error('Missing certificate subject');
     }
     // slice 4 bytes from the subject (internal model)
@@ -160,12 +169,13 @@ export const verifyAuthenticityProof = async ({
         return {
             valid: false,
             caPubKey,
+            rootPubKey: rootPubKeyMatch,
             error: 'INVALID_DEVICE_MODEL',
         };
     }
 
     // 4. validate that DEVICE certificate was created using pubKey from CA certificate
-    const isDeviceCertValid = await verifySignature(
+    const isDeviceCertValid = await verifySignatureFn(
         Buffer.from(caCert.tbsCertificate.subjectPublicKeyInfo.bits.bytes),
         deviceCert.tbsCertificate.asn1.raw,
         deviceCert.signatureValue.bits.bytes,
@@ -179,20 +189,18 @@ export const verifyAuthenticityProof = async ({
         bufferUtils.getChunkSize(challenge.length),
         challenge,
     ]);
-    const isSignatureValid = await verifySignature(
+    const isSignatureValid = await verifySignatureFn(
         Buffer.from(deviceCert.tbsCertificate.subjectPublicKeyInfo.bits.bytes),
         prefixedChallenge,
-        fixSignature(Buffer.from(optiga_signature, 'hex')),
+        fixSignature(Buffer.from(signature, 'hex')),
     );
 
-    if (rootPubKey && isDeviceCertValid && isSignatureValid) {
-        if (
-            (!isDebugRootPubKey && blacklistedCaPubKeysOptiga.includes(caPubKey)) ||
-            (isDebugRootPubKey && debugBlacklist?.blacklistedCaPubKeysOptiga.includes(caPubKey))
-        ) {
+    if (isDeviceCertValid && isSignatureValid) {
+        if (rootPubKeyBlacklist.includes(caPubKey)) {
             return {
                 valid: false,
                 caPubKey,
+                rootPubKey: rootPubKeyMatch,
                 error: 'CA_PUBKEY_BLACKLISTED',
             };
         }
@@ -200,7 +208,7 @@ export const verifyAuthenticityProof = async ({
         return {
             valid: true,
             caPubKey,
-            debugKey: isDebugRootPubKey,
+            rootPubKey: rootPubKeyMatch,
         };
     }
 
@@ -208,6 +216,7 @@ export const verifyAuthenticityProof = async ({
         return {
             valid: false,
             caPubKey,
+            rootPubKey: rootPubKeyMatch,
             error: 'INVALID_DEVICE_CERTIFICATE',
         };
     }
@@ -215,6 +224,7 @@ export const verifyAuthenticityProof = async ({
     return {
         valid: false,
         caPubKey,
+        rootPubKey: rootPubKeyMatch,
         error: 'INVALID_DEVICE_SIGNATURE',
     };
 };

--- a/packages/connect/src/api/firmware/x509certificate.ts
+++ b/packages/connect/src/api/firmware/x509certificate.ts
@@ -126,63 +126,14 @@ const derBitStringValue = (byteArray: Uint8Array) => ({
     bytes: byteArray.subarray(1),
 });
 
-// Optiga may produce a malformed signature with probability 1 in 256.
-// https://github.com/trezor/trezor-firmware/issues/3411
-export const fixSignature = (byteArray: Uint8Array) => {
-    const asn1 = derToAsn1(byteArray);
-
-    if (asn1.cls !== 0 || asn1.tag !== 16 || !asn1.structured) {
-        throw new Error('Bad signature. Not a SEQUENCE.');
-    }
-
-    const items = derToAsn1List(asn1.contents);
-    let newLength = 0;
-    const fixedItems = items.map(chunk => {
-        // find first significant byte
-        const index = chunk.contents.findIndex(value => value > 0x00);
-        const data = chunk.contents.subarray(index);
-        // According to the DER-encoding rules, the integers are supposed to be prefixed with a 0x00 byte
-        // if **and only if** the most significant byte is >= 0x80
-        const offset = data[0] >= 0x80 ? 1 : 0;
-        // create replacement for chunk
-        const chunkLength = data.length + offset;
-        const newChunk = new Uint8Array(chunkLength + 2);
-        // set first two bytes: original value and new length of the chunk
-        newChunk.set([chunk.raw[0], chunkLength]);
-        // optionally add 0
-        if (offset > 0) {
-            newChunk.set([0], 2);
-        }
-        // fill new chunk with data
-        newChunk.set(data, 2 + offset);
-        newLength += newChunk.length;
-
-        return newChunk;
-    });
-
-    // create replacement for sequence object
-    const signature = new Uint8Array(newLength + 2);
-    // set two first bytes: original value and new length of all chunks
-    signature.set([byteArray[0], newLength]);
-    // fill new sequence with fixed items
-    let signatureOffset = 2;
-    fixedItems.forEach(item => {
-        signature.set(item, signatureOffset);
-        signatureOffset += item.length;
-    });
-
-    return signature;
-};
-
 const parseSignatureValue = (asn1: Asn1) => {
     if (asn1.cls !== 0 || asn1.tag !== 3 || asn1.structured) {
         throw new Error('Bad signature value. Not a BIT STRING.');
     }
-    const { unusedBits, bytes } = derBitStringValue(asn1.contents);
 
     return {
         asn1,
-        bits: { unusedBits, bytes: fixSignature(bytes) },
+        bits: derBitStringValue(asn1.contents),
     };
 };
 

--- a/packages/connect/src/api/firmware/x509certificate.ts
+++ b/packages/connect/src/api/firmware/x509certificate.ts
@@ -14,7 +14,12 @@ interface Asn1 {
     raw: Uint8Array; // original byte array
 }
 
-type Oid = `${number}.${number}.${number}.${number}`;
+type Oid =
+    | `${number}.${number}.${number}.${number}`
+    | `${number}.${number}.${number}.${number}.${number}.${number}`;
+
+// algorithms supported by Suite to verify certificates and signatures
+export type AlgorithmName = 'P-256' | 'Ed25519' | 'unknown';
 
 type Extension =
     | {
@@ -32,6 +37,13 @@ type Extension =
           key: Oid;
           critical?: boolean;
       });
+
+const parseOidToAlgorithmName = (oid: Oid): AlgorithmName => {
+    if (oid === '1.2.840.10045.4.3.2') return 'P-256'; // https://oid-base.com/get/1.2.840.10045.4.3.2
+    if (oid === '1.3.101.112') return 'Ed25519'; // https://oid-base.com/get/1.3.101.112
+
+    return 'unknown';
+};
 
 const derToAsn1 = (byteArray: Uint8Array): Asn1 => {
     let position = 0;
@@ -209,11 +221,13 @@ const parseAlgorithmIdentifier = (asn1: Asn1) => {
     if (encodedAlgorithm.cls !== 0 || encodedAlgorithm.tag !== 6 || encodedAlgorithm.structured) {
         throw new Error('Bad algorithm identifier. Does not begin with an OBJECT IDENTIFIER.');
     }
-    const algorithm = derObjectIdentifierValue(encodedAlgorithm.contents);
+    const algorithmOid = derObjectIdentifierValue(encodedAlgorithm.contents);
+    const algorithmName = parseOidToAlgorithmName(algorithmOid);
 
     return {
         asn1,
-        algorithm,
+        algorithmOid,
+        algorithmName,
         parameters: pieces.length === 2 ? { asn1: pieces[1] } : null,
     };
 };

--- a/packages/connect/src/data/deviceAuthenticityConfig.ts
+++ b/packages/connect/src/data/deviceAuthenticityConfig.ts
@@ -8,43 +8,45 @@ import { DeviceAuthenticityConfig } from './deviceAuthenticityConfigTypes';
 export const deviceAuthenticityConfig: DeviceAuthenticityConfig = {
     version: 2,
     T2B1: {
-        rootPubKeys: [
+        rootPubKeysOptiga: [
             '04ca97480ac0d7b1e6efafe518cd433cec2bf8ab9822d76eafd34363b55d63e60380bff20acc75cde03cffcb50ab6f8ce70c878e37ebc58ff7cca0a83b16b15fa5',
         ],
         debug: {
-            rootPubKeys: [
+            rootPubKeysOptiga: [
                 '047f77368dea2d4d61e989f474a56723c3212dacf8a808d8795595ef38441427c4389bc454f02089d7f08b873005e4c28d432468997871c0bf286fd3861e21e96a',
             ],
         },
     },
     T3B1: {
-        rootPubKeys: [
+        rootPubKeysOptiga: [
             '045b5c3fdd01f3602092834209b86df0ca86a9faf25cac35c73bf6237d66eb21eafcec3706f1ccd5eb4cc7f2fa1751213eccb1c78389afba89a5788ff31ee46a5d',
         ],
         debug: {
-            rootPubKeys: [
+            rootPubKeysOptiga: [
                 '047f77368dea2d4d61e989f474a56723c3212dacf8a808d8795595ef38441427c4389bc454f02089d7f08b873005e4c28d432468997871c0bf286fd3861e21e96a',
             ],
         },
     },
     T3T1: {
-        rootPubKeys: [
+        rootPubKeysOptiga: [
             '041854b27fb1d9f65abb66828e78c9dc0ca301e66081ab0c6a4d104f9df1cd0ad5a7c75f77a8c092f55cf825d2abaf734f934c9394d5e75f75a5a06a5ee9be93ae',
         ],
         debug: {
-            rootPubKeys: [
+            rootPubKeysOptiga: [
                 '04e48b69cd7962068d3cca3bcc6b1747ef496c1e28b5529e34ad7295215ea161dbe8fb08ae0479568f9d2cb07630cb3e52f4af0692102da5873559e45e9fa72959',
             ],
         },
     },
     T3W1: {
-        rootPubKeys: [
+        rootPubKeysOptiga: [
             '040dde0d3e0d4da593fac6fd02a461d0e7eef238aca55c7c50b4e9ec37f3873303b6429ef1c9b78b4411a7dcbbc5dde5225979c1c2da3b073e82b1ed3f5f9825bb',
         ],
+        rootPubKeysTropic: [],
         debug: {
-            rootPubKeys: [
+            rootPubKeysOptiga: [
                 '04521192e173a9da4e3023f747d836563725372681eba3079c56ff11b2fc137ab189eb4155f371127651b5594f8c332fc1e9c0f3b80d4212822668b63189706578',
             ],
+            rootPubKeysTropic: [],
         },
     },
 };

--- a/packages/connect/src/data/deviceAuthenticityConfig.ts
+++ b/packages/connect/src/data/deviceAuthenticityConfig.ts
@@ -41,11 +41,13 @@ export const deviceAuthenticityConfig: DeviceAuthenticityConfig = {
         rootPubKeysOptiga: [
             '040dde0d3e0d4da593fac6fd02a461d0e7eef238aca55c7c50b4e9ec37f3873303b6429ef1c9b78b4411a7dcbbc5dde5225979c1c2da3b073e82b1ed3f5f9825bb',
         ],
-        rootPubKeysTropic: [],
+        rootPubKeysTropic: ['59237acd17134061d655b3f8d624573ca06ce8d862f38ba4e05140ce1d3d609d'],
         debug: {
             rootPubKeysOptiga: [
                 '04521192e173a9da4e3023f747d836563725372681eba3079c56ff11b2fc137ab189eb4155f371127651b5594f8c332fc1e9c0f3b80d4212822668b63189706578',
             ],
+            // TODO copy "Root debug keys for T3W1" from firmware repo when it is available (_pk_ed25519)
+            // https://github.com/trezor/trezor-firmware/blob/main/python/src/trezorlib/authentication.py
             rootPubKeysTropic: [],
         },
     },

--- a/packages/connect/src/data/deviceAuthenticityConfigTypes.ts
+++ b/packages/connect/src/data/deviceAuthenticityConfigTypes.ts
@@ -3,7 +3,8 @@ import { Static, Type } from '@trezor/schema-utils';
 
 type CertPubKeys = Static<typeof CertPubKeys>;
 const CertPubKeys = Type.Object({
-    rootPubKeys: Type.Array(Type.String()),
+    rootPubKeysOptiga: Type.Array(Type.String()),
+    rootPubKeysTropic: Type.Optional(Type.Array(Type.String())),
 });
 
 type ModelPubKeys = Static<typeof ModelPubKeys>;

--- a/packages/connect/src/types/api/authenticateDevice.ts
+++ b/packages/connect/src/types/api/authenticateDevice.ts
@@ -1,5 +1,6 @@
 import { Static, Type } from '@trezor/schema-utils';
 
+import { VerifyAuthenticityProofResult } from '../../api/firmware/verifyAuthenticity/types';
 import { DeviceAuthenticityBlacklistConfig } from '../../data/deviceAuthenticityBlacklistConfig';
 import { DeviceAuthenticityConfig } from '../../data/deviceAuthenticityConfigTypes';
 import type { Params, Response } from '../params';
@@ -11,26 +12,10 @@ export const AuthenticateDeviceParams = Type.Object({
     allowDebugKeys: Type.Optional(Type.Boolean()),
 });
 
-export type AuthenticateDeviceResult =
-    | {
-          valid: true;
-          caPubKey: string;
-          debugKey?: boolean;
-          configExpired?: typeof undefined;
-          error?: typeof undefined;
-      }
-    | {
-          valid: false;
-          caPubKey: string;
-          debugKey?: boolean;
-          configExpired?: boolean;
-          error:
-              | 'ROOT_PUBKEY_NOT_FOUND'
-              | 'CA_PUBKEY_BLACKLISTED'
-              | 'INVALID_DEVICE_MODEL'
-              | 'INVALID_DEVICE_CERTIFICATE'
-              | 'INVALID_DEVICE_SIGNATURE';
-      };
+export type AuthenticateDeviceResult = {
+    optigaResult: VerifyAuthenticityProofResult;
+    tropicResult: VerifyAuthenticityProofResult | null;
+};
 
 export declare function authenticateDevice(
     params: Params<AuthenticateDeviceParams>,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceModal.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { isRejected } from '@reduxjs/toolkit';
+
 import { checkDeviceAuthenticityThunk } from '@suite-common/device-authenticity';
 import { TranslationKey } from '@suite-common/intl-types';
 import { Icon, IconName, List, Modal, Paragraph } from '@trezor/components';
@@ -26,11 +28,11 @@ export const AuthenticateDeviceModal = () => {
 
         const result = await dispatch(
             checkDeviceAuthenticityThunk({ allowDebugKeys: isDebugModeActive }),
-        ).unwrap();
+        );
 
         setIsLoading(false);
 
-        if (result?.valid === false) {
+        if (isRejected(result)) {
             dispatch(openModal({ type: 'authenticate-device-fail' }));
         }
     };

--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -127,17 +127,31 @@ const sentryMiddleware =
                 break;
             }
             case deviceAuthenticityActions.result.type: {
-                if (!action.payload.result?.error) return;
+                const { result } = action.payload;
+                if (!result) return;
 
-                withSentryScope(scope => {
-                    scope.setLevel('error');
-                    scope.setTag('deviceAuthenticityError', action.payload.result?.error);
-                    captureSentryMessage(
-                        `Device authenticity invalid!
-                        ${JSON.stringify(action.payload.result, null, 2)}`,
-                        scope,
-                    );
-                });
+                const reportToSentry = (error: string) => {
+                    withSentryScope(scope => {
+                        scope.setLevel('error');
+                        scope.setTag('deviceAuthenticityError', error);
+                        captureSentryMessage(
+                            `Device authenticity invalid! ${JSON.stringify(result, null, 2)}`,
+                            scope,
+                        );
+                    });
+                };
+
+                // report error from the TrezorConnect call itself
+                if ('error' in result) {
+                    reportToSentry(result.error);
+                }
+                // report errors from either one of the secure elements (or both)
+                if ('optigaResult' in result && result.optigaResult.error) {
+                    reportToSentry(result.optigaResult.error);
+                }
+                if ('tropicResult' in result && result.tropicResult?.error) {
+                    reportToSentry(result.tropicResult.error);
+                }
                 break;
             }
             default:

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/index.tsx
@@ -38,7 +38,7 @@ export const DeviceAuthenticityStep = ({ goToNext }: DeviceAuthenticityProps) =>
             request.code === 'ButtonRequest_PinEntry', // Device can be locked, and we can get Pin Request first
     );
     const isCheckFailed = isSubmitted && selectedDeviceAuthenticity?.valid === false;
-    const isCheckSuccessful = isSubmitted && selectedDeviceAuthenticity?.valid;
+    const isCheckSuccessful = isSubmitted && selectedDeviceAuthenticity?.valid === true;
 
     const getHeadingText = () => {
         if (isCheckSuccessful) {

--- a/suite-common/analytics/src/events/suite-native/definitions.ts
+++ b/suite-common/analytics/src/events/suite-native/definitions.ts
@@ -9,12 +9,7 @@ export type AnalyticsSendFlowStep =
     | 'utxo_selection'
     | 'destination_tag_review';
 
-export type DeviceAuthenticityCheckResult =
-    | 'successful'
-    | 'compromised'
-    | 'configExpired'
-    | 'cancelled'
-    | 'failed';
+export type DeviceAuthenticityCheckResult = 'successful' | 'compromised' | 'cancelled' | 'failed';
 
 export type FirmwareUpdatePayload = {
     model: DeviceModelInternal;

--- a/suite-common/device-authenticity/src/deviceAuthenticityActions.ts
+++ b/suite-common/device-authenticity/src/deviceAuthenticityActions.ts
@@ -1,15 +1,10 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import { TrezorDevice } from '@suite-common/suite-types';
-import { AuthenticateDeviceResult } from '@trezor/connect';
+
+import { StoredAuthenticateDeviceResult } from './types';
 
 export const ACTION_PREFIX = '@device-authenticity';
-
-export type StoredAuthenticateDeviceResult =
-    | (Omit<Partial<AuthenticateDeviceResult>, 'error'> & {
-          error?: string;
-      })
-    | undefined;
 
 const result = createAction(
     `${ACTION_PREFIX}/result`,

--- a/suite-common/device-authenticity/src/deviceAuthenticityThunks.ts
+++ b/suite-common/device-authenticity/src/deviceAuthenticityThunks.ts
@@ -1,82 +1,78 @@
 import { createThunk } from '@suite-common/redux-utils';
-import { ToastPayload, notificationsActions } from '@suite-common/toast-notifications';
-import TrezorConnect, { AuthenticateDeviceResult } from '@trezor/connect';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import TrezorConnect from '@trezor/connect';
 
 import { ACTION_PREFIX, deviceAuthenticityActions } from './deviceAuthenticityActions';
+import { StoredAuthenticateDeviceResult } from './types';
+import { isDeviceAuthenticityValid } from './utils';
 
 type CheckDeviceAuthenticityThunkParams = {
     allowDebugKeys: boolean;
     skipSuccessToast?: boolean;
 };
 
-export type CheckDeviceAuthenticityThunkResult =
-    | AuthenticateDeviceResult
-    | { error: string; valid?: boolean }
-    | undefined;
-
 export const checkDeviceAuthenticityThunk = createThunk<
-    CheckDeviceAuthenticityThunkResult,
+    StoredAuthenticateDeviceResult,
     CheckDeviceAuthenticityThunkParams,
-    void
+    { rejectValue: StoredAuthenticateDeviceResult }
 >(
     `${ACTION_PREFIX}/checkDeviceAuthenticity`,
     async (
         { allowDebugKeys, skipSuccessToast },
-        { dispatch, getState, extra, fulfillWithValue },
+        { dispatch, getState, extra, fulfillWithValue, rejectWithValue },
     ) => {
-        const {
-            selectors: { selectDevice },
-        } = extra;
-        const device = selectDevice(getState());
+        const device = extra.selectors.selectDevice(getState());
         if (!device) {
             throw new Error('device is not connected');
         }
 
         const result = await TrezorConnect.authenticateDevice({
-            device: {
-                path: device.path,
-            },
+            device: { path: device.path },
             allowDebugKeys,
         });
 
-        let storedResult: CheckDeviceAuthenticityThunkResult = result.payload;
-        let toastPayload: ToastPayload | undefined;
-
+        // error from the TrezorConnect call itself (e.g. device cannot perform the check)
         if (!result.success) {
-            toastPayload = {
-                type: 'error',
-                error: `Unable to validate device: ${result.payload.error}`,
-            };
-            storedResult = device.features?.bootloader_locked
-                ? undefined
-                : {
-                      valid: false,
-                      error: result.payload.error,
-                  };
-        } else if (result.payload.error === 'CA_PUBKEY_BLACKLISTED') {
-            toastPayload = {
-                type: 'device-authenticity-error',
-                error: `Device is not authentic: ${result.payload.error}`,
-            };
-            storedResult = {
-                error: result.payload.error,
-                valid: false,
-            };
-        } else if (!result.payload.valid) {
-            toastPayload = {
-                type: 'device-authenticity-error',
-                error: `Device is not authentic: ${result.payload.error}`,
-            };
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: `Unable to validate device: ${result.payload.error}`,
+                }),
+            );
+            const isDeviceBootloaderUnlocked = device?.features?.bootloader_locked !== true;
+            const storedResult = isDeviceBootloaderUnlocked
+                ? // error can be because bootloader is unlocked (definite cause of failure, should persist)
+                  { valid: false, error: result.payload.error }
+                : // or internal error (then skip the check by storing undefined)
+                  undefined;
+            dispatch(deviceAuthenticityActions.result({ device, result: storedResult }));
+
+            return rejectWithValue(storedResult);
         }
 
-        if (!skipSuccessToast && storedResult?.valid) {
-            toastPayload = { type: 'device-authenticity-success' };
+        const isOverallValid = isDeviceAuthenticityValid(result.payload);
+        const storedResult = { valid: isOverallValid, ...result.payload };
+
+        // successful TrezorConnect call, but the signature authenticity validation failed
+        if (!isOverallValid) {
+            // to keep the notification short, display only the first error that failed
+            const error = result.payload.optigaResult.error ?? result.payload.tropicResult?.error;
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'device-authenticity-error',
+                    error: `Device is not authentic: ${error}`,
+                }),
+            );
+
+            dispatch(deviceAuthenticityActions.result({ device, result: storedResult }));
+
+            return rejectWithValue(storedResult);
         }
 
-        if (toastPayload) {
-            dispatch(notificationsActions.addToast(toastPayload));
+        // successful TrezorConnect call and signature is authentic
+        if (!skipSuccessToast) {
+            dispatch(notificationsActions.addToast({ type: 'device-authenticity-success' }));
         }
-
         dispatch(deviceAuthenticityActions.result({ device, result: storedResult }));
 
         return fulfillWithValue(storedResult);

--- a/suite-common/device-authenticity/src/index.ts
+++ b/suite-common/device-authenticity/src/index.ts
@@ -1,2 +1,4 @@
 export * from './deviceAuthenticityActions';
 export * from './deviceAuthenticityThunks';
+export * from './types';
+export * from './utils';

--- a/suite-common/device-authenticity/src/types.ts
+++ b/suite-common/device-authenticity/src/types.ts
@@ -1,0 +1,16 @@
+import { AuthenticateDeviceResult, Unsuccessful } from '@trezor/connect';
+
+type ConnectErrorPayload = Unsuccessful['payload'];
+// note: corresponds to Awaited<Response<AuthenticateDeviceResult>>['payload'] but this is IMO clearer
+export type ConnectResponsePayload = AuthenticateDeviceResult | ConnectErrorPayload;
+
+/**
+ * Processed result of TrezorConnect.authenticateDevice call that we may store in the Redux state.
+ * We want to:
+ * 1. keep both successful response as well as error payload from the TrezorConnect call itself .
+ * 2. evaluate overall `valid`, because Connect returns result for each secure element vendor (e.g. optiga & tropic)
+ *    and it is up to Suite to decide which results to use.
+ */
+export type StoredAuthenticateDeviceResult =
+    | (ConnectResponsePayload & { valid: boolean })
+    | undefined;

--- a/suite-common/device-authenticity/src/utils.ts
+++ b/suite-common/device-authenticity/src/utils.ts
@@ -1,0 +1,4 @@
+import { AuthenticateDeviceResult } from '@trezor/connect';
+
+export const isDeviceAuthenticityValid = (result: AuthenticateDeviceResult) =>
+    result.optigaResult.valid && result.tropicResult?.valid !== false;

--- a/suite-common/device-authenticity/tests/deviceAuthenticityThunks.test.ts
+++ b/suite-common/device-authenticity/tests/deviceAuthenticityThunks.test.ts
@@ -1,7 +1,14 @@
 import { TrezorDevice } from '@suite-common/suite-types';
 import { configureMockStore, testMocks } from '@suite-common/test-utils';
-import { notificationsActions } from '@suite-common/toast-notifications';
+import { ToastPayload, notificationsActions } from '@suite-common/toast-notifications';
+import type {
+    AuthenticateDeviceResult,
+    Response,
+    SuccessWithDevice,
+    Unsuccessful,
+} from '@trezor/connect';
 
+import type { StoredAuthenticateDeviceResult } from '../src';
 import { deviceAuthenticityActions } from '../src/deviceAuthenticityActions';
 import { checkDeviceAuthenticityThunk } from '../src/deviceAuthenticityThunks';
 
@@ -18,70 +25,110 @@ const getDevice = (isLocked: boolean) => ({
     ...testMocks.getSuiteDevice(undefined, { bootloader_locked: isLocked }),
 });
 
-const successResponse = {
-    success: true,
-    payload: {
-        valid: true,
-    },
-};
-const failResponse = {
+const connectCallFailResponse: Unsuccessful = {
     success: false,
     payload: { error: 'error' },
 };
-const failResult = { valid: false, error: 'error' };
+
+const verificationSuccessResponse: SuccessWithDevice<AuthenticateDeviceResult> = {
+    success: true,
+    payload: {
+        optigaResult: {
+            valid: true,
+            caPubKey: 'not-blacklisted-ca-pub-key',
+            rootPubKey: 'recognized-root-pub-key',
+        },
+        tropicResult: null,
+    },
+};
+
+const verifyFailureResponseNotFound: SuccessWithDevice<AuthenticateDeviceResult> = {
+    success: true,
+    payload: {
+        optigaResult: {
+            valid: false,
+            error: 'ROOT_PUBKEY_NOT_FOUND',
+            caPubKey: 'bad-ca-pub-key',
+        },
+        tropicResult: null,
+    },
+};
+
+const verifyFailureResponseBlacklisted: SuccessWithDevice<AuthenticateDeviceResult> = {
+    success: true,
+    payload: {
+        optigaResult: {
+            valid: false,
+            error: 'CA_PUBKEY_BLACKLISTED',
+            caPubKey: 'blacklisted-root-pub-key',
+        },
+        tropicResult: null,
+    },
+};
+
 const deviceWithLockedBootloader = getDevice(true);
 
-const fixtures = [
+type Fixture = {
+    description: string;
+    device: TrezorDevice | undefined;
+    mockedConnectResponse?: Awaited<Response<AuthenticateDeviceResult>>;
+    expectedFulfilled: boolean;
+    expectedToastType?: ToastPayload['type'];
+    expectedResult?: StoredAuthenticateDeviceResult;
+};
+
+const fixtures: Fixture[] = [
     {
         description: 'Success',
         device: deviceWithLockedBootloader,
-        connectResponse: successResponse,
+        mockedConnectResponse: verificationSuccessResponse,
+        expectedFulfilled: true,
         expectedToastType: 'device-authenticity-success',
-        expectedResult: { valid: true },
+        expectedResult: { valid: true, ...verificationSuccessResponse.payload },
     },
     {
         description: 'Success - skip toast',
         device: deviceWithLockedBootloader,
-        connectResponse: successResponse,
-        expectedResult: { valid: true },
+        mockedConnectResponse: verificationSuccessResponse,
+        expectedFulfilled: true,
+        expectedResult: { valid: true, ...verificationSuccessResponse.payload },
     },
     {
         description: 'Exception - missing device',
         device: undefined,
+        expectedFulfilled: false,
     },
     {
         description: 'No result - aborted on device or some other error',
         device: deviceWithLockedBootloader,
-        connectResponse: failResponse,
+        mockedConnectResponse: connectCallFailResponse,
+        expectedFulfilled: false,
         expectedToastType: 'error',
         expectedResult: undefined,
     },
     {
+        description: 'Fail - root pub key not found',
+        device: deviceWithLockedBootloader,
+        mockedConnectResponse: verifyFailureResponseNotFound,
+        expectedFulfilled: false,
+        expectedToastType: 'device-authenticity-error',
+        expectedResult: { valid: false, ...verifyFailureResponseNotFound.payload },
+    },
+    {
         description: 'Fail - caPubKey is blacklisted',
         device: deviceWithLockedBootloader,
-        connectResponse: {
-            success: true,
-            payload: { valid: false, error: 'CA_PUBKEY_BLACKLISTED' },
-        },
+        mockedConnectResponse: verifyFailureResponseBlacklisted,
+        expectedFulfilled: false,
         expectedToastType: 'device-authenticity-error',
-        expectedResult: { valid: false, error: 'CA_PUBKEY_BLACKLISTED' },
+        expectedResult: { valid: false, ...verifyFailureResponseBlacklisted.payload },
     },
     {
         description: 'Fail - bootloader unlocked',
         device: getDevice(false),
-        connectResponse: failResponse,
+        mockedConnectResponse: connectCallFailResponse,
+        expectedFulfilled: false,
         expectedToastType: 'error',
-        expectedResult: failResult,
-    },
-    {
-        description: 'Fail',
-        device: deviceWithLockedBootloader,
-        connectResponse: {
-            success: true,
-            payload: failResult,
-        },
-        expectedToastType: 'device-authenticity-error',
-        expectedResult: failResult,
+        expectedResult: { valid: false, error: 'error' },
     },
 ];
 
@@ -89,7 +136,7 @@ describe('Check device authenticity', () => {
     fixtures.forEach(f => {
         it(f.description, async () => {
             const store = initStore(f.device);
-            testMocks.setTrezorConnectFixtures(f.connectResponse);
+            testMocks.setTrezorConnectFixtures(f.mockedConnectResponse);
             await store.dispatch(
                 checkDeviceAuthenticityThunk({
                     allowDebugKeys: false,
@@ -98,13 +145,18 @@ describe('Check device authenticity', () => {
             );
 
             const actions = store.getActions();
+            // always expecting to have started
             const expectedActions = [checkDeviceAuthenticityThunk.pending.type];
+            // expected to have emitted toast
             if (f.expectedToastType) {
                 expectedActions.splice(1, 0, notificationsActions.addToast.type);
-                expect(actions[1].payload.type).toBe(f.expectedToastType);
+                expect(actions[actions.length - 3].payload.type).toBe(f.expectedToastType);
             }
+            // thunk is expected to fail fast if there is no device, and not emit a result, which is always bound to device
             if (f.device) {
                 expectedActions.push(deviceAuthenticityActions.result.type);
+            }
+            if (f.expectedFulfilled) {
                 expectedActions.push(checkDeviceAuthenticityThunk.fulfilled.type);
                 expect(actions[actions.length - 2].payload.result).toEqual(f.expectedResult);
             } else {

--- a/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
+++ b/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
@@ -4,8 +4,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import {
-    CheckDeviceAuthenticityThunkResult,
+    StoredAuthenticateDeviceResult,
     deviceAuthenticityActions,
+    isDeviceAuthenticityValid,
 } from '@suite-common/device-authenticity';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { DeviceAuthenticityCheckResult, EventType, analytics } from '@suite-native/analytics';
@@ -14,8 +15,10 @@ import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import { useTranslate } from '@suite-native/intl';
 import { captureSentryException, withSentryScope } from '@suite-native/sentry';
 import { useToast } from '@suite-native/toasts';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { AuthenticateDeviceResult, Response } from '@trezor/connect';
 import { isArrayMember } from '@trezor/utils';
+
+type RawResult = Awaited<Response<AuthenticateDeviceResult>>;
 
 type CheckDeviceAuthenticityParams = {
     handleSuccess: () => void;
@@ -35,18 +38,14 @@ export const useDeviceAuthenticityCheck = () => {
         (
             result: DeviceAuthenticityCheckResult,
             error?: string,
-            payload?: CheckDeviceAuthenticityThunkResult,
+            payload?: StoredAuthenticateDeviceResult,
         ) => {
             analytics.report({
                 type: EventType.DeviceSettingsAuthenticityCheck,
                 payload: { result },
             });
-            if (isArrayMember(result, ['compromised', 'configExpired', 'failed'])) {
-                const sentryLevelMap = {
-                    compromised: 'fatal',
-                    configExpired: 'warning',
-                    failed: 'error',
-                } as const;
+            if (isArrayMember(result, ['compromised', 'failed'])) {
+                const sentryLevelMap = { compromised: 'fatal', failed: 'error' } as const;
                 const sentryLevel = sentryLevelMap[result];
 
                 withSentryScope(scope => {
@@ -66,31 +65,20 @@ export const useDeviceAuthenticityCheck = () => {
     );
 
     const createStoredResult = useCallback(
-        (payload: CheckDeviceAuthenticityThunkResult) => {
-            if (
-                payload?.error === 'CA_PUBKEY_NOT_FOUND' &&
-                'configExpired' in payload &&
-                payload?.configExpired
-            ) {
-                // CA_PUBKEY_NOT_FOUND with configExpired is temporarily allowed and just logged to Sentry
-                reportCheckResult('configExpired', payload.error, payload);
-
-                return {
-                    ...payload,
-                    valid: true,
-                };
+        (result: RawResult): StoredAuthenticateDeviceResult => {
+            // Error from the TrezorConnect call itself. It is considered as valid: false if the cause was bootloader unlocked.
+            // Otherwise it may be cancel on device (must not be considered device compromised), or a transport error, etc.
+            if (!result.success) {
+                return isDeviceBootloaderUnlocked
+                    ? { valid: false, error: result.payload.error }
+                    : undefined;
             }
 
-            if (isDeviceBootloaderUnlocked) {
-                return {
-                    valid: false,
-                    error: payload?.error ?? 'Bootloader unlocked!',
-                };
-            }
+            const isOverallValid = isDeviceAuthenticityValid(result.payload);
 
-            return payload;
+            return { valid: isOverallValid, ...result.payload };
         },
-        [isDeviceBootloaderUnlocked, reportCheckResult],
+        [isDeviceBootloaderUnlocked],
     );
 
     const handleDeviceAccessError = useCallback(
@@ -178,15 +166,18 @@ export const useDeviceAuthenticityCheck = () => {
                 handleError(error, code);
             }
 
-            const storedResult: CheckDeviceAuthenticityThunkResult = createStoredResult(
-                result.payload,
-            );
+            const storedResult: StoredAuthenticateDeviceResult = createStoredResult(result);
 
             dispatch(deviceAuthenticityActions.result({ device, result: storedResult }));
 
             if (storedResult?.valid === false) {
                 handleFailure();
-                reportCheckResult('compromised', storedResult.error, storedResult);
+                if ('optigaResult' in storedResult && storedResult.optigaResult.error) {
+                    reportCheckResult('compromised', storedResult.optigaResult.error, storedResult);
+                }
+                if ('tropicResult' in storedResult && storedResult.tropicResult?.error) {
+                    reportCheckResult('compromised', storedResult.tropicResult.error, storedResult);
+                }
             } else if (result.success) {
                 handleSuccess();
                 reportCheckResult('successful');


### PR DESCRIPTION
## Description

Major refactoring of `authenticateDevice` call, which currently returns only Optiga result, to return multiple secure element results (Optiga + Tropic), of which either can fail.

All config related to DAC is doubled to cover both Optiga and Tropic. For Tropic it's optional (not defined for older models, but will fail if required & missing) 

## Related Issue

Resolve #22170

## Screenshots

[Suite settings DAC.webm](https://github.com/user-attachments/assets/7110be79-dba7-44ee-9dbf-1a08a03060be)
[Suite onboarding DAC.webm](https://github.com/user-attachments/assets/731730ab-f1c8-470c-b8f3-4a95cd59fc0c)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/DAC-tropic&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/DAC-tropic&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/DAC-tropic&lookback=7)