### PR TITLE
fix(suite): Choose correct device in thp pairing failed

### DIFF
--- a/packages/suite/src/components/connection/thp/ThpPairingFailedModal.tsx
+++ b/packages/suite/src/components/connection/thp/ThpPairingFailedModal.tsx
@@ -1,16 +1,16 @@
 import { useState } from 'react';
 
 import { thpActions } from '@suite-common/thp';
-import { acquireDevice } from '@suite-common/wallet-core';
+import { acquireDevice, selectSelectedFirstThpDevice } from '@suite-common/wallet-core';
 import { Column, Modal, Paragraph } from '@trezor/components';
 
 import { ThpPairingCodeEntry } from './ThpPairingCodeEntry';
-import { useDevice, useDispatch, useSelector } from '../../../hooks/suite';
+import { useDispatch, useSelector } from '../../../hooks/suite';
 import { Translation } from '../../suite/Translation';
 
 export const ThpPairingFailedModal = () => {
     const [isLoading, setIsLoading] = useState(false);
-    const { device } = useDevice();
+    const device = useSelector(selectSelectedFirstThpDevice);
     const dispatch = useDispatch();
     const lastThpCode = useSelector(state => state.thp.lastThpCode);
 


### PR DESCRIPTION
Chooses correct* selected device for thp pairing after failed attempt.

## Related Issue

Fixes #22472

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/wrong-thp-code&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/wrong-thp-code&lookback=7)