### PR TITLE
chore(message-system): A/B test fiat rates

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2025-10-20T12:00:00+00:00",
-    "sequence": 118,
+    "timestamp": "2025-10-30T00:00:00+00:00",
+    "sequence": 119,
     "actions": [
         {
             "conditions": [
@@ -2253,6 +2253,30 @@
                     {
                         "variant": "B",
                         "percentage": 50
+                    }
+                ]
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": "*",
+                        "mobile": "!",
+                        "web": "*"
+                    }
+                }
+            ],
+            "experiment": {
+                "id": "b73df44d-37ed-4b66-aba1-5c4164493bae",
+                "groups": [
+                    {
+                        "variant": "A",
+                        "percentage": 90
+                    },
+                    {
+                        "variant": "B",
+                        "percentage": 10
                     }
                 ]
             }


### PR DESCRIPTION
## Description

Adding an A/B test for fiat rates.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=release-message-system-develop&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=release-message-system-develop&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=release-message-system-develop&lookback=7)