### PR TITLE
Add a network filter to the SearchAsset component

### DIFF
--- a/packages/product-components/src/components/SelectAssetModal/SearchAsset.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/SearchAsset.tsx
@@ -1,10 +1,39 @@
-import { Icon, Input } from '@trezor/components';
+import styled from 'styled-components';
 
-interface SearchAssetProps {
+import { Icon, Input, Select } from '@trezor/components';
+import { spacingsPx } from '@trezor/theme';
+
+import { CoinLogo } from '../CoinLogo/CoinLogo';
+import { SearchAssetSelectConfig, useNetworkSelect } from './hooks/useNetworkSelect';
+
+const SelectWrapper = styled.div`
+    /* stylelint-disable selector-class-pattern */
+    .react-select__value-container {
+        justify-content: flex-end;
+    }
+
+    .react-select__control {
+        &:focus,
+        &:focus-within {
+            border-color: transparent;
+        }
+    }
+    /* stylelint-enable selector-class-pattern */
+`;
+
+const Option = styled.div`
+    display: flex;
+    align-items: center;
+    gap: ${spacingsPx.xs};
+`;
+
+export interface SearchAssetProps {
     searchPlaceholder: string;
     search: string;
     setSearch: (value: string) => void;
     'data-testid'?: string;
+    selectConfig?: SearchAssetSelectConfig;
+    autoFocus?: boolean;
 }
 
 export const SearchAsset = ({
@@ -12,16 +41,44 @@ export const SearchAsset = ({
     search,
     setSearch,
     'data-testid': dataTestId,
-}: SearchAssetProps) => (
-    <Input
-        data-testid={dataTestId}
-        placeholder={searchPlaceholder}
-        value={search}
-        onChange={event => setSearch(event.target.value)}
-        onClear={() => setSearch('')}
-        showClearButton="always"
-        leftContent={<Icon name="magnifyingGlass" variant="tertiary" size="medium" />}
-        // eslint-disable-next-line jsx-a11y/no-autofocus
-        autoFocus
-    />
-);
+    selectConfig,
+    autoFocus = true,
+}: SearchAssetProps) => {
+    const { options, selectedOption } = useNetworkSelect(selectConfig);
+
+    const networkSelect = selectConfig ? (
+        <SelectWrapper>
+            <Select
+                options={options}
+                value={selectedOption}
+                onChange={option => selectConfig.onChange(option.value)}
+                size="small"
+                formatOptionLabel={option => (
+                    <Option>
+                        {option.value && (
+                            <CoinLogo size={20} symbol={option.value} type="network" />
+                        )}
+                        <span>{option.label}</span>
+                    </Option>
+                )}
+                width="auto"
+                minValueWidth="170px"
+                isRenderedInModal
+            />
+        </SelectWrapper>
+    ) : undefined;
+
+    return (
+        <Input
+            data-testid={dataTestId}
+            placeholder={searchPlaceholder}
+            value={search}
+            onChange={event => setSearch(event.target.value)}
+            onClear={() => setSearch('')}
+            leftContent={<Icon name="magnifyingGlass" variant="tertiary" size="medium" />}
+            rightContent={networkSelect}
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus={autoFocus}
+        />
+    );
+};

--- a/packages/product-components/src/components/SelectAssetModal/hooks/useNetworkSelect.ts
+++ b/packages/product-components/src/components/SelectAssetModal/hooks/useNetworkSelect.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+
+import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+
+export interface SearchAssetSelectConfig {
+    networks: NetworkSymbol[];
+    selectedNetwork: NetworkSymbol | undefined;
+    onChange: (network?: NetworkSymbol) => void;
+    includeAllOption?: boolean;
+    allLabel?: string;
+}
+
+export const useNetworkSelect = (config?: SearchAssetSelectConfig) => {
+    const { networks = [], includeAllOption, allLabel, selectedNetwork } = config ?? {};
+
+    const options = useMemo(() => {
+        const networkOptions = networks
+            .map(symbol => {
+                const network = getNetwork(symbol);
+
+                return network ? { label: network.name, value: network.symbol } : null;
+            })
+            .filter(option => !!option);
+
+        return includeAllOption
+            ? [{ label: allLabel ?? 'All networks', value: undefined }, ...networkOptions]
+            : networkOptions;
+    }, [networks, includeAllOption, allLabel]);
+
+    const selectedOption =
+        selectedNetwork === undefined
+            ? options.find(option => option.value === undefined)
+            : options.find(option => option.value === selectedNetwork);
+
+    return { options, selectedOption };
+};

--- a/packages/suite/src/actions/wallet/accountSearchActions.ts
+++ b/packages/suite/src/actions/wallet/accountSearchActions.ts
@@ -1,3 +1,5 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+
 import { ACCOUNT_SEARCH } from 'src/actions/wallet/constants';
 import type { Account } from 'src/types/wallet';
 
@@ -9,6 +11,10 @@ export type AccountSearchAction =
     | {
           type: typeof ACCOUNT_SEARCH.SET_SEARCH_STRING;
           payload?: string;
+      }
+    | {
+          type: typeof ACCOUNT_SEARCH.SET_SELECTED_NETWORK;
+          payload?: NetworkSymbol;
       };
 
 export const setCoinFilter = (payload?: Account['symbol']): AccountSearchAction => ({
@@ -18,5 +24,10 @@ export const setCoinFilter = (payload?: Account['symbol']): AccountSearchAction 
 
 export const setSearchString = (payload?: string): AccountSearchAction => ({
     type: ACCOUNT_SEARCH.SET_SEARCH_STRING,
+    payload,
+});
+
+export const setSelectedNetwork = (payload?: NetworkSymbol): AccountSearchAction => ({
+    type: ACCOUNT_SEARCH.SET_SELECTED_NETWORK,
     payload,
 });

--- a/packages/suite/src/actions/wallet/constants/accountSearch.ts
+++ b/packages/suite/src/actions/wallet/constants/accountSearch.ts
@@ -1,2 +1,3 @@
 export const SET_COIN_FILTER = '@account-search/set-coin-filter' as const;
 export const SET_SEARCH_STRING = '@account-search/set-search-string' as const;
+export const SET_SELECTED_NETWORK = '@account-search/set-selected-network' as const;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveModalBase.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveModalBase.tsx
@@ -1,10 +1,13 @@
+import { selectEnabledNetworks } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
-import { Box, Column, ElevationContext, Input, Modal, Row } from '@trezor/components';
+import { Box, Column, ElevationContext, Modal, Row } from '@trezor/components';
+import { SearchAsset } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
+import { useAccountSearch, useSelector, useTranslation } from 'src/hooks/suite';
+import { AccountItemType } from 'src/types/wallet';
+
 import { AccountList } from './AccountList';
-import { useAccountSearch, useTranslation } from '../../../../../../hooks/suite';
-import { AccountItemType } from '../../../../../../types/wallet';
 
 type GlobalSendReceiveModalBaseProps = {
     heading?: React.ReactNode;
@@ -19,19 +22,29 @@ export const GlobalSendReceiveModalBase = ({
     onSubmit,
     additionalAction,
 }: GlobalSendReceiveModalBaseProps) => {
-    const { searchString, setSearchString } = useAccountSearch();
+    const { searchString, setSearchString, selectedNetwork, setSelectedNetwork } =
+        useAccountSearch();
     const { translationString } = useTranslation();
+    const enabledNetworksSymbol = useSelector(selectEnabledNetworks);
 
     return (
         <Modal heading={heading} onCancel={() => onCancel(!!searchString)} size="small">
             <Column height={500} gap={spacings.sm}>
                 <Row gap={spacings.xs}>
                     <Box flex="1">
-                        <Input
-                            placeholder={translationString('TR_SEARCH')}
-                            size="small"
-                            value={searchString ?? ''}
-                            onChange={event => setSearchString(event.target.value)}
+                        <SearchAsset
+                            searchPlaceholder={translationString('TR_SEARCH')}
+                            search={searchString ?? ''}
+                            setSearch={setSearchString}
+                            selectConfig={{
+                                networks: enabledNetworksSymbol,
+                                selectedNetwork,
+                                onChange: setSelectedNetwork,
+                                includeAllOption: true,
+                                allLabel: translationString('TR_ALL_NETWORKS', {
+                                    networkCount: enabledNetworksSymbol.length,
+                                }),
+                            }}
                         />
                     </Box>
                     {additionalAction}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -116,7 +116,7 @@ export const AccountsList = ({
 
     const { getDefaultAccountLabel } = useDefaultAccountLabel();
     const { isSidebarCollapsed } = useResponsiveContext();
-    const { coinFilter, searchString } = useAccountSearch();
+    const { coinFilter, searchString, selectedNetwork } = useAccountSearch();
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
     const discoveryInProgress = discoveryStatus && discoveryStatus.status === 'loading';
 
@@ -125,7 +125,7 @@ export const AccountsList = ({
     }
 
     const filteredAccounts =
-        searchString || coinFilter
+        searchString || coinFilter || selectedNetwork
             ? accounts.filter(account => {
                   const { key, accountType, symbol, index } = account;
                   const accountLabelOld = Object.prototype.hasOwnProperty.call(accountLabels, key)
@@ -140,6 +140,10 @@ export const AccountsList = ({
                           accountDescriptor,
                           networkSymbol,
                       })?.label ?? accountLabelOld;
+
+                  if (selectedNetwork && networkSymbol !== selectedNetwork) {
+                      return false;
+                  }
 
                   return accountSearchFn(account, searchString, coinFilter, accountLabel);
               })

--- a/packages/suite/src/hooks/suite/useAccountSearch.tsx
+++ b/packages/suite/src/hooks/suite/useAccountSearch.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useMemo, useState } from 'react';
 
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 
 import * as accountSearchActions from 'src/actions/wallet/accountSearchActions';
@@ -8,24 +9,37 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 type AccountSearchContextType = {
     coinFilter: Account['symbol'] | undefined;
     searchString: string | undefined;
+    selectedNetwork: NetworkSymbol | undefined;
     setCoinFilter: (filter?: Account['symbol']) => void;
     setSearchString: (search?: string) => void;
+    setSelectedNetwork: (network?: NetworkSymbol) => void;
 };
 
 const AccountSearchContext = createContext<AccountSearchContextType>({
     coinFilter: undefined,
     searchString: '',
+    selectedNetwork: undefined,
     setCoinFilter: () => {},
     setSearchString: () => {},
+    setSelectedNetwork: () => {},
 });
 
 export const LocalAccountSearchProvider = ({ children }: { children: React.ReactNode }) => {
     const [coinFilter, setCoinFilter] = useState<Account['symbol'] | undefined>(undefined);
     const [searchString, setSearchString] = useState<string | undefined>(undefined);
+    const [selectedNetwork, setSelectedNetwork] =
+        useState<AccountSearchContextType['selectedNetwork']>(undefined);
 
     return (
         <AccountSearchContext.Provider
-            value={{ coinFilter, searchString, setCoinFilter, setSearchString }}
+            value={{
+                coinFilter,
+                searchString,
+                selectedNetwork,
+                setCoinFilter,
+                setSearchString,
+                setSelectedNetwork,
+            }}
         >
             {children}
         </AccountSearchContext.Provider>
@@ -33,7 +47,9 @@ export const LocalAccountSearchProvider = ({ children }: { children: React.React
 };
 
 export const ReduxAccountSearchProvider = ({ children }: { children: React.ReactNode }) => {
-    const { coinFilter, searchString } = useSelector(state => state.wallet.accountSearch);
+    const { coinFilter, searchString, selectedNetwork } = useSelector(
+        state => state.wallet.accountSearch,
+    );
     const dispatch = useDispatch();
 
     const actions = useMemo(
@@ -42,6 +58,8 @@ export const ReduxAccountSearchProvider = ({ children }: { children: React.React
                 dispatch(accountSearchActions.setCoinFilter(filter)),
             setSearchString: (search?: string) =>
                 dispatch(accountSearchActions.setSearchString(search)),
+            setSelectedNetwork: (network?: NetworkSymbol) =>
+                dispatch(accountSearchActions.setSelectedNetwork(network)),
         }),
         [dispatch],
     );
@@ -49,6 +67,7 @@ export const ReduxAccountSearchProvider = ({ children }: { children: React.React
     const value = {
         coinFilter,
         searchString,
+        selectedNetwork,
         ...actions,
     };
 

--- a/packages/suite/src/reducers/wallet/accountSearchReducer.ts
+++ b/packages/suite/src/reducers/wallet/accountSearchReducer.ts
@@ -1,5 +1,6 @@
 import { produce } from 'immer';
 
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { changeNetworks, deviceActions } from '@suite-common/wallet-core';
 
 import { ACCOUNT_SEARCH } from 'src/actions/wallet/constants';
@@ -9,11 +10,13 @@ import { Account as AccountType } from 'src/types/wallet';
 export interface State {
     coinFilter: AccountType['symbol'] | undefined;
     searchString: string | undefined;
+    selectedNetwork: NetworkSymbol | undefined;
 }
 
 export const initialState: State = {
     coinFilter: undefined,
     searchString: undefined,
+    selectedNetwork: undefined,
 };
 
 const accountSearchReducer = (state: State = initialState, action: Action): State =>


### PR DESCRIPTION
## Description

Adds optional single-select network filter support to the `SearchAsset` component. The select is passed via props (`selectConfig`) to keep the component generic and reusable across products.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22831

## Screenshots:

<img width="665" height="631" alt="image" src="https://github.com/user-attachments/assets/95491a6b-88ec-4125-8bd1-f8b72648e0e8" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/search-asset-network-filter&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/search-asset-network-filter&lookback=7)