### PR TITLE
THP pairing retry

### DIFF
--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -219,7 +219,7 @@ const setupTest = () => {
         registerEvents: () => {},
         log: new Log('Test', false),
         abortSignal: new AbortController().signal,
-        uiPromises: { create: jest.fn() },
+        uiPromises: { create: jest.fn(), rejectAll: jest.fn() },
     };
 
     return {

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -39,7 +39,7 @@ type ReconnectContext = {
     postMessage: PostMessage;
     log: Log;
     abortSignal: AbortSignal;
-    uiPromises: { create: UiPromiseCreator };
+    uiPromises: { create: UiPromiseCreator; rejectAll: (e: Error) => void };
 };
 
 const waitForReconnectedDevice = async (
@@ -139,6 +139,8 @@ const waitForReconnectedDevice = async (
                     skipLanguageChecks: true,
                 });
             } catch (error) {
+                uiPromises.rejectAll(error);
+
                 // error in THP pairing
                 if (error.code === 'Device_ThpPairingTagInvalid') {
                     thpPairingError = true;

--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -169,7 +169,7 @@ const waitForPairingTag = async (device: Device) => {
         selectedMethod: thpState.pairingMethod,
         nfcData: thpState.nfcData?.toString('hex'),
     };
-    device.prompt('thp_pairing', { payload }).then(response => {
+    device.prompt(DEVICE.THP_PAIRING, { payload }).then(response => {
         if (response.success) {
             dfd.resolve(response.payload);
         } else {

--- a/packages/connect/src/utils/uiPromiseManager.ts
+++ b/packages/connect/src/utils/uiPromiseManager.ts
@@ -14,6 +14,13 @@ export const createUiPromiseManager = (interactionTimeout: () => void) => {
             ...createDeferred(promiseEvent),
             device,
         };
+
+        const existing = _uiPromises.findIndex(p => p.id === promiseEvent);
+        if (existing >= 0) {
+            console.warn(`UiPromise '${promiseEvent}' already exists.`);
+            _uiPromises.splice(existing, 1);
+        }
+
         _uiPromises.push(uiPromise as unknown as AnyUiPromise);
 
         // Interaction timeout

--- a/packages/suite/src/components/connection/thp/ThpPairingCodeEntry.tsx
+++ b/packages/suite/src/components/connection/thp/ThpPairingCodeEntry.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { thpActions } from '@suite-common/thp';
 import { PinInput, Row, Spinner } from '@trezor/components';
@@ -21,17 +21,17 @@ export const ThpPairingCodeEntry = ({ disabled, lastCode }: ThpPairingPinEntryPr
 
     const dispatch = useDispatch();
 
-    const onCodeEntry = (tag: string) => {
-        setLoading(true);
-        dispatch(thpActions.setLastThpCode({ code: tag }));
-        TrezorConnect.uiResponse({
-            type: 'ui-receive_thp_pairing_tag',
-            payload: {
-                source: 'code-entry',
-                tag,
-            },
-        });
-    };
+    const onCodeEntry = useCallback(
+        (tag: string) => {
+            setLoading(true);
+            dispatch(thpActions.setLastThpCode({ code: tag }));
+            TrezorConnect.uiResponse({
+                type: 'ui-receive_thp_pairing_tag',
+                payload: { source: 'code-entry', tag },
+            });
+        },
+        [dispatch],
+    );
 
     return (
         <Row


### PR DESCRIPTION
## Description

Resolve an issue where Trezor can't get THP paired after fw installation and cancelled THP pairing from device hamburger menu:

a) `TrezorConnect.uiResponse` is now not sent twice on desktop because of unstable reference to `onCodeEntry`.
b) When `UiPromise` is created, possibly existing `UiPromise` of the same type is silently thrown away (which could lead to memory leaks but we will make the correct/riskier fix as a followup).

## Related PRs

#22530

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thp-pairing-retry&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-pairing-retry&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-pairing-retry&lookback=7)