### PR TITLE
refactor: extend coin image sizes

### DIFF
--- a/packages/asset-utils/package.json
+++ b/packages/asset-utils/package.json
@@ -5,6 +5,9 @@
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "src/index",
+    "dependencies": {
+        "@suite-common/icons": "workspace:*"
+    },
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build"

--- a/packages/asset-utils/src/asset-logo-urls.ts
+++ b/packages/asset-utils/src/asset-logo-urls.ts
@@ -1,18 +1,35 @@
-const ICONS_URL_BASE = 'https://data.trezor.io/suite/icons/coins/';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import {
+    COIN_IMAGE_SIZES,
+    CoinImageQuality,
+    CoinImageSize,
+    ICONS_URL_BASE,
+    createCoinImageName,
+} from '@suite-common/icons/src/index';
 
-const composeAssetLogoUrl = (fileName: string, quality?: '@2x') =>
-    `${ICONS_URL_BASE}${fileName}${quality === undefined ? '' : quality}.webp`;
+export interface GetAssetLogoUrlParams {
+    coingeckoId: string;
+    contractAddress?: string;
+    quality?: CoinImageQuality;
+    size?: CoinImageSize;
+}
 
 export const getAssetLogoUrl = ({
     coingeckoId,
     contractAddress,
-    quality,
-}: {
-    coingeckoId: string;
-    contractAddress?: string;
-    quality?: '@2x';
-}) =>
-    composeAssetLogoUrl(
-        contractAddress ? `${coingeckoId}--${contractAddress}` : coingeckoId,
-        quality,
-    );
+    quality = '1x',
+    size = 24,
+}: GetAssetLogoUrlParams) => {
+    const name = contractAddress ? `${coingeckoId}--${contractAddress}` : coingeckoId;
+    const fileName = createCoinImageName(name, { size, quality });
+
+    return `${ICONS_URL_BASE}/${fileName}` as const;
+};
+
+/**
+ * - Coin images are generated only in specific sizes (defined in `COIN_IMAGE_SIZES` constant).
+ * - This util. finds the `COIN_IMAGE_SIZES` size that is at least as big as the `size` parameter.
+ */
+export function resolveAssetLogoSize(size: number, defaultSize: CoinImageSize = 24): CoinImageSize {
+    return COIN_IMAGE_SIZES.find(s => s >= size) ?? defaultSize;
+}

--- a/packages/asset-utils/src/index.ts
+++ b/packages/asset-utils/src/index.ts
@@ -1,1 +1,1 @@
-export { getAssetLogoUrl } from './asset-logo-urls';
+export * from './asset-logo-urls';

--- a/packages/asset-utils/tsconfig.json
+++ b/packages/asset-utils/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": []
+    "references": [
+        { "path": "../../suite-common/icons" }
+    ]
 }

--- a/packages/components/src/components/AssetLogo/AssetLogo.tsx
+++ b/packages/components/src/components/AssetLogo/AssetLogo.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 // TODO: suite-common imports in non-suite packages should not be allowed
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { getNetwork, getNetworkByCoingeckoId, isNetworkSymbol } from '@suite-common/wallet-config';
-import { getAssetLogoUrl } from '@trezor/asset-utils';
+import { getAssetLogoUrl, resolveAssetLogoSize } from '@trezor/asset-utils';
 import { Elevation, borders, mapElevationToBackground, mapElevationToBorder } from '@trezor/theme';
 
 import { AssetInitials } from './AssetInitials';
@@ -18,7 +18,7 @@ import {
 import { TransientProps } from '../../utils/transientProps';
 import { ElevationUp, useElevation } from '../ElevationContext/ElevationContext';
 
-export const allowedAssetLogoSizes = [20, 24];
+export const allowedAssetLogoSizes = [20, 24, 32, 40] as const;
 type AssetLogoSize = (typeof allowedAssetLogoSizes)[number];
 
 export const allowedAssetLogoFrameProps = ['margin'] as const satisfies FramePropsKeys[];
@@ -100,11 +100,14 @@ export const AssetLogo = ({
     const logoUrl = getAssetLogoUrl({
         coingeckoId: coingeckoIdLogo,
         contractAddress: contractAddressLogo,
+        quality: '1x',
+        size: resolveAssetLogoSize(size),
     });
     const logoUrl2x = getAssetLogoUrl({
         coingeckoId: coingeckoIdLogo,
         contractAddress: contractAddressLogo,
-        quality: '@2x',
+        quality: '2x',
+        size: resolveAssetLogoSize(size),
     });
 
     const frameProps = pickAndPrepareFrameProps(rest, allowedAssetLogoFrameProps);

--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -34,7 +34,6 @@ export const useConnectPopupWeb = () => {
 
     useEffect(() => {
         const onMessage = async (event: MessageEvent) => {
-            console.log('onMessage', event.data);
             if (event.data?.type === 'channel-handshake-request') {
                 postMessageToParent({ type: 'channel-handshake-confirm' });
             } else if (event.data.type === POPUP.HANDSHAKE) {

--- a/suite-common/icons/scripts/constants/index.ts
+++ b/suite-common/icons/scripts/constants/index.ts
@@ -1,18 +1,15 @@
 import { join, resolve } from 'path';
 
+import { ICONS_URL_BASE } from '../../src/coinImages';
+
 export const PACKAGE_ROOT = resolve(__dirname, '..', '..');
 
 export const FILES_CRYPTOICONS_PATH = join(PACKAGE_ROOT, 'files', 'cryptoIcons');
 export const UPDATED_ICONS_LIST_FILE = join(FILES_CRYPTOICONS_PATH, 'icons.json');
-export const UPDATED_ICONS_LIST_URL = 'https://data.trezor.io/suite/icons/coins/icons.json';
+export const UPDATED_ICONS_LIST_URL = join(ICONS_URL_BASE, 'icons.json');
 
 export const COIN_LIST_URL = 'https://pro-api.coingecko.com/api/v3/coins/list';
 export const COIN_DATA_URL = 'https://pro-api.coingecko.com/api/v3/coins/';
 
 export const RATE_LIMIT_PER_MINUTE = 60;
 export const RUN_LIMIT_SECONDS = 60 * 60; // 1 hour
-
-export const COIN_IMAGE_SIZES = {
-    '1x': 24,
-    '2x': 48,
-};

--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -5,7 +5,6 @@ import { join } from 'path';
 import sharp from 'sharp';
 
 import {
-    COIN_IMAGE_SIZES,
     FILES_CRYPTOICONS_PATH,
     RATE_LIMIT_PER_MINUTE,
     RUN_LIMIT_SECONDS,
@@ -14,6 +13,35 @@ import {
 import { CoinListData } from './types';
 import { getCoinData, getCoinList, getUpdatedIconsList } from './utils/fetchCoins';
 import { sleep } from './utils/sleep';
+import {
+    COIN_IMAGE_QUALITIES,
+    COIN_IMAGE_SIZES,
+    createCoinImageName,
+    createCoinImageNameLegacy,
+} from '../src/coinImages';
+
+function writeImageSync(fileName: string, imageBuffer: Buffer) {
+    const destinationFile = join(FILES_CRYPTOICONS_PATH, fileName);
+
+    fs.writeFileSync(destinationFile, Buffer.from(imageBuffer));
+}
+
+async function resizeImage(imageBuffer: ArrayBuffer, size: number) {
+    const fullQualityImageBuffer = await sharp(imageBuffer)
+        .resize(size, size)
+        .webp({ quality: 100 })
+        .toBuffer();
+
+    const lossLessImageBuffer = await sharp(imageBuffer)
+        .resize(size, size)
+        .webp({ lossless: true })
+        .toBuffer();
+
+    // sometimes lossless image is much smaller than 100 quality compressed image
+    return fullQualityImageBuffer.byteLength < lossLessImageBuffer.byteLength
+        ? fullQualityImageBuffer
+        : lossLessImageBuffer;
+}
 
 const updateIcon = async (coin: CoinListData) => {
     console.log('Start icon updating for:', coin.id);
@@ -48,40 +76,38 @@ const updateIcon = async (coin: CoinListData) => {
     try {
         const originImageBuffer = await originImage.arrayBuffer();
 
-        for (const [size, COIN_IMAGE_SIZE] of Object.entries(COIN_IMAGE_SIZES)) {
-            const fullQualityImageBuffer = await sharp(originImageBuffer)
-                .resize(COIN_IMAGE_SIZE, COIN_IMAGE_SIZE)
-                .webp({ quality: 100 })
-                .toBuffer();
+        const platforms = Object.entries(coinData.platforms).filter(
+            ([platform, contract]) => platform && contract,
+        );
 
-            const lossLessImageBuffer = await sharp(originImageBuffer)
-                .resize(COIN_IMAGE_SIZE, COIN_IMAGE_SIZE)
-                .webp({ lossless: true })
-                .toBuffer();
+        for (const size of COIN_IMAGE_SIZES) {
+            const finalImageBuffer = await resizeImage(originImageBuffer, size);
 
-            // sometimes lossless image is much smaller than 100 quality compressed image
-            const finalImageBuffer =
-                fullQualityImageBuffer.byteLength < lossLessImageBuffer.byteLength
-                    ? fullQualityImageBuffer
-                    : lossLessImageBuffer;
-
-            const platforms = Object.entries(coinData.platforms).filter(
-                ([platform, contract]) => platform && contract,
-            );
-            if (platforms.length > 0) {
+            for (const quality of COIN_IMAGE_QUALITIES) {
                 platforms.forEach(([platform, contract]) => {
                     const name = `${platform}--${contract}`;
-                    const fileName = `${encodeURIComponent(name)}${size !== '1x' ? `@${size}` : ''}.webp`;
-                    const destinationFile = join(FILES_CRYPTOICONS_PATH, fileName);
 
-                    fs.writeFileSync(destinationFile, Buffer.from(finalImageBuffer));
+                    const fileName = createCoinImageName(name, { size, quality });
+                    writeImageSync(fileName, finalImageBuffer);
+
+                    // Make sure it's backwards compatible for older versions of the Trezor Suite
+                    if (size === 24) {
+                        const fileNameLegacy = createCoinImageNameLegacy(name, quality);
+                        writeImageSync(fileNameLegacy, finalImageBuffer);
+                    }
                 });
+
+                const name = coinData.id;
+
+                const fileName = createCoinImageName(name, { size, quality });
+                writeImageSync(fileName, finalImageBuffer);
+
+                // Make sure it's backwards compatible for older versions of the Trezor Suite
+                if (size === 24) {
+                    const fileNameLegacy = createCoinImageNameLegacy(name, quality);
+                    writeImageSync(fileNameLegacy, finalImageBuffer);
+                }
             }
-
-            const fileName = `${encodeURIComponent(coinData.id)}${size !== '1x' ? `@${size}` : ''}.webp`;
-            const destinationFile = join(FILES_CRYPTOICONS_PATH, fileName);
-
-            fs.writeFileSync(destinationFile, Buffer.from(finalImageBuffer));
         }
     } catch (error) {
         console.error('Error:', error);

--- a/suite-common/icons/scripts/types/index.ts
+++ b/suite-common/icons/scripts/types/index.ts
@@ -15,8 +15,17 @@ export interface CoinData {
     contract_address?: string;
     platforms: Record<string, string>;
     image: {
+        /**
+         * 25x25
+         */
         thumb: string;
+        /**
+         * 50x50
+         */
         small: string;
+        /**
+         * 250x250
+         */
         large: string;
     };
 }

--- a/suite-common/icons/scripts/utils/fetchCoins.ts
+++ b/suite-common/icons/scripts/utils/fetchCoins.ts
@@ -1,6 +1,6 @@
+import { sleep } from './sleep';
 import { COIN_DATA_URL, COIN_LIST_URL, UPDATED_ICONS_LIST_URL } from '../constants';
 import { CoinData, CoinListData, UpdatedIconsList } from '../types';
-import { sleep } from './sleep';
 
 const coingeckoApiOptions = {
     method: 'GET',

--- a/suite-common/icons/src/coinImages.ts
+++ b/suite-common/icons/src/coinImages.ts
@@ -1,0 +1,24 @@
+export const ICONS_URL_BASE = 'https://data.trezor.io/suite/icons/coins';
+
+export const COIN_IMAGE_SIZES = [24, 40] as const satisfies number[];
+export const COIN_IMAGE_QUALITIES = ['1x', '2x'] as const satisfies string[];
+
+export type CoinImageSize = (typeof COIN_IMAGE_SIZES)[number];
+export type CoinImageQuality = (typeof COIN_IMAGE_QUALITIES)[number];
+
+export function createCoinImageName<
+    Name extends string,
+    Size extends CoinImageSize,
+    Quality extends CoinImageQuality,
+>(name: Name, { size, quality }: { size: Size; quality: Quality }) {
+    const qualitySuffix =
+        quality !== '1x'
+            ? (`@${quality as Exclude<Quality, '1x'>}` as const)
+            : ('' as const satisfies string);
+
+    return `${encodeURIComponent(name)}--${size}${qualitySuffix}.webp` as const;
+}
+
+export function createCoinImageNameLegacy(name: string, quality: CoinImageQuality) {
+    return `${encodeURIComponent(name)}${quality !== '1x' ? `@${quality}` : ''}.webp` as const;
+}

--- a/suite-common/icons/src/index.ts
+++ b/suite-common/icons/src/index.ts
@@ -7,3 +7,4 @@ export * from './constants';
 export * from './tokenIcons';
 export * from './cryptoIcons';
 export * from './networkIcons';
+export * from './coinImages';

--- a/suite-native/icons/src/CryptoIcon.tsx
+++ b/suite-native/icons/src/CryptoIcon.tsx
@@ -11,7 +11,7 @@ import {
 } from '@suite-common/wallet-config';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { useTranslate } from '@suite-native/intl';
-import { getAssetLogoUrl } from '@trezor/asset-utils';
+import { getAssetLogoUrl, resolveAssetLogoSize } from '@trezor/asset-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 export interface CryptoIconProps {
     symbol: NetworkSymbol | NetworkDisplaySymbol;
@@ -58,13 +58,14 @@ export const CryptoIcon = ({ symbol, contractAddress, size = 'small' }: CryptoIc
                 url = getAssetLogoUrl({
                     coingeckoId,
                     contractAddress: formattedAddress,
-                    quality: '@2x',
+                    quality: '2x',
+                    size: resolveAssetLogoSize(sizeNumber, 24),
                 });
             }
         }
 
         return url;
-    }, [contractAddress, symbol]);
+    }, [contractAddress, sizeNumber, symbol]);
 
     return (
         <Image

--- a/yarn.lock
+++ b/yarn.lock
@@ -13367,6 +13367,8 @@ __metadata:
 "@trezor/asset-utils@workspace:*, @trezor/asset-utils@workspace:packages/asset-utils":
   version: 0.0.0-use.local
   resolution: "@trezor/asset-utils@workspace:packages/asset-utils"
+  dependencies:
+    "@suite-common/icons": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

- Currently, it was possible to generate coin images from Coingecko only in single size (24x24) in two image qualities (1x, 2x).
- Now it's possible to easily add additionally sizes to the `COIN_IMAGE_SIZES` or qualities to `COIN_IMAGE_QUALITIES`.
- The script generates the old name for backwards compatibility too.

Coin image name:
```
 type OldCoinImageName = `${string}--{'' | '2x'}.webp`
 type NewCoinImageName = `${string}--${24 | 40}{'' | '2x'}.webp`
```

## Related Issue

Resolve #22832

## Todo
- [x] Run https://github.com/trezor/trezor-suite/actions/workflows/release-suite-coin-icons.yml once merged


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/22832-big-network-icons&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/22832-big-network-icons&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/22832-big-network-icons&lookback=7)