### PR TITLE
fix(native): fixed BTC fees rounding, correct decimal pad for custom fee

### DIFF
--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeInputs.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeInputs.tsx
@@ -70,7 +70,7 @@ export const CustomFeeInputs = ({ symbol }: CustomFeeInputsProps) => {
                 name={feePerUnitFieldName}
                 testID={`@transactionManagement/${feePerUnitFieldName}-input`}
                 accessibilityLabel="address input"
-                keyboardType="number-pad"
+                keyboardType={networkType === 'bitcoin' ? 'decimal-pad' : 'number-pad'}
                 rightIcon={<Text color="textSubdued">{feeUnits}</Text>}
                 onChangeText={handleFieldChangeValue(feePerUnitFieldName, cryptoAmountTransformer)}
             />

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOption.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOption.tsx
@@ -75,7 +75,9 @@ const getFeePerUnit = ({
     }
 
     if (networkType === 'bitcoin') {
-        return String(Math.round(Number(feeLevel.fee) / transactionBytes));
+        const feePerVb = Number(feeLevel.fee) / transactionBytes;
+
+        return Number.isInteger(Number(feePerVb)) ? String(feePerVb) : Number(feePerVb).toFixed(2);
     }
 
     return feeLevel.feePerByte;


### PR DESCRIPTION
**Changes**:
- fixed correct rounding for BTC fees
- shows a correct decimal pad for BTC custom fee

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22400

## Screenshots:
**BEFORE**:
<img width="375" height="667" alt="499877285-4fa91cab-842f-4eb1-bd61-c1e6e8d93939" src="https://github.com/user-attachments/assets/37998693-bd0b-46cd-abcf-8781606a050a" />
<img width="375" height="667" alt="499877284-a1548086-6a48-42cc-9112-3e6b8807a468" src="https://github.com/user-attachments/assets/2df26b0d-f8ba-4428-a4b5-894512c5d803" />


**AFTER**:
<img width="1290" height="2796" alt="simulator_screenshot_9CF399FF-173D-4F99-BDF4-0B8C90CE46DC" src="https://github.com/user-attachments/assets/1be9d746-461a-4a50-8475-fbd69c64a07b" />
<img width="1290" height="2796" alt="simulator_screenshot_0EFBE276-54AA-479E-AB9B-BB4B909D289A" src="https://github.com/user-attachments/assets/9accb91a-63db-467d-b40a-1908f4cb64ce" />




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/btc-fees&lookback=7)