### PR TITLE
feat(crypto-utils): add `getSubtleCrypto`

### DIFF
--- a/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
+++ b/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
@@ -1,5 +1,6 @@
 import * as crypto from 'crypto';
 
+import { getSubtleCrypto } from '@trezor/crypto-utils';
 import { bufferUtils } from '@trezor/utils';
 
 import { fixSignature, parseCertificate } from './x509certificate';
@@ -15,13 +16,7 @@ const verifySignature = async (rawKey: Buffer, data: Uint8Array, signature: Uint
     const signer = crypto.createVerify('sha256');
     signer.update(Buffer.from(data));
 
-    // use native SubtleCrypto api.
-    // Unfortunately `crypto-browserify`.subtle polyfill is missing so needs to be referenced directly from window object (if exists)
-    // https://github.com/browserify/crypto-browserify/issues/221
-    const SubtleCrypto = typeof window !== 'undefined' ? window.crypto.subtle : crypto.subtle;
-    if (!SubtleCrypto) {
-        throw new Error('SubtleCrypto not supported');
-    }
+    const SubtleCrypto = getSubtleCrypto();
 
     // get ECDSA P-256 (secp256r1) key from RAW key
     const ecPubKey = await SubtleCrypto.importKey(

--- a/packages/crypto-utils/src/getSubtleCrypto.ts
+++ b/packages/crypto-utils/src/getSubtleCrypto.ts
@@ -1,0 +1,11 @@
+// use native SubtleCrypto api.
+// Unfortunately `crypto-browserify`.subtle polyfill is missing so needs to be referenced directly from window object (if exists)
+// https://github.com/browserify/crypto-browserify/issues/221
+export const getSubtleCrypto = () => {
+    const subtleCrypto = typeof window !== 'undefined' ? window.crypto.subtle : crypto.subtle;
+    if (!subtleCrypto) {
+        throw new Error('SubtleCrypto not supported');
+    }
+
+    return subtleCrypto;
+};

--- a/packages/crypto-utils/src/index.ts
+++ b/packages/crypto-utils/src/index.ts
@@ -1,1 +1,2 @@
 export { bip39 } from './bip39';
+export { getSubtleCrypto } from './getSubtleCrypto';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Related  to https://github.com/trezor/trezor-suite/pull/22171

create getter for SubtleCrypto in `@trezor/crypto-utils`


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/get-subtle-crypto&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/get-subtle-crypto&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/get-subtle-crypto&lookback=7)