### PR TITLE
chore(suite-native): simplify device connection conditions

### DIFF
--- a/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
+++ b/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
@@ -304,23 +304,6 @@ export const deviceConnectBlockedFixtures: NoNavigationFixture[] = [
         },
     },
     {
-        description: 'blocks navigation when device is using passphrase',
-        initialState: buildInitialState({
-            device: {
-                selectedDevice: getSuiteDevice(
-                    {
-                        useEmptyPassphrase: false,
-                    },
-                    { passphrase_protection: true },
-                ),
-            },
-        }),
-        action: {
-            type: deviceActions.connectDevice.type,
-            payload: { device: getSuiteDevice() },
-        },
-    },
-    {
         description: 'blocks navigation when device is remembered and a network is enabled',
         initialState: buildInitialState({
             device: {
@@ -473,9 +456,7 @@ export const deviceConnectAuthorizedFixtures: NavigationFixture[] = [
         description: 'Skips coin enabling for bitcoin only FW and goes to connecting screen',
         initialState: buildInitialState({
             device: {
-                selectedDevice: getSuiteDevice({
-                    useEmptyPassphrase: false,
-                }),
+                selectedDevice: getSuiteDevice(),
             },
         }),
         action: {

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -16,7 +16,6 @@ import {
     selectDevices,
     selectIsAnyNetworkEnabled,
     selectIsDeviceRemembered,
-    selectIsDeviceUsingPassphrase,
 } from '@suite-common/wallet-core';
 import { selectWasDeviceOnboardingCancelled } from '@suite-native/device-onboarding';
 import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
@@ -154,12 +153,6 @@ deviceConnectionMiddleware.startListening({
 
             return;
         }
-
-        // Passphrase protected devices are only connected through passphrase form
-        // The passphrase flow handles connection differently and redirect to connecting screen is not wanted.
-        const isDeviceUsingPassphrase = selectIsDeviceUsingPassphrase(getState());
-
-        if (isDeviceUsingPassphrase) return;
 
         // If device is authorized already (usually in case of remembered device which has already been authorized)
         // We need to use the state before we add connected device to the array so we find out whether it was previously remembered


### PR DESCRIPTION
- first passphrase connection doesn't call create new device instance that would trigger DEVICE.CONNECT anymore and on second connection, the device physical ID is already persisted if its a second connection so the condition for passphrase is not necessary anymore

Notes for @trezor/qa @STew790 
- This PR tweaks logic of passphrase creation 
- Please test that you are not redirected to connecting screen/coin enabling/device onboarding when you create or authorize passphrase wallet

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/simplify-connection-handling&lookback=7)