### PR TITLE
chore(scripts): reassign some dependencies

### DIFF
--- a/scripts/list-outdated-dependencies/connect-dependencies.txt
+++ b/scripts/list-outdated-dependencies/connect-dependencies.txt
@@ -87,7 +87,6 @@ stream-browserify
 swr
 tailwindcss
 tar
-terser-webpack-plugin
 tiny-worker
 ts-mixer
 ts-node

--- a/scripts/list-outdated-dependencies/foundation-dependencies.txt
+++ b/scripts/list-outdated-dependencies/foundation-dependencies.txt
@@ -15,6 +15,7 @@
 @evolu/react-native
 @evolu/web
 @noble/curves
+@pmmmwh/react-refresh-webpack-plugin
 @sentry/browser
 @sentry/core
 @sentry/electron
@@ -24,7 +25,6 @@
 @types/file-saver
 @types/webpack-bundle-analyzer
 @types/webpack-plugin-serve
-babel-jest
 babel-loader
 babel-plugin-transform-remove-console
 chalk
@@ -53,12 +53,10 @@ express
 fake-indexeddb
 file-saver
 globals
-golomb
 html-webpack-plugin
 husky
 idb
 minimatch
-n64
 nx
 openpgp
 prettier
@@ -66,8 +64,8 @@ react-native-ble-plx
 react-native-mmkv
 react-freeze
 react-native-nitro-modules
-simple-git
 sort-package-json
+terser-webpack-plugin
 typescript-eslint
 uuid
 vm-browserify

--- a/scripts/list-outdated-dependencies/growth-dependencies.txt
+++ b/scripts/list-outdated-dependencies/growth-dependencies.txt
@@ -67,6 +67,7 @@ react-svg
 react-toastify
 recharts
 sharp
+simple-git
 storybook
 style-loader
 styled-components

--- a/scripts/list-outdated-dependencies/qa-dependencies.txt
+++ b/scripts/list-outdated-dependencies/qa-dependencies.txt
@@ -10,6 +10,7 @@ chai
 @playwright/browser-webkit
 @playwright/test
 @types/jest
+babel-jest
 detox
 dotenv
 eslint-plugin-playwright

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -6,7 +6,6 @@
 @hookform/resolvers
 @metamask/eth-sig-util
 @noble/hashes
-@pmmmwh/react-refresh-webpack-plugin
 @reduxjs/toolkit
 @solana-program/compute-budget
 @solana-program/stake
@@ -44,11 +43,13 @@ cashaddrjs
 create-hmac
 eth-phishing-detect
 event-target-shim
+golomb
 immer
 int64-buffer
 json-schema-to-typescript
 jws
 minimaldata
+n64
 patch-package
 raw-loader
 react-hook-form


### PR DESCRIPTION
## Description

Suggestion to slightly reorganize a few dependencies after #22747:

- all webpack related → foundation
- simple-git → growth (it's only used for Suite Guide)
- `golomb, n64` = libs related to that cursed feature which shall not be named → wallet team (it's bitcoin)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/rearrange-foundation-dependencies&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/rearrange-foundation-dependencies&lookback=7)