### PR TITLE
feat(suite): move global send & receive out of experimental features

### DIFF
--- a/packages/suite-data/files/translations/cs-CZ.json
+++ b/packages/suite-data/files/translations/cs-CZ.json
@@ -1037,8 +1037,6 @@
   "TR_EXPERIMENTAL_FEATURES": "Experimentální",
   "TR_EXPERIMENTAL_FEATURES_ALLOW": "Experimentální funkce",
   "TR_EXPERIMENTAL_FEATURES_WARNING": "Pouze pro zkušené uživatele. Používejte jen na vlastní nebezpečí. Tyto funkce jsou ve fázi testování, mohou být nestabilní a nemusí mít dlouhodobou podporu.",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE": "Odesílání a přijímání z hlavního panelu",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION": "Odesílejte a přijímejte transakce přímo z hlavního panelu na jakýkoliv účet.",
   "TR_EXPERIMENTAL_NFT_SECTION": "NFT (nezaměnitelné tokeny)",
   "TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION": "Přidává NFT sekci k EVM účtům, ve které si můžete prohlížet NFT kolekce. Odesílání NFT aktuálně není podporováno.",
   "TR_EXPERIMENTAL_PASSWORD_MANAGER": "Migrovat hesla Dropbox",

--- a/packages/suite-data/files/translations/de-DE.json
+++ b/packages/suite-data/files/translations/de-DE.json
@@ -1037,8 +1037,6 @@
   "TR_EXPERIMENTAL_FEATURES": "Experimentell",
   "TR_EXPERIMENTAL_FEATURES_ALLOW": "Experimentelle Funktionen",
   "TR_EXPERIMENTAL_FEATURES_WARNING": "Der langfristige Support dieser Funktionen ist von der Garantie ausgeschlossen.",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE": "Globales Senden und Empfangen",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION": "Sende und empfange Transaktionen von deinem Dashboard direkt an jedes Konto.",
   "TR_EXPERIMENTAL_NFT_SECTION": "NFTs (Non-Fungible Tokens)",
   "TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION": "Füge einen NFT-Bereich auf EVM-basierten Chain-Konten hinzu, sodass NFTs angezeigt werden können. Das Senden von NFTs wird derzeit nicht unterstützt.",
   "TR_EXPERIMENTAL_PASSWORD_MANAGER": "Dropbox-Passwörter migrieren",

--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -1040,8 +1040,6 @@
   "TR_EXPERIMENTAL_FEATURES": "Experimental",
   "TR_EXPERIMENTAL_FEATURES_ALLOW": "Experimental features",
   "TR_EXPERIMENTAL_FEATURES_WARNING": "For experienced users only. Use at your own risk. These features are in testing, may be unstable, and might not have long-term support.",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE": "Global send & receive",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION": "Send and receive transactions from your dashboard directly to any account.",
   "TR_EXPERIMENTAL_NETWORKS": "{networkNames} {count, plural, one {network} other {networks}}",
   "TR_EXPERIMENTAL_NFT_SECTION": "NFTs (non-fungible tokens)",
   "TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION": "Add an NFT section to EVM-based chain accounts, allowing you to view NFTs. Sending NFTs isn't currently supported.",

--- a/packages/suite-data/files/translations/es-ES.json
+++ b/packages/suite-data/files/translations/es-ES.json
@@ -1037,8 +1037,6 @@
   "TR_EXPERIMENTAL_FEATURES": "Experimental",
   "TR_EXPERIMENTAL_FEATURES_ALLOW": "Funciones experimentales",
   "TR_EXPERIMENTAL_FEATURES_WARNING": "Solo para usuarios con experiencia. Utilízala bajo tu propia responsabilidad. Estas funciones están en fase de prueba, pueden ser inestables y podrían dejar de recibir soporte a largo plazo.",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE": "Envió y recepción global",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION": "Envía y recibe transacciones desde tu panel directamente a cualquier cuenta.",
   "TR_EXPERIMENTAL_NFT_SECTION": "NFT (tokens no fungibles)",
   "TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION": "Añade una sección de NFT a las cuentas de cadenas de EVM para consultar los NFT. Por ahora no se pueden enviar NFT.",
   "TR_EXPERIMENTAL_PASSWORD_MANAGER": "Migrar contraseñas de Dropbox",

--- a/packages/suite-data/files/translations/fr-FR.json
+++ b/packages/suite-data/files/translations/fr-FR.json
@@ -1037,8 +1037,6 @@
   "TR_EXPERIMENTAL_FEATURES": "Expérimental",
   "TR_EXPERIMENTAL_FEATURES_ALLOW": "Fonctionnalités expérimentales",
   "TR_EXPERIMENTAL_FEATURES_WARNING": "Destiné uniquement aux utilisateurs expérimentés. Cette utilisation se fait à vos risques et périls. Ces fonctionnalités sont en cours de test, peuvent être instables et ne pas être prises en charge à long terme.",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE": "Envoyer et recevoir",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION": "Envoyez et recevez des transactions directement depuis votre tableau de bord sur n'importe quel compte.",
   "TR_EXPERIMENTAL_NFT_SECTION": "NFT (jetons non fongibles)",
   "TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION": "Ajoutez une section NFT aux comptes de chaîne basés sur l’EVM (Ethereum Virtual Machine), ce qui vous permet d’afficher les NFT. L’envoi de NFT n’est pas pris en charge actuellement.",
   "TR_EXPERIMENTAL_PASSWORD_MANAGER": "Migration des mots de passe Dropbox",

--- a/packages/suite-data/files/translations/it-IT.json
+++ b/packages/suite-data/files/translations/it-IT.json
@@ -1012,7 +1012,6 @@
   "TR_EXPERIMENTAL_FEATURES": "Sperimentale",
   "TR_EXPERIMENTAL_FEATURES_ALLOW": "Funzionalità sperimentali",
   "TR_EXPERIMENTAL_FEATURES_WARNING": "Solo per utenti esperti. L'utilizzo del presente servizio avviene a proprio rischio e pericolo. Queste funzioni sono in fase di test. Di conseguenza potrebbero risultare instabili e non essere supportate a lungo termine.",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION": "Invia e ricevi transazioni dalla tua dashboard direttamente su qualsiasi conto.",
   "TR_EXPERIMENTAL_NFT_SECTION": "NFT (token non fungibili)",
   "TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION": "Aggiungi una sezione NFT ai conti della chain basati su EVM per visualizzare i token non fungibili. L'invio di token non fungibili non è attualmente supportato.",
   "TR_EXPERIMENTAL_PASSWORD_MANAGER": "Migrazione delle password Dropbox",

--- a/packages/suite-data/files/translations/ja-JP.json
+++ b/packages/suite-data/files/translations/ja-JP.json
@@ -1037,8 +1037,6 @@
   "TR_EXPERIMENTAL_FEATURES": "実験的な機能",
   "TR_EXPERIMENTAL_FEATURES_ALLOW": "実験的な機能",
   "TR_EXPERIMENTAL_FEATURES_WARNING": "上級者向けです。自己責任で使用してください。これらの機能はテスト中であり、不安定な場合があり、長期的なサポートがない可能性があります。",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE": "グローバル送信と受信",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION": "ダッシュボードから任意のアカウントに取引を直接送信または受信します。",
   "TR_EXPERIMENTAL_NFT_SECTION": "NFTs (非代替性トークン)",
   "TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION": "EVMベースのチェーンのアカウントにNFTセクションを追加し、NFTを表示できるようにします。NFTの送信は現在サポートされていません。",
   "TR_EXPERIMENTAL_PASSWORD_MANAGER": "Dropboxのパスワードを移行する",

--- a/packages/suite-data/files/translations/pt-BR.json
+++ b/packages/suite-data/files/translations/pt-BR.json
@@ -1037,8 +1037,6 @@
   "TR_EXPERIMENTAL_FEATURES": "Experimental",
   "TR_EXPERIMENTAL_FEATURES_ALLOW": "Recursos experimentais",
   "TR_EXPERIMENTAL_FEATURES_WARNING": "Apenas para usuários experientes. Use por sua conta e risco. Estes recursos estão em teste, talvez estejam instáveis e podem não ter suporte a longo prazo.",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE": "Enviar e receber globalmente",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION": "Envie e receba transações do seu painel diretamente para qualquer conta.",
   "TR_EXPERIMENTAL_NFT_SECTION": "NFTs (tokens não fungíveis)",
   "TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION": "Adicione uma seção de NFT para contas em cadeia baseadas em EVM, o que permite a você visualizar NFTs. Não há suporte para o envio de NFTs no momento.",
   "TR_EXPERIMENTAL_PASSWORD_MANAGER": "Migre senhas do Dropbox",

--- a/packages/suite-data/files/translations/zh-CN.json
+++ b/packages/suite-data/files/translations/zh-CN.json
@@ -1041,8 +1041,6 @@
   "TR_EXPERIMENTAL_FEATURES": "实验性",
   "TR_EXPERIMENTAL_FEATURES_ALLOW": "实验性功能",
   "TR_EXPERIMENTAL_FEATURES_WARNING": "仅限有经验的用户使用。风险自负。这些功能处于测试阶段，可能不稳定，也可能不提供长期支持。",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE": "仪表板发送与接收",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION": "从仪表板直接向任意账户发送和接收交易。",
   "TR_EXPERIMENTAL_NETWORKS": "{networkNames} {count, plural, one {网络} other {网络}}",
   "TR_EXPERIMENTAL_NETWORKS_DESCRIPTION": "在 {networkNames} {count, plural, one {网络} other {网络}} 上发送和接收交易。",
   "TR_EXPERIMENTAL_NFT_SECTION": "NFT（非同质化代币）",

--- a/packages/suite-data/files/translations/zh-TW.json
+++ b/packages/suite-data/files/translations/zh-TW.json
@@ -1015,8 +1015,6 @@
   "TR_EXPERIMENTAL_FEATURES": "實驗室",
   "TR_EXPERIMENTAL_FEATURES_ALLOW": "實驗功能",
   "TR_EXPERIMENTAL_FEATURES_WARNING": "僅提供給經驗豐富的使用者使用，使用時請自負風險。這些功能還在測試當中，有時可能會壞掉，並且也不保證有長期支援。",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE": "全域收送",
-  "TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION": "直接從儀表板收送交易到任何帳戶。",
   "TR_EXPERIMENTAL_NFT_SECTION": "NFT (非同值型代幣)",
   "TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION": "在 EVM 區塊鏈帳戶增加 NFT 項目，以便檢視非同值型代幣(NFT)。目前還不支援傳送代幣。",
   "TR_EXPERIMENTAL_PASSWORD_MANAGER": "移轉 Dropbox 密碼",

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
@@ -1,10 +1,5 @@
-import { useSelector } from 'react-redux';
-
-import { selectHasBitcoinOnlyFirmware } from '@suite-common/wallet-core';
 import { ButtonGroup, ButtonVariant } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
-
-import { ExperimentalFeatureFlag } from 'src/support/suite/ExperimentalFeatureFlag';
 
 import { Translation } from '../../../../Translation';
 import { HeaderActionButton } from '../HeaderActionButton';
@@ -18,40 +13,34 @@ export const GlobalSendReceiveButtons = ({
     setIsSendModalOpen,
     setIsReceiveModalOpen,
     variant,
-}: GlobalSendReceiveButtonsProps) => {
-    const btcOnlyFw = useSelector(selectHasBitcoinOnlyFirmware);
+}: GlobalSendReceiveButtonsProps) => (
+    <ButtonGroup size="small">
+        <HeaderActionButton
+            key="wallet-send"
+            icon="arrowUp"
+            onClick={() => {
+                setIsSendModalOpen(true);
 
-    return (
-        <ExperimentalFeatureFlag feature="global-send-receive" featureFlagDisabled={btcOnlyFw}>
-            <ButtonGroup size="small">
-                <HeaderActionButton
-                    key="wallet-send"
-                    icon="arrowUp"
-                    onClick={() => {
-                        setIsSendModalOpen(true);
+                analytics.report({ type: EventType.DashboardSendModal });
+            }}
+            data-testid="@wallet/menu/wallet-global-send"
+            variant={variant}
+        >
+            <Translation id="TR_NAV_SEND" />
+        </HeaderActionButton>
 
-                        analytics.report({ type: EventType.DashboardSendModal });
-                    }}
-                    data-testid="@wallet/menu/wallet-global-send"
-                    variant={variant}
-                >
-                    <Translation id="TR_NAV_SEND" />
-                </HeaderActionButton>
+        <HeaderActionButton
+            key="wallet-receive"
+            icon="arrowDown"
+            onClick={() => {
+                setIsReceiveModalOpen(true);
 
-                <HeaderActionButton
-                    key="wallet-receive"
-                    icon="arrowDown"
-                    onClick={() => {
-                        setIsReceiveModalOpen(true);
-
-                        analytics.report({ type: EventType.DashboardReceiveModal });
-                    }}
-                    data-testid="@wallet/menu/wallet-global-receive"
-                    variant={variant}
-                >
-                    <Translation id="TR_NAV_RECEIVE" />
-                </HeaderActionButton>
-            </ButtonGroup>
-        </ExperimentalFeatureFlag>
-    );
-};
+                analytics.report({ type: EventType.DashboardReceiveModal });
+            }}
+            data-testid="@wallet/menu/wallet-global-receive"
+            variant={variant}
+        >
+            <Translation id="TR_NAV_RECEIVE" />
+        </HeaderActionButton>
+    </ButtonGroup>
+);

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -16,7 +16,6 @@ export type ExperimentalFeature =
     | 'password-manager'
     | 'tor-external'
     | 'nft-section'
-    | 'global-send-receive'
     | 'experimental-networks';
 
 export type ExperimentalFeatureConfig = {
@@ -53,10 +52,6 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
     'nft-section': {
         title: { id: 'TR_EXPERIMENTAL_NFT_SECTION' },
         description: { id: 'TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION' },
-    },
-    'global-send-receive': {
-        title: { id: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE' },
-        description: { id: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION' },
     },
     'experimental-networks': {
         title: {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5309,15 +5309,6 @@ export default defineMessages({
         defaultMessage:
             'For experienced users only. Use at your own risk. These features are in testing, may be unstable, and might not have long-term support.',
     },
-    TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE: {
-        id: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE',
-        defaultMessage: 'Global send & receive',
-    },
-    TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION: {
-        id: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION',
-        defaultMessage:
-            'Send and receive transactions from your dashboard directly to any account.',
-    },
     TR_GO_TO_EXP_FEATURE: {
         id: 'TR_GO_TO_EXP_FEATURE',
         defaultMessage: 'Open',


### PR DESCRIPTION
## Description

Moves the Global Send & Receive functionality out of experimental features.

- remove option from **Settings - Application - Experimental**
- remove lang labels:
  - _TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_
  - _TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION_

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22737

## Screenshots:

<img width="1210" height="596" alt="image" src="https://github.com/user-attachments/assets/8b894ed8-f414-4d83-8592-96a263593b2b" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/global-send-receive-exit-experimental&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/global-send-receive-exit-experimental&lookback=7)