### PR TITLE
chore(suite-native): connect&unlock redirect

### DIFF
--- a/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreen.tsx
@@ -1,0 +1,49 @@
+import { ReactNode, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useFocusEffect } from '@react-navigation/native';
+
+import { selectIsDeviceAuthorized } from '@suite-common/wallet-core';
+import { Screen, useNavigateToInitialScreen } from '@suite-native/navigation';
+import TrezorConnect, { DEVICE } from '@trezor/connect';
+
+import { ConnectDeviceScreenHeader } from './ConnectDeviceScreenHeader';
+
+type ConnectDeviceScreenProps = {
+    children: ReactNode;
+    helpButton?: ReactNode;
+};
+
+export const ConnectDeviceScreen = ({ children, helpButton }: ConnectDeviceScreenProps) => {
+    const navigateToInitialScreen = useNavigateToInitialScreen();
+    const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
+
+    const onDeviceConnect = useCallback(() => {
+        // By waiting for authorized device (meaning that discovery is already running),
+        // we will redirect at appropriate time (could be resolved by connecting screen instead).
+        // This is needed because remembered devices are ignored by deviceConnectionMiddleware
+        if (isDeviceAuthorized) {
+            navigateToInitialScreen();
+        }
+    }, [isDeviceAuthorized, navigateToInitialScreen]);
+
+    useFocusEffect(
+        useCallback(() => {
+            TrezorConnect.on(DEVICE.CONNECT, onDeviceConnect);
+
+            return () => TrezorConnect.off(DEVICE.CONNECT, onDeviceConnect);
+        }, [onDeviceConnect]),
+    );
+
+    return (
+        <Screen
+            header={<ConnectDeviceScreenHeader helpButton={helpButton} />}
+            noHorizontalPadding
+            noBottomPadding
+            hasBottomInset={false}
+            isScrollable={false}
+        >
+            {children}
+        </Screen>
+    );
+};

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectAndUnlockDeviceScreen.tsx
@@ -1,12 +1,8 @@
-import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
-import { useIsFocused } from '@react-navigation/native';
 
 import { bluetoothActions } from '@suite-common/bluetooth';
 import {
     selectIsBluetoothSupportedByDevice,
-    selectIsDeviceAuthorized,
     selectIsDeviceConnected,
 } from '@suite-common/wallet-core';
 import { ConnectAndUnlockDeviceScreenContent } from '@suite-native/device';
@@ -15,11 +11,10 @@ import {
     AuthorizeDeviceStackParamList,
     AuthorizeDeviceStackRoutes,
     RootStackParamList,
-    Screen,
     StackToStackCompositeScreenProps,
 } from '@suite-native/navigation';
 
-import { ConnectDeviceScreenHeader } from '../../components/connect/ConnectDeviceScreenHeader';
+import { ConnectDeviceScreen } from '../../components/connect/ConnectDeviceScreen';
 
 export const ConnectAndUnlockDeviceScreen = ({
     navigation,
@@ -31,20 +26,11 @@ export const ConnectAndUnlockDeviceScreen = ({
     const dispatch = useDispatch();
 
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
-    const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
 
     const isBluetoothEnabled = useFeatureFlag(FeatureFlag.IsBluetoothEnabled);
     const isBluetoothSupportedByDevice = useSelector(selectIsBluetoothSupportedByDevice);
     const isBluetoothButtonVisible =
         isBluetoothEnabled && (!isDeviceConnected || isBluetoothSupportedByDevice);
-
-    const isFocused = useIsFocused();
-
-    const navigateBack = useCallback(() => {
-        if (navigation.canGoBack()) {
-            navigation.goBack();
-        }
-    }, [navigation]);
 
     const navigateToTurnOnAndUnlockDeviceScreen = () => {
         // Make sure auto-connect is enabled in case some device was manually disconnected.
@@ -52,34 +38,13 @@ export const ConnectAndUnlockDeviceScreen = ({
         navigation.replace(AuthorizeDeviceStackRoutes.TurnOnAndUnlockDevice);
     };
 
-    useEffect(() => {
-        if (!isFocused || !isDeviceConnected) return;
-
-        if (isDeviceAuthorized) {
-            // When selected device become connected, we need to navigate out of this screen.
-            navigateBack();
-        } else {
-            console.warn(' == meow == authorize device thnk needs to be replaced here ');
-            // If user cancelled the authorization, we need to authorize the device again.
-            // requestPrioritizedDeviceAccess({
-            //     deviceCallback: () => dispatch(authorizeDeviceThunk()),
-            // });
-        }
-    }, [isDeviceAuthorized, isDeviceConnected, isFocused, navigateBack]);
-
     return (
-        <Screen
-            header={<ConnectDeviceScreenHeader />}
-            noHorizontalPadding
-            noBottomPadding
-            hasBottomInset={false}
-            isScrollable={false}
-        >
+        <ConnectDeviceScreen>
             <ConnectAndUnlockDeviceScreenContent
                 onConnectViaBluetooth={
                     isBluetoothButtonVisible ? navigateToTurnOnAndUnlockDeviceScreen : undefined
                 }
             />
-        </Screen>
+        </ConnectDeviceScreen>
     );
 };

--- a/suite-native/module-authorize-device/src/screens/connect/TurnOnAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/TurnOnAndUnlockDeviceScreen.tsx
@@ -15,14 +15,13 @@ import { Translation } from '@suite-native/intl';
 import {
     AuthorizeDeviceStackParamList,
     AuthorizeDeviceStackRoutes,
-    Screen,
     StackNavigationProps,
 } from '@suite-native/navigation';
 import { TimerId } from '@trezor/type-utils';
 
 import { BluetoothPairingHelpButton } from '../../components/connect/BluetoothPairingHelpButton';
 import { BluetoothPairingHints } from '../../components/connect/BluetoothPairingHints';
-import { ConnectDeviceScreenHeader } from '../../components/connect/ConnectDeviceScreenHeader';
+import { ConnectDeviceScreen } from '../../components/connect/ConnectDeviceScreen';
 
 type NavigationProps = StackNavigationProps<
     AuthorizeDeviceStackParamList,
@@ -96,23 +95,15 @@ export const TurnOnAndUnlockDeviceScreen = () => {
     useBluetoothManager();
 
     return (
-        <Screen
-            header={
-                <ConnectDeviceScreenHeader
-                    helpButton={
-                        <BluetoothPairingHelpButton
-                            onShowAlert={clearBluetoothPairingAlertTimeout}
-                            onHideAlert={setBluetoothPairingAlertTimeout}
-                        />
-                    }
+        <ConnectDeviceScreen
+            helpButton={
+                <BluetoothPairingHelpButton
+                    onShowAlert={clearBluetoothPairingAlertTimeout}
+                    onHideAlert={setBluetoothPairingAlertTimeout}
                 />
             }
-            noHorizontalPadding
-            noBottomPadding
-            hasBottomInset={false}
-            isScrollable={false}
         >
             <TurnOnAndUnlockDeviceScreenContent />
-        </Screen>
+        </ConnectDeviceScreen>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- unify device connection for different transports for new device connections and keep it event based so we don't have to rely on selectors.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/connect-device-redirect&lookback=7)