### PR TITLE
feat(desktop): increase unresponsive timeout progressively

### DIFF
--- a/packages/suite/src/actions/bluetooth/__tests__/createMockedBluetoothDevice.ts
+++ b/packages/suite/src/actions/bluetooth/__tests__/createMockedBluetoothDevice.ts
@@ -9,11 +9,11 @@ export const createMockedBluetoothDevice = (
 
     return {
         ...bluetoothDeviceCommon,
-        rssi: partialDevice.rssi ?? -35, // -35 dBm is a good strong signal
-        macAddress: partialDevice.macAddress ?? '00:11:22:33:44:55',
-        paired: partialDevice.paired ?? false,
-        connected: partialDevice.connected ?? false,
-        connectionStatus: partialDevice.connectionStatus ?? { type: 'connected' },
-        lastUpdatedTimestamp: partialDevice.lastUpdatedTimestamp ?? Date.now(),
+        rssi: -35, // -35 dBm is a good strong signal
+        macAddress: '00:11:22:33:44:55',
+        paired: false,
+        connected: false,
+        connectionStatus: { type: 'connected' },
+        ...partialDevice,
     };
 };

--- a/packages/suite/src/actions/bluetooth/__tests__/createMockedBluetoothDevice.ts
+++ b/packages/suite/src/actions/bluetooth/__tests__/createMockedBluetoothDevice.ts
@@ -1,0 +1,19 @@
+import { createBluetoothDeviceCommon } from '@suite-common/bluetooth/src/support/mocks';
+
+import { type DesktopBluetoothDevice } from '../DesktopBluetoothDevice';
+
+export const createMockedBluetoothDevice = (
+    partialDevice: Partial<DesktopBluetoothDevice>,
+): DesktopBluetoothDevice => {
+    const bluetoothDeviceCommon = createBluetoothDeviceCommon(partialDevice);
+
+    return {
+        ...bluetoothDeviceCommon,
+        rssi: partialDevice.rssi ?? -35, // -35 dBm is a good strong signal
+        macAddress: partialDevice.macAddress ?? '00:11:22:33:44:55',
+        paired: partialDevice.paired ?? false,
+        connected: partialDevice.connected ?? false,
+        connectionStatus: partialDevice.connectionStatus ?? { type: 'connected' },
+        lastUpdatedTimestamp: partialDevice.lastUpdatedTimestamp ?? Date.now(),
+    };
+};

--- a/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.test.ts
+++ b/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.test.ts
@@ -1,13 +1,13 @@
-import { createBluetoothDevice } from '@suite-common/bluetooth/src/support/mocks';
-import { BluetoothDeviceCommon } from '@suite-common/bluetooth/src/types';
 import { asBluetoothDeviceId } from '@trezor/connect';
 import * as envUtils from '@trezor/env-utils';
 
+import { DesktopBluetoothDevice } from './DesktopBluetoothDevice';
+import { createMockedBluetoothDevice } from './__tests__/createMockedBluetoothDevice';
 import { filterOutNonResponsiveDevices } from './filterOutNonResponsiveDevices';
 
 describe(filterOutNonResponsiveDevices.name, () => {
     beforeAll(() => {
-        jest.spyOn(Date, 'now').mockReturnValue(5_000);
+        jest.spyOn(Date, 'now').mockReturnValue(8_000);
         jest.spyOn(envUtils, 'isLinux').mockReturnValue(false);
     });
 
@@ -16,17 +16,17 @@ describe(filterOutNonResponsiveDevices.name, () => {
     });
 
     it('keeps devices that are in pairing mode regardless of lastUpdatedTimestamp', () => {
-        const devices: BluetoothDeviceCommon[] = [
-            createBluetoothDevice({
+        const devices: DesktopBluetoothDevice[] = [
+            createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('1'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 1_000,
+                lastUpdatedTimestamp: 4_000,
                 connectionStatus: { type: 'pairing' },
             }),
-            createBluetoothDevice({
+            createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('2'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 1_000,
+                lastUpdatedTimestamp: 4_000,
                 connectionStatus: { type: 'pairing' },
             }),
         ];
@@ -36,21 +36,21 @@ describe(filterOutNonResponsiveDevices.name, () => {
     });
 
     it('filters non responsive devices', () => {
-        const devices: BluetoothDeviceCommon[] = [
-            createBluetoothDevice({
+        const devices: DesktopBluetoothDevice[] = [
+            createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('1'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 1_000,
+                lastUpdatedTimestamp: 4_000,
             }),
-            createBluetoothDevice({
+            createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('2'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 1_000,
+                lastUpdatedTimestamp: 4_000,
             }),
-            createBluetoothDevice({
+            createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('3'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 5_000,
+                lastUpdatedTimestamp: 9_000,
             }),
         ];
 
@@ -59,20 +59,45 @@ describe(filterOutNonResponsiveDevices.name, () => {
     });
 
     it('keeps responsive devices', () => {
-        const devices: BluetoothDeviceCommon[] = [
-            createBluetoothDevice({
+        const devices: DesktopBluetoothDevice[] = [
+            createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('1'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 3_500,
+                lastUpdatedTimestamp: 7_500,
             }),
-            createBluetoothDevice({
+            createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('2'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 4_000,
+                lastUpdatedTimestamp: 7_000,
             }),
         ];
 
         const result = filterOutNonResponsiveDevices(devices);
+        expect(result).toHaveLength(2);
+    });
+
+    it('progressively increases the unresponsive device timeout', () => {
+        const weakSignalDevices: DesktopBluetoothDevice[] = [
+            createMockedBluetoothDevice({
+                id: asBluetoothDeviceId('1'),
+                name: 'DeviceA',
+                lastUpdatedTimestamp: 6_000,
+                rssi: -90,
+            }),
+            createMockedBluetoothDevice({
+                id: asBluetoothDeviceId('2'),
+                name: 'DeviceB',
+                lastUpdatedTimestamp: 5_000,
+                rssi: -100,
+            }),
+            createMockedBluetoothDevice({
+                id: asBluetoothDeviceId('3'),
+                name: 'DeviceC',
+                lastUpdatedTimestamp: 1_000,
+            }),
+        ];
+
+        const result = filterOutNonResponsiveDevices(weakSignalDevices);
         expect(result).toHaveLength(2);
     });
 });

--- a/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.test.ts
+++ b/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.test.ts
@@ -3,11 +3,16 @@ import * as envUtils from '@trezor/env-utils';
 
 import { DesktopBluetoothDevice } from './DesktopBluetoothDevice';
 import { createMockedBluetoothDevice } from './__tests__/createMockedBluetoothDevice';
-import { filterOutNonResponsiveDevices } from './filterOutNonResponsiveDevices';
+import {
+    filterOutNonResponsiveDevices,
+    getLastUpdatedLimitForDevice,
+} from './filterOutNonResponsiveDevices';
+
+const NOW = 8_000;
 
 describe(filterOutNonResponsiveDevices.name, () => {
     beforeAll(() => {
-        jest.spyOn(Date, 'now').mockReturnValue(8_000);
+        jest.spyOn(Date, 'now').mockReturnValue(NOW);
         jest.spyOn(envUtils, 'isLinux').mockReturnValue(false);
     });
 
@@ -20,13 +25,13 @@ describe(filterOutNonResponsiveDevices.name, () => {
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('1'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 4_000,
+                lastUpdatedTimestamp: NOW - 4_000,
                 connectionStatus: { type: 'pairing' },
             }),
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('2'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 4_000,
+                lastUpdatedTimestamp: NOW - 4_000,
                 connectionStatus: { type: 'pairing' },
             }),
         ];
@@ -40,17 +45,17 @@ describe(filterOutNonResponsiveDevices.name, () => {
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('1'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 4_000,
+                lastUpdatedTimestamp: NOW - 4_000,
             }),
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('2'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 4_000,
+                lastUpdatedTimestamp: NOW - 4_000,
             }),
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('3'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 9_000,
+                lastUpdatedTimestamp: NOW + 1_000,
             }),
         ];
 
@@ -63,12 +68,12 @@ describe(filterOutNonResponsiveDevices.name, () => {
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('1'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 7_500,
+                lastUpdatedTimestamp: NOW - 500,
             }),
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('2'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 7_000,
+                lastUpdatedTimestamp: NOW - 1_000,
             }),
         ];
 
@@ -81,23 +86,58 @@ describe(filterOutNonResponsiveDevices.name, () => {
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('1'),
                 name: 'DeviceA',
-                lastUpdatedTimestamp: 6_000,
+                lastUpdatedTimestamp: NOW - 2_000,
                 rssi: -90,
             }),
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('2'),
                 name: 'DeviceB',
-                lastUpdatedTimestamp: 5_000,
+                lastUpdatedTimestamp: NOW - 5_000,
+                rssi: -100,
+            }),
+            createMockedBluetoothDevice({
+                id: asBluetoothDeviceId('2'),
+                name: 'DeviceB',
+                lastUpdatedTimestamp: NOW - 5_001,
                 rssi: -100,
             }),
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('3'),
                 name: 'DeviceC',
-                lastUpdatedTimestamp: 1_000,
+                lastUpdatedTimestamp: NOW - 7000,
             }),
         ];
 
         const result = filterOutNonResponsiveDevices(weakSignalDevices);
         expect(result).toHaveLength(2);
+    });
+});
+
+describe(getLastUpdatedLimitForDevice.name, () => {
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
+    it('calculates limit as per rssi for platforms other than linux', () => {
+        jest.spyOn(envUtils, 'isLinux').mockReturnValue(false);
+        expect(getLastUpdatedLimitForDevice(undefined)).toBe(3_000);
+        expect(getLastUpdatedLimitForDevice(-35)).toBe(3_000);
+        expect(getLastUpdatedLimitForDevice(-70)).toBe(3_000);
+        expect(getLastUpdatedLimitForDevice(-80)).toBe(3_000);
+        expect(getLastUpdatedLimitForDevice(-81)).toBe(4_000);
+        expect(getLastUpdatedLimitForDevice(-89)).toBe(4_000);
+        expect(getLastUpdatedLimitForDevice(-91)).toBe(5_000);
+        expect(getLastUpdatedLimitForDevice(-111)).toBe(7_000);
+    });
+
+    it('calculates limit as per rssi for linux', () => {
+        jest.spyOn(envUtils, 'isLinux').mockReturnValue(true);
+        expect(getLastUpdatedLimitForDevice(undefined)).toBe(5_000);
+        expect(getLastUpdatedLimitForDevice(-35)).toBe(5_000);
+        expect(getLastUpdatedLimitForDevice(-70)).toBe(5_000);
+        expect(getLastUpdatedLimitForDevice(-80)).toBe(5_000);
+        expect(getLastUpdatedLimitForDevice(-81)).toBe(6_000);
+        expect(getLastUpdatedLimitForDevice(-89)).toBe(6_000);
+        expect(getLastUpdatedLimitForDevice(-91)).toBe(7_000);
+        expect(getLastUpdatedLimitForDevice(-111)).toBe(9_000);
     });
 });

--- a/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.ts
+++ b/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.ts
@@ -1,11 +1,15 @@
-import type {
-    BluetoothDeviceCommon,
-    DeviceBluetoothConnectionStatusType,
-} from '@suite-common/bluetooth/src/types';
+import type { DeviceBluetoothConnectionStatusType } from '@suite-common/bluetooth/src/types';
 import { isLinux } from '@trezor/env-utils';
+
+import { DesktopBluetoothDevice } from './DesktopBluetoothDevice';
 
 export const NEARBY_DEVICES_LAST_UPDATED_LIMIT = 3_000;
 export const NEARBY_DEVICES_LAST_UPDATED_LIMIT_LINUX = 5_000;
+
+const NEARBY_DEVICE_WEAK_SIGNAL_LIMIT = -80; // dBm
+
+const NEARBY_DEVICE_INCREASE_PER = 10; // dBm
+const NEARBY_DEVICE_INCREASE = 1_000; // ms
 
 const CONNECTION_STATUSES_TO_KEEP: DeviceBluetoothConnectionStatusType[] = [
     'connecting',
@@ -18,15 +22,27 @@ const CONNECTION_STATUSES_TO_KEEP: DeviceBluetoothConnectionStatusType[] = [
  *
  * Devices in 'pairing' state are kept regardless of last updated timestamp, as they are actively being paired.
  */
-export const filterOutNonResponsiveDevices = <T extends BluetoothDeviceCommon>(devices: T[]) => {
+export const filterOutNonResponsiveDevices = (devices: DesktopBluetoothDevice[]) => {
     const now = Date.now();
-    const limit = isLinux()
+    const baseLimit = isLinux()
         ? NEARBY_DEVICES_LAST_UPDATED_LIMIT_LINUX
         : NEARBY_DEVICES_LAST_UPDATED_LIMIT;
 
-    return devices.filter(
-        device =>
+    return devices.filter(device => {
+        let limit = baseLimit;
+
+        if (device.rssi && device.rssi <= NEARBY_DEVICE_WEAK_SIGNAL_LIMIT) {
+            // for each additional 10 dBm below the weak signal limit, increase the limit by 2 seconds
+            // e.g. -90 dBm => 4 seconds increase, -100 dBm => 6 seconds increase, ...
+            limit +=
+                Math.floor(
+                    (NEARBY_DEVICE_WEAK_SIGNAL_LIMIT - device.rssi) / NEARBY_DEVICE_INCREASE_PER,
+                ) * NEARBY_DEVICE_INCREASE;
+        }
+
+        return (
             device.lastUpdatedTimestamp >= now - limit ||
-            CONNECTION_STATUSES_TO_KEEP.includes(device.connectionStatus.type),
-    );
+            CONNECTION_STATUSES_TO_KEEP.includes(device.connectionStatus.type)
+        );
+    });
 };

--- a/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.ts
+++ b/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.ts
@@ -8,13 +8,33 @@ export const NEARBY_DEVICES_LAST_UPDATED_LIMIT_LINUX = 5_000;
 
 const NEARBY_DEVICE_WEAK_SIGNAL_LIMIT = -80; // dBm
 
-const NEARBY_DEVICE_INCREASE_PER = 10; // dBm
-const NEARBY_DEVICE_INCREASE = 1_000; // ms
+const NEARBY_DEVICE_DECREASE_PER = 10; // dBm
+const NEARBY_DEVICE_DECREASE = -1_000; // ms
 
 const CONNECTION_STATUSES_TO_KEEP: DeviceBluetoothConnectionStatusType[] = [
     'connecting',
     'pairing',
 ] as const;
+
+/**
+ * For each additional 10 dBm below the weak signal limit, increase the limit by 2 seconds
+ * e.g. -90 dBm => 2 seconds increase, -100 dBm => 4 seconds increase, ...
+ */
+export const getLastUpdatedLimitForDevice = (rssi?: number) => {
+    const baseLimit = isLinux()
+        ? NEARBY_DEVICES_LAST_UPDATED_LIMIT_LINUX
+        : NEARBY_DEVICES_LAST_UPDATED_LIMIT;
+
+    if (rssi === undefined) return baseLimit;
+
+    const limit =
+        baseLimit +
+        Math.floor((rssi - NEARBY_DEVICE_WEAK_SIGNAL_LIMIT) / NEARBY_DEVICE_DECREASE_PER) *
+            NEARBY_DEVICE_DECREASE;
+
+    // if above NEARBY_DEVICE_WEAK_SIGNAL_LIMIT, return always base limit
+    return Math.max(limit, baseLimit);
+};
 
 /**
  * Filters out devices that have not been responsive for a certain period of time.
@@ -24,25 +44,10 @@ const CONNECTION_STATUSES_TO_KEEP: DeviceBluetoothConnectionStatusType[] = [
  */
 export const filterOutNonResponsiveDevices = (devices: DesktopBluetoothDevice[]) => {
     const now = Date.now();
-    const baseLimit = isLinux()
-        ? NEARBY_DEVICES_LAST_UPDATED_LIMIT_LINUX
-        : NEARBY_DEVICES_LAST_UPDATED_LIMIT;
 
-    return devices.filter(device => {
-        let limit = baseLimit;
-
-        if (device.rssi && device.rssi <= NEARBY_DEVICE_WEAK_SIGNAL_LIMIT) {
-            // for each additional 10 dBm below the weak signal limit, increase the limit by 2 seconds
-            // e.g. -90 dBm => 4 seconds increase, -100 dBm => 6 seconds increase, ...
-            limit +=
-                Math.floor(
-                    (NEARBY_DEVICE_WEAK_SIGNAL_LIMIT - device.rssi) / NEARBY_DEVICE_INCREASE_PER,
-                ) * NEARBY_DEVICE_INCREASE;
-        }
-
-        return (
-            device.lastUpdatedTimestamp >= now - limit ||
-            CONNECTION_STATUSES_TO_KEEP.includes(device.connectionStatus.type)
-        );
-    });
+    return devices.filter(
+        device =>
+            device.lastUpdatedTimestamp >= now - getLastUpdatedLimitForDevice(device.rssi) ||
+            CONNECTION_STATUSES_TO_KEEP.includes(device.connectionStatus.type),
+    );
 };

--- a/packages/suite/src/actions/bluetooth/removeNonResponsiveNearbyDevicesThunk.ts
+++ b/packages/suite/src/actions/bluetooth/removeNonResponsiveNearbyDevicesThunk.ts
@@ -1,12 +1,13 @@
 import { BLUETOOTH_PREFIX, bluetoothActions, selectNearbyDevices } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 
+import { DesktopBluetoothDevice } from './DesktopBluetoothDevice';
 import { filterOutNonResponsiveDevices } from './filterOutNonResponsiveDevices';
 
 export const removeNonResponsiveNearbyDevicesThunk = createThunk<void, void>(
     `${BLUETOOTH_PREFIX}/removeNonResponsiveNearbyDevicesThunk`,
     (_, { dispatch, getState }) => {
-        const nearbyDevices = selectNearbyDevices(getState());
+        const nearbyDevices = selectNearbyDevices<DesktopBluetoothDevice>(getState());
 
         dispatch(
             bluetoothActions.nearbyDevicesUpdateAction({

--- a/suite-common/bluetooth/src/support/mocks.ts
+++ b/suite-common/bluetooth/src/support/mocks.ts
@@ -8,7 +8,7 @@ import { BluetoothDeviceCommon } from '../types';
 /**
  * Generate a mock bluetooth known or nearby device.
  */
-export const createBluetoothDevice = (
+export const createBluetoothDeviceCommon = (
     partialBluetoothDevice?: Partial<BluetoothDeviceCommon>,
 ): BluetoothDeviceCommon => ({
     id: asBluetoothDeviceId('bt-device-1'),

--- a/suite-common/bluetooth/tests/filterOutOldDuplicates.test.ts
+++ b/suite-common/bluetooth/tests/filterOutOldDuplicates.test.ts
@@ -2,7 +2,7 @@ import { asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { filterOutOldDuplicates } from '../src/filterOutOldDuplicates';
-import { createBluetoothDevice } from '../src/support/mocks';
+import { createBluetoothDeviceCommon } from '../src/support/mocks';
 import { BluetoothDeviceCommon } from '../src/types';
 import type { BluetoothManufacturerData } from '../src/types';
 
@@ -26,19 +26,19 @@ const mockedManufacturerDataWithFilterPolicy: BluetoothManufacturerData = {
 describe(filterOutOldDuplicates.name, () => {
     it('returns all devices if names and props are unique', () => {
         const devices: BluetoothDeviceCommon[] = [
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('1'),
                 name: 'DeviceA',
                 lastUpdatedTimestamp: 100,
                 manufacturerData: mockedManufacturerDataWithFilterPolicy,
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('2'),
                 name: 'DeviceB',
                 lastUpdatedTimestamp: 200,
                 manufacturerData: mockedManufacturerDataWithFilterPolicy,
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('3'),
                 name: 'DeviceC',
                 lastUpdatedTimestamp: 300,
@@ -52,19 +52,19 @@ describe(filterOutOldDuplicates.name, () => {
 
     it('keeps only the latest device for duplicate names and props', () => {
         const devices: BluetoothDeviceCommon[] = [
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('1'),
                 name: 'DeviceA',
                 lastUpdatedTimestamp: 100,
                 manufacturerData: mockedManufacturerDataWithFilterPolicy,
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('2'),
                 name: 'DeviceA',
                 lastUpdatedTimestamp: 200,
                 manufacturerData: mockedManufacturerDataWithFilterPolicy,
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('3'),
                 name: 'DeviceB',
                 lastUpdatedTimestamp: 150,
@@ -74,13 +74,13 @@ describe(filterOutOldDuplicates.name, () => {
         const result = filterOutOldDuplicates(devices);
         expect(result).toHaveLength(2);
         expect(result).toEqual([
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('2'),
                 name: 'DeviceA',
                 lastUpdatedTimestamp: 200,
                 manufacturerData: mockedManufacturerDataWithFilterPolicy,
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('3'),
                 name: 'DeviceB',
                 lastUpdatedTimestamp: 150,
@@ -91,31 +91,31 @@ describe(filterOutOldDuplicates.name, () => {
 
     it('handles multiple sets of duplicates', () => {
         const devices: BluetoothDeviceCommon[] = [
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('1'),
                 name: 'DeviceA',
                 lastUpdatedTimestamp: 100,
                 manufacturerData: mockedManufacturerDataWithFilterPolicy,
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('2'),
                 name: 'DeviceA',
                 lastUpdatedTimestamp: 200,
                 manufacturerData: mockedManufacturerDataWithFilterPolicy,
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('3'),
                 name: 'DeviceB',
                 lastUpdatedTimestamp: 150,
                 manufacturerData: mockedManufacturerDataWithFilterPolicy,
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('4'),
                 name: 'DeviceB',
                 lastUpdatedTimestamp: 250,
                 manufacturerData: mockedManufacturerDataWithFilterPolicy,
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('5'),
                 name: 'DeviceC',
                 lastUpdatedTimestamp: 300,
@@ -125,19 +125,19 @@ describe(filterOutOldDuplicates.name, () => {
         const result = filterOutOldDuplicates(devices);
         expect(result).toHaveLength(3);
         expect(result).toEqual([
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('2'),
                 name: 'DeviceA',
                 lastUpdatedTimestamp: 200,
                 manufacturerData: mockedManufacturerDataWithFilterPolicy,
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('4'),
                 name: 'DeviceB',
                 lastUpdatedTimestamp: 250,
                 manufacturerData: mockedManufacturerDataWithFilterPolicy,
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('5'),
                 name: 'DeviceC',
                 lastUpdatedTimestamp: 300,
@@ -148,7 +148,7 @@ describe(filterOutOldDuplicates.name, () => {
 
     it('keeps the duplicated devices if filterPolicy.pairing is false or undefined', () => {
         const devices: BluetoothDeviceCommon[] = [
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('1'),
                 name: 'DeviceA',
                 lastUpdatedTimestamp: 100,
@@ -162,12 +162,12 @@ describe(filterOutOldDuplicates.name, () => {
                     },
                 },
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('2'),
                 name: 'DeviceA',
                 lastUpdatedTimestamp: 200,
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('3'),
                 name: 'DeviceB',
                 lastUpdatedTimestamp: 150,
@@ -180,19 +180,19 @@ describe(filterOutOldDuplicates.name, () => {
 
     it('keeps the duplicated devices if filterPolicy is undefined', () => {
         const devices: BluetoothDeviceCommon[] = [
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('1'),
                 name: 'DeviceA',
                 lastUpdatedTimestamp: 100,
                 manufacturerData: mockedManufacturerData,
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('2'),
                 name: 'DeviceA',
                 lastUpdatedTimestamp: 200,
                 manufacturerData: mockedManufacturerData,
             }),
-            createBluetoothDevice({
+            createBluetoothDeviceCommon({
                 id: asBluetoothDeviceId('3'),
                 name: 'DeviceB',
                 lastUpdatedTimestamp: 150,

--- a/suite-common/wallet-core/src/device/__fixtures__/forgetPersistentDataPreloadedState.ts
+++ b/suite-common/wallet-core/src/device/__fixtures__/forgetPersistentDataPreloadedState.ts
@@ -1,5 +1,5 @@
 import { BluetoothState, prepareInitialState } from '@suite-common/bluetooth';
-import { createBluetoothDevice } from '@suite-common/bluetooth/src/support/mocks';
+import { createBluetoothDeviceCommon } from '@suite-common/bluetooth/src/support/mocks';
 import { BluetoothDeviceCommon } from '@suite-common/bluetooth/src/types';
 import { ThpState, initialThpState } from '@suite-common/thp';
 import { createCredential, createDeviceThp } from '@suite-common/thp/src/support/mocks';
@@ -14,9 +14,9 @@ type ForgetPersistentDataPreloadedState = {
     thp: ThpState;
 };
 
-const BTDevice1 = createBluetoothDevice({ id: asBluetoothDeviceId('bt-id-1') });
-const BTDevice3 = createBluetoothDevice({ id: asBluetoothDeviceId('bt-id-3') });
-const orphanedBTDevice = createBluetoothDevice({ id: asBluetoothDeviceId('bt-id-4') });
+const BTDevice1 = createBluetoothDeviceCommon({ id: asBluetoothDeviceId('bt-id-1') });
+const BTDevice3 = createBluetoothDeviceCommon({ id: asBluetoothDeviceId('bt-id-3') });
+const orphanedBTDevice = createBluetoothDeviceCommon({ id: asBluetoothDeviceId('bt-id-4') });
 
 const credential1A = createCredential({ credential: '1A' });
 const credential1B = createCredential({ credential: '1B' });


### PR DESCRIPTION
As device can have weak signal (for various reasons like bad BT adapter, a lot of other BT devices nearby) we need to progresivelly increment the unresponsive device timeout for these cases.

Changes:
- if device's rssi value is over `NEARBY_DEVICE_WEAK_SIGNAL_LIMIT` we than increase the timeout limit by 1s for each `-10` dBm
- renamed `createBluetoothDevice` to `createBluetoothDeviceCommon`
- created `createMockedBluetoothDevice` for desktop

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22488



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/increase-unresponsive-timeout-progressively&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/increase-unresponsive-timeout-progressively&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/increase-unresponsive-timeout-progressively&lookback=7)