### PR TITLE
chore(suite-native): move testing related dependencies to qa file

### DIFF
--- a/scripts/list-outdated-dependencies/mobile-dependencies.txt
+++ b/scripts/list-outdated-dependencies/mobile-dependencies.txt
@@ -2,7 +2,6 @@
 @evolu/react-native
 @expo/config-plugins
 @gorhom/bottom-sheet
-@jest/reporters
 @mobily/ts-belt
 @types/react-native-get-random-values
 @react-native-async-storage/async-storage
@@ -25,7 +24,6 @@
 @shopify/flash-list
 @shopify/react-native-skia
 @testing-library/react-native
-@types/jest
 @types/node
 @types/react
 @whatwg-node/events
@@ -100,6 +98,5 @@ react-native-webview
 react-qr-code
 redux-devtools-expo-dev-plugin
 redux-persist
-ts-jest
 type-fest
 yup

--- a/scripts/list-outdated-dependencies/qa-dependencies.txt
+++ b/scripts/list-outdated-dependencies/qa-dependencies.txt
@@ -1,12 +1,15 @@
+chai
 @currents/cmd
 @currents/playwright
+@jest/reporters
 @octokit/rest
 @playwright/browser-chromium
 @playwright/browser-firefox
 @playwright/browser-webkit
 @playwright/test
+@types/jest
 dotenv
 eslint-plugin-playwright
 jest-diff
 jest-junit
-chai
+ts-jest


### PR DESCRIPTION
## Description
- moving testing related dependencies from `mobile-dependencies.txt` to `qa-dependencies.txt` since those packages should be intuitively maintained by QA.



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/qa-dependencies&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/qa-dependencies&lookback=7)