### PR TITLE
Feat/make japanese official

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/Language.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Language.tsx
@@ -22,6 +22,12 @@ const onlyOfficial = (locale: [string, LocaleInfo]): locale is [Locale, LocaleIn
 const onlyCommunity = (locale: [string, LocaleInfo]): locale is [Locale, LocaleInfo] =>
     locale[1].type === 'community';
 
+const getOptions = (filterPolicy: (locale: [string, LocaleInfo]) => boolean) =>
+    typedObjectEntries(LANGUAGES)
+        .filter(filterPolicy)
+        .map(([value, { name }]) => ({ value, label: name }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+
 const useLanguageOptions = () => {
     const { translationString } = useTranslation();
     const systemOption = useMemo(
@@ -38,15 +44,11 @@ const useLanguageOptions = () => {
             },
             {
                 label: translationString('TR_OFFICIAL_LANGUAGES'),
-                options: typedObjectEntries(LANGUAGES)
-                    .filter(onlyOfficial)
-                    .map(([value, { name }]) => ({ value, label: name })),
+                options: getOptions(onlyOfficial),
             },
             {
                 label: translationString('TR_COMMUNITY_LANGUAGES'),
-                options: typedObjectEntries(LANGUAGES)
-                    .filter(onlyCommunity)
-                    .map(([value, { name }]) => ({ value, label: name })),
+                options: getOptions(onlyCommunity),
             },
         ],
         [systemOption, translationString],

--- a/suite-common/suite-types/src/languages.ts
+++ b/suite-common/suite-types/src/languages.ts
@@ -14,7 +14,7 @@ export const LANGUAGES = {
     'fr-FR': { name: 'Français', en: 'French', type: 'official' },
     'hu-HU': { name: 'Magyar', en: 'Hungarian', type: 'community' },
     'it-IT': { name: 'Italiano', en: 'Italian', type: 'community' },
-    'ja-JP': { name: '日本語', en: 'Japanese', type: 'community' },
+    'ja-JP': { name: '日本語', en: 'Japanese', type: 'official' },
     'pt-BR': { name: 'Português (BR)', en: 'Portuguese (BR)', type: 'official' },
     'ru-RU': { name: 'Русский', en: 'Russian', type: 'community' },
     'tr-TR': { name: 'Türkçe', en: 'Turkish', type: 'community' },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add Japanese as official language
- Order languages alphabetically

## Related Issue

Resolve https://satoshilabs.slack.com/archives/C04FLM3PZAB/p1761134265130969

## Screenshots:
before:
<img width="217" height="394" alt="Screenshot 2025-10-22 at 14 36 07" src="https://github.com/user-attachments/assets/61a6f31d-402e-4672-b94c-e9b8dd31d154" />

after:
<img width="214" height="401" alt="Screenshot 2025-10-22 at 14 35 44" src="https://github.com/user-attachments/assets/4bb85402-a283-4a4b-b8f2-fb7833f00ad0" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/make-japanese-official&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/make-japanese-official&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/make-japanese-official&lookback=7)