### PR TITLE
Trading - Include country in Trading feedback form

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
@@ -59,6 +59,8 @@ export const TradingDetailBuy = () => {
     const supportUrlTemplate = provider?.statusUrl || provider?.supportUrl;
     const supportUrl = supportUrlTemplate?.replace('{{paymentId}}', trade?.data?.paymentId || '');
 
+    const country = trade?.data?.country;
+
     const quoteAmounts: TradingGetCryptoQuoteAmountProps = {
         amountInCrypto: trade?.data?.wantCrypto,
         sendAmount: trade?.data?.fiatStringAmount ?? '',
@@ -127,6 +129,7 @@ export const TradingDetailBuy = () => {
                     provider={provider?.name}
                     id={trade.data.id}
                     quoteAmounts={quoteAmounts}
+                    country={country}
                 />
             </Column>
             <Card>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -155,6 +155,7 @@ export const TradingDetailExchange = () => {
                         <TradingDetailExchangePaymentSending supportUrl={supportUrl} />
                     )}
                 </Card>
+
                 {tradingSurveyFeature ? (
                     <TradingDetailSurvey />
                 ) : (

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback.tsx
@@ -8,6 +8,7 @@ import {
 } from 'invity-api';
 
 import { Rating, buildUserFeedbackData, sendFeedbackAction } from '@suite-common/feedback';
+import { selectCountryCode } from '@suite-common/geolocation';
 import { ExperimentId } from '@suite-common/message-system';
 import { TradingType } from '@suite-common/trading';
 import { Card, Column, IconCircle, NewButton, Row, Text, Textarea } from '@trezor/components';
@@ -16,7 +17,7 @@ import { spacings } from '@trezor/theme';
 import { EmojiRatingSelector } from 'src/components/suite/EmojiRatingSelector';
 import { ExperimentWrapper } from 'src/components/suite/Experiment/ExperimentWrapper';
 import { Translation } from 'src/components/suite/Translation';
-import { useDevice, useDispatch } from 'src/hooks/suite';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
 
 interface TradingDetailFeedbackProps {
@@ -25,6 +26,7 @@ interface TradingDetailFeedbackProps {
     provider?: ExchangeProviderInfo['name'];
     id?: string;
     quoteAmounts: TradingGetCryptoQuoteAmountProps;
+    country?: string;
 }
 
 export const TradingDetailFeedback = ({
@@ -33,6 +35,7 @@ export const TradingDetailFeedback = ({
     provider,
     id,
     quoteAmounts: { sendCurrency, receiveCurrency },
+    country,
 }: TradingDetailFeedbackProps) => {
     const [rating, setRating] = useState<Rating | undefined>();
     const [description, setDescription] = useState<string>('');
@@ -40,6 +43,7 @@ export const TradingDetailFeedback = ({
 
     const { device } = useDevice();
     const dispatch = useDispatch();
+    const geolocation = useSelector(selectCountryCode);
 
     const submitFeedback = () => {
         if (!rating) return;
@@ -59,6 +63,8 @@ export const TradingDetailFeedback = ({
                     type,
                     sendCurrency,
                     receiveCurrency,
+                    geolocation: geolocation || undefined,
+                    countryOfResidence: country || undefined,
                     ...userData,
                 },
             }),

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
@@ -52,6 +52,8 @@ export const TradingDetailSell = () => {
     const supportUrlTemplate = provider?.statusUrl || provider?.supportUrl;
     const supportUrl = supportUrlTemplate?.replace('{{orderId}}', trade?.data?.orderId || '');
 
+    const country = trade?.data?.country;
+
     const quoteAmounts: TradingGetCryptoQuoteAmountProps = {
         amountInCrypto: trade?.data?.amountInCrypto,
         sendAmount: trade?.data?.fiatStringAmount ?? '',
@@ -119,6 +121,7 @@ export const TradingDetailSell = () => {
                     provider={provider?.name}
                     id={trade.data.id}
                     quoteAmounts={quoteAmounts}
+                    country={country}
                 />
             </Column>
             <Card>


### PR DESCRIPTION
## Description

Include country of residence and geolocation in the trading feedback form.

## Related Issue

Resolve #22611 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-feedback-country&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-feedback-country&lookback=7)