### PR TITLE
chore(suite): unify dashboard section subheadings

### DIFF
--- a/packages/suite/src/components/dashboard/DashboardSection.tsx
+++ b/packages/suite/src/components/dashboard/DashboardSection.tsx
@@ -1,20 +1,11 @@
-import {
-    HTMLAttributes,
-    ReactElement,
-    ReactNode,
-    Ref,
-    forwardRef,
-    useEffect,
-    useState,
-} from 'react';
+import { HTMLAttributes, ReactElement, Ref, forwardRef, useEffect, useState } from 'react';
 
-import { Box, Column, H3, IconButton, Paragraph, Row } from '@trezor/components';
+import { Box, Column, H3, IconButton, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 type DashboardSectionProps = HTMLAttributes<HTMLDivElement> & {
     heading: ReactElement;
     subheading?: ReactElement;
-    text?: ReactNode;
     actions?: ReactElement;
     collapsible?: boolean;
     defaultCollapsed?: boolean;
@@ -27,7 +18,6 @@ export const DashboardSection = forwardRef(
         {
             heading,
             subheading,
-            text,
             actions,
             collapsible = false,
             defaultCollapsed = false,
@@ -66,9 +56,8 @@ export const DashboardSection = forwardRef(
                                     ></IconButton>
                                 )}
                             </Row>
-                            {subheading}
+                            {subheading && <Text variant="tertiary">{subheading}</Text>}
                         </Box>
-                        {text && <Paragraph variant="tertiary">{text}</Paragraph>}
                     </Column>
                     {!collapsed && children}
                 </Column>

--- a/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
@@ -1,7 +1,6 @@
 import { TrezorDevice } from '@suite-common/suite-types';
 import { getNetworkFeatures } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
-import { Text } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { capitalizeFirstLetter, union } from '@trezor/utils';
 
@@ -74,7 +73,5 @@ export const UnsupportedAssetsMessage = ({
     affectedNetworks,
     hasTokens,
 }: UnsupportedAssetsMessageProps) => (
-    <Text variant="tertiary" typographyStyle="hint">
-        <Message affectedNetworks={affectedNetworks} hasTokens={hasTokens} />
-    </Text>
+    <Message affectedNetworks={affectedNetworks} hasTokens={hasTokens} />
 );

--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboard.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboard.tsx
@@ -159,7 +159,7 @@ export const StakingDashboard = () => {
                     </Badge>
                 </>
             }
-            text={<Translation id="TR_STAKING_DASHBOARD_TEXT" />}
+            subheading={<Translation id="TR_STAKING_DASHBOARD_TEXT" />}
             collapsible
             defaultCollapsed={collapsed}
             onCollapseChange={onCollapseChange}
@@ -187,6 +187,7 @@ export const StakingDashboard = () => {
                             <Table.Cell></Table.Cell>
                         </Table.Row>
                     </Table.Header>
+
                     <Table.Body>
                         {sortedAccounts.map(account => (
                             <StakingDashboardAccountRow account={account} key={account.key} />


### PR DESCRIPTION
## Description

`Portfolio` and `Staking` sections had different font sizes for their texts. This PR unifies them.

## Related Issue

Resolve #22623 

## Screenshots:

<img width="100%" alt="Screenshot 2025-10-23 at 10 44 52" src="https://github.com/user-attachments/assets/f2cfce61-23f3-4825-8d2e-e705fbd32001" />

<img width="100%" alt="Screenshot 2025-10-23 at 10 45 00" src="https://github.com/user-attachments/assets/d26db17a-c5d6-403a-838d-8a32a1539cb0" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/unify-dashboard-fonts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/unify-dashboard-fonts&lookback=7)