### PR TITLE
Staking Dashboard fixes

### DIFF
--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -2,7 +2,13 @@ import { ReactNode, createContext, useContext } from 'react';
 
 import styled from 'styled-components';
 
-import { TypographyStyle, mapElevationToBackgroundToken } from '@trezor/theme';
+import {
+    Elevation,
+    TypographyStyle,
+    borders,
+    mapElevationToBackgroundToken,
+    mapElevationToBorder,
+} from '@trezor/theme';
 
 import { TableBody } from './TableBody';
 import { TableCell } from './TableCell';
@@ -46,9 +52,12 @@ const Container = styled.table<TransientProps<AllowedFrameProps>>`
     ${withFrameProps}
 `;
 
-const ScrollContainer = styled.div`
+const ScrollContainer = styled.div<{ $elevation: Elevation }>`
     overflow: auto hidden;
     -webkit-overflow-scrolling: touch;
+
+    border-radius: ${borders.radii.md};
+    border: 1px solid ${({ theme, $elevation }) => mapElevationToBorder({ theme, $elevation })};
 `;
 
 export type TableProps = AllowedFrameProps &
@@ -72,12 +81,12 @@ export const Table = ({
     typographyStyle = 'body',
 }: TableProps) => {
     const { scrollElementRef, onScroll, ShadowContainer, ShadowRight } = useScrollShadow();
-    const { parentElevation } = useElevation();
+    const { elevation, parentElevation } = useElevation();
 
     return (
         <TableContext.Provider value={{ isRowHighlightedOnHover, hasBorders, typographyStyle }}>
             <ShadowContainer>
-                <ScrollContainer onScroll={onScroll} ref={scrollElementRef}>
+                <ScrollContainer onScroll={onScroll} ref={scrollElementRef} $elevation={elevation}>
                     <Container {...makePropsTransient({ margin })}>
                         {colWidths && (
                             <colgroup>

--- a/packages/components/src/components/Table/TableCell.tsx
+++ b/packages/components/src/components/Table/TableCell.tsx
@@ -75,15 +75,13 @@ export const TableCell = ({
     'data-testid': dataTestId,
 }: TableCellProps) => {
     const isHeader = useTableHeader();
-    const { hasBorders, typographyStyle } = useTable();
+    const { hasBorders, typographyStyle = 'body' } = useTable();
     const { parentElevation } = useElevation();
 
     const defaultPadding = {
         vertical: hasBorders ? spacings.sm : spacings.xs,
         horizontal: spacings.lg,
     };
-
-    const defaultTypographyStyle = isHeader ? 'hint' : 'body';
 
     return (
         <Cell
@@ -97,7 +95,7 @@ export const TableCell = ({
         >
             <Text
                 as="div"
-                typographyStyle={typographyStyle ?? defaultTypographyStyle}
+                typographyStyle={isHeader ? 'hint' : typographyStyle}
                 variant={isHeader ? 'tertiary' : 'default'}
             >
                 <Content $align={align}>{children}</Content>

--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardAccountRow.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardAccountRow.tsx
@@ -101,7 +101,7 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
 
         if (stakingBalance !== '0') {
             if (!hasEnoughBalanceForStaking) {
-                return 'staking-max';
+                return 'staked-but-insufficient-funds';
             }
 
             return 'staking-active';
@@ -227,6 +227,30 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
 
                     <Table.Cell align="end">
                         <Button variant="tertiary" size="small" onClick={navigateToTradingBuy}>
+                            <Translation id="TR_BUY" />
+                        </Button>
+                    </Table.Cell>
+                </>
+            )}
+
+            {state === 'staked-but-insufficient-funds' && (
+                <>
+                    <CurrentRewardsCell />
+
+                    <Table.Cell>
+                        <Paragraph typographyStyle="body" variant="tertiary">
+                            <Translation
+                                id="TR_STAKING_DASHBOARD_MINIMUM_STAKE"
+                                values={{
+                                    amount: minStakingAmount?.toString(),
+                                    displaySymbol,
+                                }}
+                            />
+                        </Paragraph>
+                    </Table.Cell>
+
+                    <Table.Cell align="end">
+                        <Button variant="primary" size="small" onClick={navigateToTradingBuy}>
                             <Translation id="TR_BUY" />
                         </Button>
                     </Table.Cell>


### PR DESCRIPTION
## Description

This PR fixes three things:

- adds borders around ALL TABLES
- reduces table header font size to `14px` for ALL TABLES
- if an account has staked, but has insufficient funds for staking more, prompt the user to buy more

## Related Issue

Resolve #21989 

## Screenshots:

<img width="100%" alt="Screenshot 2025-10-30 at 10 54 09" src="https://github.com/user-attachments/assets/67b6951c-e53e-4880-90d7-0263553c1ae7" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/staking-dashboard&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/staking-dashboard&lookback=7)