### PR TITLE
feat: revert colour of battery level alert buttons to red

### DIFF
--- a/packages/suite/src/components/suite/modals/LowBatteryModal.tsx
+++ b/packages/suite/src/components/suite/modals/LowBatteryModal.tsx
@@ -40,7 +40,7 @@ export const LowBatteryModal = ({ onClose, children }: LowBatteryModalProps) => 
             heading={<LowBatteryModalHeading batteryLevel={bateryLevel} />}
             onCancel={onClose}
             bottomContent={
-                <Button variant="warning" onClick={onClose}>
+                <Button variant="destructive" onClick={onClose}>
                     <Translation id="TR_GOT_IT" />
                 </Button>
             }

--- a/suite-native/device/src/hooks/useDeviceLowBatteryAlert.tsx
+++ b/suite-native/device/src/hooks/useDeviceLowBatteryAlert.tsx
@@ -25,7 +25,7 @@ export const useDeviceLowBatteryAlert = () => {
                     />
                 ),
                 primaryButtonTitle: <Translation id="generic.buttons.gotIt" />,
-                primaryButtonVariant: 'yellowBold',
+                primaryButtonVariant: 'redBold',
             });
 
             return true;


### PR DESCRIPTION
Reverting to original colour after @shenkys's request.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/battery-level-alert-buttons&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/battery-level-alert-buttons&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/battery-level-alert-buttons&lookback=7)