### PR TITLE
Graph fixes + addresses in trading

### DIFF
--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -73,6 +73,7 @@ export const PortfolioCard = memo(() => {
         showGraphControls,
         device,
         accounts,
+        dashboardGraphHidden,
     });
 
     const goToReceive = () => dispatch(goto('wallet-receive'));

--- a/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
@@ -15,10 +15,12 @@ export const useUnsupportedNetworkMessage = ({
     showGraphControls,
     device,
     accounts,
+    dashboardGraphHidden,
 }: {
     showGraphControls: boolean;
     device?: TrezorDevice;
     accounts: Account[];
+    dashboardGraphHidden: boolean;
 }) => {
     const affectedAccounts =
         showGraphControls && !hasBitcoinOnlyFirmware(device)
@@ -29,7 +31,8 @@ export const useUnsupportedNetworkMessage = ({
 
     const affectedNetworks = union(affectedAccounts);
     const hasTokens = hasAnyAccountWithTokens(accounts);
-    const showMissingDataTooltip = affectedNetworks.length > 0 || hasAnyAccountWithTokens(accounts);
+    const showMissingDataTooltip =
+        !dashboardGraphHidden && (affectedNetworks.length > 0 || hasAnyAccountWithTokens(accounts));
 
     return { affectedNetworks, showMissingDataTooltip, hasTokens };
 };
@@ -63,7 +66,7 @@ const Message = ({ affectedNetworks, hasTokens }: MessageProps) => {
 };
 
 type UnsupportedAssetsMessageProps = {
-    affectedNetworks: string[];
+    affectedNetworks: NetworkSymbol[];
     hasTokens: boolean;
 };
 

--- a/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
@@ -1,8 +1,8 @@
 import { TrezorDevice } from '@suite-common/suite-types';
-import { getNetworkFeatures } from '@suite-common/wallet-config';
+import { NetworkSymbol, getNetwork, getNetworkFeatures } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
-import { capitalizeFirstLetter, union } from '@trezor/utils';
+import { union } from '@trezor/utils';
 
 import { isNetworkWithGraphFeature } from 'src/utils/wallet/graph';
 
@@ -24,7 +24,7 @@ export const useUnsupportedNetworkMessage = ({
         showGraphControls && !hasBitcoinOnlyFirmware(device)
             ? accounts
                   .filter(account => account.history && !isNetworkWithGraphFeature(account.symbol))
-                  .map(({ networkType }) => networkType)
+                  .map(({ symbol }) => symbol)
             : [];
 
     const affectedNetworks = union(affectedAccounts);
@@ -35,15 +35,13 @@ export const useUnsupportedNetworkMessage = ({
 };
 
 type MessageProps = {
-    affectedNetworks: string[];
+    affectedNetworks: NetworkSymbol[];
     hasTokens: boolean;
 };
 
 const Message = ({ affectedNetworks, hasTokens }: MessageProps) => {
     const hasNetworks = affectedNetworks.length > 0;
-    const networksString = affectedNetworks
-        .map(network => capitalizeFirstLetter(network))
-        .join(', ');
+    const networksString = affectedNetworks.map(network => getNetwork(network).name).join(', ');
 
     if (hasNetworks && hasTokens) {
         return (

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAccountModal/TradingReceiveAccountSuiteOption.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAccountModal/TradingReceiveAccountSuiteOption.tsx
@@ -87,8 +87,8 @@ export const TradingReceiveAccountSuiteOption = ({
                             shouldAllowCopy={false}
                             variant="tertiary"
                             typographyStyle="hint"
-                            showStart={14}
-                            showEnd={0}
+                            showStart={10}
+                            showEnd={4}
                         />
                     )}
                 </Column>

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress.tsx
@@ -77,8 +77,8 @@ export const TradingReceiveAddress = ({ type }: TradingReceiveAddressProps) => {
                                     shouldAllowCopy={false}
                                     variant="tertiary"
                                     typographyStyle="hint"
-                                    showStart={14}
-                                    showEnd={0}
+                                    showStart={10}
+                                    showEnd={4}
                                 />
                             </>
                         ) : (
@@ -89,8 +89,8 @@ export const TradingReceiveAddress = ({ type }: TradingReceiveAddressProps) => {
                                         shouldAllowCopy={false}
                                         variant="default"
                                         typographyStyle="body"
-                                        showStart={14}
-                                        showEnd={0}
+                                        showStart={10}
+                                        showEnd={4}
                                     />
                                 ) : (
                                     <Text typographyStyle="hint" variant="tertiary">

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressOption.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressOption.tsx
@@ -65,7 +65,7 @@ export const TradingUtxoReceiveAddressOption = ({
                             shouldAllowCopy={false}
                             variant="default"
                             typographyStyle="body"
-                            showStart={14}
+                            showStart={10}
                             showEnd={4}
                         />
                         <Text typographyStyle="hint" variant="tertiary">

--- a/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
@@ -52,10 +52,11 @@ const getFormattedLabelLong = (rangeLabel: GraphRange['label']) => {
 interface SummaryCardProps {
     selectedRange: GraphRange;
     data: AggregatedAccountHistory[];
-    dataInterval: [number, number];
+    dataInterval: [number | undefined, number | undefined];
     localCurrency: BaseCurrencyCode;
     account: Account;
     isLoading?: boolean;
+    isGraphSupported: boolean;
     className?: string;
 }
 
@@ -77,6 +78,7 @@ export const SummaryCards = ({
     localCurrency,
     account,
     isLoading,
+    isGraphSupported,
     className,
 }: SummaryCardProps) => {
     const { BaseCurrencyAmountFormatter } = useFormatters();
@@ -86,6 +88,12 @@ export const SummaryCards = ({
 
     // aggregate values from shown graph data
     const numOfTransactions = data.reduce((acc, d) => (acc += d.txs), 0) || account.history.total;
+
+    // on some networks it is not easy to get total number of txs (e.g. Ripple & Stellar)
+    if (numOfTransactions === -1) {
+        return null;
+    }
+
     const totalSentAmount = asBaseCurrencyAmount(
         data.reduce((acc, d) => acc.plus(d.sent), new BigNumber(0)),
     );
@@ -124,7 +132,8 @@ export const SummaryCards = ({
                     ) : null
                 }
             />
-            {account.networkType !== 'solana' && (
+            {/* without graph data, we do not know incoming/outgoing info */}
+            {isGraphSupported && (
                 <>
                     <InfoCard
                         title={<Translation id="TR_INCOMING" />}

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
@@ -2,7 +2,7 @@ import { getUnixTime } from 'date-fns';
 import styled from 'styled-components';
 
 import { calcTicks, calcTicksFromData } from '@suite-common/suite-utils';
-import { hasNetworkPotentialFraudTransactions } from '@suite-common/token-definitions';
+import { getNetworkFeatures } from '@suite-common/wallet-config';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
 import { Button, Card, Column, Row, variables } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
@@ -44,10 +44,6 @@ export const TransactionSummary = ({ account }: TransactionSummaryProps) => {
 
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const dispatch = useDispatch();
-
-    if (account.networkType === 'ripple' || account.networkType === 'stellar') {
-        return null;
-    }
 
     const intervalGraphData = getGraphDataForInterval({ account, graph });
     const data = intervalGraphData[0]?.data
@@ -96,9 +92,11 @@ export const TransactionSummary = ({ account }: TransactionSummaryProps) => {
             }),
         );
 
+    const isGraphSupported = getNetworkFeatures(account.symbol).includes('graph');
+
     return (
         <Column alignItems="stretch" gap={20}>
-            {account.networkType !== 'solana' && (
+            {isGraphSupported && (
                 <>
                     <Row justifyContent="space-between" alignItems="center">
                         <GraphRangeSelector
@@ -153,16 +151,15 @@ export const TransactionSummary = ({ account }: TransactionSummaryProps) => {
                     </Column>
                 </>
             )}
-            {!hasNetworkPotentialFraudTransactions(account.symbol) && (
-                <SummaryCards
-                    selectedRange={selectedRange}
-                    dataInterval={dataInterval}
-                    data={data}
-                    localCurrency={baseCurrencyCode}
-                    account={account}
-                    isLoading={isLoading}
-                />
-            )}
+            <SummaryCards
+                selectedRange={selectedRange}
+                dataInterval={dataInterval}
+                data={data}
+                localCurrency={baseCurrencyCode}
+                account={account}
+                isGraphSupported={isGraphSupported}
+                isLoading={isLoading}
+            />
         </Column>
     );
 };

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -274,6 +274,7 @@ export const networks = {
             'coin-definitions',
             'nft-definitions',
             'eip1559',
+            'graph',
         ],
         backendTypes: ['blockbook'],
         accountTypes: {


### PR DESCRIPTION
## Description

- in graph message, there was network type, not network itself. I put there network name (maybe it would make more sense to have network display symbol there?)
- `graph` feature was missing for AVAX in config
- `graph` feature was incorrectly used in code. Fixed
- removed `hasNetworkPotentialFraudTransactions` condition. It does not make sense.
- fixed missing last 4 chars in addresses in trading. Before it was shown only for UTXO based accounts, but it should be for all.
- graph missing data info is not required when graph is hidden

## Screenshots:

Fixed network type in dashboard portfolio
<img width="1338" height="399" alt="Screenshot 2025-10-27 at 8 36 21" src="https://github.com/user-attachments/assets/9126ede5-9391-418d-ac1e-ba9ded2ca53d" />

Now:
<img width="1055" height="321" alt="Screenshot 2025-10-27 at 8 56 43" src="https://github.com/user-attachments/assets/a49fbeb8-a997-4ae8-8471-a8e6a66136f7" />

Before:
<img width="826" height="353" alt="Screenshot 2025-10-27 at 8 57 09" src="https://github.com/user-attachments/assets/5641f08b-eaef-497f-9ccc-30012aff7f66" />

All, incoming, outgoing is back
<img width="1043" height="811" alt="Screenshot 2025-10-27 at 8 41 32" src="https://github.com/user-attachments/assets/2bb06bca-f997-49cf-bae2-0fd4217c69de" />

AVAX graph is shown
<img width="1045" height="974" alt="Screenshot 2025-10-27 at 8 36 10" src="https://github.com/user-attachments/assets/ba29232d-95dc-4cb4-b6e9-93778f20ea5c" />

Address
<img width="696" height="478" alt="Screenshot 2025-10-27 at 8 19 24" src="https://github.com/user-attachments/assets/81bc092f-af86-455d-aef9-0e08225d4440" />
<img width="822" height="598" alt="Screenshot 2025-10-27 at 8 19 17" src="https://github.com/user-attachments/assets/032ccd72-f3da-4a47-be52-7c2a209c1c74" />

Networks with no graph feature (AVAX is just to test)
<img width="832" height="778" alt="Screenshot 2025-10-27 at 8 18 43" src="https://github.com/user-attachments/assets/2121727d-947c-42bc-a303-5314a073ea5f" />
<img width="840" height="719" alt="Screenshot 2025-10-27 at 8 18 33" src="https://github.com/user-attachments/assets/d5baf8c7-6fb2-474d-ac4c-eca22c399ee2" />
<img width="839" height="699" alt="Screenshot 2025-10-27 at 8 18 37" src="https://github.com/user-attachments/assets/73769771-3e65-4d1e-8453-525a7f164929" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bunch-of-things&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bunch-of-things&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/bunch-of-things&lookback=7)