### PR TITLE
feat(suite): show DAC in settings for seedless device with FW

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -96,6 +96,9 @@ export const SettingsDevice = () => {
     const deviceModelInternal = device.features.internal_model;
 
     const supportsDeviceAuthentication = SUPPORTS_DEVICE_AUTHENTICITY_CHECK[deviceModelInternal];
+    // because Device authenticity check is something you can (and have to) do on a device with FW but without seed
+    const isSecuritySectionVisible =
+        isNormalMode || (initializeMode && supportsDeviceAuthentication);
 
     const isThpDevice = device?.thp !== undefined;
 
@@ -148,29 +151,30 @@ export const SettingsDevice = () => {
                 <ChangeLanguage isDeviceLocked={isDeviceLocked} />
             </SettingsSection>
 
-            {isNormalMode && (
-                <>
-                    <SettingsSection
-                        title={<Translation id="TR_DEVICE_SECURITY" />}
-                        icon="shieldCheck"
-                    >
-                        <PinProtection isDeviceLocked={isDeviceLocked} />
-                        {pinProtection && <ChangePin isDeviceLocked={isDeviceLocked} />}
-                        {safetyChecks && <SafetyChecks isDeviceLocked={isDeviceLocked} />}
-                        {supportsDeviceAuthentication && (
-                            <AuthenticateDevice isDeviceLocked={isDeviceLocked} />
-                        )}
-                    </SettingsSection>
+            {isSecuritySectionVisible && (
+                <SettingsSection title={<Translation id="TR_DEVICE_SECURITY" />} icon="shieldCheck">
+                    {isNormalMode && (
+                        <>
+                            <PinProtection isDeviceLocked={isDeviceLocked} />
+                            {pinProtection && <ChangePin isDeviceLocked={isDeviceLocked} />}
+                            {safetyChecks && <SafetyChecks isDeviceLocked={isDeviceLocked} />}
+                        </>
+                    )}
+                    {supportsDeviceAuthentication && (
+                        <AuthenticateDevice isDeviceLocked={isDeviceLocked} />
+                    )}
+                </SettingsSection>
+            )}
 
-                    <SettingsSection title={<Translation id="TR_PERSONALIZATION" />} icon="palette">
-                        <DeviceLabel isDeviceLocked={isDeviceLocked} />
-                        <Homescreen isDeviceLocked={isDeviceLocked} />
-                        <DisplayRotation isDeviceLocked={isDeviceLocked} />
-                        <Brightness isDeviceLocked={isDeviceLocked} />
-                        <HapticFeedback isDeviceLocked={isDeviceLocked} />
-                        {pinProtection && <AutoLock isDeviceLocked={isDeviceLocked} />}
-                    </SettingsSection>
-                </>
+            {isNormalMode && (
+                <SettingsSection title={<Translation id="TR_PERSONALIZATION" />} icon="palette">
+                    <DeviceLabel isDeviceLocked={isDeviceLocked} />
+                    <Homescreen isDeviceLocked={isDeviceLocked} />
+                    <DisplayRotation isDeviceLocked={isDeviceLocked} />
+                    <Brightness isDeviceLocked={isDeviceLocked} />
+                    <HapticFeedback isDeviceLocked={isDeviceLocked} />
+                    {pinProtection && <AutoLock isDeviceLocked={isDeviceLocked} />}
+                </SettingsSection>
             )}
 
             <SettingsSection title={<Translation id="TR_DEVICE_CONNECTION" />} icon="plugs">


### PR DESCRIPTION
## Description

When Trezor Safe with FW but without seed, offer DAC in settings.

## Notes for QA

See screenshots for all relevant cases..

## Related Issue

Resolve #22874

## Screenshots:

Main case:

[T3T1 uninitialized BEFORE](https://github.com/user-attachments/assets/3fd1e973-4f4d-4240-9b9d-91d25f7130c7) (no Security section)
[T3T1 uninitialized AFTER](https://github.com/user-attachments/assets/522bd72d-37b1-4aeb-a3d0-bb413d9d1389) (Security section with **only** DAC)

Other cases are unchanged:

[T3T1 initialized](https://github.com/user-attachments/assets/c65d2b3a-320d-4d97-bcdb-5d0a3fcfab68) (Security section with everything)
[T3T1 bootloader](https://github.com/user-attachments/assets/73cf2556-fae3-4f6a-9dc5-af9a984a3c34) (no Security section)
[T2T1 initialized](https://github.com/user-attachments/assets/b7e71886-ae9c-419e-b8f3-eb539cedb3aa) (Security section with everything **but** DAC)
[T2T1 uninitialized](https://github.com/user-attachments/assets/800a31d9-2c10-4666-8d82-0b96625b6a14) (no Security section)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/settings-DAC-with-no-seed&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/settings-DAC-with-no-seed&lookback=7)