### PR TITLE
Add missing alert dependency to suite-native/module-device-settings

### DIFF
--- a/suite-native/module-device-settings/package.json
+++ b/suite-native/module-device-settings/package.json
@@ -18,6 +18,7 @@
         "@suite-common/thp": "workspace:*",
         "@suite-common/validators": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
+        "@suite-native/alerts": "workspace:*",
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/bluetooth": "workspace:*",

--- a/suite-native/module-device-settings/tsconfig.json
+++ b/suite-native/module-device-settings/tsconfig.json
@@ -12,6 +12,7 @@
         {
             "path": "../../suite-common/wallet-core"
         },
+        { "path": "../alerts" },
         { "path": "../analytics" },
         { "path": "../atoms" },
         { "path": "../bluetooth" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12037,6 +12037,7 @@ __metadata:
     "@suite-common/thp": "workspace:*"
     "@suite-common/validators": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
+    "@suite-native/alerts": "workspace:*"
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/bluetooth": "workspace:*"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes missing dependency in suite-native/module-device-settings



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mobile-fix-missing-dep&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mobile-fix-missing-dep&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mobile-fix-missing-dep&lookback=7)