### PR TITLE
chore(suite-common): set default flagship to T3T1

### DIFF
--- a/suite-common/suite-constants/src/device.ts
+++ b/suite-common/suite-constants/src/device.ts
@@ -1,6 +1,6 @@
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-export const DEFAULT_FLAGSHIP_MODEL = DeviceModelInternal.T3W1;
+export const DEFAULT_FLAGSHIP_MODEL = DeviceModelInternal.T3T1;
 
 export const SUPPORTS_DEVICE_AUTHENTICITY_CHECK: Record<DeviceModelInternal, boolean> = {
     [DeviceModelInternal.UNKNOWN]: true, // We must require device authenticity check so it cannot be used as an exploit to bypass it


### PR DESCRIPTION
before:
<img width="1208" height="798" alt="Screenshot 2025-10-07 at 16 26 45" src="https://github.com/user-attachments/assets/2f77f89e-2c1a-4d5a-a407-6f2b86dba8a4" />
after:
<img width="1243" height="821" alt="Screenshot 2025-10-07 at 16 15 10" src="https://github.com/user-attachments/assets/a7f128a9-8c8f-4199-b3af-6918137124ba" />

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/flagship-model&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/flagship-model&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/flagship-model&lookback=7)