### PR TITLE
Suite native: Improve test:unit execution time

### DIFF
--- a/suite-native/module-trading/jest.config.js
+++ b/suite-native/module-trading/jest.config.js
@@ -2,6 +2,7 @@ const baseConfig = require('../../jest.config.native');
 
 module.exports = {
     ...baseConfig,
+    workerIdleMemoryLimit: '1024MB',
     coverageThreshold: {
         global: {
             statements: 80,

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
@@ -444,7 +444,8 @@ describe('useExchangeFlow', () => {
     });
 
     describe('getCommonFunctions', () => {
-        it('should return undefined when no trade is provided and no selectedQuote', async () => {
+        it('should return false when no trade is provided and no selectedQuote', async () => {
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
             // Mock the selector to return undefined for selectedQuote
             const modifiedStore = await getInitializedStore();
             modifiedStore.getState().wallet.trading.exchange.selectedQuote = undefined;
@@ -465,6 +466,9 @@ describe('useExchangeFlow', () => {
             );
 
             expect(resultValue).toBe(false);
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                'Trade, send account and common functions are required to confirm trade',
+            );
         });
     });
 

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellQuotes.test.ts
@@ -77,8 +77,10 @@ describe('useSellQuotes', () => {
             result.current.setValue('fiatCurrency', 'usd');
             result.current.setValue('amountInCrypto', true);
         });
-        act(() => {
+        await act(async () => {
             result.current.setValue('cryptoStringAmount', '1');
+            // allow validations to run
+            await Promise.resolve();
         });
 
         expect(dispatchSpy).toHaveBeenCalledWith(
@@ -99,8 +101,10 @@ describe('useSellQuotes', () => {
                 result.current.setValue('sendAsset', bnbAsset);
                 result.current.setValue('fiatCurrency', 'usd');
             });
-            act(() => {
+            await act(async () => {
                 result.current.setValue('cryptoStringAmount', amount);
+                // allow validations to run
+                await Promise.resolve();
             });
 
             expect(dispatchSpy).not.toHaveBeenCalledWith(
@@ -121,8 +125,10 @@ describe('useSellQuotes', () => {
             result.current.setValue('fiatCurrency', 'usd');
             result.current.setValue('amountInCrypto', false);
         });
-        act(() => {
+        await act(async () => {
             result.current.setValue('fiatStringAmount', '100');
+            // allow validations to run
+            await Promise.resolve();
         });
 
         expect(dispatchSpy).toHaveBeenCalledWith(
@@ -160,8 +166,10 @@ describe('useSellQuotes', () => {
                 result.current.setValue('sendAsset', usdcAsset);
                 result.current.setValue('fiatCurrency', 'usd');
             });
-            act(() => {
+            await act(async () => {
                 result.current.setValue('fiatStringAmount', '100');
+                // allow validations to run
+                await Promise.resolve();
             });
 
             dispatchSpy.mockClear();
@@ -187,8 +195,10 @@ describe('useSellQuotes', () => {
             result.current.setValue('fiatCurrency', 'usd');
         });
 
-        act(() => {
+        await act(async () => {
             result.current.setValue('fiatStringAmount', '100');
+            // allow validations to run
+            await Promise.resolve();
         });
 
         dispatchSpy.mockClear();
@@ -230,8 +240,10 @@ describe('useSellQuotes', () => {
             result.current.setValue('fiatStringAmount', '100');
         });
         // handleRequestThunk is mocked, add quotes manually
-        act(() => {
+        await act(async () => {
             store.dispatch(tradingSellActions.saveQuotes(sellQuotes));
+            // allow validations to run
+            await Promise.resolve();
         });
 
         dispatchSpy.mockClear();
@@ -253,15 +265,23 @@ describe('useSellQuotes', () => {
         const dispatchSpy = jest.spyOn(store, 'dispatch');
         const { result } = await renderUseSellQuotes(store);
 
-        act(() => {
+        await act(async () => {
             result.current.setValue('sendAsset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
             result.current.setValue('amountInCrypto', true);
             result.current.setValue('cryptoStringAmount', '1');
+            // allow validations to run
+            await Promise.resolve();
+        });
+
+        dispatchSpy.mockClear();
+        await act(async () => {
             result.current.setError('cryptoStringAmount', {
                 type: 'manual',
                 message: 'Some error',
             });
+            // allow validations to run
+            await Promise.resolve();
         });
 
         expect(dispatchSpy).not.toHaveBeenCalledWith(


### PR DESCRIPTION


## Description

- set `workerIdleMemoryLimit` for`suite-native/module-trading`
- no production changes

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native/tests-execution-time&lookback=7)