### PR TITLE
fix(connect): FW hash check for T3W1 2.9.3

### DIFF
--- a/packages/connect/src/api/firmware/__tests__/calculateFirmwareHash.test.ts
+++ b/packages/connect/src/api/firmware/__tests__/calculateFirmwareHash.test.ts
@@ -9,12 +9,13 @@ const bin = Buffer.from('ff', 'hex');
 describe('firmware/calculateFirmwareHash', () => {
     it('T1B1 without internal_model', () => {
         expect(
-            calculateFirmwareHash(
-                // @ts-expect-error - Testing some might be real case when T1B1 does not report interna_model
-                undefined,
-                bin,
-                Buffer.from('0123456789abcdef'),
-            ),
+            calculateFirmwareHash({
+                // @ts-expect-error - Testing some might be real case when T1B1 does not report internal_model
+                internal_model: undefined,
+                firmwareVersion: [1, 5, 0],
+                fw: bin,
+                key: Buffer.from('0123456789abcdef'),
+            }),
         ).toStrictEqual({
             hash: 'f5f1097835c9a7c45486230b4f40389a85a4442b5c2c7766e7ca8ef22bf84bd1',
             challenge: '30313233343536373839616263646566',
@@ -23,7 +24,12 @@ describe('firmware/calculateFirmwareHash', () => {
 
     it('T1B1 with challenge', () => {
         expect(
-            calculateFirmwareHash(DeviceModelInternal.T1B1, bin, Buffer.from('0123456789abcdef')),
+            calculateFirmwareHash({
+                internal_model: DeviceModelInternal.T1B1,
+                firmwareVersion: [1, 13, 0],
+                fw: bin,
+                key: Buffer.from('0123456789abcdef'),
+            }),
         ).toStrictEqual({
             hash: 'f5f1097835c9a7c45486230b4f40389a85a4442b5c2c7766e7ca8ef22bf84bd1',
             challenge: '30313233343536373839616263646566',
@@ -31,7 +37,13 @@ describe('firmware/calculateFirmwareHash', () => {
     });
 
     it('T1B1 without challenge', () => {
-        expect(calculateFirmwareHash(DeviceModelInternal.T1B1, bin)).toStrictEqual({
+        expect(
+            calculateFirmwareHash({
+                internal_model: DeviceModelInternal.T1B1,
+                firmwareVersion: [1, 13, 0],
+                fw: bin,
+            }),
+        ).toStrictEqual({
             hash: 'a184d460adaac3c059bf2240521b5ff89a6aa6c2a765165d28bee7f4cb9af051',
             challenge: '',
         });
@@ -40,7 +52,12 @@ describe('firmware/calculateFirmwareHash', () => {
     // T2T1 results from https://github.com/trezor/trezor-firmware/blob/main/core/tests/test_trezor.utils.py
     it('T2T1 with challenge', () => {
         expect(
-            calculateFirmwareHash(DeviceModelInternal.T2T1, bin, Buffer.from('0123456789abcdef')),
+            calculateFirmwareHash({
+                internal_model: DeviceModelInternal.T2T1,
+                firmwareVersion: [2, 9, 2],
+                fw: bin,
+                key: Buffer.from('0123456789abcdef'),
+            }),
         ).toStrictEqual({
             hash: 'a0934098a680db076ddf7ee22745f119d8fda4601048f05fdb66a64eddc0cfed',
             challenge: '30313233343536373839616263646566',
@@ -48,7 +65,13 @@ describe('firmware/calculateFirmwareHash', () => {
     });
 
     it('T2T1 without challenge', () => {
-        expect(calculateFirmwareHash(DeviceModelInternal.T2T1, bin)).toStrictEqual({
+        expect(
+            calculateFirmwareHash({
+                internal_model: DeviceModelInternal.T2T1,
+                firmwareVersion: [2, 9, 2],
+                fw: bin,
+            }),
+        ).toStrictEqual({
             hash: 'd2db90a76a5636a7004ec3b48e71a955e0cbb2cb5a6fd7ae9fbef846bc166c8c',
             challenge: '',
         });
@@ -56,15 +79,40 @@ describe('firmware/calculateFirmwareHash', () => {
 
     it('T3W1 with challenge', () => {
         expect(
-            calculateFirmwareHash(DeviceModelInternal.T3W1, bin, Buffer.from('0123456789abcdef')),
+            calculateFirmwareHash({
+                internal_model: DeviceModelInternal.T3W1,
+                firmwareVersion: [2, 9, 2],
+                fw: bin,
+                key: Buffer.from('0123456789abcdef'),
+            }),
         ).toStrictEqual({
             hash: '9fb271f171cb9b6a915bac9b62ad80d2319f52dbae7501ddb1d7db43fdfae86f',
             challenge: '30313233343536373839616263646566',
         });
     });
 
+    it('T3W1 2.9.3 with challenge', () => {
+        expect(
+            calculateFirmwareHash({
+                internal_model: DeviceModelInternal.T3W1,
+                firmwareVersion: [2, 9, 3],
+                fw: bin,
+                key: Buffer.from('0123456789abcdef'),
+            }),
+        ).toStrictEqual({
+            hash: 'd1e3db63003f7fbb01f3f91379f000b4eec38e63f93ea8ab457a5ed71191ff33',
+            challenge: '30313233343536373839616263646566',
+        });
+    });
+
     it('T3W1 without challenge', () => {
-        expect(calculateFirmwareHash(DeviceModelInternal.T3W1, bin)).toStrictEqual({
+        expect(
+            calculateFirmwareHash({
+                internal_model: DeviceModelInternal.T3W1,
+                firmwareVersion: [2, 9, 2],
+                fw: bin,
+            }),
+        ).toStrictEqual({
             hash: '6f64d60f29dadd23f0383c51a0c595b4a4d7da952a1f3c7a03de149f1f7a394c',
             challenge: '',
         });
@@ -73,10 +121,11 @@ describe('firmware/calculateFirmwareHash', () => {
     // just for coverage
     it('no padding', () => {
         expect(
-            calculateFirmwareHash(
-                DeviceModelInternal.T2T1,
-                Buffer.alloc(13 * 128 * 1024).fill(bin),
-            ),
+            calculateFirmwareHash({
+                internal_model: DeviceModelInternal.T2T1,
+                firmwareVersion: [2, 9, 2],
+                fw: Buffer.alloc(13 * 128 * 1024).fill(bin),
+            }),
         ).toStrictEqual({
             hash: 'd2db90a76a5636a7004ec3b48e71a955e0cbb2cb5a6fd7ae9fbef846bc166c8c',
             challenge: '',
@@ -85,7 +134,11 @@ describe('firmware/calculateFirmwareHash', () => {
 
     it('T2T1, Firmware too big', () => {
         expect(() =>
-            calculateFirmwareHash(DeviceModelInternal.T2T1, Buffer.alloc(100000000)),
+            calculateFirmwareHash({
+                internal_model: DeviceModelInternal.T2T1,
+                firmwareVersion: [2, 9, 2],
+                fw: Buffer.alloc(100000000),
+            }),
         ).toThrow('Firmware too big');
     });
 });

--- a/packages/connect/src/api/firmware/calculateFirmwareHash.ts
+++ b/packages/connect/src/api/firmware/calculateFirmwareHash.ts
@@ -1,6 +1,7 @@
 import { blake2sHex } from 'blakejs';
 
-import { DeviceModelInternal } from '@trezor/device-utils';
+import { DeviceModelInternal, VersionArray } from '@trezor/device-utils';
+import { versionUtils } from '@trezor/utils';
 
 // Size values are taken from
 // https://github.com/trezor/trezor-firmware/blob/56f9490c01b40e99d94fe5d8a283955800d86562/core/embed/models/T3T1/memory.h#L62
@@ -22,13 +23,41 @@ const firmwareSizeMap: Partial<Record<DeviceModelInternal, number>> = {
     [DeviceModelInternal.T3W1]: SIZE_T3W1,
 };
 
-export const calculateFirmwareHash = (
-    internal_model: DeviceModelInternal,
-    fw: ArrayBuffer,
-    key?: Buffer,
-) => {
+type CalculateFirmwareHashParams = {
+    internal_model: DeviceModelInternal;
+    fw: ArrayBuffer;
+    firmwareVersion: VersionArray;
+    key?: Buffer;
+};
+
+const getSizeForModel = ({
+    internal_model,
+    firmwareVersion,
+}: Pick<CalculateFirmwareHashParams, 'firmwareVersion' | 'internal_model'>) => {
     // Default is SIZE_T1B1 since some old T1 do not report internal_model.
     const size = firmwareSizeMap[internal_model] ?? SIZE_T1B1;
+
+    // Fix for T3W1 2.9.3, which had a bug causing the calculated area to be 16kB smaller.
+    // This can be removed once 2.9.3 is no longer supported.
+    if (
+        firmwareVersion !== undefined &&
+        internal_model === DeviceModelInternal.T3W1 &&
+        versionUtils.isEqual(firmwareVersion, [2, 9, 3])
+    ) {
+        return size - 16 * 1024;
+    }
+
+    return size;
+};
+
+export const calculateFirmwareHash = ({
+    internal_model,
+    firmwareVersion,
+    fw,
+    key,
+}: CalculateFirmwareHashParams) => {
+    // Default is SIZE_T1B1 since some old T1 do not report internal_model.
+    const size = getSizeForModel({ internal_model, firmwareVersion });
 
     const padding = size - fw.byteLength;
     if (padding < 0) {

--- a/packages/connect/src/device/workflow/checkFirmwareHash.ts
+++ b/packages/connect/src/device/workflow/checkFirmwareHash.ts
@@ -75,11 +75,12 @@ export const checkFirmwareHash = async ({
     }
 
     const strippedBinary = stripFwHeaders(firmwareBinary.binary);
-    const { hash: expectedHash, challenge } = calculateFirmwareHash(
-        device.features.internal_model,
-        strippedBinary,
-        randomBytes(32),
-    );
+    const { hash: expectedHash, challenge } = calculateFirmwareHash({
+        internal_model: device.features.internal_model,
+        firmwareVersion,
+        fw: strippedBinary,
+        key: randomBytes(32),
+    });
 
     // handle rejection of call by a counterfeit device. If unhandled, it crashes device initialization,
     // so device can't be used, but it's preferable to display proper message about counterfeit device


### PR DESCRIPTION
## Description

Introduce a permanently temporaryworkaround for FW hash check on T3W1 2.9.3, where the firmware incorrectly selects the area for its hash check. Suite therefore has to calculate the same thing so it will pass.

FW 2.9.4 will be fixed in https://github.com/trezor/trezor-firmware/pull/6011
and previous versions won't be released so 

I tested this on 2.9.3 test-unsigned, 2.9.3 test-signed, and other models production :heavy_check_mark: 
 
Note: must be tested on FW 2.9.4

Suite E2E manually executed: [Web](https://github.com/trezor/trezor-suite/actions/runs/18530446472), [Desktop](https://github.com/trezor/trezor-suite/actions/runs/18530444597)

## Screenshots:

Failure before this PR
<img width="631" height="338" alt="FW hash check fail" src="https://github.com/user-attachments/assets/f6c71ef9-ce3f-48b9-8eaf-c624ef71164e" />

After:
```
{
    "firmwareRevision": {
        "success": true
    },
    "firmwareHash": {
        "success": true,
        "attemptCount": 1
    }
}
```

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/hash-check-293&lookback=7)