### PR TITLE
feat(suite): ADA StakingBanner

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -181,6 +181,7 @@ const initialRun: Array<{ description: string; state?: Partial<SuiteState> }> = 
                 showSettingsDesktopAppPromoBanner: true,
                 stakeEthBannerClosed: false,
                 stakeSolBannerClosed: false,
+                stakeCardanoBannerClosed: false,
                 suspiciousTransactionsTooltipClosed: false,
                 showDashboardStakingPromoBanner: true,
                 showCopyAddressModal: true,

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -2,15 +2,12 @@ import { useMemo } from 'react';
 
 import { useFormatters } from '@suite-common/formatters';
 import { NetworkType, getDisplaySymbol } from '@suite-common/wallet-config';
-import {
-    MIN_ETH_AMOUNT_FOR_STAKING,
-    MIN_SOL_AMOUNT_FOR_STAKING,
-} from '@suite-common/wallet-constants';
 import { selectAccountIsStakingActive, selectPoolStatsApyData } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import {
     getStakingDataForNetwork,
     getStakingLimitsByNetworkSymbol,
+    isSupportedStakingNetworkSymbol,
 } from '@suite-common/wallet-utils';
 import {
     Button,
@@ -25,6 +22,7 @@ import {
 } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
+import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { goto } from 'src/actions/suite/routerActions';
@@ -41,7 +39,8 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
     const { isBelowLaptop } = useLayoutSize();
     const dispatch = useDispatch();
     const { CryptoAmountFormatter } = useFormatters();
-    const { stakeEthBannerClosed, stakeSolBannerClosed } = useSelector(selectSuiteFlags);
+    const { stakeEthBannerClosed, stakeSolBannerClosed, stakeCardanoBannerClosed } =
+        useSelector(selectSuiteFlags);
     const { route } = useSelector(state => state.router);
     const apy = useSelector(state => selectPoolStatsApyData(state, account.symbol));
     const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
@@ -73,6 +72,16 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
             case 'solana':
                 dispatch(setFlag('stakeSolBannerClosed', true));
                 break;
+            case 'cardano':
+                dispatch(setFlag('stakeCardanoBannerClosed', true));
+                break;
+            default:
+                if (isSupportedStakingNetworkSymbol(account.symbol)) {
+                    exhaustive(
+                        account.networkType as never,
+                        `Add missing case for ${account.symbol} network type`,
+                    );
+                }
         }
 
         analytics.report({
@@ -98,32 +107,31 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
         });
     };
 
-    const getNetworkDetails = (networkType: NetworkType) => {
+    const isStakingBannerClosed = (networkType: NetworkType) => {
         switch (networkType) {
             case 'ethereum':
-                return {
-                    isStakingBannerClosed: stakeEthBannerClosed,
-                    minStakingAmount: MIN_ETH_AMOUNT_FOR_STAKING,
-                };
+                return stakeEthBannerClosed;
             case 'solana':
-                return {
-                    isStakingBannerClosed: stakeSolBannerClosed,
-                    minStakingAmount: MIN_SOL_AMOUNT_FOR_STAKING,
-                };
+                return stakeSolBannerClosed;
+            case 'cardano':
+                return stakeCardanoBannerClosed;
             default:
-                return {
-                    isStakingBannerClosed: true,
-                    minStakingAmount: undefined,
-                };
+                if (isSupportedStakingNetworkSymbol(account.symbol)) {
+                    exhaustive(
+                        account.networkType as never,
+                        `Add missing case for ${account.symbol} network type`,
+                    );
+                }
+
+                return true;
         }
     };
 
-    const { isStakingBannerClosed } = getNetworkDetails(account.networkType) ?? {};
     const stakingLimits = getStakingLimitsByNetworkSymbol(account.symbol);
 
     if (
         route?.name !== 'wallet-index' ||
-        isStakingBannerClosed ||
+        isStakingBannerClosed(account.networkType) ||
         !account ||
         isStakingActive ||
         !stakingLimits

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -63,6 +63,7 @@ export interface Flags {
     showSettingsDesktopAppPromoBanner: boolean;
     stakeEthBannerClosed: boolean; // banner in account view (Overview tab) presenting ETH staking feature
     stakeSolBannerClosed: boolean; // banner in account view (Overview tab) presenting SOL staking feature
+    stakeCardanoBannerClosed: boolean; // banner in account view (Overview tab) presenting Cardano staking feature
     showDashboardStakingPromoBanner: boolean;
     suspiciousTransactionsTooltipClosed: boolean;
     showUnhideTokenModal: boolean;
@@ -157,6 +158,7 @@ const initialState: SuiteState = {
         showSettingsDesktopAppPromoBanner: true,
         stakeEthBannerClosed: false,
         stakeSolBannerClosed: false,
+        stakeCardanoBannerClosed: false,
         showDashboardStakingPromoBanner: true,
         suspiciousTransactionsTooltipClosed: false,
         showCopyAddressModal: true,

--- a/packages/suite/src/views/wallet/staking/components/CardanoNewProviderCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/CardanoNewProviderCard.tsx
@@ -1,5 +1,8 @@
 import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
-import { hasPendingStakeTypeTransaction } from '@suite-common/wallet-core';
+import {
+    hasPendingStakeTypeTransaction,
+    selectAccountIsStakingActive,
+} from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { isCardanoStakedWithEverstake } from '@suite-common/wallet-utils';
 
@@ -17,8 +20,9 @@ export function CardanoNewProviderCard({ account }: CardanoNewProviderCardProps)
     const isNewProviderBannerEnabled = useSelector(state =>
         selectIsFeatureEnabled(state, Feature.banners.staking.ada.newProvider, true),
     );
+    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
 
-    if (isStakedWithEverstake || hasPendingTx || !isNewProviderBannerEnabled) {
+    if (isStakedWithEverstake || hasPendingTx || !isNewProviderBannerEnabled || !isStakingActive) {
         return null;
     }
 


### PR DESCRIPTION
## Description

Display StakingBanner at the overview tab if ADA staking is inactive.

## Notes for QA

- Feat: The `StakingBanner` should be displayed at the overview tab if staking isn't active. It can be dismissed too.  
- Fix: Hide Cardano new provider banner if staking isn't active.

## Related Issue

Resolve #22746

## Screenshots:

<img width="828" height="792" alt="Snímek obrazovky 2025-11-03 v 10 52 41" src="https://github.com/user-attachments/assets/618cdb85-7084-473f-95f6-b5199ca1fb58" />

