### PR TITLE
fix(connect-explorer): union input issue

### DIFF
--- a/packages/connect-explorer/src/actions/methodActions.ts
+++ b/packages/connect-explorer/src/actions/methodActions.ts
@@ -136,8 +136,8 @@ export const onCodeChange = (value: string) => (dispatch: Dispatch, getState: Ge
         const { fields } = getState().method;
         const parsed = JSON5.parse(value);
         const processField = (field: Field<unknown>) => {
-            const value = getDeepValue(parsed, [...(field.path ?? []), ...field.name.split('.')]);
-            dispatch(onFieldChange(field, value));
+            const valuePath = [...(field.path || []), ...field.name.split('.')].filter(f => !!f);
+            const value = getDeepValue(parsed, valuePath);
 
             if (field.type === 'array') {
                 // ensure the array has the correct number of items
@@ -157,6 +157,8 @@ export const onCodeChange = (value: string) => (dispatch: Dispatch, getState: Ge
                 field.options.forEach(batch => {
                     batch.forEach(processField);
                 });
+            } else {
+                dispatch(onFieldChange(field, value));
             }
         };
         fields.forEach(processField);

--- a/packages/connect-explorer/src/components/fields/Input.tsx
+++ b/packages/connect-explorer/src/components/fields/Input.tsx
@@ -14,7 +14,7 @@ const Input = ({ 'data-testid': dataTest, field, onChange }: InputProps) => (
         <InputComponent
             data-testid={dataTest}
             label={field.name}
-            value={field.value}
+            value={field.value || ''}
             onChange={event => onChange(field, event.target.value)}
         />
     </Row>

--- a/packages/connect-explorer/src/components/fields/UnionWrapper.tsx
+++ b/packages/connect-explorer/src/components/fields/UnionWrapper.tsx
@@ -30,7 +30,7 @@ interface UnionWrapperProps {
 export const UnionWrapper = ({ field, onChange, children }: UnionWrapperProps) => (
     <Wrapper>
         <UnionHeader>
-            <p>Union</p>
+            <p>{field.name ? field.name : 'Union'}</p>
             <SelectBar
                 selectedOption={0}
                 options={field.labels.map((label, index) => ({ value: index, label }))}

--- a/packages/connect-explorer/src/reducers/methodCommon.ts
+++ b/packages/connect-explorer/src/reducers/methodCommon.ts
@@ -229,12 +229,7 @@ export const prepareBundle = (field: Field<unknown>) => {
             });
         });
     } else if (field.type === 'union') {
-        field.current.forEach(batchField => {
-            if (field.name && batchField.name) {
-                batchField.name = field.name + '.' + batchField.name;
-            } else if (field.name) {
-                batchField.name = field.name;
-            }
+        const processBatchField = (batchField: Field<unknown>) => {
             batchField.path = [field.name];
             if (field.path) {
                 batchField.path = [...field.path, ...batchField.path];
@@ -242,6 +237,10 @@ export const prepareBundle = (field: Field<unknown>) => {
             if (batchField.type === 'array' || batchField.type === 'union') {
                 prepareBundle(batchField);
             }
+        };
+        field.current.forEach(processBatchField);
+        field.options.forEach(optionFields => {
+            optionFields.forEach(processBatchField);
         });
     }
 


### PR DESCRIPTION
## Description

There was a problem with certain unions in Connect Explorer's method tester, where the union would be incorrectly interpreted as a nested object, instead of a nested field. 
This also caused issues with editing in manual (JSON) mode. 

For example [solanaSignTransaction](https://connect.trezor.io/9/methods/solana/solanaSignTransaction/) (advanced schema) -> [after fix](https://dev.suite.sldev.cz/connect/fix/connect-explorer-unions/methods/solana/solanaSignTransaction/)

## Screenshots

<img width="1166" height="440" alt="Screenshot 2025-10-20 at 13 51 57" src="https://github.com/user-attachments/assets/d70758ee-e362-4686-a8d3-9c74020835fe" />

<img width="1166" height="440" alt="Screenshot 2025-10-20 at 13 53 22" src="https://github.com/user-attachments/assets/efde3720-0730-4dbd-91bc-594b47de2bc0" />

