### PR TITLE
fix(suite): unstake solana fee limit computation

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -74,7 +74,7 @@ const calculateTransaction = (
         ),
     };
 
-    const estimatedFeeLevel = { ...feeLevel, ...estimatedFee };
+    const estimatedFeeLevel = { ...feeLevel, ...estimatedFee?.payload };
 
     return calculate(
         availableBalance,

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -66,7 +66,7 @@ const calculateTransaction = (
         ),
     };
 
-    const estimatedFeeLevel = { ...feeLevel, ...estimatedFee };
+    const estimatedFeeLevel = { ...feeLevel, ...estimatedFee?.payload };
 
     return calculate(
         availableBalance,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- user was unable to unstake in case he had a lot of staking accounts

## Related Issue

Resolve https://satoshilabs.slack.com/archives/C06DHAY5HU6/p1758957927730149

## Screenshots:
before:
<img width="1573" height="1263" alt="Screenshot 2025-09-27 at 9 16 51" src="https://github.com/user-attachments/assets/732f2436-5b82-48ab-b796-0b55b65ecbe5" />
<img width="455" height="229" alt="Screenshot 2025-09-27 at 9 23 35" src="https://github.com/user-attachments/assets/f4508541-b6cb-4a92-9f02-d1c99c97b75e" />

After

https://github.com/user-attachments/assets/1f4fac4c-28ab-444a-8732-f651271d4dea



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-unstkae-fee&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-unstkae-fee&lookback=7)