### PR TITLE
fix(suite-native): handling navigation ref safely

### DIFF
--- a/suite-native/navigation/src/components/NavigationContainerWithAnalytics.tsx
+++ b/suite-native/navigation/src/components/NavigationContainerWithAnalytics.tsx
@@ -1,11 +1,6 @@
 import { ReactNode, createContext, useMemo, useRef, useState } from 'react';
 
-import {
-    DarkTheme,
-    DefaultTheme,
-    NavigationContainer,
-    createNavigationContainerRef,
-} from '@react-navigation/native';
+import { DarkTheme, DefaultTheme, NavigationContainer } from '@react-navigation/native';
 import { useReactNavigationDevTools } from '@rozenite/react-navigation-plugin';
 
 import { EventType, analytics } from '@suite-native/analytics';
@@ -13,11 +8,11 @@ import { addSentryBreadcrumb, setSentryTag } from '@suite-native/sentry';
 import { useNativeStyles } from '@trezor/styles';
 
 import { useReportSendFlowExitToAnalytics } from '../hooks/useReportSendFlowExitToAnalytics';
-import { RootStackParamList } from '../navigators';
+import { createSafeNavigationContainerRef } from '../utils/createSafeNavigationContainerRef';
 
 export const IsNavigationReadyContext = createContext(false);
 
-export const navigationContainerRef = createNavigationContainerRef<RootStackParamList>();
+export const navigationContainerRef = createSafeNavigationContainerRef();
 
 export const NavigationContainerWithAnalytics = ({ children }: { children: ReactNode }) => {
     const [isNavigationReady, setIsNavigationReady] = useState(false);

--- a/suite-native/navigation/src/utils/createSafeNavigationContainerRef.test.ts
+++ b/suite-native/navigation/src/utils/createSafeNavigationContainerRef.test.ts
@@ -1,0 +1,73 @@
+import { createNavigationContainerRef } from '@react-navigation/native';
+
+import { createSafeNavigationContainerRef } from './createSafeNavigationContainerRef';
+import {
+    AuthorizeDeviceStackRoutes,
+    DeviceOnboardingStackRoutes,
+    RootStackRoutes,
+} from '../routes';
+
+jest.mock('@react-navigation/native', () => ({
+    createNavigationContainerRef: jest.fn(),
+}));
+
+describe('createSafeNavigationContainerRef', () => {
+    let mockNavigationRef: any;
+    let mockNavigate: jest.Mock;
+    let mockIsReady: jest.Mock;
+
+    beforeEach(() => {
+        mockNavigate = jest.fn();
+        mockIsReady = jest.fn(() => true);
+
+        mockNavigationRef = {
+            navigate: mockNavigate,
+            isReady: mockIsReady,
+        };
+
+        (createNavigationContainerRef as jest.Mock).mockReturnValue(mockNavigationRef);
+    });
+
+    it('should call navigate when navigation is ready', () => {
+        mockIsReady.mockReturnValue(true);
+
+        const safeRef = createSafeNavigationContainerRef();
+        safeRef.navigate(RootStackRoutes.DeviceOnboardingStack, {
+            screen: DeviceOnboardingStackRoutes.DeviceDisconnected,
+            params: { wasDeviceConnectedViaBluetooth: false },
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.DeviceOnboardingStack, {
+            screen: DeviceOnboardingStackRoutes.DeviceDisconnected,
+            params: { wasDeviceConnectedViaBluetooth: false },
+        });
+    });
+
+    it('should NOT call navigate when navigation is not ready', () => {
+        mockIsReady.mockReturnValue(false);
+
+        const safeRef = createSafeNavigationContainerRef();
+        const result = safeRef.navigate(RootStackRoutes.AuthorizeDeviceStack, {
+            screen: AuthorizeDeviceStackRoutes.ThpConfirmation,
+        });
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(result).toBeUndefined();
+    });
+
+    it('should handle transition from not ready to ready', () => {
+        mockIsReady.mockReturnValue(false);
+
+        const safeRef = createSafeNavigationContainerRef();
+        safeRef.navigate(RootStackRoutes.AuthorizeDeviceStack, {
+            screen: AuthorizeDeviceStackRoutes.ThpConfirmation,
+        });
+
+        mockIsReady.mockReturnValue(true);
+        safeRef.navigate(RootStackRoutes.AuthorizeDeviceStack, {
+            screen: AuthorizeDeviceStackRoutes.ThpConfirmation,
+        });
+
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+    });
+});

--- a/suite-native/navigation/src/utils/createSafeNavigationContainerRef.ts
+++ b/suite-native/navigation/src/utils/createSafeNavigationContainerRef.ts
@@ -1,0 +1,37 @@
+import {
+    NavigationContainerRefWithCurrent,
+    createNavigationContainerRef,
+} from '@react-navigation/native';
+
+import { RootStackParamList } from '../navigators';
+
+/**
+ * Creates a safe navigation container ref that checks if navigation is ready
+ * before executing navigation methods. If not ready, methods are safely ignored.
+ */
+export const createSafeNavigationContainerRef =
+    (): NavigationContainerRefWithCurrent<RootStackParamList> => {
+        const navigationRef = createNavigationContainerRef<RootStackParamList>();
+        // Get all prototype methods to filter them out later
+        const protoMethods = Object.getOwnPropertyNames(Object.prototype);
+
+        return new Proxy(navigationRef, {
+            get(target, prop) {
+                const value = Reflect.get(target, prop);
+                const isNavigationMethod =
+                    typeof value === 'function' &&
+                    typeof prop === 'string' &&
+                    !protoMethods.includes(prop);
+
+                if (!isNavigationMethod) return value;
+
+                return (...args: any[]) => {
+                    if (navigationRef.isReady()) {
+                        return value.apply(target, args);
+                    }
+
+                    return undefined;
+                };
+            },
+        });
+    };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

create Proxy for calling navigation methods only when its ready

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22067

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/safe-navigationRef-handling&lookback=7)