### PR TITLE
fix(suite): cardano staking update provider warning

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/CardanoStakingDashboard/NewCardanoStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/CardanoStakingDashboard/NewCardanoStakingDashboard.tsx
@@ -76,7 +76,7 @@ export const NewCardanoStakingDashboard = ({
                                 {!isDeviceConnected && <ConnectDeviceGenericPromo />}
                                 {isDiscoveryRunning && <DiscoveryWarning />}
 
-                                {!isStakedWithEverstake && <NewProviderCard />}
+                                {!isStakedWithEverstake && !hasPendingTx && <NewProviderCard />}
 
                                 <Grid
                                     columns={isBelowLaptop || !canClaim ? 1 : 2}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prevented the Everstake provider update warning from appearing while a Cardano staking transaction is already in progress.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22755

