### PR TITLE
chore(transport-bluetooth): update `btleplug` dependency

### DIFF
--- a/packages/transport-bluetooth/Cargo.lock
+++ b/packages/transport-bluetooth/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "btleplug"
 version = "0.11.8"
-source = "git+https://github.com/trezor/btleplug?rev=7a479f259fc56006c096bbdf9c82e256aa25ad17#7a479f259fc56006c096bbdf9c82e256aa25ad17"
+source = "git+https://github.com/trezor/btleplug?rev=f66eb37ca293bea1708264a319ec02b14e7935ab#f66eb37ca293bea1708264a319ec02b14e7935ab"
 dependencies = [
  "async-trait",
  "bitflags",

--- a/packages/transport-bluetooth/Cargo.toml
+++ b/packages/transport-bluetooth/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "^1.0.140"
 tokio = { version = "^1.44.0", features = ["sync", "rt", "macros", "rt-multi-thread", "io-util"] }
 thiserror = "^2.0.16"
 
-btleplug = { git = "https://github.com/trezor/btleplug", rev="7a479f259fc56006c096bbdf9c82e256aa25ad17" }
+btleplug = { git = "https://github.com/trezor/btleplug", rev="f66eb37ca293bea1708264a319ec02b14e7935ab" }
 # btleplug = "0.11.8"
 dashmap = "6.1.0"
 uuid = "1.6.1"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
update `btleplug` dependency with fixed bluez (linux) [device disconnection](https://github.com/deviceplug/btleplug/pull/446) bug.

yet this is still [our fork](https://github.com/trezor/btleplug/commits/upstream/441/) rebased

related to https://github.com/trezor/trezor-suite/issues/17835


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/update-btleplug&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/update-btleplug&lookback=7)