### PR TITLE
refactor(e2e-native): Removes appIsFullyLoaded method to rely on default Detox sync

### DIFF
--- a/suite-native/app/.detoxrc.js
+++ b/suite-native/app/.detoxrc.js
@@ -1,12 +1,15 @@
 /** @type {Detox.DetoxConfig} */
 module.exports = {
+    session: {
+        debugSynchronization: 30_000,
+    },
     testRunner: {
         args: {
             $0: 'jest',
             config: 'e2e/jest.config.js',
         },
         jest: {
-            setupTimeout: 120000,
+            setupTimeout: 120_000,
         },
     },
     apps: {

--- a/suite-native/app/e2e/jest.perTestFile.teardown.ts
+++ b/suite-native/app/e2e/jest.perTestFile.teardown.ts
@@ -2,14 +2,21 @@ import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 const TEARDOWN_TIMEOUT = 5_000;
 
+// We want to stop trezor at two places:
+// 1) afterAll - to cover normal test run teardowns
+// 2) beforeEach - to cover cases where previous tests hang and afterAll is not called
+const stopTrezorUserEnv = async () => {
+    if (device.getPlatform() === 'android') {
+        await TrezorUserEnvLink.stopEmu();
+        await TrezorUserEnvLink.stopBridge();
+        await TrezorUserEnvLink.disconnect();
+    }
+};
+
 const teardownPromises = async () => {
     try {
         await device.terminateApp();
-        if (device.getPlatform() === 'android') {
-            await TrezorUserEnvLink.stopEmu();
-            await TrezorUserEnvLink.stopBridge();
-            await TrezorUserEnvLink.disconnect();
-        }
+        await stopTrezorUserEnv();
     } catch (error) {
         console.error('Error during Detox global teardown:', error);
     }
@@ -17,8 +24,14 @@ const teardownPromises = async () => {
 
 afterAll(async () => {
     // We don't want timed out global teardown to fail test run.
-    await Promise.race([
-        teardownPromises(),
-        new Promise<void>(resolve => setTimeout(resolve, TEARDOWN_TIMEOUT)),
-    ]);
+    let timer: ReturnType<typeof setTimeout>;
+    const timeoutPromise = new Promise<void>(resolve => {
+        timer = setTimeout(resolve, TEARDOWN_TIMEOUT);
+        (timer as any).unref?.();
+    });
+    await Promise.race([teardownPromises(), timeoutPromise]);
+});
+
+beforeEach(async () => {
+    await stopTrezorUserEnv();
 });

--- a/suite-native/app/e2e/pageObjects/deviceManagerActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceManagerActions.ts
@@ -2,7 +2,10 @@ class DeviceManagerActions {
     async tapDeviceSwitch() {
         const deviceSwitch = element(by.id('@device-manager/device-switch'));
 
-        await waitFor(deviceSwitch).toBeVisible().withTimeout(30000);
+        await waitFor(deviceSwitch).toBeVisible().withTimeout(30_000);
+        await waitFor(element(by.id('@screen/ConnectingDevice')))
+            .not.toBeVisible()
+            .withTimeout(30_000);
         await deviceSwitch.tap();
     }
 

--- a/suite-native/app/e2e/pageObjects/homeActions.ts
+++ b/suite-native/app/e2e/pageObjects/homeActions.ts
@@ -17,8 +17,12 @@ class HomeActions {
         await waitForElementByIdToBeVisible('@home/portfolio/graph');
     }
 
-    async tapSyncCoinsButton() {
+    async scrollScreenToBottom() {
         await element(by.id('@screen/mainScrollView')).scrollTo('bottom');
+    }
+
+    async tapSyncCoinsButton() {
+        await this.scrollScreenToBottom();
         await element(by.id('@home/portfolio/sync-coins-button')).tap();
 
         await detoxExpect(element(by.id('@screen/SelectNetwork'))).toBeVisible();

--- a/suite-native/app/e2e/pageObjects/myAssetsActions.ts
+++ b/suite-native/app/e2e/pageObjects/myAssetsActions.ts
@@ -10,6 +10,7 @@ class MyAssetsActions {
     }
 
     async addAccount() {
+        await waitForElementByIdToBeVisible('@screen/mainScrollView');
         await element(by.id('@screen/mainScrollView')).scrollTo('top');
         const addAccountButtonId = '@myAssets/addAccountButton/import';
         await waitForElementByIdToBeVisible(addAccountButtonId);

--- a/suite-native/app/e2e/pageObjects/trading/TradingActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/TradingActions.ts
@@ -29,10 +29,6 @@ export class TradingActions {
         return element(by.id(this.getTestId(suffix)));
     }
 
-    async scrollScreenToBottom() {
-        await element(by.id('@screen/mainScrollView')).scrollTo('bottom');
-    }
-
     async closeBottomSheet() {
         await element(by.id('@bottom-sheet/header/close-button')).tap();
         await wait(this.BOTTOM_SHEET_ANIMATION_DURATION);

--- a/suite-native/app/e2e/pageObjects/trading/tradingExchangeActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/tradingExchangeActions.ts
@@ -2,6 +2,7 @@ import { expect as detoxExpect } from 'detox';
 
 import { TradingFormActions } from './TradingFormActions';
 import { waitForElementByIdToBeVisible } from '../../support/utils';
+import { onTabBar } from '../tabBarActions';
 
 class TradingExchangeActions extends TradingFormActions {
     constructor() {
@@ -20,6 +21,12 @@ class TradingExchangeActions extends TradingFormActions {
         await detoxExpect(element(by.text('Rate'))).toBeVisible();
         await detoxExpect(element(by.text('Provider'))).toBeVisible();
         await detoxExpect(this.getElementById('continue-button')).toBeVisible();
+    }
+
+    async openSwapForm() {
+        await onTabBar.navigateToTrade();
+        await this.tapTradingSectionHeaderTab();
+        await this.waitForTradeDataToLoad();
     }
 }
 

--- a/suite-native/app/e2e/support/deepLinkServer.ts
+++ b/suite-native/app/e2e/support/deepLinkServer.ts
@@ -1,0 +1,44 @@
+import http from 'http';
+
+import TrezorConnect from '@trezor/connect-mobile';
+
+export class DeepLinkServer {
+    private server?: http.Server;
+    readonly port = 8080;
+    readonly url = `http://localhost:${this.port}`;
+
+    async start() {
+        if (this.server && this.server.listening) {
+            return;
+        }
+
+        await new Promise<void>(resolve => {
+            this.server = http.createServer((req, res) => {
+                if (req.url) {
+                    const url = new URL(req.url, this.url);
+                    TrezorConnect.handleDeeplink(url.href);
+                    res.statusCode = 200;
+                    res.setHeader('Content-Type', 'text/plain');
+                    res.end('Callback URL received successfully!\n');
+                }
+            });
+
+            this.server.listen(this.port, 'localhost', () => {
+                // eslint-disable-next-line no-console
+                console.info(`Server running at ${this.url}`);
+                resolve();
+            });
+        });
+    }
+
+    async stop(): Promise<void> {
+        if (!this.server) return;
+
+        await new Promise<void>(resolve => {
+            this.server!.close(() => resolve());
+            this.server!.closeAllConnections();
+        });
+
+        this.server = undefined;
+    }
+}

--- a/suite-native/app/e2e/support/setup.ts
+++ b/suite-native/app/e2e/support/setup.ts
@@ -1,3 +1,4 @@
+import { expect as jestExpect } from '@jest/globals';
 import { resolveConfig } from 'detox/internals';
 
 import { LaunchArguments } from '@suite-native/config';
@@ -139,12 +140,11 @@ export const prepareTrezorEmulator = async ({
     args,
 }: PrepareTrezorEmulatorProps & { args?: LaunchArguments } = {}) => {
     if (platform === 'android') {
-        // We need to restart the bridge and emulator to ensure a clean state
-        await TrezorUserEnvLink.stopEmu();
-        await TrezorUserEnvLink.stopBridge();
-        await TrezorUserEnvLink.disconnect();
+        const { currentTestName, testPath } = jestExpect.getState();
+        await TrezorUserEnvLink.logTestDetails(
+            ` - - - STARTING TEST ${currentTestName} (${testPath})`,
+        );
         await TrezorUserEnvLink.connect();
-
         const fwVersion = getFwVersion(model, version);
         // start with latest officially released firmware (necessary to pass the firmware checks)
         await TrezorUserEnvLink.startEmu({ model, version: fwVersion, wipe: true });

--- a/suite-native/app/e2e/support/utils.ts
+++ b/suite-native/app/e2e/support/utils.ts
@@ -1,5 +1,3 @@
-import { expect as detoxExpect } from 'detox';
-
 export const platform = device.getPlatform();
 
 // There is inconsistency between platforms. Android needs to have 100% of an element visible to be able to interact with it.
@@ -20,22 +18,10 @@ export const scrollUntilVisible = async (
     target: Detox.IndexableNativeElement,
     scrollViewTestId: string = '@screen/mainScrollView',
 ) => {
-    try {
-        // Try to confirm that the element is visible without scrolling.
-        await detoxExpect(target).toBeVisible(SCROLL_VISIBILITY_THRESHOLD);
-    } catch {
-        // If the element is not visible, then use the scroll to find it.
-        const scrollViewElement = element(by.id(scrollViewTestId));
-        await waitFor(scrollViewElement).toBeVisible().withTimeout(5000);
-
-        await waitFor(target)
-            .toBeVisible(SCROLL_VISIBILITY_THRESHOLD)
-            .whileElement(by.id(scrollViewTestId))
-            .scroll(300, 'down', 0.5, 0.5);
-
-        // wait for scroll animation to finish before performing next action
-        await wait(1000);
-    }
+    await waitFor(target)
+        .toBeVisible(SCROLL_VISIBILITY_THRESHOLD)
+        .whileElement(by.id(scrollViewTestId))
+        .scroll(300, 'down', 0.5, 0.5);
 };
 
 export const waitForElementByTextToBeVisible = (text: string, timeout = 30000) =>

--- a/suite-native/app/e2e/tests/appSettings.test.ts
+++ b/suite-native/app/e2e/tests/appSettings.test.ts
@@ -1,3 +1,5 @@
+import { expect as detoxExpect } from 'detox';
+
 import { PROTO } from '@trezor/connect';
 
 import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
@@ -16,38 +18,29 @@ describe('App Settings - without device interactions [@noDevice]', () => {
     beforeEach(async () => {
         await openApp({ args: { preloadedState } });
         await onHome.assertIsPortfolioGraphVisible();
+        await onHome.scrollScreenToBottom();
     });
 
     it('Localization - Currency', async () => {
-        await waitFor(element(by.text(/^.*\$.*$/i)))
-            .toBeVisible()
-            .withTimeout(10000);
-
+        await detoxExpect(element(by.text(/^.*\$.*$/i))).toBeVisible();
         await onTabBar.navigateToSettings();
         await onSettings.tapPreferences();
         await onSettings.changeLocalizationCurrency('czk');
         await onTabBar.tapBackButton();
         await onTabBar.navigateToHome();
 
-        await waitFor(element(by.text(/^.*CZK.*$/i)))
-            .toBeVisible()
-            .withTimeout(10000);
+        await detoxExpect(element(by.text(/^.*CZK.*$/i))).toBeVisible();
     });
 
     it('Localization - Bitcoin Units', async () => {
-        await waitFor(element(by.text('0 BTC')))
-            .toBeVisible()
-            .withTimeout(10000);
-
+        await detoxExpect(element(by.text('0 BTC'))).toBeVisible();
         await onTabBar.navigateToSettings();
         await onSettings.tapPreferences();
         await onSettings.changeBitcoinUnits(PROTO.AmountUnit.SATOSHI);
         await onTabBar.tapBackButton();
         await onTabBar.navigateToHome();
 
-        await waitFor(element(by.text('0 sat')))
-            .toBeVisible()
-            .withTimeout(10000);
+        await detoxExpect(element(by.text('0 sat'))).toBeVisible();
     });
 
     it('Privacy & Security - Discreet Mode', async () => {

--- a/suite-native/app/e2e/tests/bitcoinAccountsImport.test.ts
+++ b/suite-native/app/e2e/tests/bitcoinAccountsImport.test.ts
@@ -8,12 +8,9 @@ import { openApp, preparePreloadedReduxState } from '../support/setup';
 const preloadedState = preparePreloadedReduxState(onboardingCompletedState);
 
 describe('Import Bitcoin network accounts. [@noDevice]', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await openApp({ args: { preloadedState } });
         await onTabBar.navigateToMyAssets();
-    });
-
-    beforeEach(async () => {
         await onMyAssets.addAccount();
     });
 

--- a/suite-native/app/e2e/tests/deeplinkPopup.test.ts
+++ b/suite-native/app/e2e/tests/deeplinkPopup.test.ts
@@ -1,6 +1,5 @@
 import { expect as jestExpect } from '@jest/globals';
 import { exec } from 'child_process';
-import http from 'http';
 
 import { conditionalDescribe } from '@suite-common/test-utils';
 import TrezorConnect from '@trezor/connect-mobile';
@@ -12,18 +11,15 @@ import { deviceAutoEjectState } from '../fixtures/deviceAutoEjectState';
 import { deviceChecksDisabledState } from '../fixtures/deviceChecksDisabledState';
 import { deviceChecksEnabledState } from '../fixtures/deviceChecksEnabledState';
 import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
+import { DeepLinkServer } from '../support/deepLinkServer';
 import {
     getModelFromEnv,
     openApp,
     preparePreloadedReduxState,
     prepareTrezorEmulator,
 } from '../support/setup';
-import { appIsFullyLoaded } from '../support/utils';
 
-const SERVER_PORT = 8080;
-const SERVER_URL = `http://localhost:${SERVER_PORT}`;
-
-let server: http.Server | undefined;
+const deepLinkServer = new DeepLinkServer();
 
 const openUriScheme = (url: string, platformToOpen: 'android') => {
     const command = `npx uri-scheme open '${url.replace(/'/g, '%27')}' --${platformToOpen} --raw`;
@@ -52,28 +48,13 @@ conditionalDescribe(
     'Deeplink connect popup. [@fixT3W1]',
     () => {
         beforeAll(async () => {
-            await new Promise(resolve => {
-                server = http.createServer((req, res) => {
-                    if (req.url) {
-                        const url = new URL(req.url, SERVER_URL);
-                        TrezorConnect.handleDeeplink(url.href);
-                        res.statusCode = 200;
-                        res.setHeader('Content-Type', 'text/plain');
-                        res.end('Callback URL received successfully!\n');
-                    }
-                });
+            await deepLinkServer.start();
+            await device.reverseTcpPort(deepLinkServer.port);
+        });
 
-                server.listen(SERVER_PORT, 'localhost', () => {
-                    // eslint-disable-next-line no-console
-                    console.info(`Server running at ${SERVER_URL}`);
-                    resolve(null);
-                });
-            });
-            await device.reverseTcpPort(SERVER_PORT);
-
+        beforeEach(async () => {
             await openApp({ args: { preloadedState } });
             await prepareTrezorEmulator();
-
             // This `TrezorConnect` instance here is pretending to be the integrator or @trezor/connect-mobile
             await TrezorConnect.init({
                 manifest: {
@@ -84,20 +65,13 @@ conditionalDescribe(
                 deeplinkOpen: url => {
                     openUriScheme(url, 'android');
                 },
-                deeplinkCallbackUrl: `${SERVER_URL}/connect/`,
+                deeplinkCallbackUrl: `${deepLinkServer.url}/connect/`,
                 connectSrc: 'https://dev.suite.sldev.cz/connect/develop/',
             });
-            await appIsFullyLoaded();
         });
 
         afterAll(async () => {
-            await new Promise(resolve => {
-                if (server) {
-                    server.close(() => {
-                        resolve(null);
-                    });
-                }
-            });
+            await deepLinkServer.stop();
         });
 
         it('Handle deeplink', async () => {

--- a/suite-native/app/e2e/tests/deviceSettingsT1B1.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettingsT1B1.test.ts
@@ -5,7 +5,6 @@ import { regtestDiscoveryFinishedStateT1B1 } from '../fixtures/regtestDiscoveryF
 import { onDeviceManager } from '../pageObjects/deviceManagerActions';
 import { onDeviceSettings } from '../pageObjects/deviceSettingsActions';
 import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
-import { appIsFullyLoaded } from '../support/utils';
 
 const preloadedStateT1B1 = preparePreloadedReduxState(
     onboardingCompletedState,
@@ -14,12 +13,11 @@ const preloadedStateT1B1 = preparePreloadedReduxState(
 
 conditionalDescribe(
     device.getPlatform() === 'android',
-    'Device Settings - Tests with T1B1 device model [@specificModel]',
+    'Device Settings T1B1 [@specificModel]',
     () => {
         beforeEach(async () => {
             await openApp({ args: { preloadedState: preloadedStateT1B1 } });
             await prepareTrezorEmulator({ model: 'T1B1' });
-            await appIsFullyLoaded();
 
             await onDeviceManager.tapDeviceSwitch();
             await onDeviceManager.tapDeviceSettingsButton();

--- a/suite-native/app/e2e/tests/deviceSettingsT3T1.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettingsT3T1.test.ts
@@ -8,19 +8,19 @@ import { onDeviceAuthenticitySuccess } from '../pageObjects/deviceAuthenticitySu
 import { onDeviceManager } from '../pageObjects/deviceManagerActions';
 import { onDeviceSettings } from '../pageObjects/deviceSettingsActions';
 import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
-import { appIsFullyLoaded } from '../support/utils';
 
 const preloadedStateT3T1 = preparePreloadedReduxState(
     onboardingCompletedState,
     regtestDiscoveryFinishedStateT3T1,
 );
 
-conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () => {
-    describe('Tests with T3T1 device model [@specificModel]', () => {
+conditionalDescribe(
+    device.getPlatform() === 'android',
+    'Device settings T3T1 [@specificModel]',
+    () => {
         beforeEach(async () => {
             await openApp({ args: { preloadedState: preloadedStateT3T1 } });
             await prepareTrezorEmulator({ model: 'T3T1' });
-            await appIsFullyLoaded();
 
             await onDeviceManager.tapDeviceSwitch();
             await onDeviceManager.tapDeviceSettingsButton();
@@ -100,5 +100,5 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
 
             await onDeviceSettings.passCheckBackupFlow();
         });
-    });
-});
+    },
+);

--- a/suite-native/app/e2e/tests/ejectWallets.test.ts
+++ b/suite-native/app/e2e/tests/ejectWallets.test.ts
@@ -16,7 +16,6 @@ import {
     preparePreloadedReduxState,
     prepareTrezorEmulator,
 } from '../support/setup';
-import { appIsFullyLoaded } from '../support/utils';
 
 const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
@@ -35,7 +34,6 @@ conditionalDescribe(device.getPlatform() === 'android', 'Eject wallets [@fixT3W1
     beforeEach(async () => {
         await openApp({ args: { preloadedState } });
         await prepareTrezorEmulator();
-        await appIsFullyLoaded();
     });
 
     it('Eject single wallet with disconnected device', async () => {

--- a/suite-native/app/e2e/tests/firmwareUpdateRequired.test.ts
+++ b/suite-native/app/e2e/tests/firmwareUpdateRequired.test.ts
@@ -5,22 +5,22 @@ import { regtestDiscoveryFinishedStateT3T1 } from '../fixtures/regtestDiscoveryF
 import { onDeviceManager } from '../pageObjects/deviceManagerActions';
 import { onDeviceSettings } from '../pageObjects/deviceSettingsActions';
 import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
-import { appIsFullyLoaded } from '../support/utils';
 
 const preloadedStateT3T1 = preparePreloadedReduxState(
     onboardingCompletedState,
     regtestDiscoveryFinishedStateT3T1,
 );
 
-conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () => {
-    describe('Tests with FW update required [@specificModel]', () => {
+conditionalDescribe(
+    device.getPlatform() === 'android',
+    'FW update required [@specificModel]',
+    () => {
         beforeEach(async () => {
             await openApp({ args: { preloadedState: preloadedStateT3T1 } });
             await prepareTrezorEmulator({
                 version: '2.8.9',
                 args: { isFirmwareUpdateEnabled: true },
             });
-            await appIsFullyLoaded();
         });
 
         test('Device Check Backup is possible from firmware update', async () => {
@@ -32,5 +32,5 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
 
             await onDeviceSettings.passCheckBackupFlow();
         });
-    });
-});
+    },
+);

--- a/suite-native/app/e2e/tests/onboardAndConnect.test.ts
+++ b/suite-native/app/e2e/tests/onboardAndConnect.test.ts
@@ -10,7 +10,7 @@ conditionalDescribe(
     device.getPlatform() === 'android',
     'Go through onboarding and connect Trezor. [@fixT3W1]',
     () => {
-        beforeAll(async () => {
+        beforeEach(async () => {
             await openApp({});
             await prepareTrezorEmulator();
         });

--- a/suite-native/app/e2e/tests/othersAccountsImport.test.ts
+++ b/suite-native/app/e2e/tests/othersAccountsImport.test.ts
@@ -8,12 +8,9 @@ import { openApp, preparePreloadedReduxState } from '../support/setup';
 const preloadedState = preparePreloadedReduxState(onboardingCompletedState);
 
 describe('Import accounts of other networks. [@noDevice]', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await openApp({ args: { preloadedState } });
         await onTabBar.navigateToMyAssets();
-    });
-
-    beforeEach(async () => {
         await onMyAssets.addAccount();
     });
 

--- a/suite-native/app/e2e/tests/passphraseFlow.test.ts
+++ b/suite-native/app/e2e/tests/passphraseFlow.test.ts
@@ -17,7 +17,7 @@ import {
     preparePreloadedReduxState,
     prepareTrezorEmulator,
 } from '../support/setup';
-import { appIsFullyLoaded, wait } from '../support/utils';
+import { wait } from '../support/utils';
 
 const INITIAL_ACCOUNT_BALANCE = 3.14;
 
@@ -84,7 +84,6 @@ conditionalDescribe(device.getPlatform() === 'android', 'passphrase flow [@fixT3
         beforeEach(async () => {
             await openApp({ args: { preloadedState } });
             await prepareTrezorEmulator();
-            await appIsFullyLoaded();
             await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
         });
 
@@ -121,7 +120,6 @@ conditionalDescribe(device.getPlatform() === 'android', 'passphrase flow [@fixT3
         beforeEach(async () => {
             await openApp({ args: { preloadedState } });
             await prepareTrezorEmulator({ passphrase_protection: true });
-            await appIsFullyLoaded();
         });
 
         it('Open empty passphrase wallet', async () => {

--- a/suite-native/app/e2e/tests/receive.test.ts
+++ b/suite-native/app/e2e/tests/receive.test.ts
@@ -25,7 +25,7 @@ const preloadedState = preparePreloadedReduxState(
 );
 
 conditionalDescribe(device.getPlatform() === 'android', 'Receive [@fixT3W1]', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await openApp({ args: { preloadedState } });
         await prepareTrezorEmulator();
     });

--- a/suite-native/app/e2e/tests/send.test.ts
+++ b/suite-native/app/e2e/tests/send.test.ts
@@ -20,7 +20,6 @@ import {
     preparePreloadedReduxState,
     prepareTrezorEmulator,
 } from '../support/setup';
-import { appIsFullyLoaded } from '../support/utils';
 
 const SEND_FORM_ERROR_MESSAGES = {
     invalidAddress: 'The address format is incorrect.',
@@ -85,7 +84,6 @@ conditionalDescribe(device.getPlatform() === 'android', 'Send transaction flow. 
     beforeEach(async () => {
         await openApp({ args: { preloadedState } });
         await prepareTrezorEmulator();
-        await appIsFullyLoaded();
 
         await onHome.waitForScreen();
         await onTabBar.navigateToMyAssets();

--- a/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
@@ -26,7 +26,7 @@ describe('Trade Buy [@noDevice]', () => {
         await tradingBuyActions.selectCountry('Polan', '🇵🇱 Poland');
         await tradingBuyActions.setFiatAmount('100');
 
-        await tradingBuyActions.scrollScreenToBottom();
+        await onHome.scrollScreenToBottom();
         await tradingBuyActions.viewPaymentMethods();
         await tradingBuyActions.viewProviders();
         await tradingBuyActions.expectValidBuyForm();

--- a/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
@@ -1,9 +1,10 @@
 import { conditionalDescribe } from '@suite-common/test-utils';
-import { MNEMONICS, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+import { MNEMONICS } from '@trezor/trezor-user-env-link';
 
 import { ethCoinEnabled } from '../fixtures/ethCoinEnabled';
 import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
 import { portfolioTrackerBtcAccountState } from '../fixtures/portfolioTrackerBtcAccountState';
+import { onHome } from '../pageObjects/homeActions';
 import { onPassphrase } from '../pageObjects/passphraseModule';
 import { onTabBar } from '../pageObjects/tabBarActions';
 // import { exchangePreviewActions } from '../pageObjects/trading/exchangePreviewActions';
@@ -28,19 +29,9 @@ const passphrase = process.env.TRADING_ACADEMIC_SEED_WALLET_PASSPHRASE;
 conditionalDescribe(device.getPlatform() === 'android', 'Trade Exchange', () => {
     describe('with portfolio tracker [@noDevice]', () => {
         beforeEach(async () => {
-            await openApp({
-                newInstance: true,
-                args: {
-                    preloadedState: preloadedStateWithoutTrezor,
-                },
-                wipeData: true,
-            });
+            await openApp({ args: { preloadedState: preloadedStateWithoutTrezor } });
             await onTabBar.navigateToTrade();
             await tradingExchangeActions.tapTradingSectionHeaderTab();
-        });
-
-        afterEach(async () => {
-            await device.terminateApp();
         });
 
         it('should display info card', async () => {
@@ -49,12 +40,6 @@ conditionalDescribe(device.getPlatform() === 'android', 'Trade Exchange', () => 
     });
 
     conditionalDescribe(isCIRun || passphrase, 'with device connected [@fixT3W1]', () => {
-        const openSwapForm = async () => {
-            await onTabBar.navigateToTrade();
-            await tradingExchangeActions.tapTradingSectionHeaderTab();
-            await tradingExchangeActions.waitForTradeDataToLoad();
-        };
-
         beforeAll(() => {
             if (!passphrase) {
                 throw new Error(
@@ -64,27 +49,10 @@ conditionalDescribe(device.getPlatform() === 'android', 'Trade Exchange', () => 
         });
 
         beforeEach(async () => {
-            await openApp({
-                newInstance: true,
-                args: {
-                    preloadedState: preloadedStateWithTrezor,
-                },
-                wipeData: true,
-            });
-            await prepareTrezorEmulator({
-                seed: MNEMONICS.mnemonic_academic,
-            });
-
+            await openApp({ args: { preloadedState: preloadedStateWithTrezor } });
+            await prepareTrezorEmulator({ seed: MNEMONICS.mnemonic_academic });
             await onPassphrase.openPassphraseWallet(passphrase);
-            await openSwapForm();
-        });
-
-        afterEach(async () => {
-            await TrezorUserEnvLink.stopEmu();
-        });
-
-        afterAll(async () => {
-            await device.terminateApp();
+            await tradingExchangeActions.openSwapForm();
         });
 
         it('Basic exchange USDC to USDT', async () => {
@@ -94,7 +62,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Trade Exchange', () => 
             await tradingExchangeActions.setSendCryptoAmount('10');
             await tradingExchangeActions.waitForQuotesToLoad();
 
-            await tradingExchangeActions.scrollScreenToBottom();
+            await onHome.scrollScreenToBottom();
             await tradingExchangeActions.viewProviders();
             await tradingExchangeActions.expectValidExchangeForm();
 


### PR DESCRIPTION
mixed bag of improvements and refactorings:
- removes appIsFullyLoaded() except from openApp -> I want to shift towards recommended Detox sync mechanism
- cleans up setup of trading tests
- fixes and improves global setup/teardown (covers situation when possibly last teardown failed, or test should be run without emulator)
- switches from beforeAll (openApp) to beforeEach to promote isolation and stability at cost of test runtime
- eliminates majority of nested describes -> it made logging problematic due to how describes and test names are merged together in logs
- other minor refactorings

note: artifact related fixes and changes were split off to different PR


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor-native-e2e-waits&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-native-e2e-waits&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-native-e2e-waits&lookback=7)

IOS build is failing on nightly, but [passed](https://github.com/trezor/trezor-suite/actions/runs/18913408102) on this branch. :sweat_smile: 