### PR TITLE
chore(suite): undrill BluetoothDeviceList props

### DIFF
--- a/packages/suite/src/components/connection/BluetoothConnectionModal.tsx
+++ b/packages/suite/src/components/connection/BluetoothConnectionModal.tsx
@@ -16,7 +16,7 @@ type BluetoothConnectionModalProps = {
 const selectedDeviceConnectionTypes = ['connecting', 'pairing'];
 
 export const BluetoothConnectionModal = ({ onClose }: BluetoothConnectionModalProps) => {
-    const { handlePairingCancel, onReScanClick, onConnect, devices, selectedDevice } =
+    const { handlePairingCancel, onReScanClick, selectedDevice } =
         useConnectionGlobalModalContext();
     const connectingDevices = useSelector(selectConnectingDevices);
 
@@ -64,11 +64,7 @@ export const BluetoothConnectionModal = ({ onClose }: BluetoothConnectionModalPr
             description={<Translation id="TR_CONNECT_YOUR_TREZOR_DESCRIPTION" />}
             size="small"
         >
-            <BluetoothScanningList
-                devices={devices}
-                onConnect={onConnect}
-                onReScanClick={onReScanClick}
-            />
+            <BluetoothScanningList />
         </Modal>
     );
 };

--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -72,7 +72,6 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
         toggleShowHints,
         isBluetoothMode,
         showHints,
-        onConnect,
         openShowRemoveFromOsBluetooth,
         shouldShowBluetoothUnPairDeviceList,
         notConnectedKnownDevices,
@@ -123,7 +122,6 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
             >
                 <BluetoothDeviceList
                     deviceList={notConnectedKnownDevices}
-                    onConnect={onConnect}
                     isScanning={false}
                     onPairAgain={openShowRemoveFromOsBluetooth}
                 />

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceList.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceList.tsx
@@ -1,5 +1,4 @@
 import { Card, Column, Row, SkeletonRectangle } from '@trezor/components';
-import { BluetoothDeviceId } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
 import { BluetoothDeviceListItem } from './BluetoothDeviceListItem';
@@ -18,13 +17,11 @@ const SkeletonDevice = () => (
 
 type BluetoothDeviceListProps = {
     deviceList: DesktopBluetoothDevice[];
-    onConnect: (deviceId: BluetoothDeviceId) => Promise<void>;
     isScanning: boolean;
     onPairAgain?: () => void;
 };
 
 export const BluetoothDeviceList = ({
-    onConnect,
     deviceList,
     isScanning,
     onPairAgain,
@@ -35,7 +32,6 @@ export const BluetoothDeviceList = ({
                 <BluetoothDeviceListItem
                     key={device.id}
                     device={device}
-                    onConnect={onConnect}
                     onPairAgain={onPairAgain}
                 />
             ))}

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx
@@ -15,6 +15,7 @@ import { selectConnectingDevices } from '../../../actions/bluetooth/desktopBluet
 import { useDispatch, useSelector } from '../../../hooks/suite';
 import { Translation, TranslationKey } from '../Translation';
 import { PairingState } from './PairingState';
+import { useConnectionGlobalModalContext } from '../../connection/context/ConnectionGlobalModalContext';
 
 const connectionStatusMap: Record<
     DeviceBluetoothConnectionStatusType,
@@ -63,7 +64,6 @@ type ActionButtonProps = {
     isGhostDevice: boolean;
     isManuallyPairedDevice: boolean;
     device: DesktopBluetoothDevice;
-    onConnect: (deviceId: BluetoothDeviceId) => void;
     onPairAgain?: (deviceId: BluetoothDeviceId) => void;
 };
 
@@ -71,10 +71,10 @@ const ActionButton = ({
     isGhostDevice,
     isManuallyPairedDevice,
     device,
-    onConnect,
     onPairAgain,
 }: ActionButtonProps) => {
     const connectingDevicesIds = useSelector(selectConnectingDevices);
+    const { onConnect } = useConnectionGlobalModalContext();
 
     const isSuiteTryingToConnectToDevice = connectingDevicesIds.includes(device.id);
     const connectionStatus = connectionStatusMap[device.connectionStatus.type];
@@ -118,15 +118,10 @@ const ActionButton = ({
 
 type BluetoothDeviceItemProps = {
     device: DesktopBluetoothDevice;
-    onConnect: (deviceId: BluetoothDeviceId) => void;
     onPairAgain?: (deviceId: BluetoothDeviceId) => void;
 };
 
-export const BluetoothDeviceListItem = ({
-    device,
-    onConnect,
-    onPairAgain,
-}: BluetoothDeviceItemProps) => {
+export const BluetoothDeviceListItem = ({ device, onPairAgain }: BluetoothDeviceItemProps) => {
     const nearbyDevices = useSelector(selectNearbyDevices);
     const isNearbyDevice = (nearbyDevices ?? []).some(
         nearbyDevice => nearbyDevice.id === device.id,
@@ -146,7 +141,6 @@ export const BluetoothDeviceListItem = ({
                 isGhostDevice={isGhostDevice}
                 isManuallyPairedDevice={isManuallyPairedDevice}
                 device={device}
-                onConnect={onConnect}
             />
         </Row>
     );

--- a/packages/suite/src/components/suite/bluetooth/BluetoothScanningList.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothScanningList.tsx
@@ -1,24 +1,14 @@
 import { selectScanStatus } from '@suite-common/bluetooth';
-import { BluetoothDeviceId } from '@trezor/connect';
 
 import { BluetoothDeviceList } from './BluetoothDeviceList';
 import { BluetoothTips } from './BluetoothTips';
-import { DesktopBluetoothDevice } from '../../../actions/bluetooth/DesktopBluetoothDevice';
 import { useSelector } from '../../../hooks/suite';
+import { useConnectionGlobalModalContext } from '../../connection/context/ConnectionGlobalModalContext';
 import { Translation } from '../Translation';
 
-type BluetoothScanningListProps = {
-    devices: DesktopBluetoothDevice[];
-    onConnect: (deviceId: BluetoothDeviceId) => Promise<void>;
-    onReScanClick: () => void;
-};
-
-export const BluetoothScanningList = ({
-    devices,
-    onConnect,
-    onReScanClick,
-}: BluetoothScanningListProps) => {
+export const BluetoothScanningList = () => {
     const scanStatus = useSelector(selectScanStatus);
+    const { onReScanClick, devices } = useConnectionGlobalModalContext();
 
     // This is fake, we scan for devices all the time
     const isScanning = scanStatus === 'running';
@@ -30,7 +20,7 @@ export const BluetoothScanningList = ({
             header={<Translation id="TR_BLUETOOTH_CHECK_TIPS_TRY_AGAIN" />}
         />
     ) : (
-        <BluetoothDeviceList onConnect={onConnect} deviceList={devices} isScanning={isScanning} />
+        <BluetoothDeviceList deviceList={devices} isScanning={isScanning} />
     );
 
     return content;


### PR DESCRIPTION
## Description

Instead of prop drilling, use the context from which the props were sourced.
There is no other context provider in between, so the behavior will be unchanged.

I tested superficially that the connecting modal still works.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/undrill-props&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/undrill-props&lookback=7)