### PR TITLE
chore(message-system): deescalate error when fetching JWS

### DIFF
--- a/suite-common/message-system/src/messageSystemThunks.ts
+++ b/suite-common/message-system/src/messageSystemThunks.ts
@@ -52,7 +52,7 @@ const getConfigJws = async (forceLocalJws: boolean) => {
             isRemote: true,
         };
     } catch (error) {
-        console.error(`Fetching of remote JWS config failed: ${error}`);
+        console.warn(`Fetching of remote JWS config failed: ${error}`);
 
         return {
             configJws: configJwsLocal,


### PR DESCRIPTION
Deescalate "Fetching of remote JWS failed" error to warning.

To silence https://satoshilabs.sentry.io/issues/4109819713
[Notion here](https://www.notion.so/satoshilabs/Fetching-of-remote-JWS-config-failed-TypeError-NetworkError-when-attempting-to-fetch-resource-280dc526060680c68a5dcb71b84c65dc)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/silence-fetching-JWS-error&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/silence-fetching-JWS-error&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/silence-fetching-JWS-error&lookback=7)