### PR TITLE
fix: downgrade Electron back to 35 to make WebWorkers to work :(, neded for Evolu

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
         "type-fest": "4.24.0",
         "bcrypto": "5.4.0",
         "react": "19.1.0",
-        "electron": "38.0.0",
+        "electron": "35.7.5",
         "@types/node": "22.13.10",
         "bn.js": "5.2.2",
         "node-addon-api": "8.5.0",

--- a/packages/connect-examples/electron-main-process/package.json
+++ b/packages/connect-examples/electron-main-process/package.json
@@ -56,7 +56,7 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "electron": "38.0.0",
+        "electron": "35.7.5",
         "electron-builder": "26.0.3"
     }
 }

--- a/packages/connect-examples/electron-renderer-with-popup/package.json
+++ b/packages/connect-examples/electron-renderer-with-popup/package.json
@@ -53,7 +53,7 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "electron": "38.0.0",
+        "electron": "35.7.5",
         "electron-builder": "26.0.3"
     }
 }

--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -18,7 +18,7 @@ const baseDir = getPathForProject('desktop');
 
 const config: webpack.Configuration = {
     // Electron 35 runs on Chromium 134 https://www.electronjs.org/blog/electron-35-0#stack-changes
-    // but we are limited to 133 (supported by latest browserslist, as included by latest webpack)
+    target: 'browserslist:Chrome >= 134',
     entry: [path.join(baseDirUI, 'src', 'index.tsx')],
     output: {
         path: path.join(baseDir, 'build'),

--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -17,9 +17,8 @@ const baseDirUI = getPathForProject('desktop-ui');
 const baseDir = getPathForProject('desktop');
 
 const config: webpack.Configuration = {
-    // Electron 38 runs on Chromium 140 https://github.com/electron/electron/releases/tag/v38.0.0
-    // but we are limited to 138 (supported by latest browserslist, as included by latest webpack)
-    target: 'browserslist:Chrome >= 138',
+    // Electron 35 runs on Chromium 134 https://www.electronjs.org/blog/electron-35-0#stack-changes
+    // but we are limited to 133 (supported by latest browserslist, as included by latest webpack)
     entry: [path.join(baseDirUI, 'src', 'index.tsx')],
     output: {
         path: path.join(baseDir, 'build'),

--- a/packages/suite-desktop-api/package.json
+++ b/packages/suite-desktop-api/package.json
@@ -19,6 +19,6 @@
         "depcheck": "yarn g:depcheck"
     },
     "dependencies": {
-        "electron": "38.0.0"
+        "electron": "35.7.5"
     }
 }

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -77,7 +77,7 @@
         "@types/ws": "^8.5.13",
         "app-builder-lib": "^26.0.12",
         "dotenv": "^16.4.7",
-        "electron": "38.0.0",
+        "electron": "35.7.5",
         "electron-devtools-installer": "^4.0.0",
         "fs-extra": "^11.3.1",
         "glob": "^11.0.3",

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -162,6 +162,13 @@ const init = async () => {
     // https://github.com/electron/electron/issues/46538#issuecomment-2808806722
     app.commandLine.appendSwitch('gtk-version', '3');
 
+    // This is needed for web-workers to work.
+    // This only works up to Electron ^35. The flag was removed in
+    // later versions of the Chromium.
+    //
+    // See: https://github.com/electron/electron/issues/43556
+    app.commandLine.appendSwitch('disable-features', 'PlzDedicatedWorker');
+
     await app.whenReady();
 
     // Load bridge module first, it is required in both UI and daemon mode

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -29,7 +29,7 @@
         "usb": "^2.15.0"
     },
     "devDependencies": {
-        "electron": "38.0.0",
+        "electron": "35.7.5",
         "electron-builder": "26.0.3"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14118,7 +14118,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-desktop-api@workspace:packages/suite-desktop-api"
   dependencies:
-    electron: "npm:38.0.0"
+    electron: "npm:35.7.5"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14173,7 +14173,7 @@ __metadata:
     app-builder-lib: "npm:^26.0.12"
     chalk: "npm:^4.1.2"
     dotenv: "npm:^16.4.7"
-    electron: "npm:38.0.0"
+    electron: "npm:35.7.5"
     electron-devtools-installer: "npm:^4.0.0"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
@@ -14237,7 +14237,7 @@ __metadata:
   resolution: "@trezor/suite-desktop@workspace:packages/suite-desktop"
   dependencies:
     blake-hash: "npm:^2.0.0"
-    electron: "npm:38.0.0"
+    electron: "npm:35.7.5"
     electron-builder: "npm:26.0.3"
     openpgp: "npm:^6.2.2"
     usb: "npm:^2.15.0"
@@ -20613,7 +20613,7 @@ __metadata:
   dependencies:
     "@trezor/connect": "workspace:*"
     "@trezor/eslint": "workspace:*"
-    electron: "npm:38.0.0"
+    electron: "npm:35.7.5"
     electron-builder: "npm:26.0.3"
   languageName: unknown
   linkType: soft
@@ -20623,7 +20623,7 @@ __metadata:
   resolution: "connect-example-electron-renderer-popup@workspace:packages/connect-examples/electron-renderer-with-popup"
   dependencies:
     "@trezor/eslint": "workspace:*"
-    electron: "npm:38.0.0"
+    electron: "npm:35.7.5"
     electron-builder: "npm:26.0.3"
   languageName: unknown
   linkType: soft
@@ -23069,16 +23069,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:38.0.0":
-  version: 38.0.0
-  resolution: "electron@npm:38.0.0"
+"electron@npm:35.7.5":
+  version: 35.7.5
+  resolution: "electron@npm:35.7.5"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/a245bf63fae60d1db85acddbe5787750e4d07acb273a1a5058163aee427fe07e52100b0d5a1e6b41efbdc1b398b6e7ec0fb3df75672e9148e95b31309d0c8f3a
+  checksum: 10/f3757f0b6f21ddd5ebf8b83becdaa3e47dc13473e5375e6e6aee638d7029e73d08d6a4170b37ad8c594057da139e7cdf4c8b82b70c2c1ad0306abdcc274c5fee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/22570

--------------------

It's sad, it sucks. But I see no other way. :crying_cat_face: 

Until this is fixed, I fear we are stucked: https://github.com/electron/electron/issues/43556

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=webworker-test&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=webworker-test&lookback=7)