### PR TITLE
feat(suite-native): add sell preview screen

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2390,6 +2390,15 @@ export const messages = {
                 bullet3: 'Your swap might be partially filled based on the market conditions',
             },
         },
+        tradingSellPreviewScreen: {
+            title: 'Sell',
+            fromAccount: 'From',
+            toFiat: 'To',
+            paymentMethods: {
+                bankTransfer: 'Bank Transfer',
+                creditCard: 'Credit/Debit Card',
+            },
+        },
         tradingExchangeApprovalScreen: {
             title: 'Set {symbol} spending',
             subtitle:

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.tsx
@@ -5,8 +5,8 @@ import type { ExchangeTrade } from 'invity-api';
 import { Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
-import { ExchangeTradePreviewCard } from './ExchangeTradePreviewCard';
 import { selectExchangeSelectedSendAccount } from '../../../selectors/exchangeSelectors';
+import { TradeSideCard } from '../../general/TradeSideCard';
 
 export type ExchangeFromAccountTradePreviewCardProps = {
     quote?: ExchangeTrade;
@@ -24,7 +24,7 @@ export const ExchangeFromAccountTradePreviewCard = ({
     }
 
     return (
-        <ExchangeTradePreviewCard
+        <TradeSideCard
             account={fromAccount}
             cryptoId={quote.send}
             amount={

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx
@@ -5,8 +5,8 @@ import type { ExchangeTrade } from 'invity-api';
 import { Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
-import { ExchangeTradePreviewCard } from './ExchangeTradePreviewCard';
 import { selectExchangeSelectedReceiveAccount } from '../../../selectors/exchangeSelectors';
+import { TradeSideCard } from '../../general/TradeSideCard';
 
 export type ExchangeToAccountTradePreviewCardProps = {
     quote?: ExchangeTrade;
@@ -24,13 +24,15 @@ export const ExchangeToAccountTradePreviewCard = ({
     }
 
     return (
-        <ExchangeTradePreviewCard
+        <TradeSideCard
             account={toAccount.account}
             cryptoId={quote.receive}
             amount={
-                <Text variant="hint" color="textSecondaryHighlight">
-                    +{toStringValue}
-                </Text>
+                !!toStringValue && (
+                    <Text variant="hint" color="textSecondaryHighlight">
+                        +{toStringValue}
+                    </Text>
+                )
             }
             title={<Translation id="moduleTrading.tradingExchangePreviewScreen.toAccount" />}
         />

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFromAccountTradePreviewCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFromAccountTradePreviewCard.comp.test.tsx
@@ -41,7 +41,7 @@ describe('ExchangeFromAccountTradePreviewCard', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should ExchangeTradePreviewCard otherwise', async () => {
+    it('should render TradeSideCard otherwise', async () => {
         const { getByText } = await renderExchangeFromAccountTradePreviewCard({
             quote: exchangeQuotes[0],
         });

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeToAccountTradePreviewCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeToAccountTradePreviewCard.comp.test.tsx
@@ -39,7 +39,7 @@ describe('ExchangeToAccountTradePreviewCard', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should ExchangeTradePreviewCard otherwise', async () => {
+    it('should render TradeSideCard otherwise', async () => {
         const { getByText } = await renderExchangeToAccountTradePreviewCard({
             quote: exchangeQuotes[0],
         });

--- a/suite-native/module-trading/src/components/general/TradeFiatSideCard.tsx
+++ b/suite-native/module-trading/src/components/general/TradeFiatSideCard.tsx
@@ -1,0 +1,48 @@
+import { ReactNode } from 'react';
+
+import type { SellCryptoPaymentMethod } from 'invity-api';
+
+import { Card, HStack, Text, VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { exhaustive } from '@trezor/type-utils';
+
+import { FiatCurrencyIcon } from './FiatCurrencyIcon';
+import { TradeInfoHeader } from '../TradeInfo/TradeInfoHeader';
+import { TradeInfoRow } from '../TradeInfo/TradeInfoRow';
+
+export type TradeFiatSideCardProps = {
+    paymentMethod: SellCryptoPaymentMethod;
+    amount: ReactNode;
+    title: ReactNode;
+};
+
+const getPaymentMethodTranslation = (paymentMethod: SellCryptoPaymentMethod) => {
+    switch (paymentMethod) {
+        case 'bankTransfer':
+            return (
+                <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.bankTransfer" />
+            );
+        case 'creditCard':
+            return (
+                <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.creditCard" />
+            );
+        default:
+            exhaustive(paymentMethod);
+    }
+};
+
+export const TradeFiatSideCard = ({ paymentMethod, amount, title }: TradeFiatSideCardProps) => (
+    <Card noPadding>
+        <TradeInfoHeader title={title} />
+        <TradeInfoRow>
+            <Text variant="hint">{getPaymentMethodTranslation(paymentMethod)}</Text>
+        </TradeInfoRow>
+
+        <TradeInfoRow>
+            <HStack alignItems="center">
+                <FiatCurrencyIcon size="small" />
+                <VStack spacing="sp2">{amount}</VStack>
+            </HStack>
+        </TradeInfoRow>
+    </Card>
+);

--- a/suite-native/module-trading/src/components/general/TradeSideCard.tsx
+++ b/suite-native/module-trading/src/components/general/TradeSideCard.tsx
@@ -15,22 +15,17 @@ import { Card, HStack, Text, VStack } from '@suite-native/atoms';
 import { CryptoIcon, NetworkIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 
-import { TradeInfoHeader } from '../../TradeInfo/TradeInfoHeader';
-import { TradeInfoRow } from '../../TradeInfo/TradeInfoRow';
+import { TradeInfoHeader } from '../TradeInfo/TradeInfoHeader';
+import { TradeInfoRow } from '../TradeInfo/TradeInfoRow';
 
-type ExchangeTradePreviewProps = {
+type TradeSideCardProps = {
     account: Account;
     cryptoId?: CryptoId;
     amount: ReactNode;
     title: ReactNode;
 };
 
-export const ExchangeTradePreviewCard = ({
-    account,
-    cryptoId,
-    amount,
-    title,
-}: ExchangeTradePreviewProps) => {
+export const TradeSideCard = ({ account, cryptoId, amount, title }: TradeSideCardProps) => {
     const accountLabel = useSelector((state: AccountsRootState) =>
         account ? selectAccountLabel(state, account.key) : null,
     );

--- a/suite-native/module-trading/src/components/general/__tests__/TradeFiatSideCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradeFiatSideCard.comp.test.tsx
@@ -1,0 +1,42 @@
+import { renderWithBasicProvider } from '@suite-native/test-utils';
+
+import { TradeFiatSideCard, type TradeFiatSideCardProps } from '../TradeFiatSideCard';
+
+describe('TradeFiatSideCard', () => {
+    const renderTradeFiatSideCard = (props: TradeFiatSideCardProps) =>
+        renderWithBasicProvider(<TradeFiatSideCard {...props} />);
+
+    it('should render credit card payment method', () => {
+        const { getByText } = renderTradeFiatSideCard({
+            paymentMethod: 'creditCard',
+            amount: '+90.17',
+            title: 'To',
+        });
+
+        expect(getByText('To')).toBeOnTheScreen();
+        expect(getByText('Credit/Debit Card')).toBeOnTheScreen();
+    });
+
+    it('should render bank transfer payment method', () => {
+        const { getByText } = renderTradeFiatSideCard({
+            paymentMethod: 'bankTransfer',
+            amount: '+100.00',
+            title: 'To',
+        });
+
+        expect(getByText('To')).toBeOnTheScreen();
+        expect(getByText('Bank Transfer')).toBeOnTheScreen();
+    });
+
+    it('should handle exhaustive case for unknown payment method', () => {
+        // This test ensures the exhaustive function is called for unknown payment methods
+        // The exhaustive function will throw an error for unknown values
+        expect(() => {
+            renderTradeFiatSideCard({
+                paymentMethod: 'unknown' as any,
+                amount: '+90.17',
+                title: 'To',
+            });
+        }).toThrow();
+    });
+});

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellFromAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellFromAccountTradePreviewCard.tsx
@@ -1,0 +1,40 @@
+import { useSelector } from 'react-redux';
+
+import type { SellFiatTrade } from 'invity-api';
+
+import { Text } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+import { selectSellSelectedSendAccount } from '../../../selectors/sellSelectors';
+import { TradeSideCard } from '../../general/TradeSideCard';
+
+export type SellFromAccountTradePreviewCardProps = {
+    quote?: SellFiatTrade;
+    fromStringValue: string | undefined;
+};
+
+export const SellFromAccountTradePreviewCard = ({
+    quote,
+    fromStringValue,
+}: SellFromAccountTradePreviewCardProps) => {
+    const fromAccount = useSelector(selectSellSelectedSendAccount);
+
+    if (!quote?.cryptoCurrency || !fromAccount) {
+        return null;
+    }
+
+    return (
+        <TradeSideCard
+            account={fromAccount}
+            cryptoId={quote.cryptoCurrency}
+            amount={
+                fromStringValue ? (
+                    <Text variant="hint" color="textAlertRed">
+                        -{fromStringValue}
+                    </Text>
+                ) : null
+            }
+            title={<Translation id="moduleTrading.tradingSellPreviewScreen.fromAccount" />}
+        />
+    );
+};

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewScreenHeader.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewScreenHeader.tsx
@@ -1,0 +1,11 @@
+import { memo } from 'react';
+
+import { Translation } from '@suite-native/intl';
+import { ScreenHeader } from '@suite-native/navigation';
+
+export const SellPreviewScreenHeader = memo(() => (
+    <ScreenHeader
+        title={<Translation id="moduleTrading.tradingSellPreviewScreen.title" />}
+        closeActionType="close"
+    />
+));

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.tsx
@@ -1,0 +1,32 @@
+import { memo } from 'react';
+import Animated from 'react-native-reanimated';
+
+import type { SellFiatTrade } from 'invity-api';
+
+import { InlineAlertBox, VStack } from '@suite-native/atoms';
+
+import { SellFromAccountTradePreviewCard } from './SellFromAccountTradePreviewCard';
+import { SellToFiatTradePreviewCard } from './SellToFiatTradePreviewCard';
+import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
+
+export type SellPreviewViewProps = {
+    quote: SellFiatTrade | undefined;
+    txnErrorString: string | null;
+};
+
+export const SellPreviewView = memo(({ quote, txnErrorString }: SellPreviewViewProps) => {
+    const { fromStringValue, toStringValue } = useChangeStringsExtractor(quote);
+    const isTxnError = !!txnErrorString;
+
+    return (
+        <VStack spacing="sp20" paddingVertical="sp20">
+            {isTxnError && (
+                <Animated.View>
+                    <InlineAlertBox variant="critical" title={txnErrorString} />
+                </Animated.View>
+            )}
+            <SellFromAccountTradePreviewCard quote={quote} fromStringValue={fromStringValue} />
+            <SellToFiatTradePreviewCard quote={quote} toStringValue={toStringValue} />
+        </VStack>
+    );
+});

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellToFiatTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellToFiatTradePreviewCard.tsx
@@ -1,0 +1,34 @@
+import type { SellFiatTrade } from 'invity-api';
+
+import { Text } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+import { TradeFiatSideCard } from '../../general/TradeFiatSideCard';
+
+export type SellToFiatTradePreviewCardProps = {
+    quote?: SellFiatTrade;
+    toStringValue: string | undefined;
+};
+
+export const SellToFiatTradePreviewCard = ({
+    quote,
+    toStringValue,
+}: SellToFiatTradePreviewCardProps) => {
+    if (!quote?.fiatCurrency || !quote.paymentMethod) {
+        return null;
+    }
+
+    return (
+        <TradeFiatSideCard
+            paymentMethod={quote.paymentMethod}
+            amount={
+                !!toStringValue && (
+                    <Text variant="hint" color="textSecondaryHighlight">
+                        +{toStringValue}
+                    </Text>
+                )
+            }
+            title={<Translation id="moduleTrading.tradingSellPreviewScreen.toFiat" />}
+        />
+    );
+};

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFromAccountTradePreviewCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFromAccountTradePreviewCard.comp.test.tsx
@@ -1,0 +1,52 @@
+import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { sellQuotes } from '../../../../__fixtures__/sellQuotes';
+import { getWalletState } from '../../../../__fixtures__/walletState';
+import {
+    SellFromAccountTradePreviewCard,
+    SellFromAccountTradePreviewCardProps,
+} from '../SellFromAccountTradePreviewCard';
+
+describe('SellFromAccountTradePreviewCard', () => {
+    const renderSellFromAccountTradePreviewCard = (
+        props: Partial<SellFromAccountTradePreviewCardProps> = {},
+        tradingAccountKey = 'eth-account-1',
+    ) => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'sell' }),
+        };
+        preloadedState.wallet!.trading!.sell!.tradingAccountKey = tradingAccountKey;
+
+        return renderWithStoreProviderAsync(
+            <SellFromAccountTradePreviewCard fromStringValue="0.0233" {...props} />,
+            {
+                preloadedState,
+            },
+        );
+    };
+
+    it('should render nothing when there is no quote', async () => {
+        const { toJSON } = await renderSellFromAccountTradePreviewCard({});
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render nothing when account is not found', async () => {
+        const { toJSON } = await renderSellFromAccountTradePreviewCard(
+            { quote: sellQuotes[0] },
+            'unknown-account-key',
+        );
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render TradeSideCard otherwise', async () => {
+        const { getByText } = await renderSellFromAccountTradePreviewCard({
+            quote: sellQuotes[0],
+        });
+
+        expect(getByText('From')).toBeOnTheScreen();
+        expect(getByText('Ethereum #1')).toBeOnTheScreen();
+        expect(getByText('-0.0233')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewScreenHeader.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewScreenHeader.comp.test.tsx
@@ -1,0 +1,14 @@
+import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { SellPreviewScreenHeader } from '../SellPreviewScreenHeader';
+
+describe('SellPreviewScreenHeader', () => {
+    const renderSellPreviewScreenHeader = () =>
+        renderWithStoreProviderAsync(<SellPreviewScreenHeader />);
+
+    it('should render screen header with correct title', async () => {
+        const { getByText } = await renderSellPreviewScreenHeader();
+
+        expect(getByText('Sell')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewView.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewView.comp.test.tsx
@@ -1,0 +1,41 @@
+import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { sellQuotes } from '../../../../__fixtures__/sellQuotes';
+import { getWalletState } from '../../../../__fixtures__/walletState';
+import { SellPreviewView, SellPreviewViewProps } from '../SellPreviewView';
+
+describe('SellPreviewView', () => {
+    const renderSellPreviewView = (props: Partial<SellPreviewViewProps> = {}) => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'sell' }),
+        };
+        preloadedState.wallet!.trading!.composedTransactionInfo = { composed: { fee: '1000' } };
+        preloadedState.wallet!.trading!.sell!.tradingAccountKey = 'eth-account-1';
+
+        return renderWithStoreProviderAsync(
+            <SellPreviewView quote={sellQuotes[0]} txnErrorString={null} {...props} />,
+            { preloadedState },
+        );
+    };
+
+    it('should render all sections except alert', async () => {
+        const { getByText } = await renderSellPreviewView({});
+
+        expect(getByText('From')).toBeOnTheScreen();
+        expect(getByText('Ethereum #1')).toBeOnTheScreen();
+        expect(getByText('To')).toBeOnTheScreen();
+        expect(getByText('Credit/Debit Card')).toBeOnTheScreen();
+    });
+
+    it('should render txnErrorString when isTxnError is true', async () => {
+        const { getByText } = await renderSellPreviewView({
+            txnErrorString: 'Transaction error occurred',
+        });
+
+        expect(getByText('From')).toBeOnTheScreen();
+        expect(getByText('Ethereum #1')).toBeOnTheScreen();
+        expect(getByText('To')).toBeOnTheScreen();
+        expect(getByText('Credit/Debit Card')).toBeOnTheScreen();
+        expect(getByText('Transaction error occurred')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellToFiatTradePreviewCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellToFiatTradePreviewCard.comp.test.tsx
@@ -1,0 +1,68 @@
+import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { sellQuotes } from '../../../../__fixtures__/sellQuotes';
+import { getWalletState } from '../../../../__fixtures__/walletState';
+import {
+    SellToFiatTradePreviewCard,
+    SellToFiatTradePreviewCardProps,
+} from '../SellToFiatTradePreviewCard';
+
+describe('SellToFiatTradePreviewCard', () => {
+    const renderSellToFiatTradePreviewCard = (
+        props: Partial<SellToFiatTradePreviewCardProps> = {},
+    ) => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'sell' }),
+        };
+
+        return renderWithStoreProviderAsync(
+            <SellToFiatTradePreviewCard toStringValue="90.17" {...props} />,
+            { preloadedState },
+        );
+    };
+
+    it('should render nothing when there is no quote', async () => {
+        const { toJSON } = await renderSellToFiatTradePreviewCard({});
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render nothing when quote has no fiatCurrency', async () => {
+        const quoteWithoutFiat = { ...sellQuotes[0], fiatCurrency: undefined };
+        const { toJSON } = await renderSellToFiatTradePreviewCard({
+            quote: quoteWithoutFiat,
+        });
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render nothing when quote has no paymentMethod', async () => {
+        const quoteWithoutPaymentMethod = { ...sellQuotes[0], paymentMethod: undefined };
+        const { toJSON } = await renderSellToFiatTradePreviewCard({
+            quote: quoteWithoutPaymentMethod,
+        });
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render TradeFiatSideCard otherwise', async () => {
+        const { getByText } = await renderSellToFiatTradePreviewCard({
+            quote: sellQuotes[0],
+        });
+
+        expect(getByText('To')).toBeOnTheScreen();
+        expect(getByText('Credit/Debit Card')).toBeOnTheScreen();
+        expect(getByText('+90.17')).toBeOnTheScreen();
+    });
+
+    it('should render bank transfer payment method', async () => {
+        const { getByText } = await renderSellToFiatTradePreviewCard({
+            quote: sellQuotes[1], // This quote has bankTransfer payment method
+            toStringValue: '100.00', // Override the default toStringValue
+        });
+
+        expect(getByText('To')).toBeOnTheScreen();
+        expect(getByText('Bank Transfer')).toBeOnTheScreen();
+        expect(getByText('+100.00')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/sell/SellPreview/index.ts
+++ b/suite-native/module-trading/src/components/sell/SellPreview/index.ts
@@ -1,0 +1,4 @@
+export { SellPreviewScreenHeader } from './SellPreviewScreenHeader';
+export { SellPreviewView } from './SellPreviewView';
+export { SellFromAccountTradePreviewCard } from './SellFromAccountTradePreviewCard';
+export { SellToFiatTradePreviewCard } from './SellToFiatTradePreviewCard';

--- a/suite-native/module-trading/src/components/sell/SellPreviewScreenHeader.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreviewScreenHeader.tsx
@@ -1,0 +1,11 @@
+import { memo } from 'react';
+
+import { Translation } from '@suite-native/intl';
+import { ScreenHeader } from '@suite-native/navigation';
+
+export const SellPreviewScreenHeader = memo(() => (
+    <ScreenHeader
+        title={<Translation id="moduleTrading.tradingSellPreviewScreen.title" />}
+        closeActionType="close"
+    />
+));

--- a/suite-native/module-trading/src/components/sell/index.ts
+++ b/suite-native/module-trading/src/components/sell/index.ts
@@ -1,0 +1,1 @@
+export * from './SellPreview';

--- a/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
@@ -15,6 +15,9 @@ import {
     RootStackParamList,
     RootStackRoutes,
     StackNavigationProps,
+    StackToStackCompositeNavigationProps,
+    TradingStackParamList,
+    TradingStackRoutes,
 } from '@suite-native/navigation';
 import { useTimer } from '@trezor/react-utils';
 
@@ -23,6 +26,12 @@ import { SellFormType } from '../../types/sell';
 import { buildTradingUrl, getSourceForForm } from '../../utils/general/formUtils';
 import { useConsent } from '../general/useConsent';
 import { useConsentDenier } from '../general/useConsentDenier';
+
+type NavigationProps = StackToStackCompositeNavigationProps<
+    TradingStackParamList,
+    TradingStackRoutes.TradingSellPreview,
+    RootStackParamList
+>;
 
 type SellFlowReturn = {
     canProceed: boolean;
@@ -38,6 +47,7 @@ export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
     const dispatch = useDispatch();
     const rootNavigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
+    const navigation = useNavigation<NavigationProps>();
     const timer = useTimer();
     const candidateQuote = watch('quote');
     const isLoading = useSelector(selectTradingSellIsLoading);
@@ -179,6 +189,7 @@ export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
             ) {
                 doSellTrade(candidateQuote);
             }
+            navigation.navigate(TradingStackRoutes.TradingSellPreview);
         };
 
         await dispatch(
@@ -193,11 +204,12 @@ export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
     }, [
         candidateQuote,
         isLoading,
-        sellInfo,
-        doSellTrade,
+        navigation,
         dispatch,
         timer,
         waitForLegalTermsConsent,
+        sellInfo,
+        doSellTrade,
     ]);
 
     return {

--- a/suite-native/module-trading/src/navigation/TradingStackNavigator.tsx
+++ b/suite-native/module-trading/src/navigation/TradingStackNavigator.tsx
@@ -14,6 +14,7 @@ import { TradingHistoryScreen } from '../screens/TradingHistoryScreen';
 import { TradingOutputsReviewScreen } from '../screens/TradingOutputsReviewScreen';
 import { TradingReceiveAccountsPickerScreen } from '../screens/TradingReceiveAccountsPickerScreen';
 import { TradingScreen } from '../screens/TradingScreen';
+import { TradingSellPreviewScreen } from '../screens/TradingSellPreviewScreen';
 
 const TradingStack = createNativeStackNavigator<TradingStackParamList>();
 
@@ -51,6 +52,11 @@ export const TradingStackNavigator = () => (
             options={{ title: TradingStackRoutes.TradingExchangeRevoke }}
             name={TradingStackRoutes.TradingExchangeRevoke}
             component={TradingExchangeRevokeScreen}
+        />
+        <TradingStack.Screen
+            options={{ title: TradingStackRoutes.TradingSellPreview }}
+            name={TradingStackRoutes.TradingSellPreview}
+            component={TradingSellPreviewScreen}
         />
         <TradingStack.Screen
             options={{ title: TradingStackRoutes.TradingFees }}

--- a/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { selectTradingSellSelectedQuote } from '@suite-common/trading';
+import { Screen } from '@suite-native/navigation';
+
+import { SellPreviewScreenHeader, SellPreviewView } from '../components/sell/SellPreview';
+import { clearTradingStateThunk } from '../thunks';
+
+export const TradingSellPreviewScreen = () => {
+    const dispatch = useDispatch();
+
+    const quote = useSelector(selectTradingSellSelectedQuote);
+
+    // clear trading state on unmount
+    useEffect(
+        () => () => {
+            dispatch(clearTradingStateThunk());
+        },
+        [dispatch],
+    );
+
+    return (
+        <Screen header={<SellPreviewScreenHeader />}>
+            <SellPreviewView quote={quote} txnErrorString={null} />
+        </Screen>
+    );
+};

--- a/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.comp.test.tsx
@@ -1,0 +1,28 @@
+import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { sellQuotes } from '../../__fixtures__/sellQuotes';
+import { getWalletState } from '../../__fixtures__/walletState';
+import { TradingSellPreviewScreen } from '../TradingSellPreviewScreen';
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useRoute: () => ({ name: 'TradingSellPreviewScreen' }),
+}));
+
+describe('TradingSellPreviewScreen', () => {
+    const renderTradingSellPreviewScreen = (preloadedState?: PreloadedState) =>
+        renderWithStoreProviderAsync(<TradingSellPreviewScreen />, { preloadedState });
+
+    it('should render screen with header and preview view', async () => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'sell' }),
+        };
+        preloadedState.wallet!.trading!.sell!.selectedQuote = sellQuotes[0];
+
+        const { getByText } = await renderTradingSellPreviewScreen(preloadedState);
+
+        expect(getByText('Sell')).toBeOnTheScreen();
+        expect(getByText('To')).toBeOnTheScreen();
+        expect(getByText('Credit/Debit Card')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -357,6 +357,7 @@ export type TradingStackParamList = {
         quote: ExchangeTrade;
         shouldIncreaseLimit?: boolean;
     };
+    [TradingStackRoutes.TradingSellPreview]: undefined;
     [TradingStackRoutes.TradingFees]: {
         accountKey: AccountKey;
         tradingType: TradingType;

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -207,6 +207,7 @@ export enum TradingStackRoutes {
     TradingExchangePreview = 'TradingExchangePreview',
     TradingExchangeApproval = 'TradingExchangeApproval',
     TradingExchangeRevoke = 'TradingExchangeRevoke',
+    TradingSellPreview = 'TradingSellPreview',
     TradingFees = 'TradingFees',
     TradingOutputsReview = 'TradingOutputsReview',
 }


### PR DESCRIPTION
After quote is selected, navigate to a screen with trade preview. 


## Related Issue

Resolve #22296

## Screenshots:
<img width="350" src="https://github.com/user-attachments/assets/8853a90e-78ff-488c-9cd9-77a014849c7c" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22296-mobile-sell-prepare-sell-preview-screen-and-navigate-there&lookback=7)