### PR TITLE
chore(github): add Notes for QA to PR template to make it more prominent

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,10 @@
 
 <!--- Describe your changes in detail -->
 
+## Notes for QA
+
+<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->
+
 ## Related Issue
 
 Resolve <!--- link the issue here -->


### PR DESCRIPTION
QA found those notes very useful and extremly important, so let's make it a bit more prominent in the PR template. Developer should either put there a notes for QA or mention that there is nothing to test (and so moving the issue manually to Approved right away).
