### PR TITLE
chore(suite): disable redux immutableCheck

### DIFF
--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -138,6 +138,7 @@ export const initStore = <E extends Partial<ExtraDependencies>>(
         preloadedState: patchedState,
         middleware: getDefaultMiddleware =>
             getDefaultMiddleware({
+                immutableCheck: false,
                 serializableCheck: {
                     ignoredActions: [OPEN_USER_CONTEXT],
                     ignoredPaths: [


### PR DESCRIPTION
## Description

Remove Immutability Middleware from dev, as it spams warnings that are not useful.
 
We don't write vanilla redux without immer anymore, so you cannot really make this mistake.
Old reducers are vanilla redux but with immer, while new reducers are always made with @reduxjs/toolkit so it's safe.

In Suite Native [we already have it disabled](https://github.com/trezor/trezor-suite/blob/840f17207ef3a0e18893ba4f9b6dab5dd4403200/suite-native/state/src/store.ts#L52) for a long time. 

## Screenshots:

These warnings are never useful, I discovered that the stack track points to random parts of our code (a middleware or a thunk). It's like a stack trace spinning wheel :game_die: So there's no useful info for debugging performance.

<img width="630" height="97" alt="image" src="https://github.com/user-attachments/assets/f059bb46-3e2d-401b-9caf-9a19c9c74b55" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/disable-redux-immutableCheck&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/disable-redux-immutableCheck&lookback=7)