### PR TITLE
refactor(suite): DeviceAnimation has width and height as frame props

### DIFF
--- a/packages/components/src/components/animations/AnimationPrimitives.tsx
+++ b/packages/components/src/components/animations/AnimationPrimitives.tsx
@@ -1,4 +1,4 @@
-import styled, { CSSProperties, css } from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { borders } from '@trezor/theme';
 
@@ -9,6 +9,8 @@ export const allowedAnimationPrimitivesFrameProps = [
     'margin',
     'maxWidth',
     'maxHeight',
+    'width',
+    'height',
 ] as const satisfies FramePropsKeys[];
 export type AllowedAnimationPrimitiveFrameProps = Pick<
     FrameProps,
@@ -20,8 +22,6 @@ export type Shape = (typeof shapes)[number];
 
 export const AnimationWrapper = styled.div<
     TransientProps<AllowedAnimationPrimitiveFrameProps> & {
-        height?: CSSProperties['height'];
-        width?: CSSProperties['width'];
         shape?: Shape;
     }
 >`
@@ -29,9 +29,6 @@ export const AnimationWrapper = styled.div<
     display: flex;
     justify-content: center;
     align-items: center;
-
-    width: ${({ width }) => width};
-    height: ${({ height }) => height};
 
     ${withFrameProps}
 

--- a/packages/components/src/components/animations/LottieAnimation.tsx
+++ b/packages/components/src/components/animations/LottieAnimation.tsx
@@ -66,7 +66,7 @@ export const LottieAnimation = ({
     }, [type, deviceModelInternal]);
 
     return (
-        <AnimationWrapper height={`${size}px`} width={`${size}px`} shape={shape} {...props}>
+        <AnimationWrapper $height={size} $width={size} shape={shape} {...props}>
             <>
                 {lottieAnimationData && (
                     <StyledLottie animationData={lottieAnimationData} loop={loop} />

--- a/packages/product-components/src/components/ConfirmOnDevice/ConfirmOnDevicePillContent.tsx
+++ b/packages/product-components/src/components/ConfirmOnDevice/ConfirmOnDevicePillContent.tsx
@@ -59,7 +59,7 @@ export const ConfirmOnDevicePillContent = ({
             <RotateDeviceImage
                 deviceModel={deviceModelInternal}
                 deviceColor={deviceUnitColor}
-                animationHeight="34px"
+                height={34}
                 maxWidth={30}
             />
 

--- a/packages/product-components/src/components/DeviceAnimation/DeviceAnimation.tsx
+++ b/packages/product-components/src/components/DeviceAnimation/DeviceAnimation.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, MouseEventHandler, forwardRef } from 'react';
+import { MouseEventHandler, forwardRef } from 'react';
 
 import { useTheme } from 'styled-components';
 
@@ -23,8 +23,6 @@ const getThemeVariant = (theme: any) =>
     (theme?.legacy?.THEME as string | undefined)?.toLowerCase() === 'dark' ? 'dark' : 'light';
 
 type Base = AllowedAnimationPrimitiveFrameProps & {
-    height?: CSSProperties['height'];
-    width?: CSSProperties['width'];
     loop?: boolean;
     shape?: Shape;
     onEnded?: () => void;
@@ -49,8 +47,6 @@ export type DeviceAnimationProps = {
 export const DeviceAnimation = forwardRef<HTMLVideoElement, DeviceAnimationProps>(
     (props, videoRef) => {
         const {
-            height,
-            width,
             type,
             loop = false,
             shape,
@@ -138,7 +134,7 @@ export const DeviceAnimation = forwardRef<HTMLVideoElement, DeviceAnimationProps
         })();
 
         return (
-            <AnimationWrapper height={height} width={width} shape={shape} {...frameProps}>
+            <AnimationWrapper shape={shape} {...frameProps}>
                 {content}
             </AnimationWrapper>
         );

--- a/packages/product-components/src/components/RotateDeviceImage/RotateDeviceImage.stories.tsx
+++ b/packages/product-components/src/components/RotateDeviceImage/RotateDeviceImage.stories.tsx
@@ -18,8 +18,6 @@ export const RotateDeviceImage: StoryObj<RotateDeviceImageProps> = {
     args: {
         deviceModel: DeviceModelInternal.T3B1,
         deviceColor: undefined,
-        animationHeight: undefined,
-        animationWidth: undefined,
         ...getFramePropsStory(allowedAnimationPrimitivesFrameProps).args,
     },
     argTypes: {

--- a/packages/product-components/src/components/RotateDeviceImage/RotateDeviceImage.tsx
+++ b/packages/product-components/src/components/RotateDeviceImage/RotateDeviceImage.tsx
@@ -11,8 +11,6 @@ export type RotateDeviceImageProps = AllowedAnimationPrimitiveFrameProps & {
     deviceColor?: number;
     className?: string;
     loop?: boolean;
-    animationHeight?: string;
-    animationWidth?: string;
 };
 
 export const RotateDeviceImage = ({
@@ -20,8 +18,6 @@ export const RotateDeviceImage = ({
     deviceColor,
     className,
     loop,
-    animationHeight,
-    animationWidth,
     ...rest
 }: RotateDeviceImageProps) => {
     if (!deviceModel) {
@@ -41,8 +37,6 @@ export const RotateDeviceImage = ({
                 deviceModel === DeviceModelInternal.T2B1 ? DeviceModelInternal.T3B1 : deviceModel
             }
             deviceUnitColor={normalizeDeviceColorVariant(deviceColor) as any}
-            height={animationHeight}
-            width={animationWidth}
             {...rest}
         />
     );

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -71,8 +71,8 @@ const RebootDeviceGraphics = ({
     return (
         <DeviceAnimation
             {...(deviceAnimationProps as DeviceAnimationProps)}
-            height="220px"
-            width="220px"
+            height={220}
+            width={220}
             shape="ROUNDED"
             loop
         />

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx
@@ -65,7 +65,7 @@ export const SecurityCheckLayout = ({
                                 type="ROTATE"
                                 deviceModelInternal={model}
                                 deviceUnitColor={deviceUnitColor as any}
-                                height="300px"
+                                height={300}
                                 sizeVariant="LARGE"
                             />
                         ) : (

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
@@ -32,7 +32,7 @@ export const DeviceStatus = ({
                 <RotateDeviceImage
                     deviceModel={deviceModel}
                     deviceColor={getDeviceColorVariant(device)}
-                    animationHeight="34px"
+                    height={34}
                 />
             )}
         </Row>

--- a/packages/suite/src/views/wallet/trading/common/ConfirmedOnTrezor.tsx
+++ b/packages/suite/src/views/wallet/trading/common/ConfirmedOnTrezor.tsx
@@ -31,8 +31,8 @@ export const ConfirmedOnTrezor = ({ device }: ConfirmedOnTrezorProps) => (
         <RotateDeviceImage
             deviceModel={device?.features?.internal_model}
             deviceColor={device?.features?.unit_color}
-            animationHeight="34px"
-            animationWidth="34px"
+            height={34}
+            width={34}
         />
 
         <Translation id="TR_BUY_CONFIRMED_ON_TREZOR" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=device-animation-width-height-as-frame-props&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=device-animation-width-height-as-frame-props&lookback=7)