### PR TITLE
Mobile Trade: update invariant message for receive account utils

### DIFF
--- a/suite-native/module-trading/src/utils/general/__tests__/receiveAccountUtils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/receiveAccountUtils.test.ts
@@ -152,13 +152,13 @@ describe('receiveAccountUtils', () => {
         it('should throw when invalid address string is specified', () => {
             expect(() =>
                 getReceiveAccountFromAccountAndAddressString(account, 'NONEXISTING'),
-            ).toThrow('Address NONEXISTING not found in the account btc-account-2');
+            ).toThrow('Address not found in the account');
         });
 
         it('should throw when address is specified for account without addresses', () => {
             expect(() =>
                 getReceiveAccountFromAccountAndAddressString(getEthAccount(), 'ANYADDRESS'),
-            ).toThrow('Account eth-account-1 has no addresses');
+            ).toThrow('Account has no addresses');
         });
     });
 });

--- a/suite-native/module-trading/src/utils/general/receiveAccountUtils.ts
+++ b/suite-native/module-trading/src/utils/general/receiveAccountUtils.ts
@@ -32,7 +32,7 @@ export const getReceiveAccountFromAccountAndAddressString = (
         return { account };
     }
 
-    invariant(account.addresses, `Account ${account.key} has no addresses`);
+    invariant(account.addresses, `Account has no addresses`);
 
     const addressPredicate = ({ address }: NonNullable<ReceiveAccount['address']>) =>
         address === receiveAddress;
@@ -41,7 +41,7 @@ export const getReceiveAccountFromAccountAndAddressString = (
         used.find(addressPredicate) ??
         unused.find(addressPredicate) ??
         change.find(addressPredicate);
-    invariant(address, `Address ${receiveAddress} not found in the account ${account.key}`);
+    invariant(address, `Address not found in the account`);
 
     return { account, address };
 };


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Do not log sensitive data in receiveAccountUtils invariants.



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native/update-invariant-message&lookback=7)