### PR TITLE
chore(suite): when device.status bootloder-locked show bootloader sta…

### DIFF
--- a/packages/suite/src/components/suite/getMessageId.tsx
+++ b/packages/suite/src/components/suite/getMessageId.tsx
@@ -100,7 +100,10 @@ export const getMessageId = ({
         },
         'device-busy': defaultKey, // TODO: device returned Busy error - we don't know exactly why it depends on the workflow
         'device-rebooting': defaultKey, // TODO: device is booting to normal mode
-        'device-bootloader-locked': defaultKey, // TODO: device is  a) rebooting or b) its was rebooted to bootloader
+        // TODO: device is  a) rebooting or b) its was rebooted to bootloader
+        'device-bootloader-locked': {
+            heading: 'TR_DEVICE_CONNECTED_BOOTLOADER',
+        },
         'device-hard-locked': defaultKey, // TODO: device is hard locked and will not respond to messages, unlock it
         'device-disconnect-required': defaultKey,
         'device-disconnected': defaultKey,


### PR DESCRIPTION
…tus text

before
<img width="1256" height="759" alt="Image" src="https://github.com/user-attachments/assets/e8fcaa8b-072c-4a1e-bf6c-70336da6e2b4" />

after
<img width="1266" height="817" alt="image" src="https://github.com/user-attachments/assets/a542621d-d5ee-404f-aec8-46455648e968" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bootloader-locked&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bootloader-locked&lookback=7)