### PR TITLE
fix(suite-native): handle cancelling of THP via device during onboarding

### DIFF
--- a/suite-native/module-device-onboarding/src/screens/ThpCodeEntryScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ThpCodeEntryScreen.tsx
@@ -20,7 +20,9 @@ export const ThpCodeEntryScreen = ({
     const thpStep = useSelector(selectThpStep);
 
     useEffect(() => {
-        if (thpStep === null) {
+        if (thpStep === 'BeforeConnectionInfo') {
+            navigation.replace(DeviceOnboardingStackRoutes.ThpPairingInfo);
+        } else if (thpStep === null) {
             navigation.replace(DeviceOnboardingStackRoutes.ThpPairingSuccess);
         }
     }, [thpStep, navigation]);


### PR DESCRIPTION
Resolve #22525

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-onboarding-thp-code-entry&lookback=7)