### PR TITLE
fix(suite-native): delete unnecessary migration

### DIFF
--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -89,23 +89,12 @@ export const prepareRootReducers = async () => {
         reducer: appSettingsReducer,
         persistedKeys: appSettingsPersistWhitelist,
         key: 'appSettings',
+        // Note: Migration to version 3 has been removed.
+        // The `isCoinEnablingInitFinished` property was deleted, and
+        // `areTestnetsEnabled` is a developer-only option and does not require migration.
         version: 3,
         migrations: {
             2: (oldState: any) => ({ ...oldState, fiatCurrencyCode: oldState.fiatCurrency.label }),
-            3: async (oldState: any) => {
-                const discoveryConfig = (await getStoredState({
-                    key: 'discoveryConfig',
-                    storage: await initMmkvStorage(),
-                })) as any;
-                if (discoveryConfig)
-                    return {
-                        ...oldState,
-                        areTestnetsEnabled: discoveryConfig.areTestnetsEnabled,
-                        isCoinEnablingInitFinished: discoveryConfig.isCoinEnablingInitFinished,
-                    };
-
-                return oldState;
-            },
         },
     });
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- It was potentially buggy, because it passed async function in createMigrate that use reduce over the array of functions internally.
- It is no longer needed since isCoinEnablingInitFinished has been deleted completely in https://github.com/trezor/trezor-suite/pull/21445

## Notes for QA

I would skip QA for this, if reviewer agree. 

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/delete-extra-migration&lookback=7)