### PR TITLE
fix(suite-native): remove deprecated safeAreaView

### DIFF
--- a/suite-native/device/src/components/ConfirmOnTrezorImage.tsx
+++ b/suite-native/device/src/components/ConfirmOnTrezorImage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useMemo } from 'react';
-import { Image, Pressable, SafeAreaView } from 'react-native';
+import { Image, Pressable } from 'react-native';
 import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
 
 import { useBottomSheetModal } from '@suite-native/atoms';
@@ -29,7 +29,7 @@ export const ConfirmOnTrezorImage = ({ bottomSheetText }: ConfirmOnTrezorImagePr
     const imageSource = useMemo(() => require('../assets/confirmOnTrezor.webp'), []);
 
     return (
-        <SafeAreaView>
+        <>
             <AnimatedPressable
                 entering={SlideInDown}
                 exiting={SlideOutDown}
@@ -45,6 +45,6 @@ export const ConfirmOnTrezorImage = ({ bottomSheetText }: ConfirmOnTrezorImagePr
                     onClose={closeModal}
                 />
             )}
-        </SafeAreaView>
+        </>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove unneeded SareArea wrapper

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22544

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/safe-area-replacement&lookback=7)