### PR TITLE
fix(suite-native): ios hold to confirm vibrations

### DIFF
--- a/suite-native/atoms/src/HoldToConfirmButton.tsx
+++ b/suite-native/atoms/src/HoldToConfirmButton.tsx
@@ -76,13 +76,14 @@ export const HoldToConfirmButton = ({
     );
 
     const tapGesture = Gesture.LongPress()
+        .minDuration(0)
         .hitSlop({
             top: GESTURE_HIT_SLOP,
             bottom: GESTURE_HIT_SLOP,
             left: GESTURE_HIT_SLOP,
             right: GESTURE_HIT_SLOP,
         })
-        .onBegin(() => {
+        .onStart(() => {
             runOnJS(startOnHoldVibration)();
             animationProgress.value = withTiming(1, { duration: BUTTON_ANIMATION_DURATION });
         })


### PR DESCRIPTION
## Description
This fix addresses a bug where tapping the `hold to confirm` button on iOS causes the button to load and vibrate indefinitely.

There was an `onBegin` event handler that fired every time the gesture handler was tapped. However, `onStart` should be used instead because it is only triggered when the gesture is recognized as valid. After the gesture ends, `onFinalize` is also called correctly in that scenario.

More here: https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/long-press-gesture/#callbacks


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/hold-to-confirm-button-ios&lookback=7)