### PR TITLE
Staking - Show Cardano staking when balance is zero

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/staking/initial-stake.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/initial-stake.test.ts
@@ -149,7 +149,7 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                 await expect(stakingSection.speedUpButton).toBeEnabled();
                 await stakingSection.expectStakingAmounts({
                     pending: '0.100204158497493752',
-                    staked: 'hidden',
+                    staked: '0',
                     rewards: '0',
                     unstaking: 'hidden',
                 });
@@ -178,7 +178,7 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                 await stakingSection.expectProgressIndicatorsToMatchPhase('addingToPool');
                 await stakingSection.expectStakingAmounts({
                     pending: '0.100204158497493752',
-                    staked: 'hidden',
+                    staked: '0',
                     rewards: '0',
                     unstaking: 'hidden',
                 });

--- a/packages/suite-desktop-core/e2e/tests/staking/unstake.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/unstake.test.ts
@@ -135,7 +135,7 @@ test.describe('ETH unstaking and claim', { tag: ['@group=staking'] }, () => {
                 await page.clock.fastForward(stakingSection.watchPeriod);
                 await stakingSection.expectStakingAmounts({
                     pending: '300',
-                    staked: 'hidden',
+                    staked: '0',
                     rewards: '0',
                     unstaking: '3,234',
                 });
@@ -165,7 +165,7 @@ test.describe('ETH unstaking and claim', { tag: ['@group=staking'] }, () => {
                 await page.clock.fastForward(stakingSection.watchPeriod);
                 await stakingSection.expectStakingAmounts({
                     pending: '300',
-                    staked: 'hidden',
+                    staked: '0',
                     rewards: '0',
                     unstaking: 'hidden',
                 });

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
@@ -131,7 +131,6 @@ export const StakingCard = ({
 
     const canUnstake = new BigNumber(autocompoundBalance).gt(0);
     const isStakePending = new BigNumber(totalPendingStakeBalance).gt(0);
-    const hasDepositedBalance = new BigNumber(depositedBalance).gt(0);
 
     const isUnstakePending = new BigNumber(withdrawTotalAmount).gt(0);
 
@@ -216,24 +215,23 @@ export const StakingCard = ({
                             data-testid="@account/staking/pending"
                         />
                     )}
-                    {hasDepositedBalance && (
-                        <Item
-                            label={
-                                <Translation
-                                    id={
-                                        isCardanoNetworkType
-                                            ? 'TR_STAKE_ACTIVE_STAKE'
-                                            : 'TR_STAKE_STAKE'
-                                    }
-                                />
-                            }
-                            iconName="lock"
-                            symbol={selectedAccount?.symbol}
-                            cryptoAmount={depositedBalance}
-                            fiatAmount={depositedBalance}
-                            data-testid="@account/staking/staked"
-                        />
-                    )}
+
+                    <Item
+                        label={
+                            <Translation
+                                id={
+                                    isCardanoNetworkType
+                                        ? 'TR_STAKE_ACTIVE_STAKE'
+                                        : 'TR_STAKE_STAKE'
+                                }
+                            />
+                        }
+                        iconName="lock"
+                        symbol={selectedAccount?.symbol}
+                        cryptoAmount={depositedBalance || '0'}
+                        fiatAmount={depositedBalance || '0'}
+                        data-testid="@account/staking/staked"
+                    />
 
                     <Item
                         label={


### PR DESCRIPTION
## Description

When active staking balance is zero, show it in the staking dashboard.

## Related Issue

Resolve #22627 

## Screenshots:

<img width="100%" alt="Screenshot 2025-10-29 at 15 38 40" src="https://github.com/user-attachments/assets/9197a605-3b0f-493a-a5c8-5cf70f4c5832" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ada-staking-zero-balance&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ada-staking-zero-balance&lookback=7)