### PR TITLE
Trading - Refresh Button in Approve/Revoke Modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
@@ -80,6 +80,7 @@ export const ApproveModal = ({
         changeFeeLevel,
         trigger,
         fetchFeesAndCompose,
+        tradingReceiveAddress,
     } = context;
 
     const cryptoInfo = useTradingExchangeCryptoAndProviderInfo();
@@ -177,6 +178,25 @@ export const ApproveModal = ({
         setIsWaitingForDevice(false);
     };
 
+    const onRefreshClick = async () => {
+        const { receiveAddress } = tradingReceiveAddress;
+        if (!receiveAddress) return;
+
+        analytics.report({
+            type: EventType.TradingExchangeApproval,
+            payload: {
+                type: 'approve-modal',
+                action: 'refresh',
+                ...cryptoInfo,
+            },
+        });
+
+        await context.confirmTrade({
+            receiveAddress,
+            trade: { ...selectedQuote, status: 'CONFIRM' },
+        });
+    };
+
     const onClose = (isSubmitting?: boolean) => {
         analytics.report({
             type: EventType.TradingExchangeApproval,
@@ -220,6 +240,17 @@ export const ApproveModal = ({
                             onClick={confirmAndSend}
                         >
                             <Translation id="TR_CONTINUE" />
+                        </Modal.Button>
+                    )}
+
+                    {selectedQuote.status === 'ERROR' && (
+                        <Modal.Button
+                            size="medium"
+                            isLoading={isFormLoading}
+                            isDisabled={!device?.connected || isFormLoading}
+                            onClick={onRefreshClick}
+                        >
+                            <Translation id="TR_EXCHANGE_APPROVAL_FORM_REFRESH_BUTTON" />
                         </Modal.Button>
                     )}
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
@@ -69,6 +69,7 @@ export const RevokeModal = ({ setIsWaitingForDevice, onCancel }: RevokeModalProp
         getValues,
         changeFeeLevel,
         trigger,
+        tradingReceiveAddress,
     } = context;
 
     const cryptoInfo = useTradingExchangeCryptoAndProviderInfo();
@@ -102,6 +103,25 @@ export const RevokeModal = ({ setIsWaitingForDevice, onCancel }: RevokeModalProp
 
         setIsConfirmButtonLoading(false);
         setIsWaitingForDevice(false);
+    };
+
+    const onRefreshClick = async () => {
+        const { receiveAddress } = tradingReceiveAddress;
+        if (!receiveAddress) return;
+
+        analytics.report({
+            type: EventType.TradingExchangeApproval,
+            payload: {
+                type: 'revoke-modal',
+                action: 'refresh',
+                ...cryptoInfo,
+            },
+        });
+
+        await context.confirmTrade({
+            receiveAddress,
+            trade: { ...selectedQuote, status: 'CONFIRM' },
+        });
     };
 
     const onClose = (isSubmitting?: boolean) => {
@@ -140,14 +160,27 @@ export const RevokeModal = ({ setIsWaitingForDevice, onCancel }: RevokeModalProp
             }
             bottomContent={
                 <>
-                    <Modal.Button
-                        size="medium"
-                        isLoading={isFormLoading || isConfirmButtonLoading}
-                        isDisabled={!device?.connected}
-                        onClick={confirmAndSend}
-                    >
-                        <Translation id="TR_CONTINUE" />
-                    </Modal.Button>
+                    {selectedQuote.status === 'CONFIRM' && (
+                        <Modal.Button
+                            size="medium"
+                            isLoading={isFormLoading || isConfirmButtonLoading}
+                            isDisabled={!device?.connected}
+                            onClick={confirmAndSend}
+                        >
+                            <Translation id="TR_CONTINUE" />
+                        </Modal.Button>
+                    )}
+
+                    {selectedQuote.status === 'ERROR' && (
+                        <Modal.Button
+                            size="medium"
+                            isLoading={isFormLoading}
+                            isDisabled={!device?.connected || isFormLoading}
+                            onClick={onRefreshClick}
+                        >
+                            <Translation id="TR_EXCHANGE_APPROVAL_FORM_REFRESH_BUTTON" />
+                        </Modal.Button>
+                    )}
 
                     <Modal.Button size="medium" variant="tertiary" onClick={() => onClose()}>
                         <Translation id="TR_CANCEL" />

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -390,7 +390,7 @@ export type SuiteAnalyticsEvent =
           type: EventType.TradingExchangeApproval;
           payload: {
               type: 'approve-modal';
-              action: 'continue' | 'cancel' | 'limit-exact' | 'limit-unlimited';
+              action: 'continue' | 'cancel' | 'refresh' | 'limit-exact' | 'limit-unlimited';
 
               sendCryptoLabel?: string;
               sendCryptoNetworkSymbol?: string;
@@ -408,7 +408,7 @@ export type SuiteAnalyticsEvent =
           type: EventType.TradingExchangeApproval;
           payload: {
               type: 'revoke-modal';
-              action: 'continue' | 'cancel';
+              action: 'continue' | 'cancel' | 'refresh';
 
               sendCryptoLabel?: string;
               sendCryptoNetworkSymbol?: string;


### PR DESCRIPTION
## Description

In case of quote error, show `Refresh` button in approve/revoke modal to refresh the quote.
Also add `refresh` analytics event.

## Related Issue

Resolve #20988 

## Screenshots:

Approve modal:

<img width="100%" alt="Screenshot 2025-10-22 at 13 21 52" src="https://github.com/user-attachments/assets/4bb98267-a590-475b-be9b-e85f82e885e6" />

Revoke modal:

<img width="100%" alt="Screenshot 2025-10-22 at 13 21 28" src="https://github.com/user-attachments/assets/e6ec8551-7c45-467c-9aa0-c92a73833c84" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/approval&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/approval&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/approval&lookback=7)