### PR TITLE
feat(suite-native): english translations source of truth

### DIFF
--- a/suite-native/intl/src/hooks/useTranslatedMessages.ts
+++ b/suite-native/intl/src/hooks/useTranslatedMessages.ts
@@ -7,7 +7,7 @@ import { messages as defaultMessages } from '../messages';
 import { flatten } from '../utils';
 
 const LANGUAGE_TRANSLATIONS_MAP = {
-    'en-US': require('../../translations/en-US.json'),
+    'en-US': {}, // english is always read from `messages.ts` source
     'cs-CZ': require('../../translations/cs-CZ.json'),
 } as const satisfies Record<NativeLocale, any>;
 


### PR DESCRIPTION
## Description
- this PR makes `message.ts` as the only source of truth for english translation in the Trezor Suite mobile app
- what about `en-SU.json` file from Crowdin?
  - 1. it is downloaded from crowdin servers
  - 2. all its changes are backported to the `messages.ts` with use of `backportEnglish.ts` script
  - 3. When is the app launched it ignores `en-US.json` and uses `messages.ts`

This means that:
  1. All the changes made at Crowdin by translators are correctly fetched to GitHub
  2. Developers do not have to care about editing translations via the Crowdin UI, making changes to the `message.ts` is enough


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/english-translations-source-of-truth&lookback=7)