### PR TITLE
Update SOL Staking `Learn more` Link

### DIFF
--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -228,7 +228,7 @@ export const HELP_CENTER_ETH_STAKING: Url = withPlatformUtm(
     'https://trezor.io/guides/sending-receiving-staking-funds/staking-assets-in-trezor-suite/staking-ethereum-eth-in-trezor-suite',
 );
 export const HELP_CENTER_SOL_STAKING: Url = withPlatformUtm(
-    'https://trezor.io/learn/supported-assets/solana/solana-sol-on-trezor',
+    'https://trezor.io/guides/sending-receiving-staking-funds/staking-assets-in-trezor-suite/staking-solana-in-trezor-suite',
 );
 export const HELP_CENTER_SEED_CARD_URL: Url = withPlatformUtm(
     'https://trezor.io/learn/security-privacy/personal-security-standards/wallet-backup-card',


### PR DESCRIPTION
## Description

This PR updates the `SOL` staking `Learn more` link to:
https://trezor.io/guides/sending-receiving-staking-funds/staking-assets-in-trezor-suite/staking-solana-in-trezor-suite

## Related Issue

Resolve #22575 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/solana-staking-link&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/solana-staking-link&lookback=7)