### PR TITLE
fix(suite-native): emit interface change on disconnect

### DIFF
--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -82,7 +82,9 @@ export class UsbApi extends AbstractApi {
                 );
 
                 // trezor devices have serial number 468E58AE386B5D2EA8C572A2 or 000000000000000000000000 (for bootloader devices)
-                return this.enumerate();
+                return this.enumerate().then(() => {
+                    this.emit('transport-interface-change', this.devicesToDescriptors())
+                });
             }
 
             const index = this.devices.findIndex(d => d.path === device.serialNumber);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- emit `transport-interface-change` to connect so that we're able to handle device disconnect for devices, that do not have serial number. 

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/disconnect-usb-device&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/disconnect-usb-device&lookback=7)