### PR TITLE
Throw away invalid THP credentials

### DIFF
--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -127,6 +127,17 @@ export const thpHandshake = async (device: Device, unlockPin = false) => {
         encryptedPayload: handshakeCredentials.encryptedPayload,
     });
 
+    if (!handshakeCompletion.message.state && handshakeCredentials.credentials) {
+        // Known credentials was used but not accepted by device -> throw them away
+        thpState.removePairingCredential(handshakeCredentials.credentials);
+
+        const { credential } = handshakeCredentials.credentials;
+        const index = settings?.knownCredentials?.findIndex(c => c.credential === credential) ?? -1;
+        if (index >= 0) {
+            settings?.knownCredentials?.splice(index, 1);
+        }
+    }
+
     thpState.setIsPaired(!!handshakeCompletion.message.state);
     thpState.setPhase('pairing');
 

--- a/packages/protocol/src/protocol-thp/ThpState.ts
+++ b/packages/protocol/src/protocol-thp/ThpState.ts
@@ -102,6 +102,11 @@ export class ThpState {
         }
     }
 
+    removePairingCredential({ credential }: ThpCredentials) {
+        const index = this._pairingCredentials.findIndex(c => c.credential === credential);
+        if (index >= 0) this._pairingCredentials.splice(index, 1);
+    }
+
     setNfcSecret(secret: Buffer) {
         this._nfcSecret = secret;
     }

--- a/packages/protocol/src/protocol-thp/crypto/pairing.ts
+++ b/packages/protocol/src/protocol-thp/crypto/pairing.ts
@@ -118,7 +118,7 @@ export const handleHandshakeInit = ({
         trezorEphemeralPubkey,
     );
     // and use first from the list (could be undefined)
-    const credentials: ThpCredentialResponse | undefined = allCredentials[0];
+    const credentials = allCredentials.length ? allCredentials[0] : undefined;
 
     // 11.1 If found set (temp_host_static_privkey, temp_host_static_pubkey) = (host_static_privkey, host_static_pubkey).
     // 11.2 If not found set (temp_host_static_privkey, temp_host_static_pubkey) = (X25519(0, B), 0).

--- a/packages/protocol/src/protocol-thp/messages/messageTypes.ts
+++ b/packages/protocol/src/protocol-thp/messages/messageTypes.ts
@@ -48,7 +48,7 @@ export type ThpHandshakeCompletionRequest = {
 };
 
 export type ThpHandshakeCompletionResponse = {
-    state: 0 | 1;
+    state: 0 | 1 | 2;
 };
 
 export type ThpMessageType = ThpProtobufMessageType & {

--- a/suite-common/thp/src/thpReducer.ts
+++ b/suite-common/thp/src/thpReducer.ts
@@ -10,6 +10,7 @@ import {
     UiRequestConfirmation,
     UiRequestThpPairing,
 } from '@trezor/connect';
+import type { ThpCredentials } from '@trezor/protocol';
 
 import { thpActions } from './thpActions';
 
@@ -51,6 +52,11 @@ export const initialThpState: ThpState = {
     credentials: [] as ThpSuiteCredentials[],
 };
 
+const addCredential = (credentials: ThpSuiteCredentials[], credential: ThpCredentials) =>
+    credentials
+        .filter(c => c.trezor_static_public_key !== credential.trezor_static_public_key)
+        .concat([{ ...credential, connectionCounter: 0 }]);
+
 export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
     initialThpState,
     (builder, extra) =>
@@ -74,7 +80,7 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
                 }
             })
             .addCase(thpActions.addCredential, (state, { payload }) => {
-                state.credentials.push({ ...payload.credential, connectionCounter: 0 });
+                state.credentials = addCredential(state.credentials, payload.credential);
             })
             .addCase(thpActions.removeCredentials, (state, { payload }) => {
                 state.credentials = state.credentials.filter(
@@ -102,10 +108,7 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
                 (state, action: DeviceThpCredentialsChanged) => {
                     const { credentials, staticKey } = action.payload;
 
-                    state.credentials.push({
-                        ...credentials,
-                        connectionCounter: 0,
-                    });
+                    state.credentials = addCredential(state.credentials, credentials);
                     state.staticKey = staticKey;
                 },
             )


### PR DESCRIPTION
## Description

a) When Suite receives new THP credentials, the previous ones for the same device are thrown away.
b) In Connect, when device rejects previously known credentials, they're thrown away from both `ThpState` and `DataManager`.

This should ensure that even when credentials are reseted only device-side, Suite won't try to use the old ones again and again, resulting in multiple THP code pairing.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-credential-reuse&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-credential-reuse&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thp-credential-reuse&lookback=7)