### PR TITLE
chore(suite-native): remove default of helpButton in ConnectDeviceScreenHeader

### DIFF
--- a/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreen.tsx
@@ -11,7 +11,7 @@ import { ConnectDeviceScreenHeader } from './ConnectDeviceScreenHeader';
 
 type ConnectDeviceScreenProps = {
     children: ReactNode;
-    helpButton?: ReactNode;
+    helpButton: ReactNode;
 };
 
 export const ConnectDeviceScreen = ({ children, helpButton }: ConnectDeviceScreenProps) => {

--- a/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenHeader.tsx
+++ b/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenHeader.tsx
@@ -21,8 +21,6 @@ import {
 } from '@suite-native/navigation';
 import TrezorConnect from '@trezor/connect';
 
-import { ConnectingTrezorHelp } from './ConnectingTrezorHelp';
-
 type ConnectDeviceScreenHeaderProps = {
     shouldDisplayCancelButton?: boolean;
     onCancelNavigationTarget?: NavigateParameters<RootStackParamList>;
@@ -38,7 +36,7 @@ type NavigationProp = StackToStackCompositeNavigationProps<
 export const ConnectDeviceScreenHeader = ({
     shouldDisplayCancelButton = true,
     onCancelNavigationTarget,
-    helpButton = <ConnectingTrezorHelp />,
+    helpButton,
 }: ConnectDeviceScreenHeaderProps) => {
     const navigation = useNavigation<NavigationProp>();
     const { showAlert, hideAlert } = useAlert();

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectAndUnlockDeviceScreen.tsx
@@ -15,6 +15,7 @@ import {
 } from '@suite-native/navigation';
 
 import { ConnectDeviceScreen } from '../../components/connect/ConnectDeviceScreen';
+import { ConnectingTrezorHelp } from '../../components/connect/ConnectingTrezorHelp';
 
 export const ConnectAndUnlockDeviceScreen = ({
     navigation,
@@ -39,7 +40,7 @@ export const ConnectAndUnlockDeviceScreen = ({
     };
 
     return (
-        <ConnectDeviceScreen>
+        <ConnectDeviceScreen helpButton={<ConnectingTrezorHelp />}>
             <ConnectAndUnlockDeviceScreenContent
                 onConnectViaBluetooth={
                     isBluetoothButtonVisible ? navigateToTurnOnAndUnlockDeviceScreen : undefined

--- a/suite-native/module-authorize-device/src/screens/connect/DeviceConnectionGuardScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/DeviceConnectionGuardScreen.tsx
@@ -57,7 +57,6 @@ export const DeviceConnectionGuardScreen = ({
             header={
                 <ConnectDeviceScreenHeader
                     onCancelNavigationTarget={params?.onCancelNavigationTarget}
-                    helpButton={null}
                 />
             }
             noHorizontalPadding


### PR DESCRIPTION
- It makes sense for `helpButton` to be mandatory in `ConnectDeviceScreen`.
- Default in `ConnectDeviceScreenHeader` doesn't make sense any more.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/connect-device-screen-help&lookback=7)