### PR TITLE
chore(suite): update network backends

### DIFF
--- a/packages/blockchain-link/src/ui/config.ts
+++ b/packages/blockchain-link/src/ui/config.ts
@@ -104,12 +104,7 @@ export default [
         blockchain: {
             name: 'Ethereum',
             worker: 'js/blockbook-worker.js',
-            server: [
-                'https://eth1.trezor.io',
-                'https://eth2.trezor.io',
-                'https://eth3.trezor.io',
-                'https://eth4.trezor.io',
-            ],
+            server: ['https://eth.trezor.io'],
             debug: true,
         },
         data: {
@@ -141,12 +136,7 @@ export default [
         blockchain: {
             name: 'BNB Smart Chain',
             worker: 'js/blockbook-worker.js',
-            server: [
-                'https://bsc1.trezor.io',
-                'https://bsc2.trezor.io',
-                'https://bsc3.trezor.io',
-                'https://bsc4.trezor.io',
-            ],
+            server: ['https://bsc.trezor.io'],
             debug: true,
         },
         data: {
@@ -168,12 +158,7 @@ export default [
         blockchain: {
             name: 'Arbitrum One',
             worker: 'js/blockbook-worker.js',
-            server: [
-                'https://arb1.trezor.io',
-                'https://arb2.trezor.io',
-                'https://arb3.trezor.io',
-                'https://arb4.trezor.io',
-            ],
+            server: ['https://arb.trezor.io'],
             debug: true,
         },
         data: {
@@ -195,12 +180,7 @@ export default [
         blockchain: {
             name: 'Base',
             worker: 'js/blockbook-worker.js',
-            server: [
-                'https://base1.trezor.io',
-                'https://base2.trezor.io',
-                'https://base3.trezor.io',
-                'https://base4.trezor.io',
-            ],
+            server: ['https://base.trezor.io'],
             debug: true,
         },
         data: {
@@ -222,12 +202,7 @@ export default [
         blockchain: {
             name: 'Optimism',
             worker: 'js/blockbook-worker.js',
-            server: [
-                'https://op1.trezor.io',
-                'https://op2.trezor.io',
-                'https://op3.trezor.io',
-                'https://op4.trezor.io',
-            ],
+            server: ['https://op.trezor.io'],
             debug: true,
         },
         data: {
@@ -271,7 +246,7 @@ export default [
         blockchain: {
             name: 'Ethereum Classic',
             worker: 'js/blockbook-worker.js',
-            server: ['https://etc1.trezor.io', 'https://etc2.trezor.io'],
+            server: ['https://etc.trezor.io'],
             debug: true,
         },
         data: {
@@ -293,13 +268,7 @@ export default [
         blockchain: {
             name: 'Bitcoin',
             worker: 'js/blockbook-worker.js',
-            server: [
-                'https://btc1.trezor.io',
-                'https://btc2.trezor.io',
-                'https://btc3.trezor.io',
-                'https://btc4.trezor.io',
-                'https://btc5.trezor.io',
-            ],
+            server: ['https://btc.trezor.io'],
             debug: true,
         },
         data: {
@@ -321,7 +290,7 @@ export default [
         blockchain: {
             name: 'Bitcoin Testnet',
             worker: 'js/blockbook-worker.js',
-            server: ['https://tbtc1.trezor.io', 'https://tbtc2.trezor.io'],
+            server: ['https://tbtc.trezor.io'],
             debug: true,
         },
         data: {
@@ -355,7 +324,7 @@ export default [
         blockchain: {
             name: 'Bitcoin Testnet 4',
             worker: 'js/blockbook-worker.js',
-            server: ['https://tbtc4-1.trezor.io', 'https://tbtc4-2.trezor.io'],
+            server: ['https://tbtc4.trezor.io'],
             debug: true,
         },
         data: {
@@ -379,13 +348,7 @@ export default [
         blockchain: {
             name: 'Bitcoin Cash',
             worker: 'js/blockbook-worker.js',
-            server: [
-                'https://bch1.trezor.io',
-                'https://bch2.trezor.io',
-                'https://bch3.trezor.io',
-                'https://bch4.trezor.io',
-                'https://bch5.trezor.io',
-            ],
+            server: ['https://bch.trezor.io'],
             debug: true,
         },
         data: {
@@ -481,13 +444,7 @@ export default [
         blockchain: {
             name: 'Doge',
             worker: 'js/blockbook-worker.js',
-            server: [
-                'https://doge1.trezor.io',
-                'https://doge2.trezor.io',
-                'https://doge3.trezor.io',
-                'https://doge4.trezor.io',
-                'https://doge5.trezor.io',
-            ],
+            server: ['https://doge.trezor.io'],
             debug: true,
         },
         data: {
@@ -508,13 +465,7 @@ export default [
         blockchain: {
             name: 'Litecoin',
             worker: 'js/blockbook-worker.js',
-            server: [
-                'https://ltc1.trezor.io',
-                'https://ltc2.trezor.io',
-                'https://ltc3.trezor.io',
-                'https://ltc4.trezor.io',
-                'https://ltc5.trezor.io',
-            ],
+            server: ['https://ltc.trezor.io'],
             debug: true,
         },
         data: {
@@ -583,13 +534,7 @@ export default [
         blockchain: {
             name: 'ZCash',
             worker: 'js/blockbook-worker.js',
-            server: [
-                'https://zec1.trezor.io',
-                'https://zec2.trezor.io',
-                'https://zec3.trezor.io',
-                'https://zec4.trezor.io',
-                'https://zec5.trezor.io',
-            ],
+            server: ['https://zec.trezor.io'],
             debug: true,
         },
         data: {
@@ -610,7 +555,7 @@ export default [
         blockchain: {
             name: 'Cardano Mainnet',
             worker: 'js/blockfrost-worker.js',
-            server: ['wss://ada1.trezor.io', 'wss://ada2.trezor.io'],
+            server: ['wss://ada.trezor.io'],
             debug: true,
         },
         data: {
@@ -715,12 +660,7 @@ export default [
         blockchain: {
             name: 'Polygon PoS',
             worker: 'js/blockbook-worker.js',
-            server: [
-                'https://pol1.trezor.io',
-                'https://pol2.trezor.io',
-                'https://pol3.trezor.io',
-                'https://pol4.trezor.io',
-            ],
+            server: ['https://pol.trezor.io'],
             debug: true,
         },
         data: {

--- a/packages/connect-common/files/coins-eth.json
+++ b/packages/connect-common/files/coins-eth.json
@@ -3,12 +3,7 @@
         {
             "blockchain_link": {
                 "type": "blockbook",
-                "url": [
-                    "https://eth1.trezor.io",
-                    "https://eth2.trezor.io",
-                    "https://eth3.trezor.io",
-                    "https://eth4.trezor.io"
-                ]
+                "url": ["https://eth.trezor.io"]
             },
             "chain": "eth",
             "chain_id": 1,
@@ -31,12 +26,7 @@
         {
             "blockchain_link": {
                 "type": "blockbook",
-                "url": [
-                    "https://op1.trezor.io",
-                    "https://op2.trezor.io",
-                    "https://op3.trezor.io",
-                    "https://op4.trezor.io"
-                ]
+                "url": ["https://op.trezor.io"]
             },
             "chain": "op",
             "chain_id": 10,
@@ -82,12 +72,7 @@
         {
             "blockchain_link": {
                 "type": "blockbook",
-                "url": [
-                    "https://bsc1.trezor.io",
-                    "https://bsc2.trezor.io",
-                    "https://bsc3.trezor.io",
-                    "https://bsc4.trezor.io"
-                ]
+                "url": ["https://bsc.trezor.io"]
             },
             "chain": "bsc",
             "chain_id": 56,
@@ -110,7 +95,7 @@
         {
             "blockchain_link": {
                 "type": "blockbook",
-                "url": ["https://etc1.trezor.io", "https://etc2.trezor.io"]
+                "url": ["https://etc.trezor.io"]
             },
             "chain": "etc",
             "chain_id": 61,
@@ -133,12 +118,7 @@
         {
             "blockchain_link": {
                 "type": "blockbook",
-                "url": [
-                    "https://pol1.trezor.io",
-                    "https://pol2.trezor.io",
-                    "https://pol3.trezor.io",
-                    "https://pol4.trezor.io"
-                ]
+                "url": ["https://pol.trezor.io"]
             },
             "chain": "pol",
             "chain_id": 137,
@@ -161,12 +141,7 @@
         {
             "blockchain_link": {
                 "type": "blockbook",
-                "url": [
-                    "https://base1.trezor.io",
-                    "https://base2.trezor.io",
-                    "https://base3.trezor.io",
-                    "https://base4.trezor.io"
-                ]
+                "url": ["https://base.trezor.io"]
             },
             "chain": "base",
             "chain_id": 8453,
@@ -189,7 +164,7 @@
         {
             "blockchain_link": {
                 "type": "blockbook",
-                "url": ["https://hoodi1.trezor.io", "https://hoodi2.trezor.io"]
+                "url": ["https://hoodi.trezor.io"]
             },
             "chain": "hod",
             "chain_id": 560048,
@@ -211,12 +186,7 @@
         {
             "blockchain_link": {
                 "type": "blockbook",
-                "url": [
-                    "https://arb1.trezor.io",
-                    "https://arb2.trezor.io",
-                    "https://arb3.trezor.io",
-                    "https://arb4.trezor.io"
-                ]
+                "url": ["https://arb.trezor.io"]
             },
             "chain": "arb",
             "chain_id": 42161,
@@ -239,7 +209,7 @@
         {
             "blockchain_link": {
                 "type": "blockbook",
-                "url": ["https://sepolia1.trezor.io"]
+                "url": ["https://sepolia.trezor.io"]
             },
             "chain": "sep",
             "chain_id": 11155111,

--- a/packages/connect-common/files/coins.json
+++ b/packages/connect-common/files/coins.json
@@ -6,13 +6,7 @@
             "bech32_prefix": "bc",
             "blockchain_link": {
                 "type": "blockbook",
-                "url": [
-                    "https://btc1.trezor.io",
-                    "https://btc2.trezor.io",
-                    "https://btc3.trezor.io",
-                    "https://btc4.trezor.io",
-                    "https://btc5.trezor.io"
-                ]
+                "url": ["https://btc.trezor.io"]
             },
             "blocktime_seconds": 600,
             "cashaddr_prefix": null,
@@ -107,7 +101,7 @@
             "address_type": 111,
             "address_type_p2sh": 196,
             "bech32_prefix": "tb",
-            "blockchain_link": { "type": "blockbook", "url": ["https://tbtc4-1.trezor.io"] },
+            "blockchain_link": { "type": "blockbook", "url": ["https://tbtc4.trezor.io"] },
             "blocktime_seconds": 600,
             "cashaddr_prefix": null,
             "coin_label": "Testnet",
@@ -250,13 +244,7 @@
             "bech32_prefix": null,
             "blockchain_link": {
                 "type": "blockbook",
-                "url": [
-                    "https://bch1.trezor.io",
-                    "https://bch2.trezor.io",
-                    "https://bch3.trezor.io",
-                    "https://bch4.trezor.io",
-                    "https://bch5.trezor.io"
-                ]
+                "url": ["https://bch.trezor.io"]
             },
             "blocktime_seconds": 600,
             "cashaddr_prefix": "bitcoincash",
@@ -891,13 +879,7 @@
             "bech32_prefix": null,
             "blockchain_link": {
                 "type": "blockbook",
-                "url": [
-                    "https://doge1.trezor.io",
-                    "https://doge2.trezor.io",
-                    "https://doge3.trezor.io",
-                    "https://doge4.trezor.io",
-                    "https://doge5.trezor.io"
-                ]
+                "url": ["https://doge.trezor.io"]
             },
             "blocktime_seconds": 60,
             "cashaddr_prefix": null,
@@ -1423,13 +1405,7 @@
             "bech32_prefix": "ltc",
             "blockchain_link": {
                 "type": "blockbook",
-                "url": [
-                    "https://ltc1.trezor.io",
-                    "https://ltc2.trezor.io",
-                    "https://ltc3.trezor.io",
-                    "https://ltc4.trezor.io",
-                    "https://ltc5.trezor.io"
-                ]
+                "url": ["https://ltc.trezor.io"]
             },
             "blocktime_seconds": 150,
             "cashaddr_prefix": null,
@@ -2484,13 +2460,7 @@
             "bech32_prefix": null,
             "blockchain_link": {
                 "type": "blockbook",
-                "url": [
-                    "https://zec1.trezor.io",
-                    "https://zec2.trezor.io",
-                    "https://zec3.trezor.io",
-                    "https://zec4.trezor.io",
-                    "https://zec5.trezor.io"
-                ]
+                "url": ["https://zec.trezor.io"]
             },
             "blocktime_seconds": 150,
             "cashaddr_prefix": null,
@@ -2633,7 +2603,7 @@
         {
             "blockchain_link": {
                 "type": "blockfrost",
-                "url": ["wss://ada1.trezor.io", "wss://ada2.trezor.io"]
+                "url": ["wss://ada.trezor.io"]
             },
             "curve": "ed25519",
             "decimals": 6,

--- a/packages/connect/e2e/__fixtures__/signTransactionMultisig.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionMultisig.ts
@@ -40,7 +40,7 @@ export default {
         mnemonic: 'mnemonic_all',
     },
     tests: [
-        // https://tbtc1.trezor.io/api/tx/4123415574c16899b4bb5b691f9b65643dbe566a9b68e4e2e7a8b29c79c83f2b
+        // https://tbtc.trezor.io/api/tx/4123415574c16899b4bb5b691f9b65643dbe566a9b68e4e2e7a8b29c79c83f2b
         {
             description: 'Testnet (multisig): 2 of 3 (sign with 1st key)',
             params: {
@@ -73,7 +73,7 @@ export default {
                 signatures: [SIGNATURES_2_OF_3[0]],
             },
         },
-        // https://tbtc1.trezor.io/api/tx/4123415574c16899b4bb5b691f9b65643dbe566a9b68e4e2e7a8b29c79c83f2b
+        // https://tbtc.trezor.io/api/tx/4123415574c16899b4bb5b691f9b65643dbe566a9b68e4e2e7a8b29c79c83f2b
         {
             description: 'Testnet (multisig): 2 of 3 (sign with 3rd key)',
             params: {
@@ -108,7 +108,7 @@ export default {
                     '0100000001fc935b8e20518d2585154edf8c70411b43eb135e69f94357c8d9521b32c1076b00000000fdfd000047304402206c99b48a12f340599076b93efdc2578b0cdeaedf9092aed628788f4ffc579a50022031b16212dd1f0f62f01bb5862b6d128276c7a5430746aa27a04ae0c8acbcb3b10148304502210089153ad97c0d69656cd9bd9eb2056552acaec91365dd7ab31250f3f707123baa02200f884de63041d73bd20fbe8804c6036968d8149b7f46963a82b561cd8211ab08014c69522103725d6c5253f2040a9a73af24bcc196bf302d6cc94374dd7197b138e10912670121038924e94fff15302a3fb45ad4fc0ed17178800f0f1c2bdacb1017f4db951aa9f12102aae8affd0eb8e1181d665daef4de1828f23053c548ec9bafc3a787f558aa014153aeffffffff01c6ad1600000000001976a9144cfc772f24b600762f905a1ee799ce0e9c26831f88ac00000000',
             },
         },
-        // https://tbtc1.trezor.io/api/tx/b41284067577e1266ad3632f7caffead5d58277cc35f42642455bfd2a3fa0325
+        // https://tbtc.trezor.io/api/tx/b41284067577e1266ad3632f7caffead5d58277cc35f42642455bfd2a3fa0325
         {
             description: 'Testnet (multisig): 15 of 15 (sign with 15th key)',
             params: {

--- a/packages/connect/e2e/__fixtures__/signTransactionTaproot.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionTaproot.ts
@@ -8,7 +8,7 @@ export default {
         mnemonic: 'mnemonic_all',
     },
     tests: [
-        // https://tbtc1.trezor.io/api/tx/6dfac2f0d66e1972fea2bca80b6d6db80f6f48deacfdef42f15ff9625acdca59
+        // https://tbtc.trezor.io/api/tx/6dfac2f0d66e1972fea2bca80b6d6db80f6f48deacfdef42f15ff9625acdca59
         {
             description: 'Testnet (P2TR): send Taproot',
             skip: ['<1.10.4', '<2.4.3'],
@@ -38,7 +38,7 @@ export default {
                     '010000000001012554839b5b50466d597ec674a63f879a04c5da157addfbd56b74a3be949451ec0000000000ffffffff016211000000000000225120e9af2fc69e20b0be2629cd0e9c34da9f3ef56af7beac4fb4298262bc5a45ec5d0140aacd291b886f40025e93236f69653423b0c50912fbe43aacced10f2690cfc4872fb37694a947e893389084577ffce3c214b09ff4801006b1e7542ee23719abd100000000',
             },
         },
-        // https://tbtc1.trezor.io/api/tx/1054eb649110534518239bca2abebebee76d50addac27d0d582cef2b9b9d80c0
+        // https://tbtc.trezor.io/api/tx/1054eb649110534518239bca2abebebee76d50addac27d0d582cef2b9b9d80c0
         {
             description: 'Testnet (P2TR): 2 inputs, 1 output, 1 change',
             skip: ['<1.10.4', '<2.4.3'],

--- a/packages/connect/e2e/__fixtures__/signTransactionZcash.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionZcash.ts
@@ -7,7 +7,7 @@ export default {
     },
     tests: [
         {
-            // See https://zec1.trezor.io/tx/e5229ae8c02f74af5e0c2100371710424fa85902c29752498c39921de2246824
+            // See https://zec.trezor.io/tx/e5229ae8c02f74af5e0c2100371710424fa85902c29752498c39921de2246824
             description: 'Zcash: inputs v1, no change',
             skip: ['>1.8.3', '>2.1.8'], // test works only in FW range [1.8.1 - 1.8.3] and [2.1.1 - 2.1.8]
             params: {
@@ -41,7 +41,7 @@ export default {
             },
         },
         {
-            // See https://zec1.trezor.io/tx/0f762a2da5252d684fb3510a3104bcfb556fab34583b3b0e1994d0f7409cc075
+            // See https://zec.trezor.io/tx/0f762a2da5252d684fb3510a3104bcfb556fab34583b3b0e1994d0f7409cc075
             description: 'Zcash: input v2, no change',
             skip: ['>1.8.3', '>2.1.8'], // test works only in FW range [1.8.1 - 1.8.3] and [2.1.1 - 2.1.8]
             params: {
@@ -70,7 +70,7 @@ export default {
         },
         {
             // NOTE: this is not a valid transaction
-            // Inputs from https://zec1.trezor.io/tx/e2802f0118d9f41f68b65f2b9f4a7c2efc876aee4e8c4b48c4a4deef6b7c0c28
+            // Inputs from https://zec.trezor.io/tx/e2802f0118d9f41f68b65f2b9f4a7c2efc876aee4e8c4b48c4a4deef6b7c0c28
             description: 'Zcash: unsupported inputs v3, with change',
             params: {
                 coin: 'Zcash',
@@ -121,7 +121,7 @@ export default {
         },
         {
             // NOTE: this is not a valid transaction
-            // Inputs from https://zec1.trezor.io/tx/234b2cf6cb2a50be29f45efae27fe717e3bb31967a72927d122cac1f50988cab
+            // Inputs from https://zec.trezor.io/tx/234b2cf6cb2a50be29f45efae27fe717e3bb31967a72927d122cac1f50988cab
             description: 'Zcash: input v4',
             skip: ['<1.9.0', '<2.2.0', '>1.11.0', '>2.5.0'],
             params: {

--- a/packages/connect/src/api/bitcoin/__fixtures__/refTx.ts
+++ b/packages/connect/src/api/bitcoin/__fixtures__/refTx.ts
@@ -206,7 +206,7 @@ export const validateReferencedTransactions = [
         description: 'transform AccountTransaction with opreturn output to OrigTransaction',
         params: {
             transactions: [
-                // see https://tbtc1.trezor.io/tx/ba917a2b563966e324ab37ed7de5f5cd7503b970b0f0bb9a5208f5835557e99c
+                // see https://tbtc.trezor.io/tx/ba917a2b563966e324ab37ed7de5f5cd7503b970b0f0bb9a5208f5835557e99c
                 {
                     txid: 'ba917a2b563966e324ab37ed7de5f5cd7503b970b0f0bb9a5208f5835557e99c',
                     details: {

--- a/packages/connect/src/api/bitcoin/__fixtures__/signtxVerify.ts
+++ b/packages/connect/src/api/bitcoin/__fixtures__/signtxVerify.ts
@@ -114,7 +114,7 @@ export default [
         vbytes: 201,
     },
     {
-        // https://tbtc1.trezor.io/tx/d7bae8f41c45f43447ec6eedf2b900c5e15359a1b88771d2e4dee9a1aaf3e23e
+        // https://tbtc.trezor.io/tx/d7bae8f41c45f43447ec6eedf2b900c5e15359a1b88771d2e4dee9a1aaf3e23e
         description: 'external P2TR output',
         network: 'testnet',
         inputs: [...inputs, ...inputs, ...inputs],
@@ -129,7 +129,7 @@ export default [
         vbytes: 497,
     },
     {
-        // https://tbtc1.trezor.io/tx/ab1494fd55bcfe16822d2eb7f7619e34168f4d41e082e7868c753e7c87971d19
+        // https://tbtc.trezor.io/tx/ab1494fd55bcfe16822d2eb7f7619e34168f4d41e082e7868c753e7c87971d19
         description: 'internal P2TR output',
         network: 'testnet',
         inputs,

--- a/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTx.ts
+++ b/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTx.ts
@@ -18,7 +18,7 @@ interface EthereumTxFixture {
 
 export const serializeEthereumTx: EthereumTxFixture[] = [
     {
-        // https://eth1.trezor.io/tx/0xf6652a681b4474132b8b96512eb0bd5311f5ed8414af59e715c9738a3b3673f3
+        // https://eth.trezor.io/tx/0xf6652a681b4474132b8b96512eb0bd5311f5ed8414af59e715c9738a3b3673f3
         description: 'Legacy tx - ETH regular',
         from: '0x73d0385f4d8e00c5e6504c6030f47bf6212736a8',
         tx: {
@@ -40,7 +40,7 @@ export const serializeEthereumTx: EthereumTxFixture[] = [
         result: '0xf6652a681b4474132b8b96512eb0bd5311f5ed8414af59e715c9738a3b3673f3',
     },
     {
-        // https://eth1.trezor.io/tx/0xdcaf3eba690a3cdbad8c2926a8f5a95cd20003c5ba2aace91d8c5fe8048e395b
+        // https://eth.trezor.io/tx/0xdcaf3eba690a3cdbad8c2926a8f5a95cd20003c5ba2aace91d8c5fe8048e395b
         description: 'Legacy tx - ETH with ERC20',
         from: '0x73d0385f4d8e00c5e6504c6030f47bf6212736a8',
         tx: {
@@ -60,7 +60,7 @@ export const serializeEthereumTx: EthereumTxFixture[] = [
         result: '0xdcaf3eba690a3cdbad8c2926a8f5a95cd20003c5ba2aace91d8c5fe8048e395b',
     },
     {
-        // https://etc1.trezor.io/tx/0xebd7ef20c4358a6fdb09a951d6e77b8e88b37ac0f7a8d4e3b68f1666bf4c1d1a
+        // https://etc.trezor.io/tx/0xebd7ef20c4358a6fdb09a951d6e77b8e88b37ac0f7a8d4e3b68f1666bf4c1d1a
         description: 'Legacy tx - ETC regular',
         from: '0xf410e37e9c8bcf8cf319c84ae9dcebe057804a04',
         tx: {

--- a/packages/connect/src/types/api/__tests__/blockchain.ts
+++ b/packages/connect/src/types/api/__tests__/blockchain.ts
@@ -140,7 +140,7 @@ export const others = async (api: TrezorConnect) => {
         coin: 'btc',
         blockchainLink: {
             type: 'blockbook',
-            url: ['https://btc1.trezor.io/'],
+            url: ['https://btc.trezor.io/'],
         },
     });
 };

--- a/packages/suite-desktop-core/e2e/tests/wallet/blockbook-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/blockbook-discovery.test.ts
@@ -19,7 +19,7 @@ test.describe('Custom-blockbook-discovery', { tag: ['@group=wallet'] }, () => {
             }),
         },
         async ({ settingsPage, dashboardPage }) => {
-            const btcBlockbook = 'https://btc1.trezor.io';
+            const btcBlockbook = 'https://btc.trezor.io';
             await settingsPage.navigateTo('coins');
             await settingsPage.coins.openNetworkAdvanceSettings('btc');
             await settingsPage.coins.changeBackend('blockbook', btcBlockbook);
@@ -30,7 +30,7 @@ test.describe('Custom-blockbook-discovery', { tag: ['@group=wallet'] }, () => {
     );
 
     test('LTC blockbook discovery', async ({ page, settingsPage, dashboardPage }) => {
-        const ltcBlockbook = 'https://ltc1.trezor.io';
+        const ltcBlockbook = 'https://ltc.trezor.io';
         await settingsPage.navigateTo('coins');
         await settingsPage.coins.disableNetwork('btc');
         await settingsPage.coins.enableNetwork('ltc');

--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -40,13 +40,16 @@ const validateUrl = (type: BackendOption, value: string) => {
 const getUrlPlaceholder = (symbol: NetworkSymbol, type: BackendOption) => {
     switch (type) {
         case 'blockbook':
-            return `https://${symbol}1.trezor.io/`;
+            return `https://${symbol}.trezor.io/`;
         case 'blockfrost':
-            return `wss://blockfrost.io`;
+            return `wss://${symbol}.trezor.io/`;
         case 'electrum':
             return `electrum.example.com:50001:t`;
         case 'solana':
+        case 'stellar':
             return 'https://';
+        case 'ripple':
+            return 'wss://';
         default:
             return '';
     }

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -24,13 +24,7 @@ export const COINJOIN_NETWORKS: PartialRecord<CoinjoinSymbol, ServerEnvironment>
             coordinatorName: 'CoinJoinCoordinatorIdentifier',
             coordinatorUrl: 'https://wasabiwallet.io/wabisabi/',
             wabisabiBackendUrl: 'https://api.wasabiwallet.io/',
-            blockbookUrls: [
-                'https://btc1.trezor.io',
-                'https://btc2.trezor.io',
-                'https://btc3.trezor.io',
-                'https://btc4.trezor.io',
-                'https://btc5.trezor.io',
-            ],
+            blockbookUrls: ['https://btc.trezor.io'],
             onionDomains: {
                 'trezor.io': 'trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion',
                 'wasabiwallet.io': 'wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion',
@@ -60,7 +54,7 @@ export const COINJOIN_NETWORKS: PartialRecord<CoinjoinSymbol, ServerEnvironment>
             coordinatorUrl: 'https://wasabiwallet.co/wabisabi/',
             // backend settings
             wabisabiBackendUrl: 'https://wasabiwallet.co/',
-            blockbookUrls: ['https://tbtc4-1.trezor.io', 'https://tbtc4-2.trezor.io'],
+            blockbookUrls: ['https://tbtc4.trezor.io'],
             onionDomains: {
                 'trezor.io': 'trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion',
                 'wasabiwallet.co': 'testwnp3fugjln6vh5vpj7mvq3lkqqwjj3c2aafyu7laxz42kgwh2rad.onion',
@@ -107,7 +101,7 @@ export const COINJOIN_NETWORKS: PartialRecord<CoinjoinSymbol, ServerEnvironment>
             coordinatorUrl: 'https://dev-coinjoin-testnet.trezor.io/wabisabi/',
             // backend settings
             wabisabiBackendUrl: 'https://dev-coinjoin-testnet.trezor.io/',
-            blockbookUrls: ['https://tbtc4-1.trezor.io', 'https://tbtc4-2.trezor.io'],
+            blockbookUrls: ['https://tbtc4.trezor.io'],
             baseBlockHeight: 0,
             baseBlockHash: '00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043',
             filtersBatchSize: 5000,

--- a/packages/suite/src/utils/suite/__tests__/tor.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/tor.test.ts
@@ -34,8 +34,8 @@ describe('tor', () => {
             },
             {
                 desc: 'with query - blockbook',
-                in: 'https://btc1.trezor.io/api/v2/multi-tickers/?timestamp=12345678',
-                out: `http://btc1.${TOR_URLS['trezor.io']}/api/v2/multi-tickers/?timestamp=12345678`,
+                in: 'https://btc.trezor.io/api/v2/multi-tickers/?timestamp=12345678',
+                out: `http://btc.${TOR_URLS['trezor.io']}/api/v2/multi-tickers/?timestamp=12345678`,
             },
             {
                 desc: 'with query - coingecko',

--- a/packages/utils/src/isWhitelistedHost.ts
+++ b/packages/utils/src/isWhitelistedHost.ts
@@ -13,7 +13,7 @@ export const isWhitelistedHost = (
     return whitelist.some(
         whitelistedUrl =>
             whitelistedUrl === hostname ||
-            // This needs to be here to allow sub-domains (like btc1.trezor.io, hoodi1.trezor.io, ...,
+            // This needs to be here to allow sub-domains (like btc.trezor.io, hoodi.trezor.io, ...,
             hostname.endsWith(`.${whitelistedUrl}`),
     );
 };

--- a/packages/utils/tests/isWhitelistedHost.test.ts
+++ b/packages/utils/tests/isWhitelistedHost.test.ts
@@ -7,8 +7,8 @@ describe(isWhitelistedHost.name, () => {
         { hostname: 'trezor.io', result: true },
         { hostname: '', result: false },
         { hostname: '    ', result: false },
-        { hostname: 'hoodi1.trezor.io', result: true },
-        { hostname: 'tbtc1.trezor.io', result: true },
+        { hostname: 'hoodi.trezor.io', result: true },
+        { hostname: 'tbtc.trezor.io', result: true },
         { hostname: 'scam-url.io', result: false },
         { hostname: 'scam-url-trezor.io', result: false },
     ];

--- a/packages/utils/tests/parseHostname.test.ts
+++ b/packages/utils/tests/parseHostname.test.ts
@@ -3,7 +3,7 @@ import { parseHostname } from '../src/parseHostname';
 const fixtures = [
     ['localHOst', 'localhost'],
     ['localhost.cz:3', 'localhost.cz'],
-    ['wss://btc1.trezor.io/foo', 'btc1.trezor.io'],
+    ['wss://btc.trezor.io/foo', 'btc.trezor.io'],
     ['127.0.0.1:9050/?a=b', '127.0.0.1'],
     ['http://suite.trezor.io/', 'suite.trezor.io'],
     ['electrum.exAMple.com:50001:t', 'electrum.example.com'],

--- a/packages/utils/tests/urlToOnion.test.ts
+++ b/packages/utils/tests/urlToOnion.test.ts
@@ -13,7 +13,7 @@ const FIXTURE = [
     ['simple domain https', 'https://trezor.io/', `http://trezorioabcd.onion/`],
     ['subdomain', 'https://cdn.trezor.io/x/1*ab.png', `http://cdn.trezorioabcd.onion/x/1*ab.png`],
     ['subsubdomain', 'http://alpha.beta.trezor.io', `http://alpha.beta.trezorioabcd.onion`],
-    ['blockbook', 'https://btc1.trezor.io/api?t=13#a', `http://btc1.trezorioabcd.onion/api?t=13#a`],
+    ['blockbook', 'https://btc.trezor.io/api?t=13#a', `http://btc.trezorioabcd.onion/api?t=13#a`],
     ['coingecko', 'https://coingecko.com/?dt=5-1-2021', `http://coingeckoabcd.onion/?dt=5-1-2021`],
     ['websocket wss', 'wss://trezor.io', 'ws://trezorioabcd.onion'],
     ['websocket ws', 'ws://foo.bar.trezor.io/?foo=bar', 'ws://foo.bar.trezorioabcd.onion/?foo=bar'],

--- a/packages/utxo-lib/src/vsize.ts
+++ b/packages/utxo-lib/src/vsize.ts
@@ -59,7 +59,7 @@ export const getTransactionVbytes = (
     const ins = vin.map(({ addresses = [] }) => addresses[0] ?? '');
 
     // Blockbook sometimes cannot parse any address from output
-    // e.g. https://tbtc1.trezor.io/tx/904f2c2dabc95c504d758d683a00110b324c2bb3caa8163019495fc0d0a82c42
+    // e.g. https://tbtc.trezor.io/tx/904f2c2dabc95c504d758d683a00110b324c2bb3caa8163019495fc0d0a82c42
     const outs = vout.map(({ addresses = [] }) => addresses[0] ?? '');
 
     return getTransactionVbytesFromAddresses(ins, outs, network);

--- a/packages/utxo-lib/tests/__fixtures__/compose.crosscheck.ts
+++ b/packages/utxo-lib/tests/__fixtures__/compose.crosscheck.ts
@@ -35,13 +35,13 @@ export const fixturesCrossCheck: Fixture[] = [
             ],
         },
         result: {
-            'p2pkh-p2pkh': { bytes: 192 }, // https://btc1.trezor.io/tx/b676df70d6f1f14eca0dc947e831b319236e3ac9a3a90b6601ec8956fc4da369
-            'p2pkh-p2sh': { bytes: 190 }, // should be 189? https://btc1.trezor.io/tx/f80c22b750cef6eae1a0b880b9ec0ebb1fa8cbe88d57de25dd270842628bd0e6
+            'p2pkh-p2pkh': { bytes: 192 }, // https://btc.trezor.io/tx/b676df70d6f1f14eca0dc947e831b319236e3ac9a3a90b6601ec8956fc4da369
+            'p2pkh-p2sh': { bytes: 190 }, // should be 189? https://btc.trezor.io/tx/f80c22b750cef6eae1a0b880b9ec0ebb1fa8cbe88d57de25dd270842628bd0e6
             'p2pkh-p2tr': { bytes: 201 },
-            'p2pkh-p2wpkh': { bytes: 189 }, // https://btc1.trezor.io/tx/ea6add0bcaf36cd495b269c8af47d9f330095d14d6cbf9c6c24bed83b53f2bf2
+            'p2pkh-p2wpkh': { bytes: 189 }, // https://btc.trezor.io/tx/ea6add0bcaf36cd495b269c8af47d9f330095d14d6cbf9c6c24bed83b53f2bf2
             'p2pkh-p2wsh': { bytes: 201 },
-            'p2sh-p2pkh': { bytes: 136 }, // https://btc1.trezor.io/tx/6e6ad85c99bfb6ed7c0fa3ec99af02dfcdb805aeda36674bbeb3960bfc6418ba
-            'p2sh-p2sh': { bytes: 134 }, // https://btc1.trezor.io/tx/d10a4078b8d557ec5280a202fa7df7be8838b4c9f7265ee4ed7737700257cbf7
+            'p2sh-p2pkh': { bytes: 136 }, // https://btc.trezor.io/tx/6e6ad85c99bfb6ed7c0fa3ec99af02dfcdb805aeda36674bbeb3960bfc6418ba
+            'p2sh-p2sh': { bytes: 134 }, // https://btc.trezor.io/tx/d10a4078b8d557ec5280a202fa7df7be8838b4c9f7265ee4ed7737700257cbf7
             'p2sh-p2tr': { bytes: 145 },
             'p2sh-p2wpkh': { bytes: 133 },
             'p2sh-p2wsh': { bytes: 145 },
@@ -49,7 +49,7 @@ export const fixturesCrossCheck: Fixture[] = [
             'p2tr-p2sh': { bytes: 100 },
             'p2tr-p2tr': { bytes: 111 },
             'p2tr-p2wpkh': { bytes: 99 },
-            'p2tr-p2wsh': { bytes: 111 }, // https://btc1.trezor.io/tx/9f472739fa7034dfb9736fa4d98915f2e8ddf70a86ee5e0a9ac0634f8c1d0007
+            'p2tr-p2wsh': { bytes: 111 }, // https://btc.trezor.io/tx/9f472739fa7034dfb9736fa4d98915f2e8ddf70a86ee5e0a9ac0634f8c1d0007
             'p2wpkh-p2pkh': { bytes: 113 },
             'p2wpkh-p2sh': { bytes: 111 },
             'p2wpkh-p2tr': { bytes: 122 },
@@ -75,14 +75,14 @@ export const fixturesCrossCheck: Fixture[] = [
         },
         result: {
             'p2pkh-p2pkh': { bytes: 226 },
-            'p2pkh-p2sh': { bytes: 224 }, // should be 223? https://btc3.trezor.io/tx/918f59f7144fa389f66b6776e3417e1ec356214e18684050237acc056d5efbc1
+            'p2pkh-p2sh': { bytes: 224 }, // should be 223? https://btc.trezor.io/tx/918f59f7144fa389f66b6776e3417e1ec356214e18684050237acc056d5efbc1
             'p2pkh-p2tr': { bytes: 235 },
             'p2pkh-p2wpkh': { bytes: 223 },
             'p2pkh-p2wsh': { bytes: 235 },
             'p2sh-p2pkh': { bytes: 168 },
-            'p2sh-p2sh': { bytes: 166 }, // https://btc1.trezor.io/tx/941eb4e6deded748848388cb110d7fdfc8ff9512028f21efd39854bdb1e34305
+            'p2sh-p2sh': { bytes: 166 }, // https://btc.trezor.io/tx/941eb4e6deded748848388cb110d7fdfc8ff9512028f21efd39854bdb1e34305
             'p2sh-p2tr': { bytes: 177 },
-            'p2sh-p2wpkh': { bytes: 165 }, // https://btc3.trezor.io/tx/fa80a9949f1094119195064462f54d0e0eabd3139becd4514ae635b8c7fe3a46
+            'p2sh-p2wpkh': { bytes: 165 }, // https://btc.trezor.io/tx/fa80a9949f1094119195064462f54d0e0eabd3139becd4514ae635b8c7fe3a46
             'p2sh-p2wsh': { bytes: 177 },
             'p2tr-p2pkh': { bytes: 145 },
             'p2tr-p2sh': { bytes: 143 },
@@ -92,7 +92,7 @@ export const fixturesCrossCheck: Fixture[] = [
             'p2wpkh-p2pkh': { bytes: 144 },
             'p2wpkh-p2sh': { bytes: 142 },
             'p2wpkh-p2tr': { bytes: 153 },
-            'p2wpkh-p2wpkh': { bytes: 141 }, // https://btc3.trezor.io/tx/5dfd1b037633adc7f84a17b2df31c9994fe50b3ab3e246c44c4ceff3d326f62e
+            'p2wpkh-p2wpkh': { bytes: 141 }, // https://btc.trezor.io/tx/5dfd1b037633adc7f84a17b2df31c9994fe50b3ab3e246c44c4ceff3d326f62e
             'p2wpkh-p2wsh': { bytes: 153 },
         },
     },
@@ -133,12 +133,12 @@ export const fixturesCrossCheck: Fixture[] = [
             'p2sh-p2pkh': { bytes: 259 },
             'p2sh-p2sh': { bytes: 257 },
             'p2sh-p2tr': { bytes: 268 },
-            'p2sh-p2wpkh': { bytes: 256 }, // https://btc3.trezor.io/tx/799a8923515e0303b15dda074b8341b2cf5efab946fce0d68a6614f32a8fc935
+            'p2sh-p2wpkh': { bytes: 256 }, // https://btc.trezor.io/tx/799a8923515e0303b15dda074b8341b2cf5efab946fce0d68a6614f32a8fc935
             'p2sh-p2wsh': { bytes: 268 },
             'p2tr-p2pkh': { bytes: 203 },
             'p2tr-p2sh': { bytes: 201 },
             'p2tr-p2tr': { bytes: 212 },
-            'p2tr-p2wpkh': { bytes: 200 }, // https://tbtc1.trezor.io/tx/48bc29fc42a64b43d043b0b7b99b21aa39654234754608f791c60bcbd91a8e92
+            'p2tr-p2wpkh': { bytes: 200 }, // https://tbtc.trezor.io/tx/48bc29fc42a64b43d043b0b7b99b21aa39654234754608f791c60bcbd91a8e92
             'p2tr-p2wsh': { bytes: 212 },
             'p2wpkh-p2pkh': { bytes: 212 },
             'p2wpkh-p2sh': { bytes: 210 },

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -365,7 +365,7 @@ export const networks = {
         bip43Path: "m/44'/61'/0'/0/i",
         decimals: 18,
         testnet: false,
-        explorer: getExplorerUrls('https://etc1.trezor.io', 'ethereum'),
+        explorer: getExplorerUrls('https://etc.trezor.io', 'ethereum'),
         features: ['sign-verify', 'tokens', 'coin-definitions', 'graph'],
         backendTypes: ['blockbook'],
         accountTypes: {},

--- a/suite-common/wallet-utils/src/__fixtures__/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/sendFormUtils.ts
@@ -21,7 +21,7 @@ export const prepareEthereumTransaction = [
         },
     },
     {
-        // https://eth1.trezor.io/tx/0xdcaf3eba690a3cdbad8c2926a8f5a95cd20003c5ba2aace91d8c5fe8048e395b
+        // https://eth.trezor.io/tx/0xdcaf3eba690a3cdbad8c2926a8f5a95cd20003c5ba2aace91d8c5fe8048e395b
         description: 'erc20',
         txInfo: {
             token: {


### PR DESCRIPTION
## Description

Updated network backends from e.g. `eth1.trezor.io`, `eth2.trezor.io`, ..., to `eth.trezor.io`.

Updated mainnets:
- [x] Bitcoin
- [x] Ethereum
- [x] Polygon
- [x] BNB Smart Chain
- [x] Arbitrum One
- [x] Base
- [x] Optimism
- [x] Avalanche C-Chain
- [ ] Solana
- [x] Cardano
- [x] Ethereum Classic
- [ ] Ripple
- [ ] Stellar
- [x] Litecoin
- [x] Bitcoin Cash
- [x] Dogecoin
- [x] ZCash

Updates testnets:
- [x] Bitcoin Testnet
- [x] Bitcoin Testnet 4
- [x] Ethereum Sepolia
- [x] Ethereum Hoodi
- [ ] Solana Devnet
- [ ] Cardano Testnet
- [ ] XRP Testnet
- [ ] Stellar Testnet

## Related Issue

Resolve #22639 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/backends&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/backends&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/backends&lookback=7)