### PR TITLE
fix(suite): disable approve/revoke when waiting for device

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
@@ -48,11 +48,13 @@ const Icon = styled.img`
 
 type ApproveModalProps = {
     setApprovalType: (approvalType: TradingExchangeApprovalType) => void;
+    setIsWaitingForDevice: (value: boolean) => void;
     onCancel: (isSubmitting?: boolean) => void;
 };
 
 export const ApproveModal = ({
     setApprovalType: setParentApprovalType,
+    setIsWaitingForDevice,
     onCancel,
 }: ApproveModalProps) => {
     const dispatch = useDispatch();
@@ -165,9 +167,14 @@ export const ApproveModal = ({
         });
 
         setIsConfirmButtonLoading(true);
+        setIsWaitingForDevice(true);
+
         onCancel(true);
+
         await sendTransaction();
+
         setIsConfirmButtonLoading(false);
+        setIsWaitingForDevice(false);
     };
 
     const onClose = (isSubmitting?: boolean) => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
@@ -42,10 +42,11 @@ const CustomIcon = styled.img`
 `;
 
 type RevokeModalProps = {
+    setIsWaitingForDevice: (value: boolean) => void;
     onCancel: (isSubmitting?: boolean) => void;
 };
 
-export const RevokeModal = ({ onCancel }: RevokeModalProps) => {
+export const RevokeModal = ({ setIsWaitingForDevice, onCancel }: RevokeModalProps) => {
     const context = useTradingFormContext<TradingExchangeType>();
     const {
         form: {
@@ -89,9 +90,14 @@ export const RevokeModal = ({ onCancel }: RevokeModalProps) => {
         });
 
         setIsConfirmButtonLoading(true);
+        setIsWaitingForDevice(true);
+
         onCancel(true);
+
         await sendTransaction();
+
         setIsConfirmButtonLoading(false);
+        setIsWaitingForDevice(false);
     };
 
     const onClose = (isSubmitting?: boolean) => {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -54,6 +54,7 @@ type ApprovalStep = 'REQUIRED' | 'APPROVED' | 'LOADING' | 'ERROR';
 interface TradingFormApprovalProps {
     openApproveModal: () => void;
     openRevokeModal: () => void;
+    isWaitingForDevice: boolean;
     approvalType: TradingExchangeApprovalType;
     setApprovalType: (approvalType: TradingExchangeApprovalType) => void;
     isManuallyApproved: boolean;
@@ -63,6 +64,7 @@ interface TradingFormApprovalProps {
 export const TradingFormApproval = ({
     openApproveModal,
     openRevokeModal,
+    isWaitingForDevice,
     approvalType,
     setApprovalType,
     setIsManuallyApproved,
@@ -280,21 +282,24 @@ export const TradingFormApproval = ({
         (approvalStep === 'LOADING' && approvalType === 'REVOKE') ||
         isFormLoading ||
         isScheduledQuotesRefresh ||
-        isDiscoveryRunning;
+        isDiscoveryRunning ||
+        isWaitingForDevice;
 
     const isSwapButtonDisabled =
         isSwapButtonLoading ||
         (approvalStep === 'LOADING' && approvalType === 'APPROVE') ||
         isFormLoading ||
         isScheduledQuotesRefresh ||
-        isDiscoveryRunning;
+        isDiscoveryRunning ||
+        isWaitingForDevice;
 
     const isRevokeButtonDisabled =
         isRevokeButtonLoading ||
         (approvalStep === 'LOADING' && approvalType === 'APPROVE') ||
         isFormLoading ||
         isScheduledQuotesRefresh ||
-        isDiscoveryRunning;
+        isDiscoveryRunning ||
+        isWaitingForDevice;
 
     const isRefreshButtonDisabled =
         isRefreshButtonLoading || isFormLoading || isScheduledQuotesRefresh || isDiscoveryRunning;

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -133,6 +133,7 @@ export const TradingFormOffer = () => {
         );
 
     const [approvalType, setApprovalType] = useState<TradingExchangeApprovalType>('APPROVE');
+    const [isWaitingForDevice, setIsWaitingForDevice] = useState(false);
 
     const requiresTokenApproval =
         isTradingExchangeContext(context) &&
@@ -445,6 +446,7 @@ export const TradingFormOffer = () => {
                         <TradingFormApproval
                             openApproveModal={onOpenApproveModal}
                             openRevokeModal={onOpenRevokeModal}
+                            isWaitingForDevice={isWaitingForDevice}
                             approvalType={approvalType}
                             setApprovalType={setApprovalType}
                             isManuallyApproved={isManuallyApproved}
@@ -471,10 +473,19 @@ export const TradingFormOffer = () => {
             {(type === 'buy' || type === 'sell') && <TradingFormOfferOTC />}
 
             {isApproveModalOpen && (
-                <ApproveModal onCancel={onCloseApproveModal} setApprovalType={setApprovalType} />
+                <ApproveModal
+                    onCancel={onCloseApproveModal}
+                    setApprovalType={setApprovalType}
+                    setIsWaitingForDevice={setIsWaitingForDevice}
+                />
             )}
 
-            {isRevokeModalOpen && <RevokeModal onCancel={onCloseRevokeModal} />}
+            {isRevokeModalOpen && (
+                <RevokeModal
+                    onCancel={onCloseRevokeModal}
+                    setIsWaitingForDevice={setIsWaitingForDevice}
+                />
+            )}
         </Column>
     );
 };


### PR DESCRIPTION
## Description

Disable approve/revoke buttons when waiting for the device.

## Related Issue

Resolve #22262 

## Screenshots:

https://github.com/user-attachments/assets/f8da9b73-c209-4013-8091-becc1713b980


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/approval&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/approval&lookback=7)