### PR TITLE
Refactor: entropy thunks cleanup

### DIFF
--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -2,11 +2,7 @@ import { FIRMWARE_MODULE_PREFIX } from '@suite-common/firmware';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import {
-    deviceActions,
-    failEntropyCheckThunk,
-    selectSelectedDevice,
-} from '@suite-common/wallet-core';
+import { processEntropyCheckResultThunk, selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect, { ERRORS } from '@trezor/connect';
 
 import * as modalActions from 'src/actions/suite/modalActions';
@@ -164,18 +160,7 @@ export const resetDevice =
         });
 
         if (isEntropyCheckEnabled) {
-            if (!result.success) {
-                dispatch(
-                    notificationsActions.addToast({ type: 'error', error: result.payload.error }),
-                );
-                if (result.payload.code === 'Failure_EntropyCheck') {
-                    dispatch(failEntropyCheckThunk({ device, error: result.payload }));
-                }
-            } else {
-                dispatch(
-                    deviceActions.setEntropyCheckResult({ deviceId: device.id, success: true }),
-                );
-            }
+            dispatch(processEntropyCheckResultThunk({ device, result }));
         }
 
         return result;

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -557,7 +557,7 @@ type FailEntropyCheckParams = {
     error: { code?: string; error: string };
 };
 
-export const failEntropyCheckThunk = createThunk(
+const failEntropyCheckThunk = createThunk(
     `${DEVICE_MODULE_PREFIX}/failEntropyCheckThunk`,
     ({ device, error }: FailEntropyCheckParams, { dispatch, extra }) => {
         const contextData = {
@@ -583,6 +583,25 @@ export const failEntropyCheckThunk = createThunk(
         ];
         if (!temporarilySkippedErrorsToBeInvestigated.includes(error.error)) {
             dispatch(deviceActions.setEntropyCheckResult({ deviceId: device.id, success: false }));
+        }
+    },
+);
+
+type ProcessEntropyCheckResultThunkParams = {
+    device: AcquiredDevice;
+    result: Awaited<ReturnType<typeof TrezorConnect.resetDevice>>;
+};
+
+export const processEntropyCheckResultThunk = createThunk(
+    `${DEVICE_MODULE_PREFIX}/processEntropyCheckResultThunk`,
+    ({ device, result }: ProcessEntropyCheckResultThunkParams, { dispatch }) => {
+        if (result.success) {
+            dispatch(deviceActions.setEntropyCheckResult({ deviceId: device.id, success: true }));
+        } else {
+            dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
+            if (result.payload.code === 'Failure_EntropyCheck') {
+                dispatch(failEntropyCheckThunk({ device, error: result.payload }));
+            }
         }
     },
 );

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -9,8 +9,7 @@ import {
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
-import { RootStackRoutes, navigationContainerRef } from '@suite-native/navigation';
-import TrezorConnect, { PROTO } from '@trezor/connect';
+import TrezorConnect, { PROTO, SuccessWithDevice, Unsuccessful } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
 const NATIVE_DEVICE_MODULE_PREFIX = 'nativeDevice';
@@ -63,9 +62,13 @@ const getResetDeviceConfig = (walletBackupType: BackupType): PROTO.ResetDevice =
     }
 };
 
-export const createAndBackupWalletThunk = createThunk(
+export const createAndBackupWalletThunk = createThunk<
+    Unsuccessful | SuccessWithDevice<PROTO.Success>,
+    { walletBackupType: BackupType },
+    { rejectValue: string }
+>(
     `${NATIVE_DEVICE_MODULE_PREFIX}/createAndBackupWalletThunk`,
-    async ({ walletBackupType }: { walletBackupType: BackupType }, { getState, dispatch }) => {
+    async ({ walletBackupType }, { getState, dispatch, fulfillWithValue, rejectWithValue }) => {
         const device = selectSelectedDevice(getState());
         const devicePath = selectDevicePath(getState());
         const isDeviceInitialized = selectIsDeviceInitialized(getState());
@@ -76,7 +79,7 @@ export const createAndBackupWalletThunk = createThunk(
         );
 
         if (!device || !device.features || !devicePath) {
-            throw new Error('Device not found');
+            return rejectWithValue('Device not found');
         }
 
         // If the device already has a seed, backup is created.
@@ -95,17 +98,14 @@ export const createAndBackupWalletThunk = createThunk(
                 deviceCallback: () =>
                     TrezorConnect.backupDevice({
                         ...backupParams,
-                        device: {
-                            path: device.path,
-                        },
+                        device: { path: device.path },
                     }),
             });
+            // error from device-mutex
+            if (!deviceResponse.success) return rejectWithValue(deviceResponse.error);
 
-            if (!deviceResponse.success) {
-                throw new Error(deviceResponse.error);
-            }
-
-            return deviceResponse.payload;
+            // full response from connect, which is either success or error
+            return fulfillWithValue(deviceResponse.payload);
         }
 
         const deviceResponse = await requestPrioritizedDeviceAccess({
@@ -118,16 +118,14 @@ export const createAndBackupWalletThunk = createThunk(
                     entropy_check: isEntropyCheckEnabled,
                 }),
         });
+        // error from device-mutex
+        if (!deviceResponse.success) return rejectWithValue(deviceResponse.error);
 
-        if (!deviceResponse.success) {
-            throw new Error(deviceResponse.error);
-        }
-
+        // full response from connect, which is either success or error
         const result = deviceResponse.payload;
         if (isEntropyCheckEnabled) {
             if (!result.success && result.payload.code === 'Failure_EntropyCheck') {
                 dispatch(failEntropyCheckThunk({ device, error: result.payload }));
-                navigationContainerRef.navigate(RootStackRoutes.DeviceCompromisedModal);
             } else {
                 dispatch(
                     deviceActions.setEntropyCheckResult({ deviceId: device.id, success: true }),
@@ -135,7 +133,7 @@ export const createAndBackupWalletThunk = createThunk(
             }
         }
 
-        return result;
+        return fulfillWithValue(result);
     },
 );
 

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -3,7 +3,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { BackupType } from '@suite-common/suite-types';
 import {
     deviceActions,
-    failEntropyCheckThunk,
+    processEntropyCheckResultThunk,
     selectDevicePath,
     selectIsDeviceInitialized,
     selectSelectedDevice,
@@ -124,13 +124,7 @@ export const createAndBackupWalletThunk = createThunk<
         // full response from connect, which is either success or error
         const result = deviceResponse.payload;
         if (isEntropyCheckEnabled) {
-            if (!result.success && result.payload.code === 'Failure_EntropyCheck') {
-                dispatch(failEntropyCheckThunk({ device, error: result.payload }));
-            } else {
-                dispatch(
-                    deviceActions.setEntropyCheckResult({ deviceId: device.id, success: true }),
-                );
-            }
+            dispatch(processEntropyCheckResultThunk({ device, result }));
         }
 
         return fulfillWithValue(result);

--- a/suite-native/module-device-onboarding/package.json
+++ b/suite-native/module-device-onboarding/package.json
@@ -17,6 +17,7 @@
         "@react-navigation/native-stack": "7.3.25",
         "@reduxjs/toolkit": "2.8.2",
         "@shopify/react-native-skia": "2.2.3",
+        "@suite-common/message-system": "workspace:*",
         "@suite-common/suite-constants": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/thp": "workspace:*",

--- a/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
@@ -1,13 +1,21 @@
 import { useCallback, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { isFulfilled } from '@reduxjs/toolkit';
 
+import {
+    Feature,
+    MessageSystemRootState,
+    selectIsFeatureEnabled,
+} from '@suite-common/message-system';
 import { createAndBackupWalletThunk } from '@suite-native/device';
 import {
     DeviceOnboardingStackParamList,
     DeviceOnboardingStackRoutes,
-    StackProps,
+    RootStackParamList,
+    RootStackRoutes,
+    StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 import { ERRORS } from '@trezor/connect';
 
@@ -22,12 +30,26 @@ const DEFINITIVE_ERRORS: ERRORS.ErrorCode[] = [
     'Failure_EntropyCheck',
 ];
 
-export const WalletCreationScreen = ({
-    navigation,
-    route,
-}: StackProps<DeviceOnboardingStackParamList, DeviceOnboardingStackRoutes.WalletCreation>) => {
+type NavigationProp = StackToStackCompositeNavigationProps<
+    DeviceOnboardingStackParamList,
+    DeviceOnboardingStackRoutes.WalletCreation,
+    RootStackParamList
+>;
+
+type RouteProps = RouteProp<
+    DeviceOnboardingStackParamList,
+    DeviceOnboardingStackRoutes.WalletCreation
+>;
+
+export const WalletCreationScreen = () => {
+    const route = useRoute<RouteProps>();
     const { walletBackupType } = route.params;
     const dispatch = useDispatch();
+    const navigation = useNavigation<NavigationProp>();
+
+    const isEntropyCheckEnabled = useSelector((state: MessageSystemRootState) =>
+        selectIsFeatureEnabled(state, Feature.entropyCheckMobile, true),
+    );
 
     const handleCreateAndBackupWallet = useCallback(async () => {
         const response = await dispatch(createAndBackupWalletThunk({ walletBackupType }));
@@ -40,16 +62,18 @@ export const WalletCreationScreen = ({
                     flowType: 'create',
                 });
             }
-            if (
-                responsePayload.payload.code &&
-                DEFINITIVE_ERRORS.includes(responsePayload.payload.code)
-            ) {
+            const { code } = responsePayload.payload;
+            if (code && DEFINITIVE_ERRORS.includes(code)) {
+                if (isEntropyCheckEnabled && code === 'Failure_EntropyCheck') {
+                    navigation.navigate(RootStackRoutes.DeviceCompromisedModal);
+                }
+
                 return;
             }
         }
-
+        // repeat the attempt if error was not one of the DEFINITIVE_ERRORS
         handleCreateAndBackupWallet();
-    }, [dispatch, walletBackupType, navigation]);
+    }, [dispatch, walletBackupType, navigation, isEntropyCheckEnabled]);
 
     useEffect(() => {
         handleCreateAndBackupWallet();

--- a/suite-native/module-device-onboarding/tsconfig.json
+++ b/suite-native/module-device-onboarding/tsconfig.json
@@ -3,6 +3,9 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
+            "path": "../../suite-common/message-system"
+        },
+        {
             "path": "../../suite-common/suite-constants"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11982,6 +11982,7 @@ __metadata:
     "@react-navigation/native-stack": "npm:7.3.25"
     "@reduxjs/toolkit": "npm:2.8.2"
     "@shopify/react-native-skia": "npm:2.2.3"
+    "@suite-common/message-system": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/thp": "workspace:*"


### PR DESCRIPTION
## Description

- refactor mobile `createAndBackupWalletThunk`
  - fullfill/reject with value instead of return/throw 
  - move navigation side-effect to React
- unify a key part of entropy check result handling to `suite-common` 

## QA instructions

Test the happy path:
- mobile device onboarding
- mobile device onboarding after partial onboarding in web (wallet created but backup not done)
- web device onboarding

If possible, test both with a device that does not pass entropy check.

## Screenshots:

:information_source: entropy check failure tested [with the testing branch](https://github.com/trezor/trezor-suite/tree/FW-check-UI-testing-branch)

[mobile entropy success.webm](https://github.com/user-attachments/assets/a2d4490b-2b06-488f-b395-4db49512f332)
[mobile entropy fail.webm](https://github.com/user-attachments/assets/391d3278-af7b-4ed2-a8fd-f3432d2943cc)
[mobile entropy check disabled.webm](https://github.com/user-attachments/assets/329dcdc4-a9a2-44f2-8945-5b5a168d1a89) (via local message system)
[mobile initiating backup.webm](https://github.com/user-attachments/assets/5083e7d6-625d-4c3d-b283-5a4e6dab40a2) (device needs backup after partial onboarding in suite)
[desktop entropy success.webm](https://github.com/user-attachments/assets/02d06e77-ee1b-41a9-88fe-7a42ff417ad4)
[desktop entropy fail.webm](https://github.com/user-attachments/assets/2e1372f1-f121-4206-a80f-e41ed948815c)
[desktop entropy disabled.webm](https://github.com/user-attachments/assets/22da6dc8-a648-4414-9b13-170b20d0587d)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/entropy-thunks-cleanup&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/entropy-thunks-cleanup&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/entropy-thunks-cleanup&lookback=7)