### PR TITLE
fix(connect): caching firmware type

### DIFF
--- a/packages/connect/src/api/firmware/getBinary.ts
+++ b/packages/connect/src/api/firmware/getBinary.ts
@@ -1,4 +1,4 @@
-import { VersionArray } from '@trezor/device-utils';
+import { FirmwareRelease } from '@trezor/device-utils';
 import { removeTrailingSlashes } from '@trezor/utils';
 
 import { parseFirmwareHeaders } from './parseFirmwareHeaders';
@@ -11,13 +11,13 @@ const MIN_FIRMWARE_SIZE_BYTES = 200;
 interface GetBinaryParams {
     baseUrl: string;
     path: string;
-    version: VersionArray;
+    release: FirmwareRelease;
 }
 
 export const getBinary = async ({
     baseUrl,
     path,
-    version,
+    release,
 }: GetBinaryParams): Promise<BinaryInfo> => {
     const sanitizedBaseUrl = removeTrailingSlashes(baseUrl);
     const url = `${sanitizedBaseUrl}/${path}`;
@@ -35,7 +35,7 @@ export const getBinary = async ({
     return {
         binary: binaryArrayBuffer,
         binaryVersion,
-        releaseVersion: version,
+        release,
     };
 };
 

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -284,7 +284,7 @@ const getBinaryHelper = async ({
         return Promise.resolve({
             binary: params.binary,
             binaryVersion: parseFirmwareHeaders(Buffer.from(params.binary)).version,
-            releaseVersion: undefined,
+            release: undefined,
         });
     }
 
@@ -324,7 +324,7 @@ const getBinaryHelper = async ({
         intermediaryVersion: isIntermediary && intermediary ? intermediary.version : undefined,
     });
 
-    return getBinary({ baseUrl, path, version });
+    return getBinary({ baseUrl, path, release });
 };
 
 export type Params = {
@@ -437,18 +437,17 @@ export const onCallFirmwareUpdate = async ({
         }),
     );
 
-    const finalBinaryRelease = device?.firmwareReleaseConfigInfo?.release;
-
     // We have completed binary download, and we should notify sending an event,
     // if desktop wants to store it. We only do this for final FW, not intermediaries.
-    if (isFirmwareCacheUsedForSelectedSource()) {
+    // We also check if `BinaryInfo.release` is present, otherwise it is custom FW, not to store.
+    if (isFirmwareCacheUsedForSelectedSource() && finalBinaryInfo.release) {
         const message = createUiMessage(UI.FIRMWARE_DOWNLOADED, {
             binary: finalBinaryInfo.binary,
             binaryVersion: finalBinaryInfo.binaryVersion,
-            releaseVersion: finalBinaryInfo.releaseVersion,
-            firmwareType: device.firmwareType,
+            releaseVersion: finalBinaryInfo.release?.version,
+            firmwareType,
+            release: finalBinaryInfo.release,
             internalModel: device.features.internal_model,
-            release: finalBinaryRelease,
         });
         postMessage(message);
     }
@@ -568,11 +567,13 @@ export const onCallFirmwareUpdate = async ({
         throw ERRORS.TypedError('Runtime', 'reconnectedDevice.installedVersion is not set');
     }
 
-    const { binaryVersion, releaseVersion } = finalBinaryInfo;
+    const { binaryVersion, release } = finalBinaryInfo;
     // check if installed version matches binary version
     const assertBinaryVersion = isEqual(installedVersion, binaryVersion);
     // check if installed version matches requested release version
-    const assertReleaseVersion = releaseVersion ? isEqual(installedVersion, releaseVersion) : true; // binary
+    const assertReleaseVersion = release?.version
+        ? isEqual(installedVersion, release?.version)
+        : true; // binary
 
     await reconnectedDevice.release();
 
@@ -583,6 +584,6 @@ export const onCallFirmwareUpdate = async ({
         bootloaderVersion,
         installedVersion,
         binaryVersion,
-        releaseVersion,
+        releaseVersion: release?.version,
     };
 };

--- a/packages/connect/src/device/workflow/checkFirmwareHash.ts
+++ b/packages/connect/src/device/workflow/checkFirmwareHash.ts
@@ -60,7 +60,7 @@ export const checkFirmwareHash = async ({
     const firmwareBinary = await getBinaryOptional({
         baseUrl,
         path,
-        version: firmwareVersion,
+        release,
     });
 
     // release was found, but not its binary - happens on desktop, where only local files are searched

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -237,7 +237,7 @@ export type FirmwareStoreEvent = {
     binaryVersion: VersionArray;
     internalModel: DeviceModelInternal;
     release: FirmwareRelease | undefined;
-    firmwareType?: FirmwareType;
+    firmwareType: FirmwareType;
     releaseVersion?: number[];
 };
 

--- a/packages/connect/src/types/firmware.ts
+++ b/packages/connect/src/types/firmware.ts
@@ -18,7 +18,7 @@ export type FirmwareRange = Record<
 export type BinaryInfo = {
     binary: ArrayBuffer;
     binaryVersion: VersionArray;
-    releaseVersion?: VersionArray;
+    release?: FirmwareRelease;
 };
 
 export type FirmwareReleaseConfigInfo = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There was an issue when caching firmware in Desktop when changing firmware type. The issue was that it was stored as the current firmware type but it was actually the other FW type, so if you changed FW type 2 types then you were not able to change it until you wiped desktop data. 

This issue is probably not happening often since most likely users are not changing firmware type more tan 1 time per new FW version.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22616

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/caching-firmware-type-changing&lookback=7)