### PR TITLE
fix(suite-native): scan for Bluetooth devices only when the app is active

### DIFF
--- a/suite-native/bluetooth/src/hooks/useBluetoothAdapter.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothAdapter.ts
@@ -20,6 +20,7 @@ import {
 import { useBluetoothAlerts } from './useBluetoothAlerts';
 import { useBluetoothDevice } from './useBluetoothDevice';
 import { useBluetoothPermissions } from './useBluetoothPermissions';
+import { useBluetoothScanner } from './useBluetoothScanner';
 
 const toBluetoothDevice = (device: TransportBluetoothDevice) => ({
     ...device,
@@ -34,6 +35,7 @@ export const useBluetoothAdapter = () => {
 
     const { checkBluetoothPermission } = useBluetoothPermissions();
     const { showPairingFailedAlert } = useBluetoothAlerts();
+    const { startDeviceScan } = useBluetoothScanner();
     const { connectBluetoothDevice } = useBluetoothDevice();
 
     const bluetoothPermissionStatus = useSelector(selectBluetoothPermissionStatus);
@@ -98,22 +100,9 @@ export const useBluetoothAdapter = () => {
 
     useEffect(() => {
         if (bluetoothAdapterStatus === 'enabled' && knownBluetoothDevices.length > 0) {
-            bluetoothManager.startDeviceScan();
-
-            const subscription = AppState.addEventListener('change', nextAppState => {
-                if (nextAppState === 'active') {
-                    bluetoothManager.startDeviceScan();
-                } else {
-                    bluetoothManager.stopDeviceScan();
-                }
-            });
-
-            return () => {
-                subscription.remove();
-                bluetoothManager.stopDeviceScan();
-            };
+            return startDeviceScan();
         }
-    }, [bluetoothAdapterStatus, knownBluetoothDevices]);
+    }, [bluetoothAdapterStatus, knownBluetoothDevices, startDeviceScan]);
 
     useEffect(() => {
         knownConnectableBluetoothDevices.forEach(connectBluetoothDevice);

--- a/suite-native/bluetooth/src/hooks/useBluetoothManager.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothManager.ts
@@ -2,15 +2,17 @@ import { useCallback, useEffect, useState } from 'react';
 import { AppState } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import { BleError, BleErrorCode, bluetoothManager } from '@trezor/transport-native-bluetooth';
+import { BleError, BleErrorCode } from '@trezor/transport-native-bluetooth';
 
 import { selectBluetoothAdapterStatus, selectBluetoothPermissionStatus } from '../selectors';
 import { useBluetoothAlerts } from './useBluetoothAlerts';
 import { useBluetoothPermissions } from './useBluetoothPermissions';
+import { useBluetoothScanner } from './useBluetoothScanner';
 
 export const useBluetoothManager = () => {
     const { requestBluetoothPermission } = useBluetoothPermissions();
     const { showOrHideBluetoothAlert, showLocationServicesDisabledAlert } = useBluetoothAlerts();
+    const { startDeviceScan } = useBluetoothScanner();
 
     const bluetoothPermissionStatus = useSelector(selectBluetoothPermissionStatus);
     const bluetoothAdapterStatus = useSelector(selectBluetoothAdapterStatus);
@@ -56,11 +58,7 @@ export const useBluetoothManager = () => {
 
     useEffect(() => {
         if (bluetoothAdapterStatus === 'enabled') {
-            bluetoothManager.startDeviceScan(scanErrorHandler);
-
-            return () => {
-                bluetoothManager.stopDeviceScan();
-            };
+            return startDeviceScan(scanErrorHandler);
         }
-    }, [bluetoothAdapterStatus, scanErrorHandler]);
+    }, [bluetoothAdapterStatus, startDeviceScan, scanErrorHandler]);
 };

--- a/suite-native/bluetooth/src/hooks/useBluetoothScanner.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothScanner.ts
@@ -1,0 +1,25 @@
+import { useCallback } from 'react';
+import { AppState } from 'react-native';
+
+import { BleError, bluetoothManager } from '@trezor/transport-native-bluetooth';
+
+export const useBluetoothScanner = () => {
+    const startDeviceScan = useCallback((errorHandler?: (error: BleError) => void) => {
+        bluetoothManager.startDeviceScan(errorHandler);
+
+        const subscription = AppState.addEventListener('change', nextAppState => {
+            if (nextAppState === 'active') {
+                bluetoothManager.startDeviceScan(errorHandler);
+            } else {
+                bluetoothManager.stopDeviceScan();
+            }
+        });
+
+        return () => {
+            subscription.remove();
+            bluetoothManager.stopDeviceScan();
+        };
+    }, []);
+
+    return { startDeviceScan };
+};


### PR DESCRIPTION
Resolve #22844.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/use-bluetooth-manager&lookback=7)