### PR TITLE
refactor(suite): update OnboardingOption component to use Card and Gr…

### DIFF
--- a/packages/suite/src/components/onboarding/OnboardingOption.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingOption.tsx
@@ -1,81 +1,37 @@
-import { HTMLAttributes, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
-import styled from 'styled-components';
+import { Card, Column, H4, Icon, IconName, Paragraph, Row } from '@trezor/components';
 
-import { Icon, IconName, useElevation, variables } from '@trezor/components';
-import {
-    Elevation,
-    borders,
-    mapElevationToBackground,
-    mapElevationToBorder,
-    spacingsPx,
-} from '@trezor/theme';
-
-const Wrapper = styled.div<{ $elevation: Elevation }>`
-    display: flex;
-    padding: ${spacingsPx.md} ${spacingsPx.md} ${spacingsPx.md} ${spacingsPx.xl};
-    border-radius: ${borders.radii.xs};
-    border: solid 1px ${mapElevationToBorder};
-    background: ${mapElevationToBackground};
-    align-items: center;
-    width: 100%;
-    cursor: pointer;
-    transition: all 0.3s;
-
-    &:hover {
-        box-shadow: 0 6px 40px 0 ${({ theme }) => theme.legacy.BOX_SHADOW_OPTION_CARD};
-        border: 1px solid ${({ theme }) => theme.legacy.STROKE_GREY_ALT};
-    }
-`;
-
-const Content = styled.div`
-    display: flex;
-    flex-direction: column;
-    justify-items: center;
-`;
-
-const Heading = styled.span`
-    color: ${({ theme }) => theme.legacy.TYPE_DARK_GREY};
-    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-    font-size: ${variables.FONT_SIZE.NORMAL};
-`;
-
-const Description = styled.span`
-    margin-top: 5px;
-    color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
-    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    font-size: ${variables.FONT_SIZE.SMALL};
-`;
-
-const IconWrapper = styled.div`
-    margin-right: 24px;
-`;
-
-interface OnboardingOptionProps extends HTMLAttributes<HTMLDivElement> {
+type OnboardingOptionProps = {
     heading: ReactNode;
+    onClick: () => void;
     description?: ReactNode;
-    icon?: IconName;
-}
+    iconName?: IconName;
+    'data-testid'?: string;
+};
 
 export const OnboardingOption = ({
-    icon,
+    iconName,
     heading,
     description,
-    ...rest
-}: OnboardingOptionProps) => {
-    const { elevation } = useElevation();
-
-    return (
-        <Wrapper $elevation={elevation} {...rest}>
-            {icon && (
-                <IconWrapper>
-                    <Icon name={icon} size={48} />
-                </IconWrapper>
-            )}
-            <Content>
-                <Heading>{heading}</Heading>
-                {description && <Description>{description}</Description>}
-            </Content>
-        </Wrapper>
-    );
-};
+    onClick,
+    'data-testid': dataTestId,
+}: OnboardingOptionProps) => (
+    <Card onClick={onClick} data-testid={dataTestId} paddingType="none">
+        <Row
+            gap={20}
+            justifyContent={iconName ? 'flex-start' : 'center'}
+            padding={{ vertical: 20, horizontal: 32 }}
+        >
+            {iconName && <Icon name={iconName} size={48} />}
+            <Column gap={2}>
+                <H4>{heading}</H4>
+                {description && (
+                    <Paragraph typographyStyle="hint" variant="tertiary" textWrap="pretty">
+                        {description}
+                    </Paragraph>
+                )}
+            </Column>
+        </Row>
+    </Card>
+);

--- a/packages/suite/src/components/recovery/SelectRecoveryType.tsx
+++ b/packages/suite/src/components/recovery/SelectRecoveryType.tsx
@@ -15,14 +15,14 @@ export const SelectRecoveryType = ({ onSelect }: SelectRecoveryTypeProps) => {
         <Grid columns={isBelowTablet ? 1 : 2} gap={20}>
             <OnboardingOption
                 onClick={() => onSelect('standard')}
-                icon="recoverySeedFilled"
+                iconName="recoverySeedFilled"
                 heading={<Translation id="TR_BASIC_RECOVERY" />}
                 description={<Translation id="TR_BASIC_RECOVERY_OPTION" />}
                 data-testid="@recovery/select-type/standard"
             />
             <OnboardingOption
                 onClick={() => onSelect('advanced')}
-                icon="trezorModelOneFilled"
+                iconName="trezorModelOneFilled"
                 heading={<Translation id="TR_ADVANCED_RECOVERY" />}
                 description={<Translation id="TR_ADVANCED_RECOVERY_OPTION" />}
                 data-testid="@recovery/select-type/advanced"

--- a/packages/suite/src/components/recovery/SelectWordCount.tsx
+++ b/packages/suite/src/components/recovery/SelectWordCount.tsx
@@ -1,15 +1,9 @@
-import styled from 'styled-components';
-
 import { Grid } from '@trezor/components';
 
 import { OnboardingOption } from 'src/components/onboarding/OnboardingOption';
 import { Translation } from 'src/components/suite/Translation';
 import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 import { WordCount } from 'src/types/recovery';
-
-const StyledOption = styled(OnboardingOption)`
-    justify-content: center;
-`;
 
 type SelectWordCountProps = {
     onSelect: (number: WordCount) => void;
@@ -20,21 +14,21 @@ export const SelectWordCount = ({ onSelect }: SelectWordCountProps) => {
 
     return (
         <Grid columns={isBelowTablet ? 1 : 3} gap={20}>
-            <StyledOption
+            <OnboardingOption
                 onClick={() => {
                     onSelect(12);
                 }}
                 heading={<Translation id="TR_WORDS" values={{ count: '12' }} />}
                 data-testid="@recovery/select-count/12"
             />
-            <StyledOption
+            <OnboardingOption
                 onClick={() => {
                     onSelect(18);
                 }}
                 heading={<Translation id="TR_WORDS" values={{ count: '18' }} />}
                 data-testid="@recovery/select-count/18"
             />
-            <StyledOption
+            <OnboardingOption
                 onClick={() => {
                     onSelect(24);
                 }}

--- a/packages/suite/src/views/onboarding/steps/CreateOrRecoverStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/CreateOrRecoverStep.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@trezor/components';
+import { Grid } from '@trezor/components';
 
 import { OnboardingCard } from 'src/components/onboarding/OnboardingCard/OnboardingCard';
 import { OnboardingOption } from 'src/components/onboarding/OnboardingOption';
@@ -15,28 +15,28 @@ export const CreateOrRecoverStep = () => {
             iconName="wallet"
             heading={<Translation id="TR_WELCOME_TO_TREZOR_TEXT_WALLET_CREATION" />}
         >
-            <Flex gap={24} direction={isBelowTablet ? 'column' : 'row'}>
+            <Grid gap={24} columns={isBelowTablet ? 1 : 2}>
                 <OnboardingOption
-                    icon="plusCircle"
-                    data-testid="@onboarding/path-create-button"
                     onClick={() => {
                         addPath(STEP.PATH_CREATE);
                         goToNextStep();
                         updateAnalytics({ seed: 'create' });
                     }}
+                    data-testid="@onboarding/path-create-button"
+                    iconName="plusCircle"
                     heading={<Translation id="TR_CREATE_WALLET" />}
                 />
                 <OnboardingOption
-                    icon="trezorBackup"
-                    data-testid="@onboarding/path-recovery-button"
                     onClick={() => {
                         addPath(STEP.PATH_RECOVERY);
                         goToNextStep();
                         updateAnalytics({ seed: 'recovery' });
                     }}
+                    data-testid="@onboarding/path-recovery-button"
+                    iconName="trezorBackup"
                     heading={<Translation id="TR_RESTORE_EXISTING_WALLET" />}
                 />
-            </Flex>
+            </Grid>
         </OnboardingCard>
     );
 };


### PR DESCRIPTION
Rebuilt OnboardingOption around Card, Row, and Column primitives, dropped the custom styled-components wrapper, renamed icon to iconName, and added optional data-testid wiring; overall styling now comes from shared UI tokens instead of elevation hooks.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/onboarding-option&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/onboarding-option&lookback=7)