### PR TITLE
chore(suite-native): better disabling of custom fees for solana fee form

### DIFF
--- a/suite-native/transaction-management/package.json
+++ b/suite-native/transaction-management/package.json
@@ -16,6 +16,7 @@
         "@reduxjs/toolkit": "2.8.2",
         "@suite-common/local-first-storage": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/suite-utils": "workspace:*",
         "@suite-common/validators": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFee.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFee.tsx
@@ -41,7 +41,7 @@ export const CustomFeeButton = ({ onPress }: CustomFeeButtonProps) => (
     </Animated.View>
 );
 
-export const CustomFee = ({ accountKey, symbol, formDraft, onCustomFeeSet }: CustomFeeProps) => {
+const CustomFeeContentWrapper = ({ accountKey, formDraft, onCustomFeeSet }: CustomFeeProps) => {
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
 
     const [previousSelectedFeeLevelLabel, setPreviousSelectedFeeLevelLabel] =
@@ -69,11 +69,6 @@ export const CustomFee = ({ accountKey, symbol, formDraft, onCustomFeeSet }: Cus
         closeModal();
     };
 
-    // custom fees are not allowed for solana
-    if (getNetworkType(symbol) === 'solana') {
-        return null;
-    }
-
     return (
         <Box flex={1}>
             {isCustomFeeSelected ? (
@@ -97,5 +92,22 @@ export const CustomFee = ({ accountKey, symbol, formDraft, onCustomFeeSet }: Cus
                 isErrorBoxVisible={isErrorBoxVisible}
             />
         </Box>
+    );
+};
+
+export const CustomFee = ({ accountKey, symbol, formDraft, onCustomFeeSet }: CustomFeeProps) => {
+    // custom fees are not allowed for solana
+    // we return null here so we don't need to mount the hooks there
+    if (getNetworkType(symbol) === 'solana') {
+        return null;
+    }
+
+    return (
+        <CustomFeeContentWrapper
+            accountKey={accountKey}
+            symbol={symbol}
+            formDraft={formDraft}
+            onCustomFeeSet={onCustomFeeSet}
+        />
     );
 };

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFee.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFee.comp.test.tsx
@@ -12,7 +12,15 @@ import {
 import { getWalletState } from '../../../../__fixtures__/walletState';
 import { FeesFormType } from '../../../../feesFormSchema';
 import { useFeesForm } from '../../../../hooks';
+import { useCustomFee } from '../../../../hooks/fees/useCustomFee';
 import { CustomFee } from '../CustomFee';
+
+// Mock the useCustomFee hook
+jest.mock('../../../../hooks/fees/useCustomFee', () => ({
+    useCustomFee: jest.fn(),
+}));
+
+const mockUseCustomFee = jest.mocked(useCustomFee);
 
 type CustomFeeProps = {
     accountKey: AccountKey;
@@ -85,6 +93,16 @@ describe('CustomFee', () => {
         });
     };
 
+    beforeEach(() => {
+        // Default mock implementation for useCustomFee
+        mockUseCustomFee.mockReturnValue({
+            feeValue: '1000',
+            isFeeLoading: false,
+            isErrorBoxVisible: false,
+            isSubmittable: true,
+        });
+    });
+
     afterEach(() => {
         jest.clearAllMocks();
     });
@@ -126,6 +144,43 @@ describe('CustomFee', () => {
         });
 
         expect(toJSON()).toBeNull();
+    });
+
+    it('should not call useCustomFee hook for solana network', async () => {
+        const form = await renderUseFeesForm();
+
+        // Clear any previous calls
+        mockUseCustomFee.mockClear();
+
+        await renderCustomFee({
+            form,
+            props: {
+                symbol: 'sol' as NetworkSymbol,
+            },
+        });
+
+        // Verify that useCustomFee was not called for Solana
+        expect(mockUseCustomFee).not.toHaveBeenCalled();
+    });
+
+    it('should call useCustomFee hook for ethereum network', async () => {
+        const form = await renderUseFeesForm();
+
+        // Clear any previous calls
+        mockUseCustomFee.mockClear();
+
+        await renderCustomFee({
+            form,
+            props: {
+                symbol: 'eth' as NetworkSymbol,
+            },
+        });
+
+        // Verify that useCustomFee was called for Ethereum
+        expect(mockUseCustomFee).toHaveBeenCalledWith({
+            accountKey: 'eth-account-1',
+            formState: expect.any(Object),
+        });
     });
 
     it('should render for bitcoin network', async () => {

--- a/suite-native/transaction-management/src/hooks/fees/useCustomFee.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useCustomFee.ts
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { G } from '@mobily/ts-belt';
 import { isRejected } from '@reduxjs/toolkit';
 
+import { invariant } from '@suite-common/suite-utils';
 import { AccountsRootState, selectAccountNetworkType } from '@suite-common/wallet-core';
 import { AccountKey, FormState, isFinalPrecomposedTransaction } from '@suite-common/wallet-types';
 import { useFormContext } from '@suite-native/forms';
@@ -57,7 +58,11 @@ export const useCustomFee = ({ accountKey, formState }: UseCustomFeeProps) => {
 
     const handleValuesChange = useCallback(async () => {
         trigger();
+
+        invariant(networkType !== 'solana', 'Custom fee is not supported for solana');
+
         if (!customFeePerUnit || !formState) {
+            console.warn('Cannot calculate custom fee because of missing values');
             setIsFeeLoading(false);
 
             return;
@@ -100,11 +105,6 @@ export const useCustomFee = ({ accountKey, formState }: UseCustomFeeProps) => {
     ]);
 
     useEffect(() => {
-        // we don't support custom fee for solana
-        if (networkType === 'solana') {
-            return;
-        }
-
         setIsFeeLoading(true);
         debounce(handleValuesChange);
     }, [watchedFeePerUnit, watchedFeeLimit, handleValuesChange, debounce, networkType]);

--- a/suite-native/transaction-management/tsconfig.json
+++ b/suite-native/transaction-management/tsconfig.json
@@ -9,6 +9,9 @@
             "path": "../../suite-common/redux-utils"
         },
         {
+            "path": "../../suite-common/suite-utils"
+        },
+        {
             "path": "../../suite-common/validators"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12687,6 +12687,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:2.8.2"
     "@suite-common/local-first-storage": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/suite-utils": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/validators": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"


### PR DESCRIPTION
Don't even mount useCustomFee hook for solana


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/solana-better-handle-no-custom-fee&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/solana-better-handle-no-custom-fee&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/solana-better-handle-no-custom-fee&lookback=7)