### PR TITLE
fix(e2e-suite): adds await for fiat rate loading in trading sell tests

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
@@ -393,16 +393,25 @@ export class TradingPage {
     }
 
     @step()
-    async fillSellForm(
-        amount: string,
-        cryptoCurrency: string = 'bitcoin',
-        fiatCurrencyCode: BaseCurrencyCode = 'eur',
-        country: TradingCountryCode = 'CZ',
-    ) {
+    async fillSellForm({
+        cryptoAmount,
+        networkSymbolOrTokenId = 'btc',
+        cryptoCurrency = 'bitcoin',
+        fiatCurrencyCode = 'eur',
+        country = 'CZ',
+    }: {
+        cryptoAmount: string;
+        networkSymbolOrTokenId?: string;
+        cryptoCurrency?: string;
+        fiatCurrencyCode?: BaseCurrencyCode;
+        country?: TradingCountryCode;
+    }) {
         await this.selectCountryOfResidence(country);
         await this.selectFiatCurrency(fiatCurrencyCode);
+        const isFiatRateLoadingFlag = `wallet.fiat.current.${networkSymbolOrTokenId}-${fiatCurrencyCode}.isLoading`;
+        await this.page.expectReduxObjectToEqual(isFiatRateLoadingFlag, false);
         const quoteRequestPromise = this.page.waitForRequest(invityEndpoint.sellQuotes);
-        await this.youPayCryptoInput.fill(amount);
+        await this.youPayCryptoInput.fill(cryptoAmount);
         await expect(
             this.page.getByText(messages['AMOUNT_IS_NOT_ENOUGH'].defaultMessage),
             'Insufficient funds in the account to run sell flow test. Please contact the "tech_qa" Slack group immediately.',
@@ -413,7 +422,7 @@ export class TradingPage {
                 cryptoCurrency,
                 fiatCurrency: fiatCurrencyCode.toUpperCase(),
                 country,
-                cryptoStringAmount: amount,
+                cryptoStringAmount: cryptoAmount,
                 flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
             },
             { omit: ['fiatStringAmount'] },

--- a/packages/suite-desktop-core/e2e/support/testExtends/enhancePage.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/enhancePage.ts
@@ -1,5 +1,7 @@
 import { Locator, Page, expect, test } from '@playwright/test';
+import { writeFileSync } from 'fs';
 import { get } from 'lodash';
+import { join } from 'path';
 
 declare module '@playwright/test' {
     interface Page {
@@ -17,6 +19,10 @@ declare module '@playwright/test' {
             objectPath: string,
             expectedValue: any,
             options?: { timeout?: number },
+        ): Promise<void>;
+        runWithReduxDump<T>(
+            action: () => Promise<T>,
+            options?: { slice?: string; filePrefix?: string },
         ): Promise<void>;
     }
 }
@@ -83,6 +89,31 @@ export const enhancePage = (page: Page): Page => {
                 expect(testedObject).toStrictEqual(expectedValue);
             }).toPass({ timeout: options.timeout });
         });
+    };
+
+    page.runWithReduxDump = async function <T>(
+        action: () => Promise<T>,
+        options?: { slice?: string; filePrefix?: string },
+    ): Promise<void> {
+        const slice = options?.slice ?? 'wallet';
+        const prefix = options?.filePrefix ?? slice;
+        const ts = new Date().toISOString().replace(/[:.]/g, '-');
+
+        const beforeRaw = await page.getReduxObject(slice);
+        const beforePath = join(process.cwd(), `${prefix}_before_${ts}.json`);
+        writeFileSync(beforePath, JSON.stringify(beforeRaw, null, 2), 'utf-8');
+
+        await action();
+
+        const afterRaw = await page.getReduxObject(slice);
+        const afterPath = join(process.cwd(), `${prefix}_after_${ts}.json`);
+        writeFileSync(afterPath, JSON.stringify(afterRaw, null, 2), 'utf-8');
+
+        throw new Error(`Redux dumps written to:
+- ${beforePath}
+- ${afterPath}
+You can use a diff tool to compare the state before and after the action.
+        `);
     };
 
     return page;

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
@@ -52,7 +52,7 @@ test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () 
         });
 
         await test.step('Fill in a sell request', async () => {
-            await tradingPage.fillSellForm(cryptoAmount);
+            await tradingPage.fillSellForm({ cryptoAmount });
             await expect(tradingPage.bestOfferAmount).toHaveText(fiatAmount);
             await expect(tradingPage.quoteProvider).toHaveText(capitalizeFirstLetter(provider));
             await tradingPage.fees.expectBitcoinFeeCalculated();
@@ -131,7 +131,7 @@ test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () 
 
                 await test.step(`Fill in a sell form with ${feeType} fee`, async () => {
                     await feeSwitchFunction();
-                    await tradingPage.fillSellForm(cryptoAmount);
+                    await tradingPage.fillSellForm({ cryptoAmount });
                     feeRate = await tradingPage.fees.getBitcoinFeeRate(feeType);
                 });
 

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
@@ -48,10 +48,11 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
 
     test('Sell Ethereum token USDC', async ({ tradingPage, devicePrompt }) => {
         await test.step('Fill in a sell request', async () => {
-            await tradingPage.fillSellForm(
+            await tradingPage.fillSellForm({
                 cryptoAmount,
-                'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-            );
+                networkSymbolOrTokenId: 'eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                cryptoCurrency: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            });
             await expect(tradingPage.bestOfferAmount).toHaveText(fiatAmount);
             await expect(tradingPage.quoteProvider).toHaveText(capitalizeFirstLetter(provider));
         });

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
@@ -74,7 +74,11 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
                 maxFeePerGas,
                 maxPriorityFeePerGas,
             });
-            await tradingPage.fillSellForm(cryptoAmount, 'ethereum');
+            await tradingPage.fillSellForm({
+                cryptoAmount,
+                networkSymbolOrTokenId: 'eth',
+                cryptoCurrency: 'ethereum',
+            });
             await expect(tradingPage.bestOfferAmount).toHaveText(fiatAmount);
             await expect(tradingPage.quoteProvider).toHaveText(capitalizeFirstLetter(provider));
         });

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -65,7 +65,11 @@ test.describe('Trading - Sell Solana', { tag: ['@group=trading', '@webOnly'] }, 
     test('Sell Solana', async ({ page, tradingPage, tradingMock, devicePrompt }) => {
         await test.step('Fill in a sell request', async () => {
             const solanaFeePromise = tradingPage.fees.promiseForResponseSolanaFeeCalls();
-            await tradingPage.fillSellForm(cryptoAmount, 'solana');
+            await tradingPage.fillSellForm({
+                cryptoAmount,
+                networkSymbolOrTokenId: 'sol',
+                cryptoCurrency: 'solana',
+            });
             // Automation is too fast, we need to wait for Fees to be resolved
             await solanaFeePromise;
             await expect(tradingPage.fees.miscAmount).toBeVisible();
@@ -132,7 +136,11 @@ test.describe('Trading - Sell Solana', { tag: ['@group=trading', '@webOnly'] }, 
     test('Sell Solana for compared offer', async ({ page, tradingPage }) => {
         await test.step('Fill input amount and opens offer comparison', async () => {
             const solanaFeePromise = tradingPage.fees.promiseForResponseSolanaFeeCalls();
-            await tradingPage.fillSellForm(cryptoAmount, 'solana');
+            await tradingPage.fillSellForm({
+                cryptoAmount,
+                cryptoCurrency: 'solana',
+                networkSymbolOrTokenId: 'sol',
+            });
             // Automation is too fast, we need to wait for Fees to be resolved
             await solanaFeePromise;
             await expect(tradingPage.fees.miscAmount).toBeVisible();


### PR DESCRIPTION
fixes Solana and potentially other sell test by introducing an await for fiat rate loading. Something introduced race condition. No impact on user cause we are talking 100s miliseconds. but tests were too fast.

minor refactor for fillSellForm - there were several optional psitional parameters
new troubeshooting method that dumps redux state before and after action

you can run it this way: 
```
await this.page.runWithReduxDump(async () => {
            await this.page.waitForTimeout(1000);
});
```

In my case I knew test is too fast for product. So I first placed hardcoded waits, identified the spot that way. Then I was looking for what to grab and await. I tried to make redux dump before and after the wait, compare the dumps and found our there is some loading flag I can wait for

<img width="1198" height="363" alt="Screenshot from 2025-10-15 12-28-12" src="https://github.com/user-attachments/assets/ea02e635-a3e7-4cf2-b458-37ac90b0ebb3" />

```
        const isFiatRateLoadingFlag = `wallet.fiat.current.${networkSymbolOrTokenId}-${fiatCurrencyCode}.isLoading`;
        await this.page.expectReduxObjectToEqual(isFiatRateLoadingFlag, false);
```

Since it helped me and I see its fucture uses -> I made a handy method on page object for us. You can ofc do the dump around other actions than just waits.

:feelsgood: 
<img width="1860" height="877" alt="image" src="https://github.com/user-attachments/assets/5631df16-2b8c-41f0-b252-c3ea06845df4" />


## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-solana&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-solana&lookback=7)