### PR TITLE
fix(e2e-native): disable t3w1 eject tests and part of trading

### DIFF
--- a/suite-native/app/e2e/tests/ejectWallets.test.ts
+++ b/suite-native/app/e2e/tests/ejectWallets.test.ts
@@ -31,7 +31,7 @@ const navigateToEjectWallets = async () => {
     await onSettings.tapEjectWallets();
 };
 
-conditionalDescribe(device.getPlatform() === 'android', 'Eject wallets', () => {
+conditionalDescribe(device.getPlatform() === 'android', 'Eject wallets [@fixT3W1]', () => {
     beforeEach(async () => {
         await openApp({ args: { preloadedState } });
         await prepareTrezorEmulator();

--- a/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
@@ -6,10 +6,10 @@ import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
 import { portfolioTrackerBtcAccountState } from '../fixtures/portfolioTrackerBtcAccountState';
 import { onPassphrase } from '../pageObjects/passphraseModule';
 import { onTabBar } from '../pageObjects/tabBarActions';
-import { exchangePreviewActions } from '../pageObjects/trading/exchangePreviewActions';
-import { outputsReviewActions } from '../pageObjects/trading/outputsReviewActions';
+// import { exchangePreviewActions } from '../pageObjects/trading/exchangePreviewActions';
+// import { outputsReviewActions } from '../pageObjects/trading/outputsReviewActions';
 import { tradingExchangeActions } from '../pageObjects/trading/tradingExchangeActions';
-import { tradingFeeActions } from '../pageObjects/trading/tradingFeeActions';
+// import { tradingFeeActions } from '../pageObjects/trading/tradingFeeActions';
 import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
 
 const preloadedStateWithoutTrezor = preparePreloadedReduxState(
@@ -103,24 +103,26 @@ conditionalDescribe(device.getPlatform() === 'android', 'Trade Exchange', () => 
             await tradingExchangeActions.expectValidExchangeForm();
             await tradingExchangeActions.confirmTradingForm();
 
-            await exchangePreviewActions.expectExchangePreviewScreenToBeVisible();
-            await exchangePreviewActions.waitForFeesToLoad();
-            await exchangePreviewActions.scrollScreenToBottom();
-            await exchangePreviewActions.goToFees();
+            // Fees are not being loaded on CI. Skipping the rest of the flow tests for now.
+            // await exchangePreviewActions.expectExchangePreviewScreenToBeVisible();
 
-            await tradingFeeActions.expectFeesScreenToBeVisible();
-            await tradingFeeActions.goBack();
+            // await exchangePreviewActions.waitForFeesToLoad();
+            // await exchangePreviewActions.scrollScreenToBottom();
+            // await exchangePreviewActions.goToFees();
 
-            await exchangePreviewActions.goToTransactionSigning();
+            // await tradingFeeActions.expectFeesScreenToBeVisible();
+            // await tradingFeeActions.goBack();
 
-            await outputsReviewActions.expectOutputsReviewScreenToBeVisible();
-            await outputsReviewActions.expectAndConfirmRecipientAddress();
-            await outputsReviewActions.expectAndConfirmTotalFee();
-            await outputsReviewActions.signTransaction();
-            await outputsReviewActions.expectSendTransactionButton();
-            await outputsReviewActions.cancelTransaction();
+            // await exchangePreviewActions.goToTransactionSigning();
 
-            await tradingExchangeActions.waitForTradeDataToLoad();
+            // await outputsReviewActions.expectOutputsReviewScreenToBeVisible();
+            // await outputsReviewActions.expectAndConfirmRecipientAddress();
+            // await outputsReviewActions.expectAndConfirmTotalFee();
+            // await outputsReviewActions.signTransaction();
+            // await outputsReviewActions.expectSendTransactionButton();
+            // await outputsReviewActions.cancelTransaction();
+
+            // await tradingExchangeActions.waitForTradeDataToLoad();
         });
     });
 });


### PR DESCRIPTION
Due to my limited availability at start of this week, I am putting these failing test into "quarantine". I will get back to them on Thrusday / Friday

Trading issue: Fees are not loaded at all. But just on CI. Locally test passes and it is atm hard for me to troubleshoot
Eject: T3w1 pairing does not work. Code is pasted and flow returns back to disconnected device. I am able to duplicate that locally.

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=quarantine-e2e-native-trading-eject&lookback=7)