### PR TITLE
fix(suite): fix empty offers translations

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1174,8 +1174,12 @@ export default defineMessages({
         id: 'TR_BUY_DETAIL_WAITING_FOR_USER_GATE',
     },
     TR_TRADING_OFFERS_EMPTY: {
-        defaultMessage: 'No offers available for your request. Change country or amount.',
+        defaultMessage: 'Select your from/to assets and amount to search for your best offer.',
         id: 'TR_TRADING_OFFERS_EMPTY',
+    },
+    TR_BUY_SELL_OFFERS_EMPTY: {
+        defaultMessage: 'Select your assets and amount to search for your best offer.',
+        id: 'TR_BUY_SELL_OFFERS_EMPTY',
     },
     TR_TRADING_UNKNOWN_PROVIDER: {
         defaultMessage: 'Unknown provider',

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferItem.tsx
@@ -47,7 +47,7 @@ export const TradingFormOfferItem = ({
                     margin={{ vertical: spacings.xs }}
                     data-testid="trading-offer-found-none"
                 >
-                    <Translation id="TR_TRADING_OFFERS_EMPTY" />
+                    <Translation id="TR_BUY_SELL_OFFERS_EMPTY" />
                 </Paragraph>
             </Card>
         );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I've already done this issue however Crowdin override those translations. 

## Related Issue

Resolve #20610

## Screenshots:

<img width="1237" height="785" alt="Snímek obrazovky 2025-10-07 v 9 59 05" src="https://github.com/user-attachments/assets/0b6aed57-ccbf-468a-a509-33fce56ffc67" />

<img width="1251" height="863" alt="Snímek obrazovky 2025-10-07 v 9 59 14" src="https://github.com/user-attachments/assets/cacc9f05-9f72-463c-babe-046e8c94a075" />
(only default message updated, that's why the old message is still here)




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/20610-empty-offer-translations&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/20610-empty-offer-translations&lookback=7)