### PR TITLE
fix(suite-native): eject wallets: display only authorized wallets

### DIFF
--- a/suite-common/wallet-utils/src/deviceUtils.ts
+++ b/suite-common/wallet-utils/src/deviceUtils.ts
@@ -13,11 +13,11 @@ export const parseDeviceStaticSessionId = (deviceStaticSessionId: StaticSessionI
 };
 
 export const shouldDeviceBeRemembered = ({
-    isDeviceAutoEjectEnabled,
     device,
+    isDeviceAutoEjectEnabled = false,
 }: {
-    isDeviceAutoEjectEnabled: boolean;
     device: TrezorDevice | Device;
+    isDeviceAutoEjectEnabled?: boolean;
 }) => {
     if (!isNative()) return true;
 

--- a/suite-native/module-settings/package.json
+++ b/suite-native/module-settings/package.json
@@ -21,6 +21,7 @@
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
+        "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/alerts": "workspace:*",
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",

--- a/suite-native/module-settings/src/components/EjectWallets/DevicesManagement.tsx
+++ b/suite-native/module-settings/src/components/EjectWallets/DevicesManagement.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { selectPhysicalDevicesGrouppedById } from '@suite-common/wallet-core';
+import { shouldDeviceBeRemembered } from '@suite-common/wallet-utils';
 import { Box, Card, Divider, HStack, Text, VStack } from '@suite-native/atoms';
 import { ConnectionDot } from '@suite-native/device-manager';
 import { DeviceModelIcon } from '@suite-native/icons';
@@ -17,6 +18,9 @@ export const DevicesManagement = () => {
             <AutoEjectSwitch />
             {deviceGroups.map(devices => {
                 const [firstDevice] = devices;
+
+                if (!shouldDeviceBeRemembered({ device: firstDevice })) return null;
+
                 const deviceModel = firstDevice.features?.internal_model;
 
                 return (

--- a/suite-native/module-settings/src/components/EjectWallets/WalletRow.tsx
+++ b/suite-native/module-settings/src/components/EjectWallets/WalletRow.tsx
@@ -24,7 +24,6 @@ export const WalletRow = ({ device }: WalletRowProps) => {
     const { applyStyle } = useNativeStyles();
     const hasDiscovery = useSelector(selectHasRunningDiscovery);
 
-    // todo: only makes sense if device is already authorized (has state)
     const walletNameLabel = device.useEmptyPassphrase ? (
         <Translation id="moduleSettings.viewOnly.wallet.standard" />
     ) : (
@@ -39,7 +38,6 @@ export const WalletRow = ({ device }: WalletRowProps) => {
     return (
         <HStack key={device.instance} style={applyStyle(walletRowStyle)}>
             <HStack spacing="sp12" alignItems="center">
-                {/* // todo: only makes sense if device is already authorized (has state) */}
                 <Icon name={device.useEmptyPassphrase ? 'wallet' : 'password'} size="mediumLarge" />
                 <Text variant="callout">{walletNameLabel}</Text>
             </HStack>

--- a/suite-native/module-settings/tsconfig.json
+++ b/suite-native/module-settings/tsconfig.json
@@ -17,6 +17,9 @@
         {
             "path": "../../suite-common/wallet-core"
         },
+        {
+            "path": "../../suite-common/wallet-utils"
+        },
         { "path": "../alerts" },
         { "path": "../analytics" },
         { "path": "../atoms" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12201,6 +12201,7 @@ __metadata:
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
+    "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/alerts": "workspace:*"
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

 - Prevent unauthorized wallets from appearing in the eject wallets list.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22080

## Screenshots:
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-10-07 at 15 48 32" src="https://github.com/user-attachments/assets/5b4624cc-7b0c-4dbe-b673-9153ad53561f" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/eject-wallets-list&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/eject-wallets-list&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/eject-wallets-list&lookback=7)