### PR TITLE
Evolu desktop persistency

### DIFF
--- a/packages/suite/src/actions/labeling/labelingSlice.ts
+++ b/packages/suite/src/actions/labeling/labelingSlice.ts
@@ -5,6 +5,10 @@ import {
 } from '@suite-common/local-first-storage';
 import { AnyAction, createSliceWithExtraDeps } from '@suite-common/redux-utils';
 
+import { Action } from 'src/types/suite';
+
+import { STORAGE } from '../suite/constants';
+
 export type DesktopLabelingState = LabelingState & {
     showEnableLocalFirstStorageModal: boolean;
 };
@@ -29,9 +33,20 @@ export const labelingSlice = createSliceWithExtraDeps({
     extraReducers: (builder, extra) => {
         const commonReducer = prepareLabelingReducer(extra);
 
-        builder.addDefaultCase((state, action) => {
-            commonReducer(state, action as AnyAction);
-        });
+        builder
+            .addCase(STORAGE.LOAD, (state, action) => {
+                const actionWithPayload = action as Action;
+
+                if (
+                    actionWithPayload.type === STORAGE.LOAD &&
+                    actionWithPayload.payload.labelingSettings
+                ) {
+                    return { ...state, ...actionWithPayload.payload.labelingSettings };
+                }
+            })
+            .addDefaultCase((state, action) => {
+                commonReducer(state, action as AnyAction);
+            });
     },
 });
 

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -454,6 +454,7 @@ const saveMetadata = async (metadata: Partial<Pick<MetadataState, MetadataPersis
 
 /**
  * save general metadata settings
+ * obsolete - will be replaced with labeling settings
  */
 export const saveMetadataSettings = () => async (_dispatch: Dispatch, getState: GetState) => {
     // for some strage race-condition reason it has to be awaited, so that the getState runs async
@@ -466,6 +467,24 @@ export const saveMetadataSettings = () => async (_dispatch: Dispatch, getState: 
         enabled: metadata.enabled,
         selectedProvider: metadata.selectedProvider,
     });
+};
+
+export const saveLabelingSettings = () => (_dispatch: Dispatch, getState: GetState) => {
+    if (!db.isAccessible()) return;
+
+    const { labeling } = getState();
+
+    return db.addItem(
+        'labelingSettings',
+        {
+            isFeatureLocalFirstStorageAvailable: labeling.isFeatureLocalFirstStorageAvailable,
+            isLocalFirstStorageEnabled: labeling.isLocalFirstStorageEnabled,
+            isLocalFirstStorageDebugEnabled: labeling.isLocalFirstStorageDebugEnabled,
+            localFirstStorageRelayUrl: labeling.localFirstStorageRelayUrl,
+        },
+        'labelingSettings',
+        true,
+    );
 };
 
 export const saveDeviceMetadataError =

--- a/packages/suite/src/hooks/suite/useLabelingCombined.ts
+++ b/packages/suite/src/hooks/suite/useLabelingCombined.ts
@@ -38,9 +38,9 @@ export const useLabelingCombined = ({ deviceStaticSessionId }: UseLabelingCombin
 
     const legacyMetadataState = useSelector(state => state.metadata);
 
-    const toggleisFeatureLocalFirstStorageAvailable = () => {
+    const toggleIsFeatureLocalFirstStorageAvailable = () => {
         dispatch(
-            labelingActions.updateisFeatureLocalFirstStorageAvailable({
+            labelingActions.updateIsFeatureLocalFirstStorageAvailable({
                 isShownInSettings: !isFeatureLocalFirstStorageAvailable,
             }),
         );
@@ -52,7 +52,7 @@ export const useLabelingCombined = ({ deviceStaticSessionId }: UseLabelingCombin
 
     const localFirstDisableIfNeeded = () => {
         if (isLocalFirstStorageEnabled) {
-            dispatch(labelingActions.updateLocaleFirstStorageEnabled({ isEnabled: false }));
+            dispatch(labelingActions.updateLocalFirstStorageEnabled({ isEnabled: false }));
             dispatch(disposeAllLocalFirstStorageThunk());
         }
     };
@@ -62,7 +62,7 @@ export const useLabelingCombined = ({ deviceStaticSessionId }: UseLabelingCombin
         if (legacyMetadataState.enabled) legacyDisableIfNeeded();
 
         if (!isLocalFirstStorageEnabled) {
-            dispatch(labelingActions.updateLocaleFirstStorageEnabled({ isEnabled: true }));
+            dispatch(labelingActions.updateLocalFirstStorageEnabled({ isEnabled: true }));
             dispatch(initSuiteLocalFirstStorageThunk());
         }
     };
@@ -81,7 +81,7 @@ export const useLabelingCombined = ({ deviceStaticSessionId }: UseLabelingCombin
     return {
         /** New Labeling: LocalFirstStorage (Evolu) */
         isFeatureLocalFirstStorageAvailable,
-        toggleisFeatureLocalFirstStorageAvailable,
+        toggleIsFeatureLocalFirstStorageAvailable,
         isLocalFirstStorageEnabled,
         isEvoluSupportedByDevice,
         isLocalFirstStorageDebugEnabled,

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -5,6 +5,7 @@ import { analyticsActions } from '@suite-common/analytics';
 import { bluetoothActions } from '@suite-common/bluetooth';
 import { connectPopupActions } from '@suite-common/connect-popup';
 import { firmwareActions } from '@suite-common/firmware';
+import { labelingActions } from '@suite-common/local-first-storage';
 import { messageSystemActions } from '@suite-common/message-system';
 import { isDeviceRemembered } from '@suite-common/suite-utils';
 import { thpActions } from '@suite-common/thp';
@@ -173,6 +174,17 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 )(action)
             ) {
                 api.dispatch(storageActions.saveAnalytics());
+            }
+
+            if (
+                isAnyOf(
+                    labelingActions.updateLocalFirstStorageDebugEnabled,
+                    labelingActions.updateLocalFirstStorageEnabled,
+                    labelingActions.updateIsFeatureLocalFirstStorageAvailable,
+                    labelingActions.setLocalFirstStorageRelayUrl,
+                )(action)
+            ) {
+                api.dispatch(storageActions.saveLabelingSettings());
             }
 
             if (deviceActions.setRememberDevice.match(action)) {

--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -4,6 +4,7 @@ import type { DBSchema } from 'idb';
 
 import { AnalyticsState } from '@suite-common/analytics';
 import { AppRememberedPermission } from '@suite-common/connect-popup/src/connectPopupTypes';
+import { LabelingSettings } from '@suite-common/local-first-storage';
 import type { MessageState } from '@suite-common/message-system';
 import type {
     DeviceWithEmptyPath,
@@ -138,6 +139,10 @@ export interface SuiteDBSchema extends DBSchema {
     metadata: {
         key: 'state';
         value: MetadataState;
+    };
+    labelingSettings: {
+        key: 'labelingSettings';
+        value: LabelingSettings;
     };
     messageSystem: {
         key: string;

--- a/packages/suite/src/storage/migrations/versions/25.11.0.1.ts
+++ b/packages/suite/src/storage/migrations/versions/25.11.0.1.ts
@@ -1,0 +1,19 @@
+import { createMigration } from '@suite/idb-migration-utils';
+
+import { SuiteDBSchema } from 'src/storage/definitions';
+
+export default createMigration<SuiteDBSchema>('25.11.0.1', (db, tx) => {
+    if (!db.objectStoreNames.contains('labelingSettings')) {
+        db.createObjectStore('labelingSettings');
+
+        tx.objectStore('labelingSettings').put(
+            {
+                isFeatureLocalFirstStorageAvailable: false,
+                isLocalFirstStorageEnabled: false,
+                isLocalFirstStorageDebugEnabled: false,
+                localFirstStorageRelayUrl: null,
+            },
+            'labelingSettings',
+        );
+    }
+});

--- a/packages/suite/src/storage/migrations/versions/index.ts
+++ b/packages/suite/src/storage/migrations/versions/index.ts
@@ -8,3 +8,4 @@ export { default as m25_8_0 } from './25.8.0';
 export { default as m25_9_2 } from './25.9.2';
 export { default as m25_10_0 } from './25.10.0';
 export { default as m25_11_0 } from './25.11.0';
+export { default as m25_11_0_1 } from './25.11.0.1';

--- a/packages/suite/src/support/suite/preloadStore.ts
+++ b/packages/suite/src/support/suite/preloadStore.ts
@@ -51,6 +51,7 @@ export const preloadStore = async () => {
             explorer,
             bioAuth,
             firmware,
+            labelingSettings,
         ] = await Promise.all([
             db.getItemByPK('suiteSettings', 'suite'),
             db.getItemsExtended('devices'),
@@ -76,6 +77,7 @@ export const preloadStore = async () => {
             db.getItemsExtended('explorer'),
             db.getItemByPK('bioAuth', 'bioAuth'),
             db.getItemByPK('firmware', 'firmware'),
+            db.getItemByPK('labelingSettings', 'labelingSettings'),
         ]);
 
         return {
@@ -105,6 +107,7 @@ export const preloadStore = async () => {
                 connect,
                 explorer,
                 firmware,
+                labelingSettings,
             },
         } as const;
     } catch (error) {

--- a/packages/suite/src/views/settings/SettingsDebug/LocalFirstStorageSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/LocalFirstStorageSettings.tsx
@@ -20,7 +20,7 @@ export const LocalFirstStorageSettings = () => {
 
     const {
         isLocalFirstStorageDebugEnabled,
-        toggleisFeatureLocalFirstStorageAvailable,
+        toggleIsFeatureLocalFirstStorageAvailable,
         isFeatureLocalFirstStorageAvailable,
     } = useLabelingCombined({
         // In debug, there may not be any device selected and it is in fact irrelevant
@@ -35,7 +35,7 @@ export const LocalFirstStorageSettings = () => {
 
     const handleToggleLocalFirstStorageDebug = () => {
         dispatch(
-            labelingActions.updateLocaleFirstStorageDebugEnabled({
+            labelingActions.updateLocalFirstStorageDebugEnabled({
                 isEnabled: !isLocalFirstStorageDebugEnabled,
             }),
         );
@@ -66,7 +66,7 @@ export const LocalFirstStorageSettings = () => {
                 <ActionColumn>
                     <Checkbox
                         isChecked={isFeatureLocalFirstStorageAvailable}
-                        onClick={toggleisFeatureLocalFirstStorageAvailable}
+                        onClick={toggleIsFeatureLocalFirstStorageAvailable}
                     />
                 </ActionColumn>
             </SectionItem>

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -8,7 +8,7 @@ import { HELP_CENTER_LABELING } from '@trezor/urls';
 
 import { SettingsSectionItem } from 'src/components/settings/SettingsSectionItem';
 import { ActionColumn, ActionSelect, TextColumn } from 'src/components/suite';
-import { Translation, TranslationKey } from 'src/components/suite/Translation';
+import { Translation } from 'src/components/suite/Translation';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import {
     LABELING_LEGACY_OPTION_LABEL,
@@ -89,14 +89,14 @@ export const Labeling = () => {
         });
     };
 
-    const getSelectedOption = (): LabelingOptionTranslated => {
-        const LABELING_SELECT_TRANSLATED_OPTIONS_MAP = LABELING_SELECT_OPTIONS.reduce(
+    const getSelectedOption = () => {
+        const LABELING_SELECT_TRANSLATED_OPTIONS_MAP = translatedOptions.reduce(
             (acc, option) => {
                 acc[option.value] = option;
 
                 return acc;
             },
-            {} as Record<LabelingSelectValue, LabelingOption<TranslationKey>>,
+            {} as Record<LabelingSelectValue, LabelingOption<string>>,
         );
 
         if (showLocalFirstStorage) {

--- a/suite-common/local-first-storage/src/index.ts
+++ b/suite-common/local-first-storage/src/index.ts
@@ -27,6 +27,10 @@ export {
 export { findAccountLabel, findOutputLabel, findAddressLabel } from './labeling/selectorUtils';
 export type { WithLabelingState } from './labeling/labelingSelectors';
 export { labelingActions } from './labeling/labelingActions';
-export { prepareLabelingReducer, initialLabelingState } from './labeling/labelingReducer';
+export {
+    prepareLabelingReducer,
+    initialLabelingState,
+    type LabelingSettings,
+} from './labeling/labelingReducer';
 export type { LabelingState } from './labeling/labelingReducer';
 export { processMetadataMessageThunk } from './labeling/processMetadataMessageThunk';

--- a/suite-common/local-first-storage/src/labeling/labelingActions.ts
+++ b/suite-common/local-first-storage/src/labeling/labelingActions.ts
@@ -44,17 +44,17 @@ export const clearAllLabels = createAction(
     (payload: { walletDescriptor: WalletDescriptor }) => ({ payload }),
 );
 
-export const updateLocaleFirstStorageEnabled = createAction(
+export const updateLocalFirstStorageEnabled = createAction(
     `${LABELING_PREFIX}/update-locale-first-storage-enabled`,
     (payload: { isEnabled: boolean }) => ({ payload }),
 );
 
-export const updateLocaleFirstStorageDebugEnabled = createAction(
+export const updateLocalFirstStorageDebugEnabled = createAction(
     `${LABELING_PREFIX}/update-locale-first-storage-debug-enabled`,
     (payload: { isEnabled: boolean }) => ({ payload }),
 );
 
-export const updateisFeatureLocalFirstStorageAvailable = createAction(
+export const updateIsFeatureLocalFirstStorageAvailable = createAction(
     `${LABELING_PREFIX}/update-show-locale-first-storage`,
     (payload: { isShownInSettings: boolean }) => ({ payload }),
 );
@@ -70,8 +70,8 @@ export const labelingActions = {
     setAddressLabel,
     setOutputLabel,
     clearAllLabels,
-    updateLocaleFirstStorageEnabled,
-    updateLocaleFirstStorageDebugEnabled,
-    updateisFeatureLocalFirstStorageAvailable,
+    updateLocalFirstStorageEnabled,
+    updateLocalFirstStorageDebugEnabled,
+    updateIsFeatureLocalFirstStorageAvailable,
     setLocalFirstStorageRelayUrl,
 };

--- a/suite-common/local-first-storage/src/labeling/labelingReducer.ts
+++ b/suite-common/local-first-storage/src/labeling/labelingReducer.ts
@@ -14,12 +14,15 @@ export type WalletLabelState = {
     outputLabels: OutputLabel[];
 };
 
-export type LabelingState = {
-    walletsLabels: Record<WalletDescriptor, WalletLabelState>; // key: WalletDescriptor = First btc testnet address
+export type LabelingSettings = {
     isFeatureLocalFirstStorageAvailable: boolean;
     isLocalFirstStorageEnabled: boolean;
     isLocalFirstStorageDebugEnabled: boolean;
     localFirstStorageRelayUrl: string | null;
+};
+
+export type LabelingState = LabelingSettings & {
+    walletsLabels: Record<WalletDescriptor, WalletLabelState>; // key: WalletDescriptor = First btc testnet address
 };
 
 export const initialLabelingState: LabelingState = {

--- a/suite-common/local-first-storage/src/labeling/labelingReducer.ts
+++ b/suite-common/local-first-storage/src/labeling/labelingReducer.ts
@@ -116,14 +116,14 @@ export const prepareLabelingReducer = createReducerWithExtraDeps<LabelingState>(
             .addCase(labelingActions.clearAllLabels, (state, { payload }) => {
                 delete state.walletsLabels[payload.walletDescriptor];
             })
-            .addCase(labelingActions.updateLocaleFirstStorageEnabled, (state, { payload }) => {
+            .addCase(labelingActions.updateLocalFirstStorageEnabled, (state, { payload }) => {
                 state.isLocalFirstStorageEnabled = payload.isEnabled;
             })
-            .addCase(labelingActions.updateLocaleFirstStorageDebugEnabled, (state, { payload }) => {
+            .addCase(labelingActions.updateLocalFirstStorageDebugEnabled, (state, { payload }) => {
                 state.isLocalFirstStorageDebugEnabled = payload.isEnabled;
             })
             .addCase(
-                labelingActions.updateisFeatureLocalFirstStorageAvailable,
+                labelingActions.updateIsFeatureLocalFirstStorageAvailable,
                 (state, { payload }) => {
                     state.isFeatureLocalFirstStorageAvailable = payload.isShownInSettings;
                 },

--- a/suite-native/module-dev-utils/src/components/LocalFirstRelaySettings.tsx
+++ b/suite-native/module-dev-utils/src/components/LocalFirstRelaySettings.tsx
@@ -43,7 +43,7 @@ export const LocalFirstRelaySettings = () => {
     const handleLocalFirstEnableToggle = () => {
         const originalIsLocalFirstStorageEnabled = isLocalFirstStorageEnabled;
         dispatch(
-            labelingActions.updateLocaleFirstStorageEnabled({
+            labelingActions.updateLocalFirstStorageEnabled({
                 isEnabled: !isLocalFirstStorageEnabled,
             }),
         );


### PR DESCRIPTION
Added labeling settings persistency on desktop.

**Changes**:
- created a new `labelingSettings` store
    - this should ideally eliminate the `metadata` store in the future as the naming does makes sense anymore
- added migration for the new store
- fixed typo
- fixed `getSelectedOption` to return translated selected option 

## Notes for QA

**Main test scenario**:
- open debug settings
- turn on evolu
- CMR + R or close the app and see if it persists

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22899


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/evolu/persistency&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/evolu/persistency&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/evolu/persistency&lookback=7)