### PR TITLE
Don't use zero keypair in first THP pairing

### DIFF
--- a/packages/protocol/src/protocol-thp/crypto/curve25519.ts
+++ b/packages/protocol/src/protocol-thp/crypto/curve25519.ts
@@ -245,7 +245,8 @@ export function elligator2(point: Uint8Array): Uint8Array {
 
 // https://cr.yp.to/ecdh.html
 // Computing secret keys
-export const getCurve25519KeyPair = (randomPriv: Buffer) => {
+export const getCurve25519KeyPair = (randomBytes: Buffer) => {
+    const randomPriv = Buffer.from(randomBytes);
     randomPriv[0] &= 248;
     randomPriv[31] &= 127;
     randomPriv[31] |= 64;

--- a/packages/protocol/src/protocol-thp/crypto/pairing.ts
+++ b/packages/protocol/src/protocol-thp/crypto/pairing.ts
@@ -122,21 +122,20 @@ export const handleHandshakeInit = ({
 
     // 11.1 If found set (temp_host_static_privkey, temp_host_static_pubkey) = (host_static_privkey, host_static_pubkey).
     // 11.2 If not found set (temp_host_static_privkey, temp_host_static_pubkey) = (X25519(0, B), 0).
-    const hostTempKeys = credentials
-        ? hostStaticKeys
-        : getCurve25519KeyPair(Buffer.alloc(32).fill(0));
+    // NOTE: This logic is deprecated and zero keypair should never be used, source:
+    // https://satoshilabs.slack.com/archives/C078GRAK58U/p1740132971826629?thread_ts=1739181741.870599&cid=C078GRAK58Us
 
     // 12. Set encrypted_host_static_pubkey = AES-GCM-ENCRYPT(key=k, IV=0^95 || 1, ad=h, plaintext=temp_host_static_pubkey).
     aes = aesgcm(k, iv1);
     aes.auth(h);
     const hostEncryptedStaticPubkey = Buffer.concat([
-        aes.encrypt(hostTempKeys.publicKey),
+        aes.encrypt(hostStaticKeys.publicKey),
         aes.finish(),
     ]);
     // 13. Set h = SHA-256(h || encrypted_host_static_pubkey).
     h = hashOfTwo(h, hostEncryptedStaticPubkey);
     // 14. Set ck, k = HKDF(ck, X25519(temp_host_static_privkey, trezor_ephemeral_pubkey)).
-    point = curve25519(hostTempKeys.privateKey, trezorEphemeralPubkey);
+    point = curve25519(hostStaticKeys.privateKey, trezorEphemeralPubkey);
     [ck, k] = hkdf(ck, point);
     // 15. Set payload_binary = PROTOBUF-ENCODE(type=HandshakeCompletionReqNoisePayload, host_pairing_credential).
     const { message } = protobufEncoder('ThpHandshakeCompletionReqNoisePayload', {


### PR DESCRIPTION
## Description

a) Don't mutate input param in `getCurve25519KeyPair` (small bug, but because of it `staticKey` silently changed when `hostStaticKeys` were first derived from it)

b) Don't use dummy zero keypair for the first pairing, but the same randomly generated `hostStaticKeys` as in the consecutive pairings (which was discussed in https://satoshilabs.slack.com/archives/C078GRAK58U/p1740132971826629?thread_ts=1739181741.870599&cid=C078GRAK58U but didn't make it into THP spec).

This should resolve the behavior where the device asks for THP confirmation after the first reconnection (= no channel replacement) but doesn't after the second one ( = channel replacement).

Resolves https://github.com/trezor/trezor-suite/issues/22263

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-channel-replacement&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-channel-replacement&lookback=7)