### PR TITLE
feat(suite-native): show walletconnect and connect popup only for real devices

### DIFF
--- a/suite-native/module-settings/src/components/ConnectionSettings.tsx
+++ b/suite-native/module-settings/src/components/ConnectionSettings.tsx
@@ -1,7 +1,9 @@
 import { TouchableOpacity } from 'react-native';
+import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/core';
 
+import { selectIsPortfolioTrackerDevice } from '@suite-common/wallet-core';
 import {
     Box,
     Card,
@@ -12,6 +14,7 @@ import {
     TitledSection,
     useBottomSheetModal,
 } from '@suite-native/atoms';
+import { selectIsDeviceReadyToUseAndAuthorized } from '@suite-native/device';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { WalletConnectPairBottomSheet } from '@suite-native/module-connect-popup';
@@ -27,6 +30,14 @@ export const ConnectionSettings = () => {
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
 
     const navigation = useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
+
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
+    const isDeviceReadyToUseAndAuthorized = useSelector(selectIsDeviceReadyToUseAndAuthorized);
+
+    // show only for real devices that are ready to be used
+    if (isPortfolioTrackerDevice || !isDeviceReadyToUseAndAuthorized) {
+        return null;
+    }
 
     return (
         <TitledSection title={<Translation id="moduleSettings.items.connections.title" />}>


### PR DESCRIPTION
We want to show wallet connect and connect popup settings when device is connected or in the  view only mode. Hide it for Portfolio tracker or when device is not ready to be used. Discussion in [slack](https://satoshilabs.slack.com/archives/C02V2PSDNA2/p1759914722275429?thread_ts=1759754539.933429&cid=C02V2PSDNA2)

## Screenshots:

not initialized device:

https://github.com/user-attachments/assets/cfd3a206-621d-4e2c-b794-87ce7d2a541c



connected device:
<img width="300" src="https://github.com/user-attachments/assets/8672d299-da85-4fb9-8001-6ea2d5c9e20a" />

view only device:
<img width="300" src="https://github.com/user-attachments/assets/1408d452-953f-475a-b0c8-07845651d40a" />

portfolio tracker
<img width="300" src="https://github.com/user-attachments/assets/1b5f1317-d9a8-4798-abb2-7a3415fef701" />





🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/walletconnect-and-connectpopup-visibility&lookback=7)