### PR TITLE
fix(e2e): Temporarily disable authenticity check for T3W1

### DIFF
--- a/packages/suite-desktop-core/e2e/support/electron.ts
+++ b/packages/suite-desktop-core/e2e/support/electron.ts
@@ -5,11 +5,14 @@ import path from 'path';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { BRIDGE_VERSION } from './bridge';
+import { getModelFromEnv } from './helpers/modelFromEnv';
 
 const appDir = path.join(__dirname, '../../../suite-desktop');
 const disableHashChecksPatch = '--state.suite.settings.enabledSecurityChecks.firmwareHash=false';
 const disableFirmwareRevisionChecksPatch =
     '--state.suite.settings.enabledSecurityChecks.firmwareRevision=false';
+const disableAuthenticityCheckPatch =
+    '--state.suite.settings.enabledSecurityChecks.deviceAuthenticity=false';
 const showDebugMenuStatePatch = '--state.suite.settings.debug.showDebugMenu=true';
 const disableDisconnectPromptPatch = '--state.suite.flags.hasSeenDisconnectTooltip=true';
 const showConnectLogsArgument = '--state.suite.settings.debug.showConnectLogs=true';
@@ -75,6 +78,10 @@ const buildArgs = (params: LaunchSuiteParams) => {
 
     if (process.env.CANARY_FIRMWARE) {
         args.push(disableFirmwareRevisionChecksPatch);
+    }
+
+    if (getModelFromEnv() === 'T3W1') {
+        args.push(disableAuthenticityCheckPatch);
     }
 
     return args;

--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -10,6 +10,7 @@ import { BackupSection } from './backupSection';
 import { FirmwareSection } from './firmwareSection';
 import { PinSection } from './pinSection';
 import { TutorialSection } from './tutorialSection';
+import { getModelFromEnv } from '../../helpers/modelFromEnv';
 import { ModelFixture } from '../../modelFixture';
 import { SettingsPage } from '../settings/settingsPage';
 
@@ -123,7 +124,7 @@ export class OnboardingPage {
         }
 
         await this.onboardingExitButton.click();
-        if (this.model.isModelWithSecureElement()) {
+        if (this.model.isModelWithSecureElement() && getModelFromEnv() !== 'T3W1') {
             await this.passThroughAuthenticityCheck();
         }
         // Enabled debug mode is needed for passing firmware checks but it also enables several hidden features
@@ -216,6 +217,22 @@ export class OnboardingPage {
     }
 
     @step()
+    async disableAuthenticityCheck() {
+        // Desktop starts with already disabled authenticity check. Web needs to disable it.
+        if (!isWebProject(this.testInfo)) {
+            return;
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        await this.page.evaluate(SuiteActions => {
+            window.store.dispatch({
+                type: SuiteActions.TOGGLE_DEVICE_AUTHENTICITY_CHECK,
+                payload: false,
+            });
+        }, SuiteActions);
+    }
+
+    @step()
     async disableDisconnectPrompt() {
         // Desktop starts with already disabled disconnect prompt. Web needs to disable it.
         if (!isWebProject(this.testInfo)) {
@@ -237,6 +254,10 @@ export class OnboardingPage {
         await this.disableFirmwareHashCheck(options);
         if (process.env.CANARY_FIRMWARE) {
             await this.disableFirmwareRevisionCheck();
+        }
+
+        if (getModelFromEnv() === 'T3W1') {
+            await this.disableAuthenticityCheck();
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I needed to disable the authenticity check for T3W1 to make tests pass with current state of emulator. Once it is fixed, this should be removed. I have created https://github.com/trezor/trezor-suite/issues/22765 as a reminder.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-t3w1-autenticity-e2e&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-t3w1-autenticity-e2e&lookback=7)