### PR TITLE
Mobile Trade: Remove sorting of tradable assets

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
@@ -9,7 +9,7 @@ import { BuyCryptoAmountInput } from './BuyCryptoAmountInput';
 import { BuyTradeableAssetsSheet } from './BuyTradeableAssetsSheet';
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { useSheetControls } from '../../hooks/general/useSheetControls';
-import { selectBuyTradeableAssetsSorted } from '../../selectors/buySelectors';
+import { selectBuyTradeableAssets } from '../../selectors/buySelectors';
 import { TradeableAsset } from '../../types/general';
 import { SelectTradeableAssetButton } from '../general/SelectTradeableAssetButton';
 
@@ -24,7 +24,7 @@ export const BuyTradeableAssetPicker = () => {
     const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
         useSheetControls(form, 'asset');
     const hasBitcoinOnlyFirmware = useSelector(selectHasBitcoinOnlyFirmware);
-    const assets = useSelector(selectBuyTradeableAssetsSorted);
+    const assets = useSelector(selectBuyTradeableAssets);
 
     const btcAsset = useMemo(() => assets.find(asset => asset.cryptoId === 'bitcoin'), [assets]);
 

--- a/suite-native/module-trading/src/hooks/buy/useBuyTradeableAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyTradeableAssetsFilteredData.ts
@@ -1,10 +1,10 @@
 import { useSelector } from 'react-redux';
 
-import { selectBuyTradeableAssetsSorted } from '../../selectors/buySelectors';
+import { selectBuyTradeableAssets } from '../../selectors/buySelectors';
 import { useTradeableAssetsFilteredData } from '../general/useTradeableAssetsFilteredData';
 
 export const useBuyTradeableAssetsFilteredData = () => {
-    const assets = useSelector(selectBuyTradeableAssetsSorted);
+    const assets = useSelector(selectBuyTradeableAssets);
 
     return useTradeableAssetsFilteredData({ assets });
 };

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeBuyTradeableAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeBuyTradeableAssetsFilteredData.ts
@@ -1,10 +1,10 @@
 import { useSelector } from 'react-redux';
 
-import { selectExchangeBuyTradeableAssetsSorted } from '../../selectors/exchangeSelectors';
+import { selectExchangeBuyTradeableAssets } from '../../selectors/exchangeSelectors';
 import { useTradeableAssetsFilteredData } from '../general/useTradeableAssetsFilteredData';
 
 export const useExchangeBuyTradeableAssetsFilteredData = () => {
-    const assets = useSelector(selectExchangeBuyTradeableAssetsSorted);
+    const assets = useSelector(selectExchangeBuyTradeableAssets);
 
     return useTradeableAssetsFilteredData({ assets });
 };

--- a/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 
-import type { BuyTrade, CryptoId } from 'invity-api';
+import type { BuyTrade } from 'invity-api';
 
 import { AccountsRootState } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
@@ -17,7 +17,7 @@ import {
     selectBuySelectedReceiveAccount,
     selectBuySupportedFiatCurrencies,
     selectBuySupportedFiatCurrenciesList,
-    selectBuyTradeableAssetsSorted,
+    selectBuyTradeableAssets,
     selectTradingBuy,
     selectValidTradingBuyQuotesNative,
 } from '../buySelectors';
@@ -77,45 +77,23 @@ describe('buySelectors', () => {
         });
     });
 
-    describe('selectBuyTradeableAssetsSorted', () => {
+    describe('selectBuyTradeableAssets', () => {
         it('should select only coins with buy set to true', () => {
-            expect(selectBuyTradeableAssetsSorted(state)).toEqual([
-                expect.objectContaining({ cryptoId: 'bitcoin' }),
-                expect.objectContaining({ cryptoId: 'ethereum' }),
-                expect.objectContaining({
-                    cryptoId: 'base--0x0000000000000000000000000000000000000000',
-                }),
+            expect(selectBuyTradeableAssets(state)).toEqual([
                 expect.objectContaining({
                     cryptoId: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
                 }),
-            ]);
-        });
-
-        it('should sort coins', () => {
-            state.wallet.trading.buy.buyInfo!.supportedCryptoCurrencies = [
-                'bitcoin',
-                'ethereum',
-                'eos',
-                'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-                'base--0x0000000000000000000000000000000000000000',
-                'ethereum--0xWithoutObjectInCoinsInfo',
-            ] as CryptoId[];
-
-            expect(selectBuyTradeableAssetsSorted(state)).toEqual([
-                expect.objectContaining({ cryptoId: 'bitcoin' }),
-                expect.objectContaining({ cryptoId: 'ethereum' }),
                 expect.objectContaining({
                     cryptoId: 'base--0x0000000000000000000000000000000000000000',
                 }),
-                expect.objectContaining({
-                    cryptoId: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-                }),
+                expect.objectContaining({ cryptoId: 'ethereum' }),
+                expect.objectContaining({ cryptoId: 'bitcoin' }),
             ]);
         });
 
         it('should be stable', () => {
-            const first = selectBuyTradeableAssetsSorted(state);
-            const second = selectBuyTradeableAssetsSorted(state);
+            const first = selectBuyTradeableAssets(state);
+            const second = selectBuyTradeableAssets(state);
 
             expect(first).toBe(second);
         });
@@ -123,7 +101,7 @@ describe('buySelectors', () => {
         it('should be empty array when coins are not set', () => {
             state.wallet.trading.info.coins = undefined;
 
-            expect(selectBuyTradeableAssetsSorted(state)).toEqual([]);
+            expect(selectBuyTradeableAssets(state)).toEqual([]);
         });
     });
 

--- a/suite-native/module-trading/src/selectors/__tests__/exchangeSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/exchangeSelectors.test.ts
@@ -1,5 +1,3 @@
-import type { CryptoId } from 'invity-api';
-
 import { AccountsRootState } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { FeatureFlag, FeatureFlagsRootState } from '@suite-native/feature-flags';
@@ -10,7 +8,7 @@ import { getWalletState } from '../../__fixtures__/walletState';
 import { TradingRootState } from '../../reducers';
 import {
     selectExchangeAmountLimits,
-    selectExchangeBuyTradeableAssetsSorted,
+    selectExchangeBuyTradeableAssets,
     selectExchangeQuotes,
     selectExchangeSelectedReceiveAccount,
     selectExchangeSelectedSendAccount,
@@ -100,42 +98,20 @@ describe('exchangeSelectors', () => {
         });
     });
 
-    describe('selectExchangeBuyTradeableAssetsSorted', () => {
+    describe('selectExchangeBuyTradeableAssets', () => {
         it('should select only coins with exchange set to true', () => {
-            expect(selectExchangeBuyTradeableAssetsSorted(state)).toEqual([
-                expect.objectContaining({ cryptoId: 'bitcoin' }),
-                expect.objectContaining({ cryptoId: 'ethereum' }),
+            expect(selectExchangeBuyTradeableAssets(state)).toEqual([
                 expect.objectContaining({
                     cryptoId: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
                 }),
-            ]);
-        });
-
-        it('should sort coins', () => {
-            state.wallet.trading.exchange.exchangeInfo!.buyCryptoIds = [
-                'bitcoin',
-                'ethereum',
-                'eos',
-                'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-                'base--0x0000000000000000000000000000000000000000',
-                'ethereum--0xWithoutObjectInCoinsInfo',
-            ] as CryptoId[];
-
-            expect(selectExchangeBuyTradeableAssetsSorted(state)).toEqual([
-                expect.objectContaining({ cryptoId: 'bitcoin' }),
                 expect.objectContaining({ cryptoId: 'ethereum' }),
-                expect.objectContaining({
-                    cryptoId: 'base--0x0000000000000000000000000000000000000000',
-                }),
-                expect.objectContaining({
-                    cryptoId: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-                }),
+                expect.objectContaining({ cryptoId: 'bitcoin' }),
             ]);
         });
 
         it('should be stable', () => {
-            const first = selectExchangeBuyTradeableAssetsSorted(state);
-            const second = selectExchangeBuyTradeableAssetsSorted(state);
+            const first = selectExchangeBuyTradeableAssets(state);
+            const second = selectExchangeBuyTradeableAssets(state);
 
             expect(first).toBe(second);
         });
@@ -143,7 +119,7 @@ describe('exchangeSelectors', () => {
         it('should be empty array when coins are not set', () => {
             state.wallet.trading.info.coins = undefined;
 
-            expect(selectExchangeBuyTradeableAssetsSorted(state)).toEqual([]);
+            expect(selectExchangeBuyTradeableAssets(state)).toEqual([]);
         });
     });
 

--- a/suite-native/module-trading/src/selectors/buySelectors.ts
+++ b/suite-native/module-trading/src/selectors/buySelectors.ts
@@ -25,10 +25,7 @@ import { BuyFormValues } from '../types/buy';
 import { FiatCurrencyItem } from '../types/general';
 import { getCurrencyLabel } from '../utils/general/currencyUtils';
 import { getReceiveAccountFromAccountAndAddressString } from '../utils/general/receiveAccountUtils';
-import {
-    coinInfoToTradeableAsset,
-    tradeableAssetSortingComparator,
-} from '../utils/general/tradeableAssetUtils';
+import { coinInfoToTradeableAsset } from '../utils/general/tradeableAssetUtils';
 
 const DEFAULT_FIAT_CURRENCY_FALLBACK = 'USD';
 
@@ -51,7 +48,7 @@ export const selectBuySelectedReceiveAccount = createMemoizedSelectorWithAccount
 export const selectBuySupportedFiatCurrencies = (state: TradingRootState) =>
     returnStableArrayIfEmpty(selectTradingBuy(state).buyInfo?.supportedFiatCurrencies);
 
-export const selectBuyTradeableAssetsSorted = createMemoizedSelector(
+export const selectBuyTradeableAssets = createMemoizedSelector(
     [
         selectTradingBuySupportedCryptoIds as unknown as (
             state: TradingRootState,
@@ -63,9 +60,7 @@ export const selectBuyTradeableAssetsSorted = createMemoizedSelector(
             return [];
         }
 
-        return cryptoIds
-            .map(cryptoId => coinInfoToTradeableAsset(cryptoId, coins[cryptoId]))
-            .sort(tradeableAssetSortingComparator);
+        return cryptoIds.map(cryptoId => coinInfoToTradeableAsset(cryptoId, coins[cryptoId]));
     },
 );
 

--- a/suite-native/module-trading/src/selectors/exchangeSelectors.ts
+++ b/suite-native/module-trading/src/selectors/exchangeSelectors.ts
@@ -19,10 +19,7 @@ import {
     createMemoizedSelectorWithAccounts,
 } from '../reducers';
 import { getReceiveAccountFromAccountAndAddressString } from '../utils/general/receiveAccountUtils';
-import {
-    coinInfoToTradeableAsset,
-    tradeableAssetSortingComparator,
-} from '../utils/general/tradeableAssetUtils';
+import { coinInfoToTradeableAsset } from '../utils/general/tradeableAssetUtils';
 
 export type TradingWithFeatureFlagsRootState = TradingRootState & FeatureFlagsRootState;
 
@@ -57,7 +54,7 @@ export const selectExchangeSelectedReceiveAccount = createMemoizedSelectorWithAc
     },
 );
 
-export const selectExchangeBuyTradeableAssetsSorted = createMemoizedSelector(
+export const selectExchangeBuyTradeableAssets = createMemoizedSelector(
     [
         selectTradingExchangeBuyCryptoIds as unknown as (
             state: TradingRootState,
@@ -69,9 +66,7 @@ export const selectExchangeBuyTradeableAssetsSorted = createMemoizedSelector(
             return [];
         }
 
-        return cryptoIds
-            .map(cryptoId => coinInfoToTradeableAsset(cryptoId, coins[cryptoId]))
-            .sort(tradeableAssetSortingComparator);
+        return cryptoIds.map(cryptoId => coinInfoToTradeableAsset(cryptoId, coins[cryptoId]));
     },
 );
 

--- a/suite-native/module-trading/src/utils/general/__tests__/tradeableAssetUtils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/tradeableAssetUtils.test.ts
@@ -1,17 +1,8 @@
 import type { CoinInfo, CryptoId } from 'invity-api';
 
 import coins from '../../../__fixtures__/coins.json';
-import {
-    btcAsset,
-    ethAsset,
-    ethOnBaseAsset,
-    usdcAsset,
-} from '../../../__fixtures__/tradeableAssets';
-import {
-    coinInfoToTradeableAsset,
-    getSymbolFromTradeableAsset,
-    tradeableAssetSortingComparator,
-} from '../tradeableAssetUtils';
+import { btcAsset, usdcAsset } from '../../../__fixtures__/tradeableAssets';
+import { coinInfoToTradeableAsset, getSymbolFromTradeableAsset } from '../tradeableAssetUtils';
 
 describe('tradeableAssetUtils', () => {
     describe('coinInfoToTradeableAsset', () => {
@@ -59,23 +50,6 @@ describe('tradeableAssetUtils', () => {
             [usdcAsset, 'eth'],
         ])('should return symbol based on asset.cryptoId', (asset, expectedSymbol) => {
             expect(getSymbolFromTradeableAsset(asset)).toEqual(expectedSymbol);
-        });
-    });
-
-    describe('tradeableAssetSortingComparator', () => {
-        it('should sort assets', () => {
-            const assets = [btcAsset, ethAsset, usdcAsset, ethOnBaseAsset];
-
-            expect(assets.sort(tradeableAssetSortingComparator)).toEqual([
-                expect.objectContaining({ cryptoId: 'bitcoin' }),
-                expect.objectContaining({ cryptoId: 'ethereum' }),
-                expect.objectContaining({
-                    cryptoId: 'base--0x0000000000000000000000000000000000000000',
-                }),
-                expect.objectContaining({
-                    cryptoId: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-                }),
-            ]);
         });
     });
 });

--- a/suite-native/module-trading/src/utils/general/tradeableAssetUtils.ts
+++ b/suite-native/module-trading/src/utils/general/tradeableAssetUtils.ts
@@ -6,26 +6,6 @@ import { TokenAddress } from '@suite-common/wallet-types';
 
 import { TradeableAsset } from '../../types/general';
 
-const FAVOURITE_NETWORKS_PRIORITY_ORDER = ['bitcoin', 'ethereum', 'litecoin', 'cardano', 'solana'];
-
-const getNonFavouritePriority = ({ contractAddress }: TradeableAsset) =>
-    FAVOURITE_NETWORKS_PRIORITY_ORDER.length + (contractAddress ? 1 : 0);
-
-export const tradeableAssetSortingComparator = (a: TradeableAsset, b: TradeableAsset) => {
-    let indexA = FAVOURITE_NETWORKS_PRIORITY_ORDER.indexOf(a.cryptoId);
-    let indexB = FAVOURITE_NETWORKS_PRIORITY_ORDER.indexOf(b.cryptoId);
-
-    if (indexA === -1) {
-        indexA = getNonFavouritePriority(a);
-    }
-
-    if (indexB === -1) {
-        indexB = getNonFavouritePriority(b);
-    }
-
-    return indexA - indexB;
-};
-
 export const coinInfoToTradeableAsset = (
     cryptoId: CryptoId,
     coinInfo: CoinInfo,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes sorting of assets and keeps order returned from backend.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #22810

## Screenshots:
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2025-11-03 at 13 05 01" src="https://github.com/user-attachments/assets/6ea403f8-53b5-499c-8eb7-2af2c0e724ad" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22810-mobile-trade-remove-sorting-of-tradable-assets&lookback=7)