### PR TITLE
Data analytics: add analytic events for active staking

### DIFF
--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -157,7 +157,7 @@ const analyticsMiddleware =
                 if (action.payload.status.status !== 'complete') return;
 
                 const accumulateAccountCountBySymbolAndType = (
-                    acc: { [key: string]: number },
+                    acc: Record<string, number>,
                     { symbol, accountType }: Account,
                 ) => {
                     // change coinjoin accounts to taproot for analytics
@@ -202,6 +202,12 @@ const analyticsMiddleware =
                         return acc;
                     }, {});
 
+                const accountsWithStaking = state.wallet.accounts
+                    .filter(account =>
+                        new BigNumber(getAccountTotalStakingBalance(account) || 0).gt(0),
+                    )
+                    .reduce(accumulateAccountCountBySymbolAndType, {});
+
                 analytics.report({
                     type: EventType.AccountsStatus,
                     payload: { ...accountsWithTransactions },
@@ -216,6 +222,12 @@ const analyticsMiddleware =
                     type: EventType.AccountsTokensStatus,
                     payload: { ...accountsWithTokens },
                 });
+
+                analytics.report({
+                    type: EventType.AccountsActiveStaking,
+                    payload: { ...accountsWithStaking },
+                });
+
                 break;
             }
             case ROUTER.LOCATION_CHANGE:

--- a/suite-common/analytics/src/events/suite/constants.ts
+++ b/suite-common/analytics/src/events/suite/constants.ts
@@ -43,6 +43,7 @@ export enum EventType {
     AccountsStatus = 'accounts/status',
     AccountsTokensStatus = 'accounts/tokens-status',
     AccountsNonZeroBalance = 'accounts/non-zero-balance',
+    AccountsActiveStaking = 'accounts/active-staking',
     AccountsNewAccount = 'accounts/new-account',
     AccountsActions = 'accounts/actions',
     AddToken = 'add-token',

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -199,21 +199,19 @@ export type SuiteAnalyticsEvent =
       }
     | {
           type: EventType.AccountsStatus;
-          payload: {
-              [key: string]: number;
-          };
+          payload: Record<string, number>;
       }
     | {
           type: EventType.AccountsNonZeroBalance;
-          payload: {
-              [key: string]: number;
-          };
+          payload: Record<string, number>;
+      }
+    | {
+          type: EventType.AccountsActiveStaking;
+          payload: Record<string, number>;
       }
     | {
           type: EventType.AccountsTokensStatus;
-          payload: {
-              [key: string]: number;
-          };
+          payload: Record<string, number>;
       }
     | {
           type: EventType.AccountsNewAccount;


### PR DESCRIPTION
## Description

Added new analytics event: `accounts/active-staking`. Event is triggered after discovery of all accounts is completed. Payload includes counts of accounts that have any amount staked

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21908

## Screenshot

<img width="579" height="309" alt="image" src="https://github.com/user-attachments/assets/f80abed9-c09a-4291-8550-f001198d741e" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/data-analytics-active-staking&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/data-analytics-active-staking&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/data-analytics-active-staking&lookback=7)