### PR TITLE
fix(suite): onboarding last step with BTC-only

### DIFF
--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -1,7 +1,7 @@
 import { BackupType } from '@suite-common/suite-types';
-import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice, startDiscoveryThunk } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
-import { OnboardingAnalytics } from '@trezor/suite-analytics';
+import { EventType, OnboardingAnalytics, analytics } from '@trezor/suite-analytics';
 
 import { ONBOARDING } from 'src/actions/onboarding/constants';
 import { stepCategories } from 'src/config/onboarding/steps';
@@ -9,6 +9,10 @@ import * as STEP from 'src/constants/onboarding/steps';
 import { AnyPath, AnyStepId } from 'src/types/onboarding';
 import { Dispatch, GetState } from 'src/types/suite';
 import { findNextStep, findPrevStep, isStepUsed } from 'src/utils/onboarding/steps';
+
+import { selectOnboardingAnalytics } from '../../reducers/onboarding/onboardingReducer';
+import * as routerActions from '../suite/routerActions';
+import * as suiteActions from '../suite/suiteActions';
 
 export type OnboardingAction =
     | {
@@ -67,15 +71,6 @@ const getAllStepsInPath = (getState: GetState) => {
     return allSteps.filter(step => isStepUsed(step, isStepUsedProps));
 };
 
-const goToNextStep = (stepId?: AnyStepId) => (dispatch: Dispatch, getState: GetState) => {
-    if (stepId) {
-        return dispatch(goToStep(stepId));
-    }
-    const stepsInPath = getAllStepsInPath(getState);
-    const nextStep = findNextStep(getState().onboarding.activeStepId, stepsInPath);
-    dispatch(goToStep(nextStep.id));
-};
-
 const goToPreviousStep = (stepId?: AnyStepId) => (dispatch: Dispatch, getState: GetState) => {
     if (stepId) {
         return dispatch(goToStep(stepId));
@@ -101,6 +96,50 @@ const goToPreviousStep = (stepId?: AnyStepId) => (dispatch: Dispatch, getState: 
 const resetOnboarding = (): OnboardingAction => ({
     type: ONBOARDING.RESET_ONBOARDING,
 });
+
+const goToSuite = () => (dispatch: Dispatch, getState: GetState) => {
+    const device = selectSelectedDevice(getState());
+    const onboardingAnalytics = selectOnboardingAnalytics(getState());
+
+    dispatch(suiteActions.initialRunCompleted());
+    dispatch(resetOnboarding());
+    dispatch(routerActions.closeModalApp(true));
+
+    dispatch(startDiscoveryThunk({ device }));
+
+    // only to satisfy typescript, there must be a device to progress with onboarding
+    if (device?.features === undefined) return;
+    const reportAnalytics = () => {
+        const payload = {
+            ...onboardingAnalytics,
+            duration: Date.now() - onboardingAnalytics.startTime!,
+            device: device.features.internal_model,
+            unitPackaging: device.features.unit_packaging ?? 0,
+        };
+        delete payload.startTime;
+
+        analytics.report({
+            type: EventType.DeviceSetupCompleted,
+            payload,
+        });
+    };
+    reportAnalytics();
+};
+
+const goToNextStep = (stepId?: AnyStepId) => (dispatch: Dispatch, getState: GetState) => {
+    if (stepId) {
+        return dispatch(goToStep(stepId));
+    }
+    const stepsInPath = getAllStepsInPath(getState);
+    const nextStep = findNextStep(getState().onboarding.activeStepId, stepsInPath);
+    // we are at last step, so go to Suite
+    if (nextStep === null) {
+        dispatch(goToSuite());
+
+        return;
+    }
+    dispatch(goToStep(nextStep.id));
+};
 
 /**
  * Make onboarding reducer listen to actions.
@@ -138,6 +177,7 @@ export {
     addPath,
     removePath,
     resetOnboarding,
+    goToSuite,
     updateAnalytics,
     beginOnboardingTutorial,
     updateBackupType,

--- a/packages/suite/src/hooks/suite/useOnboarding.ts
+++ b/packages/suite/src/hooks/suite/useOnboarding.ts
@@ -6,8 +6,6 @@ import { OnboardingAnalytics } from '@trezor/suite-analytics';
 
 import * as onboardingActions from 'src/actions/onboarding/onboardingActions';
 import * as recoveryActions from 'src/actions/recovery/recoveryActions';
-import * as routerActions from 'src/actions/suite/routerActions';
-import * as suiteActions from 'src/actions/suite/suiteActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { AnyPath, AnyStepId } from 'src/types/onboarding';
 
@@ -36,20 +34,10 @@ export const useOnboarding = () => {
             addPath: (payload: AnyPath) => dispatch(onboardingActions.addPath(payload)),
             updateBackupType: (payload: BackupType) =>
                 dispatch(onboardingActions.updateBackupType(payload)),
+            goToSuite: () => dispatch(onboardingActions.goToSuite()),
         }),
         [dispatch],
     );
-
-    const goToSuite = (initialRedirection = false) => {
-        dispatch(suiteActions.initialRunCompleted());
-        dispatch(onboardingActions.resetOnboarding());
-        dispatch(routerActions.closeModalApp(true));
-
-        // fixes a bug that user ends up in settings after initialization of a new device because he navigated to settings before
-        if (initialRedirection) {
-            dispatch(routerActions.goto('suite-index'));
-        }
-    };
 
     const { activeStepId } = onboarding;
     const { activeStep, activeStepCategory } = useMemo(
@@ -63,6 +51,5 @@ export const useOnboarding = () => {
         activeStep,
         activeStepCategory,
         showPinMatrix,
-        goToSuite,
     };
 };

--- a/packages/suite/src/reducers/onboarding/onboardingReducer.ts
+++ b/packages/suite/src/reducers/onboarding/onboardingReducer.ts
@@ -91,4 +91,7 @@ const onboarding = (state: OnboardingState = initialState, action: Action) => {
 
 export const selectIsOnboardingActive = (state: OnboardingRootState) => state.onboarding.isActive;
 
+export const selectOnboardingAnalytics = (state: OnboardingRootState) =>
+    state.onboarding.onboardingAnalytics;
+
 export default onboarding;

--- a/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
+++ b/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
@@ -57,8 +57,8 @@ describe('steps', () => {
             expect(findNextStep(firmwareStep.id, stepsMock)).toEqual(backupStep);
         });
 
-        it('should throw on improper use (no more step exists)', () => {
-            expect(() => findNextStep(backupStep.id, stepsMock)).toThrow('no next step exists');
+        it('should return null in no next step exists', () => {
+            expect(findNextStep(backupStep.id, stepsMock)).toBe(null);
         });
     });
 

--- a/packages/suite/src/utils/onboarding/steps.ts
+++ b/packages/suite/src/utils/onboarding/steps.ts
@@ -87,10 +87,10 @@ export const isStepUsed = (step: Step, props: IsStepUsedProps): boolean => {
 export const isStepCategoryUsed = (stepCategory: StepCategory, props: IsStepUsedProps): boolean =>
     stepCategory.steps.some(step => isStepUsed(step, props));
 
-export const findNextStep = (currentStepId: AnyStepId, steps: Step[]) => {
+export const findNextStep = (currentStepId: AnyStepId, steps: Step[]): Step | null => {
     const currentIndex = steps.findIndex((step: Step) => step.id === currentStepId);
     if (!steps[currentIndex + 1]) {
-        throw new Error('no next step exists');
+        return null;
     }
 
     return steps[currentIndex + 1];

--- a/packages/suite/src/views/onboarding/steps/CoinsStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/CoinsStep/index.tsx
@@ -1,9 +1,8 @@
-import { selectEnabledNetworks, startDiscoveryThunk } from '@suite-common/wallet-core';
-import { EventType, analytics } from '@trezor/suite-analytics';
+import { selectEnabledNetworks } from '@suite-common/wallet-core';
 
 import { OnboardingCard } from 'src/components/onboarding/OnboardingCard/OnboardingCard';
 import { Translation } from 'src/components/suite/Translation';
-import { useDevice, useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
+import { useOnboarding, useSelector } from 'src/hooks/suite';
 import { getIsTorLoading } from 'src/utils/suite/tor';
 
 import { CoinsStepBox } from './CoinsStepBox';
@@ -11,38 +10,10 @@ import { CoinsStepBox } from './CoinsStepBox';
 export const CoinsStep = () => {
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const torStatus = useSelector(state => state.suite.torStatus);
-    const onboardingAnalytics = useSelector(state => state.onboarding.onboardingAnalytics);
     const { goToSuite } = useOnboarding();
-    const { device } = useDevice();
-    const dispatch = useDispatch();
 
     const noNetworkEnabled = !enabledNetworks.length;
     const isTorLoading = getIsTorLoading(torStatus);
-
-    if (device?.features === undefined) {
-        return null;
-    }
-
-    const reportAnalytics = () => {
-        const payload = {
-            ...onboardingAnalytics,
-            duration: Date.now() - onboardingAnalytics.startTime!,
-            device: device.features.internal_model,
-            unitPackaging: device.features.unit_packaging ?? 0,
-        };
-        delete payload.startTime;
-
-        analytics.report({
-            type: EventType.DeviceSetupCompleted,
-            payload,
-        });
-    };
-
-    const handleGoToSuite = () => {
-        reportAnalytics();
-        goToSuite();
-        dispatch(startDiscoveryThunk({ device }));
-    };
 
     return (
         <CoinsStepBox
@@ -51,9 +22,7 @@ export const CoinsStep = () => {
             innerActions={
                 <OnboardingCard.Button
                     data-testid="@onboarding/exit-app-button"
-                    onClick={() => {
-                        handleGoToSuite();
-                    }}
+                    onClick={goToSuite}
                     isLoading={isTorLoading}
                     isDisabled={noNetworkEnabled}
                 >


### PR DESCRIPTION
## Description

When `goToNextStep`, and there is no more step, then `goToSuite` instead of crashing.

This also cleans up the code a bit :slightly_smiling_face: 

I tested:
- onboarding BTC only skipping PIN (goes to suite)
- onboarding BTC only setting PIN (goes to suite)
- onboarding universal (goes to suite from coin selection screen no matter what you do with PIN)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22506


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/onboarding-BTC-only&lookback=7)