### PR TITLE
fix(suite-common): Make selectAddressByNetworkAndPath take device into account

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
@@ -4,6 +4,7 @@ import { TrezorDevice } from '@suite-common/suite-types';
 import { NetworkSymbol, getNetwork, getNetworkByEvmChainId } from '@suite-common/wallet-config';
 import {
     AccountsRootState,
+    DeviceRootState,
     selectAddressByNetworkAndPath,
     selectDeviceAccounts,
 } from '@suite-common/wallet-core';
@@ -71,7 +72,7 @@ export const SignMessageModal = ({
         ? getNetworkByEvmChainId(eip712ChainId)
         : getNetwork(networkSymbol ?? 'eth');
 
-    const address = useSelector((state: AccountsRootState) =>
+    const address = useSelector((state: AccountsRootState & DeviceRootState) =>
         selectAddressByNetworkAndPath(state, network, serializedPath),
     );
     const account =

--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -295,7 +295,7 @@ export const selectSolAccountHasStaked = createMemoizedSelector([selectAccountBy
 
 export const selectAddressByNetworkAndPath = createMemoizedSelector(
     [
-        selectAccounts,
+        selectDeviceAccounts,
         (_state: AccountsRootState, network?: Network) => network,
         (_state: AccountsRootState, _network?: Network, path?: string) => path,
     ],

--- a/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
@@ -1,4 +1,5 @@
 import { TrezorDevice } from '@suite-common/suite-types';
+import { testMocks } from '@suite-common/test-utils';
 import { networks } from '@suite-common/wallet-config';
 
 import { DeviceRootState } from '../../device/deviceReducer';
@@ -8,11 +9,18 @@ import {
     selectVisibleDeviceAccountsMap,
 } from '../accountsSelectors';
 
+const BTC_DEVICE_SSID: `${string}@${string}:${number}` =
+    'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@AC94BB9C1B08FE73BE1E3322:0';
+const BTC_DEVICE = testMocks.getSuiteDevice({ state: BTC_DEVICE_SSID });
+
+const ETH_DEVICE_SSID: `${string}@${string}:${number}` = '1stTestnetAddress@device_id:0';
+const ETH_DEVICE = testMocks.getSuiteDevice({ state: ETH_DEVICE_SSID });
+
 const mockState: AccountsRootState & DeviceRootState = {
     wallet: {
         accounts: [
             {
-                deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@AC94BB9C1B08FE73BE1E3322:0',
+                deviceState: BTC_DEVICE_SSID,
                 index: 0,
                 backendType: undefined,
                 misc: undefined,
@@ -74,7 +82,7 @@ const mockState: AccountsRootState & DeviceRootState = {
                 symbol: 'eth',
                 networkType: 'ethereum',
                 descriptor: '0xEthereumAddress',
-                deviceState: '1stTestnetAddress@device_id:0',
+                deviceState: ETH_DEVICE_SSID,
                 key: '0xEthereumAddress-eth-deviceState',
                 accountType: 'normal',
                 index: 0,
@@ -106,22 +114,25 @@ const mockState: AccountsRootState & DeviceRootState = {
         ],
     },
     device: {
-        devices: [],
-        selectedDevice: {
-            state: {
-                staticSessionId: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@AC94BB9C1B08FE73BE1E3322:0',
-            },
-        } as unknown as TrezorDevice,
+        devices: [BTC_DEVICE, ETH_DEVICE],
         persistentDeviceData: [],
         isDeviceAutoEjectEnabled: true,
     },
 };
 
+const getStateWithSelectedDevice = (
+    state: AccountsRootState & DeviceRootState,
+    selectedDevice: TrezorDevice,
+): AccountsRootState & DeviceRootState => ({
+    ...state,
+    device: { ...state.device, selectedDevice },
+});
+
 describe('accountsSelectors', () => {
     describe(selectAddressByNetworkAndPath.name, () => {
         it('returns unused address for BTC', () => {
             const result = selectAddressByNetworkAndPath(
-                mockState,
+                getStateWithSelectedDevice(mockState, BTC_DEVICE),
                 networks['btc'],
                 "m/84'/0'/0'/0/0",
             );
@@ -130,7 +141,7 @@ describe('accountsSelectors', () => {
 
         it('returns used address for BTC', () => {
             const result = selectAddressByNetworkAndPath(
-                mockState,
+                getStateWithSelectedDevice(mockState, BTC_DEVICE),
                 networks['btc'],
                 "m/84'/0'/0'/0/1",
             );
@@ -139,16 +150,25 @@ describe('accountsSelectors', () => {
 
         it('returns change address for BTC', () => {
             const result = selectAddressByNetworkAndPath(
-                mockState,
+                getStateWithSelectedDevice(mockState, BTC_DEVICE),
                 networks['btc'],
                 "m/84'/0'/0'/1/0",
             );
             expect(result).toBe('bc1change');
         });
 
+        it('does not return address from another device', () => {
+            const result = selectAddressByNetworkAndPath(
+                getStateWithSelectedDevice(mockState, ETH_DEVICE),
+                networks['btc'],
+                "m/84'/0'/0'/0/0",
+            );
+            expect(result).toBeUndefined();
+        });
+
         it('returns descriptor for ETH', () => {
             const result = selectAddressByNetworkAndPath(
-                mockState,
+                getStateWithSelectedDevice(mockState, ETH_DEVICE),
                 networks['eth'],
                 "m/44'/60'/0'/0",
             );
@@ -157,7 +177,7 @@ describe('accountsSelectors', () => {
 
         it('returns undefined for unknown path', () => {
             const result = selectAddressByNetworkAndPath(
-                mockState,
+                getStateWithSelectedDevice(mockState, BTC_DEVICE),
                 networks['btc'],
                 "m/84'/0'/0'/9/9",
             );
@@ -165,19 +185,29 @@ describe('accountsSelectors', () => {
         });
 
         it('returns undefined if network is missing', () => {
-            const result = selectAddressByNetworkAndPath(mockState, undefined, "m/84'/0'/0'/0/0");
+            const result = selectAddressByNetworkAndPath(
+                getStateWithSelectedDevice(mockState, BTC_DEVICE),
+                undefined,
+                "m/84'/0'/0'/0/0",
+            );
             expect(result).toBeUndefined();
         });
 
         it('returns undefined if path is missing', () => {
-            const result = selectAddressByNetworkAndPath(mockState, networks['btc'], undefined);
+            const result = selectAddressByNetworkAndPath(
+                getStateWithSelectedDevice(mockState, BTC_DEVICE),
+                networks['btc'],
+                undefined,
+            );
             expect(result).toBeUndefined();
         });
     });
 
     describe('selectVisibleDeviceAccountsMap', () => {
         it('should return map of accounts for selected device only', () => {
-            const result = selectVisibleDeviceAccountsMap(mockState);
+            const result = selectVisibleDeviceAccountsMap(
+                getStateWithSelectedDevice(mockState, BTC_DEVICE),
+            );
 
             expect(result).toBeInstanceOf(Map);
             expect(result.size).toBe(1);


### PR DESCRIPTION
`selectAdressByNetworkAndPath` does need to take device into acccount, as there can be multiple addresses with same network & path (from different devices).

## Related Issue

Resolve #22288

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sign-wrong-address&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/sign-wrong-address&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sign-wrong-address&lookback=7)