### PR TITLE
Trading - Fix fees for non-EVM DEX Swaps & Solana CEX swaps

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -93,7 +93,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
             );
 
             if (values?.outputs?.[0] && typeof address === 'string') {
-                if (type !== 'exchange') {
+                if (!values.outputs[0].address) {
                     setValue(TRADING_FORM_OUTPUT_ADDRESS, address);
                 }
                 setState(initState);

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -790,7 +790,10 @@ export const useTradingExchangeForm = ({
         if (isFormLoading || isLoadingQuote) return;
 
         if (exchangeType !== TRADING_EXCHANGE_FORM_DEX) {
-            return setValue('transactionData', '');
+            setValue('transactionData', '');
+            setValue(TRADING_FORM_OUTPUT_ADDRESS, '');
+
+            return;
         }
 
         const network = cryptoIdToNetwork(sendCryptoSelect.value);
@@ -800,7 +803,10 @@ export const useTradingExchangeForm = ({
         const quote = preselectedQuote ?? (requiresApproval ? selectedQuote : dexQuotes[0]);
 
         if (!quote || !quote.dexTx) {
-            return setValue('transactionData', '');
+            setValue('transactionData', '');
+            setValue(TRADING_FORM_OUTPUT_ADDRESS, '');
+
+            return;
         }
 
         const { dexTx } = quote;

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -17,6 +17,7 @@ import {
     type TradingSendRejectedProps,
     type TradingSignAndPushSendFormTransactionProps,
     type TradingTransactionExchange,
+    cryptoIdToNetwork,
     exchangeThunks,
     getUnusedAddressFromAccount,
     invityAPI,
@@ -784,21 +785,19 @@ export const useTradingExchangeForm = ({
 
     // set transactionData from DEX quote for correct fees fetching
     useEffect(() => {
-        if (pageType !== 'form') {
-            return;
-        }
+        if (pageType !== 'form') return;
+        if (!sendCryptoSelect?.value) return;
+        if (isFormLoading || isLoadingQuote) return;
 
         if (exchangeType !== TRADING_EXCHANGE_FORM_DEX) {
-            setValue('transactionData', '');
+            return setValue('transactionData', '');
         }
 
-        if (isFormLoading || isLoadingQuote) {
-            return;
-        }
+        const network = cryptoIdToNetwork(sendCryptoSelect.value);
+        const isEvmNativeToken = isSendingEvmNativeToken(sendCryptoSelect.value);
+        const requiresApproval = network?.networkType === 'ethereum' && !isEvmNativeToken;
 
-        const isEvmNativeToken = isSendingEvmNativeToken(sendCryptoSelect?.value);
-
-        const quote = preselectedQuote ?? (isEvmNativeToken ? dexQuotes[0] : selectedQuote);
+        const quote = preselectedQuote ?? (requiresApproval ? selectedQuote : dexQuotes[0]);
 
         if (!quote || !quote.dexTx) {
             return setValue('transactionData', '');


### PR DESCRIPTION
## Description

This PR fixes two things:
1. incorrect condition for non-EVM DEX swaps
2. issues with swapping Solana (due to incorrectly set `toAddress`)

### 1. Non-EVM DEX Swaps

Fees for `DEX` swaps were not correctly set up.

When the user is swapping an `EVM` token, the DEX quote is automatically confirmed by the `confirmTrade` function in order to retrieve the approval status of the quote. The quote is then saved to `selectedQuote` which is then used for all subsequent actions. Otherwise the `dexQuotes[0]` is used.

The original condition for selecting the current quote was:
```ts
const isEvmNativeToken = isSendingEvmNativeToken(sendCryptoSelect?.value);

const quote = preselectedQuote ?? (isEvmNativeToken ? dexQuotes[0] : selectedQuote);
```

However, when swapping e.g. `SOL`, the `isEvmNativeToken` condition evaluates to `false` and `selectedQuote` was used instead of `dexQuotes[0]`, which was incorrect.

The corrected condition is:
```ts
const network = cryptoIdToNetwork(sendCryptoSelect.value);
const isEvmNativeToken = isSendingEvmNativeToken(sendCryptoSelect.value);
const requiresApproval = network?.networkType === 'ethereum' && !isEvmNativeToken;

const quote = preselectedQuote ?? (requiresApproval ? selectedQuote : dexQuotes[0]);
```

If the `networkType` isn't `ethereum`, `dexQuotes[0]` is used. Otherwise `selectedQuote` is used only if the user is sending an `EVM` token.

### 2. Solana Swaps

The `toAddress` has not been set for swaps due to this condition:
```ts
if (type !== 'exchange') {
    setValue(TRADING_FORM_OUTPUT_ADDRESS, address);
}
```
The new condition is:
```ts
if (!values.outputs[0].address) {
    setValue(TRADING_FORM_OUTPUT_ADDRESS, address);
}
```
The original incorrect condition was added there due to issues with overwriting the `toAddress` set by the DEX quote's `dexTx.to`. However, it breaks CEX quotes, therefore now it sets the `toAddress` only when it is empty (not previously set by the DEX quote).

## Related issue

Resolve #22375 