### PR TITLE
fix(suite-desktop): windows hello filename

### DIFF
--- a/packages/suite-desktop-core/webpack/core.webpack.config.ts
+++ b/packages/suite-desktop-core/webpack/core.webpack.config.ts
@@ -53,6 +53,7 @@ const threads = sync(`${threadPath}/**/*.ts`).map(globMatch => {
 });
 
 // Add Windows Hello child process to the build
+const winHelloChildProcessKey = 'winHelloChildProcess'; // must match the expected /dist filename that WinHelloProcessManager requires
 const winHelloChildProcessPath = path.join(
     __dirname,
     '../../suite-desktop-native/src/winHelloChildProcess.ts',
@@ -76,12 +77,13 @@ const config: webpack.Configuration = {
     target: 'electron-main',
     mode: isDev ? 'development' : 'production',
     devtool: 'source-map',
+    // Note that the entries key is important, it sets the the output file name in dist/
     entry: [
         // NOTE: in DEV ONLY pick app with react dev tools installed
         { app: isDev ? 'app-with-devtools' : 'app' },
         { preload: 'preload' },
         ...threads.map(thread => ({ [String(thread)]: thread })),
-        { winHelloChildProcessPath },
+        { [winHelloChildProcessKey]: winHelloChildProcessPath },
     ].reduce(
         (prev, cur) => ({
             ...prev,
@@ -89,7 +91,7 @@ const config: webpack.Configuration = {
                 (acc, [key, value]) => ({
                     ...acc,
                     [key]:
-                        key === 'winHelloChildProcessPath'
+                        key === winHelloChildProcessKey
                             ? value
                             : path.resolve(__dirname, `../src/${value}.ts`),
                 }),


### PR DESCRIPTION
## Description

Fix windows hello module path, accidentally changed in 797583e0967078944fa601d9bf3396e37789c6d9

## Related Issue

Resolve #22194

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/windows-hello-filename&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/windows-hello-filename&lookback=7)