### PR TITLE
fix(suite-native): import invity types as types

### DIFF
--- a/suite-native/module-trading/.depcheckrc.json
+++ b/suite-native/module-trading/.depcheckrc.json
@@ -1,4 +1,0 @@
-{
-    "ignore-patterns": ["libDev", "lib"],
-    "ignores": ["invity-api"]
-}

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -75,6 +75,7 @@
         "@suite-common/test-utils": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/test-utils": "workspace:*",
-        "@trezor/theme": "workspace:*"
+        "@trezor/theme": "workspace:*",
+        "@types/invity-api": "^1.1.11"
     }
 }

--- a/suite-native/module-trading/src/__fixtures__/buyProviders.ts
+++ b/suite-native/module-trading/src/__fixtures__/buyProviders.ts
@@ -1,4 +1,4 @@
-import { BuyProviderInfo } from 'invity-api';
+import type { BuyProviderInfo } from 'invity-api';
 
 export const buyInvity = {
     name: 'invity',

--- a/suite-native/module-trading/src/__fixtures__/exchangeProviders.ts
+++ b/suite-native/module-trading/src/__fixtures__/exchangeProviders.ts
@@ -1,4 +1,4 @@
-import { CryptoId, ExchangeProviderInfo } from 'invity-api';
+import type { CryptoId, ExchangeProviderInfo } from 'invity-api';
 
 export const exchangeInvity: ExchangeProviderInfo = {
     name: 'invity',

--- a/suite-native/module-trading/src/__fixtures__/exchangeQuotes.ts
+++ b/suite-native/module-trading/src/__fixtures__/exchangeQuotes.ts
@@ -1,4 +1,4 @@
-import { ExchangeTrade } from 'invity-api';
+import type { ExchangeTrade } from 'invity-api';
 
 export const exchangeQuotes = [
     {

--- a/suite-native/module-trading/src/__fixtures__/sellProviders.ts
+++ b/suite-native/module-trading/src/__fixtures__/sellProviders.ts
@@ -1,4 +1,4 @@
-import { CryptoId, SellProviderInfo } from 'invity-api';
+import type { CryptoId, SellProviderInfo } from 'invity-api';
 
 export const sellInvity = {
     name: 'invity',

--- a/suite-native/module-trading/src/__fixtures__/sellQuotes.ts
+++ b/suite-native/module-trading/src/__fixtures__/sellQuotes.ts
@@ -1,4 +1,4 @@
-import { SellFiatTrade } from 'invity-api';
+import type { SellFiatTrade } from 'invity-api';
 
 export const sellQuotes = [
     {

--- a/suite-native/module-trading/src/__fixtures__/tradeableAssets.ts
+++ b/suite-native/module-trading/src/__fixtures__/tradeableAssets.ts
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { TokenAddress } from '@suite-common/wallet-types';
 

--- a/suite-native/module-trading/src/__fixtures__/trades.ts
+++ b/suite-native/module-trading/src/__fixtures__/trades.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     BuyTrade,
     BuyTradeStatus,
     CryptoId,

--- a/suite-native/module-trading/src/__fixtures__/tradingState.ts
+++ b/suite-native/module-trading/src/__fixtures__/tradingState.ts
@@ -1,4 +1,4 @@
-import { Coins, CryptoId, FiatCurrenciesProps, FiatCurrencyCode, Platforms } from 'invity-api';
+import type { Coins, CryptoId, FiatCurrenciesProps, FiatCurrencyCode, Platforms } from 'invity-api';
 
 import {
     TradingBuyState,

--- a/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { BuyTrade } from 'invity-api';
+import type { BuyTrade } from 'invity-api';
 
 import { selectTradingBuyIsLoading } from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';

--- a/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { BuyTrade } from 'invity-api';
+import type { BuyTrade } from 'invity-api';
 
 import { invariant } from '@suite-common/suite-utils';
 import {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFormFieldErrorBadge.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFormFieldErrorBadge.comp.test.tsx
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { Form } from '@suite-native/forms';
 import {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
@@ -1,5 +1,5 @@
 import { EnhancedStore } from '@reduxjs/toolkit';
-import { BuyTrade } from 'invity-api';
+import type { BuyTrade } from 'invity-api';
 
 import { tradingBuyActions } from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.comp.test.tsx
@@ -1,4 +1,4 @@
-import { BuyTrade } from 'invity-api';
+import type { BuyTrade } from 'invity-api';
 
 import { EventType, analytics } from '@suite-native/analytics';
 import { Form } from '@suite-native/forms';

--- a/suite-native/module-trading/src/components/exchange/ExchangeLegalSheet.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeLegalSheet.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, memo, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import {
     TradingRootState as CommonTradingRootState,

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFeePickerCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFeePickerCard.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { ExchangeTrade } from 'invity-api';
+import type { ExchangeTrade } from 'invity-api';
 
 import { selectExchangeSelectedSendAccount } from '../../../selectors/exchangeSelectors';
 import { FeePickerCard } from '../../fees/FeePickerCard';

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { ExchangeTrade } from 'invity-api';
+import type { ExchangeTrade } from 'invity-api';
 
 import { Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
-import { ExchangeTrade } from 'invity-api';
+import type { ExchangeTrade } from 'invity-api';
 
 import { parseCryptoId } from '@suite-common/trading';
 import { selectSendPrecomposedTx } from '@suite-common/wallet-core';

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 import { ScrollView } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
 
-import { ExchangeTrade } from 'invity-api';
+import type { ExchangeTrade } from 'invity-api';
 
 import { InlineAlertBox, VStack } from '@suite-native/atoms';
 

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { ExchangeTrade } from 'invity-api';
+import type { ExchangeTrade } from 'invity-api';
 
 import { Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeTradePreviewCard.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { cryptoIdToNetworkSymbolAndContractAddress } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';

--- a/suite-native/module-trading/src/components/exchange/ExchangeProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeProviderPicker.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { ExchangeTrade } from 'invity-api';
+import type { ExchangeTrade } from 'invity-api';
 
 import { invariant } from '@suite-common/suite-utils';
 import {

--- a/suite-native/module-trading/src/components/exchange/ExchangeRateAndProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeRateAndProviderPicker.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { ExchangeTrade } from 'invity-api';
+import type { ExchangeTrade } from 'invity-api';
 
 import { selectTradingExchangeIsLoading } from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';

--- a/suite-native/module-trading/src/components/exchange/ExchangeRatePicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeRatePicker.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { ExchangeProviderInfo, ExchangeTrade } from 'invity-api';
+import type { ExchangeProviderInfo, ExchangeTrade } from 'invity-api';
 
 import {
     TradingRootState as CommonTradingRootState,

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.comp.test.tsx
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { asBaseCurrencyAmount } from '@suite-common/wallet-utils';
 import { Form } from '@suite-native/forms';

--- a/suite-native/module-trading/src/components/fees/FeePickerCard.tsx
+++ b/suite-native/module-trading/src/components/fees/FeePickerCard.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
-import { ExchangeTrade, SellFiatTrade } from 'invity-api';
+import type { ExchangeTrade, SellFiatTrade } from 'invity-api';
 
 import { TradingType, selectTradingComposedTransactionInfo } from '@suite-common/trading';
 import { NetworkSymbol } from '@suite-common/wallet-config';

--- a/suite-native/module-trading/src/components/general/FiatCurrencyButton.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencyButton.tsx
@@ -1,6 +1,6 @@
 import { Pressable } from 'react-native';
 
-import { FiatCurrencyCode } from 'invity-api';
+import type { FiatCurrencyCode } from 'invity-api';
 
 import { Text } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';

--- a/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencySheet.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencySheet.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback } from 'react';
 
-import { FiatCurrencyCode } from 'invity-api';
+import type { FiatCurrencyCode } from 'invity-api';
 
 import { Translation, useTranslate } from '@suite-native/intl';
 

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetListItem.comp.test.tsx
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenAddress, TokenSymbol } from '@suite-common/wallet-types';

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.comp.test.tsx
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { selectFormattedAccountType } from '@suite-common/wallet-core';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-utils';

--- a/suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx
@@ -1,7 +1,7 @@
 import Animated, { FadeIn } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
-import { ExchangeTrade, SellFiatTrade } from 'invity-api';
+import type { ExchangeTrade, SellFiatTrade } from 'invity-api';
 
 import {
     TradingRootState,

--- a/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.comp.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ExchangeTrade, SellFiatTrade } from 'invity-api';
+import type { ExchangeTrade, SellFiatTrade } from 'invity-api';
 
 import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
 

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAlert.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAlert.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
-import { BuyTrade } from 'invity-api';
+import type { BuyTrade } from 'invity-api';
 
 import {
     TradingRootState,

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailTransactionInfo.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailTransactionInfo.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import {
     TradingRootState,

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAlert.comp.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAlert.comp.test.tsx
@@ -1,4 +1,4 @@
-import { BuyTradeStatus, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
+import type { BuyTradeStatus, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
 
 import { TradingTransaction } from '@suite-common/trading';
 import {

--- a/suite-native/module-trading/src/components/history/__tests__/TradeStatusBadge.comp.test.tsx
+++ b/suite-native/module-trading/src/components/history/__tests__/TradeStatusBadge.comp.test.tsx
@@ -1,4 +1,4 @@
-import { BuyTradeStatus, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
+import type { BuyTradeStatus, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
 
 import { TradingTransactionStatus } from '@suite-common/trading';
 import { BadgeVariant } from '@suite-native/atoms';

--- a/suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.tsx
@@ -1,7 +1,7 @@
 import { StretchInY, StretchOutY } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
-import { SellFiatTrade } from 'invity-api';
+import type { SellFiatTrade } from 'invity-api';
 
 import { selectTradingSellIsLoading } from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';

--- a/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAssetPicker.test.tsx
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { asBaseCurrencyAmount } from '@suite-common/wallet-utils';
 import { Form } from '@suite-native/forms';

--- a/suite-native/module-trading/src/consts/general/fiatCurrencies.ts
+++ b/suite-native/module-trading/src/consts/general/fiatCurrencies.ts
@@ -1,4 +1,4 @@
-import { FiatCurrencyCode } from 'invity-api';
+import type { FiatCurrencyCode } from 'invity-api';
 
 export const supportedFiatCurrenciesMap: Readonly<Record<FiatCurrencyCode, string>> = {
     aed: 'United Arab Emirates Dirham',

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
@@ -1,4 +1,4 @@
-import { BuyTrade } from 'invity-api';
+import type { BuyTrade } from 'invity-api';
 
 import {
     PreloadedState,

--- a/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
-import { BuyTrade, BuyTradeResponse, FormResponse } from 'invity-api';
+import type { BuyTrade, BuyTradeResponse, FormResponse } from 'invity-api';
 
 import { invariant } from '@suite-common/suite-utils';
 import {

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { Platform } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { BuyCryptoPaymentMethod, BuyTrade, CryptoId, FiatCurrencyCode } from 'invity-api';
+import type { BuyCryptoPaymentMethod, BuyTrade, CryptoId, FiatCurrencyCode } from 'invity-api';
 
 import {
     TradingAmountLimitProps,

--- a/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
@@ -2,7 +2,7 @@ import { RefObject, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { isFulfilled } from '@reduxjs/toolkit';
-import { BuyTrade } from 'invity-api';
+import type { BuyTrade } from 'invity-api';
 
 import { invariant } from '@suite-common/suite-utils';
 import {

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeAnalyticReportCallback.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeAnalyticReportCallback.test.ts
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { EventType, analytics } from '@suite-native/analytics';
 import { PreloadedState, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -1,4 +1,4 @@
-import { ExchangeTrade } from 'invity-api';
+import type { ExchangeTrade } from 'invity-api';
 
 import { tradingExchangeActions } from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeAnalyticReportCallback.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeAnalyticReportCallback.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import { ExchangeProviderInfo, ExchangeTrade } from 'invity-api';
+import type { ExchangeProviderInfo, ExchangeTrade } from 'invity-api';
 
 import {
     TradingRootState,

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { CryptoId, ExchangeTrade } from 'invity-api';
+import type { CryptoId, ExchangeTrade } from 'invity-api';
 
 import {
     TradingExchangeAmountLimitProps,

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
@@ -2,7 +2,7 @@ import { RefObject, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { isFulfilled } from '@reduxjs/toolkit';
-import { ExchangeTrade } from 'invity-api';
+import type { ExchangeTrade } from 'invity-api';
 
 import { invariant } from '@suite-common/suite-utils';
 import {

--- a/suite-native/module-trading/src/hooks/general/__tests__/useFavouriteAssetsSectionList.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useFavouriteAssetsSectionList.test.tsx
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import {
     PreloadedState,

--- a/suite-native/module-trading/src/hooks/general/useFavouriteAssetsSectionList.ts
+++ b/suite-native/module-trading/src/hooks/general/useFavouriteAssetsSectionList.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { useTranslate } from '@suite-native/intl';
 

--- a/suite-native/module-trading/src/hooks/history/__tests__/useSymbolExtractor.test.ts
+++ b/suite-native/module-trading/src/hooks/history/__tests__/useSymbolExtractor.test.ts
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
 

--- a/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
+++ b/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { useFormatters } from '@suite-common/formatters';
 import { TradingTradeType, useTradingInfo } from '@suite-common/trading';

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
@@ -1,4 +1,4 @@
-import { SellFiatTrade } from 'invity-api';
+import type { SellFiatTrade } from 'invity-api';
 
 import { tradingSellActions } from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { CryptoId, FiatCurrencyCode, SellFiatTrade } from 'invity-api';
+import type { CryptoId, FiatCurrencyCode, SellFiatTrade } from 'invity-api';
 
 import {
     TradingAmountLimitProps,

--- a/suite-native/module-trading/src/reducers/__tests__/buySlice.test.ts
+++ b/suite-native/module-trading/src/reducers/__tests__/buySlice.test.ts
@@ -1,4 +1,4 @@
-import { BuyTrade, CryptoId } from 'invity-api';
+import type { BuyTrade, CryptoId } from 'invity-api';
 
 import quotes from '../../__fixtures__/buyQuotes.json';
 import { TradingBuyState, buyActions, buyInitialState, buyReducer } from '../buySlice';

--- a/suite-native/module-trading/src/reducers/__tests__/exchangeSlice.test.ts
+++ b/suite-native/module-trading/src/reducers/__tests__/exchangeSlice.test.ts
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { exchangeQuotes } from '../../__fixtures__/exchangeQuotes';
 import {

--- a/suite-native/module-trading/src/reducers/__tests__/sellSlice.test.ts
+++ b/suite-native/module-trading/src/reducers/__tests__/sellSlice.test.ts
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { sellQuotes } from '../../__fixtures__/sellQuotes';
 import { TradingSellState, sellActions, sellInitialState, sellReducer } from '../sellSlice';

--- a/suite-native/module-trading/src/reducers/__tests__/tradingSlice.test.ts
+++ b/suite-native/module-trading/src/reducers/__tests__/tradingSlice.test.ts
@@ -1,4 +1,4 @@
-import { BuyTrade, CryptoId } from 'invity-api';
+import type { BuyTrade, CryptoId } from 'invity-api';
 
 import { TrezorDevice } from '@suite-common/suite-types';
 import { extraDependenciesMock } from '@suite-common/test-utils';

--- a/suite-native/module-trading/src/reducers/tradingSlice.ts
+++ b/suite-native/module-trading/src/reducers/tradingSlice.ts
@@ -1,5 +1,5 @@
 import { PayloadAction, isAnyOf } from '@reduxjs/toolkit';
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import {

--- a/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 
-import { BuyTrade, CryptoId } from 'invity-api';
+import type { BuyTrade, CryptoId } from 'invity-api';
 
 import { AccountsRootState } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';

--- a/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { Action, Feature, Message, TrezorDevice } from '@suite-common/suite-types';
 import {

--- a/suite-native/module-trading/src/selectors/__tests__/exchangeSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/exchangeSelectors.test.ts
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { AccountsRootState } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';

--- a/suite-native/module-trading/src/selectors/__tests__/favouritesSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/favouritesSelectors.test.ts
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { extraDependenciesMock } from '@suite-common/test-utils';
 

--- a/suite-native/module-trading/src/selectors/__tests__/sellSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/sellSelectors.test.ts
@@ -1,4 +1,4 @@
-import { SellFiatTrade } from 'invity-api';
+import type { SellFiatTrade } from 'invity-api';
 
 import { AccountsRootState } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';

--- a/suite-native/module-trading/src/selectors/buySelectors.ts
+++ b/suite-native/module-trading/src/selectors/buySelectors.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 
-import { BuyCryptoPaymentMethod, BuyTrade } from 'invity-api';
+import type { BuyCryptoPaymentMethod, BuyTrade } from 'invity-api';
 
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { invariant } from '@suite-common/suite-utils';

--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import {
     Feature,

--- a/suite-native/module-trading/src/selectors/exchangeSelectors.ts
+++ b/suite-native/module-trading/src/selectors/exchangeSelectors.ts
@@ -1,4 +1,4 @@
-import { ExchangeTrade } from 'invity-api';
+import type { ExchangeTrade } from 'invity-api';
 
 import { createWeakMapSelector } from '@suite-common/redux-utils';
 import {

--- a/suite-native/module-trading/src/selectors/sellSelectors.ts
+++ b/suite-native/module-trading/src/selectors/sellSelectors.ts
@@ -1,4 +1,4 @@
-import { FiatCurrencyCode, SellCryptoPaymentMethod, SellFiatTrade } from 'invity-api';
+import type { FiatCurrencyCode, SellCryptoPaymentMethod, SellFiatTrade } from 'invity-api';
 
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import {

--- a/suite-native/module-trading/src/utils/buy/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/buy/__tests__/quotesUtils.test.ts
@@ -1,4 +1,4 @@
-import { BuyTrade } from 'invity-api';
+import type { BuyTrade } from 'invity-api';
 
 import { act, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
 

--- a/suite-native/module-trading/src/utils/buy/quotesUtils.ts
+++ b/suite-native/module-trading/src/utils/buy/quotesUtils.ts
@@ -1,4 +1,4 @@
-import { BuyTrade, CoinInfo } from 'invity-api';
+import type { BuyTrade, CoinInfo } from 'invity-api';
 
 import { invariant } from '@suite-common/suite-utils';
 import {

--- a/suite-native/module-trading/src/utils/exchange/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/exchange/__tests__/quotesUtils.test.ts
@@ -1,6 +1,6 @@
 import { act } from 'react';
 
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import type { TokenAddress } from '@suite-common/wallet-types';
 import { renderHookWithStoreProviderAsync } from '@suite-native/test-utils';

--- a/suite-native/module-trading/src/utils/exchange/quotesUtils.ts
+++ b/suite-native/module-trading/src/utils/exchange/quotesUtils.ts
@@ -1,4 +1,4 @@
-import { CoinInfo, ExchangeTrade } from 'invity-api';
+import type { CoinInfo, ExchangeTrade } from 'invity-api';
 
 import { invariant } from '@suite-common/suite-utils';
 import { MinimalExchangeFormProps } from '@suite-common/trading';

--- a/suite-native/module-trading/src/utils/general/__tests__/kycUtils.test.tsx
+++ b/suite-native/module-trading/src/utils/general/__tests__/kycUtils.test.tsx
@@ -1,4 +1,4 @@
-import { ExchangeKYCType } from 'invity-api';
+import type { ExchangeKYCType } from 'invity-api';
 
 import { Text } from '@suite-native/atoms';
 import { renderWithBasicProvider } from '@suite-native/test-utils';

--- a/suite-native/module-trading/src/utils/general/__tests__/tradeableAssetUtils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/tradeableAssetUtils.test.ts
@@ -1,4 +1,4 @@
-import { CoinInfo, CryptoId } from 'invity-api';
+import type { CoinInfo, CryptoId } from 'invity-api';
 
 import coins from '../../../__fixtures__/coins.json';
 import {

--- a/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { BuyTradeStatus, CryptoId, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
+import type { BuyTradeStatus, CryptoId, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
 
 import type { TradingTransaction, TradingType } from '@suite-common/trading';
 import { FormDraftKeyPrefix } from '@suite-common/wallet-types';

--- a/suite-native/module-trading/src/utils/general/currencyUtils.ts
+++ b/suite-native/module-trading/src/utils/general/currencyUtils.ts
@@ -1,4 +1,4 @@
-import { FiatCurrencyCode } from 'invity-api';
+import type { FiatCurrencyCode } from 'invity-api';
 
 import {
     otherCurrenciesMap,

--- a/suite-native/module-trading/src/utils/general/formUtils.ts
+++ b/suite-native/module-trading/src/utils/general/formUtils.ts
@@ -1,4 +1,4 @@
-import { FormResponse } from 'invity-api';
+import type { FormResponse } from 'invity-api';
 
 import { trezorLogo } from '@suite-common/suite-constants';
 import { TradingType } from '@suite-common/trading';

--- a/suite-native/module-trading/src/utils/general/kycUtils.tsx
+++ b/suite-native/module-trading/src/utils/general/kycUtils.tsx
@@ -1,4 +1,4 @@
-import { ExchangeKYCType } from 'invity-api';
+import type { ExchangeKYCType } from 'invity-api';
 
 import { Translation } from '@suite-native/intl';
 

--- a/suite-native/module-trading/src/utils/general/tradeableAssetUtils.ts
+++ b/suite-native/module-trading/src/utils/general/tradeableAssetUtils.ts
@@ -1,4 +1,4 @@
-import { CoinInfo, CryptoId } from 'invity-api';
+import type { CoinInfo, CryptoId } from 'invity-api';
 
 import { cryptoIdToSymbol, isCryptoIdForNativeToken, parseCryptoId } from '@suite-common/trading';
 import { NetworkSymbolExtended } from '@suite-common/wallet-config';

--- a/suite-native/module-trading/src/utils/general/utils.ts
+++ b/suite-native/module-trading/src/utils/general/utils.ts
@@ -1,4 +1,4 @@
-import { BuyTradeStatus, CryptoId, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
+import type { BuyTradeStatus, CryptoId, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
 
 import {
     TradingExchangeType,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12317,6 +12317,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
+    "@types/invity-api": "npm:^1.1.11"
     expo-linear-gradient: "npm:~14.1.5"
     expo-linking: "npm:7.1.7"
     react: "npm:19.0.0"


### PR DESCRIPTION
explicitly mark imports as types



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/import-invity-types-as-types&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/import-invity-types-as-types&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/import-invity-types-as-types&lookback=7)