### PR TITLE
fix(connect-popup): open trezor-suite download url as fallback when d…

### DIFF
--- a/packages/connect-ui/src/components/Notification.tsx
+++ b/packages/connect-ui/src/components/Notification.tsx
@@ -3,7 +3,10 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { Button, Icon } from '@trezor/components';
-import { SUITE_BRIDGE_DEEPLINK } from '@trezor/urls';
+import { useWindowFocus } from '@trezor/react-utils';
+import { SUITE_BRIDGE_DEEPLINK, SUITE_URL } from '@trezor/urls';
+
+import { openDeeplinkWithWebFallback } from '../utils/openDeeplinkWithWebFallback';
 
 const NotificationBox = styled.div`
     background-color: ${({ color }) => color};
@@ -66,7 +69,8 @@ interface NotificationProps {
     variant: 'warning' | 'danger';
     cta?: {
         desc: string;
-        url: string;
+        url?: string;
+        onClick?: () => void;
     };
 }
 
@@ -96,10 +100,13 @@ const Notification = ({ header, body, cta, variant }: NotificationProps) => {
                 {cta && (
                     <NotificationCta>
                         <StyledButton
-                            onClick={() => {
-                                window.open(cta.url);
-                                window.close();
-                            }}
+                            onClick={
+                                cta?.onClick ||
+                                (() => {
+                                    window.open(cta.url);
+                                    window.close();
+                                })
+                            }
                         >
                             {cta.desc}
                         </StyledButton>
@@ -110,15 +117,23 @@ const Notification = ({ header, body, cta, variant }: NotificationProps) => {
     );
 };
 
-export const UseSuiteDesktopNotification = () => (
-    <Notification
-        variant="warning"
-        header="Try something new"
-        body="Switch to Trezor Suite desktop for the best experience."
-        cta={{ desc: 'Try Trezor Suite', url: SUITE_BRIDGE_DEEPLINK }}
-    />
-);
+export const UseSuiteDesktopNotification = () => {
+    const windowFocused = useWindowFocus();
 
+    return (
+        <Notification
+            variant="warning"
+            header="Try something new"
+            body="Switch to Trezor Suite desktop for the best experience."
+            cta={{
+                desc: 'Try Trezor Suite',
+                onClick: () => {
+                    openDeeplinkWithWebFallback(windowFocused, SUITE_BRIDGE_DEEPLINK, SUITE_URL);
+                },
+            }}
+        />
+    );
+};
 export const SuspiciousOriginNotification = () => (
     <Notification
         variant="danger"

--- a/packages/connect-ui/src/utils/openDeeplinkWithWebFallback.ts
+++ b/packages/connect-ui/src/utils/openDeeplinkWithWebFallback.ts
@@ -1,0 +1,20 @@
+import type { RefObject } from 'react';
+
+export const openDeeplinkWithWebFallback = (
+    windowFocusedRef: RefObject<boolean>,
+    deeplinkUrl: string,
+    webUrl: string,
+) => {
+    // trigger deep link using iframe (to avoid beforeUnload and avoid opening new blank tab)
+    const iframeDeeplink = document.createElement('iframe');
+    iframeDeeplink.src = deeplinkUrl;
+    iframeDeeplink.style.display = 'none';
+    document.body.appendChild(iframeDeeplink);
+
+    // fallback in case deeplink does not work
+    window.setTimeout(() => {
+        if (!windowFocusedRef.current) return;
+
+        window.open(webUrl);
+    }, 500);
+};

--- a/packages/connect-ui/src/views/Transport.tsx
+++ b/packages/connect-ui/src/views/Transport.tsx
@@ -7,25 +7,13 @@ import { SUITE_BRIDGE_DEEPLINK, SUITE_URL } from '@trezor/urls';
 
 import { View } from '../components/View';
 import imageSrc from '../images/man_with_laptop.svg';
+import { openDeeplinkWithWebFallback } from '../utils/openDeeplinkWithWebFallback';
 
 export type TransportEventProps = Extract<UiEvent, { type: 'ui-no_transport' }>;
 
 export const Transport = () => {
     const windowFocused = useWindowFocus();
-    const handleOpenSuite = () => {
-        // trigger deep link using iframe (to avoid beforeUnload and avoid opening new blank tab)
-        const iframeDeeplink = document.createElement('iframe');
-        iframeDeeplink.src = SUITE_BRIDGE_DEEPLINK;
-        iframeDeeplink.style.display = 'none';
-        document.body.appendChild(iframeDeeplink);
 
-        // fallback in case deeplink does not work
-        window.setTimeout(() => {
-            if (!windowFocused.current) return;
-
-            window.open(SUITE_URL);
-        }, 500);
-    };
     // @ts-expect-error usb is not included in types here
     const wouldSupportWebUSB = window.navigator.usb?.getDevices !== undefined;
 
@@ -59,14 +47,18 @@ export const Transport = () => {
             }
             image={<Image imageSrc={imageSrc} />}
             buttons={
-                <>
-                    <Button intent="brand" iconRight="arrowUpRight" onClick={handleOpenSuite}>
-                        <FormattedMessage
-                            id="TR_OPEN_TREZOR_SUITE_DESKTOP"
-                            defaultMessage="Open Trezor Suite desktop app"
-                        />
-                    </Button>
-                </>
+                <Button
+                    intent="brand"
+                    iconRight="arrowUpRight"
+                    onClick={() =>
+                        openDeeplinkWithWebFallback(windowFocused, SUITE_BRIDGE_DEEPLINK, SUITE_URL)
+                    }
+                >
+                    <FormattedMessage
+                        id="TR_OPEN_TREZOR_SUITE_DESKTOP"
+                        defaultMessage="Open Trezor Suite desktop app"
+                    />
+                </Button>
             }
         />
     );

--- a/packages/suite/src/views/suite/bridge-requested/index.tsx
+++ b/packages/suite/src/views/suite/bridge-requested/index.tsx
@@ -98,7 +98,7 @@ export const BridgeRequested = () => {
             <Metadata title="Bridge | Trezor Suite" />
             <Column gap={spacings.xxs}>
                 <H3>
-                    <Translation id="TR_BRIDGE" />
+                    <Translation id="TR_TREZOR_CONNECT" />
                 </H3>
                 <Paragraph variant="tertiary">
                     <Translation id="TR_BRIDGE_REQUESTED_DESCRIPTION" />


### PR DESCRIPTION
…eeplink not available on notification

ok, this was quite stupid and not very helpful. The deeplink I have added to a notification in popup wouldn't help very much. How it could open suite-desktop if it was probably not installed yet? So I fixed it by covering it with already exsiting logic that fallbacks to open suite download page if deeplink is not registered yet. 

<img width="747" height="343" alt="image" src="https://github.com/user-attachments/assets/ab1e4187-55c5-4016-b2b1-44b4187961bf" />

<img width="1246" height="310" alt="image" src="https://github.com/user-attachments/assets/149055cd-dce6-4df8-9cf2-8fe9c96bda57" />


+ removed one more Trezor Bridge reference 

<img width="608" height="551" alt="image" src="https://github.com/user-attachments/assets/186f678f-16a3-4de0-b7ef-51cd4b39724b" />

<img width="615" height="542" alt="image" src="https://github.com/user-attachments/assets/6f0fabc9-a76b-4cd1-b53a-41b065beab1e" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-open-suite-notif-in-popup&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-open-suite-notif-in-popup&lookback=7)