### PR TITLE
fix(suite): max button and receive crypto change

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -60,6 +60,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     const initState = useMemo(() => ({ account, network, feeInfo }), [account, network, feeInfo]);
     const outputAddress = values?.outputs?.[0].address;
     const [state, setState] = useState<TradingUseComposeTransactionStateProps>(initState);
+    const [shouldUpdateMaxAmount, setShouldUpdateMaxAmount] = useState(true);
 
     // sub-hook, Composing transaction
     const {
@@ -150,12 +151,16 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
         }
 
         if (composed.type === 'final' || composed.type === 'nonfinal') {
-            if (typeof setMaxOutputId === 'number' && composed.max) {
+            if (typeof setMaxOutputId === 'number' && composed.max && shouldUpdateMaxAmount) {
+                setShouldUpdateMaxAmount(false);
+
                 setValue(TRADING_FORM_OUTPUT_AMOUNT, composed.max, {
                     shouldValidate: true,
                     shouldDirty: true,
                 });
                 clearErrors(TRADING_FORM_OUTPUT_AMOUNT);
+            } else {
+                setShouldUpdateMaxAmount(true);
             }
 
             dispatch(
@@ -167,6 +172,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
 
             setValue('estimatedFeeLimit', composed.estimatedFeeLimit, { shouldDirty: true });
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
         account.symbol,
         composedLevels,

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -295,12 +295,17 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
         const formValues = values as TradingExchangeFormProps | null;
         const prevFormValues = previousValues.current as TradingExchangeFormProps | null;
 
+        const receiveCryptoChanged = isChanged(
+            formValues?.receiveCryptoSelect,
+            prevFormValues?.receiveCryptoSelect,
+        );
+
         const receiveAddressChanged = isChanged(
             formValues?.receiveAddress,
             prevFormValues?.receiveAddress,
         );
 
-        if (receiveAddressChanged) {
+        if (receiveCryptoChanged || receiveAddressChanged) {
             dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
             handleSubmit(() => {


### PR DESCRIPTION
## Description

This PR fixes 3 bugs:

1. selecting `Max` value in swap/sell caused a bug where the quotes were refreshed periodically and infinitelly
2. changing the receive crypto didn't refresh quotes
3. Solana `Max` button was not working correctly

## Screenshots:

https://github.com/user-attachments/assets/86caf007-4e9b-4699-8298-5a37de05f380




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-exchange&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-exchange&lookback=7)