### PR TITLE
fix(e2e): Db migration test is not valid for T3W1

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/suite/db-migration.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/db-migration.test.ts
@@ -14,11 +14,14 @@ const workaroundBtcAddressInputSelector = 'outputs.0.address';
 
 test.describe(
     'Database migration',
-    // This test is run only on web nightly builds, it works with web instances of 25.7 and develop branch
+    // This test is run only on web nightly builds, it works with web instances of 22.5 and develop branch
     // On PR and release CI run it would provide no value and potentially false failures
-    { tag: ['@group=migrations', '@webOnly', '@nightlyOnly'] },
+    { tag: ['@group=migrations', '@webOnly', '@nightlyOnly', '@specificModel'] },
     () => {
-        test.use({ emulatorSetupConf: { passphrase_protection: true, mnemonic: 'mnemonic_all' } });
+        test.use({
+            emulatorStartConf: { model: 'T3T1' },
+            emulatorSetupConf: { passphrase_protection: true, mnemonic: 'mnemonic_all' },
+        });
 
         test(
             `Db migration between: ${migrateFromVersion} => ${migrateToVersion}`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The test is not possible to do with T3W1, because it has to start with suite version 22.5, which doesn't even have the ability to connect T3T1 devices.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-t3w1-db-migration&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-t3w1-db-migration&lookback=7)