### PR TITLE
feat(suite): Add default padding for Tooltip

### DIFF
--- a/packages/components/src/components/Tooltip/TooltipFloatingUi.tsx
+++ b/packages/components/src/components/Tooltip/TooltipFloatingUi.tsx
@@ -32,6 +32,8 @@ import {
 } from '@floating-ui/react';
 import type { Placement, ShiftOptions, UseFloatingReturn } from '@floating-ui/react';
 
+import { spacings } from '@trezor/theme';
+
 /**
  * Based on https://floating-ui.com/docs/tooltip but heavily modified
  */
@@ -85,7 +87,7 @@ export const useTooltip = ({
         const middlewareArray = [
             offset(offsetValue),
             ...(!disableFlip ? [flip()] : []),
-            shiftFloatingUI(shift),
+            shiftFloatingUI(shift || { padding: spacings.xs }),
             arrow({ element: arrowRef }),
         ];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds default padding from window.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before
<img width="236" height="189" alt="Screenshot 2025-10-16 at 9 30 48" src="https://github.com/user-attachments/assets/bdf65473-a12f-4b91-a18a-102447015ba8" />


after
<img width="272" height="192" alt="image" src="https://github.com/user-attachments/assets/eb322734-518a-4953-8269-2f4bef9e7076" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=tooltip-padding&lookback=7)