### PR TITLE
fix(suite-native): detox connecting device async

### DIFF
--- a/suite-native/app/e2e/pageObjects/deviceConnectingActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceConnectingActions.ts
@@ -1,8 +1,11 @@
 class DeviceConnectingActions {
     async waitForDeviceConnectingScreen() {
+        // Connecting screen is rendered when discovery is running in the background so we need to disable synchronization to reliably test its presence
+        await device.disableSynchronization();
         await waitFor(element(by.id('@screen/ConnectingDevice')))
             .toBeVisible()
             .withTimeout(10000);
+        await device.enableSynchronization();
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Disable synchronization for connecting screen matching. Discovery is running and this screen redirects before discovery finishes so we need to match it synchronously.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/detox/synchronization-issues&lookback=7)