### PR TITLE
Fix async migrations

### DIFF
--- a/packages/suite-storage/package.json
+++ b/packages/suite-storage/package.json
@@ -17,6 +17,7 @@
     "main": "./src/index.ts",
     "browser": "./src/index.ts",
     "dependencies": {
+        "@suite-common/wallet-types": "workspace:*",
         "@trezor/eslint": "workspace:*",
         "@trezor/utils": "workspace:*",
         "idb": "^8.0.3"

--- a/packages/suite-storage/tsconfig.json
+++ b/packages/suite-storage/tsconfig.json
@@ -3,6 +3,9 @@
     "compilerOptions": { "outDir": "./libDev" },
     "include": [".", "**/*.json"],
     "references": [
+        {
+            "path": "../../suite-common/wallet-types"
+        },
         { "path": "../eslint" },
         { "path": "../utils" }
     ]

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -24,6 +24,7 @@
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/token-definitions": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
+        "@suite-common/wallet-types": "workspace:*",
         "@suite-common/walletconnect": "workspace:*",
         "@suite-native/banner-flags": "workspace:*",
         "@suite-native/blockchain": "workspace:*",

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -1,5 +1,4 @@
 import { combineReducers } from '@reduxjs/toolkit';
-import { DEFAULT_VERSION } from 'redux-persist';
 
 import { prepareAnalyticsReducer } from '@suite-common/analytics';
 import { prepareConnectPopupReducer } from '@suite-common/connect-popup';
@@ -94,7 +93,11 @@ export const prepareRootReducers = async () => {
         // `areTestnetsEnabled` is a developer-only option and does not require migration.
         version: 3,
         migrations: {
-            2: (oldState: any) => ({ ...oldState, fiatCurrencyCode: oldState.fiatCurrency.label }),
+            2: oldState => {
+                if (!oldState?.fiatCurrency?.label) return oldState;
+
+                return { ...oldState, fiatCurrencyCode: oldState?.fiatCurrency?.label };
+            },
         },
     });
 
@@ -110,34 +113,9 @@ export const prepareRootReducers = async () => {
         persistedKeys: walletSettingsPersistedWhitelist,
         key: 'walletSettings',
         version: 2,
-        asyncMigrate: async (oldState: any, currentVersion: number) => {
-            let migratedState = { ...oldState };
-
-            const inboundVersion: number =
-                oldState._persist && oldState._persist.version !== undefined
-                    ? oldState._persist.version
-                    : DEFAULT_VERSION;
-
-            if (inboundVersion === currentVersion) {
-                return Promise.resolve(oldState);
-            }
-
-            if (inboundVersion > currentVersion) {
-                if (process.env.NODE_ENV !== 'production')
-                    console.error('redux-persist: downgrading version is not supported');
-
-                return Promise.resolve(oldState);
-            }
-
-            if (inboundVersion < 1) {
-                migratedState = await migrateAppSettingsAndDiscoveryConfig(migratedState);
-            }
-
-            if (inboundVersion < 2) {
-                migratedState = await migrateAutoEjectToWalletSettings(migratedState);
-            }
-
-            return Promise.resolve(migratedState);
+        migrations: {
+            1: migrateAppSettingsAndDiscoveryConfig,
+            2: migrateAutoEjectToWalletSettings,
         },
     });
 
@@ -162,19 +140,19 @@ export const prepareRootReducers = async () => {
         key: 'wallet',
         version: 3,
         migrations: {
-            2: (oldState: any) => {
-                if (!oldState.accounts) return oldState;
+            2: oldState => {
+                if (!oldState?.accounts) return oldState;
 
-                const oldAccountsState: { accounts: any } = { accounts: oldState.accounts };
+                const oldAccountsState = { accounts: oldState.accounts };
                 const migratedAccounts = migrateAccountLabel(oldAccountsState.accounts);
                 const migratedState = { ...oldState, accounts: migratedAccounts };
 
                 return migratedState;
             },
             3: oldState => {
-                if (!oldState.accounts) return oldState;
+                if (!oldState?.accounts) return oldState;
 
-                const oldAccountsState: { accounts: any } = { accounts: oldState.accounts };
+                const oldAccountsState = { accounts: oldState.accounts };
                 const migratedAccounts = deriveAccountTypeFromPaymentType(
                     oldAccountsState.accounts,
                 );
@@ -204,7 +182,7 @@ export const prepareRootReducers = async () => {
         transforms: [devicePersistTransform],
         migrations: {
             2: oldState => {
-                if (!oldState.devices) return oldState;
+                if (!oldState?.devices) return oldState;
 
                 const oldDevicesState: { devices: any } = { devices: oldState.devices };
                 const migratedDevices = migrateDeviceState(oldDevicesState.devices);
@@ -213,7 +191,7 @@ export const prepareRootReducers = async () => {
                 return migratedState;
             },
             3: oldState => {
-                if (!oldState.devices) return oldState;
+                if (!oldState?.devices) return oldState;
                 const migratedDevices = backfillDeviceAuthenticityChecks(oldState.devices);
 
                 return { ...oldState, devices: migratedDevices };
@@ -313,12 +291,9 @@ export const prepareRootReducers = async () => {
         key: 'root',
         version: 3,
         migrations: {
-            2: (oldState: {
-                wallet: {
-                    accounts: any;
-                    transactions: { transactions: any; fetchStatusDetail: any };
-                };
-            }) => {
+            2: oldState => {
+                if (!oldState?.wallet) return oldState;
+
                 const oldStateWallet = oldState.wallet;
                 const migratedAccounts = migrateAccountBnbToBsc(oldStateWallet.accounts);
 
@@ -340,12 +315,9 @@ export const prepareRootReducers = async () => {
 
                 return migratedState;
             },
-            3: (oldState: {
-                wallet: {
-                    accounts: any;
-                    transactions: { transactions: any; fetchStatusDetail: any };
-                };
-            }) => {
+            3: oldState => {
+                if (!oldState?.wallet) return oldState;
+
                 const oldStateWallet = oldState.wallet;
                 const migratedAccounts = migrateAccountsDeprecateNetworks(oldStateWallet.accounts);
                 const migratedTransactions = migrateTransactionsDeprecateNetworks(

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -28,6 +28,7 @@ import {
     prepareWalletSettingsReducer,
     walletSettingsPersistedWhitelist,
 } from '@suite-common/wallet-core';
+import { WalletSettings } from '@suite-common/wallet-types';
 // Suite Native has circular in @suite-native/test-utils -> @suite-native/state -> ... -> @suite-native/test-utils
 // This is causing problems handling types in WalletConnect, so we import the reducer directly instead of the whole module
 import { prepareWalletConnectReducer } from '@suite-common/walletconnect/src/walletConnectReducer';
@@ -50,6 +51,7 @@ import {
     migrateAccountBnbToBsc,
     migrateAccountLabel,
     migrateAccountsDeprecateNetworks,
+    migrateAutoEjectToWalletSettings,
     migrateDeviceState,
     migrateDiscoveryConfigToWalletSettings,
     migrateTransactionsBnbToBsc,
@@ -120,7 +122,7 @@ export const prepareRootReducers = async () => {
         reducer: walletSettingsReducer,
         persistedKeys: walletSettingsPersistedWhitelist,
         key: 'walletSettings',
-        version: 1,
+        version: 2,
         initialMigration: async () => {
             const appSettings = (await getStoredState({
                 key: 'appSettings',
@@ -141,6 +143,16 @@ export const prepareRootReducers = async () => {
                     bitcoinAmountUnit: appSettings.bitcoinUnits,
                 };
             }
+        },
+        migrations: {
+            2: async (oldState: WalletSettings) => {
+                const devicesState = await getStoredState({
+                    key: 'devices',
+                    storage: await initMmkvStorage(),
+                });
+
+                return migrateAutoEjectToWalletSettings(devicesState, oldState);
+            },
         },
     });
 

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -1,5 +1,5 @@
 import { combineReducers } from '@reduxjs/toolkit';
-import { getStoredState } from 'redux-persist';
+import { DEFAULT_VERSION } from 'redux-persist';
 
 import { prepareAnalyticsReducer } from '@suite-common/analytics';
 import { prepareConnectPopupReducer } from '@suite-common/connect-popup';
@@ -28,7 +28,6 @@ import {
     prepareWalletSettingsReducer,
     walletSettingsPersistedWhitelist,
 } from '@suite-common/wallet-core';
-import { WalletSettings } from '@suite-common/wallet-types';
 // Suite Native has circular in @suite-native/test-utils -> @suite-native/state -> ... -> @suite-native/test-utils
 // This is causing problems handling types in WalletConnect, so we import the reducer directly instead of the whole module
 import { prepareWalletConnectReducer } from '@suite-common/walletconnect/src/walletConnectReducer';
@@ -47,13 +46,12 @@ import {
     bluetoothPersistTransform,
     deriveAccountTypeFromPaymentType,
     devicePersistTransform,
-    initMmkvStorage,
     migrateAccountBnbToBsc,
     migrateAccountLabel,
     migrateAccountsDeprecateNetworks,
+    migrateAppSettingsAndDiscoveryConfig,
     migrateAutoEjectToWalletSettings,
     migrateDeviceState,
-    migrateDiscoveryConfigToWalletSettings,
     migrateTransactionsBnbToBsc,
     migrateTransactionsDeprecateNetworks,
     preparePersistReducer,
@@ -112,36 +110,34 @@ export const prepareRootReducers = async () => {
         persistedKeys: walletSettingsPersistedWhitelist,
         key: 'walletSettings',
         version: 2,
-        initialMigration: async () => {
-            const appSettings = (await getStoredState({
-                key: 'appSettings',
-                storage: await initMmkvStorage(),
-            })) as any;
-            const discoveryConfig = (await getStoredState({
-                key: 'discoveryConfig',
-                storage: await initMmkvStorage(),
-            })) as any;
-            if (appSettings && discoveryConfig) {
-                const enabledNetworks = migrateDiscoveryConfigToWalletSettings(
-                    discoveryConfig.enabledDiscoveryNetworkSymbols,
-                );
+        asyncMigrate: async (oldState: any, currentVersion: number) => {
+            let migratedState = { ...oldState };
 
-                return {
-                    localCurrency: appSettings.fiatCurrencyCode,
-                    enabledNetworks,
-                    bitcoinAmountUnit: appSettings.bitcoinUnits,
-                };
+            const inboundVersion: number =
+                oldState._persist && oldState._persist.version !== undefined
+                    ? oldState._persist.version
+                    : DEFAULT_VERSION;
+
+            if (inboundVersion === currentVersion) {
+                return Promise.resolve(oldState);
             }
-        },
-        migrations: {
-            2: async (oldState: WalletSettings) => {
-                const devicesState = await getStoredState({
-                    key: 'devices',
-                    storage: await initMmkvStorage(),
-                });
 
-                return migrateAutoEjectToWalletSettings(devicesState, oldState);
-            },
+            if (inboundVersion > currentVersion) {
+                if (process.env.NODE_ENV !== 'production')
+                    console.error('redux-persist: downgrading version is not supported');
+
+                return Promise.resolve(oldState);
+            }
+
+            if (inboundVersion < 1) {
+                migratedState = await migrateAppSettingsAndDiscoveryConfig(migratedState);
+            }
+
+            if (inboundVersion < 2) {
+                migratedState = await migrateAutoEjectToWalletSettings(migratedState);
+            }
+
+            return Promise.resolve(migratedState);
         },
     });
 

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -91,23 +91,12 @@ export const prepareRootReducers = async () => {
         reducer: appSettingsReducer,
         persistedKeys: appSettingsPersistWhitelist,
         key: 'appSettings',
+        // Note: Migration to version 3 has been removed.
+        // The `isCoinEnablingInitFinished` property was deleted, and
+        // `areTestnetsEnabled` is a developer-only option and does not require migration.
         version: 3,
         migrations: {
             2: (oldState: any) => ({ ...oldState, fiatCurrencyCode: oldState.fiatCurrency.label }),
-            3: async (oldState: any) => {
-                const discoveryConfig = (await getStoredState({
-                    key: 'discoveryConfig',
-                    storage: await initMmkvStorage(),
-                })) as any;
-                if (discoveryConfig)
-                    return {
-                        ...oldState,
-                        areTestnetsEnabled: discoveryConfig.areTestnetsEnabled,
-                        isCoinEnablingInitFinished: discoveryConfig.isCoinEnablingInitFinished,
-                    };
-
-                return oldState;
-            },
         },
     });
 

--- a/suite-native/state/tsconfig.json
+++ b/suite-native/state/tsconfig.json
@@ -36,6 +36,9 @@
             "path": "../../suite-common/wallet-core"
         },
         {
+            "path": "../../suite-common/wallet-types"
+        },
+        {
             "path": "../../suite-common/walletconnect"
         },
         { "path": "../banner-flags" },

--- a/suite-native/storage/package.json
+++ b/suite-native/storage/package.json
@@ -19,6 +19,7 @@
         "@suite-common/suite-utils": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
+        "@trezor/connect": "workspace:*",
         "@trezor/transport-native-bluetooth": "workspace:*",
         "bs58": "^6.0.0",
         "expo-crypto": "~15.0.7",

--- a/suite-native/storage/src/createAsyncMigrate.ts
+++ b/suite-native/storage/src/createAsyncMigrate.ts
@@ -1,13 +1,12 @@
 import { DEFAULT_VERSION, PersistedState } from 'redux-persist';
 
-export type UnknownPersistedState =
-    | Record<string, any>
-    | (Record<string, any> & PersistedState)
-    | undefined;
-export type MigrationsManifest = {
+export type UnknownPersistedState<T> = (T & PersistedState) | undefined;
+
+export type MigrationsManifest<T> = {
     [key: string]: (
-        state: UnknownPersistedState,
-    ) => UnknownPersistedState | Promise<UnknownPersistedState>;
+        // <any> because this is the old state = won't conform to the current reducer type
+        state: UnknownPersistedState<any>,
+    ) => UnknownPersistedState<T> | Promise<UnknownPersistedState<T>>;
 };
 
 /**
@@ -17,9 +16,13 @@ export type MigrationsManifest = {
  * Debug config is not implemented, but it can be added if needed.
  */
 export const createAsyncMigrate =
-    (migrations: MigrationsManifest) =>
-    async (oldState: UnknownPersistedState, currentVersion: number) => {
+    <T>(migrations: MigrationsManifest<T>) =>
+    async (
+        oldState: UnknownPersistedState<any>,
+        currentVersion: number,
+    ): Promise<UnknownPersistedState<T>> => {
         // If there is migration for version 1 it is considered as initial migration from empty state.
+        // Note that migrations will be indexed from 1 in the manifest.
         if (!oldState && !migrations[1]) return undefined;
 
         const inboundVersion: number =
@@ -44,7 +47,8 @@ export const createAsyncMigrate =
             .sort((a, b) => a - b);
 
         try {
-            let migratedState = oldState;
+            // `as` for two reasons: 1) this state is still old, will be new after all migrations, 2) _persist is not guaranteed
+            let migratedState = oldState as UnknownPersistedState<T>;
 
             // Run migrations sequentially.
             for (const versionKey of migrationKeys) {

--- a/suite-native/storage/src/createAsyncMigrate.ts
+++ b/suite-native/storage/src/createAsyncMigrate.ts
@@ -53,6 +53,8 @@ export const createAsyncMigrate =
 
             return migratedState;
         } catch (err) {
-            return err;
+            console.error(err); // in order to log this to Sentry
+
+            return undefined;
         }
     };

--- a/suite-native/storage/src/createAsyncMigrate.ts
+++ b/suite-native/storage/src/createAsyncMigrate.ts
@@ -1,0 +1,58 @@
+import { DEFAULT_VERSION, PersistedState } from 'redux-persist';
+
+export type UnknownPersistedState =
+    | Record<string, any>
+    | (Record<string, any> & PersistedState)
+    | undefined;
+export type MigrationsManifest = {
+    [key: string]: (
+        state: UnknownPersistedState,
+    ) => UnknownPersistedState | Promise<UnknownPersistedState>;
+};
+
+/**
+ * This is a replacement of createMigrate helper from redux-persist that allows to use async migrations
+ * and also allows initial migration from empty state.
+ *
+ * Debug config is not implemented, but it can be added if needed.
+ */
+export const createAsyncMigrate =
+    (migrations: MigrationsManifest) =>
+    async (oldState: UnknownPersistedState, currentVersion: number) => {
+        // If there is migration for version 1 it is considered as initial migration from empty state.
+        if (!oldState && !migrations[1]) return undefined;
+
+        const inboundVersion: number =
+            oldState?._persist?.version !== undefined
+                ? oldState._persist.version
+                : DEFAULT_VERSION; /* -1 */
+
+        if (inboundVersion === currentVersion) {
+            return Promise.resolve(oldState);
+        }
+
+        if (inboundVersion > currentVersion) {
+            if (process.env.NODE_ENV !== 'production')
+                console.error('redux-persist: downgrading version is not supported');
+
+            return Promise.resolve(oldState);
+        }
+
+        const migrationKeys = Object.keys(migrations)
+            .map(ver => parseInt(ver))
+            .filter(key => currentVersion >= key && key > inboundVersion)
+            .sort((a, b) => a - b);
+
+        try {
+            let migratedState = oldState;
+
+            // Run migrations sequentially.
+            for (const versionKey of migrationKeys) {
+                migratedState = await migrations[versionKey.toString()](migratedState);
+            }
+
+            return migratedState;
+        } catch (err) {
+            return err;
+        }
+    };

--- a/suite-native/storage/src/index.ts
+++ b/suite-native/storage/src/index.ts
@@ -13,6 +13,7 @@ export * from './migrations/wallet/accounts/v2';
 export * from './migrations/wallet/accounts/v3';
 export * from './migrations/wallet/transactions/v3';
 export * from './migrations/walletSettings/v1';
+export * from './migrations/walletSettings/v2';
 
 export * from './transforms/bluetoothTransforms';
 export * from './transforms/deviceTransforms';

--- a/suite-native/storage/src/migrations/walletSettings/v1.ts
+++ b/suite-native/storage/src/migrations/walletSettings/v1.ts
@@ -1,6 +1,10 @@
 import { pipe } from '@mobily/ts-belt';
+import { getStoredState } from 'redux-persist';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { WalletSettings } from '@suite-common/wallet-types';
+
+import { initMmkvStorage } from '../../storage';
 
 type NetworkSymbolOld = Exclude<NetworkSymbol, 'bsc'> | 'bnb';
 
@@ -26,7 +30,7 @@ const migrateDiscoveryDeprecateNetworks = (
  * to the walletSettings reducer shared in suite-common.
  * All migrations that were done on discoveryConfig are moved here
  */
-export const migrateDiscoveryConfigToWalletSettings = (
+const migrateDiscoveryConfigToWalletSettings = (
     oldEnabledDiscoveryNetworkSymbols: NetworkSymbol[],
 ): NetworkSymbol[] =>
     pipe(
@@ -34,3 +38,32 @@ export const migrateDiscoveryConfigToWalletSettings = (
         migrateEnabledDiscoveryNetworkSymbols,
         migrateDiscoveryDeprecateNetworks,
     );
+
+export const migrateAppSettingsAndDiscoveryConfig = async (
+    walletSettingsState: WalletSettings,
+): Promise<WalletSettings> => {
+    const storage = await initMmkvStorage();
+    const appSettings = (await getStoredState({
+        key: 'appSettings',
+        storage,
+    })) as any;
+    const discoveryConfig = (await getStoredState({
+        key: 'discoveryConfig',
+        storage,
+    })) as any;
+
+    if (appSettings && discoveryConfig) {
+        const enabledNetworks = migrateDiscoveryConfigToWalletSettings(
+            discoveryConfig.enabledDiscoveryNetworkSymbols,
+        );
+
+        return {
+            ...walletSettingsState,
+            localCurrency: appSettings.fiatCurrencyCode,
+            enabledNetworks,
+            bitcoinAmountUnit: appSettings.bitcoinUnits,
+        };
+    }
+
+    return walletSettingsState;
+};

--- a/suite-native/storage/src/migrations/walletSettings/v1.ts
+++ b/suite-native/storage/src/migrations/walletSettings/v1.ts
@@ -2,7 +2,6 @@ import { pipe } from '@mobily/ts-belt';
 import { getStoredState } from 'redux-persist';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { WalletSettings } from '@suite-common/wallet-types';
 
 import { initMmkvStorage } from '../../storage';
 
@@ -39,9 +38,7 @@ const migrateDiscoveryConfigToWalletSettings = (
         migrateDiscoveryDeprecateNetworks,
     );
 
-export const migrateAppSettingsAndDiscoveryConfig = async (
-    walletSettingsState: WalletSettings,
-): Promise<WalletSettings> => {
+export const migrateAppSettingsAndDiscoveryConfig = async (walletSettingsState: any) => {
     const storage = await initMmkvStorage();
     const appSettings = (await getStoredState({
         key: 'appSettings',

--- a/suite-native/storage/src/migrations/walletSettings/v1.ts
+++ b/suite-native/storage/src/migrations/walletSettings/v1.ts
@@ -2,10 +2,21 @@ import { pipe } from '@mobily/ts-belt';
 import { getStoredState } from 'redux-persist';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { WalletSettings } from '@suite-common/wallet-types';
+import { PROTO } from '@trezor/connect';
 
+import { UnknownPersistedState } from '../../createAsyncMigrate';
 import { initMmkvStorage } from '../../storage';
 
 type NetworkSymbolOld = Exclude<NetworkSymbol, 'bsc'> | 'bnb';
+
+type AppSettingsStateOld = {
+    fiatCurrencyCode: string;
+    bitcoinUnits: PROTO.AmountUnit;
+};
+type DiscoveryConfigStateOld = {
+    enabledDiscoveryNetworkSymbols: NetworkSymbol[];
+};
 
 const migrateEnabledDiscoveryNetworkSymbols = (
     oldEnabledDiscoveryNetworkSymbols: NetworkSymbol[],
@@ -38,16 +49,16 @@ const migrateDiscoveryConfigToWalletSettings = (
         migrateDiscoveryDeprecateNetworks,
     );
 
-export const migrateAppSettingsAndDiscoveryConfig = async (walletSettingsState: any) => {
+export const migrateAppSettingsAndDiscoveryConfig = async (walletSettingsState: WalletSettings) => {
     const storage = await initMmkvStorage();
     const appSettings = (await getStoredState({
         key: 'appSettings',
         storage,
-    })) as any;
+    })) as AppSettingsStateOld;
     const discoveryConfig = (await getStoredState({
         key: 'discoveryConfig',
         storage,
-    })) as any;
+    })) as DiscoveryConfigStateOld;
 
     if (appSettings && discoveryConfig) {
         const enabledNetworks = migrateDiscoveryConfigToWalletSettings(
@@ -59,8 +70,9 @@ export const migrateAppSettingsAndDiscoveryConfig = async (walletSettingsState: 
             localCurrency: appSettings.fiatCurrencyCode,
             enabledNetworks,
             bitcoinAmountUnit: appSettings.bitcoinUnits,
-        };
+        } as UnknownPersistedState<WalletSettings>;
     }
 
-    return walletSettingsState;
+    // _persist is not guaranteed but required by Typescript
+    return walletSettingsState as UnknownPersistedState<WalletSettings>;
 };

--- a/suite-native/storage/src/migrations/walletSettings/v2.ts
+++ b/suite-native/storage/src/migrations/walletSettings/v2.ts
@@ -1,0 +1,24 @@
+import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { WalletSettings } from '@suite-common/wallet-types';
+
+type OldDevicesState = { isDeviceAutoEjectEnabled?: boolean } | undefined;
+
+/**
+ * Migrates device.isDeviceAutoEjectEnabled to walletSettings.autoEject
+ * If the value is not present, it falls back to walletSettings initial state (false)
+ */
+export const migrateAutoEjectToWalletSettings = (
+    devicesState: OldDevicesState,
+    walletSettingsState: WalletSettings,
+): WalletSettings => {
+    const isAutoEjectEnabled =
+        devicesState?.isDeviceAutoEjectEnabled ?? initialWalletSettingsState.isAutoEjectEnabled;
+
+    const migratedState = {
+        ...walletSettingsState,
+        isAutoEjectEnabled,
+        isAutoForgetDeviceDataEnabled: initialWalletSettingsState.isAutoEjectEnabled,
+    };
+
+    return migratedState;
+};

--- a/suite-native/storage/src/migrations/walletSettings/v2.ts
+++ b/suite-native/storage/src/migrations/walletSettings/v2.ts
@@ -1,7 +1,6 @@
 import { getStoredState } from 'redux-persist';
 
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
-import { WalletSettings } from '@suite-common/wallet-types';
 
 import { initMmkvStorage } from '../../storage';
 
@@ -11,9 +10,9 @@ type OldDevicesState = { isDeviceAutoEjectEnabled?: boolean } | undefined;
  * Migrates device.isDeviceAutoEjectEnabled to walletSettings.autoEject
  * If the value is not present, it falls back to walletSettings initial state (false)
  */
-export const migrateAutoEjectToWalletSettings = async (
-    walletSettingsState: WalletSettings,
-): Promise<WalletSettings> => {
+export const migrateAutoEjectToWalletSettings = async (walletSettingsState: any) => {
+    if (!walletSettingsState) return walletSettingsState;
+
     const devicesState: OldDevicesState = await getStoredState({
         key: 'devices',
         storage: await initMmkvStorage(),

--- a/suite-native/storage/src/migrations/walletSettings/v2.ts
+++ b/suite-native/storage/src/migrations/walletSettings/v2.ts
@@ -1,7 +1,9 @@
 import { getStoredState } from 'redux-persist';
 
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { WalletSettings } from '@suite-common/wallet-types';
 
+import { UnknownPersistedState } from '../../createAsyncMigrate';
 import { initMmkvStorage } from '../../storage';
 
 type OldDevicesState = { isDeviceAutoEjectEnabled?: boolean } | undefined;
@@ -10,7 +12,7 @@ type OldDevicesState = { isDeviceAutoEjectEnabled?: boolean } | undefined;
  * Migrates device.isDeviceAutoEjectEnabled to walletSettings.autoEject
  * If the value is not present, it falls back to walletSettings initial state (false)
  */
-export const migrateAutoEjectToWalletSettings = async (walletSettingsState: any) => {
+export const migrateAutoEjectToWalletSettings = async (walletSettingsState: WalletSettings) => {
     if (!walletSettingsState) return walletSettingsState;
 
     const devicesState: OldDevicesState = await getStoredState({
@@ -21,11 +23,12 @@ export const migrateAutoEjectToWalletSettings = async (walletSettingsState: any)
     const isAutoEjectEnabled =
         devicesState?.isDeviceAutoEjectEnabled ?? initialWalletSettingsState.isAutoEjectEnabled;
 
-    const migratedState = {
+    const migratedState: WalletSettings = {
         ...walletSettingsState,
         isAutoEjectEnabled,
         isAutoForgetDeviceDataEnabled: initialWalletSettingsState.isAutoEjectEnabled,
     };
 
-    return migratedState;
+    // _persist is not guaranteed but required by Typescript
+    return migratedState as UnknownPersistedState<WalletSettings>;
 };

--- a/suite-native/storage/src/migrations/walletSettings/v2.ts
+++ b/suite-native/storage/src/migrations/walletSettings/v2.ts
@@ -1,5 +1,9 @@
+import { getStoredState } from 'redux-persist';
+
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { WalletSettings } from '@suite-common/wallet-types';
+
+import { initMmkvStorage } from '../../storage';
 
 type OldDevicesState = { isDeviceAutoEjectEnabled?: boolean } | undefined;
 
@@ -7,10 +11,14 @@ type OldDevicesState = { isDeviceAutoEjectEnabled?: boolean } | undefined;
  * Migrates device.isDeviceAutoEjectEnabled to walletSettings.autoEject
  * If the value is not present, it falls back to walletSettings initial state (false)
  */
-export const migrateAutoEjectToWalletSettings = (
-    devicesState: OldDevicesState,
+export const migrateAutoEjectToWalletSettings = async (
     walletSettingsState: WalletSettings,
-): WalletSettings => {
+): Promise<WalletSettings> => {
+    const devicesState: OldDevicesState = await getStoredState({
+        key: 'devices',
+        storage: await initMmkvStorage(),
+    });
+
     const isAutoEjectEnabled =
         devicesState?.isDeviceAutoEjectEnabled ?? initialWalletSettingsState.isAutoEjectEnabled;
 

--- a/suite-native/storage/src/tests/asyncInReduce.test.ts
+++ b/suite-native/storage/src/tests/asyncInReduce.test.ts
@@ -1,0 +1,64 @@
+// This is just a demonstrations why we should not use createMigrate util from redux-persist together with async functions.
+// Check the implementation of createMigrate here https://github.com/rt2zz/redux-persist/blob/d8b01a085e3679db43503a3858e8d4759d6f22fa/src/createMigrate.ts#L44-L51
+
+const helperFunctionUsingReduce = (
+    initialState: any,
+    objectOfFunctions: Record<string, (state: any) => any>,
+) => {
+    const keys = Object.keys(objectOfFunctions)
+        .map(ver => parseInt(ver))
+        .sort((a, b) => a - b);
+
+    const migratedState = keys.reduce((state, key) => objectOfFunctions[key](state), initialState);
+
+    return migratedState;
+};
+
+const delay = (ms: number) => jest.advanceTimersByTime(ms);
+
+describe('Function using reduce on object of functions', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers(); // Ensure all timers are flushed
+        jest.useRealTimers(); // Restore real timers after each test
+    });
+
+    const initialState = { a: 0, b: 0, c: 0 };
+
+    it('works just fine for sync functions', () => {
+        const objectOfFunctions = {
+            1: (state: any) => ({ ...state, a: 1 }),
+            2: (state: any) => ({ ...state, b: 2 }),
+            3: (state: any) => ({ ...state, c: 3 }),
+        };
+
+        const expectedResult = { a: 1, b: 2, c: 3 };
+
+        const result = helperFunctionUsingReduce(initialState, objectOfFunctions);
+
+        expect(result).toEqual(expectedResult);
+    });
+
+    it('breaks with async functions', () => {
+        const objectOfFunctions = {
+            1: (state: any) => ({ ...state, a: 1 }),
+            2: async (state: any) => {
+                await delay(100);
+
+                return { ...state, b: 2 };
+            },
+            3: (state: any) => ({ ...state, c: 3 }),
+        };
+
+        const expectedResult = { a: 1, b: 2, c: 3 };
+        const unexpectedResult = { c: 3 };
+
+        const result = helperFunctionUsingReduce(initialState, objectOfFunctions);
+
+        expect(result).not.toEqual(expectedResult);
+        expect(result).toEqual(unexpectedResult);
+    });
+});

--- a/suite-native/storage/src/tests/migrations/walletSettingsV1.test.ts
+++ b/suite-native/storage/src/tests/migrations/walletSettingsV1.test.ts
@@ -1,22 +1,77 @@
+import { getStoredState } from 'redux-persist';
+
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
-import { migrateDiscoveryConfigToWalletSettings } from '../../migrations/walletSettings/v1';
+jest.mock('../../storage', () => ({
+    initMmkvStorage: jest.fn().mockResolvedValue({}),
+}));
 
-describe(migrateDiscoveryConfigToWalletSettings.name, () => {
-    it('should migrate enabled network symbols by changing bnb to bsc and removing deprecated coins', () => {
-        const oldEnabledDiscoveryNetworkSymbols = [
-            'btc',
-            'eth',
-            'nmc',
-            'bnb',
-            'test',
-            'dash',
-        ] as NetworkSymbol[];
+jest.mock('redux-persist', () => ({
+    getStoredState: jest.fn(),
+}));
 
-        const migratedAccounts = migrateDiscoveryConfigToWalletSettings(
-            oldEnabledDiscoveryNetworkSymbols,
-        );
+import { migrateAppSettingsAndDiscoveryConfig } from '../../migrations/walletSettings/v1';
 
-        expect(migratedAccounts).toEqual(['btc', 'eth', 'bsc', 'test']);
+const mockGetStoredState = getStoredState as jest.MockedFunction<typeof getStoredState>;
+
+describe(migrateAppSettingsAndDiscoveryConfig.name, () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should migrate enabled network symbols by changing bnb to bsc and removing deprecated coins', async () => {
+        mockGetStoredState.mockImplementation(({ key }) => {
+            if (key === 'appSettings') {
+                return Promise.resolve({
+                    fiatCurrencyCode: 'usd',
+                    bitcoinUnits: 'btc',
+                });
+            }
+            if (key === 'discoveryConfig') {
+                return Promise.resolve({
+                    enabledDiscoveryNetworkSymbols: [
+                        'btc',
+                        'eth',
+                        'nmc',
+                        'bnb',
+                        'test',
+                        'dash',
+                    ] as NetworkSymbol[],
+                });
+            }
+
+            return Promise.resolve(undefined);
+        });
+
+        const walletSettingsState = {};
+
+        const migratedState = await migrateAppSettingsAndDiscoveryConfig(walletSettingsState);
+
+        expect(migratedState).toEqual({
+            localCurrency: 'usd',
+            enabledNetworks: ['btc', 'eth', 'bsc', 'test'],
+            bitcoinAmountUnit: 'btc',
+        });
+    });
+
+    it('should return original state when appSettings or discoveryConfig is missing', async () => {
+        mockGetStoredState.mockImplementation(({ key }) => {
+            if (key === 'appSettings') {
+                return Promise.resolve(undefined);
+            }
+            if (key === 'discoveryConfig') {
+                return Promise.resolve({
+                    enabledDiscoveryNetworkSymbols: ['btc', 'eth'],
+                });
+            }
+
+            return Promise.resolve(undefined);
+        });
+
+        const walletSettingsState = { someProperty: 'value' };
+
+        const migratedState = await migrateAppSettingsAndDiscoveryConfig(walletSettingsState);
+
+        expect(migratedState).toEqual(walletSettingsState);
     });
 });

--- a/suite-native/storage/src/tests/migrations/walletSettingsV1.test.ts
+++ b/suite-native/storage/src/tests/migrations/walletSettingsV1.test.ts
@@ -1,6 +1,7 @@
 import { getStoredState } from 'redux-persist';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { WalletSettings } from '@suite-common/wallet-types';
 
 jest.mock('../../storage', () => ({
     initMmkvStorage: jest.fn().mockResolvedValue({}),
@@ -43,7 +44,7 @@ describe(migrateAppSettingsAndDiscoveryConfig.name, () => {
             return Promise.resolve(undefined);
         });
 
-        const walletSettingsState = {};
+        const walletSettingsState = {} as WalletSettings;
 
         const migratedState = await migrateAppSettingsAndDiscoveryConfig(walletSettingsState);
 
@@ -68,7 +69,7 @@ describe(migrateAppSettingsAndDiscoveryConfig.name, () => {
             return Promise.resolve(undefined);
         });
 
-        const walletSettingsState = { someProperty: 'value' };
+        const walletSettingsState = { someProperty: 'value' } as unknown as WalletSettings;
 
         const migratedState = await migrateAppSettingsAndDiscoveryConfig(walletSettingsState);
 

--- a/suite-native/storage/src/tests/migrations/walletSettingsV2.test.ts
+++ b/suite-native/storage/src/tests/migrations/walletSettingsV2.test.ts
@@ -1,16 +1,67 @@
-import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { getStoredState } from 'redux-persist';
+
+jest.mock('../../storage', () => ({
+    initMmkvStorage: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('redux-persist', () => ({
+    getStoredState: jest.fn(),
+}));
 
 import { migrateAutoEjectToWalletSettings } from '../../migrations/walletSettings/v2';
 
+const mockGetStoredState = getStoredState as jest.MockedFunction<typeof getStoredState>;
+
 describe(migrateAutoEjectToWalletSettings.name, () => {
-    it('migrates value from devices.isDeviceAutoEjectEnabled to walletSettings.autoEject', () => {
-        const devicesState = { isDeviceAutoEjectEnabled: true };
-        const oldWalletSettings = initialWalletSettingsState;
-        // simulate old state without isAutoEjectEnabled
-        delete (oldWalletSettings as any).autoEject;
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
 
-        const migrated = migrateAutoEjectToWalletSettings(devicesState, oldWalletSettings);
+    it('migrates value from devices.isDeviceAutoEjectEnabled to walletSettings.isAutoEjectEnabled', async () => {
+        mockGetStoredState.mockImplementation(({ key }) => {
+            if (key === 'devices') {
+                return Promise.resolve({
+                    isDeviceAutoEjectEnabled: true,
+                });
+            }
 
-        expect(migrated.isAutoEjectEnabled).toBe(true);
+            return Promise.resolve(undefined);
+        });
+
+        const walletSettingsState = { someOtherProperty: 'value' };
+
+        const migratedState = await migrateAutoEjectToWalletSettings(walletSettingsState);
+
+        expect(migratedState).toEqual({
+            someOtherProperty: 'value',
+            isAutoEjectEnabled: true,
+            isAutoForgetDeviceDataEnabled: false,
+        });
+    });
+
+    it('uses initial state value when devices.isDeviceAutoEjectEnabled is not present', async () => {
+        mockGetStoredState.mockImplementation(({ key }) => {
+            if (key === 'devices') {
+                return Promise.resolve({});
+            }
+
+            return Promise.resolve(undefined);
+        });
+
+        const walletSettingsState = { someOtherProperty: 'value' };
+
+        const migratedState = await migrateAutoEjectToWalletSettings(walletSettingsState);
+
+        expect(migratedState).toEqual({
+            someOtherProperty: 'value',
+            isAutoEjectEnabled: false,
+            isAutoForgetDeviceDataEnabled: false,
+        });
+    });
+
+    it('returns original state when walletSettingsState is null/undefined', async () => {
+        const migratedState = await migrateAutoEjectToWalletSettings(null);
+
+        expect(migratedState).toBeNull();
     });
 });

--- a/suite-native/storage/src/tests/migrations/walletSettingsV2.test.ts
+++ b/suite-native/storage/src/tests/migrations/walletSettingsV2.test.ts
@@ -1,0 +1,16 @@
+import { initialWalletSettingsState } from '@suite-common/wallet-core';
+
+import { migrateAutoEjectToWalletSettings } from '../../migrations/walletSettings/v2';
+
+describe(migrateAutoEjectToWalletSettings.name, () => {
+    it('migrates value from devices.isDeviceAutoEjectEnabled to walletSettings.autoEject', () => {
+        const devicesState = { isDeviceAutoEjectEnabled: true };
+        const oldWalletSettings = initialWalletSettingsState;
+        // simulate old state without isAutoEjectEnabled
+        delete (oldWalletSettings as any).autoEject;
+
+        const migrated = migrateAutoEjectToWalletSettings(devicesState, oldWalletSettings);
+
+        expect(migrated.isAutoEjectEnabled).toBe(true);
+    });
+});

--- a/suite-native/storage/src/tests/migrations/walletSettingsV2.test.ts
+++ b/suite-native/storage/src/tests/migrations/walletSettingsV2.test.ts
@@ -1,5 +1,7 @@
 import { getStoredState } from 'redux-persist';
 
+import { WalletSettings } from '@suite-common/wallet-types';
+
 jest.mock('../../storage', () => ({
     initMmkvStorage: jest.fn().mockResolvedValue({}),
 }));
@@ -28,7 +30,7 @@ describe(migrateAutoEjectToWalletSettings.name, () => {
             return Promise.resolve(undefined);
         });
 
-        const walletSettingsState = { someOtherProperty: 'value' };
+        const walletSettingsState = { someOtherProperty: 'value' } as unknown as WalletSettings;
 
         const migratedState = await migrateAutoEjectToWalletSettings(walletSettingsState);
 
@@ -48,7 +50,7 @@ describe(migrateAutoEjectToWalletSettings.name, () => {
             return Promise.resolve(undefined);
         });
 
-        const walletSettingsState = { someOtherProperty: 'value' };
+        const walletSettingsState = { someOtherProperty: 'value' } as unknown as WalletSettings;
 
         const migratedState = await migrateAutoEjectToWalletSettings(walletSettingsState);
 
@@ -60,6 +62,7 @@ describe(migrateAutoEjectToWalletSettings.name, () => {
     });
 
     it('returns original state when walletSettingsState is null/undefined', async () => {
+        // @ts-expect-error
         const migratedState = await migrateAutoEjectToWalletSettings(null);
 
         expect(migratedState).toBeNull();

--- a/suite-native/storage/src/typedPersistReducer.ts
+++ b/suite-native/storage/src/typedPersistReducer.ts
@@ -5,13 +5,23 @@ import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 
 import { initMmkvStorage } from './storage';
 
+type ExclusiveMigrationsOrAsyncMigrate =
+    | {
+          migrations?: { [key: number]: (state: any) => any };
+          asyncMigrate?: undefined;
+      }
+    | {
+          migrations?: undefined;
+          asyncMigrate?: (state: any, currentVersion: number) => Promise<any>;
+      };
+
 export const preparePersistReducer = async <TReducerInitialState>({
     reducer,
     persistedKeys,
     key,
     version,
     migrations,
-    initialMigration,
+    asyncMigrate,
     transforms,
     mergeLevel = 1,
 }: {
@@ -19,27 +29,18 @@ export const preparePersistReducer = async <TReducerInitialState>({
     persistedKeys: Array<keyof TReducerInitialState>;
     key: string;
     version: number;
-    migrations?: { [key: string]: (state: any) => any };
-    initialMigration?: () => any;
     transforms?: Array<Transform<any, any>>;
     mergeLevel?: 1 | 2;
-}) => {
+} & ExclusiveMigrationsOrAsyncMigrate) => {
     const storage = await initMmkvStorage();
     const defaultMigrate = createMigrate(migrations ?? {}, { debug: false });
-    const migrate = (state: any, currentVersion: number) => {
-        if (!state && initialMigration) {
-            return initialMigration();
-        }
-
-        return defaultMigrate(state, currentVersion);
-    };
 
     const persistConfig = {
         key,
         storage,
         whitelist: persistedKeys as string[],
         version,
-        migrate,
+        migrate: asyncMigrate ?? defaultMigrate,
         transforms,
         stateReconciler: (mergeLevel === 2 ? autoMergeLevel2 : autoMergeLevel1) as any,
     };

--- a/suite-native/storage/src/typedPersistReducer.ts
+++ b/suite-native/storage/src/typedPersistReducer.ts
@@ -1,19 +1,10 @@
 import { Reducer } from '@reduxjs/toolkit';
-import { Transform, createMigrate, persistReducer } from 'redux-persist';
+import { Transform, persistReducer } from 'redux-persist';
 import autoMergeLevel1 from 'redux-persist/lib/stateReconciler/autoMergeLevel1';
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 
+import { MigrationsManifest, createAsyncMigrate } from './createAsyncMigrate';
 import { initMmkvStorage } from './storage';
-
-type ExclusiveMigrationsOrAsyncMigrate =
-    | {
-          migrations?: { [key: number]: (state: any) => any };
-          asyncMigrate?: undefined;
-      }
-    | {
-          migrations?: undefined;
-          asyncMigrate?: (state: any, currentVersion: number) => Promise<any>;
-      };
 
 export const preparePersistReducer = async <TReducerInitialState>({
     reducer,
@@ -21,7 +12,6 @@ export const preparePersistReducer = async <TReducerInitialState>({
     key,
     version,
     migrations,
-    asyncMigrate,
     transforms,
     mergeLevel = 1,
 }: {
@@ -29,18 +19,18 @@ export const preparePersistReducer = async <TReducerInitialState>({
     persistedKeys: Array<keyof TReducerInitialState>;
     key: string;
     version: number;
+    migrations?: MigrationsManifest;
     transforms?: Array<Transform<any, any>>;
     mergeLevel?: 1 | 2;
-} & ExclusiveMigrationsOrAsyncMigrate) => {
+}) => {
     const storage = await initMmkvStorage();
-    const defaultMigrate = createMigrate(migrations ?? {}, { debug: false });
 
     const persistConfig = {
         key,
         storage,
         whitelist: persistedKeys as string[],
         version,
-        migrate: asyncMigrate ?? defaultMigrate,
+        migrate: createAsyncMigrate(migrations ?? {}),
         transforms,
         stateReconciler: (mergeLevel === 2 ? autoMergeLevel2 : autoMergeLevel1) as any,
     };

--- a/suite-native/storage/src/typedPersistReducer.ts
+++ b/suite-native/storage/src/typedPersistReducer.ts
@@ -19,7 +19,7 @@ export const preparePersistReducer = async <TReducerInitialState>({
     persistedKeys: Array<keyof TReducerInitialState>;
     key: string;
     version: number;
-    migrations?: MigrationsManifest;
+    migrations?: MigrationsManifest<TReducerInitialState>;
     transforms?: Array<Transform<any, any>>;
     mergeLevel?: 1 | 2;
 }) => {

--- a/suite-native/storage/tsconfig.json
+++ b/suite-native/storage/tsconfig.json
@@ -17,6 +17,7 @@
         {
             "path": "../../suite-common/wallet-core"
         },
+        { "path": "../../packages/connect" },
         {
             "path": "../../packages/transport-native-bluetooth"
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12741,6 +12741,7 @@ __metadata:
     "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/token-definitions": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
     "@suite-common/walletconnect": "workspace:*"
     "@suite-native/banner-flags": "workspace:*"
     "@suite-native/blockchain": "workspace:*"
@@ -14256,6 +14257,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-storage@workspace:packages/suite-storage"
   dependencies:
+    "@suite-common/wallet-types": "workspace:*"
     "@trezor/eslint": "workspace:*"
     "@trezor/utils": "workspace:*"
     idb: "npm:^8.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12791,6 +12791,7 @@ __metadata:
     "@suite-common/suite-utils": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
+    "@trezor/connect": "workspace:*"
     "@trezor/transport-native-bluetooth": "workspace:*"
     bs58: "npm:^6.0.0"
     expo-crypto: "npm:~15.0.7"


### PR DESCRIPTION

## Description

- Enable asynchronous migration by avoiding `createMigrate` helper function for them.
- Delete the last `appSettings` migration that was potentially buggy, because it passed async function in `createMigrate` that use reduce over the array of functions internally. It is no longer needed since `isCoinEnablingInitFinished` has been deleted completely.
- Add migration for #21639


## QA instructions
- Open Suite Lite before this migration
- Turn on AutoEject
- Open Suite Lite after this migration
- AutoEject shall be on

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/auto-eject-settings-migration-fixes&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/auto-eject-settings-migration-fixes&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/auto-eject-settings-migration-fixes&lookback=7)