### PR TITLE
Feat/22773 ada update provider banner analytics

### DIFF
--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -1,3 +1,4 @@
+import { StakingFlow } from '@suite-common/suite-types/src/staking';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     ComposeActionContext,
@@ -71,7 +72,14 @@ export const cancelSignTx = (isSuccessTx?: boolean) => (dispatch: Dispatch, getS
 
     const { stakeType } = precomposedForm ?? {};
     if (stakeType && !isSuccessTx) {
-        dispatch(openModal({ type: stakeType }));
+        switch (stakeType) {
+            case 'stake':
+                dispatch(openModal({ type: stakeType, flow: StakingFlow.Stake }));
+                break;
+
+            default:
+                dispatch(openModal({ type: stakeType }));
+        }
     }
 };
 
@@ -250,7 +258,14 @@ export const signTransaction =
 
             const { stakeType } = formValues;
             if (stakeType) {
-                dispatch(openModal({ type: stakeType }));
+                switch (stakeType) {
+                    case 'stake':
+                        dispatch(openModal({ type: stakeType, flow: StakingFlow.Stake }));
+                        break;
+
+                    default:
+                        dispatch(openModal({ type: stakeType }));
+                }
             }
 
             return;

--- a/packages/suite/src/components/suite/StakingProcess/StakingInfo.tsx
+++ b/packages/suite/src/components/suite/StakingProcess/StakingInfo.tsx
@@ -1,6 +1,7 @@
 import React, { JSX } from 'react';
 
 import { getDaysToAddToPoolInitial } from '@suite-common/staking';
+import { StakingFlow } from '@suite-common/suite-types/src/staking';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     CARDANO_ACTIVATION_PERIOD_DAYS,
@@ -13,7 +14,7 @@ import {
     selectPoolStatsApyData,
     selectValidatorsQueueData,
 } from '@suite-common/wallet-core';
-import { isCardanoUpdateProviderFlow, isStakingNetworkType } from '@suite-common/wallet-utils';
+import { isStakingNetworkType } from '@suite-common/wallet-utils';
 import { BulletList } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { exhaustive } from '@trezor/type-utils';
@@ -32,7 +33,11 @@ type InfoRowsData = {
     rewardsEarningHeading: JSX.Element;
 };
 
-const getInfoRowsData = (account: Account, daysToAddToPool?: number): InfoRowsData | null => {
+const getInfoRowsData = (
+    account: Account,
+    flow: StakingFlow,
+    daysToAddToPool?: number,
+): InfoRowsData | null => {
     const { networkType, symbol } = account;
 
     if (!isStakingNetworkType(networkType)) return null;
@@ -76,25 +81,26 @@ const getInfoRowsData = (account: Account, daysToAddToPool?: number): InfoRowsDa
             };
         case 'cardano':
             return {
-                payoutDays: isCardanoUpdateProviderFlow(account) ? (
-                    <Translation
-                        id="TR_STAKE_APPROXIMATE_EPOCHS"
-                        values={{
-                            count: CARDANO_APPROXIMATE_EPOCHS,
-                        }}
-                    />
-                ) : (
-                    <Translation
-                        id="TR_STAKE_APPROXIMATE_DAYS"
-                        values={{
-                            count: CARDANO_ACTIVATION_PERIOD_DAYS,
-                        }}
-                    />
-                ),
+                payoutDays:
+                    flow === StakingFlow.UpdateProvider ? (
+                        <Translation
+                            id="TR_STAKE_APPROXIMATE_EPOCHS"
+                            values={{
+                                count: CARDANO_APPROXIMATE_EPOCHS,
+                            }}
+                        />
+                    ) : (
+                        <Translation
+                            id="TR_STAKE_APPROXIMATE_DAYS"
+                            values={{
+                                count: CARDANO_ACTIVATION_PERIOD_DAYS,
+                            }}
+                        />
+                    ),
                 rewardsPeriodHeading: (
                     <Translation
                         id={
-                            isCardanoUpdateProviderFlow(account)
+                            flow === StakingFlow.UpdateProvider
                                 ? 'TR_STAKE_KEEP_EARNING_REWARDS_WITH_CURRENT_PROVIDER'
                                 : 'TR_STAKE_ENTER_ACTIVATION_PERIOD'
                         }
@@ -105,7 +111,7 @@ const getInfoRowsData = (account: Account, daysToAddToPool?: number): InfoRowsDa
                 rewardsEarningHeading: (
                     <Translation
                         id={
-                            isCardanoUpdateProviderFlow(account)
+                            flow === StakingFlow.UpdateProvider
                                 ? 'TR_STAKE_START_EARNING_FROM_NEW_PROVIDER'
                                 : 'TR_STAKE_EARN_REWARDS_EVERY'
                         }
@@ -120,9 +126,10 @@ const getInfoRowsData = (account: Account, daysToAddToPool?: number): InfoRowsDa
 
 interface StakingInfoProps {
     isExpanded?: boolean;
+    flow: StakingFlow;
 }
 
-export const StakingInfo = ({ isExpanded }: StakingInfoProps) => {
+export const StakingInfo = ({ isExpanded, flow }: StakingInfoProps) => {
     const { account } = useSelector((state: CoinjoinRootState) => state.wallet.selectedAccount);
 
     const validatorsQueue = useSelector(state => selectValidatorsQueueData(state, account?.symbol));
@@ -134,7 +141,7 @@ export const StakingInfo = ({ isExpanded }: StakingInfoProps) => {
     if (!account) return null;
 
     const daysToAddToPoolInitial = getDaysToAddToPoolInitial(validatorsQueue);
-    const infoRowsData = getInfoRowsData(account, daysToAddToPoolInitial);
+    const infoRowsData = getInfoRowsData(account, flow, daysToAddToPoolInitial);
 
     const infoRows = [
         {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/EverstakeModal/EverstakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/EverstakeModal/EverstakeModal.tsx
@@ -1,5 +1,6 @@
 import { JSX, useMemo, useState } from 'react';
 
+import { StakingFlow } from '@suite-common/suite-types/src/staking';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     selectAccountIsStakingActive,
@@ -7,11 +8,12 @@ import {
 } from '@suite-common/wallet-core';
 import { validateCardanoDrep } from '@suite-common/wallet-utils';
 import { Banner, Card, Checkbox, Column, IconName, Modal } from '@trezor/components';
-import { EventType, analytics } from '@trezor/suite-analytics';
+import { analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
 import { Translation } from 'src/components/suite/Translation';
+import { stakingFlowToEventTypeMap } from 'src/constants/suite/staking';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 
@@ -19,9 +21,10 @@ import { VotingDelegations } from './VotingDelegations';
 
 interface EverstakeModalProps {
     onCancel: () => void;
+    flow: StakingFlow;
 }
 
-export const EverstakeModal = ({ onCancel }: EverstakeModalProps) => {
+export const EverstakeModal = ({ onCancel, flow }: EverstakeModalProps) => {
     const dispatch = useDispatch();
     const [hasAgreed, setHasAgreed] = useState(false);
     const account = useSelector(selectSelectedAccount);
@@ -42,14 +45,15 @@ export const EverstakeModal = ({ onCancel }: EverstakeModalProps) => {
 
     const proceedToStaking = () => {
         onCancel();
-        dispatch(openModal({ type: 'stake' }));
+        dispatch(openModal({ type: 'stake', flow }));
 
         analytics.report({
-            type: EventType.StakingStake,
+            type: stakingFlowToEventTypeMap[flow],
             payload: {
                 action: 'continue',
                 step: 'funds-maintained-modal',
                 networkSymbol: account?.symbol,
+                votingDelegation: selectedVotingDelegation.type,
             },
         });
     };
@@ -58,11 +62,12 @@ export const EverstakeModal = ({ onCancel }: EverstakeModalProps) => {
         onCancel();
 
         analytics.report({
-            type: EventType.StakingStake,
+            type: stakingFlowToEventTypeMap[flow],
             payload: {
                 action: 'cancel',
                 step: 'funds-maintained-modal',
                 networkSymbol: account?.symbol,
+                votingDelegation: selectedVotingDelegation.type,
             },
         });
     };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeInANutshellModal/StakeInANutshellModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeInANutshellModal/StakeInANutshellModal.tsx
@@ -1,14 +1,12 @@
-import React from 'react';
-
 import { TranslationKey } from '@suite-common/intl-types';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { StakingFlow } from '@suite-common/suite-types/src/staking';
+import { NetworkType, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     StakeRootState,
     selectPoolStatsApyData,
     selectValidatorsQueueData,
 } from '@suite-common/wallet-core';
-import { Account } from '@suite-common/wallet-types';
-import { getUnstakingPeriodInDays, isCardanoUpdateProviderFlow } from '@suite-common/wallet-utils';
+import { getUnstakingPeriodInDays } from '@suite-common/wallet-utils';
 import {
     Badge,
     CollapsibleBox,
@@ -22,13 +20,14 @@ import {
     Row,
     Text,
 } from '@trezor/components';
-import { EventType, analytics } from '@trezor/suite-analytics';
+import { analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
 import { StakingInfo } from 'src/components/suite/StakingProcess/StakingInfo';
 import { UnstakingInfo } from 'src/components/suite/StakingProcess/UnstakingInfo';
 import { Translation } from 'src/components/suite/Translation';
+import { stakingFlowToEventTypeMap } from 'src/constants/suite/staking';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 
@@ -38,10 +37,8 @@ interface StakingDetails {
     translationId: TranslationKey;
 }
 
-const getStakingDetails = (account: Account): StakingDetails[] => {
-    const { networkType } = account;
-
-    if (isCardanoUpdateProviderFlow(account))
+const getStakingDetails = (flow: StakingFlow, networkType: NetworkType): StakingDetails[] => {
+    if (flow === StakingFlow.UpdateProvider)
         return [
             {
                 id: 0,
@@ -103,9 +100,10 @@ const getStakingDetails = (account: Account): StakingDetails[] => {
 
 interface StakeInANutshellModalProps {
     onCancel: () => void;
+    flow: StakingFlow;
 }
 
-export const StakeInANutshellModal = ({ onCancel }: StakeInANutshellModalProps) => {
+export const StakeInANutshellModal = ({ onCancel, flow }: StakeInANutshellModalProps) => {
     const account = useSelector(selectSelectedAccount);
     const dispatch = useDispatch();
     const { validatorWithdrawTime, validatorExitTime } = useSelector(state =>
@@ -125,10 +123,10 @@ export const StakeInANutshellModal = ({ onCancel }: StakeInANutshellModalProps) 
 
     const proceedToEverstakeModal = () => {
         onCancel();
-        dispatch(openModal({ type: 'everstake' }));
+        dispatch(openModal({ type: 'everstake', flow }));
 
         analytics.report({
-            type: EventType.StakingStake,
+            type: stakingFlowToEventTypeMap[flow],
             payload: {
                 action: 'continue',
                 step: 'stake-in-a-nutshell-modal',
@@ -141,7 +139,7 @@ export const StakeInANutshellModal = ({ onCancel }: StakeInANutshellModalProps) 
         onCancel();
 
         analytics.report({
-            type: EventType.StakingStake,
+            type: stakingFlowToEventTypeMap[flow],
             payload: {
                 action: 'cancel',
                 step: 'stake-in-a-nutshell-modal',
@@ -155,14 +153,14 @@ export const StakeInANutshellModal = ({ onCancel }: StakeInANutshellModalProps) 
             heading: (
                 <Translation
                     id={
-                        isCardanoUpdateProviderFlow(account)
+                        flow === StakingFlow.UpdateProvider
                             ? 'TR_STAKE_PROVIDER_UPDATE'
                             : 'TR_STAKE_STAKING_PROCESS'
                     }
                 />
             ),
             badge: <Translation id="TR_TX_FEE" />,
-            content: <StakingInfo />,
+            content: <StakingInfo flow={flow} />,
         },
         {
             heading: <Translation id="TR_STAKE_UNSTAKING_PROCESS" />,
@@ -200,7 +198,7 @@ export const StakeInANutshellModal = ({ onCancel }: StakeInANutshellModalProps) 
                 typographyStyle="hint"
                 margin={{ top: spacings.xs }}
             >
-                {getStakingDetails(account).map(({ id, icon, translationId }) => (
+                {getStakingDetails(flow, account.networkType).map(({ id, icon, translationId }) => (
                     <List.Item key={id} bulletComponent={<Icon name={icon} variant="primary" />}>
                         <Paragraph variant="tertiary">
                             <Translation

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/ConfirmStakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/ConfirmStakeModal.tsx
@@ -7,7 +7,11 @@ import { selectValidatorsQueueData } from '@suite-common/wallet-core';
 import { Banner, Card, Checkbox, Column, Modal } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
-import { HELP_CENTER_ETH_STAKING, HELP_CENTER_SOL_STAKING } from '@trezor/urls';
+import {
+    HELP_CENTER_ADA_STAKING,
+    HELP_CENTER_ETH_STAKING,
+    HELP_CENTER_SOL_STAKING,
+} from '@trezor/urls';
 
 import { openModal } from 'src/actions/suite/modalActions';
 import { Translation } from 'src/components/suite/Translation';
@@ -39,7 +43,7 @@ export const ConfirmStakeModal = ({ isLoading, onConfirm, onCancel }: ConfirmSta
 
     const handleOnCancel = () => {
         onCancel();
-        dispatch(openModal({ type: 'stake' }));
+        dispatch(openModal({ type: 'stake', flow: EventType.StakingStake }));
 
         analytics.report({
             type: EventType.StakingStake,
@@ -70,6 +74,8 @@ export const ConfirmStakeModal = ({ isLoading, onConfirm, onCancel }: ConfirmSta
                 return HELP_CENTER_ETH_STAKING;
             case 'solana':
                 return HELP_CENTER_SOL_STAKING;
+            case 'cardano':
+                return HELP_CENTER_ADA_STAKING;
             default:
                 return undefined;
         }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/ConfirmStakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/ConfirmStakeModal.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from 'react';
 
 import { getDaysToAddToPoolInitial } from '@suite-common/staking';
+import { StakingFlow } from '@suite-common/suite-types/src/staking';
 import { type NetworkType, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
 import { selectValidatorsQueueData } from '@suite-common/wallet-core';
 import { Banner, Card, Checkbox, Column, Modal } from '@trezor/components';
-import { EventType, analytics } from '@trezor/suite-analytics';
+import { analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 import {
     HELP_CENTER_ADA_STAKING,
@@ -15,6 +16,7 @@ import {
 
 import { openModal } from 'src/actions/suite/modalActions';
 import { Translation } from 'src/components/suite/Translation';
+import { stakingFlowToEventTypeMap } from 'src/constants/suite/staking';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 
@@ -28,9 +30,15 @@ interface ConfirmStakeModalProps {
     isLoading: boolean;
     onConfirm: () => void;
     onCancel: () => void;
+    flow: StakingFlow;
 }
 
-export const ConfirmStakeModal = ({ isLoading, onConfirm, onCancel }: ConfirmStakeModalProps) => {
+export const ConfirmStakeModal = ({
+    isLoading,
+    onConfirm,
+    onCancel,
+    flow,
+}: ConfirmStakeModalProps) => {
     const dispatch = useDispatch();
     const [hasAgreed, setHasAgreed] = useState(false);
     const account = useSelector(selectSelectedAccount);
@@ -43,10 +51,10 @@ export const ConfirmStakeModal = ({ isLoading, onConfirm, onCancel }: ConfirmSta
 
     const handleOnCancel = () => {
         onCancel();
-        dispatch(openModal({ type: 'stake', flow: EventType.StakingStake }));
+        dispatch(openModal({ type: 'stake', flow }));
 
         analytics.report({
-            type: EventType.StakingStake,
+            type: stakingFlowToEventTypeMap[flow],
             payload: {
                 action: 'cancel',
                 step: 'entry-period-stake-modal',
@@ -59,7 +67,7 @@ export const ConfirmStakeModal = ({ isLoading, onConfirm, onCancel }: ConfirmSta
         onConfirm();
 
         analytics.report({
-            type: EventType.StakingStake,
+            type: stakingFlowToEventTypeMap[flow],
             payload: {
                 action: 'continue',
                 step: 'entry-period-stake-modal',

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeButton.tsx
@@ -1,15 +1,21 @@
+import { StakingFlow } from '@suite-common/suite-types/src/staking';
 import { selectAreFeesLoading, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Modal, Tooltip } from '@trezor/components';
-import { EventType, analytics } from '@trezor/suite-analytics';
+import { analytics } from '@trezor/suite-analytics';
 
 import { Translation } from 'src/components/suite/Translation';
+import { stakingFlowToEventTypeMap } from 'src/constants/suite/staking';
 import { useDevice, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import { useStakeFormContext } from 'src/hooks/wallet/useStakeForm';
 import { CRYPTO_INPUT, FIAT_INPUT } from 'src/types/wallet/stakeForms';
 
-export const StakeButton = () => {
+interface StakeButtonProps {
+    flow: StakingFlow;
+}
+
+export const StakeButton = ({ flow }: StakeButtonProps) => {
     const { device, isLocked } = useDevice();
     const selectedAccount = useSelector(
         state => state.wallet.selectedAccount,
@@ -50,7 +56,7 @@ export const StakeButton = () => {
         }
 
         analytics.report({
-            type: EventType.StakingStake,
+            type: stakingFlowToEventTypeMap[flow],
             payload: {
                 action: 'continue',
                 step: 'stake-form-modal',

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeForm.tsx
@@ -1,5 +1,6 @@
 import { FormProvider } from 'react-hook-form';
 
+import { StakingFlow } from '@suite-common/suite-types/src/staking';
 import { Card, Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -12,7 +13,11 @@ import { StakeAvailableBalance } from './StakeAvailableBalance';
 import { StakeInputs } from './StakeInputs';
 import { StakeRegistrationDepositCard } from './StakeRegistrationDepositCard';
 
-export const StakeForm = () => {
+interface StakeFormProps {
+    flow: StakingFlow;
+}
+
+export const StakeForm = ({ flow }: StakeFormProps) => {
     const {
         account,
         isConfirmModalOpen,
@@ -37,6 +42,7 @@ export const StakeForm = () => {
                     isLoading={isLoading}
                     onConfirm={signTx}
                     onCancel={closeConfirmModal}
+                    flow={flow}
                 />
             )}
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeInfoCards/StakeInfoCards.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeInfoCards/StakeInfoCards.tsx
@@ -1,3 +1,4 @@
+import { StakingFlow } from '@suite-common/suite-types/src/staking';
 import { CollapsibleBox, Column, H3 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -6,11 +7,15 @@ import { Translation } from 'src/components/suite/Translation';
 
 import { EstimatedGains } from './EstimatedGains';
 
-export const StakeInfoCards = () => {
+interface StakeInfoCardsProps {
+    flow: StakingFlow;
+}
+
+export const StakeInfoCards = ({ flow }: StakeInfoCardsProps) => {
     const cards = [
         {
             heading: <Translation id="TR_STAKING_ONCE_YOU_CONFIRM" />,
-            content: <StakingInfo isExpanded />,
+            content: <StakingInfo isExpanded flow={flow} />,
             defaultIsOpen: true,
         },
         {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
@@ -1,11 +1,13 @@
+import { StakingFlow } from '@suite-common/suite-types/src/staking';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { selectAccountIsStakingActive } from '@suite-common/wallet-core';
 import { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Grid, Modal } from '@trezor/components';
-import { EventType, analytics } from '@trezor/suite-analytics';
+import { analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite/Translation';
+import { stakingFlowToEventTypeMap } from 'src/constants/suite/staking';
 import { useLayoutSize, useSelector } from 'src/hooks/suite';
 import { StakeFormContext, useStakeForm } from 'src/hooks/wallet/useStakeForm';
 
@@ -16,9 +18,10 @@ import { StakeInfoCards } from './StakeInfoCards/StakeInfoCards';
 interface StakeModalModalProps {
     onCancel?: () => void;
     selectedAccount: SelectedAccountLoaded;
+    flow: StakingFlow;
 }
 
-export const StakeModalLoaded = ({ onCancel, selectedAccount }: StakeModalModalProps) => {
+export const StakeModalLoaded = ({ onCancel, selectedAccount, flow }: StakeModalModalProps) => {
     const { account } = selectedAccount;
 
     const stakeContextValues = useStakeForm({ selectedAccount });
@@ -31,7 +34,7 @@ export const StakeModalLoaded = ({ onCancel, selectedAccount }: StakeModalModalP
         onCancel?.();
 
         analytics.report({
-            type: EventType.StakingStake,
+            type: stakingFlowToEventTypeMap[flow],
             payload: {
                 action: 'cancel',
                 step: 'stake-form-modal',
@@ -59,18 +62,18 @@ export const StakeModalLoaded = ({ onCancel, selectedAccount }: StakeModalModalP
                     />
                 }
                 onCancel={onCancelClick}
-                bottomContent={<StakeButton />}
+                bottomContent={<StakeButton flow={flow} />}
             >
                 <Grid columns={isBelowTablet ? 1 : 2} gap={spacings.xxl}>
-                    <StakeForm />
-                    <StakeInfoCards />
+                    <StakeForm flow={flow} />
+                    <StakeInfoCards flow={flow} />
                 </Grid>
             </Modal>
         </StakeFormContext.Provider>
     );
 };
 
-export const StakeModal = ({ onCancel }: Pick<StakeModalModalProps, 'onCancel'>) => {
+export const StakeModal = ({ onCancel, flow }: Pick<StakeModalModalProps, 'onCancel' | 'flow'>) => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
 
     if (selectedAccount.status !== 'loaded' || !selectedAccount.account) {
@@ -83,6 +86,7 @@ export const StakeModal = ({ onCancel }: Pick<StakeModalModalProps, 'onCancel'>)
         <StakeModalLoaded
             onCancel={onCancel}
             selectedAccount={selectedAccount as SelectedAccountLoaded}
+            flow={flow}
         />
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -11,7 +11,11 @@ import type { AcquiredDevice } from 'src/types/suite';
 import { CardanoWithdrawModal } from '../CardanoWithdrawModal';
 import { ConfirmAddressModal } from '../ConfirmAddressModal';
 import { ConfirmXpubModal } from '../ConfirmXpubModal';
+import { CopyAddressModal } from '../CopyAddressModal';
+import { PinInvalidModal } from '../DeviceContextModal/PinInvalidModal';
 import type { ReduxModalProps } from '../ReduxModal';
+import { TransactionReviewModal } from '../TransactionReviewModal/TransactionReviewModal';
+import { UnhideTokenModal } from '../UnhideTokenModal';
 import { AddAccountModal } from './AddAccountModal/AddAccountModal';
 import { AddTokenModal } from './AddTokenModal';
 import { AdvancedCoinSettingsModal } from './AdvancedCoinSettingsModal/AdvancedCoinSettingsModal';
@@ -19,7 +23,6 @@ import { ApplicationLogModal } from './ApplicationLogModal';
 import { AutoStartBeforeQuitModal } from './AutoStartBeforeQuitModal';
 import { BackgroundGalleryModal } from './BackgroundGalleryModal';
 import { CancelCoinjoinModal } from './CancelCoinjoinModal';
-import { UnhideTokenModal } from '../UnhideTokenModal';
 import { ClaimModal } from './ClaimModal/ClaimModal';
 import { CoinjoinSuccessModal } from './CoinjoinSuccessModal';
 import { ConfirmUnverifiedAddressModal } from './ConfirmUnverifiedAddressModal';
@@ -29,7 +32,6 @@ import { ConnectAddressConfirmation } from './ConnectAddressConfirmation';
 import { ConnectErrorModal } from './ConnectErrorModal';
 import { ConnectLoadingModal } from './ConnectLoadingModal';
 import { ConnectPermissionsModal } from './ConnectPermissionsModal';
-import { CopyAddressModal } from '../CopyAddressModal';
 import { CriticalCoinjoinPhaseModal } from './CriticalCoinjoinPhaseModal/CriticalCoinjoinPhaseModal';
 import { DeviceAuthenticityOptOutModal } from './DeviceAuthenticityOptOutModal';
 import { DisableTorModal } from './DisableTorModal';
@@ -51,11 +53,9 @@ import { TradingTermsModal } from './TradingTermsModal';
 import { TxDetailModal } from './TxDetailModal/TxDetailModal';
 import { TxSimulationModal } from './TxSimulationModal';
 import { UnecoCoinjoinModal } from './UnecoCoinjoinModal';
+import { UnstakeModal } from './UnstakeModal/UnstakeModal';
 import { WalletConnectProposalModal } from './WalletConnectProposalModal';
 import { WalletConnectSwitchAccountModal } from './WalletConnectSwitchAccountModal';
-import { PinInvalidModal } from '../DeviceContextModal/PinInvalidModal';
-import { TransactionReviewModal } from '../TransactionReviewModal/TransactionReviewModal';
-import { UnstakeModal } from './UnstakeModal/UnstakeModal';
 
 /** Modals opened as a result of user action */
 export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL.CONTEXT_USER>) => {
@@ -186,15 +186,15 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL.CONTE
         case 'uneco-coinjoin-warning':
             return <UnecoCoinjoinModal />;
         case 'stake-in-a-nutshell':
-            return <StakeInANutshellModal onCancel={onCancel} />;
+            return <StakeInANutshellModal onCancel={onCancel} flow={payload.flow} />;
         case 'stake':
-            return <StakeModal onCancel={onCancel} />;
+            return <StakeModal onCancel={onCancel} flow={payload.flow} />;
         case 'unstake':
             return <UnstakeModal onCancel={onCancel} />;
         case 'claim':
             return <ClaimModal onCancel={onCancel} />;
         case 'everstake':
-            return <EverstakeModal onCancel={onCancel} />;
+            return <EverstakeModal onCancel={onCancel} flow={payload.flow} />;
         case 'copy-address':
             return (
                 <CopyAddressModal

--- a/packages/suite/src/constants/suite/staking.ts
+++ b/packages/suite/src/constants/suite/staking.ts
@@ -1,0 +1,7 @@
+import { StakingFlow } from '@suite-common/suite-types/src/staking';
+import { EventType } from '@trezor/suite-analytics';
+
+export const stakingFlowToEventTypeMap = {
+    [StakingFlow.Stake]: EventType.StakingStake,
+    [StakingFlow.UpdateProvider]: EventType.StakingUpdateProvider,
+} as const satisfies Record<StakingFlow, EventType>;

--- a/packages/suite/src/reducers/suite/modalReducer.ts
+++ b/packages/suite/src/reducers/suite/modalReducer.ts
@@ -16,7 +16,7 @@ import type { Action, TrezorDevice } from 'src/types/suite';
 
 export type State = ModalState & { preserve?: boolean };
 
-type ModalState =
+export type ModalState =
     | { context: typeof MODAL.CONTEXT_NONE }
     | {
           context: typeof MODAL.CONTEXT_DEVICE;

--- a/packages/suite/src/views/wallet/staking/components/CardanoNewProviderCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/CardanoNewProviderCard.tsx
@@ -21,8 +21,15 @@ export function CardanoNewProviderCard({ account }: CardanoNewProviderCardProps)
         selectIsFeatureEnabled(state, Feature.banners.staking.ada.newProvider, true),
     );
     const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const isCardanoNetworkType = account?.networkType === 'cardano';
 
-    if (isStakedWithEverstake || hasPendingTx || !isNewProviderBannerEnabled || !isStakingActive) {
+    if (
+        isStakedWithEverstake ||
+        hasPendingTx ||
+        !isNewProviderBannerEnabled ||
+        !isCardanoNetworkType ||
+        !isStakingActive
+    ) {
         return null;
     }
 

--- a/packages/suite/src/views/wallet/staking/components/CardanoStakingDashboard/NewCardanoStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/CardanoStakingDashboard/NewCardanoStakingDashboard.tsx
@@ -8,7 +8,7 @@ import {
     selectPoolStatsApyData,
 } from '@suite-common/wallet-core';
 import { SelectedAccountLoaded } from '@suite-common/wallet-types';
-import { getStakingDataForNetwork, isCardanoUpdateProviderFlow } from '@suite-common/wallet-utils';
+import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
 import { Column, Flex, Grid } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -76,13 +76,7 @@ export const NewCardanoStakingDashboard = ({
                                 >
                                     <ClaimCard />
                                     <Flex direction={canClaim ? 'column' : 'row'} gap={spacings.sm}>
-                                        <ApyCard
-                                            apy={
-                                                !isCardanoUpdateProviderFlow(account)
-                                                    ? apy
-                                                    : undefined
-                                            }
-                                        />
+                                        <ApyCard apy={apy} />
                                         <PayoutCard
                                             nextRewardPayout={CARDANO_EPOCH_DAYS}
                                             daysToAddToPool={CARDANO_EPOCH_DAYS}

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { useFormatters } from '@suite-common/formatters';
 import { Context } from '@suite-common/message-system';
+import { StakingFlow } from '@suite-common/suite-types/src/staking';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { selectHasRunningDiscovery, selectPoolStatsApyData } from '@suite-common/wallet-core';
 import {
@@ -127,7 +128,7 @@ export const EmptyStakingCard = () => {
 
     const openStakeInANutshellModal = () => {
         if (!isStakingDisabled) {
-            dispatch(openModal({ type: 'stake-in-a-nutshell' }));
+            dispatch(openModal({ type: 'stake-in-a-nutshell', flow: StakingFlow.Stake }));
 
             analytics.report({
                 type: EventType.StakingStake,

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx
@@ -1,3 +1,4 @@
+import { StakingFlow } from '@suite-common/suite-types/src/staking';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { selectPoolStatsApyData } from '@suite-common/wallet-core';
 import { Card, Column, H3, Icon, NewButton, Paragraph, Row, Tooltip } from '@trezor/components';
@@ -22,10 +23,15 @@ export const NewProviderCard = () => {
 
     const openStakeInANutshellModal = () => {
         if (!isStakingDisabled) {
-            dispatch(openModal({ type: 'stake-in-a-nutshell' }));
+            dispatch(
+                openModal({
+                    type: 'stake-in-a-nutshell',
+                    flow: StakingFlow.UpdateProvider,
+                }),
+            );
 
             analytics.report({
-                type: EventType.StakingStake,
+                type: EventType.StakingUpdateProvider,
                 payload: {
                     action: 'continue',
                     step: 'staking-dashboard',

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
@@ -1,4 +1,5 @@
 import { getStakingTotalRewards } from '@suite-common/staking';
+import { StakingFlow } from '@suite-common/suite-types/src/staking';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     StakeRootState,
@@ -35,9 +36,9 @@ import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 
-import { ProgressLabels } from './ProgressLabels/ProgressLabels';
 import { useIsTxStatusShown } from '../hooks/useIsTxStatusShown';
 import { useProgressLabelsData } from '../hooks/useProgressLabelsData';
+import { ProgressLabels } from './ProgressLabels/ProgressLabels';
 
 type ItemProps = {
     label: React.ReactNode;
@@ -153,7 +154,7 @@ export const StakingCard = ({
 
     const openStakeModal = () => {
         if (!isStakingDisabled) {
-            dispatch(openModal({ type: 'stake' }));
+            dispatch(openModal({ type: 'stake', flow: StakingFlow.Stake }));
 
             analytics.report({
                 type: EventType.StakingStake,

--- a/suite-common/analytics/src/events/suite/constants.ts
+++ b/suite-common/analytics/src/events/suite/constants.ts
@@ -72,6 +72,7 @@ export enum EventType {
     StakingUnstake = 'staking/unstake',
     StakingClaim = 'staking/claim',
     StakingConfirm = 'staking/confirm',
+    StakingUpdateProvider = 'staking/update-provider',
 
     MenuGuide = 'menu/guide',
     MenuNotificationsToggle = 'menu/notifications/toggle',

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -455,6 +455,22 @@ export type SuiteAnalyticsEvent =
                   | 'entry-period-stake-modal';
               networkSymbol?: string;
               currency?: 'crypto' | 'fiat';
+              votingDelegation?: 'everstake' | 'another_drep';
+          };
+      }
+    | {
+          type: EventType.StakingUpdateProvider;
+          payload: {
+              action: 'continue' | 'cancel';
+              step:
+                  | 'staking-dashboard'
+                  | 'stake-in-a-nutshell-modal'
+                  | 'funds-maintained-modal'
+                  | 'stake-form-modal'
+                  | 'entry-period-stake-modal';
+              networkSymbol?: string;
+              currency?: 'crypto' | 'fiat';
+              votingDelegation?: 'everstake' | 'another_drep';
           };
       }
     | {

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -5,6 +5,7 @@ import { UI } from '@trezor/connect';
 import { Deferred } from '@trezor/utils';
 
 import { TrezorDevice } from './device';
+import { StakingFlow } from './staking';
 
 export type UserContextPayload =
     | {
@@ -156,9 +157,11 @@ export type UserContextPayload =
       }
     | {
           type: 'stake-in-a-nutshell';
+          flow: StakingFlow;
       }
     | {
           type: 'stake';
+          flow: StakingFlow;
       }
     | {
           type: 'unstake';
@@ -168,6 +171,7 @@ export type UserContextPayload =
       }
     | {
           type: 'everstake';
+          flow: StakingFlow;
       }
     | {
           type: 'copy-address';

--- a/suite-common/suite-types/src/staking.ts
+++ b/suite-common/suite-types/src/staking.ts
@@ -1,0 +1,4 @@
+export enum StakingFlow {
+    Stake = 'stake',
+    UpdateProvider = 'update-provider',
+}

--- a/suite-common/wallet-utils/src/cardanoStakingUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoStakingUtils.ts
@@ -27,14 +27,6 @@ export const isCardanoStakedWithEverstake = (account: Account) => {
     return account?.misc.staking.poolId === CARDANO_EVERSTAKE_STAKING_POOL.bech32;
 };
 
-export const isCardanoUpdateProviderFlow = (account?: Account) => {
-    if (!account || account.networkType !== 'cardano') return false;
-
-    const isStakeActive = account?.misc?.staking?.isActive;
-
-    return !isCardanoStakedWithEverstake(account) && isStakeActive;
-};
-
 export const isStakedWithFiveBinaries = (account?: Account, fiveBinariesPools?: PoolsResponse) => {
     if (account?.networkType !== 'cardano' || !fiveBinariesPools) return false;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

__Task changes__

* b433d7873a feat: implement staking/update-provider event
     - It's same as EventType.StakingStake but used while updating provider.
    - Add `votingDelegation` param to distinguish between Everstake and other DRep.
    
     The implementation required adding `flow: EventType.StakingStake | EventType.StakingUpdateProvider` type to modal payload to distinguish the event type since these modals are for both flows but need context to dispatch correct analytic event.

---

__Unrelated fixes__:

* ba0c292d4e fix(suite): add learn more link for ADA
* 25b47d89c5 fix(suite): display CardanoNewProviderCard only for ADA


## Related Issue

Resolve #22773

## Screenshots:

<img width="1003" height="292" alt="Snímek obrazovky 2025-11-03 v 15 15 40" src="https://github.com/user-attachments/assets/32ef9875-d9e2-464d-8b7d-f9e05c2b8981" />
<img width="708" height="312" alt="Snímek obrazovky 2025-11-03 v 15 16 06" src="https://github.com/user-attachments/assets/9f39b329-dc81-4822-b4e1-e3f507b778ee" />
<img width="499" height="285" alt="Snímek obrazovky 2025-11-03 v 15 20 59" src="https://github.com/user-attachments/assets/90a8957b-ccc4-4384-b88b-ef31c7f2fe54" />
<img width="488" height="259" alt="Snímek obrazovky 2025-11-03 v 15 21 17" src="https://github.com/user-attachments/assets/159a3a88-b340-4dda-a918-354b9dcc605f" />

<img width="569" height="434" alt="Snímek obrazovky 2025-11-03 v 15 34 04" src="https://github.com/user-attachments/assets/a5b8fdfe-b597-4dd9-903a-f9e7db82dd0c" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/22773-ada-update-provider-banner-analytics&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/22773-ada-update-provider-banner-analytics&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/22773-ada-update-provider-banner-analytics&lookback=7)