### PR TITLE
Update select asset modal

### DIFF
--- a/packages/components/src/components/VirtualizedList/VirtualizedList.tsx
+++ b/packages/components/src/components/VirtualizedList/VirtualizedList.tsx
@@ -145,8 +145,7 @@ export function VirtualizedListComponent<T extends BaseItemProps>({
             setItemsFingerprint(initialItemsFingerprint);
             resetScroll();
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [initialItemsFingerprint, itemsFingerprint, resetScroll]);
+    }, [initialItems, initialItemsFingerprint, itemsFingerprint, resetScroll]);
 
     const itemHeights = useMemo(() => items.map(item => calculateItemHeight(item)), [items]);
     const totalHeight = useMemo(

--- a/packages/product-components/src/components/SelectAssetModal/SelectAssetModal.stories.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/SelectAssetModal.stories.tsx
@@ -10,11 +10,10 @@ import {
     AssetProps,
     ITEM_HEIGHT,
     SelectAssetModal as SelectAssetModalComponent,
-    SelectAssetModalProps,
 } from './SelectAssetModal';
 import { selectAssetModalOptions } from './SelectAssetModal.storiesData';
 
-const meta: Meta = {
+const meta = {
     title: 'SelectAssetModal',
     component: SelectAssetModalComponent,
     decorators: [
@@ -28,7 +27,8 @@ const meta: Meta = {
             </ThemeProvider>
         ),
     ],
-} as Meta;
+} satisfies Meta<typeof SelectAssetModalComponent>;
+
 export default meta;
 
 const getData = (options: typeof selectAssetModalOptions): AssetProps[] =>
@@ -44,11 +44,17 @@ const getData = (options: typeof selectAssetModalOptions): AssetProps[] =>
             height: ITEM_HEIGHT,
         }));
 
-export const SelectAssetModal: StoryObj<SelectAssetModalProps> = {
+export const SelectAssetModal: StoryObj<typeof meta> = {
     args: {
         onSelectAsset: action('onSelectAsset'),
         onClose: action('onClose'),
         options: getData(selectAssetModalOptions),
+        optionsFingerprint: 'mocked-fingerprint',
+        renderOptionBalance: () => null,
+        noItemsAvailablePlaceholder: {
+            heading: 'No items available',
+            body: 'No items available',
+        },
     },
     argTypes: {},
 };

--- a/packages/product-components/src/components/SelectAssetModal/SelectAssetModal.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/SelectAssetModal.tsx
@@ -3,11 +3,18 @@ import { useIntl } from 'react-intl';
 
 import type { NetworkSymbolExtended } from '@suite-common/wallet-config';
 import { BaseCurrencyAmount } from '@suite-common/wallet-utils';
+import { TokenInfo } from '@trezor/blockchain-link-types';
 import { Column, Modal, VirtualizedList, useScrollShadow } from '@trezor/components';
 import { mapElevationToBackgroundToken, spacings } from '@trezor/theme';
 
 import { AssetItem } from './AssetItem';
 import { AssetItemNotFound } from './AssetItemNotFound';
+
+export interface AssetTokenBalance {
+    baseSymbol: TokenInfo['symbol'];
+    baseAmount: string;
+    fiatAmount: BaseCurrencyAmount | null;
+}
 
 export interface AssetProps {
     ticker: string;
@@ -18,10 +25,7 @@ export interface AssetProps {
     contractAddress: string | null;
     height: number;
     shouldTryToFetch?: boolean;
-    tokenBalance?: {
-        baseAmount: string;
-        fiatAmount: BaseCurrencyAmount | null;
-    };
+    tokenBalance?: AssetTokenBalance;
 }
 
 export type AssetOptionBaseProps = Omit<AssetProps, 'height' | 'formattedBalance'>;

--- a/packages/product-components/src/index.ts
+++ b/packages/product-components/src/index.ts
@@ -3,6 +3,7 @@ export {
     SelectAssetModal,
     type AssetProps,
     type AssetOptionBaseProps,
+    type AssetTokenBalance,
 } from './components/SelectAssetModal/SelectAssetModal';
 export { SearchAsset } from './components/SelectAssetModal/SearchAsset';
 export { PassphraseTypeCard } from './components/PassphraseTypeCard/PassphraseTypeCard';

--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
@@ -14,17 +14,6 @@ import { Fees } from './fees';
 
 const quoteProviderLocator = '@trading/offers/quote/provider';
 
-const accountTabFilters = [
-    'all-networks',
-    'eth',
-    'pol',
-    'bsc',
-    'arb',
-    'base',
-    'op',
-    'sol',
-] as const;
-
 const paymentMethodNameMap: Record<string, PaymentMethods> = {
     'Credit/Debit Card': 'creditCard',
     'Bank Transfer': 'bankTransfer',
@@ -34,11 +23,7 @@ const paymentMethodNameMap: Record<string, PaymentMethods> = {
     'Revolut Pay': 'revolutPay',
 };
 
-type AccountTabFilter = (typeof accountTabFilters)[number];
-
-function isAccountTabFilter(network: string): network is AccountTabFilter {
-    return accountTabFilters.includes(network as AccountTabFilter);
-}
+type AccountTabFilter = 'all-networks' | 'eth' | 'pol' | 'bsc' | 'arb' | 'base' | 'op' | 'sol';
 
 export class TradingPage {
     readonly fees: Fees;
@@ -304,11 +289,7 @@ export class TradingPage {
     @step()
     async selectAccount(cryptoName: string, symbol: NetworkSymbol) {
         await this.accountDropdown.click();
-        if (isAccountTabFilter(symbol)) {
-            await this.accountTabFilter(symbol).click();
-        } else {
-            await this.accountTabFilter('all-networks').click();
-        }
+        await this.accountTabFilter('all-networks').click();
         await this.accountSearchInput.fill(cryptoName);
         await this.accountOption(cryptoName, symbol).click();
     }

--- a/packages/suite/src/components/wallet/TokenBalance.tsx
+++ b/packages/suite/src/components/wallet/TokenBalance.tsx
@@ -1,5 +1,4 @@
 import { useFormatters } from '@suite-common/formatters';
-import { NetworkSymbolExtended } from '@suite-common/wallet-config';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
 import { Column, Text } from '@trezor/components';
 import { AssetProps } from '@trezor/product-components';
@@ -8,12 +7,11 @@ import { FormattedCryptoAmount } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 
 export interface TokenBalanceProps {
-    symbol: NetworkSymbolExtended;
     contractAddress: string;
     tokenBalance: NonNullable<AssetProps['tokenBalance']>;
 }
 
-export function TokenBalance({ symbol, contractAddress, tokenBalance }: TokenBalanceProps) {
+export function TokenBalance({ contractAddress, tokenBalance }: TokenBalanceProps) {
     const { BaseCurrencyAmountFormatter } = useFormatters();
     const fiatCurrency = useSelector(selectBaseCurrency);
 
@@ -21,7 +19,7 @@ export function TokenBalance({ symbol, contractAddress, tokenBalance }: TokenBal
         <Column alignItems="flex-end">
             <FormattedCryptoAmount
                 value={tokenBalance.baseAmount}
-                symbol={symbol}
+                symbol={tokenBalance.baseSymbol}
                 contractAddress={contractAddress}
             />
             {tokenBalance.fiatAmount && (

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -403,9 +403,13 @@ export default defineMessages({
         defaultMessage: 'Select asset',
         id: 'TR_SELECT_TOKEN',
     },
-    TR_SELECT_NAME_OR_ADDRESS: {
+    TR_SELECT_ASSET_OF_NETWORKS_PLACEHOLDER: {
         defaultMessage: 'Search by name, symbol, network, or contract address',
-        id: 'TR_SELECT_NAME_OR_ADDRESS',
+        id: 'TR_SELECT_ASSET_OF_NETWORKS_PLACEHOLDER',
+    },
+    TR_SELECT_ASSET_OF_NETWORK_PLACEHOLDER: {
+        defaultMessage: 'Search by name, symbol, or contract address',
+        id: 'TR_SELECT_ASSET_OF_NETWORK_PLACEHOLDER',
     },
     TR_SEARCH_TOKEN_IN_SEND_FORM_MODAL: {
         defaultMessage: 'Search by name, symbol, or contract address',

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx
@@ -151,7 +151,6 @@ export function SelectTokenAssetModal({
             renderOptionBalance={option =>
                 option.tokenBalance && option.contractAddress ? (
                     <TokenBalance
-                        symbol={option.symbol}
                         contractAddress={option.contractAddress}
                         tokenBalance={option.tokenBalance}
                     />

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/hooks/useBuildOptionsForTabs.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/hooks/useBuildOptionsForTabs.tsx
@@ -16,6 +16,7 @@ import { Account } from 'src/types/wallet';
 import {
     EnahncedTokenInfoWithFiat,
     enhanceTokensWithRates,
+    formatTokenSymbol,
     getTokens,
     sortTokensWithRates,
 } from 'src/utils/wallet/tokenUtils';
@@ -37,6 +38,7 @@ const createTokenOption = (
         token.balance && verified
             ? {
                   baseAmount: token.balance,
+                  baseSymbol: formatTokenSymbol(token.symbol ?? ''),
                   fiatAmount: toFiatCurrency({ amount: token.balance, rate: token.fiatRate?.rate }),
               }
             : undefined,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/TradingSelectAssetModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/TradingSelectAssetModal.tsx
@@ -162,7 +162,6 @@ export function TradingSelectAssetModal({
             renderOptionBalance={option =>
                 option.tokenBalance && option.contractAddress ? (
                     <TokenBalance
-                        symbol={option.symbol}
                         contractAddress={option.contractAddress}
                         tokenBalance={option.tokenBalance}
                     />

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/TradingSelectAssetModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/TradingSelectAssetModal.tsx
@@ -78,7 +78,12 @@ export function TradingSelectAssetModal({
         () => getCurrencyOptionsMappedToAssetProps(filteredOptions),
         [filteredOptions],
     );
-    const optionsFingerprint = useMemo(() => getFingerprint(assetOptions), [assetOptions]);
+    const optionsFingerprint = useMemo(
+        () =>
+            // Ignore `tokenBalance` to prevent unwanted scroll resets, we don't actually need realtime updates for these two fields.
+            getFingerprint(assetOptions.map(({ tokenBalance, ...rest }) => rest)),
+        [assetOptions],
+    );
 
     const handleSelectChange = useCallback(
         (selectedAsset: AssetOptionBaseProps) => {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/TradingSelectAssetModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/TradingSelectAssetModal.tsx
@@ -25,7 +25,10 @@ import { Translation } from 'src/components/suite/Translation';
 import { TokenBalance } from 'src/components/wallet/TokenBalance';
 import { useDispatch, useTranslation } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
-import { SelectAssetOptionProps, TradingTradeBuyExchangeType } from 'src/types/trading/trading';
+import {
+    SelectAssetOptionCurrencyProps,
+    TradingTradeBuyExchangeType,
+} from 'src/types/trading/trading';
 import { getFingerprint } from 'src/utils/wallet/getFingerprint';
 import { isTradingExchangeContext } from 'src/utils/wallet/trading/tradingTypingUtils';
 
@@ -34,19 +37,19 @@ import { useNetworksCount } from './hooks/useNetworksCount';
 import { useNetworksTabs } from './hooks/useNetworksTabs';
 import { useOptionsSearch } from './hooks/useOptionsSearch';
 
-const getCurrencyOptionsMappedToAssetProps = (options: SelectAssetOptionProps[]): AssetProps[] =>
-    options
-        .filter(item => item.type === 'currency')
-        .map(item => ({
-            ticker: item.label ?? item.ticker,
-            symbol: item.symbol,
-            cryptoName: item.cryptoName ?? item.ticker,
-            badge: item.badge ?? item.networkName,
-            coingeckoId: item.coingeckoId,
-            contractAddress: item.contractAddress,
-            height: ITEM_HEIGHT,
-            tokenBalance: item.tokenBalance,
-        }));
+const getCurrencyOptionsMappedToAssetProps = (
+    options: SelectAssetOptionCurrencyProps[],
+): AssetProps[] =>
+    options.map(item => ({
+        ticker: item.label ?? item.ticker,
+        symbol: item.symbol,
+        cryptoName: item.cryptoName ?? item.ticker,
+        badge: item.badge ?? item.networkName,
+        coingeckoId: item.coingeckoId,
+        contractAddress: item.contractAddress,
+        height: ITEM_HEIGHT,
+        tokenBalance: item.tokenBalance,
+    }));
 
 export interface TradingSelectAssetModalProps {
     onModalClose: () => void;
@@ -66,7 +69,16 @@ export function TradingSelectAssetModal({
     const context = useTradingFormContext<TradingTradeBuyExchangeType>();
 
     const options = useBuildOptions(rawOptions, sortTokensByFiatBalanceInDesc);
-    const allOptions = useMemo(() => getCurrencyOptionsMappedToAssetProps(options), [options]);
+    const networkCount = useNetworksCount(options);
+
+    const { activeTab, setActiveTab, activeTabOptions } = useNetworksTabs(options);
+    const { filteredOptions, setSearch, search } = useOptionsSearch(activeTabOptions);
+
+    const assetOptions = useMemo(
+        () => getCurrencyOptionsMappedToAssetProps(filteredOptions),
+        [filteredOptions],
+    );
+    const optionsFingerprint = useMemo(() => getFingerprint(assetOptions), [assetOptions]);
 
     const handleSelectChange = useCallback(
         (selectedAsset: AssetOptionBaseProps) => {
@@ -103,22 +115,21 @@ export function TradingSelectAssetModal({
         [context, dispatch, onModalClose, rawOptions],
     );
 
-    const networkCount = useNetworksCount(options);
-    const { activeTab, setActiveTab } = useNetworksTabs();
-    const { filteredOptions, setSearch, search } = useOptionsSearch(allOptions, activeTab);
-    const optionsFingerprint = useMemo(() => getFingerprint(filteredOptions), [filteredOptions]);
-
     return (
         <SelectAssetModal
             data-testid={dataTestId ?? '@trading/form/select-crypto'}
-            options={filteredOptions}
+            options={assetOptions}
             optionsFingerprint={optionsFingerprint}
             onSelectAsset={handleSelectChange}
             onClose={onModalClose}
             searchInput={
                 <SearchAsset
                     data-testid="@trading/form/select-crypto/search-input"
-                    searchPlaceholder={translationString('TR_SELECT_NAME_OR_ADDRESS')}
+                    searchPlaceholder={
+                        activeTab
+                            ? translationString('TR_SELECT_ASSET_OF_NETWORK_PLACEHOLDER')
+                            : translationString('TR_SELECT_ASSET_OF_NETWORKS_PLACEHOLDER')
+                    }
                     search={search}
                     setSearch={setSearch}
                 />

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/hooks/useBuildOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/hooks/useBuildOptions.ts
@@ -10,12 +10,14 @@ import {
 import { RatesByKey, TokenAddress } from '@suite-common/wallet-types';
 import { getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
 import { BaseCurrencyCode, TokenInfo } from '@trezor/blockchain-link-types';
+import { formatTokenSymbol } from '@trezor/blockchain-link-utils';
+import { AssetTokenBalance } from '@trezor/product-components';
 
 import { useSelector } from 'src/hooks/suite';
 import { SelectAssetOptionCurrencyProps } from 'src/types/trading/trading';
 import { Account } from 'src/types/wallet';
 
-type MinimalTokenInfo = Pick<TokenInfo, 'contract' | 'balance'>;
+type MinimalTokenInfo = Pick<TokenInfo, 'contract' | 'balance' | 'symbol'>;
 type TokensInfoByContract = Record<Lowercase<TokenInfo['contract']>, MinimalTokenInfo>;
 
 function groupAccountsWithTokensByNetworkSymbol(
@@ -31,11 +33,12 @@ function groupAccountsWithTokensByNetworkSymbol(
 
                 if (account.tokens?.length) {
                     const tokensByContract = Object.fromEntries(
-                        account.tokens.map(({ contract, balance }) => [
+                        account.tokens.map(({ contract, balance, symbol }) => [
                             contract.toLowerCase(),
                             {
                                 contract,
                                 balance,
+                                symbol,
                             },
                         ]),
                     ) as TokensInfoByContract;
@@ -107,7 +110,7 @@ function getTokenBalance({
     symbol,
     currentRates,
     fiatCurrency,
-}: GetTokenBalanceProps) {
+}: GetTokenBalanceProps): AssetTokenBalance | undefined {
     const tokenInfo = findTokenInNetworkAccounts(
         accountsWithTokensGroupedByNetworkSymbol,
         symbol,
@@ -121,7 +124,8 @@ function getTokenBalance({
     const tokenBalanceInFiat = getTokenBalanceInFiat(symbol, tokenInfo, currentRates, fiatCurrency);
 
     return {
-        baseAmount: tokenInfo.balance,
+        baseAmount: tokenInfo.balance!,
+        baseSymbol: formatTokenSymbol(tokenInfo.symbol ?? ''),
         fiatAmount: tokenBalanceInFiat,
     };
 }

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/hooks/useBuildOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/hooks/useBuildOptions.ts
@@ -12,7 +12,7 @@ import { getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
 import { BaseCurrencyCode, TokenInfo } from '@trezor/blockchain-link-types';
 
 import { useSelector } from 'src/hooks/suite';
-import { SelectAssetOptionCurrencyProps, SelectAssetOptionProps } from 'src/types/trading/trading';
+import { SelectAssetOptionCurrencyProps } from 'src/types/trading/trading';
 import { Account } from 'src/types/wallet';
 
 type MinimalTokenInfo = Pick<TokenInfo, 'contract' | 'balance'>;
@@ -150,7 +150,7 @@ function orderAssetOptionsByFiatBalanceInDesc(
 export function useBuildOptions(
     rawOptions: TradingCryptoSelectOptionProps[],
     sortTokensByFiatBalanceInDesc: boolean,
-): SelectAssetOptionProps[] {
+): SelectAssetOptionCurrencyProps[] {
     const currentRates = useSelector(selectCurrentFiatRates);
     const accounts = useSelector(selectAllAccountsToList);
     const accountsWithTokensGroupedByNetworkSymbol = useMemo(

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/hooks/useNetworksCount.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/hooks/useNetworksCount.ts
@@ -2,11 +2,11 @@ import { useMemo } from 'react';
 
 import { getNetworkByCoingeckoId } from '@suite-common/wallet-config';
 
-import { SelectAssetOptionProps } from 'src/types/trading/trading';
+import { SelectAssetOptionCurrencyProps } from 'src/types/trading/trading';
 
-const getNetworkCount = (options: SelectAssetOptionProps[]) => {
+const getNetworkCount = (options: SelectAssetOptionCurrencyProps[]) => {
     const networkNetworkGroups = options
-        .filter(item => item.type === 'group' && item.networkName && item.coingeckoId)
+        .filter(item => item.networkName && item.coingeckoId)
         .map(networkGroup => ({
             ...networkGroup,
             tradeCryptoId: getNetworkByCoingeckoId(networkGroup.coingeckoId!)?.tradeCryptoId,
@@ -27,7 +27,6 @@ const getNetworkCount = (options: SelectAssetOptionProps[]) => {
 
     const networkCurrencies = options.filter(
         item =>
-            item.type === 'currency' &&
             !item.contractAddress &&
             !networkNetworkGroups.coingeckoIds.has(item.coingeckoId) &&
             !networkNetworkGroups.tradeCryptoIds.has(item.coingeckoId),
@@ -36,6 +35,6 @@ const getNetworkCount = (options: SelectAssetOptionProps[]) => {
     return networkNetworkGroups.coingeckoIds.size + networkCurrencies.length;
 };
 
-export function useNetworksCount(options: SelectAssetOptionProps[]): number {
+export function useNetworksCount(options: SelectAssetOptionCurrencyProps[]): number {
     return useMemo(() => getNetworkCount(options), [options]);
 }

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/hooks/useNetworksTabs.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/hooks/useNetworksTabs.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import {
     TOKEN_SELECT_SELECTABLE_NETWORKS,
@@ -7,10 +7,11 @@ import {
 import { Network } from '@suite-common/wallet-config';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { SelectAssetOptionCurrencyProps } from 'src/types/trading/trading';
 
 export type NetworkTab = Network | null;
 
-export function useNetworksTabs() {
+export function useNetworksTabs(options: SelectAssetOptionCurrencyProps[]) {
     const [activeTab, setActiveTab] = useState<NetworkTab>(null);
     const context = useTradingFormContext<TradingTradeBuyExchangeType>();
 
@@ -24,8 +25,23 @@ export function useNetworksTabs() {
         }
     }, [context.network]);
 
+    const activeTabOptions = useMemo(() => {
+        if (!activeTab) {
+            return options;
+        }
+
+        return options.filter(
+            option =>
+                option.coingeckoId === activeTab.coingeckoId &&
+                option.symbol === activeTab.symbol &&
+                // E.g. Don't show Solana network in Solana tab
+                option.ticker !== activeTab.displaySymbol,
+        );
+    }, [activeTab, options]);
+
     return {
         activeTab,
         setActiveTab,
+        activeTabOptions,
     } as const;
 }

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/hooks/useOptionsSearch.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/hooks/useOptionsSearch.ts
@@ -1,8 +1,6 @@
 import { useMemo, useState } from 'react';
 
-import { AssetProps } from '@trezor/product-components';
-
-import { NetworkTab } from './useNetworksTabs';
+import { SelectAssetOptionCurrencyProps } from 'src/types/trading/trading';
 
 function createSearchFilter(search: string) {
     return function searchFor(property?: string) {
@@ -10,20 +8,12 @@ function createSearchFilter(search: string) {
     };
 }
 
-export function useOptionsSearch(allOptions: AssetProps[], activeTab: NetworkTab) {
+export function useOptionsSearch(activeTabOptions: SelectAssetOptionCurrencyProps[]) {
     const [search, setSearch] = useState('');
 
-    const filteredOptions = useMemo(
+    const filteredOptions = useMemo<SelectAssetOptionCurrencyProps[]>(
         () =>
-            allOptions.filter(item => {
-                if (
-                    activeTab &&
-                    item.coingeckoId !== activeTab.coingeckoId &&
-                    item.symbol !== activeTab.symbol
-                ) {
-                    return false;
-                }
-
+            activeTabOptions.filter(item => {
                 const contractAddress = item.contractAddress || undefined;
                 const searchFor = createSearchFilter(search);
 
@@ -35,7 +25,7 @@ export function useOptionsSearch(allOptions: AssetProps[], activeTab: NetworkTab
                     searchFor(item.symbol)
                 );
             }),
-        [activeTab, allOptions, search],
+        [activeTabOptions, search],
     );
 
     return {


### PR DESCRIPTION
## Description

1. refactor(suite): update network filter in select asset modal:
   - When user selects a network tab, the network name itself won't as one the options.
   - Also, move filtering based on active tab to `useNetworksTabs` and let the `useOptionsSearch` only to actually search options. This provides perf. and readibility benefit.
   - Use narrow type whenever possible (`SelectAssetOptionProps` -> `SelectAssetOptionCurrencyProps`).

2. fix(suite): prevent unwanted scroll resets in the select asset modal
3. fix(suite): fix token units

## Related Issue

Resolve #21439

## Screenshots:

https://github.com/user-attachments/assets/3f2236cd-246c-4d91-a11a-85a2b4fe0639

Fix token units:
<img width="716" height="1117" alt="Snímek obrazovky 2025-10-14 v 15 44 48" src="https://github.com/user-attachments/assets/8400735a-c15d-454c-b510-1c0e6a94df7f" />
<img width="679" height="1098" alt="Snímek obrazovky 2025-10-14 v 15 45 06" src="https://github.com/user-attachments/assets/5c44ab70-5d7e-4a2f-9511-06148bd7cae7" />




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/21439-assets-modal&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/21439-assets-modal&lookback=7)