### PR TITLE
Fix passphraseOnDevice test

### DIFF
--- a/packages/connect-popup/webpack/prod.webpack.config.ts
+++ b/packages/connect-popup/webpack/prod.webpack.config.ts
@@ -131,7 +131,7 @@ const config: webpack.Configuration = {
                     to: `${DIST}/fonts`,
                 },
                 {
-                    from: path.join(__dirname, '../../suite-data/files/images/png/trezor-*'),
+                    from: path.join(__dirname, '../../suite-data/files/images/images/trezor-*'),
                     to: `${DIST}/images/[name][ext]`,
                 },
             ],

--- a/packages/connect/e2e/tests/device/passphrase.test.ts
+++ b/packages/connect/e2e/tests/device/passphrase.test.ts
@@ -176,7 +176,10 @@ describe('TrezorConnect passphrase', () => {
                 },
             });
             TrezorConnect.removeAllListeners('ui-request_passphrase');
-            controller.send({ type: 'emulator-input', value: 'a' });
+            // Due to race condition with node-bridge, we have to wait a bit
+            setTimeout(() => {
+                controller.send({ type: 'emulator-input', value: 'a' });
+            }, 50);
         });
         const walletA = await TrezorConnect.getDeviceState({
             device: {


### PR DESCRIPTION
## Description

Fix failing `passphrase.test.ts` with node-bridge by adding a delay between `uiResponse` with `passphraseOnDevice` and typing the passphrase on emulator.

Also fixing path to images.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/passphrase-e2e-test&lookback=7)