### PR TITLE
Passphrase discovery persisting

### DIFF
--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -19,7 +19,8 @@ import {
     deviceActions,
     explorerActions,
     selectAccountByKey,
-    selectAccounts,
+    selectAccountsByDeviceState,
+    selectDeviceByState,
     selectDeviceByStaticSessionId,
     selectDevices,
     selectHistoricFiatRates,
@@ -62,30 +63,26 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 const state = api.getState();
                 const device = findAccountDevice(newAccount, selectDevices(state));
 
-                // ensure index 0 gets saved once index 1+ appears, since it may be skipped during initial discovery
-                if (newAccount.index > 0) {
-                    const prevAccount = selectAccounts(state).find(
-                        account =>
-                            account.deviceState === newAccount.deviceState &&
-                            account.accountType === newAccount.accountType &&
-                            account.symbol === newAccount.symbol &&
-                            account.index === newAccount.index - 1,
-                    );
-
-                    if (
-                        prevAccount &&
-                        prevAccount.index === 0 &&
-                        prevAccount.balance === '0' &&
-                        isAccountSuccessful(prevAccount)
-                    ) {
-                        storageActions.saveAccounts([prevAccount]);
-                    }
-                }
-
                 // update only transactions for remembered device
                 if (isDeviceRemembered(device) && isAccountSuccessful(newAccount)) {
                     storageActions.saveAccounts([newAccount]);
                     api.dispatch(storageActions.saveCoinjoinAccount(newAccount.key));
+                }
+            }
+
+            if (isAnyOf(deviceActions.setDeviceState, deviceActions.addAuthorizedDevice)(action)) {
+                const device = selectDeviceByState(api.getState(), action.payload.state);
+
+                // When setDeviceState/addAuthorizedDevice is dispatched for passphrase wallet,
+                // it means that its device was just created, but already discovered accounts
+                // may have not been persisted, so try to do it now
+                if (device && !device.useEmptyPassphrase && isDeviceRemembered(device)) {
+                    const accounts = selectAccountsByDeviceState(
+                        api.getState(),
+                        action.payload.state,
+                    ).filter(isAccountSuccessful);
+
+                    storageActions.saveAccounts(accounts);
                 }
             }
 

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -22,6 +22,13 @@ export type DeviceConnectActionPayload = {
     isAutoEjectEnabled: boolean;
 };
 
+export type DeviceStateActionPayload = {
+    device: AcquiredDevice;
+    state: DeviceState & { staticSessionId: StaticSessionId };
+    useEmptyPassphrase: boolean;
+    isAutoEjectEnabled: boolean;
+};
+
 const connectDevice = createAction(DEVICE.CONNECT, (payload: DeviceConnectActionPayload) => ({
     payload,
 }));
@@ -51,21 +58,12 @@ const devicePushNotification = createAction(
 
 const setDeviceState = createAction(
     `${DEVICE_MODULE_PREFIX}/set-device-state`,
-    (payload: {
-        device: TrezorDevice;
-        state: DeviceState & { staticSessionId: StaticSessionId };
-        useEmptyPassphrase: boolean;
-        isAutoEjectEnabled: boolean;
-    }) => ({
-        payload,
-    }),
+    (payload: DeviceStateActionPayload) => ({ payload }),
 );
 
 const addAuthorizedDevice = createAction(
     `${DEVICE_MODULE_PREFIX}/addAuthorizedDevice`,
-    (payload: { device: TrezorDevice }) => ({
-        payload,
-    }),
+    (payload: DeviceStateActionPayload) => ({ payload }),
 );
 
 const deviceDisconnect = createAction(DEVICE.DISCONNECT, (payload: TrezorDevice) => ({

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -17,7 +17,7 @@ import { shouldDeviceBeRemembered } from '@suite-common/wallet-utils';
 import { Device, DeviceState, Features, KnownDevice, StaticSessionId } from '@trezor/connect';
 import { getFirmwareVersionArray } from '@trezor/device-utils';
 
-import { deviceActions } from './deviceActions';
+import { DeviceStateActionPayload, deviceActions } from './deviceActions';
 import { PORTFOLIO_TRACKER_DEVICE_ID } from './deviceConstants';
 
 export type DeviceReducerState = {
@@ -115,7 +115,7 @@ const merge = (
 const connectDevice = (
     draft: DeviceReducerState,
     device: Device,
-    options: { isAutoEjectEnabled: boolean },
+    { isAutoEjectEnabled }: { isAutoEjectEnabled: boolean },
 ) => {
     const currentTime = new Date().getTime();
 
@@ -194,10 +194,7 @@ const connectDevice = (
         ...deviceCommonFields,
         state: device._state,
         useEmptyPassphrase: undefined,
-        remember: shouldDeviceBeRemembered({
-            isDeviceAutoEjectEnabled: options.isAutoEjectEnabled,
-            device,
-        }),
+        remember: shouldDeviceBeRemembered({ isAutoEjectEnabled, device }),
         temporaryRemember: false,
         available: true,
         instance: deviceInstance,
@@ -230,12 +227,6 @@ const connectDevice = (
         // add new device
         draft.devices.push(newDevice);
     }
-};
-
-const addAuthorizedDevice = (draft: DeviceReducerState, device: TrezorDevice) => {
-    device.walletNumber = deviceUtils.getNewWalletNumber(draft.devices, device);
-    delete device.discovered;
-    draft.devices.push(device);
 };
 
 /**
@@ -337,12 +328,28 @@ const changeDevice = (
     }
 };
 
+const addAuthorizedDevice = (
+    draft: DeviceReducerState,
+    { device, state, useEmptyPassphrase, isAutoEjectEnabled }: DeviceStateActionPayload,
+) => {
+    const { discovered, ...oldDevice } = device;
+    const newDevice = {
+        ...oldDevice,
+        metadata: {},
+        instance: deviceUtils.getNewInstanceNumber(draft.devices, device),
+        walletNumber: deviceUtils.getNewWalletNumber(draft.devices, device),
+        useEmptyPassphrase,
+        remember: shouldDeviceBeRemembered({ isAutoEjectEnabled, device }),
+        state,
+        localFirstStorageSecret: undefined,
+    };
+
+    draft.devices.push(newDevice);
+};
+
 const setDeviceState = (
     draft: DeviceReducerState,
-    device: TrezorDevice,
-    state: DeviceState,
-    useEmptyPassphrase: boolean,
-    isAutoEjectEnabled: boolean,
+    { device, state, useEmptyPassphrase, isAutoEjectEnabled }: DeviceStateActionPayload,
 ) => {
     // change only acquired devices
     if (!device.features) return;
@@ -366,10 +373,7 @@ const setDeviceState = (
     affectedDevice[0].walletNumber = deviceUtils.getNewWalletNumber(draft.devices, device);
     delete affectedDevice[0].discovered;
 
-    affectedDevice[0].remember = shouldDeviceBeRemembered({
-        isDeviceAutoEjectEnabled: isAutoEjectEnabled,
-        device,
-    });
+    affectedDevice[0].remember = shouldDeviceBeRemembered({ isAutoEjectEnabled, device });
 };
 
 /**
@@ -617,18 +621,11 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
                 updatePersistentDeviceData(state, payload);
             })
             .addCase(deviceActions.setDeviceState, (state, { payload }) => {
-                setDeviceState(
-                    state,
-                    payload.device,
-                    payload.state,
-                    payload.useEmptyPassphrase,
-                    payload.isAutoEjectEnabled,
-                );
+                setDeviceState(state, payload);
             })
             .addCase(deviceActions.addAuthorizedDevice, (state, { payload }) => {
-                addAuthorizedDevice(state, payload.device);
+                addAuthorizedDevice(state, payload);
             })
-
             .addCase(deviceActions.deviceDisconnect, (state, { payload }) => {
                 disconnectDevice(state, payload);
             })

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -367,7 +367,7 @@ export const setDeviceAutoEjectThunk = createThunk(
         const physicalDeviceWallets = selectPhysicalDeviceWallets(getState());
         physicalDeviceWallets.forEach(wallet => {
             const shouldRemember = shouldDeviceBeRemembered({
-                isDeviceAutoEjectEnabled: shouldEnable,
+                isAutoEjectEnabled: shouldEnable,
                 device: wallet,
             });
 

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -3,7 +3,6 @@ import { AcquiredDevice, AuthorizedDevice, TrezorDevice } from '@suite-common/su
 import { getNewInstanceNumber } from '@suite-common/suite-utils';
 import { Bip43Path, TrezorConnectBackendType } from '@suite-common/wallet-config';
 import { DiscoveryStatus } from '@suite-common/wallet-types';
-import { shouldDeviceBeRemembered } from '@suite-common/wallet-utils';
 import TrezorConnect, {
     AccountInfo,
     BundleProgress,
@@ -124,7 +123,7 @@ const applyDeviceStatesThunk = createThunk(
             // sanity check that there is no 2 devices sharing the same path. this shouldn't happen, the only way that comes to my mind
             // is when you would create a copy of device and store it in redux before authorizing it (this is actually the old way of doing things)
             // todo: this sanity check could be moved somewhere higher.
-            if (devicesByPathWithoutState.length !== 1 && devicesByPathWithoutState.length !== 0) {
+            if (devicesByPathWithoutState.length > 1) {
                 console.error('there must be either one or zero physical devices without state');
 
                 return;
@@ -138,7 +137,7 @@ const applyDeviceStatesThunk = createThunk(
             const useEmptyPassphrase = !isAddingHiddenWallet;
 
             // now we expect that there is exactly one device without state - meaning that we want to update its state
-            const isDeviceAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(getState());
+            const isAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(getState());
 
             if (devicesByPathWithoutState.length === 1) {
                 dispatch(
@@ -146,24 +145,16 @@ const applyDeviceStatesThunk = createThunk(
                         device,
                         state: newDeviceState,
                         useEmptyPassphrase,
-                        isAutoEjectEnabled: isDeviceAutoEjectEnabled,
+                        isAutoEjectEnabled,
                     }),
                 );
             } else {
                 dispatch(
                     deviceActions.addAuthorizedDevice({
-                        device: {
-                            ...device,
-                            metadata: {},
-                            instance: getNewInstanceNumber(selectDevices(getState()), device),
-                            useEmptyPassphrase,
-                            remember: shouldDeviceBeRemembered({
-                                isDeviceAutoEjectEnabled,
-                                device,
-                            }),
-                            state: newDeviceState,
-                            localFirstStorageSecret: undefined,
-                        },
+                        device,
+                        state: newDeviceState,
+                        useEmptyPassphrase,
+                        isAutoEjectEnabled,
                     }),
                 );
 
@@ -308,11 +299,7 @@ export const runDiscoveryThunk = createThunk(
                 : getNewInstanceNumber(selectDevices(getState()), device);
 
             const deviceStateResponse = await TrezorConnect.getDeviceState({
-                device: {
-                    path: device.path,
-                    instance,
-                    state: undefined,
-                },
+                device: { path: device.path, instance, state: undefined },
                 useEmptyPassphrase: !isAddingHiddenWallet,
             });
 
@@ -434,11 +421,7 @@ export const runDiscoveryThunk = createThunk(
             // before asnyc onBundleProgress is called which sets progress
             dispatch(
                 discoveryActions.updateDiscovery(
-                    {
-                        status: 'progress',
-                        total: Infinity,
-                        progress: 0,
-                    },
+                    { status: 'progress', total: Infinity, progress: 0 },
                     device.path,
                 ),
             );

--- a/suite-common/wallet-utils/src/deviceUtils.ts
+++ b/suite-common/wallet-utils/src/deviceUtils.ts
@@ -13,16 +13,16 @@ export const parseDeviceStaticSessionId = (deviceStaticSessionId: StaticSessionI
 
 export const shouldDeviceBeRemembered = ({
     device,
-    isDeviceAutoEjectEnabled = false,
+    isAutoEjectEnabled = false,
 }: {
     device: TrezorDevice | Device;
-    isDeviceAutoEjectEnabled?: boolean;
+    isAutoEjectEnabled?: boolean;
 }) => {
     if (device.mode !== 'normal') return false;
 
     if (device.type !== 'acquired') return false;
 
-    return !isDeviceAutoEjectEnabled;
+    return !isAutoEjectEnabled;
 };
 
 export const isApprovalFlowSupported = (device: TrezorDevice | undefined) =>


### PR DESCRIPTION
## Description

Should fix a bug regarding passphrase discovery persisting.

1) `setDeviceState` and `addAuthorizedDevice` actions' params are now unified (`addAuthorizedDevice` transformation logic moved to reducer), and in the future they may be even merged together (_set device state when there's appropriate stateless device, or add a new one when there isn't_).

2) Remove the hacky solution of storing 1st account when 2nd is added, and replace it by storing all device accounts whenever
`setDeviceState` or `addAuthorizedDevice` is dispatched for passphrase device (that's the moment during discovery where we're sure that the passphrase is correct)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/discovery-persisting&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/discovery-persisting&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/discovery-persisting&lookback=7)