### PR TITLE
delete incorrect claim on both platforms

### DIFF
--- a/packages/suite/src/components/firmware/RotatingPhrases.tsx
+++ b/packages/suite/src/components/firmware/RotatingPhrases.tsx
@@ -19,7 +19,6 @@ const PHRASES: TranslationKey[] = [
     'TR_DYK_ITEM_9',
     'TR_DYK_ITEM_10',
     'TR_DYK_ITEM_11',
-    'TR_DYK_ITEM_12',
 ];
 
 type RotatingPhrasesProps = {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10726,11 +10726,6 @@ export default defineMessages({
         defaultMessage:
             'In January 2025, Trezor introduced the Trezor Safe 5 Freedom Edition, a limited release of just 2,100 units.',
     },
-    TR_DYK_ITEM_12: {
-        id: 'TR_DYK_ITEM_12',
-        defaultMessage:
-            'Trezor hardware wallets offer secure, all-in-one storage for over 9,000 cryptocurrencies.',
-    },
     TR_FIRMWARE_UPDATE_TIME_WARNING: {
         id: 'TR_FIRMWARE_UPDATE_TIME_WARNING',
         defaultMessage: 'This firmware update may take some time to complete.',

--- a/suite-native/firmware/src/components/TrezorFacts.tsx
+++ b/suite-native/firmware/src/components/TrezorFacts.tsx
@@ -21,7 +21,6 @@ const FACTS_TRANSLATION_KEYS: TxKeyPath[] = [
     'firmware.firmwareUpdateProgress.trezorFacts.9',
     'firmware.firmwareUpdateProgress.trezorFacts.10',
     'firmware.firmwareUpdateProgress.trezorFacts.11',
-    'firmware.firmwareUpdateProgress.trezorFacts.12',
 ];
 const FACTS_COUNT = FACTS_TRANSLATION_KEYS.length;
 

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2693,7 +2693,6 @@ export const messages = {
                 9: 'Trezor began controlling its own chip supply chain in 2023 for better security.',
                 10: 'Trezor has sold wallets in over 150 countries.',
                 11: 'Trezor’s Safe 5 Freedom Edition, limited to 2,100 units, launched in Jan 2025.',
-                12: 'Trezor wallets can store and manage over 9,000+ cryptocurrencies securely in one place.',
             },
             confirmOnDeviceMessage: 'Go to your device and confirm the firmware update.',
             retryButton: 'Retry',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Deleting a claim I don’t like. (Just kidding, approved by @fang314 ). Trezor can’t store any cryptocurrency, only the keys.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/delete-false-claim&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/delete-false-claim&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/delete-false-claim&lookback=7)