### PR TITLE
fix(suite-native): fw update alerts discrepancies

### DIFF
--- a/suite-native/firmware/src/components/DoNotCloseAppBottomSheetTrigger.tsx
+++ b/suite-native/firmware/src/components/DoNotCloseAppBottomSheetTrigger.tsx
@@ -1,6 +1,8 @@
+import { FadeInDown, FadeOutDown } from 'react-native-reanimated';
+
 import {
+    AnimatedBox,
     BottomSheetModal,
-    Box,
     Button,
     InlineAlertBox,
     Text,
@@ -8,20 +10,35 @@ import {
     useBottomSheetModal,
 } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type DoNotCloseAppBottomSheetTriggerProps = {
     isTriggerDisplayed: boolean;
 };
 
+const triggerStyle = prepareNativeStyle(utils => ({
+    position: 'absolute',
+    bottom: 0,
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: utils.spacings.sp32,
+}));
+
 export const DoNotCloseAppBottomSheetTrigger = ({
     isTriggerDisplayed,
 }: DoNotCloseAppBottomSheetTriggerProps) => {
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
+    const { applyStyle } = useNativeStyles();
 
     return (
         <>
             {isTriggerDisplayed && (
-                <Box marginBottom="sp32" alignItems="center" justifyContent="center">
+                <AnimatedBox
+                    entering={FadeInDown}
+                    exiting={FadeOutDown}
+                    style={applyStyle(triggerStyle)}
+                >
                     <InlineAlertBox
                         variant="info"
                         title={
@@ -32,7 +49,7 @@ export const DoNotCloseAppBottomSheetTrigger = ({
                         }
                         onButtonPress={openModal}
                     />
-                </Box>
+                </AnimatedBox>
             )}
             <BottomSheetModal ref={bottomSheetRef} paddingHorizontal="sp24">
                 <VStack spacing="sp24" paddingBottom="sp24">

--- a/suite-native/module-device-onboarding/src/screens/FirmwareInfoScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/FirmwareInfoScreen.tsx
@@ -8,17 +8,15 @@ import { useDeviceLowBatteryAlert } from '@suite-native/device';
 import { FirmwareInfoScreenContent, FirmwareInfoScreenFooter } from '@suite-native/firmware';
 import { Translation, TxKeyPath } from '@suite-native/intl';
 import {
-    AppTabsRoutes,
     DeviceOnboardingStackParamList,
     DeviceOnboardingStackRoutes,
-    HomeStackRoutes,
     RootStackParamList,
-    RootStackRoutes,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 
 import { updateOnboardingAnalyticsAtom } from '../../atoms';
 import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
+import { useExitAlert } from '../hooks/useExitAlert';
 
 type NavigationProps = StackToStackCompositeNavigationProps<
     DeviceOnboardingStackParamList,
@@ -30,6 +28,7 @@ export const FirmwareInfoScreen = () => {
     const navigation = useNavigation<NavigationProps>();
     const hasDeviceFirmwareInstalled = useSelector(selectHasDeviceFirmwareInstalled);
     const { showLowBatteryAlertIfNecessary } = useDeviceLowBatteryAlert();
+    const { handleExitButtonPress } = useExitAlert();
 
     const updateOnboardingAnalytics = useSetAtom(updateOnboardingAnalyticsAtom);
 
@@ -43,15 +42,6 @@ export const FirmwareInfoScreen = () => {
         navigation.replace(DeviceOnboardingStackRoutes.FirmwareInstallation);
     };
 
-    const handleCancel = () => {
-        navigation.popTo(RootStackRoutes.AppTabs, {
-            screen: AppTabsRoutes.HomeStack,
-            params: {
-                screen: HomeStackRoutes.Home,
-            },
-        });
-    };
-
     const screenTitleTranslationId: TxKeyPath = hasDeviceFirmwareInstalled
         ? 'firmware.firmwareInfoScreen.title.update'
         : 'firmware.firmwareInfoScreen.title.install';
@@ -63,7 +53,7 @@ export const FirmwareInfoScreen = () => {
             footer={
                 <FirmwareInfoScreenFooter
                     onUpdateConfirmation={handleUpdateConfirmation}
-                    onCancel={handleCancel}
+                    onCancel={handleExitButtonPress}
                 />
             }
         >


### PR DESCRIPTION
## Description
Fixes two minor FW install problems discovered yesterday.

1. There was a layout shift in the FW installation screen when the `DoNotCloseAppBottomSheetTrigger` was unmounted
2. There was no exit alert displayed on pressing the cancel button from FirmwareInfoScreen

## Related issue
relates to #22040
relates to #22039 

## Screenshots:

https://github.com/user-attachments/assets/1a04482e-0212-4a5e-bbdb-0c4a1a806ff6


https://github.com/user-attachments/assets/c573e231-1bfc-40ad-8004-238f370df324




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/fw-update-alert-discrepancies&lookback=7)