### PR TITLE
fix(e2e-suite): fix passphrase-cardano, add debugging for Solana fees

### DIFF
--- a/packages/suite-desktop-core/e2e/support/testExtends/enhancePage.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/enhancePage.ts
@@ -8,6 +8,7 @@ declare module '@playwright/test' {
         // Methods
         discoveryShouldFinish(): Promise<void>;
         selectDropdownOptionWithRetry(dropdown: Locator, option: Locator): Promise<void>;
+        getReduxObject(objectPath: string): Promise<any>;
         expectReduxObjectNotToBeEmpty(
             objectPath: string,
             options?: { timeout?: number },
@@ -51,14 +52,19 @@ export const enhancePage = (page: Page): Page => {
         });
     };
 
+    page.getReduxObject = async (objectPath: string) => {
+        const state = await page.evaluate(() => window.store.getState());
+
+        return get(state, objectPath);
+    };
+
     page.expectReduxObjectNotToBeEmpty = async function (
         objectPath: string,
         options = { timeout: 5000 },
     ) {
         await test.step('Expect Redux object not to be empty', async () => {
             await expect(async () => {
-                const state = await page.evaluate(() => window.store.getState());
-                const testedObject = get(state, objectPath);
+                const testedObject = await page.getReduxObject(objectPath);
                 expect(testedObject).toBeDefined();
                 expect(testedObject).not.toBeNull();
                 expect(testedObject).not.toEqual({});
@@ -73,8 +79,7 @@ export const enhancePage = (page: Page): Page => {
     ) {
         await test.step('Expect Redux object to equal', async () => {
             await expect(async () => {
-                const state = await page.evaluate(() => window.store.getState());
-                const testedObject = get(state, objectPath);
+                const testedObject = await page.getReduxObject(objectPath);
                 expect(testedObject).toStrictEqual(expectedValue);
             }).toPass({ timeout: options.timeout });
         });

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
@@ -25,7 +25,9 @@ test.describe('Passphrase with cardano', { tag: ['@group=passphrase'] }, () => {
                 await trezorUserEnvLink.stopEmu();
                 await expect(page.getByTestId('@deviceStatus-disconnected')).toBeVisible();
                 await trezorUserEnvLink.startEmu({ model: emulatorStartConf.model, wipe: false });
-                await expect(page.getByTestId('@deviceStatus-connected')).toBeVisible();
+                await expect(page.getByTestId('@deviceStatus-connected')).toBeVisible({
+                    timeout: 15_000,
+                });
             });
         }
 

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
@@ -90,7 +90,21 @@ test.describe('Trading - Swap coins', { tag: ['@group=trading', '@webOnly'] }, (
             await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
                 formattedSendAmount,
             );
-            await expect(devicePrompt.cryptoAmountOf('fee')).toHaveText(solanaFee);
+            // Temporary debug information to solve issue that is happening only on CI.
+            // Suite probably fails to simulate fees and use fallback. That is correct behaviour.
+            // We are trying to find out whether there is something in redux state that could help us detect such situation.
+            // Goal would be to detect such a state and adjust expected fee to fallback value.
+            const debugFeeInfo = JSON.stringify(
+                await page.getReduxObject('wallet.trading.composedTransactionInfo'),
+                null,
+                2,
+            );
+            const verboseErrorMessage =
+                'Fee displayed on the device does not match expected fee from form. Redux transaction info: ' +
+                debugFeeInfo;
+            await expect(devicePrompt.cryptoAmountOf('fee'), verboseErrorMessage).toHaveText(
+                solanaFee,
+            );
             await expect(devicePrompt).toDisplayOnEmulator({
                 header: { title: 'Summary' },
                 body: [
@@ -105,7 +119,6 @@ test.describe('Trading - Swap coins', { tag: ['@group=trading', '@webOnly'] }, (
 
             await devicePrompt.waitForFinalPromptAndConfirm();
         });
-
         // Thanks to our mocked responses, the crypto is actually not send.
         await test.step('Send crypto to provider', async () => {
             await page.clock.install();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-tests&lookback=7)