### PR TITLE
fix(suite): make a harmless translation change to test out if crowdin…

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -238,7 +238,7 @@ export default defineMessages({
         dynamic: true,
     },
     TR_TRADING_SWAP_MODAL_CONFIRM: {
-        defaultMessage: 'I’m ready to swap',
+        defaultMessage: 'I am ready to swap',
         id: 'TR_TRADING_SWAP_MODAL_CONFIRM',
         dynamic: true,
     },


### PR DESCRIPTION
… notifies the translators

<!--- Provide a general summary of your changes in the Title above -->

## Description
In this PR we test if the update of the defaultMessage in messages.ts will cause the crowdin notification about some underlying transaltion to be changed.

Thsi should be reverted

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=crowdin-sync-test-default-message-notify&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=crowdin-sync-test-default-message-notify&lookback=7)