### PR TITLE
feat(connect-web): enable suite-web instead of old popup

### DIFF
--- a/packages/connect-examples/webextension-mv3/README.md
+++ b/packages/connect-examples/webextension-mv3/README.md
@@ -1,6 +1,7 @@
 # Web extension manifest V3 example
 
 `@trezor/connect` running in an `html` page from the extension and communicating with `@trezor/popup` through `chrome.runtime` messages.
+This mode of integration is no longer recommended, please refer to the [webextension-mv3-sw](../webextension-mv3-sw/README.md) example instead.
 
 Tested in Chrome
 

--- a/packages/connect-examples/webextension-mv3/src/connect-manager.js
+++ b/packages/connect-examples/webextension-mv3/src/connect-manager.js
@@ -8,6 +8,8 @@ window.TrezorConnect.init({
         appUrl: 'http://your.application.com',
     },
     connectSrc: DEFAULT_SRC,
+    // coreMode is set only for purposes of legacy tests, do not use in production
+    coreMode: 'iframe',
 });
 
 const getAddressButton = document.getElementById('get-address');

--- a/packages/connect-examples/webextension-mv3/src/manifest.json
+++ b/packages/connect-examples/webextension-mv3/src/manifest.json
@@ -16,6 +16,13 @@
             "js": ["./vendor/trezor-content-script.js"]
         }
     ],
+    "host_permissions": [
+        "*://connect.trezor.io/9/*",
+        "*://suite.corp.sldev.cz/*",
+        "*://localhost/*",
+        "*://staging-connect.trezor.io/*",
+        "*://dev.suite.sldev.cz/*"
+    ],
     "background": {
         "service_worker": "serviceWorker.js"
     }

--- a/packages/connect-popup/e2e/support/helpers.ts
+++ b/packages/connect-popup/e2e/support/helpers.ts
@@ -158,10 +158,10 @@ export const setConnectSettings = async (
         connectSrc,
         isCoreInPopup,
     }: { trustedHost?: boolean; connectSrc?: string; isCoreInPopup?: boolean },
-    _isWebExtension: boolean,
+    isWebExtension: boolean,
 ) => {
     await explorerPage.goto(
-        formatUrl(explorerUrl, _isWebExtension ? `settings/index.html` : `settings`),
+        formatUrl(explorerUrl, isWebExtension ? `settings/index.html` : `settings`),
     );
     /*if (isWebExtension) {
         // When webextension and using service-worker we need to wait for handshake is confirmed with proxy.
@@ -175,7 +175,7 @@ export const setConnectSettings = async (
         await expect(input).toBeVisible();
         await input.fill(connectSrc);
     }
-    if (isCoreInPopup) {
+    if (isCoreInPopup || isWebExtension) {
         await waitAndClick(explorerPage, ['@select/coreMode/input']);
         await waitAndClick(explorerPage, ['@select/coreMode/option/popup']);
     }

--- a/packages/connect-web/e2e/tests/init.test.ts
+++ b/packages/connect-web/e2e/tests/init.test.ts
@@ -42,7 +42,8 @@ fixtures.forEach(f => {
                         appName: 'Trezor Connect Example',
                         appUrl: 'http://your.application.com',
                     },
-                    connectSrc: '${f.params.connectSrc}'
+                    connectSrc: '${f.params.connectSrc}',
+                    coreMode: 'iframe'
                 });
         `,
         });

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -53,7 +53,7 @@ const impl = new TrezorConnectDynamic<
                 console.warn(`Invalid coreMode: ${settings.coreMode}`);
             }
 
-            return 'iframe';
+            return 'core-in-suite-web';
         }
     },
     handleBeforeCall: async () => {
@@ -77,7 +77,7 @@ const impl = new TrezorConnectDynamic<
             impl.getTargetType() === 'core-in-suite-desktop' &&
             (errorCode === 'Desktop_ConnectionMissing' || errorCode === 'Method_Unsupported')
         ) {
-            await impl.switchTarget('iframe');
+            await impl.switchTarget('core-in-suite-web');
 
             return true;
         }

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -42,10 +42,10 @@ const impl = new TrezorConnectDynamic<
     getInitTarget: (settings: Partial<ConnectSettingsPublic & ConnectSettingsWebextension>) => {
         if (settings.coreMode === 'suite-desktop') {
             return 'core-in-suite-desktop';
-        } else if (settings.coreMode === 'suite-web') {
-            return 'core-in-suite-web';
-        } else {
+        } else if (settings.coreMode === 'popup') {
             return 'core-in-popup';
+        } else {
+            return 'core-in-suite-web';
         }
     },
     handleBeforeCall: async () => {
@@ -63,7 +63,7 @@ const impl = new TrezorConnectDynamic<
             impl.getTargetType() === 'core-in-suite-desktop' &&
             errorCode === 'Desktop_ConnectionMissing'
         ) {
-            await impl.switchTarget('core-in-popup');
+            await impl.switchTarget('core-in-suite-web');
 
             return true;
         }

--- a/packages/connect/e2e/tests/api/init.test.ts
+++ b/packages/connect/e2e/tests/api/init.test.ts
@@ -42,10 +42,14 @@ describe('TrezorConnect.init', () => {
     it('calling .init() multiple times', async () => {
         await TrezorConnect.init({
             manifest: { appName: 'a', appUrl: 'a', email: 'b' },
+            coreMode: 'iframe', // for connect-web
         });
 
         try {
-            await TrezorConnect.init({ manifest: { appName: 'a', appUrl: 'a', email: 'b' } });
+            await TrezorConnect.init({
+                manifest: { appName: 'a', appUrl: 'a', email: 'b' },
+                coreMode: 'iframe', // for connect-web
+            });
             throw new Error('Should not be resolved');
         } catch (error) {
             expect(error).toMatchObject({ code: 'Init_AlreadyInitialized' });
@@ -53,10 +57,9 @@ describe('TrezorConnect.init', () => {
     });
 
     it('calling multiple methods synchronously', async () => {
-        TrezorConnect.manifest({
-            appName: 'a',
-            appUrl: 'a',
-            email: 'b',
+        await TrezorConnect.init({
+            manifest: { appName: 'a', appUrl: 'a', email: 'b' },
+            coreMode: 'iframe', // for connect-web
         });
 
         const result = await Promise.all([
@@ -69,7 +72,10 @@ describe('TrezorConnect.init', () => {
     });
 
     it('init success', async () => {
-        await TrezorConnect.init({ manifest: { appName: 'a', appUrl: 'a', email: 'b' } });
+        await TrezorConnect.init({
+            manifest: { appName: 'a', appUrl: 'a', email: 'b' },
+            coreMode: 'iframe', // for connect-web
+        });
 
         const resp = await TrezorConnect.getCoinInfo({ coin: 'btc' });
         expect(resp).toMatchObject({
@@ -77,7 +83,8 @@ describe('TrezorConnect.init', () => {
         });
     });
 
-    it('manifest success', async () => {
+    // manifest doesn't allow us to control the coreMode, therefore the test won't run
+    it.skip('manifest success', async () => {
         TrezorConnect.manifest({
             appName: 'a',
             appUrl: 'a',


### PR DESCRIPTION
## Description

Follow-up to #22651, can be merged after Suite is released. 
Legacy tests are adjusted to keep using old iframe/popup. 

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/new-connect-popup-suite-web-default&lookback=7)