### PR TITLE
Feat/21744 mev protection event

### DIFF
--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -82,6 +82,8 @@ export const getSuiteReadyPayload = async (
         isAutomaticUpdateEnabled: state.desktopUpdate.isAutomaticUpdateEnabled,
 
         experimentVariants: experimentVariants.map(({ name, variant }) => `${name}:${variant}`),
+
+        mevProtection: state.wallet.settings.mevProtection,
     };
 };
 

--- a/packages/suite/src/views/settings/SettingsGeneral/MevProtection.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/MevProtection.tsx
@@ -3,6 +3,7 @@ import { FormattedList } from 'react-intl';
 import { networksCollection } from '@suite-common/wallet-config';
 import { WALLET_SETTINGS, selectIsMevProtectionEnabled } from '@suite-common/wallet-core';
 import { Switch } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { SettingsSectionItem } from 'src/components/settings/SettingsSectionItem';
 import { ActionColumn, TextColumn } from 'src/components/suite';
@@ -18,12 +19,19 @@ export const MevProtection = () => {
         .filter(network => network.features.includes('mev-protection'))
         .map(network => network.name);
 
-    const handleSubmit = () => {
+    function handleSwitchChange() {
+        const nextIsMevProtectionEnabled = !isMevProtectionEnabled;
+
         dispatch({
             type: WALLET_SETTINGS.SET_MEV_PROTECTION,
-            payload: !isMevProtectionEnabled,
+            payload: nextIsMevProtectionEnabled,
         });
-    };
+
+        analytics.report({
+            type: EventType.SettingsGeneralMevProtection,
+            payload: { value: nextIsMevProtectionEnabled },
+        });
+    }
 
     return (
         <SettingsSectionItem anchorId={SettingsAnchor.MevProtection}>
@@ -47,7 +55,7 @@ export const MevProtection = () => {
             <ActionColumn>
                 <Switch
                     isChecked={isMevProtectionEnabled}
-                    onChange={handleSubmit}
+                    onChange={handleSwitchChange}
                     data-testid="@settings/auto-eject-switch"
                 />
             </ActionColumn>

--- a/suite-common/analytics/src/events/suite/constants.ts
+++ b/suite-common/analytics/src/events/suite/constants.ts
@@ -114,6 +114,7 @@ export enum EventType {
     SettingsGeneralLabelingProvider = 'settings/general/labeling-provider',
     SettingsGeneralAutoEject = 'settings/general/auto-eject',
     SettingsGeneralStoreDeviceData = 'settings/general/store-device-data',
+    SettingsGeneralMevProtection = 'settings/general/mev-protection',
     SettingsCoinsBackend = 'settings/coins/backend',
     SettingsCoins = 'settings/coins',
     SettingsTor = 'settings/tor',

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -694,6 +694,12 @@ export type SuiteAnalyticsEvent =
           };
       }
     | {
+          type: EventType.SettingsGeneralMevProtection;
+          payload: {
+              value: boolean;
+          };
+      }
+    | {
           type: EventType.SettingsCoins;
           payload: {
               symbol: string;

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -37,6 +37,7 @@ export type SuiteAnalyticsEventSuiteReady = {
         desktopOsArchitecture?: string;
         isAutomaticUpdateEnabled: boolean;
         experimentVariants: string[];
+        mevProtection: boolean;
     };
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Add event that user interacts with mev protection in settings (`settings/general/mev-protection` event).
2. Add mev protection attribute into `suite-ready` event.


## Related Issue

Resolve #21744


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/21744-mev-protection-event&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/21744-mev-protection-event&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/21744-mev-protection-event&lookback=7)