### PR TITLE
fix(suite): setting PIN during BTC-only onboarding

### DIFF
--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -11,6 +11,7 @@ import { Dispatch, GetState } from 'src/types/suite';
 import { findNextStep, findPrevStep, isStepUsed } from 'src/utils/onboarding/steps';
 
 import { selectOnboardingAnalytics } from '../../reducers/onboarding/onboardingReducer';
+import * as modalActions from '../suite/modalActions';
 import * as routerActions from '../suite/routerActions';
 import * as suiteActions from '../suite/suiteActions';
 
@@ -100,6 +101,11 @@ const resetOnboarding = (): OnboardingAction => ({
 const goToSuite = () => (dispatch: Dispatch, getState: GetState) => {
     const device = selectSelectedDevice(getState());
     const onboardingAnalytics = selectOnboardingAnalytics(getState());
+    // Clear modals that might block navigation. They aren't relevant anyway, as there is no <ModalSwitcher /> in onboarding.
+    // After device interaction, Connect sends UI_REQUEST.CLOSE_UI_WINDOW to close any open modal. On Web this is
+    // instant, so nothing blocks navigation, but on Desktop there is delay, so we must clear the modal manually to
+    // ensure navigation to 'suite-index'. Particularly, setting PIN leaves ButtonRequest_Success hanging for a moment.
+    dispatch(modalActions.onCancel());
 
     dispatch(suiteActions.initialRunCompleted());
     dispatch(resetOnboarding());

--- a/packages/suite/src/views/onboarding/steps/PinStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/PinStep.tsx
@@ -47,12 +47,6 @@ export const PinStep = () => {
     };
 
     useEffect(() => {
-        if (status === 'success') {
-            goToNextStep();
-        }
-    }, [status, goToNextStep]);
-
-    useEffect(() => {
         // This is where we detect requests from a device, figure out whether the PIN functionality got enabled,
         // and set a status of the setup process accordingly
         if (device?.features) {
@@ -70,9 +64,10 @@ export const PinStep = () => {
 
             if (device && device.features.pin_protection) {
                 setStatus('success');
+                goToNextStep();
             }
         }
-    }, [device]);
+    }, [device, goToNextStep]);
 
     if (!device || !device.features) {
         return null;


### PR DESCRIPTION
## Description

Very strange bug, where after successful PIN setup, `@modal/context-device` (`ButtonRequest_Success`) is hanging for apx. 300 milliseconds, before Connect emits the `UI_REQUEST.CLOSE_UI_WINDOW` and Suite clears the modal context to `@modal/context-none`. But in the meantime, `goTo('suite-index')` has failed :grimacing: 

On Web, `UI_REQUEST.CLOSE_UI_WINDOW` is sent instantly so navigation is not blocked.

## Related Issue

Resolve #22600

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/btc-only-onboarding&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/btc-only-onboarding&lookback=7)