### PR TITLE
feat(suite): cleanup messages in FW install onboarding step

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2632,12 +2632,6 @@ export default defineMessages({
         description: 'Main text on firmware page for devices without firmware',
         id: 'TR_FIRMWARE_SUBHEADING_NONE',
     },
-    TR_FIRMWARE_SUBHEADING_NONE_BITCOIN_ONLY_DEVICE: {
-        defaultMessage:
-            "Your device is ready for the latest firmware update to keep it secure. If you're a Bitcoin enthusiast, a Bitcoin-only firmware is also available.",
-        description: 'Main text on firmware page for Bitcoin-only devices without firmware',
-        id: 'TR_FIRMWARE_SUBHEADING_NONE_BITCOIN_ONLY_DEVICE',
-    },
     TR_FIRMWARE_SUBHEADING_UNKNOWN: {
         defaultMessage:
             'Your Trezor ships without firmware for security reasons. To start using it safely, install the latest firmware. Bitcoin-only user? We recommend the <button>{bitcoinOnly} firmware</button>.',
@@ -2645,15 +2639,16 @@ export default defineMessages({
             'Main text on firmware page for devices in bootloader mode, i.e. when Suite cannot determine current firmware type',
         id: 'TR_FIRMWARE_SUBHEADING_UNKNOWN',
     },
+    TR_FIRMWARE_SUBHEADING_BITCOIN_ONLY_DEVICE: {
+        defaultMessage:
+            'Your Trezor ships without firmware for security reasons. To start using it safely, install the latest Bitcoin-only firmware.',
+        description: 'Main text on firmware page for Bitcoin-only devices without firmware',
+        id: 'TR_FIRMWARE_SUBHEADING_BITCOIN_ONLY_DEVICE',
+    },
     TR_FIRMWARE_SUBHEADING_BITCOIN: {
         defaultMessage: 'A lightweight firmware supporting Bitcoin-only operations.',
         description: 'Explanation of Bitcoin-only firmware in onboarding',
         id: 'TR_FIRMWARE_SUBHEADING_BITCOIN',
-    },
-    TR_FIRMWARE_SUBHEADING_UNKNOWN_BITCOIN_ONLY_DEVICE: {
-        defaultMessage: 'A lightweight firmware supporting Bitcoin-only operations.',
-        description: 'Explanation of Bitcoin-only firmware in onboarding for Bitcoin-only devices',
-        id: 'TR_FIRMWARE_SUBHEADING_UNKNOWN_BITCOIN_ONLY_DEVICE',
     },
     TR_CHANGE_FIRMWARE_TYPE_ANYTIME: {
         defaultMessage: 'You can change your firmware type in Settings anytime.',

--- a/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx
@@ -64,9 +64,9 @@ const getNoFirmwareInstalledSubheading = (device: AcquiredDevice) => {
     const bitcoinOnlyDevice = isBitcoinOnlyDevice(device);
 
     if (bitcoinOnlyDevice) {
-        return device.firmware === 'none'
-            ? 'TR_FIRMWARE_SUBHEADING_NONE_BITCOIN_ONLY_DEVICE'
-            : 'TR_FIRMWARE_SUBHEADING_UNKNOWN_BITCOIN_ONLY_DEVICE';
+        // device.firmware === 'unknown' is for T1B1 in bootloader (most likely fresh or factory reset),
+        // but T1B1 is never bitcoin-only device (meaning you can always choose Universal or BTC-only)
+        return 'TR_FIRMWARE_SUBHEADING_BITCOIN_ONLY_DEVICE';
     }
 
     return device.firmware === 'none'


### PR DESCRIPTION
## Description

Unify description text for FW installation in Onboarding, requested [here slack link](https://satoshilabs.slack.com/archives/CKZHV2G13/p1762248157687619?thread_ts=1762191817.591209&cid=CKZHV2G13)

## Notes for QA

Try installing FW in onboarding for fresh or factory-reset device:
- T1B1 
- any newer
- any newer; BTC-only

Should behave as per screenshots/videos below.

## Screenshots:

### Before & after Normal device:

[Before & after normal device.webm](https://github.com/user-attachments/assets/f5a141da-310c-4de0-b6a9-f4c896a8371d)

### Before BTC-only

<img width="895" height="896" alt="Before BTC-only" src="https://github.com/user-attachments/assets/d371775e-403c-46f8-a61a-25bb47f711c5" />

### After BTC-only

[After BTC-only device.webm](https://github.com/user-attachments/assets/3fbbe007-7ddf-40fa-b669-945eaa154fe4)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tweak-FW-install-messages&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tweak-FW-install-messages&lookback=7)