### PR TITLE
chore(suite-native): device connection disconnect tests

### DIFF
--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -223,7 +223,7 @@ const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Feat
  * Note that type inferrence for AcquiredDevice | UnknownDevice | UnreadableDevice cannot work here because of Partial<>.
  * If you want tighter types in a test, do narrowing with type guards (e.g. throw if not acquired).
  */
-const getSuiteDevice = (
+export const getSuiteDevice = (
     dev?: Partial<
         Omit<StringPath<TrezorDevice>, 'state'> & {
             state?: `${string}@${string}:${number}`;

--- a/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
+++ b/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
@@ -1,41 +1,103 @@
-import { nativeFirmwareReducer } from '@suite-native/firmware';
-import { AuthorizeDeviceStackRoutes, RootStackRoutes } from '@suite-native/navigation';
+import { UnknownAction } from '@reduxjs/toolkit';
+
+import { prepareMessageSystemReducer } from '@suite-common/message-system';
+import { extraDependenciesMock, getSuiteDevice } from '@suite-common/test-utils';
+import { deviceActions, prepareDeviceReducer } from '@suite-common/wallet-core';
+import { NativeFirmwareState, nativeFirmwareReducer } from '@suite-native/firmware';
+import {
+    AuthorizeDeviceStackRoutes,
+    DeviceOnboardingStackRoutes,
+    HomeStackRoutes,
+    RootStackRoutes,
+} from '@suite-native/navigation';
 import { UI } from '@trezor/connect';
 
-type NativeFirmwareState = ReturnType<typeof nativeFirmwareReducer>;
+const INIT_ACTION = { type: 'foo' };
 
-type GetInitialState = {
+const deviceReducer = prepareDeviceReducer(extraDependenciesMock);
+const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesMock);
+
+type InitialStateConfig = {
     nativeFirmware?: Partial<NativeFirmwareState>;
+    device?: Partial<ReturnType<typeof deviceReducer>>;
 };
 
-const getInitialState = ({ nativeFirmware }: GetInitialState) => ({
+type RootState = {
+    nativeFirmware: NativeFirmwareState;
+    device: ReturnType<typeof deviceReducer>;
+    messageSystem: ReturnType<typeof messageSystemReducer>;
+};
+
+type NavigationTarget = {
+    route: RootStackRoutes;
+    params: {
+        screen: string;
+        params?: Record<string, any>;
+    };
+};
+
+type ResetNavigationTarget = {
+    index: number;
+    routes: Array<{
+        name: RootStackRoutes;
+        params: {
+            screen: string;
+        };
+    }>;
+};
+
+type NavigationFixture = {
+    description: string;
+    initialState: RootState;
+    action: UnknownAction;
+    expectedNavigation: NavigationTarget;
+};
+
+type ResetNavigationFixture = {
+    description: string;
+    initialState: RootState;
+    action: UnknownAction;
+    expectedReset: ResetNavigationTarget;
+};
+
+type NoNavigationFixture = {
+    description: string;
+    initialState: RootState;
+    action: UnknownAction;
+};
+
+const buildInitialState = ({ nativeFirmware, device }: InitialStateConfig = {}): RootState => ({
     nativeFirmware: {
-        ...nativeFirmwareReducer(undefined, { type: 'foo' }),
+        ...nativeFirmwareReducer(undefined, INIT_ACTION),
         ...nativeFirmware,
     },
+    device: {
+        ...deviceReducer(undefined, INIT_ACTION),
+        ...device,
+    },
+    messageSystem: messageSystemReducer(undefined, INIT_ACTION),
 });
 
-export const invalidThpPairingFixtures = [
+// THP Pairing Fixtures
+export const thpPairingBlockedFixtures: NoNavigationFixture[] = [
     {
-        description: 'should not react to any UI Request Button action',
-        initialState: getInitialState({}),
+        description: 'blocks non-THP UI.REQUEST_BUTTON actions',
+        initialState: buildInitialState(),
         action: { type: UI.REQUEST_BUTTON },
     },
     {
-        description: 'should not react to any UI Request Button action',
-        initialState: getInitialState({}),
+        description: 'blocks UI.REQUEST_BUTTON with invalid payload name',
+        initialState: buildInitialState(),
         action: { type: UI.REQUEST_BUTTON, payload: { name: 'non-valid-name' } },
     },
     {
-        description: 'should not react to any random action',
-        initialState: getInitialState({}),
-        action: { type: 'foo' },
+        description: 'blocks unrelated action types',
+        initialState: buildInitialState(),
+        action: { type: 'RANDOM_ACTION' },
     },
-
     {
-        description:
-            'should not redirect to THP pairing screen on thp_pairing_request action if FW install is running',
-        initialState: getInitialState({
+        description: 'blocks thp_pairing_request when firmware installation is running',
+        initialState: buildInitialState({
             nativeFirmware: {
                 isFirmwareInstallationRunning: true,
             },
@@ -43,38 +105,126 @@ export const invalidThpPairingFixtures = [
         action: { type: UI.REQUEST_BUTTON, payload: { name: 'thp_pairing_request' } },
     },
     {
-        description:
-            'should not redirect to THP pairing screen on thp_connection_request action if FW install is running',
-        initialState: getInitialState({
+        description: 'blocks thp_connection_request when firmware installation is running',
+        initialState: buildInitialState({
             nativeFirmware: {
                 isFirmwareInstallationRunning: true,
             },
         }),
         action: { type: UI.REQUEST_BUTTON, payload: { name: 'thp_connection_request' } },
     },
+];
+
+export const thpPairingNavigationFixtures: NavigationFixture[] = [
+    {
+        description: 'navigates to ThpConfirmation on thp_pairing_request',
+        initialState: buildInitialState(),
+        action: { type: UI.REQUEST_BUTTON, payload: { name: 'thp_pairing_request' } },
+        expectedNavigation: {
+            route: RootStackRoutes.AuthorizeDeviceStack,
+            params: {
+                screen: AuthorizeDeviceStackRoutes.ThpConfirmation,
+            },
+        },
+    },
+    {
+        description: 'navigates to ThpConfirmation on thp_connection_request',
+        initialState: buildInitialState(),
+        action: { type: UI.REQUEST_BUTTON, payload: { name: 'thp_connection_request' } },
+        expectedNavigation: {
+            route: RootStackRoutes.AuthorizeDeviceStack,
+            params: {
+                screen: AuthorizeDeviceStackRoutes.ThpConfirmation,
+            },
+        },
+    },
 ] as const;
 
-export const validThpPairingFixtures = [
+// Device Disconnect Fixtures
+export const deviceDisconnectBlockedFixtures: NoNavigationFixture[] = [
     {
-        description: 'should redirect to THP pairing screen on thp_pairing_request action',
-        initialState: getInitialState({}),
-        action: { type: UI.REQUEST_BUTTON, payload: { name: 'thp_pairing_request' } },
-        redirectTarget: {
-            route: RootStackRoutes.AuthorizeDeviceStack,
+        description: 'blocks navigation when firmware installation is running',
+        initialState: buildInitialState({
+            nativeFirmware: {
+                isFirmwareInstallationRunning: true,
+            },
+        }),
+        action: { type: deviceActions.deviceDisconnect.type, payload: getSuiteDevice() },
+    },
+];
+
+export const deviceDisconnectHomeResetFixtures: ResetNavigationFixture[] = [
+    {
+        description: 'resets to Home screen on device disconnect',
+        initialState: buildInitialState(),
+        action: { type: deviceActions.deviceDisconnect.type, payload: getSuiteDevice() },
+        expectedReset: {
+            index: 0,
+            routes: [
+                {
+                    name: RootStackRoutes.AppTabs,
+                    params: {
+                        screen: HomeStackRoutes.Home,
+                    },
+                },
+            ],
+        },
+    },
+];
+
+export const deviceDisconnectDuringOnboardingFixtures: NavigationFixture[] = [
+    {
+        description: 'navigates to DeviceDisconnected screen (USB connection)',
+        initialState: buildInitialState(),
+        action: { type: deviceActions.deviceDisconnect.type, payload: getSuiteDevice() },
+        expectedNavigation: {
+            route: RootStackRoutes.DeviceOnboardingStack,
             params: {
-                screen: AuthorizeDeviceStackRoutes.ThpConfirmation,
+                screen: DeviceOnboardingStackRoutes.DeviceDisconnected,
+                params: { wasDeviceConnectedViaBluetooth: false },
             },
         },
     },
     {
-        description: 'should redirect to THP pairing screen on thp_connection_request action',
-        initialState: getInitialState({}),
-        action: { type: UI.REQUEST_BUTTON, payload: { name: 'thp_connection_request' } },
-        redirectTarget: {
-            route: RootStackRoutes.AuthorizeDeviceStack,
+        description: 'navigates to DeviceDisconnected screen (Bluetooth connection)',
+        initialState: buildInitialState(),
+        action: {
+            type: deviceActions.deviceDisconnect.type,
+            payload: { ...getSuiteDevice(), descriptor: { apiType: 'bluetooth' } },
+        },
+        expectedNavigation: {
+            route: RootStackRoutes.DeviceOnboardingStack,
             params: {
-                screen: AuthorizeDeviceStackRoutes.ThpConfirmation,
+                screen: DeviceOnboardingStackRoutes.DeviceDisconnected,
+                params: { wasDeviceConnectedViaBluetooth: true },
             },
         },
     },
-] as const;
+];
+
+export const deviceDisconnectNotOnHomeFixtures: ResetNavigationFixture[] = [
+    {
+        description: 'resets to Home screen when not already on Home',
+        initialState: buildInitialState(),
+        action: { type: deviceActions.deviceDisconnect.type, payload: getSuiteDevice() },
+        expectedReset: {
+            index: 0,
+            routes: [
+                {
+                    name: RootStackRoutes.AppTabs,
+                    params: {
+                        screen: HomeStackRoutes.Home,
+                    },
+                },
+            ],
+        },
+    },
+];
+
+export const deviceDisconnectOnHomeFixtures: NoNavigationFixture[] = [
+    {
+        description: 'does not navigate when already on Home screen',
+        initialState: buildInitialState(),
+        action: { type: deviceActions.deviceDisconnect.type, payload: getSuiteDevice() },
+    },
+];

--- a/suite-native/device/src/__tests__/deviceConnectionMiddleware.test.ts
+++ b/suite-native/device/src/__tests__/deviceConnectionMiddleware.test.ts
@@ -1,7 +1,21 @@
-import { configureMockStore } from '@suite-common/test-utils';
-import { navigationContainerRef } from '@suite-native/navigation';
+import { UnknownAction } from '@reduxjs/toolkit';
 
-import { invalidThpPairingFixtures, validThpPairingFixtures } from './deviceConnectionFixtures';
+import { configureMockStore } from '@suite-common/test-utils';
+import {
+    checkIsDeviceOnboardingFocused,
+    checkIsHomeStackFocused,
+    navigationContainerRef,
+} from '@suite-native/navigation';
+
+import {
+    deviceDisconnectBlockedFixtures,
+    deviceDisconnectDuringOnboardingFixtures,
+    deviceDisconnectHomeResetFixtures,
+    deviceDisconnectNotOnHomeFixtures,
+    deviceDisconnectOnHomeFixtures,
+    thpPairingBlockedFixtures,
+    thpPairingNavigationFixtures,
+} from './deviceConnectionFixtures';
 import { deviceConnectionMiddleware } from '../middlewares/deviceConnectionMiddleware';
 
 jest.mock('@suite-native/navigation', () => {
@@ -11,44 +25,133 @@ jest.mock('@suite-native/navigation', () => {
         ...navigation,
         navigationContainerRef: {
             navigate: jest.fn(),
+            reset: jest.fn(),
         },
+        checkIsActiveRouteAnyOf: jest.fn().mockReturnValue(false),
+        checkIsDeviceOnboardingFocused: jest.fn().mockReturnValue(false),
+        checkIsHomeStackFocused: jest.fn().mockReturnValue(false),
     };
 });
 
-describe('Ignored UI button request redirects', () => {
+const createMockStoreAndDispatch = (initialState: any, action: UnknownAction) => {
+    const mockStore = configureMockStore({
+        middleware: [deviceConnectionMiddleware.middleware],
+        preloadedState: initialState,
+    });
+    mockStore.dispatch(action);
+
+    return mockStore;
+};
+
+describe('deviceConnectionMiddleware', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    invalidThpPairingFixtures.forEach(({ description, action, initialState }) => {
-        it(description, () => {
-            const mockStore = configureMockStore({
-                middleware: [deviceConnectionMiddleware.middleware],
-                preloadedState: initialState,
-            });
-            mockStore.dispatch(action);
+    describe('THP pairing navigation', () => {
+        describe('when navigation should be blocked', () => {
+            thpPairingBlockedFixtures.forEach(({ description, action, initialState }) => {
+                it(description, () => {
+                    createMockStoreAndDispatch(initialState, action);
 
-            expect(navigationContainerRef.navigate).toHaveBeenCalledTimes(0);
+                    expect(navigationContainerRef.navigate).not.toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe('when navigation should proceed', () => {
+            thpPairingNavigationFixtures.forEach(
+                ({ description, action, expectedNavigation, initialState }) => {
+                    it(description, () => {
+                        createMockStoreAndDispatch(initialState, action);
+
+                        expect(navigationContainerRef.navigate).toHaveBeenCalledWith(
+                            expectedNavigation.route,
+                            expectedNavigation.params,
+                        );
+                        expect(navigationContainerRef.navigate).toHaveBeenCalledTimes(1);
+                    });
+                },
+            );
         });
     });
-});
 
-describe('THP confirmation redirect upon button request', () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
-    });
+    describe('Device disconnect handling', () => {
+        describe('when navigation should be blocked', () => {
+            deviceDisconnectBlockedFixtures.forEach(({ description, action, initialState }) => {
+                it(description, () => {
+                    createMockStoreAndDispatch(initialState, action);
 
-    validThpPairingFixtures.forEach(({ description, action, redirectTarget, initialState }) => {
-        it(description, () => {
-            const mockStore = configureMockStore({
-                middleware: [deviceConnectionMiddleware.middleware],
-                preloadedState: initialState,
+                    expect(navigationContainerRef.reset).not.toHaveBeenCalled();
+                    expect(navigationContainerRef.navigate).not.toHaveBeenCalled();
+                });
             });
-            mockStore.dispatch(action);
+        });
 
-            expect(navigationContainerRef.navigate).toHaveBeenCalledWith(
-                redirectTarget.route,
-                redirectTarget.params,
+        describe('when device disconnects during onboarding', () => {
+            deviceDisconnectDuringOnboardingFixtures.forEach(
+                ({ description, action, expectedNavigation, initialState }) => {
+                    it(description, () => {
+                        jest.mocked(checkIsDeviceOnboardingFocused).mockReturnValue(true);
+
+                        createMockStoreAndDispatch(initialState, action);
+
+                        expect(navigationContainerRef.navigate).toHaveBeenCalledWith(
+                            expectedNavigation.route,
+                            {
+                                screen: expectedNavigation.params.screen,
+                                params: expectedNavigation.params.params,
+                            },
+                        );
+                        expect(navigationContainerRef.navigate).toHaveBeenCalledTimes(1);
+                    });
+                },
+            );
+        });
+
+        describe('when device disconnects while NOT on Home screen', () => {
+            deviceDisconnectNotOnHomeFixtures.forEach(
+                ({ description, action, expectedReset, initialState }) => {
+                    it(description, () => {
+                        jest.mocked(checkIsDeviceOnboardingFocused).mockReturnValue(false);
+                        jest.mocked(checkIsHomeStackFocused).mockReturnValue(false);
+
+                        createMockStoreAndDispatch(initialState, action);
+
+                        expect(navigationContainerRef.reset).toHaveBeenCalledWith(expectedReset);
+                        expect(navigationContainerRef.reset).toHaveBeenCalledTimes(1);
+                    });
+                },
+            );
+        });
+
+        describe('when device disconnects while ON Home screen', () => {
+            deviceDisconnectOnHomeFixtures.forEach(({ description, action, initialState }) => {
+                it(description, () => {
+                    jest.mocked(checkIsDeviceOnboardingFocused).mockReturnValue(false);
+                    jest.mocked(checkIsHomeStackFocused).mockReturnValue(true);
+
+                    createMockStoreAndDispatch(initialState, action);
+
+                    expect(navigationContainerRef.reset).not.toHaveBeenCalled();
+                    expect(navigationContainerRef.navigate).not.toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe('when device disconnects and should reset to Home', () => {
+            deviceDisconnectHomeResetFixtures.forEach(
+                ({ description, action, expectedReset, initialState }) => {
+                    it(description, () => {
+                        jest.mocked(checkIsDeviceOnboardingFocused).mockReturnValue(false);
+                        jest.mocked(checkIsHomeStackFocused).mockReturnValue(false);
+
+                        createMockStoreAndDispatch(initialState, action);
+
+                        expect(navigationContainerRef.reset).toHaveBeenCalledWith(expectedReset);
+                        expect(navigationContainerRef.reset).toHaveBeenCalledTimes(1);
+                    });
+                },
             );
         });
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add tests for device connection middleware navigation redirect on DEVICE.DISCONNECT

<img width="654" height="574" alt="image" src="https://github.com/user-attachments/assets/33334059-4247-4ebf-8b2b-fb62c3b7a034" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/disconnect-navigation-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/disconnect-navigation-tests&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/disconnect-navigation-tests&lookback=7)