### PR TITLE
Mobile Trade: Add fallback for missing account in trade history

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -29,6 +29,7 @@ export const messages = {
         },
         validateForm: 'Validate form',
         savedToClipboard: 'Saved to clipboard',
+        unknown: 'Unknown',
         unknownError: 'Something went wrong',
         default: 'Default',
         orSeparator: 'OR',

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailTransactionInfo.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailTransactionInfo.tsx
@@ -9,13 +9,14 @@ import {
     selectTradingTradeByOrderId,
 } from '@suite-common/trading';
 import { NetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { AccountsRootState, DeviceRootState, selectAccountByKey } from '@suite-common/wallet-core';
+import { AccountsRootState } from '@suite-common/wallet-core';
 import { Card, HStack, Text } from '@suite-native/atoms';
 import { CryptoIcon } from '@suite-native/icons';
-import { Translation } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 
 import { TradeDetailInfoRow } from './TradeDetailInfoRow';
 import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
+import { selectAccountLabelWithNetworkFallback } from '../../../selectors/commonSelectors';
 
 export type TradeDetailTransactionInfoProps = {
     orderId: string;
@@ -39,6 +40,7 @@ const CryptoIdIcon = ({ cryptoId }: CryptoIdIconProps) => {
 };
 
 export const TradeDetailTransactionInfo = ({ orderId }: TradeDetailTransactionInfoProps) => {
+    const { translate } = useTranslate();
     const trade = useSelector((state: TradingRootState) =>
         selectTradingTradeByOrderId(state, orderId),
     );
@@ -46,16 +48,32 @@ export const TradeDetailTransactionInfo = ({ orderId }: TradeDetailTransactionIn
     const isSell = tradeType === 'sell';
     const isBuy = tradeType === 'buy';
 
-    const fromAccount = useSelector((state: AccountsRootState & DeviceRootState) =>
-        isBuy ? undefined : selectAccountByKey(state, trade?.sendAccountKey),
-    );
-
-    const toAccount = useSelector((state: AccountsRootState & DeviceRootState) =>
-        isSell ? undefined : selectAccountByKey(state, trade?.receiveAccountKey),
-    );
-
     const { fromStringValue, toStringValue, fromCurrency, toCurrency, isFromCrypto, isToCrypto } =
         useChangeStringsExtractor(trade?.data);
+
+    const fromAccountLabel = useSelector((state: AccountsRootState) => {
+        if (isBuy) {
+            return undefined;
+        }
+
+        return selectAccountLabelWithNetworkFallback(
+            state,
+            trade?.sendAccountKey,
+            fromCurrency as CryptoId | undefined,
+        );
+    });
+
+    const toAccountLabel = useSelector((state: AccountsRootState) => {
+        if (isSell) {
+            return undefined;
+        }
+
+        return selectAccountLabelWithNetworkFallback(
+            state,
+            trade?.receiveAccountKey,
+            toCurrency as CryptoId | undefined,
+        );
+    });
 
     if (!trade) {
         return null;
@@ -77,7 +95,7 @@ export const TradeDetailTransactionInfo = ({ orderId }: TradeDetailTransactionIn
             {!isBuy && (
                 <TradeDetailInfoRow
                     title={<Translation id="moduleTrading.tradeHistory.detail.fromAccount" />}
-                    content={fromAccount?.accountLabel}
+                    content={fromAccountLabel ?? translate('generic.unknown')}
                 />
             )}
             <TradeDetailInfoRow
@@ -92,7 +110,7 @@ export const TradeDetailTransactionInfo = ({ orderId }: TradeDetailTransactionIn
             {!isSell && (
                 <TradeDetailInfoRow
                     title={<Translation id="moduleTrading.tradeHistory.detail.toAccount" />}
-                    content={toAccount?.accountLabel}
+                    content={toAccountLabel ?? translate('generic.unknown')}
                     contentTestID={TRADE_DETAIL_TEST_ID + '/receive-account'}
                 />
             )}

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailTransactionInfo.comp.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailTransactionInfo.comp.test.tsx
@@ -75,6 +75,33 @@ describe('TradeDetailTransactionInfo', () => {
         expect(getAllByText('SOL Account #1')).toHaveLength(2);
     });
 
+    it('should render exchange trade even when accounts are not found', async () => {
+        const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
+        const preloadedState = getPreloadedState([exchangeTrade]);
+        preloadedState!.wallet!.accounts = []; // remove all accounts
+
+        const { getByText, getAllByText } = await renderComponent(
+            exchangeTrade.data.orderId!,
+            preloadedState,
+        );
+
+        expect(getByText('10.1232 JTO')).toBeTruthy();
+        expect(getByText('0.462586 SOL')).toBeTruthy();
+        expect(getAllByText('Solana')).toHaveLength(2);
+    });
+
+    it('should render "Unknown" when asset network is not found', async () => {
+        const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
+        exchangeTrade.data.send = 'unknown-asset' as any;
+        exchangeTrade.data.receive = 'unknown-asset' as any;
+        const preloadedState = getPreloadedState([exchangeTrade]);
+        preloadedState!.wallet!.accounts = []; // remove all accounts
+
+        const { getAllByText } = await renderComponent(exchangeTrade.data.orderId!, preloadedState);
+
+        expect(getAllByText('Unknown')).toHaveLength(2);
+    });
+
     it('should render sell trade transaction info correctly', async () => {
         const sellTrade = getSellTrade({ status: 'SEND_CRYPTO' });
 

--- a/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
@@ -1,3 +1,5 @@
+import { CryptoId } from 'invity-api';
+
 import { Action, Feature, Message, TrezorDevice } from '@suite-common/suite-types';
 import {
     InvityServerEnvironment,
@@ -20,6 +22,7 @@ import { getWalletState } from '../../__fixtures__/walletState';
 import { TradingRootState, initialState } from '../../reducers';
 import { TradeableAsset } from '../../types/general';
 import {
+    selectAccountLabelWithNetworkFallback,
     selectAccountsWithTokensToSellSectionCondensedListByTradingType,
     selectAccountsWithTokensToSellSectionListByTradingType,
     selectActiveTradingType,
@@ -1199,6 +1202,45 @@ describe('commonSelectors', () => {
             expect(selectVisibleDeviceAccountsByNetworkSymbolSorted(preloadedState, 'btc')).toBe(
                 selectVisibleDeviceAccountsByNetworkSymbolSorted(preloadedState, 'btc'),
             );
+        });
+    });
+
+    describe('selectAccountLabelWithNetworkFallback', () => {
+        it('should return account label if account exists', () => {
+            expect(
+                selectAccountLabelWithNetworkFallback(
+                    { wallet: { accounts: [getEthAccount()] } },
+                    'eth-account-1',
+                    'eth' as CryptoId,
+                ),
+            ).toBe('Ethereum #1');
+        });
+
+        it.each([
+            ['ethereum', 'Ethereum'],
+            ['ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7', 'Ethereum'],
+            ['base--0x0000000000000000000000000000000000000000', 'Base'],
+        ])(
+            'should return network name for %s when account is not found',
+            (asset, expectedLabel) => {
+                expect(
+                    selectAccountLabelWithNetworkFallback(
+                        { wallet: { accounts: [getEthAccount()] } },
+                        'eth-account-2',
+                        asset as CryptoId,
+                    ),
+                ).toBe(expectedLabel);
+            },
+        );
+
+        it('should return undefined when neither account nor asset are specified', () => {
+            expect(
+                selectAccountLabelWithNetworkFallback(
+                    { wallet: { accounts: [getEthAccount()] } },
+                    undefined,
+                    undefined,
+                ),
+            ).toBeUndefined();
         });
     });
 });

--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -16,6 +16,7 @@ import {
     TradingRootStateWithDeviceAndAccounts,
     TradingTransaction,
     TradingType,
+    cryptoIdToSymbol,
     isFinalStatus,
     selectDeviceTradingTrades,
     selectTradingSupportedSymbols,
@@ -27,15 +28,17 @@ import {
     getNetworkType,
 } from '@suite-common/wallet-config';
 import {
+    AccountsRootState,
     FiatRatesRootState,
     WalletSettingsRootState,
+    selectAccountByKey,
     selectBaseCurrency,
     selectCurrentFiatRates,
     selectVisibleDeviceAccounts,
     selectVisibleDeviceAccountsByNetworkSymbol,
     selectVisibleDeviceAccountsMap,
 } from '@suite-common/wallet-core';
-import { Account, TokenAddress, TokenSymbol } from '@suite-common/wallet-types';
+import { Account, AccountKey, TokenAddress, TokenSymbol } from '@suite-common/wallet-types';
 import { getAccountFiatBalance, getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
 import { sortAccountsByNetworksAndAccountTypes } from '@suite-native/accounts/src/utils';
 import {
@@ -351,3 +354,23 @@ export const selectVisibleDeviceAccountsByNetworkSymbolSorted =
             return returnStableArrayIfEmpty(sortedAccounts);
         },
     );
+
+export const selectAccountLabelWithNetworkFallback = (
+    state: AccountsRootState,
+    accountKey?: AccountKey,
+    cryptoId?: CryptoId,
+) => {
+    const label = selectAccountByKey(state, accountKey)?.accountLabel;
+    if (label) {
+        return label;
+    }
+
+    if (cryptoId) {
+        const networkSymbol = cryptoIdToSymbol(cryptoId);
+        if (networkSymbol) {
+            return getNetwork(networkSymbol).name;
+        }
+    }
+
+    return undefined;
+};


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Use network name as fallback for missing account label in trade history

## Related Issue

Resolve #22342


## Screenshots:

<img width="300" alt="Simulator Screenshot - iPhone 16e - 2025-10-10 at 22 20 07" src="https://github.com/user-attachments/assets/b9a37f6b-21c8-4cc7-93cd-e5bf914f8428" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22342-Mobile-Trade-history-account-fallback&lookback=7)