### PR TITLE
Mobile Trade: Introduce IsTradingResidenceCheckEnabled FF

### DIFF
--- a/suite-native/config/src/launch-arguments.ts
+++ b/suite-native/config/src/launch-arguments.ts
@@ -16,6 +16,7 @@ export type LaunchArguments = {
     isLocalizationEnabled?: boolean;
     isLocalFirstStorageEnabled?: boolean;
     areTradingExchangeDexesEnabled?: boolean;
+    isTradingResidenceCheckEnabled?: boolean;
 };
 
 export const launchArguments = LaunchArguments.value<LaunchArguments>();

--- a/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
@@ -21,6 +21,7 @@ describe('featureFlagsSlice', () => {
                 isTradingExchangeEnabled: false,
                 isTradingSellEnabled: false,
                 areTradingExchangeDexesEnabled: false,
+                isTradingResidenceCheckEnabled: false,
                 isLocalizationEnabled: false,
             });
         });

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -10,6 +10,7 @@ export const FeatureFlag = {
     IsTradingExchangeEnabled: 'isTradingExchangeEnabled',
     IsTradingSellEnabled: 'isTradingSellEnabled',
     AreTradingExchangeDexesEnabled: 'areTradingExchangeDexesEnabled',
+    IsTradingResidenceCheckEnabled: 'isTradingResidenceCheckEnabled',
     IsLocalizationEnabled: 'isLocalizationEnabled',
     IsLocalFirstStorageEnabled: 'isLocalFirstStorageEnabled',
 } as const;
@@ -38,6 +39,8 @@ export const featureFlagsInitialState: FeatureFlagsState = {
         process.env.EXPO_PUBLIC_FF_IS_TRADING_SELL_ENABLED === 'true',
     [FeatureFlag.AreTradingExchangeDexesEnabled]:
         process.env.EXPO_PUBLIC_FF_ARE_TRADING_EXCHANGE_DEXES_ENABLED === 'true',
+    [FeatureFlag.IsTradingResidenceCheckEnabled]:
+        process.env.EXPO_PUBLIC_FF_IS_TRADING_RESIDENCE_CHECK_ENABLED === 'true',
     [FeatureFlag.IsLocalizationEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_LOCALIZATION_ENABLED === 'true',
     [FeatureFlag.IsLocalFirstStorageEnabled]:
@@ -53,6 +56,7 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsTradingExchangeEnabled,
     FeatureFlag.IsTradingSellEnabled,
     FeatureFlag.AreTradingExchangeDexesEnabled,
+    FeatureFlag.IsTradingResidenceCheckEnabled,
     FeatureFlag.IsLocalFirstStorageEnabled,
     FeatureFlag.IsLocalizationEnabled,
 ];

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -21,7 +21,8 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsTradingBuyEnabled]: '💰 Trading Buy',
     [FeatureFlagEnum.IsTradingExchangeEnabled]: '💰 Trading Swap',
     [FeatureFlagEnum.IsTradingSellEnabled]: '💰 Trading Sell',
-    [FeatureFlagEnum.AreTradingExchangeDexesEnabled]: '💰 Trading Exchange Dexes Enabled',
+    [FeatureFlagEnum.AreTradingExchangeDexesEnabled]: '💰 Trading Exchange Dexes',
+    [FeatureFlagEnum.IsTradingResidenceCheckEnabled]: '💰 Trading Residence Check',
     [FeatureFlagEnum.IsLocalizationEnabled]: '🌍 Localization',
     [FeatureFlagEnum.IsLocalFirstStorageEnabled]: 'Local First Storage (Labels)',
 } as const satisfies Record<FeatureFlagEnum, string>;

--- a/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
@@ -3,6 +3,7 @@ import { CryptoId } from 'invity-api';
 import { Action, Feature, Message, TrezorDevice } from '@suite-common/suite-types';
 import {
     InvityServerEnvironment,
+    TradingCountryCode,
     TradingRootStateWithDeviceAndAccounts,
 } from '@suite-common/trading';
 import {
@@ -48,11 +49,15 @@ const getPreloadedState = ({
     sell,
     exchange,
     blacklist,
+    residence,
+    countryCode,
 }: {
     buy?: boolean;
     sell?: boolean;
     exchange?: boolean;
     blacklist?: boolean;
+    residence?: boolean;
+    countryCode?: TradingCountryCode | undefined;
 }) => {
     const features: Feature[] = [];
     if (buy !== undefined) {
@@ -81,7 +86,10 @@ const getPreloadedState = ({
     }
 
     return {
-        featureFlags: featureFlagsInitialState,
+        featureFlags: {
+            ...featureFlagsInitialState,
+            [FeatureFlag.IsTradingResidenceCheckEnabled]: residence ?? false,
+        },
         messageSystem: {
             config: {
                 version: 1,
@@ -128,6 +136,15 @@ const getPreloadedState = ({
             configSource: 'local' as const,
             manuallyAddedMessageIds: {},
             manuallyAddedExperimentIds: {},
+        },
+        wallet: {
+            trading: {
+                ...initialState,
+                residence: {
+                    ...initialState.residence,
+                    country: countryCode,
+                },
+            },
         },
     };
 };
@@ -187,18 +204,36 @@ describe('commonSelectors', () => {
     });
 
     describe('selectIsTradingEnabled', () => {
-        it('should correctly select that trading is enabled if one of remote features is enabled', () => {
-            expect(selectIsTradingEnabled(getPreloadedState({ sell: true }))).toBe(true);
+        describe('when residence check is disabled', () => {
+            it('should correctly select that trading is enabled if one of remote features is enabled', () => {
+                expect(selectIsTradingEnabled(getPreloadedState({ sell: true }))).toBe(true);
+            });
+
+            it('should correctly select that trading is enabled if no remote feature is set', () => {
+                expect(selectIsTradingEnabled(getPreloadedState({}))).toBe(true);
+            });
+
+            it('should correctly select that trading is not enabled when buy and exchange are disabled (and sell is not set)', () => {
+                expect(
+                    selectIsTradingEnabled(getPreloadedState({ buy: false, exchange: false })),
+                ).toBe(false);
+            });
         });
 
-        it('should correctly select that trading is enabled if no remote feature is set', () => {
-            expect(selectIsTradingEnabled(getPreloadedState({}))).toBe(true);
-        });
+        describe('when residence check is enabled', () => {
+            it('should correctly select that trading is not enabled when country is not set', () => {
+                expect(
+                    selectIsTradingEnabled(getPreloadedState({ residence: true, buy: true })),
+                ).toBe(false);
+            });
 
-        it('should correctly select that trading is not enabled when buy and exchange are disabled (and sell is not set)', () => {
-            expect(selectIsTradingEnabled(getPreloadedState({ buy: false, exchange: false }))).toBe(
-                false,
-            );
+            it('should correctly select that trading is enabled when country is whitelisted', () => {
+                expect(
+                    selectIsTradingEnabled(
+                        getPreloadedState({ residence: true, buy: true, countryCode: 'US' }),
+                    ),
+                ).toBe(true);
+            });
         });
     });
 

--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -47,6 +47,7 @@ import {
     selectIsFeatureFlagEnabled,
 } from '@suite-native/feature-flags';
 import { TokensRootState } from '@suite-native/tokens';
+import { selectIsTradingEnabledForCountry } from '@suite-native/trading-residence';
 
 import { SectionListData } from '../hooks/general/useSectionList';
 import { TradingRootState } from '../reducers';
@@ -92,10 +93,19 @@ export const selectIsTradingSellEnabled = (state: MessageSystemRootState & Featu
     selectIsFeatureFlagEnabled(state, FeatureFlag.IsTradingSellEnabled) ||
     selectIsFeatureEnabled(state, Feature.trading.sell, false);
 
-export const selectIsTradingEnabled = (state: MessageSystemRootState & FeatureFlagsRootState) =>
-    selectIsTradingBuyEnabled(state) ||
-    selectIsTradingExchangeEnabled(state) ||
-    selectIsTradingSellEnabled(state);
+export const selectIsTradingEnabled = (
+    state: MessageSystemRootState & FeatureFlagsRootState & TradingRootState,
+) => {
+    if (!selectIsTradingEnabledForCountry(state)) {
+        return false;
+    }
+
+    return (
+        selectIsTradingBuyEnabled(state) ||
+        selectIsTradingExchangeEnabled(state) ||
+        selectIsTradingSellEnabled(state)
+    );
+};
 
 export const selectEnabledTradingTypes = createFeatureFlagsMemoizedSelector(
     [selectIsTradingBuyEnabled, selectIsTradingExchangeEnabled, selectIsTradingSellEnabled],

--- a/suite-native/trading-residence/jest.config.js
+++ b/suite-native/trading-residence/jest.config.js
@@ -8,4 +8,13 @@ const baseConfig = require('../../jest.config.native');
 
 module.exports = {
     ...baseConfig,
+    workerIdleMemoryLimit: '1024MB',
+    coverageThreshold: {
+        global: {
+            statements: 80,
+            branches: 80,
+            functions: 80,
+            lines: 80,
+        },
+    },
 };

--- a/suite-native/trading-residence/package.json
+++ b/suite-native/trading-residence/package.json
@@ -8,12 +8,13 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "yarn g:jest",
+        "test:unit": "yarn g:jest --coverage",
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.8.2",
         "@suite-common/trading": "workspace:*",
+        "@suite-native/feature-flags": "workspace:*",
         "react": "19.0.0",
         "react-redux": "9.2.0"
     }

--- a/suite-native/trading-residence/src/consts/countriesWhitelist.ts
+++ b/suite-native/trading-residence/src/consts/countriesWhitelist.ts
@@ -1,0 +1,15 @@
+import { TradingCountryCode } from '@suite-common/trading';
+
+export const tradingCountriesWhitelistSet = new Set<TradingCountryCode>([
+    'US', // United States
+    'IT', // Italy
+    'LI', // Liechtenstein
+    'IE', // Ireland
+    'CY', // Cyprus
+    'ES', // Spain
+    'CR', // Costa Rica
+    'CA', // Canada
+    'LT', // Lithuania
+    'BS', // Bahamas
+    'CZ', // Czech Republic
+]);

--- a/suite-native/trading-residence/src/selectors/__tests__/residenceSelectors.test.ts
+++ b/suite-native/trading-residence/src/selectors/__tests__/residenceSelectors.test.ts
@@ -1,9 +1,18 @@
+import { TradingCountryCode } from '@suite-common/trading';
+import {
+    FeatureFlag,
+    FeatureFlagsRootState,
+    featureFlagsInitialState,
+} from '@suite-native/feature-flags';
+
 import {
     TradingResidenceRootState,
     TradingResidenceState,
     tradingResidenceInitialState,
 } from '../../reducers/residenceSlice';
 import {
+    selectIsTradingEnabledForCountry,
+    selectIsTradingResidenceCheckEnabled,
     selectTradingResidenceCountry,
     selectWasTradingResidenceOnboardingVisited,
 } from '../residenceSelectors';
@@ -14,25 +23,90 @@ describe('residenceSelectors', () => {
         wasOnboardingVisited: true,
     };
 
-    const rootState = (residence: TradingResidenceState): TradingResidenceRootState => ({
-        wallet: { trading: { residence } },
+    const getRootResidenceState = (
+        overrides: Partial<TradingResidenceState>,
+    ): TradingResidenceRootState => ({
+        wallet: {
+            trading: {
+                residence: {
+                    ...tradingResidenceInitialState,
+                    ...overrides,
+                },
+            },
+        },
+    });
+
+    const getRootFFState = (isResidenceCheckEnabled = false): FeatureFlagsRootState => ({
+        featureFlags: {
+            ...featureFlagsInitialState,
+            [FeatureFlag.IsTradingResidenceCheckEnabled]: isResidenceCheckEnabled,
+        },
     });
 
     describe('selectTradingResidenceCountry', () => {
         it(' should select the country', () => {
-            expect(selectTradingResidenceCountry(rootState(tradingResidenceInitialState))).toBe(
-                undefined,
-            );
-            expect(selectTradingResidenceCountry(rootState(visitedState))).toBe('US');
+            expect(
+                selectTradingResidenceCountry(getRootResidenceState(tradingResidenceInitialState)),
+            ).toBe(undefined);
+            expect(selectTradingResidenceCountry(getRootResidenceState(visitedState))).toBe('US');
         });
     });
 
     describe('selectWasTradingResidenceOnboardingVisited', () => {
         it('should select wasOnboardingVisited', () => {
             expect(
-                selectWasTradingResidenceOnboardingVisited(rootState(tradingResidenceInitialState)),
+                selectWasTradingResidenceOnboardingVisited(
+                    getRootResidenceState(tradingResidenceInitialState),
+                ),
             ).toBe(false);
-            expect(selectWasTradingResidenceOnboardingVisited(rootState(visitedState))).toBe(true);
+            expect(
+                selectWasTradingResidenceOnboardingVisited(getRootResidenceState(visitedState)),
+            ).toBe(true);
         });
+    });
+
+    describe('selectIsTradingResidenceCheckEnabled', () => {
+        it.each([true, false])('should return correct flag state for FF [%s]', flag => {
+            const ffState = getRootFFState(flag);
+
+            expect(selectIsTradingResidenceCheckEnabled(ffState)).toBe(flag);
+        });
+    });
+
+    describe('selectIsTradingEnabledForCountry', () => {
+        it.each<TradingCountryCode | undefined>([undefined, 'unknown', 'US', 'SK'])(
+            'should return true for country [%s] and FF disabled',
+            countryCode => {
+                const state = {
+                    ...getRootResidenceState({ country: countryCode }),
+                    ...getRootFFState(false),
+                };
+                expect(selectIsTradingEnabledForCountry(state)).toBe(true);
+            },
+        );
+
+        it.each<TradingCountryCode>(['US', 'CZ'])(
+            'should return true for whitelisted country [%s] and FF enabled',
+            countryCode => {
+                const state = {
+                    ...getRootResidenceState({ country: countryCode }),
+                    ...getRootFFState(true),
+                };
+
+                expect(selectIsTradingEnabledForCountry(state)).toBe(true);
+            },
+        );
+
+        it.each<TradingCountryCode | undefined>([undefined, 'unknown', 'SK'])(
+            'should return false for non-whitelisted country [%s] and FF enabled',
+            countryCode => {
+                const state = {
+                    ...getRootResidenceState({ country: countryCode }),
+                    ...getRootFFState(true),
+                };
+
+                expect(selectIsTradingEnabledForCountry(state)).toBe(false);
+            },
+        );
     });
 });

--- a/suite-native/trading-residence/src/selectors/residenceSelectors.ts
+++ b/suite-native/trading-residence/src/selectors/residenceSelectors.ts
@@ -1,7 +1,33 @@
-import { TradingResidenceRootState } from '../reducers/residenceSlice';
+import {
+    FeatureFlag,
+    FeatureFlagsRootState,
+    selectIsFeatureFlagEnabled,
+} from '@suite-native/feature-flags';
+
+import { tradingCountriesWhitelistSet } from '../consts/countriesWhitelist';
+import type { TradingResidenceRootState } from '../reducers/residenceSlice';
 
 export const selectTradingResidenceCountry = (state: TradingResidenceRootState) =>
     state.wallet.trading.residence.country;
 
 export const selectWasTradingResidenceOnboardingVisited = (state: TradingResidenceRootState) =>
     state.wallet.trading.residence.wasOnboardingVisited;
+
+export const selectIsTradingResidenceCheckEnabled = (state: FeatureFlagsRootState) =>
+    selectIsFeatureFlagEnabled(state, FeatureFlag.IsTradingResidenceCheckEnabled);
+
+export const selectIsTradingEnabledForCountry = (
+    state: TradingResidenceRootState & FeatureFlagsRootState,
+) => {
+    const isResidenceCheckEnabled = selectIsTradingResidenceCheckEnabled(state);
+    if (!isResidenceCheckEnabled) {
+        return true;
+    }
+
+    const country = selectTradingResidenceCountry(state);
+    if (!country) {
+        return false;
+    }
+
+    return tradingCountriesWhitelistSet.has(country);
+};

--- a/suite-native/trading-residence/tsconfig.json
+++ b/suite-native/trading-residence/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
-        { "path": "../../suite-common/trading" }
+        { "path": "../../suite-common/trading" },
+        { "path": "../feature-flags" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12691,6 +12691,7 @@ __metadata:
   dependencies:
     "@reduxjs/toolkit": "npm:2.8.2"
     "@suite-common/trading": "workspace:*"
+    "@suite-native/feature-flags": "workspace:*"
     react: "npm:19.0.0"
     react-redux: "npm:9.2.0"
   languageName: unknown


### PR DESCRIPTION
Introduces FF for residence check.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22469-mobile-trade-residence-ff&lookback=7)