### PR TITLE
fix(suite-native): thp pairing middleware predicate

### DIFF
--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -230,8 +230,8 @@ deviceConnectionMiddleware.startListening({
 });
 
 deviceConnectionMiddleware.startListening({
-    predicate: (action: UnknownAction) => isThpPairingUIRequestButtonAction(action),
-    effect: (_action: UnknownAction, { getState }) => {
+    predicate: isThpPairingUIRequestButtonAction,
+    effect: (_, { getState }) => {
         if (selectIsFirmwareInstallationRunning(getState())) return;
 
         // Nothing can be accomplished before a THP connection is established.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Small code-style change to simplify THP pairing middleware predicate. No changes in behavior, just a simplification. 

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/thp-pairing-predicate&lookback=7)