### PR TITLE
fix(suite-common): increment THP connection counter during THP confirmation

### DIFF
--- a/suite-common/thp/src/connectThpDeviceThunk.ts
+++ b/suite-common/thp/src/connectThpDeviceThunk.ts
@@ -3,7 +3,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { Device } from '@trezor/connect';
 
 import { THP_PREFIX, thpActions } from './thpActions';
-import { selectThpCredentials } from './thpSelectors';
+import { selectIsThpInProgress, selectThpCredentials } from './thpSelectors';
 
 const NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT = 3;
 
@@ -16,29 +16,23 @@ export const connectThpDeviceThunk = createThunk<void, ConnectThpDeviceThinkPara
     ({ device }, { dispatch, getState }) => {
         const credentials = selectThpCredentials(getState());
         const isFwInstall = selectFirmware(getState()).status !== 'initial';
+        const isThpInProgress = selectIsThpInProgress(getState());
 
-        const credential = credentials.find(
-            stateCredential =>
-                device.thp?.credentials.find(
-                    deviceCredential => deviceCredential.credential === stateCredential.credential,
-                ) !== undefined,
+        const credential = credentials.find(stateCredential =>
+            device.thp?.credentials.some(
+                deviceCredential => deviceCredential.credential === stateCredential.credential,
+            ),
         );
 
-        if (credential !== undefined) {
-            // We do not want to offer Autoconnect after reconnection dues to Firmware installation.
-            // Autoconnect will be offered on the next reconnection.
-            if (!isFwInstall) {
-                dispatch(thpActions.incrementCredentialConnectionCounter({ credential }));
-            }
+        if (credential !== undefined && !isFwInstall && isThpInProgress) {
+            // Increment the counter only after FW installation and during a THP confirmation.
+            dispatch(thpActions.incrementCredentialConnectionCounter({ credential }));
 
-            const hasAutoconnectCredential =
-                device?.thp?.credentials?.find(it => it?.autoconnect) !== undefined;
-
+            const hasAutoConnectCredential = device?.thp?.credentials?.some(c => c?.autoconnect);
             const shallShowAutoConnectDialog =
-                // -1 because it was just about incremented
+                // subtract 1 because the counter has just been incremented
                 credential.connectionCounter === NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT - 1 &&
-                !hasAutoconnectCredential &&
-                !isFwInstall;
+                !hasAutoConnectCredential;
 
             dispatch(
                 shallShowAutoConnectDialog

--- a/suite-common/thp/tests/connectThpDeviceThunk.test.ts
+++ b/suite-common/thp/tests/connectThpDeviceThunk.test.ts
@@ -11,7 +11,7 @@ import { ThpState, prepareThpReducer } from '../src/thpReducer';
 const thpReduce = prepareThpReducer(extraDependenciesMock);
 const firmwareReduce = prepareFirmwareReducer(extraDependenciesMock);
 
-const thpCredential1 = createCredential({ credential: 'credential-1' });
+const thpCredential1 = createCredential({ credential: 'credential-1', connectionCounter: 2 });
 const thpCredential2 = createCredential({ credential: 'credential-2' });
 
 const initialThpState: ThpState = {
@@ -35,7 +35,37 @@ const device: Pick<Device, 'thp'> = {
 };
 
 describe(connectThpDeviceThunk.name, () => {
-    it('updates the connection counter for credential', () => {
+    it.each([
+        [1, 2, null],
+        [2, 3, 'AutoconnectInfo'],
+        [3, 4, null],
+    ])(
+        'updates the connection counter with initial value %d',
+        (initialCounter, expectedCounter, expectedStep) => {
+            const store = configureMockStore({
+                extra: {},
+                reducer: combineReducers({ thp: thpReduce, firmware: firmwareReduce }),
+                preloadedState: {
+                    thp: {
+                        ...initialThpState,
+                        step: 'ConfirmOnlyConnection',
+                        credentials: [
+                            { ...thpCredential1, connectionCounter: initialCounter },
+                            thpCredential2,
+                        ],
+                    },
+                    firmware: initialFirmwareState,
+                },
+            });
+
+            store.dispatch(connectThpDeviceThunk({ device }));
+            expect(store.getState().thp.credentials[0].connectionCounter).toEqual(expectedCounter);
+            expect(store.getState().thp.credentials[1].connectionCounter).toEqual(0);
+            expect(store.getState().thp.step).toEqual(expectedStep);
+        },
+    );
+
+    it('does not update the connection counter without THP confirmation', () => {
         const store = configureMockStore({
             extra: {},
             reducer: combineReducers({ thp: thpReduce, firmware: firmwareReduce }),
@@ -43,38 +73,23 @@ describe(connectThpDeviceThunk.name, () => {
         });
 
         store.dispatch(connectThpDeviceThunk({ device }));
-        expect(store.getState().thp.credentials[0].connectionCounter).toEqual(1);
-        expect(store.getState().thp.credentials[1].connectionCounter).toEqual(0);
-        expect(store.getState().thp.step).toEqual(null);
-
-        store.dispatch(connectThpDeviceThunk({ device }));
         expect(store.getState().thp.credentials[0].connectionCounter).toEqual(2);
-        expect(store.getState().thp.credentials[1].connectionCounter).toEqual(0);
-        expect(store.getState().thp.step).toEqual(null);
-
-        store.dispatch(connectThpDeviceThunk({ device }));
-        expect(store.getState().thp.credentials[0].connectionCounter).toEqual(3);
-        expect(store.getState().thp.credentials[1].connectionCounter).toEqual(0);
-        expect(store.getState().thp.step).toEqual('AutoconnectInfo');
-
-        store.dispatch(connectThpDeviceThunk({ device }));
-        expect(store.getState().thp.credentials[0].connectionCounter).toEqual(4);
         expect(store.getState().thp.credentials[1].connectionCounter).toEqual(0);
         expect(store.getState().thp.step).toEqual(null);
     });
 
-    it("won't update the connection counter for credential during Firmware Installation", () => {
+    it('does not update the connection counter during firmware installation', () => {
         const store = configureMockStore({
             extra: {},
             reducer: combineReducers({ thp: thpReduce, firmware: firmwareReduce }),
             preloadedState: {
-                thp: initialThpState,
+                thp: { ...initialThpState, step: 'ConfirmOnlyConnection' },
                 firmware: { ...initialFirmwareState, status: 'done' },
             },
         });
 
         store.dispatch(connectThpDeviceThunk({ device }));
-        expect(store.getState().thp.credentials[0].connectionCounter).toEqual(0);
+        expect(store.getState().thp.credentials[0].connectionCounter).toEqual(2);
         expect(store.getState().thp.credentials[1].connectionCounter).toEqual(0);
         expect(store.getState().thp.step).toEqual(null);
     });


### PR DESCRIPTION
Resolve #22451

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/common/thp-connection-counter&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/common/thp-connection-counter&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/common/thp-connection-counter&lookback=7)