### PR TITLE
Refactor useExchangeFlow to be partially reused for sell

### DIFF
--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -31,6 +31,7 @@ import {
     selectDeviceTradingTradesOrderedByDate,
     selectTrading,
     selectTradingAccountAccordingActiveSection,
+    selectTradingAccountKeyByTradeType,
     selectTradingActiveSection,
     selectTradingBuy,
     selectTradingBuyInfo,
@@ -1443,6 +1444,51 @@ describe('tradingSelectors', () => {
 
         it('should return supported symbols for exchange', () => {
             expect(selectTradingSupportedSymbols(state, 'exchange')).toEqual(supportedSymbols);
+        });
+    });
+
+    describe(selectTradingAccountKeyByTradeType.name, () => {
+        it('should return exchange account key for exchange trade type', () => {
+            const result = selectTradingAccountKeyByTradeType(state, 'exchange');
+            expect(result).toBe('eth-descriptor-eth');
+        });
+
+        it('should return sell account key for sell trade type', () => {
+            const result = selectTradingAccountKeyByTradeType(state, 'sell');
+            expect(result).toBe('btc-descriptor-btc');
+        });
+
+        it('should return buy account key for buy trade type', () => {
+            const result = selectTradingAccountKeyByTradeType(state, 'buy');
+            expect(result).toBe('btc-descriptor-btc');
+        });
+
+        it('should return undefined when exchange account key is not set', () => {
+            state.wallet.trading.exchange.tradingAccountKey = undefined;
+
+            const result = selectTradingAccountKeyByTradeType(state, 'exchange');
+            expect(result).toBeUndefined();
+        });
+
+        it('should return undefined when sell account key is not set', () => {
+            state.wallet.trading.sell.tradingAccountKey = undefined;
+
+            const result = selectTradingAccountKeyByTradeType(state, 'sell');
+            expect(result).toBeUndefined();
+        });
+
+        it('should return undefined when buy account key is not set', () => {
+            state.wallet.trading.buy.tradingAccountKey = undefined;
+
+            const result = selectTradingAccountKeyByTradeType(state, 'buy');
+            expect(result).toBeUndefined();
+        });
+
+        it('should be stable for same trade type', () => {
+            const first = selectTradingAccountKeyByTradeType(state, 'exchange');
+            const second = selectTradingAccountKeyByTradeType(state, 'exchange');
+
+            expect(first).toBe(second);
         });
     });
 });

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -592,6 +592,27 @@ export const selectTradingExchangeReceiveAddress = (state: TradingRootState) =>
 export const selectTradingSellAccountKey = (state: TradingRootState) =>
     state.wallet.trading.sell.tradingAccountKey;
 
+export const selectTradingAccountKeyByTradeType = createMemoizedSelector(
+    [
+        selectTradingExchangeAccountKey,
+        selectTradingSellAccountKey,
+        selectTradingBuyReceiveAccountKey,
+        (_: TradingRootState, tradeType: TradingType) => tradeType,
+    ],
+    (exchangeAccountKey, sellAccountKey, buyAccountKey, tradeType) => {
+        switch (tradeType) {
+            case 'exchange':
+                return exchangeAccountKey;
+            case 'sell':
+                return sellAccountKey;
+            case 'buy':
+                return buyAccountKey;
+            default:
+                exhaustive(tradeType, 'Unexpected trade type');
+        }
+    },
+);
+
 export const selectTradingModalAccountKey = (state: TradingRootState) =>
     state.wallet.trading.modalAccountKey;
 

--- a/suite-native/module-trading/src/components/sell/SellConfirmation.tsx
+++ b/suite-native/module-trading/src/components/sell/SellConfirmation.tsx
@@ -15,8 +15,13 @@ const CONFIRMATION_TEST_ID = '@trading/sell/continue-button';
 
 export const SellConfirmation = ({ enteringAnimation }: ConfirmationProps) => {
     const form = useSellFormContext();
-    const { canProceed, isConsentRequested, cancelConsent, giveConsent, selectQuote } =
-        useSellFlow(form);
+    const {
+        canProceed,
+        isLegalTermsConsentRequested,
+        cancelLegalTermsConsent,
+        giveLegalTermsConsent,
+        selectQuote,
+    } = useSellFlow(form);
 
     const [quote, sendAsset] = form.watch(['quote', 'sendAsset']);
 
@@ -30,9 +35,9 @@ export const SellConfirmation = ({ enteringAnimation }: ConfirmationProps) => {
                 </AnimatedBox>
             )}
             <SellLegalSheet
-                isVisible={isConsentRequested}
-                onConsent={giveConsent}
-                onDismiss={cancelConsent}
+                isVisible={isLegalTermsConsentRequested}
+                onConsent={giveLegalTermsConsent}
+                onDismiss={cancelLegalTermsConsent}
                 tradeProvider={quote?.exchange ?? ''}
                 sendSymbol={sendAsset?.symbol ?? ''}
             />

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
@@ -26,36 +26,7 @@ jest.mock('@suite-common/trading', () => ({
             payload,
             unwrap: () => Promise.resolve(true),
         }),
-        sendTransactionThunk: (payload: unknown) => ({
-            type: 'sendTransactionThunkMock',
-            payload,
-            unwrap: () => Promise.resolve(true),
-        }),
     },
-}));
-
-// Mock the thunks
-jest.mock('../../../thunks', () => ({
-    composeTradingTransactionThunk: (payload: unknown) => ({
-        type: 'composeTradingTransactionThunkMock',
-        payload,
-        unwrap: () => Promise.resolve(true),
-    }),
-    signAndPushSendFormTransactionThunk: (payload: unknown) => ({
-        type: 'signAndPushSendFormTransactionThunkMock',
-        payload,
-        unwrap: () => Promise.resolve(true),
-    }),
-}));
-
-// Mock the wallet-core thunks
-jest.mock('@suite-common/wallet-core', () => ({
-    ...jest.requireActual('@suite-common/wallet-core'),
-    updateFeeInfoThunk: (payload: unknown) => ({
-        type: 'updateFeeInfoThunkMock',
-        payload,
-        unwrap: () => Promise.resolve(true),
-    }),
 }));
 
 describe('useExchangeFlow', () => {
@@ -84,13 +55,6 @@ describe('useExchangeFlow', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-
-        // Mock the serializedTx selector to return a proper value
-        jest.spyOn(require('@suite-common/wallet-core'), 'selectSendSerializedTx').mockReturnValue({
-            type: 'bitcoin',
-            txid: 'test-txid',
-            hex: 'test-hex',
-        });
     });
 
     describe('confirmTrade', () => {
@@ -171,280 +135,72 @@ describe('useExchangeFlow', () => {
             require('@suite-common/trading').exchangeThunks.confirmTradeThunk =
                 originalConfirmTradeThunk;
         });
-    });
 
-    describe('composeRequest', () => {
-        it('should call composeTradingTransactionThunk with correct parameters', async () => {
+        it('should return false when trade is missing', async () => {
             const store = await getInitializedStore();
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
 
-            // Mock the networkFeeInfo selector to return proper data
-            const mockNetworkFeeInfo = {
-                feePerUnit: '1000',
-                feeLimit: '21000',
-                estimatedFee: '21000000',
+            const { result } = await renderUseExchangeFlow({ store });
+
+            const confirmResult = await act(
+                async () =>
+                    await result.current.confirmTrade({
+                        receiveAddress: 'test-address',
+                        trade: undefined,
+                        approvalFlow: false,
+                        nextStep: jest.fn(),
+                    }),
+            );
+
+            expect(confirmResult).toBe(false);
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                'Trade, send account and common functions are required to confirm trade',
+            );
+        });
+
+        it('should return false when sendAccount is missing', async () => {
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+
+            // Create a store with invalid tradingAccountKey
+            const tradingState = getInitializedTradingStateWithQuotes();
+            tradingState.exchange.tradingAccountKey = 'invalid-account-key';
+            tradingState.exchange.receiveAccountKey = 'btc2';
+            tradingState.exchange.selectedQuote = tradingState.exchange.quotes[0];
+
+            const preloadedState: PreloadedState = {
+                wallet: {
+                    trading: tradingState,
+                    accounts: getMockAccounts(),
+                },
             };
 
-            // Mock the selectConvertedNetworkFeeInfo selector
-            jest.spyOn(
-                require('@suite-common/wallet-core'),
-                'selectConvertedNetworkFeeInfo',
-            ).mockReturnValue(mockNetworkFeeInfo);
-
+            const store = await initStore(preloadedState);
             const { result } = await renderUseExchangeFlow({ store });
 
-            await act(async () => {
-                await result.current.composeRequest({
-                    selectedFeeLevel: 'high',
-                    feePerUnit: '2000',
-                    feeLimit: '25000',
-                });
-            });
-
-            expect(dispatchSpy).toHaveBeenCalledWith({
-                type: 'composeTradingTransactionThunkMock',
-                payload: {
-                    tradeType: 'exchange',
-                    account: expect.objectContaining({
-                        key: 'btc1',
-                    }),
-                    network: expect.any(Object),
-                    feeInfo: mockNetworkFeeInfo,
-                    selectedFeeLevel: 'high',
-                    feePerUnit: '2000',
-                    feeLimit: '25000',
-                },
-                unwrap: expect.any(Function),
-            });
-        });
-
-        it('should call composeTradingTransactionThunk with minimal parameters', async () => {
-            const store = await getInitializedStore();
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-            // Mock the networkFeeInfo selector to return proper data
-            const mockNetworkFeeInfo = {
-                feePerUnit: '1000',
-                feeLimit: '21000',
-                estimatedFee: '21000000',
+            const mockTrade = {
+                exchange: 'test-exchange',
+                orderId: 'test-order',
             };
 
-            jest.spyOn(
-                require('@suite-common/wallet-core'),
-                'selectConvertedNetworkFeeInfo',
-            ).mockReturnValue(mockNetworkFeeInfo);
-
-            const { result } = await renderUseExchangeFlow({ store });
-
-            await act(async () => {
-                await result.current.composeRequest({});
-            });
-
-            expect(dispatchSpy).toHaveBeenCalledWith({
-                type: 'composeTradingTransactionThunkMock',
-                payload: {
-                    tradeType: 'exchange',
-                    account: expect.objectContaining({
-                        key: 'btc1',
+            const confirmResult = await act(
+                async () =>
+                    await result.current.confirmTrade({
+                        receiveAddress: 'test-address',
+                        trade: mockTrade,
+                        approvalFlow: false,
+                        nextStep: jest.fn(),
                     }),
-                    network: expect.any(Object),
-                    feeInfo: mockNetworkFeeInfo,
-                    selectedFeeLevel: undefined,
-                    feePerUnit: undefined,
-                    feeLimit: undefined,
-                },
-                unwrap: expect.any(Function),
-            });
-        });
-    });
+            );
 
-    describe('fetchFeesAndCompose', () => {
-        it('should call updateFeeInfoThunk and then composeRequest with draft fee values', async () => {
-            const store = await getInitializedStore();
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-            // Mock the networkFeeInfo selector to return proper data
-            const mockNetworkFeeInfo = {
-                feePerUnit: '1000',
-                feeLimit: '21000',
-                estimatedFee: '21000000',
-            };
-
-            jest.spyOn(
-                require('@suite-common/wallet-core'),
-                'selectConvertedNetworkFeeInfo',
-            ).mockReturnValue(mockNetworkFeeInfo);
-
-            // Mock the selectDeepCopyOfFormDraft selector to return draft fee values
-            jest.spyOn(
-                require('@suite-common/wallet-core'),
-                'selectDeepCopyOfFormDraft',
-            ).mockReturnValue({
-                selectedFee: 'high',
-                feePerUnit: '5000',
-                feeLimit: '30000',
-            });
-
-            const { result } = await renderUseExchangeFlow({ store });
-
-            await act(async () => {
-                await result.current.fetchFeesAndCompose();
-            });
-
-            // Should call updateFeeInfoThunk first
-            expect(dispatchSpy).toHaveBeenCalledWith({
-                type: 'updateFeeInfoThunkMock',
-                payload: {
-                    networkSymbol: 'btc',
-                },
-                unwrap: expect.any(Function),
-            });
-
-            // Then should call composeRequest with draft fee values
-            expect(dispatchSpy).toHaveBeenCalledWith({
-                type: 'composeTradingTransactionThunkMock',
-                payload: {
-                    tradeType: 'exchange',
-                    account: expect.objectContaining({
-                        key: 'btc1',
-                    }),
-                    network: expect.any(Object),
-                    feeInfo: mockNetworkFeeInfo,
-                    selectedFeeLevel: 'high',
-                    feePerUnit: '5000',
-                    feeLimit: '30000',
-                },
-                unwrap: expect.any(Function),
-            });
-        });
-
-        it('should handle undefined draft values', async () => {
-            const store = await getInitializedStore();
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-            // Mock the networkFeeInfo selector to return proper data
-            const mockNetworkFeeInfo = {
-                feePerUnit: '1000',
-                feeLimit: '21000',
-                estimatedFee: '21000000',
-            };
-
-            jest.spyOn(
-                require('@suite-common/wallet-core'),
-                'selectConvertedNetworkFeeInfo',
-            ).mockReturnValue(mockNetworkFeeInfo);
-
-            // Mock the selectDeepCopyOfFormDraft selector to return undefined
-            jest.spyOn(
-                require('@suite-common/wallet-core'),
-                'selectDeepCopyOfFormDraft',
-            ).mockReturnValue(undefined);
-
-            const { result } = await renderUseExchangeFlow({ store });
-
-            await act(async () => {
-                await result.current.fetchFeesAndCompose();
-            });
-
-            // Should call updateFeeInfoThunk first
-            expect(dispatchSpy).toHaveBeenCalledWith({
-                type: 'updateFeeInfoThunkMock',
-                payload: {
-                    networkSymbol: 'btc',
-                },
-                unwrap: expect.any(Function),
-            });
-
-            // Then should call composeRequest with undefined values
-            expect(dispatchSpy).toHaveBeenCalledWith({
-                type: 'composeTradingTransactionThunkMock',
-                payload: {
-                    tradeType: 'exchange',
-                    account: expect.objectContaining({
-                        key: 'btc1',
-                    }),
-                    network: expect.any(Object),
-                    feeInfo: mockNetworkFeeInfo,
-                    selectedFeeLevel: undefined,
-                    feePerUnit: undefined,
-                    feeLimit: undefined,
-                },
-                unwrap: expect.any(Function),
-            });
-        });
-    });
-
-    describe('signAndSendTransaction', () => {
-        it('should call sendTransactionThunk with correct parameters', async () => {
-            const store = await getInitializedStore();
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const mockNextStep = jest.fn();
-
-            const { result } = await renderUseExchangeFlow({ store });
-
-            await act(async () => {
-                await result.current.signAndSendTransaction({
-                    nextStep: mockNextStep,
-                    onError: jest.fn(),
-                });
-            });
-
-            expect(dispatchSpy).toHaveBeenCalledWith({
-                type: 'sendTransactionThunkMock',
-                payload: {
-                    account: expect.objectContaining({ key: 'btc1' }),
-                    trade: expect.any(Object),
-                    returnUrl: expect.any(String),
-                    setMaxOutputId: undefined,
-                    decimals: expect.any(Number),
-                    shouldSendInSats: expect.any(Boolean),
-                    isSlip24Active: false,
-                    nextStep: mockNextStep,
-                    processResponseData: expect.any(Function),
-                    triggerAnalyticsTradeConfirmation: expect.any(Function),
-                    signAndPushSendFormTransaction: expect.any(Function),
-                },
-                unwrap: expect.any(Function),
-            });
-        });
-    });
-
-    describe('resolveConsent', () => {
-        it('should set isConsentRequested to false and resolve the promise', async () => {
-            const store = await getInitializedStore();
-
-            const { result } = await renderUseExchangeFlow({ store });
-
-            // First, trigger the signAndSendTransaction to set up the promise
-            const originalSendTransactionThunk =
-                require('@suite-common/trading').exchangeThunks.sendTransactionThunk;
-            require('@suite-common/trading').exchangeThunks.sendTransactionThunk = () => ({
-                type: 'sendTransactionThunkMock',
-                unwrap: () => Promise.resolve(true),
-            });
-
-            await act(async () => {
-                await result.current.signAndSendTransaction({
-                    nextStep: jest.fn(),
-                    onError: jest.fn(),
-                });
-            });
-
-            // Now resolve the push consent
-            act(() => {
-                result.current.resolveConsent(true);
-            });
-
-            expect(result.current.isConsentRequested).toBe(false);
-
-            // Restore the original mock
-            require('@suite-common/trading').exchangeThunks.sendTransactionThunk =
-                originalSendTransactionThunk;
+            expect(confirmResult).toBe(false);
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                'Trade, send account and common functions are required to confirm trade',
+            );
         });
     });
 
     describe('getCommonFunctions', () => {
-        it('should return false when no trade is provided and no selectedQuote', async () => {
+        it('should return null when no trade is provided and no selectedQuote', async () => {
             const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
             // Mock the selector to return undefined for selectedQuote
             const modifiedStore = await getInitializedStore();
@@ -470,22 +226,28 @@ describe('useExchangeFlow', () => {
                 'Trade, send account and common functions are required to confirm trade',
             );
         });
-    });
 
-    describe('useEffect cleanup', () => {
-        it('should call TrezorConnect.cancel on unmount', async () => {
+        it('should return common functions when trade is provided', async () => {
             const store = await getInitializedStore();
-            const { unmount } = await renderUseExchangeFlow({ store });
+            const { result } = await renderUseExchangeFlow({ store });
 
-            // Get the mocked TrezorConnect.cancel function
-            const TrezorConnect = require('@trezor/connect');
-            const mockCancel = TrezorConnect.cancel;
+            const mockTrade = {
+                exchange: 'test-exchange',
+                orderId: 'test-order',
+            };
 
-            // Unmount the component to trigger the cleanup useEffect
-            unmount();
+            // Test by calling confirmTrade which uses getCommonFunctions internally
+            await act(async () => {
+                await result.current.confirmTrade({
+                    receiveAddress: 'test-address',
+                    trade: mockTrade,
+                    approvalFlow: false,
+                    nextStep: jest.fn(),
+                });
+            });
 
-            // Verify that TrezorConnect.cancel was called
-            expect(mockCancel).toHaveBeenCalled();
+            // If we get here without errors, getCommonFunctions worked correctly
+            expect(true).toBe(true);
         });
     });
 

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
@@ -1,50 +1,24 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
-import { isFulfilled } from '@reduxjs/toolkit';
 import type { ExchangeTrade, FormResponse } from 'invity-api';
 
 import {
-    TradingFulfillValue,
     TradingSendRejectedProps,
-    TradingSignAndPushSendFormTransactionProps,
-    cryptoIdToNetworkAndContractAddress,
     exchangeThunks,
     selectTradingExchangeSelectedQuote,
 } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
-import {
-    FeesRootState,
-    FormDraftRootState,
-    WalletSettingsRootState,
-    selectConvertedNetworkFeeInfo,
-    selectDeepCopyOfFormDraft,
-    selectIsAmountInSats,
-    selectSendSerializedTx,
-    updateFeeInfoThunk,
-} from '@suite-common/wallet-core';
-import { TokenAddress } from '@suite-common/wallet-types';
-import { getFormDraftKey } from '@suite-common/wallet-utils';
 import { EventType, analytics } from '@suite-native/analytics';
 import {
     RootStackParamList,
     RootStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
-import { TokensRootState, selectAccountTokenDecimals } from '@suite-native/tokens';
-import {
-    NativeSupportedFeeLevel,
-    selectFeeLevels,
-    useFeesFetching,
-    usePrecomposedTransactionError,
-} from '@suite-native/transaction-management';
-import TrezorConnect from '@trezor/connect';
 
 import { selectExchangeSelectedSendAccount } from '../../selectors/exchangeSelectors';
-import { composeTradingTransactionThunk, signAndPushSendFormTransactionThunk } from '../../thunks';
 import { buildTradingUrl, getSourceForForm } from '../../utils/general/formUtils';
-import { useConsent } from '../general/useConsent';
+import { useTradingTransaction } from '../general/useTradingTransaction';
 
 export type TradingExchangeConfirmTradeProps = {
     receiveAddress: string;
@@ -69,53 +43,6 @@ export const useExchangeFlow = () => {
 
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);
 
-    const draft = useSelector((state: FormDraftRootState) =>
-        selectDeepCopyOfFormDraft(state, getFormDraftKey('trading-exchange', '')),
-    );
-
-    const { selectedFee, feePerUnit: feePerUnitDraft, feeLimit: feeLimitDraft } = draft ?? {};
-
-    const { contractAddress } = cryptoIdToNetworkAndContractAddress(selectedQuote?.send);
-
-    const tokenDecimals = useSelector((state: TokensRootState) =>
-        selectAccountTokenDecimals(state, sendAccount?.key, contractAddress as TokenAddress),
-    );
-
-    const shouldSendInSats = useSelector((state: WalletSettingsRootState) =>
-        selectIsAmountInSats(state, sendAccount?.symbol),
-    );
-
-    const networkFeeInfo = useSelector((state: FeesRootState) =>
-        selectConvertedNetworkFeeInfo(state, sendAccount?.symbol),
-    );
-
-    const serializedTx = useSelector(selectSendSerializedTx);
-
-    const feeLevels = useSelector(selectFeeLevels);
-
-    const selectedLevel = feeLevels[(selectedFee as NativeSupportedFeeLevel) ?? 'normal'];
-    const feeError = selectedLevel?.type === 'error' ? selectedLevel.error : null;
-
-    const txnErrorString = usePrecomposedTransactionError({
-        error: feeError,
-        context: {
-            networkSymbol: sendAccount?.symbol,
-        },
-    });
-
-    const { isConsentRequested, waitForConsent, resolveConsent } = useConsent();
-
-    useFeesFetching({
-        networkSymbol: sendAccount?.symbol,
-        isRefetchDisabled: selectedFee === 'custom',
-    });
-
-    // TODO: slip24 - not implemented in mobile
-    const isSlip24Active = false;
-
-    // cancel txn signing on unmount
-    useEffect(() => () => TrezorConnect.cancel(), []);
-
     // whenever we get a form from the webview, we need to navigate to the webview screen
     const handleWebview = useCallback(
         (trade: ExchangeTrade, formData: FormResponse['form'], returnUrl: string) => {
@@ -132,62 +59,6 @@ export const useExchangeFlow = () => {
         },
         [rootNavigation],
     );
-
-    // this is called when we want to compose a transaction
-    const composeRequest = useCallback(
-        async ({
-            selectedFeeLevel,
-            feePerUnit,
-            feeLimit,
-        }: {
-            selectedFeeLevel?: NativeSupportedFeeLevel;
-            feePerUnit?: string;
-            feeLimit?: string;
-        }) => {
-            if (!sendAccount || !networkFeeInfo) {
-                console.error(
-                    'Send account and networkFeeInfo are required for composing transaction',
-                );
-
-                return;
-            }
-
-            try {
-                const levels = await dispatch(
-                    composeTradingTransactionThunk({
-                        tradeType: 'exchange',
-                        account: sendAccount,
-                        network: getNetwork(sendAccount.symbol),
-                        feeInfo: networkFeeInfo,
-                        selectedFeeLevel,
-                        feePerUnit,
-                        feeLimit,
-                    }),
-                ).unwrap();
-
-                return levels;
-            } catch (error) {
-                console.error('Failed to compose trading transaction:', error);
-            }
-        },
-        [dispatch, networkFeeInfo, sendAccount],
-    );
-
-    // this is called when we want to fetch fees and compose a transaction
-    const fetchFeesAndCompose = useCallback(async () => {
-        if (!sendAccount) {
-            console.error('Send account is required to fetch fees and compose transaction');
-
-            return;
-        }
-
-        await dispatch(updateFeeInfoThunk({ networkSymbol: sendAccount.symbol }));
-        await composeRequest({
-            selectedFeeLevel: selectedFee as NativeSupportedFeeLevel,
-            feePerUnit: feePerUnitDraft,
-            feeLimit: feeLimitDraft,
-        });
-    }, [dispatch, sendAccount, composeRequest, selectedFee, feePerUnitDraft, feeLimitDraft]);
 
     const getCommonFunctions = useCallback(
         (trade?: ExchangeTrade) => {
@@ -226,6 +97,21 @@ export const useExchangeFlow = () => {
         },
         [handleWebview, selectedQuote],
     );
+
+    const {
+        txnErrorString,
+        composeRequest,
+        fetchFeesAndCompose,
+        signAndSendTransaction,
+        serializedTx,
+        resolveTransactionSendConsent,
+        isTransactionSendConsentRequested,
+    } = useTradingTransaction({
+        tradeType: 'exchange',
+        returnUrl: getCommonFunctions()?.returnUrl,
+        processResponseData: getCommonFunctions()?.processResponseData,
+        triggerAnalyticsTradeConfirmation: getCommonFunctions()?.triggerAnalyticsTradeConfirmation,
+    });
 
     // changing trade state and initial confirmation
     const confirmTrade = useCallback(
@@ -266,95 +152,6 @@ export const useExchangeFlow = () => {
         [getCommonFunctions, sendAccount, dispatch],
     );
 
-    // this is called when we want to sign and send a transaction
-    // waitForPushApproval is used so that we can wait for the user to approve the transaction before sending it
-    const signAndSendTransaction = useCallback(
-        async ({ nextStep, onError }: TradingExchangeSignAndSendTransactionProps) => {
-            const commonFunctions = getCommonFunctions(selectedQuote);
-
-            if (!commonFunctions || !sendAccount) {
-                console.error(
-                    'Common functions and send account are required to sign and send transaction',
-                );
-
-                return false;
-            }
-
-            const network = getNetwork(sendAccount.symbol);
-            const decimals = tokenDecimals ?? network.decimals;
-
-            const { returnUrl, triggerAnalyticsTradeConfirmation, processResponseData } =
-                commonFunctions;
-
-            const signAndPushSendFormTransaction = async ({
-                formState,
-                precomposedTransaction,
-                selectedAccount,
-                paymentRequests,
-            }: TradingSignAndPushSendFormTransactionProps): Promise<TradingFulfillValue> => {
-                const result = await dispatch(
-                    signAndPushSendFormTransactionThunk({
-                        formState,
-                        precomposedTransaction,
-                        selectedAccount,
-                        paymentRequests,
-                        waitForPushApprovalPromise: waitForConsent,
-                    }),
-                );
-
-                if (isFulfilled(result)) {
-                    return result.payload as TradingFulfillValue;
-                }
-
-                return result.error as TradingFulfillValue;
-            };
-
-            try {
-                await dispatch(
-                    exchangeThunks.sendTransactionThunk({
-                        account: sendAccount,
-                        trade: selectedQuote,
-                        returnUrl,
-                        setMaxOutputId: undefined,
-                        decimals,
-                        shouldSendInSats,
-                        isSlip24Active,
-                        nextStep,
-                        processResponseData,
-                        triggerAnalyticsTradeConfirmation,
-                        signAndPushSendFormTransaction,
-                    }),
-                ).unwrap();
-
-                return true;
-            } catch (e) {
-                onError(e as TradingSendRejectedProps);
-
-                return false;
-            }
-        },
-        [
-            dispatch,
-            getCommonFunctions,
-            isSlip24Active,
-            selectedQuote,
-            sendAccount,
-            shouldSendInSats,
-            tokenDecimals,
-            waitForConsent,
-        ],
-    );
-
-    useEffect(() => {
-        if (selectedFee && networkFeeInfo) {
-            composeRequest({
-                selectedFeeLevel: selectedFee as NativeSupportedFeeLevel,
-                feePerUnit: feePerUnitDraft,
-                feeLimit: feeLimitDraft,
-            });
-        }
-    }, [selectedFee, composeRequest, feePerUnitDraft, feeLimitDraft, networkFeeInfo]);
-
     return {
         txnErrorString,
         confirmTrade,
@@ -362,7 +159,7 @@ export const useExchangeFlow = () => {
         fetchFeesAndCompose,
         signAndSendTransaction,
         serializedTx,
-        resolveConsent,
-        isConsentRequested,
+        resolveTransactionSendConsent,
+        isTransactionSendConsentRequested,
     };
 };

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
@@ -1,0 +1,406 @@
+import {
+    PreloadedState,
+    TestStore,
+    act,
+    initStore,
+    renderHookWithStoreProviderAsync,
+} from '@suite-native/test-utils';
+
+import { getBtcAccount } from '../../../__fixtures__/account';
+import { getInitializedTradingStateWithQuotes } from '../../../__fixtures__/tradingState';
+import { useTradingTransaction } from '../useTradingTransaction';
+
+// Mock TrezorConnect to prevent errors during cleanup
+jest.mock('@trezor/connect', () => ({
+    ...jest.requireActual('@trezor/connect'),
+    cancel: jest.fn(),
+}));
+
+// Mock the exchange thunks
+jest.mock('@suite-common/trading', () => ({
+    ...jest.requireActual('@suite-common/trading'),
+    exchangeThunks: {
+        sendTransactionThunk: (payload: unknown) => ({
+            type: 'sendTransactionThunkMock',
+            payload,
+            unwrap: () => Promise.resolve(true),
+        }),
+    },
+    sellThunks: {
+        sendTransactionThunk: (payload: unknown) => ({
+            type: 'sellSendTransactionThunkMock',
+            payload,
+            unwrap: () => Promise.resolve(true),
+        }),
+    },
+}));
+
+// Mock the thunks
+jest.mock('../../../thunks', () => ({
+    composeTradingTransactionThunk: (payload: unknown) => ({
+        type: 'composeTradingTransactionThunkMock',
+        payload,
+        unwrap: () => Promise.resolve(true),
+    }),
+    signAndPushSendFormTransactionThunk: (payload: unknown) => ({
+        type: 'signAndPushSendFormTransactionThunkMock',
+        payload,
+        unwrap: () => Promise.resolve(true),
+    }),
+}));
+
+// Mock the wallet-core thunks
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    updateFeeInfoThunk: (payload: unknown) => ({
+        type: 'updateFeeInfoThunkMock',
+        payload,
+        unwrap: () => Promise.resolve(true),
+    }),
+}));
+
+describe('useTradingTransaction', () => {
+    const getMockAccounts = () => [getBtcAccount('btc1'), getBtcAccount('btc2')];
+
+    const getInitializedStore = async () => {
+        const tradingState = getInitializedTradingStateWithQuotes();
+
+        // Add the required account keys to the exchange state
+        tradingState.exchange.tradingAccountKey = 'btc1';
+        tradingState.exchange.receiveAccountKey = 'btc2';
+        // Set a selected quote so the hook can access selectedQuote.send
+        tradingState.exchange.selectedQuote = tradingState.exchange.quotes[0];
+
+        const preloadedState: PreloadedState = {
+            wallet: {
+                trading: tradingState,
+                accounts: getMockAccounts(),
+            },
+        };
+
+        return await initStore(preloadedState);
+    };
+
+    const renderUseTradingTransaction = ({ store }: { store: TestStore }) =>
+        renderHookWithStoreProviderAsync(() => useTradingTransaction({ tradeType: 'exchange' }), {
+            store,
+        });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        // Mock the serializedTx selector to return a proper value
+        jest.spyOn(require('@suite-common/wallet-core'), 'selectSendSerializedTx').mockReturnValue({
+            type: 'bitcoin',
+            txid: 'test-txid',
+            hex: 'test-hex',
+        });
+
+        // Mock the selectConvertedNetworkFeeInfo selector to return proper data by default
+        jest.spyOn(
+            require('@suite-common/wallet-core'),
+            'selectConvertedNetworkFeeInfo',
+        ).mockReturnValue({
+            feePerUnit: '1000',
+            feeLimit: '21000',
+            estimatedFee: '21000000',
+        });
+
+        // Mock the selectDeepCopyOfFormDraft selector to return proper data by default
+        jest.spyOn(
+            require('@suite-common/wallet-core'),
+            'selectDeepCopyOfFormDraft',
+        ).mockReturnValue({
+            selectedFee: 'normal',
+            feePerUnit: '1000',
+            feeLimit: '21000',
+        });
+    });
+
+    describe('composeRequest', () => {
+        it('should call composeTradingTransactionThunk with correct parameters', async () => {
+            const store = await getInitializedStore();
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+            // Mock the networkFeeInfo selector to return proper data
+            const mockNetworkFeeInfo = {
+                feePerUnit: '1000',
+                feeLimit: '21000',
+                estimatedFee: '21000000',
+            };
+
+            // Mock the selectConvertedNetworkFeeInfo selector
+            jest.spyOn(
+                require('@suite-common/wallet-core'),
+                'selectConvertedNetworkFeeInfo',
+            ).mockReturnValue(mockNetworkFeeInfo);
+
+            const { result } = await renderUseTradingTransaction({ store });
+
+            await act(async () => {
+                await result.current.composeRequest({
+                    selectedFeeLevel: 'high',
+                    feePerUnit: '2000',
+                    feeLimit: '25000',
+                });
+            });
+
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: 'composeTradingTransactionThunkMock',
+                payload: {
+                    tradeType: 'exchange',
+                    account: expect.objectContaining({
+                        key: 'btc1',
+                    }),
+                    network: expect.any(Object),
+                    feeInfo: mockNetworkFeeInfo,
+                    selectedFeeLevel: 'high',
+                    feePerUnit: '2000',
+                    feeLimit: '25000',
+                },
+                unwrap: expect.any(Function),
+            });
+        });
+
+        it('should call composeTradingTransactionThunk with minimal parameters', async () => {
+            const store = await getInitializedStore();
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+            // Mock the networkFeeInfo selector to return proper data
+            const mockNetworkFeeInfo = {
+                feePerUnit: '1000',
+                feeLimit: '21000',
+                estimatedFee: '21000000',
+            };
+
+            jest.spyOn(
+                require('@suite-common/wallet-core'),
+                'selectConvertedNetworkFeeInfo',
+            ).mockReturnValue(mockNetworkFeeInfo);
+
+            const { result } = await renderUseTradingTransaction({ store });
+
+            await act(async () => {
+                await result.current.composeRequest({});
+            });
+
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: 'composeTradingTransactionThunkMock',
+                payload: {
+                    tradeType: 'exchange',
+                    account: expect.objectContaining({
+                        key: 'btc1',
+                    }),
+                    network: expect.any(Object),
+                    feeInfo: mockNetworkFeeInfo,
+                    selectedFeeLevel: undefined,
+                    feePerUnit: undefined,
+                    feeLimit: undefined,
+                },
+                unwrap: expect.any(Function),
+            });
+        });
+    });
+
+    describe('fetchFeesAndCompose', () => {
+        it('should call updateFeeInfoThunk and then composeRequest with draft fee values', async () => {
+            const store = await getInitializedStore();
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+            // Mock the networkFeeInfo selector to return proper data
+            const mockNetworkFeeInfo = {
+                feePerUnit: '1000',
+                feeLimit: '21000',
+                estimatedFee: '21000000',
+            };
+
+            jest.spyOn(
+                require('@suite-common/wallet-core'),
+                'selectConvertedNetworkFeeInfo',
+            ).mockReturnValue(mockNetworkFeeInfo);
+
+            // Mock the selectDeepCopyOfFormDraft selector to return draft fee values
+            jest.spyOn(
+                require('@suite-common/wallet-core'),
+                'selectDeepCopyOfFormDraft',
+            ).mockReturnValue({
+                selectedFee: 'high',
+                feePerUnit: '5000',
+                feeLimit: '30000',
+            });
+
+            const { result } = await renderUseTradingTransaction({ store });
+
+            await act(async () => {
+                await result.current.fetchFeesAndCompose();
+            });
+
+            // Should call updateFeeInfoThunk first
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: 'updateFeeInfoThunkMock',
+                payload: {
+                    networkSymbol: 'btc',
+                },
+                unwrap: expect.any(Function),
+            });
+
+            // Then should call composeRequest with draft fee values
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: 'composeTradingTransactionThunkMock',
+                payload: {
+                    tradeType: 'exchange',
+                    account: expect.objectContaining({
+                        key: 'btc1',
+                    }),
+                    network: expect.any(Object),
+                    feeInfo: mockNetworkFeeInfo,
+                    selectedFeeLevel: 'high',
+                    feePerUnit: '5000',
+                    feeLimit: '30000',
+                },
+                unwrap: expect.any(Function),
+            });
+        });
+
+        it('should handle undefined draft values', async () => {
+            const store = await getInitializedStore();
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+            // Mock the networkFeeInfo selector to return proper data
+            const mockNetworkFeeInfo = {
+                feePerUnit: '1000',
+                feeLimit: '21000',
+                estimatedFee: '21000000',
+            };
+
+            jest.spyOn(
+                require('@suite-common/wallet-core'),
+                'selectConvertedNetworkFeeInfo',
+            ).mockReturnValue(mockNetworkFeeInfo);
+
+            // Mock the selectDeepCopyOfFormDraft selector to return undefined
+            jest.spyOn(
+                require('@suite-common/wallet-core'),
+                'selectDeepCopyOfFormDraft',
+            ).mockReturnValue(undefined);
+
+            const { result } = await renderUseTradingTransaction({ store });
+
+            await act(async () => {
+                await result.current.fetchFeesAndCompose();
+            });
+
+            // Should call updateFeeInfoThunk first
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: 'updateFeeInfoThunkMock',
+                payload: {
+                    networkSymbol: 'btc',
+                },
+                unwrap: expect.any(Function),
+            });
+
+            // Then should call composeRequest with undefined values
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: 'composeTradingTransactionThunkMock',
+                payload: {
+                    tradeType: 'exchange',
+                    account: expect.objectContaining({
+                        key: 'btc1',
+                    }),
+                    network: expect.any(Object),
+                    feeInfo: mockNetworkFeeInfo,
+                    selectedFeeLevel: undefined,
+                    feePerUnit: undefined,
+                    feeLimit: undefined,
+                },
+                unwrap: expect.any(Function),
+            });
+        });
+    });
+
+    describe('signAndSendTransaction', () => {
+        it('should call sendTransactionThunk with correct parameters', async () => {
+            const store = await getInitializedStore();
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const mockNextStep = jest.fn();
+
+            const { result } = await renderUseTradingTransaction({ store });
+
+            await act(async () => {
+                await result.current.signAndSendTransaction({
+                    nextStep: mockNextStep,
+                    onError: jest.fn(),
+                });
+            });
+
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: 'sendTransactionThunkMock',
+                payload: {
+                    account: expect.objectContaining({ key: 'btc1' }),
+                    trade: expect.any(Object),
+                    returnUrl: '',
+                    setMaxOutputId: undefined,
+                    decimals: expect.any(Number),
+                    shouldSendInSats: expect.any(Boolean),
+                    isSlip24Active: false,
+                    nextStep: mockNextStep,
+                    processResponseData: expect.any(Function),
+                    triggerAnalyticsTradeConfirmation: expect.any(Function),
+                    signAndPushSendFormTransaction: expect.any(Function),
+                },
+                unwrap: expect.any(Function),
+            });
+        });
+    });
+
+    describe('resolveConsent', () => {
+        it('should set isConsentRequested to false and resolve the promise', async () => {
+            const store = await getInitializedStore();
+
+            const { result } = await renderUseTradingTransaction({ store });
+
+            // First, trigger the signAndSendTransaction to set up the promise
+            const originalSendTransactionThunk =
+                require('@suite-common/trading').exchangeThunks.sendTransactionThunk;
+            require('@suite-common/trading').exchangeThunks.sendTransactionThunk = () => ({
+                type: 'sendTransactionThunkMock',
+                unwrap: () => Promise.resolve(true),
+            });
+
+            await act(async () => {
+                await result.current.signAndSendTransaction({
+                    nextStep: jest.fn(),
+                    onError: jest.fn(),
+                });
+            });
+
+            // Now resolve the push consent
+            act(() => {
+                result.current.resolveTransactionSendConsent(true);
+            });
+
+            expect(result.current.isTransactionSendConsentRequested).toBe(false);
+
+            // Restore the original mock
+            require('@suite-common/trading').exchangeThunks.sendTransactionThunk =
+                originalSendTransactionThunk;
+        });
+    });
+
+    describe('useEffect cleanup', () => {
+        it('should call TrezorConnect.cancel on unmount', async () => {
+            const store = await getInitializedStore();
+            const { unmount } = await renderUseTradingTransaction({ store });
+
+            // Get the mocked TrezorConnect.cancel function
+            const TrezorConnect = require('@trezor/connect');
+            const mockCancel = TrezorConnect.cancel;
+
+            // Unmount the component to trigger the cleanup useEffect
+            unmount();
+
+            // Verify that TrezorConnect.cancel was called
+            expect(mockCancel).toHaveBeenCalled();
+        });
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
@@ -1,0 +1,314 @@
+import { useCallback, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { isFulfilled } from '@reduxjs/toolkit';
+import type { ExchangeTrade, SellFiatTrade } from 'invity-api';
+
+import {
+    TradingFulfillValue,
+    TradingSellFormProps,
+    TradingSendRejectedProps,
+    TradingSignAndPushSendFormTransactionProps,
+    cryptoIdToNetworkAndContractAddress,
+    exchangeThunks,
+    selectTradingAccountKeyByTradeType,
+    selectTradingExchangeSelectedQuote,
+    selectTradingSellSelectedQuote,
+    sellThunks,
+} from '@suite-common/trading';
+import { getNetwork } from '@suite-common/wallet-config';
+import {
+    AccountsRootState,
+    FeesRootState,
+    FormDraftRootState,
+    WalletSettingsRootState,
+    selectAccountByKey,
+    selectConvertedNetworkFeeInfo,
+    selectDeepCopyOfFormDraft,
+    selectIsAmountInSats,
+    selectSendSerializedTx,
+    updateFeeInfoThunk,
+} from '@suite-common/wallet-core';
+import { TokenAddress } from '@suite-common/wallet-types';
+import { TokensRootState, selectAccountTokenDecimals } from '@suite-native/tokens';
+import {
+    NativeSupportedFeeLevel,
+    selectFeeLevels,
+    useFeesFetching,
+    usePrecomposedTransactionError,
+} from '@suite-native/transaction-management';
+import TrezorConnect from '@trezor/connect';
+
+import { useConsent } from './useConsent';
+import { TradingRootState } from '../../reducers';
+import { composeTradingTransactionThunk, signAndPushSendFormTransactionThunk } from '../../thunks';
+import { getFormDraftKeyByTradeType } from '../../utils/general/utils';
+
+export type TradingTransactionSignAndSendProps = {
+    nextStep: () => void;
+    onError: (error: TradingSendRejectedProps) => void;
+};
+
+export type TradingTransactionComposeProps = {
+    selectedFeeLevel?: NativeSupportedFeeLevel;
+    feePerUnit?: string;
+    feeLimit?: string;
+};
+
+export type UseTradingTransactionProps = {
+    tradeType: 'exchange' | 'sell';
+    returnUrl?: string;
+    processResponseData?: (response: any) => void;
+    triggerAnalyticsTradeConfirmation?: () => void;
+};
+
+export const useTradingTransaction = ({
+    tradeType,
+    returnUrl,
+    processResponseData,
+    triggerAnalyticsTradeConfirmation,
+}: UseTradingTransactionProps) => {
+    const dispatch = useDispatch();
+
+    const sendAccountKey = useSelector((state: TradingRootState) =>
+        selectTradingAccountKeyByTradeType(state, tradeType),
+    );
+
+    const sendAccount = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, sendAccountKey),
+    );
+
+    const selectedQuote = useSelector((state: TradingRootState) =>
+        tradeType === 'exchange'
+            ? selectTradingExchangeSelectedQuote(state)
+            : selectTradingSellSelectedQuote(state),
+    );
+
+    const draft = useSelector((state: FormDraftRootState) =>
+        selectDeepCopyOfFormDraft(state, getFormDraftKeyByTradeType(tradeType)),
+    );
+
+    const { selectedFee, feePerUnit: feePerUnitDraft, feeLimit: feeLimitDraft } = draft ?? {};
+
+    const { contractAddress } = cryptoIdToNetworkAndContractAddress(
+        tradeType === 'exchange'
+            ? (selectedQuote as ExchangeTrade)?.send
+            : (selectedQuote as SellFiatTrade)?.cryptoCurrency,
+    );
+
+    const tokenDecimals = useSelector((state: TokensRootState) =>
+        selectAccountTokenDecimals(state, sendAccount?.key, contractAddress as TokenAddress),
+    );
+
+    const shouldSendInSats = useSelector((state: WalletSettingsRootState) =>
+        selectIsAmountInSats(state, sendAccount?.symbol),
+    );
+
+    const networkFeeInfo = useSelector((state: FeesRootState) =>
+        selectConvertedNetworkFeeInfo(state, sendAccount?.symbol),
+    );
+
+    const serializedTx = useSelector(selectSendSerializedTx);
+
+    const feeLevels = useSelector(selectFeeLevels);
+
+    const selectedLevel = feeLevels[(selectedFee as NativeSupportedFeeLevel) ?? 'normal'];
+    const feeError = selectedLevel?.type === 'error' ? selectedLevel.error : null;
+
+    const txnErrorString = usePrecomposedTransactionError({
+        error: feeError,
+        context: {
+            networkSymbol: sendAccount?.symbol,
+        },
+    });
+
+    const {
+        isConsentRequested: isTransactionSendConsentRequested,
+        waitForConsent: waitForTransactionSendConsent,
+        resolveConsent: resolveTransactionSendConsent,
+    } = useConsent();
+
+    useFeesFetching({
+        networkSymbol: sendAccount?.symbol,
+        isRefetchDisabled: selectedFee === 'custom',
+    });
+
+    // TODO: slip24 - not implemented in mobile
+    const isSlip24Active = false;
+
+    // cancel txn signing on unmount
+    useEffect(() => () => TrezorConnect.cancel(), []);
+
+    // this is called when we want to compose a transaction
+    const composeRequest = useCallback(
+        async ({ selectedFeeLevel, feePerUnit, feeLimit }: TradingTransactionComposeProps) => {
+            if (!sendAccount || !networkFeeInfo) {
+                console.error(
+                    'Send account and networkFeeInfo are required for composing transaction',
+                );
+
+                return;
+            }
+
+            try {
+                const levels = await dispatch(
+                    composeTradingTransactionThunk({
+                        tradeType,
+                        account: sendAccount,
+                        network: getNetwork(sendAccount.symbol),
+                        feeInfo: networkFeeInfo,
+                        selectedFeeLevel,
+                        feePerUnit,
+                        feeLimit,
+                    }),
+                ).unwrap();
+
+                return levels;
+            } catch (error) {
+                console.error('Failed to compose trading transaction:', error);
+            }
+        },
+        [dispatch, networkFeeInfo, sendAccount, tradeType],
+    );
+
+    // this is called when we want to fetch fees and compose a transaction
+    const fetchFeesAndCompose = useCallback(async () => {
+        if (!sendAccount) {
+            console.error('Send account is required to fetch fees and compose transaction');
+
+            return;
+        }
+
+        await dispatch(updateFeeInfoThunk({ networkSymbol: sendAccount.symbol }));
+        await composeRequest({
+            selectedFeeLevel: selectedFee as NativeSupportedFeeLevel,
+            feePerUnit: feePerUnitDraft,
+            feeLimit: feeLimitDraft,
+        });
+    }, [dispatch, sendAccount, composeRequest, selectedFee, feePerUnitDraft, feeLimitDraft]);
+
+    // this is the reusable signAndPushSendFormTransaction function
+    // waitForPushApproval is used so that we can wait for the user to approve the transaction before sending it
+    const signAndPushSendFormTransaction = useCallback(
+        async ({
+            formState,
+            precomposedTransaction,
+            selectedAccount,
+            paymentRequests,
+        }: TradingSignAndPushSendFormTransactionProps): Promise<TradingFulfillValue> => {
+            const result = await dispatch(
+                signAndPushSendFormTransactionThunk({
+                    formState,
+                    precomposedTransaction,
+                    selectedAccount,
+                    paymentRequests,
+                    waitForPushApprovalPromise: waitForTransactionSendConsent,
+                }),
+            );
+
+            if (isFulfilled(result)) {
+                return result.payload as TradingFulfillValue;
+            }
+
+            return result.error as TradingFulfillValue;
+        },
+        [dispatch, waitForTransactionSendConsent],
+    );
+
+    // this is called when we want to sign and send a transaction
+    const signAndSendTransaction = useCallback(
+        async ({ nextStep, onError }: TradingTransactionSignAndSendProps) => {
+            if (!selectedQuote || !sendAccount) {
+                console.error(
+                    'Selected quote and send account are required to sign and send transaction',
+                );
+
+                return false;
+            }
+
+            const network = getNetwork(sendAccount.symbol);
+            const decimals = tokenDecimals ?? network.decimals;
+
+            try {
+                if (tradeType === 'exchange') {
+                    await dispatch(
+                        exchangeThunks.sendTransactionThunk({
+                            account: sendAccount,
+                            trade: selectedQuote as ExchangeTrade,
+                            returnUrl: returnUrl || '',
+                            setMaxOutputId: draft?.setMaxOutputId,
+                            decimals,
+                            shouldSendInSats,
+                            isSlip24Active,
+                            nextStep,
+                            processResponseData: processResponseData || (() => {}),
+                            triggerAnalyticsTradeConfirmation:
+                                triggerAnalyticsTradeConfirmation || (() => {}),
+                            signAndPushSendFormTransaction,
+                        }),
+                    ).unwrap();
+
+                    return true;
+                }
+
+                await dispatch(
+                    sellThunks.sendTransactionThunk({
+                        account: sendAccount,
+                        trade: selectedQuote as SellFiatTrade,
+                        formValues: draft as TradingSellFormProps,
+                        decimals,
+                        shouldSendInSats,
+                        isSlip24Active,
+                        nextStep,
+                        signAndPushSendFormTransaction,
+                    }),
+                ).unwrap();
+
+                return true;
+            } catch (e) {
+                onError(e as TradingSendRejectedProps);
+
+                return false;
+            }
+        },
+        [
+            selectedQuote,
+            sendAccount,
+            tokenDecimals,
+            tradeType,
+            dispatch,
+            draft,
+            shouldSendInSats,
+            isSlip24Active,
+            signAndPushSendFormTransaction,
+            returnUrl,
+            processResponseData,
+            triggerAnalyticsTradeConfirmation,
+        ],
+    );
+
+    useEffect(() => {
+        if (selectedFee && networkFeeInfo) {
+            composeRequest({
+                selectedFeeLevel: selectedFee as NativeSupportedFeeLevel,
+                feePerUnit: feePerUnitDraft,
+                feeLimit: feeLimitDraft,
+            });
+        }
+    }, [selectedFee, composeRequest, feePerUnitDraft, feeLimitDraft, networkFeeInfo]);
+
+    return {
+        txnErrorString,
+        composeRequest,
+        fetchFeesAndCompose,
+        signAndSendTransaction,
+        signAndPushSendFormTransaction,
+        serializedTx,
+        resolveTransactionSendConsent,
+        isTransactionSendConsentRequested,
+        waitForTransactionSendConsent,
+        tokenDecimals,
+        shouldSendInSats,
+        isSlip24Active,
+    };
+};

--- a/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewScreenControls.hook.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewScreenControls.hook.test.ts
@@ -14,8 +14,8 @@ import { useTradingOutputsReviewScreenControls } from '../useTradingOutputsRevie
 
 const mockUseExchangeFlow = {
     signAndSendTransaction: jest.fn(() => Promise.resolve(true)),
-    isConsentRequested: false,
-    resolveConsent: jest.fn(),
+    isTransactionSendConsentRequested: false,
+    resolveTransactionSendConsent: jest.fn(),
 };
 
 const mockUseConfirmOnTrezorController = {
@@ -77,8 +77,12 @@ describe('useTradingOutputsReviewScreenControls', () => {
     it('should return values from useExchangeFlow', async () => {
         const { result } = await renderUseTradingOutputsReviewScreenControls();
 
-        expect(result.current.isConsentRequested).toBe(mockUseExchangeFlow.isConsentRequested);
-        expect(result.current.resolveConsent).toBe(mockUseExchangeFlow.resolveConsent);
+        expect(result.current.isConsentRequested).toBe(
+            mockUseExchangeFlow.isTransactionSendConsentRequested,
+        );
+        expect(result.current.resolveConsent).toBe(
+            mockUseExchangeFlow.resolveTransactionSendConsent,
+        );
     });
 
     it('should return confirmOnTrezorRef', async () => {

--- a/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.ts
@@ -38,7 +38,11 @@ export const useTradingOutputsReviewScreenControls = (orderId: string, accountKe
 
     const navigation = useNavigation<TradingOutputsReviewScreenNavigationProp>();
     const dispatch = useDispatch();
-    const { signAndSendTransaction, isConsentRequested, resolveConsent } = useExchangeFlow();
+    const {
+        signAndSendTransaction,
+        isTransactionSendConsentRequested: isConsentRequested,
+        resolveTransactionSendConsent: resolveConsent,
+    } = useExchangeFlow();
     const { confirmOnTrezorRef, closeSheet } = useConfirmOnTrezorController();
     const showOutputsReviewErrorAlert = useTradingOutputsReviewErrorAlert(accountKey);
 

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
@@ -84,7 +84,7 @@ describe('useSellFlow', () => {
                 result.current.selectQuote();
             });
 
-            expect(result.current.isConsentRequested).toEqual(false);
+            expect(result.current.isLegalTermsConsentRequested).toEqual(false);
         });
 
         it('should request consent', async () => {
@@ -115,7 +115,7 @@ describe('useSellFlow', () => {
                 });
             });
 
-            expect(result.current.isConsentRequested).toEqual(true);
+            expect(result.current.isLegalTermsConsentRequested).toEqual(true);
         });
     });
 
@@ -151,13 +151,13 @@ describe('useSellFlow', () => {
                 });
             });
 
-            expect(result.current.isConsentRequested).toEqual(true);
+            expect(result.current.isLegalTermsConsentRequested).toEqual(true);
 
             act(() => {
-                result.current.giveConsent();
+                result.current.giveLegalTermsConsent();
             });
 
-            expect(result.current.isConsentRequested).toEqual(false);
+            expect(result.current.isLegalTermsConsentRequested).toEqual(false);
         });
     });
 
@@ -193,13 +193,13 @@ describe('useSellFlow', () => {
                 });
             });
 
-            expect(result.current.isConsentRequested).toEqual(true);
+            expect(result.current.isLegalTermsConsentRequested).toEqual(true);
 
             act(() => {
-                result.current.cancelConsent();
+                result.current.cancelLegalTermsConsent();
             });
 
-            expect(result.current.isConsentRequested).toEqual(false);
+            expect(result.current.isLegalTermsConsentRequested).toEqual(false);
         });
 
         it('should reset consent when quote provider changes', async () => {
@@ -220,7 +220,7 @@ describe('useSellFlow', () => {
                 });
             });
 
-            expect(result.current.isConsentRequested).toEqual(true);
+            expect(result.current.isLegalTermsConsentRequested).toEqual(true);
 
             // Change quote to one with different provider
             act(() => {
@@ -228,7 +228,7 @@ describe('useSellFlow', () => {
             });
             rerender({});
 
-            expect(result.current.isConsentRequested).toEqual(false);
+            expect(result.current.isLegalTermsConsentRequested).toEqual(false);
         });
     });
 });

--- a/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
@@ -26,10 +26,10 @@ import { useConsentDenier } from '../general/useConsentDenier';
 
 type SellFlowReturn = {
     canProceed: boolean;
-    isConsentRequested: boolean;
+    isLegalTermsConsentRequested: boolean;
     selectQuote: () => Promise<void>;
-    giveConsent: () => void;
-    cancelConsent: () => void;
+    giveLegalTermsConsent: () => void;
+    cancelLegalTermsConsent: () => void;
     doSellTrade: (trade: SellFiatTrade) => Promise<void>;
     confirmTrade: (bankAccount: BankAccount) => Promise<void>;
 };
@@ -42,22 +42,17 @@ export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
     const candidateQuote = watch('quote');
     const isLoading = useSelector(selectTradingSellIsLoading);
     const sellInfo = useSelector(selectTradingSellInfo);
-    const { isConsentRequested, waitForConsent, resolveConsent } = useConsent();
-    useConsentDenier(candidateQuote?.exchange, resolveConsent);
 
     const selectedQuote = useSelector(selectTradingSellSelectedQuote);
 
     const sendAccount = useSelector(selectSellSelectedSendAccount);
 
-    const canProceed = !!candidateQuote && !!sendAccount && !isLoading;
-
-    const giveConsent = useCallback(() => {
-        resolveConsent(true);
-    }, [resolveConsent]);
-
-    const cancelConsent = useCallback(() => {
-        resolveConsent(false);
-    }, [resolveConsent]);
+    const {
+        isConsentRequested: isLegalTermsConsentRequested,
+        waitForConsent: waitForLegalTermsConsent,
+        resolveConsent: resolveLegalTermsConsent,
+    } = useConsent();
+    useConsentDenier(candidateQuote?.exchange, resolveLegalTermsConsent);
 
     // whenever we get a form from the webview, we need to navigate to the webview screen
     const handleWebview = useCallback(
@@ -106,6 +101,16 @@ export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
         },
         [handleWebview, selectedQuote],
     );
+
+    const canProceed = !!candidateQuote && !!sendAccount && !isLoading;
+
+    const giveLegalTermsConsent = useCallback(() => {
+        resolveLegalTermsConsent(true);
+    }, [resolveLegalTermsConsent]);
+
+    const cancelLegalTermsConsent = useCallback(() => {
+        resolveLegalTermsConsent(false);
+    }, [resolveLegalTermsConsent]);
 
     const doSellTrade = useCallback(
         async (trade: SellFiatTrade) => {
@@ -180,18 +185,26 @@ export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
             sellThunks.selectQuoteThunk({
                 quote: candidateQuote,
                 timer,
-                userConsent: waitForConsent,
+                userConsent: waitForLegalTermsConsent,
                 nextStep,
                 onCancel: () => {},
             }),
         );
-    }, [candidateQuote, isLoading, sellInfo, doSellTrade, dispatch, timer, waitForConsent]);
+    }, [
+        candidateQuote,
+        isLoading,
+        sellInfo,
+        doSellTrade,
+        dispatch,
+        timer,
+        waitForLegalTermsConsent,
+    ]);
 
     return {
         canProceed,
-        isConsentRequested,
-        giveConsent,
-        cancelConsent,
+        isLegalTermsConsentRequested,
+        giveLegalTermsConsent,
+        cancelLegalTermsConsent,
         doSellTrade,
         confirmTrade,
         selectQuote,

--- a/suite-native/module-trading/src/middlewares/tradingMiddleware.ts
+++ b/suite-native/module-trading/src/middlewares/tradingMiddleware.ts
@@ -2,9 +2,9 @@ import { UnknownAction, isAnyOf } from '@reduxjs/toolkit';
 
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { deviceActions, formDraftActions } from '@suite-common/wallet-core';
-import { getFormDraftKey } from '@suite-common/wallet-utils';
 
 import { buyActions, exchangeActions, sellActions, tradingActions } from '../reducers';
+import { getFormDraftKeyByTradeType } from '../utils/general/utils';
 
 export const prepareTradingMiddleware = createMiddlewareWithExtraDeps(
     (action: UnknownAction, { dispatch, next }) => {
@@ -19,10 +19,8 @@ export const prepareTradingMiddleware = createMiddlewareWithExtraDeps(
                 sellActions.clearState,
             )(action)
         ) {
-            dispatch(formDraftActions.removeDraft({ key: getFormDraftKey('trading-sell', '') }));
-            dispatch(
-                formDraftActions.removeDraft({ key: getFormDraftKey('trading-exchange', '') }),
-            );
+            dispatch(formDraftActions.removeDraft({ key: getFormDraftKeyByTradeType('sell') }));
+            dispatch(formDraftActions.removeDraft({ key: getFormDraftKeyByTradeType('exchange') }));
         }
 
         return action;

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -30,7 +30,7 @@ import {
     PrecomposedTransactionFinal,
     isFinalPrecomposedTransaction,
 } from '@suite-common/wallet-types';
-import { getFormDraftKey, tryGetAccountIdentity } from '@suite-common/wallet-utils';
+import { tryGetAccountIdentity } from '@suite-common/wallet-utils';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import {
     NativeSupportedFeeLevel,
@@ -41,7 +41,10 @@ import {
 import TrezorConnect from '@trezor/connect';
 
 import { createFormStateForSendForm } from './utils';
-import { getErrorStrFromThunkRejectedValue } from './utils/general/utils';
+import {
+    getErrorStrFromThunkRejectedValue,
+    getFormDraftKeyByTradeType,
+} from './utils/general/utils';
 
 const NATIVE_TRADING_EXCHANGE_THUNK_PREFIX = 'trading/native';
 
@@ -60,8 +63,8 @@ export const clearTradingStateThunk = createThunk(
         dispatch(transactionManagementActions.clearFeeLevels());
 
         // Clear form draft with selected fees
-        dispatch(formDraftActions.removeDraft({ key: getFormDraftKey('trading-sell', '') }));
-        dispatch(formDraftActions.removeDraft({ key: getFormDraftKey('trading-exchange', '') }));
+        dispatch(formDraftActions.removeDraft({ key: getFormDraftKeyByTradeType('sell') }));
+        dispatch(formDraftActions.removeDraft({ key: getFormDraftKeyByTradeType('exchange') }));
     },
 );
 
@@ -197,7 +200,8 @@ export const composeTradingTransactionThunk = createThunk(
                         }),
                     );
 
-                    const formDraftKey = getFormDraftKey('trading-exchange', '');
+                    const formDraftKey = getFormDraftKeyByTradeType(tradeType);
+
                     // Store the form state in trading draft so it's available for TradingFeesForm
                     dispatch(
                         formDraftActions.storeDraft({

--- a/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
@@ -10,6 +10,7 @@ import { INVITY_CALLBACK_TREZOR_BUY_URL, TRADING_URL_DEFAULT_BACK } from '../for
 import {
     doesUrlContainCloseCallbackUrl,
     getErrorStrFromThunkRejectedValue,
+    getFormDraftKeyByTradeType,
     getFormDraftKeyPrefixFromTradingType,
     getRandomAccountDescriptor,
     getTradeOperationData,
@@ -221,6 +222,18 @@ describe('utils', () => {
             ],
         ])('should return %s for %s', (expectedValue, cryptoId) => {
             expect(toCaseAwareCryptoId(cryptoId)).toBe(expectedValue);
+        });
+    });
+
+    describe('getFormDraftKeyByTradeType', () => {
+        it('should return correct form draft key for exchange trade type', () => {
+            const result = getFormDraftKeyByTradeType('exchange');
+            expect(result).toBe('trading-exchange/');
+        });
+
+        it('should return correct form draft key for sell trade type', () => {
+            const result = getFormDraftKeyByTradeType('sell');
+            expect(result).toBe('trading-sell/');
         });
     });
 });

--- a/suite-native/module-trading/src/utils/general/utils.ts
+++ b/suite-native/module-trading/src/utils/general/utils.ts
@@ -1,6 +1,8 @@
 import { BuyTradeStatus, CryptoId, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
 
 import {
+    TradingExchangeType,
+    TradingSellType,
     TradingTradeType,
     TradingTransaction,
     TradingType,
@@ -13,7 +15,7 @@ import {
     tradeFinalStatuses,
 } from '@suite-common/trading';
 import type { FormDraftKeyPrefix } from '@suite-common/wallet-types';
-import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils/';
+import { getContractAddressForNetworkSymbol, getFormDraftKey } from '@suite-common/wallet-utils/';
 import type { Translate } from '@suite-native/intl';
 import { exhaustive } from '@trezor/type-utils';
 import { getWeakRandomId } from '@trezor/utils';
@@ -247,4 +249,15 @@ export const toCaseAwareCryptoId = (cryptoId: CryptoId): CryptoId => {
     const adjustedContractAddress = getContractAddressForNetworkSymbol(symbol, contractAddress);
 
     return toTokenCryptoId(symbol, adjustedContractAddress);
+};
+
+export const getFormDraftKeyByTradeType = (tradeType: TradingSellType | TradingExchangeType) => {
+    switch (tradeType) {
+        case 'exchange':
+            return getFormDraftKey('trading-exchange', '');
+        case 'sell':
+            return getFormDraftKey('trading-sell', '');
+        default:
+            return exhaustive(tradeType);
+    }
 };


### PR DESCRIPTION
## Description

Extracts common transaction handling logic from `useExchangeFlow` into `useTradingTransaction` hook for reuse between exchange and sell flows.

__Changes__
_New_: `useTradingTransaction` with Transaction composition, fee handling, signing, consent, and error handling
_Updated_: `useExchangeFlow` and `useSellFlow` can now use the shared hook for txn composure

## Related Issue

Resolve #21209


https://github.com/user-attachments/assets/254ba47f-d9e8-4ad0-b993-1d158ef68cc6



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=21209-mobile-sell-refactor-useexchangeflow-to-be-partially-reused-for-sell&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=21209-mobile-sell-refactor-useexchangeflow-to-be-partially-reused-for-sell&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=21209-mobile-sell-refactor-useexchangeflow-to-be-partially-reused-for-sell&lookback=7)