### PR TITLE
Staking - Fix Cardano fiat amount in Portfolio

### DIFF
--- a/suite-common/wallet-utils/src/cardanoStakingUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoStakingUtils.ts
@@ -7,7 +7,10 @@ import {
     SupportedCardanoNetworkSymbols,
     supportedCardanoNetworkSymbols,
 } from '@suite-common/wallet-types';
-import { isArrayMember } from '@trezor/utils';
+import { BigNumber, isArrayMember } from '@trezor/utils';
+
+import { asAmountSubunit } from './AmountTypes';
+import { subunitsToUnits } from './amountUtils';
 
 export function isSupportedAdaStakingNetworkSymbol(
     symbol: NetworkSymbol,
@@ -57,4 +60,9 @@ export const drepBech32ToKeyHashHex = (drepId: string): string => {
 };
 
 export const getAdaAccountTotalStakingBalance = (account: Account) =>
-    account?.networkType === 'cardano' && account.misc?.staking?.isActive ? account.balance : null;
+    account?.networkType === 'cardano' && account.misc?.staking?.isActive
+        ? subunitsToUnits({
+              value: asAmountSubunit(new BigNumber(account.balance)),
+              symbol: account.symbol,
+          }).toString()
+        : null;


### PR DESCRIPTION
## Description

Cardano accounts with active staking were showing incorrect amount in fiat. This PR fixes it by converting Lovelace to ADA (same as for other networks).

## Related Issue

Resolve #22698 

## Screenshots:

<img width="100%" alt="Screenshot 2025-10-29 at 15 13 44" src="https://github.com/user-attachments/assets/d061ba35-65d0-4a19-bec3-4d15a2b02b1c" />

<img width="100%" alt="Screenshot 2025-10-29 at 15 13 50" src="https://github.com/user-attachments/assets/0661e030-d159-489c-9988-1fa9f05497c4" />

<img width="100%" alt="Screenshot 2025-10-29 at 15 13 58" src="https://github.com/user-attachments/assets/98b5bec8-589d-4f7e-b4dd-747f2657d5b3" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ada-staking-balance&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ada-staking-balance&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/ada-staking-balance&lookback=7)