### PR TITLE
fix(suite-native): add isReady check to NavigationRef

### DIFF
--- a/suite-native/device/src/__tests__/deviceConnectionMiddleware.test.ts
+++ b/suite-native/device/src/__tests__/deviceConnectionMiddleware.test.ts
@@ -31,6 +31,7 @@ jest.mock('@suite-native/navigation', () => {
         navigationContainerRef: {
             navigate: jest.fn(),
             reset: jest.fn(),
+            isReady: jest.fn().mockReturnValue(true),
         },
         checkIsActiveRouteAnyOf: jest.fn().mockReturnValue(false),
         checkIsDeviceOnboardingFocused: jest.fn().mockReturnValue(false),

--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -240,7 +240,8 @@ export const useDetectDeviceError = () => {
             shouldFactoryResetBeVisible &&
             !isFirmwareInstallationRunning &&
             !wasDeviceEjectedByUser &&
-            isOnboardingFinished
+            isOnboardingFinished &&
+            navigationContainerRef.isReady()
         ) {
             navigationContainerRef.reset({
                 index: 0,

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -59,6 +59,7 @@ const handleDeviceConnectNavigation = ({
     isDeviceSetupSupported: boolean;
     wasDeviceOnboardingCancelled: boolean;
 }) => {
+    if (!navigationContainerRef.isReady()) return;
     if (!isDeviceInitialized) {
         // If device setup is not supported, we don't want to navigate anywhere
         // We handle it separately in `useDetectDeviceError` hook. Ideally, the alert would be triggered here (it would need to be in redux though).
@@ -131,6 +132,8 @@ deviceConnectionMiddleware.startListening({
             getOriginalState,
         }: ListenerEffectAPI<NativeDeviceRootState, Dispatch<UnknownAction>>,
     ) => {
+        if (!navigationContainerRef.isReady()) return;
+
         if (!deviceActions.connectDevice.match(action)) {
             throw new Error('This listener only handles connectDevice action');
         }
@@ -180,6 +183,8 @@ deviceConnectionMiddleware.startListening({
 deviceConnectionMiddleware.startListening({
     predicate: action => deviceActions.deviceDisconnect.match(action),
     effect: (action: UnknownAction, { getState }) => {
+        if (!navigationContainerRef.isReady()) return;
+
         if (!deviceActions.deviceDisconnect.match(action)) {
             throw new Error('This listener only handles deviceDisconnect action');
         }
@@ -225,6 +230,8 @@ deviceConnectionMiddleware.startListening({
 deviceConnectionMiddleware.startListening({
     predicate: isThpPairingUIRequestButtonAction,
     effect: (_, { getState }) => {
+        if (!navigationContainerRef.isReady()) return;
+
         if (selectIsFirmwareInstallationRunning(getState())) return;
 
         // Nothing can be accomplished before a THP connection is established.

--- a/suite-native/navigation/src/__tests__/routeUtils.test.ts
+++ b/suite-native/navigation/src/__tests__/routeUtils.test.ts
@@ -5,6 +5,7 @@ import { DeviceOnboardingStackRoutes, HomeStackRoutes, RootStackRoutes } from '.
 jest.mock('../components/NavigationContainerWithAnalytics', () => ({
     navigationContainerRef: {
         getState: jest.fn(),
+        isReady: jest.fn().mockReturnValue(true),
     },
 }));
 

--- a/suite-native/navigation/src/components/NavigationContainerWithAnalytics.tsx
+++ b/suite-native/navigation/src/components/NavigationContainerWithAnalytics.tsx
@@ -58,6 +58,8 @@ export const NavigationContainerWithAnalytics = ({ children }: { children: React
     };
 
     const handleStateChange = () => {
+        if (!navigationContainerRef.isReady()) return;
+
         const previousRouteName = routeNameRef.current;
         const currentRouteName = navigationContainerRef.getCurrentRoute()?.name;
 

--- a/suite-native/navigation/src/routeUtils.ts
+++ b/suite-native/navigation/src/routeUtils.ts
@@ -30,11 +30,14 @@ export const checkIsRouteAnyOf = (routeList: string[], route?: string): boolean 
     return routeList.includes(route);
 };
 
-export const checkIsActiveRouteAnyOf = (routeList: string[]): boolean =>
-    checkIsRouteAnyOf(
+export const checkIsActiveRouteAnyOf = (routeList: string[]): boolean => {
+    if (!navigationContainerRef.isReady()) return false;
+
+    return checkIsRouteAnyOf(
         routeList,
         getActiveRouteName(navigationContainerRef.getState() as AppNavigationState),
     );
+};
 
 export const checkIsDeviceOnboardingFocused = () => {
     const DEVICE_ONBOARDING_ROUTES = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

 add `isReady` check to NavigationRef to prevent background calls


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22067

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/nav-ref-handling&lookback=7)