### PR TITLE
chore(suite): use isBluetoothDeviceConnected instead of .connected

### DIFF
--- a/packages/suite/src/actions/bluetooth/isBluetoothDeviceConnected.ts
+++ b/packages/suite/src/actions/bluetooth/isBluetoothDeviceConnected.ts
@@ -1,0 +1,4 @@
+import { DesktopBluetoothDevice } from './DesktopBluetoothDevice';
+
+export const isBluetoothDeviceConnected = (device: DesktopBluetoothDevice) =>
+    ['paired', 'connected'].includes(device.connectionStatus.type);

--- a/packages/suite/src/components/connection/context/ConnectionGlobalModalContext.tsx
+++ b/packages/suite/src/components/connection/context/ConnectionGlobalModalContext.tsx
@@ -10,6 +10,7 @@ import { isDesktop } from '@trezor/env-utils';
 
 import { DesktopBluetoothDevice } from 'src/actions/bluetooth/DesktopBluetoothDevice';
 import { NEARBY_DEVICES_LAST_UPDATED_LIMIT } from 'src/actions/bluetooth/filterOutNonResponsiveDevices';
+import { isBluetoothDeviceConnected } from 'src/actions/bluetooth/isBluetoothDeviceConnected';
 import { selectDeviceDefaultConnectionMode } from 'src/actions/device/deviceSelectors';
 import { setConnectionMode } from 'src/actions/device/deviceSlice';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -117,7 +118,7 @@ const useConnectionGlobalModal = () => {
         if (isDeviceUnresponsiveForTooLong) {
             // If the device is connected or paired (it may have been paired in the OS system directly)
             // => do not filter it based isDeviceUnresponsiveForTooLong
-            return it.connected;
+            return isBluetoothDeviceConnected(it);
         }
 
         return true;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PowerMonitor/PowerMonitor.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PowerMonitor/PowerMonitor.tsx
@@ -5,6 +5,7 @@ import { isMacOs } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { bluetoothDisconnectDeviceThunk } from 'src/actions/bluetooth/bluetoothDisconnectDeviceThunk';
+import { isBluetoothDeviceConnected } from 'src/actions/bluetooth/isBluetoothDeviceConnected';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const PowerMonitorManager = () => {
@@ -21,7 +22,8 @@ export const PowerMonitorManager = () => {
         const disconnectAllDevices = () => {
             dispatch(bluetoothActions.adapterEventAction({ status: 'power-suspending' }));
             knownDevices.forEach(device => {
-                if (device.connected) dispatch(bluetoothDisconnectDeviceThunk({ id: device.id }));
+                if (isBluetoothDeviceConnected(device))
+                    dispatch(bluetoothDisconnectDeviceThunk({ id: device.id }));
             });
         };
         desktopApi.on('power-monitor/suspend', disconnectAllDevices);


### PR DESCRIPTION
## Description

Small cleanup to use `DesktopBluetoothDevice.connectionStatus` instead of `DesktopBluetoothDevice.connected`.
The latter should probably be considered a low-level API, used only when appropriate.

:thought_balloon: It comes directly from `transport-bluetooth` so I don't want to artificially _remove it_ for Suite. IMO we should not obscure primary source information.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bt-connected&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bt-connected&lookback=7)