### PR TITLE
chrome local-network-access permission handling

### DIFF
--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -30,6 +30,7 @@ export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSet
     public eventEmitter = new EventEmitter();
     protected _settings: ConnectSettings;
     private ws: WebsocketClient<{}>;
+    private localNetworkPermissionState: PermissionState | 'unknown' = 'unknown';
 
     public constructor() {
         this._settings = parseConnectSettings();
@@ -87,6 +88,19 @@ export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSet
     }
 
     public async init(settings: Partial<ConnectSettingsPublic>): Promise<void> {
+        const permission = await navigator.permissions
+            .query({
+                // @ts-expect-error outdated type definitions
+                name: 'local-network-access',
+            })
+            .catch(() => undefined);
+        if (permission) {
+            this.localNetworkPermissionState = permission.state;
+            permission.onchange = () => {
+                this.localNetworkPermissionState = permission.state;
+            };
+        }
+
         const newSettings = parseConnectSettings({
             ...this._settings,
             ...settings,
@@ -109,13 +123,23 @@ export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSet
         return await this.connect();
     }
 
+    private error(err: Error): Error {
+        if (err instanceof WebsocketError) {
+            if (this.localNetworkPermissionState === 'denied') {
+                return ERRORS.TypedError('Browser_LocalNetworkPermissionMissing');
+            } else {
+                return ERRORS.TypedError('Desktop_ConnectionMissing', err.message);
+            }
+        }
+
+        return err;
+    }
+
     private async connect(): Promise<void> {
         try {
             await this.ws.connect();
         } catch (err) {
-            throw err instanceof WebsocketError
-                ? ERRORS.TypedError('Desktop_ConnectionMissing', err.message)
-                : err;
+            throw this.error(err);
         }
     }
 
@@ -151,11 +175,7 @@ export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSet
         } catch (err) {
             return {
                 success: false,
-                payload: ERRORS.serializeError(
-                    err instanceof WebsocketError
-                        ? ERRORS.TypedError('Desktop_ConnectionMissing', err.message)
-                        : err,
-                ),
+                payload: ERRORS.serializeError(this.error(err)),
             };
         }
     }

--- a/packages/connect/src/constants/errors.ts
+++ b/packages/connect/src/constants/errors.ts
@@ -55,6 +55,9 @@ export const ERROR_CODES = {
     Failure_EntropyCheck: '', // message from verifyEntropy process
 
     Deeplink_VersionMismatch: 'Not compatible with current version of the app',
+
+    Browser_LocalNetworkPermissionMissing:
+        'Local network permission is missing. Please allow local network access in browser settings.',
 } as const;
 
 type TypedErrorCode = keyof typeof ERROR_CODES;

--- a/packages/suite/src/components/suite/banners/SuiteBanners/LocalNetworkAccessPermission.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/LocalNetworkAccessPermission.tsx
@@ -1,0 +1,16 @@
+import { Banner } from '@trezor/components';
+
+import { Translation } from '../../Translation';
+
+/**
+ * This is very unimportant warning and should be displayed only under specific conditions (see caller) so that we don't bother users that don't need to care.
+ * To get into trouble user would need to:
+ * 1] use suite-web
+ * 2] have standalone bridge running
+ * 3] have webusb disabled in debug settings or be using Firefox browser.
+ */
+export const LocalNetworkAccessPermission = () => (
+    <Banner icon variant="info">
+        <Translation id="TR_LOCAL_NETWORK_ACCESS_PERMISSION_WARNING" />
+    </Banner>
+);

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -8,10 +8,12 @@ import {
     selectIsDeviceBackupUnfinished,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
+import { isWeb } from '@trezor/env-utils';
 import { spacingsPx } from '@trezor/theme';
 
 import { MAX_CONTENT_WIDTH } from 'src/constants/suite/layout';
 import { useSelector } from 'src/hooks/suite';
+import { useLocalNetworkAccessPermission } from 'src/hooks/suite/useLocalNetworkAccessPermission';
 import {
     selectFirmwareHashCheckErrorIfEnabled,
     selectFirmwareRevisionCheckErrorIfEnabled,
@@ -22,6 +24,7 @@ import { MessageSystemBanner } from '../MessageSystemBanner';
 import { BridgeDeprecated } from './BridgeDeprecatedBanner';
 import { FailedBackup } from './FailedBackupBanner';
 import { FirmwareAuthenticityCheckBanner } from './FirmwareAuthenticityCheckBanner';
+import { LocalNetworkAccessPermission } from './LocalNetworkAccessPermission';
 import { NoBackup } from './NoBackupBanner';
 import { NoConnectionBanner } from './NoConnectionBanner';
 import { SafetyChecksBanner } from './SafetyChecksBanner';
@@ -50,6 +53,8 @@ export const SuiteBanners = ({ isOnboarding, fill }: SuiteBannersProps) => {
     const firmwareHashError = useSelector(selectFirmwareHashCheckErrorIfEnabled);
     const isDeviceBackupUnfinished = useSelector(selectIsDeviceBackupUnfinished);
     const isDeviceBackupRequired = useSelector(selectIsDeviceBackupRequired);
+    const transport = useSelector(state => state.suite.transport);
+    const { localNetworkAccessPermission } = useLocalNetworkAccessPermission();
 
     // The dismissal doesn't need to outlive the session. Use local state.
     const [safetyChecksDismissed, setSafetyChecksDismissed] = useState(false);
@@ -67,6 +72,7 @@ export const SuiteBanners = ({ isOnboarding, fill }: SuiteBannersProps) => {
 
     let banner = null;
     let priority = 0;
+
     // firmware hash & revision check (performed when connecting a device), either of them may fail
     if (firmwareRevisionError || firmwareHashError) {
         banner = <FirmwareAuthenticityCheckBanner />;
@@ -90,6 +96,15 @@ export const SuiteBanners = ({ isOnboarding, fill }: SuiteBannersProps) => {
         // Let the user dismiss the warning.
         banner = <SafetyChecksBanner onDismiss={() => setSafetyChecksDismissed(true)} />;
         priority = 50;
+    } else if (
+        isWeb() &&
+        window.location.hostname !== 'localhost' && // localhost is not cross-origin so it is not needed there
+        // transport error is unfortunately not very specific but we don't have anything better
+        transport?.error === 'Network request failed' &&
+        localNetworkAccessPermission === 'denied'
+    ) {
+        banner = <LocalNetworkAccessPermission />;
+        priority = 40;
     } else if (bridge?.outdated) {
         banner = <BridgeDeprecated />;
         priority = 30;

--- a/packages/suite/src/hooks/suite/useLocalNetworkAccessPermission.ts
+++ b/packages/suite/src/hooks/suite/useLocalNetworkAccessPermission.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+import { isWeb } from '@trezor/env-utils';
+
+export const useLocalNetworkAccessPermission = () => {
+    const [localNetworkAccessPermission, setLocalNetworkAccessPermission] = useState<
+        'unknown' | 'granted' | 'denied' | 'prompt'
+    >('unknown');
+
+    useEffect(() => {
+        if (isWeb()) {
+            navigator.permissions
+                .query({
+                    // @ts-expect-error outdated type definitions
+                    name: 'local-network-access',
+                })
+                .then(permission => {
+                    setLocalNetworkAccessPermission(permission.state);
+                    permission.onchange = ev => {
+                        if (ev?.target && 'state' in ev.target) {
+                            // @ts-expect-error outdated type definitions
+                            setLocalNetworkAccessPermission(ev!.target!.state);
+                        }
+                    };
+                })
+                .catch(() => {
+                    // empty handler, we keep 'unknown'. Possibly unsupported browser version
+                });
+        }
+    }, []);
+
+    return {
+        localNetworkAccessPermission,
+    };
+};

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -111,6 +111,7 @@ export interface SuiteSettings {
 
 export interface TransportState extends InstallerInfo {
     transports: TransportInfo[];
+    error?: string;
 }
 
 export interface SuiteState {
@@ -379,12 +380,12 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                 break;
             }
             case TRANSPORT.ERROR: {
-                const { udev, apiType } = action.payload;
+                const { udev, apiType, error } = action.payload;
                 const transports =
                     !draft.transport || !apiType
                         ? (draft.transport?.transports ?? [])
                         : draft.transport.transports?.filter(t => t.apiType !== apiType);
-                draft.transport = { udev, transports };
+                draft.transport = { udev, transports, error };
                 break;
             }
             case SUITE.ONLINE_STATUS:

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10989,4 +10989,9 @@ export default defineMessages({
         id: 'TR_ERROR_LOADING_TOKENS',
         defaultMessage: 'Failed to load tokens',
     },
+    TR_LOCAL_NETWORK_ACCESS_PERMISSION_WARNING: {
+        id: 'TR_LOCAL_NETWORK_ACCESS_PERMISSION_WARNING',
+        defaultMessage:
+            'In order to use all features of Trezor Suite web version please allow local network access in your browser settings.',
+    },
 } as const);


### PR DESCRIPTION
Chrome 142 restricts the ability to make requests to the user's local network, gated behind a permission prompt. [source](https://chromestatus.com/feature/5152728072060928)

<img width="526" height="273" alt="image" src="https://github.com/user-attachments/assets/e434ece9-34ae-4857-9a2d-e94e235e0062" />

this happnes (in our stack) when: 
- we try to communicate with bridge 
- we try to initiate connect-in-suite-desktop mode


user now has these options:
- click allow - this sets permission status to `granted` and everything continues normally
- click block - this sets permission status to `denied` and nothing happens. 
- click x - this does not set permission status, it only closes this window, if user clicks "x" 3 times, it sets permission status to `denied`. 

### what can user do when status is set to `denied`?: 

- change permission manually here, or click the reset button.
<img width="372" height="256" alt="Image" src="https://github.com/user-attachments/assets/65d4722c-1702-4d38-8f1f-fbbf56aaebbb" />

- it happend to me, that after clicking reset button and then clicking "x" button 3 times I got again into the `denied` state and this reset button stopped working, so I had to go here to get back to fresh state

<img width="695" height="109" alt="Image" src="https://github.com/user-attachments/assets/18792db8-1ae0-47a0-9892-43599401e1de" />

### How to test it 

- for http requests (bridge in our case), this is already default, but you can check using
```
 chrome://flags/#local-network-access-check
 ```

[suite-web build](https://dev.suite.sldev.cz/suite-web/local-permissions/web/start/)

- as for websockets you need to opt-in at the moment
``` 
chrome://flags/#local-network-access-check-websockets
```

[connect-web build](https://dev.suite.sldev.cz/connect/local-permissions/)

## Cases

### Iframe mode

low prio, iframe is now more or less deprecated, some notes here #23012

### suite-desktop mode 

- suite desktop is running, mode is set to core-in-suite-desktop. permission is granted  
<img width="780" height="518" alt="image" src="https://github.com/user-attachments/assets/f62ff7a5-fd90-4eaf-8c58-44255be9c5bc" />

- suite desktop is running, mode is set to core-in-suite-desktop. permission is blocked
<img width="717" height="181" alt="image" src="https://github.com/user-attachments/assets/395096d5-2078-4b4f-8d6b-0e06a79fad16" /> 

- suite desktop is not running, mode is set to core-in-suite-desktop. permission is granted  
<img width="383" height="85" alt="image" src="https://github.com/user-attachments/assets/a771440d-7967-4f5c-a875-607f6b68d3b2" />

- suite desktop is not running, mode is set to core-in-suite-desktop. permission is blocked  
<img width="713" height="181" alt="image" src="https://github.com/user-attachments/assets/5771f1b4-d27a-416b-ab0f-dca360035c31" />

### Suite web

- this is low priority but since we still allow suite-web  to work along with suite-desktop, it might make sense to add a warning. 

<img width="809" height="642" alt="image" src="https://github.com/user-attachments/assets/2bbbdbaa-f022-4320-816a-648cd3cccda3" />

## side notes
 
- what about webextensions? these should not be included. _"We do not currently have plans to apply LNA restrictions to extensions. Currently, extensions that have the necessary [host permissions](https://developer.chrome.com/docs/extensions/develop/concepts/declare-permissions#host-permissions) are allowed to make local network requests."_ [source](https://docs.google.com/document/d/1QQkqehw8umtAgz5z0um7THx-aoU251p705FbIQjDuGs/edit?tab=t.0)
- external testing tool https://lna-testing.notyetsecure.com/

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=local-permissions&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=local-permissions&lookback=7)