### PR TITLE
fix(suite-native): enable Bluetooth auto-connect on Connect press

### DIFF
--- a/suite-common/bluetooth/src/bluetoothActions.ts
+++ b/suite-common/bluetooth/src/bluetoothActions.ts
@@ -4,7 +4,6 @@ import { BluetoothDeviceId } from '@trezor/connect';
 
 import {
     BluetoothAdapterStatus,
-    BluetoothAutoConnectPolicy,
     BluetoothDeviceCommon,
     BluetoothScanStatus,
     DeviceBluetoothConnectionStatus,
@@ -71,11 +70,9 @@ const scanStatusAction = createAction(
     ({ status }: { status: BluetoothScanStatus }) => ({ payload: { status } }),
 );
 
-const setAutoConnectPolicyAction = createAction(
-    `${BLUETOOTH_PREFIX}/set-autoconnect-policy`,
-    ({ id, policy }: { id: string; policy: BluetoothAutoConnectPolicy }) => ({
-        payload: { id, policy },
-    }),
+const enableAutoConnect = createAction(
+    `${BLUETOOTH_PREFIX}/enable-auto-connect`,
+    (payload?: { deviceId: BluetoothDeviceId }) => ({ payload }),
 );
 
 const setIsDeviceOsUnpairingRequired = createAction(
@@ -91,6 +88,6 @@ export const bluetoothActions = {
     knownDevicesUpdateAction,
     removeKnownDeviceAction,
     updateDeviceConnectionStatus,
-    setAutoConnectPolicyAction,
+    enableAutoConnect,
     setIsDeviceOsUnpairingRequired,
 };

--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -2,7 +2,7 @@ import { AnyAction, Draft } from '@reduxjs/toolkit';
 
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { DeviceConnectActionPayload, deviceActions } from '@suite-common/wallet-core';
-import { TrezorPushNotificationType } from '@trezor/connect';
+import { BluetoothDeviceId, TrezorPushNotificationType } from '@trezor/connect';
 
 import { bluetoothActions } from './bluetoothActions';
 import { deserializeBluetoothDeviceSerialization } from './deserializeBluetoothDeviceSerialization';
@@ -23,7 +23,7 @@ export type BluetoothState<T extends BluetoothDeviceCommon> = {
     // (because we already successfully paired them in the Suite) in the Operating System
     knownDevices: T[];
     ignoredDeviceIds: string[];
-    autoConnectPolicy: Record<string, BluetoothAutoConnectPolicy | undefined>;
+    autoConnectPolicy: Record<BluetoothDeviceId, BluetoothAutoConnectPolicy | undefined>;
     isDeviceOsUnpairingRequired: boolean;
 };
 
@@ -117,8 +117,12 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                     }
                 }
             })
-            .addCase(bluetoothActions.setAutoConnectPolicyAction, (state, { payload }) => {
-                state.autoConnectPolicy[payload.id] = payload.policy;
+            .addCase(bluetoothActions.enableAutoConnect, (state, { payload }) => {
+                if (payload) {
+                    delete state.autoConnectPolicy[payload.deviceId];
+                } else {
+                    state.autoConnectPolicy = {};
+                }
             })
             .addCase(bluetoothActions.setIsDeviceOsUnpairingRequired, (state, { payload }) => {
                 state.isDeviceOsUnpairingRequired = payload;

--- a/suite-native/bluetooth/src/__tests__/selectors.test.ts
+++ b/suite-native/bluetooth/src/__tests__/selectors.test.ts
@@ -14,7 +14,9 @@ import { BluetoothDevice } from '../types';
 const initialState: NativeBluetoothState = {
     ...prepareInitialState<BluetoothDevice>(),
     autoConnectPolicy: {
-        '1ec77690-be29-43c6-8859-dfeca15c7c0f': { type: 'autoconnect-disabled' },
+        [asBluetoothDeviceId('1ec77690-be29-43c6-8859-dfeca15c7c0f')]: {
+            type: 'autoconnect-disabled',
+        },
     },
     permissionStatus: 'granted',
 };
@@ -180,7 +182,7 @@ describe('selectKnownConnectableBluetoothDevices', () => {
                 knownPairableDevice,
                 knownUserDisconnectedDevice,
             ],
-            [knownDevice],
+            [knownDevice, knownUserDisconnectedDevice],
         ],
     ])('returns correct value for %s', (_, nearbyDevices, knownDevices, expectedDevices) => {
         expect(

--- a/suite-native/bluetooth/src/selectors.ts
+++ b/suite-native/bluetooth/src/selectors.ts
@@ -52,7 +52,6 @@ export const selectKnownConnectableBluetoothDevices = createMemoizedSelector(
                     knownBluetoothDevices.some(knownDevice => knownDevice.id === id) &&
                     autoConnectPolicy[id]?.type !== 'autoconnect-disabled' &&
                     manufacturerData.filterPolicy?.pairing !== true &&
-                    manufacturerData.filterPolicy?.user_disconnected !== true &&
                     connectionStatus.type === 'disconnected',
             ),
         ),

--- a/suite-native/device-authorization/package.json
+++ b/suite-native/device-authorization/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "@react-navigation/native": "7.1.17",
         "@reduxjs/toolkit": "2.8.2",
+        "@suite-common/bluetooth": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/navigation": "workspace:*",

--- a/suite-native/device-authorization/src/hooks/useDeviceConnectionGuard.ts
+++ b/suite-native/device-authorization/src/hooks/useDeviceConnectionGuard.ts
@@ -1,9 +1,10 @@
 import { useCallback } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 
-import { selectIsDeviceConnected } from '@suite-common/wallet-core';
+import { bluetoothActions } from '@suite-common/bluetooth';
+import { selectDeviceBluetoothId, selectIsDeviceConnected } from '@suite-common/wallet-core';
 import {
     AuthorizeDeviceStackRoutes,
     DeviceSettingsStackRoutes,
@@ -20,11 +21,16 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 >;
 
 export const useDeviceConnectionGuard = () => {
+    const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
 
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
+    const deviceBluetoothId = useSelector(selectDeviceBluetoothId);
 
-    const redirectToConnectAndUnlockScreen = useCallback(() => {
+    const navigateToDeviceConnectionGuardScreen = useCallback(() => {
+        if (deviceBluetoothId) {
+            dispatch(bluetoothActions.enableAutoConnect({ deviceId: deviceBluetoothId }));
+        }
         navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
             screen: AuthorizeDeviceStackRoutes.DeviceConnectionGuard,
             params: {
@@ -34,14 +40,14 @@ export const useDeviceConnectionGuard = () => {
                 },
             },
         });
-    }, [navigation]);
+    }, [deviceBluetoothId, dispatch, navigation]);
 
     useFocusEffect(
         useCallback(() => {
             if (!isDeviceConnected) {
-                redirectToConnectAndUnlockScreen();
+                navigateToDeviceConnectionGuardScreen();
             }
-        }, [isDeviceConnected, redirectToConnectAndUnlockScreen]),
+        }, [isDeviceConnected, navigateToDeviceConnectionGuardScreen]),
     );
 
     return { isDeviceConnected };

--- a/suite-native/device-authorization/tsconfig.json
+++ b/suite-native/device-authorization/tsconfig.json
@@ -3,6 +3,9 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
+            "path": "../../suite-common/bluetooth"
+        },
+        {
             "path": "../../suite-common/wallet-core"
         },
         { "path": "../atoms" },

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -15,6 +15,7 @@
         "@react-navigation/native": "7.1.17",
         "@react-navigation/native-stack": "7.3.25",
         "@reduxjs/toolkit": "2.8.2",
+        "@suite-common/bluetooth": "workspace:*",
         "@suite-common/device-authenticity": "workspace:*",
         "@suite-common/firmware-authenticity": "workspace:*",
         "@suite-common/message-system": "workspace:*",

--- a/suite-native/device/src/hooks/useConnectDeviceHandler.tsx
+++ b/suite-native/device/src/hooks/useConnectDeviceHandler.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
+import { bluetoothActions } from '@suite-common/bluetooth';
 import { acquireDevice, selectIsDeviceThpRequired } from '@suite-common/wallet-core';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import {
@@ -23,23 +24,25 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 
 export const useConnectDeviceHandler = () => {
     const dispatch = useDispatch();
-
     const navigation = useNavigation<NavigationProps>();
 
     const isBluetoothEnabled = useFeatureFlag(FeatureFlag.IsBluetoothEnabled);
+    const isIosWithBluetoothEnabled = Platform.OS === 'ios' && isBluetoothEnabled;
 
     const isDeviceThpRequired = useSelector(selectIsDeviceThpRequired);
-
-    const isIosWithBluetoothEnabled = Platform.OS === 'ios' && isBluetoothEnabled;
 
     const onConnectDevicePress = useCallback(() => {
         if (isDeviceThpRequired) {
             dispatch(acquireDevice({}));
+        } else if (isIosWithBluetoothEnabled) {
+            // Make sure auto-connect is enabled in case some device was manually disconnected.
+            dispatch(bluetoothActions.enableAutoConnect());
+            navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
+                screen: AuthorizeDeviceStackRoutes.TurnOnAndUnlockDevice,
+            });
         } else {
             navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
-                screen: isIosWithBluetoothEnabled
-                    ? AuthorizeDeviceStackRoutes.TurnOnAndUnlockDevice
-                    : AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
+                screen: AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
             });
         }
     }, [dispatch, isDeviceThpRequired, isIosWithBluetoothEnabled, navigation]);

--- a/suite-native/device/tsconfig.json
+++ b/suite-native/device/tsconfig.json
@@ -3,6 +3,9 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
+            "path": "../../suite-common/bluetooth"
+        },
+        {
             "path": "../../suite-common/device-authenticity"
         },
         {

--- a/suite-native/module-authorize-device/package.json
+++ b/suite-native/module-authorize-device/package.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "7.1.17",
         "@react-navigation/native-stack": "7.3.25",
         "@reduxjs/toolkit": "2.8.2",
+        "@suite-common/bluetooth": "workspace:*",
         "@suite-common/thp": "workspace:*",
         "@suite-common/validators": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectAndUnlockDeviceScreen.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useIsFocused } from '@react-navigation/native';
 
+import { bluetoothActions } from '@suite-common/bluetooth';
 import {
     selectIsBluetoothSupportedByDevice,
     selectIsDeviceAuthorized,
@@ -27,6 +28,8 @@ export const ConnectAndUnlockDeviceScreen = ({
     AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
     RootStackParamList
 >) => {
+    const dispatch = useDispatch();
+
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
     const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
 
@@ -44,6 +47,8 @@ export const ConnectAndUnlockDeviceScreen = ({
     }, [navigation]);
 
     const navigateToTurnOnAndUnlockDeviceScreen = () => {
+        // Make sure auto-connect is enabled in case some device was manually disconnected.
+        dispatch(bluetoothActions.enableAutoConnect());
         navigation.replace(AuthorizeDeviceStackRoutes.TurnOnAndUnlockDevice);
     };
 

--- a/suite-native/module-authorize-device/tsconfig.json
+++ b/suite-native/module-authorize-device/tsconfig.json
@@ -2,6 +2,9 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        {
+            "path": "../../suite-common/bluetooth"
+        },
         { "path": "../../suite-common/thp" },
         {
             "path": "../../suite-common/validators"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11260,6 +11260,7 @@ __metadata:
   dependencies:
     "@react-navigation/native": "npm:7.1.17"
     "@reduxjs/toolkit": "npm:2.8.2"
+    "@suite-common/bluetooth": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/navigation": "workspace:*"
@@ -11331,6 +11332,7 @@ __metadata:
     "@react-navigation/native": "npm:7.1.17"
     "@react-navigation/native-stack": "npm:7.3.25"
     "@reduxjs/toolkit": "npm:2.8.2"
+    "@suite-common/bluetooth": "workspace:*"
     "@suite-common/device-authenticity": "workspace:*"
     "@suite-common/firmware-authenticity": "workspace:*"
     "@suite-common/message-system": "workspace:*"
@@ -11834,6 +11836,7 @@ __metadata:
     "@react-navigation/native": "npm:7.1.17"
     "@react-navigation/native-stack": "npm:7.3.25"
     "@reduxjs/toolkit": "npm:2.8.2"
+    "@suite-common/bluetooth": "workspace:*"
     "@suite-common/thp": "workspace:*"
     "@suite-common/validators": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"


### PR DESCRIPTION
Partial fix for #22268.

- Enable auto-connect for all devices when the Connect button is pressed.
- Enable auto-connect for a specific device when a specific device is supposed to be connected.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/clear-autoconnect-policy&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/clear-autoconnect-policy&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/clear-autoconnect-policy&lookback=7)