### PR TITLE
Do not increment connection counter after threshold has been met

### DIFF
--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -257,7 +257,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
             if (
                 !isAutoForgetEnabled &&
                 (deviceActions.setThpCredentials.match(action) ||
-                    deviceActions.connectDevice.match(action) || // To save the `connectionCounter`
+                    thpActions.incrementCredentialConnectionCounter.match(action) ||
                     thpActions.removeCredentials.match(action) ||
                     action.type === 'device-thp_credentials_changed')
             ) {

--- a/suite-common/thp/src/connectThpDeviceThunk.ts
+++ b/suite-common/thp/src/connectThpDeviceThunk.ts
@@ -5,7 +5,7 @@ import { Device } from '@trezor/connect';
 import { THP_PREFIX, thpActions } from './thpActions';
 import { selectIsThpInProgress, selectThpCredentials } from './thpSelectors';
 
-const NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT = 3;
+export const NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT = 3;
 
 type ConnectThpDeviceThinkParams = {
     device: Pick<Device, 'thp'>;

--- a/suite-common/thp/src/connectThpDeviceThunk.ts
+++ b/suite-common/thp/src/connectThpDeviceThunk.ts
@@ -3,9 +3,8 @@ import { createThunk } from '@suite-common/redux-utils';
 import { Device } from '@trezor/connect';
 
 import { THP_PREFIX, thpActions } from './thpActions';
+import { NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT } from './thpConstants';
 import { selectIsThpInProgress, selectThpCredentials } from './thpSelectors';
-
-export const NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT = 3;
 
 type ConnectThpDeviceThinkParams = {
     device: Pick<Device, 'thp'>;

--- a/suite-common/thp/src/index.ts
+++ b/suite-common/thp/src/index.ts
@@ -1,8 +1,9 @@
-export { prepareThpReducer, initialThpState, THP_BUTTON_REQUESTS_NAMES } from './thpReducer';
+export { prepareThpReducer, initialThpState } from './thpReducer';
 export type { ThpStep, ThpState } from './thpReducer';
 export { selectIsThpInProgress, selectThpStep, selectThpCredentials } from './thpSelectors';
 export { thpActions } from './thpActions';
 export * from './thpUtils';
+export { THP_BUTTON_REQUESTS_NAMES } from './thpConstants';
 export { connectThpDeviceThunk } from './connectThpDeviceThunk';
 export { finishThpAutoconnectThunk } from './finishThpAutoconnectThunk';
 export { startThpAutoconnectThunk } from './startThpAutoconnectThunk';

--- a/suite-common/thp/src/thpConstants.ts
+++ b/suite-common/thp/src/thpConstants.ts
@@ -1,0 +1,6 @@
+export const NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT = 3;
+export const THP_BUTTON_REQUESTS_NAMES = [
+    'thp_pairing_request',
+    'thp_connection_request',
+    'thp_autoconnect_credential_request',
+] as const;

--- a/suite-common/thp/src/thpReducer.ts
+++ b/suite-common/thp/src/thpReducer.ts
@@ -12,14 +12,11 @@ import {
 } from '@trezor/connect';
 import type { ThpCredentials } from '@trezor/protocol';
 
-import { NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT } from './connectThpDeviceThunk';
 import { thpActions } from './thpActions';
-
-export const THP_BUTTON_REQUESTS_NAMES = [
-    'thp_pairing_request',
-    'thp_connection_request',
-    'thp_autoconnect_credential_request',
-] as const;
+import {
+    NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT,
+    THP_BUTTON_REQUESTS_NAMES,
+} from './thpConstants';
 
 export type THPButtonRequestName = (typeof THP_BUTTON_REQUESTS_NAMES)[number];
 

--- a/suite-common/thp/src/thpReducer.ts
+++ b/suite-common/thp/src/thpReducer.ts
@@ -12,6 +12,7 @@ import {
 } from '@trezor/connect';
 import type { ThpCredentials } from '@trezor/protocol';
 
+import { NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT } from './connectThpDeviceThunk';
 import { thpActions } from './thpActions';
 
 export const THP_BUTTON_REQUESTS_NAMES = [
@@ -75,7 +76,11 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
                     it => it.credential == payload.credential.credential,
                 );
 
-                if (credentialToUpdate !== undefined) {
+                if (
+                    credentialToUpdate !== undefined &&
+                    credentialToUpdate.connectionCounter <
+                        NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT
+                ) {
                     credentialToUpdate.connectionCounter = credentialToUpdate.connectionCounter + 1;
                 }
             })

--- a/suite-common/thp/tests/connectThpDeviceThunk.test.ts
+++ b/suite-common/thp/tests/connectThpDeviceThunk.test.ts
@@ -4,10 +4,7 @@ import { FirmwareUpdateState, prepareFirmwareReducer } from '@suite-common/firmw
 import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
 import { Device } from '@trezor/connect';
 
-import {
-    NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT,
-    connectThpDeviceThunk,
-} from '../src/connectThpDeviceThunk';
+import { connectThpDeviceThunk } from '../src/connectThpDeviceThunk';
 import { createCredential, createDeviceThp } from '../src/support/mocks';
 import { ThpState, prepareThpReducer } from '../src/thpReducer';
 

--- a/suite-common/thp/tests/connectThpDeviceThunk.test.ts
+++ b/suite-common/thp/tests/connectThpDeviceThunk.test.ts
@@ -4,7 +4,10 @@ import { FirmwareUpdateState, prepareFirmwareReducer } from '@suite-common/firmw
 import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
 import { Device } from '@trezor/connect';
 
-import { connectThpDeviceThunk } from '../src/connectThpDeviceThunk';
+import {
+    NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT,
+    connectThpDeviceThunk,
+} from '../src/connectThpDeviceThunk';
 import { createCredential, createDeviceThp } from '../src/support/mocks';
 import { ThpState, prepareThpReducer } from '../src/thpReducer';
 
@@ -38,9 +41,9 @@ describe(connectThpDeviceThunk.name, () => {
     it.each([
         [1, 2, null],
         [2, 3, 'AutoconnectInfo'],
-        [3, 4, null],
+        [3, 3, null],
     ])(
-        'updates the connection counter with initial value %d',
+        'updates the connection counter, unless the threshold has already been reached',
         (initialCounter, expectedCounter, expectedStep) => {
             const store = configureMockStore({
                 extra: {},


### PR DESCRIPTION
No need to increment the counter, it unnecessarily reveals how many times a user has connected the device.

Also, no need to save THP credentials on every connection if we are only doing it because of the counter.

**QA:** The autoconnect modal should appear on the third connection as always, no change.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connection-counter&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connection-counter&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connection-counter&lookback=7)