### PR TITLE
feat(suite): added translations for labeling switch

### DIFF
--- a/packages/suite/src/constants/suite/labeling.ts
+++ b/packages/suite/src/constants/suite/labeling.ts
@@ -1,13 +1,20 @@
+import { TranslationKey } from '@suite-common/intl-types';
 import { typedObjectValues } from '@trezor/utils';
 
 export type LabelingSelectValue = 'off' | 'secure-sync' | 'legacy';
 
-export type LabelingOption = { label: string; value: LabelingSelectValue };
+export type LabelingOption<T> = { label: T; value: LabelingSelectValue };
+export type LabelingOptionTranslated = LabelingOption<TranslationKey>;
 
-export const LABELING_SELECT_OPTIONS_MAP: Record<LabelingSelectValue, LabelingOption> = {
-    off: { label: 'Off', value: 'off' },
-    'secure-sync': { label: 'Secure sync (recommended)', value: 'secure-sync' },
-    legacy: { label: 'Legacy', value: 'legacy' },
+export const LABELING_SELECT_OPTIONS_MAP: Record<
+    LabelingSelectValue,
+    LabelingOption<TranslationKey>
+> = {
+    off: { label: 'TR_LABELING_OFF', value: 'off' },
+    'secure-sync': { label: 'TR_LABELING_SECURE_SYNC', value: 'secure-sync' },
+    legacy: { label: 'TR_LABELING_LEGACY', value: 'legacy' },
 };
+
+export const LABELING_LEGACY_OPTION_LABEL = 'TR_LABELING_ON';
 
 export const LABELING_SELECT_OPTIONS = typedObjectValues(LABELING_SELECT_OPTIONS_MAP);

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6457,6 +6457,22 @@ export default defineMessages({
         id: 'TR_LABELING_REMOVE_OUTPUT',
         defaultMessage: 'Remove label',
     },
+    TR_LABELING_ON: {
+        id: 'TR_LABELING_ON',
+        defaultMessage: 'On',
+    },
+    TR_LABELING_OFF: {
+        id: 'TR_LABELING_OFF',
+        defaultMessage: 'Off',
+    },
+    TR_LABELING_LEGACY: {
+        id: 'TR_LABELING_LEGACY',
+        defaultMessage: 'Legacy',
+    },
+    TR_LABELING_SECURE_SYNC: {
+        id: 'TR_LABELING_SECURE_SYNC',
+        defaultMessage: 'Secure Sync (recommended)',
+    },
     TR_GRAPH_MISSING_DATA_WITH_TOKENS: {
         id: 'TR_GRAPH_MISSING_DATA_WITH_TOKENS',
         defaultMessage:

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -8,20 +8,24 @@ import { HELP_CENTER_LABELING } from '@trezor/urls';
 
 import { SettingsSectionItem } from 'src/components/settings/SettingsSectionItem';
 import { ActionColumn, ActionSelect, TextColumn } from 'src/components/suite';
-import { Translation } from 'src/components/suite/Translation';
+import { Translation, TranslationKey } from 'src/components/suite/Translation';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import {
+    LABELING_LEGACY_OPTION_LABEL,
     LABELING_SELECT_OPTIONS,
-    LABELING_SELECT_OPTIONS_MAP,
     LabelingOption,
+    LabelingOptionTranslated,
+    LabelingSelectValue,
 } from 'src/constants/suite/labeling';
-import { useDevice, useSelector } from 'src/hooks/suite';
+import { useDevice, useSelector, useTranslation } from 'src/hooks/suite';
 import { useLabelingCombined } from 'src/hooks/suite/useLabelingCombined';
 import { useLabelingDeviceState } from 'src/hooks/suite/useLabelingDeviceState';
 
 import { LabelingSwitchToLegacyModal } from '../../../components/suite/labeling/LabelingSwitchToLegacyModal';
 
 export const Labeling = () => {
+    const translate = useTranslation();
+
     const [legacyModalWarningVisible, setLegacyModalWarningVisible] = useState(false);
     const { device } = useDevice();
     const { isDeviceLabelingDisabled } = useLabelingDeviceState();
@@ -40,7 +44,15 @@ export const Labeling = () => {
         deviceStaticSessionId: device?.state?.staticSessionId,
     });
 
-    const handleOnChange = (selected: LabelingOption) => {
+    const translatedOptions: LabelingOption<string>[] = LABELING_SELECT_OPTIONS.map(option => ({
+        ...option,
+        label:
+            !showLocalFirstStorage && option.value === 'legacy'
+                ? translate.translationString(LABELING_LEGACY_OPTION_LABEL)
+                : translate.translationString(option.label),
+    }));
+
+    const handleOnChange = (selected: LabelingOptionTranslated) => {
         const { value } = selected;
 
         // show a warning legacy modal when user selects legacy option while using local first storage
@@ -77,17 +89,30 @@ export const Labeling = () => {
         });
     };
 
-    const getSelectedOption = (): LabelingOption => {
-        if (showLocalFirstStorage) {
-            if (isLocalFirstStorageEnabled) return LABELING_SELECT_OPTIONS_MAP['secure-sync'];
-            if (legacyMetadataState.enabled) return LABELING_SELECT_OPTIONS_MAP.legacy;
+    const getSelectedOption = (): LabelingOptionTranslated => {
+        const LABELING_SELECT_TRANSLATED_OPTIONS_MAP = LABELING_SELECT_OPTIONS.reduce(
+            (acc, option) => {
+                acc[option.value] = option;
 
-            return LABELING_SELECT_OPTIONS_MAP.off;
+                return acc;
+            },
+            {} as Record<LabelingSelectValue, LabelingOption<TranslationKey>>,
+        );
+
+        if (showLocalFirstStorage) {
+            if (isLocalFirstStorageEnabled)
+                return LABELING_SELECT_TRANSLATED_OPTIONS_MAP['secure-sync'];
+            if (legacyMetadataState.enabled) return LABELING_SELECT_TRANSLATED_OPTIONS_MAP.legacy;
+
+            return LABELING_SELECT_TRANSLATED_OPTIONS_MAP.off;
         }
 
         return legacyMetadataState.enabled
-            ? LABELING_SELECT_OPTIONS_MAP.legacy
-            : LABELING_SELECT_OPTIONS_MAP.off;
+            ? {
+                  ...LABELING_SELECT_TRANSLATED_OPTIONS_MAP.legacy,
+                  label: LABELING_LEGACY_OPTION_LABEL,
+              }
+            : LABELING_SELECT_TRANSLATED_OPTIONS_MAP.off;
     };
 
     return (
@@ -118,7 +143,7 @@ export const Labeling = () => {
                 />
                 <ActionColumn>
                     <ActionSelect
-                        options={LABELING_SELECT_OPTIONS.filter(
+                        options={translatedOptions.filter(
                             option =>
                                 option.value !== 'secure-sync' ||
                                 (showLocalFirstStorage && isEvoluSupportedByDevice),


### PR DESCRIPTION
I've added a translation keys to each of labeling option so that they can be translated. Also, the legacy label uses the translation key for "on" if the local first storage is not enabled.

**changes**:
- labeling options now uses translations
- legacy label shows 'on' when local first storage is not enabled in debug settings

## Notes for QA

**Scenario for legacy (current default labeling):**
- open suite
- go to settings
- see labeling options -> you should see translated strings in different languages (if there are translations)
- also you should see "on" or "off"

Scenario for evolu enabled (via debug settings):
- open suite
- go to settings
- see labeling options -> you should see translated strings in different languages (if there are translations)
- also you should see "Secure sync (recommended)", "Legacy" and "Off"

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22796


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/evolu/option-copy&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/evolu/option-copy&lookback=7)