### PR TITLE
feat: add adaNewProviderBanner feature flag

### DIFF
--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Feature, selectFeaturesConfig } from '@suite-common/message-system';
 import { Feature as MessageFeature } from '@suite-common/suite-types';
@@ -25,7 +25,7 @@ export const DashboardPromoBanner = () => {
     const selectedDevice = useSelector(selectSelectedDevice);
 
     const allPromoBanners = useSelector(state =>
-        selectFeaturesConfig(state, Feature.dashboardPromoBanner),
+        selectFeaturesConfig(state, Feature.banners.dashboard.promo),
     );
 
     const deduplicatedBanners = allPromoBanners

--- a/packages/suite/src/views/wallet/staking/components/CardanoStakingDashboard/NewCardanoStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/CardanoStakingDashboard/NewCardanoStakingDashboard.tsx
@@ -1,3 +1,6 @@
+import { useMemo } from 'react';
+
+import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { CARDANO_EPOCH_DAYS } from '@suite-common/wallet-constants';
 import {
@@ -53,8 +56,11 @@ export const NewCardanoStakingDashboard = ({
     const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
 
     const stakeTxs = useSelector(state => selectAccountStakeTypeTransactions(state, account.key));
-    const hasPendingTx = stakeTxs.some(tx => isPending(tx));
+    const hasPendingTx = useMemo(() => stakeTxs.some(tx => isPending(tx)), [stakeTxs]);
     const isStakedWithEverstake = isCardanoStakedWithEverstake(account);
+    const isNewProviderBannerEnabled = useSelector(state =>
+        selectIsFeatureEnabled(state, Feature.banners.staking.ada.newProvider, true),
+    );
 
     const shouldShowStakingDashboard = isStakingActive || hasPendingTx;
 
@@ -76,7 +82,9 @@ export const NewCardanoStakingDashboard = ({
                                 {!isDeviceConnected && <ConnectDeviceGenericPromo />}
                                 {isDiscoveryRunning && <DiscoveryWarning />}
 
-                                {!isStakedWithEverstake && !hasPendingTx && <NewProviderCard />}
+                                {!isStakedWithEverstake &&
+                                    !hasPendingTx &&
+                                    isNewProviderBannerEnabled && <NewProviderCard />}
 
                                 <Grid
                                     columns={isBelowLaptop || !canClaim ? 1 : 2}

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -40,6 +40,18 @@ export const Feature = {
         eth: 'eth.staking.claim',
         sol: 'sol.staking.claim',
     },
+
+    banners: {
+        staking: {
+            ada: {
+                newProvider: 'ada.staking.banner.newProvider',
+            },
+        },
+        dashboard: {
+            promo: 'dashboard.promoBanner',
+        },
+    },
+
     firmwareRevisionCheck: 'security.firmware.revisionCheck',
     firmwareRevisionCheckMobile: 'security.firmware.revisionCheck.mobile',
     firmwareHashCheck: 'security.firmware.hashCheck',
@@ -62,7 +74,6 @@ export const Feature = {
         },
         survey: 'trading.survey',
     },
-    dashboardPromoBanner: 'dashboard.promoBanner',
     mevProtection: 'settings.mevProtection',
 
     // Feature flags implemented only for mobile app


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add new `ada.staking.newProviderBanner` feature flag to optionally disable the new provider banner at Cardano staking.

## Related Issue

Resolve #22750

## Screenshots:
<img width="1035" height="778" alt="Snímek obrazovky 2025-10-30 v 17 18 31" src="https://github.com/user-attachments/assets/2eeeece6-a9ad-4377-9844-f3e78355578a" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/22750-ada-banner-feature-flag&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/22750-ada-banner-feature-flag&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/22750-ada-banner-feature-flag&lookback=7)