### PR TITLE
fix(suite): disconnect BT before installing FW via USB

### DIFF
--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -90,7 +90,8 @@ export const initBluetoothThunk = createThunk<void, void, void>(
             // if FW update is in progress, only connect if it's the same device
             const fwUpdatingDifferentDevice =
                 firmwareStatus.status === 'started' &&
-                firmwareStatus.cachedDevice?.bluetoothProps?.id !== device.id;
+                (firmwareStatus.cachedDevice?.descriptor?.id !== device.id ||
+                    firmwareStatus.cachedDevice?.descriptor?.apiType !== 'bluetooth');
 
             if (hasUnacquiredDevice || hasSameUsbDevice || fwUpdatingDifferentDevice) {
                 return;

--- a/packages/suite/src/hooks/suite/useFirmwareDesktopUpdate.ts
+++ b/packages/suite/src/hooks/suite/useFirmwareDesktopUpdate.ts
@@ -1,13 +1,20 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { selectNearbyDevices } from '@suite-common/bluetooth';
 import {
     type FirmwareUpdateProps,
     selectFirmware,
     useFirmwareInstallation,
 } from '@suite-common/firmware';
-import { selectIsDeviceConnectedViaBluetoothLowOnBattery } from '@suite-common/wallet-core';
+import {
+    selectIsDeviceConnectedViaBluetooth,
+    selectIsDeviceConnectedViaBluetoothLowOnBattery,
+} from '@suite-common/wallet-core';
 import { UI } from '@trezor/connect';
 
+import { bluetoothDisconnectDeviceThunk } from 'src/actions/bluetooth/bluetoothDisconnectDeviceThunk';
+
+import { useDispatch } from './useDispatch';
 import { useSelector } from './useSelector';
 
 const INTERVAL_CHECK_SLOW_INSTALLATION_MS = 1_000;
@@ -20,6 +27,9 @@ export const useFirmwareDesktopUpdate = () => {
     const isDeviceConnectedViaBluetoothLowOnBattery = useSelector(
         selectIsDeviceConnectedViaBluetoothLowOnBattery,
     );
+    const isDeviceConnectedViaBluetooth = useSelector(selectIsDeviceConnectedViaBluetooth);
+    const bluetoothDevices = useSelector(selectNearbyDevices);
+    const dispatch = useDispatch();
 
     const { firmwareUpdate, originalDevice, reconnectEvent, pinRequested, ...rest } =
         useFirmwareInstallation();
@@ -59,11 +69,19 @@ export const useFirmwareDesktopUpdate = () => {
         return () => clearInterval(interval);
     }, [startTime, isSlow, firmware.uiEvent]);
 
-    const desktopFirmwareUpdate = (arg: FirmwareUpdateProps) => {
+    const desktopFirmwareUpdate = async (arg: FirmwareUpdateProps) => {
         if (isDeviceConnectedViaBluetoothLowOnBattery) {
             setShowLowBatteryModal(true);
 
             return;
+        }
+        if (!isDeviceConnectedViaBluetooth) {
+            // Not using Bluetooth - preventively disconnect any connected Bluetooth devices
+            await Promise.all(
+                bluetoothDevices
+                    .filter(device => device.connectionStatus.type === 'connected')
+                    .map(device => dispatch(bluetoothDisconnectDeviceThunk({ id: device.id }))),
+            );
         }
         firmwareUpdate(arg);
     };

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -383,7 +383,9 @@ const setDeviceState = (
  */
 const disconnectDevice = (draft: DeviceReducerState, device: TrezorDevice) => {
     // find all devices with "path"
-    const affectedDevices = draft.devices.filter(d => d.path === device.path);
+    const affectedDevices = draft.devices.filter(
+        d => d.path === device.path && d.descriptor.apiType === device.descriptor.apiType,
+    );
     affectedDevices.forEach(d => {
         // do not remove devices with state, they are potential candidates to remember if not remembered already
         const skip = d.features && d.remember;


### PR DESCRIPTION
## Description

Before installing FW via USB, make sure to disconnect any connected Bluetooth devices. 
Also process the disconnect event only for the same API type. 

## Related Issue

Resolve #21700

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/fw-install-bt-usb-conflict&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/fw-install-bt-usb-conflict&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/fw-install-bt-usb-conflict&lookback=7)