### PR TITLE
refactor: introduce a common flag for Bluetooth OS unpairing

### DIFF
--- a/packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts
+++ b/packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts
@@ -23,7 +23,6 @@ const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependenciesMock);
 
 const initialState: DesktopBluetoothState = {
     ...prepareInitialState(),
-    unpairedDeviceNeedsManualOsRemoval: false,
     connectingDeviceIds: [],
     isUnpairingDevice: false,
 };

--- a/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
@@ -6,7 +6,6 @@ import { desktopApi } from '@trezor/suite-desktop-api';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
 import {
-    setBluetoothDeviceNeedsManualOsRemoval,
     startConnectingBluetoothDevice,
     stopConnectingBluetoothDevice,
 } from './desktopBluetoothReducer';
@@ -40,7 +39,7 @@ export const bluetoothConnectDeviceThunk = createThunk<
                 result.error.includes('Operation already in progress') ||
                 result.error.includes('Peer removed pairing information');
             if (isUnpaired) {
-                dispatch(setBluetoothDeviceNeedsManualOsRemoval({ needsManualRemoval: true }));
+                dispatch(bluetoothActions.setIsDeviceOsUnpairingRequired(true));
                 dispatch(bluetoothActions.removeKnownDeviceAction({ id: deviceId }));
             } else {
                 dispatch(

--- a/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
@@ -1,4 +1,8 @@
-import { BLUETOOTH_PREFIX, bluetoothActions } from '@suite-common/bluetooth';
+import {
+    BLUETOOTH_PREFIX,
+    ForgetBluetoothDeviceThunkParams,
+    bluetoothActions,
+} from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
@@ -10,16 +14,7 @@ import TrezorConnect, { BluetoothDeviceId } from '@trezor/connect';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
 import { bluetoothDisconnectDeviceThunk } from './bluetoothDisconnectDeviceThunk';
-import {
-    setBluetoothDeviceNeedsManualOsRemoval,
-    setIsUnpairingDevice,
-} from './desktopBluetoothReducer';
-
-type ForgetBluetoothDeviceThunkParams = {
-    // This thunk must rely on `bluetoothId` directly. When this thunk is called,
-    // the device may already be disconnected, and therefore, it cannot be selected from the state.
-    bluetoothId: BluetoothDeviceId;
-};
+import { setIsUnpairingDevice } from './desktopBluetoothReducer';
 
 export const forgetBluetoothDeviceThunk = createThunk<void, ForgetBluetoothDeviceThunkParams, void>(
     `${BLUETOOTH_PREFIX}/forgetBluetoothDevice`,
@@ -29,7 +24,7 @@ export const forgetBluetoothDeviceThunk = createThunk<void, ForgetBluetoothDevic
         const resultForget = await bluetoothIpc.forgetDevice(bluetoothId);
         dispatch(setIsUnpairingDevice({ isUnpairing: false }));
         if (!resultForget.success) {
-            dispatch(setBluetoothDeviceNeedsManualOsRemoval({ needsManualRemoval: true }));
+            dispatch(bluetoothActions.setIsDeviceOsUnpairingRequired(true));
         }
         dispatch(bluetoothActions.removeKnownDeviceAction({ id: bluetoothId }));
     },

--- a/packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts
+++ b/packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts
@@ -9,10 +9,6 @@ import { deviceActions } from '@suite-common/wallet-core';
 import { DesktopBluetoothDevice } from './DesktopBluetoothDevice';
 
 export type DesktopBluetoothState = BluetoothState<DesktopBluetoothDevice> & {
-    // Flag to display some extra info (Modal) to instruct the user to remove
-    // the device from the OS settings manually
-    unpairedDeviceNeedsManualOsRemoval: boolean;
-
     // When we get an update that KnownDevice appeared, we start auto-connecting to it.
     // But there may be other updates before the connection is done, and we want to skip them
     // during the connection process.
@@ -36,14 +32,10 @@ export const bluetoothSlice = createSliceWithExtraDeps({
     name: 'bluetooth',
     initialState: {
         ...prepareInitialState<DesktopBluetoothDevice>(),
-        unpairedDeviceNeedsManualOsRemoval: false,
         connectingDeviceIds: [] as string[],
         isUnpairingDevice: false,
     } satisfies DesktopBluetoothState,
     reducers: {
-        setBluetoothDeviceNeedsManualOsRemoval: (state, { payload: { needsManualRemoval } }) => {
-            state.unpairedDeviceNeedsManualOsRemoval = needsManualRemoval;
-        },
         startConnectingBluetoothDevice: (state, { payload: { deviceId } }) => {
             state.connectingDeviceIds.push(deviceId);
         },
@@ -79,7 +71,6 @@ export const bluetoothSlice = createSliceWithExtraDeps({
 });
 
 export const {
-    setBluetoothDeviceNeedsManualOsRemoval,
     startConnectingBluetoothDevice,
     stopConnectingBluetoothDevice,
     setIsUnpairingDevice,

--- a/packages/suite/src/actions/bluetooth/desktopBluetoothSelectors.ts
+++ b/packages/suite/src/actions/bluetooth/desktopBluetoothSelectors.ts
@@ -3,8 +3,5 @@ import { WithBluetoothRootState } from './desktopBluetoothReducer';
 export const selectConnectingDevices = (state: WithBluetoothRootState) =>
     state.bluetooth.connectingDeviceIds;
 
-export const selectUnpairedDeviceNeedsManualOsRemoval = (state: WithBluetoothRootState) =>
-    state.bluetooth.unpairedDeviceNeedsManualOsRemoval;
-
 export const selectIsUnpairingDevice = (state: WithBluetoothRootState) =>
     state.bluetooth.isUnpairingDevice;

--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -1,13 +1,10 @@
 import { useTheme } from 'styled-components';
 
-import { selectAdapterStatus } from '@suite-common/bluetooth';
+import { selectAdapterStatus, selectIsDeviceOsUnpairingRequired } from '@suite-common/bluetooth';
 import { Box, Button, Column, Modal, Row, Spinner, Text } from '@trezor/components';
 import { borders } from '@trezor/theme';
 
-import {
-    selectIsUnpairingDevice,
-    selectUnpairedDeviceNeedsManualOsRemoval,
-} from 'src/actions/bluetooth/desktopBluetoothSelectors';
+import { selectIsUnpairingDevice } from 'src/actions/bluetooth/desktopBluetoothSelectors';
 import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
@@ -79,7 +76,7 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
         selectedDevice,
     } = useConnectionGlobalModalContext();
 
-    const wasBluetoothDeviceWiped = useSelector(selectUnpairedDeviceNeedsManualOsRemoval);
+    const wasBluetoothDeviceWiped = useSelector(selectIsDeviceOsUnpairingRequired);
     const isUnpairingDevice = useSelector(selectIsUnpairingDevice);
 
     const { isBluetoothEnabled } = useSelector(selectSuiteFlags);

--- a/packages/suite/src/components/suite/bluetooth/UnpairBluetoothDeviceFromOsModal.tsx
+++ b/packages/suite/src/components/suite/bluetooth/UnpairBluetoothDeviceFromOsModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { bluetoothActions } from '@suite-common/bluetooth';
 import { Banner, Column, H3, Modal, Paragraph, Spinner } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -7,7 +8,6 @@ import { openSystemSettingsThunk } from 'src/actions/bluetooth/openSystemSetting
 import { toggleConnectionModal } from 'src/actions/device/deviceSlice';
 import { Translation } from 'src/components/suite/Translation';
 
-import { setBluetoothDeviceNeedsManualOsRemoval } from '../../../actions/bluetooth/desktopBluetoothReducer';
 import { selectIsUnpairingDevice } from '../../../actions/bluetooth/desktopBluetoothSelectors';
 import { useDispatch, useSelector } from '../../../hooks/suite';
 
@@ -32,7 +32,7 @@ export const UnpairBluetoothDeviceFromOsModal = ({
     };
 
     const onCancel = () => {
-        dispatch(setBluetoothDeviceNeedsManualOsRemoval({ needsManualRemoval: false }));
+        dispatch(bluetoothActions.setIsDeviceOsUnpairingRequired(false));
         dispatch(toggleConnectionModal());
         onFinish?.();
     };

--- a/packages/suite/src/components/suite/bluetooth/WipedBleDeviceNeedsManualOsRemovalModalManager.tsx
+++ b/packages/suite/src/components/suite/bluetooth/WipedBleDeviceNeedsManualOsRemovalModalManager.tsx
@@ -1,9 +1,10 @@
+import { selectIsDeviceOsUnpairingRequired } from '@suite-common/bluetooth';
+
 import { UnpairBluetoothDeviceFromOsModal } from './UnpairBluetoothDeviceFromOsModal';
-import { selectUnpairedDeviceNeedsManualOsRemoval } from '../../../actions/bluetooth/desktopBluetoothSelectors';
 import { useSelector } from '../../../hooks/suite';
 
 export const WipedBleDeviceNeedsManualOsRemovalModalManager = () => {
-    const wasBluetoothDeviceWiped = useSelector(selectUnpairedDeviceNeedsManualOsRemoval);
+    const wasBluetoothDeviceWiped = useSelector(selectIsDeviceOsUnpairingRequired);
 
     if (!wasBluetoothDeviceWiped) {
         return null;

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -18,7 +18,6 @@ export const initialAppState: AppState = {
     suite: suiteInitialState,
     device: initialState,
     bluetooth: {
-        unpairedDeviceNeedsManualOsRemoval: false,
         connectingDeviceIds: [],
         isUnpairingDevice: false,
         adapterStatus: 'unknown',
@@ -27,6 +26,7 @@ export const initialAppState: AppState = {
         knownDevices: [],
         ignoredDeviceIds: [],
         autoConnectPolicy: {},
+        isDeviceOsUnpairingRequired: false,
     },
     thp: {
         step: null,

--- a/suite-common/bluetooth/src/bluetoothActions.ts
+++ b/suite-common/bluetooth/src/bluetoothActions.ts
@@ -78,6 +78,11 @@ const setAutoConnectPolicyAction = createAction(
     }),
 );
 
+const setIsDeviceOsUnpairingRequired = createAction(
+    `${BLUETOOTH_PREFIX}/set-is-device-os-unpairing-required`,
+    (isDeviceOsUnpairingRequired: boolean) => ({ payload: isDeviceOsUnpairingRequired }),
+);
+
 export const bluetoothActions = {
     adapterEventAction,
     nearbyDevicesUpdateAction,
@@ -87,4 +92,5 @@ export const bluetoothActions = {
     removeKnownDeviceAction,
     updateDeviceConnectionStatus,
     setAutoConnectPolicyAction,
+    setIsDeviceOsUnpairingRequired,
 };

--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -24,6 +24,7 @@ export type BluetoothState<T extends BluetoothDeviceCommon> = {
     knownDevices: T[];
     ignoredDeviceIds: string[];
     autoConnectPolicy: Record<string, BluetoothAutoConnectPolicy | undefined>;
+    isDeviceOsUnpairingRequired: boolean;
 };
 
 export const prepareInitialState = <T extends BluetoothDeviceCommon>(): BluetoothState<T> => ({
@@ -33,6 +34,7 @@ export const prepareInitialState = <T extends BluetoothDeviceCommon>(): Bluetoot
     knownDevices: [] as T[],
     ignoredDeviceIds: [],
     autoConnectPolicy: {},
+    isDeviceOsUnpairingRequired: false,
 });
 
 export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>() =>
@@ -117,6 +119,9 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
             })
             .addCase(bluetoothActions.setAutoConnectPolicyAction, (state, { payload }) => {
                 state.autoConnectPolicy[payload.id] = payload.policy;
+            })
+            .addCase(bluetoothActions.setIsDeviceOsUnpairingRequired, (state, { payload }) => {
+                state.isDeviceOsUnpairingRequired = payload;
             })
 
             .addMatcher(

--- a/suite-common/bluetooth/src/bluetoothSelectors.ts
+++ b/suite-common/bluetooth/src/bluetoothSelectors.ts
@@ -51,6 +51,10 @@ export const selectAutoConnectPolicy = <T extends BluetoothDeviceCommon>(
     state: WithBluetoothState<T>,
 ) => state.bluetooth.autoConnectPolicy;
 
+export const selectIsDeviceOsUnpairingRequired = <T extends BluetoothDeviceCommon>(
+    state: WithBluetoothState<T>,
+) => state.bluetooth.isDeviceOsUnpairingRequired;
+
 export const selectKnownDeviceByDeviceId = <T extends BluetoothDeviceCommon>(
     state: WithBluetoothState<T>,
     deviceId?: string,

--- a/suite-common/bluetooth/src/index.ts
+++ b/suite-common/bluetooth/src/index.ts
@@ -4,6 +4,7 @@ export type {
     BluetoothFilterPolicy,
     BluetoothAutoConnectPolicy,
     DeviceBluetoothConnectionStatusType,
+    ForgetBluetoothDeviceThunkParams,
 } from './types';
 export type { BluetoothState } from './bluetoothReducer';
 export type { WithBluetoothState } from './bluetoothSelectors';
@@ -17,6 +18,7 @@ export {
     selectScanStatus,
     selectNearbyDevices,
     selectAutoConnectPolicy,
+    selectIsDeviceOsUnpairingRequired,
 } from './bluetoothSelectors';
 
 export { filterOutOldDuplicates } from './filterOutOldDuplicates';

--- a/suite-common/bluetooth/src/types.ts
+++ b/suite-common/bluetooth/src/types.ts
@@ -57,3 +57,9 @@ export type BluetoothDeviceCommon = {
 };
 
 export type DeviceBluetoothConnectionStatusType = DeviceBluetoothConnectionStatus['type'];
+
+export type ForgetBluetoothDeviceThunkParams = {
+    // This thunk must rely on `bluetoothId` directly. When this thunk is called,
+    // the device may already be disconnected, and therefore, it cannot be selected from the state.
+    bluetoothId: BluetoothDeviceId;
+};

--- a/suite-native/bluetooth/src/__tests__/selectors.test.ts
+++ b/suite-native/bluetooth/src/__tests__/selectors.test.ts
@@ -17,7 +17,6 @@ const initialState: NativeBluetoothState = {
         '1ec77690-be29-43c6-8859-dfeca15c7c0f': { type: 'autoconnect-disabled' },
     },
     permissionStatus: 'granted',
-    shouldShowSystemUnpairingAlert: false,
 };
 
 const unknownDevice: BluetoothDevice = {

--- a/suite-native/bluetooth/src/bluetoothSlice.ts
+++ b/suite-native/bluetooth/src/bluetoothSlice.ts
@@ -13,7 +13,6 @@ import { BluetoothDevice, BluetoothPermissionStatus } from './types';
 
 export type NativeBluetoothState = BluetoothState<BluetoothDevice> & {
     permissionStatus: BluetoothPermissionStatus;
-    shouldShowSystemUnpairingAlert: boolean;
 };
 
 export type NativeBluetoothRootState = {
@@ -35,9 +34,6 @@ export const bluetoothSlice = createSliceWithExtraDeps({
                 state.permissionStatus = payload;
             }
         },
-        setShouldShowSystemUnpairingAlert: (state, { payload }: PayloadAction<boolean>) => {
-            state.shouldShowSystemUnpairingAlert = payload;
-        },
     },
     extraReducers: (builder, extra) => {
         const commonReducer = prepareBluetoothReducerCreator<BluetoothDevice>()(extra);
@@ -54,4 +50,4 @@ export const bluetoothSlice = createSliceWithExtraDeps({
     },
 });
 
-export const { updatePermissionStatus, setShouldShowSystemUnpairingAlert } = bluetoothSlice.actions;
+export const { updatePermissionStatus } = bluetoothSlice.actions;

--- a/suite-native/bluetooth/src/bluetoothThunks.ts
+++ b/suite-native/bluetooth/src/bluetoothThunks.ts
@@ -1,0 +1,14 @@
+import {
+    BLUETOOTH_PREFIX,
+    ForgetBluetoothDeviceThunkParams,
+    bluetoothActions,
+} from '@suite-common/bluetooth';
+import { createThunk } from '@suite-common/redux-utils';
+
+export const forgetBluetoothDeviceThunk = createThunk<void, ForgetBluetoothDeviceThunkParams, void>(
+    `${BLUETOOTH_PREFIX}/forgetBluetoothDevice`,
+    ({ bluetoothId }, { dispatch }) => {
+        dispatch(bluetoothActions.removeKnownDeviceAction({ id: bluetoothId }));
+        dispatch(bluetoothActions.setIsDeviceOsUnpairingRequired(true));
+    },
+);

--- a/suite-native/bluetooth/src/hooks/useBluetoothDevice.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothDevice.ts
@@ -7,7 +7,7 @@ import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import TrezorConnect from '@trezor/connect';
 import { bluetoothManager } from '@trezor/transport-native-bluetooth';
 
-import { setShouldShowSystemUnpairingAlert } from '../bluetoothSlice';
+import { forgetBluetoothDeviceThunk } from '../bluetoothThunks';
 import { BluetoothDevice } from '../types';
 
 type UnpairDeviceProps = {
@@ -49,8 +49,7 @@ export const useBluetoothDevice = () => {
 
             const { success, payload } = result.payload;
             if (success || payload.code === 'Device_Disconnected') {
-                dispatch(bluetoothActions.removeKnownDeviceAction({ id: deviceBluetoothId }));
-                dispatch(setShouldShowSystemUnpairingAlert(true));
+                dispatch(forgetBluetoothDeviceThunk({ bluetoothId: deviceBluetoothId }));
                 onSuccess();
             } else if (
                 payload.code === 'Failure_ActionCancelled' ||

--- a/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.android.tsx
+++ b/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.android.tsx
@@ -5,10 +5,10 @@ import { useDispatch } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
+import { bluetoothActions } from '@suite-common/bluetooth';
 import { useAlert } from '@suite-native/alerts';
 import { useTranslate } from '@suite-native/intl';
 
-import { setShouldShowSystemUnpairingAlert } from '../bluetoothSlice';
 import { useBluetoothSettings } from './useBluetoothSettings';
 
 export const useBluetoothPlatformSpecificAlerts = () => {
@@ -47,12 +47,12 @@ export const useBluetoothPlatformSpecificAlerts = () => {
             description: translate('bluetooth.alerts.systemUnpairing.description.android'),
             primaryButtonTitle: translate('bluetooth.alerts.systemUnpairing.primaryButton'),
             onPressPrimaryButton: () => {
-                dispatch(setShouldShowSystemUnpairingAlert(false));
+                dispatch(bluetoothActions.setIsDeviceOsUnpairingRequired(false));
                 openBluetoothSettings();
             },
             secondaryButtonTitle: translate('bluetooth.alerts.systemUnpairing.secondaryButton'),
             onPressSecondaryButton: () => {
-                dispatch(setShouldShowSystemUnpairingAlert(false));
+                dispatch(bluetoothActions.setIsDeviceOsUnpairingRequired(false));
             },
         });
     }, [showAlert, dispatch, openBluetoothSettings, translate]);

--- a/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.ios.tsx
+++ b/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.ios.tsx
@@ -3,11 +3,11 @@
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { bluetoothActions } from '@suite-common/bluetooth';
 import { selectDeviceName } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { useTranslate } from '@suite-native/intl';
 
-import { setShouldShowSystemUnpairingAlert } from '../bluetoothSlice';
 import { SystemUnpairingAlertIosInstructions } from '../components/SystemUnpairingAlertIosInstructions';
 
 export const useBluetoothPlatformSpecificAlerts = () => {
@@ -47,7 +47,7 @@ export const useBluetoothPlatformSpecificAlerts = () => {
             ),
             primaryButtonTitle: translate('generic.buttons.gotIt'),
             onPressPrimaryButton: () => {
-                dispatch(setShouldShowSystemUnpairingAlert(false));
+                dispatch(bluetoothActions.setIsDeviceOsUnpairingRequired(false));
             },
         });
     }, [showAlert, dispatch, translate, deviceName]);

--- a/suite-native/bluetooth/src/index.ts
+++ b/suite-native/bluetooth/src/index.ts
@@ -1,5 +1,6 @@
 export * from './types';
 export * from './bluetoothSlice';
+export * from './bluetoothThunks';
 export * from './selectors';
 export * from './hooks/useBluetoothAdapter';
 export * from './hooks/useBluetoothAlerts';

--- a/suite-native/bluetooth/src/redux.d.ts
+++ b/suite-native/bluetooth/src/redux.d.ts
@@ -1,0 +1,7 @@
+import { AsyncThunkAction } from '@reduxjs/toolkit';
+
+declare module 'redux' {
+    export interface Dispatch {
+        <TThunk extends AsyncThunkAction<any, any, any>>(thunk: TThunk): ReturnType<TThunk>;
+    }
+}

--- a/suite-native/bluetooth/src/selectors.ts
+++ b/suite-native/bluetooth/src/selectors.ts
@@ -1,6 +1,7 @@
 import {
     selectAdapterStatus,
     selectAutoConnectPolicy,
+    selectIsDeviceOsUnpairingRequired,
     selectKnownDevices,
     selectNearbyDevices,
 } from '@suite-common/bluetooth';
@@ -15,9 +16,6 @@ export const selectBluetoothAutoConnectPolicy = (state: NativeBluetoothRootState
 
 export const selectBluetoothPermissionStatus = (state: NativeBluetoothRootState) =>
     state.bluetooth.permissionStatus;
-
-export const selectShouldShowSystemUnpairingAlert = (state: NativeBluetoothRootState) =>
-    state.bluetooth.shouldShowSystemUnpairingAlert;
 
 export const selectBluetoothAdapterStatus = (state: NativeBluetoothRootState) =>
     selectAdapterStatus(state);
@@ -57,3 +55,6 @@ export const selectKnownConnectableBluetoothDevices = createMemoizedSelector(
                 connectionStatus.type === 'disconnected',
         ),
 );
+
+export const selectIsBluetoothDeviceOsUnpairingRequired = (state: NativeBluetoothRootState) =>
+    selectIsDeviceOsUnpairingRequired(state);

--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -16,7 +16,6 @@ import {
 } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { EventType, analytics } from '@suite-native/analytics';
-import { selectShouldShowSystemUnpairingAlert } from '@suite-native/bluetooth';
 import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
 import { Translation } from '@suite-native/intl';
 import { SUITE_MOBILE_SUPPORT_URL, useOpenLink } from '@suite-native/link';
@@ -69,7 +68,6 @@ export const useDetectDeviceError = () => {
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
     const shouldShowAutoEjectAlert = useSelector(selectShouldShowAutoEjectAlert);
-    const shouldShowSystemUnpairingAlert = useSelector(selectShouldShowSystemUnpairingAlert);
 
     const isDeviceFirmwareSupported = useSelector(selectIsDeviceFirmwareSupported);
     const deviceError = useSelector(selectDeviceError);
@@ -295,17 +293,8 @@ export const useDetectDeviceError = () => {
         // Device with error can't be view-only.
         // Edge case: If user has connected two devices simultaneously,
         // it will not hide the alert.
-        if (
-            isNoPhysicalDeviceConnected &&
-            !shouldShowAutoEjectAlert &&
-            !shouldShowSystemUnpairingAlert
-        ) {
+        if (isNoPhysicalDeviceConnected && !shouldShowAutoEjectAlert) {
             hideAlert('deviceError');
         }
-    }, [
-        isNoPhysicalDeviceConnected,
-        hideAlert,
-        shouldShowAutoEjectAlert,
-        shouldShowSystemUnpairingAlert,
-    ]);
+    }, [isNoPhysicalDeviceConnected, hideAlert, shouldShowAutoEjectAlert]);
 };

--- a/suite-native/device/src/hooks/useWipeDevice.tsx
+++ b/suite-native/device/src/hooks/useWipeDevice.tsx
@@ -4,12 +4,7 @@ import { CompositeNavigationProp, useNavigation } from '@react-navigation/native
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { isFulfilled } from '@reduxjs/toolkit';
 
-import {
-    selectIsDeviceConnectedViaBluetooth,
-    selectSelectedDevice,
-    wipeDeviceThunk,
-} from '@suite-common/wallet-core';
-import { setShouldShowSystemUnpairingAlert } from '@suite-native/bluetooth';
+import { selectSelectedDevice, wipeDeviceThunk } from '@suite-common/wallet-core';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { setWasDeviceOnboardingCancelled } from '@suite-native/device-onboarding';
 import {
@@ -34,7 +29,6 @@ export const useWipeDevice = () => {
     const navigation = useNavigation<NavigationProps>();
 
     const device = useSelector(selectSelectedDevice);
-    const isDeviceConnectedViaBluetooth = useSelector(selectIsDeviceConnectedViaBluetooth);
 
     const wipeDevice = async () => {
         if (!device) return;
@@ -55,9 +49,6 @@ export const useWipeDevice = () => {
         });
 
         if (response.success && isFulfilled(response.payload)) {
-            if (isDeviceConnectedViaBluetooth) {
-                dispatch(setShouldShowSystemUnpairingAlert(true));
-            }
             navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
                 screen: DeviceSettingsStackRoutes.WipeDeviceStack,
                 params: {

--- a/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
@@ -9,7 +9,10 @@ import {
     selectIsDeviceUnlocked,
     selectIsDiscoveredDeviceAccountless,
 } from '@suite-common/wallet-core';
-import { selectShouldShowSystemUnpairingAlert, useBluetoothAlerts } from '@suite-native/bluetooth';
+import {
+    selectIsBluetoothDeviceOsUnpairingRequired,
+    useBluetoothAlerts,
+} from '@suite-native/bluetooth';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { Screen } from '@suite-native/navigation';
 
@@ -26,7 +29,9 @@ export const HomeScreen = () => {
     const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
     const isDeviceUnlocked = useSelector(selectIsDeviceUnlocked);
     const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
-    const shouldShowSystemUnpairingAlert = useSelector(selectShouldShowSystemUnpairingAlert);
+    const isBluetoothDeviceOsUnpairingRequired = useSelector(
+        selectIsBluetoothDeviceOsUnpairingRequired,
+    );
 
     const isEmptyHomeRendererShown =
         (isDiscoveredDeviceAccountless && // There has to be no accounts and discovery not active.
@@ -42,10 +47,10 @@ export const HomeScreen = () => {
 
     useFocusEffect(
         useCallback(() => {
-            if (shouldShowSystemUnpairingAlert) {
+            if (isBluetoothDeviceOsUnpairingRequired) {
                 showSystemUnpairingAlert();
             }
-        }, [shouldShowSystemUnpairingAlert, showSystemUnpairingAlert]),
+        }, [isBluetoothDeviceOsUnpairingRequired, showSystemUnpairingAlert]),
     );
 
     useShowAutoEjectAlert();

--- a/suite-native/module-home/src/screens/HomeScreen/useShowAutoEjectAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/useShowAutoEjectAlert.tsx
@@ -7,7 +7,7 @@ import { toggleAutoEjectThunk } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { EventType, SuiteNativeAnalyticsEvent, analytics } from '@suite-native/analytics';
 import { CenteredTitleHeader, VStack } from '@suite-native/atoms';
-import { selectShouldShowSystemUnpairingAlert } from '@suite-native/bluetooth';
+import { selectIsBluetoothDeviceOsUnpairingRequired } from '@suite-native/bluetooth';
 import { Translation } from '@suite-native/intl';
 import {
     selectHasAutoEjectAlertBeenDisplayed,
@@ -26,7 +26,9 @@ export const useShowAutoEjectAlert = () => {
     const { showToast } = useToast();
 
     const shouldShowAutoEjectAlert = useSelector(selectShouldShowAutoEjectAlert);
-    const shouldShowSystemUnpairingAlert = useSelector(selectShouldShowSystemUnpairingAlert);
+    const isBluetoothDeviceOsUnpairingRequired = useSelector(
+        selectIsBluetoothDeviceOsUnpairingRequired,
+    );
     const hasAutoEjectAlertBeenDisplayed = useSelector(selectHasAutoEjectAlertBeenDisplayed);
 
     const reportAutoEjectToAnalytics = useCallback(
@@ -41,7 +43,7 @@ export const useShowAutoEjectAlert = () => {
 
     useFocusEffect(
         useCallback(() => {
-            if (shouldShowSystemUnpairingAlert) {
+            if (isBluetoothDeviceOsUnpairingRequired) {
                 // The alert regarding system unpairing has a higher priority.
                 return;
             }
@@ -93,7 +95,7 @@ export const useShowAutoEjectAlert = () => {
             hideAlert,
             reportAutoEjectToAnalytics,
             shouldShowAutoEjectAlert,
-            shouldShowSystemUnpairingAlert,
+            isBluetoothDeviceOsUnpairingRequired,
             showAlert,
             showToast,
         ]),

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -9,6 +9,7 @@ import {
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { extraDependenciesMock } from '@suite-common/test-utils/src/extraDependenciesMock'; // precise import path to avoid circular dependencies
 import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { forgetBluetoothDeviceThunk } from '@suite-native/bluetooth';
 import { selectTokenDefinitionsEnabledNetworks } from '@suite-native/discovery';
 import { selectTradingEnvironment } from '@suite-native/module-trading';
 import { reportSecurityCheck } from '@suite-native/sentry';
@@ -66,6 +67,7 @@ export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDepende
         // `@suite-common/local-first-storage` depends on `wallet-core`
         subscribeLocalFirstStorage: subscribeLocalFirstStorageThunk,
         unsubscribeAndDisposeLocalFirstStorage: unsubscribeAndDisposeLocalFirstStorageThunk,
+        forgetBluetoothDevice: forgetBluetoothDeviceThunk,
     } as Partial<ExtraDependencies['thunks']>,
     actions: {} as Partial<ExtraDependencies['actions']>,
     actionTypes: {} as Partial<ExtraDependencies['actionTypes']>,


### PR DESCRIPTION
Since all platforms need this kind of flag, moving it to `suite-common`.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/bluetooth-os-unpairing&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/bluetooth-os-unpairing&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/bluetooth-os-unpairing&lookback=7)

### Notes for QA

Make sure that the dialog instructing users to remove BT pairing from OS settings is shown as expected on both mobile and desktop.