### PR TITLE
Suite-web based Connect popup

### DIFF
--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -48,6 +48,9 @@
         "tslib": "^2.6.2"
     },
     "devDependencies": {
+        "@types/chrome": "^0.0.299",
+        "@types/jest": "29.5.12",
+        "@types/node": "22.13.10",
         "tsx": "^4.20.3"
     }
 }

--- a/packages/connect-common/src/index.ts
+++ b/packages/connect-common/src/index.ts
@@ -1,4 +1,7 @@
 export * from './storage';
 export * from './messageChannel/abstract';
+export * from './messageChannel/window-window';
+export * from './messageChannel/serviceworker-window';
+export * from './messageChannel/window-serviceworker';
 export * from './systemInfo';
 export * from './map-releases';

--- a/packages/connect-common/src/messageChannel/serviceworker-window.ts
+++ b/packages/connect-common/src/messageChannel/serviceworker-window.ts
@@ -2,7 +2,7 @@ import {
     AbstractMessageChannel,
     AbstractMessageChannelConstructorParams,
     Message,
-} from '@trezor/connect-common';
+} from './abstract';
 
 /**
  * Communication channel between:

--- a/packages/connect-common/src/messageChannel/serviceworker-window.ts
+++ b/packages/connect-common/src/messageChannel/serviceworker-window.ts
@@ -70,6 +70,9 @@ export class ServiceWorkerWindowChannel<
                     'https://suite.corp.sldev.cz',
                     'https://dev.suite.sldev.cz',
                     'http://localhost:8088',
+                    'https://suite.trezor.io',
+                    'https://staging-suite.trezor.io',
+                    'http://localhost:8000',
                 ];
 
                 // If service worker is running in web extension and other env of this webextension

--- a/packages/connect-common/src/messageChannel/window-serviceworker.ts
+++ b/packages/connect-common/src/messageChannel/window-serviceworker.ts
@@ -2,7 +2,7 @@ import {
     AbstractMessageChannel,
     AbstractMessageChannelConstructorParams,
     Message,
-} from '@trezor/connect-common';
+} from './abstract';
 
 /**
  * Communication channel between:

--- a/packages/connect-common/src/messageChannel/window-window.ts
+++ b/packages/connect-common/src/messageChannel/window-window.ts
@@ -2,7 +2,7 @@ import {
     AbstractMessageChannel,
     AbstractMessageChannelConstructorParams,
     Message,
-} from '@trezor/connect-common';
+} from './abstract';
 
 /**
  * Communication channel between:

--- a/packages/connect-common/tsconfig.json
+++ b/packages/connect-common/tsconfig.json
@@ -1,6 +1,9 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": { "outDir": "./libDev" },
+    "compilerOptions": {
+        "outDir": "./libDev",
+        "types": ["node", "chrome", "jest"]
+    },
     "include": ["."],
     "references": [
         { "path": "../env-utils" },

--- a/packages/connect-common/tsconfig.lib.json
+++ b/packages/connect-common/tsconfig.lib.json
@@ -2,7 +2,8 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "./lib",
-        "esModuleInterop": false
+        "esModuleInterop": false,
+        "types": ["node", "chrome", "jest"]
     },
     "include": ["./src"],
     "references": [

--- a/packages/connect-explorer/src/components/Settings.tsx
+++ b/packages/connect-explorer/src/components/Settings.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { Button } from '@trezor/components';
 
 import * as trezorConnectActions from '../actions/trezorConnectActions';
-import { isBetaOnly } from '../components/BetaOnly';
 import { getField } from '../components/Method';
 import { useActions, useSelector } from '../hooks';
 
@@ -56,8 +55,9 @@ export const Settings = () => {
                 { value: 'auto', label: 'Auto' },
                 { value: 'iframe', label: 'Iframe' },
                 { value: 'popup', label: 'Popup' },
-                ...(isBetaOnly ? [{ value: 'deeplink', label: 'Deeplink (mobile)' }] : []),
-                ...(isBetaOnly ? [{ value: 'suite-desktop', label: 'Suite desktop' }] : []),
+                { value: 'deeplink', label: 'Deeplink (mobile)' },
+                { value: 'suite-desktop', label: 'Suite desktop' },
+                { value: 'suite-web', label: 'Suite web' },
             ],
         },
         {

--- a/packages/connect-explorer/src/middlewares/trezorConnectMiddleware.ts
+++ b/packages/connect-explorer/src/middlewares/trezorConnectMiddleware.ts
@@ -8,7 +8,6 @@ import { getQueryVariable } from '../utils/windowUtils';
 export const trezorConnectMiddleware =
     (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => (action: Action) => {
         const prevConnectOptions = api.getState().connect.options;
-        console.log('trezorConnectMiddleware', action, prevConnectOptions);
 
         next(action);
 

--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -121,7 +121,7 @@ export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSet
 
     public setTransports() {
         // not supported, transports are controlled by suite-desktop.
-        throw new Error('Unsupported');
+        throw new Error('Method_InvalidPackage');
     }
 
     public async call(params: CallMethodPayload): Promise<CallMethodAnyResponse> {

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -1,0 +1,207 @@
+import EventEmitter from 'events';
+
+// NOTE: @trezor/connect part is intentionally not imported from the index so we do include the whole library.
+import * as ERRORS from '@trezor/connect/src/constants/errors';
+import {
+    CallMethodAnyResponse,
+    CallMethodPayload,
+    UiResponseEvent,
+    createErrorMessage,
+} from '@trezor/connect/src/events';
+import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
+import type {
+    ConnectSettings,
+    ConnectSettingsWeb,
+    Manifest,
+    Response,
+} from '@trezor/connect/src/types';
+import { InitFullSettings } from '@trezor/connect/src/types/api/init';
+import { Login } from '@trezor/connect/src/types/api/requestLogin';
+import { Log, initLog } from '@trezor/connect/src/utils/debug';
+import { Deferred, createDeferred, createDeferredManager } from '@trezor/utils';
+
+import { parseConnectSettings } from '../connectSettings';
+
+/**
+ * Base class for CoreInPopup methods for TrezorConnect factory.
+ * This implementation is directly used here in connect-web, but it is also extended in connect-webextension.
+ */
+export class CoreInSuiteWeb implements ConnectFactoryDependencies<ConnectSettingsWeb> {
+    public eventEmitter = new EventEmitter();
+    protected _settings: ConnectSettings;
+
+    protected logger: Log;
+
+    private _popup?: WindowProxy;
+    private _popupLoaded?: Deferred<void>;
+    private _responsePromises = createDeferredManager<CallMethodAnyResponse>();
+
+    public constructor() {
+        this._settings = parseConnectSettings();
+        this.logger = initLog('@trezor/connect-web');
+
+        if (typeof window === 'undefined' || !window) return;
+        window.addEventListener('message', (event: MessageEvent) => {
+            this.logger.debug('window: message event', event.data);
+            if (event.data?.type === 'connect-popup/ready') {
+                this._popupLoaded?.resolve();
+            }
+            if (event.data?.type === 'connect-popup/response') {
+                this._responsePromises.resolve(event.data.id, event.data);
+            }
+        });
+    }
+
+    public manifest(data: Manifest) {
+        this._settings = parseConnectSettings({
+            ...this._settings,
+            manifest: data,
+        });
+    }
+
+    public dispose() {
+        this.eventEmitter.removeAllListeners();
+        this._settings = parseConnectSettings();
+
+        return Promise.resolve(undefined);
+    }
+
+    public cancel(_error?: string) {
+        this._popup?.postMessage(
+            {
+                type: 'connect-popup/cancel',
+            },
+            '*',
+        );
+    }
+
+    public init(settings: InitFullSettings<{}>): Promise<void> {
+        this._settings = parseConnectSettings({
+            ...this._settings,
+            ...settings,
+        });
+        this.logger.enabled = !!this._settings.debug;
+
+        if (!this._settings.manifest) {
+            throw ERRORS.TypedError('Init_ManifestMissing');
+        }
+
+        this.logger.debug('initiated');
+
+        return Promise.resolve();
+    }
+
+    public setTransports() {
+        // not supported, transports are controlled by suite.
+        throw new Error('Unsupported');
+    }
+
+    private getSuiteUrl() {
+        if (this._settings.connectSrc?.startsWith('http://localhost')) {
+            return 'http://localhost:8000/connect-popup';
+        }
+        if (this._settings.connectSrc?.startsWith('https://dev.suite.sldev.cz/connect/')) {
+            const branch = this._settings.connectSrc?.replace(
+                'https://dev.suite.sldev.cz/connect/',
+                '',
+            );
+
+            return `https://dev.suite.sldev.cz/suite-web/${branch}web/connect-popup`;
+        }
+
+        return 'https://suite.trezor.io/web/connect-popup';
+    }
+
+    /**
+     * 1. opens popup
+     * 2. sends request to popup where the request is handled by core
+     * 3. returns response
+     */
+    public async call(params: CallMethodPayload): Promise<CallMethodAnyResponse> {
+        this.logger.debug('call', params);
+
+        if (!this._popup || this._popup.closed) {
+            this._popup = window.open(this.getSuiteUrl(), 'trezor-connect-popup') || undefined;
+
+            if (!this._popup) {
+                throw ERRORS.TypedError('Init_NotInitialized');
+            }
+            this.logger.debug('call: opening popup');
+            // wait for popup to load
+            this._popupLoaded = createDeferred<void>();
+            /*setTimeout(() => {
+                popupLoaded.reject(ERRORS.TypedError('Init_NotInitialized'));
+            }, 10000);*/
+            this.logger.debug('call: popup waiting for ready message');
+            await this._popupLoaded.promise;
+            this.logger.debug('call: popup loaded');
+        }
+
+        try {
+            // post message to core in popup
+            const { promiseId, promise } = this._responsePromises.create();
+            this._popup.postMessage(
+                {
+                    id: promiseId,
+                    type: 'connect-popup/call',
+                    method: params.method,
+                    payload: params,
+                    manifest: this._settings.manifest,
+                },
+                '*',
+            );
+
+            const response = await promise;
+            this.logger.debug('call: response: ', response);
+
+            if (!response) {
+                throw ERRORS.TypedError('Method_NoResponse');
+            }
+
+            return response;
+        } catch (error) {
+            this.logger.error('call: error', error);
+
+            return createErrorMessage(error);
+        }
+    }
+
+    // this shouldn't be needed, ui response should be handled in suite-desktop
+    uiResponse(_response: UiResponseEvent) {
+        throw ERRORS.TypedError('Method_InvalidPackage');
+    }
+
+    // todo: not supported yet
+    requestLogin(): Response<Login> {
+        throw ERRORS.TypedError('Method_InvalidPackage');
+    }
+
+    // not needed, only because of types
+    disableWebUSB() {
+        throw ERRORS.TypedError('Method_InvalidPackage');
+    }
+
+    // not needed, only because of types
+    requestWebUSBDevice() {
+        throw ERRORS.TypedError('Method_InvalidPackage');
+    }
+
+    // not needed, only because of types
+    renderWebUSBButton() {}
+}
+
+const impl = new CoreInSuiteWeb();
+
+// Exported to enable using directly
+export const TrezorConnect = factory({
+    // Bind all methods due to shadowing `this`
+    eventEmitter: impl.eventEmitter,
+    init: impl.init.bind(impl),
+    call: impl.call.bind(impl),
+    setTransports: impl.setTransports.bind(impl),
+    manifest: impl.manifest.bind(impl),
+    requestLogin: impl.requestLogin.bind(impl),
+    uiResponse: impl.uiResponse.bind(impl),
+    cancel: impl.cancel.bind(impl),
+    dispose: impl.dispose.bind(impl),
+});

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -5,6 +5,9 @@ import * as ERRORS from '@trezor/connect/src/constants/errors';
 import {
     CallMethodAnyResponse,
     CallMethodPayload,
+    DEVICE_EVENT,
+    IFRAME,
+    POPUP,
     UiResponseEvent,
     createErrorMessage,
 } from '@trezor/connect/src/events';
@@ -18,9 +21,9 @@ import type {
 import { InitFullSettings } from '@trezor/connect/src/types/api/init';
 import { Login } from '@trezor/connect/src/types/api/requestLogin';
 import { Log, initLog } from '@trezor/connect/src/utils/debug';
-import { Deferred, createDeferred, createDeferredManager } from '@trezor/utils';
 
 import { parseConnectSettings } from '../connectSettings';
+import { PopupManager } from '../popup';
 
 /**
  * Base class for CoreInPopup methods for TrezorConnect factory.
@@ -29,27 +32,13 @@ import { parseConnectSettings } from '../connectSettings';
 export class CoreInSuiteWeb implements ConnectFactoryDependencies<ConnectSettingsWeb> {
     public eventEmitter = new EventEmitter();
     protected _settings: ConnectSettings;
+    private _popupManager?: PopupManager;
 
     protected logger: Log;
-
-    private _popup?: WindowProxy;
-    private _popupLoaded?: Deferred<void>;
-    private _responsePromises = createDeferredManager<CallMethodAnyResponse>();
 
     public constructor() {
         this._settings = parseConnectSettings();
         this.logger = initLog('@trezor/connect-web');
-
-        if (typeof window === 'undefined' || !window) return;
-        window.addEventListener('message', (event: MessageEvent) => {
-            this.logger.debug('window: message event', event.data);
-            if (event.data?.type === 'connect-popup/ready') {
-                this._popupLoaded?.resolve();
-            }
-            if (event.data?.type === 'connect-popup/response') {
-                this._responsePromises.resolve(event.data.id, event.data);
-            }
-        });
     }
 
     public manifest(data: Manifest) {
@@ -66,15 +55,6 @@ export class CoreInSuiteWeb implements ConnectFactoryDependencies<ConnectSetting
         return Promise.resolve(undefined);
     }
 
-    public cancel(_error?: string) {
-        this._popup?.postMessage(
-            {
-                type: 'connect-popup/cancel',
-            },
-            '*',
-        );
-    }
-
     public init(settings: InitFullSettings<{}>): Promise<void> {
         this._settings = parseConnectSettings({
             ...this._settings,
@@ -85,15 +65,21 @@ export class CoreInSuiteWeb implements ConnectFactoryDependencies<ConnectSetting
         if (!this._settings.manifest) {
             throw ERRORS.TypedError('Init_ManifestMissing');
         }
+        if (!this._popupManager) {
+            this._popupManager = new PopupManager(
+                { ...this._settings, useCoreInPopup: true, popupSrc: this.getSuiteUrl() },
+                {
+                    logger: this.logger,
+                },
+            );
+            this._popupManager.on(DEVICE_EVENT, event => {
+                this.eventEmitter.emit(DEVICE_EVENT, event);
+            });
+        }
 
         this.logger.debug('initiated');
 
         return Promise.resolve();
-    }
-
-    public setTransports() {
-        // not supported, transports are controlled by suite.
-        throw new Error('Unsupported');
     }
 
     private getSuiteUrl() {
@@ -120,45 +106,33 @@ export class CoreInSuiteWeb implements ConnectFactoryDependencies<ConnectSetting
     public async call(params: CallMethodPayload): Promise<CallMethodAnyResponse> {
         this.logger.debug('call', params);
 
-        if (!this._popup || this._popup.closed) {
-            this._popup = window.open(this.getSuiteUrl(), 'trezor-connect-popup') || undefined;
-
-            if (!this._popup) {
-                throw ERRORS.TypedError('Init_NotInitialized');
-            }
-            this.logger.debug('call: opening popup');
-            // wait for popup to load
-            this._popupLoaded = createDeferred<void>();
-            /*setTimeout(() => {
-                popupLoaded.reject(ERRORS.TypedError('Init_NotInitialized'));
-            }, 10000);*/
-            this.logger.debug('call: popup waiting for ready message');
-            await this._popupLoaded.promise;
-            this.logger.debug('call: popup loaded');
+        if (!this._popupManager) {
+            return createErrorMessage(ERRORS.TypedError('Init_NotInitialized'));
         }
+        await this._popupManager.request();
+        await this._popupManager.channel.init();
+        await this._popupManager.handshakePromise?.promise;
 
         try {
             // post message to core in popup
-            const { promiseId, promise } = this._responsePromises.create();
-            this._popup.postMessage(
-                {
-                    id: promiseId,
-                    type: 'connect-popup/call',
-                    method: params.method,
-                    payload: params,
-                    manifest: this._settings.manifest,
-                },
-                '*',
-            );
-
-            const response = await promise;
+            const response = await this._popupManager.channel.postMessage({
+                type: IFRAME.CALL,
+                payload: params,
+            });
             this.logger.debug('call: response: ', response);
 
-            if (!response) {
+            if (!response?.payload) {
                 throw ERRORS.TypedError('Method_NoResponse');
             }
+            if (response.payload.error && response.payload.code) {
+                throw response.payload;
+            }
 
-            return response;
+            return {
+                success: response.payload.success,
+                payload: response.payload.payload,
+                device: response.payload.device,
+            };
         } catch (error) {
             this.logger.error('call: error', error);
 
@@ -166,7 +140,19 @@ export class CoreInSuiteWeb implements ConnectFactoryDependencies<ConnectSetting
         }
     }
 
-    // this shouldn't be needed, ui response should be handled in suite-desktop
+    public cancel(_error?: string) {
+        this._popupManager?.channel?.postMessage({
+            type: POPUP.CLOSED,
+            payload: { error: _error },
+        });
+    }
+
+    // not supported, transports are controlled by suite
+    public setTransports() {
+        throw new Error('Method_InvalidPackage');
+    }
+
+    // this shouldn't be needed, ui response should be handled in suite
     uiResponse(_response: UiResponseEvent) {
         throw ERRORS.TypedError('Method_InvalidPackage');
     }

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -6,6 +6,7 @@ import { getEnv } from './connectSettings';
 import { CoreInIframe } from './impl/core-in-iframe';
 import { CoreInPopup } from './impl/core-in-popup';
 import { CoreInSuiteDesktop } from './impl/core-in-suite-desktop';
+import { CoreInSuiteWeb } from './impl/core-in-suite-web';
 
 const IFRAME_ERRORS = ['Init_IframeBlocked', 'Init_IframeTimeout', 'Transport_Missing'];
 
@@ -16,7 +17,7 @@ type ConnectWebExtraMethods = {
 };
 
 const impl = new TrezorConnectDynamic<
-    'iframe' | 'core-in-popup' | 'core-in-suite-desktop',
+    'iframe' | 'core-in-popup' | 'core-in-suite-desktop' | 'core-in-suite-web',
     ConnectSettingsWeb,
     ConnectFactoryDependencies<ConnectSettingsWeb> & ConnectWebExtraMethods
 >({
@@ -33,6 +34,10 @@ const impl = new TrezorConnectDynamic<
             type: 'core-in-suite-desktop',
             impl: new CoreInSuiteDesktop(),
         },
+        {
+            type: 'core-in-suite-web',
+            impl: new CoreInSuiteWeb(),
+        },
     ],
     getInitTarget: (settings: Partial<ConnectSettingsPublic & ConnectSettingsWeb>) => {
         if (settings.coreMode === 'iframe') {
@@ -41,6 +46,8 @@ const impl = new TrezorConnectDynamic<
             return 'core-in-popup';
         } else if (settings.coreMode === 'suite-desktop') {
             return 'core-in-suite-desktop';
+        } else if (settings.coreMode === 'suite-web') {
+            return 'core-in-suite-web';
         } else {
             if (settings.coreMode && settings.coreMode !== 'auto') {
                 console.warn(`Invalid coreMode: ${settings.coreMode}`);

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -18,12 +18,12 @@ import {
     AbstractMessageChannel,
     Message,
 } from '@trezor/connect-common/src/messageChannel/abstract';
+import { ServiceWorkerWindowChannel } from '@trezor/connect-common/src/messageChannel/serviceworker-window';
+import { WindowWindowChannel } from '@trezor/connect-common/src/messageChannel/window-window';
 import type { IntervalId, TimerId } from '@trezor/type-utils';
 import { Deferred, createDeferred, scheduleAction } from '@trezor/utils';
 
 import { showPopupRequest } from './showPopupRequest';
-import { ServiceWorkerWindowChannel } from '../channels/serviceworker-window';
-import { WindowWindowChannel } from '../channels/window-window';
 
 // Util
 const checkIfTabExists = (tabId: number | undefined) =>

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -40,6 +40,7 @@
     },
     "dependencies": {
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-common": "workspace:*",
         "@trezor/connect-web": "workspace:*"
     },
     "devDependencies": {

--- a/packages/connect-webextension/src/contentScript.ts
+++ b/packages/connect-webextension/src/contentScript.ts
@@ -1,6 +1,6 @@
 import { CONTENT_SCRIPT_VERSION } from '@trezor/connect/src/data/version';
 import { POPUP } from '@trezor/connect/src/events/popup';
-import { WindowServiceWorkerChannel } from '@trezor/connect-web/src/channels/window-serviceworker';
+import { WindowServiceWorkerChannel } from '@trezor/connect-common/src/messageChannel/window-serviceworker';
 
 function trezorContentScript() {
     // Check if extension ID matches the popup URL

--- a/packages/connect-webextension/src/impl.ts
+++ b/packages/connect-webextension/src/impl.ts
@@ -2,6 +2,7 @@ import { InitFullSettings } from '@trezor/connect/src/types/api/init';
 import { initLog } from '@trezor/connect/src/utils/debug';
 import { CoreInPopup } from '@trezor/connect-web/src/impl/core-in-popup';
 import { CoreInSuiteDesktop } from '@trezor/connect-web/src/impl/core-in-suite-desktop';
+import { CoreInSuiteWeb } from '@trezor/connect-web/src/impl/core-in-suite-web';
 
 import { parseConnectSettings } from './connectSettings';
 import { ConnectSettingsWebextension } from './proxy';
@@ -40,6 +41,16 @@ export class CoreInPopupWebextension extends CoreInPopup {
 }
 
 export class CoreInSuiteDesktopWebextension extends CoreInSuiteDesktop {
+    public init(settings: InitFullSettings<ConnectSettingsWebextension>): Promise<void> {
+        if (settings._extendWebextensionLifetime) {
+            extendLifetime();
+        }
+
+        return super.init(settings);
+    }
+}
+
+export class CoreInSuiteWebWebextension extends CoreInSuiteWeb {
     public init(settings: InitFullSettings<ConnectSettingsWebextension>): Promise<void> {
         if (settings._extendWebextensionLifetime) {
             extendLifetime();

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -9,7 +9,7 @@ import {
 import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
 import { TrezorConnectDynamic } from '@trezor/connect/src/impl/dynamic';
 // Import as src not lib due to webpack issues with inlining content script later
-import { ServiceWorkerWindowChannel } from '@trezor/connect-web/src/channels/serviceworker-window';
+import { ServiceWorkerWindowChannel } from '@trezor/connect-common/src/messageChannel/serviceworker-window';
 
 import { parseConnectSettings } from './connectSettings';
 import { CoreInPopupWebextension, CoreInSuiteDesktopWebextension } from './impl';

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -12,12 +12,16 @@ import { TrezorConnectDynamic } from '@trezor/connect/src/impl/dynamic';
 import { ServiceWorkerWindowChannel } from '@trezor/connect-common/src/messageChannel/serviceworker-window';
 
 import { parseConnectSettings } from './connectSettings';
-import { CoreInPopupWebextension, CoreInSuiteDesktopWebextension } from './impl';
+import {
+    CoreInPopupWebextension,
+    CoreInSuiteDesktopWebextension,
+    CoreInSuiteWebWebextension,
+} from './impl';
 
 const _settings = parseConnectSettings();
 
 const impl = new TrezorConnectDynamic<
-    'core-in-popup' | 'core-in-suite-desktop',
+    'core-in-popup' | 'core-in-suite-desktop' | 'core-in-suite-web',
     ConnectSettingsWebextension,
     ConnectFactoryDependencies<ConnectSettingsWebextension>
 >({
@@ -30,10 +34,16 @@ const impl = new TrezorConnectDynamic<
             type: 'core-in-suite-desktop',
             impl: new CoreInSuiteDesktopWebextension(),
         },
+        {
+            type: 'core-in-suite-web',
+            impl: new CoreInSuiteWebWebextension(),
+        },
     ],
     getInitTarget: (settings: Partial<ConnectSettingsPublic & ConnectSettingsWebextension>) => {
         if (settings.coreMode === 'suite-desktop') {
             return 'core-in-suite-desktop';
+        } else if (settings.coreMode === 'suite-web') {
+            return 'core-in-suite-web';
         } else {
             return 'core-in-popup';
         }

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -12,7 +12,7 @@ import {
     createErrorMessage,
 } from '@trezor/connect/src/exports';
 import { factory } from '@trezor/connect/src/factory';
-import { WindowServiceWorkerChannel } from '@trezor/connect-web/src/channels/window-serviceworker';
+import { WindowServiceWorkerChannel } from '@trezor/connect-common/src/messageChannel/window-serviceworker';
 
 const eventEmitter = new EventEmitter();
 let _channel: any;

--- a/packages/connect-webextension/tsconfig.json
+++ b/packages/connect-webextension/tsconfig.json
@@ -8,6 +8,7 @@
     "include": ["**/*.ts", "**/*.js"],
     "references": [
         { "path": "../connect" },
+        { "path": "../connect-common" },
         { "path": "../connect-web" },
         { "path": "../eslint" }
     ]

--- a/packages/connect-webextension/tsconfig.lib.json
+++ b/packages/connect-webextension/tsconfig.lib.json
@@ -10,6 +10,9 @@
             "path": "../connect"
         },
         {
+            "path": "../connect-common"
+        },
+        {
             "path": "../connect-web"
         },
         {

--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -158,7 +158,7 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
 
     if (
         typeof input.coreMode === 'string' &&
-        ['auto', 'popup', 'iframe', 'suite-desktop'].includes(input.coreMode)
+        ['auto', 'popup', 'iframe', 'suite-desktop', 'suite-web'].includes(input.coreMode)
     ) {
         settings.coreMode = input.coreMode;
     }

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -80,12 +80,12 @@ export interface ConnectSettingsInternal {
 
 export interface ConnectSettingsWeb {
     hostLabel?: string;
-    coreMode?: 'auto' | 'popup' | 'iframe' | 'deeplink' | 'suite-desktop';
+    coreMode?: 'auto' | 'popup' | 'iframe' | 'deeplink' | 'suite-desktop' | 'suite-web';
 }
 export interface ConnectSettingsWebextension {
     /** _extendWebextensionLifetime features makes the service worker in @trezor/connect-webextension stay alive longer */
     _extendWebextensionLifetime?: boolean;
-    coreMode?: 'auto' | 'popup' | 'suite-desktop';
+    coreMode?: 'auto' | 'popup' | 'suite-desktop' | 'suite-web';
 }
 export interface ConnectSettingsMobile {
     deeplinkUrl: string;

--- a/packages/suite-desktop-ui/src/support/desktopComponents.ts
+++ b/packages/suite-desktop-ui/src/support/desktopComponents.ts
@@ -2,6 +2,7 @@ import { ComponentType } from 'react';
 
 import { PageName } from '@suite-common/suite-types';
 
+import { ConnectPopup } from 'src/views/connect-popup';
 import { Dashboard } from 'src/views/dashboard';
 import PasswordManager from 'src/views/password-manager';
 import { SettingsCoins } from 'src/views/settings/SettingsCoins/SettingsCoins';
@@ -37,6 +38,7 @@ import { Transactions } from 'src/views/wallet/transactions/Transactions';
 
 export const desktopComponents: Record<PageName, ComponentType> = {
     'suite-index': Dashboard,
+    'suite-connect-popup': ConnectPopup,
     'notifications-index': Notification,
 
     'wallet-index': Transactions,

--- a/packages/suite-web/src/MainWeb.tsx
+++ b/packages/suite-web/src/MainWeb.tsx
@@ -17,6 +17,7 @@ import { createRouterServices } from 'src/support/extraDependencies';
 import { Main } from 'src/support/suite/Main';
 import { preloadStore } from 'src/support/suite/preloadStore';
 import { LoadingScreen } from 'src/support/suite/screens/LoadingScreen';
+import { useConnectPopupWeb } from 'src/support/suite/useConnectPopupWeb';
 import { useTor } from 'src/support/suite/useTor';
 
 import { usePlaywright } from './support/usePlaywright';
@@ -26,6 +27,7 @@ const MainWeb = ({ history }: { history: History }) => {
     usePlaywright();
     useTor();
     useDebugLanguageShortcut();
+    useConnectPopupWeb();
 
     return (
         <Main history={history}>

--- a/packages/suite-web/src/support/webComponents.ts
+++ b/packages/suite-web/src/support/webComponents.ts
@@ -8,6 +8,11 @@ export const webComponents: Record<PageName, LazyExoticComponent<ComponentType>>
             ({ Dashboard }) => ({ default: Dashboard }),
         ),
     ),
+    'suite-connect-popup': lazy(() =>
+        import(/* webpackChunkName: "connect-popup" */ 'src/views/connect-popup/index').then(
+            ({ ConnectPopup }) => ({ default: ConnectPopup }),
+        ),
+    ),
     'notifications-index': lazy(
         () => import(/* webpackChunkName: "notifications" */ 'src/views/suite/notifications'),
     ),

--- a/packages/suite/src/components/suite/ConnectAppBar.tsx
+++ b/packages/suite/src/components/suite/ConnectAppBar.tsx
@@ -14,6 +14,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { TrafficLightOffset } from './TrafficLightOffset';
 import { Translation } from './Translation';
+import { SuiteBanners } from './banners';
 
 export const ConnectBarWrapper = styled.div`
     position: absolute;
@@ -90,6 +91,7 @@ export const ConnectAppBar = ({ canSwitchDevice }: ConnectAppBarProps) => {
                     </Row>
                 </TrafficLightOffset>
             </Box>
+            <SuiteBanners fill />
         </ConnectBarWrapper>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
@@ -1,4 +1,9 @@
-import { connectPopupActions, selectConnectPopupCall } from '@suite-common/connect-popup';
+import {
+    connectPopupActions,
+    connectPopupCallThunkInner,
+    selectConnectPopupCall,
+} from '@suite-common/connect-popup';
+import { selectDevices, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Card, Column, H3, Icon, Modal, Paragraph, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -6,15 +11,64 @@ import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
 import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { SwitchDeviceContent } from 'src/views/suite/SwitchDevice/SwitchDevice';
+
+export const ConnectSelectDeviceModal = () => {
+    const dispatch = useDispatch();
+    const popupCall = useSelector(selectConnectPopupCall);
+    const devices = useSelector(selectDevices);
+    const selectedDevice = useSelector(selectSelectedDevice);
+    const hasConnectedDevice = devices.some(d => d.connected);
+    const selectedDeviceConnected = selectedDevice?.connected;
+    const onCancel = () => {
+        dispatch(connectPopupActions.finishCall());
+    };
+    const onResume = () => {
+        if (popupCall?.state === 'call-error')
+            dispatch(
+                connectPopupCallThunkInner({
+                    ...popupCall,
+                }),
+            );
+    };
+
+    return (
+        <ConnectModalBackdrop>
+            <Modal.ModalBase
+                variant="primary"
+                size="tiny"
+                onCancel={onCancel}
+                heading={
+                    <Translation
+                        id={
+                            hasConnectedDevice
+                                ? 'TR_SELECT_TREZOR_TO_CONTINUE'
+                                : 'TR_CONNECT_UNLOCK_YOUR_DEVICE'
+                        }
+                    />
+                }
+                bottomContent={
+                    selectedDeviceConnected && (
+                        <Modal.Button onClick={onResume} size="medium">
+                            <Translation id="TR_CONTINUE" />
+                        </Modal.Button>
+                    )
+                }
+            >
+                <Column gap={spacings.xs}>
+                    <ConnectCallSource />
+                    <SwitchDeviceContent cancelable={false} onCancel={() => {}} />
+                </Column>
+            </Modal.ModalBase>
+        </ConnectModalBackdrop>
+    );
+};
 
 export const ConnectErrorModal = () => {
     const dispatch = useDispatch();
     const popupCall = useSelector(selectConnectPopupCall);
     const onFinish = () => {
         dispatch(connectPopupActions.finishCall());
-    };
-    const onSwitchDevice = () => {
-        dispatch(connectPopupActions.switchDevice());
     };
 
     if (!popupCall || (popupCall?.state !== 'error' && popupCall?.state !== 'call-error'))
@@ -29,6 +83,8 @@ export const ConnectErrorModal = () => {
         popupCall.error?.code === 'Device_Disconnected' ||
         popupCall.error?.code === 'Device_UsedElsewhere' ||
         popupCall.error?.code === 'Device_InvalidState';
+
+    if (isDeviceReconnectError) return <ConnectSelectDeviceModal />;
 
     const getVariant = () => {
         if (isCancelled) return 'warning';
@@ -58,11 +114,6 @@ export const ConnectErrorModal = () => {
                 variant="primary"
                 bottomContent={
                     <>
-                        {isDeviceReconnectError && (
-                            <Modal.Button onClick={onSwitchDevice} size="medium">
-                                <Translation id="TR_SWITCH_DEVICE" />
-                            </Modal.Button>
-                        )}
                         <Modal.Button variant="tertiary" onClick={onFinish} size="medium">
                             <Translation id="TR_CLOSE" />
                         </Modal.Button>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
@@ -5,6 +5,7 @@ import {
 } from '@suite-common/connect-popup';
 import { selectDevices, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Card, Column, H3, Icon, Modal, Paragraph, Row } from '@trezor/components';
+import { UI_REQUEST } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
 import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
@@ -103,6 +104,20 @@ export const ConnectErrorModal = () => {
     };
     const getErrorText = () => {
         if (isCancelled) return <Translation id="TR_CONNECT_ERROR_CANCELED" />;
+        if (popupCall.error?.error === UI_REQUEST.BOOTLOADER)
+            return <Translation id="TR_DEVICE_IN_BOOTLOADER" />;
+        if (popupCall.error?.error === UI_REQUEST.NOT_IN_BOOTLOADER)
+            return <Translation id="TR_RECONNECT_IN_BOOTLOADER" />;
+        if (popupCall.error?.error === UI_REQUEST.SEEDLESS)
+            return <Translation id="TR_YOUR_DEVICE_IS_SEEDLESS" />;
+        if (popupCall.error?.error === UI_REQUEST.INITIALIZE)
+            return <Translation id="TR_DEVICE_NOT_INITIALIZED" />;
+        if (popupCall.error?.error === UI_REQUEST.FIRMWARE_NOT_INSTALLED)
+            return <Translation id="TR_NO_FIRMWARE" />;
+        if (popupCall.error?.error === UI_REQUEST.FIRMWARE_NOT_SUPPORTED)
+            return <Translation id="TR_UNSUPPORTED_COINS_DESCRIPTION" />;
+        if (popupCall.error?.error === UI_REQUEST.FIRMWARE_OLD)
+            return <Translation id="TR_FIRMWARE_UPDATE_REQUIRED_EXPLAINED" />;
         if (popupCall.error?.error) return popupCall.error.error;
 
         return <Translation id="TR_UNKNOWN_ERROR_SEE_CONSOLE" />;

--- a/packages/suite/src/hooks/suite/usePreferredModal.ts
+++ b/packages/suite/src/hooks/suite/usePreferredModal.ts
@@ -1,3 +1,4 @@
+import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { Route } from '@suite-common/suite-types';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { UI } from '@trezor/connect';
@@ -58,6 +59,9 @@ export const usePreferredModal = () => {
             discoveryForSelectedDevice?.status === 'progress' &&
             discoveryForSelectedDevice.hasLoadedAnyNonEmptyAccount
         );
+    const isConnectPopupFlow = useSelector(
+        state => selectConnectPopupCall(state)?.state === 'call-error',
+    );
 
     if (route && isForegroundApp(route) && hasPriority(route)) {
         return getForegroundAppAction(route, params);
@@ -77,6 +81,13 @@ export const usePreferredModal = () => {
             return {
                 type: 'device-request-passphrase',
                 payload: modal,
+            } as const;
+        }
+
+        // edge case for connect popup, since it itself is a modal, but we can enter passphrase flow from there
+        if (isPassphraseFlow && discoveryForSelectedDevice && isConnectPopupFlow) {
+            return {
+                type: 'passphrase-flow',
             } as const;
         }
 

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -422,6 +422,7 @@ export const getRootReducer = (selectedAccount = BTC_ACCOUNT, fees = DEFAULT_FEE
             } satisfies LabelingState,
             state => state,
         ),
+        connectPopup: createReducer({}, () => ({})),
     });
 
 const DEFAULT_DRAFT = {

--- a/packages/suite/src/support/suite/useConnectPopupModals.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupModals.tsx
@@ -4,6 +4,7 @@ import { connectPopupCallThunkInner, selectConnectPopupCall } from '@suite-commo
 import { isDiscoveryInProgress, selectDiscoveryForSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 
+import { selectIsConnectionModalOpen } from 'src/actions/device/deviceSelectors';
 import { CONTEXT_NONE, CONTEXT_USER } from 'src/actions/suite/constants/modalConstants';
 import { onCancel as cancelModal, openModal } from 'src/actions/suite/modalActions';
 import { goto } from 'src/actions/suite/routerActions';
@@ -21,6 +22,7 @@ export const useConnectPopupModals = () => {
     const modalContext = useSelector(state => state.modal.context);
     const modalType = useSelector(selectModalType);
     const activeRoute = useSelector(selectRouteName);
+    const isConnectionModalOpen = useSelector(selectIsConnectionModalOpen);
     useEffect(() => {
         const isConnectModal =
             modalContext === CONTEXT_USER &&
@@ -103,7 +105,8 @@ export const useConnectPopupModals = () => {
             // This check prevents restarting the call immediately after it was created, since the route may not be updated yet
             popupCall?.timestamp < Date.now() - 500 &&
             // Wait for discovery user flow to finish
-            !isInDiscoveryFlow
+            !isInDiscoveryFlow &&
+            !isConnectionModalOpen
         ) {
             dispatch(
                 connectPopupCallThunkInner({
@@ -111,5 +114,5 @@ export const useConnectPopupModals = () => {
                 }),
             );
         }
-    }, [popupCall, activeRoute, dispatch, isInDiscoveryFlow]);
+    }, [popupCall, activeRoute, dispatch, isInDiscoveryFlow, isConnectionModalOpen]);
 };

--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import {
     CALL_SOURCE_WEB,
@@ -29,23 +29,25 @@ export const useConnectPopupWeb = () => {
     const dispatch = useDispatch();
     const popupCall = useSelector(selectConnectPopupCall);
     const lifecycle = useSelector(state => state.suite.lifecycle);
-    const [manifest, setManifest] = useState<ManifestPartial | undefined>();
+    const manifest = useRef<ManifestPartial | undefined>(undefined);
+    const [pendingHandshake, setPendingHandshake] = useState<string | undefined>();
 
     useEffect(() => {
-        if (lifecycle.status !== 'ready') return;
-
         const onMessage = async (event: MessageEvent) => {
             console.log('onMessage', event.data);
             if (event.data?.type === 'channel-handshake-request') {
                 postMessageToParent({ type: 'channel-handshake-confirm' });
             } else if (event.data.type === POPUP.HANDSHAKE) {
-                setManifest(event.data.payload.settings.manifest);
-                postMessageToParent({
-                    id: event.data.id,
-                    type: POPUP.HANDSHAKE,
-                });
+                manifest.current = event.data.payload.settings.manifest;
+                setPendingHandshake(event.data.id);
             } else if (event.data?.type === IFRAME.CALL) {
-                if (!manifest) return;
+                if (!manifest.current) {
+                    console.warn(
+                        'Connect Popup Web: manifest is not set yet, cannot process IFRAME.CALL',
+                    );
+
+                    return;
+                }
 
                 await queuePopupCall();
                 const deferred = getPopupCallDeferred(true);
@@ -56,7 +58,7 @@ export const useConnectPopupWeb = () => {
                         source: {
                             type: CALL_SOURCE_WEB,
                             origin: event.origin,
-                            manifest,
+                            manifest: manifest.current,
                         },
                     }),
                 );
@@ -76,13 +78,23 @@ export const useConnectPopupWeb = () => {
         return () => {
             window.removeEventListener('message', onMessage);
         };
-    }, [dispatch, manifest, lifecycle.status]);
+    }, [dispatch]);
 
     useEffect(() => {
         if (lifecycle.status !== 'ready') return;
 
         postMessageToParent(createPopupMessage(POPUP.CORE_LOADED));
     }, [lifecycle.status]);
+
+    useEffect(() => {
+        // respond to handshake, but only after suite is ready
+        if (lifecycle.status !== 'ready' || !pendingHandshake) return;
+
+        postMessageToParent({
+            id: pendingHandshake,
+            type: POPUP.HANDSHAKE,
+        });
+    }, [lifecycle.status, pendingHandshake]);
 
     // Window close control
     useEffect(() => {

--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -1,59 +1,88 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import {
     CALL_SOURCE_WEB,
+    ManifestPartial,
     connectPopupCallThunk,
     connectPopupCancelThunk,
     getPopupCallDeferred,
     queuePopupCall,
     selectConnectPopupCall,
 } from '@suite-common/connect-popup';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { IFRAME, POPUP, RESPONSE_EVENT, createPopupMessage } from '@trezor/connect';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
+
+const postMessageToParent = (message: any) => {
+    message.channel = {
+        here: '@trezor/connect-popup',
+        peer: '@trezor/connect-web',
+    };
+    if (window.opener) {
+        window.opener.postMessage(message, '*');
+    } else {
+        window.postMessage(message, window.location.origin);
+    }
+};
 
 export const useConnectPopupWeb = () => {
     const dispatch = useDispatch();
     const popupCall = useSelector(selectConnectPopupCall);
     const lifecycle = useSelector(state => state.suite.lifecycle);
+    const [manifest, setManifest] = useState<ManifestPartial | undefined>();
 
     useEffect(() => {
-        if (lifecycle.status !== 'ready' || !window.opener) return;
+        if (lifecycle.status !== 'ready') return;
 
         const onMessage = async (event: MessageEvent) => {
-            if (event.data?.type === 'connect-popup/call') {
+            console.log('onMessage', event.data);
+            if (event.data?.type === 'channel-handshake-request') {
+                postMessageToParent({ type: 'channel-handshake-confirm' });
+            } else if (event.data.type === POPUP.HANDSHAKE) {
+                setManifest(event.data.payload.settings.manifest);
+                postMessageToParent({
+                    id: event.data.id,
+                    type: POPUP.HANDSHAKE,
+                });
+            } else if (event.data?.type === IFRAME.CALL) {
+                if (!manifest) return;
+
                 await queuePopupCall();
                 const deferred = getPopupCallDeferred(true);
                 dispatch(
                     connectPopupCallThunk({
-                        method: event.data.method as keyof typeof TrezorConnect,
+                        method: event.data.payload.method as keyof typeof TrezorConnect,
                         payload: event.data.payload,
                         source: {
                             type: CALL_SOURCE_WEB,
                             origin: event.origin,
-                            manifest: event.data.manifest,
+                            manifest,
                         },
                     }),
                 );
                 const response = await deferred.promise;
-                window.opener?.postMessage(
-                    { ...response, type: 'connect-popup/response', id: event.data.id },
-                    '*',
-                );
-            }
-            if (event.data?.type === 'connect-popup/cancel') {
+                postMessageToParent({
+                    id: event.data.id,
+                    type: RESPONSE_EVENT,
+                    payload: response,
+                });
+            } else if (event.data?.type === POPUP.CLOSED) {
                 dispatch(connectPopupCancelThunk(event.data.payload));
             }
         };
-
-        window.opener?.postMessage({ type: 'connect-popup/ready' }, '*');
 
         window.addEventListener('message', onMessage);
 
         return () => {
             window.removeEventListener('message', onMessage);
         };
-    }, [dispatch, lifecycle.status]);
+    }, [dispatch, manifest, lifecycle.status]);
+
+    useEffect(() => {
+        if (lifecycle.status !== 'ready') return;
+
+        postMessageToParent(createPopupMessage(POPUP.CORE_LOADED));
+    }, [lifecycle.status]);
 
     // Window close control
     useEffect(() => {

--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -1,0 +1,64 @@
+import { useEffect } from 'react';
+
+import {
+    CALL_SOURCE_WEB,
+    connectPopupCallThunk,
+    connectPopupCancelThunk,
+    getPopupCallDeferred,
+    queuePopupCall,
+    selectConnectPopupCall,
+} from '@suite-common/connect-popup';
+import TrezorConnect from '@trezor/connect';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+export const useConnectPopupWeb = () => {
+    const dispatch = useDispatch();
+    const popupCall = useSelector(selectConnectPopupCall);
+    const lifecycle = useSelector(state => state.suite.lifecycle);
+
+    useEffect(() => {
+        if (lifecycle.status !== 'ready' || !window.opener) return;
+
+        const onMessage = async (event: MessageEvent) => {
+            if (event.data?.type === 'connect-popup/call') {
+                await queuePopupCall();
+                const deferred = getPopupCallDeferred(true);
+                dispatch(
+                    connectPopupCallThunk({
+                        method: event.data.method as keyof typeof TrezorConnect,
+                        payload: event.data.payload,
+                        source: {
+                            type: CALL_SOURCE_WEB,
+                            origin: event.origin,
+                            manifest: event.data.manifest,
+                        },
+                    }),
+                );
+                const response = await deferred.promise;
+                window.opener?.postMessage(
+                    { ...response, type: 'connect-popup/response', id: event.data.id },
+                    '*',
+                );
+            }
+            if (event.data?.type === 'connect-popup/cancel') {
+                dispatch(connectPopupCancelThunk(event.data.payload));
+            }
+        };
+
+        window.opener?.postMessage({ type: 'connect-popup/ready' }, '*');
+
+        window.addEventListener('message', onMessage);
+
+        return () => {
+            window.removeEventListener('message', onMessage);
+        };
+    }, [dispatch, lifecycle.status]);
+
+    // Window close control
+    useEffect(() => {
+        if (popupCall?.state === 'finished' && popupCall?.source.type === CALL_SOURCE_WEB) {
+            window.close();
+        }
+    }, [popupCall]);
+};

--- a/packages/suite/src/views/connect-popup/index.tsx
+++ b/packages/suite/src/views/connect-popup/index.tsx
@@ -1,0 +1,14 @@
+import { Column } from '@trezor/components';
+
+import { useLayout } from 'src/hooks/suite';
+
+export const ConnectPopup = () => {
+    useLayout('Trezor Connect', null);
+
+    // No content, this is handled by modals
+    return (
+        <Column data-testid="@connect-popup/index">
+            <div />
+        </Column>
+    );
+};

--- a/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
@@ -12,7 +12,7 @@ import { ForegroundAppProps } from 'src/types/suite';
 import { DeviceItem } from './DeviceItem/DeviceItem';
 import { SwitchDeviceModal } from './SwitchDeviceModal';
 
-export const SwitchDevice = ({ cancelable, onCancel }: ForegroundAppProps) => {
+export const SwitchDeviceContent = ({ cancelable, onCancel }: ForegroundAppProps) => {
     const dispatch = useDispatch();
     const bluetoothAdapterStatus = useSelector(selectAdapterStatus);
     const devices = useSelector(selectDevices);
@@ -35,25 +35,29 @@ export const SwitchDevice = ({ cancelable, onCancel }: ForegroundAppProps) => {
     };
 
     return (
-        <SwitchDeviceModal isAnimationEnabled onCancel={cancelable ? onCancel : undefined}>
-            <Column gap={spacings.md}>
-                {sortedDevices.map(device => (
-                    <DeviceItem
-                        key={`${device.path}-${device.id}-${device.instance}`}
-                        device={device}
-                        instances={deviceUtils.getDeviceInstances(device, devices)}
-                        onCancel={cancelable ? onCancel : undefined}
-                    />
-                ))}
-                <Button
-                    variant="tertiary"
-                    icon="trezorDevices"
-                    isFullWidth
-                    onClick={openDeviceConnectionModal}
-                >
-                    <Translation id="TR_CONNECT_DEVICE" />
-                </Button>
-            </Column>
-        </SwitchDeviceModal>
+        <Column gap={spacings.md}>
+            {sortedDevices.map(device => (
+                <DeviceItem
+                    key={`${device.path}-${device.id}-${device.instance}`}
+                    device={device}
+                    instances={deviceUtils.getDeviceInstances(device, devices)}
+                    onCancel={cancelable ? onCancel : undefined}
+                />
+            ))}
+            <Button
+                variant="tertiary"
+                icon="trezorDevices"
+                isFullWidth
+                onClick={openDeviceConnectionModal}
+            >
+                <Translation id="TR_CONNECT_DEVICE" />
+            </Button>
+        </Column>
     );
 };
+
+export const SwitchDevice = ({ cancelable, onCancel }: ForegroundAppProps) => (
+    <SwitchDeviceModal isAnimationEnabled onCancel={cancelable ? onCancel : undefined}>
+        <SwitchDeviceContent cancelable={cancelable} onCancel={onCancel} />
+    </SwitchDeviceModal>
+);

--- a/packages/suite/src/views/suite/SwitchDevice/SwitchDeviceModal.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/SwitchDeviceModal.tsx
@@ -3,8 +3,11 @@ import { useEvent } from 'react-use';
 import { motion } from 'framer-motion';
 import styled from 'styled-components';
 
+import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { Column, Modal } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+
+import { useSelector } from 'src/hooks/suite/useSelector';
 
 import { TrafficLightOffset } from '../../../components/suite/TrafficLightOffset';
 
@@ -37,12 +40,16 @@ export const SwitchDeviceModal = ({
         }
     });
 
+    const connectPopupCall = useSelector(selectConnectPopupCall);
+    const isInConnectPopup = connectPopupCall && connectPopupCall.state !== 'finished';
+
     return (
         <Modal.Backdrop
             onClick={onCancel}
             data-testid={`${dataTest}/backdrop`}
             alignment={{ x: 'start', y: 'start' }}
             padding={spacings.xs}
+            opaque={isInConnectPopup}
         >
             <TrafficLightOffset expand={false}>
                 <Container data-testid={`${dataTest}/switch-device`}>

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -14,7 +14,11 @@ import { resolveAfter } from '@trezor/utils';
 import { connectPopupActions } from './connectPopupActions';
 import { getPermissionDeferred, getPopupCallDeferred } from './connectPopupPromiseManager';
 import { selectConnectAppPermissions, selectConnectPopupCall } from './connectPopupReducer';
-import { CALL_SOURCE_WALLETCONNECT, ConnectCallSource } from './connectPopupTypes';
+import {
+    CALL_SOURCE_DEEPLINK,
+    CALL_SOURCE_WALLETCONNECT,
+    ConnectCallSource,
+} from './connectPopupTypes';
 import { postCallHooks, preCallHooks } from './methodHooks';
 
 const CONNECT_POPUP_MODULE = '@common/connect-popup';
@@ -85,12 +89,15 @@ export const connectPopupCallThunkInner = createThunk<
 
             let device = selectSelectedDevice(getState());
             let attempt = 0;
+            // more time needed on mobile deeplink, less on desktop
+            // todo: be smarter about the timeout based on actual connection events
+            const maxAttempts = source.type === CALL_SOURCE_DEEPLINK ? 10 : 5;
             // retry loop to wait for device to reconnect
             while (!device || !device.connected) {
                 await resolveAfter(1000);
                 device = selectSelectedDevice(getState());
                 attempt++;
-                if (attempt > 10) {
+                if (attempt > maxAttempts) {
                     throw TypedError('Device_Disconnected');
                 }
             }
@@ -161,6 +168,15 @@ export const connectPopupCallThunkInner = createThunk<
                 dispatch(connectPopupActions.finishCall());
             } else {
                 dispatch(connectPopupActions.setError(serializeError(error)));
+
+                // don't return error, allow user to reconnect device
+                if (
+                    error?.code === 'Device_NotFound' ||
+                    error?.code === 'Device_Disconnected' ||
+                    error?.code === 'Device_UsedElsewhere' ||
+                    error?.code === 'Device_InvalidState'
+                )
+                    return;
             }
 
             analytics.report({

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -8,6 +8,7 @@ export type ManifestPartial = {
 };
 
 export const CALL_SOURCE_DESKTOP_WS = 'desktop-ws';
+export const CALL_SOURCE_WEB = 'web';
 export const CALL_SOURCE_WALLETCONNECT = 'walletconnect';
 export const CALL_SOURCE_DEEPLINK = 'deeplink';
 
@@ -28,6 +29,11 @@ export type ConnectCallSource = {
       }
     | {
           type: typeof CALL_SOURCE_WALLETCONNECT;
+          process?: undefined;
+          manifest: ManifestPartial;
+      }
+    | {
+          type: typeof CALL_SOURCE_WEB;
           process?: undefined;
           manifest: ManifestPartial;
       }

--- a/suite-common/suite-config/src/routes.ts
+++ b/suite-common/suite-config/src/routes.ts
@@ -50,6 +50,12 @@ export const routes = [
         params: modalAppParams,
     },
     {
+        name: 'suite-connect-popup',
+        pattern: '/connect-popup',
+        app: 'connect-popup',
+        params: modalAppParams,
+    },
+    {
         name: 'suite-udev',
         pattern: '/udev',
         app: 'udev',

--- a/yarn.lock
+++ b/yarn.lock
@@ -13407,6 +13407,9 @@ __metadata:
     "@trezor/env-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
+    "@types/chrome": "npm:^0.0.299"
+    "@types/jest": "npm:29.5.12"
+    "@types/node": "npm:22.13.10"
     tsx: "npm:^4.20.3"
   peerDependencies:
     tslib: ^2.6.2
@@ -13697,6 +13700,7 @@ __metadata:
   dependencies:
     "@babel/preset-typescript": "npm:^7.27.1"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-common": "workspace:*"
     "@trezor/connect-web": "workspace:*"
     "@trezor/eslint": "workspace:*"
     "@types/chrome": "npm:^0.0.299"


### PR DESCRIPTION
## Description

Connect popup is dead. Long live Connect popup. 

Try [here in Connect explorer](https://dev.suite.sldev.cz/connect/feat/new-connect-popup-suite-web/methods/bitcoin/getAddress/?core-mode=suite-web)

## TODO

- [x] Basic implementation
- [x] Better flow for device connection and switching
- [x] Support for webextension environment
- [x] Handle edge cases in UI
  - Suite first open
  - Invalid states (not initialized, bootloader, old FW)
  - Authenticity check fail / message system

Next steps
- E2E #22757
- Enable by default #22797
- Kill old popup 🔥 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/new-connect-popup-suite-web&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/new-connect-popup-suite-web&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/new-connect-popup-suite-web&lookback=7)