### PR TITLE
Emit pin request in THP handshake with interactions

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -580,11 +580,9 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
                 if (this.protocol.name === 'v2') {
                     const withInteraction = !!fn;
-                    await getThpChannel(this, withInteraction);
-                    if (this.getThpState()?.isAutoconnectPaired || withInteraction) {
+                    this.busy = await getThpChannel(this, withInteraction);
+                    if (!this.busy) {
                         await this.getFeatures();
-                    } else {
-                        this.busy = 'thp-locked';
                     }
                 } else if (fn) {
                     await this.initialize(!!options.useCardanoDerivation);

--- a/packages/connect/src/device/thp/index.ts
+++ b/packages/connect/src/device/thp/index.ts
@@ -1,3 +1,4 @@
+import { DEVICE } from '../../events/device';
 import type { Device } from '../Device';
 import { createThpChannel, thpHandshake } from './handshake';
 import { thpPairing } from './pairing';
@@ -9,15 +10,25 @@ export { createThpSession } from './session';
 export const getThpChannel = async (device: Device, withInteraction?: boolean) => {
     const thpState = device.getThpState();
 
+    if (!thpState) return;
+
     try {
-        if (thpState?.phase === 'handshake') {
+        if (thpState.phase === 'handshake') {
             await createThpChannel(device);
             try {
                 await thpHandshake(device);
             } catch (error) {
                 if (error.code === 'ThpDeviceLocked') {
-                    // Device is pin-locked, retry handshake with tryToUnlock param
                     thpState.resetState();
+                    if (!withInteraction) {
+                        return 'pin-locked';
+                    }
+
+                    // Device is pin-locked and interactions enabled, retry handshake with tryToUnlock param
+                    device.emit(DEVICE.BUTTON, {
+                        device,
+                        payload: { code: 'ButtonRequest_PinEntry' },
+                    });
                     await createThpChannel(device);
                     await thpHandshake(device, true);
                 } else {
@@ -25,9 +36,13 @@ export const getThpChannel = async (device: Device, withInteraction?: boolean) =
                 }
             }
         }
-        if (thpState?.phase === 'pairing' && withInteraction) {
+        if (thpState.phase === 'pairing' && withInteraction) {
             // start pairing with UI interaction
             await thpPairing(device);
+        }
+
+        if (thpState.phase !== 'paired') {
+            return 'thp-locked';
         }
     } catch (error) {
         thpState?.resetState();


### PR DESCRIPTION
## Description

This is a followup of #22146 which removes the `tryToUnlock` variant of `ThpHandshakeInitRequest` in initial device handshake (so the device is without any interaction connected as unacquired, with busy status `pin-locked`) and emits the PIN button request in every other consecutive handshake attempt (where the device is already known to Suite so it can show the popup).


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/thp-handshake-pin-modal&lookback=7)