### PR TITLE
fix(e2e-suite): fix t2t1-receovery-persistance test

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts
@@ -129,11 +129,11 @@ test.describe(
                 await trezorUserEnvLink.stopEmu();
                 await devicePrompt.connectDevicePromptIsShown();
                 await trezorUserEnvLink.startEmu({ wipe: false, model: 'T2T1' });
-                await devicePrompt.confirmOnDevicePromptIsShown();
+                await devicePrompt.confirmOnDevicePromptIsShown({ timeout: 15_000 });
 
                 // This is needed, because there seem to be some weird refreshes on the emu
                 // which means you confirm too early if you don't wait
-                await page.waitForTimeout(3000);
+                await page.waitForTimeout(3_000);
                 await trezorUserEnvLink.pressYes();
             });
 


### PR DESCRIPTION
there was a big downgrade in performance or there is big range of how fast this operation can be done. Problably the later since the test is flaky and not completely failing.
Sometimes the prompt after reconnect is there n 800ms and sometimes in 6000ms. I will ask around.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-ci-issues&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-ci-issues&lookback=7)