### PR TITLE
feat(suite): inform to pair BT device manually if unsupported

### DIFF
--- a/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
@@ -2,6 +2,7 @@ import { BLUETOOTH_PREFIX, bluetoothActions } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import TrezorConnect, { BluetoothDeviceId, Device } from '@trezor/connect';
+import { isLinux } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
@@ -15,6 +16,11 @@ type BluetoothConnectDeviceThunkResult = {
     success: boolean;
     unpaired?: boolean;
 };
+
+// This is a terrible hotfix, should be removed. Problem is that even on Gnome or KDE, you get this error if you cancel BT pairing in OS dialog.
+// TODO #22272 shall be fixed in transport-bluetooth, or moving to Suite code so we can handle it better.
+const unsupportedLinuxEnvToast =
+    'Authentication failed. Try pairing the device manually via your system settings and restarting Trezor Suite.';
 
 export const bluetoothConnectDeviceThunk = createThunk<
     BluetoothConnectDeviceThunkResult,
@@ -43,12 +49,10 @@ export const bluetoothConnectDeviceThunk = createThunk<
                 dispatch(setBluetoothDeviceNeedsManualOsRemoval({ needsManualRemoval: true }));
                 dispatch(bluetoothActions.removeKnownDeviceAction({ id: deviceId }));
             } else {
-                dispatch(
-                    notificationsActions.addToast({
-                        type: 'error',
-                        error: result.error,
-                    }),
-                );
+                const isUnsupportedLinuxEnvError =
+                    isLinux() && result.error.includes('Authentication Failed');
+                const error = isUnsupportedLinuxEnvError ? unsupportedLinuxEnvToast : result.error;
+                dispatch(notificationsActions.addToast({ type: 'error', error }));
             }
 
             dispatch(stopConnectingBluetoothDevice({ deviceId }));


### PR DESCRIPTION
## Description

Followup to #21953 which fixed only the "Open settings" buttons.
This PR tries to solve an even worse problem, which is connecting the device on an unsupported Linux desktop env.
Shall be fixed better in https://github.com/trezor/trezor-suite/issues/22272

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21920

## Screenshots:

On XFCE, BT settings do not open at all, so we need to inform the user, otherwise they'd have no clue why "Authentication failed"  

[XFCE.webm](https://github.com/user-attachments/assets/0dedf321-34d0-4127-a470-61da2ee8714e)

Undesired side effect :disappointed: on Gnome you get the same toast if you cancel the pairing dialog. Video is outdated I changed the toast text to cover both cases without confusion.

[GNOME bad.webm](https://github.com/user-attachments/assets/3bcc1914-3352-41ff-8f46-971df3add65a)
