### PR TITLE
fix(suite-native): unacquired device alert with pin

### DIFF
--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -606,3 +606,8 @@ export const selectFirmwareHashCheckError = (state: DeviceRootState) => {
 
     return checkResult.error;
 };
+
+export const selectIsDevicePinLocked = createMemoizedSelector(
+    [selectSelectedDevice],
+    selectedDevice => selectedDevice && getStatus(selectedDevice) === 'device-pin-locked',
+);

--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -8,6 +8,7 @@ import {
     deviceActions,
     selectHasDeviceFirmwareInstalled,
     selectIsConnectedDeviceUninitialized,
+    selectIsDevicePinLocked,
     selectIsDeviceThpRequired,
     selectIsNoPhysicalDeviceConnected,
     selectIsPortfolioTrackerDevice,
@@ -68,6 +69,7 @@ export const useDetectDeviceError = () => {
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
     const shouldShowAutoEjectAlert = useSelector(selectShouldShowAutoEjectAlert);
+    const isDevicePinLocked = useSelector(selectIsDevicePinLocked);
 
     const isDeviceFirmwareSupported = useSelector(selectIsDeviceFirmwareSupported);
     const deviceError = useSelector(selectDeviceError);
@@ -93,6 +95,7 @@ export const useDetectDeviceError = () => {
         if (
             isOnboardingFinished &&
             isUnacquiredDevice &&
+            !isDevicePinLocked &&
             !isDeviceThpRequired &&
             !isFirmwareInstallationRunning
         ) {
@@ -116,6 +119,7 @@ export const useDetectDeviceError = () => {
             hideAlert('deviceError');
         }
     }, [
+        isDevicePinLocked,
         isOnboardingFinished,
         isUnacquiredDevice,
         isDeviceThpRequired,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Since pin lock during unacquired device is handled, we don't want to overlay it with Unacquired device alert. This PR fixes that. 
<img width="1601" height="3446" alt="image" src="https://github.com/user-attachments/assets/0ae75d7b-1771-47c1-a075-7da96db2f5de" />

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

https://github.com/user-attachments/assets/cb8a5f7b-c899-4ab4-9f16-165f49501a5f



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/unacquired-device-alert&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/unacquired-device-alert&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/unacquired-device-alert&lookback=7)