### PR TITLE
refactor: the Fee component can now use react-hook-form hooks

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useIntl } from 'react-intl';
 
 import { selectConnectPopupCall } from '@suite-common/connect-popup';
@@ -180,23 +180,25 @@ export const SelectFeeModal = ({ data }: SelectAccountModalProps) => {
                     </>
                 }
             >
-                <Column gap={spacings.md}>
-                    {popupCall?.state === 'ongoing' && popupCall?.payload?.outputs && (
-                        <OutputsSummary account={account} outputs={popupCall.payload.outputs} />
-                    )}
-                    <Fees
-                        account={account}
-                        feeInfo={feeInfo}
-                        control={control}
-                        register={register}
-                        setValue={setValue}
-                        getValues={getValues}
-                        errors={errors}
-                        isDirty={isDirty}
-                        changeFeeLevel={changeFeeLevel}
-                        trigger={trigger}
-                    />
-                </Column>
+                <FormProvider {...methods}>
+                    <Column gap={spacings.md}>
+                        {popupCall?.state === 'ongoing' && popupCall?.payload?.outputs && (
+                            <OutputsSummary account={account} outputs={popupCall.payload.outputs} />
+                        )}
+                        <Fees
+                            account={account}
+                            feeInfo={feeInfo}
+                            control={control}
+                            register={register}
+                            setValue={setValue}
+                            getValues={getValues}
+                            errors={errors}
+                            isDirty={isDirty}
+                            changeFeeLevel={changeFeeLevel}
+                            trigger={trigger}
+                        />
+                    </Column>
+                </FormProvider>
             </Modal.ModalBase>
         </ConnectModalBackdrop>
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { FormProvider } from 'react-hook-form';
 
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { selectAreFeesLoading, selectHasRunningDiscovery } from '@suite-common/wallet-core';
@@ -45,6 +46,7 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
         onClaimChange,
         signTx,
         trigger,
+        methods,
     } = useClaimForm({ selectedAccount });
     const areFeesLoading = useSelector(state => selectAreFeesLoading(state, account.symbol));
 
@@ -126,57 +128,59 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
                 </>
             }
         >
-            <form onSubmit={onClaimClick}>
-                <Column gap={spacings.lg}>
-                    <SolanaStakingLimitBanner
-                        account={account}
-                        composedLevels={composedLevels}
-                        type="claim"
-                    />
+            <FormProvider {...methods}>
+                <form onSubmit={onClaimClick}>
+                    <Column gap={spacings.lg}>
+                        <SolanaStakingLimitBanner
+                            account={account}
+                            composedLevels={composedLevels}
+                            type="claim"
+                        />
 
-                    <InfoItem direction="column" label={<Translation id="AMOUNT" />}>
-                        <Paragraph typographyStyle="titleSmall">
-                            <FormattedCryptoAmount
-                                data-testid="@staking/claim-modal/amount"
-                                value={claimableAmount}
-                                symbol={account.symbol}
-                            />
-                        </Paragraph>
-                        <Paragraph typographyStyle="label" variant="tertiary">
-                            <BaseCurrencyValue
-                                showApproximationIndicator
-                                amount={claimableAmount}
-                                symbol={account.symbol}
-                            />
-                        </Paragraph>
-                    </InfoItem>
+                        <InfoItem direction="column" label={<Translation id="AMOUNT" />}>
+                            <Paragraph typographyStyle="titleSmall">
+                                <FormattedCryptoAmount
+                                    data-testid="@staking/claim-modal/amount"
+                                    value={claimableAmount}
+                                    symbol={account.symbol}
+                                />
+                            </Paragraph>
+                            <Paragraph typographyStyle="label" variant="tertiary">
+                                <BaseCurrencyValue
+                                    showApproximationIndicator
+                                    amount={claimableAmount}
+                                    symbol={account.symbol}
+                                />
+                            </Paragraph>
+                        </InfoItem>
 
-                    <InfoItem
-                        direction="column"
-                        label={<Translation id="TR_STAKE_CLAIMING_PERIOD" />}
-                    >
-                        <Translation id="TR_STAKE_CLAIM_IN_NEXT_BLOCK" />
-                    </InfoItem>
+                        <InfoItem
+                            direction="column"
+                            label={<Translation id="TR_STAKE_CLAIMING_PERIOD" />}
+                        >
+                            <Translation id="TR_STAKE_CLAIM_IN_NEXT_BLOCK" />
+                        </InfoItem>
 
-                    <Fees
-                        control={control}
-                        errors={errors}
-                        isDirty={isDirty}
-                        register={register}
-                        feeInfo={feeInfo}
-                        setValue={setValue}
-                        getValues={getValues}
-                        account={account}
-                        composedLevels={composedLevels}
-                        changeFeeLevel={changeFeeLevel}
-                        trigger={trigger}
-                    />
+                        <Fees
+                            control={control}
+                            errors={errors}
+                            isDirty={isDirty}
+                            register={register}
+                            feeInfo={feeInfo}
+                            setValue={setValue}
+                            getValues={getValues}
+                            account={account}
+                            composedLevels={composedLevels}
+                            changeFeeLevel={changeFeeLevel}
+                            trigger={trigger}
+                        />
 
-                    {errors[CRYPTO_INPUT] && (
-                        <Banner variant="destructive">{errors[CRYPTO_INPUT]?.message}</Banner>
-                    )}
-                </Column>
-            </form>
+                        {errors[CRYPTO_INPUT] && (
+                            <Banner variant="destructive">{errors[CRYPTO_INPUT]?.message}</Banner>
+                        )}
+                    </Column>
+                </form>
+            </FormProvider>
         </Modal>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeForm.tsx
@@ -1,3 +1,5 @@
+import { FormProvider } from 'react-hook-form';
+
 import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -27,6 +29,7 @@ export const StakeForm = () => {
         composedLevels,
         trigger,
         isStakingDisabled,
+        methods,
     } = useStakeFormContext();
 
     const { formattedBalance, symbol, networkType } = account;
@@ -34,7 +37,7 @@ export const StakeForm = () => {
     const isCardanoNetwork = networkType === 'cardano';
 
     return (
-        <>
+        <FormProvider {...methods}>
             {isConfirmModalOpen && (
                 <ConfirmStakeModal
                     isLoading={isLoading}
@@ -78,6 +81,6 @@ export const StakeForm = () => {
                     />
                 )}
             </Column>
-        </>
+        </FormProvider>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { FormProvider } from 'react-hook-form';
 
 import { NetworkType, getNetwork } from '@suite-common/wallet-config';
 import { WalletAccountTransaction } from '@suite-common/wallet-types';
@@ -50,12 +51,13 @@ const ChangeFeeLoaded = (props: ChangeFeeProps) => {
     const {
         account: { networkType },
         chainedTxs,
+        methods,
     } = useRbfContext();
 
     const fee = formatNetworkAmount(tx.fee, tx.symbol);
 
     return (
-        <>
+        <FormProvider {...methods}>
             <Card
                 fillType="flat"
                 paddingType="small"
@@ -106,7 +108,7 @@ const ChangeFeeLoaded = (props: ChangeFeeProps) => {
             <DecreasedOutputs />
 
             <AffectedTransactions chainedTxs={chainedTxs} showChained={showChained} />
-        </>
+        </FormProvider>
     );
 };
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 
 import { numberToHex, toWei } from 'web3-utils';
 
@@ -354,235 +354,238 @@ export const TxSimulationModal = () => {
                     </>
                 }
             >
-                <Column gap={spacings.xs}>
-                    {isLoading && <Spinner size={50} />}
+                <FormProvider {...methods}>
+                    <Column gap={spacings.xs}>
+                        {isLoading && <Spinner size={50} />}
 
-                    {simulationResult && (
-                        <>
-                            {simulationResult.simulation?.status === 'Success' && (
-                                <>
-                                    <Card
-                                        header={
-                                            <H4
-                                                margin={{ left: spacings.xxs }}
-                                                typographyStyle="callout"
-                                            >
-                                                <Translation id="TR_SIMULATION" />
-                                            </H4>
-                                        }
-                                        paddingType="small"
-                                    >
-                                        <Column
-                                            margin={{
-                                                // @ts-expect-error - negative margins to align with card
-                                                horizontal: -spacings.md,
-                                                // @ts-expect-error - negative margins to align with card
-                                                vertical: -spacings.sm,
-                                            }}
-                                            hasDivider
-                                        >
-                                            {simulationResult.simulation.account_summary.assets_diffs.map(
-                                                (assetDiff, index) => (
-                                                    <TxSimulationAsset
-                                                        key={index}
-                                                        assetDiff={assetDiff}
-                                                        network={network}
-                                                    />
-                                                ),
-                                            )}
-                                            {simulationResult.simulation.account_summary.exposures.map(
-                                                (assetExposure, index) => (
-                                                    <TxSimulationAsset
-                                                        key={index}
-                                                        assetExposure={assetExposure}
-                                                        network={network}
-                                                    />
-                                                ),
-                                            )}
-                                            {simulationResult.simulation.account_summary
-                                                .assets_diffs.length === 0 &&
-                                                simulationResult.simulation.account_summary
-                                                    .exposures.length === 0 && (
-                                                    <Row
-                                                        padding={{
-                                                            horizontal: spacings.md,
-                                                            vertical: spacings.sm,
-                                                        }}
-                                                        justifyContent="center"
-                                                    >
-                                                        <Text variant="tertiary">
-                                                            <Translation id="TR_SIMULATION_NO_ASSETS" />
-                                                        </Text>
-                                                    </Row>
-                                                )}
-                                        </Column>
-                                    </Card>
-
-                                    <CollapsibleBox
-                                        heading={
-                                            <Row
-                                                gap={spacings.xs}
-                                                alignItems="center"
-                                                justifyContent="space-between"
-                                                flex="1"
-                                            >
-                                                <H4 typographyStyle="callout" flex="1">
-                                                    <Translation id="TR_CONTRACT_INFO" />
+                        {simulationResult && (
+                            <>
+                                {simulationResult.simulation?.status === 'Success' && (
+                                    <>
+                                        <Card
+                                            header={
+                                                <H4
+                                                    margin={{ left: spacings.xxs }}
+                                                    typographyStyle="callout"
+                                                >
+                                                    <Translation id="TR_SIMULATION" />
                                                 </H4>
-                                            </Row>
-                                        }
-                                    >
-                                        {targetContract && (
+                                            }
+                                            paddingType="small"
+                                        >
                                             <Column
-                                                hasDivider
                                                 margin={{
-                                                    // @ts-expect-error - negative margins to align with collapsible box
+                                                    // @ts-expect-error - negative margins to align with card
                                                     horizontal: -spacings.md,
-                                                    // @ts-expect-error - negative margins to align with collapsible box
-                                                    vertical: -spacings.lg,
+                                                    // @ts-expect-error - negative margins to align with card
+                                                    vertical: -spacings.sm,
                                                 }}
+                                                hasDivider
                                             >
-                                                {[
-                                                    {
-                                                        label: <Translation id="TR_PROTOCOL" />,
-                                                        value: Object.entries(
-                                                            simulationResult.simulation
-                                                                .address_details,
-                                                        ).find(
-                                                            ([address]) =>
-                                                                address.toLowerCase() ===
-                                                                targetContract.toLowerCase(),
-                                                        )?.[1]?.name_tag,
-                                                    },
-                                                    {
-                                                        label: (
-                                                            <Translation
-                                                                id={getTokenAddressTranslationId(
-                                                                    network.networkType,
-                                                                )}
-                                                            />
-                                                        ),
-                                                        value: (
-                                                            <TxAddress
-                                                                txAddress={targetContract}
-                                                                explorerUrl={getExplorerUrl(
-                                                                    explorer,
-                                                                    'address',
-                                                                )}
-                                                                explorerUrlQueryString={
-                                                                    explorer?.queryString
-                                                                }
-                                                                shouldAllowCopy
-                                                                typographyStyle="label"
-                                                            />
-                                                        ),
-                                                    },
-                                                    {
-                                                        label: (
-                                                            <Translation id="TR_CONTRACT_FUNCTION" />
-                                                        ),
-                                                        value: simulationResult.simulation.params
-                                                            ?.calldata?.function_signature,
-                                                    },
-                                                ].map((item, index) =>
-                                                    item.value ? (
-                                                        <Row
+                                                {simulationResult.simulation.account_summary.assets_diffs.map(
+                                                    (assetDiff, index) => (
+                                                        <TxSimulationAsset
                                                             key={index}
-                                                            gap={spacings.xs}
+                                                            assetDiff={assetDiff}
+                                                            network={network}
+                                                        />
+                                                    ),
+                                                )}
+                                                {simulationResult.simulation.account_summary.exposures.map(
+                                                    (assetExposure, index) => (
+                                                        <TxSimulationAsset
+                                                            key={index}
+                                                            assetExposure={assetExposure}
+                                                            network={network}
+                                                        />
+                                                    ),
+                                                )}
+                                                {simulationResult.simulation.account_summary
+                                                    .assets_diffs.length === 0 &&
+                                                    simulationResult.simulation.account_summary
+                                                        .exposures.length === 0 && (
+                                                        <Row
                                                             padding={{
                                                                 horizontal: spacings.md,
                                                                 vertical: spacings.sm,
                                                             }}
-                                                            alignItems="center"
-                                                            justifyContent="flex-start"
+                                                            justifyContent="center"
                                                         >
-                                                            <Text flex="1">{item.label}</Text>
-                                                            <Text
-                                                                flex="2"
-                                                                wordBreak="break-all"
-                                                                typographyStyle="label"
-                                                            >
-                                                                {item.value}
+                                                            <Text variant="tertiary">
+                                                                <Translation id="TR_SIMULATION_NO_ASSETS" />
                                                             </Text>
                                                         </Row>
-                                                    ) : null,
-                                                )}
+                                                    )}
                                             </Column>
+                                        </Card>
+
+                                        <CollapsibleBox
+                                            heading={
+                                                <Row
+                                                    gap={spacings.xs}
+                                                    alignItems="center"
+                                                    justifyContent="space-between"
+                                                    flex="1"
+                                                >
+                                                    <H4 typographyStyle="callout" flex="1">
+                                                        <Translation id="TR_CONTRACT_INFO" />
+                                                    </H4>
+                                                </Row>
+                                            }
+                                        >
+                                            {targetContract && (
+                                                <Column
+                                                    hasDivider
+                                                    margin={{
+                                                        // @ts-expect-error - negative margins to align with collapsible box
+                                                        horizontal: -spacings.md,
+                                                        // @ts-expect-error - negative margins to align with collapsible box
+                                                        vertical: -spacings.lg,
+                                                    }}
+                                                >
+                                                    {[
+                                                        {
+                                                            label: <Translation id="TR_PROTOCOL" />,
+                                                            value: Object.entries(
+                                                                simulationResult.simulation
+                                                                    .address_details,
+                                                            ).find(
+                                                                ([address]) =>
+                                                                    address.toLowerCase() ===
+                                                                    targetContract.toLowerCase(),
+                                                            )?.[1]?.name_tag,
+                                                        },
+                                                        {
+                                                            label: (
+                                                                <Translation
+                                                                    id={getTokenAddressTranslationId(
+                                                                        network.networkType,
+                                                                    )}
+                                                                />
+                                                            ),
+                                                            value: (
+                                                                <TxAddress
+                                                                    txAddress={targetContract}
+                                                                    explorerUrl={getExplorerUrl(
+                                                                        explorer,
+                                                                        'address',
+                                                                    )}
+                                                                    explorerUrlQueryString={
+                                                                        explorer?.queryString
+                                                                    }
+                                                                    shouldAllowCopy
+                                                                    typographyStyle="label"
+                                                                />
+                                                            ),
+                                                        },
+                                                        {
+                                                            label: (
+                                                                <Translation id="TR_CONTRACT_FUNCTION" />
+                                                            ),
+                                                            value: simulationResult.simulation
+                                                                .params?.calldata
+                                                                ?.function_signature,
+                                                        },
+                                                    ].map((item, index) =>
+                                                        item.value ? (
+                                                            <Row
+                                                                key={index}
+                                                                gap={spacings.xs}
+                                                                padding={{
+                                                                    horizontal: spacings.md,
+                                                                    vertical: spacings.sm,
+                                                                }}
+                                                                alignItems="center"
+                                                                justifyContent="flex-start"
+                                                            >
+                                                                <Text flex="1">{item.label}</Text>
+                                                                <Text
+                                                                    flex="2"
+                                                                    wordBreak="break-all"
+                                                                    typographyStyle="label"
+                                                                >
+                                                                    {item.value}
+                                                                </Text>
+                                                            </Row>
+                                                        ) : null,
+                                                    )}
+                                                </Column>
+                                            )}
+                                        </CollapsibleBox>
+                                    </>
+                                )}
+
+                                {simulationResult.validation?.result_type === 'Malicious' && (
+                                    <TxSimulationBanner
+                                        type="error"
+                                        title={<Translation id="TR_SIMULATION_MALICIOUS" />}
+                                        description={simulationResult.validation?.description}
+                                        disclaimerAccepted={disclaimerAccepted}
+                                        setDisclaimerAccepted={setDisclaimerAccepted}
+                                    />
+                                )}
+
+                                {simulationResult.validation?.result_type === 'Warning' && (
+                                    <TxSimulationBanner
+                                        type="warning"
+                                        title={<Translation id="TR_SIMULATION_WARNING" />}
+                                        description={simulationResult.validation?.description}
+                                        disclaimerAccepted={disclaimerAccepted}
+                                        setDisclaimerAccepted={setDisclaimerAccepted}
+                                    />
+                                )}
+
+                                {simulationResult.simulation?.status === 'Error' && (
+                                    <TxSimulationBanner
+                                        type={getSimulationErrorRiskLevel(
+                                            simulationResult.simulation.error,
                                         )}
-                                    </CollapsibleBox>
-                                </>
-                            )}
+                                        title={<Translation id="TR_SIMULATION_ERROR" />}
+                                        description={simulationResult.simulation.error}
+                                        disclaimerAccepted={disclaimerAccepted}
+                                        setDisclaimerAccepted={setDisclaimerAccepted}
+                                    />
+                                )}
+                            </>
+                        )}
 
-                            {simulationResult.validation?.result_type === 'Malicious' && (
-                                <TxSimulationBanner
-                                    type="error"
-                                    title={<Translation id="TR_SIMULATION_MALICIOUS" />}
-                                    description={simulationResult.validation?.description}
-                                    disclaimerAccepted={disclaimerAccepted}
-                                    setDisclaimerAccepted={setDisclaimerAccepted}
-                                />
-                            )}
-
-                            {simulationResult.validation?.result_type === 'Warning' && (
-                                <TxSimulationBanner
-                                    type="warning"
-                                    title={<Translation id="TR_SIMULATION_WARNING" />}
-                                    description={simulationResult.validation?.description}
-                                    disclaimerAccepted={disclaimerAccepted}
-                                    setDisclaimerAccepted={setDisclaimerAccepted}
-                                />
-                            )}
-
-                            {simulationResult.simulation?.status === 'Error' && (
-                                <TxSimulationBanner
-                                    type={getSimulationErrorRiskLevel(
-                                        simulationResult.simulation.error,
-                                    )}
-                                    title={<Translation id="TR_SIMULATION_ERROR" />}
-                                    description={simulationResult.simulation.error}
-                                    disclaimerAccepted={disclaimerAccepted}
-                                    setDisclaimerAccepted={setDisclaimerAccepted}
-                                />
-                            )}
-                        </>
-                    )}
-
-                    {error && (
-                        <TxSimulationBanner
-                            type="error"
-                            title={<Translation id="TR_SIMULATION_ERROR" />}
-                            description={error.message}
-                            disclaimerAccepted={disclaimerAccepted}
-                            setDisclaimerAccepted={setDisclaimerAccepted}
-                        />
-                    )}
-
-                    <Column margin={{ left: spacings.xs }} gap={spacings.md}>
-                        <Text variant="tertiary">
-                            <Translation
-                                id="TR_SIMULATION_POWERED_BY"
-                                values={{
-                                    provider: <Link href="https://blockaid.io">Blockaid</Link>,
-                                }}
-                            />
-                        </Text>
-
-                        {isSigningTransaction && account && (
-                            <Fees
-                                account={account}
-                                feeInfo={feeInfo}
-                                control={control}
-                                register={register}
-                                setValue={setValue}
-                                getValues={getValues}
-                                errors={errors}
-                                isDirty={isDirty}
-                                changeFeeLevel={changeFeeLevel}
-                                trigger={trigger}
+                        {error && (
+                            <TxSimulationBanner
+                                type="error"
+                                title={<Translation id="TR_SIMULATION_ERROR" />}
+                                description={error.message}
+                                disclaimerAccepted={disclaimerAccepted}
+                                setDisclaimerAccepted={setDisclaimerAccepted}
                             />
                         )}
+
+                        <Column margin={{ left: spacings.xs }} gap={spacings.md}>
+                            <Text variant="tertiary">
+                                <Translation
+                                    id="TR_SIMULATION_POWERED_BY"
+                                    values={{
+                                        provider: <Link href="https://blockaid.io">Blockaid</Link>,
+                                    }}
+                                />
+                            </Text>
+
+                            {isSigningTransaction && account && (
+                                <Fees
+                                    account={account}
+                                    feeInfo={feeInfo}
+                                    control={control}
+                                    register={register}
+                                    setValue={setValue}
+                                    getValues={getValues}
+                                    errors={errors}
+                                    isDirty={isDirty}
+                                    changeFeeLevel={changeFeeLevel}
+                                    trigger={trigger}
+                                />
+                            )}
+                        </Column>
                     </Column>
-                </Column>
+                </FormProvider>
             </Modal.ModalBase>
         </ConnectModalBackdrop>
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeForm.tsx
@@ -1,3 +1,5 @@
+import { FormProvider } from 'react-hook-form';
+
 import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
 import { Banner, Column, InfoItem, Tooltip } from '@trezor/components';
@@ -33,6 +35,7 @@ export const UnstakeForm = () => {
         feeInfo,
         composedLevels,
         trigger,
+        methods,
     } = useUnstakeFormContext();
 
     const { symbol, networkType } = account;
@@ -51,85 +54,87 @@ export const UnstakeForm = () => {
         approximatedInstantEthAmount && BigNumber(approximatedInstantEthAmount).gt(0);
 
     return (
-        <form onSubmit={handleSubmit(signTx)}>
-            <Column gap={spacings.xxl} margin={{ bottom: spacings.lg }}>
-                <Column gap={spacings.md}>
-                    {canClaim && (
-                        <Banner variant="info">
-                            <Translation
-                                id="TR_STAKE_CAN_CLAIM_WARNING"
-                                values={{
-                                    amount: claimableAmount,
-                                    symbol: getDisplaySymbol(account.symbol),
-                                    br: <br />,
-                                }}
-                            />
-                        </Banner>
-                    )}
-                    <SolanaStakingLimitBanner
-                        account={account}
-                        composedLevels={composedLevels}
-                        type="unstake"
-                    />
-                </Column>
-                {!isCardanoNetwork && (
-                    <>
-                        <StakeAvailableBalance
-                            formattedBalance={autocompoundBalance}
-                            symbol={symbol}
-                        />
-
-                        <Column gap={spacings.lg}>
-                            <UnstakeInputs />
-                            {showError && (
-                                <Banner variant="destructive">{inputError?.message}</Banner>
-                            )}
-                        </Column>
-                    </>
-                )}
-
-                <Fees
-                    control={control}
-                    errors={errors}
-                    isDirty={isDirty}
-                    register={register}
-                    feeInfo={feeInfo}
-                    setValue={setValue}
-                    getValues={getValues}
-                    account={account}
-                    composedLevels={composedLevels}
-                    changeFeeLevel={changeFeeLevel}
-                    trigger={trigger}
-                />
-
-                {shouldShowInstantUnstakeEthAmount && (
-                    <InfoItem
-                        label={
-                            <Tooltip
-                                maxWidth={328}
-                                content={
-                                    <Translation id="TR_STAKE_UNSTAKING_APPROXIMATE_DESCRIPTION" />
-                                }
-                                hasIcon
-                            >
+        <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(signTx)}>
+                <Column gap={spacings.xxl} margin={{ bottom: spacings.lg }}>
+                    <Column gap={spacings.md}>
+                        {canClaim && (
+                            <Banner variant="info">
                                 <Translation
-                                    id="TR_STAKE_UNSTAKING_APPROXIMATE"
+                                    id="TR_STAKE_CAN_CLAIM_WARNING"
                                     values={{
+                                        amount: claimableAmount,
                                         symbol: getDisplaySymbol(account.symbol),
+                                        br: <br />,
                                     }}
                                 />
-                            </Tooltip>
-                        }
-                        typographyStyle="body"
-                        direction="row"
-                    >
-                        <ApproximateInstantEthAmount
-                            value={approximatedInstantEthAmount}
-                            symbol={account.symbol}
+                            </Banner>
+                        )}
+                        <SolanaStakingLimitBanner
+                            account={account}
+                            composedLevels={composedLevels}
+                            type="unstake"
                         />
-                    </InfoItem>
-                )}
-            </Column>
-        </form>
+                    </Column>
+                    {!isCardanoNetwork && (
+                        <>
+                            <StakeAvailableBalance
+                                formattedBalance={autocompoundBalance}
+                                symbol={symbol}
+                            />
+
+                            <Column gap={spacings.lg}>
+                                <UnstakeInputs />
+                                {showError && (
+                                    <Banner variant="destructive">{inputError?.message}</Banner>
+                                )}
+                            </Column>
+                        </>
+                    )}
+
+                    <Fees
+                        control={control}
+                        errors={errors}
+                        isDirty={isDirty}
+                        register={register}
+                        feeInfo={feeInfo}
+                        setValue={setValue}
+                        getValues={getValues}
+                        account={account}
+                        composedLevels={composedLevels}
+                        changeFeeLevel={changeFeeLevel}
+                        trigger={trigger}
+                    />
+
+                    {shouldShowInstantUnstakeEthAmount && (
+                        <InfoItem
+                            label={
+                                <Tooltip
+                                    maxWidth={328}
+                                    content={
+                                        <Translation id="TR_STAKE_UNSTAKING_APPROXIMATE_DESCRIPTION" />
+                                    }
+                                    hasIcon
+                                >
+                                    <Translation
+                                        id="TR_STAKE_UNSTAKING_APPROXIMATE"
+                                        values={{
+                                            symbol: getDisplaySymbol(account.symbol),
+                                        }}
+                                    />
+                                </Tooltip>
+                            }
+                            typographyStyle="body"
+                            direction="row"
+                        >
+                            <ApproximateInstantEthAmount
+                                value={approximatedInstantEthAmount}
+                                symbol={account.symbol}
+                            />
+                        </InfoItem>
+                    )}
+                </Column>
+            </form>
+        </FormProvider>
     );
 };

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -128,7 +128,7 @@ export const useTradingBuyForm = ({
         mode: 'onChange',
         defaultValues: redirectValues || (isDraft && draftUpdated ? draftUpdated : defaultValues),
     });
-    const { register, control, formState, reset, setValue, handleSubmit } = methods;
+    const { control, formState, reset, setValue, handleSubmit } = methods;
     const values = useWatch<TradingBuyFormProps>({ control });
     const previousValues = useRef<typeof values | TradingBuyFormProps | null>(
         !isFromRedirect && isNotFormPage ? draftUpdated : null,
@@ -477,7 +477,7 @@ export const useTradingBuyForm = ({
             },
         },
         ...methods,
-        register,
+        methods,
         account,
         defaultCountry,
         defaultCurrency,
@@ -487,7 +487,6 @@ export const useTradingBuyForm = ({
         amountLimits,
         network,
         cryptoInputValue: values.cryptoInput,
-        formState,
         device,
         verifiedAddress,
         timer,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -933,7 +933,7 @@ export const useTradingExchangeForm = ({
             },
             helpers,
         },
-
+        methods,
         device,
         timer,
         exchangeInfo,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -590,6 +590,7 @@ export const useTradingSellForm = ({
             helpers,
         },
         ...methods,
+        methods,
         account,
         defaultCountry,
         defaultCurrency,

--- a/packages/suite/src/hooks/wallet/useClaimForm.ts
+++ b/packages/suite/src/hooks/wallet/useClaimForm.ts
@@ -133,6 +133,7 @@ export const useClaimForm = ({ selectedAccount }: UseClaimFormsProps): ClaimCont
 
     return {
         ...methods,
+        methods,
         account,
         network,
         formState,

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -309,6 +309,7 @@ export const useRbf = (props: UseRbfProps) => {
 
     return {
         ...state,
+        methods: useFormMethods,
         isLoading,
         showDecreasedOutputs,
         register,

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -397,6 +397,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     return {
         ...state,
         ...useFormMethods,
+        methods: useFormMethods,
         feeInfo,
         isLoading,
         register,

--- a/packages/suite/src/hooks/wallet/useStakeForm.ts
+++ b/packages/suite/src/hooks/wallet/useStakeForm.ts
@@ -410,6 +410,7 @@ export const useStakeForm = ({
 
     return {
         ...methods,
+        methods,
         onSubmit,
         account,
         network,

--- a/packages/suite/src/hooks/wallet/useUnstakeForm.ts
+++ b/packages/suite/src/hooks/wallet/useUnstakeForm.ts
@@ -279,6 +279,7 @@ export const useUnstakeForm = ({ selectedAccount }: UseUnstakeFormsProps): Unsta
 
     return {
         ...methods,
+        methods,
         account,
         network,
         formState,

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -146,6 +146,7 @@ export interface TradingBuyFormContextProps
     verifyAddress: TradingVerifyAccountProps;
     removeDraft: (key: string) => void;
     setAmountLimits: (limits?: AmountLimitProps) => void;
+    methods: UseFormReturn<TradingBuyFormProps>;
 }
 
 export interface TradingSellFormContextProps
@@ -178,6 +179,7 @@ export interface TradingSellFormContextProps
     confirmTrade: (bankAccount: BankAccount) => void;
     sendTransaction: () => Promise<boolean>;
     selectQuote: (quote: SellFiatTrade) => void;
+    methods: UseFormReturn<TradingSellFormProps>;
 }
 
 export type TradingExchangeConfirmTradeProps = {
@@ -249,6 +251,7 @@ export interface TradingExchangeFormContextProps
     setIsLoadingQuote: (isLoadingQuote: boolean) => void;
     isApproval: boolean;
     setIsApproval: (isApproval: boolean) => void;
+    methods: UseFormReturn<TradingExchangeFormProps>;
 }
 
 export type TradingExchangeApprovalType = 'APPROVE' | 'REVOKE';

--- a/packages/suite/src/types/wallet/claimForm.ts
+++ b/packages/suite/src/types/wallet/claimForm.ts
@@ -11,4 +11,6 @@ export type ClaimFormState = Omit<
 export type ClaimContextValues = UseFormReturn<ClaimFormState> &
     BaseStakeContextValues & {
         onClaimChange: (amount: string) => Promise<void>;
+    } & {
+        methods: UseFormReturn<ClaimFormState>;
     };

--- a/packages/suite/src/types/wallet/sendForm.ts
+++ b/packages/suite/src/types/wallet/sendForm.ts
@@ -67,6 +67,7 @@ export interface GetDefaultValue {
 export type SendContextValues<TFormValues extends FormState = FormState> =
     UseFormReturn<TFormValues> &
         UseSendFormState & {
+            methods: UseFormReturn<TFormValues>;
             isLoading: boolean;
             feeInfo: FeeInfo;
             // additional fields

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { FormProvider } from 'react-hook-form';
 
 import styled from 'styled-components';
 
@@ -86,25 +87,27 @@ const SendLoaded = ({ children, selectedAccount }: SendLoadedProps) => {
     return (
         <WalletLayout title="TR_NAV_SEND" isSubpage account={selectedAccount}>
             <SendContext.Provider value={sendContextValues}>
-                <Column gap={spacings.xl}>
-                    <SendHeader />
+                <FormProvider {...sendContextValues.methods}>
+                    <Column gap={spacings.xl}>
+                        <SendHeader />
 
-                    <FormGrid data-testid="@wallet/send/outputs-and-options">
-                        <Outputs disableAnim={!!children} />
-                        <Options />
-                        <SendFees />
+                        <FormGrid data-testid="@wallet/send/outputs-and-options">
+                            <Outputs disableAnim={!!children} />
+                            <Options />
+                            <SendFees />
 
-                        {symbol === 'dsol' && (
-                            <Banner icon>
-                                <Translation id="TR_SOLANA_DEVNET_SHORTCUT_WARNING" />
-                            </Banner>
-                        )}
+                            {symbol === 'dsol' && (
+                                <Banner icon>
+                                    <Translation id="TR_SOLANA_DEVNET_SHORTCUT_WARNING" />
+                                </Banner>
+                            )}
 
-                        <TotalSent />
-                    </FormGrid>
-                </Column>
+                            <TotalSent />
+                        </FormGrid>
+                    </Column>
 
-                {children}
+                    {children}
+                </FormProvider>
             </SendContext.Provider>
 
             <ConfirmEvmExplanationModal account={selectedAccount.account} route="wallet-send" />

--- a/packages/suite/src/views/wallet/trading/buy/TradingBuyConfirm.tsx
+++ b/packages/suite/src/views/wallet/trading/buy/TradingBuyConfirm.tsx
@@ -1,3 +1,5 @@
+import { FormProvider } from 'react-hook-form';
+
 import { useTradingBuyForm } from 'src/hooks/wallet/trading/form/useTradingBuyForm';
 import { TradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { UseTradingProps } from 'src/types/trading/trading';
@@ -12,7 +14,9 @@ const TradingBuyConfirmComponent = ({ selectedAccount }: UseTradingProps) => {
 
     return (
         <TradingFormContext.Provider value={tradingBuyContextValues}>
-            <TradingSelectedOffer />
+            <FormProvider {...tradingBuyContextValues.methods}>
+                <TradingSelectedOffer />
+            </FormProvider>
         </TradingFormContext.Provider>
     );
 };

--- a/packages/suite/src/views/wallet/trading/buy/TradingBuyForm.tsx
+++ b/packages/suite/src/views/wallet/trading/buy/TradingBuyForm.tsx
@@ -1,3 +1,5 @@
+import { FormProvider } from 'react-hook-form';
+
 import { Context } from '@suite-common/message-system';
 import { TradingType } from '@suite-common/trading';
 
@@ -19,7 +21,9 @@ const TradingBuyFormContent = ({ selectedAccount }: UseTradingProps) => {
 
     return (
         <TradingFormContext.Provider value={tradingBuyContextValues}>
-            <TradingFormLayout />
+            <FormProvider {...tradingBuyContextValues.methods}>
+                <TradingFormLayout />
+            </FormProvider>
         </TradingFormContext.Provider>
     );
 };

--- a/packages/suite/src/views/wallet/trading/buy/TradingBuyOffers.tsx
+++ b/packages/suite/src/views/wallet/trading/buy/TradingBuyOffers.tsx
@@ -1,3 +1,5 @@
+import { FormProvider } from 'react-hook-form';
+
 import { useTradingBuyForm } from 'src/hooks/wallet/trading/form/useTradingBuyForm';
 import { TradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { UseTradingProps } from 'src/types/trading/trading';
@@ -12,7 +14,9 @@ const TradingBuyOffersComponent = ({ selectedAccount }: UseTradingProps) => {
 
     return (
         <TradingFormContext.Provider value={tradingBuyFormContextValues}>
-            <TradingOffers />
+            <FormProvider {...tradingBuyFormContextValues.methods}>
+                <TradingOffers />
+            </FormProvider>
         </TradingFormContext.Provider>
     );
 };

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx
@@ -1,3 +1,5 @@
+import { FormProvider } from 'react-hook-form';
+
 import { Context } from '@suite-common/message-system';
 import { TradingType } from '@suite-common/trading';
 
@@ -19,7 +21,9 @@ const TradingExchangeFormContent = ({ selectedAccount }: UseTradingProps) => {
 
     return (
         <TradingFormContext.Provider value={tradingExchangeContextValue}>
-            <TradingFormLayout />
+            <FormProvider {...tradingExchangeContextValue.methods}>
+                <TradingFormLayout />
+            </FormProvider>
         </TradingFormContext.Provider>
     );
 };

--- a/packages/suite/src/views/wallet/trading/sell/TradingSellForm.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingSellForm.tsx
@@ -1,3 +1,5 @@
+import { FormProvider } from 'react-hook-form';
+
 import { Context } from '@suite-common/message-system';
 import { TradingType } from '@suite-common/trading';
 
@@ -19,7 +21,9 @@ const TradingSellFormContent = ({ selectedAccount }: UseTradingProps) => {
 
     return (
         <TradingFormContext.Provider value={tradingSellContextValues}>
-            <TradingFormLayout />
+            <FormProvider {...tradingSellContextValues.methods}>
+                <TradingFormLayout />
+            </FormProvider>
         </TradingFormContext.Provider>
     );
 };

--- a/suite-common/wallet-core/src/stake/stakeTypes.ts
+++ b/suite-common/wallet-core/src/stake/stakeTypes.ts
@@ -66,6 +66,7 @@ export interface BaseStakeContextValues {
 
 export type StakeContextValues = UseFormReturn<StakeFormState> &
     BaseStakeContextValues & {
+        methods: UseFormReturn<StakeFormState>;
         formState: ReactHookFormState<StakeFormState>;
         removeDraft: (key: string) => void;
         isDraft: boolean;
@@ -91,6 +92,7 @@ export type UnstakeFormState = Omit<StakeFormState, 'setMaxOutputId'>;
 
 export type UnstakeContextValues = UseFormReturn<UnstakeFormState> &
     BaseStakeContextValues & {
+        methods: UseFormReturn<UnstakeFormState>;
         formState: ReactHookFormState<StakeFormState>;
         onCryptoAmountChange: (amount: string) => Promise<void>;
         onFiatAmountChange: (amount: string) => void;


### PR DESCRIPTION
## Description

Add `FormProvider` to enable usage of use generic react hook form hooks such as are `useFormContext` or `useWatch` in React components down stream used across multiple contexts.

This is prep. for #21683.

## Related Issue

Relates #21683



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/21683-collapse-network-fees-1&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/21683-collapse-network-fees-1&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/21683-collapse-network-fees-1&lookback=7)