### PR TITLE
Global Send/Receive modal: behavior and navigation improvements

### DIFF
--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -95,6 +95,7 @@ const getInitialState = ({
     wallet: {
         ...initialAppState.wallet,
         selectedAccount: initialAppState.wallet?.selectedAccount ?? { account: null },
+        accounts: initialAppState.wallet?.accounts ?? [],
     },
 });
 

--- a/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
@@ -31,6 +31,7 @@ const getInitialState = (device: DeviceReducerState): AppState =>
         wallet: {
             ...initialAppState.wallet,
             selectedAccount: initialAppState.wallet?.selectedAccount ?? { account: null },
+            accounts: initialAppState.wallet?.accounts ?? [],
         },
     }) as AppState;
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx
@@ -1,69 +1,27 @@
-import { useState } from 'react';
-
 import { Account } from '@suite-common/wallet-types';
-import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
 import { useDevice } from 'src/hooks/suite';
 import { LocalAccountSearchProvider } from 'src/hooks/suite/useAccountSearch';
 import { AccountItemType } from 'src/types/wallet';
 
-import { useGoToWithAnalytics } from '../useGoToWithAnalytics';
 import { GlobalReceiveModal } from './GlobalReceiveModal';
 import { GlobalSendModal } from './GlobalSendModal';
 import { GlobalSendReceiveButtons } from './GlobalSendReceiveButtons';
+import { useGlobalSendReceiveAnalytics } from './hooks/useGlobalSendReceiveAnalytics';
+import { useGlobalSendReceiveModal } from './hooks/useGlobalSendReceiveModal';
 
 export const GlobalSendReceive = () => {
     const { device } = useDevice();
+    const { activeModal, openModal, closeModal } = useGlobalSendReceiveModal();
+    const { sendAnalytics, receiveAnalytics } = useGlobalSendReceiveAnalytics();
 
-    const goToWithAnalytics = useGoToWithAnalytics();
     const buttonIntent = device?.connected && device?.available ? 'brand' : 'neutral';
     const buttonPriority = device?.connected && device?.available ? 'primary' : 'secondary';
-    const [isSendModalOpen, setIsSendModalOpen] = useState(false);
-    const [isReceiveModalOpen, setIsReceiveModalOpen] = useState(false);
-
-    const handleSendCancel = (filledSearch: boolean) => {
-        setIsSendModalOpen(false);
-
-        analytics.report({
-            type: EventType.DashboardSendModalOptions,
-            payload: {
-                option: 'close',
-                filledSearch,
-            },
-        });
-    };
 
     const handleSendSubmit = (account: Account, type: AccountItemType, filledSearch: boolean) => {
-        setIsSendModalOpen(false);
-
-        analytics.report({
-            type: EventType.DashboardSendModalOptions,
-            payload: {
-                option: 'account',
-                filledSearch,
-            },
-        });
-
-        goToWithAnalytics(type === 'tokens' ? 'wallet-tokens' : 'wallet-send', {
-            params: {
-                symbol: account.symbol,
-                accountIndex: account.index,
-                accountType: account.accountType,
-            },
-        });
-    };
-
-    const handleReceiveCancel = (filledSearch: boolean) => {
-        setIsReceiveModalOpen(false);
-
-        analytics.report({
-            type: EventType.DashboardReceiveModalOptions,
-            payload: {
-                option: 'close',
-                filledSearch,
-            },
-        });
+        sendAnalytics.account(filledSearch);
+        closeModal(type === 'tokens' ? 'wallet-tokens' : 'wallet-send', account);
     };
 
     const handleReceiveSubmit = (
@@ -71,39 +29,35 @@ export const GlobalSendReceive = () => {
         type: AccountItemType,
         filledSearch: boolean,
     ) => {
-        setIsReceiveModalOpen(false);
+        receiveAnalytics.account(filledSearch);
+        closeModal(type === 'tokens' ? 'wallet-tokens' : 'wallet-receive', account);
+    };
 
-        analytics.report({
-            type: EventType.DashboardReceiveModalOptions,
-            payload: {
-                option: 'account',
-                filledSearch,
-            },
-        });
+    const handleSendCancel = (filledSearch: boolean) => {
+        sendAnalytics.close(filledSearch);
+        closeModal();
+    };
 
-        goToWithAnalytics(type === 'tokens' ? 'wallet-tokens' : 'wallet-receive', {
-            params: {
-                symbol: account.symbol,
-                accountIndex: account.index,
-                accountType: account.accountType,
-            },
-        });
+    const handleReceiveCancel = (filledSearch: boolean) => {
+        receiveAnalytics.close(filledSearch);
+        closeModal();
     };
 
     return (
         <AppNavigationTooltip>
             <GlobalSendReceiveButtons
-                setIsSendModalOpen={setIsSendModalOpen}
-                setIsReceiveModalOpen={setIsReceiveModalOpen}
+                setActiveModal={modal => {
+                    openModal(modal);
+                }}
                 intent={buttonIntent}
                 priority={buttonPriority}
             />
-            {isSendModalOpen && (
+            {activeModal === 'send' && (
                 <LocalAccountSearchProvider>
                     <GlobalSendModal onCancel={handleSendCancel} onSubmit={handleSendSubmit} />
                 </LocalAccountSearchProvider>
             )}
-            {isReceiveModalOpen && (
+            {activeModal === 'receive' && (
                 <LocalAccountSearchProvider>
                     <GlobalReceiveModal
                         onCancel={handleReceiveCancel}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
@@ -1,3 +1,4 @@
+import { GlobalSendReceiveType } from '@suite-common/wallet-types';
 import { NewButtonGroup, NewButtonProps } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
@@ -5,14 +6,12 @@ import { Translation } from '../../../../Translation';
 import { HeaderActionButton } from '../HeaderActionButton';
 
 type GlobalSendReceiveButtonsProps = {
-    setIsSendModalOpen: (isSendModalOpen: boolean) => void;
-    setIsReceiveModalOpen: (isReceiveModalOpen: boolean) => void;
+    setActiveModal: (activeModal: NonNullable<GlobalSendReceiveType>) => void;
     intent: NonNullable<NewButtonProps['intent']>;
     priority: NonNullable<NewButtonProps['priority']>;
 };
 export const GlobalSendReceiveButtons = ({
-    setIsSendModalOpen,
-    setIsReceiveModalOpen,
+    setActiveModal,
     intent,
     priority,
 }: GlobalSendReceiveButtonsProps) => (
@@ -21,7 +20,7 @@ export const GlobalSendReceiveButtons = ({
             key="wallet-send"
             icon="arrowUp"
             onClick={() => {
-                setIsSendModalOpen(true);
+                setActiveModal('send');
 
                 analytics.report({ type: EventType.DashboardSendModal });
             }}
@@ -34,7 +33,7 @@ export const GlobalSendReceiveButtons = ({
             key="wallet-receive"
             icon="arrowDown"
             onClick={() => {
-                setIsReceiveModalOpen(true);
+                setActiveModal('receive');
 
                 analytics.report({ type: EventType.DashboardReceiveModal });
             }}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveAnalytics.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveAnalytics.ts
@@ -1,0 +1,41 @@
+import { useCallback } from 'react';
+
+import { EventType, SuiteAnalyticsEvent, analytics } from '@trezor/suite-analytics';
+
+type SendModalEventOptions = Extract<
+    SuiteAnalyticsEvent,
+    { type: EventType.DashboardSendModalOptions }
+>['payload']['option'];
+
+type ReceiveModalEventOptions = Extract<
+    SuiteAnalyticsEvent,
+    { type: EventType.DashboardReceiveModalOptions }
+>['payload']['option'];
+
+export const useGlobalSendReceiveAnalytics = () => {
+    const reportSend = useCallback((option: SendModalEventOptions, filledSearch: boolean) => {
+        analytics.report({
+            type: EventType.DashboardSendModalOptions,
+            payload: { option, filledSearch },
+        });
+    }, []);
+
+    const reportReceive = useCallback((option: ReceiveModalEventOptions, filledSearch: boolean) => {
+        analytics.report({
+            type: EventType.DashboardReceiveModalOptions,
+            payload: { option, filledSearch },
+        });
+    }, []);
+
+    const sendAnalytics = {
+        account: (filledSearch: boolean) => reportSend('account', filledSearch),
+        close: (filledSearch: boolean) => reportSend('close', filledSearch),
+    };
+
+    const receiveAnalytics = {
+        account: (filledSearch: boolean) => reportReceive('account', filledSearch),
+        close: (filledSearch: boolean) => reportReceive('close', filledSearch),
+    };
+
+    return { reportSend, reportReceive, sendAnalytics, receiveAnalytics };
+};

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveModal.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveModal.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+
+import { yup } from '@suite-common/validators';
+import { Account, GlobalSendReceiveType } from '@suite-common/wallet-types';
+
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { Route } from 'src/types/suite';
+
+import { useGoToWithAnalytics } from '../../useGoToWithAnalytics';
+
+export const dashboardParamsSchema = yup
+    .object({
+        modal: yup
+            .mixed<NonNullable<GlobalSendReceiveType>>()
+            .oneOf(['send', 'receive'])
+            .required(),
+    })
+    .notRequired();
+
+const getDashboardParamModal = (param: unknown): GlobalSendReceiveType => {
+    try {
+        const parsedParams = dashboardParamsSchema.validateSync(param, {
+            abortEarly: false,
+            strict: true,
+        });
+
+        return parsedParams?.modal ?? null;
+    } catch (error) {
+        console.error(error);
+    }
+
+    return null;
+};
+
+export function useGlobalSendReceiveModal() {
+    const dispatch = useDispatch();
+    const goToWithAnalytics = useGoToWithAnalytics();
+    const routerParams = useSelector(state => state.router.params);
+    const [activeModal, setActiveModal] = useState<GlobalSendReceiveType>(null);
+
+    useEffect(() => {
+        setActiveModal(getDashboardParamModal(routerParams));
+    }, [routerParams]);
+
+    const openModal = (modal: NonNullable<GlobalSendReceiveType>) => {
+        setActiveModal(modal);
+        dispatch(goto('suite-index', { params: { modal } }));
+    };
+
+    const closeModal = (routeName?: Route['name'], account?: Account) => {
+        setActiveModal(null);
+
+        if (routeName && account) {
+            goToWithAnalytics(routeName, {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            });
+        } else {
+            dispatch(goto('suite-index'));
+        }
+    };
+
+    return {
+        activeModal,
+        openModal,
+        closeModal,
+    };
+}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
@@ -2,9 +2,9 @@ import { ReactNode } from 'react';
 
 import styled from 'styled-components';
 
-import { Route } from '@suite-common/suite-types';
+import { selectAccounts } from '@suite-common/wallet-core';
 import { Row } from '@trezor/components';
-import { spacingsPx, zIndices } from '@trezor/theme';
+import { spacings, spacingsPx, zIndices } from '@trezor/theme';
 
 import { HEADER_HEIGHT } from 'src/constants/suite/layout';
 import { useSelector } from 'src/hooks/suite';
@@ -34,12 +34,12 @@ const Container = styled.div`
 
 // TODO: perhaps this could be a part of some router config / useLayoutHook / somthing else?
 interface PageHeaderProps {
-    backRoute?: Route['name'];
     children?: ReactNode;
 }
 
-export const PageHeader = ({ backRoute, children }: PageHeaderProps) => {
+export const PageHeader = ({ children }: PageHeaderProps) => {
     const selectedAccount = useSelector(selectSelectedAccount);
+    const accounts = useSelector(selectAccounts);
     // TODO subpages + tabs could be in some router config? this approach feels a bit fragile
     const isAccountTabPage = useSelector(selectIsAccountTabPage);
     const routeName = useSelector(selectRouteName);
@@ -47,14 +47,16 @@ export const PageHeader = ({ backRoute, children }: PageHeaderProps) => {
     // handle moment when children are not rendered yet in the Trade section
     const isTradeSection = routeName?.includes('wallet-trading');
 
+    const hasAccounts = accounts.length > 0;
+
     return isTradeSection || children ? (
         <Container>{children ?? null}</Container>
     ) : (
         <Container>
-            <PageName backRoute={backRoute} />
+            <PageName />
 
-            {routeName === 'suite-index' && (
-                <Row gap={8}>
+            {routeName === 'suite-index' && hasAccounts && (
+                <Row gap={spacings.xxs}>
                     <HeaderDropdown />
                     <TradeActions />
                     <GlobalSendReceive />

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountSubpageName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountSubpageName.tsx
@@ -1,12 +1,11 @@
 import styled from 'styled-components';
 
-import { Route } from '@suite-common/suite-types';
 import { Account } from '@suite-common/wallet-types';
 import { NewIconButton } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { AccountDetails } from './AccountDetails';
 
@@ -18,25 +17,14 @@ const Container = styled.div`
 
 interface AccountSubpageNameProps {
     selectedAccount: Account;
-    backRoute?: Route['name'];
 }
 
-export const AccountSubpageName = ({
-    selectedAccount,
-    backRoute = 'wallet-index',
-}: AccountSubpageNameProps) => {
+export const AccountSubpageName = ({ selectedAccount }: AccountSubpageNameProps) => {
     const dispatch = useDispatch();
+    const previousRoute = useSelector(state => state.router.settingsBackRoute);
 
     const handleBackClick = () =>
-        dispatch(
-            goto(backRoute, {
-                params: {
-                    symbol: selectedAccount.symbol,
-                    accountIndex: selectedAccount.index,
-                    accountType: selectedAccount.accountType,
-                },
-            }),
-        );
+        dispatch(goto(previousRoute.name, { params: previousRoute.params }));
 
     return (
         <Container>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
@@ -1,5 +1,3 @@
-import { Route } from '@suite-common/suite-types';
-
 import { useSelector } from 'src/hooks/suite';
 import { selectIsAccountTabPage } from 'src/reducers/suite/routerReducer';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
@@ -9,11 +7,7 @@ import { AccountSubpageName } from './AccountName/AccountSubpageName';
 import { BasicName } from './BasicName';
 import { SettingsName } from './SettingsName';
 
-interface PageNameProps {
-    backRoute?: Route['name'];
-}
-
-export const PageName = ({ backRoute }: PageNameProps) => {
+export const PageName = () => {
     const currentRoute = useSelector(state => state.router.route?.name);
     const selectedAccount = useSelector(selectSelectedAccount);
     const isAccountTabPage = useSelector(selectIsAccountTabPage);
@@ -29,7 +23,7 @@ export const PageName = ({ backRoute }: PageNameProps) => {
         return <AccountName selectedAccount={selectedAccount} />;
     }
     if (selectedAccount) {
-        return <AccountSubpageName selectedAccount={selectedAccount} backRoute={backRoute} />;
+        return <AccountSubpageName selectedAccount={selectedAccount} />;
     }
 
     return <BasicName nameId="TR_DASHBOARD" />;

--- a/packages/suite/src/utils/suite/router.ts
+++ b/packages/suite/src/utils/suite/router.ts
@@ -1,5 +1,5 @@
 import { ExtraDependencies } from '@suite-common/redux-utils';
-import { modalAppParams } from '@suite-common/suite-config';
+import { dashboardParams, modalAppParams } from '@suite-common/suite-config';
 import { Route } from '@suite-common/suite-types';
 import { getNetworkOptional, isAccountOfNetwork } from '@suite-common/wallet-config';
 import { WalletParams as CommonWalletParams } from '@suite-common/wallet-types';
@@ -85,7 +85,7 @@ const modalAppParamsDefaultValues: ModalAppParams = {
     variant: undefined,
 };
 
-const validateModalAppParams = (url: string, params?: Route['params']): ModalAppParams | null => {
+const validateModalAppParams = (url: string, params?: Route['params']): ModalAppParams => {
     const [, hash] = stripPrefixedURL(url).split('#');
     const splitted = hash?.split('/').filter(p => p.length > 0);
     if (!splitted || splitted.length === 0) return modalAppParamsDefaultValues;
@@ -104,6 +104,24 @@ const validateModalAppParams = (url: string, params?: Route['params']): ModalApp
     } as ModalAppParams;
 };
 
+export type DashboardParams = {
+    [key in (typeof dashboardParams)[number]]: string | boolean | undefined;
+};
+
+const validateDashboardParams = (url: string): DashboardParams | undefined => {
+    const stripped = stripPrefixedURL(url);
+    const hashIndex = stripped.indexOf('#');
+
+    const hash = hashIndex >= 0 ? stripped.slice(hashIndex + 1) : '';
+    const [modal] = hash.split('/').filter(Boolean);
+
+    if (modal === undefined) {
+        return undefined;
+    }
+
+    return { modal };
+};
+
 // Used in routerReducer
 export const getAppWithParams = (url: string): RouterAppWithParams => {
     const route = findRoute(url);
@@ -113,6 +131,14 @@ export const getAppWithParams = (url: string): RouterAppWithParams => {
             app: 'unknown',
             route: undefined,
             params: undefined,
+        };
+    }
+
+    if (route.app === 'dashboard') {
+        return {
+            app: route.app,
+            params: validateDashboardParams(url),
+            route,
         };
     }
 
@@ -141,7 +167,9 @@ export const getAppWithParams = (url: string): RouterAppWithParams => {
 
 export type WalletParams = CommonWalletParams;
 export type RouteParams = {
-    [K in keyof (WalletParams & ModalAppParams)]?: (WalletParams & ModalAppParams)[K];
+    [K in keyof (WalletParams & ModalAppParams & DashboardParams)]?: (WalletParams &
+        ModalAppParams &
+        DashboardParams)[K];
 };
 
 export const getRoute = (name: Route['name'], params?: RouteParams) => {

--- a/suite-common/suite-config/src/routes.ts
+++ b/suite-common/suite-config/src/routes.ts
@@ -6,6 +6,7 @@
 
 export const walletParams = ['symbol', 'accountIndex', 'accountType'] as const;
 export const modalAppParams = ['cancelable', 'variant'] as const;
+export const dashboardParams = ['modal'] as const;
 
 export const routes = [
     {
@@ -20,6 +21,7 @@ export const routes = [
         name: 'suite-index',
         pattern: '/',
         app: 'dashboard',
+        params: dashboardParams,
     },
     {
         name: 'suite-version',

--- a/suite-common/wallet-types/src/globalSendReceive.ts
+++ b/suite-common/wallet-types/src/globalSendReceive.ts
@@ -1,0 +1,1 @@
+export type GlobalSendReceiveType = 'send' | 'receive' | null;

--- a/suite-common/wallet-types/src/index.ts
+++ b/suite-common/wallet-types/src/index.ts
@@ -13,3 +13,4 @@ export * from './stakeForm';
 export * from './send';
 export * from './solanaStaking';
 export * from './wallet';
+export * from './globalSendReceive';


### PR DESCRIPTION
## Description

- Improves navigation from the Receive page: pressing Back now routes to the Dashboard and reopens the global modal when relevant.
- Prevents displaying the Receive button when the user has no accounts (avoids opening empty modal).

## Related Issue

Resolve #22914

## Videos:

### Back button
https://github.com/user-attachments/assets/b9de83b1-3e06-465f-8fa1-6654c580bb92

### No accounts
https://github.com/user-attachments/assets/961d19f3-b252-4019-9cc0-59c7bc36b8aa

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/global-send-receive-modal-behavior&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/global-send-receive-modal-behavior&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/global-send-receive-modal-behavior&lookback=7)