### PR TITLE
Fix/suite open bt settings

### DIFF
--- a/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
@@ -14,10 +14,6 @@ export class BluetoothProcess extends BaseProcess {
         super('bluetooth', 'trezor-bluetooth', {
             autoRestart: 0,
             env: {
-                // https://github.com/electron/electron/blob/ab2a4fd836d539194bc5cde5f0d665eddeb6a134/docs/api/environment-variables.md?plain=1#L190
-                // Electron sometimes modifies the value of XDG_CURRENT_DESKTOP
-                XDG_CURRENT_DESKTOP:
-                    process.env.ORIGINAL_XDG_CURRENT_DESKTOP || process.env.XDG_CURRENT_DESKTOP,
                 TREZOR_BLUETOOTH_PORT: port.toString(),
             },
             stdio: debug && !isWindows() ? 'inherit' : undefined,

--- a/packages/suite-desktop-core/src/modules/system-settings.ts
+++ b/packages/suite-desktop-core/src/modules/system-settings.ts
@@ -11,23 +11,11 @@ export const SERVICE_NAME = 'system-settings';
 const getOSErrorDescription = (reason: string) =>
     `Cannot open system settings (${reason}). Please open the settings manually.`;
 
-// If opening system settings was attempted but failed, try to guess the reason of failure.
-const detectFailureReason = (error: Error) => {
-    const flatpakId = process.env.FLATPAK_ID ?? process.env.FLATPAK_APP_ID;
-    if (flatpakId !== undefined && flatpakId !== '') {
-        return getOSErrorDescription('running in Flatpak sandbox');
-    }
-
-    // cannot detect reason, return original error
-    return error.toString();
-};
-
 const openSettings = (cmd: string, env?: Record<string, string>) =>
     new Promise<InvokeResult>(resolve => {
         exec(cmd, { env: { ...process.env, ...env } }, error => {
             if (error) {
-                const errorMessage = detectFailureReason(error);
-                resolve({ success: false, error: errorMessage });
+                resolve({ success: false, error: getOSErrorDescription('unsupported system') });
             } else {
                 resolve({ success: true });
             }
@@ -39,20 +27,35 @@ const openSettings = (cmd: string, env?: Record<string, string>) =>
  * or a particular desktop environment in case of Linux (Gnome or KDE supported).
  * In case of other systems, fail right away without attempting it.
  */
-const openBluetoothSettings = () => {
+const openBluetoothSettings = async () => {
     if (isLinux()) {
         // https://github.com/electron/electron/blob/ab2a4fd836d539194bc5cde5f0d665eddeb6a134/docs/api/environment-variables.md?plain=1#L190
         // Electron modifies the value of XDG_CURRENT_DESKTOP
-        const xdg = process.env.ORIGINAL_XDG_CURRENT_DESKTOP || process.env.XDG_CURRENT_DESKTOP;
-        if (xdg?.includes('GNOME')) {
-            return openSettings('gnome-control-center bluetooth', {
-                XDG_CURRENT_DESKTOP: xdg,
-            });
-        } else if (xdg?.includes('KDE')) {
-            return openSettings('systemsettings5', {
-                XDG_CURRENT_DESKTOP: xdg,
-            });
+        const xdg =
+            process.env.ORIGINAL_XDG_CURRENT_DESKTOP || process.env.XDG_CURRENT_DESKTOP || '';
+        const flatpak = process.env.FLATPAK_ID ?? process.env.FLATPAK_APP_ID;
+        const flatpakPrefix = flatpak ? 'flatpak-spawn --host ' : '';
+        const commands = {
+            GNOME: 'gnome-control-center bluetooth',
+            KDE: 'systemsettings5 bluetooth',
+            PANTHEON: 'switchboard bluetooth',
+            BLUEMAN: 'blueman-manager',
+        };
+
+        const xdgMatch = xdg
+            ? Object.entries(commands).find(([key]) => xdg.includes(key))
+            : undefined;
+        const cmd = xdgMatch?.[1];
+        const env = { XDG_CURRENT_DESKTOP: xdg };
+        if (cmd) {
+            const result = await openSettings(`${flatpakPrefix}${cmd}`, env);
+            if (result.success) {
+                return result;
+            }
         }
+
+        // fallback to blueman
+        return openSettings(`${flatpakPrefix}${commands.BLUEMAN}`, env);
     }
 
     if (isMacOs()) {

--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -4,12 +4,14 @@ import {
     selectAdapterStatus,
     selectAutoConnectPolicy,
     selectKnownDevices,
+    selectNearbyDevices,
 } from '@suite-common/bluetooth';
 import { selectFirmware } from '@suite-common/firmware';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { selectDevices } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
+import { desktopApi } from '@trezor/suite-desktop-api';
 import { BluetoothDevice, bluetoothIpc } from '@trezor/transport-bluetooth';
 import { resolveAfter } from '@trezor/utils';
 
@@ -158,6 +160,21 @@ export const initBluetoothThunk = createThunk<void, void, void>(
             const device = fromBluetoothDevice(deviceIpc);
 
             dispatch(bluetoothActions.deviceUpdateAction({ device }));
+        });
+
+        bluetoothIpc.on('open-bluetooth-settings', async () => {
+            const result = await desktopApi.openSystemSettings('bluetooth');
+            if (!result.success) {
+                // stop here and disconnect the device (abort pairing before it starts)
+                // device needs to be paired manually via system settings
+                const connectingDevices = selectConnectingDevices(getState());
+                const nearbyDevices = selectNearbyDevices(getState());
+                nearbyDevices.forEach(({ id }) => {
+                    if (connectingDevices.includes(id)) {
+                        bluetoothIpc.disconnectDevice(id);
+                    }
+                });
+            }
         });
 
         // Wait for 3 seconds or earlier if a connected device is detected.

--- a/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
@@ -76,6 +76,10 @@ export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements Bl
             }
         });
 
+        this.api.on('device_settings_ui', () => {
+            this.emit('open-bluetooth-settings');
+        });
+
         return this.result();
     }
 

--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -86,6 +86,7 @@ export interface BluetoothIpcEvents {
     'adapter-event': BluetoothAdapterState;
     'device-list-update': BluetoothDevice[];
     'device-update': BluetoothDevice;
+    'open-bluetooth-settings': undefined;
 }
 
 type TypedManagerEvents = TypedEmitter<BluetoothIpcEvents>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

#### fix(suite-desktop): open BT settings on linux

- add `PANTHEON` case (switchboard bluetooth)
- add fallback (blueman) if default/expected settings are not found
- add flatpack prefix (requires `--talk-name=org.freedesktop.Flatpak` permissions in suite - shoud be added in flathub, or manually)
- remove `detectFailureReason` - openSettings should always fail with "unsupported system" message instead of generic error: "Command failed: XXX command not found"

#### feat(suite-desktop): open bluetooth settings while pairing on linux
- remove `XDG_CURRENT_DESKTOP` from `trezor-bluetooth` env (this will disable opening BT settings via BT server)
- add `open-bluetooth-settings` handler (event emitted by BT server while pairing on linux) and open BT settings from suite

## Related Issue

https://github.com/trezor/trezor-suite/issues/22272


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-open-bt-settings&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-open-bt-settings&lookback=7)