### PR TITLE
feat(connect): make Tropic DAC compulsory for TS7

### DIFF
--- a/packages/connect/e2e/tests/device/authenticateDevice.test.ts
+++ b/packages/connect/e2e/tests/device/authenticateDevice.test.ts
@@ -47,8 +47,9 @@ describe('TrezorConnect.authenticateDevice', () => {
             success: true,
             payload: {
                 optigaResult: { valid: true },
-                // trezor-user-env T3W1 has no tropic debug keys provisioned. This test will fail if that changes in future.
-                tropicResult: null,
+                // trezor-user-env T3W1 has no tropic debug keys provisioned, but it is now required.
+                // TODO change to true when it's fixed in trezor-user-env (this E2E will start failing)
+                tropicResult: { valid: false },
             },
         });
     });

--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -1,4 +1,5 @@
 import {
+    VerifyAuthenticityProofResult,
     deviceAuthenticityBlacklistConfig,
     deviceAuthenticityConfig,
     getRandomChallenge,
@@ -53,25 +54,32 @@ export default class AuthenticateDevice extends AbstractMethod<
             blacklistConfig,
         } as const;
 
-        // when this method is called, optiga is currently always expected to be there
-        const optigaResult = await verifyAuthenticityProof({
-            ...commonParams,
-            certificates: message.optiga_certificates,
-            signature: message.optiga_signature,
-        });
+        const getOptigaResult = async (): Promise<VerifyAuthenticityProofResult> => {
+            const { optiga_signature: signature, optiga_certificates: certificates } = message;
+            const isAvailable = signature !== undefined && certificates.length > 0;
+            if (isAvailable) {
+                return await verifyAuthenticityProof({ ...commonParams, certificates, signature });
+            }
 
-        // Tropic check is still is optional = not enforced
-        // TODO make it compulsory for T3W1 which is expected to have it https://github.com/trezor/trezor-suite/issues/22448
-        const { tropic_signature } = message;
-        const isTropicAvailable =
-            tropic_signature !== undefined && message.tropic_certificates.length > 0;
-        const tropicResult = isTropicAvailable
-            ? await verifyAuthenticityProof({
-                  ...commonParams,
-                  certificates: message.tropic_certificates,
-                  signature: tropic_signature,
-              })
-            : null;
+            // all devices capable of 'authenticateDevice' (see src/data/config.ts) have Optiga, so it's always required
+            return { valid: false, error: 'RESPONSE_PAYLOAD_MISSING' };
+        };
+
+        const getTropicResult = async (): Promise<VerifyAuthenticityProofResult | null> => {
+            const { tropic_signature: signature, tropic_certificates: certificates } = message;
+            const isAvailable = signature !== undefined && certificates.length > 0;
+            const isRequired = !this.device.unavailableCapabilities['tropicDeviceAuthentication'];
+            if (isAvailable) {
+                return await verifyAuthenticityProof({ ...commonParams, certificates, signature });
+            }
+            if (isRequired) {
+                return { valid: false, error: 'RESPONSE_PAYLOAD_MISSING' };
+            }
+
+            return null;
+        };
+        const optigaResult = await getOptigaResult();
+        const tropicResult = await getTropicResult();
 
         return { optigaResult, tropicResult };
     }

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -272,6 +272,16 @@ export const config: Config = {
             },
         },
         {
+            capabilities: ['tropicDeviceAuthentication'],
+            min: {
+                // devices that don't support 'authenticateDevice' don't have to be listed here
+                T2B1: '0',
+                T3B1: '0',
+                T3T1: '0',
+                T3W1: '2.9.3',
+            },
+        },
+        {
             capabilities: ['getFirmwareHash'],
             methods: ['getFirmwareHash'],
             min: { T1B1: '1.11.1', T2T1: '2.5.1' },

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -229,6 +229,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 sol: 'no-capability',
                 dsol: 'no-capability',
                 thod: 'update-required',
+                tropicDeviceAuthentication: 'no-support',
                 tsep: 'update-required',
                 usdt: 'no-capability',
                 vtc: 'no-support',

--- a/packages/device-authenticity/src/types.ts
+++ b/packages/device-authenticity/src/types.ts
@@ -28,12 +28,13 @@ export type VerifyAuthenticityProofResult =
       }
     | {
           valid: false;
-          caPubKey: string;
+          caPubKey?: string;
           rootPubKey?: string;
           error:
               | 'ROOT_PUBKEY_NOT_FOUND'
               | 'CA_PUBKEY_BLACKLISTED'
               | 'INVALID_DEVICE_MODEL'
               | 'INVALID_DEVICE_CERTIFICATE'
-              | 'INVALID_DEVICE_SIGNATURE';
+              | 'INVALID_DEVICE_SIGNATURE'
+              | 'RESPONSE_PAYLOAD_MISSING';
       };


### PR DESCRIPTION
## Description

- define new device capability `tropicDeviceAuthentication`, make it enabled for T3W1 >= 2.9.3
- fail the check if tropic payload required but missing
- update E2E to expect failure because waiting for trezor-user-env...

## Related Issue

Resolve #22448

## Screenshots

Normal screens for Success | Device Compromised are expected.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/enforce-tropic-DAC-on-TS7&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/enforce-tropic-DAC-on-TS7&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/enforce-tropic-DAC-on-TS7&lookback=7)