### PR TITLE
chore(suite-native): make type the first attribute

### DIFF
--- a/suite-native/bluetooth/src/hooks/useBluetoothAlerts.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothAlerts.ts
@@ -29,8 +29,8 @@ export const useBluetoothAlerts = () => {
     const showOrHideBluetoothAlert = useCallback(() => {
         if (bluetoothPermissionStatus === 'denied') {
             showAlert({
-                title: translate('bluetooth.alerts.permissionDenied.title'),
                 type: 'bluetoothAdapter',
+                title: translate('bluetooth.alerts.permissionDenied.title'),
                 description: translate('bluetooth.alerts.permissionDenied.description'),
                 primaryButtonTitle: translate('bluetooth.alerts.permissionDenied.primaryButton'),
                 onPressPrimaryButton: requestBluetoothPermission,
@@ -39,8 +39,8 @@ export const useBluetoothAlerts = () => {
             });
         } else if (bluetoothPermissionStatus === 'blocked') {
             showAlert({
-                title: translate('bluetooth.alerts.permissionBlocked.title'),
                 type: 'bluetoothAdapter',
+                title: translate('bluetooth.alerts.permissionBlocked.title'),
                 description: translate('bluetooth.alerts.permissionBlocked.description'),
                 primaryButtonTitle: translate('bluetooth.alerts.permissionBlocked.primaryButton'),
                 onPressPrimaryButton: openSettings,

--- a/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.android.tsx
+++ b/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.android.tsx
@@ -21,8 +21,8 @@ export const useBluetoothPlatformSpecificAlerts = () => {
 
     const showBluetoothAdapterDisabledAlert = useCallback(() => {
         showAlert({
-            title: translate('bluetooth.alerts.adapterDisabled.title'),
             type: 'bluetoothAdapter',
+            title: translate('bluetooth.alerts.adapterDisabled.title'),
             description: translate('bluetooth.alerts.adapterDisabled.description.android'),
             primaryButtonTitle: translate('bluetooth.alerts.adapterDisabled.primaryButton'),
             onPressPrimaryButton: openBluetoothSettings,

--- a/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.ios.tsx
+++ b/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.ios.tsx
@@ -18,8 +18,8 @@ export const useBluetoothPlatformSpecificAlerts = () => {
 
     const showBluetoothAdapterDisabledAlert = useCallback(() => {
         showAlert({
-            title: translate('bluetooth.alerts.adapterDisabled.title'),
             type: 'bluetoothAdapter',
+            title: translate('bluetooth.alerts.adapterDisabled.title'),
             description: translate('bluetooth.alerts.adapterDisabled.description.ios'),
             primaryButtonTitle: translate('generic.buttons.gotIt'),
         });


### PR DESCRIPTION
Alert `type` is used to "group" Bluetooth alerts.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/bluetooth-alerts-tweak&lookback=7)