### PR TITLE
fix(suite): Add max-width in confirm on device pill

### DIFF
--- a/packages/product-components/src/components/ConfirmOnDevice/ConfirmOnDevicePillContent.tsx
+++ b/packages/product-components/src/components/ConfirmOnDevice/ConfirmOnDevicePillContent.tsx
@@ -60,6 +60,7 @@ export const ConfirmOnDevicePillContent = ({
                 deviceModel={deviceModelInternal}
                 deviceColor={deviceUnitColor}
                 animationHeight="34px"
+                maxWidth={30}
             />
 
             <Column alignItems="center">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


Should partially fixed this case:
<img width="475" height="85" alt="image" src="https://github.com/user-attachments/assets/d0af11d0-f880-4054-ba6f-7f8c11f91c03" />


## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add-max-width-in-confirm-on-device-pill&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-max-width-in-confirm-on-device-pill&lookback=7)