### PR TITLE
Test/refactor settings coins tests

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/dashboardPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/dashboardPage.ts
@@ -43,6 +43,9 @@ export class DashboardPage {
     readonly buyButton = (networkSymbol: NetworkSymbol): Locator =>
         this.page.getByTestId(`@dashboard/asset/${networkSymbol}/buy-button`);
     readonly walletReady: Locator;
+    readonly discoveryEmptyHeader: Locator;
+    readonly discoveryEmptyDesc: Locator;
+    readonly discoveryEmptyPrimaryButton: Locator;
 
     constructor(
         private readonly page: Page,
@@ -80,6 +83,11 @@ export class DashboardPage {
             '@passphrase-confirmation/step2-button',
         );
         this.walletReady = this.page.getByTestId('@dashboard/wallet-ready');
+        this.discoveryEmptyHeader = this.page.getByTestId('@exception/discovery-empty/header');
+        this.discoveryEmptyDesc = this.page.getByTestId('@exception/discovery-empty/description');
+        this.discoveryEmptyPrimaryButton = this.page.getByTestId(
+            '@exception/discovery-empty/primary-button',
+        );
     }
 
     @step()

--- a/packages/suite-desktop-core/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/settings/settingsPage.ts
@@ -91,6 +91,7 @@ export class SettingsPage {
             : this.page.getByTestId(`@radio-button-${level}`);
     readonly safetyChecksRadioButtonCheck = (check: boolean): Locator =>
         this.page.locator(`[data-testid*="@radio-button"][data-checked="${check}"]`);
+    readonly settingsLoader: Locator;
 
     constructor(private readonly page: Page) {
         this.coins = new CoinsTab(page);
@@ -132,6 +133,7 @@ export class SettingsPage {
         this.btcUnitsInput = this.page.getByTestId('@settings/btc-units-select/input');
         this.safetyChecksButton = this.page.getByTestId('@settings/device/safety-checks-button');
         this.safetyChecksConfirmButton = this.page.getByTestId('@safety-checks-apply');
+        this.settingsLoader = this.page.getByTestId('@settings/loader');
     }
 
     @step()
@@ -264,5 +266,15 @@ export class SettingsPage {
             this.btcUnitsInputOption(units),
         );
         await expect(this.btcUnitsInput).toHaveText(units);
+    }
+
+    @step()
+    async verifyDiscoveryLoaderFinishes() {
+        await expect(this.settingsLoader, 'Discovery loader should became visible').toBeVisible({
+            timeout: 15_000,
+        });
+        await expect(this.settingsLoader, 'Discovery loader should hide').toBeHidden({
+            timeout: 120_000,
+        });
     }
 }

--- a/packages/suite-desktop-core/e2e/support/pageObjects/walletPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/walletPage.ts
@@ -48,6 +48,8 @@ export class WalletPage {
     readonly segwitGroupButton: Locator;
     readonly addAccountButton: Locator;
     readonly copyToCliboardToast: Locator;
+    readonly accountNotLoaded: Locator;
+    readonly emptyAccount: Locator;
     readonly buyButton: Locator;
     readonly sellButton: Locator;
     readonly swapButton: Locator;
@@ -87,6 +89,8 @@ export class WalletPage {
         this.copyToCliboardToast = this.page.getByTestId('@toast/copy-to-clipboard');
         this.segwitGroupButton = this.page.getByTestId('@account-menu/segwit');
         this.addAccountButton = this.page.getByTestId('@account-menu/add-account');
+        this.accountNotLoaded = this.page.getByTestId('@accounts/account-not-loaded');
+        this.emptyAccount = this.page.getByTestId('@accounts/empty-account');
         this.buyButton = this.page.getByTestId('@accounts/empty-account/buy');
         this.sellButton = this.page.getByTestId('@trading/menu/wallet-trading-sell');
         this.swapButton = this.page.getByTestId('@trading/menu/wallet-trading-exchange');

--- a/packages/suite-desktop-core/e2e/tests/settings/coins-custom-backend.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/coins-custom-backend.test.ts
@@ -1,0 +1,127 @@
+import { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
+
+type Coin = {
+    coin: NetworkSymbol;
+    backendType: BackendType;
+    customBackendUrlRight: string;
+    customBackendUrlWrong: string;
+};
+
+test.describe('Coin Settings', { tag: ['@group=settings'] }, () => {
+    test.use({
+        emulatorSetupConf: {
+            mnemonic:
+                'mammal walnut prosper gesture level ozone armed coffee tuna feature good december',
+        },
+    });
+
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
+        await onboardingPage.completeOnboarding();
+        await settingsPage.navigateTo('coins');
+    });
+
+    const coins: Coin[] = [
+        {
+            coin: 'btc',
+            backendType: 'blockbook',
+            customBackendUrlRight: `https://btc1.trezor.io`,
+            customBackendUrlWrong: `https://btc1-wrong.trezor.io`,
+        },
+        {
+            coin: 'eth',
+            backendType: 'blockbook',
+            customBackendUrlRight: `https://eth1.trezor.io`,
+            customBackendUrlWrong: `https://eth1-wrong.trezor.io`,
+        },
+    ];
+
+    for (const { coin, backendType, customBackendUrlRight, customBackendUrlWrong } of coins) {
+        test(
+            `Enable ${coin.toUpperCase()} asset & connect to backend server ${customBackendUrlRight} successfully`,
+            {
+                annotation: createTestAnnotation({
+                    testCase: `Verifies that settings up a custom ${backendType} server for ${coin.toUpperCase()} with correct url ${customBackendUrlRight} will succeed.`,
+                    category: TestCategory.Settings,
+                    priority: TestPriority.Medium,
+                    stream: TestStream.Foundation,
+                }),
+            },
+            async ({ page, settingsPage, walletPage }) => {
+                if (coin === 'btc') {
+                    await settingsPage.coins.disableNetwork(coin);
+                }
+                await test.step(`Enable ${coin.toUpperCase()} asset`, async () => {
+                    await expect(settingsPage.coins.networkButton(coin)).toBeDisabledCoin();
+                    await settingsPage.coins.enableNetwork(coin);
+                    await expect(settingsPage.coins.networkButton(coin)).toBeEnabledCoin();
+                });
+                await test.step(`Enable custom ${backendType} server`, async () => {
+                    await settingsPage.coins.openNetworkAdvanceSettings(coin);
+                    await settingsPage.coins.changeBackend(backendType, customBackendUrlRight);
+                    await expect(settingsPage.coins.networkButton(coin)).toContainTranslation(
+                        'TR_CUSTOM_BACKEND',
+                    );
+                });
+                await test.step('Refresh coins', async () => {
+                    await settingsPage.coins.activateCoinsButton.click();
+                    await Promise.all([
+                        settingsPage.verifyDiscoveryLoaderFinishes(),
+                        page.discoveryShouldFinish(),
+                    ]);
+                });
+                await test.step(`Open ${coin.toUpperCase()} account & verify it is loaded successfully`, async () => {
+                    await walletPage.openAccount({ symbol: coin });
+                    await expect(walletPage.emptyAccount).toContainTranslation(
+                        'TR_ACCOUNT_IS_EMPTY_TITLE',
+                    );
+                });
+            },
+        );
+
+        test(
+            `Enable ${coin.toUpperCase()} asset & connect to backend server ${customBackendUrlWrong} failes`,
+            {
+                annotation: createTestAnnotation({
+                    testCase: `Verifies that settings up a custom ${backendType} server for ${coin.toUpperCase()} with wrong url ${customBackendUrlWrong} will fail.`,
+                    category: TestCategory.Settings,
+                    priority: TestPriority.Medium,
+                    stream: TestStream.Foundation,
+                }),
+            },
+            async ({ page, settingsPage, walletPage }) => {
+                if (coin === 'btc') {
+                    await settingsPage.coins.disableNetwork(coin);
+                }
+                await test.step(`Enable ${coin.toUpperCase()} asset`, async () => {
+                    await expect(settingsPage.coins.networkButton(coin)).toBeDisabledCoin();
+                    await settingsPage.coins.enableNetwork(coin);
+                    await expect(settingsPage.coins.networkButton(coin)).toBeEnabledCoin();
+                });
+                await test.step(`Enable custom ${backendType} server`, async () => {
+                    await settingsPage.coins.openNetworkAdvanceSettings(coin);
+                    await settingsPage.coins.changeBackend(backendType, customBackendUrlWrong);
+                    await expect(settingsPage.coins.networkButton(coin)).toContainTranslation(
+                        'TR_CUSTOM_BACKEND',
+                    );
+                });
+                await test.step('Refresh coins', async () => {
+                    await settingsPage.coins.activateCoinsButton.click();
+                    await Promise.all([
+                        settingsPage.verifyDiscoveryLoaderFinishes(),
+                        page.discoveryShouldFinish(),
+                    ]);
+                });
+                await test.step(`Open ${coin.toUpperCase()} account & verify it fails to load`, async () => {
+                    await walletPage.accountButton({ symbol: coin }).click();
+                    await expect(walletPage.accountNotLoaded).toContainTranslation(
+                        'TR_ACCOUNT_EXCEPTION_DISCOVERY_ERROR',
+                    );
+                });
+            },
+        );
+    }
+});

--- a/packages/suite-desktop-core/e2e/tests/settings/coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/coins.test.ts
@@ -5,10 +5,9 @@ import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Coin Settings', { tag: ['@group=settings'] }, () => {
-    test.beforeEach(async ({ analytics, onboardingPage, settingsPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
         await settingsPage.navigateTo('coins');
-        await analytics.interceptAnalytics();
     });
 
     test(
@@ -22,7 +21,7 @@ test.describe('Coin Settings', { tag: ['@group=settings'] }, () => {
                 stream: TestStream.Foundation,
             }),
         },
-        async ({ dashboardPage, settingsPage, page }) => {
+        async ({ dashboardPage, settingsPage }) => {
             const defaultUnchecked: NetworkSymbol[] = [
                 'ltc',
                 'eth',
@@ -42,51 +41,43 @@ test.describe('Coin Settings', { tag: ['@group=settings'] }, () => {
                 'dsol',
             ];
 
-            await expect(settingsPage.coins.networkButton('btc')).toBeEnabledCoin();
-            for (const network of defaultUnchecked) {
-                await expect(settingsPage.coins.networkButton(network)).toBeDisabledCoin();
-            }
+            await test.step('No assets are acitve', async () => {
+                await expect(settingsPage.coins.networkButton('btc')).toBeEnabledCoin();
+                for (const network of defaultUnchecked) {
+                    await expect(settingsPage.coins.networkButton(network)).toBeDisabledCoin();
+                }
+                await settingsPage.coins.disableNetwork('btc');
+                // check dashboard with all coins disabled
+                await dashboardPage.navigateTo();
+                await expect(dashboardPage.discoveryEmptyHeader).toHaveTranslation(
+                    'TR_ACCOUNT_EXCEPTION_DISCOVERY_EMPTY',
+                );
+                await expect(dashboardPage.discoveryEmptyDesc).toHaveTranslation(
+                    'TR_ACCOUNT_EXCEPTION_DISCOVERY_EMPTY_DESC',
+                );
+                await expect(dashboardPage.discoveryEmptyPrimaryButton).toHaveTranslation(
+                    'TR_COIN_SETTINGS',
+                );
+            });
 
-            await settingsPage.coins.disableNetwork('btc');
+            await test.step('Activate assets', async () => {
+                await dashboardPage.discoveryEmptyPrimaryButton.click();
+                for (const network of ['btc', ...defaultUnchecked] as NetworkSymbol[]) {
+                    await settingsPage.coins.enableNetwork(network);
+                }
+            });
 
-            // check dashboard with all coins disabled
-            await dashboardPage.navigateTo();
-            await expect(page.getByTestId('@exception/discovery-empty/header')).toHaveTranslation(
-                'TR_ACCOUNT_EXCEPTION_DISCOVERY_EMPTY',
-            );
-            await expect(
-                page.getByTestId('@exception/discovery-empty/description'),
-            ).toHaveTranslation('TR_ACCOUNT_EXCEPTION_DISCOVERY_EMPTY_DESC');
-            await expect(
-                page.getByTestId('@exception/discovery-empty/primary-button'),
-            ).toHaveTranslation('TR_COIN_SETTINGS');
+            await test.step('Connect to trusted ETH backend server', async () => {
+                const backendType = 'blockbook';
+                const customServer = 'https://eth.marek.pl/';
 
-            await page.getByTestId('@exception/discovery-empty/primary-button').click();
-            // just do some clicking on switches and check result
-            for (const network of ['btc', ...defaultUnchecked] as NetworkSymbol[]) {
-                await settingsPage.coins.enableNetwork(network);
-            }
-
-            //TODO: #15811 this is just not useful validation. To be refactored
-            // const settingsCoinsEvent = analytics.findAnalyticsEventByType<
-            //     ExtractByEventType<EventType.SettingsCoins>
-            // >(EventType.SettingsCoins);
-            // expect(settingsCoinsEvent.symbol).to.be.oneOf(['btc', ...defaultUnchecked]);
-            // expect(settingsCoinsEvent.value).to.be.oneOf(['true', 'false']);
-
-            // custom eth backend
-            await page.getByTestId('@settings/wallet/network/eth/advance').click();
-            await page.getByTestId('@settings/advance/select-type/input').click();
-            await page.getByTestId('@settings/advance/select-type/option/blockbook').click();
-            // sometimes select stays open after click, no idea why, experimenting with wait
-            await page.getByTestId('@settings/advance/url').fill('https://eth.marek.pl/');
-            await page.getByTestId('@settings/advance/button/save').click();
-
-            //TODO: #15811 this is just not useful validation. To be refactored
-            // const settingsCoinsBackendEvent = analytics.findAnalyticsEventByType<ExtractByEventType<EventType.SettingsCoinsBackend>>(EventType.SettingsCoinsBackend)
-            // expect(settingsCoinsBackendEvent.type).to.equal('blockbook');
-            // expect(settingsCoinsBackendEvent.totalRegular).to.equal('1');
-            // expect(settingsCoinsBackendEvent.totalOnion).to.equal('0');
+                await expect(settingsPage.coins.networkButton('eth')).toBeEnabledCoin();
+                await settingsPage.coins.openNetworkAdvanceSettings('eth');
+                await settingsPage.coins.changeBackend(backendType, customServer);
+                await expect(settingsPage.coins.networkButton('eth')).toContainTranslation(
+                    'TR_CUSTOM_BACKEND',
+                );
+            });
         },
     );
 });

--- a/packages/suite/src/components/wallet/AccountExceptionLayout.tsx
+++ b/packages/suite/src/components/wallet/AccountExceptionLayout.tsx
@@ -21,10 +21,11 @@ interface AccountExceptionLayoutProps {
     iconName?: IconName;
     iconVariant?: IconCircleVariant;
     actions?: ({ key: string } & ButtonProps)[];
+    'data-testid'?: string;
 }
 
 export const AccountExceptionLayout = (props: AccountExceptionLayoutProps) => (
-    <Card>
+    <Card data-testid={props['data-testid']}>
         <Column alignItems="center">
             {props.iconName && props.iconVariant && (
                 <IconCircle

--- a/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotLoaded.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotLoaded.tsx
@@ -18,6 +18,7 @@ export const AccountNotLoaded = () => {
 
     return (
         <AccountExceptionLayout
+            data-testid="@accounts/account-not-loaded"
             title={<Translation id="TR_ACCOUNT_EXCEPTION_DISCOVERY_ERROR" />}
             description={<Translation id="TR_ACCOUNT_EXCEPTION_DISCOVERY_DESCRIPTION" />}
             iconName="warning"

--- a/packages/suite/src/views/settings/SettingsLoader.tsx
+++ b/packages/suite/src/views/settings/SettingsLoader.tsx
@@ -79,7 +79,7 @@ export const SettingsLoading = ({ isPresent = false }: SettingsLoadingProps) => 
     <AnimatePresence initial={false}>
         {isPresent && (
             <motion.div {...getContainerAnimation(isPresent)}>
-                <Container {...getContentAnimation(isPresent)}>
+                <Container {...getContentAnimation(isPresent)} data-testid="@settings/loader">
                     <SpinnerContainer>
                         <Spinner size={40} isGrey={false} />
                     </SpinnerContainer>

--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
@@ -48,6 +48,7 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
 
     return (
         <AccountExceptionLayout
+            data-testid="@accounts/empty-account"
             title={<Translation id="TR_ACCOUNT_IS_EMPTY_TITLE" />}
             description={
                 isTokensNetwork ? (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

🚀 New Tests: Settings: Coins - Custom Backend Scenarios

* verify connecting to a custom backend URL (blockbook).
* covers the success case (correct URL), ensuring the account loads.
* covers the failure case (incorrect URL), ensuring the account loads error.

🛠️ Refactoring: Settings: Coins

* group the test steps into more logical parts using playwright's `test.step()` 
* move the locators to page object


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/refactor-settings-coins-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/refactor-settings-coins-tests&lookback=7)