### PR TITLE
fix(suite): show use here button also when device status is unacquired

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
@@ -40,7 +40,11 @@ export const DeviceStatus = ({
 
     const content = device && (
         <DeviceDetail label={deviceLabel}>
-            <DeviceStatusText device={device} forceConnectionInfo={forceConnectionInfo} />
+            <DeviceStatusText
+                device={device}
+                forceConnectionInfo={forceConnectionInfo}
+                deviceNeedsRefresh={deviceNeedsRefresh}
+            />
         </DeviceDetail>
     );
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/SidebarDeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/SidebarDeviceStatus.tsx
@@ -9,7 +9,7 @@ import { useSelector } from '../../../../../hooks/suite';
 import { useIsSidebarCollapsed } from '../Sidebar/utils';
 
 const needsRefresh = (device?: TrezorDevice) => {
-    if (!device) return false;
+    if (!device?.connected) return false;
 
     const deviceStatus = deviceUtils.getStatus(device);
     const needsAcquire = [

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/SidebarDeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/SidebarDeviceStatus.tsx
@@ -12,10 +12,11 @@ const needsRefresh = (device?: TrezorDevice) => {
     if (!device) return false;
 
     const deviceStatus = deviceUtils.getStatus(device);
-    const needsAcquire =
-        device.type === 'unacquired' ||
-        deviceStatus === 'used-in-other-window' ||
-        deviceStatus === 'was-used-in-other-window';
+    const needsAcquire = [
+        'unacquired',
+        'used-in-other-window',
+        'was-used-in-other-window',
+    ].includes(deviceStatus);
 
     return needsAcquire;
 };

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
@@ -23,7 +23,7 @@ export const DeviceStatusText = ({ device, forceConnectionInfo }: DeviceStatusTe
     const dispatch = useDispatch();
     if (
         connected &&
-        ['was-used-in-other-window', 'used-in-other-window', 'unacquired'].includes(deviceStatus)
+        ['unacquired', 'used-in-other-window', 'was-used-in-other-window'].includes(deviceStatus)
     ) {
         return (
             <DeviceConnectionText

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
@@ -22,10 +22,9 @@ export const DeviceStatusText = ({
     forceConnectionInfo,
     deviceNeedsRefresh,
 }: DeviceStatusTextProps) => {
-    const { connected } = device;
     const deviceStatus = deviceUtils.getStatus(device);
     const dispatch = useDispatch();
-    if (connected && deviceNeedsRefresh) {
+    if (deviceNeedsRefresh) {
         return (
             <DeviceConnectionText
                 variant="warning"

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
@@ -21,7 +21,10 @@ export const DeviceStatusText = ({ device, forceConnectionInfo }: DeviceStatusTe
     const { connected } = device;
     const deviceStatus = deviceUtils.getStatus(device);
     const dispatch = useDispatch();
-    if (connected && ['was-used-in-other-window', 'used-in-other-window'].includes(deviceStatus)) {
+    if (
+        connected &&
+        ['was-used-in-other-window', 'used-in-other-window', 'unacquired'].includes(deviceStatus)
+    ) {
         return (
             <DeviceConnectionText
                 variant="warning"

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
@@ -12,7 +12,6 @@ import { DeviceConnectionText } from './DeviceConnectionText';
 import { DeviceStatusTextThp } from './DeviceStatusTextThp';
 
 type DeviceStatusTextProps = {
-    onRefreshClick?: (e: React.MouseEvent) => void;
     device: TrezorDevice;
     forceConnectionInfo: boolean;
 };

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
@@ -14,16 +14,18 @@ import { DeviceStatusTextThp } from './DeviceStatusTextThp';
 type DeviceStatusTextProps = {
     device: TrezorDevice;
     forceConnectionInfo: boolean;
+    deviceNeedsRefresh?: boolean;
 };
 
-export const DeviceStatusText = ({ device, forceConnectionInfo }: DeviceStatusTextProps) => {
+export const DeviceStatusText = ({
+    device,
+    forceConnectionInfo,
+    deviceNeedsRefresh,
+}: DeviceStatusTextProps) => {
     const { connected } = device;
     const deviceStatus = deviceUtils.getStatus(device);
     const dispatch = useDispatch();
-    if (
-        connected &&
-        ['unacquired', 'used-in-other-window', 'was-used-in-other-window'].includes(deviceStatus)
-    ) {
+    if (connected && deviceNeedsRefresh) {
         return (
             <DeviceConnectionText
                 variant="warning"


### PR DESCRIPTION
1st commit 

before 
<img width="707" height="682" alt="image" src="https://github.com/user-attachments/assets/8ba6db87-ae4a-4087-87aa-723656e060ae" />

after 
<img width="710" height="698" alt="image" src="https://github.com/user-attachments/assets/71752b8f-2936-4706-9097-3ce9715223fe" />

other commits - refactoring and unification


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=device-status-nitpicks&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=device-status-nitpicks&lookback=7)