### PR TITLE
fix(suite-native): discovery after killing coin enabling init

### DIFF
--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -161,17 +161,19 @@ deviceConnectionMiddleware.startListening({
         const isDeviceRemembered =
             !!device.features && selectDevices(getOriginalState()).some(d => d.id === device.id);
 
-        if (isDeviceRemembered) return;
+        const isCoinEnablingInitFinished = selectIsCoinEnablingInitFinished(getState());
+
+        if (isDeviceRemembered && isCoinEnablingInitFinished) return;
 
         handleDeviceConnectNavigation({
             hasDeviceBitcoinOnlyFirmware: hasBitcoinOnlyFirmware(device),
-            isCoinEnablingInitFinished: selectIsCoinEnablingInitFinished(getState()),
             isDeviceInitialized: getIsDeviceInitialized({
                 deviceMode: device.mode,
                 deviceFeatures: device.features,
             }),
             isDeviceSetupSupported: getIsDeviceSetupSupported(getDeviceInternalModel(device)),
             wasDeviceOnboardingCancelled: selectWasDeviceOnboardingCancelled(getState()),
+            isCoinEnablingInitFinished,
         });
     },
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- If user kills the app on coin enabling init before submitting the form, the connected device is remembered so we don't do the connection navigation, however coin enabling is not finished 🤷 😮 

This is an edge case, but in this case, we actually want to trigger the connection navigation, so we can run discovery. 


Resolve https://github.com/trezor/trezor-suite/issues/22180


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/broken-discovery-after-killing-app-on-coin-enabling&lookback=7)