### PR TITLE
feat(suite): disiplay the warning during update when the THP device i…

### DIFF
--- a/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
+++ b/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
@@ -143,6 +143,9 @@ export const useFirmwareInstallation = (
     const showManualReconnectPrompt = reconnectEvent?.method === 'manual';
     const deviceIsWaitingForConfirmationToConnectToHost =
         reconnectEvent?.method === 'auto' && reconnectEvent.target === 'bootloader';
+    const pinRequested = Boolean(
+        buttonEvent?.code && ['ButtonRequest_PinEntry'].includes(buttonEvent.code),
+    );
 
     const showReconnectPrompt =
         shouldShowReconnectPrompt({
@@ -151,7 +154,8 @@ export const useFirmwareInstallation = (
             originalDevice,
         }) ||
         showManualReconnectPrompt ||
-        deviceIsWaitingForConfirmationToConnectToHost;
+        deviceIsWaitingForConfirmationToConnectToHost ||
+        pinRequested;
 
     const deviceWillBeWiped = determineIfDeviceWillBeWiped(
         originalDevice,
@@ -164,10 +168,8 @@ export const useFirmwareInstallation = (
         // Show the confirmation pill before starting the installation using the "wait" or "manual" method,
         // after ReconnectDevicePrompt is closed and user selects the option to install firmware while in bootloader.
         // Also, in case the device is PIN-locked at the start of the process.
-        (buttonEvent?.code &&
-            ['ButtonRequest_FirmwareUpdate', 'ButtonRequest_PinEntry'].includes(
-                buttonEvent.code,
-            )) ||
+        (buttonEvent?.code && ['ButtonRequest_FirmwareUpdate'].includes(buttonEvent.code)) ||
+        pinRequested ||
         // Show the confirmation pill right after ReconnectDevicePrompt is closed while using the "wait" or "manual" method,
         // before the user selects the option to install firmware while in bootloader
         // When a PIN-protected device reconnects to normal mode after installation, PIN is requested and the pill is shown.
@@ -214,7 +216,7 @@ export const useFirmwareInstallation = (
         }
 
         return { operation: null, progress: 0 };
-    }, [isThpInProgress, firmware.status, reconnectEvent, progressEvent]);
+    }, [isThpInProgress, firmware.status, progressEvent, reconnectEvent?.method]);
 
     const targetFirmwareType = useMemo(() => {
         const isCurrentlyBitcoinOnly = hasBitcoinOnlyFirmware(originalDevice);


### PR DESCRIPTION
…s locked with PIN

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22254

## Screenshots:
<img width="749" height="697" alt="Screenshot 2025-10-09 at 1 29 22 PM" src="https://github.com/user-attachments/assets/625cab78-8107-47d1-b273-067f03f62d9d" />






🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=22254-locked-device-update-info&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=22254-locked-device-update-info&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22254-locked-device-update-info&lookback=7)