### PR TITLE
feat(firmware-authenticity): exclude sentry report for non-production FW sources

### DIFF
--- a/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
+++ b/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
@@ -17,11 +17,10 @@ const useCommonData = () => {
     const revision = device?.features?.revision;
     const version = getFirmwareVersion(device);
     const vendor = device?.features?.fw_vendor;
-    const firmwareSource = useSelector(selectFirmwareUpdateSource);
 
     return useMemo(
-        () => ({ model, revision, version, vendor, firmwareSource }),
-        [model, revision, version, vendor, firmwareSource],
+        () => ({ model, revision, version, vendor }),
+        [model, revision, version, vendor],
     );
 };
 
@@ -29,6 +28,7 @@ const useReportRevisionCheck = () => {
     const dispatch = useDispatch();
     const device = useSelector(selectSelectedDevice);
     const commonData = useCommonData();
+    const firmwareSource = useSelector(selectFirmwareUpdateSource);
 
     const revisionCheck = isDeviceAcquired(device)
         ? device.authenticityChecks.firmwareRevision
@@ -38,6 +38,7 @@ const useReportRevisionCheck = () => {
     const errorPayload = isError ? revisionCheck.errorPayload : null;
 
     const shouldReport =
+        firmwareSource === 'production' &&
         device?.connected === true &&
         errorType !== null &&
         revisionCheckErrorScenarios[errorType].shouldReport;
@@ -60,6 +61,7 @@ const useReportHashCheck = () => {
     const dispatch = useDispatch();
     const device = useSelector(selectSelectedDevice);
     const commonData = useCommonData();
+    const firmwareSource = useSelector(selectFirmwareUpdateSource);
 
     const hashCheck = isDeviceAcquired(device) ? device.authenticityChecks.firmwareHash : null;
     const isError = hashCheck && !hashCheck.success;
@@ -68,6 +70,7 @@ const useReportHashCheck = () => {
     const attemptCount = isError ? hashCheck.attemptCount : null;
 
     const shouldReport =
+        firmwareSource === 'production' &&
         device?.connected === true &&
         errorType !== null &&
         hashCheckErrorScenarios[errorType].shouldReport;


### PR DESCRIPTION
## Description

Instead of logging `firmwareSource` to FW device compromised sentry, which was done in 965f8f49, rather just log only production.

Other envs create unnecessary noise. 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/fw-sentry-exclude-non-production-fw-source&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/fw-sentry-exclude-non-production-fw-source&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/fw-sentry-exclude-non-production-fw-source&lookback=7)