### PR TITLE
feat(suite): add Array.prototype.toSorted polyfill and load in renderer

### DIFF
--- a/packages/suite-desktop-ui/src/index.tsx
+++ b/packages/suite-desktop-ui/src/index.tsx
@@ -1,3 +1,4 @@
+import '../../suite/src/globalPolyfills';
 import { init } from './MainDesktop';
 
 window.onload = () => {

--- a/packages/suite-web/src/index.ts
+++ b/packages/suite-web/src/index.ts
@@ -1,3 +1,4 @@
+import '../../suite/src/globalPolyfills';
 /*
  * On the start of the app, the index.html file is without div with id="app" to which React app should be rendered.
  * This div is added thanks to browser detection plugin in case that a user uses supported browser.

--- a/packages/suite/src/globalPolyfills.ts
+++ b/packages/suite/src/globalPolyfills.ts
@@ -1,0 +1,12 @@
+// Global polyfills for the suite
+
+// Polyfill for Array.prototype.toSorted
+if (!Array.prototype.toSorted) {
+    Object.defineProperty(Array.prototype, 'toSorted', {
+        value: function toSorted(compareFn: (a: any, b: any) => number) {
+            return [...this].sort(compareFn);
+        },
+        writable: true,
+        configurable: true,
+    });
+}


### PR DESCRIPTION
## Description

Adds a small runtime polyfill for `Array.prototype.toSorted` and ensures it’s loaded first in renderer (web + desktop). The polyfill is feature-detected and preserves immutability semantics.

On older Chromium/Electron versions (e.g., Chrome 109 / Electron 22–23) `toSorted` is missing, which led to `TypeError: toSorted is not a function`.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22225


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/polyfill-toSorted&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/polyfill-toSorted&lookback=7)