### PR TITLE
feat(suite-common): add 2.9.1 fw releases

### DIFF
--- a/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.9.1-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.9.1-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 9, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "acd56d0113a547e9b5983510b0ce9de079e30e05",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.9.1.bin",
+        "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.9.1.bin",
+        "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.9.1.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.9.1.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.9.1.bin"
+    },
+    "url": "firmware/t2b1/trezor-t2b1-2.9.1-bitcoinonly.bin",
+    "fingerprint": "4021f750b194d4663c9dbc79048b6cf0acca3abe05eca4a27db563cb579d1829",
+    "changelog": "* Make space between value and unit non-breakable.\n* Other small improvements and bug fixes."
+}

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.10-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.10-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2fcf27e4884efbceefd037ba47ebb603ce720575271e69ad0bb6f5b9dc565172
-size 1183744

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.10.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.10.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cc8e38f5ca715e3764553149614310b5fc941293e4864e0f9c9db5a76218e14
-size 1467904

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.9.1-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.9.1-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:083adc9b35ab189f36dd3d1e150da494aa53b148d3b3939d57b175f01dd2d8e1
+size 1211904

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.9.1.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.9.1.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b3982944bdb9cd56da3bc5b3a160e262fd139e9b56fe6b66b89573b40451abc
+size 1501184

--- a/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.9.1-universal.json
+++ b/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.9.1-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 9, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "acd56d0113a547e9b5983510b0ce9de079e30e05",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.9.1.bin",
+        "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.9.1.bin",
+        "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.9.1.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.9.1.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.9.1.bin"
+    },
+    "url": "firmware/t2b1/trezor-t2b1-2.9.1.bin",
+    "fingerprint": "a3f4b7dd49aa7b22533bdff20b83ff07fbf4946794df0b1b830397d4cf3983e4",
+    "changelog": "* Add support for signing arbitrary messages in Cardano.\n* Add support for displaying the message hash when signing Ethereum EIP-712 typed data.\n* Allow using Ethereum mainnet addresses on all non-Ethereum networks.\n* Improved Stellar transaction signing interface for a more streamlined user experience.\n* Implement multi-item menus for Solana staking.\n* Make space between value and unit non-breakable.\n* Fixed Solana signature failure.\n* Other small improvements and bug fixes."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.9.1-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.9.1-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 9, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "acd56d0113a547e9b5983510b0ce9de079e30e05",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.9.1.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.9.1.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.9.1.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.9.1.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.9.1.bin"
+    },
+    "url": "firmware/t2t1/trezor-t2t1-2.9.1-bitcoinonly.bin",
+    "fingerprint": "77b53ba1e381fcf8ce0868e8d158484e57ef22de1389b60df0a287199b92c14f",
+    "changelog": "* Limit swipe detection to the component's bounds.\n* Make space between value and unit non-breakable.\n* Do not hide the shown PIN until the touch is released.\n* Other small improvements and bug fixes."
+}

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.10-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.10-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b04bfb97723dbbc6db3edc2abe1daf603e2936cab6d180773645a2dd19f685c
-size 1273856

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.10.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.10.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f97b11599f68fe01f2f9414af6d876fb3dbedfc1e375e1e18486177e7523cb4d
-size 1589248

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.9.1-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.9.1-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24d77c6adf172045ab8149417f5020881cd1e63640434cd9cd973db47a10fd41
+size 1295360

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.9.1.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.9.1.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a84c200f13b564ffc2f16c2a6806272b0e7561d04d434f55b495d15c5a0c027
+size 1614848

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.9.1-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.9.1-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 9, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "acd56d0113a547e9b5983510b0ce9de079e30e05",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.9.1.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.9.1.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.9.1.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.9.1.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.9.1.bin"
+    },
+    "url": "firmware/t2t1/trezor-t2t1-2.9.1.bin",
+    "fingerprint": "aaa616c14904cf6eb940497d7fd5da8735ab0d0ecdebd3f6ced49fff0ce278a0",
+    "changelog": "* Add support for signing arbitrary messages in Cardano.\n* Add support for displaying the message hash when signing Ethereum EIP-712 typed data.\n* Allow using Ethereum mainnet addresses on all non-Ethereum networks.\n* Improved Stellar transaction signing interface for a more streamlined user experience.\n* Limit swipe detection to the component's bounds.\n* Make space between value and unit non-breakable.\n* Do not hide the shown PIN until the touch is released.\n* Fixed Solana signature failure.\n* Other small improvements and bug fixes."
+}

--- a/packages/connect-common/files/firmware/t3b1/bitcoinonly/t3b1-2.9.1-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t3b1/bitcoinonly/t3b1-2.9.1-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 9, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 7],
+    "min_firmware_version": [2, 8, 3],
+    "bootloader_version": [2, 1, 10],
+    "firmware_revision": "acd56d0113a547e9b5983510b0ce9de079e30e05",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3b1/translation-T3B1-cs-CZ-2.9.1.bin",
+        "de-DE": "firmware/translations/t3b1/translation-T3B1-de-DE-2.9.1.bin",
+        "es-ES": "firmware/translations/t3b1/translation-T3B1-es-ES-2.9.1.bin",
+        "fr-FR": "firmware/translations/t3b1/translation-T3B1-fr-FR-2.9.1.bin",
+        "pt-BR": "firmware/translations/t3b1/translation-T3B1-pt-BR-2.9.1.bin"
+    },
+    "url": "firmware/t3b1/trezor-t3b1-2.9.1-bitcoinonly.bin",
+    "fingerprint": "7588c0d41586268562837b8b302b8a4825fbec24ef94921e55ce820ff6dc2da6",
+    "changelog": "* Make space between value and unit non-breakable.\n* Fix crash on first boot.\n* Other small improvements and bug fixes."
+}

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.10-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.10-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb64b3a6597b7bf27105cb4c303aaf4da6f6525bc78a75bdffcc5a3dd58c4303
-size 991744

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.10.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.10.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b082e2584c93ba815e3a4ca01e8906c126c87ea698c747b4a2138827fca95a7
-size 1345024

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.9.1-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.9.1-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abdc49ee0a5182bdf48360d8ca0793d3b62c39a9c0c1003a91d09ebbc4a4d776
+size 1023488

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.9.1.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.9.1.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82fc68344c461aba5076f1dc9198527e8fb1a7d228919dc373209e839ceb2197
+size 1380864

--- a/packages/connect-common/files/firmware/t3b1/universal/t3b1-2.9.1-universal.json
+++ b/packages/connect-common/files/firmware/t3b1/universal/t3b1-2.9.1-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 9, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 7],
+    "min_firmware_version": [2, 8, 3],
+    "bootloader_version": [2, 1, 10],
+    "firmware_revision": "acd56d0113a547e9b5983510b0ce9de079e30e05",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3b1/translation-T3B1-cs-CZ-2.9.1.bin",
+        "de-DE": "firmware/translations/t3b1/translation-T3B1-de-DE-2.9.1.bin",
+        "es-ES": "firmware/translations/t3b1/translation-T3B1-es-ES-2.9.1.bin",
+        "fr-FR": "firmware/translations/t3b1/translation-T3B1-fr-FR-2.9.1.bin",
+        "pt-BR": "firmware/translations/t3b1/translation-T3B1-pt-BR-2.9.1.bin"
+    },
+    "url": "firmware/t3b1/trezor-t3b1-2.9.1.bin",
+    "fingerprint": "8a52e82d21a151cfa542b5ca0e265e9b4997f481365ff1b2bb047b45fac3a167",
+    "changelog": "* Add support for signing arbitrary messages in Cardano.\n* Add support for displaying the message hash when signing Ethereum EIP-712 typed data.\n* Allow using Ethereum mainnet addresses on all non-Ethereum networks.\n* Improved Stellar transaction signing interface for a more streamlined user experience.\n* Implement multi-item menus for Solana staking.\n* Make space between value and unit non-breakable.\n* Fixed Solana signature failure.\n* Fix crash on first boot.\n* Other small improvements and bug fixes."
+}

--- a/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.9.1-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.9.1-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 9, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 10],
+    "firmware_revision": "acd56d0113a547e9b5983510b0ce9de079e30e05",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.9.1.bin",
+        "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.9.1.bin",
+        "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.9.1.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.9.1.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.9.1.bin"
+    },
+    "url": "firmware/t3t1/trezor-t3t1-2.9.1-bitcoinonly.bin",
+    "fingerprint": "f19a88717e8eb7eb75ead0be5b5a0f1a129e2827658e587310fe285826138b2d",
+    "changelog": "* Limit swipe detection to the component's bounds.\n* Make space between value and unit non-breakable.\n* Do not hide the shown PIN until the touch is released.\n* Fix incomplete disabling of haptics.\n* Other small improvements and bug fixes."
+}

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.10-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.10-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad66099c6bf2dd037c9844a9236f6dc3bd8eab200d5b6b0138aa29bcb4f35628
-size 1150464

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.10.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.10.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd6b59f0cb501f8d372e2b8e7369195fdf1980f5915ca6fe61223fcd0601df6a
-size 1523200

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.9.1-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.9.1-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30f223ad74da22f5f04538da37cedd74e8197aa07244bc8ae95de83bb4b3cd59
+size 1184768

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.9.1.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.9.1.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b44f13df789c8aa40958c7caaad05b6a129f857a1ae8786481d16ab9c95a7ef
+size 1561088

--- a/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.9.1-universal.json
+++ b/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.9.1-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 9, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 10],
+    "firmware_revision": "acd56d0113a547e9b5983510b0ce9de079e30e05",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.9.1.bin",
+        "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.9.1.bin",
+        "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.9.1.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.9.1.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.9.1.bin"
+    },
+    "url": "firmware/t3t1/trezor-t3t1-2.9.1.bin",
+    "fingerprint": "2db8a9aace0557a348237c0a2d2fb44249714d7e2002f253ed06446701f7658a",
+    "changelog": "* Add support for signing arbitrary messages in Cardano.\n* Provider contract address in ETH approve.\n* Add support for displaying the message hash when signing Ethereum EIP-712 typed data.\n* Allow using Ethereum mainnet addresses on all non-Ethereum networks.\n* Improved Stellar transaction signing interface for a more streamlined user experience.\n* Limit swipe detection to the component's bounds.\n* Make space between value and unit non-breakable.\n* Do not hide the shown PIN until the touch is released.\n* Fixed Solana signature failure.\n* Fix incomplete disabling of haptics.\n* Other small improvements and bug fixes."
+}


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/22198

1. Copy-pasted from: https://github.com/trezor/data/tree/master/firmware
2. Running `./packages/connect-common/scripts/check-all-firmware-revisions.sh` produced no errors - but I am not sure if it is working correctly. There are some `No such file or directory` errors ... investigating...