### PR TITLE
fix(suite): correctly update known devices on device disconnect

### DIFF
--- a/packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts
+++ b/packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts
@@ -4,6 +4,7 @@ import {
     prepareInitialState,
 } from '@suite-common/bluetooth';
 import { AnyAction, createSliceWithExtraDeps } from '@suite-common/redux-utils';
+import { deviceActions } from '@suite-common/wallet-core';
 
 import { DesktopBluetoothDevice } from './DesktopBluetoothDevice';
 
@@ -56,9 +57,24 @@ export const bluetoothSlice = createSliceWithExtraDeps({
     extraReducers: (builder, extra) => {
         const commonReducer = prepareBluetoothReducerCreator<DesktopBluetoothDevice>()(extra);
 
-        builder.addDefaultCase((state, action) => {
-            commonReducer(state, action as AnyAction);
-        });
+        builder
+            .addCase(deviceActions.deviceDisconnect, (state, action) => {
+                commonReducer(state, action as AnyAction);
+
+                state.knownDevices = state.knownDevices.map(device => {
+                    if (device.deviceId === action.payload.id) {
+                        device.connected = false;
+                        device.connectionStatus = {
+                            type: 'disconnected',
+                        };
+                    }
+
+                    return device;
+                });
+            })
+            .addDefaultCase((state, action) => {
+                commonReducer(state, action as AnyAction);
+            });
     },
 });
 

--- a/packages/suite/src/components/connection/hook/useBluetoothConnection.tsx
+++ b/packages/suite/src/components/connection/hook/useBluetoothConnection.tsx
@@ -44,12 +44,12 @@ export const useBluetoothConnection = ({
     );
 
     const notConnectedKnownDevices = useMemo(
-        () => knownDevices.filter(device => device.connected === false),
+        () => knownDevices.filter(device => device.connectionStatus.type === 'disconnected'),
         [knownDevices],
     );
 
     const notConnectedNearbyDevices = useMemo(
-        () => devices.filter(device => device.connected === false),
+        () => devices.filter(device => device.connectionStatus.type === 'disconnected'),
         [devices],
     );
 


### PR DESCRIPTION
When device is turned off via `Power` -> `Turn off` suite does not correctly update `knownDevices`.

Changes:
- base `notConnected` selectors on `connectionStatus`
- correctly update `knownDevice` on `deviceDisconnect` action

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22150


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/known-device-disconnect-update&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/known-device-disconnect-update&lookback=7)