### PR TITLE
feat(token-definitions): add `home_domain` and `rating` field for Stellar assets

### DIFF
--- a/scripts/list-outdated-dependencies/trends-dependencies.txt
+++ b/scripts/list-outdated-dependencies/trends-dependencies.txt
@@ -59,6 +59,7 @@ redux-logger
 redux-mock-store
 redux-thunk
 reselect
+toml
 web3-eth-abi
 web3-utils
 webpack

--- a/suite-common/token-definitions/package.json
+++ b/suite-common/token-definitions/package.json
@@ -30,6 +30,7 @@
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
         "ajv": "^8.17.1",
-        "jws": "^4.0.0"
+        "jws": "^4.0.0",
+        "toml": "^3.0.0"
     }
 }

--- a/suite-common/token-definitions/scripts/constants/index.ts
+++ b/suite-common/token-definitions/scripts/constants/index.ts
@@ -13,4 +13,7 @@ export const FILES_PATH = join(PACKAGE_ROOT, 'files');
 export const NFT_LIST_URL = 'https://pro-api.coingecko.com/api/v3/nfts/list';
 export const COIN_LIST_URL = 'https://pro-api.coingecko.com/api/v3/coins/list';
 
+export const STELLAR_HORIZON_URL = 'https://horizon.stellar.org';
+export const STELLAR_EXPERT_URL = 'https://api.stellar.expert/explorer/public';
+
 export const NFTS_PER_PAGE = 250;

--- a/suite-common/token-definitions/scripts/utils/fetchCoins.ts
+++ b/suite-common/token-definitions/scripts/utils/fetchCoins.ts
@@ -1,8 +1,10 @@
 /* eslint-disable no-console */
+import * as toml from 'toml';
+
 import { blockfrostUtils } from '@trezor/blockchain-link-utils';
 
 import { AdvancedTokenStructure, SimpleTokenStructure } from '../../src/tokenDefinitionsTypes';
-import { COIN_LIST_URL } from '../constants';
+import { COIN_LIST_URL, STELLAR_EXPERT_URL, STELLAR_HORIZON_URL } from '../constants';
 import { CoinData } from '../types';
 
 export const getContractAddress = (assetPlatformId: string, platforms: CoinData['platforms']) => {
@@ -36,6 +38,118 @@ export const getContractAddress = (assetPlatformId: string, platforms: CoinData[
     return undefined;
 };
 
+interface StellarCurrency {
+    code: string;
+    issuer: string;
+}
+
+interface StellarToml {
+    CURRENCIES?: StellarCurrency[];
+}
+
+/**
+ * Fetch Stellar home_domain from Horizon API
+ */
+const fetchStellarHomeDomain = async (issuer: string): Promise<string | null> => {
+    try {
+        const response = await fetch(`${STELLAR_HORIZON_URL}/accounts/${issuer}`);
+        if (!response.ok) {
+            console.warn(`Stellar Horizon API returned ${response.status} for issuer ${issuer}`);
+
+            return null;
+        }
+        const data = await response.json();
+
+        return data.home_domain || null;
+    } catch (error) {
+        console.warn(`Error fetching Stellar home_domain for ${issuer}:`, error);
+
+        return null;
+    }
+};
+
+/**
+ * Verify Stellar asset in stellar.toml file
+ *
+ * @see https://centre.io/.well-known/stellar.toml
+ * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
+ */
+const verifyStellarToml = async (
+    homeDomain: string,
+    code: string,
+    issuer: string,
+): Promise<boolean> => {
+    try {
+        const response = await fetch(`https://${homeDomain}/.well-known/stellar.toml`);
+        if (!response.ok) {
+            console.warn(`stellar.toml fetch returned ${response.status} for domain ${homeDomain}`);
+
+            return false;
+        }
+
+        const tomlContent = await response.text();
+        const parsed = toml.parse(tomlContent) as StellarToml;
+
+        if (!parsed.CURRENCIES || !Array.isArray(parsed.CURRENCIES)) {
+            return false;
+        }
+
+        const currency = parsed.CURRENCIES.find(c => c.code === code && c.issuer === issuer);
+
+        return !!currency;
+    } catch (error) {
+        console.warn(`Error verifying stellar.toml for ${homeDomain}:`, error);
+
+        return false;
+    }
+};
+
+/**
+ * Get and verify Stellar home_domain for a given asset
+ * Fetches home_domain from Horizon API and verifies it in stellar.toml
+ * This ensures the asset is officially published by the issuer
+ */
+const getStellarHomeDomain = async (contractAddress: string): Promise<string | undefined> => {
+    const [code, issuer] = contractAddress.split('-');
+
+    const homeDomain = await fetchStellarHomeDomain(issuer);
+    if (!homeDomain) {
+        return undefined;
+    }
+
+    const isValid = await verifyStellarToml(homeDomain, code, issuer);
+    if (!isValid) {
+        return undefined;
+    }
+
+    return homeDomain;
+};
+
+/**
+ * Fetch Stellar token rating from StellarExpert API
+ *
+ * @see https://stellar.expert/openapi.html#tag/Asset-Info-API/operation/getAssetRating
+ */
+const fetchStellarTokenRating = async (contractAddress: string): Promise<number | undefined> => {
+    try {
+        const response = await fetch(`${STELLAR_EXPERT_URL}/asset/${contractAddress}/rating`);
+        if (!response.ok) {
+            console.warn(
+                `StellarExpert API returned ${response.status} for asset ${contractAddress}`,
+            );
+
+            return undefined;
+        }
+        const data = await response.json();
+
+        return data.rating?.average || undefined;
+    } catch (error) {
+        console.warn(`Error fetching Stellar token rating for ${contractAddress}:`, error);
+
+        return undefined;
+    }
+};
+
 export const fetchCoinData = async (assetPlatformId: string, structure: string) => {
     console.log('Start fetching coin data for:', assetPlatformId, 'platform');
 
@@ -65,14 +179,29 @@ export const fetchCoinData = async (assetPlatformId: string, structure: string) 
     console.log('Number of coin records fetched:', data.length);
 
     if (structure === 'advanced') {
-        return data.reduce<AdvancedTokenStructure>((acc, { platforms, symbol, name }) => {
+        const result: AdvancedTokenStructure = {};
+
+        for (const { platforms, symbol, name } of data) {
             const contractAddress = getContractAddress(assetPlatformId, platforms);
             if (contractAddress) {
-                acc[contractAddress] = { symbol, name };
-            }
+                result[contractAddress] = { symbol, name };
 
-            return acc;
-        }, {});
+                // For Stellar, add `home_domain` and `rating` if available
+                if (assetPlatformId === 'stellar') {
+                    const homeDomain = await getStellarHomeDomain(contractAddress);
+                    if (homeDomain) {
+                        result[contractAddress].home_domain = homeDomain;
+                    }
+
+                    const rating = await fetchStellarTokenRating(contractAddress);
+                    if (rating !== undefined) {
+                        result[contractAddress].rating = rating;
+                    }
+                }
+            }
+        }
+
+        return result;
     } else {
         return [
             ...new Set(

--- a/suite-common/token-definitions/src/tokenDefinitionsTypes.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsTypes.ts
@@ -6,7 +6,12 @@ import type { PartialRecord } from '@trezor/type-utils';
 export type SimpleTokenStructure = string[];
 
 export interface AdvancedTokenStructure {
-    [contractAddress: string]: { symbol: string; name: string };
+    [contractAddress: string]: {
+        symbol: string;
+        name: string;
+        home_domain?: string;
+        rating?: number;
+    };
 }
 
 export type TokenStructure = SimpleTokenStructure | AdvancedTokenStructure;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10649,6 +10649,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     ajv: "npm:^8.17.1"
     jws: "npm:^4.0.0"
+    toml: "npm:^3.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In the design specifications included in #22330, we need to display the asset issuer's home domain on the page for unactivated tokens and sort them according to a specific rule. This Pull Request will add the `home_domain` to Stellar assets within the token-definitions and introduce a `rating` fetched from stellar.expert. We will subsequently use this rating as the standard for sorting the assets.


## Related Issue

#22330

## Screenshots:
