### PR TITLE
fix(suite): Fix positioning in device confirm prompt

### DIFF
--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -3,7 +3,7 @@ import * as semver from 'semver';
 import { TranslationKey } from '@suite-common/intl-types';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
-import { BulletList, Column, H2, Modal, Paragraph } from '@trezor/components';
+import { BulletList, Column, H2, Modal, Paragraph, Row } from '@trezor/components';
 import { Device } from '@trezor/connect';
 import { DeviceModelInternal, getFirmwareVersion } from '@trezor/device-utils';
 import { ConfirmOnDevicePill, DeviceAnimation } from '@trezor/product-components';
@@ -215,7 +215,7 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
                                 />
                             </Paragraph>
                         )}
-                        {showWebUsbButton && <WebUsbButton />}
+                        <Row justifyContent="center">{showWebUsbButton && <WebUsbButton />}</Row>
                     </Column>
                 )}
             </Modal.ModalBase>

--- a/packages/suite/src/components/suite/DeviceConfirmImage.tsx
+++ b/packages/suite/src/components/suite/DeviceConfirmImage.tsx
@@ -25,6 +25,7 @@ export const DeviceConfirmImage = ({
             width={width}
             unitColor={device?.features?.unit_color}
             height={height}
+            margin={20}
             {...rest}
         />
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
@@ -52,7 +52,7 @@ export const ConfirmActionModal = ({
             />
             <Modal.ModalBase size="tiny">
                 <Column alignItems="center" gap={16}>
-                    <DeviceConfirmImage device={device} margin={20} />
+                    <DeviceConfirmImage device={device} />
                     <H2
                         align="center"
                         margin={{ left: spacings.md, right: spacings.md, bottom: spacings.md }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before
<img width="722" height="850" alt="Screenshot 2025-10-22 at 12 23 50" src="https://github.com/user-attachments/assets/b2c3aa4f-9f9d-4489-bb24-3363d5e128d7" />

after
<img width="531" height="722" alt="Screenshot 2025-10-22 at 12 36 16" src="https://github.com/user-attachments/assets/ca982f2a-42a8-49ac-a670-32fa3d76979c" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-positioning-in-confirm-prompt&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-positioning-in-confirm-prompt&lookback=7)