### PR TITLE
Feat/connection type analytics attribute

### DIFF
--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -3,7 +3,10 @@ import { MiddlewareAPI } from 'redux';
 
 import { firmwareUpdate } from '@suite-common/firmware';
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';
-import { getPhysicalDeviceCount } from '@suite-common/suite-utils';
+import {
+    getIsDeviceDescriptorApiTypeBluetooth,
+    getPhysicalDeviceCount,
+} from '@suite-common/suite-utils';
 import {
     WALLET_SETTINGS,
     deviceActions,
@@ -104,31 +107,33 @@ const analyticsMiddleware =
                 });
                 break;
             case DEVICE.CONNECT: {
-                const {
-                    device: { features, mode },
-                } = action.payload;
+                const { device } = action.payload;
+                const { features, mode } = device;
 
                 if (!features || !mode) return;
 
-                if (!isDeviceInBootloaderMode(action.payload.device)) {
+                if (!isDeviceInBootloaderMode(device)) {
                     analytics.report({
                         type: EventType.DeviceConnect,
                         payload: {
                             mode,
-                            firmware: getFirmwareVersion(action.payload.device),
-                            firmwareRevision: getFirmwareRevision(action.payload.device),
-                            bootloaderHash: getBootloaderHash(action.payload.device),
+                            firmware: getFirmwareVersion(device),
+                            firmwareRevision: getFirmwareRevision(device),
+                            bootloaderHash: getBootloaderHash(device),
                             backup_type: features.backup_type || 'Bip39',
                             pin_protection: features.pin_protection,
                             passphrase_protection: features.passphrase_protection,
                             totalInstances: selectDevicesCount(state),
-                            isBitcoinOnly: hasBitcoinOnlyFirmware(action.payload.device),
+                            isBitcoinOnly: hasBitcoinOnlyFirmware(device),
                             isBitcoinOnlyDevice: !!features?.unit_btconly,
                             totalDevices: getPhysicalDeviceCount(selectDevices(state)),
                             language: features.language,
                             model: features.internal_model,
                             optiga_sec: features.optiga_sec,
-                            firmwareSource: getFirmwareSource(action.payload.device),
+                            firmwareSource: getFirmwareSource(device),
+                            connectionType: getIsDeviceDescriptorApiTypeBluetooth(device)
+                                ? 'bluetooth'
+                                : 'cable',
                         },
                     });
                 } else {

--- a/suite-common/analytics/src/events/suite-native/types.ts
+++ b/suite-common/analytics/src/events/suite-native/types.ts
@@ -185,6 +185,7 @@ export type SuiteNativeAnalyticsEvent =
               deviceModel: DeviceModelInternal | null;
               isBitcoinOnly: boolean;
               deviceLanguage: string | null;
+              connectionType: 'cable' | 'bluetooth';
           };
       }
     | {

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -127,6 +127,7 @@ export type SuiteAnalyticsEvent =
               firmwareRevision?: string;
               bootloaderHash?: string;
               optiga_sec?: number;
+              connectionType?: 'cable' | 'bluetooth';
           };
       }
     | {

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -512,3 +512,6 @@ export const getIsDeviceConnectedAndAuthorized = ({
     deviceState: TrezorDevice['state'];
     deviceFeatures?: PROTO.Features;
 }) => !!deviceState && !!deviceFeatures;
+
+export const getIsDeviceDescriptorApiTypeBluetooth = (device: Device) =>
+    device.descriptor.apiType === 'bluetooth';

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -72,24 +72,24 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
         }
 
         switch (action.type) {
-            case DEVICE.CONNECT:
-            case DEVICE.CONNECT_UNACQUIRED: {
+            case DEVICE.CONNECT: {
                 const { device } = action.payload;
                 const { features, mode } = device;
+                const isDeviceConnectedViaBluetooth =
+                    action.payload.device.descriptor.apiType === 'bluetooth';
+                analytics.report({
+                    type: EventType.ConnectDevice,
+                    payload: {
+                        mode: isDeviceInBootloaderMode(device) ? 'bootloader' : mode,
+                        firmwareVersion: getFirmwareVersionArray(device),
+                        pinProtection: features.pin_protection,
+                        isBitcoinOnly: hasBitcoinOnlyFirmware(device),
+                        deviceLanguage: features.language,
+                        deviceModel: features.internal_model,
+                        connectionType: isDeviceConnectedViaBluetooth ? 'bluetooth' : 'cable',
+                    },
+                });
 
-                if (features && mode) {
-                    analytics.report({
-                        type: EventType.ConnectDevice,
-                        payload: {
-                            mode: isDeviceInBootloaderMode(device) ? 'bootloader' : mode,
-                            firmwareVersion: getFirmwareVersionArray(device),
-                            pinProtection: features.pin_protection,
-                            isBitcoinOnly: hasBitcoinOnlyFirmware(device),
-                            deviceLanguage: features.language,
-                            deviceModel: features.internal_model,
-                        },
-                    });
-                }
                 break;
             }
             case DEVICE.DISCONNECT:

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -1,7 +1,10 @@
 import { AnyAction, isAnyOf } from '@reduxjs/toolkit';
 
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
-import { isAnyDeviceEventAction } from '@suite-common/suite-utils';
+import {
+    getIsDeviceDescriptorApiTypeBluetooth,
+    isAnyDeviceEventAction,
+} from '@suite-common/suite-utils';
 import {
     accountsActions,
     deviceActions,
@@ -75,8 +78,7 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
             case DEVICE.CONNECT: {
                 const { device } = action.payload;
                 const { features, mode } = device;
-                const isDeviceConnectedViaBluetooth =
-                    action.payload.device.descriptor.apiType === 'bluetooth';
+
                 analytics.report({
                     type: EventType.ConnectDevice,
                     payload: {
@@ -86,7 +88,9 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
                         isBitcoinOnly: hasBitcoinOnlyFirmware(device),
                         deviceLanguage: features.language,
                         deviceModel: features.internal_model,
-                        connectionType: isDeviceConnectedViaBluetooth ? 'bluetooth' : 'cable',
+                        connectionType: getIsDeviceDescriptorApiTypeBluetooth(device)
+                            ? 'bluetooth'
+                            : 'cable',
                     },
                 });
 


### PR DESCRIPTION
## Description
- Adds the deviceConnect `connectionType` attribute (`cable` | `bluetooth`) to both desktop and mobile analytics
  - [580f33e](https://github.com/trezor/trezor-suite/pull/22209/commits/580f33eca11e5141165b1a57ed5a2fc3a3432717) adds the attribute for mobile
    - Closes #21526
  - [580f33e](https://github.com/trezor/trezor-suite/pull/22209/commits/580f33eca11e5141165b1a57ed5a2fc3a3432717): adds the attribute for desktop
    - Closes #22200

## Links to analytics docs
- [Mobile](https://www.notion.so/satoshilabs/Mobile-app-data-analytics-changelog-946307159a294bcdb90b94e90eefd292?source=copy_link#284dc5260606805e8a91dbc411588cac)
- [Desktop](https://www.notion.so/satoshilabs/c63bdab01b704b099cab3bbb3227e1b1?v=406d107d6d584577a47d7580e8b2df89&p=4f6b6f058fad42878410fd3b56ad7077&pm=s) 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connection-type-analytics-attribute&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connection-type-analytics-attribute&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connection-type-analytics-attribute&lookback=7)