### PR TITLE
Update ownership for analytics types and constants

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,17 @@
 /scripts @karliatto
 
 /packages/analytics @tomasklim
+/packages/suite-analytics @tomasklim
+
+/packages/connect-analytics/src/constants.ts @kolomaznikt
+/suite-common/analytics/src/events/shared/constants.ts @kolomaznikt
+/suite-common/analytics/src/events/suite/constants.ts @kolomaznikt
+/suite-common/analytics/src/events/suite-native/constants.ts @kolomaznikt
+
+/packages/connect-analytics/src/types @kolomaznikt
+/suite-common/analytics/src/events/shared/types.ts @kolomaznikt
+/suite-common/analytics/src/events/suite/types.ts @kolomaznikt
+/suite-common/analytics/src/events/suite-native/types.ts @kolomaznikt
 
 /packages/blockchain-link @mroz22 @marekrjpolak
 
@@ -53,8 +64,6 @@
 /suite-common/message-system @tomasklim @matejkriz @MiroslavProchazka @pavelmario
 
 /suite-common/token-definitions @tomasklim
-
-/packages/suite-analytics @tomasklim
 
 /packages/suite-build @komret
 


### PR DESCRIPTION
## Description

Add @kolomaznikt into CODEOWNERS for specific analytics files (types.ts, constants.ts). desktop, native, connect, shared

## Related Issue

Resolve #21909


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/21909-codeowners&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/21909-codeowners&lookback=7)