### PR TITLE
Fix/device bt connection

### DIFF
--- a/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.ts
+++ b/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.ts
@@ -1,8 +1,16 @@
-import type { BluetoothDeviceCommon } from '@suite-common/bluetooth/src/types';
+import type {
+    BluetoothDeviceCommon,
+    DeviceBluetoothConnectionStatusType,
+} from '@suite-common/bluetooth/src/types';
 import { isLinux } from '@trezor/env-utils';
 
 export const NEARBY_DEVICES_LAST_UPDATED_LIMIT = 3_000;
 export const NEARBY_DEVICES_LAST_UPDATED_LIMIT_LINUX = 5_000;
+
+const CONNECTION_STATUSES_TO_KEEP: DeviceBluetoothConnectionStatusType[] = [
+    'connecting',
+    'pairing',
+] as const;
 
 /**
  * Filters out devices that have not been responsive for a certain period of time.
@@ -19,6 +27,6 @@ export const filterOutNonResponsiveDevices = <T extends BluetoothDeviceCommon>(d
     return devices.filter(
         device =>
             device.lastUpdatedTimestamp >= now - limit ||
-            device.connectionStatus.type === 'pairing',
+            CONNECTION_STATUSES_TO_KEEP.includes(device.connectionStatus.type),
     );
 };


### PR DESCRIPTION
In some cases a device in `connecting` state does not update regularly (and sometimes does).

Because of that, we do not filter unresponsive devices in connecting state.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22393

## Screenshots:

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/device-bt-connection&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/device-bt-connection&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/device-bt-connection&lookback=7)