### PR TITLE
Prevent "Portfolio Tracker" in BLE pairing instructions

### DIFF
--- a/suite-native/bluetooth/src/components/SystemUnpairingAlertIosInstructions.tsx
+++ b/suite-native/bluetooth/src/components/SystemUnpairingAlertIosInstructions.tsx
@@ -1,41 +1,30 @@
 import { BottomSheetListItem, Box, Text, VStack } from '@suite-native/atoms';
-import { Translation, TxKeyPath, useTranslate } from '@suite-native/intl';
+import { Translation, TxKeyPath } from '@suite-native/intl';
 
 type SystemUnpairingAlertIosInstructionsProps = {
     translationKey: TxKeyPath;
-    deviceName?: string;
 };
 
 export const SystemUnpairingAlertIosInstructions = ({
     translationKey,
-    deviceName,
-}: SystemUnpairingAlertIosInstructionsProps) => {
-    const { translate } = useTranslate();
-
-    return (
-        <Box>
-            <Text>
-                <Translation id={translationKey} />
-            </Text>
-            <VStack paddingTop="sp24">
-                <BottomSheetListItem
-                    iconNumber={1}
-                    translationKey="bluetooth.alerts.pairingInstructions.step1"
-                />
-                <BottomSheetListItem
-                    iconNumber={2}
-                    translationKey="bluetooth.alerts.pairingInstructions.step2"
-                    translationValues={{
-                        deviceName:
-                            deviceName ??
-                            translate('bluetooth.alerts.pairingFailed.deviceNamePlaceholder'),
-                    }}
-                />
-                <BottomSheetListItem
-                    iconNumber={3}
-                    translationKey="bluetooth.alerts.pairingInstructions.step3"
-                />
-            </VStack>
-        </Box>
-    );
-};
+}: SystemUnpairingAlertIosInstructionsProps) => (
+    <Box>
+        <Text>
+            <Translation id={translationKey} />
+        </Text>
+        <VStack paddingTop="sp24">
+            <BottomSheetListItem
+                iconNumber={1}
+                translationKey="bluetooth.alerts.pairingInstructions.step1"
+            />
+            <BottomSheetListItem
+                iconNumber={2}
+                translationKey="bluetooth.alerts.pairingInstructions.step2"
+            />
+            <BottomSheetListItem
+                iconNumber={3}
+                translationKey="bluetooth.alerts.pairingInstructions.step3"
+            />
+        </VStack>
+    </Box>
+);

--- a/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.ios.tsx
+++ b/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.ios.tsx
@@ -1,10 +1,9 @@
 // This is iOS version, see the file name.
 
 import { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { bluetoothActions } from '@suite-common/bluetooth';
-import { selectDeviceName } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { useTranslate } from '@suite-native/intl';
 
@@ -14,7 +13,6 @@ export const useBluetoothPlatformSpecificAlerts = () => {
     const { showAlert } = useAlert();
     const { translate } = useTranslate();
     const dispatch = useDispatch();
-    const deviceName = useSelector(selectDeviceName);
 
     const showBluetoothAdapterDisabledAlert = useCallback(() => {
         showAlert({
@@ -40,17 +38,14 @@ export const useBluetoothPlatformSpecificAlerts = () => {
             title: translate('bluetooth.alerts.systemUnpairing.title.ios'),
             textAlign: 'left',
             description: (
-                <SystemUnpairingAlertIosInstructions
-                    translationKey="bluetooth.alerts.systemUnpairing.description.ios"
-                    deviceName={deviceName}
-                />
+                <SystemUnpairingAlertIosInstructions translationKey="bluetooth.alerts.systemUnpairing.description.ios" />
             ),
             primaryButtonTitle: translate('generic.buttons.gotIt'),
             onPressPrimaryButton: () => {
                 dispatch(bluetoothActions.setIsDeviceOsUnpairingRequired(false));
             },
         });
-    }, [showAlert, dispatch, translate, deviceName]);
+    }, [showAlert, dispatch, translate]);
 
     return {
         showBluetoothAdapterDisabledAlert,

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -194,7 +194,6 @@ export const messages = {
                     'The Trezor you’re trying to connect may still be remembered in your phone’s Bluetooth settings. Remove it and try again.',
                 primaryButton: 'Open system settings',
                 secondaryButton: 'Device removed',
-                deviceNamePlaceholder: 'your Trezor',
             },
             systemUnpairing: {
                 title: {
@@ -212,7 +211,7 @@ export const messages = {
             },
             pairingInstructions: {
                 step1: 'Go to Settings > Bluetooth',
-                step2: 'Find {deviceName} and tap on ⓘ',
+                step2: 'Find your Trezor and tap on ⓘ',
                 step3: 'Tap “Forget this device”',
             },
         },


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Prevent wrong device name to be used (i.e. "Portfolio tracker")

Steps to reproduce:
1. Connect TS7 via bluetooth
1. Wait for discovery to be finished
1. Wipe from the trezor itself
1. See error

## Screenshots:

|  BEFORE |  AFTER | 
|---|---|
|  <img alt="image" src="https://github.com/user-attachments/assets/5a0ff3bf-9b64-478a-b33b-8306af324a94" /> | <img alt="image" src="https://github.com/user-attachments/assets/d2ce60ca-c091-44a9-aa0f-cf552eb6b96c" />  |  

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/portfolio-tracker-name-in-ble-unpair-instructions&lookback=7)