### PR TITLE
chore(suite-native): bump version to 25.10.3

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@suite-native/app",
     "version": "1.0.0",
-    "suiteNativeVersion": "25.10.1",
+    "suiteNativeVersion": "25.10.3",
     "main": "index.js",
     "scripts": {
         "depcheck": "yarn g:depcheck",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

25.10.2 is current production. We do not plan to release 25.10.3 so far, but we don't want develop to be on lower version than production. It should be bumped automatically to 25.11.1 next month.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/bump-25-10-3&lookback=7)