### PR TITLE
fix(suite): all statuses in isBluetoothDeviceConnected

### DIFF
--- a/packages/suite/src/actions/bluetooth/isBluetoothDeviceConnected.ts
+++ b/packages/suite/src/actions/bluetooth/isBluetoothDeviceConnected.ts
@@ -1,4 +1,4 @@
 import { DesktopBluetoothDevice } from './DesktopBluetoothDevice';
 
 export const isBluetoothDeviceConnected = (device: DesktopBluetoothDevice) =>
-    ['paired', 'connected'].includes(device.connectionStatus.type);
+    ['paired', 'pairing', 'connecting', 'connected'].includes(device.connectionStatus.type);


### PR DESCRIPTION
Small followup to e7e6bf69e464711078dc0ed281700fe27c1767f0
I don't know if there were any issues with, but this is the correct definition.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/isBluetoothDeviceConnected&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/isBluetoothDeviceConnected&lookback=7)