### PR TITLE
fix(suite-native): prevent unexpected line break on device name and color line

### DIFF
--- a/suite-native/bluetooth/src/components/BluetoothDeviceCard.tsx
+++ b/suite-native/bluetooth/src/components/BluetoothDeviceCard.tsx
@@ -1,4 +1,11 @@
-import { Box, Button, Card, InlineAlertBoxProps, Text } from '@suite-native/atoms';
+import {
+    Box,
+    Button,
+    Card,
+    InlineAlertBoxProps,
+    Text,
+    resetLetterSpacingOnAndroidStyle,
+} from '@suite-native/atoms';
 import { Translation, TxKeyPath } from '@suite-native/intl';
 import { models } from '@trezor/device-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -57,7 +64,11 @@ export const BluetoothDeviceCard = ({
             </Box>
             <Box alignItems="center">
                 <Text variant="titleSmall">{device.name}</Text>
-                <Text variant="hint" color="textSubdued">
+                <Text
+                    variant="hint"
+                    color="textSubdued"
+                    style={applyStyle(resetLetterSpacingOnAndroidStyle)}
+                >
                     {modelConfig.name}
                     {' • '}
                     {modelConfig.colors[deviceColor] ?? (


### PR DESCRIPTION

## Description

Reported internally here https://satoshilabs.slack.com/archives/C04JZAYEV41/p1759999459130029 see for the screenshot



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/prevent-device-color-line-break&lookback=7)