### PR TITLE
fix(suite): attempt to recognize which language crashes suite

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
@@ -24,12 +24,20 @@ export const ChangeLanguage = ({ isDeviceLocked }: ChangeLanguageProps) => {
 
     const isSupportedDevice = device?.features?.capabilities?.includes('Capability_Translations');
 
-    const deviceSupportedTranslations = Object.keys(device?.availableTranslations ?? {}).map(
-        it => ({
-            value: it,
-            label: `${LANGUAGES[it as Locale].name} (beta)`,
-        }),
-    );
+    const deviceSupportedTranslations = Object.keys(device?.availableTranslations ?? {})
+        .map(it => {
+            if (!LANGUAGES[it as Locale]) {
+                console.error('LANGUAGES[it as Locale] not found', it);
+
+                return null;
+            }
+
+            return {
+                value: it,
+                label: `${LANGUAGES[it as Locale].name} (beta)`,
+            };
+        })
+        .filter((lang): lang is { value: string; label: string } => Boolean(lang));
 
     if (isSupportedDevice !== true || deviceSupportedTranslations.length === 0) {
         return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This weird issue seems that user has flashed a FW with additional languages which we don't officially support.  So I am adding a logging so that we know what's the language to validate the custom FW hypothesis right at user.

## Related Issue

addresses https://github.com/trezor/trezor-suite/issues/22156

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=22156-attempt-to-recognize-language-crash&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=22156-attempt-to-recognize-language-crash&lookback=7)