### PR TITLE
chore(suite-native): avoid instable selector warning

### DIFF
--- a/suite-common/bluetooth/src/bluetoothSelectors.ts
+++ b/suite-common/bluetooth/src/bluetoothSelectors.ts
@@ -1,4 +1,4 @@
-import { createWeakMapSelector } from '@suite-common/redux-utils';
+import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 
 import { BluetoothState } from './bluetoothReducer';
 import { BluetoothDeviceCommon } from './types';
@@ -16,7 +16,7 @@ export const selectKnownDevices = <T extends BluetoothDeviceCommon>(state: WithB
 
 export const selectNearbyDevices = <T extends BluetoothDeviceCommon>(
     state: WithBluetoothState<T>,
-) => state.bluetooth.nearbyDevices ?? [];
+) => returnStableArrayIfEmpty(state.bluetooth.nearbyDevices ?? []);
 
 /**
  * We need to have generic `createWeakMapSelector.withTypes` so we need to wrap it into Higher Order Function,

--- a/suite-native/bluetooth/src/selectors.ts
+++ b/suite-native/bluetooth/src/selectors.ts
@@ -28,10 +28,8 @@ export const selectHasKnownBluetoothDevices = createMemoizedSelector(
     knownBluetoothDevices => knownBluetoothDevices.length > 0,
 );
 
-export const selectNearbyBluetoothDevices = createMemoizedSelector(
-    [selectNearbyDevices],
-    nearbyDevices => nearbyDevices ?? [],
-);
+export const selectNearbyBluetoothDevices = (state: NativeBluetoothRootState) =>
+    selectNearbyDevices(state);
 
 export const selectNearbyPairableBluetoothDevices = createMemoizedSelector(
     [selectNearbyBluetoothDevices, selectKnownBluetoothDevices],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

followup of https://github.com/trezor/trezor-suite/pull/22248

## Description

- prevent `An input selector returned a different result when passed same arguments.` warning



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/avoid-instable-selector-warning&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/avoid-instable-selector-warning&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/avoid-instable-selector-warning&lookback=7)