### PR TITLE
fix(suite-native): fix removal of send form drafts for tokens

### DIFF
--- a/suite-common/wallet-core/src/send/sendFormActions.ts
+++ b/suite-common/wallet-core/src/send/sendFormActions.ts
@@ -20,7 +20,7 @@ const storeDraft = createAction(
 
 const removeDraft = createAction(
     `${SEND_MODULE_PREFIX}/remove-draft`,
-    (payload: { accountKey: AccountKey }) => ({
+    (payload: { accountKey: AccountKey; tokenContract?: TokenAddress }) => ({
         payload,
     }),
 );

--- a/suite-common/wallet-core/src/send/sendFormReducer.ts
+++ b/suite-common/wallet-core/src/send/sendFormReducer.ts
@@ -14,6 +14,7 @@ import { accountsActions } from '../accounts/accountsActions';
 
 export type SendState = {
     drafts: {
+        // Note: suite-native store drafts per tokens, desktop and web store drafts per accountKey only
         [key: SendFormDraftKey]: FormState;
     };
     sendRaw?: boolean;
@@ -50,9 +51,14 @@ export const prepareSendFormReducer = createReducerWithExtraDeps(initialState, (
                 state.drafts[draftKey] = cloneObject(formState);
             },
         )
-        .addCase(sendFormActions.removeDraft, (state, { payload: { accountKey } }) => {
-            delete state.drafts[accountKey];
-        })
+        .addCase(
+            sendFormActions.removeDraft,
+            (state, { payload: { accountKey, tokenContract } }) => {
+                const draftKey = getSendFormDraftKey(accountKey, tokenContract);
+
+                delete state.drafts[draftKey];
+            },
+        )
         .addCase(
             sendFormActions.storePrecomposedTransaction,
             (state, { payload: { precomposedTransaction, formState } }) => {

--- a/suite-native/module-send/src/components/OutputsReviewFooter.tsx
+++ b/suite-native/module-send/src/components/OutputsReviewFooter.tsx
@@ -115,7 +115,7 @@ export const OutputsReviewFooter = ({ accountKey, tokenContract }: OutputsReview
                 }),
             );
 
-            dispatch(cleanupSendFormThunk({ accountKey }));
+            dispatch(cleanupSendFormThunk({ accountKey, tokenContract }));
         }
     }, [isTransactionProcessedByBackend, accountKey, tokenContract, txid, navigation, dispatch]);
 
@@ -167,7 +167,9 @@ export const OutputsReviewFooter = ({ accountKey, tokenContract }: OutputsReview
             primaryButtonTitle: <Translation id="generic.buttons.tryAgain" />,
             primaryButtonVariant: 'redBold',
             onPressPrimaryButton: () => {
-                dispatch(cleanupSendFormThunk({ accountKey, shouldDeleteDraft: false }));
+                dispatch(
+                    cleanupSendFormThunk({ accountKey, tokenContract, shouldDeleteDraft: false }),
+                );
                 navigation.navigate(SendStackRoutes.SendOutputs, {
                     accountKey,
                     tokenContract,
@@ -177,7 +179,9 @@ export const OutputsReviewFooter = ({ accountKey, tokenContract }: OutputsReview
                 <Translation id="moduleSend.review.outputs.errorAlert.secondaryButtonTitle" />
             ),
             onPressSecondaryButton: () => {
-                dispatch(cleanupSendFormThunk({ accountKey, shouldDeleteDraft: true }));
+                dispatch(
+                    cleanupSendFormThunk({ accountKey, tokenContract, shouldDeleteDraft: true }),
+                );
                 navigation.dispatch(
                     navigateOutOfSendFlowAction({
                         accountKey,

--- a/suite-native/module-send/src/sendFormThunks.ts
+++ b/suite-native/module-send/src/sendFormThunks.ts
@@ -105,15 +105,16 @@ export const cleanupSendFormThunk = createThunk(
     (
         {
             accountKey,
+            tokenContract,
             shouldDeleteDraft = true,
-        }: { accountKey: AccountKey; shouldDeleteDraft?: boolean },
+        }: { accountKey: AccountKey; tokenContract?: TokenAddress; shouldDeleteDraft?: boolean },
         { dispatch, getState },
     ) => {
         const device = selectSelectedDevice(getState());
 
         dispatch(sendFormActions.dispose());
 
-        if (shouldDeleteDraft) dispatch(sendFormActions.removeDraft({ accountKey }));
+        if (shouldDeleteDraft) dispatch(sendFormActions.removeDraft({ accountKey, tokenContract }));
 
         // todo: maybe not needed anymore
         dispatch(deviceActions.removeButtonRequests({ device }));
@@ -124,6 +125,7 @@ export const removeSendFormDraftsSupportingAmountUnitThunk = createThunk(
     `${SEND_MODULE_PREFIX}/removeSendFormDraftsSupportingAmountUnitThunk`,
     (_, { dispatch, getState }) => {
         const sendFormDrafts = selectSendFormDrafts(getState());
+        // Draft keys may include tokenContract, but no token networks use amount-unit, so it's fine (for now).
         const accountKeys = Object.keys(sendFormDrafts);
 
         accountKeys.forEach(accountKey => {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

In suite-navtive we store send form drafts per token, but we were removing only by account key so token drafts were never deleted.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22203



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/delete-send-form-draft-tokens&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/delete-send-form-draft-tokens&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/delete-send-form-draft-tokens&lookback=7)