### PR TITLE
feat(suite-native): improve availability of the Connect Trezor button

### DIFF
--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -409,6 +409,11 @@ export const selectIsNoPhysicalDeviceConnected = createMemoizedSelector(
     devices => devices.every(device => !device.connected),
 );
 
+export const selectIsAnyPhysicalDeviceConnectedViaUsb = createMemoizedSelector(
+    [selectPhysicalDeviceWallets],
+    devices => devices.some(device => device.connected && device.descriptor.apiType === 'usb'),
+);
+
 export const selectHasOnlyPortfolioDevice = createMemoizedSelector(
     [selectDevices],
     devices => devices.length === 1 && devices[0].id === PORTFOLIO_TRACKER_DEVICE_ID,

--- a/suite-native/device-manager/src/components/ConnectButton.tsx
+++ b/suite-native/device-manager/src/components/ConnectButton.tsx
@@ -2,11 +2,7 @@ import { FadeInUp, FadeOutUp, LinearTransition } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import { TrezorDevice } from '@suite-common/suite-types';
-import {
-    selectHasRunningDiscovery,
-    selectIsNoPhysicalDeviceConnected,
-    selectSelectedDevice,
-} from '@suite-common/wallet-core';
+import { selectHasRunningDiscovery, selectSelectedDevice } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
 import { AnimatedBox, Button } from '@suite-native/atoms';
 import { useConnectDeviceHandler } from '@suite-native/device';
@@ -29,12 +25,13 @@ export const ConnectButton = ({ onSelectDevice }: ConnectButtonProps) => {
     const { applyStyle } = useNativeStyles();
 
     const hasDiscovery = useSelector(selectHasRunningDiscovery);
-    const isNoPhysicalDeviceConnected = useSelector(selectIsNoPhysicalDeviceConnected);
     const device = useSelector(selectSelectedDevice);
 
-    const isConnectButtonVisible = !hasDiscovery && isNoPhysicalDeviceConnected;
-
     const { onConnectDevicePress } = useConnectDeviceHandler();
+
+    if (hasDiscovery) {
+        return null;
+    }
 
     const handleConnectDevice = () => {
         if (device) {
@@ -49,8 +46,6 @@ export const ConnectButton = ({ onSelectDevice }: ConnectButtonProps) => {
             payload: { action: 'connectDeviceButton' },
         });
     };
-
-    if (!isConnectButtonVisible) return null;
 
     return (
         <AnimatedBox

--- a/suite-native/device/src/hooks/useConnectDeviceHandler.tsx
+++ b/suite-native/device/src/hooks/useConnectDeviceHandler.tsx
@@ -5,7 +5,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { bluetoothActions } from '@suite-common/bluetooth';
-import { acquireDevice, selectIsDeviceThpRequired } from '@suite-common/wallet-core';
+import {
+    acquireDevice,
+    selectIsAnyPhysicalDeviceConnectedViaUsb,
+    selectIsDeviceThpRequired,
+} from '@suite-common/wallet-core';
 import {
     AuthorizeDeviceStackRoutes,
     HomeStackParamList,
@@ -26,11 +30,14 @@ export const useConnectDeviceHandler = () => {
     const navigation = useNavigation<NavigationProps>();
 
     const isDeviceThpRequired = useSelector(selectIsDeviceThpRequired);
+    const isAnyPhysicalDeviceConnectedViaUsb = useSelector(
+        selectIsAnyPhysicalDeviceConnectedViaUsb,
+    );
 
     const onConnectDevicePress = useCallback(() => {
         if (isDeviceThpRequired) {
             dispatch(acquireDevice({}));
-        } else if (Platform.OS === 'ios') {
+        } else if (isAnyPhysicalDeviceConnectedViaUsb || Platform.OS === 'ios') {
             // Make sure auto-connect is enabled in case some device was manually disconnected.
             dispatch(bluetoothActions.enableAutoConnect());
             navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
@@ -41,7 +48,7 @@ export const useConnectDeviceHandler = () => {
                 screen: AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
             });
         }
-    }, [dispatch, isDeviceThpRequired, navigation]);
+    }, [dispatch, isDeviceThpRequired, isAnyPhysicalDeviceConnectedViaUsb, navigation]);
 
     return { onConnectDevicePress };
 };


### PR DESCRIPTION
- Show the _Connect Trezor_ button whenever discovery is not in progress.
- In case any device is connected via USB, navigate to the _Turn on & unlock_ screen instead of _Connect & unlock_.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/connect-button&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/connect-button&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/connect-button&lookback=7)