### PR TITLE
chore(suite-common): rename property lastConnectedBy to lastConnectedVia

### DIFF
--- a/packages/suite/src/storage/migrations/versions/25.10.0.ts
+++ b/packages/suite/src/storage/migrations/versions/25.10.0.ts
@@ -34,7 +34,7 @@ export default createMigration<SuiteDBSchema>('25.10.0', async (db, tx) => {
                     label: null,
                     initialized: null,
                     firmwareVersion: null,
-                    lastConnectedBy: null,
+                    lastConnectedVia: null,
                 }),
             );
 

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -99,7 +99,7 @@ type PersistedFeatureKey = UnionSubset<
 export type PersistentDeviceData = Pick<AcquiredDevice, PersistedDeviceKey> &
     Pick<Features, PersistedFeatureKey> & {
         firmwareVersion: VersionArray | null;
-        lastConnectedBy: 'bluetooth' | 'usb' | null;
+        lastConnectedVia: 'bluetooth' | 'usb' | null;
         lastEntropyCheckResult?: { success: boolean };
         // TODO move deviceAuthenticity to this object and newly introduce persistence
     };

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -602,7 +602,7 @@ const updatePersistentDeviceData = (draft: DeviceReducerState, device: Device | 
         initialized: device.features.initialized,
         thp: device.thp,
         bluetoothProps: device.bluetoothProps,
-        lastConnectedBy: device.bluetoothProps ? 'bluetooth' : 'usb',
+        lastConnectedVia: device.bluetoothProps ? 'bluetooth' : 'usb',
         firmwareVersion: getFirmwareVersionArray(device),
     };
 

--- a/suite-common/wallet-core/src/support/deviceMocks.ts
+++ b/suite-common/wallet-core/src/support/deviceMocks.ts
@@ -13,5 +13,5 @@ export const defaultDevicePersistentData: PersistentDeviceData = {
     label: null,
     initialized: null,
     firmwareVersion: null,
-    lastConnectedBy: null,
+    lastConnectedVia: null,
 };


### PR DESCRIPTION


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/common/last-connnected-via&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/common/last-connnected-via&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/common/last-connnected-via&lookback=7)