### PR TITLE
fix(suite-native): Mobile Trade: Run exchange E2E tests on android only

### DIFF
--- a/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
@@ -25,7 +25,7 @@ const preloadedStateWithTrezor = preparePreloadedReduxState(
 const isCIRun = !!process.env.GITHUB_ACTION;
 const passphrase = process.env.TRADING_ACADEMIC_SEED_WALLET_PASSPHRASE;
 
-describe('Trade Exchange', () => {
+conditionalDescribe(device.getPlatform() === 'android', 'Trade Exchange', () => {
     describe('with portfolio tracker', () => {
         beforeEach(async () => {
             await openApp({


### PR DESCRIPTION
Skip Trading exchange E2Es on iOS.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=skip-trading-e2e&lookback=7)