### PR TITLE
chore(ci): fix version of expo-cli to prevent failing builds

### DIFF
--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          eas-version: latest
+          eas-version: 16.24.1
           token: ${{ secrets.EXPO_TOKEN_DEVELOP }}
       - name: Install libs
         run: |

--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          eas-version: latest
+          eas-version: 16.24.1
           token: ${{ secrets.EXPO_TOKEN_DEVELOP }}
       - name: Install libs
         run: |

--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          eas-version: latest
+          eas-version: 16.24.1
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install libs
         run: |

--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          eas-version: latest
+          eas-version: 16.24.1
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install libs
         run: |
@@ -68,7 +68,7 @@ jobs:
       - name: Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          eas-version: latest
+          eas-version: 16.24.1
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install libs
         run: |
@@ -99,7 +99,7 @@ jobs:
       - name: Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          eas-version: latest
+          eas-version: 16.24.1
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Just a workaround until we found out what is the issue with the new eas-cli version.
- eas-cli@16.24.1 worked, 16.25.1 start failing with `EAS project not configured.`, [see example](https://github.com/trezor/trezor-suite/actions/runs/19040068442/job/54374569109).


Followup issue to fix it properly: https://github.com/trezor/trezor-suite/issues/22859



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/fix-eas-build&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/fix-eas-build&lookback=7)