### PR TITLE
fix(connect-common): check FW revision only new format

### DIFF
--- a/packages/connect-common/scripts/check-all-firmware-revisions.sh
+++ b/packages/connect-common/scripts/check-all-firmware-revisions.sh
@@ -4,18 +4,11 @@ PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )
 
 cd "$PARENT_PATH/../files/firmware" || exit
 
-IS_LEGACY="false"
-
 for dir in */ ; do
-    DEVICE=${dir%/}
-    # TODO: we excude t3w1 until we have releases on it.
-    if [[ $EXCLUDED_DIR == "$DEVICE" || $DEVICE == "t3w1" ]]; then continue; fi
-        is_legacy_for_device="$IS_LEGACY"
-    if [[ "$DEVICE" == "1" || "$DEVICE" == "2" ]]; then
-        is_legacy_for_device="true"
-    fi
+    DIRECTORY=${dir%/}
+    if [[ "$DIRECTORY" == "release" ]]; then continue; fi
     if [ -d "$dir" ]; then
-        if ! "$PARENT_PATH/check-firmware-revisions.sh" "$DEVICE" "$is_legacy_for_device" ; then
+        if ! "$PARENT_PATH/check-firmware-revisions.sh" "$DIRECTORY" ; then
             exit 1
         fi;
     fi

--- a/packages/connect-common/scripts/check-firmware-revisions.sh
+++ b/packages/connect-common/scripts/check-firmware-revisions.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 
+# There is a similar script like this in trezor/data
+# https://github.com/trezor/data/blob/master/scripts/check-firmware-revisions.sh
+#
+# The difference is that in here we only have to check for new release JSONs but
+# in trezor/data repository we have to keep checking for legacy releases.json files.
+
 PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )
 
-if [[ $# -ne 2 ]]
+if [[ $# -ne 1 ]]
     then
-        echo "must provide 2 argument. $# provided"
+        echo "must provide 1 argument. $# provided"
         exit 1
 fi
 
 DEVICE=$1
-IS_LEGACY=$2
 
 RELEASES_FOLDER="$PARENT_PATH"/../files/firmware
 
@@ -37,18 +42,10 @@ git fetch origin
 git checkout "$BRANCH"
 git reset "origin/$BRANCH" --hard
 
-DATA=""
 
-# When checking legacy "1" and "2" directories we do not check `bitcoinonly` and `universal` directories
-# with new format, we only check it for legacy `releases.json`. For the rest we check it for both formats.
-if [[ "$IS_LEGACY" == "true" ]]; then
-  DATA=$(jq -r '.[] | .version |= join(".") | .firmware_revision + "%" + .version' < "$RELEASES_FOLDER/$DEVICE"/releases.json)
-else
-  DATA=$(
-    jq -r '.[] | .version |= join(".") | .firmware_revision + "%" + .version' < "$RELEASES_FOLDER/$DEVICE"/releases.json
+DATA=$(
     jq -r '.version |= join(".") | .firmware_revision + "%" + .version' "$RELEASES_FOLDER/$DEVICE"/{bitcoinonly,universal}/*.json
-  )
-fi
+)
 
 for ROW in $DATA;
 do 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removing checking for legacy releases JSONs in Suite since they are not there, so there was nothing to validate anymore. This removes that unnecessary check and simplifies the script.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22202
