### PR TITLE
fix(suite-native): send max for solana works again

### DIFF
--- a/suite-native/transaction-management/src/hooks/fees/useCustomFee.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useCustomFee.ts
@@ -100,9 +100,14 @@ export const useCustomFee = ({ accountKey, formState }: UseCustomFeeProps) => {
     ]);
 
     useEffect(() => {
+        // we don't support custom fee for solana
+        if (networkType === 'solana') {
+            return;
+        }
+
         setIsFeeLoading(true);
         debounce(handleValuesChange);
-    }, [watchedFeePerUnit, watchedFeeLimit, handleValuesChange, debounce]);
+    }, [watchedFeePerUnit, watchedFeeLimit, handleValuesChange, debounce, networkType]);
 
     // If the trezor-connect is unable to compose the transaction, we display rough estimate of the fee instead.
     const feeEstimate = useMemo(


### PR DESCRIPTION
User was not able to send all SOL from solana account using `Send max` button. The issue was because of computation of custom fee level, that was preparing txn with bigger fee, than previously computed, making it try to send more SOL than user actually holds on the account even for normal fee level=> failed to send txn


## Screenshots:
https://github.com/user-attachments/assets/708d74ec-c597-43dd-be90-e9573049f398

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-solana-send-max&lookback=7)