### PR TITLE
fix(suite): preselected quote

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -162,7 +162,7 @@ export const TradingFormOffer = () => {
 
         initConfirmTrade();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [quote, requiresTokenApproval]);
+    }, [quote, requiresTokenApproval, tradingReceiveAddress?.receiveAddress]);
 
     const onSelectQuote = async () => {
         if (!quote) {


### PR DESCRIPTION
## Description

Due to new receive address picker, when selecting a different quote from `Compare all offers`, it has not been initialized and confirmed properly.

### Before

The user clicked on `Compare all offers`, selected a different quote, was redirected back to the swap form and the `Refresh` button appeared (meaning something went wrong).

### After

The user clicks on `Compare all offers`, selects a different quote, is redirected back to the swap form and the quote is properly loaded.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/preselected-quote&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/preselected-quote&lookback=7)