### PR TITLE
Bank account selection for trade sell

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2384,6 +2384,12 @@ export const messages = {
                 bankTransfer: 'Bank Transfer',
                 creditCard: 'Credit/Debit Card',
             },
+            bankAccount: 'Bank account',
+            verified: 'Verified',
+            notVerified: 'Not verified',
+            bankAccountSheetTitle: {
+                title: 'Select an account',
+            },
         },
         tradingExchangeApprovalScreen: {
             title: 'Set {symbol} spending',

--- a/suite-native/module-trading/src/__fixtures__/bankAccounts.ts
+++ b/suite-native/module-trading/src/__fixtures__/bankAccounts.ts
@@ -1,0 +1,25 @@
+import type { BankAccount } from 'invity-api';
+
+export const bankAccounts: BankAccount[] = [
+    {
+        bankAccount: 'CZ6508000000192000145399',
+        bic: 'GIBACZPX',
+        holder: 'John Doe',
+        verified: true,
+    },
+    {
+        bankAccount: 'CZ6508000000192000145400',
+        bic: 'GIBACZPX',
+        holder: 'Jane Smith',
+        verified: false,
+    },
+    {
+        bankAccount: 'CZ6508000000192000145401',
+        bic: 'GIBACZPX',
+        holder: 'Bob Johnson',
+        verified: true,
+    },
+];
+
+export const verifiedBankAccount: BankAccount = bankAccounts[0];
+export const unverifiedBankAccount: BankAccount = bankAccounts[1];

--- a/suite-native/module-trading/src/__fixtures__/sellQuotes.ts
+++ b/suite-native/module-trading/src/__fixtures__/sellQuotes.ts
@@ -1,5 +1,7 @@
 import type { SellFiatTrade } from 'invity-api';
 
+import { bankAccounts } from './bankAccounts';
+
 export const sellQuotes = [
     {
         amountInCrypto: false,
@@ -39,6 +41,7 @@ export const sellQuotes = [
         paymentMethodName: 'Bank Transfer',
         rate: 3937.6279729091198,
         tags: ['wantFiat'],
+        bankAccounts,
     },
     {
         amountInCrypto: false,

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountItem.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountItem.tsx
@@ -1,0 +1,83 @@
+import type { BankAccount } from 'invity-api';
+
+import { sellUtils } from '@suite-common/trading';
+import { HStack, Radio, Text, VStack } from '@suite-native/atoms';
+import { Icon } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+import { exhaustive } from '@trezor/type-utils';
+
+import { TradeInfoRow } from '../../../TradeInfo/TradeInfoRow';
+
+export type AccessoryType = 'caret' | 'select' | 'none';
+
+export type SellBankAccountItemP = {
+    bankAccount: BankAccount;
+    accessoryType: AccessoryType;
+    noBorder?: boolean;
+    isSelected?: boolean;
+    onPress?: () => void;
+};
+
+export type AccessoryViewProps = {
+    accessoryType: AccessoryType;
+    isSelected: boolean;
+    onPress: () => void;
+};
+
+export const BANK_ACCOUNT_ITEM_TEST_ID = '@trading/sell/bank-account-item';
+
+const AccessoryView = ({ accessoryType, isSelected, onPress }: AccessoryViewProps) => {
+    switch (accessoryType) {
+        case 'caret':
+            return <Icon name="caretRight" size="medium" testID="caret-right-icon" />;
+        case 'select':
+            return (
+                <Radio
+                    value="select"
+                    onPress={onPress}
+                    isChecked={isSelected}
+                    testID="radio-button-select"
+                />
+            );
+        case 'none':
+            return null;
+
+        default:
+            return exhaustive(accessoryType);
+    }
+};
+
+export const SellBankAccountItem = ({
+    bankAccount,
+    isSelected = false,
+    accessoryType,
+    noBorder = false,
+    onPress = () => {},
+}: SellBankAccountItemP) => (
+    <TradeInfoRow onPress={onPress} noBorder={noBorder} testID={BANK_ACCOUNT_ITEM_TEST_ID}>
+        <VStack spacing={0}>
+            <Text variant="hint">{bankAccount.holder}</Text>
+            <Text variant="hint" color="textSubdued">
+                {sellUtils.formatIban(bankAccount.bankAccount)}
+            </Text>
+            {bankAccount.verified ? (
+                <HStack spacing="sp8">
+                    <Icon
+                        name="check"
+                        size="mediumLarge"
+                        testID="check-icon"
+                        color="iconPrimaryDefault"
+                    />
+                    <Text variant="hint" color="textPrimaryDefault">
+                        <Translation id="moduleTrading.tradingSellPreviewScreen.verified" />
+                    </Text>
+                </HStack>
+            ) : (
+                <Text variant="hint" color="textSubdued">
+                    <Translation id="moduleTrading.tradingSellPreviewScreen.notVerified" />
+                </Text>
+            )}
+        </VStack>
+        <AccessoryView accessoryType={accessoryType} isSelected={isSelected} onPress={onPress} />
+    </TradeInfoRow>
+);

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountPicker.tsx
@@ -1,0 +1,99 @@
+import { memo } from 'react';
+import { useSelector } from 'react-redux';
+
+import type { BankAccount } from 'invity-api';
+
+import {
+    TradingRootState,
+    selectTradingAccountKeyByTradeType,
+    selectTradingTradeByOrderId,
+} from '@suite-common/trading';
+import { AnimatedCard, useBottomSheetModal } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+import { SellBankAccountItem } from './SellBankAccountItem';
+import { SellBankAccountSheet } from './SellBankAccountSheet';
+import { useWatchTrade } from '../../../../hooks/general/useWatchTrade';
+import { TradeInfoHeader } from '../../../TradeInfo/TradeInfoHeader';
+
+type SellBankAccountPickerProps = {
+    orderId: string | undefined;
+    selectedBankAccountIban: string;
+    onBankAccountSelect: (bankAccount: BankAccount) => void;
+};
+
+type MemoizedSellBankAccountPickerProps = {
+    bankAccount: BankAccount;
+    onPress?: () => void;
+    hasCaret: boolean;
+};
+
+// memoize the component because useWatchTrade needs useTimer and it causes re-renders
+const MemoizedSellBankAccountPicker = memo(
+    ({ bankAccount, onPress = () => {}, hasCaret }: MemoizedSellBankAccountPickerProps) => (
+        <AnimatedCard noPadding>
+            <TradeInfoHeader
+                title={<Translation id="moduleTrading.tradingSellPreviewScreen.bankAccount" />}
+            />
+            <SellBankAccountItem
+                bankAccount={bankAccount}
+                accessoryType={hasCaret ? 'caret' : 'none'}
+                onPress={onPress}
+            />
+        </AnimatedCard>
+    ),
+);
+
+export const SellBankAccountPicker = ({
+    orderId,
+    selectedBankAccountIban,
+    onBankAccountSelect,
+}: SellBankAccountPickerProps) => {
+    const trade = useSelector((state: TradingRootState) =>
+        selectTradingTradeByOrderId(state, orderId),
+    );
+
+    const accountKey = useSelector((state: TradingRootState) =>
+        selectTradingAccountKeyByTradeType(state, 'sell'),
+    );
+
+    useWatchTrade({
+        accountKey,
+        orderId,
+        isInProgress: true,
+    });
+    const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
+
+    if (
+        trade?.tradeType !== 'sell' ||
+        !trade.data.bankAccounts ||
+        trade.data.bankAccounts.length === 0
+    ) {
+        return null;
+    }
+
+    const { bankAccounts } = trade.data;
+
+    const handleBankAccountSelect = (bankAccount: BankAccount) => {
+        onBankAccountSelect(bankAccount);
+        closeModal();
+    };
+
+    return (
+        <>
+            <MemoizedSellBankAccountPicker
+                bankAccount={bankAccounts[0]}
+                onPress={openModal}
+                hasCaret={bankAccounts.length > 1}
+            />
+
+            <SellBankAccountSheet
+                ref={bottomSheetRef}
+                bankAccounts={bankAccounts}
+                selectedBankAccountIban={selectedBankAccountIban}
+                onBankAccountSelect={handleBankAccountSelect}
+                closeModal={closeModal}
+            />
+        </>
+    );
+};

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountSheet.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountSheet.tsx
@@ -1,0 +1,49 @@
+import { forwardRef } from 'react';
+
+import { BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
+import type { BankAccount } from 'invity-api';
+
+import { BottomSheetModal, Card, VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+import { SellBankAccountItem } from './SellBankAccountItem';
+
+type SellBankAccountSheetProps = {
+    bankAccounts: BankAccount[];
+    selectedBankAccountIban: string;
+    onBankAccountSelect: (bankAccount: BankAccount) => void;
+    closeModal: () => void;
+};
+
+export const SellBankAccountSheet = forwardRef<BottomSheetModalMethods, SellBankAccountSheetProps>(
+    ({ bankAccounts, selectedBankAccountIban, onBankAccountSelect, closeModal }, ref) => {
+        const handleBankAccountPress = (bankAccount: BankAccount) => {
+            onBankAccountSelect(bankAccount);
+            closeModal();
+        };
+
+        return (
+            <BottomSheetModal
+                ref={ref}
+                title={
+                    <Translation id="moduleTrading.tradingSellPreviewScreen.bankAccountSheetTitle" />
+                }
+                isCloseDisplayed
+            >
+                <VStack spacing="sp12" paddingHorizontal="sp12">
+                    {bankAccounts.map(bankAccount => (
+                        <Card key={bankAccount.bankAccount} noPadding>
+                            <SellBankAccountItem
+                                bankAccount={bankAccount}
+                                accessoryType="select"
+                                noBorder={true}
+                                isSelected={selectedBankAccountIban === bankAccount.bankAccount}
+                                onPress={() => handleBankAccountPress(bankAccount)}
+                            />
+                        </Card>
+                    ))}
+                </VStack>
+            </BottomSheetModal>
+        );
+    },
+);

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountItem.comp.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+
+import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
+
+import { bankAccounts } from '../../../../../__fixtures__/bankAccounts';
+import { BANK_ACCOUNT_ITEM_TEST_ID, SellBankAccountItem } from '../SellBankAccountItem';
+
+describe('SellBankAccountItem', () => {
+    const verifiedBankAccount = bankAccounts[0]; // John Doe - verified
+    const unverifiedBankAccount = bankAccounts[1]; // Jane Smith - not verified
+
+    const renderSellBankAccountItem = (props = {}) =>
+        renderWithBasicProvider(
+            <SellBankAccountItem
+                bankAccount={verifiedBankAccount}
+                accessoryType="none"
+                {...props}
+            />,
+        );
+
+    describe('Rendering', () => {
+        it('should render bank account holder name', () => {
+            const { getByText } = renderSellBankAccountItem();
+
+            expect(getByText('John Doe')).toBeOnTheScreen();
+        });
+
+        it('should render formatted IBAN', () => {
+            const { getByText } = renderSellBankAccountItem();
+
+            expect(getByText('CZ65 0800 0000 1920 0014 5399')).toBeOnTheScreen();
+        });
+
+        it('should render verified status for verified bank account', () => {
+            const { getByText, getByTestId } = renderSellBankAccountItem({
+                bankAccount: verifiedBankAccount,
+            });
+
+            expect(getByText('Verified')).toBeOnTheScreen();
+            expect(getByTestId('check-icon')).toBeOnTheScreen();
+        });
+
+        it('should render not verified status for unverified bank account', () => {
+            const { getByText, queryByTestId } = renderSellBankAccountItem({
+                bankAccount: unverifiedBankAccount,
+            });
+
+            expect(getByText('Not verified')).toBeOnTheScreen();
+            expect(queryByTestId('check-icon')).not.toBeOnTheScreen();
+        });
+    });
+
+    describe('Accessory Types', () => {
+        it('should render caret accessory', () => {
+            const { getByTestId } = renderSellBankAccountItem({
+                accessoryType: 'caret',
+            });
+
+            expect(getByTestId('caret-right-icon')).toBeOnTheScreen();
+        });
+
+        it('should render select accessory (radio button)', () => {
+            const { getByTestId } = renderSellBankAccountItem({
+                accessoryType: 'select',
+                isSelected: false,
+            });
+
+            expect(getByTestId('radio-button-select')).toBeOnTheScreen();
+        });
+
+        it('should render no accessory', () => {
+            const { queryByTestId } = renderSellBankAccountItem({
+                accessoryType: 'none',
+            });
+
+            expect(queryByTestId('caret-right-icon')).not.toBeOnTheScreen();
+            expect(queryByTestId('radio-button-select')).not.toBeOnTheScreen();
+        });
+    });
+
+    describe('User Interactions', () => {
+        it('should call onPress when pressed', async () => {
+            const mockOnPress = jest.fn();
+            const { getByTestId } = renderSellBankAccountItem({
+                onPress: mockOnPress,
+            });
+
+            await userEvent.press(getByTestId(BANK_ACCOUNT_ITEM_TEST_ID));
+
+            expect(mockOnPress).toHaveBeenCalledTimes(1);
+        });
+
+        it('should call onPress when radio button is pressed', async () => {
+            const mockOnPress = jest.fn();
+            const { getByTestId } = renderSellBankAccountItem({
+                accessoryType: 'select',
+                onPress: mockOnPress,
+            });
+
+            // Since Radio is a TouchableOpacity, we can press the main component
+            // The onPress will be called through the AccessoryView
+            await userEvent.press(getByTestId(BANK_ACCOUNT_ITEM_TEST_ID));
+
+            expect(mockOnPress).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountPicker.comp.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+
+import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { bankAccounts } from '../../../../../__fixtures__/bankAccounts';
+import { getWalletState } from '../../../../../__fixtures__/walletState';
+import { SellBankAccountPicker } from '../SellBankAccountPicker';
+
+// Mock the useWatchTrade hook since it's complex and not the focus of this test
+jest.mock('../../../../../hooks/general/useWatchTrade', () => ({
+    useWatchTrade: jest.fn(),
+}));
+
+// Mock the SellBankAccountSheet component to isolate the picker component
+jest.mock('../SellBankAccountSheet', () => ({
+    SellBankAccountSheet: jest.fn().mockImplementation(() => <div>Bank Account Sheet</div>),
+}));
+
+describe('SellBankAccountPicker', () => {
+    const mockOnBankAccountSelect = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('Conditional Rendering', () => {
+        it('should not render when no bank accounts are available', async () => {
+            const preloadedState: PreloadedState = {
+                wallet: getWalletState({ tradeType: 'sell' }),
+            };
+
+            preloadedState.wallet!.trading!.sell!.tradingAccountKey = 'eth-account-1';
+            preloadedState.wallet!.trading!.trades = [
+                {
+                    tradeType: 'sell',
+                    data: {
+                        orderId: 'order_id_1',
+                        bankAccounts: [], // No bank accounts
+                    },
+                },
+            ];
+
+            const { queryByTestId } = await renderWithStoreProviderAsync(
+                <SellBankAccountPicker
+                    orderId="order_id_1"
+                    selectedBankAccountIban=""
+                    onBankAccountSelect={mockOnBankAccountSelect}
+                />,
+                { preloadedState },
+            );
+
+            expect(queryByTestId('@trading/sell/bank-account-item')).not.toBeOnTheScreen();
+        });
+
+        it('should not render when bankAccounts is undefined', async () => {
+            const preloadedState: PreloadedState = {
+                wallet: getWalletState({ tradeType: 'sell' }),
+            };
+
+            preloadedState.wallet!.trading!.sell!.tradingAccountKey = 'eth-account-1';
+            preloadedState.wallet!.trading!.trades = [
+                {
+                    tradeType: 'sell',
+                    data: {
+                        orderId: 'order_id_1',
+                        bankAccounts: undefined, // Undefined bank accounts
+                    },
+                },
+            ];
+
+            const { queryByTestId } = await renderWithStoreProviderAsync(
+                <SellBankAccountPicker
+                    orderId="order_id_1"
+                    selectedBankAccountIban=""
+                    onBankAccountSelect={mockOnBankAccountSelect}
+                />,
+                { preloadedState },
+            );
+
+            expect(queryByTestId('@trading/sell/bank-account-item')).not.toBeOnTheScreen();
+        });
+
+        it('should not render when orderId is undefined', async () => {
+            const preloadedState: PreloadedState = {
+                wallet: getWalletState({ tradeType: 'sell' }),
+            };
+
+            preloadedState.wallet!.trading!.sell!.tradingAccountKey = 'eth-account-1';
+            preloadedState.wallet!.trading!.trades = [
+                {
+                    tradeType: 'sell',
+                    data: {
+                        orderId: 'order_id_1',
+                        bankAccounts,
+                    },
+                },
+            ];
+
+            const { queryByTestId } = await renderWithStoreProviderAsync(
+                <SellBankAccountPicker
+                    orderId={undefined}
+                    selectedBankAccountIban={bankAccounts[0].bankAccount}
+                    onBankAccountSelect={mockOnBankAccountSelect}
+                />,
+                { preloadedState },
+            );
+
+            expect(queryByTestId('@trading/sell/bank-account-item')).not.toBeOnTheScreen();
+        });
+    });
+});

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountSheet.comp.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
+
+import { bankAccounts } from '../../../../../__fixtures__/bankAccounts';
+import { SellBankAccountSheet } from '../SellBankAccountSheet';
+
+describe('SellBankAccountSheet', () => {
+    const mockOnBankAccountSelect = jest.fn();
+    const mockCloseModal = jest.fn();
+    const mockRef = { current: null };
+
+    const renderSellBankAccountSheet = (props = {}) =>
+        renderWithBasicProvider(
+            <SellBankAccountSheet
+                ref={mockRef}
+                bankAccounts={bankAccounts}
+                selectedBankAccountIban={bankAccounts[0].bankAccount}
+                onBankAccountSelect={mockOnBankAccountSelect}
+                closeModal={mockCloseModal}
+                {...props}
+            />,
+        );
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('User Experience', () => {
+        it('should display all bank accounts', () => {
+            const { getByText } = renderSellBankAccountSheet();
+
+            // User should see bank account holder names
+            expect(getByText('John Doe')).toBeOnTheScreen();
+            expect(getByText('Jane Smith')).toBeOnTheScreen();
+            expect(getByText('Bob Johnson')).toBeOnTheScreen();
+        });
+
+        it('should allow user to select a bank account', async () => {
+            const { getByText } = renderSellBankAccountSheet();
+
+            // User should be able to tap on a bank account to select it
+            await userEvent.press(getByText('John Doe'));
+
+            expect(mockOnBankAccountSelect).toHaveBeenCalledWith(bankAccounts[0]);
+        });
+
+        it('should close the modal after user selects a bank account', async () => {
+            const { getByText } = renderSellBankAccountSheet();
+
+            // When user selects any bank account, modal should close
+            await userEvent.press(getByText('Jane Smith'));
+
+            expect(mockCloseModal).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.tsx
@@ -1,22 +1,37 @@
-import { memo } from 'react';
+import { memo, useState } from 'react';
 import Animated from 'react-native-reanimated';
+import { useSelector } from 'react-redux';
 
-import type { SellFiatTrade } from 'invity-api';
+import type { BankAccount } from 'invity-api';
 
+import { selectTradingSellFormStep, selectTradingSellSelectedQuote } from '@suite-common/trading';
 import { InlineAlertBox, VStack } from '@suite-native/atoms';
 
+import { SellBankAccountPicker } from './BankAccount/SellBankAccountPicker';
 import { SellFromAccountTradePreviewCard } from './SellFromAccountTradePreviewCard';
 import { SellToFiatTradePreviewCard } from './SellToFiatTradePreviewCard';
 import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
 
 export type SellPreviewViewProps = {
-    quote: SellFiatTrade | undefined;
     txnErrorString: string | null;
 };
 
-export const SellPreviewView = memo(({ quote, txnErrorString }: SellPreviewViewProps) => {
-    const { fromStringValue, toStringValue } = useChangeStringsExtractor(quote);
+export const SellPreviewView = memo(({ txnErrorString }: SellPreviewViewProps) => {
+    const formStep = useSelector(selectTradingSellFormStep);
+    const selectedQuote = useSelector(selectTradingSellSelectedQuote);
+    const { fromStringValue, toStringValue } = useChangeStringsExtractor(selectedQuote);
+    const [selectedBankAccountIban, setSelectedBankAccountIban] = useState(
+        selectedQuote?.bankAccounts?.[0].bankAccount,
+    );
+
     const isTxnError = !!txnErrorString;
+
+    const shouldSelectBankAccount = formStep === 'BANK_ACCOUNT';
+    const showBankAccountPicker = shouldSelectBankAccount && selectedBankAccountIban;
+
+    const handleBankAccountSelect = (bankAccount: BankAccount) => {
+        setSelectedBankAccountIban(bankAccount.bankAccount);
+    };
 
     return (
         <VStack spacing="sp20" paddingVertical="sp20">
@@ -25,8 +40,18 @@ export const SellPreviewView = memo(({ quote, txnErrorString }: SellPreviewViewP
                     <InlineAlertBox variant="critical" title={txnErrorString} />
                 </Animated.View>
             )}
-            <SellFromAccountTradePreviewCard quote={quote} fromStringValue={fromStringValue} />
-            <SellToFiatTradePreviewCard quote={quote} toStringValue={toStringValue} />
+            <SellFromAccountTradePreviewCard
+                quote={selectedQuote}
+                fromStringValue={fromStringValue}
+            />
+            <SellToFiatTradePreviewCard quote={selectedQuote} toStringValue={toStringValue} />
+            {showBankAccountPicker && (
+                <SellBankAccountPicker
+                    orderId={selectedQuote?.orderId}
+                    selectedBankAccountIban={selectedBankAccountIban}
+                    onBankAccountSelect={handleBankAccountSelect}
+                />
+            )}
         </VStack>
     );
 });

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewView.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewView.comp.test.tsx
@@ -1,21 +1,44 @@
 import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import { sellQuotes } from '../../../../__fixtures__/sellQuotes';
+import { getSellTrade } from '../../../../__fixtures__/trades';
 import { getWalletState } from '../../../../__fixtures__/walletState';
+import { BANK_ACCOUNT_ITEM_TEST_ID } from '../BankAccount/SellBankAccountItem';
 import { SellPreviewView, SellPreviewViewProps } from '../SellPreviewView';
 
 describe('SellPreviewView', () => {
-    const renderSellPreviewView = (props: Partial<SellPreviewViewProps> = {}) => {
+    const getSellTradeWithBankAccounts = () => ({
+        ...getSellTrade({ status: undefined }),
+        data: {
+            ...getSellTrade({ status: undefined }).data,
+            orderId: sellQuotes[1].orderId,
+            bankAccounts: sellQuotes[1].bankAccounts,
+        },
+    });
+
+    const getPreloadedSellState = (overrides: { formStep?: string }): PreloadedState => {
         const preloadedState: PreloadedState = {
             wallet: getWalletState({ tradeType: 'sell' }),
         };
         preloadedState.wallet!.trading!.composedTransactionInfo = { composed: { fee: '1000' } };
         preloadedState.wallet!.trading!.sell!.tradingAccountKey = 'eth-account-1';
+        preloadedState.wallet!.trading!.sell!.selectedQuote = sellQuotes[1]; // Use quote with bank accounts
+        preloadedState.wallet!.trading!.trades = [getSellTradeWithBankAccounts()];
 
-        return renderWithStoreProviderAsync(
-            <SellPreviewView quote={sellQuotes[0]} txnErrorString={null} {...props} />,
-            { preloadedState },
-        );
+        Object.assign(preloadedState.wallet!.trading!.sell!, overrides);
+
+        return preloadedState;
+    };
+
+    const renderSellPreviewView = (
+        props: Partial<SellPreviewViewProps> = {},
+        preloadedStateOverrides?: { formStep?: string },
+    ) => {
+        const preloadedState = getPreloadedSellState(preloadedStateOverrides ?? {});
+
+        return renderWithStoreProviderAsync(<SellPreviewView txnErrorString={null} {...props} />, {
+            preloadedState,
+        });
     };
 
     it('should render all sections except alert', async () => {
@@ -24,7 +47,7 @@ describe('SellPreviewView', () => {
         expect(getByText('From')).toBeOnTheScreen();
         expect(getByText('Ethereum #1')).toBeOnTheScreen();
         expect(getByText('To')).toBeOnTheScreen();
-        expect(getByText('Credit/Debit Card')).toBeOnTheScreen();
+        expect(getByText('Bank Transfer')).toBeOnTheScreen();
     });
 
     it('should render txnErrorString when isTxnError is true', async () => {
@@ -35,7 +58,29 @@ describe('SellPreviewView', () => {
         expect(getByText('From')).toBeOnTheScreen();
         expect(getByText('Ethereum #1')).toBeOnTheScreen();
         expect(getByText('To')).toBeOnTheScreen();
-        expect(getByText('Credit/Debit Card')).toBeOnTheScreen();
+        expect(getByText('Bank Transfer')).toBeOnTheScreen();
         expect(getByText('Transaction error occurred')).toBeOnTheScreen();
+    });
+
+    it('should not render bank account picker when form step is not BANK_ACCOUNT', async () => {
+        const { queryByTestId } = await renderSellPreviewView(
+            {},
+            {
+                formStep: 'SEND_TRANSACTION', // Not BANK_ACCOUNT
+            },
+        );
+
+        expect(queryByTestId(BANK_ACCOUNT_ITEM_TEST_ID)).not.toBeOnTheScreen();
+    });
+
+    it('should render bank account picker when form step is BANK_ACCOUNT', async () => {
+        const { getAllByTestId } = await renderSellPreviewView(
+            {},
+            {
+                formStep: 'BANK_ACCOUNT',
+            },
+        );
+
+        expect(getAllByTestId(BANK_ACCOUNT_ITEM_TEST_ID).length).toBeGreaterThan(0);
     });
 });

--- a/suite-native/module-trading/src/components/sell/SellPreview/index.ts
+++ b/suite-native/module-trading/src/components/sell/SellPreview/index.ts
@@ -2,3 +2,4 @@ export { SellPreviewScreenHeader } from './SellPreviewScreenHeader';
 export { SellPreviewView } from './SellPreviewView';
 export { SellFromAccountTradePreviewCard } from './SellFromAccountTradePreviewCard';
 export { SellToFiatTradePreviewCard } from './SellToFiatTradePreviewCard';
+export { SellBankAccountPicker } from './BankAccount/SellBankAccountPicker';

--- a/suite-native/module-trading/src/hooks/general/__tests__/useWatchTrade.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useWatchTrade.test.ts
@@ -1,0 +1,238 @@
+import {
+    PreloadedState,
+    initStore,
+    renderHookWithStoreProviderAsync,
+} from '@suite-native/test-utils';
+
+import { getBuyTrade } from '../../../__fixtures__/trades';
+import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
+import { useWatchTrade } from '../useWatchTrade';
+
+// Mock the useReloadTimer hook
+jest.mock('../useReloadTimer', () => ({
+    useReloadTimer: jest.fn(),
+}));
+
+// Mock analytics
+jest.mock('@suite-native/analytics', () => ({
+    analytics: {
+        report: jest.fn(),
+    },
+    EventType: {
+        TradingStatus: 'TradingStatus',
+    },
+}));
+
+// Mock trading thunks
+jest.mock('@suite-common/trading', () => ({
+    ...jest.requireActual('@suite-common/trading'),
+    tradingThunks: {
+        watchTradeThunk: jest.fn(() => ({ type: 'watchTradeThunk' })),
+    },
+}));
+
+const mockWatchTradeThunk = require('@suite-common/trading').tradingThunks.watchTradeThunk;
+
+const mockUseReloadTimer = require('../useReloadTimer').useReloadTimer;
+
+describe('useWatchTrade', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        // Default mock implementation
+        mockUseReloadTimer.mockReturnValue({
+            timer: {
+                reset: jest.fn(),
+            },
+            shouldReload: false,
+            resetCount: 0,
+        });
+    });
+
+    const getInitializedStore = async ({
+        trades = [],
+        accounts = [],
+    }: { trades?: any[]; accounts?: any[] } = {}) => {
+        const preloadedState: PreloadedState = {
+            wallet: {
+                trading: {
+                    ...getInitializedTradingState(),
+                    trades,
+                },
+                accounts:
+                    accounts.length > 0
+                        ? accounts
+                        : [
+                              {
+                                  key: 'btc1',
+                                  symbol: 'btc',
+                                  deviceState: 'device1@test:123',
+                                  descriptor: 'btc-descriptor',
+                                  addresses: { unused: [{ address: 'btc-address' }] },
+                                  visible: true,
+                              },
+                          ],
+            },
+            device: {
+                selectedDevice: {
+                    state: { staticSessionId: 'device1@test:123' },
+                },
+            },
+        };
+
+        return await initStore(preloadedState);
+    };
+
+    const renderUseWatchTrade = (
+        store: any,
+        props: { accountKey?: string; orderId?: string; isInProgress?: boolean },
+    ) =>
+        renderHookWithStoreProviderAsync(
+            () =>
+                useWatchTrade({
+                    accountKey: props.accountKey,
+                    orderId: props.orderId,
+                    isInProgress: props.isInProgress ?? false,
+                }),
+            { store },
+        );
+
+    describe('Trade Watching Behavior', () => {
+        it('should not dispatch watch trade thunk when no trade is found', async () => {
+            const store = await getInitializedStore();
+            await renderUseWatchTrade(store, {
+                accountKey: 'btc1',
+                orderId: 'non-existent-order',
+            });
+
+            expect(mockWatchTradeThunk).not.toHaveBeenCalled();
+        });
+
+        it('should not dispatch watch trade thunk when no account is found', async () => {
+            const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
+            const store = await getInitializedStore({
+                trades: [buyTrade],
+            });
+
+            await renderUseWatchTrade(store, {
+                accountKey: 'non-existent-account',
+                orderId: buyTrade.data.orderId,
+            });
+
+            expect(mockWatchTradeThunk).not.toHaveBeenCalled();
+        });
+
+        it('should dispatch watch trade thunk when trade and account are found', async () => {
+            const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
+            const store = await getInitializedStore({
+                trades: [buyTrade],
+            });
+
+            await renderUseWatchTrade(store, {
+                accountKey: 'btc1',
+                orderId: buyTrade.data.orderId,
+            });
+
+            expect(mockWatchTradeThunk).toHaveBeenCalledWith({
+                account: expect.objectContaining({ key: 'btc1' }),
+                trade: buyTrade,
+                refreshCount: 0,
+            });
+        });
+
+        it('should dispatch watch trade thunk when shouldReload is true', async () => {
+            const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
+            const store = await getInitializedStore({
+                trades: [buyTrade],
+            });
+
+            mockUseReloadTimer.mockReturnValue({
+                timer: {
+                    reset: jest.fn(),
+                },
+                shouldReload: true,
+                resetCount: 1,
+            });
+
+            await renderUseWatchTrade(store, {
+                accountKey: 'btc1',
+                orderId: buyTrade.data.orderId,
+            });
+
+            expect(mockWatchTradeThunk).toHaveBeenCalledWith({
+                account: expect.objectContaining({ key: 'btc1' }),
+                trade: buyTrade,
+                refreshCount: 1,
+            });
+        });
+
+        it('should not dispatch watch trade thunk when trade is in final status', async () => {
+            const buyTrade = getBuyTrade({ status: 'SUCCESS' });
+            const store = await getInitializedStore({
+                trades: [buyTrade],
+            });
+
+            await renderUseWatchTrade(store, {
+                accountKey: 'btc1',
+                orderId: buyTrade.data.orderId,
+            });
+
+            expect(mockWatchTradeThunk).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Timer Management', () => {
+        it('should use faster refresh rate when trade is in progress', async () => {
+            const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
+            const store = await getInitializedStore({
+                trades: [buyTrade],
+            });
+
+            await renderUseWatchTrade(store, {
+                accountKey: 'btc1',
+                orderId: buyTrade.data.orderId,
+                isInProgress: true,
+            });
+
+            expect(mockUseReloadTimer).toHaveBeenCalledWith({
+                isEnabled: true,
+                refreshLimitSeconds: 10, // REFRESH_SECONDS_IN_PROGRESS
+            });
+        });
+
+        it('should use slower refresh rate when trade is not in progress', async () => {
+            const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
+            const store = await getInitializedStore({
+                trades: [buyTrade],
+            });
+
+            await renderUseWatchTrade(store, {
+                accountKey: 'btc1',
+                orderId: buyTrade.data.orderId,
+                isInProgress: false,
+            });
+
+            expect(mockUseReloadTimer).toHaveBeenCalledWith({
+                isEnabled: true,
+                refreshLimitSeconds: 30, // REFRESH_SECONDS_BASE
+            });
+        });
+
+        it('should disable timer when trade is in final status', async () => {
+            const buyTrade = getBuyTrade({ status: 'SUCCESS' });
+            const store = await getInitializedStore({
+                trades: [buyTrade],
+            });
+
+            await renderUseWatchTrade(store, {
+                accountKey: 'btc1',
+                orderId: buyTrade.data.orderId,
+            });
+
+            expect(mockUseReloadTimer).toHaveBeenCalledWith({
+                isEnabled: false,
+                refreshLimitSeconds: 30,
+            });
+        });
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/useWatchTrade.ts
+++ b/suite-native/module-trading/src/hooks/general/useWatchTrade.ts
@@ -1,19 +1,20 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import {
     TradingTransaction,
     TradingTransactionBuy,
     TradingTransactionExchange,
     TradingTransactionSell,
-    TradingType,
+    selectTradingTradeByOrderId,
     tradeFinalStatuses,
     tradingThunks,
 } from '@suite-common/trading';
-import { Account } from '@suite-common/wallet-types';
+import { AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
 
 import { useReloadTimer } from './useReloadTimer';
+import { TradingRootState } from '../../reducers';
 import { getTradeStatusStep } from '../../utils/general/utils';
 
 export type TradingTradeMapProps = {
@@ -22,9 +23,9 @@ export type TradingTradeMapProps = {
     exchange: TradingTransactionExchange;
 };
 
-export interface TradingUseWatchTradeProps<T extends TradingType> {
-    account: Account | undefined;
-    trade: TradingTradeMapProps[T] | undefined;
+export interface TradingUseWatchTradeProps {
+    accountKey: string | undefined;
+    orderId: string | undefined;
     isInProgress: boolean;
 }
 const REFRESH_SECONDS_BASE = 30;
@@ -33,12 +34,14 @@ const REFRESH_SECONDS_IN_PROGRESS = 10;
 export const shouldRefreshTrade = (trade: TradingTransaction | undefined) =>
     trade && trade.data.status && !tradeFinalStatuses[trade.tradeType].includes(trade.data.status);
 
-export const useWatchTrade = <T extends TradingType>({
-    account,
-    trade,
-    isInProgress,
-}: TradingUseWatchTradeProps<T>) => {
+export const useWatchTrade = ({ accountKey, orderId, isInProgress }: TradingUseWatchTradeProps) => {
     const dispatch = useDispatch();
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+    const trade = useSelector((state: TradingRootState) =>
+        selectTradingTradeByOrderId(state, orderId),
+    );
     const shouldRefresh = useMemo(() => shouldRefreshTrade(trade), [trade]);
     const { timer, shouldReload, resetCount } = useReloadTimer({
         isEnabled: shouldRefresh,

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
@@ -12,21 +12,19 @@ import { SellFormType } from '../../../types/sell';
 import { useSellFlow } from '../useSellFlow';
 import { useSellForm } from '../useSellForm';
 
+// Store the thunk arguments for testing
+let capturedThunkArgs: any = null;
+
 jest.mock('@suite-common/trading', () => ({
     ...jest.requireActual('@suite-common/trading'),
     sellThunks: {
-        selectQuoteThunk: (payload: unknown) => ({
-            type: 'selectQuoteThunkMock',
-            payload,
-        }),
-        handleTradeThunk: (payload: unknown) => ({
-            type: 'handleTradeThunkMock',
-            payload,
-        }),
-        confirmTradeThunk: (payload: unknown) => ({
-            type: 'confirmTradeThunkMock',
-            payload,
-        }),
+        selectQuoteThunk: (args: any) => {
+            capturedThunkArgs = args;
+
+            return () => args;
+        },
+        handleTradeThunk: (args: unknown) => () => args,
+        confirmTradeThunk: (args: unknown) => () => args,
     },
 }));
 
@@ -44,6 +42,7 @@ describe('useSellFlow', () => {
 
         const { result } = await renderSellForm();
         sellForm = result.current;
+        capturedThunkArgs = null; // Reset before each test
     });
 
     describe('canProceed', () => {
@@ -98,15 +97,13 @@ describe('useSellFlow', () => {
                     }),
                 );
             });
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
             const { result } = await renderUseSellFlow();
 
             act(() => {
                 result.current.selectQuote();
             });
 
-            const dispatchCall = dispatchSpy.mock.calls[0][0];
-            const { userConsent } = dispatchCall.payload;
+            const { userConsent } = capturedThunkArgs;
 
             act(() => {
                 userConsent({
@@ -134,15 +131,13 @@ describe('useSellFlow', () => {
         });
 
         it('should resolve consent', async () => {
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
             const { result } = await renderUseSellFlow();
 
             act(() => {
                 result.current.selectQuote();
             });
 
-            const dispatchCall = dispatchSpy.mock.calls[0][0];
-            const { userConsent } = dispatchCall.payload;
+            const { userConsent } = capturedThunkArgs;
 
             act(() => {
                 userConsent({
@@ -176,15 +171,13 @@ describe('useSellFlow', () => {
         });
 
         it('should resolve consent (with false value)', async () => {
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
             const { result } = await renderUseSellFlow();
 
             act(() => {
                 result.current.selectQuote();
             });
 
-            const dispatchCall = dispatchSpy.mock.calls[0][0];
-            const { userConsent } = dispatchCall.payload;
+            const { userConsent } = capturedThunkArgs;
 
             act(() => {
                 userConsent({
@@ -203,15 +196,13 @@ describe('useSellFlow', () => {
         });
 
         it('should reset consent when quote provider changes', async () => {
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
             const { result, rerender } = await renderUseSellFlow();
 
             act(() => {
                 result.current.selectQuote();
             });
 
-            const dispatchCall = dispatchSpy.mock.calls[0][0];
-            const { userConsent } = dispatchCall.payload;
+            const { userConsent } = capturedThunkArgs;
 
             act(() => {
                 userConsent({
@@ -229,6 +220,66 @@ describe('useSellFlow', () => {
             rerender({});
 
             expect(result.current.isLegalTermsConsentRequested).toEqual(false);
+        });
+    });
+
+    describe('Form Step Logic', () => {
+        it('should set form step to BANK_ACCOUNT when provider flow is BANK_ACCOUNT', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+            act(() => {
+                sellForm.setValue('quote', sellQuotes[1]); // banxa-sell provider with BANK_ACCOUNT flow
+                store.dispatch(
+                    tradingSellActions.saveQuoteRequest({
+                        cryptoCurrency: sellQuotes[1].cryptoCurrency!,
+                        amountInCrypto: sellQuotes[1].amountInCrypto!,
+                        fiatCurrency: sellQuotes[1].fiatCurrency!,
+                    }),
+                );
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            // Check that setFormStep was called with BANK_ACCOUNT
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                tradingSellActions.setFormStep('BANK_ACCOUNT'),
+            );
+        });
+
+        it('should set form step to SEND_TRANSACTION when provider flow is not BANK_ACCOUNT', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+            // Create a quote with a provider that doesn't have BANK_ACCOUNT flow
+            const customQuote = {
+                ...sellQuotes[0],
+                exchange: 'custom-provider', // This provider won't be in providerInfos
+            };
+
+            act(() => {
+                sellForm.setValue('quote', customQuote);
+                store.dispatch(
+                    tradingSellActions.saveQuoteRequest({
+                        cryptoCurrency: customQuote.cryptoCurrency!,
+                        amountInCrypto: customQuote.amountInCrypto!,
+                        fiatCurrency: customQuote.fiatCurrency!,
+                    }),
+                );
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            // Check that setFormStep was called with SEND_TRANSACTION
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                tradingSellActions.setFormStep('SEND_TRANSACTION'),
+            );
         });
     });
 });

--- a/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
@@ -10,6 +10,7 @@ import {
     selectTradingSellSelectedQuote,
     sellThunks,
     sellUtils,
+    tradingSellActions,
 } from '@suite-common/trading';
 import {
     RootStackParamList,
@@ -175,6 +176,16 @@ export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
     const selectQuote = useCallback(async () => {
         if (!candidateQuote || isLoading) {
             return;
+        }
+
+        const provider = candidateQuote.exchange
+            ? sellInfo?.providerInfos[candidateQuote.exchange]
+            : undefined;
+
+        if (provider?.flow === 'BANK_ACCOUNT') {
+            dispatch(tradingSellActions.setFormStep('BANK_ACCOUNT'));
+        } else {
+            dispatch(tradingSellActions.setFormStep('SEND_TRANSACTION'));
         }
 
         const nextStep = () => {

--- a/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
-import { selectTradingSellSelectedQuote } from '@suite-common/trading';
 import { Screen } from '@suite-native/navigation';
 
 import { SellPreviewScreenHeader, SellPreviewView } from '../components/sell/SellPreview';
@@ -9,8 +8,6 @@ import { clearTradingStateThunk } from '../thunks';
 
 export const TradingSellPreviewScreen = () => {
     const dispatch = useDispatch();
-
-    const quote = useSelector(selectTradingSellSelectedQuote);
 
     // clear trading state on unmount
     useEffect(
@@ -22,7 +19,7 @@ export const TradingSellPreviewScreen = () => {
 
     return (
         <Screen header={<SellPreviewScreenHeader />}>
-            <SellPreviewView quote={quote} txnErrorString={null} />
+            <SellPreviewView txnErrorString={null} />
         </Screen>
     );
 };

--- a/suite-native/module-trading/src/screens/TradingWebViewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingWebViewScreen.tsx
@@ -56,8 +56,8 @@ export const TradingWebViewScreen = () => {
     }, [reportToAnalytics, trade?.tradeType]);
 
     useWatchTrade({
-        account: account ?? undefined,
-        trade,
+        accountKey: account?.key ?? undefined,
+        orderId: trade?.data.orderId ?? undefined,
         isInProgress: true,
     });
 


### PR DESCRIPTION
Some sell trades can have option for selecting bank account in app. This PR adds functionality to handle it. 



To test you can try to sell `BTC` to `EUR` in `Czechia` to `Bank account`  via `BTCDirect`

## Related Issue

Resolve #22581 

## Screenshots:
<img width="350" src="https://github.com/user-attachments/assets/24c80925-d642-46fd-9dee-6bce83ba6b04" />
<img width="350" src="https://github.com/user-attachments/assets/3b6897dc-45be-4347-a72b-f5b85bef51a6" />
<img width="350" src="https://github.com/user-attachments/assets/d09e507c-517d-426f-b545-659ef669d2f7" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22581-mobile-sell-prepare-ui-for-confirming-bank-account&lookback=7)