### PR TITLE
Move AVAX to Experimental Features

### DIFF
--- a/packages/blockchain-link/src/ui/config.ts
+++ b/packages/blockchain-link/src/ui/config.ts
@@ -249,7 +249,7 @@ export default [
         blockchain: {
             name: 'Avalanche C-Chain',
             worker: 'js/blockbook-worker.js',
-            server: ['https://blockbook-dev.corp.sldev.cz:9199'],
+            server: ['https://avax.trezor.io'],
             debug: true,
         },
         data: {

--- a/packages/connect-common/files/coins-eth.json
+++ b/packages/connect-common/files/coins-eth.json
@@ -59,7 +59,7 @@
         {
             "blockchain_link": {
                 "type": "blockbook",
-                "url": ["https://blockbook-dev.corp.sldev.cz:9199"]
+                "url": ["https://avax.trezor.io"]
             },
             "chain": "avax",
             "chain_id": 43114,

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -1,20 +1,27 @@
-import { TranslationKey } from '@suite-common/intl-types';
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { Route } from '@suite-common/suite-types';
+import { networksCollection } from '@suite-common/wallet-config';
 import { isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { EXPERIMENTAL_PASSWORD_MANAGER_KB_URL, HELP_CENTER_TOR_URL, Url } from '@trezor/urls';
 
 import { Dispatch } from '../../types/suite';
 
+const experimentalNetworks = networksCollection.filter(
+    network => network.isExperimentalOnlyNetwork,
+);
+const experimentalNetworkNames = experimentalNetworks.map(network => network.name);
+
 export type ExperimentalFeature =
     | 'password-manager'
     | 'tor-external'
     | 'nft-section'
-    | 'global-send-receive';
+    | 'global-send-receive'
+    | 'experimental-networks';
 
 export type ExperimentalFeatureConfig = {
-    title: TranslationKey;
-    description: TranslationKey;
+    title: ExtendedMessageDescriptor;
+    description: ExtendedMessageDescriptor;
     knowledgeBaseUrl?: Url;
     routeName?: Route['name'];
     isDisabled?: (context: { isDebug: boolean }) => boolean;
@@ -23,14 +30,14 @@ export type ExperimentalFeatureConfig = {
 
 export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeatureConfig> = {
     'password-manager': {
-        title: 'TR_EXPERIMENTAL_PASSWORD_MANAGER',
-        description: 'TR_EXPERIMENTAL_PASSWORD_MANAGER_DESCRIPTION',
+        title: { id: 'TR_EXPERIMENTAL_PASSWORD_MANAGER' },
+        description: { id: 'TR_EXPERIMENTAL_PASSWORD_MANAGER_DESCRIPTION' },
         knowledgeBaseUrl: EXPERIMENTAL_PASSWORD_MANAGER_KB_URL,
         routeName: 'password-manager-index',
     },
     'tor-external': {
-        title: 'TR_EXPERIMENTAL_TOR_EXTERNAL',
-        description: 'TR_EXPERIMENTAL_TOR_EXTERNAL_DESCRIPTION',
+        title: { id: 'TR_EXPERIMENTAL_TOR_EXTERNAL' },
+        description: { id: 'TR_EXPERIMENTAL_TOR_EXTERNAL_DESCRIPTION' },
         knowledgeBaseUrl: HELP_CENTER_TOR_URL,
         isDisabled: () => !isDesktop(),
         onToggle: async ({ newValue }) => {
@@ -44,11 +51,27 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
         },
     },
     'nft-section': {
-        title: 'TR_EXPERIMENTAL_NFT_SECTION',
-        description: 'TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION',
+        title: { id: 'TR_EXPERIMENTAL_NFT_SECTION' },
+        description: { id: 'TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION' },
     },
     'global-send-receive': {
-        title: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE',
-        description: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION',
+        title: { id: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE' },
+        description: { id: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION' },
+    },
+    'experimental-networks': {
+        title: {
+            id: 'TR_EXPERIMENTAL_NETWORKS',
+            values: {
+                networkNames: experimentalNetworkNames.join(', '),
+                count: experimentalNetworks.length,
+            },
+        },
+        description: {
+            id: 'TR_EXPERIMENTAL_NETWORKS_DESCRIPTION',
+            values: {
+                networkNames: experimentalNetworkNames.join(', '),
+                count: experimentalNetworks.length,
+            },
+        },
     },
 };

--- a/packages/suite/src/hooks/settings/useNetworkSupport.ts
+++ b/packages/suite/src/hooks/settings/useNetworkSupport.ts
@@ -4,15 +4,21 @@ import { DeviceModelInternal, hasBitcoinOnlyFirmware } from '@trezor/device-util
 import { arrayPartition } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
+import {
+    selectHasExperimentalFeature,
+    selectIsDebugModeActive,
+} from 'src/selectors/suite/suiteSelectors';
 
 export const useNetworkSupport = () => {
     const device = useSelector(selectSelectedDevice);
     const isDebug = useSelector(selectIsDebugModeActive);
+    const useExperimentalNetworks = useSelector(
+        selectHasExperimentalFeature('experimental-networks'),
+    );
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
 
-    const mainnets = getMainnets(isDebug);
-    const testnets = getTestnets(isDebug);
+    const mainnets = getMainnets(isDebug, useExperimentalNetworks);
+    const testnets = getTestnets(isDebug, useExperimentalNetworks);
 
     const isNetworkSupported = (network: Network) =>
         deviceSupportedNetworkSymbols.includes(network.symbol);

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5393,6 +5393,15 @@ export default defineMessages({
         defaultMessage:
             'Use Tor daemon running in an external process instead of the one bundled with Trezor Suite.',
     },
+    TR_EXPERIMENTAL_NETWORKS: {
+        id: 'TR_EXPERIMENTAL_NETWORKS',
+        defaultMessage: '{networkNames} {count, plural, one {network} other {networks}}',
+    },
+    TR_EXPERIMENTAL_NETWORKS_DESCRIPTION: {
+        id: 'TR_EXPERIMENTAL_NETWORKS_DESCRIPTION',
+        defaultMessage:
+            'Send and receive transactions on the {networkNames} {count, plural, one {network} other {networks}}.',
+    },
     TR_EARLY_ACCESS: {
         id: 'TR_EARLY_ACCESS',
         defaultMessage: 'Early Access Program',

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -25,8 +25,7 @@ const FeatureLine = ({ feature, enabledFeatures }: FeatureLineProps) => {
     const checked = enabledFeatures.includes(feature);
 
     const config = EXPERIMENTAL_FEATURES[feature];
-    const titleId = config.title;
-    const descId = config.description;
+    const { title, description } = config;
     const url = config.knowledgeBaseUrl;
 
     const onChangeFeature = async () => {
@@ -54,8 +53,8 @@ const FeatureLine = ({ feature, enabledFeatures }: FeatureLineProps) => {
     return (
         <Row gap={spacings.sm}>
             <TextColumn
-                title={titleId ? <Translation id={titleId} /> : feature}
-                description={descId && <Translation id={descId} />}
+                title={title ? <Translation {...title} /> : feature}
+                description={description ? <Translation {...description} /> : undefined}
                 buttonLink={url}
                 buttonTitle={<Translation id="TR_LEARN_MORE" />}
             />

--- a/suite-common/wallet-config/src/__tests__/utils.test.ts
+++ b/suite-common/wallet-config/src/__tests__/utils.test.ts
@@ -7,19 +7,19 @@ const mockNetworks = [bitcoin, ethereum, testnet, regtest];
 
 describe(getMainnets.name, () => {
     it('returns non-testnet, non-debug-only networks when debug is false', () => {
-        const result = getMainnets(false, mockNetworks);
+        const result = getMainnets(false, false, mockNetworks);
         expect(result).toEqual([bitcoin, ethereum]);
     });
 });
 
 describe(getTestnets.name, () => {
     it('returns testnet, non-debug-only networks when debug is false', () => {
-        const result = getTestnets(false, mockNetworks);
+        const result = getTestnets(false, false, mockNetworks);
         expect(result).toEqual([testnet]);
     });
 
     it('includes all testnets when debug is true', () => {
-        const result = getTestnets(true, mockNetworks);
+        const result = getTestnets(true, false, mockNetworks);
         expect(result).toEqual([testnet, regtest]);
     });
 });

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -284,7 +284,7 @@ export const networks = {
                 isDebugOnlyAccountType: true,
             },
         },
-        isDebugOnlyNetwork: true,
+        isExperimentalOnlyNetwork: true,
         coingeckoId: 'avalanche',
         tradeCryptoId: 'avalanche-2',
         caipId: 'eip155:43114',

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -128,6 +128,7 @@ type NetworkWithSpecificKey<TKey extends NetworkSymbol> = {
     backendTypes: BackendType[];
     support?: NetworkDeviceSupport;
     isDebugOnlyNetwork?: boolean;
+    isExperimentalOnlyNetwork?: boolean;
     coingeckoId?: string;
     tradeCryptoId?: string;
     caipId?: string; // CAIP-2 chain id, used by WalletConnect

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -19,11 +19,29 @@ export const networksCollection: Network[] = Object.values(networks);
  */
 export const networkSymbolCollection = networksCollection.map(n => n.symbol);
 
-export const getMainnets = (debug = false, allNetworks = networksCollection) =>
-    allNetworks.filter(n => !n.testnet && (!n.isDebugOnlyNetwork || debug));
+export const getMainnets = (
+    debug = false,
+    useExperimentalNetworks = false,
+    allNetworks = networksCollection,
+) =>
+    allNetworks.filter(
+        n =>
+            !n.testnet &&
+            (!n.isDebugOnlyNetwork || debug) &&
+            (!n.isExperimentalOnlyNetwork || useExperimentalNetworks),
+    );
 
-export const getTestnets = (debug = false, allNetworks = networksCollection) =>
-    allNetworks.filter(n => n.testnet === true && (!n.isDebugOnlyNetwork || debug));
+export const getTestnets = (
+    debug = false,
+    useExperimentalNetworks = false,
+    allNetworks = networksCollection,
+) =>
+    allNetworks.filter(
+        n =>
+            n.testnet === true &&
+            (!n.isDebugOnlyNetwork || debug) &&
+            (!n.isExperimentalOnlyNetwork || useExperimentalNetworks),
+    );
 
 export const getTestnetSymbols = () => getTestnets().map(n => n.symbol);
 

--- a/suite-native/config/src/launch-arguments.ts
+++ b/suite-native/config/src/launch-arguments.ts
@@ -9,6 +9,7 @@ export type LaunchArguments = {
     isTradingExchangeEnabled?: boolean;
     isTradingSellEnabled?: boolean;
     areDebugOnlyNetworksEnabled?: boolean;
+    areExperimentalOnlyNetworksEnabled?: boolean;
     preloadedState?: string; // stringified object
     isFirmwareUpdateEnabled?: boolean;
     isLocalizationEnabled?: boolean;

--- a/suite-native/discovery/src/discoverySelectors.ts
+++ b/suite-native/discovery/src/discoverySelectors.ts
@@ -68,12 +68,14 @@ export const selectDiscoverySupportedNetworks = createMemoizedSelector(
         selectAreTestnetsEnabled,
         (_state, forcedAreTestnetsEnabled?: boolean) => forcedAreTestnetsEnabled,
         state => selectIsFeatureFlagEnabled(state, FeatureFlag.AreDebugOnlyNetworksEnabled),
+        state => selectIsFeatureFlagEnabled(state, FeatureFlag.AreExperimentalOnlyNetworksEnabled),
     ],
     (
         deviceNetworks,
         defaultAreTestnetsEnabled,
         forcedAreTestnetsEnabled,
         areDebugOnlyNetworksEnabled,
+        areExperimentalOnlyNetworksEnabled,
     ) => {
         const areTestnetsEnabled = forcedAreTestnetsEnabled ?? defaultAreTestnetsEnabled;
 
@@ -81,11 +83,19 @@ export const selectDiscoverySupportedNetworks = createMemoizedSelector(
             deviceNetworks,
             networkSymbols => filterTestnetNetworks(networkSymbols, areTestnetsEnabled),
             networkSymbols =>
-                networkSymbols.filter(symbol =>
-                    (getNetwork(symbol).isDebugOnlyNetwork ?? false)
-                        ? areDebugOnlyNetworksEnabled
-                        : true,
-                ),
+                networkSymbols.filter(symbol => {
+                    const network = getNetwork(symbol);
+
+                    if (network.isDebugOnlyNetwork) {
+                        return areDebugOnlyNetworksEnabled;
+                    }
+
+                    if (network.isExperimentalOnlyNetwork) {
+                        return areExperimentalOnlyNetworksEnabled;
+                    }
+
+                    return true;
+                }),
             filterUnavailableNetworks,
             sortNetworks,
             returnStableArrayIfEmpty,

--- a/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
@@ -12,6 +12,7 @@ describe('featureFlagsSlice', () => {
 
             expect(initialState).toEqual({
                 areDebugOnlyNetworksEnabled: false,
+                areExperimentalOnlyNetworksEnabled: false,
                 isCardanoSendEnabled: false,
                 isDebugKeysAllowed: false,
                 isLocalFirstStorageEnabled: false,

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -2,6 +2,7 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 export const FeatureFlag = {
     AreDebugOnlyNetworksEnabled: 'areDebugOnlyNetworksEnabled',
+    AreExperimentalOnlyNetworksEnabled: 'areExperimentalOnlyNetworksEnabled',
     IsCardanoSendEnabled: 'isCardanoSendEnabled',
     IsDebugKeysAllowed: 'isDebugKeysAllowed',
     IsTradingBuyEnabled: 'isTradingBuyEnabled',
@@ -23,6 +24,8 @@ export type FeatureFlagsRootState = {
 export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.AreDebugOnlyNetworksEnabled]:
         process.env.EXPO_PUBLIC_FF_ARE_DEBUG_ONLY_NETWORKS_ENABLED === 'true',
+    [FeatureFlag.AreExperimentalOnlyNetworksEnabled]:
+        process.env.EXPO_PUBLIC_FF_ARE_EXPERIMENTAL_ONLY_NETWORKS_ENABLED === 'true',
     [FeatureFlag.IsCardanoSendEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_CARDANO_SEND_ENABLED === 'true',
     [FeatureFlag.IsDebugKeysAllowed]: process.env.EXPO_PUBLIC_FF_IS_DEBUG_KEYS_ALLOWED === 'true',
@@ -41,6 +44,7 @@ export const featureFlagsInitialState: FeatureFlagsState = {
 
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.AreDebugOnlyNetworksEnabled,
+    FeatureFlag.AreExperimentalOnlyNetworksEnabled,
     FeatureFlag.IsCardanoSendEnabled,
     FeatureFlag.IsTradingBuyEnabled,
     FeatureFlag.IsTradingExchangeEnabled,

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -14,6 +14,7 @@ import { initNativeLocalFirstStorageThunk } from '@suite-native/local-first-stor
 
 const featureFlagsTitleMap = {
     [FeatureFlagEnum.AreDebugOnlyNetworksEnabled]: '🧪 Debug only networks',
+    [FeatureFlagEnum.AreExperimentalOnlyNetworksEnabled]: '🧪 Experimental only networks',
     [FeatureFlagEnum.IsCardanoSendEnabled]: 'Cardano send',
     [FeatureFlagEnum.IsDebugKeysAllowed]: 'Device Auth Check Debug Keys',
     [FeatureFlagEnum.IsTradingBuyEnabled]: '💰 Trading Buy',


### PR DESCRIPTION
## Description

Move AVAX out of debug mode to experimental features.

## Related Issue

Resolve #22626 

## Screenshots:

<img width="1512" height="859" alt="Screenshot 2025-10-24 at 16 25 59" src="https://github.com/user-attachments/assets/89a6a02c-f34a-4312-8543-9657d5e1b6c0" />

<img width="1512" height="859" alt="Screenshot 2025-10-24 at 16 26 16" src="https://github.com/user-attachments/assets/1bab51dc-cf69-41e6-bea1-33336cd3016e" />

<img width="1512" height="859" alt="Screenshot 2025-10-24 at 16 26 26" src="https://github.com/user-attachments/assets/fba58568-8aeb-41b1-b809-5fdf3bf08d35" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/avax-experimental-features&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/avax-experimental-features&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/avax-experimental-features&lookback=7)