### PR TITLE
fix(suite-native): fix receive text alignment

### DIFF
--- a/suite-native/receive/src/components/UnverifiedAddressWarning.tsx
+++ b/suite-native/receive/src/components/UnverifiedAddressWarning.tsx
@@ -7,10 +7,10 @@ import { Translation } from '@suite-native/intl';
 const pictogramContent = {
     portfolioTracker: {
         title: (
-            <Text>
+            <Text textAlign="center">
                 <TrezorSuiteHeader />
                 {'\n'}
-                <Text variant="titleSmall">
+                <Text variant="titleSmall" textAlign="center">
                     <Translation id="moduleReceive.receiveAddressCard.unverifiedWarning.portfolioTracker.title" />
                 </Text>
             </Text>
@@ -21,7 +21,7 @@ const pictogramContent = {
     },
     viewOnly: {
         title: (
-            <Text variant="titleSmall">
+            <Text variant="titleSmall" textAlign="center">
                 <Translation id="moduleReceive.receiveAddressCard.unverifiedWarning.viewOnly.title" />
             </Text>
         ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix text alignment on Receive Screen

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21533

## Screenshots:
<img width="1206" height="2622" alt="IMG_1794" src="https://github.com/user-attachments/assets/87ed4fbb-f10f-47cc-8a5a-515f52da0a77" />
<img width="1206" height="2622" alt="IMG_1793" src="https://github.com/user-attachments/assets/04ce58cc-a827-457d-89b2-a6b6346af75d" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/unverifed-receive-text-alignment&lookback=7)