### PR TITLE
feat(suite): update device to bluetooth after disconnecting from cable

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -282,8 +282,8 @@ const changeDevice = (
     const affectedDevices = draft.devices.filter(
         d =>
             d.features &&
-            ((d.connected &&
-                (d.id === device.id || (d.path.length > 0 && d.path === device.path))) ||
+            (d.id === device.id ||
+                (d.path.length > 0 && d.path === device.path) ||
                 // update "disconnected" remembered devices if in bootloader mode
                 (d.mode === 'bootloader' && d.remember && d.id === device.id)),
     ) as AcquiredDevice[];


### PR DESCRIPTION
device is bluetooth paired, autoconnect credentials are issued.

1. connect device over usb 

<img width="230" height="80" alt="image" src="https://github.com/user-attachments/assets/b780077b-f6e6-4f52-a309-65242f8fd079" />

2. disconnect device from usb - you will see device disconnected for a while

<img width="212" height="73" alt="image" src="https://github.com/user-attachments/assets/dd94f7b4-d5d1-4a3f-bc6e-5e27f76d6fb4" />

3. once next device-change event comes, your device will update to connected again (this time over bluetooth). Btw it would be nice to communicate communication medium in UI (ble vs usb) 

<img width="230" height="80" alt="image" src="https://github.com/user-attachments/assets/b780077b-f6e6-4f52-a309-65242f8fd079" />

without this fix you would stay on point 2.


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=update-disconnected-device&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=update-disconnected-device&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=update-disconnected-device&lookback=7)