### PR TITLE
feat(suite): limit RBF min fees

### DIFF
--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -33,7 +33,7 @@ import { useCompose } from './form/useCompose';
 import { useFees } from './form/useFees';
 import { useBitcoinAmountUnit } from './useBitcoinAmountUnit';
 
-const MIN_FEE_RATE = 1; // minimum fee rate in sat/vB, introduced because nodes lowered min relay tx fee, but not incremental fee
+const MIN_FEE_RATE_PER_VB = 1; // minimum fee rate in sat/vB, introduced because nodes lowered min relay tx fee, but not incremental fee
 
 export type UseRbfProps = {
     selectedAccount: SelectedAccountLoaded;
@@ -50,13 +50,19 @@ const getBitcoinFeeInfo = (info: FeeInfo, rbfParams: RbfTransactionParamsBitcoin
     });
     const levels = feeInfo.levels.map(level => ({
         ...level,
-        feePerUnit: new BigNumber(level.feePerUnit).plus(feeRate).toString(),
+        feePerUnit: Math.max(
+            new BigNumber(level.feePerUnit).plus(feeRate).toNumber(),
+            new BigNumber(feeRate).plus(MIN_FEE_RATE_PER_VB).toNumber(),
+        ).toString(),
     }));
 
     return {
         ...feeInfo,
         levels,
-        minFee: Math.max(new BigNumber(feeRate).plus(feeInfo.minFee).toNumber(), MIN_FEE_RATE),
+        minFee: Math.max(
+            new BigNumber(feeRate).plus(feeInfo.minFee).toNumber(),
+            new BigNumber(feeRate).plus(MIN_FEE_RATE_PER_VB).toNumber(),
+        ),
     };
 };
 


### PR DESCRIPTION
This PR limits the minimum incremental fee for performing a RBF. 

**Why?**
Most nodes lowered their fees down to `0.1sat/vb`, so signing and broadcasting a `tx` with this fee is totally possible. You can also verify if the node's peers that you're submitting the `tx` to has the following feefilter policy.

However...

RBF `tx` is handled by the node's mempool policy `incrementalRelayFee` config param and even though most nodes have a lowered relay fee, they did not lower the incremental fee.

This is a bit tricky, because the incremental relay fee is not included in the feefilter message, so you basically don't know if you can broadcast the `tx` successfully to other nodes -> leaving this into a stuck `tx`, which we don't want.

Also, there are no stats regarding to the incremental fee available, since the only way to check the node's value is to directly submit a RBF `tx` to it.

**So, because of that** we have the min RBF fee set to TX_FEE + MIN_FEE_RATE_PER_VB (1sat/vb) to ensure that the `tx` won't be stuck.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22332


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/limit-rbf-min-fee&lookback=7)