### PR TITLE
Mobile Swap: Hide DEX option when disabled by FF

### DIFF
--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
@@ -1,7 +1,11 @@
+import { useSelector } from 'react-redux';
+
 import { TradingTradeMapProps, TradingTradeType, TradingType } from '@suite-common/trading';
+import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 import { prepareNativeStyle } from '@trezor/styles';
 
 import { useProviderFilters } from '../../../hooks/general/useProviderFilters';
+import { TradingWithFeatureFlagsRootState } from '../../../selectors/exchangeSelectors';
 import { QuotesByCategories, QuotesCategory } from '../../../types/general';
 import { LegalGatewayContextMessage } from '../LegalGatewayContextMessage';
 import { NoProvidersPlaceholder } from './NoProvidersPlaceholder';
@@ -34,11 +38,15 @@ export const ProviderSheet = <
     selectedQuote,
     tradingType,
 }: ProviderSheetProps<K, T>) => {
-    const shouldShowFilters = tradingType === 'exchange';
+    const areTradingExchangeDexesEnabled = useSelector((state: TradingWithFeatureFlagsRootState) =>
+        selectIsFeatureFlagEnabled(state, FeatureFlag.AreTradingExchangeDexesEnabled),
+    );
+    const shouldShowFilters = tradingType === 'exchange' && areTradingExchangeDexesEnabled;
 
     const { filterItems, filteredSections, selectedFilter, setSelectedFilter } = useProviderFilters(
         quotes,
         shouldShowFilters,
+        areTradingExchangeDexesEnabled,
     );
 
     const onQuoteSelectCallback = (quote: T) => {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.comp.test.tsx
@@ -1,4 +1,5 @@
 import { TradingTradeType, TradingType } from '@suite-common/trading';
+import { FeatureFlag } from '@suite-native/feature-flags';
 import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import buyQuotes from '../../../../__fixtures__/buyQuotes.json';
@@ -34,6 +35,28 @@ describe('ProviderSheet', () => {
 
         expect(getByText('No offers available.')).toBeOnTheScreen();
         expect(getByText('Fixed-rate CEX')).toBeOnTheScreen();
+    });
+
+    it('should render all section headers for exchange', async () => {
+        const { getByText } = await renderProviderSheet(
+            { tradingType: 'exchange', quotes: { fixed: [], float: [], dex: [] } },
+            { featureFlags: { [FeatureFlag.AreTradingExchangeDexesEnabled]: true } },
+        );
+
+        expect(getByText('Fixed-rate CEX')).toBeOnTheScreen();
+        expect(getByText('Floating-rate CEX')).toBeOnTheScreen();
+        expect(getByText('DEX')).toBeOnTheScreen();
+    });
+
+    it('should not render DEX section header for exchange when DEXes are disabled', async () => {
+        const { queryByText, getByText } = await renderProviderSheet(
+            { tradingType: 'exchange', quotes: { fixed: [], float: [], dex: [] } },
+            { featureFlags: { [FeatureFlag.AreTradingExchangeDexesEnabled]: false } },
+        );
+
+        expect(getByText('Fixed-rate CEX')).toBeOnTheScreen();
+        expect(getByText('Floating-rate CEX')).toBeOnTheScreen();
+        expect(queryByText('DEX')).toBeNull();
     });
 
     it('should render provided quotes', async () => {

--- a/suite-native/module-trading/src/hooks/general/__tests__/useProviderFilters.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useProviderFilters.test.ts
@@ -8,12 +8,16 @@ import { useProviderFilters } from '../useProviderFilters';
 type UseProviderFilterProps = {
     quotes?: QuotesByCategories<ExchangeTrade>;
     shouldShowFilters?: boolean;
+    areTradingExchangeDexesEnabled?: boolean;
 };
 describe('useProviderFilters', () => {
     const renderUseProviderFilters = (initialProps: UseProviderFilterProps) =>
         renderHookWithBasicProvider(
-            ({ quotes = { fixed: [], float: [], dex: [] }, shouldShowFilters = true }) =>
-                useProviderFilters(quotes, shouldShowFilters),
+            ({
+                quotes = { fixed: [], float: [], dex: [] },
+                shouldShowFilters = true,
+                areTradingExchangeDexesEnabled = true,
+            }) => useProviderFilters(quotes, shouldShowFilters, areTradingExchangeDexesEnabled),
             {
                 initialProps,
             },
@@ -91,7 +95,7 @@ describe('useProviderFilters', () => {
         ]);
     });
 
-    it('should return all section when dex is selected but shouldShowFilters is false', () => {
+    it('should return all section when cex is selected but shouldShowFilters is false', () => {
         const { result } = renderUseProviderFilters({ shouldShowFilters: false });
 
         act(() => {
@@ -103,6 +107,18 @@ describe('useProviderFilters', () => {
             { key: 'fixed', data: [], label: '', sectionData: 'fixed' },
             { key: 'float', data: [], label: '', sectionData: 'float' },
             { key: 'dex', data: [], label: '', sectionData: 'dex' },
+        ]);
+    });
+
+    it('should return only CEX sections when DEX is disabled', () => {
+        const { result } = renderUseProviderFilters({
+            shouldShowFilters: false,
+            areTradingExchangeDexesEnabled: false,
+        });
+
+        expect(result.current.filteredSections).toEqual([
+            { key: 'fixed', data: [], label: '', sectionData: 'fixed' },
+            { key: 'float', data: [], label: '', sectionData: 'float' },
         ]);
     });
 });

--- a/suite-native/module-trading/src/hooks/general/useProviderFilters.ts
+++ b/suite-native/module-trading/src/hooks/general/useProviderFilters.ts
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 
 import { TradingTradeType } from '@suite-common/trading';
 import { useTranslate } from '@suite-native/intl';
+import { exhaustive } from '@trezor/type-utils';
 
 import { SectionListData, SectionListDataArray } from './useSectionList';
 import { FilterItem } from '../../components/general/FilterTabs';
@@ -12,6 +13,7 @@ export type FilterValue = 'all' | 'cex' | 'dex';
 export const useProviderFilters = <T extends TradingTradeType>(
     quotes: QuotesByCategories<T>,
     shouldShowFilters: boolean,
+    areTradingExchangeDexesEnabled: boolean,
 ) => {
     const { translate } = useTranslate();
     const [selectedFilter, setSelectedFilter] = useState<FilterValue>('all');
@@ -26,33 +28,36 @@ export const useProviderFilters = <T extends TradingTradeType>(
     );
 
     const filteredSections: SectionListData<T, QuotesCategory> = useMemo(() => {
-        const allSections = Object.entries(quotes).map(([category, items]) => {
-            const typedCategory = category as QuotesCategory;
+        const allSections = Object.entries(quotes)
+            .filter(([category]) => areTradingExchangeDexesEnabled || category !== 'dex')
+            .map(([category, items]) => {
+                const typedCategory = category as QuotesCategory;
 
-            return {
-                key: category,
-                data: items as SectionListDataArray<T>,
-                label: '',
-                sectionData: typedCategory,
-            };
-        });
+                return {
+                    key: category,
+                    data: items as SectionListDataArray<T>,
+                    label: '',
+                    sectionData: typedCategory,
+                };
+            });
 
-        if (!shouldShowFilters || selectedFilter === 'all') {
+        if (!areTradingExchangeDexesEnabled || !shouldShowFilters || selectedFilter === 'all') {
             return allSections;
         }
 
-        if (selectedFilter === 'cex') {
-            return allSections.filter(
-                section => section.key === 'fixed' || section.key === 'float',
-            );
-        }
+        switch (selectedFilter) {
+            case 'cex':
+                return allSections.filter(
+                    section => section.key === 'fixed' || section.key === 'float',
+                );
 
-        if (selectedFilter === 'dex') {
-            return allSections.filter(section => section.key === 'dex');
-        }
+            case 'dex':
+                return allSections.filter(section => section.key === 'dex');
 
-        return allSections;
-    }, [quotes, selectedFilter, shouldShowFilters]);
+            default:
+                return exhaustive(selectedFilter, 'Unexpected filter value');
+        }
+    }, [quotes, selectedFilter, shouldShowFilters, areTradingExchangeDexesEnabled]);
 
     return {
         selectedFilter,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- do not display providers filters when DEXes are disabled by FF
- do not display DEX offers when dsabled by FF

## Related Issue

Resolve #22385


## Screenshots:

### With FF set to false
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2025-10-10 at 22 52 37" src="https://github.com/user-attachments/assets/b4b28315-cbe5-4739-95a2-8171e38bbce6" />


### With FF set to true
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2025-10-10 at 18 27 47" src="https://github.com/user-attachments/assets/443070e6-18d8-4e11-9d5b-09d388ac436c" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22385-DEX-option-available-in-Swap&lookback=7)