### PR TITLE
Trading - Receive Address UI Fixes

### DIFF
--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -2245,7 +2245,7 @@
   "TR_TRADING_RECEIVE_ACCOUNT_NOT_FOUND_TEXT": "We couldn’t find an account that matches this asset.",
   "TR_TRADING_RECEIVE_ACCOUNT_NOT_FOUND_TITLE": "Account not found",
   "TR_TRADING_RECEIVE_ADDRESS_ENTER_TEXT": "Enter {networkName} address that isn't in Trezor Suite.",
-  "TR_TRADING_RECEIVE_ADDRESS_NEW_ADDRESSES": "New addresses",
+  "TR_TRADING_RECEIVE_ADDRESS_NEW_ADDRESS": "New address",
   "TR_TRADING_RECEIVE_ADDRESS_NOT_FOUND_TEXT": "Check the address or browse the list to select an option.",
   "TR_TRADING_RECEIVE_ADDRESS_NOT_FOUND_TITLE": "Address not found",
   "TR_TRADING_RECEIVE_ADDRESS_USED_ADDRESSES": "Used addresses",

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1570,9 +1570,9 @@ export default defineMessages({
         defaultMessage: "Enter {networkName} address that isn't in Trezor Suite.",
         id: 'TR_TRADING_RECEIVE_ADDRESS_ENTER_TEXT',
     },
-    TR_TRADING_RECEIVE_ADDRESS_NEW_ADDRESSES: {
-        defaultMessage: 'New addresses',
-        id: 'TR_TRADING_RECEIVE_ADDRESS_NEW_ADDRESSES',
+    TR_TRADING_RECEIVE_ADDRESS_NEW_ADDRESS: {
+        defaultMessage: 'New address',
+        id: 'TR_TRADING_RECEIVE_ADDRESS_NEW_ADDRESS',
     },
     TR_TRADING_RECEIVE_ADDRESS_USED_ADDRESSES: {
         defaultMessage: 'Used addresses',

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
@@ -101,7 +101,7 @@ export const TradingBuyFormInputs = () => {
                         />
                     </Column>
 
-                    {cryptoId && !isLoading && <TradingReceiveAddress />}
+                    {cryptoId && !isLoading && <TradingReceiveAddress type="buy" />}
                 </Column>
             </Card>
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -136,7 +136,7 @@ export const TradingExchangeFormInputs = () => {
                     />
                 </Column>
 
-                {receiveCryptoId && !isLoading && <TradingReceiveAddress />}
+                {receiveCryptoId && !isLoading && <TradingReceiveAddress type="exchange" />}
 
                 <Column
                     gap={spacings.lg}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAccountModal/TradingReceiveAccountSuiteOption.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAccountModal/TradingReceiveAccountSuiteOption.tsx
@@ -108,7 +108,9 @@ export const TradingReceiveAccountSuiteOption = ({
                     </Text>
                 </Column>
 
-                {(isUtxoBasedNetwork || requiresExtraField) && <Icon name="caretRight" size={20} />}
+                {(isUtxoBasedNetwork || requiresExtraField) && (
+                    <Icon name="caretRight" size={20} variant="tertiary" />
+                )}
             </Row>
         </TradingReceiveAccountOptionRow>
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 
+import { TradingTradeBuyExchangeType } from '@suite-common/trading';
 import { Column, Divider, Icon, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -24,7 +25,11 @@ export const TradingReceiveAddressEmpty = ({ title, text }: TradingReceiveAddres
     </Column>
 );
 
-export const TradingReceiveAddress = () => {
+interface TradingReceiveAddressProps {
+    type: TradingTradeBuyExchangeType;
+}
+
+export const TradingReceiveAddress = ({ type }: TradingReceiveAddressProps) => {
     const { tradingReceiveAddress } = useTradingReceiveAddressValues();
     const modalControls = useReceiveAddressModalControls();
 
@@ -43,7 +48,10 @@ export const TradingReceiveAddress = () => {
                 alignItems="center"
                 justifyContent="space-between"
                 onClick={onReceiveAccountClick}
-                padding={{ vertical: spacings.sm, horizontal: spacings.lg }}
+                padding={{
+                    vertical: !receiveAddress ? spacings.lg : spacings.sm,
+                    horizontal: spacings.lg,
+                }}
             >
                 <Text typographyStyle="body">
                     <Translation
@@ -93,11 +101,11 @@ export const TradingReceiveAddress = () => {
                         )}
                     </Column>
 
-                    <Icon name="caretRight" size={20} />
+                    <Icon name="caretRight" size={20} variant="tertiary" />
                 </Row>
             </Row>
 
-            <Divider margin={0} />
+            {type === 'exchange' && <Divider margin={0} />}
         </Column>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressList.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressList.tsx
@@ -2,7 +2,8 @@ import { ReactNode } from 'react';
 
 import { Account } from '@suite-common/wallet-types';
 import { Address } from '@trezor/blockchain-link-types';
-import { Card, Divider, Text } from '@trezor/components';
+import { Card, Column, Divider, Text } from '@trezor/components';
+import { spacings } from '@trezor/theme';
 
 import { TradingUtxoReceiveAddressOption } from './TradingUtxoReceiveAddressOption';
 
@@ -20,7 +21,7 @@ export const TradingUtxoReceiveAddressList = ({
     if (addresses.length === 0) return null;
 
     return (
-        <>
+        <Column gap={spacings.sm}>
             <Text typographyStyle="body" variant="tertiary">
                 {title}
             </Text>
@@ -33,6 +34,6 @@ export const TradingUtxoReceiveAddressList = ({
                     </>
                 ))}
             </Card>
-        </>
+        </Column>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressModal.tsx
@@ -13,6 +13,8 @@ import { useReceiveAddressModalControls } from 'src/views/wallet/trading/common/
 import { TradingUtxoReceiveAddressList } from './TradingUtxoReceiveAddressList';
 import { useTradingReceiveAddressValues } from '../useTradingReceiveAddressValues';
 
+const MAX_UNUSED_ADDRESSES = 1;
+
 export const TradingUtxoReceiveAddressModal = () => {
     const { tradingReceiveAddress } = useTradingReceiveAddressValues();
     const modalControls = useReceiveAddressModalControls();
@@ -26,7 +28,7 @@ export const TradingUtxoReceiveAddressModal = () => {
 
     const [usedAddresses, unusedAddresses] = useMemo(() => {
         const used = addresses?.used ?? [];
-        const unused = addresses?.unused ?? [];
+        const unused = addresses?.unused?.slice(0, MAX_UNUSED_ADDRESSES) ?? [];
         const query = search.trim();
 
         const filterPredicate = (address: Address) =>
@@ -58,7 +60,7 @@ export const TradingUtxoReceiveAddressModal = () => {
             onCancel={onCancel}
             onBackClick={onBackClick}
         >
-            <Column gap={spacings.sm}>
+            <Column gap={spacings.xl}>
                 <SearchAsset
                     searchPlaceholder={translationString('TR_SEARCH')}
                     search={search}
@@ -75,7 +77,7 @@ export const TradingUtxoReceiveAddressModal = () => {
                         <TradingUtxoReceiveAddressList
                             account={account}
                             addresses={unusedAddresses}
-                            title={<Translation id="TR_TRADING_RECEIVE_ADDRESS_NEW_ADDRESSES" />}
+                            title={<Translation id="TR_TRADING_RECEIVE_ADDRESS_NEW_ADDRESS" />}
                         />
 
                         <TradingUtxoReceiveAddressList


### PR DESCRIPTION
## Description

Minor receive address UI fixes:

- adjust padding for `Not selected` receive account
- don't show bottom border of the receive address picker in buy, since it is the last element in the card
- set chevron icon colors to tertiary
- show only one unused (new) address for UTXO-based networks in receive address modal

## Related Issue

Resolve #22593 

## Screenshots:

Account not selected padding:

<img width="100%" alt="Screenshot 2025-10-22 at 12 51 43" src="https://github.com/user-attachments/assets/65f121ee-5728-45f0-a4df-d83ba6059f32" />

Bottom border omitted in buy:

<img width="100%" alt="Screenshot 2025-10-22 at 12 51 20" src="https://github.com/user-attachments/assets/cceeacf6-20ff-44be-a7e2-a06af8282885" />

Chevron icon color tertiary:

<img width="100%" alt="Screenshot 2025-10-22 at 12 51 58" src="https://github.com/user-attachments/assets/75d304fe-a532-4ddf-a50f-09f1bfce92b4" />

Show only one new unused address for UTXO-based networks:

<img width="100%" alt="Screenshot 2025-10-22 at 12 52 10" src="https://github.com/user-attachments/assets/b2919b05-de78-401f-8172-4f5367b17a1d" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/receive-address&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/receive-address&lookback=7)