### PR TITLE
fix(suite): onboarding thp icon for cable

### DIFF
--- a/packages/suite/src/views/onboarding/steps/ThpPairingFailedStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/ThpPairingFailedStep.tsx
@@ -2,12 +2,11 @@ import { useState } from 'react';
 
 import { Column, Paragraph } from '@trezor/components';
 
+import { startThpSessionThunk } from 'src/actions/thp/startThpSessionThunk';
+import { ThpPairingFailedForFirmwareInstallation } from 'src/components/connection/thp/ThpPairingFailedForFirmwareInstallation';
 import { OnboardingCard } from 'src/components/onboarding/OnboardingCard/OnboardingCard';
 import { Translation } from 'src/components/suite/Translation';
-
-import { startThpSessionThunk } from '../../../actions/thp/startThpSessionThunk';
-import { ThpPairingFailedForFirmwareInstallation } from '../../../components/connection/thp/ThpPairingFailedForFirmwareInstallation';
-import { useDispatch } from '../../../hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 
 export const ThpPairingFailedStep = () => {
     const dispatch = useDispatch();
@@ -22,7 +21,7 @@ export const ThpPairingFailedStep = () => {
 
     return (
         <OnboardingCard
-            iconName="bluetooth"
+            iconName="plugsConnected"
             heading={<Translation id="TR_THP_ENTER_ONE_TIME_CODE" />}
             description={<Translation id="TR_THP_CHECK_TREZOR_FOR_CODE" />}
             innerActions={

--- a/packages/suite/src/views/onboarding/steps/ThpPairingStartStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/ThpPairingStartStep.tsx
@@ -16,7 +16,7 @@ export const ThpPairingStartStep = () => {
 
     return (
         <OnboardingCard
-            iconName="bluetooth"
+            iconName="plugsConnected"
             description={<Translation id="TR_THP_CREATE_SECURE_CONNECTION_DESCRIPTION" />}
             heading={<Translation id="TR_THP_CREATE_SECURE_CONNECTION" />}
             innerActions={

--- a/packages/suite/src/views/onboarding/steps/ThpPairingStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/ThpPairingStep.tsx
@@ -4,11 +4,10 @@ import { useIntl } from 'react-intl';
 import { Column } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
 
+import { ThpPairingCodeEntry } from 'src/components/connection/thp/ThpPairingCodeEntry';
 import { OnboardingCard } from 'src/components/onboarding/OnboardingCard/OnboardingCard';
 import { Translation } from 'src/components/suite/Translation';
-
-import { ThpPairingCodeEntry } from '../../../components/connection/thp/ThpPairingCodeEntry';
-import messages from '../../../support/messages';
+import messages from 'src/support/messages';
 
 export const ThpPairingStep = () => {
     const intl = useIntl();
@@ -20,7 +19,7 @@ export const ThpPairingStep = () => {
 
     return (
         <OnboardingCard
-            iconName="bluetooth"
+            iconName="plugsConnected"
             heading={<Translation id="TR_THP_ENTER_ONE_TIME_CODE" />}
             description={<Translation id="TR_THP_CHECK_TREZOR_FOR_CODE" />}
             innerActions={


### PR DESCRIPTION
## Description

In the new onboarding UI, THP steps show a Bluetooth icon, even when using cable.

We agreed with @komret and @hynek-jina to use the plugs icon for both, to represent THP in general. 

## Screenshots:
Before 
<img width="1126" height="721" alt="Screenshot 2025-10-15 at 09 54 14" src="https://github.com/user-attachments/assets/f129dc59-80f1-4d78-9632-1d0697c9061f" />
After
<img width="1110" height="733" alt="Screenshot 2025-10-15 at 14 17 19" src="https://github.com/user-attachments/assets/4c486bb9-441b-40f1-92a9-cd53d94e0712" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-cable-bt-icon&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-cable-bt-icon&lookback=7)