### PR TITLE
fix(suite): remove vite flags from the production code

### DIFF
--- a/packages/suite-build/vite.config.mts
+++ b/packages/suite-build/vite.config.mts
@@ -78,6 +78,10 @@ const alias = [
         replacement: '@trezor/connect-web/src/module',
     },
     {
+        find: 'core-js/actual',
+        replacement: 'noop-core-js-actual',
+    },
+    {
         find: 'src',
         replacement: resolve(__dirname, '../suite/src'),
     },
@@ -256,6 +260,26 @@ const serveCorePlugin = () => ({
 
 const commitId = execSync('git rev-parse HEAD').toString().trim();
 
+// Plugin to provide a no-op replacement for core-js/actual as a virtual module
+const noopCoreJsPlugin = (): Plugin => {
+    const virtualModuleId = 'noop-core-js-actual';
+    const resolvedVirtualModuleId = '\0' + virtualModuleId;
+
+    return {
+        name: 'noop-core-js-actual',
+        resolveId(id) {
+            if (id === virtualModuleId) {
+                return resolvedVirtualModuleId;
+            }
+        },
+        load(id) {
+            if (id === resolvedVirtualModuleId) {
+                return '// No-op replacement for core-js/actual\nexport default {};';
+            }
+        },
+    };
+};
+
 // Plugin to provide Buffer polyfill via a virtual module
 const bufferPolyfillPlugin = (): Plugin => {
     const virtualModuleId = 'virtual:buffer-polyfill';
@@ -336,6 +360,7 @@ export default defineConfig({
     plugins: [
         htmlTemplatePlugin(),
         bufferPolyfillPlugin(),
+        noopCoreJsPlugin(),
         staticAliasPlugin(),
         serveCorePlugin(),
         sessionsSharedWorkerPlugin(),
@@ -361,7 +386,6 @@ export default defineConfig({
         preserveSymlinks: true,
     },
     define: {
-        'process.env.VITE': true,
         'process.browser': true,
         'process.env.VERSION': JSON.stringify(suiteVersion),
         'process.env.COMMIT_HASH': JSON.stringify(commitId),

--- a/packages/suite-web/src/MainWeb.tsx
+++ b/packages/suite-web/src/MainWeb.tsx
@@ -1,8 +1,4 @@
-// Don't include core-js polyfills when using Vite instead of Webpack. Vite already handles this on its own.
-if (!process.env.VITE) {
-    // @ts-expect-error
-    await import('core-js/actual');
-}
+import 'core-js/actual';
 
 import { Suspense } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I realize taht we do not need / want the vite-specific code to be in the production code. I think it is easier and cleaner to handle it just as a vite plugin.

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/pull/21803

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-vite-flag-from-proudction&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-vite-flag-from-proudction&lookback=7)