### PR TITLE
fix: language update based on Suite language when on-boarding

### DIFF
--- a/suite-common/firmware/src/firmwareThunks.ts
+++ b/suite-common/firmware/src/firmwareThunks.ts
@@ -98,9 +98,14 @@ export const firmwareUpdate = createThunk<
             btcOnly: toBitcoinOnlyFirmware,
             binary,
             baseUrl,
-            // Firmware language should only be set during the initial firmware installation.
-            language: device.firmware === 'none' ? targetTranslationLanguage : undefined,
         });
+
+        // Firmware language should only be set during the initial firmware installation.
+        if (device.firmware === 'none' && targetTranslationLanguage) {
+            await TrezorConnect.changeLanguage({
+                language: targetTranslationLanguage,
+            });
+        }
 
         const targetProperties = binary
             ? {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There was an issue when we stopped uploading language blobs during FW installation due to change in language blobs version that made incompatible with most of devices FW and created other complication. 
We relied on language version match in Device.ts https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/device/Device.ts#L633 but that functions works well only when device has already changed the language of the device.

During on-boarding of a fresh device, the device is configure to default `en-US`, so in order for that function to work we would have to change the the language of the device first.

So the solution I propose is right after the FW installation when installing from fresh device update the language based on Suite language.

There might be other solutions, I have experimented with different ideas and this is the on that worked the best, but I am open to other possible ways to solve it.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

Please check that when using a factory reset device and suite is configured in a language that is not English, it changes the language of the device during FW installation process in on-boarding.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/language-change-based-on-suite-during-on-boarding&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/language-change-based-on-suite-during-on-boarding&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/language-change-based-on-suite-during-on-boarding&lookback=7)