### PR TITLE
feat(firmware-authenticity): add FW source to device compromised Sentry

### DIFF
--- a/suite-common/firmware-authenticity/package.json
+++ b/suite-common/firmware-authenticity/package.json
@@ -11,6 +11,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.8.2",
+        "@suite-common/firmware": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",

--- a/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
+++ b/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { selectFirmwareUpdateSource } from '@suite-common/firmware';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { FIRMWARE } from '@trezor/connect';
@@ -16,10 +17,11 @@ const useCommonData = () => {
     const revision = device?.features?.revision;
     const version = getFirmwareVersion(device);
     const vendor = device?.features?.fw_vendor;
+    const firmwareSource = useSelector(selectFirmwareUpdateSource);
 
     return useMemo(
-        () => ({ model, revision, version, vendor }),
-        [model, revision, version, vendor],
+        () => ({ model, revision, version, vendor, firmwareSource }),
+        [model, revision, version, vendor, firmwareSource],
     );
 };
 

--- a/suite-common/firmware-authenticity/tsconfig.json
+++ b/suite-common/firmware-authenticity/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../firmware" },
         { "path": "../redux-utils" },
         { "path": "../suite-utils" },
         { "path": "../wallet-core" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10282,6 +10282,7 @@ __metadata:
   resolution: "@suite-common/firmware-authenticity@workspace:suite-common/firmware-authenticity"
   dependencies:
     "@reduxjs/toolkit": "npm:2.8.2"
+    "@suite-common/firmware": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"


### PR DESCRIPTION
## Description

When you set FW source to something else than production, the FW hash || revision check can fail even with proper production FW.

Because you can change FW source even on prod Suite, we need this information so we can disregard such Sentry issues, [like this one](https://satoshilabs.sentry.io/issues/6945982807/).

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/add-FW-source-to-device-compro-sentry&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/add-FW-source-to-device-compro-sentry&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/add-FW-source-to-device-compro-sentry&lookback=7)