### PR TITLE
Don't show staking dashboard on bitcoin-only fw

### DIFF
--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboard.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboard.tsx
@@ -52,6 +52,15 @@ export const StakingDashboard = () => {
     const isSolStakingDisabled = !!solStakingMessageSystem.isStakingDisabled;
 
     const accounts = useSelector(selectVisibleDeviceAccounts);
+
+    if (!accounts.some(account => account.networkType !== 'bitcoin')) {
+        return null;
+    }
+
+    if (isEthStakingDisabled && isSolStakingDisabled) {
+        return null;
+    }
+
     const stakingAccounts = accounts.filter(
         account =>
             (account.symbol === 'eth' && !isEthStakingDisabled) ||
@@ -135,10 +144,6 @@ export const StakingDashboard = () => {
     const onCollapseChange = (collapsed: boolean) => {
         dispatch(setStakingDashboardCollapsed(collapsed));
     };
-
-    if (isEthStakingDisabled && isSolStakingDisabled) {
-        return null;
-    }
 
     return (
         <DashboardSection

--- a/packages/suite/src/views/dashboard/index.tsx
+++ b/packages/suite/src/views/dashboard/index.tsx
@@ -1,14 +1,12 @@
 import styled from 'styled-components';
 
 import { Context } from '@suite-common/message-system';
-import { getNetworkType } from '@suite-common/wallet-config';
-import { selectEnabledNetworks } from '@suite-common/wallet-core';
 import { Column } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
 
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
-import { useLayout, useSelector } from 'src/hooks/suite';
+import { useLayout } from 'src/hooks/suite';
 
 import { AssetsView } from './AssetsView/AssetsView';
 import { DashboardFooter } from './DashboardFooter';
@@ -27,11 +25,6 @@ export const Dashboard = () => {
     useLayout('Home', <PageHeader />);
     useNotificationForDisconnectedDevice();
 
-    const enabledNetworks = useSelector(selectEnabledNetworks);
-    const hasNonBitcoinNetwork = enabledNetworks
-        .map(getNetworkType)
-        .some(networkType => networkType !== 'bitcoin');
-
     return (
         <Column gap={spacings.xxxxl} data-testid="@dashboard/index">
             <Container>
@@ -40,7 +33,7 @@ export const Dashboard = () => {
             </Container>
             <DashboardPromoBanner />
             <AssetsView />
-            {hasNonBitcoinNetwork && <StakingDashboard />}
+            <StakingDashboard />
             <DashboardFooter />
         </Column>
     );


### PR DESCRIPTION
## Description

When condition for displaying staking dashboard was changed so it's shown only when there's any non-bitcoin-like network enabled, it didn't take into account that it will be shown for bitcoin-only devices as well, as they don't change enabled networks.

Now it's shown when there's any non-bitcoin-like account visible for given device, which should cover both enabled networks and firmware type. 

## Notes for QA

Please check that staking dashboard is:
- visible when there's any non-bitcoin-like network enabled
- hidden when there are only bitcoin-like networks enabled
- hidden in any case with bitcoin-only device

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/no-bitcoin-staking&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/no-bitcoin-staking&lookback=7)