### PR TITLE
fix(suite): don't log walletconnect errors

### DIFF
--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -184,10 +184,6 @@ export const sessionRequestThunk = createThunk<
                 },
             },
         });
-        analytics.report({
-            type: EventType.WalletConnectError,
-            payload: { error: error.message },
-        });
     }
 });
 
@@ -324,16 +320,10 @@ export const sessionProposalApproveThunk = createThunk<
                     origin: pendingProposal.origin,
                 },
             });
-        } catch (error) {
-            console.error(error);
-
+        } catch {
             await walletKit.rejectSession({
                 id: eventId,
                 reason: getSdkError('USER_REJECTED'),
-            });
-            analytics.report({
-                type: EventType.WalletConnectError,
-                payload: { error: error.message },
             });
         }
     },
@@ -430,15 +420,8 @@ export const walletConnectPairThunk = createThunk<void, { uri: string }>(
             analytics.report({
                 type: EventType.WalletConnectPaired,
             });
-        } catch (error) {
-            console.error('WalletKit.pair:', error);
-
-            analytics.report({
-                type: EventType.WalletConnectError,
-                payload: { error: error.message },
-            });
-
-            throw error;
+        } catch {
+            throw new Error('Invalid WalletConnect URI');
         }
     },
 );


### PR DESCRIPTION
## Description

Quick fix that removes error logging from WalletConnect, it seems to be relatively stable and it was causing unnecessary noise.
 
## Related Issue

Resolve #22310

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/wc-error-logging&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/wc-error-logging&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/wc-error-logging&lookback=7)