### PR TITLE
fix(suite): move slow BLE FW installation to only desktop

### DIFF
--- a/packages/connect/src/api/firmware/uploadFirmware.ts
+++ b/packages/connect/src/api/firmware/uploadFirmware.ts
@@ -85,6 +85,14 @@ export const uploadFirmware = async ({
         const length = payload.byteLength;
         let progress = 0;
         let response = await typedCall('FirmwareErase', ['FirmwareRequest', 'Success'], { length });
+        // We are starting the flashing process.
+        postMessage(
+            createUiMessage(UI.FIRMWARE_PROGRESS, {
+                device: device.toMessageObject(),
+                operation: 'start-flashing',
+                progress,
+            }),
+        );
         while (response.type !== 'Success') {
             // NOTE: offset and message are present in T2
             const start = response.message.offset;

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -308,7 +308,7 @@ export interface FirmwareProgress {
     type: typeof UI_REQUEST.FIRMWARE_PROGRESS;
     payload: {
         device: Device;
-        operation: 'downloading' | 'flashing';
+        operation: 'downloading' | 'flashing' | 'start-flashing';
         progress: number;
     };
 }

--- a/packages/suite/src/hooks/suite/useFirmwareDesktopUpdate.ts
+++ b/packages/suite/src/hooks/suite/useFirmwareDesktopUpdate.ts
@@ -1,18 +1,63 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
-import { type FirmwareUpdateProps, useFirmwareInstallation } from '@suite-common/firmware';
+import {
+    type FirmwareUpdateProps,
+    selectFirmware,
+    useFirmwareInstallation,
+} from '@suite-common/firmware';
 import { selectIsDeviceConnectedViaBluetoothLowOnBattery } from '@suite-common/wallet-core';
+import { UI } from '@trezor/connect';
 
 import { useSelector } from './useSelector';
 
+const INTERVAL_CHECK_SLOW_INSTALLATION_MS = 1_000;
+const TIME_THRESHOLD_SLOW_INSTALLATION_MS = 30_000;
+const PERCENTAGE_THRESHOLD_SLOW_INSTALLATION = 20;
+
 export const useFirmwareDesktopUpdate = () => {
     const [showLowBatteryModal, setShowLowBatteryModal] = useState(false);
+    const firmware = useSelector(selectFirmware);
     const isDeviceConnectedViaBluetoothLowOnBattery = useSelector(
         selectIsDeviceConnectedViaBluetoothLowOnBattery,
     );
 
     const { firmwareUpdate, originalDevice, reconnectEvent, pinRequested, ...rest } =
         useFirmwareInstallation();
+
+    const [isSlow, setIsSlow] = useState(false);
+    const [startTime, setStartTime] = useState<null | number>(null);
+
+    useEffect(() => {
+        if (
+            !startTime &&
+            firmware.uiEvent?.type === UI.FIRMWARE_PROGRESS &&
+            firmware.uiEvent.payload.operation === 'start-flashing'
+        ) {
+            setStartTime(new Date().getTime());
+        }
+    }, [firmware.uiEvent, startTime]);
+
+    useEffect(() => {
+        if (!startTime || isSlow) {
+            return;
+        }
+
+        const interval = setInterval(() => {
+            const now = new Date().getTime();
+
+            if (now - startTime > TIME_THRESHOLD_SLOW_INSTALLATION_MS) {
+                if (
+                    firmware.uiEvent?.type === UI.FIRMWARE_PROGRESS &&
+                    firmware.uiEvent.payload.progress < PERCENTAGE_THRESHOLD_SLOW_INSTALLATION
+                ) {
+                    setIsSlow(true);
+                    clearInterval(interval);
+                }
+            }
+        }, INTERVAL_CHECK_SLOW_INSTALLATION_MS);
+
+        return () => clearInterval(interval);
+    }, [startTime, isSlow, firmware.uiEvent]);
 
     const desktopFirmwareUpdate = (arg: FirmwareUpdateProps) => {
         if (isDeviceConnectedViaBluetoothLowOnBattery) {
@@ -41,5 +86,6 @@ export const useFirmwareDesktopUpdate = () => {
         reconnectEvent,
         showReconnectPrompt: rest.showReconnectPrompt || restartingToNormalWithPinProtection,
         pinRequested: pinRequested || restartingToNormalWithPinProtection,
+        isSlow,
     };
 };

--- a/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
+++ b/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { ButtonRequest, FirmwareStatus, TrezorDevice } from '@suite-common/suite-types';
@@ -16,10 +16,6 @@ import { isArrayMember } from '@trezor/utils';
 import { firmwareActions } from '../firmwareActions';
 import { selectFirmware, selectSwitchFirmwareType } from '../firmwareReducer';
 import { FirmwareUpdateProps, firmwareUpdate as firmwareUpdateThunk } from '../firmwareThunks';
-
-const INTERVAL_CHECK_SLOW_INSTALLATION_MS = 1_000;
-const TIME_THRESHOLD_SLOW_INSTALLATION_MS = 30_000;
-const PERCENTAGE_THRESHOLD_SLOW_INSTALLATION = 20;
 
 /*
 There are three firmware update flows, depending on current firmware version:
@@ -112,41 +108,6 @@ export const useFirmwareInstallation = () => {
     const isThpInProgress = useSelector(selectIsThpInProgress);
     const thpStep = useSelector(selectThpStep);
     const switchFirmwareType = useSelector(selectSwitchFirmwareType);
-
-    const [isSlow, setIsSlow] = useState(false);
-    const [startTime, setStartTime] = useState<null | number>(null);
-
-    useEffect(() => {
-        if (
-            !startTime &&
-            firmware.uiEvent?.type === UI.FIRMWARE_PROGRESS &&
-            firmware.uiEvent.payload.progress === 1
-        ) {
-            setStartTime(new Date().getTime());
-        }
-    }, [firmware.uiEvent, startTime]);
-
-    useEffect(() => {
-        if (!startTime || isSlow) {
-            return;
-        }
-
-        const interval = setInterval(() => {
-            const now = new Date().getTime();
-
-            if (now - startTime > TIME_THRESHOLD_SLOW_INSTALLATION_MS) {
-                if (
-                    firmware.uiEvent?.type === UI.FIRMWARE_PROGRESS &&
-                    firmware.uiEvent.payload.progress < PERCENTAGE_THRESHOLD_SLOW_INSTALLATION
-                ) {
-                    setIsSlow(true);
-                    clearInterval(interval);
-                }
-            }
-        }, INTERVAL_CHECK_SLOW_INSTALLATION_MS);
-
-        return () => clearInterval(interval);
-    }, [startTime, isSlow, firmware.uiEvent]);
 
     const [reconnectEvent, buttonEvent, progressEvent] = useMemo(() => {
         if (firmware.uiEvent) {
@@ -294,6 +255,5 @@ export const useFirmwareInstallation = () => {
         pinRequested,
         progressEvent,
         deviceIsWaitingForConfirmationToInitiateConnection,
-        isSlow,
     };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Move slow BLE FW installation to only desktop

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/move-slow-fw-install-indicator-to-only-desktop&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/move-slow-fw-install-indicator-to-only-desktop&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/move-slow-fw-install-indicator-to-only-desktop&lookback=7)