### PR TITLE
feat: banner with tip when slow ble fw install

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareInstallation.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallation.tsx
@@ -25,8 +25,12 @@ export const FirmwareInstallation = ({
     install,
     onPromptClose,
 }: FirmwareInstallationProps) => {
-    const { status, showReconnectPrompt, targetType, reconnectEvent } = useFirmwareDesktopUpdate();
+    const { status, showReconnectPrompt, targetType, reconnectEvent, isSlow } =
+        useFirmwareDesktopUpdate();
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
+    const isBluetoothTransport = useSelector(selectHasTransportOfType('BluetoothTransport'));
+
+    const displayIsSlow = isSlow && isBluetoothTransport;
 
     // Device needs to be paired twice when using web usb transport. // Once in
     // bootloader mode and once in normal mode. Without 2nd pairing step would get stuck at waiting for
@@ -63,6 +67,11 @@ export const FirmwareInstallation = ({
                         }
                     >
                         <Translation id="TR_SELECT_TREZOR_TO_CONTINUE" />
+                    </Banner>
+                )}
+                {displayIsSlow && (
+                    <Banner variant="info" icon="bluetooth">
+                        <Translation id="TR_INSTALLATION_FW_SLOW_TIP_BANNER" />
                     </Banner>
                 )}
                 <Card>

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -779,6 +779,11 @@ export default defineMessages({
         defaultMessage: 'Your swap might be partially filled based on market conditions',
         id: 'TR_TRADING_EXCHANGE_SIGN_BANNER_POINT_3',
     },
+    TR_INSTALLATION_FW_SLOW_TIP_BANNER: {
+        id: 'TR_INSTALLATION_FW_SLOW_TIP_BANNER',
+        defaultMessage:
+            'Firmware installation is taking longer than usual. This may be cause by other connected bluetooth devices. Consider disconnecting them.',
+    },
     TR_SELL_STATUS_ERROR: {
         defaultMessage: 'Rejected',
         id: 'TR_SELL_STATUS_ERROR',

--- a/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
+++ b/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { ButtonRequest, FirmwareStatus, TrezorDevice } from '@suite-common/suite-types';
@@ -16,6 +16,10 @@ import { isArrayMember } from '@trezor/utils';
 import { firmwareActions } from '../firmwareActions';
 import { selectFirmware, selectSwitchFirmwareType } from '../firmwareReducer';
 import { FirmwareUpdateProps, firmwareUpdate as firmwareUpdateThunk } from '../firmwareThunks';
+
+const INTERVAL_CHECK_SLOW_INSTALLATION_MS = 1_000;
+const TIME_THRESHOLD_SLOW_INSTALLATION_MS = 30_000;
+const PERCENTAGE_THRESHOLD_SLOW_INSTALLATION = 20;
 
 /*
 There are three firmware update flows, depending on current firmware version:
@@ -108,6 +112,41 @@ export const useFirmwareInstallation = () => {
     const isThpInProgress = useSelector(selectIsThpInProgress);
     const thpStep = useSelector(selectThpStep);
     const switchFirmwareType = useSelector(selectSwitchFirmwareType);
+
+    const [isSlow, setIsSlow] = useState(false);
+    const [startTime, setStartTime] = useState<null | number>(null);
+
+    useEffect(() => {
+        if (
+            !startTime &&
+            firmware.uiEvent?.type === UI.FIRMWARE_PROGRESS &&
+            firmware.uiEvent.payload.progress === 1
+        ) {
+            setStartTime(new Date().getTime());
+        }
+    }, [firmware.uiEvent, startTime]);
+
+    useEffect(() => {
+        if (!startTime || isSlow) {
+            return;
+        }
+
+        const interval = setInterval(() => {
+            const now = new Date().getTime();
+
+            if (now - startTime > TIME_THRESHOLD_SLOW_INSTALLATION_MS) {
+                if (
+                    firmware.uiEvent?.type === UI.FIRMWARE_PROGRESS &&
+                    firmware.uiEvent.payload.progress < PERCENTAGE_THRESHOLD_SLOW_INSTALLATION
+                ) {
+                    setIsSlow(true);
+                    clearInterval(interval);
+                }
+            }
+        }, INTERVAL_CHECK_SLOW_INSTALLATION_MS);
+
+        return () => clearInterval(interval);
+    }, [startTime, isSlow, firmware.uiEvent]);
 
     const [reconnectEvent, buttonEvent, progressEvent] = useMemo(() => {
         if (firmware.uiEvent) {
@@ -255,5 +294,6 @@ export const useFirmwareInstallation = () => {
         pinRequested,
         progressEvent,
         deviceIsWaitingForConfirmationToInitiateConnection,
+        isSlow,
     };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding new logic to identify that FW installation is taking to long (bellow 20% after 30 seconds) and letting user know in a banner that disconnecting other Bluetooth devices might help speeding it up.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22521

## Screenshots:
<img width="709" height="471" alt="image" src="https://github.com/user-attachments/assets/c0dccb47-b391-4d58-a3bb-03cbf2196a42" />

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tips-when-ble-fw-installation-slow&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tips-when-ble-fw-installation-slow&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tips-when-ble-fw-installation-slow&lookback=7)