### PR TITLE
Solana: simulation attempted with zero-balance fee-payer due to missing fiat-amount validation

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
@@ -20,6 +20,7 @@ import { useDidUpdate } from '@trezor/react-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { useSelector, useTranslation } from 'src/hooks/suite';
+import { useFiatFromCryptoValue } from 'src/hooks/suite/useFiatFromCryptoValue';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
@@ -58,6 +59,13 @@ export const TradingFormInputFiat = <TFieldValues extends TradingAllFormProps>({
 
     const tokenAddress = getValues('sendCryptoSelect')?.contractAddress as TokenAddress | undefined;
 
+    const { fiatAmount } = useFiatFromCryptoValue({
+        amount: account.formattedBalance || '',
+        symbol: account.symbol,
+        tokenAddress,
+        rateType: 'current',
+    });
+
     const { areSatsDisplayed } = useBitcoinAmountUnit(network.symbol);
 
     const rates = useSelector(selectCurrentFiatRates);
@@ -80,6 +88,14 @@ export const TradingFormInputFiat = <TFieldValues extends TradingAllFormProps>({
                   validate: {
                       min: validateMin(translationString),
                       decimals: validateDecimals(translationString, { decimals: 2 }),
+                      balance: (value: string) => {
+                          if (
+                              fiatAmount &&
+                              new BigNumber(value).isGreaterThan(new BigNumber(fiatAmount))
+                          ) {
+                              return translationString('AMOUNT_IS_NOT_ENOUGH');
+                          }
+                      },
                       minFiat: () => {
                           if (
                               cryptoAmount &&


### PR DESCRIPTION
## Description

Fixes an issue where entering a positive amount in the fiat input allowed Swap/claim flows to simulate a Solana transaction with a zero-balance fee-payer. This led to RPC failure with `AccountNotFound` during `simulateTransaction`.

In `buildTransferTransaction`, when constructing the transaction message, the following line sets the fee-payer explicitly:

```
setTransactionMessageFeePayer(address(fromAddress), m),
```

Here, `fromAddress` refers to the user’s main SOL account.
If this account has a zero balance, it doesn’t exist on-chain - meaning the fee-payer is invalid.
When the message is later passed to `simulateTransaction`, the RPC call fails with:

```
[SOLANA_ERROR__TRANSACTION_ERROR__ACCOUNT_NOT_FOUND]: 'Attempt to debit an account but found no record of a prior credit.'
```

### Steps to Reproduce
1) Open a Solana account with **0 SOL** but **some tokens** (so it appears in Swap).
2) Go to **Swap**.
3) Switch to **fiat** input.
4) Enter any **positive** number.
→ simulation tries to debit fees from a non-existent fee-payer → `AccountNotFound`.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22439


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-swap-fiat-zero-balance-validation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-swap-fiat-zero-balance-validation&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/solana-swap-fiat-zero-balance-validation&lookback=7)