### PR TITLE
fix(suite): do not remove inactive devices in pairing mode

### DIFF
--- a/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.test.ts
+++ b/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.test.ts
@@ -1,0 +1,78 @@
+import { createBluetoothDevice } from '@suite-common/bluetooth/src/support/mocks';
+import { BluetoothDeviceCommon } from '@suite-common/bluetooth/src/types';
+import { asBluetoothDeviceId } from '@trezor/connect';
+import * as envUtils from '@trezor/env-utils';
+
+import { filterOutNonResponsiveDevices } from './filterOutNonResponsiveDevices';
+
+describe(filterOutNonResponsiveDevices.name, () => {
+    beforeAll(() => {
+        jest.spyOn(Date, 'now').mockReturnValue(5_000);
+        jest.spyOn(envUtils, 'isLinux').mockReturnValue(false);
+    });
+
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('keeps devices that are in pairing mode regardless of lastUpdatedTimestamp', () => {
+        const devices: BluetoothDeviceCommon[] = [
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('1'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 1_000,
+                connectionStatus: { type: 'pairing' },
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('2'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 1_000,
+                connectionStatus: { type: 'pairing' },
+            }),
+        ];
+
+        const result = filterOutNonResponsiveDevices(devices);
+        expect(result).toHaveLength(2);
+    });
+
+    it('filters non responsive devices', () => {
+        const devices: BluetoothDeviceCommon[] = [
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('1'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 1_000,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('2'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 1_000,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('3'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 5_000,
+            }),
+        ];
+
+        const result = filterOutNonResponsiveDevices(devices);
+        expect(result).toHaveLength(1);
+    });
+
+    it('keeps responsive devices', () => {
+        const devices: BluetoothDeviceCommon[] = [
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('1'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 3_500,
+            }),
+            createBluetoothDevice({
+                id: asBluetoothDeviceId('2'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 4_000,
+            }),
+        ];
+
+        const result = filterOutNonResponsiveDevices(devices);
+        expect(result).toHaveLength(2);
+    });
+});

--- a/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.ts
+++ b/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.ts
@@ -7,6 +7,8 @@ export const NEARBY_DEVICES_LAST_UPDATED_LIMIT_LINUX = 5_000;
 /**
  * Filters out devices that have not been responsive for a certain period of time.
  * Linux (specifically T2 linux distro for Mac) needs more than 3 secs - tested with 5 sec, due to slow drivers.
+ *
+ * Devices in 'pairing' state are kept regardless of last updated timestamp, as they are actively being paired.
  */
 export const filterOutNonResponsiveDevices = <T extends BluetoothDeviceCommon>(devices: T[]) => {
     const now = Date.now();
@@ -14,5 +16,9 @@ export const filterOutNonResponsiveDevices = <T extends BluetoothDeviceCommon>(d
         ? NEARBY_DEVICES_LAST_UPDATED_LIMIT_LINUX
         : NEARBY_DEVICES_LAST_UPDATED_LIMIT;
 
-    return devices.filter(d => d.lastUpdatedTimestamp >= now - limit);
+    return devices.filter(
+        device =>
+            device.lastUpdatedTimestamp >= now - limit ||
+            device.connectionStatus.type === 'pairing',
+    );
 };


### PR DESCRIPTION
We do filter out inactive devices after 3s and 5s on Linux, however device in pairing mode does not send a `device-update` event, so we should not filter out devices in pairing mode...

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22224



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/device-in-parining-mode-does-not-update&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/device-in-parining-mode-does-not-update&lookback=7)