### PR TITLE
fix(suite-native): device connect analytics

### DIFF
--- a/suite-common/analytics/src/events/suite-native/types.ts
+++ b/suite-common/analytics/src/events/suite-native/types.ts
@@ -184,9 +184,9 @@ export type SuiteNativeAnalyticsEvent =
           payload: {
               mode: DeviceMode | null;
               firmwareVersion: VersionArray | null;
-              pinProtection: boolean;
+              pinProtection: boolean | null;
               deviceModel: DeviceModelInternal | null;
-              isBitcoinOnly: boolean;
+              isBitcoinOnly: boolean | null;
               deviceLanguage: string | null;
               connectionType: 'cable' | 'bluetooth';
           };

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -554,3 +554,11 @@ export const getIsDeviceDescriptorApiTypeBluetooth = (device: Device | TrezorDev
 
 export const getIsDeviceConnectedViaBluetooth = (device?: TrezorDevice): boolean =>
     !!device?.connected && getIsDeviceDescriptorApiTypeBluetooth(device);
+
+export const getIsDevicePinProtected = (device?: TrezorDevice): boolean | null =>
+    device?.features?.pin_protection ?? null;
+
+export const getDeviceLanguage = (device?: TrezorDevice): string | null =>
+    device?.features?.language ?? null;
+
+export const getDeviceMode = (device?: TrezorDevice): DeviceMode | null => device?.mode ?? null;

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -1,10 +1,7 @@
 import { AnyAction, isAnyOf } from '@reduxjs/toolkit';
 
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
-import {
-    getIsDeviceDescriptorApiTypeBluetooth,
-    isAnyDeviceEventAction,
-} from '@suite-common/suite-utils';
+import { isAnyDeviceEventAction } from '@suite-common/suite-utils';
 import {
     accountsActions,
     deviceActions,
@@ -15,18 +12,12 @@ import {
     selectDiscoveryByDevicePath,
     selectIsDeviceForceRemembered,
 } from '@suite-common/wallet-core';
-import { EventType, analytics } from '@suite-native/analytics';
 import { clearAndUnlockDeviceAccessQueue } from '@suite-native/device-mutex';
 import { reportSecurityCheck } from '@suite-native/sentry';
 import { setShouldShowAutoEjectAlert } from '@suite-native/settings';
 import { DEVICE } from '@trezor/connect';
-import {
-    getFirmwareVersionArray,
-    hasBitcoinOnlyFirmware,
-    isDeviceInBootloaderMode,
-} from '@trezor/device-utils';
 
-import { isDeviceEventAction } from '../utils';
+import { isDeviceEventAction, reportDeviceConnectionAnalytics } from '../utils';
 
 const isActionDeviceRelated = (action: AnyAction): boolean => {
     if (
@@ -76,24 +67,7 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
 
         switch (action.type) {
             case DEVICE.CONNECT: {
-                const { device } = action.payload;
-                const { features, mode } = device;
-
-                analytics.report({
-                    type: EventType.ConnectDevice,
-                    payload: {
-                        mode: isDeviceInBootloaderMode(device) ? 'bootloader' : mode,
-                        firmwareVersion: getFirmwareVersionArray(device),
-                        pinProtection: features.pin_protection,
-                        isBitcoinOnly: hasBitcoinOnlyFirmware(device),
-                        deviceLanguage: features.language,
-                        deviceModel: features.internal_model,
-                        connectionType: getIsDeviceDescriptorApiTypeBluetooth(device)
-                            ? 'bluetooth'
-                            : 'cable',
-                    },
-                });
-
+                reportDeviceConnectionAnalytics(action.payload.device);
                 break;
             }
             case DEVICE.DISCONNECT:

--- a/suite-native/device/src/utils.ts
+++ b/suite-native/device/src/utils.ts
@@ -2,8 +2,21 @@ import { G } from '@mobily/ts-belt';
 import * as semver from 'semver';
 
 import { AnyAction } from '@suite-common/redux-utils';
+import { TrezorDevice } from '@suite-common/suite-types';
+import {
+    getDeviceInternalModel,
+    getDeviceLanguage,
+    getDeviceMode,
+    getIsDeviceDescriptorApiTypeBluetooth,
+    getIsDevicePinProtected,
+} from '@suite-common/suite-utils';
+import { EventType, analytics } from '@suite-native/analytics';
 import { Device, DeviceEvent, VersionArray } from '@trezor/connect';
-import { DeviceModelInternal } from '@trezor/device-utils';
+import {
+    DeviceModelInternal,
+    getFirmwareVersionArray,
+    hasBitcoinOnlyFirmware,
+} from '@trezor/device-utils';
 import { exhaustive } from '@trezor/type-utils';
 
 export const minimalSupportedFirmwareVersion = {
@@ -53,4 +66,19 @@ export const getIsDeviceSetupSupported = (model: DeviceModelInternal) => {
         default:
             return exhaustive(model);
     }
+};
+
+export const reportDeviceConnectionAnalytics = (device: TrezorDevice) => {
+    analytics.report({
+        type: EventType.ConnectDevice,
+        payload: {
+            mode: getDeviceMode(device),
+            firmwareVersion: getFirmwareVersionArray(device),
+            pinProtection: getIsDevicePinProtected(device),
+            isBitcoinOnly: hasBitcoinOnlyFirmware(device),
+            deviceLanguage: getDeviceLanguage(device),
+            deviceModel: getDeviceInternalModel(device),
+            connectionType: getIsDeviceDescriptorApiTypeBluetooth(device) ? 'bluetooth' : 'cable',
+        },
+    });
 };


### PR DESCRIPTION
## Description
- fixes a bug when analytics were not reported if the `device.features` was undefined
## Related Issue

Resolve #22489



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/device-connection-analytics&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/device-connection-analytics&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-connection-analytics&lookback=7)