### PR TITLE
feat(suite-native): create backup from firmware install

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -860,6 +860,15 @@ export const messages = {
                 turnOnButton: 'Turn on',
             },
         },
+        firmware: {
+            noBackupAlert: {
+                title: 'Do you really want to proceed without backup?',
+                description:
+                    'Although unlikely, you may need to restore your wallet in case of firmware update issue.',
+                primaryButton: 'No, create wallet backup',
+                secondaryButton: 'Yes, update firmware',
+            },
+        },
     },
     moduleReceive: {
         receiveTitle: 'Receive',

--- a/suite-native/module-device-settings/src/screens/ConfirmFirmwareUpdateScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/ConfirmFirmwareUpdateScreen.tsx
@@ -1,9 +1,14 @@
 import React, { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
+import { CompositeNavigationProp, useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import { selectIsFirmwareUpgradable } from '@suite-common/wallet-core';
+import {
+    selectIsDeviceBackupRequired,
+    selectIsFirmwareUpgradable,
+} from '@suite-common/wallet-core';
+import { useAlert } from '@suite-native/alerts';
 import { Box, useBottomSheetModal } from '@suite-native/atoms';
 import { useDeviceLowBatteryAlert } from '@suite-native/device';
 import { useDeviceConnectionGuard } from '@suite-native/device-authorization';
@@ -15,24 +20,36 @@ import {
 import { Translation } from '@suite-native/intl';
 import { useNavigateToCheckBackup } from '@suite-native/module-check-backup';
 import {
+    DeviceOnboardingStackRoutes,
+    DeviceSettingsStackParamList,
     DynamicScreenHeader,
     FirmwareUpdateStackParamList,
     FirmwareUpdateStackRoutes,
+    RootStackParamList,
+    RootStackRoutes,
     Screen,
-    StackNavigationProps,
 } from '@suite-native/navigation';
 
-type NavigationProp = StackNavigationProps<
-    FirmwareUpdateStackParamList,
-    FirmwareUpdateStackRoutes.ConfirmFirmwareUpdate
+type NavigationProps = CompositeNavigationProp<
+    NativeStackNavigationProp<
+        FirmwareUpdateStackParamList,
+        FirmwareUpdateStackRoutes.ConfirmFirmwareUpdate
+    >,
+    CompositeNavigationProp<
+        NativeStackNavigationProp<DeviceSettingsStackParamList>,
+        NativeStackNavigationProp<RootStackParamList>
+    >
 >;
 
 export const ConfirmFirmwareUpdateScreen = () => {
-    const navigation = useNavigation<NavigationProp>();
+    const navigation = useNavigation<NavigationProps>();
     const { isDeviceConnected } = useDeviceConnectionGuard();
+    const isDeviceBackupRequired = useSelector(selectIsDeviceBackupRequired);
+
+    const { showAlert } = useAlert();
     const isFirmwareUpgradable = useSelector(selectIsFirmwareUpgradable);
 
-    const { openModal, bottomSheetRef, closeModal } = useBottomSheetModal();
+    const { openModal: openCheckBackupModal, bottomSheetRef, closeModal } = useBottomSheetModal();
     const { navigateToCheckBackup } = useNavigateToCheckBackup();
 
     const { showLowBatteryAlertIfNecessary } = useDeviceLowBatteryAlert();
@@ -51,6 +68,33 @@ export const ConfirmFirmwareUpdateScreen = () => {
 
     if (!isDeviceConnected) return;
 
+    const handleConfirmButtonPress = () => {
+        if (isDeviceBackupRequired) {
+            showAlert({
+                title: <Translation id="moduleDeviceSettings.firmware.noBackupAlert.title" />,
+                description: (
+                    <Translation id="moduleDeviceSettings.firmware.noBackupAlert.description" />
+                ),
+                primaryButtonTitle: (
+                    <Translation id="moduleDeviceSettings.firmware.noBackupAlert.primaryButton" />
+                ),
+                primaryButtonVariant: 'redBold',
+                onPressPrimaryButton: () => {
+                    navigation.navigate(RootStackRoutes.DeviceOnboardingStack, {
+                        screen: DeviceOnboardingStackRoutes.WalletBackupTutorial,
+                    });
+                },
+                secondaryButtonTitle: (
+                    <Translation id="moduleDeviceSettings.firmware.noBackupAlert.secondaryButton" />
+                ),
+                secondaryButtonVariant: 'redElevation1',
+                onPressSecondaryButton: handleUpdateConfirmation,
+            });
+        } else {
+            openCheckBackupModal();
+        }
+    };
+
     return (
         <Screen
             header={
@@ -62,7 +106,9 @@ export const ConfirmFirmwareUpdateScreen = () => {
             }
             footer={
                 isFirmwareUpgradable && (
-                    <ConfirmFirmwareUpdateScreenFooter onUpdateConfirmation={openModal} />
+                    <ConfirmFirmwareUpdateScreenFooter
+                        onUpdateConfirmation={handleConfirmButtonPress}
+                    />
                 )
             }
         >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- adds an alert to the device settings firmware update flow that warns the user in case he/she has no device backup
## Related Issue

Resolves #16485
## Screenshots:

https://github.com/user-attachments/assets/1bdc21cd-f0d4-4550-a5f1-9ff1ecb48f70




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/create-backup-from-firmware-settings&lookback=7)