### PR TITLE
chore(suite-desktop): bump electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
         "type-fest": "4.24.0",
         "bcrypto": "5.4.0",
         "react": "19.0.0",
-        "electron": "38.0.0",
+        "electron": "38.2.1",
         "@types/node": "22.13.10",
         "bn.js": "5.2.2",
         "node-addon-api": "8.5.0",

--- a/packages/connect-examples/electron-main-process/package.json
+++ b/packages/connect-examples/electron-main-process/package.json
@@ -56,7 +56,7 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "electron": "38.0.0",
+        "electron": "38.2.1",
         "electron-builder": "26.0.3"
     }
 }

--- a/packages/connect-examples/electron-renderer-with-popup/package.json
+++ b/packages/connect-examples/electron-renderer-with-popup/package.json
@@ -53,7 +53,7 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "electron": "38.0.0",
+        "electron": "38.2.1",
         "electron-builder": "26.0.3"
     }
 }

--- a/packages/suite-desktop-api/package.json
+++ b/packages/suite-desktop-api/package.json
@@ -19,6 +19,6 @@
         "depcheck": "yarn g:depcheck"
     },
     "dependencies": {
-        "electron": "38.0.0"
+        "electron": "38.2.1"
     }
 }

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -77,7 +77,7 @@
         "@types/ws": "^8.5.13",
         "app-builder-lib": "^26.0.12",
         "dotenv": "^16.4.7",
-        "electron": "38.0.0",
+        "electron": "38.2.1",
         "electron-devtools-installer": "^4.0.0",
         "fs-extra": "^11.3.1",
         "glob": "^11.0.3",

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -29,7 +29,7 @@
         "usb": "^2.15.0"
     },
     "devDependencies": {
-        "electron": "38.0.0",
+        "electron": "38.2.1",
         "electron-builder": "26.0.3"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13872,7 +13872,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-desktop-api@workspace:packages/suite-desktop-api"
   dependencies:
-    electron: "npm:38.0.0"
+    electron: "npm:38.2.1"
   languageName: unknown
   linkType: soft
 
@@ -13927,7 +13927,7 @@ __metadata:
     app-builder-lib: "npm:^26.0.12"
     chalk: "npm:^4.1.2"
     dotenv: "npm:^16.4.7"
-    electron: "npm:38.0.0"
+    electron: "npm:38.2.1"
     electron-devtools-installer: "npm:^4.0.0"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
@@ -13991,7 +13991,7 @@ __metadata:
   resolution: "@trezor/suite-desktop@workspace:packages/suite-desktop"
   dependencies:
     blake-hash: "npm:^2.0.0"
-    electron: "npm:38.0.0"
+    electron: "npm:38.2.1"
     electron-builder: "npm:26.0.3"
     openpgp: "npm:^6.2.2"
     usb: "npm:^2.15.0"
@@ -20372,7 +20372,7 @@ __metadata:
   dependencies:
     "@trezor/connect": "workspace:*"
     "@trezor/eslint": "workspace:*"
-    electron: "npm:38.0.0"
+    electron: "npm:38.2.1"
     electron-builder: "npm:26.0.3"
   languageName: unknown
   linkType: soft
@@ -20382,7 +20382,7 @@ __metadata:
   resolution: "connect-example-electron-renderer-popup@workspace:packages/connect-examples/electron-renderer-with-popup"
   dependencies:
     "@trezor/eslint": "workspace:*"
-    electron: "npm:38.0.0"
+    electron: "npm:38.2.1"
     electron-builder: "npm:26.0.3"
   languageName: unknown
   linkType: soft
@@ -22835,16 +22835,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:38.0.0":
-  version: 38.0.0
-  resolution: "electron@npm:38.0.0"
+"electron@npm:38.2.1":
+  version: 38.2.1
+  resolution: "electron@npm:38.2.1"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/a245bf63fae60d1db85acddbe5787750e4d07acb273a1a5058163aee427fe07e52100b0d5a1e6b41efbdc1b398b6e7ec0fb3df75672e9148e95b31309d0c8f3a
+  checksum: 10/418c66f33faf1b3f95df4c26f21d158c4d161a6cef6a8c9011b6435c4263133ccefe79aa8ac71269be44e93fbf90999d38086c56abfab01eeff326a087af7b27
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Bump electron to fix a macOS 26 bug https://avarayr.github.io/shamelectron/

## Related Issue

Part of https://github.com/trezor/trezor-suite/issues/22187

## Screenshots:

Small visual bug on Linux with Gnome: the window does not respect system theme, and renders close/minimize/maximize buttons on the left instead of on the right. https://github.com/electron/electron/issues/48422

<img width="315" height="162" alt="Screenshot from 2025-10-06 09-06-54" src="https://github.com/user-attachments/assets/de8008c3-cbfe-434d-b994-b2bd413b34c0" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bump-electron&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bump-electron&lookback=7)