### PR TITLE
Fix/catch missing bt settings

### DIFF
--- a/packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts
+++ b/packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts
@@ -1,14 +1,14 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
-import { BluetoothManufacturerData, prepareInitialState } from '@suite-common/bluetooth';
+import { BluetoothManufacturerData } from '@suite-common/bluetooth';
 import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
 import { asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { DesktopBluetoothDevice } from '../DesktopBluetoothDevice';
 import {
-    DesktopBluetoothState,
     bluetoothSlice,
+    initialDesktopBluetoothState,
     startConnectingBluetoothDevice,
     stopConnectingBluetoothDevice,
 } from '../desktopBluetoothReducer';
@@ -20,12 +20,6 @@ const manufacturerData: BluetoothManufacturerData = {
 };
 
 const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependenciesMock);
-
-const initialState: DesktopBluetoothState = {
-    ...prepareInitialState(),
-    connectingDeviceIds: [],
-    isUnpairingDevice: false,
-};
 
 const disconnectedDeviceB: DesktopBluetoothDevice = {
     id: asBluetoothDeviceId('B'),
@@ -42,7 +36,7 @@ describe('desktopBluetoothReducer', () => {
             extra: {},
             reducer: combineReducers({ bluetooth: bluetoothReducer }),
             preloadedState: {
-                bluetooth: { ...initialState, knownDevices: [disconnectedDeviceB] },
+                bluetooth: { ...initialDesktopBluetoothState, knownDevices: [disconnectedDeviceB] },
             },
         });
 

--- a/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
@@ -6,6 +6,7 @@ import { desktopApi } from '@trezor/suite-desktop-api';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
 import {
+    setBluetoothDeviceNeedsManualPairing,
     startConnectingBluetoothDevice,
     stopConnectingBluetoothDevice,
 } from './desktopBluetoothReducer';
@@ -30,6 +31,13 @@ export const bluetoothConnectDeviceThunk = createThunk<
         desktopApi.appFocus();
 
         if (!result.success) {
+            if (result.error === 'PairingUiMissing') {
+                dispatch(stopConnectingBluetoothDevice({ deviceId }));
+                dispatch(setBluetoothDeviceNeedsManualPairing(true));
+
+                return fulfillWithValue({ success: result.success });
+            }
+
             // This can fail, but we are silent about this as the device may not be there anymore
             await bluetoothIpc.disconnectDevice(deviceId);
 

--- a/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
@@ -31,7 +31,8 @@ export const bluetoothConnectDeviceThunk = createThunk<
         desktopApi.appFocus();
 
         if (!result.success) {
-            if (result.error === 'PairingUiMissing') {
+            // handling for this error: https://github.com/trezor/trezor-suite/blob/837cdf89c70cca80fd5dabb910e9a8509de7c3b1/packages/transport-bluetooth/src/server/platform/linux.rs#L253
+            if (result.error === 'BluetoothSettingsMissing') {
                 dispatch(stopConnectingBluetoothDevice({ deviceId }));
                 dispatch(setBluetoothDeviceNeedsManualPairing(true));
 

--- a/packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts
+++ b/packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts
@@ -22,6 +22,16 @@ export type DesktopBluetoothState = BluetoothState<DesktopBluetoothDevice> & {
     // it may take some time. During that time, the Device is already disconnected,
     // but the user needs to be notified that something is happening.
     isUnpairingDevice: boolean;
+
+    // Flag to display Modal to instruct the user to open bluetooth settings and pair manually
+    isManualPairingRequired: boolean;
+};
+
+export const initialDesktopBluetoothState: DesktopBluetoothState = {
+    ...prepareInitialState<DesktopBluetoothDevice>(),
+    connectingDeviceIds: [],
+    isUnpairingDevice: false,
+    isManualPairingRequired: false,
 };
 
 export type WithBluetoothRootState = {
@@ -30,11 +40,7 @@ export type WithBluetoothRootState = {
 
 export const bluetoothSlice = createSliceWithExtraDeps({
     name: 'bluetooth',
-    initialState: {
-        ...prepareInitialState<DesktopBluetoothDevice>(),
-        connectingDeviceIds: [] as string[],
-        isUnpairingDevice: false,
-    } satisfies DesktopBluetoothState,
+    initialState: initialDesktopBluetoothState,
     reducers: {
         startConnectingBluetoothDevice: (state, { payload: { deviceId } }) => {
             state.connectingDeviceIds.push(deviceId);
@@ -44,6 +50,9 @@ export const bluetoothSlice = createSliceWithExtraDeps({
         },
         setIsUnpairingDevice: (state, { payload: { isUnpairing } }) => {
             state.isUnpairingDevice = isUnpairing;
+        },
+        setBluetoothDeviceNeedsManualPairing: (state, { payload }) => {
+            state.isManualPairingRequired = payload;
         },
     },
     extraReducers: (builder, extra) => {
@@ -73,4 +82,5 @@ export const {
     startConnectingBluetoothDevice,
     stopConnectingBluetoothDevice,
     setIsUnpairingDevice,
+    setBluetoothDeviceNeedsManualPairing,
 } = bluetoothSlice.actions;

--- a/packages/suite/src/actions/bluetooth/desktopBluetoothSelectors.ts
+++ b/packages/suite/src/actions/bluetooth/desktopBluetoothSelectors.ts
@@ -5,3 +5,6 @@ export const selectConnectingDevices = (state: WithBluetoothRootState) =>
 
 export const selectIsUnpairingDevice = (state: WithBluetoothRootState) =>
     state.bluetooth.isUnpairingDevice;
+
+export const selectIsManualPairingRequired = (state: WithBluetoothRootState) =>
+    state.bluetooth.isManualPairingRequired;

--- a/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.test.ts
+++ b/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.test.ts
@@ -20,7 +20,7 @@ describe(filterOutNonResponsiveDevices.name, () => {
         jest.restoreAllMocks();
     });
 
-    it('keeps devices that are in pairing mode regardless of lastUpdatedTimestamp', () => {
+    it('keeps devices that are in specified modes regardless of lastUpdatedTimestamp', () => {
         const devices: DesktopBluetoothDevice[] = [
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('1'),
@@ -30,30 +30,39 @@ describe(filterOutNonResponsiveDevices.name, () => {
             }),
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('2'),
-                name: 'DeviceA',
+                name: 'DeviceB',
                 lastUpdatedTimestamp: NOW - 4_000,
-                connectionStatus: { type: 'pairing' },
+                connectionStatus: { type: 'connecting' },
+            }),
+            createMockedBluetoothDevice({
+                id: asBluetoothDeviceId('3'),
+                name: 'DeviceC',
+                lastUpdatedTimestamp: NOW - 4_000,
+                connectionStatus: { type: 'connected' },
             }),
         ];
 
         const result = filterOutNonResponsiveDevices(devices);
-        expect(result).toHaveLength(2);
+        expect(result).toHaveLength(3);
     });
 
     it('filters non responsive devices', () => {
         const devices: DesktopBluetoothDevice[] = [
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('1'),
+                connectionStatus: { type: 'paired' },
                 name: 'DeviceA',
                 lastUpdatedTimestamp: NOW - 4_000,
             }),
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('2'),
+                connectionStatus: { type: 'paired' },
                 name: 'DeviceA',
                 lastUpdatedTimestamp: NOW - 4_000,
             }),
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('3'),
+                connectionStatus: { type: 'paired' },
                 name: 'DeviceA',
                 lastUpdatedTimestamp: NOW + 1_000,
             }),
@@ -67,11 +76,13 @@ describe(filterOutNonResponsiveDevices.name, () => {
         const devices: DesktopBluetoothDevice[] = [
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('1'),
+                connectionStatus: { type: 'paired' },
                 name: 'DeviceA',
                 lastUpdatedTimestamp: NOW - 500,
             }),
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('2'),
+                connectionStatus: { type: 'paired' },
                 name: 'DeviceA',
                 lastUpdatedTimestamp: NOW - 1_000,
             }),
@@ -85,24 +96,28 @@ describe(filterOutNonResponsiveDevices.name, () => {
         const weakSignalDevices: DesktopBluetoothDevice[] = [
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('1'),
+                connectionStatus: { type: 'paired' },
                 name: 'DeviceA',
                 lastUpdatedTimestamp: NOW - 2_000,
                 rssi: -90,
             }),
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('2'),
+                connectionStatus: { type: 'paired' },
                 name: 'DeviceB',
                 lastUpdatedTimestamp: NOW - 5_000,
                 rssi: -100,
             }),
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('2'),
+                connectionStatus: { type: 'paired' },
                 name: 'DeviceB',
                 lastUpdatedTimestamp: NOW - 5_001,
                 rssi: -100,
             }),
             createMockedBluetoothDevice({
                 id: asBluetoothDeviceId('3'),
+                connectionStatus: { type: 'paired' },
                 name: 'DeviceC',
                 lastUpdatedTimestamp: NOW - 7000,
             }),

--- a/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.ts
+++ b/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.ts
@@ -14,6 +14,7 @@ const NEARBY_DEVICE_DECREASE = -1_000; // ms
 const CONNECTION_STATUSES_TO_KEEP: DeviceBluetoothConnectionStatusType[] = [
     'connecting',
     'pairing',
+    'connected', // this is relevant for devices manually paired via OS Bluetooth settings, instead of Suite
 ] as const;
 
 /**

--- a/packages/suite/src/components/connection/BluetoothManualPairingModal.tsx
+++ b/packages/suite/src/components/connection/BluetoothManualPairingModal.tsx
@@ -1,0 +1,36 @@
+import { Modal, Paragraph } from '@trezor/components';
+
+import { setBluetoothDeviceNeedsManualPairing } from 'src/actions/bluetooth//desktopBluetoothReducer';
+import { Translation } from 'src/components/suite/Translation';
+import { useDispatch } from 'src/hooks/suite';
+
+type BluetoothManualPairingModalProps = {
+    onCancel: () => void;
+};
+
+export const BluetoothManualPairingModal = ({ onCancel }: BluetoothManualPairingModalProps) => {
+    const dispatch = useDispatch();
+    const handleCancel = () => {
+        dispatch(setBluetoothDeviceNeedsManualPairing(false));
+        onCancel();
+    };
+
+    return (
+        <Modal
+            heading={<Translation id="TR_BLUETOOTH_REQUIRE_MANUAL_PAIRING" />}
+            size="small"
+            onCancel={handleCancel}
+            bottomContent={
+                <>
+                    <Modal.Button onClick={handleCancel} variant="tertiary">
+                        <Translation id="TR_DONE" />
+                    </Modal.Button>
+                </>
+            }
+        >
+            <Paragraph>
+                <Translation id="TR_BLUETOOTH_REQUIRE_MANUAL_PAIRING_TEXT" />
+            </Paragraph>
+        </Modal>
+    );
+};

--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -5,12 +5,16 @@ import { Box, Button, Column, Modal, Row, Spinner, Text } from '@trezor/componen
 import { isDesktop } from '@trezor/env-utils';
 import { borders } from '@trezor/theme';
 
-import { selectIsUnpairingDevice } from 'src/actions/bluetooth/desktopBluetoothSelectors';
+import {
+    selectIsManualPairingRequired,
+    selectIsUnpairingDevice,
+} from 'src/actions/bluetooth/desktopBluetoothSelectors';
 import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 
 import { BluetoothAdapterStatusModal } from './BluetoothAdapterStatusModal';
 import { BluetoothConnectionModal } from './BluetoothConnectionModal';
+import { BluetoothManualPairingModal } from './BluetoothManualPairingModal';
 import { CantSeeTrezorModal } from './CantSeeTrezorModal';
 import { CableConnectionAnimation } from './DeviceConnectionAnimation';
 import { useConnectionGlobalModalContext } from './context/ConnectionGlobalModalContext';
@@ -78,12 +82,17 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
         selectedDevice,
     } = useConnectionGlobalModalContext();
 
+    const isManualPairingRequired = useSelector(selectIsManualPairingRequired);
     const wasBluetoothDeviceWiped = useSelector(selectIsDeviceOsUnpairingRequired);
     const isUnpairingDevice = useSelector(selectIsUnpairingDevice);
 
     const bluetoothAdapterStatus = useSelector(selectAdapterStatus);
 
     if (wasBluetoothDeviceWiped || isUnpairingDevice) return null;
+
+    if (isBluetoothMode && isManualPairingRequired) {
+        return <BluetoothManualPairingModal onCancel={onCancel} />;
+    }
 
     if (showHints) {
         return <CantSeeTrezorModal onClose={onCancel} />;

--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -77,6 +77,7 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
         shouldShowBluetoothUnPairDeviceList,
         notConnectedKnownDevices,
         notConnectedNearbyDevices,
+        manuallyPairedConnectedDevices,
         showRemoveFromOsBluetooth,
         closeShowRemoveFromOsBluetooth,
         selectedDevice,
@@ -132,8 +133,12 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
         );
     }
 
-    // there are nearby devices, show the list and let user connect
-    if (isBluetoothMode && (notConnectedNearbyDevices.length > 0 || selectedDevice)) {
+    // there are nearby devices which can be selected to proceed, show the list and let user connect
+    const areConnectableDevices =
+        selectedDevice ||
+        notConnectedNearbyDevices.length > 0 ||
+        manuallyPairedConnectedDevices.length > 0;
+    if (isBluetoothMode && areConnectableDevices) {
         return <BluetoothConnectionModal onClose={onCancel} />;
     }
 

--- a/packages/suite/src/components/connection/context/ConnectionGlobalModalContext.tsx
+++ b/packages/suite/src/components/connection/context/ConnectionGlobalModalContext.tsx
@@ -43,6 +43,7 @@ const ConnectionGlobalModalReactContext = createContext<ConnectionGlobalModalCon
     selectedDevice: undefined,
     notConnectedKnownDevices: [],
     notConnectedNearbyDevices: [],
+    manuallyPairedConnectedDevices: [],
     shouldShowBluetoothUnPairDeviceList: false,
 
     showHints: false,
@@ -123,6 +124,7 @@ const useConnectionGlobalModal = () => {
         selectedDevice,
         notConnectedKnownDevices,
         notConnectedNearbyDevices,
+        manuallyPairedConnectedDevices,
         onConnect,
         handlePairingCancel,
     } = useBluetoothConnection({
@@ -157,6 +159,7 @@ const useConnectionGlobalModal = () => {
         notConnectedKnownDevices,
         shouldShowBluetoothUnPairDeviceList,
         notConnectedNearbyDevices,
+        manuallyPairedConnectedDevices,
     };
 };
 

--- a/packages/suite/src/components/connection/hook/useBluetoothConnection.tsx
+++ b/packages/suite/src/components/connection/hook/useBluetoothConnection.tsx
@@ -18,6 +18,7 @@ export type UseBluetoothConnectionReturn = {
     selectedDevice: DesktopBluetoothDevice | undefined;
     notConnectedKnownDevices: DesktopBluetoothDevice[];
     notConnectedNearbyDevices: DesktopBluetoothDevice[];
+    manuallyPairedConnectedDevices: DesktopBluetoothDevice[];
     onConnect: (deviceId: BluetoothDeviceId) => Promise<void>;
     handlePairingCancel: (deviceId: BluetoothDeviceId) => Promise<void>;
 };
@@ -43,10 +44,20 @@ export const useBluetoothConnection = ({
         () => knownDevices.filter(device => device.connectionStatus.type === 'disconnected'),
         [knownDevices],
     );
-
     const notConnectedNearbyDevices = useMemo(
         () => devices.filter(device => device.connectionStatus.type === 'disconnected'),
         [devices],
+    );
+
+    // Devices manually paired via OS Bluetooth settings, instead of via Suite
+    const manuallyPairedConnectedDevices = useMemo(
+        () =>
+            devices.filter(
+                device =>
+                    device.connectionStatus.type === 'connected' &&
+                    knownDevices.every(d => d.id !== device.id),
+            ),
+        [devices, knownDevices],
     );
 
     const onConnect = async (deviceId: BluetoothDeviceId): Promise<void> => {
@@ -78,6 +89,7 @@ export const useBluetoothConnection = ({
         selectedDevice,
         notConnectedKnownDevices,
         notConnectedNearbyDevices,
+        manuallyPairedConnectedDevices,
         onConnect,
         handlePairingCancel,
     };

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx
@@ -61,18 +61,27 @@ const GhostDeviceActionButton = ({
 
 type ActionButtonProps = {
     isGhostDevice: boolean;
+    isManuallyPairedDevice: boolean;
     device: DesktopBluetoothDevice;
     onConnect: (deviceId: BluetoothDeviceId) => void;
     onPairAgain?: (deviceId: BluetoothDeviceId) => void;
 };
 
-const ActionButton = ({ isGhostDevice, device, onConnect, onPairAgain }: ActionButtonProps) => {
+const ActionButton = ({
+    isGhostDevice,
+    isManuallyPairedDevice,
+    device,
+    onConnect,
+    onPairAgain,
+}: ActionButtonProps) => {
     const connectingDevicesIds = useSelector(selectConnectingDevices);
 
     const isSuiteTryingToConnectToDevice = connectingDevicesIds.includes(device.id);
     const connectionStatus = connectionStatusMap[device.connectionStatus.type];
     const isClickable = connectionStatus?.component === 'button';
     const isLoading = connectionStatus?.component === 'loader';
+
+    const handleOnClick = () => onConnect(device.id);
 
     if (isGhostDevice) {
         return (
@@ -84,12 +93,17 @@ const ActionButton = ({ isGhostDevice, device, onConnect, onPairAgain }: ActionB
             />
         );
     }
+    if (isManuallyPairedDevice) {
+        return (
+            <Button variant="primary" size="small" onClick={handleOnClick}>
+                <Translation id="TR_BLUETOOTH_CONNECT" />
+            </Button>
+        );
+    }
 
     if (isLoading) {
         return <PairingState isLoading text={connectionStatus.text} />;
     }
-
-    const handleOnClick = () => onConnect(device.id);
 
     if (isClickable) {
         return (
@@ -98,6 +112,8 @@ const ActionButton = ({ isGhostDevice, device, onConnect, onPairAgain }: ActionB
             </Button>
         );
     }
+
+    return null;
 };
 
 type BluetoothDeviceItemProps = {
@@ -119,6 +135,8 @@ export const BluetoothDeviceListItem = ({
     const isKnownDevice = knownDevices.some(knownDevice => knownDevice.id === device.id);
 
     const isGhostDevice = isKnownDevice && !isNearbyDevice;
+    // device manually paired via OS Bluetooth settings, instead of Suite
+    const isManuallyPairedDevice = isNearbyDevice && !isKnownDevice;
 
     return (
         <Row gap={16} justifyContent="space-between">
@@ -126,6 +144,7 @@ export const BluetoothDeviceListItem = ({
             <ActionButton
                 onPairAgain={onPairAgain}
                 isGhostDevice={isGhostDevice}
+                isManuallyPairedDevice={isManuallyPairedDevice}
                 device={device}
                 onConnect={onConnect}
             />

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10335,6 +10335,19 @@ export default defineMessages({
         defaultMessage: "Go to your Trezor's Menu > Pair & Connect > Pair new device",
         description: 'Displayed as hints of bluetooth connection in connect modal',
     },
+    TR_BLUETOOTH_REQUIRE_MANUAL_PAIRING: {
+        id: 'TR_BLUETOOTH_REQUIRE_MANUAL_PAIRING',
+        defaultMessage: 'Your Trezor needs to be paired manually',
+    },
+    TR_BLUETOOTH_REQUIRE_MANUAL_PAIRING_TEXT: {
+        id: 'TR_BLUETOOTH_REQUIRE_MANUAL_PAIRING_TEXT',
+        defaultMessage:
+            'Your system does not support automatic pairing via Trezor Suite. Please open your System Bluetooth Settings, find your Trezor device and pair it there.',
+    },
+    TR_DONE: {
+        id: 'TR_DONE',
+        defaultMessage: 'Done',
+    },
     TR_ALLOW_BLUETOOTH_CTA: {
         id: 'TR_ALLOW_BLUETOOTH_CTA',
         defaultMessage: 'Allow',

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -14,20 +14,12 @@ import { RouterState } from 'src/reducers/suite/routerReducer';
 import { suiteInitialState } from 'src/reducers/suite/suiteReducer';
 import WalletReducers from 'src/reducers/wallet';
 
+import { initialDesktopBluetoothState } from '../../../actions/bluetooth/desktopBluetoothReducer';
+
 export const initialAppState: AppState = {
     suite: suiteInitialState,
     device: initialState,
-    bluetooth: {
-        connectingDeviceIds: [],
-        isUnpairingDevice: false,
-        adapterStatus: 'unknown',
-        scanStatus: 'error',
-        nearbyDevices: null,
-        knownDevices: [],
-        ignoredDeviceIds: [],
-        autoConnectPolicy: {},
-        isDeviceOsUnpairingRequired: false,
-    },
+    bluetooth: initialDesktopBluetoothState,
     thp: {
         step: null,
         lastThpCode: undefined,


### PR DESCRIPTION
## Description

Followup for https://github.com/trezor/trezor-suite/pull/22466

- add `isManualPairingRequired`  flag to desktopBluetoothReducer
- display UI instructing user to pair device manually, if isManualPairingRequired is set
- fix connecting a device that was paired manually via OS settings
  - which is particularly relevant for this situation, but it could also be a problem on other platforms – currently the device is a `nearbyDevice` with `connected` status, but it is not known, which was not handled so far, so the device was hidden and not possible to continue
  - now it lets user see the device in list, and initiate connection

## Related issue

Resolve: https://github.com/trezor/trezor-suite/issues/22272

### Screenshots

[Screencast from 2025-10-29 12-15-17.webm](https://github.com/user-attachments/assets/24946ccd-38c8-4fda-9d9d-25f43204b4cd)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/catch-missing-bt-settings&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/catch-missing-bt-settings&lookback=7)