### PR TITLE
fix(trading): slip-24

### DIFF
--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -63,6 +63,7 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
     slip24: {
         title: { id: 'TR_EXPERIMENTAL_SLIP24' },
         description: { id: 'TR_EXPERIMENTAL_SLIP24_DESCRIPTION' },
+        isDisabled: ({ isDebug }) => !isDebug,
     },
     'experimental-networks': {
         title: {

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -17,6 +17,7 @@ export type ExperimentalFeature =
     | 'tor-external'
     | 'testnet-networks'
     | 'nft-section'
+    | 'slip24'
     | 'experimental-networks'
     | 'suite-sync';
 
@@ -58,6 +59,10 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
     'nft-section': {
         title: { id: 'TR_EXPERIMENTAL_NFT_SECTION' },
         description: { id: 'TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION' },
+    },
+    slip24: {
+        title: { id: 'TR_EXPERIMENTAL_SLIP24' },
+        description: { id: 'TR_EXPERIMENTAL_SLIP24_DESCRIPTION' },
     },
     'experimental-networks': {
         title: {

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -62,7 +62,7 @@ import { useTradingFormActions } from 'src/hooks/wallet/trading/form/common/useT
 import { useTradingExchangeFormDefaultValues } from 'src/hooks/wallet/trading/form/useTradingExchangeFormDefaultValues';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { useTradingNavigation } from 'src/hooks/wallet/useTradingNavigation';
-import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
+import { selectHasExperimentalFeature } from 'src/selectors/suite/suiteSelectors';
 import { useAnalytics, useLegacyAnalytics } from 'src/support/useAnalytics';
 import { Dispatch } from 'src/types/suite';
 import { UseTradingFormCommonProps } from 'src/types/trading/trading';
@@ -127,13 +127,17 @@ export const useTradingExchangeForm = ({
         navigateToExchangeConfirm,
     } = useTradingNavigation(account);
 
-    const isDebug = useSelector(selectIsDebugModeActive);
     // we consider this feature enabled unless disabled by message system
     const isSlip24FeatureEnabled = useSelector(state =>
         selectIsFeatureEnabled(state, Feature.trading.slip24, true),
     );
+    const isSlip24ExperimentalFeatureEnabled = useSelector(selectHasExperimentalFeature('slip24'));
     const isSlip24Active = useSelector(state =>
-        selectTradingIsSlip24Allowed(state, account, isSlip24FeatureEnabled && isDebug),
+        selectTradingIsSlip24Allowed(
+            state,
+            account,
+            isSlip24FeatureEnabled && isSlip24ExperimentalFeatureEnabled,
+        ),
     );
 
     const { symbol } = account;

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -6,6 +6,7 @@ import type { DexApprovalType, ExchangeTrade, FiatCurrencyCode } from 'invity-ap
 
 import { EventType } from '@suite/analytics';
 import { useTranslation } from '@suite/intl';
+import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     TRADING_EXCHANGE_FORM,
@@ -127,8 +128,12 @@ export const useTradingExchangeForm = ({
     } = useTradingNavigation(account);
 
     const isDebug = useSelector(selectIsDebugModeActive);
+    // we consider this feature enabled unless disabled by message system
+    const isSlip24FeatureEnabled = useSelector(state =>
+        selectIsFeatureEnabled(state, Feature.trading.slip24, true),
+    );
     const isSlip24Active = useSelector(state =>
-        selectTradingIsSlip24Allowed(state, account, isDebug),
+        selectTradingIsSlip24Allowed(state, account, isSlip24FeatureEnabled && isDebug),
     );
 
     const { symbol } = account;

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -49,7 +49,7 @@ import { useTradingSellFormDefaultValues } from 'src/hooks/wallet/trading/form/u
 import { useTradingSellFormRedirectValues } from 'src/hooks/wallet/trading/form/useTradingSellFormRedirectValues';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { useTradingNavigation } from 'src/hooks/wallet/useTradingNavigation';
-import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
+import { selectHasExperimentalFeature } from 'src/selectors/suite/suiteSelectors';
 import { useAnalytics, useLegacyAnalytics } from 'src/support/useAnalytics';
 import { UseTradingFormProps } from 'src/types/trading/trading';
 import { TradingSellFormContextProps } from 'src/types/trading/tradingForm';
@@ -106,13 +106,17 @@ export const useTradingSellForm = ({
     const { navigateToSellForm, navigateToSellOffers, navigateToSellConfirm } =
         useTradingNavigation(account);
 
-    const isDebug = useSelector(selectIsDebugModeActive);
     // we consider this feature enabled unless disabled by message system
     const isSlip24FeatureEnabled = useSelector(state =>
         selectIsFeatureEnabled(state, Feature.trading.slip24, true),
     );
+    const isSlip24ExperimentalFeatureEnabled = useSelector(selectHasExperimentalFeature('slip24'));
     const isSlip24Active = useSelector(state =>
-        selectTradingIsSlip24Allowed(state, account, isSlip24FeatureEnabled && isDebug),
+        selectTradingIsSlip24Allowed(
+            state,
+            account,
+            isSlip24FeatureEnabled && isSlip24ExperimentalFeatureEnabled,
+        ),
     );
 
     const baseCurrencyCode = useSelector(selectBaseCurrency);

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -6,6 +6,7 @@ import useDebounce from 'react-use/lib/useDebounce';
 
 import { EventType } from '@suite/analytics';
 import { useTranslation } from '@suite/intl';
+import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
@@ -106,8 +107,12 @@ export const useTradingSellForm = ({
         useTradingNavigation(account);
 
     const isDebug = useSelector(selectIsDebugModeActive);
+    // we consider this feature enabled unless disabled by message system
+    const isSlip24FeatureEnabled = useSelector(state =>
+        selectIsFeatureEnabled(state, Feature.trading.slip24, true),
+    );
     const isSlip24Active = useSelector(state =>
-        selectTradingIsSlip24Allowed(state, account, isDebug),
+        selectTradingIsSlip24Allowed(state, account, isSlip24FeatureEnabled && isDebug),
     );
 
     const baseCurrencyCode = useSelector(selectBaseCurrency);

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -81,6 +81,7 @@ export const Feature = {
             blacklist: 'trading.restrictions.blacklist',
         },
         survey: 'trading.survey',
+        slip24: 'trading.slip24',
     },
     mevProtection: 'settings.mevProtection',
 

--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -451,6 +451,7 @@ describe('getTradingFormState', () => {
                 providers,
                 isSlip24Active: true,
                 sendAccountKey: '',
+                receiveAccountKey: 'receive-account-key',
             });
 
             expect(result).toEqual({
@@ -490,6 +491,7 @@ describe('getTradingFormState', () => {
                 providers,
                 isSlip24Active: true,
                 sendAccountKey: '',
+                receiveAccountKey: 'receive-account-key',
             });
 
             expect(result).toEqual({
@@ -634,7 +636,7 @@ describe('getTradingFormState', () => {
                 providers,
                 isSlip24Active: true,
                 sendAccountKey: '',
-                receiveAccountKey: '',
+                receiveAccountKey: 'receive-account-key',
             });
 
             expect(result).toEqual({
@@ -649,7 +651,7 @@ describe('getTradingFormState', () => {
                     amount: '0.025',
                 },
                 receive: {
-                    accountKey: '',
+                    accountKey: 'receive-account-key',
                     cryptoId: 'ethereum',
                     symbol: 'eth',
                     contractAddress: undefined,
@@ -677,7 +679,7 @@ describe('getTradingFormState', () => {
                 providers,
                 isSlip24Active: true,
                 sendAccountKey: '',
-                receiveAccountKey: '',
+                receiveAccountKey: 'receive-account-key',
             });
 
             expect(result).toEqual({
@@ -692,7 +694,7 @@ describe('getTradingFormState', () => {
                     amount: '50',
                 },
                 receive: {
-                    accountKey: '',
+                    accountKey: 'receive-account-key',
                     cryptoId: 'ethereum--0xreceive123',
                     symbol: 'eth',
                     contractAddress: '0xreceive123',

--- a/suite-common/trading/src/thunks/common/__tests__/createPaymentRequestsThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/createPaymentRequestsThunk.test.ts
@@ -4,7 +4,7 @@ import { CryptoId, ExchangeTradeSigned } from 'invity-api';
 import { createThunk } from '@suite-common/redux-utils';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { Account, GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
-import { PROTO } from '@trezor/connect';
+import TrezorConnect, { Address, PROTO } from '@trezor/connect';
 
 import { invityAPI } from '../../../invityAPI';
 import { initialState } from '../../../reducers/tradingCommonReducer';
@@ -12,6 +12,7 @@ import { prepareTradingReducer } from '../../../reducers/tradingReducer';
 import { tradingGetCoinSlip44 } from '../../../utils/signature/signatureUtils';
 import { createPaymentRequestsThunk } from '../createPaymentRequestsThunk';
 import { getNonce } from '../getNonce';
+import { getPurchaseAddress } from '../getPurchaseAddress';
 import { getRefundAddress } from '../getRefundAddress';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
@@ -23,6 +24,10 @@ jest.mock('../getNonce', () => ({
 
 jest.mock('../getRefundAddress', () => ({
     getRefundAddress: jest.fn(),
+}));
+
+jest.mock('../getPurchaseAddress', () => ({
+    getPurchaseAddress: jest.fn(),
 }));
 
 jest.mock('../../../utils/signature/signatureUtils', () => {
@@ -40,6 +45,11 @@ jest.mock('../../../invityAPI', () => ({
     invityAPI: {
         getSignedTrade: jest.fn(),
     },
+}));
+
+jest.mock('@trezor/connect', () => ({
+    ...jest.requireActual('@trezor/connect'),
+    getAddress: jest.fn(),
 }));
 
 describe('createPaymentRequestsThunk', () => {
@@ -181,6 +191,20 @@ describe('createPaymentRequestsThunk', () => {
             ),
         );
 
+        (getPurchaseAddress as unknown as jest.Mock).mockImplementation(
+            createThunk(getPurchaseAddress.typePrefix, (_, { fulfillWithValue }) =>
+                fulfillWithValue({
+                    mac: mockMac,
+                    path: "m/44'/0'/0'",
+                }),
+            ),
+        );
+
+        (TrezorConnect.getAddress as jest.Mock).mockResolvedValue({
+            success: true,
+            payload: { address: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2' } as Address,
+        });
+
         (tradingGetCoinSlip44 as jest.Mock).mockReturnValue(Promise.resolve(2));
     });
 
@@ -190,10 +214,12 @@ describe('createPaymentRequestsThunk', () => {
             reducer: combineReducers({
                 wallet: combineReducers({
                     trading: tradingReducer,
+                    accounts: () => [mockAccount],
                 }),
             }),
             preloadedState: {
                 wallet: {
+                    accounts: [mockAccount],
                     trading: {
                         ...initialState,
                         info: {
@@ -230,7 +256,7 @@ describe('createPaymentRequestsThunk', () => {
 
         const mockPaymentRequest: PROTO.PaymentRequest = {
             recipient_name: 'Changelly',
-            amount: '100000',
+            amount: 'a086010000000000', // 8 bytes little-endian for 100000 satoshis
             nonce: mockNonce,
             signature: 'signature123',
             memos: [
@@ -239,7 +265,7 @@ describe('createPaymentRequestsThunk', () => {
                         address: '1ReceiveAddress123',
                         amount: '0.05 LTC',
                         coin_type: 2,
-                        mac: 'verified-mac',
+                        mac: 'test-mac-456',
                         address_n: [2147483692, 2147483648, 2147483648],
                     },
                 },
@@ -260,8 +286,9 @@ describe('createPaymentRequestsThunk', () => {
                 exchange: {
                     selectedQuote: mockExchangeQuote,
                     exchangeInfo: mockExchangeInfo,
+                    receiveAccountKey: mockAccount.key,
+                    receiveAddress: mockExchangeQuote.receiveAddress,
                 },
-                verifiedAddress: { mac: 'verified-mac', path: "m/44'/0'/0'" },
             });
 
             // Execute thunk
@@ -284,8 +311,9 @@ describe('createPaymentRequestsThunk', () => {
                 exchange: {
                     selectedQuote: { ...mockExchangeQuote, orderId: undefined },
                     exchangeInfo: mockExchangeInfo,
+                    receiveAccountKey: mockAccount.key,
+                    receiveAddress: mockExchangeQuote.receiveAddress,
                 },
-                verifiedAddress: { mac: 'verified-mac', path: "m/44'/0'/0'" },
             });
 
             const result = await store.dispatch(
@@ -304,13 +332,13 @@ describe('createPaymentRequestsThunk', () => {
             });
         });
 
-        it('should reject when verified address is missing', async () => {
+        it('should reject when receive account is missing', async () => {
             const store = createMockStore({
                 exchange: {
                     selectedQuote: mockExchangeQuote,
                     exchangeInfo: mockExchangeInfo,
+                    receiveAccountKey: undefined, // missing
                 },
-                verifiedAddress: null,
             });
 
             const result = await store.dispatch(
@@ -336,8 +364,9 @@ describe('createPaymentRequestsThunk', () => {
                 exchange: {
                     selectedQuote: mockExchangeQuote,
                     exchangeInfo: mockExchangeInfo,
+                    receiveAccountKey: mockAccount.key,
+                    receiveAddress: mockExchangeQuote.receiveAddress,
                 },
-                verifiedAddress: { mac: 'verified-mac', path: "m/44'/0'/0'" },
             });
 
             const result = await store.dispatch(
@@ -369,8 +398,9 @@ describe('createPaymentRequestsThunk', () => {
                         ...mockExchangeQuote,
                     },
                     exchangeInfo: mockExchangeInfo,
+                    receiveAccountKey: mockAccount.key,
+                    receiveAddress: mockExchangeQuote.receiveAddress,
                 },
-                verifiedAddress: { mac: 'verified-mac', path: "m/44'/0'/0'" },
             });
 
             const result = await store.dispatch(
@@ -393,7 +423,7 @@ describe('createPaymentRequestsThunk', () => {
     describe('sell flow', () => {
         const mockSellPaymentRequest: PROTO.PaymentRequest = {
             recipient_name: 'Coinbase',
-            amount: '100000',
+            amount: 'a086010000000000', // 8 bytes little-endian for 100000 satoshis
             nonce: mockNonce,
             signature: 'sell-signature123',
             memos: [
@@ -586,7 +616,6 @@ describe('createPaymentRequestsThunk', () => {
                     selectedQuote: mockExchangeQuote,
                     exchangeInfo: mockExchangeInfo,
                 },
-                verifiedAddress: { mac: 'verified-mac', path: "m/44'/0'/0'" },
             });
 
             const result = await store.dispatch(

--- a/suite-common/trading/src/thunks/common/__tests__/createPaymentRequestsThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/createPaymentRequestsThunk.test.ts
@@ -5,11 +5,11 @@ import { createThunk } from '@suite-common/redux-utils';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { Account, GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
 import TrezorConnect, { Address, PROTO } from '@trezor/connect';
+import { validatePath } from '@trezor/connect/src/utils/pathUtils';
 
 import { invityAPI } from '../../../invityAPI';
 import { initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
-import { tradingGetCoinSlip44 } from '../../../utils/signature/signatureUtils';
 import { createPaymentRequestsThunk } from '../createPaymentRequestsThunk';
 import { getNonce } from '../getNonce';
 import { getPurchaseAddress } from '../getPurchaseAddress';
@@ -195,7 +195,7 @@ describe('createPaymentRequestsThunk', () => {
             createThunk(getPurchaseAddress.typePrefix, (_, { fulfillWithValue }) =>
                 fulfillWithValue({
                     mac: mockMac,
-                    path: "m/44'/0'/0'",
+                    path: "m/84'/2'/0'",
                 }),
             ),
         );
@@ -204,8 +204,6 @@ describe('createPaymentRequestsThunk', () => {
             success: true,
             payload: { address: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2' } as Address,
         });
-
-        (tradingGetCoinSlip44 as jest.Mock).mockReturnValue(Promise.resolve(2));
     });
 
     const createMockStore = (preloadedState = {}) =>
@@ -266,14 +264,14 @@ describe('createPaymentRequestsThunk', () => {
                         amount: '0.05 LTC',
                         coin_type: 2,
                         mac: 'test-mac-456',
-                        address_n: [2147483692, 2147483648, 2147483648],
+                        address_n: validatePath("m/84'/2'/0'"),
                     },
                 },
                 {
                     refund_memo: {
                         address: '1RefundAddress456',
                         mac: mockMac,
-                        address_n: [2147483692, 2147483648, 2147483648],
+                        address_n: validatePath("m/44'/0'/0'"),
                     },
                 },
             ],
@@ -436,7 +434,7 @@ describe('createPaymentRequestsThunk', () => {
                     refund_memo: {
                         address: '1RefundAddress789',
                         mac: mockMac,
-                        address_n: [2147483692, 2147483648, 2147483648],
+                        address_n: validatePath("m/44'/0'/0'"),
                     },
                 },
             ],

--- a/suite-common/trading/src/thunks/common/__tests__/getPurchaseAddress.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/getPurchaseAddress.test.ts
@@ -1,0 +1,224 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { createThunk } from '@suite-common/redux-utils';
+import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
+import { confirmAddressOnDeviceThunk } from '@suite-common/wallet-core';
+import { Account, AddressDisplayOptions } from '@suite-common/wallet-types';
+
+import { accounts } from '../../../reducers/__fixtures__/account';
+import { initialState } from '../../../reducers/tradingCommonReducer';
+import { prepareTradingReducer } from '../../../reducers/tradingReducer';
+import { getPurchaseAddress } from '../getPurchaseAddress';
+
+const tradingReducer = prepareTradingReducer(extraDependenciesMock);
+
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    confirmAddressOnDeviceThunk: jest.fn(),
+}));
+
+const mockAccount: Account = {
+    ...accounts[0],
+    addresses: {
+        change: [],
+        used: [],
+        unused: [
+            {
+                address: 'tb1qvanxty2svhps2xged5n4kvm2k2zctpv9ws2grd',
+                path: "m/84'/1'/0'/0/0",
+                transfers: 0,
+                balance: '0',
+                received: '0',
+                sent: '0',
+            },
+        ],
+    },
+};
+
+describe('getPurchaseAddress thunk', () => {
+    const mockAddress = 'tb1qvanxty2svhps2xged5n4kvm2k2zctpv9ws2grd';
+    const mockPath = "m/84'/1'/0'/0/0";
+    const mockMac = 'test-mac-purchase-123';
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const createMockStore = (preloadedState = {}) =>
+        configureMockStore({
+            extra: {
+                ...extraDependenciesMock,
+                selectors: {
+                    selectAddressDisplayType: jest
+                        .fn()
+                        .mockReturnValue(AddressDisplayOptions.CHUNKED),
+                },
+            },
+            reducer: combineReducers({
+                wallet: combineReducers({
+                    trading: tradingReducer,
+                }),
+            }),
+            preloadedState: {
+                wallet: {
+                    trading: {
+                        ...initialState,
+                        ...preloadedState,
+                    },
+                },
+            },
+        });
+
+    describe('successful address confirmation', () => {
+        it('should successfully get purchase address and MAC', async () => {
+            (confirmAddressOnDeviceThunk as unknown as jest.Mock).mockImplementation(
+                createThunk('@suite/device/confirmAddressOnDeviceThunk', () => ({
+                    success: true,
+                    payload: {
+                        address: mockAddress,
+                        mac: mockMac,
+                    },
+                })),
+            );
+
+            const store = createMockStore();
+            const result = await store.dispatch(
+                getPurchaseAddress({ account: mockAccount, address: mockAddress }),
+            );
+
+            expect(result.type).toBe(getPurchaseAddress.fulfilled.type);
+            expect(result.payload).toEqual({
+                address: mockAddress,
+                mac: mockMac,
+                path: mockPath,
+            });
+
+            // Verify confirmAddressOnDeviceThunk was called with correct parameters
+            expect(confirmAddressOnDeviceThunk).toHaveBeenCalledWith({
+                accountKey: mockAccount.key,
+                addressPath: mockPath,
+                chunkify: true, // AddressDisplayOptions.CHUNKED
+                showOnTrezor: false,
+            });
+        });
+
+        it('should handle non-chunked address display', async () => {
+            // @ts-expect-error - Mock implementation for testing
+            confirmAddressOnDeviceThunk.mockImplementation(
+                createThunk('@suite/device/confirmAddressOnDeviceThunk', () => ({
+                    success: true,
+                    payload: {
+                        address: mockAddress,
+                        mac: mockMac,
+                    },
+                })),
+            );
+
+            const storeWithNonChunked = configureMockStore({
+                extra: {
+                    ...extraDependenciesMock,
+                    selectors: {
+                        selectAddressDisplayType: jest
+                            .fn()
+                            .mockReturnValue(AddressDisplayOptions.ORIGINAL),
+                    },
+                },
+                reducer: combineReducers({
+                    wallet: combineReducers({
+                        trading: tradingReducer,
+                    }),
+                }),
+                preloadedState: {
+                    wallet: {
+                        trading: initialState,
+                    },
+                },
+            });
+
+            const result = await storeWithNonChunked.dispatch(
+                getPurchaseAddress({ account: mockAccount, address: mockAddress }),
+            );
+
+            expect(result.type).toBe(getPurchaseAddress.fulfilled.type);
+            expect(confirmAddressOnDeviceThunk).toHaveBeenCalledWith({
+                accountKey: mockAccount.key,
+                addressPath: mockPath,
+                chunkify: false, // AddressDisplayOptions.ORIGINAL
+                showOnTrezor: false,
+            });
+        });
+    });
+
+    describe('error handling', () => {
+        it('should reject when address is not in account', async () => {
+            const store = createMockStore();
+            const result = await store.dispatch(
+                getPurchaseAddress({ account: mockAccount, address: 'non-existent-address' }),
+            );
+
+            expect(result.type).toBe(getPurchaseAddress.rejected.type);
+            expect(result.payload).toEqual({
+                type: 'sign-tx-error',
+                error: {
+                    id: 'TR_VERIFY_ERROR',
+                },
+            });
+
+            // Verify confirmAddressOnDeviceThunk was not called
+            expect(confirmAddressOnDeviceThunk).not.toHaveBeenCalled();
+        });
+
+        it('should reject when confirmAddressOnDeviceThunk fails', async () => {
+            (confirmAddressOnDeviceThunk as unknown as jest.Mock).mockImplementation(
+                createThunk('@suite/device/confirmAddressOnDeviceThunk', () => ({
+                    success: false,
+                    payload: { error: 'Device confirmation failed' },
+                })),
+            );
+
+            const store = createMockStore();
+            const result = await store.dispatch(
+                getPurchaseAddress({ account: mockAccount, address: mockAddress }),
+            );
+
+            expect(result.type).toBe(getPurchaseAddress.rejected.type);
+            expect(result.payload).toEqual({
+                type: 'sign-tx-error',
+                error: {
+                    id: 'TR_VERIFY_ERROR',
+                },
+            });
+        });
+
+        it('should reject when MAC is missing from response', async () => {
+            (confirmAddressOnDeviceThunk as unknown as jest.Mock).mockImplementation(
+                createThunk('@suite/device/confirmAddressOnDeviceThunk', () => ({
+                    success: true,
+                    payload: {
+                        address: mockAddress,
+                        // mac is missing
+                    },
+                })),
+            );
+
+            const store = createMockStore();
+            const result = await store.dispatch(
+                getPurchaseAddress({ account: mockAccount, address: mockAddress }),
+            );
+
+            expect(result.type).toBe(getPurchaseAddress.rejected.type);
+            expect(result.payload).toEqual({
+                type: 'sign-tx-error',
+                error: {
+                    id: 'TR_VERIFY_ERROR',
+                },
+            });
+        });
+    });
+
+    describe('thunk metadata', () => {
+        it('should have correct thunk type prefix', () => {
+            expect(getPurchaseAddress.typePrefix).toBe('@trading/thunk/getPurchaseAddress');
+        });
+    });
+});

--- a/suite-common/trading/src/thunks/common/__tests__/getPurchaseAddress.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/getPurchaseAddress.test.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
+import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { confirmAddressOnDeviceThunk } from '@suite-common/wallet-core';
 import { Account, AddressDisplayOptions } from '@suite-common/wallet-types';
 
@@ -10,7 +10,7 @@ import { initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
 import { getPurchaseAddress } from '../getPurchaseAddress';
 
-const tradingReducer = prepareTradingReducer(extraDependenciesMock);
+const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 
 jest.mock('@suite-common/wallet-core', () => ({
     ...jest.requireActual('@suite-common/wallet-core'),
@@ -47,7 +47,7 @@ describe('getPurchaseAddress thunk', () => {
     const createMockStore = (preloadedState = {}) =>
         configureMockStore({
             extra: {
-                ...extraDependenciesMock,
+                ...extraDependenciesCommonMock,
                 selectors: {
                     selectAddressDisplayType: jest
                         .fn()
@@ -116,7 +116,7 @@ describe('getPurchaseAddress thunk', () => {
 
             const storeWithNonChunked = configureMockStore({
                 extra: {
-                    ...extraDependenciesMock,
+                    ...extraDependenciesCommonMock,
                     selectors: {
                         selectAddressDisplayType: jest
                             .fn()

--- a/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
+++ b/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
@@ -9,6 +9,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 import { Account, GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
 import { PROTO } from '@trezor/connect';
+import { getSlip44ByPath, validatePath } from '@trezor/connect/src/utils/pathUtils';
 import { exhaustive } from '@trezor/type-utils';
 
 import { getNonce } from './getNonce';
@@ -31,7 +32,6 @@ import { TradingSendRejectedProps, TradingTradeSellExchangeType } from '../../ty
 import { cryptoIdToNetwork } from '../../utils';
 import {
     tradingExchangeCreatePaymentRequest,
-    tradingGetCoinSlip44,
     tradingSellCreatePaymentRequest,
 } from '../../utils/signature/signatureUtils';
 
@@ -72,8 +72,6 @@ export const createPaymentRequestsThunk = createThunk<
             case 'exchange': {
                 const quote = selectTradingExchangeSelectedQuote(getState());
                 const providers = selectTradingExchangeProviders(getState());
-                const sendSlip44 = await tradingGetCoinSlip44(quote?.send);
-                const receiveSlip44 = await tradingGetCoinSlip44(quote?.receive);
                 const receiveDisplaySymbol = selectTradingCoinSymbolByCryptoId(
                     getState(),
                     quote?.receive,
@@ -82,12 +80,10 @@ export const createPaymentRequestsThunk = createThunk<
                 const receiveAccountKey = selectTradingExchangeReceiveAccountKey(getState());
                 const receiveAddress = selectTradingExchangeReceiveAddress(getState());
                 const receiveAccount = selectAccountByKey(getState(), receiveAccountKey);
-                const sendNetwork = quote?.send ? cryptoIdToNetwork(quote.send) : undefined;
+                const sendNetwork = cryptoIdToNetwork(quote?.send);
 
                 if (
                     !quote?.orderId ||
-                    sendSlip44 === undefined ||
-                    receiveSlip44 === undefined ||
                     receiveAddress === undefined ||
                     !receiveAccount ||
                     !receiveDisplaySymbol ||
@@ -108,6 +104,9 @@ export const createPaymentRequestsThunk = createThunk<
                 const outputs = await dispatch(
                     getPaymentRequestOutputs({ network: sendNetwork, composedLevels }),
                 ).unwrap();
+
+                const sendSlip44 = getSlip44ByPath(validatePath(pathRefund));
+                const receiveSlip44 = getSlip44ByPath(validatePath(pathPurchase));
 
                 const trade = await invityAPI.getSignedTrade<
                     ExchangeTradeSigned,
@@ -161,9 +160,8 @@ export const createPaymentRequestsThunk = createThunk<
             case 'sell': {
                 const quote = selectTradingSellSelectedQuote(getState());
                 const providers = selectTradingSellProviders(getState());
-                const sendSlip44 = await tradingGetCoinSlip44(quote?.cryptoCurrency);
 
-                if (!quote?.paymentId || sendSlip44 === undefined || !quote.cryptoCurrency) {
+                if (!quote?.paymentId || !quote.cryptoCurrency) {
                     return rejectWithValue({
                         type: 'sign-tx-error',
                         error: {
@@ -193,6 +191,8 @@ export const createPaymentRequestsThunk = createThunk<
                 const outputs = await dispatch(
                     getPaymentRequestOutputs({ network: sendNetwork, composedLevels }),
                 ).unwrap();
+
+                const sendSlip44 = getSlip44ByPath(validatePath(pathRefund));
 
                 const trade = await invityAPI.getSignedTrade<
                     SellFiatTradeSigned,

--- a/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
+++ b/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
@@ -2,16 +2,18 @@ import {
     CreateTradeSignatureRequestExchange,
     CreateTradeSignatureRequestSell,
     ExchangeTradeSigned,
-    PaymentRequestOutput,
     SellFiatTradeSigned,
 } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
+import { selectAccountByKey } from '@suite-common/wallet-core';
 import { Account, GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
-import TrezorConnect, { PROTO } from '@trezor/connect';
+import { PROTO } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
 import { getNonce } from './getNonce';
+import { getPaymentRequestOutputs } from './getPaymentRequestOutputs';
+import { getPurchaseAddress } from './getPurchaseAddress';
 import { getRefundAddress } from './getRefundAddress';
 import { TRADING_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
@@ -19,12 +21,14 @@ import {
     selectTradingCoinInfoByCryptoId,
     selectTradingCoinSymbolByCryptoId,
     selectTradingExchangeProviders,
+    selectTradingExchangeReceiveAccountKey,
+    selectTradingExchangeReceiveAddress,
     selectTradingExchangeSelectedQuote,
     selectTradingSellProviders,
     selectTradingSellSelectedQuote,
-    selectTradingVerifiedAddress,
 } from '../../selectors/tradingSelectors';
 import { TradingSendRejectedProps, TradingTradeSellExchangeType } from '../../types';
+import { cryptoIdToNetwork } from '../../utils';
 import {
     tradingExchangeCreatePaymentRequest,
     tradingGetCoinSlip44,
@@ -64,37 +68,10 @@ export const createPaymentRequestsThunk = createThunk<
             });
         }
 
-        const outputs: PaymentRequestOutput[] = [];
-
-        for (const output of composedLevels.outputs) {
-            if ('address' in output && output.address) {
-                outputs.push({
-                    amount: output.amount.toString(),
-                    address: output.address,
-                });
-            }
-
-            if ('address_n' in output && output.address_n) {
-                const getAddress = await TrezorConnect.getAddress({
-                    path: output.address_n,
-                    showOnTrezor: false,
-                    keepSession: true,
-                });
-
-                if (getAddress.success) {
-                    outputs.push({
-                        amount: output.amount.toString(),
-                        address: getAddress.payload.address,
-                    });
-                }
-            }
-        }
-
         switch (type) {
             case 'exchange': {
                 const quote = selectTradingExchangeSelectedQuote(getState());
                 const providers = selectTradingExchangeProviders(getState());
-                const verifiedAddress = selectTradingVerifiedAddress(getState());
                 const sendSlip44 = await tradingGetCoinSlip44(quote?.send);
                 const receiveSlip44 = await tradingGetCoinSlip44(quote?.receive);
                 const receiveDisplaySymbol = selectTradingCoinSymbolByCryptoId(
@@ -102,13 +79,19 @@ export const createPaymentRequestsThunk = createThunk<
                     quote?.receive,
                 );
 
+                const receiveAccountKey = selectTradingExchangeReceiveAccountKey(getState());
+                const receiveAddress = selectTradingExchangeReceiveAddress(getState());
+                const receiveAccount = selectAccountByKey(getState(), receiveAccountKey);
+                const sendNetwork = quote?.send ? cryptoIdToNetwork(quote.send) : undefined;
+
                 if (
                     !quote?.orderId ||
-                    !verifiedAddress?.mac ||
-                    !verifiedAddress.path ||
                     sendSlip44 === undefined ||
                     receiveSlip44 === undefined ||
-                    !receiveDisplaySymbol
+                    receiveAddress === undefined ||
+                    !receiveAccount ||
+                    !receiveDisplaySymbol ||
+                    !sendNetwork
                 ) {
                     return rejectWithValue({
                         type: 'sign-tx-error',
@@ -117,6 +100,14 @@ export const createPaymentRequestsThunk = createThunk<
                         },
                     });
                 }
+
+                const { mac: macPurchase, path: pathPurchase } = await dispatch(
+                    getPurchaseAddress({ account: receiveAccount, address: receiveAddress }),
+                ).unwrap();
+
+                const outputs = await dispatch(
+                    getPaymentRequestOutputs({ network: sendNetwork, composedLevels }),
+                ).unwrap();
 
                 const trade = await invityAPI.getSignedTrade<
                     ExchangeTradeSigned,
@@ -131,8 +122,9 @@ export const createPaymentRequestsThunk = createThunk<
                 });
 
                 const provider = trade?.exchange ? providers?.[trade.exchange] : undefined;
+                const sendStringAmount = formattedMaxAmount ?? trade?.sendStringAmount;
 
-                if (!provider || !trade) {
+                if (!provider || !trade || !sendStringAmount) {
                     return rejectWithValue({
                         type: 'sign-tx-error',
                         error: {
@@ -142,18 +134,17 @@ export const createPaymentRequestsThunk = createThunk<
                 }
 
                 const paymentRequest = tradingExchangeCreatePaymentRequest({
-                    trade: {
-                        ...trade,
-                        sendStringAmount: formattedMaxAmount ?? trade.sendStringAmount,
-                    },
+                    trade,
                     provider,
-                    macPurchase: verifiedAddress.mac,
-                    pathPurchase: verifiedAddress.path,
+                    macPurchase,
+                    pathPurchase,
                     macRefund,
                     pathRefund,
                     nonce,
                     receiveSlip44,
                     receiveDisplaySymbol,
+                    sendStringAmount,
+                    sendTokenDecimals: composedLevels.token?.decimals,
                 });
 
                 if (!paymentRequest) {
@@ -172,7 +163,17 @@ export const createPaymentRequestsThunk = createThunk<
                 const providers = selectTradingSellProviders(getState());
                 const sendSlip44 = await tradingGetCoinSlip44(quote?.cryptoCurrency);
 
-                if (!quote?.paymentId || sendSlip44 === undefined) {
+                if (!quote?.paymentId || sendSlip44 === undefined || !quote.cryptoCurrency) {
+                    return rejectWithValue({
+                        type: 'sign-tx-error',
+                        error: {
+                            id: 'TR_PAYMENT_REQUESTS_ERROR',
+                        },
+                    });
+                }
+
+                const sendNetwork = cryptoIdToNetwork(quote.cryptoCurrency);
+                if (!sendNetwork) {
                     return rejectWithValue({
                         type: 'sign-tx-error',
                         error: {
@@ -189,6 +190,10 @@ export const createPaymentRequestsThunk = createThunk<
                 // TODO: slip24 - will be changed soon
                 const memoText = `Selling ${quote.cryptoStringAmount} ${cryptoSymbol?.symbol} for ${quote.fiatStringAmount} ${quote.fiatCurrency}`;
 
+                const outputs = await dispatch(
+                    getPaymentRequestOutputs({ network: sendNetwork, composedLevels }),
+                ).unwrap();
+
                 const trade = await invityAPI.getSignedTrade<
                     SellFiatTradeSigned,
                     CreateTradeSignatureRequestSell
@@ -202,8 +207,9 @@ export const createPaymentRequestsThunk = createThunk<
                 });
 
                 const provider = trade?.exchange ? providers?.[trade.exchange] : undefined;
+                const sendStringAmount = formattedMaxAmount ?? trade?.cryptoStringAmount;
 
-                if (!provider || !trade) {
+                if (!provider || !trade || !sendStringAmount) {
                     return rejectWithValue({
                         type: 'sign-tx-error',
                         error: {
@@ -213,15 +219,14 @@ export const createPaymentRequestsThunk = createThunk<
                 }
 
                 const paymentRequest = tradingSellCreatePaymentRequest({
-                    trade: {
-                        ...trade,
-                        cryptoStringAmount: formattedMaxAmount ?? trade.cryptoStringAmount,
-                    },
+                    trade,
                     provider,
                     macRefund,
                     pathRefund,
                     nonce,
                     memoText,
+                    sendStringAmount,
+                    sendTokenDecimals: composedLevels.token?.decimals,
                 });
 
                 if (!paymentRequest) {

--- a/suite-common/trading/src/thunks/common/getPaymentRequestOutputs.ts
+++ b/suite-common/trading/src/thunks/common/getPaymentRequestOutputs.ts
@@ -1,0 +1,54 @@
+import { PaymentRequestOutput } from 'invity-api';
+
+import { createThunk } from '@suite-common/redux-utils';
+import type { Network } from '@suite-common/wallet-config';
+import { GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import TrezorConnect from '@trezor/connect';
+
+import { TRADING_THUNK_PREFIX } from '../../constants';
+import { TradingSendRejectedProps } from '../../types';
+import { formatSlip24SendAmountByNetwork } from '../../utils/signature/signatureUtils';
+
+export const getPaymentRequestOutputs = createThunk<
+    PaymentRequestOutput[],
+    { network: Network; composedLevels: GeneralPrecomposedTransactionFinal },
+    { rejectValue: TradingSendRejectedProps }
+>(
+    `${TRADING_THUNK_PREFIX}/getPaymentRequestOutputs`,
+    async ({ network, composedLevels }, { rejectWithValue, fulfillWithValue }) => {
+        const outputs: PaymentRequestOutput[] = [];
+
+        for (const output of composedLevels.outputs) {
+            if ('address' in output && output.address) {
+                outputs.push({
+                    amount: formatSlip24SendAmountByNetwork({ value: output.amount, network }),
+                    address: output.address,
+                });
+            }
+
+            if ('address_n' in output && output.address_n) {
+                const getAddress = await TrezorConnect.getAddress({
+                    path: output.address_n,
+                    showOnTrezor: false,
+                    keepSession: true,
+                });
+
+                if (!getAddress.success) {
+                    return rejectWithValue({
+                        type: 'sign-tx-error',
+                        error: {
+                            id: 'TR_PAYMENT_REQUESTS_ERROR',
+                        },
+                    });
+                }
+
+                outputs.push({
+                    amount: formatSlip24SendAmountByNetwork({ value: output.amount, network }),
+                    address: getAddress.payload.address,
+                });
+            }
+        }
+
+        return fulfillWithValue(outputs);
+    },
+);

--- a/suite-common/trading/src/thunks/common/getPurchaseAddress.ts
+++ b/suite-common/trading/src/thunks/common/getPurchaseAddress.ts
@@ -1,0 +1,88 @@
+import { createThunk } from '@suite-common/redux-utils';
+import { confirmAddressOnDeviceThunk } from '@suite-common/wallet-core';
+import { Account, AddressDisplayOptions } from '@suite-common/wallet-types';
+
+import { TRADING_THUNK_PREFIX } from '../../constants';
+import { TradingSendRejectedProps } from '../../types';
+
+type GetPurchaseAddressProps = {
+    account: Account;
+    address: string;
+};
+
+type GetPurchaseAddressFulfillValue = {
+    address: string;
+    mac: string;
+    path: string;
+};
+
+export const getPurchaseAddress = createThunk<
+    GetPurchaseAddressFulfillValue,
+    GetPurchaseAddressProps,
+    {
+        rejectValue: TradingSendRejectedProps;
+    }
+>(
+    `${TRADING_THUNK_PREFIX}/getPurchaseAddress`,
+    async (
+        { account, address },
+        { getState, dispatch, extra, rejectWithValue, fulfillWithValue },
+    ) => {
+        let path: string | undefined;
+
+        if (account.addresses) {
+            const accountAddress = [
+                ...account.addresses.change,
+                ...account.addresses.used,
+                ...account.addresses.unused,
+            ].find(a => a.address === address);
+            path = accountAddress?.path;
+        } else if (account.descriptor === address) {
+            path = account.path;
+        }
+
+        if (!path) {
+            return rejectWithValue({
+                type: 'sign-tx-error',
+                error: {
+                    id: 'TR_VERIFY_ERROR',
+                },
+            });
+        }
+
+        const addressDisplayType = extra.selectors.selectAddressDisplayType(getState());
+
+        const params: Parameters<typeof confirmAddressOnDeviceThunk>[0] = {
+            accountKey: account.key,
+            addressPath: path,
+            chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,
+            showOnTrezor: false,
+        };
+
+        const purchase = await dispatch(confirmAddressOnDeviceThunk(params)).unwrap();
+
+        if (!purchase.success) {
+            return rejectWithValue({
+                type: 'sign-tx-error',
+                error: {
+                    id: 'TR_VERIFY_ERROR',
+                },
+            });
+        }
+
+        if (!('mac' in purchase.payload) || !purchase.payload.mac) {
+            return rejectWithValue({
+                type: 'sign-tx-error',
+                error: {
+                    id: 'TR_VERIFY_ERROR',
+                },
+            });
+        }
+
+        return fulfillWithValue({
+            address: purchase.payload.address,
+            mac: purchase.payload.mac,
+            path: params.addressPath,
+        });
+    },
+);

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -231,6 +231,9 @@ export const recomposeAndSignTxThunk = createThunk<
             ? subunitsToUnits({
                   value: asAmountSubunit(new BigNumber(sendAmount)),
                   symbol: account.symbol,
+                  ...(composed.token?.decimals
+                      ? { decimals: composed.token?.decimals }
+                      : undefined),
               }).toString()
             : undefined;
 

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -108,10 +108,10 @@ export const cryptoIdToNetworkAndContractAddress = (
     return { network, contractAddress };
 };
 
-export const cryptoIdToNetwork = (cryptoId: CryptoId): Network | undefined =>
+export const cryptoIdToNetwork = (cryptoId: CryptoId | undefined): Network | undefined =>
     cryptoIdToNetworkAndContractAddress(cryptoId)?.network;
 
-export const cryptoIdToSymbol = (cryptoId: CryptoId): NetworkSymbol | undefined =>
+export const cryptoIdToSymbol = (cryptoId: CryptoId | undefined): NetworkSymbol | undefined =>
     cryptoIdToNetwork(cryptoId)?.symbol;
 
 export const cryptoIdToNetworkSymbolAndContractAddress = (cryptoId: CryptoId | undefined) => {

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -368,9 +368,9 @@ export const getTradingFormState = ({
             }
 
             return {
-                isSlip24Active,
                 activeSection,
                 recipientName: provider.companyName,
+                isSlip24Active: isSlip24Active && !!receiveAccountKey,
                 send: {
                     cryptoId: trade.cryptoCurrency,
                     accountKey: sendAccountKey,
@@ -410,7 +410,7 @@ export const getTradingFormState = ({
             return {
                 activeSection,
                 recipientName: provider.companyName,
-                isSlip24Active,
+                isSlip24Active: isSlip24Active && !!receiveAccountKey,
                 send: {
                     cryptoId: trade.send,
                     accountKey: sendAccountKey,

--- a/suite-common/trading/src/utils/signature/__tests__/signatureUtils.test.ts
+++ b/suite-common/trading/src/utils/signature/__tests__/signatureUtils.test.ts
@@ -7,10 +7,21 @@ import {
 
 // Mock external dependencies
 jest.mock('../../../utils', () => ({
-    cryptoIdToNetworkAndContractAddress: jest.fn().mockReturnValue({
-        network: { decimals: 8 },
-        contractAddress: undefined,
-    }),
+    cryptoIdToNetworkAndContractAddress: jest
+        .fn()
+        .mockImplementation((cryptoId: CryptoId | undefined) => {
+            if (cryptoId === 'ethereum') {
+                return {
+                    network: { decimals: 18, networkType: 'ethereum', symbol: 'eth' },
+                    contractAddress: undefined,
+                };
+            }
+
+            return {
+                network: { decimals: 8, networkType: 'bitcoin', symbol: 'btc' },
+                contractAddress: undefined,
+            };
+        }),
 }));
 
 describe('signatureUtils', () => {
@@ -52,6 +63,7 @@ describe('signatureUtils', () => {
             sendSlip44: 0,
             receiveSlip44: 60,
             receiveDisplaySymbol: 'ETH',
+            sendStringAmount: mockTrade.sendStringAmount,
         };
 
         it('should create valid payment request for exchange trade', () => {
@@ -60,7 +72,7 @@ describe('signatureUtils', () => {
             expect(result).toEqual({
                 recipient_name: 'TestExchange',
                 nonce: 'nonce789',
-                amount: '10000000', // 0.1 * 10^8
+                amount: '8096980000000000', // 8 bytes little-endian for 0.1 BTC
                 memos: [
                     {
                         coin_purchase_memo: {
@@ -108,7 +120,8 @@ describe('signatureUtils', () => {
         it('should return undefined when trade sendStringAmount is missing', () => {
             const propsWithoutSendAmount = {
                 ...defaultProps,
-                trade: { ...mockTrade, sendStringAmount: undefined as any },
+                trade: { ...mockTrade },
+                sendStringAmount: undefined as any,
             };
 
             const result = tradingExchangeCreatePaymentRequest(propsWithoutSendAmount);
@@ -250,6 +263,7 @@ describe('signatureUtils', () => {
             pathRefund: "m/44'/0'/0'/1/0",
             nonce: 'sellNonce123',
             memoText: 'Test memo text',
+            sendStringAmount: mockSellTrade.cryptoStringAmount,
         };
 
         it('should create valid payment request for sell trade', () => {
@@ -258,7 +272,7 @@ describe('signatureUtils', () => {
             expect(result).toEqual({
                 recipient_name: 'TestSeller',
                 nonce: 'sellNonce123',
-                amount: '50000000', // 0.5 * 10^8
+                amount: '80f0fa0200000000', // 8 bytes little-endian for 0.5 BTC
                 memos: [
                     {
                         text_memo: {
@@ -347,7 +361,9 @@ describe('signatureUtils', () => {
             const result = tradingSellCreatePaymentRequest(propsWithEth);
 
             expect(result).toBeDefined();
-            expect(result?.amount).toBe('1050000000'); // 10.5 * 10^8
+            expect(result?.amount).toBe(
+                '0000b2d3595bf006000000000000000000000000000000000000000000000000', // 32 bytes little-endian for 10.5 ETH
+            );
         });
 
         it('should handle empty memo text', () => {
@@ -418,11 +434,12 @@ describe('signatureUtils', () => {
                 nonce: 'nonce',
                 receiveSlip44: 60,
                 receiveDisplaySymbol: 'ETH',
+                sendStringAmount: largeTrade.sendStringAmount,
             });
 
             expect(result).toBeDefined();
             if (result && result.memos && result.memos[0]) {
-                expect(result.amount).toBe('99999999999999');
+                expect(result.amount).toBe('ff3f7a10f35a0000'); // 8 bytes little-endian for 99999999999999 sats
                 expect(result.memos[0].coin_purchase_memo?.amount).toBe('1000000.12345678 ETH');
             }
         });
@@ -465,11 +482,12 @@ describe('signatureUtils', () => {
                 nonce: 'nonce',
                 receiveSlip44: 60,
                 receiveDisplaySymbol: 'ETH',
+                sendStringAmount: smallTrade.sendStringAmount,
             });
 
             expect(result).toBeDefined();
             if (result && result.memos && result.memos[0]) {
-                expect(result.amount).toBe('1');
+                expect(result.amount).toBe('0100000000000000'); // 8 bytes little-endian for 1 satoshi
                 expect(result.memos[0].coin_purchase_memo?.amount).toBe('0.00000001 ETH');
             }
         });

--- a/suite-common/trading/src/utils/signature/signatureUtils.ts
+++ b/suite-common/trading/src/utils/signature/signatureUtils.ts
@@ -1,6 +1,4 @@
-import { isRejected } from '@reduxjs/toolkit';
 import {
-    CryptoId,
     ExchangeProviderInfo,
     ExchangeTradeSigned,
     SellFiatTradeSigned,
@@ -8,12 +6,12 @@ import {
 } from 'invity-api';
 
 import type { Network } from '@suite-common/wallet-config';
-import { asAmountUnit, formatBigNumberToLE, unitsToSubunits } from '@suite-common/wallet-utils';
-import TrezorConnect, { PROTO } from '@trezor/connect';
+import { asAmountUnit, formatBigUintToLE, unitsToSubunits } from '@suite-common/wallet-utils';
+import { PROTO } from '@trezor/connect';
 import { validatePath } from '@trezor/connect/src/utils/pathUtils';
 import { BigNumber } from '@trezor/utils';
 
-import { cryptoIdToNetwork, cryptoIdToNetworkAndContractAddress } from '../../utils';
+import { cryptoIdToNetworkAndContractAddress } from '../../utils';
 
 export const formatSlip24SendAmountByNetwork = ({
     value,
@@ -22,28 +20,13 @@ export const formatSlip24SendAmountByNetwork = ({
     value: string | number;
     network: Network;
 }): string => {
+    // SLIP-24: 8 bytes for Bitcoin-like coins and 32 bytes for EVM assets
     const bytesLength = network.networkType === 'ethereum' ? 32 : 8;
 
-    return formatBigNumberToLE({
+    return formatBigUintToLE({
         value: new BigNumber(value),
         bytesLength,
     });
-};
-
-export const tradingGetCoinSlip44 = async (cryptoId: CryptoId | undefined) => {
-    if (!cryptoId) return;
-
-    const network = cryptoIdToNetwork(cryptoId);
-
-    if (!network) return;
-
-    const coinInfo = await TrezorConnect.getCoinInfo({
-        coin: network.symbol,
-    });
-
-    if (isRejected(coinInfo) || 'error' in coinInfo.payload) return;
-
-    return coinInfo.payload.slip44;
 };
 
 type TradingExchangeCreatePaymentRequestProps = {

--- a/suite-common/trading/src/utils/signature/signatureUtils.ts
+++ b/suite-common/trading/src/utils/signature/signatureUtils.ts
@@ -7,12 +7,28 @@ import {
     SellProviderInfo,
 } from 'invity-api';
 
-import { asAmountUnit, unitsToSubunits } from '@suite-common/wallet-utils';
+import type { Network } from '@suite-common/wallet-config';
+import { asAmountUnit, formatBigNumberToLE, unitsToSubunits } from '@suite-common/wallet-utils';
 import TrezorConnect, { PROTO } from '@trezor/connect';
 import { validatePath } from '@trezor/connect/src/utils/pathUtils';
 import { BigNumber } from '@trezor/utils';
 
 import { cryptoIdToNetwork, cryptoIdToNetworkAndContractAddress } from '../../utils';
+
+export const formatSlip24SendAmountByNetwork = ({
+    value,
+    network,
+}: {
+    value: string | number;
+    network: Network;
+}): string => {
+    const bytesLength = network.networkType === 'ethereum' ? 32 : 8;
+
+    return formatBigNumberToLE({
+        value: new BigNumber(value),
+        bytesLength,
+    });
+};
 
 export const tradingGetCoinSlip44 = async (cryptoId: CryptoId | undefined) => {
     if (!cryptoId) return;
@@ -40,6 +56,8 @@ type TradingExchangeCreatePaymentRequestProps = {
     nonce: string;
     receiveSlip44: number;
     receiveDisplaySymbol: string;
+    sendStringAmount: string;
+    sendTokenDecimals?: number;
 };
 
 export const tradingExchangeCreatePaymentRequest = ({
@@ -52,25 +70,35 @@ export const tradingExchangeCreatePaymentRequest = ({
     nonce,
     receiveSlip44,
     receiveDisplaySymbol,
+    sendStringAmount,
+    sendTokenDecimals,
 }: TradingExchangeCreatePaymentRequestProps): PROTO.PaymentRequest | undefined => {
     if (
         !provider?.companyName ||
         !trade.send ||
-        !trade.sendStringAmount ||
         !trade.receive ||
         !trade.receiveStringAmount ||
         !trade.receiveAddress ||
-        !trade.refundAddress
+        !trade.refundAddress ||
+        !sendStringAmount
     ) {
         return undefined;
     }
 
     const sendNetworkData = cryptoIdToNetworkAndContractAddress(trade.send);
     const sendNetworkSymbol = sendNetworkData.network?.symbol ?? 'btc';
-    const sendAmount = unitsToSubunits({
-        value: asAmountUnit(new BigNumber(trade.sendStringAmount)),
-        symbol: sendNetworkSymbol,
-    }).toString();
+    if (!sendNetworkData.network) {
+        return undefined;
+    }
+
+    const sendAmount = formatSlip24SendAmountByNetwork({
+        value: unitsToSubunits({
+            value: asAmountUnit(new BigNumber(sendStringAmount)),
+            symbol: sendNetworkSymbol,
+            ...(sendTokenDecimals !== undefined ? { decimals: sendTokenDecimals } : undefined),
+        }).toString(),
+        network: sendNetworkData.network,
+    });
 
     const receiveAmount = `${trade.receiveStringAmount} ${receiveDisplaySymbol}`;
 
@@ -109,6 +137,8 @@ type TradingSellCreatePaymentRequestProps = {
     pathRefund: string;
     nonce: string;
     memoText: string;
+    sendStringAmount: string;
+    sendTokenDecimals?: number;
 };
 
 export const tradingSellCreatePaymentRequest = ({
@@ -118,24 +148,34 @@ export const tradingSellCreatePaymentRequest = ({
     pathRefund,
     nonce,
     memoText,
+    sendStringAmount,
+    sendTokenDecimals,
 }: TradingSellCreatePaymentRequestProps): PROTO.PaymentRequest | undefined => {
     if (
         !provider?.companyName ||
         !trade.refundAddress ||
         !trade.tradeSignature ||
         !trade.cryptoStringAmount ||
-        !trade.cryptoCurrency
+        !trade.cryptoCurrency ||
+        !sendStringAmount
     ) {
         return undefined;
     }
 
     const sendNetworkData = cryptoIdToNetworkAndContractAddress(trade.cryptoCurrency);
-
     const sendNetworkSymbol = sendNetworkData.network?.symbol ?? 'btc';
-    const sendAmount = unitsToSubunits({
-        value: asAmountUnit(new BigNumber(trade.cryptoStringAmount)),
-        symbol: sendNetworkSymbol,
-    }).toString();
+    if (!sendNetworkData.network) {
+        return undefined;
+    }
+
+    const sendAmount = formatSlip24SendAmountByNetwork({
+        value: unitsToSubunits({
+            value: asAmountUnit(new BigNumber(sendStringAmount)),
+            symbol: sendNetworkSymbol,
+            ...(sendTokenDecimals !== undefined ? { decimals: sendTokenDecimals } : undefined),
+        }).toString(),
+        network: sendNetworkData.network,
+    });
 
     const memos: PROTO.PaymentRequestMemo[] = [
         {

--- a/suite-common/wallet-utils/src/__tests__/amountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/amountUtils.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@trezor/utils';
 
 import { asAmountSubunit, asAmountUnit } from '../AmountTypes';
-import { subunitsToUnits, unitsToSubunits } from '../amountUtils';
+import { formatBigNumberToLE, subunitsToUnits, unitsToSubunits } from '../amountUtils';
 
 describe(subunitsToUnits.name, () => {
     it('converts Sats->BTC', () => {
@@ -27,5 +27,38 @@ describe(unitsToSubunits.name, () => {
             decimals: 2,
         });
         expect(decimalsResult.toString()).toEqual('100');
+    });
+});
+
+describe(formatBigNumberToLE.name, () => {
+    it('formatBigNumberToLE 8 bytes (bitcoin-like)', () => {
+        const value = new BigNumber('123456789');
+        const bytesLength = 8;
+
+        // native way to write little-endian 8 bytes
+        const amountBigInt = BigInt(value.toFixed(0));
+        const byteArray = Buffer.alloc(bytesLength);
+        byteArray.writeBigUInt64LE(amountBigInt, 0);
+
+        expect(formatBigNumberToLE({ value, bytesLength })).toEqual('15cd5b0700000000');
+        expect(formatBigNumberToLE({ value, bytesLength })).toEqual(byteArray.toString('hex'));
+    });
+
+    it('formatBigNumberToLE 32 bytes (evm)', () => {
+        const value = new BigNumber('12345678901234567890');
+        const bytesLength = 32;
+
+        expect(formatBigNumberToLE({ value, bytesLength })).toEqual(
+            'd20a1feb8ca954ab000000000000000000000000000000000000000000000000',
+        );
+    });
+
+    it('formatBigNumberToLE throws if number exceeds byte length', () => {
+        expect(() =>
+            formatBigNumberToLE({ value: new BigNumber('4294967296'), bytesLength: 4 }),
+        ).toThrow('Exceeds 4 bytes');
+        expect(() =>
+            formatBigNumberToLE({ value: new BigNumber('18446744073709551616'), bytesLength: 8 }),
+        ).toThrow('Exceeds 8 bytes');
     });
 });

--- a/suite-common/wallet-utils/src/__tests__/amountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/amountUtils.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@trezor/utils';
 
 import { asAmountSubunit, asAmountUnit } from '../AmountTypes';
-import { formatBigNumberToLE, subunitsToUnits, unitsToSubunits } from '../amountUtils';
+import { formatBigUintToLE, subunitsToUnits, unitsToSubunits } from '../amountUtils';
 
 describe(subunitsToUnits.name, () => {
     it('converts Sats->BTC', () => {
@@ -30,8 +30,8 @@ describe(unitsToSubunits.name, () => {
     });
 });
 
-describe(formatBigNumberToLE.name, () => {
-    it('formatBigNumberToLE 8 bytes (bitcoin-like)', () => {
+describe(formatBigUintToLE.name, () => {
+    it('format 8 bytes (bitcoin-like)', () => {
         const value = new BigNumber('123456789');
         const bytesLength = 8;
 
@@ -40,25 +40,49 @@ describe(formatBigNumberToLE.name, () => {
         const byteArray = Buffer.alloc(bytesLength);
         byteArray.writeBigUInt64LE(amountBigInt, 0);
 
-        expect(formatBigNumberToLE({ value, bytesLength })).toEqual('15cd5b0700000000');
-        expect(formatBigNumberToLE({ value, bytesLength })).toEqual(byteArray.toString('hex'));
+        expect(formatBigUintToLE({ value, bytesLength })).toEqual('15cd5b0700000000');
+        expect(formatBigUintToLE({ value, bytesLength })).toEqual(byteArray.toString('hex'));
     });
 
-    it('formatBigNumberToLE 32 bytes (evm)', () => {
+    it('format 32 bytes (evm)', () => {
         const value = new BigNumber('12345678901234567890');
         const bytesLength = 32;
 
-        expect(formatBigNumberToLE({ value, bytesLength })).toEqual(
+        expect(formatBigUintToLE({ value, bytesLength })).toEqual(
             'd20a1feb8ca954ab000000000000000000000000000000000000000000000000',
         );
     });
 
-    it('formatBigNumberToLE throws if number exceeds byte length', () => {
+    it('throws if number exceeds byte length', () => {
         expect(() =>
-            formatBigNumberToLE({ value: new BigNumber('4294967296'), bytesLength: 4 }),
+            formatBigUintToLE({
+                value: new BigNumber('4294967296'),
+                bytesLength: 4,
+            }),
         ).toThrow('Exceeds 4 bytes');
         expect(() =>
-            formatBigNumberToLE({ value: new BigNumber('18446744073709551616'), bytesLength: 8 }),
+            formatBigUintToLE({
+                value: new BigNumber('18446744073709551616'),
+                bytesLength: 8,
+            }),
         ).toThrow('Exceeds 8 bytes');
+    });
+
+    it('throws if number is negative', () => {
+        expect(() =>
+            formatBigUintToLE({
+                value: new BigNumber('-1'),
+                bytesLength: 4,
+            }),
+        ).toThrow('Value cannot be negative');
+    });
+
+    it('throws if number is not an integer', () => {
+        expect(() =>
+            formatBigUintToLE({
+                value: new BigNumber('1.1'),
+                bytesLength: 4,
+            }),
+        ).toThrow('Value must be an integer');
     });
 });

--- a/suite-common/wallet-utils/src/amountUtils.ts
+++ b/suite-common/wallet-utils/src/amountUtils.ts
@@ -138,3 +138,26 @@ export const formatTokenAmount = (tokenTransfer: TokenTransfer) => {
 
     return tokenTransfer.symbol ? `${formattedAmount} ${tokenTransfer.symbol}` : formattedAmount;
 };
+
+type FormatBigNumberToLEParams = { value: BigNumber; bytesLength: number };
+
+/**
+ * Formats BigNumber to little-endian hex string of given byte length
+ */
+export const formatBigNumberToLE = (params: FormatBigNumberToLEParams): string => {
+    const paddingLength = params.bytesLength * 2;
+    let hexString = params.value.toString(16);
+
+    if (hexString.length > paddingLength) {
+        throw new Error(`Exceeds ${params.bytesLength} bytes`);
+    }
+
+    hexString = hexString.padStart(paddingLength, '0');
+    const bytes = new Uint8Array(params.bytesLength);
+
+    for (let i = 0; i < params.bytesLength; i++) {
+        bytes[i] = parseInt(hexString.substring(i * 2, i * 2 + 2), 16);
+    }
+
+    return Buffer.from(bytes.reverse()).toString('hex');
+};

--- a/suite-common/wallet-utils/src/amountUtils.ts
+++ b/suite-common/wallet-utils/src/amountUtils.ts
@@ -139,12 +139,27 @@ export const formatTokenAmount = (tokenTransfer: TokenTransfer) => {
     return tokenTransfer.symbol ? `${formattedAmount} ${tokenTransfer.symbol}` : formattedAmount;
 };
 
-type FormatBigNumberToLEParams = { value: BigNumber; bytesLength: number };
+type formatBigUintToLEParams = {
+    /** The BigNumber value to format, must be non-negative and an integer. */
+    value: BigNumber;
+    /** The byte length of the output string. */
+    bytesLength: number;
+};
 
 /**
- * Formats BigNumber to little-endian hex string of given byte length
+ * Formats BigNumber to little-endian hex string of given byte length.
+ * @returns A little-endian hex string.
+ * @throws {Error} If the value is negative, not an integer, or exceeds the specified byte length.
  */
-export const formatBigNumberToLE = (params: FormatBigNumberToLEParams): string => {
+export const formatBigUintToLE = (params: formatBigUintToLEParams): string => {
+    if (params.value.isNegative()) {
+        throw new Error('Value cannot be negative');
+    }
+
+    if (!params.value.isInteger()) {
+        throw new Error('Value must be an integer');
+    }
+
     const paddingLength = params.bytesLength * 2;
     let hexString = params.value.toString(16);
 

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5081,6 +5081,14 @@ export const messages = defineMessages({
         defaultMessage:
             'Keep your wallet, account, and transaction labels updated in Trezor Suite on all your devices. Your data stays safe—only your Trezor can decrypt it.',
     },
+    TR_EXPERIMENTAL_SLIP24: {
+        id: 'TR_EXPERIMENTAL_SLIP24',
+        defaultMessage: 'SLIP-24 (clear signing)',
+    },
+    TR_EXPERIMENTAL_SLIP24_DESCRIPTION: {
+        id: 'TR_EXPERIMENTAL_SLIP24_DESCRIPTION',
+        defaultMessage: 'Trezor payment request format',
+    },
     TR_EARLY_ACCESS: {
         id: 'TR_EARLY_ACCESS',
         defaultMessage: 'Early Access Program',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- add purchase address to payment request
- skip slip24 if receive address is outside suite
- add slip24 as experimental feature

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #22818

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-payment-request&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-payment-request&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-payment-request&lookback=7)