### PR TITLE
feat(message-system): add feature flag to disable Tropic DAC failures

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -89,6 +89,8 @@ runs:
         if [[ "${{ inputs.project }}" == "web" ]]; then
           npx playwright install --with-deps > /dev/null
         fi
+        # Playwright runtime may indirectly import the built config, and that would crash if message-system is not built
+        yarn message-system-sign-config
         echo "::endgroup::"
 
     - name: Pull Docker Images

--- a/suite-common/device-authenticity/package.json
+++ b/suite-common/device-authenticity/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.9.1",
+        "@suite-common/message-system": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/test-utils": "workspace:*",

--- a/suite-common/device-authenticity/src/deviceAuthenticityThunks.ts
+++ b/suite-common/device-authenticity/src/deviceAuthenticityThunks.ts
@@ -1,3 +1,4 @@
+import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import TrezorConnect from '@trezor/connect';
@@ -49,8 +50,14 @@ export const checkDeviceAuthenticityThunk = createThunk<
 
             return rejectWithValue(storedResult);
         }
-
-        const isOverallValid = isDeviceAuthenticityValid(result.payload);
+        const isTropicRemotelyDisabled = selectIsFeatureDisabled(
+            getState(),
+            Feature.deviceAuthenticityCheckTropic,
+        );
+        const isOverallValid = isDeviceAuthenticityValid({
+            result: result.payload,
+            isTropicRemotelyDisabled,
+        });
         const storedResult = { valid: isOverallValid, ...result.payload };
 
         // successful TrezorConnect call, but the signature authenticity validation failed

--- a/suite-common/device-authenticity/src/utils.ts
+++ b/suite-common/device-authenticity/src/utils.ts
@@ -1,4 +1,17 @@
 import { AuthenticateDeviceResult } from '@trezor/connect';
 
-export const isDeviceAuthenticityValid = (result: AuthenticateDeviceResult) =>
-    result.optigaResult.valid && result.tropicResult?.valid !== false;
+type IsDeviceAuthenticityValidParams = {
+    result: AuthenticateDeviceResult;
+    isTropicRemotelyDisabled: boolean;
+};
+
+export const isDeviceAuthenticityValid = ({
+    result,
+    isTropicRemotelyDisabled,
+}: IsDeviceAuthenticityValidParams) => {
+    const isOptigaValid = result.optigaResult.valid === true;
+    // Note: Tropic will be undefined for T2B1, T3B1, T3T1, but Connect takes care that it will fail for models which are expected to have it (T3W1)
+    const isTropicValid = result.tropicResult?.valid !== false || isTropicRemotelyDisabled;
+
+    return isOptigaValid && isTropicValid;
+};

--- a/suite-common/device-authenticity/tests/deviceAuthenticityThunks.test.ts
+++ b/suite-common/device-authenticity/tests/deviceAuthenticityThunks.test.ts
@@ -1,3 +1,4 @@
+import { messageSystemInitialState } from '@suite-common/message-system';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { configureMockStore, testMocks } from '@suite-common/test-utils';
 import { ToastPayload, notificationsActions } from '@suite-common/toast-notifications';
@@ -18,6 +19,9 @@ const initStore = (device?: TrezorDevice) =>
             selectors: {
                 selectDevice: () => device,
             },
+        },
+        preloadedState: {
+            messageSystem: messageSystemInitialState,
         },
     });
 

--- a/suite-common/device-authenticity/tsconfig.json
+++ b/suite-common/device-authenticity/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../message-system" },
         { "path": "../redux-utils" },
         { "path": "../suite-types" },
         { "path": "../test-utils" },

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -51,6 +51,8 @@ export const Feature = {
     entropyCheck: 'security.entropyCheck',
     entropyCheckMobile: 'security.entropyCheck.mobile',
 
+    deviceAuthenticityCheckTropic: 'security.deviceAuthenticityCheck.tropic',
+
     trading: {
         buy: 'trading.buy',
         sell: 'trading.sell',

--- a/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
+++ b/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
@@ -8,6 +8,11 @@ import {
     deviceAuthenticityActions,
     isDeviceAuthenticityValid,
 } from '@suite-common/device-authenticity';
+import {
+    Feature,
+    MessageSystemRootState,
+    selectIsFeatureDisabled,
+} from '@suite-common/message-system';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { DeviceAuthenticityCheckResult, EventType, analytics } from '@suite-native/analytics';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
@@ -31,6 +36,9 @@ export const useDeviceAuthenticityCheck = () => {
     const { translate } = useTranslate();
     const { showToast } = useToast();
     const allowDebugKeys = useFeatureFlag(FeatureFlag.IsDebugKeysAllowed);
+    const isTropicRemotelyDisabled = useSelector((state: MessageSystemRootState) =>
+        selectIsFeatureDisabled(state, Feature.deviceAuthenticityCheckTropic),
+    );
 
     const device = useSelector(selectSelectedDevice);
     const isDeviceBootloaderUnlocked = !!device && !device?.features?.bootloader_locked;
@@ -74,11 +82,14 @@ export const useDeviceAuthenticityCheck = () => {
                     : undefined;
             }
 
-            const isOverallValid = isDeviceAuthenticityValid(result.payload);
+            const isOverallValid = isDeviceAuthenticityValid({
+                result: result.payload,
+                isTropicRemotelyDisabled,
+            });
 
             return { valid: isOverallValid, ...result.payload };
         },
-        [isDeviceBootloaderUnlocked],
+        [isDeviceBootloaderUnlocked, isTropicRemotelyDisabled],
     );
 
     const handleDeviceAccessError = useCallback(

--- a/yarn.lock
+++ b/yarn.lock
@@ -10515,6 +10515,7 @@ __metadata:
   resolution: "@suite-common/device-authenticity@workspace:suite-common/device-authenticity"
   dependencies:
     "@reduxjs/toolkit": "npm:2.9.1"
+    "@suite-common/message-system": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/test-utils": "workspace:*"


### PR DESCRIPTION
## Description

Depends on https://github.com/trezor/trezor-suite/pull/22171

Add feature flag that turns off handling of Tropic DAC failures. 

## Related Issue

Resolve #22173

## Screenshots:

You can use this [testing branch](https://github.com/trezor/trezor-suite/tree/feat/DAC-tropic-message-system-TESTING/) to have tropic always fail.

No message system → failure:

[Tropic fail without msg system.webm](https://github.com/user-attachments/assets/ede23770-804f-4edb-b258-1c3023ea254c)

Disabled by a message:

[Tropic success because disabled message system.webm](https://github.com/user-attachments/assets/493b894e-9d08-4786-84d4-bbf4edd7189b)

You can use the Settings > Debug > Message manager with this message:
```
{
    "conditions": [{"environment": {"desktop": "*", "mobile": "*", "web": "*" } } ],
    "message": {
        "id": "9947f424-750b-4805-89b3-d90b82ecd983",
        "priority": 1,
        "dismissible": false,
        "variant": "info",
        "category": "feature",
        "content": {"en": "Placeholder", "es": "Placeholder", "cs": "Placeholder", "de": "Placeholder", "fr": "Placeholder", "it": "Placeholder", "pt": "Placeholder", "tr": "Placeholder", "ru": "Placeholder", "ja": "Placeholder", "uk": "Placeholder", "hu": "Placeholder" },
        "feature": [
            {
                "domain": "security.deviceAuthenticityCheck.tropic",
                "flag": false
            }
        ]
    }
}
```

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/DAC-tropic-message-system&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/DAC-tropic-message-system&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/DAC-tropic-message-system&lookback=7)