### PR TITLE
fix(suite): Fix DeviceWithScene frame props

### DIFF
--- a/packages/suite/src/components/suite/DeviceConfirmImage.tsx
+++ b/packages/suite/src/components/suite/DeviceConfirmImage.tsx
@@ -10,7 +10,12 @@ type DeviceConfirmImageProps = Omit<ImageProps, 'image'> & {
     height?: number;
 };
 
-export const DeviceConfirmImage = ({ device, height = 300, width }: DeviceConfirmImageProps) => {
+export const DeviceConfirmImage = ({
+    device,
+    height = 300,
+    width,
+    ...rest
+}: DeviceConfirmImageProps) => {
     const deviceModelInternal = getDeviceInternalModel(device);
 
     return (
@@ -20,6 +25,7 @@ export const DeviceConfirmImage = ({ device, height = 300, width }: DeviceConfir
             width={width}
             unitColor={device?.features?.unit_color}
             height={height}
+            {...rest}
         />
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

margin wasn't passed

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before

<img width="566" height="681" alt="Screenshot 2025-10-10 at 12 43 25" src="https://github.com/user-attachments/assets/a3cdbba5-6eec-49a4-a039-48614370c0a8" />

after

<img width="524" height="698" alt="Screenshot 2025-10-10 at 12 43 15" src="https://github.com/user-attachments/assets/82fbfe62-3de3-4ab9-a30f-619cd4af02b7" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-device-with-scene-frame-props&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-device-with-scene-frame-props&lookback=7)