### PR TITLE
chore(suite-native): Mobile Swap: Set enabling featureflags to enabled

### DIFF
--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeTab.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeTab.comp.test.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlag } from '@suite-native/feature-flags';
 import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import { ExchangeTab } from '../ExchangeTab';
@@ -6,6 +5,7 @@ import { ExchangeTab } from '../ExchangeTab';
 let mockIsDeviceInViewOnlyMode = false;
 let mockIsPortfolioTrackerDevice = false;
 let mockHasBitcoinOnlyFirmware = false;
+let mockIsTradingExchangeEnabled = true;
 
 jest.mock('@suite-common/wallet-core', () => ({
     ...jest.requireActual('@suite-common/wallet-core'),
@@ -22,6 +22,11 @@ jest.mock('../../../hooks/exchange/useExchangeData', () => ({
     }),
 }));
 
+jest.mock('../../../selectors/commonSelectors', () => ({
+    ...jest.requireActual('../../../selectors/commonSelectors'),
+    selectIsTradingExchangeEnabled: () => mockIsTradingExchangeEnabled,
+}));
+
 describe('ExchangeTab', () => {
     const renderExchangeTab = (preloadedState: PreloadedState = {}) =>
         renderWithStoreProviderAsync(<ExchangeTab />, { preloadedState });
@@ -30,37 +35,27 @@ describe('ExchangeTab', () => {
         mockIsDeviceInViewOnlyMode = false;
         mockIsPortfolioTrackerDevice = false;
         mockHasBitcoinOnlyFirmware = false;
+        mockIsTradingExchangeEnabled = true;
     });
 
     it('should render exchange form', async () => {
-        const { getByText } = await renderExchangeTab({
-            featureFlags: {
-                [FeatureFlag.IsTradingExchangeEnabled]: true,
-            },
-        });
+        const { getByText } = await renderExchangeTab();
 
         expect(getByText('You pay')).toBeOnTheScreen();
         expect(getByText('You get')).toBeOnTheScreen();
     });
 
     it('should render disabled info when exchange FF is not enabled', async () => {
-        const { getByText, queryByText } = await renderExchangeTab({
-            featureFlags: {
-                [FeatureFlag.IsTradingExchangeEnabled]: false,
-            },
-        });
+        mockIsTradingExchangeEnabled = false;
+        const { getByText, queryByText } = await renderExchangeTab();
 
-        expect(queryByText('Exchange Tab placeholder')).toBeNull();
         expect(getByText('Swap disabled')).toBeOnTheScreen();
+        expect(queryByText('You pay')).toBeNull();
     });
 
     it('should display BTC only firmware info with BTC only wallet connected', async () => {
         mockHasBitcoinOnlyFirmware = true;
-        const { getByText } = await renderExchangeTab({
-            featureFlags: {
-                [FeatureFlag.IsTradingExchangeEnabled]: true,
-            },
-        });
+        const { getByText } = await renderExchangeTab();
 
         expect(getByText('Bitcoin-only firmware')).toBeOnTheScreen();
     });
@@ -69,11 +64,7 @@ describe('ExchangeTab', () => {
         // Portfolio Tracker sets both selectors to true
         mockIsPortfolioTrackerDevice = true;
         mockIsDeviceInViewOnlyMode = true;
-        const { getByText, queryByText } = await renderExchangeTab({
-            featureFlags: {
-                [FeatureFlag.IsTradingExchangeEnabled]: true,
-            },
-        });
+        const { getByText, queryByText } = await renderExchangeTab();
 
         expect(getByText('Portfolio Tracker')).toBeOnTheScreen();
         expect(queryByText('View-only wallet')).toBeNull();
@@ -81,11 +72,7 @@ describe('ExchangeTab', () => {
 
     it('should display View-only info with view-only wallet', async () => {
         mockIsDeviceInViewOnlyMode = true;
-        const { getByText } = await renderExchangeTab({
-            featureFlags: {
-                [FeatureFlag.IsTradingExchangeEnabled]: true,
-            },
-        });
+        const { getByText } = await renderExchangeTab();
 
         expect(getByText('View-only wallet')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/screens/__tests__/TradingScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingScreen.comp.test.tsx
@@ -70,6 +70,10 @@ const stateWithDisabledTrading = {
                                 domain: 'trading.buy',
                                 flag: false,
                             },
+                            {
+                                domain: 'trading.exchange',
+                                flag: false,
+                            },
                         ],
                     },
                 },

--- a/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
@@ -162,8 +162,14 @@ describe('commonSelectors', () => {
             );
         });
 
-        it('should correctly select that exchange is not enabled if remote feature is not enabled', () => {
-            expect(selectIsTradingExchangeEnabled(getPreloadedState({}))).toBe(false);
+        it('should correctly select that exchange is disabled if remote feature is disabled', () => {
+            expect(selectIsTradingExchangeEnabled(getPreloadedState({ exchange: false }))).toBe(
+                false,
+            );
+        });
+
+        it('should correctly select that exchange is enabled if remote feature is not set', () => {
+            expect(selectIsTradingExchangeEnabled(getPreloadedState({}))).toBe(true);
         });
     });
 
@@ -186,8 +192,10 @@ describe('commonSelectors', () => {
             expect(selectIsTradingEnabled(getPreloadedState({}))).toBe(true);
         });
 
-        it('should correctly select that trading is not enabled when buy is disabled (and other flags are not set)', () => {
-            expect(selectIsTradingEnabled(getPreloadedState({ buy: false }))).toBe(false);
+        it('should correctly select that trading is not enabled when buy and exchange are disabled (and sell is not set)', () => {
+            expect(selectIsTradingEnabled(getPreloadedState({ buy: false, exchange: false }))).toBe(
+                false,
+            );
         });
     });
 

--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -83,7 +83,7 @@ export const selectIsTradingExchangeEnabled = (
     state: MessageSystemRootState & FeatureFlagsRootState,
 ) =>
     selectIsFeatureFlagEnabled(state, FeatureFlag.IsTradingExchangeEnabled) ||
-    selectIsFeatureEnabled(state, Feature.trading.exchange, false);
+    selectIsFeatureEnabled(state, Feature.trading.exchange, true);
 
 export const selectIsTradingSellEnabled = (state: MessageSystemRootState & FeatureFlagsRootState) =>
     selectIsFeatureFlagEnabled(state, FeatureFlag.IsTradingSellEnabled) ||


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enables mobile swap by default.

## Related Issue

Resolve [#19200](https://github.com/trezor/trezor-suite/issues/19200)

## Screenshots:
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2025-10-07 at 09 55 40" src="https://github.com/user-attachments/assets/7c1ff283-d200-4977-b5b5-e8c7d883d44b" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19200-Mobile-Swap-Set-enabling-featureflags&lookback=7)