### PR TITLE
fix(e2e-suite): fix swap tests to rely on translations for toast asserts

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -11,12 +11,12 @@ import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
 const sendAmount = swapQuotesSolanaUSDC[0].sendStringAmount;
+const receiveAmount = localizeNumber(swapQuotesSolanaUSDC[0].receiveStringAmount);
 const provider = getCompanyNameFromList(swapQuotesSolanaUSDC[0].exchange, 'swapList');
 const formattedSendAmount = `${localizeNumber(sendAmount)} SOL`;
-const formattedReceiveAmount = `${localizeNumber(swapQuotesSolanaUSDC[0].receiveStringAmount)} USDC`;
+const formattedReceiveAmount = `${receiveAmount} USDC`;
 const { sendAddress, receiveAddress, receive: usdcMint } = swapTradeSolanaUSDC;
 const formattedSendAddress = formatAddress(sendAddress);
-const toastText = `Swap transaction of ${formattedSendAmount} (Solana #1) to ${formattedReceiveAmount} (Ethereum #1) was broadcasted`;
 
 test.describe('Trading - Swap coin to token', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
@@ -49,7 +49,6 @@ test.describe('Trading - Swap coin to token', { tag: ['@group=trading', '@webOnl
                 receiveCurrency: 'USDC',
                 receiveSymbol: 'eth',
                 receiveNetwork: usdcMint,
-
                 receiveAccount: 'Ethereum #1',
                 receiveAddress,
             });
@@ -74,7 +73,19 @@ test.describe('Trading - Swap coin to token', { tag: ['@group=trading', '@webOnl
         // Thanks to our mocked responses, the crypto is actually not send.
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
-            await expect(page.getByTestId('@toast/tx-exchange')).toContainText(toastText);
+            await expect(page.getByTestId('@toast/tx-exchange')).toHaveTranslation(
+                'TOAST_TX_EXCHANGE_BROADCASTED',
+                {
+                    placeholderValues: [
+                        sendAmount,
+                        'SOL',
+                        'Solana #1',
+                        receiveAmount,
+                        'USDC',
+                        'Ethereum #1',
+                    ],
+                },
+            );
             await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                 'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
             );

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
@@ -23,12 +23,12 @@ const transactionStates = [
 
 // Expected values based on our mocked responses
 const sendAmount = swapQuotesSolanaBTC[1].sendStringAmount;
+const receiveAmount = localizeNumber(swapQuotesSolanaBTC[1].receiveStringAmount);
 const provider = getCompanyNameFromList(swapQuotesSolanaBTC[1].exchange, 'swapList');
 const formattedSendAmount = `${localizeNumber(sendAmount)} SOL`;
-const formattedReceiveAmount = `${localizeNumber(swapQuotesSolanaBTC[1].receiveStringAmount)} BTC`;
+const formattedReceiveAmount = `${receiveAmount} BTC`;
 const { sendAddress, receiveAddress } = swapTradeSolanaBTC;
 const formattedSendAddress = formatAddress(sendAddress);
-const toastText = `Swap transaction of ${formattedSendAmount} (Solana #1) to ${formattedReceiveAmount} (Bitcoin #1) was broadcasted`;
 
 test.describe('Trading - Swap coins', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
@@ -62,7 +62,6 @@ test.describe('Trading - Swap coins', { tag: ['@group=trading', '@webOnly'] }, (
                 receiveCurrency: 'Bitcoin',
                 receiveSymbol: 'btc',
                 receiveNetwork: 'bitcoin',
-
                 receiveAccount: 'Bitcoin #1',
                 receiveAddress,
             });
@@ -112,7 +111,19 @@ test.describe('Trading - Swap coins', { tag: ['@group=trading', '@webOnly'] }, (
             await page.clock.install();
             await devicePrompt.sendButton.click();
             await expect(tradingPage.transactionDetailStatus).toHaveText('Pending');
-            await expect(page.getByTestId('@toast/tx-exchange')).toContainText(toastText);
+            await expect(page.getByTestId('@toast/tx-exchange')).toHaveTranslation(
+                'TOAST_TX_EXCHANGE_BROADCASTED',
+                {
+                    placeholderValues: [
+                        sendAmount,
+                        'SOL',
+                        'Solana #1',
+                        receiveAmount,
+                        'BTC',
+                        'Bitcoin #1',
+                    ],
+                },
+            );
         });
 
         await test.step('Verify button opens provider support page in new tab', async () => {

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -11,12 +11,12 @@ import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
 const sendAmount = swapQuotesTetherBTC[2].sendStringAmount!;
+const receiveAmount = localizeNumber(swapQuotesTetherBTC[2].receiveStringAmount!);
 const provider = getCompanyNameFromList(swapQuotesTetherBTC[2].exchange, 'swapList');
 const formattedSendAmount = `${localizeNumber(sendAmount)} USDT`;
-const formattedReceiveAmount = `${localizeNumber(swapQuotesTetherBTC[2].receiveStringAmount!)} BTC`;
+const formattedReceiveAmount = `${receiveAmount} BTC`;
 const { sendAddress, receiveAddress, send: tetherMint } = swapTradeTetherBTC;
 const formattedSendAddress = formatAddress(sendAddress);
-const toastText = `Swap transaction of ${formattedSendAmount} (Solana #1) to ${formattedReceiveAmount} (Bitcoin #1) was broadcasted`;
 
 test.describe('Trading - Swap token to coin', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
@@ -46,7 +46,6 @@ test.describe('Trading - Swap token to coin', { tag: ['@group=trading', '@webOnl
                 receiveCurrency: 'Bitcoin',
                 receiveSymbol: 'btc',
                 receiveNetwork: 'bitcoin',
-
                 receiveAccount: 'Bitcoin #1',
                 receiveAddress,
             });
@@ -71,7 +70,19 @@ test.describe('Trading - Swap token to coin', { tag: ['@group=trading', '@webOnl
         // Thanks to our mocked responses, the crypto is actually not send.
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
-            await expect(page.getByTestId('@toast/tx-exchange')).toContainText(toastText);
+            await expect(page.getByTestId('@toast/tx-exchange')).toHaveTranslation(
+                'TOAST_TX_EXCHANGE_BROADCASTED',
+                {
+                    placeholderValues: [
+                        sendAmount,
+                        'USDT',
+                        'Solana #1',
+                        receiveAmount,
+                        'BTC',
+                        'Bitcoin #1',
+                    ],
+                },
+            );
             await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                 'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
             );

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
@@ -11,12 +11,12 @@ import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
 const sendAmount = swapQuotesSolanaTokens[0].sendStringAmount!;
+const receiveAmount = localizeNumber(swapQuotesSolanaTokens[0].receiveStringAmount!);
 const provider = getCompanyNameFromList(swapQuotesSolanaTokens[0].exchange, 'swapList');
 const formattedSendAmount = `${localizeNumber(sendAmount)} USDT`;
-const formattedReceiveAmount = `${localizeNumber(swapQuotesSolanaTokens[0].receiveStringAmount!)} USDC`;
+const formattedReceiveAmount = `${receiveAmount} USDC`;
 const { sendAddress, receiveAddress, send: tetherMint, receive: usdcMint } = swapTradeSolanaTokens;
 const formattedSendAddress = formatAddress(sendAddress);
-const toastText = `Swap transaction of ${formattedSendAmount} (Solana #1) to ${formattedReceiveAmount} (Solana #1) was broadcasted`;
 
 test.describe('Trading - Swap tokens', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
@@ -46,7 +46,6 @@ test.describe('Trading - Swap tokens', { tag: ['@group=trading', '@webOnly'] }, 
                 receiveCurrency: 'USDC',
                 receiveSymbol: 'sol',
                 receiveNetwork: usdcMint,
-
                 receiveAccount: 'Solana #1',
                 receiveAddress,
             });
@@ -71,7 +70,19 @@ test.describe('Trading - Swap tokens', { tag: ['@group=trading', '@webOnly'] }, 
         // Thanks to our mocked responses, the crypto is actually not send.
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
-            await expect(page.getByTestId('@toast/tx-exchange')).toContainText(toastText);
+            await expect(page.getByTestId('@toast/tx-exchange')).toHaveTranslation(
+                'TOAST_TX_EXCHANGE_BROADCASTED',
+                {
+                    placeholderValues: [
+                        sendAmount,
+                        'USDT',
+                        'Solana #1',
+                        receiveAmount,
+                        'USDC',
+                        'Solana #1',
+                    ],
+                },
+            );
             await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                 'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
             );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-tests&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-tests&lookback=7)