### PR TITLE
transport-bluetooth small fixes

### DIFF
--- a/packages/transport-bluetooth/src/server/methods/get_info.rs
+++ b/packages/transport-bluetooth/src/server/methods/get_info.rs
@@ -3,6 +3,7 @@ use crate::server::{
     types::{MethodResult, WsResponsePayload},
     utils,
 };
+#[cfg_attr(target_os = "windows", allow(unused_imports))]
 use std::process::Command;
 
 #[cfg(target_os = "linux")]
@@ -13,7 +14,7 @@ async fn get_adapter_info() -> Result<String, Box<dyn std::error::Error>> {
     let result2 = Command::new("hciconfig").arg("-a").output();
 
     match (result1, result2) {
-        (Ok(info1), Ok(info2)) => Ok(String::from_utf8_lossy(&info1.stdout).to_string()),
+        (Ok(info1), Ok(_info2)) => Ok(String::from_utf8_lossy(&info1.stdout).to_string()),
         (Ok(info1), Err(_)) => Ok(String::from_utf8_lossy(&info1.stdout).to_string()),
         (Err(_), Ok(info2)) => Ok(String::from_utf8_lossy(&info2.stdout).to_string()),
         (Err(error), Err(_)) => Err(error.into()),

--- a/packages/transport-bluetooth/src/ui/app.tsx
+++ b/packages/transport-bluetooth/src/ui/app.tsx
@@ -70,11 +70,11 @@ export const App: React.FC = () => {
     const [devices, setDevices] = useState<BluetoothDevice[]>([]);
     const [output, setOutput] = useState<string[]>([]);
     const [deviceId, setDeviceId] = useState('');
-    const [messageInput, setMessageInput] = useState('{}');
     const [connected, setConnected] = useState(false);
     const selectRef = useRef<(HTMLSelectElement & { value?: NotificationCharacteristic }) | null>(
         null,
     );
+    const messageInputRef = useRef<HTMLTextAreaElement | null>(null);
 
     const writeOutput = (message: unknown) => {
         try {
@@ -250,7 +250,7 @@ export const App: React.FC = () => {
 
     const setState = async () => {
         try {
-            const value = deviceId.split(',');
+            const value = messageInputRef.current!.value.split(',');
             const state = { devices: value.map(d => ({ id: d, macAddress: d })) };
             const r = await api().send('set_state', state);
             writeOutput(r);
@@ -259,13 +259,15 @@ export const App: React.FC = () => {
         }
     };
 
-    const sendMessage = () => {
+    const sendMessage = async () => {
         try {
-            const json = JSON.parse(messageInput);
-            const resp = api().sendMessage(json);
+            const { value } = messageInputRef.current!;
+            console.warn('VAL', value);
+            const json = JSON.parse(value);
+            const resp = await api().sendMessage(json);
             writeOutput(resp);
         } catch (e) {
-            writeOutput(e);
+            writeOutput({ error: e.message });
         }
     };
 
@@ -316,8 +318,8 @@ export const App: React.FC = () => {
 
                         <textarea
                             id="send_message_input"
-                            value={messageInput}
-                            onChange={e => setMessageInput(e.target.value)}
+                            ref={messageInputRef}
+                            defaultValue={`{"method": "get_info"}`}
                             style={{ width: '100%', height: 80 }}
                         />
                         <div style={{ marginTop: 8 }}>

--- a/packages/transport-bluetooth/src/ui/app.tsx
+++ b/packages/transport-bluetooth/src/ui/app.tsx
@@ -35,6 +35,24 @@ button:disabled {
 #send_message_input { width: 100%; height: 80px; }
 `;
 
+const getPort = () => {
+    // UI served from the server
+    if (window.location.port) {
+        return window.location.port;
+    }
+    // UI is running as standalone file
+    if (window.location.hash.length > 0) {
+        const url = new URL(window.location.href.replace(/#/g, '?'));
+        const port = url.searchParams.get('port');
+        if (port) {
+            return port;
+        }
+    }
+
+    // default
+    return 21327;
+};
+
 export const App: React.FC = () => {
     // inject inline styles on mount
     useEffect(() => {
@@ -67,7 +85,8 @@ export const App: React.FC = () => {
     };
 
     useEffect(() => {
-        const api = new TrezorBluetooth({ url: `ws://127.0.0.1:${window.location.port}/` });
+        const port = getPort();
+        const api = new TrezorBluetooth({ url: `ws://127.0.0.1:${port}/` });
         apiRef.current = api;
 
         const onDisconnected = () => writeOutput('Api disconnected');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some small adjustments found along the way:

- SERVER: disable rust lint warnings `cargo fmt` unused variables/imports
- UI: allow dynamic port from location hash `index.html#?port=12345` or fallback to default `21327`
- UI: fix send raw message input and handler


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-small-fixes&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-small-fixes&lookback=7)