### PR TITLE
fix(components): allow passing of multiple contract addresses to AssetLogo

### DIFF
--- a/packages/components/src/components/AssetLogo/AssetLogo.stories.tsx
+++ b/packages/components/src/components/AssetLogo/AssetLogo.stories.tsx
@@ -19,7 +19,7 @@ export const AssetLogo: StoryObj<AssetLogoProps> = {
     args: {
         size: 24,
         coingeckoId: 'binance-smart-chain',
-        contractAddress: '0x0203d275d2a65030889af45ed91d472be3948b92',
+        contractAddress: ['0x0203d275d2a65030889af45ed91d472be3948b92'],
         shouldTryToFetch: true,
         placeholder: 'CATWIFHAT',
         ...getFramePropsStory(allowedAssetLogoFrameProps).args,

--- a/packages/components/src/components/AssetLogo/AssetLogo.tsx
+++ b/packages/components/src/components/AssetLogo/AssetLogo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -27,12 +27,14 @@ type AllowedFrameProps = Pick<FrameProps, (typeof allowedAssetLogoFrameProps)[nu
 export type AssetLogoProps = AllowedFrameProps & {
     size: AssetLogoSize;
     coingeckoId: string;
-    contractAddress?: string;
+    contractAddress?: string[];
     shouldTryToFetch?: boolean;
     placeholderWithTooltip?: boolean;
     placeholder: string;
     'data-testid'?: string;
 };
+
+type LogoCandidate = { address: string; src: string; srcSet: string };
 
 const Container = styled.div<TransientProps<AllowedFrameProps> & { $size: number }>`
     ${({ $size }) => `
@@ -60,26 +62,38 @@ const ElevatedLogo = (props: LogoProps) => {
     return <Logo {...props} $elevation={elevation} />;
 };
 
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const resolvedLogoCache = new Map<string, LogoCandidate>();
+const failedAddressesCache = new Set<string>();
+
+const makeCacheKey = (coingeckoId: string, addressesKey: string) =>
+    `${coingeckoId.toLowerCase()}::${addressesKey}`;
+
+const makeAddressKey = (coingeckoId: string, address: string) =>
+    `${coingeckoId.toLowerCase()}::${address.toLowerCase()}`;
+
 export const getCoingeckoIdAndContractAddressIncludesNativeTokens = (
     coingeckoId: string,
-    contractAddress: string | undefined,
+    contractAddress: string[] | undefined,
 ) => {
     const mainNetworkSymbol = getNetworkByCoingeckoId(coingeckoId)?.displaySymbol.toLowerCase();
 
-    if (
-        contractAddress === '0x0000000000000000000000000000000000000000' &&
-        mainNetworkSymbol &&
-        isNetworkSymbol(mainNetworkSymbol)
-    ) {
-        return {
-            coingeckoId: getNetwork(mainNetworkSymbol).tradeCryptoId ?? coingeckoId,
-            contractAddress: undefined,
-        };
-    }
+    const addresses = ([] as Array<string | undefined>)
+        .concat(contractAddress ?? [])
+        .map(addr => addr ?? ZERO_ADDRESS);
+
+    const hasNative = addresses.some(addr => addr.toLowerCase() === ZERO_ADDRESS);
+
+    const shouldUseTradeId = hasNative && !!mainNetworkSymbol && isNetworkSymbol(mainNetworkSymbol);
+
+    const resolvedCoingeckoId = shouldUseTradeId
+        ? (getNetwork(mainNetworkSymbol).tradeCryptoId ?? coingeckoId)
+        : coingeckoId;
 
     return {
-        coingeckoId,
-        contractAddress,
+        coingeckoId: resolvedCoingeckoId,
+        contractAddresses: addresses.length ? addresses : [ZERO_ADDRESS],
     };
 };
 
@@ -93,48 +107,110 @@ export const AssetLogo = ({
     'data-testid': dataTest,
     ...rest
 }: AssetLogoProps) => {
-    const [isPlaceholder, setIsPlaceholder] = useState(!shouldTryToFetch);
-    const { coingeckoId: coingeckoIdLogo, contractAddress: contractAddressLogo } =
-        getCoingeckoIdAndContractAddressIncludesNativeTokens(coingeckoId, contractAddress);
+    const normalizedAddresses = useMemo(
+        () => getCoingeckoIdAndContractAddressIncludesNativeTokens(coingeckoId, contractAddress),
+        [coingeckoId, contractAddress],
+    );
+    const { coingeckoId: coingeckoIdLogo, contractAddresses } = normalizedAddresses;
 
-    const logoUrl = getAssetLogoUrl({
-        coingeckoId: coingeckoIdLogo,
-        contractAddress: contractAddressLogo,
-        quality: '1x',
-        size: resolveAssetLogoSize(size),
-    });
-    const logoUrl2x = getAssetLogoUrl({
-        coingeckoId: coingeckoIdLogo,
-        contractAddress: contractAddressLogo,
-        quality: '2x',
-        size: resolveAssetLogoSize(size),
-    });
+    const canonicalAddresses = useMemo(() => {
+        const set = new Set<string>();
+        for (const addr of contractAddresses) {
+            if (addr) set.add(addr);
+        }
+
+        return Array.from(set).sort();
+    }, [contractAddresses]);
+
+    const addressesKey = useMemo(() => canonicalAddresses.join('|'), [canonicalAddresses]);
+
+    const cacheKey = useMemo(
+        () => makeCacheKey(coingeckoIdLogo, addressesKey),
+        [coingeckoIdLogo, addressesKey],
+    );
+
+    const [candidateIndex, setCandidateIndex] = useState(0);
+
+    const candidates = useMemo<LogoCandidate[]>(() => {
+        if (!shouldTryToFetch || !canonicalAddresses.length) return [];
+
+        const filtered = canonicalAddresses.filter(
+            address => !failedAddressesCache.has(makeAddressKey(coingeckoIdLogo, address)),
+        );
+
+        const hasNative = filtered.some(addr => addr === ZERO_ADDRESS);
+
+        return filtered.map(address => {
+            const url1x = getAssetLogoUrl({
+                coingeckoId: coingeckoIdLogo,
+                contractAddress: !hasNative ? address : undefined,
+                quality: '1x',
+                size: resolveAssetLogoSize(size),
+            });
+            const url2x = getAssetLogoUrl({
+                coingeckoId: coingeckoIdLogo,
+                contractAddress: !hasNative ? address : undefined,
+                quality: '2x',
+                size: resolveAssetLogoSize(size),
+            });
+
+            return { address, src: url1x, srcSet: `${url1x} 1x, ${url2x} 2x` };
+        });
+    }, [shouldTryToFetch, canonicalAddresses, coingeckoIdLogo, size]);
+
+    const hasCandidates = candidates.length > 0;
+    const currentIndex = hasCandidates ? Math.min(candidateIndex, candidates.length - 1) : -1;
+    const current = hasCandidates ? candidates[currentIndex] : undefined;
+    const showPlaceholder = !hasCandidates;
+
+    useEffect(() => {
+        const cachedResult = resolvedLogoCache.get(cacheKey);
+        if (!cachedResult) {
+            setCandidateIndex(0);
+
+            return;
+        }
+
+        const idx = candidates.findIndex(
+            c => c.src === cachedResult.src && c.srcSet === cachedResult.srcSet,
+        );
+        setCandidateIndex(idx >= 0 ? idx : 0);
+    }, [cacheKey, candidates]);
 
     const frameProps = pickAndPrepareFrameProps(rest, allowedAssetLogoFrameProps);
 
-    const handleError = () => {
-        setIsPlaceholder(true);
+    const handleLoadError = () => {
+        if (!current) return;
+
+        failedAddressesCache.add(makeAddressKey(coingeckoIdLogo, current.address));
+        setCandidateIndex(prev => Math.min(prev + 1, candidates.length - 1));
     };
-    useEffect(() => {
-        setIsPlaceholder(!shouldTryToFetch);
-    }, [shouldTryToFetch]);
+
+    const handleOnLoad = () => {
+        if (!current) return;
+
+        resolvedLogoCache.set(cacheKey, current);
+    };
 
     return (
         <Container $size={size} {...frameProps}>
-            {isPlaceholder && (
+            {showPlaceholder && (
                 <AssetInitials size={size} withTooltip={placeholderWithTooltip}>
                     {placeholder}
                 </AssetInitials>
             )}
-            {!isPlaceholder && (
+            {!showPlaceholder && current && (
                 <ElevationUp>
                     <ElevatedLogo
-                        src={logoUrl}
-                        srcSet={`${logoUrl} 1x, ${logoUrl2x} 2x`}
+                        src={current.src}
+                        srcSet={current.srcSet}
+                        loading="lazy"
+                        decoding="async"
                         $size={size}
-                        onError={handleError}
                         data-testid={dataTest}
                         alt={placeholder}
+                        onLoad={handleOnLoad}
+                        onError={handleLoadError}
                     />
                 </ElevationUp>
             )}

--- a/packages/product-components/src/components/SelectAssetModal/AssetItem.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/AssetItem.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { getDisplaySymbol } from '@suite-common/wallet-config';
-import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
+import { getAssetLogoContractAddresses } from '@suite-common/wallet-utils';
 import { AssetLogo, Badge, Column, Row, Text } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
 
@@ -72,11 +72,7 @@ export const AssetItem = ({
                         <AssetLogo
                             size={24}
                             coingeckoId={coingeckoId}
-                            contractAddress={
-                                symbol && contractAddress
-                                    ? getContractAddressForNetworkSymbol(symbol, contractAddress)
-                                    : undefined
-                            }
+                            contractAddress={getAssetLogoContractAddresses(symbol, contractAddress)}
                             placeholder={displaySymbol}
                             shouldTryToFetch={shouldTryToFetch}
                         />

--- a/packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx
+++ b/packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx
@@ -1,7 +1,9 @@
+import { useMemo } from 'react';
+
 import styled, { css } from 'styled-components';
 
 import { NetworkSymbol, getCoingeckoId } from '@suite-common/wallet-config';
-import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
+import { getAssetLogoContractAddresses } from '@suite-common/wallet-utils';
 import { type TokenInfo } from '@trezor/blockchain-link-types';
 import { AssetLogo, useElevation } from '@trezor/components';
 import { Elevation, borders, mapElevationToBackground, mapElevationToBorder } from '@trezor/theme';
@@ -41,27 +43,30 @@ export const TokenIconSet = ({ symbol, tokens }: TokenIconSetProps) => {
     const { elevation } = useElevation();
     const { length } = tokens;
 
+    const visibleTokensContent = useMemo(() => {
+        const visibleTokens = tokens.slice(0, 3).reverse();
+        const coingeckoId = getCoingeckoId(symbol);
+
+        return visibleTokens?.map(token => (
+            <AssetLogo
+                key={token.contract}
+                size={20}
+                coingeckoId={coingeckoId ?? ''}
+                contractAddress={getAssetLogoContractAddresses(symbol, token.contract)}
+                placeholder={token.symbol?.toUpperCase() ?? ''}
+                placeholderWithTooltip={false}
+            />
+        ));
+    }, [symbol, tokens]);
+
     if (length === 0) {
         return null;
     }
 
-    const visibleTokens = tokens.slice(0, 3).reverse();
-
-    const coingeckoId = getCoingeckoId(symbol);
-
     return (
         <IconContainer $length={length}>
             {length > 3 && <TokenIconPlaceholder $elevation={elevation} />}
-            {visibleTokens.map(token => (
-                <AssetLogo
-                    key={token.contract}
-                    size={20}
-                    coingeckoId={coingeckoId ?? ''}
-                    contractAddress={getContractAddressForNetworkSymbol(symbol, token.contract)}
-                    placeholder={token.symbol?.toUpperCase() ?? ''}
-                    placeholderWithTooltip={false}
-                />
-            ))}
+            {visibleTokensContent}
         </IconContainer>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
@@ -9,6 +9,7 @@ import {
     FormStateTradingFiatCurrency,
     TokenAddress,
 } from '@suite-common/wallet-types';
+import { getAssetLogoContractAddresses } from '@suite-common/wallet-utils';
 import { AssetLogo, Card, Column, Divider, H4, InfoItem, Row, Text } from '@trezor/components';
 import { mapPaddingTypeToPadding } from '@trezor/components/src/components/Card/utils';
 import { CoinLogo } from '@trezor/product-components';
@@ -61,9 +62,7 @@ const TransactionReviewOutputAssetsCryptoCurrency = ({
                         <AssetLogo
                             size={20}
                             coingeckoId={network.coingeckoId}
-                            contractAddress={
-                                symbol && contractAddress ? contractAddress : undefined
-                            }
+                            contractAddress={getAssetLogoContractAddresses(symbol, contractAddress)}
                             placeholder={displaySymbol ?? ''}
                         />
                     ) : (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
@@ -15,7 +15,11 @@ import { Network, getExplorerUrl } from '@suite-common/wallet-config';
 import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import { selectDeviceAccounts, selectExplorer } from '@suite-common/wallet-core';
 import { FormState } from '@suite-common/wallet-types';
-import { asBaseCurrencyAmount, getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
+import {
+    asBaseCurrencyAmount,
+    getAssetLogoContractAddresses,
+    getConvertedOrDefaultFeeInfo,
+} from '@suite-common/wallet-utils';
 import {
     AssetLogo,
     Banner,
@@ -70,7 +74,7 @@ const TxSimulationAsset = ({
             return (
                 <AssetLogo
                     coingeckoId={network.coingeckoId}
-                    contractAddress={asset.address.toLowerCase()}
+                    contractAddress={getAssetLogoContractAddresses(network.symbol, asset.address)}
                     size={32}
                     shouldTryToFetch={true}
                     placeholder={asset.name ?? asset.symbol}

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -10,6 +10,7 @@ import {
 import { selectExplorer } from '@suite-common/wallet-core';
 import { TokenAddress } from '@suite-common/wallet-types';
 import {
+    getAssetLogoContractAddresses,
     getContractAddressForNetworkSymbol,
     getTokenExplorerUrl,
     hasNetworkFeatures,
@@ -118,10 +119,13 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
             <Card fillType="default" paddingType="normal" onClick={onOpenSelectAssetModal}>
                 <Row justifyContent="space-between" height={64}>
                     <Row justifyContent="flex-start" gap={spacings.sm}>
-                        {networkTokenContractAddress ? (
+                        {selectedToken ? (
                             <AssetLogo
                                 coingeckoId={getCoingeckoId(account.symbol)!}
-                                contractAddress={networkTokenContractAddress}
+                                contractAddress={getAssetLogoContractAddresses(
+                                    account.symbol,
+                                    selectedToken?.contract,
+                                )}
                                 size={24}
                                 placeholder={(
                                     selectedToken?.symbol || account.symbol

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -18,6 +18,7 @@ import { Explorer, Network, getCoingeckoId } from '@suite-common/wallet-config';
 import { selectExplorer, selectSelectedDevice, sendFormActions } from '@suite-common/wallet-core';
 import { Account, TokenAddress } from '@suite-common/wallet-types';
 import {
+    getAssetLogoContractAddresses,
     getContractAddressForNetworkSymbol,
     getTokenExplorerUrl,
 } from '@suite-common/wallet-utils';
@@ -99,11 +100,6 @@ export const TokenRow = ({
     const { coins } = useSelector(selectTradingInfo);
     const isDeviceLocked = isLocked(true);
     const isDeviceCompromised = useSelector(selectIsDeviceCompromised);
-
-    const networkContractAddress = getContractAddressForNetworkSymbol(
-        account.symbol,
-        token.contract,
-    );
 
     const explorer = useSelector(state => selectExplorer(state, network.symbol)) as Explorer;
 
@@ -207,7 +203,10 @@ export const TokenRow = ({
                     <AssetLogo
                         coingeckoId={coingeckoId || ''}
                         placeholder={token.name || token.symbol || 'token'}
-                        contractAddress={networkContractAddress}
+                        contractAddress={getAssetLogoContractAddresses(
+                            account.symbol,
+                            token.contract,
+                        )}
                         size={24}
                         shouldTryToFetch={isTokenKnown}
                     />

--- a/packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
-import { parseCryptoId } from '@suite-common/trading';
+import { parseCryptoId, useTradingInfo } from '@suite-common/trading';
+import { getAssetLogoContractAddresses } from '@suite-common/wallet-utils';
 import { AssetLogo } from '@trezor/components';
 
 import { TradingCoinLogoProps } from 'src/types/trading/trading';
@@ -14,12 +15,14 @@ export const TradingCoinLogo = ({
     className,
 }: TradingCoinLogoProps) => {
     const { networkId, contractAddress } = parseCryptoId(cryptoId);
+    const { cryptoIdToSymbolAndContractAddress } = useTradingInfo();
+    const symbol = cryptoIdToSymbolAndContractAddress(cryptoId).coinSymbol;
 
     return (
         <Wrapper className={className}>
             <AssetLogo
                 coingeckoId={networkId}
-                contractAddress={contractAddress}
+                contractAddress={getAssetLogoContractAddresses(symbol, contractAddress)}
                 size={size}
                 placeholder={networkId.toUpperCase()}
                 margin={margin}

--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -32,6 +32,21 @@ export const getContractAddressForNetworkSymbol = (
     }
 };
 
+export const getAssetLogoContractAddresses = (
+    symbol: NetworkSymbolExtended | undefined,
+    contract: string | null | undefined,
+) => {
+    if (!contract || !symbol) return undefined;
+
+    if (symbol === 'ada') {
+        const policyId = getContractAddressForNetworkSymbol(symbol, contract);
+
+        return [policyId, contract];
+    }
+
+    return [getContractAddressForNetworkSymbol(symbol, contract)];
+};
+
 export const getTokenExplorerUrl = (
     explorer: Explorer,
     networkType: NetworkType,


### PR DESCRIPTION
## Description

This PR updates `AssetLogo` and related components to support multiple possible contract addresses per token.
For Cardano tokens, some assets can only be resolved by `policyId`, while others require a `fingerprint`. This change ensures that if one address fails, the next candidate is tried automatically.

## Related Issue

Resolve #14806

## Screenshots:

### Before
<img width="847" height="400" alt="Screenshot 2025-10-17 at 09 01 31" src="https://github.com/user-attachments/assets/904ba718-f446-4613-8c0c-3ed83648e1de" />


### After
<img width="852" height="390" alt="image" src="https://github.com/user-attachments/assets/66d4711a-d264-4bba-a1f6-6cc1a90c1158" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/cardano-token-icons&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/cardano-token-icons&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/cardano-token-icons&lookback=7)