### PR TITLE
fix(suite): Fix modal backdrop bug

### DIFF
--- a/packages/components/src/components/Modal/ModalBackdrop.tsx
+++ b/packages/components/src/components/Modal/ModalBackdrop.tsx
@@ -55,7 +55,7 @@ export const ModalBackdrop = ({
         // eslint-disable-next-line jsx-a11y/no-autofocus
         <FocusLock autoFocus={false}>
             <Box position={{ type: 'absolute', inset: 0 }} zIndex={zIndex}>
-                <Backdrop onClick={onClick} $opaque={opaque} data-testid={dataTest}>
+                <Backdrop onMouseDown={onClick} $opaque={opaque} data-testid={dataTest}>
                     <Box padding={padding} height="100%">
                         <Column
                             alignItems={mapAlignmentToAlignItems(alignment)}
@@ -64,7 +64,7 @@ export const ModalBackdrop = ({
                             height="100%"
                             overflow="auto"
                         >
-                            <InnerWrapper onClick={e => e.stopPropagation()}>
+                            <InnerWrapper onMouseDown={e => e.stopPropagation()}>
                                 {children}
                             </InnerWrapper>
                         </Column>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It cause issues when you make onMouseDown inside of the modal and onMouseUp outside. Usually when you select text. See video below

before:



https://github.com/user-attachments/assets/52bd55a3-93b4-429d-85dd-2051b0eea975





🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-modal-backdrop-bug&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-modal-backdrop-bug&lookback=7)