### PR TITLE
fix(suite): the redacted amounts outside of html are broken (eg. in svg)

### DIFF
--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -22,7 +22,7 @@ import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { BlurUrls } from 'src/views/wallet/tokens/common/BlurUrls';
 
-import { RedactNumericalValue } from './RedactNumericalValue';
+import { RedactNumericalValue, RedactNumericalValueInner } from './RedactNumericalValue';
 
 const Value = styled.span<{ $isTabular: boolean }>`
     ${({ $isTabular }) => $isTabular && 'font-variant-numeric: tabular-nums;'}
@@ -97,7 +97,8 @@ export const FormattedCryptoAmount = ({
 
         return (
             <>
-                {displayedSignValue} <RedactNumericalValue value={formattedValue} />{' '}
+                {/* NOTE: using here just RedactNumericalValueInner as we want just the value, it cannot be in HiddePlacerholder, as it ads <span> around */}
+                {displayedSignValue} <RedactNumericalValueInner value={formattedValue} />{' '}
                 {formattedSymbol}
             </>
         );

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -98,7 +98,8 @@ export const FormattedCryptoAmount = ({
         return (
             <>
                 {/* NOTE: using here just RedactNumericalValueInner as we want just the value, it cannot be in HiddePlacerholder, as it ads <span> around */}
-                {displayedSignValue} <RedactNumericalValueInner value={formattedValue} />{' '}
+                {displayedSignValue}{' '}
+                <RedactNumericalValueInner strict={false} value={formattedValue} />{' '}
                 {formattedSymbol}
             </>
         );

--- a/packages/suite/src/components/suite/RedactNumericalValue.tsx
+++ b/packages/suite/src/components/suite/RedactNumericalValue.tsx
@@ -4,14 +4,17 @@ import { HiddenPlaceholder } from './HiddenPlaceholder';
 
 type RedactNumbersProps = {
     value: string | number;
+    strict?: boolean;
 };
 
 /**
  * Helper that redacts sensitive content, if it should be hidden in discreet mode.
  * It is effective only when wrapped by HiddenPlaceholder upstream.
  */
-export const RedactNumericalValueInner = ({ value }: RedactNumbersProps) => {
-    const shouldRedactNumbers = useShouldRedactNumbers();
+export const RedactNumericalValueInner = ({ value, strict }: RedactNumbersProps) => {
+    const shouldRedactNumbers = useShouldRedactNumbers(
+        typeof strict === 'boolean' ? { strict } : {},
+    );
 
     return shouldRedactNumbers ? redactNumericalSubstring(value) : value;
 };

--- a/packages/suite/src/components/suite/RedactNumericalValue.tsx
+++ b/packages/suite/src/components/suite/RedactNumericalValue.tsx
@@ -10,7 +10,7 @@ type RedactNumbersProps = {
  * Helper that redacts sensitive content, if it should be hidden in discreet mode.
  * It is effective only when wrapped by HiddenPlaceholder upstream.
  */
-const RedactNumericalValueInner = ({ value }: RedactNumbersProps) => {
+export const RedactNumericalValueInner = ({ value }: RedactNumbersProps) => {
     const shouldRedactNumbers = useShouldRedactNumbers();
 
     return shouldRedactNumbers ? redactNumericalSubstring(value) : value;

--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -1,20 +1,13 @@
 import { ReactNode, useState } from 'react';
-import { useIntl } from 'react-intl';
 
-import { getDeviceInternalModel } from '@suite-common/suite-utils';
 import { selectThpStep } from '@suite-common/thp';
 import { acquireDevice, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Modal } from '@trezor/components';
-import TrezorConnect from '@trezor/connect';
-import { getDeviceColorVariant } from '@trezor/device-utils';
-import { ConfirmOnDevicePill } from '@trezor/product-components';
 import { exhaustive } from '@trezor/type-utils';
 
 import { closeModalApp } from 'src/actions/suite/routerActions';
-import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useFirmwareInstallationProgressCheck, useSelector } from 'src/hooks/suite';
 import { useFirmwareDesktopUpdate } from 'src/hooks/suite/useFirmwareDesktopUpdate';
-import messages from 'src/support/messages';
 
 import { StepCheckSeed } from './Steps/StepCheckSeed';
 import { StepDone } from './Steps/StepDone';
@@ -43,32 +36,21 @@ export const FirmwareModal = ({
     isCustomFirmwareUploaded,
     shouldSwitchFirmwareType,
 }: FirmwareModalProps) => {
-    const {
-        resetReducer,
-        status,
-        setStatus,
-        deviceWillBeWiped,
-        error,
-        buttonEvent,
-        confirmOnDevice,
-        showConfirmationPill,
-    } = useFirmwareDesktopUpdate({ shouldSwitchFirmwareType });
+    const { resetReducer, status, setStatus, deviceWillBeWiped, error } = useFirmwareDesktopUpdate({
+        shouldSwitchFirmwareType,
+    });
     const device = useSelector(selectSelectedDevice);
 
     const thpStep = useSelector(selectThpStep);
 
     const dispatch = useDispatch();
-    const intl = useIntl();
     const [isChecked, setIsChecked] = useState(false);
-    const uiEventDevice = buttonEvent?.device;
     const { isProgressCheckDisplayed, handleDismissProgressCheck } =
         useFirmwareInstallationProgressCheck();
 
     // The 'started' is NOT cancellable as the FW is streamed into the device.
     // It can be canceled only via `trezorCancel`
     const isCancelable = ['initial', 'check-seed', 'done', 'error'].includes(status);
-
-    const isAwaitingPinEntry = buttonEvent?.code === 'ButtonRequest_PinEntry';
 
     const handleClose = () => {
         if (device?.status !== 'available') {
@@ -78,8 +60,6 @@ export const FirmwareModal = ({
         dispatch(closeModalApp());
         resetReducer();
     };
-
-    const trezorCancel = () => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
 
     const getContent = () => {
         if (thpStep !== null) {
@@ -171,23 +151,6 @@ export const FirmwareModal = ({
 
     return (
         <Modal.Backdrop onClick={isCancelable ? handleClose : undefined}>
-            {showConfirmationPill && (
-                <ConfirmOnDevicePill
-                    title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
-                    deviceModelInternal={
-                        uiEventDevice !== undefined
-                            ? getDeviceInternalModel(uiEventDevice)
-                            : undefined
-                    }
-                    deviceUnitColor={
-                        uiEventDevice !== undefined
-                            ? getDeviceColorVariant(uiEventDevice)
-                            : undefined
-                    }
-                    isConfirmed={!confirmOnDevice}
-                    onCancel={isAwaitingPinEntry ? trezorCancel : undefined}
-                />
-            )}
             {getContent()}
         </Modal.Backdrop>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The value was wrapped in "a context provider" that in fact unfortunately, also adds HTML around.

I wonder if this problem isn't also somewhere else. Reason being, that the hidden placeholder likely shoudn't be everywhere.

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/22331

## Screenshots:

<img width="2586" height="1370" alt="498910208-e2bf4a4c-ec6e-4519-a6dc-c110be296f70" src="https://github.com/user-attachments/assets/6aa6bdbb-acf0-46a7-8fde-e7ed6adaea48" />


<img width="423" height="465" alt="Screenshot 2025-10-09 at 12 28 33 PM" src="https://github.com/user-attachments/assets/b7532e00-e2d1-4113-9d23-3ee3e599b6c3" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=22331-fix-redacted-values-in-svg&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=22331-fix-redacted-values-in-svg&lookback=7)