### PR TITLE
fix(suite): swap fees

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
@@ -482,13 +482,16 @@ export class TradingPage {
         const quotesResponsePromise = this.page.waitForResponse(invityEndpoint.swapQuotes);
         await expect(this.bestOfferAmount).toHaveText(/0 \w+/);
         await this.youPayCryptoInput.fill(params.amount);
-        await expect.soft(quotesRequestPromise).toHavePayload({
-            receive: params.receiveNetwork,
-            send: params.sendCurrency,
-            sendStringAmount: params.amount,
-            dex: 'enable',
-            receiveAddress: params.receiveAddress,
-        });
+        await expect.soft(quotesRequestPromise).toHavePayload(
+            {
+                receive: params.receiveNetwork,
+                send: params.sendCurrency,
+                sendStringAmount: params.amount,
+                dex: 'enable',
+                receiveAddress: params.receiveAddress,
+            },
+            { omit: ['fromAddress'] },
+        );
         await quotesResponsePromise;
         await this.waitForOffersSync();
     }

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -769,10 +769,6 @@ export const useTradingExchangeForm = ({
     };
 
     useEffect(() => {
-        if (exchangeType !== TRADING_EXCHANGE_FORM_DEX) {
-            return setValue('fromAddress', undefined);
-        }
-
         const networkType = getNetworkType(account.symbol);
 
         switch (networkType) {
@@ -784,7 +780,7 @@ export const useTradingExchangeForm = ({
             default:
                 return setValue('fromAddress', undefined);
         }
-    }, [account, setValue, exchangeType]);
+    }, [account, setValue]);
 
     // set transactionData from DEX quote for correct fees fetching
     useEffect(() => {

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -35,6 +35,7 @@ import {
 } from '@suite-common/trading';
 import { getNetwork, getNetworkType } from '@suite-common/wallet-config';
 import {
+    ETHEREUM_ADJUST_GAS_LIMIT,
     fetchAndUpdateAccountThunk,
     selectAccountByKey,
     updateFeeInfoThunk,
@@ -182,8 +183,17 @@ export const useTradingExchangeForm = ({
 
     const { reset, register, getValues, setValue, formState, control } = methods;
     const values = useWatch<TradingExchangeFormProps>({ control });
-    const { rateType, exchangeType, sendCryptoSelect, receiveCryptoSelect } = getValues();
+    const {
+        rateType,
+        exchangeType,
+        sendCryptoSelect,
+        receiveCryptoSelect,
+        transactionData,
+        ethereumAdjustGasLimit,
+    } = getValues();
     const output = values.outputs?.[0];
+    const outputAddress = output?.address;
+
     const fiatValues = useTradingFiatValues({
         cryptoId: sendCryptoSelect?.value,
         amount: sendCryptoSelect?.balance,
@@ -778,6 +788,10 @@ export const useTradingExchangeForm = ({
 
     // set transactionData from DEX quote for correct fees fetching
     useEffect(() => {
+        if (pageType !== 'form') {
+            return;
+        }
+
         if (exchangeType !== TRADING_EXCHANGE_FORM_DEX) {
             setValue('transactionData', '');
         }
@@ -788,7 +802,7 @@ export const useTradingExchangeForm = ({
 
         const isEvmNativeToken = isSendingEvmNativeToken(sendCryptoSelect?.value);
 
-        const quote = isEvmNativeToken ? dexQuotes[0] : selectedQuote;
+        const quote = preselectedQuote ?? (isEvmNativeToken ? dexQuotes[0] : selectedQuote);
 
         if (!quote || !quote.dexTx) {
             return setValue('transactionData', '');
@@ -798,10 +812,12 @@ export const useTradingExchangeForm = ({
 
         setValue('transactionData', dexTx.data);
         setValue(TRADING_FORM_OUTPUT_ADDRESS, dexTx.to);
+        setValue('ethereumAdjustGasLimit', ETHEREUM_ADJUST_GAS_LIMIT);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
         dexQuotes,
         selectedQuote,
+        preselectedQuote,
         exchangeType,
         isApproval,
         sendCryptoSelect,
@@ -811,9 +827,11 @@ export const useTradingExchangeForm = ({
 
     // fetch fees when transactionData changes
     useEffect(() => {
+        if (pageType !== 'form') return;
+
         fetchFeesAndCompose();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [values.transactionData, values.outputs?.[0]?.address]);
+    }, [transactionData, outputAddress, ethereumAdjustGasLimit, pageType]);
 
     useEffect(() => {
         setValue('receiveAddress', receiveAddress);

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -2,6 +2,7 @@ import { isRejectedWithValue } from '@reduxjs/toolkit';
 import { ExchangeTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
+import { ETHEREUM_ADJUST_GAS_LIMIT } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 
 import { exchangeThunks, tradingThunks } from '../';
@@ -102,7 +103,8 @@ export const sendDexTransactionThunk = createThunk<
                 amount: selectedQuote.dexTx.value,
                 destinationTag: selectedQuote.partnerPaymentExtraId,
                 recalculateCustomLimit: true,
-                ethereumAdjustGasLimit: selectedQuote.status === 'CONFIRM' ? '1.25' : undefined,
+                ethereumAdjustGasLimit:
+                    selectedQuote.status === 'CONFIRM' ? ETHEREUM_ADJUST_GAS_LIMIT : undefined,
                 setMaxOutputId,
                 signAndPushSendFormTransaction,
                 tradingFormState,

--- a/suite-common/wallet-core/src/fees/feesUtils.ts
+++ b/suite-common/wallet-core/src/fees/feesUtils.ts
@@ -18,6 +18,8 @@ const NETWORK_FEE_OVERRIDES: Record<
     },
 } as const;
 
+export const ETHEREUM_ADJUST_GAS_LIMIT = '1.25';
+
 // sort FeeLevels in reversed order (Low > High)
 // TODO: consider to use same order in @trezor/connect to avoid double sorting
 const order: FeeLevel['label'][] = ['low', 'economy', 'normal', 'high'];


### PR DESCRIPTION
## Description

Improve fee estimation so that fees in swap form and during tx signing are identical.

- adjust gas limit by `1.25` in swap form (same as in tx signing)
- don't refetch fees when not in swap form (except during tx signing)
- fetch fees for `preselectedQuote` (if selected) instead of first `DEX` quote

Additionally fix a bug where `fromAddress` parameter has not been included in quotes request payload.

## Related Issue

Resolve #14838 
Resolve #18060 

## Screenshots

<img width="1232" height="861" alt="Screenshot 2025-10-08 at 11 05 34" src="https://github.com/user-attachments/assets/11179863-c877-4fe9-820e-f8b16eaaeb29" />

<img width="1232" height="861" alt="Screenshot 2025-10-08 at 11 05 42" src="https://github.com/user-attachments/assets/fbc2d749-503d-4309-b9d2-091be0806be3" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/fees&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/fees&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/fees&lookback=7)