### PR TITLE
fix(connect): guarantee language blobs are ArrayBuffer

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -826,7 +826,17 @@ export class Device extends TypedEmitter<DeviceEvents> {
             throw ERRORS.TypedError('Runtime', 'changeLanguage: translation not found');
         }
 
-        return this._uploadTranslationData(downloadedBinary);
+        // This is mostly to satisfy Types, since `downloadedBinary` could be ArrayBuffer or Buffer<ArrayBufferLike>
+        // but `_uploadTranslationData` takes only ArrayBuffer or null.
+        let dataToSend: ArrayBuffer;
+        if (Buffer.isBuffer(downloadedBinary)) {
+            // Creates a "copy" if given a Buffer/Uint8Array in order to guarantee dataToSend is ArrayBuffer.
+            dataToSend = new Uint8Array(downloadedBinary).buffer;
+        } else {
+            dataToSend = downloadedBinary;
+        }
+
+        return this._uploadTranslationData(dataToSend);
     }
 
     private async _uploadTranslationData(payload: ArrayBuffer | null) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I was mainly bother that `downloadedBinary` was marked with Type issues, since in theory it could be ArrayBuffer or Buffer, but `_uploadTranslationData` only needs ArrayBuffer, this way we guarantee that it will always be ArrayBuffer. 

And the type issue does not display anymore.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/arraybuffer-for-language-blobs&lookback=7)