### PR TITLE
fix(suite): fix displaing SOL rewards banner

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/hooks/useRewardsNotAvailableYet.ts
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/hooks/useRewardsNotAvailableYet.ts
@@ -1,4 +1,7 @@
+import { useMemo } from 'react';
+
 import { StakeAccountRewards } from '@suite-common/wallet-core';
+import { StakeState } from '@trezor/blockchain-link-types/src/solana';
 import { isInt } from '@trezor/utils';
 
 import { Account } from 'src/types/wallet';
@@ -8,13 +11,20 @@ export function useRewardsNotAvailableYet(
     latestReward?: StakeAccountRewards,
 ): boolean {
     if (account.networkType !== 'solana') {
-        return false;
+        throw new Error('useRewardsNotAvailableYet can be used only with solana account');
     }
 
     const currentEpoch = account.misc?.solEpoch ?? null;
     const latestRewardEpoch = latestReward?.epoch ?? null;
+    const hasActiveStakingAccount = useMemo(
+        () =>
+            (account.misc?.solStakingAccounts ?? []).some(
+                stakingAccount => stakingAccount.status === StakeState.Active,
+            ),
+        [account.misc?.solStakingAccounts],
+    );
 
-    if (!isInt(currentEpoch) || !isInt(latestRewardEpoch)) {
+    if (!isInt(currentEpoch) || !isInt(latestRewardEpoch) || !hasActiveStakingAccount) {
         return false;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Display the SOL rewards banner only if there's actually some active staking account.

## Related Issue

Resolve #21538


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/21538-rewards-banner&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/21538-rewards-banner&lookback=7)