### PR TITLE
fix(transport-bluetooth): server characteristics loader

### DIFF
--- a/packages/transport-bluetooth/src/server/utils.rs
+++ b/packages/transport-bluetooth/src/server/utils.rs
@@ -55,6 +55,12 @@ pub async fn dispatch_status(
 }
 
 pub async fn wait_for_characteristics(peripheral: &Peripheral) -> Result<(), PlatformError> {
+    // linux + macos: services are empty until `discover_services` is called (via btleplug/api/mod.rs)
+    // windows: `discover_services()` slows down the process but its not empty
+    if peripheral.services().is_empty() {
+        peripheral.discover_services().await?;
+    }
+
     let mut retries = 10;
     while retries > 0 && peripheral.characteristics().is_empty() {
         peripheral.discover_services().await?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix characteristics loader, bug introduced here: https://github.com/trezor/trezor-suite/pull/22069

`discover_services()` should be called before `wait_for_characteristics`. see [btleplug Peripheral](https://github.com/deviceplug/btleplug/blob/master/src/api/mod.rs#L241-L243)

Resolve: https://github.com/trezor/trezor-suite/issues/22378



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-server-write&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-server-write&lookback=7)