### PR TITLE
feat: Unify default passphrase settings across platforms

### DIFF
--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -10,7 +10,11 @@ import {
 import TrezorConnect, { ERRORS } from '@trezor/connect';
 
 import * as modalActions from 'src/actions/suite/modalActions';
-import * as DEVICE from 'src/constants/suite/device';
+import {
+    DEFAULT_PASSPHRASE_PROTECTION,
+    DEFAULT_SKIP_BACKUP,
+    DEFAULT_STRENGTH,
+} from 'src/constants/suite/device';
 import { selectIsEntropyCheckEnabled } from 'src/selectors/suite/suiteSelectors';
 import { Dispatch, GetState } from 'src/types/suite';
 
@@ -142,9 +146,9 @@ export const resetDevice =
         }
 
         const defaults = {
-            strength: DEVICE.DEFAULT_STRENGTH[device.features.internal_model],
-            skip_backup: DEVICE.DEFAULT_SKIP_BACKUP,
-            passphrase_protection: DEVICE.DEFAULT_PASSPHRASE_PROTECTION,
+            strength: DEFAULT_STRENGTH[device.features.internal_model],
+            skip_backup: DEFAULT_SKIP_BACKUP,
+            passphrase_protection: DEFAULT_PASSPHRASE_PROTECTION,
         };
 
         const isEntropyCheckEnabled =

--- a/packages/suite/src/constants/suite/device.ts
+++ b/packages/suite/src/constants/suite/device.ts
@@ -1,7 +1,7 @@
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 export const MAX_LABEL_LENGTH = 16;
-export const DEFAULT_PASSPHRASE_PROTECTION = true;
+export const DEFAULT_PASSPHRASE_PROTECTION = false;
 export const DEFAULT_SKIP_BACKUP = true;
 
 export const DEFAULT_STRENGTH: Record<DeviceModelInternal, number> = {

--- a/packages/suite/src/views/settings/SettingsDevice/Passphrase.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Passphrase.tsx
@@ -29,9 +29,6 @@ export const Passphrase = ({ isDeviceLocked }: PassphraseProps) => {
         });
     };
 
-    // We don't want to let users disable passphrase anymore. But we should allow users with disabled passphrase to turn it on.
-    if (passphraseProtection === true) return null;
-
     return (
         <SettingsSectionItem anchorId={SettingsAnchor.Passphrase}>
             <TextColumn


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/22070
Partially solves: https://github.com/trezor/trezor-suite/issues/22071

- After onboarding, user gets the Suite with no Passphrase.
- It can be turned ON in settings, and also turned OFF (removed the if that prevented that)


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=default-passphrase-off-on-device&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=default-passphrase-off-on-device&lookback=7)