### PR TITLE
fix(suite): block adding new BTC like account if previous is still empty

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
@@ -108,7 +108,7 @@ const AddDefaultAccountButton = ({
         : undefined;
 
     const disabledMessage = verifyAvailability({
-        emptyAccounts: scopedAccounts.filter(account => account.empty),
+        emptyAccounts: scopedAccounts.filter(account => account.empty && !account.visible),
         account: defaultAccount,
         unavailableCapability,
     });

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -63,6 +63,14 @@ export const isAccountFailed = (account: Account): account is FailedAccount => !
 export const isAccountDiscoverable = ({ accountType }: Account) =>
     accountType !== 'imported' && accountType !== 'placeholder' && accountType !== 'coinjoin';
 
+export const isEvmLedger = (networkType: NetworkType, accountType: AccountType) =>
+    networkType === 'ethereum' && accountType === 'ledger';
+
+export const getAccountIndexOffset = (
+    networkType: NetworkType,
+    accountType: AccountType,
+): number => (isEvmLedger(networkType, accountType) ? 1 : 0);
+
 export const getFirstFreshAddress = (
     account: Account,
     receiveAddresses: ReceiveInfo[],
@@ -1252,10 +1260,11 @@ export const prepareNewAccountPayload = async ({
     accountTypes?: NetworkAccount[];
     device: TrezorDevice;
 }) => {
+    const network = getNetwork(networkSymbol);
     const networkAccount =
         selectedAccount ?? accountTypes?.find(v => v.accountType === accountType);
 
-    const accountIndex = index + (accountType === 'ledger' ? 1 : 0);
+    const accountIndex = index + getAccountIndexOffset(network.networkType, accountType);
 
     const newPath = networkAccount?.bip43Path.replace('i', String(accountIndex));
 


### PR DESCRIPTION
## Description

Prevents users from adding another BTC-like account if the previously created one is still empty (no transactions, zero balance).

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15417


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/prevent-adding-new-empty-btc&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/prevent-adding-new-empty-btc&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/prevent-adding-new-empty-btc&lookback=7)