### PR TITLE
chore(suite-native): device connection THP pairing tests

### DIFF
--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -225,7 +225,7 @@ const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Feat
  * @param {Partial<Features>} [feat]
  * @returns {TrezorDevice}
  */
-const getSuiteDevice = (
+export const getSuiteDevice = (
     dev?: Partial<
         Omit<StringPath<TrezorDevice>, 'state'> & {
             state?: `${string}@${string}:${number}`;

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -225,7 +225,7 @@ const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Feat
  * @param {Partial<Features>} [feat]
  * @returns {TrezorDevice}
  */
-export const getSuiteDevice = (
+const getSuiteDevice = (
     dev?: Partial<
         Omit<StringPath<TrezorDevice>, 'state'> & {
             state?: `${string}@${string}:${number}`;

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -21,6 +21,7 @@
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
+        "@suite-common/test-utils": "workspace:*",
         "@suite-common/thp": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -7,6 +7,7 @@
     "main": "src/index",
     "scripts": {
         "depcheck": "yarn g:depcheck",
+        "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {

--- a/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
+++ b/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
@@ -1,0 +1,198 @@
+import { prepareMessageSystemReducer } from '@suite-common/message-system';
+import { extraDependenciesMock, getSuiteDevice } from '@suite-common/test-utils';
+import { deviceActions, prepareDeviceReducer } from '@suite-common/wallet-core';
+import { deviceOnboardingReducer } from '@suite-native/device-onboarding';
+import { featureFlagsReducer } from '@suite-native/feature-flags';
+import { nativeFirmwareReducer } from '@suite-native/firmware';
+import {
+    AuthorizeDeviceStackRoutes,
+    DeviceOnboardingStackRoutes,
+    HomeStackRoutes,
+    RootStackRoutes,
+} from '@suite-native/navigation';
+import { appSettingsReducer } from '@suite-native/settings';
+import { DeviceModelInternal } from '@trezor/device-utils';
+
+const DEVICE = getSuiteDevice({ path: '1', connected: true });
+
+const deviceReducer = prepareDeviceReducer(extraDependenciesMock);
+const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesMock);
+
+type DevicesState = ReturnType<typeof deviceReducer>;
+type AppSettingsState = ReturnType<typeof appSettingsReducer>;
+type FeatureFlagsState = ReturnType<typeof featureFlagsReducer>;
+type NativeFirmwareState = ReturnType<typeof nativeFirmwareReducer>;
+type DeviceOnboardingState = ReturnType<typeof deviceOnboardingReducer>;
+
+type GetInitialState = {
+    device?: Partial<DevicesState>;
+    appSettings?: Partial<AppSettingsState>;
+    featureFlags?: Partial<FeatureFlagsState>;
+    nativeFirmware?: Partial<NativeFirmwareState>;
+    deviceOnboarding?: Partial<DeviceOnboardingState>;
+};
+
+export const getInitialState = ({
+    device,
+    appSettings,
+    featureFlags,
+    nativeFirmware,
+    deviceOnboarding,
+}: GetInitialState) => ({
+    device: {
+        ...deviceReducer(undefined, { type: 'foo' }),
+        ...device,
+    },
+    appSettings: {
+        ...appSettingsReducer(undefined, { type: 'foo' }),
+        ...appSettings,
+    },
+    messageSystem: {
+        ...messageSystemReducer(undefined, { type: 'foo' }),
+    },
+    featureFlags: {
+        ...featureFlagsReducer(undefined, { type: 'foo' }),
+        ...featureFlags,
+    },
+    nativeFirmware: {
+        ...nativeFirmwareReducer(undefined, { type: 'foo' }),
+        ...nativeFirmware,
+    },
+    deviceOnboarding: {
+        ...deviceOnboardingReducer(undefined, { type: 'foo' }),
+        ...deviceOnboarding,
+    },
+});
+
+export const connectDeviceFixtures = [
+    {
+        description: 'connect device with no coins enabled',
+        initialState: getInitialState({}),
+        action: { type: deviceActions.connectDevice.type, payload: { device: DEVICE } },
+        redirectTarget: {
+            route: RootStackRoutes.AuthorizeDeviceStack,
+            params: {
+                screen: AuthorizeDeviceStackRoutes.CoinEnablingInit,
+            },
+        },
+    },
+    {
+        description: 'connect device with coin enabling finished',
+        initialState: getInitialState({
+            appSettings: {
+                isCoinEnablingInitFinished: true,
+            },
+        }),
+        action: { type: deviceActions.connectDevice.type, payload: { device: DEVICE } },
+        redirectTarget: {
+            route: RootStackRoutes.AuthorizeDeviceStack,
+            params: {
+                screen: AuthorizeDeviceStackRoutes.ConnectingDevice,
+            },
+        },
+    },
+    {
+        description: 'connect device with failed auth check',
+        initialState: getInitialState({
+            device: {
+                selectedDevice: DEVICE,
+                deviceAuthenticity: { [DEVICE.id as string]: { valid: false } },
+            },
+            appSettings: {
+                isDeviceAuthenticityCheckEnabled: true,
+            },
+        }),
+        action: { type: deviceActions.connectDevice.type, payload: { device: DEVICE } },
+        redirectTarget: {
+            route: RootStackRoutes.DeviceCompromisedModal,
+        },
+    },
+    {
+        description: 'uninitialized device connect',
+        initialState: getInitialState({}),
+        action: {
+            type: deviceActions.connectDevice.type,
+            payload: {
+                device: {
+                    ...DEVICE,
+                    mode: 'initialize',
+                    features: { internal_model: DeviceModelInternal.T3B1 },
+                },
+            },
+        },
+        redirectTarget: {
+            index: 1,
+            routes: [
+                {
+                    name: RootStackRoutes.AppTabs,
+                    params: {
+                        screen: HomeStackRoutes.Home,
+                    },
+                },
+                {
+                    name: RootStackRoutes.DeviceOnboardingStack,
+                    params: {
+                        screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
+                    },
+                },
+            ],
+        },
+        isReset: true,
+    },
+    {
+        description: 'uninitialized device connect with cancelled onboarding',
+        initialState: getInitialState({
+            deviceOnboarding: {
+                wasDeviceOnboardingCancelled: true,
+            },
+        }),
+        action: {
+            type: deviceActions.connectDevice.type,
+            payload: {
+                device: {
+                    ...DEVICE,
+                    mode: 'initialize',
+                    features: { internal_model: DeviceModelInternal.T3B1 },
+                },
+            },
+        },
+        redirectTarget: {
+            index: 0,
+            routes: [
+                {
+                    name: RootStackRoutes.AppTabs,
+                    params: {
+                        screen: HomeStackRoutes.Home,
+                    },
+                },
+            ],
+        },
+        isReset: true,
+    },
+    {
+        description: 'uninitialized unsupported device connect with cancelled onboarding',
+        initialState: getInitialState({}),
+        action: {
+            type: deviceActions.connectDevice.type,
+            payload: {
+                device: {
+                    ...DEVICE,
+                    mode: 'initialize',
+                    features: { internal_model: DeviceModelInternal.T1B1 },
+                },
+            },
+        },
+        redirectTarget: {
+            index: 0,
+            routes: [
+                {
+                    name: RootStackRoutes.AppTabs,
+                    params: {
+                        screen: HomeStackRoutes.Home,
+                    },
+                },
+            ],
+        },
+        expectNoNavigation: true,
+    },
+];

--- a/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
+++ b/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
@@ -1,198 +1,80 @@
-import { prepareMessageSystemReducer } from '@suite-common/message-system';
-import { extraDependenciesMock, getSuiteDevice } from '@suite-common/test-utils';
-import { deviceActions, prepareDeviceReducer } from '@suite-common/wallet-core';
-import { deviceOnboardingReducer } from '@suite-native/device-onboarding';
-import { featureFlagsReducer } from '@suite-native/feature-flags';
 import { nativeFirmwareReducer } from '@suite-native/firmware';
-import {
-    AuthorizeDeviceStackRoutes,
-    DeviceOnboardingStackRoutes,
-    HomeStackRoutes,
-    RootStackRoutes,
-} from '@suite-native/navigation';
-import { appSettingsReducer } from '@suite-native/settings';
-import { DeviceModelInternal } from '@trezor/device-utils';
+import { AuthorizeDeviceStackRoutes, RootStackRoutes } from '@suite-native/navigation';
+import { UI } from '@trezor/connect';
 
-const DEVICE = getSuiteDevice({ path: '1', connected: true });
-
-const deviceReducer = prepareDeviceReducer(extraDependenciesMock);
-const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesMock);
-
-type DevicesState = ReturnType<typeof deviceReducer>;
-type AppSettingsState = ReturnType<typeof appSettingsReducer>;
-type FeatureFlagsState = ReturnType<typeof featureFlagsReducer>;
 type NativeFirmwareState = ReturnType<typeof nativeFirmwareReducer>;
-type DeviceOnboardingState = ReturnType<typeof deviceOnboardingReducer>;
 
 type GetInitialState = {
-    device?: Partial<DevicesState>;
-    appSettings?: Partial<AppSettingsState>;
-    featureFlags?: Partial<FeatureFlagsState>;
     nativeFirmware?: Partial<NativeFirmwareState>;
-    deviceOnboarding?: Partial<DeviceOnboardingState>;
 };
 
-export const getInitialState = ({
-    device,
-    appSettings,
-    featureFlags,
-    nativeFirmware,
-    deviceOnboarding,
-}: GetInitialState) => ({
-    device: {
-        ...deviceReducer(undefined, { type: 'foo' }),
-        ...device,
-    },
-    appSettings: {
-        ...appSettingsReducer(undefined, { type: 'foo' }),
-        ...appSettings,
-    },
-    messageSystem: {
-        ...messageSystemReducer(undefined, { type: 'foo' }),
-    },
-    featureFlags: {
-        ...featureFlagsReducer(undefined, { type: 'foo' }),
-        ...featureFlags,
-    },
+const getInitialState = ({ nativeFirmware }: GetInitialState) => ({
     nativeFirmware: {
         ...nativeFirmwareReducer(undefined, { type: 'foo' }),
         ...nativeFirmware,
     },
-    deviceOnboarding: {
-        ...deviceOnboardingReducer(undefined, { type: 'foo' }),
-        ...deviceOnboarding,
-    },
 });
 
-export const connectDeviceFixtures = [
+export const invalidThpPairingFixtures = [
     {
-        description: 'connect device with no coins enabled',
+        description: 'should not react to any UI Request Button action',
         initialState: getInitialState({}),
-        action: { type: deviceActions.connectDevice.type, payload: { device: DEVICE } },
+        action: { type: UI.REQUEST_BUTTON },
+    },
+    {
+        description: 'should not react to any UI Request Button action',
+        initialState: getInitialState({}),
+        action: { type: UI.REQUEST_BUTTON, payload: { name: 'non-valid-name' } },
+    },
+    {
+        description: 'should not react to any random action',
+        initialState: getInitialState({}),
+        action: { type: 'foo' },
+    },
+
+    {
+        description:
+            'should not redirect to THP pairing screen on thp_pairing_request action if FW install is running',
+        initialState: getInitialState({
+            nativeFirmware: {
+                isFirmwareInstallationRunning: true,
+            },
+        }),
+        action: { type: UI.REQUEST_BUTTON, payload: { name: 'thp_pairing_request' } },
+    },
+    {
+        description:
+            'should not redirect to THP pairing screen on thp_connection_request action if FW install is running',
+        initialState: getInitialState({
+            nativeFirmware: {
+                isFirmwareInstallationRunning: true,
+            },
+        }),
+        action: { type: UI.REQUEST_BUTTON, payload: { name: 'thp_connection_request' } },
+    },
+] as const;
+
+export const validThpPairingFixtures = [
+    {
+        description: 'should redirect to THP pairing screen on thp_pairing_request action',
+        initialState: getInitialState({}),
+        action: { type: UI.REQUEST_BUTTON, payload: { name: 'thp_pairing_request' } },
         redirectTarget: {
             route: RootStackRoutes.AuthorizeDeviceStack,
             params: {
-                screen: AuthorizeDeviceStackRoutes.CoinEnablingInit,
+                screen: AuthorizeDeviceStackRoutes.ThpConfirmation,
             },
         },
     },
     {
-        description: 'connect device with coin enabling finished',
-        initialState: getInitialState({
-            appSettings: {
-                isCoinEnablingInitFinished: true,
-            },
-        }),
-        action: { type: deviceActions.connectDevice.type, payload: { device: DEVICE } },
+        description: 'should redirect to THP pairing screen on thp_connection_request action',
+        initialState: getInitialState({}),
+        action: { type: UI.REQUEST_BUTTON, payload: { name: 'thp_connection_request' } },
         redirectTarget: {
             route: RootStackRoutes.AuthorizeDeviceStack,
             params: {
-                screen: AuthorizeDeviceStackRoutes.ConnectingDevice,
+                screen: AuthorizeDeviceStackRoutes.ThpConfirmation,
             },
         },
     },
-    {
-        description: 'connect device with failed auth check',
-        initialState: getInitialState({
-            device: {
-                selectedDevice: DEVICE,
-                deviceAuthenticity: { [DEVICE.id as string]: { valid: false } },
-            },
-            appSettings: {
-                isDeviceAuthenticityCheckEnabled: true,
-            },
-        }),
-        action: { type: deviceActions.connectDevice.type, payload: { device: DEVICE } },
-        redirectTarget: {
-            route: RootStackRoutes.DeviceCompromisedModal,
-        },
-    },
-    {
-        description: 'uninitialized device connect',
-        initialState: getInitialState({}),
-        action: {
-            type: deviceActions.connectDevice.type,
-            payload: {
-                device: {
-                    ...DEVICE,
-                    mode: 'initialize',
-                    features: { internal_model: DeviceModelInternal.T3B1 },
-                },
-            },
-        },
-        redirectTarget: {
-            index: 1,
-            routes: [
-                {
-                    name: RootStackRoutes.AppTabs,
-                    params: {
-                        screen: HomeStackRoutes.Home,
-                    },
-                },
-                {
-                    name: RootStackRoutes.DeviceOnboardingStack,
-                    params: {
-                        screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
-                    },
-                },
-            ],
-        },
-        isReset: true,
-    },
-    {
-        description: 'uninitialized device connect with cancelled onboarding',
-        initialState: getInitialState({
-            deviceOnboarding: {
-                wasDeviceOnboardingCancelled: true,
-            },
-        }),
-        action: {
-            type: deviceActions.connectDevice.type,
-            payload: {
-                device: {
-                    ...DEVICE,
-                    mode: 'initialize',
-                    features: { internal_model: DeviceModelInternal.T3B1 },
-                },
-            },
-        },
-        redirectTarget: {
-            index: 0,
-            routes: [
-                {
-                    name: RootStackRoutes.AppTabs,
-                    params: {
-                        screen: HomeStackRoutes.Home,
-                    },
-                },
-            ],
-        },
-        isReset: true,
-    },
-    {
-        description: 'uninitialized unsupported device connect with cancelled onboarding',
-        initialState: getInitialState({}),
-        action: {
-            type: deviceActions.connectDevice.type,
-            payload: {
-                device: {
-                    ...DEVICE,
-                    mode: 'initialize',
-                    features: { internal_model: DeviceModelInternal.T1B1 },
-                },
-            },
-        },
-        redirectTarget: {
-            index: 0,
-            routes: [
-                {
-                    name: RootStackRoutes.AppTabs,
-                    params: {
-                        screen: HomeStackRoutes.Home,
-                    },
-                },
-            ],
-        },
-        expectNoNavigation: true,
-    },
-];
+] as const;

--- a/suite-native/device/src/__tests__/deviceConnectionMiddleware.test.ts
+++ b/suite-native/device/src/__tests__/deviceConnectionMiddleware.test.ts
@@ -1,9 +1,7 @@
-import { UnknownAction } from '@reduxjs/toolkit';
-
 import { configureMockStore } from '@suite-common/test-utils';
 import { navigationContainerRef } from '@suite-native/navigation';
 
-import { connectDeviceFixtures, getInitialState } from './deviceConnectionFixtures';
+import { invalidThpPairingFixtures, validThpPairingFixtures } from './deviceConnectionFixtures';
 import { deviceConnectionMiddleware } from '../middlewares/deviceConnectionMiddleware';
 
 jest.mock('@suite-native/navigation', () => {
@@ -13,67 +11,45 @@ jest.mock('@suite-native/navigation', () => {
         ...navigation,
         navigationContainerRef: {
             navigate: jest.fn(),
-            reset: jest.fn(),
-            getState: jest.fn(),
         },
-        checkIsActiveRouteAnyOf: jest.fn().mockReturnValue(false),
-        checkIsDeviceOnboardingFocused: jest.fn().mockReturnValue(false),
-        checkIsHomeStackFocused: jest.fn().mockReturnValue(false),
     };
 });
 
-type State = ReturnType<typeof getInitialState>;
-
-describe('DEVICE.CONNECT', () => {
+describe('Ignored UI button request redirects', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    connectDeviceFixtures.forEach(
-        ({
-            action,
-            initialState,
-            redirectTarget,
-            description,
-            isReset = false,
-            expectNoNavigation = false,
-        }: {
-            action: UnknownAction;
-            initialState: ReturnType<typeof getInitialState>;
-            redirectTarget: any;
-            description: string;
-            isReset?: boolean;
-            expectNoNavigation?: boolean;
-        }) => {
-            it(description, () => {
-                const mockStore = configureMockStore<State>({
-                    middleware: [deviceConnectionMiddleware.middleware],
-                    preloadedState: initialState,
-                });
-                mockStore.dispatch(action);
-
-                if (expectNoNavigation) {
-                    expect(navigationContainerRef.reset).toHaveBeenCalledTimes(0);
-                    expect(navigationContainerRef.navigate).toHaveBeenCalledTimes(0);
-
-                    return;
-                }
-
-                if (isReset) {
-                    expect(navigationContainerRef.reset).toHaveBeenCalledWith(redirectTarget);
-                } else {
-                    if (redirectTarget.params) {
-                        expect(navigationContainerRef.navigate).toHaveBeenCalledWith(
-                            redirectTarget.route,
-                            redirectTarget.params,
-                        );
-                    } else {
-                        expect(navigationContainerRef.navigate).toHaveBeenCalledWith(
-                            redirectTarget.route,
-                        );
-                    }
-                }
+    invalidThpPairingFixtures.forEach(({ description, action, initialState }) => {
+        it(description, () => {
+            const mockStore = configureMockStore({
+                middleware: [deviceConnectionMiddleware.middleware],
+                preloadedState: initialState,
             });
-        },
-    );
+            mockStore.dispatch(action);
+
+            expect(navigationContainerRef.navigate).toHaveBeenCalledTimes(0);
+        });
+    });
+});
+
+describe('THP confirmation redirect upon button request', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    validThpPairingFixtures.forEach(({ description, action, redirectTarget, initialState }) => {
+        it(description, () => {
+            const mockStore = configureMockStore({
+                middleware: [deviceConnectionMiddleware.middleware],
+                preloadedState: initialState,
+            });
+            mockStore.dispatch(action);
+
+            expect(navigationContainerRef.navigate).toHaveBeenCalledWith(
+                redirectTarget.route,
+                redirectTarget.params,
+            );
+        });
+    });
 });

--- a/suite-native/device/src/__tests__/deviceConnectionMiddleware.test.ts
+++ b/suite-native/device/src/__tests__/deviceConnectionMiddleware.test.ts
@@ -1,0 +1,79 @@
+import { UnknownAction } from '@reduxjs/toolkit';
+
+import { configureMockStore } from '@suite-common/test-utils';
+import { navigationContainerRef } from '@suite-native/navigation';
+
+import { connectDeviceFixtures, getInitialState } from './deviceConnectionFixtures';
+import { deviceConnectionMiddleware } from '../middlewares/deviceConnectionMiddleware';
+
+jest.mock('@suite-native/navigation', () => {
+    const navigation = jest.requireActual('@suite-native/navigation');
+
+    return {
+        ...navigation,
+        navigationContainerRef: {
+            navigate: jest.fn(),
+            reset: jest.fn(),
+            getState: jest.fn(),
+        },
+        checkIsActiveRouteAnyOf: jest.fn().mockReturnValue(false),
+        checkIsDeviceOnboardingFocused: jest.fn().mockReturnValue(false),
+        checkIsHomeStackFocused: jest.fn().mockReturnValue(false),
+    };
+});
+
+type State = ReturnType<typeof getInitialState>;
+
+describe('DEVICE.CONNECT', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    connectDeviceFixtures.forEach(
+        ({
+            action,
+            initialState,
+            redirectTarget,
+            description,
+            isReset = false,
+            expectNoNavigation = false,
+        }: {
+            action: UnknownAction;
+            initialState: ReturnType<typeof getInitialState>;
+            redirectTarget: any;
+            description: string;
+            isReset?: boolean;
+            expectNoNavigation?: boolean;
+        }) => {
+            it(description, () => {
+                const mockStore = configureMockStore<State>({
+                    middleware: [deviceConnectionMiddleware.middleware],
+                    preloadedState: initialState,
+                });
+                mockStore.dispatch(action);
+
+                if (expectNoNavigation) {
+                    expect(navigationContainerRef.reset).toHaveBeenCalledTimes(0);
+                    expect(navigationContainerRef.navigate).toHaveBeenCalledTimes(0);
+
+                    return;
+                }
+
+                if (isReset) {
+                    expect(navigationContainerRef.reset).toHaveBeenCalledWith(redirectTarget);
+                } else {
+                    if (redirectTarget.params) {
+                        expect(navigationContainerRef.navigate).toHaveBeenCalledWith(
+                            redirectTarget.route,
+                            redirectTarget.params,
+                        );
+                    } else {
+                        expect(navigationContainerRef.navigate).toHaveBeenCalledWith(
+                            redirectTarget.route,
+                        );
+                    }
+                }
+            });
+        },
+    );
+});

--- a/suite-native/device/tsconfig.json
+++ b/suite-native/device/tsconfig.json
@@ -20,6 +20,9 @@
         {
             "path": "../../suite-common/suite-utils"
         },
+        {
+            "path": "../../suite-common/test-utils"
+        },
         { "path": "../../suite-common/thp" },
         {
             "path": "../../suite-common/wallet-core"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11331,6 +11331,7 @@ __metadata:
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
+    "@suite-common/test-utils": "workspace:*"
     "@suite-common/thp": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Unit tests for navigational redirects for `deviceConnectionMiddleware` setup + basic tests for THP pairing
- More tests for DEVICE.CONNECT & DEVICE.DISCONNECT will come as a follow up PR's



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/deviceConnectionMiddleware-test&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/deviceConnectionMiddleware-test&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/deviceConnectionMiddleware-test&lookback=7)