### PR TITLE
fix(suite): Fix find trezor button with webusb

### DIFF
--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -14,6 +14,8 @@ import { BluetoothConnectionModal } from './BluetoothConnectionModal';
 import { CantSeeTrezorModal } from './CantSeeTrezorModal';
 import { CableConnectionAnimation } from './DeviceConnectionAnimation';
 import { useConnectionGlobalModalContext } from './context/ConnectionGlobalModalContext';
+import { selectHasTransportOfType } from '../../selectors/suite/suiteSelectors';
+import { WebUsbButton } from '../suite/WebUsbButton';
 import { BluetoothDeviceList } from '../suite/bluetooth/BluetoothDeviceList';
 import { UnpairBluetoothDeviceFromOsModal } from '../suite/bluetooth/UnpairBluetoothDeviceFromOsModal';
 
@@ -60,7 +62,7 @@ const ConnectModalContent = ({ children, isBluetoothMode }: ConnectModalContentP
 
 export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void }) => {
     const theme = useTheme();
-
+    const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
     const {
         toggleBluetoothMode,
         toggleShowHints,
@@ -166,6 +168,8 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
                             <Translation id="TR_PAIR_NEW_BLUETOOTH_DEVICE" />
                         </Button>
                     )}
+
+                    {isWebUsbTransport && <WebUsbButton variant="primary" size="medium" />}
                 </ConnectModalContent>
             </Modal.ModalBase>
         </Modal.Backdrop>

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
@@ -1,32 +1,17 @@
 import { Button, Column } from '@trezor/components';
 
 import { toggleConnectionModal } from 'src/actions/device/deviceSlice';
-import { WebUsbButton } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
-import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectHasTransportOfType } from 'src/selectors/suite/suiteSelectors';
+import { useDispatch } from 'src/hooks/suite';
 
 export const DeviceConnect = () => {
     const dispatch = useDispatch();
-    const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
 
     return (
         <Column alignItems="center" margin={{ bottom: 40 }}>
-            {isWebUsbTransport ? (
-                <WebUsbButton
-                    size="medium"
-                    data-testid="@webusb-button"
-                    translationId="TR_CHECK_FOR_DEVICES"
-                />
-            ) : (
-                <Button
-                    minWidth={240}
-                    size="large"
-                    onClick={() => dispatch(toggleConnectionModal())}
-                >
-                    <Translation id="TR_CONNECT" />
-                </Button>
-            )}
+            <Button minWidth={240} size="large" onClick={() => dispatch(toggleConnectionModal())}>
+                <Translation id="TR_CONNECT" />
+            </Button>
         </Column>
     );
 };

--- a/packages/suite/src/components/suite/WebUsbButton.tsx
+++ b/packages/suite/src/components/suite/WebUsbButton.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonProps, IconButton, Tooltip } from '@trezor/components';
+import { Button, ButtonProps } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
 import type TrezorConnectWeb from '@trezor/connect-web';
 
@@ -17,7 +17,7 @@ const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
 export const WebUsbButton = ({
     translationId = 'TR_CHECK_FOR_DEVICES',
     icon = 'magnifyingGlass',
-    size = 'tiny',
+    size = 'small',
     variant = 'primary',
     ...rest
 }: WebUsbButtonProps) => (
@@ -31,24 +31,5 @@ export const WebUsbButton = ({
         >
             <Translation id={translationId} />
         </Button>
-    </div>
-);
-
-export const WebUsbIconButton = ({
-    translationId = 'TR_CHECK_FOR_DEVICES',
-    size = 'tiny',
-    variant = 'primary',
-    ...rest
-}: WebUsbButtonProps) => (
-    <div data-testid="web-usb-button">
-        <Tooltip content={<Translation id={translationId} />}>
-            <IconButton
-                {...rest}
-                icon="magnifyingGlass"
-                variant={variant}
-                size={size}
-                onClick={handleClick}
-            />
-        </Tooltip>
     </div>
 );

--- a/packages/suite/src/views/suite/SwitchDevice/CardWithDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/CardWithDevice.tsx
@@ -27,7 +27,6 @@ export const CardWithDevice = ({
     onCancel,
     device,
     onBackButtonClick,
-    isFindTrezorVisible,
     isDeviceStatusVisible,
 }: CardWithDeviceProps) => {
     const deviceStatus = deviceUtils.getStatus(device);
@@ -39,7 +38,6 @@ export const CardWithDevice = ({
         <Card paddingType="none">
             <Column gap={spacings.md} margin={spacings.xs}>
                 <DeviceHeader
-                    isFindTrezorVisible={isFindTrezorVisible}
                     onCancel={onCancel}
                     device={device}
                     onBackButtonClick={onBackButtonClick}

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeader.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeader.tsx
@@ -1,23 +1,17 @@
 import { ReactNode } from 'react';
 
 import { getDeviceInternalModel } from '@suite-common/suite-utils';
-import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { IconButton, Row, TOOLTIP_DELAY_LONG, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { WebUsbButton } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
-import { WebUsbIconButton } from 'src/components/suite/WebUsbButton';
 import { DeviceStatus } from 'src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus';
-import { useSelector } from 'src/hooks/suite';
-import { selectHasTransportOfType } from 'src/selectors/suite/suiteSelectors';
 import { ForegroundAppProps, TrezorDevice } from 'src/types/suite';
 
 type DeviceHeaderProps = {
     device: TrezorDevice;
     onCancel?: ForegroundAppProps['onCancel'];
     onBackButtonClick?: () => void;
-    isFindTrezorVisible?: boolean;
     isDeviceStatusVisible?: boolean;
     actions?: ReactNode | null;
 };
@@ -26,13 +20,9 @@ export const DeviceHeader = ({
     onCancel,
     device,
     onBackButtonClick,
-    isFindTrezorVisible = false,
     isDeviceStatusVisible = true,
     actions,
 }: DeviceHeaderProps) => {
-    const selectedDevice = useSelector(selectSelectedDevice);
-    const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
-    const isDeviceConnected = selectedDevice?.connected === true;
     const deviceModelInternal = getDeviceInternalModel(device);
 
     const isDefaultCancelVisible = !actions && actions !== null && onCancel;
@@ -67,13 +57,6 @@ export const DeviceHeader = ({
             )}
 
             <Row gap={spacings.xxs} margin={{ left: 'auto' }}>
-                {isWebUsbTransport &&
-                    isFindTrezorVisible &&
-                    (isDeviceConnected ? (
-                        <WebUsbIconButton variant="tertiary" size="small" />
-                    ) : (
-                        <WebUsbButton variant="primary" size="tiny" />
-                    ))}
                 {isDefaultCancelVisible && (
                     <Tooltip delayShow={TOOLTIP_DELAY_LONG} content={<Translation id="TR_CLOSE" />}>
                         <IconButton

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -79,7 +79,6 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
 
     return (
         <CardWithDevice
-            isFindTrezorVisible
             onCancel={onCancel}
             device={device}
             actions={null} // Do not show close button


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

### before (web)

welcome screen when no trezor remembered (has find button):

<img width="1105" height="745" alt="image" src="https://github.com/user-attachments/assets/e6e731c4-cf40-421c-b275-4a8cf97dd5de" />

open wallet switcher (has find button):
<img width="411" height="361" alt="image" src="https://github.com/user-attachments/assets/f2ee98c8-e785-4185-bd1d-a6a050cd9edc" />


open wallet switcher when selected device connected (has tertiary find icon button):

<img width="415" height="339" alt="image" src="https://github.com/user-attachments/assets/6b8f8335-9975-484f-978c-35fb411d9174" />


connect trezor modal (no find button):

<img width="595" height="921" alt="image" src="https://github.com/user-attachments/assets/e30cac09-cdb6-4d11-a0be-5463ad44150e" />


### after (web)

welcome screen when no trezor remembered (no find button):

<img width="1101" height="760" alt="image" src="https://github.com/user-attachments/assets/11447345-8dc2-48ec-be05-38290b9d95aa" />


open wallet switcher (no find button):

<img width="518" height="600" alt="image" src="https://github.com/user-attachments/assets/2b655e7c-5c23-4109-9cd7-3ae58b04905d" />

connect trezor modal (new find button):

<img width="596" height="996" alt="image" src="https://github.com/user-attachments/assets/c63d4a87-6bf4-4d5c-a483-f4176cbd4a35" />


