### PR TITLE
test(e2e-native): passphrase mismatch test

### DIFF
--- a/suite-native/app/e2e/tests/passphraseFlow.test.ts
+++ b/suite-native/app/e2e/tests/passphraseFlow.test.ts
@@ -15,6 +15,7 @@ import {
     prepareTrezorEmulator,
     restartApp,
     wait,
+    waitForElementByTextToBeVisible,
     wipeAppData,
 } from '../utils';
 
@@ -163,9 +164,20 @@ conditionalDescribe(device.getPlatform() === 'android', 'passphrase flow', () =>
         it('close passphrase flow', async () => {
             await onPassphrase.openNewPassphraseFlow();
             await onPassphrase.closePassphraseFlow();
-
             await wait(5000);
             await detoxExpect(element(by.id('@screen/PassphraseForm'))).not.toExist();
         });
+
+        it('Passphrase mismatch', async () => {
+            const passphrase = 'Empty wallet';
+            const mismatchPassphrase = 'Wrong passphrase';
+            await onPassphrase.openNewPassphraseFlow();
+            await enterPassphraseFlow(passphrase);
+            await emptyPassphraseFlow(mismatchPassphrase);
+            await waitForElementByTextToBeVisible('Passphrase mismatch', 10000);
+            await element(by.text('Start over')).tap();
+            await onPassphrase.expectEnterPassphraseScreen();
+
+        })
     });
 });


### PR DESCRIPTION
Adding test for passphrase mismatch
## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/remember-wallet&lookback=7)