### PR TITLE
feat(desktop): add rssi info to ble item in debug mode

### DIFF
--- a/packages/suite/src/components/suite/bluetooth/BluetoothDebugInfo.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDebugInfo.tsx
@@ -47,7 +47,10 @@ export const BluetoothDebugInfo = ({ device }: BluetoothDeviceProps) => {
                     />
                 )}
                 {isNearbyDevice && (
-                    <Icon name="cellSignalFull" size={iconSizes.medium} variant="primary" />
+                    <>
+                        <Icon name="cellSignalFull" size={iconSizes.medium} variant="primary" />
+                        {isNearbyDevice.rssi} dBm
+                    </>
                 )}
                 <TimeAgo timestamp={device.lastUpdatedTimestamp} />
             </InfoSegments>


### PR DESCRIPTION
Currently, when Bluetooth debug mode is on - it shows a signal indicator, but the icon is same no matter how the signal quality changes.

**changes**:
- added rssi value

## Screenshots:
<img width="177" height="33" alt="Screenshot 2025-10-13 at 2 57 58" src="https://github.com/user-attachments/assets/0a719e94-e546-4f32-8469-803825bd4b0d" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/show-rssi-debug-item&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/show-rssi-debug-item&lookback=7)