### PR TITLE
fix: show homescren settings after onboarding for TS7

### DIFF
--- a/packages/suite/src/views/onboarding/steps/Final.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final.tsx
@@ -6,7 +6,7 @@ import styled, { css } from 'styled-components';
 
 import { startDiscoveryThunk } from '@suite-common/wallet-core';
 import { Button, Menu, Popover, PopoverRef, Tooltip, variables } from '@trezor/components';
-import { DeviceModelInternal } from '@trezor/device-utils';
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { DeviceAnimation } from '@trezor/product-components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacingsPx, typography } from '@trezor/theme';
@@ -15,6 +15,7 @@ import { OnboardingStepBox } from 'src/components/onboarding';
 import { HomescreenGallery } from 'src/components/suite';
 import { ChangeDeviceLabelForm } from 'src/components/suite/ChangeDeviceLabelForm';
 import { Translation } from 'src/components/suite/Translation';
+import { getHomescreens } from 'src/constants/suite/homescreens';
 import { useDevice, useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
 import { useChangeDeviceLabel } from 'src/hooks/suite/useChangeDeviceLabel';
 import { selectIsActionAbortable } from 'src/selectors/suite/suiteSelectors';
@@ -105,8 +106,6 @@ export const FinalStep = () => {
     const onboardingAnalytics = useSelector(state => state.onboarding.onboardingAnalytics);
     const isActionAbortable = useSelector(selectIsActionAbortable);
 
-    const deviceModelInternal = device?.features?.internal_model;
-
     const [state, setState] = useState<'rename' | 'homescreen' | null>(null);
 
     const isWaitingForConfirm = modalContext === '@modal/context-device';
@@ -127,7 +126,11 @@ export const FinalStep = () => {
         return () => window.removeEventListener('keydown', handleKeyDown);
     }, []);
 
-    if (!device?.features) return null;
+    if (device?.features === undefined) {
+        return null;
+    }
+
+    const deviceModelInternal = device.features.internal_model;
 
     const shouldOfferChangeHomescreen = isHomescreenSupportedOnDevice(device);
 
@@ -154,6 +157,9 @@ export const FinalStep = () => {
         goToSuite();
         dispatch(startDiscoveryThunk({ device }));
     };
+
+    const isBitcoinOnlyFirmware = hasBitcoinOnlyFirmware(device);
+    const hasGallery = getHomescreens(isBitcoinOnlyFirmware)[deviceModelInternal].length > 0;
 
     return (
         <OnboardingStepBox
@@ -186,7 +192,7 @@ export const FinalStep = () => {
                                 <Translation id="TR_ONBOARDING_DEVICE_EDIT_LABEL" />
                             </Button>
 
-                            {deviceModelInternal !== DeviceModelInternal.T3W1 && (
+                            {hasGallery && (
                                 <Tooltip
                                     maxWidth={285}
                                     content={


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/21787

- Same as settings. If model has no images, no gallery is shown.
- TS7 has no images => no gallery
- remvoed :pig: `if` for `DeviceModelInternal.T3W1`

Images needs to be added to: `packages/suite-data/files/images/homescreens/COLOR_520x380/`


Once images are added it will look like this:
<img width="1377" height="941" alt="image" src="https://github.com/user-attachments/assets/38b82566-89e7-442d-ae6e-f0c9c9d758f4" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=homesceen-onboarding&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=homesceen-onboarding&lookback=7)