### PR TITLE
fix(suite): include ADA staking balance check in active staking analytics

### DIFF
--- a/suite-common/wallet-utils/src/cardanoStakingUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoStakingUtils.ts
@@ -55,3 +55,6 @@ export const drepBech32ToKeyHashHex = (drepId: string): string => {
 
     throw new Error(`Unsupported DRep payload length: ${bytes.length}`);
 };
+
+export const getAdaAccountTotalStakingBalance = (account: Account) =>
+    account?.networkType === 'cardano' && account.misc?.staking?.isActive ? account.balance : null;

--- a/suite-common/wallet-utils/src/stakingUtils.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.ts
@@ -21,7 +21,10 @@ import { BigNumber } from '@trezor/utils';
 
 import { asAmountSubunit } from './AmountTypes';
 import { subunitsToUnits } from './amountUtils';
-import { isSupportedAdaStakingNetworkSymbol } from './cardanoStakingUtils';
+import {
+    getAdaAccountTotalStakingBalance,
+    isSupportedAdaStakingNetworkSymbol,
+} from './cardanoStakingUtils';
 import {
     getAccountEverstakeStakingPool,
     getEthAccountTotalStakingBalance,
@@ -41,6 +44,8 @@ export const getAccountTotalStakingBalance = (account: Account) => {
             return getEthAccountTotalStakingBalance(account);
         case 'solana':
             return getSolAccountTotalStakingBalance(account);
+        case 'cardano':
+            return getAdaAccountTotalStakingBalance(account);
         default:
             return null;
     }


### PR DESCRIPTION
## Description

Added missing staking balance check for Cardano accounts in accounts/active-staking analytics.
Now ADA staking accounts are correctly included in the event payload.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21908

## Screenshots:

<img width="556" height="373" alt="image" src="https://github.com/user-attachments/assets/c3e04d64-0654-4bd2-9f5e-031b53c53fdb" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/data-analytics-active-staking-cardano&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/data-analytics-active-staking-cardano&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/data-analytics-active-staking-cardano&lookback=7)