### PR TITLE
feat(suite): make swap global

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -105,7 +105,7 @@ test.describe('Trading - Swap coin to token', { tag: ['@group=trading', '@webOnl
 
         await test.step('Return to account swap form', async () => {
             await tradingPage.backToAccountButton('Swap').click();
-            await expect(page).toHaveURL(/\/accounts\/coinmarket\/exchange#\/sol\/0\/normal$/);
+            await expect(page).toHaveURL(/\/accounts\/coinmarket\/exchange$/);
         });
     });
 });

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -1,4 +1,4 @@
-import { networks } from '@suite-common/wallet-config';
+import { getNetwork } from '@suite-common/wallet-config';
 import {
     accountsActions,
     blockchainActions,
@@ -10,7 +10,7 @@ import {
     selectEnabledNetworks,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
-import { SelectedAccountStatus } from '@suite-common/wallet-types';
+import { SelectedAccountStatus, WalletParams } from '@suite-common/wallet-types';
 import { isChanged } from '@trezor/utils';
 
 import { ROUTER } from 'src/actions/suite/constants';
@@ -52,16 +52,17 @@ export const getAccountState = (state: AppState): SelectedAccountStatus => {
 
     // get params from router
     // or set first default account from discovery list
-    const params =
+    const params = (
         state.router.app === 'wallet' && state.router.params
             ? state.router.params
             : {
                   accountIndex: 0,
                   accountType: 'normal' as const,
                   symbol: accounts[0]?.symbol || 'btc',
-              };
+              }
+    ) as Pick<NonNullable<WalletParams>, 'symbol' | 'accountIndex' | 'accountType'>;
 
-    const network = networks[params.symbol];
+    const network = getNetwork(params.symbol);
 
     // account cannot exists since requested network is not selected in settings/wallet
     if (!enabledNetworks.includes(network.symbol)) {
@@ -180,8 +181,13 @@ export const syncSelectedAccount = (action: Action) => (dispatch: Dispatch, getS
     // ignore not listed actions
     if (!actions.has(action.type)) return;
     const state = getState();
-    // ignore if not in wallet
-    if (state.router.app !== 'wallet') return;
+    // ignore if not in wallet or in swap trading
+    if (
+        state.router.app !== 'wallet' ||
+        state.router.route.name.startsWith('wallet-trading-exchange')
+    ) {
+        return;
+    }
 
     // get new state
     const newState = getAccountState(state);

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
@@ -75,7 +75,7 @@ export const HeaderDropdown = ({ isDisabled, showSignAndVerify }: HeaderDropdown
             id: 'wallet-swap',
             callback: () => {
                 goToWithAnalytics('wallet-trading-exchange', {
-                    preserveParams: true,
+                    preserveParams: false,
                 });
 
                 analytics.report({

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
@@ -1,3 +1,4 @@
+import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { SelectedAccountStatus } from '@suite-common/wallet-types';
 import { Row } from '@trezor/components';
@@ -59,8 +60,16 @@ export const TradeActions = ({ selectedAccount }: TradeActionsProps) => {
     };
 
     const onSwapClick = () => {
+        if (account) {
+            dispatch(
+                tradingActions.setTradingFromPrefilledAccount(
+                    getTradingPrefilledFromAccountData(account),
+                ),
+            );
+        }
+
         goToWithAnalytics('wallet-trading-exchange', {
-            preserveParams: true,
+            preserveParams: false,
         });
 
         analytics.report({

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
@@ -93,20 +93,19 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
         }
     };
 
-    if (isSelectedAccountLoaded) {
-        if (isExchange) {
-            return (
-                <TransactionReviewModalExchange
-                    selectedAccount={selectedAccount}
-                    decision={decision}
-                    txInfoState={txInfoState}
-                    cancelSignTx={handleCancelSignTx}
-                    isRbfConfirmedError={isRbfConfirmedError}
-                    precomposedForm={precomposedForm}
-                />
-            );
-        }
+    if (isExchange) {
+        return (
+            <TransactionReviewModalExchange
+                decision={decision}
+                txInfoState={txInfoState}
+                cancelSignTx={handleCancelSignTx}
+                isRbfConfirmedError={isRbfConfirmedError}
+                precomposedForm={precomposedForm}
+            />
+        );
+    }
 
+    if (isSelectedAccountLoaded) {
         if (isSell) {
             return (
                 <TransactionReviewModalSell

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalExchange.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalExchange.tsx
@@ -1,5 +1,5 @@
 import { SendState, StakeState, sendFormActions } from '@suite-common/wallet-core';
-import { FormState, SelectedAccountLoaded } from '@suite-common/wallet-types';
+import { FormState } from '@suite-common/wallet-types';
 
 import { useDispatch } from 'src/hooks/suite';
 import { useTradingExchangeForm } from 'src/hooks/wallet/trading/form/useTradingExchangeForm';
@@ -8,7 +8,6 @@ import { TransactionReviewModalProps } from './TransactionReviewModal';
 import { TransactionReviewModalBody } from './TransactionReviewModalBody';
 
 type TransactionReviewModalExchangeProps = {
-    selectedAccount: SelectedAccountLoaded;
     txInfoState: SendState | StakeState;
     isRbfConfirmedError: boolean;
     cancelSignTx: () => void;
@@ -17,14 +16,16 @@ type TransactionReviewModalExchangeProps = {
 
 export const TransactionReviewModalExchange = ({
     decision,
-    selectedAccount,
     txInfoState,
     cancelSignTx,
     isRbfConfirmedError,
     precomposedForm,
 }: TransactionReviewModalExchangeProps) => {
     const dispatch = useDispatch();
-    const tradingExchangeForm = useTradingExchangeForm({ selectedAccount, pageType: 'retry' });
+
+    const tradingExchangeForm = useTradingExchangeForm({
+        pageType: 'retry',
+    });
 
     if (!precomposedForm) {
         return null;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -10,7 +10,9 @@ import { spacings } from '@trezor/theme';
 import { Translation } from 'src/components/suite/Translation';
 import { useAccountSearch, useDefaultAccountLabel, useSelector } from 'src/hooks/suite';
 import { selectAccountLabels as selectAccountLabelsOld } from 'src/reducers/suite/metadataReducer';
+import { selectRouterParams } from 'src/reducers/suite/routerReducer';
 import { AccountItemType } from 'src/types/wallet';
+import { RouteParams } from 'src/utils/suite/router';
 
 import { AccountGroup } from './AccountGroup';
 import { AccountItemSkeleton } from './AccountItemSkeleton';
@@ -50,9 +52,9 @@ const Accounts = ({
     deviceStaticSessionId,
 }: AccountsProps) => {
     const accountLabels = useSelector(selectAccountLabelsOld);
-    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
-    const { params } = selectedAccount;
+
     const isSkeletonShown = discoveryInProgress || (type === 'coinjoin' && coinjoinIsPreloading);
+    const params = useSelector(selectRouterParams) as RouteParams;
 
     const localFirstAccountLabels = useSelector(state =>
         selectAccountLabels({ state, deviceStaticSessionId }),
@@ -105,6 +107,7 @@ export const AccountsList = ({
     const device = useSelector(selectSelectedDevice);
     const accounts = useSelector(selectAllAccountsToList);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+
     const coinjoinIsPreloading = useSelector(state => state.wallet.coinjoin.isPreloading);
     const accountLabels = useSelector(selectAccountLabelsOld);
 
@@ -161,10 +164,9 @@ export const AccountsList = ({
     const ledgerAccounts = filterAccountsByType('ledger');
 
     const hasMultipleAccounts = filteredAccounts.some(a => a.accountType !== 'normal');
-    const { params } = selectedAccount;
 
     const keepOpen = (type: Account['accountType']) =>
-        params?.accountType === type || // selected account is from this group
+        selectedAccount.account?.accountType === type || // selected account is from this group
         (type === 'coinjoin' && coinjoinIsPreloading) || // coinjoin account is requested but not yet created
         (!!searchString && searchString.length > 0) || // filter by search string is active
         (type === 'normal' && !hasMultipleAccounts); // always keep normal accounts open

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingInitializer.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingInitializer.ts
@@ -1,24 +1,33 @@
 import { useCallback } from 'react';
 
+import { TrezorDevice } from '@suite-common/suite-types';
 import {
     INVITY_API_RELOAD_QUOTES_AFTER_SECONDS,
     tradingExchangeActions,
 } from '@suite-common/trading';
-import { useTimer } from '@trezor/react-utils';
+import { Timer, useTimer } from '@trezor/react-utils';
 
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { useServerEnvironment } from 'src/hooks/wallet/trading/useServerEnviroment';
 import { selectIsWindowVisible } from 'src/reducers/suite/windowReducer';
-import { UseTradingCommonProps, UseTradingCommonReturnProps } from 'src/types/trading/trading';
+import { TradingPageType } from 'src/types/trading/trading';
+
+export type UseTradingCommonProps = {
+    pageType: TradingPageType;
+    isLoading: boolean;
+};
+export interface UseTradingCommonReturnProps {
+    timer: Timer;
+    device: TrezorDevice | undefined;
+    checkQuotesTimer: (callback: () => Promise<void>) => void;
+}
 
 export const useTradingInitializer = ({
-    selectedAccount,
     pageType,
     isLoading,
 }: UseTradingCommonProps): UseTradingCommonReturnProps => {
     const dispatch = useDispatch();
     const timer = useTimer();
-    const { account } = selectedAccount;
     const { device } = useDevice();
 
     const isWindowVisible = useSelector(selectIsWindowVisible);
@@ -53,7 +62,6 @@ export const useTradingInitializer = ({
     useServerEnvironment();
 
     return {
-        account,
         timer,
         device,
         checkQuotesTimer,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -73,11 +73,13 @@ export const useTradingBuyForm = ({
     const isTradingTermsDismissed = useSelector(state =>
         selectIsTradingTermsDismissed(state, type),
     );
-    const { account, timer, device, checkQuotesTimer } = useTradingInitializer({
-        selectedAccount,
+    const { timer, device, checkQuotesTimer } = useTradingInitializer({
         pageType,
         isLoading,
     });
+
+    const { account } = selectedAccount;
+
     const { navigateToBuyForm, navigateToBuyOffers, navigateToBuyConfirm } =
         useTradingNavigation(account);
 

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -38,7 +38,6 @@ import { getNetwork, getNetworkType } from '@suite-common/wallet-config';
 import {
     ETHEREUM_ADJUST_GAS_LIMIT,
     fetchAndUpdateAccountThunk,
-    selectAccountByKey,
     updateFeeInfoThunk,
     useFormDraft,
 } from '@suite-common/wallet-core';
@@ -50,7 +49,6 @@ import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sen
 import { submitRequestForm } from 'src/actions/wallet/trading/tradingCommonActions';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { useSolanaSubscribeBlocks } from 'src/hooks/wallet/form/useSolanaSubscribeBlocks';
-import { useTradingAccountKey } from 'src/hooks/wallet/trading/form/common/useTradingAccountKey';
 import { useTradingComposeTransaction } from 'src/hooks/wallet/trading/form/common/useTradingComposeTransaction';
 import { useTradingCurrencySwitcher } from 'src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher';
 import { useTradingExchangeHandleChange } from 'src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange';
@@ -65,7 +63,7 @@ import {
     selectIsTradingTermsDismissed,
 } from 'src/selectors/suite/suiteSelectors';
 import { Dispatch } from 'src/types/suite';
-import { UseTradingFormProps } from 'src/types/trading/trading';
+import { UseTradingFormCommonProps } from 'src/types/trading/trading';
 import {
     TradingExchangeConfirmTradeProps,
     TradingExchangeFormContextProps,
@@ -78,12 +76,12 @@ import {
 
 import { useTradingInitializer } from './common/useTradingInitializer';
 import { useTradingPreviousRoute } from './common/useTradingPreviousRoute';
+import { useTradingFormAccount } from './useTradingFormAccount';
 import { useTradingReceiveAddress } from './useTradingReceiveAddress';
 
 export const useTradingExchangeForm = ({
-    selectedAccount,
     pageType = 'form',
-}: UseTradingFormProps): TradingExchangeFormContextProps => {
+}: UseTradingFormCommonProps): TradingExchangeFormContextProps => {
     const type = 'exchange';
     const isFormPage = pageType === 'form';
     const dispatch = useDispatch();
@@ -93,7 +91,6 @@ export const useTradingExchangeForm = ({
         isFromRedirect,
         quotes,
         transactionId,
-        tradingAccountKey,
         selectedQuote,
         preselectedQuote,
         amountLimits,
@@ -103,32 +100,19 @@ export const useTradingExchangeForm = ({
     const exchangeInfo = useSelector(selectTradingExchangeInfo);
     const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
     const { selectedFee, composed } = composedTransactionInfo;
+    const { account } = useTradingFormAccount();
 
     const isPreviousRouteFromTradeSection = useTradingPreviousRoute(type);
 
     // used for disabling approve/revoke controls when
     // quotes are scheduled to refresh after changing swap form inputs
     const [isScheduledQuotesRefresh, setIsScheduledQuotesRefresh] = useState(false);
-    const [shouldUseTradingAccountKey, setShouldUseTradingAccountKey] = useState<boolean>(
-        isPreviousRouteFromTradeSection,
-    );
-
-    const [accountKey, setAccountKey] = useTradingAccountKey({
-        type,
-        tradingAccountKey,
-        selectedAccount,
-        shouldUseTradingAccountKey,
-    });
-    const accountByKey = useSelector(state => selectAccountByKey(state, accountKey));
-
-    const account = accountByKey ?? selectedAccount.account;
 
     const isTradingTermsDismissed = useSelector(state =>
         selectIsTradingTermsDismissed(state, type),
     );
 
     const { timer, device, checkQuotesTimer } = useTradingInitializer({
-        selectedAccount,
         pageType,
         isLoading,
     });
@@ -164,7 +148,7 @@ export const useTradingExchangeForm = ({
     const sendAccountKey = useSelector(selectTradingExchangeAccountKey);
     const receiveAccountKey = useSelector(selectTradingExchangeReceiveAccountKey);
 
-    const { defaultCurrency, defaultValues } = useTradingExchangeFormDefaultValues(account);
+    const { defaultCurrency, defaultValues } = useTradingExchangeFormDefaultValues();
 
     const { draft, saveDraft, removeDraft } =
         useFormDraft<TradingExchangeFormProps>('trading-exchange');
@@ -176,7 +160,7 @@ export const useTradingExchangeForm = ({
         return null;
     };
     const draftUpdated = getDraftUpdated();
-    const methods = useForm({
+    const methods = useForm<TradingExchangeFormProps>({
         mode: 'onChange',
         defaultValues: draftUpdated ?? defaultValues,
     });
@@ -283,7 +267,6 @@ export const useTradingExchangeForm = ({
         setComposedLevels,
         setAccountOnChange: newAccount => {
             dispatch(tradingExchangeActions.setTradingAccountKey(newAccount.key));
-            setAccountKey(newAccount.key);
         },
     });
 
@@ -827,23 +810,6 @@ export const useTradingExchangeForm = ({
         setValue('extraField', extraField);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [extraField]);
-
-    useEffect(() => {
-        if (isPreviousRouteFromTradeSection && tradingAccountKey !== selectedAccount.account?.key) {
-            setShouldUseTradingAccountKey(true);
-
-            return;
-        }
-
-        if (tradingAccountKey && isFormPage) {
-            setShouldUseTradingAccountKey(selectedAccount.account?.key !== tradingAccountKey);
-        }
-    }, [
-        isPreviousRouteFromTradeSection,
-        isFormPage,
-        selectedAccount.account?.key,
-        tradingAccountKey,
-    ]);
 
     useEffect(() => {
         dispatch(tradingThunks.loadInitialDataThunk({ activeSection: type }));

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeFormDefaultValues.ts
@@ -13,9 +13,7 @@ import {
     TradingExchangeKycFilter,
     TradingExchangeRateFilter,
     TradingExchangeRateType,
-    cryptoIdToSymbol,
     enabledTradingCurrencies,
-    selectTradingPrefilledFromAccount,
 } from '@suite-common/trading';
 import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
@@ -25,18 +23,16 @@ import { isArrayMember, typedObjectValues } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
 import { useTradingBuildAccountGroups } from 'src/hooks/wallet/trading/form/common/useTradingBuildAccountGroups';
-import { TradingExchangeFormDefaultValuesProps } from 'src/types/trading/tradingForm';
-import { Account } from 'src/types/wallet';
 import {
     buildTradingFiatOption,
     getAddressAndTokenFromAccountOptionsGroupProps,
 } from 'src/utils/wallet/trading/tradingUtils';
 
-export const useTradingExchangeFormDefaultValues = (
-    account: Account,
-): TradingExchangeFormDefaultValuesProps => {
+import { useTradingFormAccount } from './useTradingFormAccount';
+
+export const useTradingExchangeFormDefaultValues = () => {
     const baseCurrencyCode = useSelector(selectBaseCurrency);
-    const prefilledFromAccount = useSelector(selectTradingPrefilledFromAccount);
+    const { tradingAccountKey, cryptoId } = useTradingFormAccount();
 
     const defaultCurrency = useMemo(
         () =>
@@ -57,19 +53,12 @@ export const useTradingExchangeFormDefaultValues = (
 
     const defaultSendCryptoSelect = useMemo(
         () =>
-            (prefilledFromAccount.cryptoId &&
-                cryptoOptions.find(
-                    option =>
-                        option.value === prefilledFromAccount.cryptoId &&
-                        option.descriptor ===
-                            parseAccountKey(prefilledFromAccount.key || '').accountDescriptor,
-                )) ||
             cryptoOptions.find(
                 option =>
-                    option.descriptor === account.descriptor &&
-                    cryptoIdToSymbol(option.value) === account.symbol,
+                    option.value === cryptoId &&
+                    option.descriptor === parseAccountKey(tradingAccountKey).accountDescriptor,
             ),
-        [account.descriptor, account.symbol, prefilledFromAccount, cryptoOptions],
+        [cryptoId, cryptoOptions, tradingAccountKey],
     );
 
     const { address, token } =

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useMemo } from 'react';
+
+import { CryptoId } from 'invity-api';
+
+import { selectTokenDefinitions } from '@suite-common/token-definitions';
+import {
+    CONTRACT_ADDRESS_FOR_NATIVE_TOKEN,
+    parseCryptoId,
+    selectTradingExchangeAccountKey,
+    selectTradingPrefilledFromAccount,
+    toTokenCryptoId,
+    tradingActions,
+    tradingExchangeActions,
+} from '@suite-common/trading';
+import { getNetwork } from '@suite-common/wallet-config';
+import {
+    selectAccountByKey,
+    selectAllAccountsToList,
+    selectSelectedDevice,
+} from '@suite-common/wallet-core';
+import { Account } from '@suite-common/wallet-types';
+import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { getTokens } from 'src/utils/wallet/tokenUtils';
+
+/*
+ * Selects the most suitable account and cryptoId for trading forms based on the trade type.
+ *
+ * Eligibility rule: Account must have a positive balance of network's native token or any other (not hidden) token
+ *
+ * Selection priority:
+ * 1) Preferred account (resolved from selected trading account key OR prefilled.key) if eligible.
+ * 2) First account with the same symbol as the preferred account that is eligible.
+ * 3) Fallbacks:
+ *    a) BTC account (eligible per rule above),
+ *    b) any eligible account,
+ *    c) otherwise the first available account (last resort).
+ *
+ * cryptoId resolution:
+ * 1) Use prefilled.cryptoId when present and account for given cryptoId is eligible.
+ * 2) Otherwise derive from the selected account's network (getNetwork(symbol).tradeCryptoId).
+ * 3) Fallback to 'bitcoin' if unavailable.
+ */
+export const useTradingFormAccount = () => {
+    const dispatch = useDispatch();
+    const accounts = useSelector(selectAllAccountsToList);
+    const device = useSelector(selectSelectedDevice);
+    const tokenDefinitions = useSelector(selectTokenDefinitions);
+
+    const prefilled = useSelector(selectTradingPrefilledFromAccount);
+    const accountKey = useSelector(selectTradingExchangeAccountKey);
+
+    const preferredKey = accountKey ?? prefilled.key;
+    const preferredAccount = useSelector(state => selectAccountByKey(state, preferredKey));
+
+    const isAccountEligibleForTrade = useCallback(
+        (account: Account, cryptoId?: CryptoId) => {
+            const { contractAddress } = cryptoId ? parseCryptoId(cryptoId) : {};
+            const isNativeToken =
+                !contractAddress || contractAddress === CONTRACT_ADDRESS_FOR_NATIVE_TOKEN;
+
+            const tokens =
+                account.tokens && (account.tokens ?? []).length > 0
+                    ? getTokens({
+                          tokens: account.tokens,
+                          symbol: account.symbol,
+                          tokenDefinitions: tokenDefinitions[account.symbol]?.coin,
+                      })
+                    : undefined;
+
+            if (isNativeToken) {
+                return tokens
+                    ? tokens.shownWithBalance.length > 0
+                    : new BigNumber(account.balance).gt(0);
+            }
+
+            return tokens?.shownWithBalance.some(token => {
+                const id = toTokenCryptoId(
+                    account.symbol,
+                    getContractAddressForNetworkSymbol(account.symbol, token.contract),
+                );
+
+                return id === cryptoId && new BigNumber(token.balance ?? '0').gt(0);
+            });
+        },
+        [tokenDefinitions],
+    );
+
+    const pickFallbackAccount = useCallback(
+        (accounts: Account[]) =>
+            accounts.find(
+                acc =>
+                    isAccountEligibleForTrade(acc) &&
+                    acc.deviceState === device?.state?.staticSessionId,
+            ) ?? accounts[0],
+        [device?.state?.staticSessionId, isAccountEligibleForTrade],
+    );
+
+    const account = useMemo(() => {
+        if (preferredAccount && isAccountEligibleForTrade(preferredAccount, prefilled.cryptoId)) {
+            return preferredAccount;
+        }
+
+        const sameSymbolAccount = accounts.find(
+            acc =>
+                acc.symbol === preferredAccount?.symbol &&
+                isAccountEligibleForTrade(acc, prefilled.cryptoId) &&
+                acc.deviceState === device?.state?.staticSessionId,
+        );
+
+        if (sameSymbolAccount) {
+            return sameSymbolAccount;
+        }
+
+        return pickFallbackAccount(accounts);
+    }, [
+        accounts,
+        device?.state?.staticSessionId,
+        isAccountEligibleForTrade,
+        pickFallbackAccount,
+        preferredAccount,
+        prefilled.cryptoId,
+    ]);
+
+    const cryptoId = useMemo(() => {
+        if (prefilled.cryptoId && account.key === preferredAccount?.key) {
+            return prefilled.cryptoId;
+        }
+
+        return (getNetwork(account.symbol).tradeCryptoId ?? 'bitcoin') as CryptoId;
+    }, [prefilled.cryptoId, account.key, account.symbol, preferredAccount?.key]);
+
+    useEffect(() => {
+        if (!accountKey && account.key) {
+            dispatch(tradingExchangeActions.setTradingAccountKey(account.key));
+        }
+    }, [account.key, accountKey, dispatch]);
+
+    useEffect(() => {
+        if (prefilled.key && accountKey) {
+            dispatch(
+                tradingActions.setTradingFromPrefilledAccount({
+                    key: undefined,
+                    cryptoId: undefined,
+                }),
+            );
+        }
+    }, [accountKey, dispatch, prefilled.key]);
+
+    return {
+        tradingAccountKey: account.key,
+        account,
+        cryptoId,
+    };
+};

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -96,7 +96,6 @@ export const useTradingSellForm = ({
     const account = accountByKey ?? selectedAccount.account;
 
     const { timer, device, checkQuotesTimer } = useTradingInitializer({
-        selectedAccount,
         pageType,
         isLoading,
     });

--- a/packages/suite/src/hooks/wallet/trading/useTradingDetail.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingDetail.ts
@@ -27,6 +27,8 @@ import {
     TradingUseDetailProps,
 } from 'src/types/trading/tradingDetail';
 
+import { useTradingFormAccount } from './form/useTradingFormAccount';
+
 const isBuyTrade = (trade: TradingTransaction): trade is TradingTransactionBuy =>
     trade.tradeType === 'buy';
 
@@ -77,7 +79,7 @@ export const useTradingDetail = <T extends TradingType>({
     tradeType,
 }: TradingUseDetailProps): TradingUseDetailOutputProps<T> => {
     const trading = useSelector(selectTrading);
-    const { account } = selectedAccount;
+    const { account: exchangeAccount } = useTradingFormAccount();
     const buyInfo = useSelector(selectTradingBuyInfo);
     const sellInfo = useSelector(selectTradingSellInfo);
     const exchangeInfo = useSelector(selectTradingExchangeInfo);
@@ -90,6 +92,8 @@ export const useTradingDetail = <T extends TradingType>({
             exchange: exchangeInfo,
         },
     });
+
+    const account = tradeType === 'exchange' ? exchangeAccount : selectedAccount.account;
     const dispatch = useDispatch();
 
     useEffect(() => {

--- a/packages/suite/src/hooks/wallet/useTradingRedirect.ts
+++ b/packages/suite/src/hooks/wallet/useTradingRedirect.ts
@@ -183,9 +183,6 @@ export const useTradingRedirect = () => {
 
     const redirectToExchangeOffers = (params: ExchangeOfferRedirectParams) => {
         const {
-            symbol,
-            index,
-            accountType,
             send,
             receive,
             amount,
@@ -221,11 +218,7 @@ export const useTradingRedirect = () => {
             }),
         );
         dispatch(tradingExchangeActions.saveTransactionId(orderId));
-        dispatch(
-            goto('wallet-trading-exchange-confirm', {
-                params: { symbol, accountIndex: index, accountType },
-            }),
-        );
+        dispatch(goto('wallet-trading-exchange-confirm'));
     };
 
     const redirectToBuyDetail = (params: DetailRedirectParams) => {

--- a/packages/suite/src/middlewares/wallet/__fixtures__/tradingMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/__fixtures__/tradingMiddleware.ts
@@ -45,7 +45,7 @@ const TRADING_EXCHANGE_ROUTE = {
         app: 'wallet',
     },
     settingsBackRoute: { name: 'wallet-index', params: undefined },
-    url: '/accounts/coinmarket/exchange#/btc/0/normal',
+    url: '/accounts/coinmarket/exchange',
 } as RouterState;
 
 const DEFAULT_ROUTE = {

--- a/packages/suite/src/middlewares/wallet/__tests__/walletMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/walletMiddleware.test.ts
@@ -39,6 +39,9 @@ interface Args {
 const getInitialState = ({ router, accounts, settings, selectedAccount, send }: Args = {}) => ({
     router: {
         app: 'wallet',
+        route: {
+            name: 'wallet-index',
+        },
         ...router,
     },
     suite: {},

--- a/packages/suite/src/middlewares/wallet/tradingMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/tradingMiddleware.ts
@@ -35,7 +35,12 @@ export const tradingMiddleware =
             const isTradingRoute = !!routeName?.includes('wallet-trading');
             const isBuy = routeName === 'wallet-trading-buy';
             const isSell = routeName === 'wallet-trading-sell';
-            const isExchange = routeName === 'wallet-trading-exchange';
+            const isExchangeCreationFlow = [
+                'wallet-trading-exchange',
+                'wallet-trading-exchange-confirm',
+                'wallet-trading-exchange-offers',
+            ].some(name => name === routeName);
+            const isExchangeTransactionDetail = routeName === 'wallet-trading-exchange-detail';
             const nextModalAccountKey = selectTradingModalAccountKey(nextState);
             const prefilledFromAccount = selectTradingPrefilledFromAccount(nextState);
 
@@ -63,15 +68,10 @@ export const tradingMiddleware =
                 }
             }
 
-            if (isExchange) {
+            if (isExchangeCreationFlow) {
                 activeSection = 'exchange';
                 api.dispatch(tradingActions.setTradingActiveSection(activeSection));
                 api.dispatch(tradingExchangeActions.saveTransactionId(undefined));
-                if (prefilledFromAccount.key) {
-                    api.dispatch(
-                        tradingExchangeActions.setTradingAccountKey(prefilledFromAccount.key),
-                    );
-                }
             }
 
             const wasBuy = state.router.route?.name === 'wallet-trading-buy';
@@ -79,11 +79,15 @@ export const tradingMiddleware =
             const isBuyToSell = wasBuy && isSell;
             const isSellToBuy = wasSell && isBuy;
 
-            const cleanupPrefilledFromCryptoId =
-                !!prefilledFromAccount.cryptoId &&
-                ((!isSell && !isExchange && !isBuy) || isBuyToSell || isSellToBuy);
+            const isInTradingSection =
+                isBuy || isSell || isExchangeCreationFlow || isExchangeTransactionDetail;
+            const isSwitchingBetweenBuyAndSell = isBuyToSell || isSellToBuy;
 
-            if (cleanupPrefilledFromCryptoId) {
+            const shouldResetTradingAccountInfo =
+                !isInTradingSection || isSwitchingBetweenBuyAndSell;
+
+            if (shouldResetTradingAccountInfo) {
+                api.dispatch(tradingExchangeActions.setTradingAccountKey(undefined));
                 api.dispatch(
                     tradingActions.setTradingFromPrefilledAccount({
                         key: undefined,

--- a/packages/suite/src/types/trading/trading.ts
+++ b/packages/suite/src/types/trading/trading.ts
@@ -31,25 +31,15 @@ import { Account, SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { AssetLogoProps } from '@trezor/components';
 import { StaticSessionId } from '@trezor/connect';
 import { AssetOptionBaseProps } from '@trezor/product-components';
-import { Timer } from '@trezor/react-utils';
 
 import { GetDefaultAccountLabelParams } from 'src/hooks/suite/useDefaultAccountLabel';
-import { ExtendedMessageDescriptor, TrezorDevice } from 'src/types/suite';
+import { ExtendedMessageDescriptor } from 'src/types/suite';
 
 export type TradingPageType = 'form' | 'offers' | 'confirm' | 'retry';
 
 export type UseTradingProps = { selectedAccount: SelectedAccountLoaded };
-export type UseTradingCommonProps = UseTradingProps & {
-    pageType: TradingPageType;
-    isLoading: boolean;
-};
-export interface UseTradingCommonReturnProps {
-    account: Account;
-    timer: Timer;
-    device: TrezorDevice | undefined;
-    checkQuotesTimer: (callback: () => Promise<void>) => void;
-}
-export type UseTradingFormProps = UseTradingProps & {
+
+export type UseTradingFormCommonProps = {
     /**
      * Difference between form and offers is that on the offers page are used all data filled in the form
      * but on the form page we prefill form with only some data from draft
@@ -58,6 +48,8 @@ export type UseTradingFormProps = UseTradingProps & {
      */
     pageType?: TradingPageType;
 };
+
+export type UseTradingFormProps = UseTradingProps & UseTradingFormCommonProps;
 
 export type TradingTradeBuySellType = Exclude<TradingType, TradingExchangeType>;
 export type TradingTradeSellExchangeType = Exclude<TradingType, TradingBuyType>;

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -9,6 +9,7 @@ import {
 } from '@suite-common/token-definitions';
 import {
     TradingType,
+    getTradingPrefilledFromAccountData,
     getUnusedAddressFromAccount,
     selectTradingInfo,
     toTokenCryptoId,
@@ -170,10 +171,9 @@ export const TokenRow = ({
 
     const onTradeButtonClick = (type: TradingType, ...[routeName]: Parameters<typeof goto>) => {
         dispatch(
-            tradingActions.setTradingFromPrefilledAccount({
-                cryptoId: tokenCryptoId,
-                key: account.key,
-            }),
+            tradingActions.setTradingFromPrefilledAccount(
+                getTradingPrefilledFromAccountData(account, tokenCryptoId),
+            ),
         );
 
         goToWithAnalytics(routeName, {
@@ -182,6 +182,7 @@ export const TokenRow = ({
                 accountIndex: account.index,
                 accountType: account.accountType,
             },
+            ...{ preserveParams: type !== 'exchange' },
         });
 
         analytics.report({

--- a/packages/suite/src/views/wallet/trading/common/TradingContainer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingContainer.tsx
@@ -17,10 +17,6 @@ export const TradingContainer = ({ SectionComponent }: TradingContainerProps) =>
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
-    if (selectedAccount.status !== 'loaded') {
-        return <TradingLayoutHeader />;
-    }
-
     return (
         <TradingLayoutHeader>
             {isDiscoveryRunning && (

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -58,7 +58,7 @@ const getTradeStatusStep = (tradeStatus: ExchangeTradeStatus) => {
 
 export const TradingDetailExchange = () => {
     const accounts = useSelector(selectAccounts);
-    const { account, trade, info } = useTradingDetailContext<TradingExchangeType>();
+    const { trade, info } = useTradingDetailContext<TradingExchangeType>();
     const tradingSurveyFeature = useSelector(state =>
         selectFeatureConfig(state, Feature.trading.survey),
     );
@@ -102,15 +102,7 @@ export const TradingDetailExchange = () => {
     // if trade not found, it is because user refreshed the page and stored transactionId got removed
     // go to the default trading page, the trade is shown there in the previous trades
     if (!trade) {
-        dispatch(
-            goto('wallet-trading-exchange', {
-                params: {
-                    symbol: account.symbol,
-                    accountIndex: account.index,
-                    accountType: account.accountType,
-                },
-            }),
-        );
+        dispatch(goto('wallet-trading-exchange'));
 
         return null;
     }
@@ -131,19 +123,15 @@ export const TradingDetailExchange = () => {
                             />
                         </InfoItem>
                     )}
-                    {tradeStatusStep === 'success' && sendAccount && (
-                        <TradingDetailExchangePaymentSuccessful account={sendAccount} />
-                    )}
-                    {tradeStatusStep === 'kyc' && sendAccount && (
+                    {tradeStatusStep === 'success' && <TradingDetailExchangePaymentSuccessful />}
+                    {tradeStatusStep === 'kyc' && (
                         <TradingDetailExchangePaymentKYC
-                            account={sendAccount}
                             provider={provider}
                             supportUrl={supportUrl}
                         />
                     )}
                     {tradeStatusStep === 'error' && sendAccount && (
                         <TradingDetailExchangePaymentFailed
-                            account={sendAccount}
                             transactionId={trade.key}
                             supportUrl={supportUrl}
                         />

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentFailed.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentFailed.tsx
@@ -6,7 +6,6 @@ import { spacings, typography } from '@trezor/theme';
 import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
-import { Account } from 'src/types/wallet';
 import { TradingTransactionId } from 'src/views/wallet/trading/common/TradingTransactionId';
 
 const Wrapper = styled.div`
@@ -31,26 +30,15 @@ const Description = styled.div`
 interface PaymentFailedProps {
     transactionId?: string;
     supportUrl?: string;
-    account: Account;
 }
 
 export const TradingDetailExchangePaymentFailed = ({
     transactionId,
     supportUrl,
-    account,
 }: PaymentFailedProps) => {
     const dispatch = useDispatch();
 
-    const goToExchange = () =>
-        dispatch(
-            goto('wallet-trading-exchange', {
-                params: {
-                    symbol: account.symbol,
-                    accountIndex: account.index,
-                    accountType: account.accountType,
-                },
-            }),
-        );
+    const goToExchange = () => dispatch(goto('wallet-trading-exchange'));
 
     return (
         <Wrapper>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentKYC.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentKYC.tsx
@@ -7,7 +7,6 @@ import { spacings, typography } from '@trezor/theme';
 import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
-import { Account } from 'src/types/wallet';
 import { TradingTransactionId } from 'src/views/wallet/trading/common/TradingTransactionId';
 
 const Wrapper = styled.div`
@@ -33,27 +32,16 @@ interface PaymentKYCProps {
     transactionId?: string;
     supportUrl?: string;
     provider?: ExchangeProviderInfo;
-    account: Account;
 }
 
 export const TradingDetailExchangePaymentKYC = ({
     transactionId,
     supportUrl,
     provider,
-    account,
 }: PaymentKYCProps) => {
     const dispatch = useDispatch();
 
-    const goToExchange = () =>
-        dispatch(
-            goto('wallet-trading-exchange', {
-                params: {
-                    symbol: account.symbol,
-                    accountIndex: account.index,
-                    accountType: account.accountType,
-                },
-            }),
-        );
+    const goToExchange = () => dispatch(goto('wallet-trading-exchange'));
 
     return (
         <Wrapper>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentSuccessful.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentSuccessful.tsx
@@ -5,7 +5,6 @@ import { Button, Image, variables } from '@trezor/components';
 import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
-import { Account } from 'src/types/wallet';
 
 const Wrapper = styled.div`
     display: flex;
@@ -31,23 +30,10 @@ const Description = styled.div`
     text-align: center;
 `;
 
-interface PaymentSuccessfulProps {
-    account: Account;
-}
-
-export const TradingDetailExchangePaymentSuccessful = ({ account }: PaymentSuccessfulProps) => {
+export const TradingDetailExchangePaymentSuccessful = () => {
     const dispatch = useDispatch();
 
-    const handleClick = () =>
-        dispatch(
-            goto('wallet-trading-exchange', {
-                params: {
-                    symbol: account.symbol,
-                    accountIndex: account.index,
-                    accountType: account.accountType,
-                },
-            }),
-        );
+    const handleClick = () => dispatch(goto('wallet-trading-exchange'));
 
     return (
         <Wrapper>

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutHeader.tsx
@@ -20,7 +20,7 @@ const getBackRoute = (route?: Route['name'], activeSection?: TradingType): Route
         return activeSection === 'exchange' ? `${routePrefix}exchange` : `${routePrefix}buy`;
     }
 
-    return match ? (`${routePrefix}${match[1]}` as Route['name']) : 'wallet-index';
+    return match ? (`${routePrefix}${match[1]}` as Route['name']) : 'suite-index';
 };
 
 type TradingPageHeaderProps = {

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeConfirm.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeConfirm.tsx
@@ -1,12 +1,10 @@
 import { TradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingExchangeForm } from 'src/hooks/wallet/trading/form/useTradingExchangeForm';
-import { UseTradingProps } from 'src/types/trading/trading';
 import { TradingContainer } from 'src/views/wallet/trading/common/TradingContainer';
 import { TradingSelectedOffer } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOffer';
 
-const TradingExchangeConfirmComponent = ({ selectedAccount }: UseTradingProps) => {
+const TradingExchangeConfirmComponent = () => {
     const tradingExchangeContextValues = useTradingExchangeForm({
-        selectedAccount,
         pageType: 'confirm',
     });
 

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx
@@ -9,7 +9,6 @@ import { useMessageSystemTrading } from 'src/hooks/suite/useMessageSystemTrading
 import { TradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingExchangeForm } from 'src/hooks/wallet/trading/form/useTradingExchangeForm';
 import { selectIsDeviceCompromised } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
-import { UseTradingProps } from 'src/types/trading/trading';
 import { TradingContainer } from 'src/views/wallet/trading/common/TradingContainer';
 import { TradingFormLayout } from 'src/views/wallet/trading/common/TradingForm/TradingFormLayout';
 import { TradingLayout } from 'src/views/wallet/trading/common/TradingLayout/TradingLayout';
@@ -17,8 +16,8 @@ import { TradingLayout } from 'src/views/wallet/trading/common/TradingLayout/Tra
 import { TradingDisabled } from '../common/TradingDisabled';
 import { TradingExchangeFormInputs } from '../common/TradingForm/TradingExchangeFormInputs';
 
-const TradingExchangeFormContent = ({ selectedAccount }: UseTradingProps) => {
-    const tradingExchangeContextValue = useTradingExchangeForm({ selectedAccount });
+const TradingExchangeFormContent = () => {
+    const tradingExchangeContextValue = useTradingExchangeForm({});
 
     return (
         <TradingFormContext.Provider value={tradingExchangeContextValue}>
@@ -31,7 +30,7 @@ const TradingExchangeFormContent = ({ selectedAccount }: UseTradingProps) => {
     );
 };
 
-const TradingExchangeFormWrapper = ({ selectedAccount }: UseTradingProps) => {
+const TradingExchangeFormWrapper = () => {
     const type: TradingType = 'exchange';
     const { isDisabled, content } = useMessageSystemTrading(type);
     const isDeviceCompromised = useSelector(selectIsDeviceCompromised);
@@ -42,7 +41,7 @@ const TradingExchangeFormWrapper = ({ selectedAccount }: UseTradingProps) => {
             {isDisabled || isDeviceCompromised ? (
                 <TradingDisabled type={type} content={content} />
             ) : (
-                <TradingExchangeFormContent selectedAccount={selectedAccount} />
+                <TradingExchangeFormContent />
             )}
         </TradingLayout>
     );

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeOffers.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeOffers.tsx
@@ -1,12 +1,10 @@
 import { TradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingExchangeForm } from 'src/hooks/wallet/trading/form/useTradingExchangeForm';
-import { UseTradingProps } from 'src/types/trading/trading';
 import { TradingContainer } from 'src/views/wallet/trading/common/TradingContainer';
 import { TradingOffers } from 'src/views/wallet/trading/common/TradingOffers/TradingOffers';
 
-const TradingExchangeOffersComponent = ({ selectedAccount }: UseTradingProps) => {
+const TradingExchangeOffersComponent = () => {
     const tradingExchangeContextValues = useTradingExchangeForm({
-        selectedAccount,
         pageType: 'offers',
     });
 

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
@@ -1,4 +1,5 @@
 import { Route } from '@suite-common/suite-types';
+import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
 import { getNetworkDisplaySymbol, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
@@ -20,6 +21,8 @@ type TradeBoxProps = {
     account: Account;
 };
 
+type ActionType = 'buy' | 'sell' | 'exchange' | 'stake';
+
 export const TradeBox = ({ account }: TradeBoxProps) => {
     const { isBelowTablet, isBelowMobile } = useLayoutSize();
     const dispatch = useDispatch();
@@ -34,7 +37,7 @@ export const TradeBox = ({ account }: TradeBoxProps) => {
         children,
         isDisabled = false,
     }: {
-        type: 'stake' | 'buy' | 'exchange' | 'sell';
+        type: ActionType;
         children: React.ReactNode;
         isDisabled?: boolean;
     }) => {
@@ -42,46 +45,54 @@ export const TradeBox = ({ account }: TradeBoxProps) => {
             type === 'stake' ? 'wallet-staking' : `wallet-trading-${type}`;
         const dataTestId = type === 'stake' ? undefined : `@trading/menu/wallet-trading-${type}`;
 
+        const handleOnClick = () => {
+            dispatch(
+                tradingActions.setTradingFromPrefilledAccount(
+                    getTradingPrefilledFromAccountData(account),
+                ),
+            );
+
+            dispatch(goto(gotoRouteName, { preserveParams: type !== 'exchange' }));
+
+            switch (type) {
+                case 'buy':
+                case 'sell':
+                case 'exchange': {
+                    analytics.report({
+                        type: EventType.TradingNavigate,
+                        payload: {
+                            action: 'navigate',
+                            type,
+                            from: 'account/tradebox',
+                            networkSymbol: account.symbol,
+                        },
+                    });
+
+                    break;
+                }
+                case 'stake': {
+                    analytics.report({
+                        type: EventType.StakingNavigate,
+                        payload: {
+                            action: 'navigate',
+                            from: 'account/tradebox',
+                            networkSymbol: account.symbol,
+                        },
+                    });
+
+                    break;
+                }
+                default:
+                    exhaustive(type);
+            }
+        };
+
         return (
             <Button
                 intent="neutral"
                 priority="secondary"
                 size="small"
-                onClick={() => {
-                    dispatch(goto(gotoRouteName, { preserveParams: true }));
-
-                    switch (type) {
-                        case 'buy':
-                        case 'sell':
-                        case 'exchange': {
-                            analytics.report({
-                                type: EventType.TradingNavigate,
-                                payload: {
-                                    action: 'navigate',
-                                    type,
-                                    from: 'account/tradebox',
-                                    networkSymbol: account.symbol,
-                                },
-                            });
-
-                            break;
-                        }
-                        case 'stake': {
-                            analytics.report({
-                                type: EventType.StakingNavigate,
-                                payload: {
-                                    action: 'navigate',
-                                    from: 'account/tradebox',
-                                    networkSymbol: account.symbol,
-                                },
-                            });
-
-                            break;
-                        }
-                        default:
-                            exhaustive(type);
-                    }
-                }}
+                onClick={handleOnClick}
                 data-testid={dataTestId}
                 isDisabled={isDisabled}
             >

--- a/suite-common/suite-config/src/routes.ts
+++ b/suite-common/suite-config/src/routes.ts
@@ -191,7 +191,6 @@ export const routes = [
         name: 'wallet-trading-exchange',
         pattern: '/accounts/coinmarket/exchange',
         app: 'wallet',
-        params: walletParams,
     },
     {
         name: 'wallet-trading-sell',
@@ -215,7 +214,6 @@ export const routes = [
         name: 'wallet-trading-exchange-offers',
         pattern: '/accounts/coinmarket/exchange/offers',
         app: 'wallet',
-        params: walletParams,
     },
     {
         name: 'wallet-trading-buy-detail',
@@ -233,7 +231,6 @@ export const routes = [
         name: 'wallet-trading-exchange-detail',
         pattern: '/accounts/coinmarket/exchange/detail',
         app: 'wallet',
-        params: walletParams,
     },
     {
         name: 'wallet-trading-buy-confirm',
@@ -251,7 +248,6 @@ export const routes = [
         name: 'wallet-trading-exchange-confirm',
         pattern: '/accounts/coinmarket/exchange/confirm',
         app: 'wallet',
-        params: walletParams,
     },
     {
         name: 'wallet-trading-dca',

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -427,3 +427,15 @@ export const getTokenSelectableNetworks = (
                 TOKEN_SELECT_SELECTABLE_NETWORKS.includes(n.symbol),
         )
         .map(n => n.symbol);
+
+export const getTradingPrefilledFromAccountData = (
+    { symbol, key }: Account,
+    cryptoId?: CryptoId | undefined,
+) => {
+    const defaultCryptoId = getNetwork(symbol).tradeCryptoId as CryptoId;
+
+    return {
+        cryptoId: cryptoId ?? defaultCryptoId,
+        key,
+    };
+};

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -505,21 +505,11 @@ export const signTransactionThunk = createThunk<
     `${SEND_MODULE_PREFIX}/signTransactionThunk`,
     async (
         { formState, precomposedTransaction, selectedAccount, paymentRequests },
-        { dispatch, rejectWithValue, extra, getState },
+        { dispatch, rejectWithValue, getState },
     ) => {
-        const {
-            selectors: { selectSelectedAccountStatus },
-        } = extra;
-        const accountStatus = selectSelectedAccountStatus(getState());
         const device = selectSelectedDevice(getState());
 
-        if (
-            G.isNullable(selectedAccount) ||
-            accountStatus !== 'loaded' ||
-            !device ||
-            !precomposedTransaction ||
-            precomposedTransaction.type !== 'final'
-        )
+        if (!device || !precomposedTransaction || precomposedTransaction.type !== 'final')
             return rejectWithValue({
                 error: 'sign-transaction-failed',
                 message: 'Invalid input data.',


### PR DESCRIPTION
## Description

This PR implements `useTradingFormAccount` hook that handles `account` and `cryptoId` selection for **swap**.

Account is selected based on the following priority:
1) Preferred account (resolved from selected trading account key OR prefilled.key) if eligible.
3) First account with the same symbol as the preferred account that is eligible.
4) Fallbacks:
   a) BTC account (eligible per rule above),
   b) any eligible account,
   c) otherwise the first available account (last resort).

CryptoId is resolved in this order:
1) Use `prefilled.cryptoId` when present and account for given cryptoId is eligible.
2) Otherwise derive from the selected account's network.
3) Fallback to `bitcoin` if unavailable.


## Related Issue

Resolve #20992

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/global-trade&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/global-trade&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/global-trade&lookback=7)