### PR TITLE
Use stable empty array for nearby BLE devices selectors

### DIFF
--- a/suite-native/bluetooth/src/selectors.ts
+++ b/suite-native/bluetooth/src/selectors.ts
@@ -4,7 +4,7 @@ import {
     selectKnownDevices,
     selectNearbyDevices,
 } from '@suite-common/bluetooth';
-import { createWeakMapSelector } from '@suite-common/redux-utils';
+import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 
 import { NativeBluetoothRootState } from './bluetoothSlice';
 
@@ -38,22 +38,26 @@ export const selectNearbyBluetoothDevices = createMemoizedSelector(
 export const selectNearbyPairableBluetoothDevices = createMemoizedSelector(
     [selectNearbyBluetoothDevices, selectKnownBluetoothDevices],
     (nearbyBluetoothDevices, knownBluetoothDevices) =>
-        nearbyBluetoothDevices.filter(
-            ({ id, manufacturerData }) =>
-                knownBluetoothDevices.every(knownDevice => knownDevice.id !== id) &&
-                manufacturerData.filterPolicy?.pairing === true,
+        returnStableArrayIfEmpty(
+            nearbyBluetoothDevices.filter(
+                ({ id, manufacturerData }) =>
+                    knownBluetoothDevices.every(knownDevice => knownDevice.id !== id) &&
+                    manufacturerData.filterPolicy?.pairing === true,
+            ),
         ),
 );
 
 export const selectKnownConnectableBluetoothDevices = createMemoizedSelector(
     [selectNearbyBluetoothDevices, selectKnownBluetoothDevices, selectBluetoothAutoConnectPolicy],
     (nearbyBluetoothDevices, knownBluetoothDevices, autoConnectPolicy) =>
-        nearbyBluetoothDevices.filter(
-            ({ id, manufacturerData, connectionStatus }) =>
-                knownBluetoothDevices.some(knownDevice => knownDevice.id === id) &&
-                autoConnectPolicy[id]?.type !== 'autoconnect-disabled' &&
-                manufacturerData.filterPolicy?.pairing !== true &&
-                manufacturerData.filterPolicy?.user_disconnected !== true &&
-                connectionStatus.type === 'disconnected',
+        returnStableArrayIfEmpty(
+            nearbyBluetoothDevices.filter(
+                ({ id, manufacturerData, connectionStatus }) =>
+                    knownBluetoothDevices.some(knownDevice => knownDevice.id === id) &&
+                    autoConnectPolicy[id]?.type !== 'autoconnect-disabled' &&
+                    manufacturerData.filterPolicy?.pairing !== true &&
+                    manufacturerData.filterPolicy?.user_disconnected !== true &&
+                    connectionStatus.type === 'disconnected',
+            ),
         ),
 );


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Prevent returning a new reference from the selector each time it's empty.

## Screenshots:
<img width="852" height="320" alt="image" src="https://github.com/user-attachments/assets/4f331557-b17f-468a-b8ed-ac9aa700c0e8" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/stable-nearby-devices&lookback=7)