### PR TITLE
fix(suite): hide bluetooth button on web

### DIFF
--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -2,6 +2,7 @@ import { useTheme } from 'styled-components';
 
 import { selectAdapterStatus, selectIsDeviceOsUnpairingRequired } from '@suite-common/bluetooth';
 import { Box, Button, Column, Modal, Row, Spinner, Text } from '@trezor/components';
+import { isDesktop } from '@trezor/env-utils';
 import { borders } from '@trezor/theme';
 
 import { selectIsUnpairingDevice } from 'src/actions/bluetooth/desktopBluetoothSelectors';
@@ -155,14 +156,16 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
             <DontSeeTrezorPill onClick={toggleShowHints} />
             <Modal.ModalBase data-testid="@suite/connection-modal" size="tiny" onCancel={onCancel}>
                 <ConnectModalContent isBluetoothMode={false}>
-                    <Button
-                        icon="bluetooth"
-                        onClick={toggleBluetoothMode}
-                        variant="info"
-                        size="medium"
-                    >
-                        <Translation id="TR_PAIR_NEW_BLUETOOTH_DEVICE" />
-                    </Button>
+                    {isDesktop() && (
+                        <Button
+                            icon="bluetooth"
+                            onClick={toggleBluetoothMode}
+                            variant="info"
+                            size="medium"
+                        >
+                            <Translation id="TR_PAIR_NEW_BLUETOOTH_DEVICE" />
+                        </Button>
+                    )}
                 </ConnectModalContent>
             </Modal.ModalBase>
         </Modal.Backdrop>


### PR DESCRIPTION
Hides the blue button on web:
<img width="469" height="909" alt="Screenshot 2025-10-21 at 16 49 13" src="https://github.com/user-attachments/assets/1f0da531-f8c8-4ef1-a27e-6497f4ed6ecd" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/hide-bt-button-on-web&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/hide-bt-button-on-web&lookback=7)