### PR TITLE
chore(message-system): disable hash check for T3W1 in 25.10.1

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -2009,6 +2009,55 @@
             "conditions": [
                 {
                     "environment": {
+                        "desktop": "25.10.1",
+                        "mobile": "25.10.1",
+                        "web": "25.10.1"
+                    },
+                    "devices": [
+                        {
+                            "model": "T3W1",
+                            "firmware": "*",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        }
+                    ]
+                }
+            ],
+            "message": {
+                "id": "35860e8f-88c6-40c2-bb51-725dec2c5e67",
+                "priority": 1,
+                "dismissible": false,
+                "variant": "info",
+                "category": "feature",
+                "content": {
+                    "en-GB": "Placeholder",
+                    "en": "Placeholder",
+                    "es": "Placeholder",
+                    "cs": "Placeholder",
+                    "de": "Placeholder",
+                    "fr": "Placeholder",
+                    "it": "Placeholder",
+                    "pt": "Placeholder",
+                    "tr": "Placeholder",
+                    "ru": "Placeholder",
+                    "ja": "Placeholder",
+                    "uk": "Placeholder",
+                    "hu": "Placeholder"
+                },
+                "feature": [
+                    {
+                        "domain": "security.firmware.hashCheck",
+                        "flag": false
+                    }
+                ]
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "environment": {
                         "desktop": ">=25.8.0 <25.9.2",
                         "mobile": "!",
                         "web": ">=25.8.0 <25.9.2"

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2025-10-03T00:00:00+00:00",
-    "sequence": 114,
+    "timestamp": "2025-10-16T00:00:00+00:00",
+    "sequence": 115,
     "actions": [
         {
             "conditions": [


### PR DESCRIPTION
## Description

Disable hash check fow T3W1 in Suite 25.10.1

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/message-system-disable-hash-check-t3w1&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/message-system-disable-hash-check-t3w1&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/message-system-disable-hash-check-t3w1&lookback=7)