### PR TITLE
fix(suite): device connected tooltip appearing when it shouldn't

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -335,17 +335,32 @@ const selectNewlyConnectedDevice = [
     },
 ];
 
-type HandleDeviceConnectFixture = {
+type MarkDeviceAsRecentlyConnectedFixture = {
     description: string;
     state: {
         suite: Partial<AppState['suite']>;
         device: Partial<AppState['device']>;
     };
     newlyConnectedDevice: Device;
-    expectedNextActionType: string;
+    isSetAsRecentlyConnected: boolean;
 };
 
-const markDeviceAsRecentlyConnected: HandleDeviceConnectFixture[] = [
+const markDeviceAsRecentlyConnected: MarkDeviceAsRecentlyConnectedFixture[] = [
+    {
+        description: `does not mark device as recently connected if there are none`,
+        state: { device: {}, suite: {} },
+        newlyConnectedDevice: CONNECT_DEVICE,
+        isSetAsRecentlyConnected: false,
+    },
+    {
+        description: `does not mark a newly connected physical device corresponding to selected remembered wallet `,
+        state: {
+            device: { devices: [SUITE_DEVICE_REMEMBERED], selectedDevice: SUITE_DEVICE_REMEMBERED },
+            suite: {},
+        },
+        newlyConnectedDevice: CONNECT_DEVICE,
+        isSetAsRecentlyConnected: false,
+    },
     {
         description: `marks device as recently connected if not seen before`,
         state: {
@@ -353,7 +368,7 @@ const markDeviceAsRecentlyConnected: HandleDeviceConnectFixture[] = [
             suite: {},
         },
         newlyConnectedDevice: { ...CONNECT_DEVICE, id: 'a-different-id' } as Device,
-        expectedNextActionType: SUITE.SET_RECENTLY_CONNECTED_DEVICE,
+        isSetAsRecentlyConnected: true,
     },
 ];
 

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -165,8 +165,9 @@ describe('Suite Actions', () => {
 
             const device = f.newlyConnectedDevice;
             await store.dispatch(markDeviceAsRecentlyConnectedThunk(device));
-            // a lot of actions may get called, and the one we are interested in may not be the last one
-            expect(store.getActions().some(a => a?.type === f.expectedNextActionType)).toBe(true);
+            expect(
+                store.getActions().some(a => a?.type === SUITE.SET_RECENTLY_CONNECTED_DEVICE),
+            ).toBe(f.isSetAsRecentlyConnected);
         });
     });
 

--- a/packages/suite/src/actions/wallet/markDeviceAsRecentlyConnectedThunk.ts
+++ b/packages/suite/src/actions/wallet/markDeviceAsRecentlyConnectedThunk.ts
@@ -1,5 +1,5 @@
 import { createThunk } from '@suite-common/redux-utils';
-import { DEVICE_MODULE_PREFIX } from '@suite-common/wallet-core';
+import { DEVICE_MODULE_PREFIX, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Device } from '@trezor/connect';
 
 import { selectRecentlyConnectedDevice } from 'src/selectors/suite/suiteSelectors';
@@ -12,6 +12,17 @@ const RECENTLY_CONNECTED_DEVICE_TIMEOUT = 5_000;
 export const markDeviceAsRecentlyConnectedThunk = createThunk<void, Device, void>(
     `${DEVICE_MODULE_PREFIX}/handleDeviceConnect`,
     (device, { dispatch, getState }) => {
+        const selectedDevice = selectSelectedDevice(getState());
+
+        // Do not show tooltip if it's the first device (selectedDevice undefined), or a physical device matching a currently selected remembered wallet
+        if (
+            selectedDevice === undefined ||
+            device.path === selectedDevice.path ||
+            device.id === selectedDevice.id
+        ) {
+            return;
+        }
+
         // Set the Device as recently connected to show a notification in the UI, and schedule disappearance.
         // device.path preferred because we only care about current session (not persistent),
         // and the device may initially connect as unacquired before becoming acquired.


### PR DESCRIPTION
## Description

Do not show tooltip for a connecting device if it's the first device (selectedDevice undefined), or a physical device matching a currently selected remembered wallet

## Related Issue

Resolve #22302

## Screenshots

[Before: new device.webm](https://github.com/user-attachments/assets/6a965f7f-f9b3-42d0-bdd7-e0cbb68007a8)
[Before: reconnect remembered.webm](https://github.com/user-attachments/assets/04fdc62d-80cc-464a-8bb6-9019044a3005)
[After: : new device.webm](https://github.com/user-attachments/assets/774a4a05-78d4-4f43-9849-0accf2e4fcf6)
[After: reconnect remembered + connect a different one.webm](https://github.com/user-attachments/assets/6e5d5e05-c633-4ae3-ad6d-1266f560bfb9)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/device-connected-tooltip&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/device-connected-tooltip&lookback=7)