### PR TITLE
fix(suite-native): handle device disconnection in device onboarding correctly

### DIFF
--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -7,7 +7,7 @@ import {
 
 import {
     getDeviceInternalModel,
-    getIsDeviceConnectedViaBluetooth,
+    getIsDeviceDescriptorApiTypeBluetooth,
     getIsDeviceInitialized,
 } from '@suite-common/suite-utils';
 import { isThpPairingUIRequestButtonAction } from '@suite-common/thp';
@@ -30,7 +30,7 @@ import {
     navigationContainerRef,
 } from '@suite-native/navigation';
 import { selectIsCoinEnablingInitFinished } from '@suite-native/settings';
-import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
+import { DeviceModelInternal, hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 
 import {
     DEVICE_CONNECTION_BLACKLISTED_ROUTES,
@@ -46,12 +46,14 @@ import { getIsDeviceSetupSupported } from '../utils';
 export const deviceConnectionMiddleware = createListenerMiddleware<NativeDeviceRootState>();
 
 const handleDeviceConnectNavigation = ({
+    deviceModel,
     hasDeviceBitcoinOnlyFirmware,
     isCoinEnablingInitFinished,
     isDeviceInitialized,
     isDeviceSetupSupported,
     wasDeviceOnboardingCancelled,
 }: {
+    deviceModel: DeviceModelInternal;
     hasDeviceBitcoinOnlyFirmware: boolean;
     isCoinEnablingInitFinished: boolean;
     isDeviceInitialized: boolean;
@@ -97,6 +99,9 @@ const handleDeviceConnectNavigation = ({
                         name: RootStackRoutes.DeviceOnboardingStack,
                         params: {
                             screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
+                            params: {
+                                deviceModel,
+                            },
                         },
                     },
                 ],
@@ -166,6 +171,7 @@ deviceConnectionMiddleware.startListening({
         if (isDeviceRemembered && isCoinEnablingInitFinished) return;
 
         handleDeviceConnectNavigation({
+            deviceModel: getDeviceInternalModel(device),
             hasDeviceBitcoinOnlyFirmware: hasBitcoinOnlyFirmware(device),
             isDeviceInitialized: getIsDeviceInitialized({
                 deviceMode: device.mode,
@@ -188,7 +194,9 @@ deviceConnectionMiddleware.startListening({
         const isDeviceRemembered = selectIsDeviceRemembered(getState());
         const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(getState());
         const isFirmwareInstallationRunning = selectIsFirmwareInstallationRunning(getState());
-        const wasDeviceConnectedViaBluetooth = getIsDeviceConnectedViaBluetooth(action.payload);
+        const wasDeviceConnectedViaBluetooth = getIsDeviceDescriptorApiTypeBluetooth(
+            action.payload,
+        );
 
         if (
             checkIsActiveRouteAnyOf(

--- a/suite-native/module-authenticity-checks/package.json
+++ b/suite-native/module-authenticity-checks/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "@react-navigation/core": "7.12.4",
         "@reduxjs/toolkit": "2.8.2",
+        "@suite-common/suite-utils": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/device": "workspace:*",

--- a/suite-native/module-authenticity-checks/src/components/FirmwareAuthenticityCheckFailModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/FirmwareAuthenticityCheckFailModalContent.tsx
@@ -2,12 +2,14 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/core';
 
+import { getDeviceInternalModel } from '@suite-common/suite-utils';
 import {
     deviceActions,
     selectIsDeviceInitialized,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { Button } from '@suite-native/atoms';
+import { selectIsDeviceSetupSupported } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import {
     AuthorizeDeviceStackRoutes,
@@ -36,6 +38,7 @@ export const FirmwareAuthenticityCheckFailModalContent = () => {
     const navigateToInitialScreen = useNavigateToInitialScreen();
 
     const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
+    const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
     const isCoinEnablingInitFinished = useSelector(selectIsCoinEnablingInitFinished);
     const device = useSelector(selectSelectedDevice);
 
@@ -48,9 +51,12 @@ export const FirmwareAuthenticityCheckFailModalContent = () => {
     const handleClose = () => {
         dismissCheck();
 
-        if (!isDeviceInitialized) {
+        if (!isDeviceInitialized && isDeviceSetupSupported) {
             navigation.popTo(RootStackRoutes.DeviceOnboardingStack, {
                 screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
+                params: {
+                    deviceModel: getDeviceInternalModel(device),
+                },
             });
         } else if (!isCoinEnablingInitFinished) {
             navigation.popTo(RootStackRoutes.AuthorizeDeviceStack, {

--- a/suite-native/module-authenticity-checks/tsconfig.json
+++ b/suite-native/module-authenticity-checks/tsconfig.json
@@ -3,6 +3,9 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
+            "path": "../../suite-common/suite-utils"
+        },
+        {
             "path": "../../suite-common/wallet-core"
         },
         { "path": "../atoms" },

--- a/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
@@ -5,7 +5,6 @@ import { useSelector } from 'react-redux';
 import { useSetAtom } from 'jotai';
 
 import {
-    selectDeviceModel,
     selectHasDeviceFirmwareInstalled,
     selectShouldOfferUpdateFirmware,
 } from '@suite-common/wallet-core';
@@ -16,7 +15,8 @@ import { Translation } from '@suite-native/intl';
 import {
     DeviceOnboardingStackParamList,
     DeviceOnboardingStackRoutes,
-    StackProps,
+    RootStackParamList,
+    StackToStackCompositeScreenProps,
 } from '@suite-native/navigation';
 
 import { resetOnboardingAnalyticsAtom, updateOnboardingAnalyticsAtom } from '../../atoms';
@@ -25,14 +25,13 @@ import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboar
 import { HeaderUnderlineSvg } from '../components/HeaderUnderlineSvg';
 import { useNavigateToNextScreenAfterFirmwareInstallation } from '../hooks/useNavigateToNextScreenAfterFirmwareInstallation';
 
-const UninitializedDeviceLandingScreenContent = () => {
-    const deviceModel = useSelector(selectDeviceModel) as SetupSupportingDeviceModel;
+const UninitializedDeviceLandingScreenContent = ({
+    deviceModel,
+}: {
+    deviceModel: SetupSupportingDeviceModel;
+}) => {
     const hasDeviceFirmwareInstalled = useSelector(selectHasDeviceFirmwareInstalled);
     const coinLabel = useCoinLabel();
-
-    if (!deviceModel) {
-        return null;
-    }
 
     return (
         <VStack spacing="sp32">
@@ -59,17 +58,22 @@ const UninitializedDeviceLandingScreenContent = () => {
 
 export const UninitializedDeviceLandingScreen = ({
     navigation,
-}: StackProps<
+    route: { params },
+}: StackToStackCompositeScreenProps<
     DeviceOnboardingStackParamList,
-    DeviceOnboardingStackRoutes.UninitializedDeviceLanding
+    DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
+    RootStackParamList
 >) => {
+    const deviceModel = params.deviceModel as SetupSupportingDeviceModel;
     const hasDeviceFirmwareInstalled = useSelector(selectHasDeviceFirmwareInstalled);
     const shouldOfferUpdateFirmware = useSelector(selectShouldOfferUpdateFirmware);
-    const deviceModel = useSelector(selectDeviceModel);
+
     const resetOnboardingAnalytics = useSetAtom(resetOnboardingAnalyticsAtom);
     const updateOnboardingAnalytics = useSetAtom(updateOnboardingAnalyticsAtom);
+
     const { navigateToNextScreenAfterFirmwareInstallation } =
         useNavigateToNextScreenAfterFirmwareInstallation();
+
     const handleConfirmButtonPress = () => {
         if (hasDeviceFirmwareInstalled) {
             if (shouldOfferUpdateFirmware) {
@@ -144,7 +148,7 @@ export const UninitializedDeviceLandingScreen = ({
         <DeviceOnboardingScreenWithExitButton {...screenHeaderProps}>
             <VStack justifyContent="space-between" flex={1}>
                 <VStack spacing="sp32">
-                    <UninitializedDeviceLandingScreenContent />
+                    <UninitializedDeviceLandingScreenContent deviceModel={deviceModel} />
                     <TextButton
                         isUnderlined
                         onPress={handleDeviceLooksDifferentButtonPress}

--- a/suite-native/module-home/package.json
+++ b/suite-native/module-home/package.json
@@ -37,6 +37,7 @@
         "@suite-native/settings": "workspace:*",
         "@suite-native/theme": "workspace:*",
         "@suite-native/toasts": "workspace:*",
+        "@trezor/device-utils": "workspace:*",
         "@trezor/styles": "workspace:*",
         "jotai": "2.13.1",
         "react": "19.0.0",
@@ -46,7 +47,6 @@
         "react-redux": "9.2.0"
     },
     "devDependencies": {
-        "@suite-native/test-utils": "workspace:*",
-        "@trezor/device-utils": "workspace:*"
+        "@suite-native/test-utils": "workspace:*"
     }
 }

--- a/suite-native/module-home/src/screens/HomeScreen/components/UninitializedConnectedDeviceState.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/UninitializedConnectedDeviceState.tsx
@@ -1,5 +1,8 @@
+import { useSelector } from 'react-redux';
+
 import { useNavigation } from '@react-navigation/native';
 
+import { selectDeviceModel } from '@suite-common/wallet-core';
 import { Button, Card, CenteredTitleHeader, VStack } from '@suite-native/atoms';
 import { ConfirmOnTrezorAnimation } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
@@ -9,6 +12,7 @@ import {
     RootStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
+import { DeviceModelInternal } from '@trezor/device-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 const cardStyle = prepareNativeStyle(utils => ({
@@ -34,9 +38,14 @@ export const UninitializedConnectedDeviceState = () => {
     const navigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AppTabs>>();
 
+    const deviceModel = useSelector(selectDeviceModel);
+
     const handleAddAccount = () => {
         navigation.navigate(RootStackRoutes.DeviceOnboardingStack, {
             screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
+            params: {
+                deviceModel: deviceModel ?? DeviceModelInternal.UNKNOWN,
+            },
         });
     };
 

--- a/suite-native/module-home/tsconfig.json
+++ b/suite-native/module-home/tsconfig.json
@@ -31,9 +31,9 @@
         { "path": "../settings" },
         { "path": "../theme" },
         { "path": "../toasts" },
+        { "path": "../../packages/device-utils" },
         { "path": "../../packages/styles" },
-        { "path": "../test-utils" },
-        { "path": "../../packages/device-utils" }
+        { "path": "../test-utils" }
     ],
     "include": [".", "**/*.json"]
 }

--- a/suite-native/navigation/package.json
+++ b/suite-native/navigation/package.json
@@ -28,6 +28,7 @@
         "@suite-native/intl": "workspace:*",
         "@suite-native/sentry": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/device-utils": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -11,6 +11,7 @@ import {
     XpubAddress,
 } from '@suite-common/wallet-types';
 import { AccountInfo } from '@trezor/connect';
+import { DeviceModelInternal } from '@trezor/device-utils';
 
 import {
     AccountsImportStackRoutes,
@@ -137,7 +138,9 @@ export type DeviceOnboardingStackParamList = {
     [DeviceOnboardingStackRoutes.DeviceDisconnected]: {
         wasDeviceConnectedViaBluetooth: boolean;
     };
-    [DeviceOnboardingStackRoutes.UninitializedDeviceLanding]: undefined;
+    [DeviceOnboardingStackRoutes.UninitializedDeviceLanding]: {
+        deviceModel: DeviceModelInternal;
+    };
     [DeviceOnboardingStackRoutes.SuspiciousDevice]: {
         suspicionCause: DeviceSuspicionCause;
     };

--- a/suite-native/navigation/tsconfig.json
+++ b/suite-native/navigation/tsconfig.json
@@ -21,6 +21,7 @@
         { "path": "../intl" },
         { "path": "../sentry" },
         { "path": "../../packages/connect" },
+        { "path": "../../packages/device-utils" },
         { "path": "../../packages/styles" },
         { "path": "../../packages/theme" },
         { "path": "../../packages/utils" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11806,6 +11806,7 @@ __metadata:
   dependencies:
     "@react-navigation/core": "npm:7.12.4"
     "@reduxjs/toolkit": "npm:2.8.2"
+    "@suite-common/suite-utils": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/device": "workspace:*"
@@ -12352,6 +12353,7 @@ __metadata:
     "@suite-native/intl": "workspace:*"
     "@suite-native/sentry": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/device-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
     "@trezor/utils": "workspace:*"


### PR DESCRIPTION
- Evaluate correctly whether device was connected via Bluetooth.
- Don't change device model upon device disconnect.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-onboarding-disconnect&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/device-onboarding-disconnect&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/device-onboarding-disconnect&lookback=7)