### PR TITLE
test(suite): fix device type narrowing in tests

### DIFF
--- a/packages/suite/src/components/suite/Preloader/__tests__/selectShouldDisplayDeviceCompromisedOnRoute.test.ts
+++ b/packages/suite/src/components/suite/Preloader/__tests__/selectShouldDisplayDeviceCompromisedOnRoute.test.ts
@@ -1,4 +1,5 @@
 import { messageSystemInitialState } from '@suite-common/message-system';
+import * as deviceUtils from '@suite-common/suite-utils';
 import { testMocks } from '@suite-common/test-utils';
 import { defaultDevicePersistentData } from '@suite-common/wallet-core/src/support/deviceMocks';
 
@@ -23,8 +24,10 @@ const authenticityChecksFail: AcquiredDevice['authenticityChecks'] = {
     firmwareHash: { success: false, error: 'hash-mismatch' },
 };
 
-// TODO fix the mocks. The device actually is acquired, but the function casts it to TrezorDevice, why???
-const defaultDevice = testMocks.getSuiteDevice() as AcquiredDevice;
+const defaultDevice = testMocks.getSuiteDevice();
+if (!deviceUtils.isDeviceAcquired(defaultDevice)) {
+    throw 'testMocks.getSuiteDevice() must return an AcquiredDevice here.';
+}
 
 const fixtures: Fixture[] = [
     {

--- a/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
@@ -1,6 +1,6 @@
 import '@suite-common/test-utils/src/globalOverrides';
 
-import { AcquiredDevice } from '@suite-common/suite-types';
+import * as deviceUtils from '@suite-common/suite-utils';
 import { testMocks } from '@suite-common/test-utils';
 import { DeviceReducerState, deviceInitialState } from '@suite-common/wallet-core';
 import { defaultDevicePersistentData } from '@suite-common/wallet-core/src/support/deviceMocks';
@@ -34,8 +34,10 @@ const getInitialState = (device: DeviceReducerState): AppState =>
         },
     }) as AppState;
 
-// TODO fix the mocks. The device actually is acquired, but the function casts it to TrezorDevice, why???
-const defaultDevice = testMocks.getSuiteDevice() as AcquiredDevice;
+const defaultDevice = testMocks.getSuiteDevice();
+if (!deviceUtils.isDeviceAcquired(defaultDevice)) {
+    throw 'testMocks.getSuiteDevice() must return an AcquiredDevice here.';
+}
 
 const deviceCompromisedFixtures: Array<{
     description: string;

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -155,10 +155,9 @@ const getDeviceFeatures = (feat?: Partial<Features>): Features => {
 type StringPath<T extends { path: DeviceUniquePath }> = Omit<T, 'path'> & { path: string };
 
 /**
- * simplified Device from '@trezor/connect'
- * @param {Partial<Device>} [dev]
- * @param {Partial<Features>} [feat]
- * @returns {Device}
+ * Create a simplified mocked Device as emitted from '@trezor/connect'.
+ * Note that type inferrence for KnownDevice | UnknownDevice | UnreadableDevice cannot work here because of Partial<>.
+ * If you want tighter types in a test, do narrowing with type guards (e.g. throw if not known).
  */
 const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Features>): Device => {
     const path = asDeviceUniquePath(dev?.path ?? '1');
@@ -220,10 +219,9 @@ const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Feat
 };
 
 /**
- * Extended device from suite reducer
- * @param {Partial<TrezorDevice>} [dev]
- * @param {Partial<Features>} [feat]
- * @returns {TrezorDevice}
+ * Create a mocked extended device, as processed by wallet-core deviceReducer.
+ * Note that type inferrence for AcquiredDevice | UnknownDevice | UnreadableDevice cannot work here because of Partial<>.
+ * If you want tighter types in a test, do narrowing with type guards (e.g. throw if not acquired).
  */
 const getSuiteDevice = (
     dev?: Partial<


### PR DESCRIPTION
## Description

Small cleanup :broom: after b1ba2bdfa1d8fbc6ede5b1e8ce846ba73fbc8632 where :pig: type casting was left in tests.

At first I wanted to fix the test utils to have proper type inference, [see `mocks.type-test.ts` here](https://github.com/trezor/trezor-suite/commit/83597832c7c771d712e90a343f5a54c3d1c6f7e3) .
That fails, bcause the fn always returns a union `KnownDevice | UnknownDevice | UnreadableDevice` no matter what.
It's not so easily doable because discriminant-based inference is not effective when `dev` is wrapped in `Partial`... _Yes I admit I've got that from ChatGPT_ :upside_down_face: You can do an overloads boilerplate to declare the type inferrence explicitely, but I think that's ugly too. :confused: 

In any case, in this PR I expect it in test runtime that the device will land as Acquired, and throw (fail the test) otherwise. Honestly I don't know if it's even worth it, just to remove an `as`. What do you think?

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/test-types&lookback=7)