### PR TITLE
fix(connect): when not bundled device provide empty {}

### DIFF
--- a/packages/connect/src/utils/assetUtils.ts
+++ b/packages/connect/src/utils/assetUtils.ts
@@ -32,12 +32,12 @@ export const getReleasesAssetByDeviceModelAndFirmwareType = (
     const firmwareTypeInFileName =
         firmwareType === FirmwareType.BitcoinOnly ? 'bitcoinonly' : 'universal';
 
-    const availableRelesesRecord = (firmwareAssets as FirmwareAssetMap)[deviceModel.toLowerCase()][
-        firmwareTypeInFileName
-    ];
-    const availableFirmwaresReleases = Object.values(availableRelesesRecord);
+    const availableReleasesRecord =
+        (firmwareAssets as FirmwareAssetMap)?.[deviceModel.toLowerCase()]?.[
+            firmwareTypeInFileName
+        ] ?? {};
 
-    return availableFirmwaresReleases.sort((a, b) =>
+    return Object.values(availableReleasesRecord).sort((a, b) =>
         versionUtils.isNewer(b.version, a.version) ? 1 : -1,
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We do not have T3W1 releases bundled yet, so this should allow a non-bundled type of release to work.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/support-not-bundled-devices&lookback=7)