### PR TITLE
fix(e2e-suite): change order of currents fixture to be first

### DIFF
--- a/packages/suite-desktop-core/e2e/support/fixtures.ts
+++ b/packages/suite-desktop-core/e2e/support/fixtures.ts
@@ -1,6 +1,4 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import { mergeTests } from '@playwright/test';
-
 import { AnalyticsFixture } from './analytics';
 import { IndexedDbFixture } from './indexedDb';
 import { BlockbookMock } from './mocks/blockBookMock';
@@ -21,7 +19,6 @@ import { StakingSection } from './pageObjects/stakingSection';
 import { TradingPage } from './pageObjects/trading/tradingPage';
 import { TrezorInput } from './pageObjects/trezorInput';
 import { WalletPage } from './pageObjects/walletPage';
-import { currentsTest } from './testExtends/currentsFixture';
 import { suiteBaseTest } from './testExtends/suiteBaseFixture';
 
 type Fixtures = {
@@ -47,7 +44,7 @@ type Fixtures = {
     model: ModelFixture;
 };
 
-const suiteTest = suiteBaseTest.extend<Fixtures>({
+const test = suiteBaseTest.extend<Fixtures>({
     dashboardPage: async ({ page, devicePrompt }, use) => {
         await use(new DashboardPage(page, devicePrompt));
     },
@@ -119,8 +116,6 @@ const suiteTest = suiteBaseTest.extend<Fixtures>({
         await use(new ModelFixture(emulatorStartConf.model));
     },
 });
-
-const test = mergeTests(suiteTest, currentsTest);
 
 export { test };
 export { expect } from './testExtends/customMatchers';

--- a/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import { BrowserContext, Page, TestInfo, test as base } from '@playwright/test';
+import { BrowserContext, Page, TestInfo, test as base, mergeTests } from '@playwright/test';
 
 import { TestAnnotationType } from '@trezor/e2e-utils';
 import { Model, SetupEmu, StartEmu, TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
@@ -12,6 +12,7 @@ import {
     mockRemoteMessageSystem,
 } from '../common';
 import { LaunchSuiteParams, Suite, launchSuite } from '../electron';
+import { currentsTest } from './currentsFixture';
 import { enhancePage } from './enhancePage';
 import { BRIDGE_VERSION } from '../bridge';
 import { getModelFromEnv } from '../helpers/modelFromEnv';
@@ -137,10 +138,12 @@ const trezorEnvSetup = async (
     }
 };
 
+// We first add currents fixtures to ensure current initialize first and quarantine works even for fails in beforeEach
+const baseWithCurrents = mergeTests(base, currentsTest);
 // This is the base Suite text fixture containing all the necessary setup and core page object
 // Depending on the project type (desktop or web) it will launch the appropriate environment
 // and provide the necessary page object which is either electron window or web page
-const suiteBaseTest = base.extend<suiteBaseFixture>({
+const suiteBaseTest = baseWithCurrents.extend<suiteBaseFixture>({
     startEmulator: true,
     setupEmulator: true,
     emulatorStartConf: { model: getModelFromEnv(), wipe: true },


### PR DESCRIPTION
We need currents fixture as first in order of initialization so if there is fail in setup of our other fixtures, it can be processed and quarantined by currents logic.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-currents-before-each&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-currents-before-each&lookback=7)