### PR TITLE
feat(suite): fees fixups

### DIFF
--- a/packages/components/src/components/Collapsible/CollapsibleToggle.tsx
+++ b/packages/components/src/components/Collapsible/CollapsibleToggle.tsx
@@ -13,12 +13,14 @@ type CollapsibleToggleProps = {
     children: ReactNode;
     onClick?: () => void;
     'data-testid'?: string;
+    disabled?: boolean;
 };
 
 export const CollapsibleToggle = ({
     children,
     onClick,
     'data-testid': dataTestId,
+    disabled,
 }: CollapsibleToggleProps) => {
     const { toggle, isOpen, contentId } = useCollapsible();
 
@@ -34,6 +36,7 @@ export const CollapsibleToggle = ({
             role="button"
             tabIndex={0}
             aria-expanded={isOpen}
+            aria-disabled={disabled}
             aria-controls={contentId}
             data-testid={dataTestId}
             onClick={clickHandler}

--- a/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
+++ b/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
@@ -55,6 +55,7 @@ export type CollapsibleBoxProps = AllowedFrameProps & {
     'data-testid-toggle'?: string;
     defaultIsOpen?: boolean;
     collapsible?: boolean;
+    headerHoverEffect?: boolean;
 } & Pick<
         CollapsibleHeaderContentProps,
         | 'heading'
@@ -127,6 +128,7 @@ export const CollapsibleBox = ({
     'data-testid': dataTest,
     'data-testid-toggle': dataTestToggleId = '@collapsible-box/toggle',
     collapsible = true,
+    headerHoverEffect = true,
     ...rest
 }: CollapsibleBoxProps) => {
     const { elevation } = useElevation();
@@ -149,11 +151,13 @@ export const CollapsibleBox = ({
                             setIsOpen(!isOpen);
                         }
                     }}
+                    disabled={!collapsible}
                 >
                     <CollapsibleHeader
                         paddingType={paddingType}
                         fillType={fillType}
                         collapsible={collapsible}
+                        hoverEffect={headerHoverEffect}
                     >
                         <CollapsibleHeaderContent
                             isOpen={isOpen}

--- a/packages/components/src/components/CollapsibleBox/CollapsibleHeader.tsx
+++ b/packages/components/src/components/CollapsibleBox/CollapsibleHeader.tsx
@@ -10,6 +10,7 @@ import { ElevationUp } from '../ElevationContext/ElevationContext';
 type HeaderProps = {
     $paddingType: PaddingType;
     $collapsible: boolean;
+    $hoverEffect: boolean;
 };
 
 const Header = styled.header<HeaderProps>`
@@ -18,7 +19,8 @@ const Header = styled.header<HeaderProps>`
 
     &:hover {
         ${Toggle} {
-            opacity: ${({ $collapsible }) => ($collapsible ? 0.5 : 1)};
+            opacity: ${({ $hoverEffect, $collapsible }) =>
+                $collapsible && $hoverEffect ? 0.5 : 1};
         }
     }
 `;
@@ -28,6 +30,7 @@ export interface CollapsibleHeaderProps {
     fillType: FillType;
     children: ReactNode;
     collapsible: boolean;
+    hoverEffect: boolean;
 }
 
 export function CollapsibleHeader({
@@ -35,9 +38,10 @@ export function CollapsibleHeader({
     fillType,
     children,
     collapsible,
+    hoverEffect,
 }: CollapsibleHeaderProps) {
     return (
-        <Header $paddingType={paddingType} $collapsible={collapsible}>
+        <Header $paddingType={paddingType} $collapsible={collapsible} $hoverEffect={hoverEffect}>
             {fillType === 'none' ? children : <ElevationUp>{children}</ElevationUp>}
         </Header>
     );

--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/fees.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/fees.ts
@@ -14,6 +14,7 @@ export class Fees {
         this.page.getByTestId(`@fee-card/${feeType}-fiat-amount`);
     readonly rateOnCard = (feeType: FeeTypes) => this.page.getByTestId(`@fee-card/${feeType}-rate`);
     readonly collapsibleFeesToggle: Locator;
+    readonly maxFeeLoading: Locator;
     readonly customInput: Locator;
     readonly maxFee: Locator;
     readonly maxFeeFiat: Locator;
@@ -25,6 +26,7 @@ export class Fees {
 
     constructor(private readonly page: Page) {
         this.collapsibleFeesToggle = this.page.getByTestId('@wallet/fees/collapsible-fees-toggle');
+        this.maxFeeLoading = this.page.getByTestId('@trading/quote/maximum-fee-amount-loading');
         this.customInput = this.page.getByTestId('feePerUnit');
         this.maxFee = this.page.getByTestId('@trading/quote/maximum-fee-amount');
         this.maxFeeFiat = this.page.getByTestId('@trading/quote/maximum-fee-fiat-amount');
@@ -67,6 +69,17 @@ export class Fees {
 
         if (isExpanded === 'true') {
             return;
+        }
+
+        // Wait for maximum fee to be calculated
+        await this.maxFeeLoading.waitFor({ state: 'hidden' });
+
+        const isDisabled = await this.collapsibleFeesToggle.getAttribute('aria-disabled');
+
+        if (isDisabled === 'true') {
+            throw new Error(
+                `Can't open collapsible fees because it is disabled. Make sure 'to' and 'amount' fields are filled so that maximum fee is calculated.`,
+            );
         }
 
         await expect(this.collapsibleFeesToggle).toHaveAttribute('aria-expanded', 'false');

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
@@ -130,8 +130,9 @@ test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () 
                 });
 
                 await test.step(`Fill in a sell form with ${feeType} fee`, async () => {
-                    await feeSwitchFunction();
                     await tradingPage.fillSellForm({ cryptoAmount });
+                    await tradingPage.fees.openCollapsibleFees();
+                    await feeSwitchFunction();
                     feeRate = await tradingPage.fees.getBitcoinFeeRate(feeType);
                 });
 

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
@@ -69,15 +69,15 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
 
     test('Sell Ethereum', async ({ tradingPage, devicePrompt }) => {
         await test.step('Fill in a sell request', async () => {
-            await tradingPage.fees.setEthereumCustomFees({
-                gasLimit,
-                maxFeePerGas,
-                maxPriorityFeePerGas,
-            });
             await tradingPage.fillSellForm({
                 cryptoAmount,
                 networkSymbolOrTokenId: 'eth',
                 cryptoCurrency: 'ethereum',
+            });
+            await tradingPage.fees.setEthereumCustomFees({
+                gasLimit,
+                maxFeePerGas,
+                maxPriorityFeePerGas,
             });
             await expect(tradingPage.bestOfferAmount).toHaveText(fiatAmount);
             await expect(tradingPage.quoteProvider).toHaveText(capitalizeFirstLetter(provider));

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
@@ -60,9 +60,6 @@ test.describe('Trading - Sell inputs', { tag: ['@group=trading', '@webOnly'] }, 
         });
 
         await test.step('Try all % inputs for Bitcoin', async () => {
-            await tradingPage.fees.switchToCustom();
-            await tradingPage.fees.customInput.fill(customFeeRate.toString());
-
             for (const percentage of [10, 25, 50]) {
                 await test.step(`${percentage}% of BTC balance`, async () => {
                     await tradingPage.cryptoInputFractionButtons
@@ -75,6 +72,9 @@ test.describe('Trading - Sell inputs', { tag: ['@group=trading', '@webOnly'] }, 
                     });
                 });
             }
+
+            await tradingPage.fees.switchToCustom();
+            await tradingPage.fees.customInput.fill(customFeeRate.toString());
 
             await test.step('Max of BTC balance', async () => {
                 await tradingPage.cryptoInputFractionButtons

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-fees-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-fees-bitcoin.test.ts
@@ -28,8 +28,6 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@group=trading', '@webOnly
     test('Swap custom fees for Bitcoin', async ({ page, tradingPage, devicePrompt }) => {
         let feeRate: string;
         await test.step('Fill in a Swap form', async () => {
-            await tradingPage.fees.switchToCustom();
-            await tradingPage.fees.customInput.fill(customFee);
             await tradingPage.fillSwapForm({
                 amount: sendAmount,
                 sendCurrency: 'bitcoin',
@@ -39,6 +37,8 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@group=trading', '@webOnly
                 receiveNetwork: 'ethereum',
                 receiveAddress,
             });
+            await tradingPage.fees.switchToCustom();
+            await tradingPage.fees.customInput.fill(customFee);
             feeRate = await tradingPage.fees.getBitcoinFeeRate('custom');
         });
 

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-fees-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-fees-ethereum.test.ts
@@ -38,11 +38,6 @@ test.describe('Trading - Swap fees', { tag: ['@group=trading', '@webOnly'] }, ()
 
     test('Swap custom fees for Ethereum', async ({ page, tradingPage, devicePrompt }) => {
         await test.step('Fill in a Swap form', async () => {
-            await tradingPage.fees.setEthereumCustomFees({
-                gasLimit,
-                maxFeePerGas,
-                maxPriorityFeePerGas,
-            });
             await tradingPage.fillSwapForm({
                 amount: sendAmount,
                 sendCurrency: 'ethereum',
@@ -51,6 +46,11 @@ test.describe('Trading - Swap fees', { tag: ['@group=trading', '@webOnly'] }, ()
                 receiveSymbol: 'btc',
                 receiveNetwork: 'bitcoin',
                 receiveAddress,
+            });
+            await tradingPage.fees.setEthereumCustomFees({
+                gasLimit,
+                maxFeePerGas,
+                maxPriorityFeePerGas,
             });
         });
 

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
@@ -16,6 +16,7 @@ import { CustomFee } from './CustomFee/CustomFee';
 import { MaximumFee } from './MaximumFee';
 import { StandardFee } from './StandardFee/StandardFee';
 import { FeesContext, FeesContextType } from '../context/FeesContext';
+import { useTransactionMaxFee } from './hooks/useTransactionMaxFee';
 
 export type CollapsibleFeesProps = {
     networkType: NetworkType;
@@ -55,6 +56,12 @@ export function CollapsibleFees({
 
     const theme = useTheme();
 
+    const txMaxFee = useTransactionMaxFee({
+        networkSymbol,
+        composedLevels,
+        selectedFeeLevel,
+    });
+
     if (!selectedFeeLevel) {
         return null;
     }
@@ -84,11 +91,12 @@ export function CollapsibleFees({
                 overflow="unset"
                 toggleComponent={
                     composedLevels === null ? null : (
-                        <MaximumFee typographyStyle={headerTypographyStyle} />
+                        <MaximumFee typographyStyle={headerTypographyStyle} txMaxFee={txMaxFee} />
                     )
                 }
-                collapsible={supportsAdjustableFees}
+                collapsible={supportsAdjustableFees && txMaxFee !== null}
                 data-testid-toggle="@wallet/fees/collapsible-fees-toggle"
+                headerHoverEffect={false}
             >
                 <Column gap={spacings.md}>
                     <Column gap={spacings.md}>
@@ -96,7 +104,7 @@ export function CollapsibleFees({
                         {isCustomFee && <CustomFee showCurrentFee={!rbfForm} />}
                     </Column>
 
-                    <Row justifyContent="center">
+                    <Row justifyContent="center" margin={{ bottom: spacings.xs }}>
                         {isCustomFee && (
                             <Button
                                 intent="neutral"

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/InlineLoader.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/InlineLoader.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+
+import { Row, Spinner, SpinnerProps } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+interface InlineLoaderProps {
+    children: ReactNode;
+    loading: boolean;
+    size?: SpinnerProps['size'];
+}
+
+export function InlineLoader({ children, loading, size = 20 }: InlineLoaderProps) {
+    if (!loading) {
+        return <>{children}</>;
+    }
+
+    return (
+        <Row gap={spacings.sm}>
+            <Spinner size={size} />
+            {children}
+        </Row>
+    );
+}

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/MaximumFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/MaximumFee.tsx
@@ -1,72 +1,63 @@
-import { memo, useEffect, useMemo, useState } from 'react';
-
-import { getNetwork } from '@suite-common/wallet-config';
-import { AmountUnit, asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
+import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import { Column, Text } from '@trezor/components';
 import { TypographyStyle } from '@trezor/theme';
-import { BigNumber } from '@trezor/utils';
 
 import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { useSelector } from 'src/hooks/suite';
 
+import { InlineLoader } from './InlineLoader';
+import { TransactionMaxFee } from './hooks/useTransactionMaxFee';
 import { useFeesContext } from '../context/FeesContext';
 
 export type MaximumFeeProps = {
     typographyStyle: TypographyStyle;
+    txMaxFee: TransactionMaxFee;
 };
 
-export const MaximumFee = memo(function MaximumFeeInner({ typographyStyle }: MaximumFeeProps) {
-    const { networkSymbol, composedLevels, selectedFeeLevel } = useFeesContext();
-    const transactionInfo = composedLevels?.[selectedFeeLevel.label];
-    const txFee = transactionInfo?.type !== 'error' ? transactionInfo?.fee : null;
-    const [txMaximumFee, setTxMaximumFee] = useState<AmountUnit | null>(null);
-    const txMaxFee = useMemo(() => {
-        if (!txFee) return null;
+export function MaximumFee({ typographyStyle, txMaxFee }: MaximumFeeProps) {
+    const { networkSymbol } = useFeesContext();
+    const areFeesLoading = useSelector(state => selectAreFeesLoading(state, networkSymbol));
 
-        return subunitsToUnits({
-            value: asAmountSubunit(new BigNumber(txFee)),
-            symbol: networkSymbol,
-            decimals: getNetwork(networkSymbol)?.decimals,
-        }) as AmountUnit;
-    }, [networkSymbol, txFee]);
-
-    useEffect(() => {
-        if (txMaxFee) {
-            setTxMaximumFee(txMaxFee);
-        }
-    }, [txMaxFee]);
-
-    if (!txMaximumFee) {
+    if (!txMaxFee) {
         return (
-            <Text variant="tertiary" typographyStyle={typographyStyle}>
-                <Translation id="TO_BE_CALCULATED" />
-            </Text>
+            <InlineLoader loading={areFeesLoading}>
+                <Text
+                    variant="tertiary"
+                    typographyStyle={typographyStyle}
+                    data-testid="@trading/quote/maximum-fee-amount-loading"
+                >
+                    <Translation id="TO_BE_CALCULATED" />
+                </Text>
+            </InlineLoader>
         );
     }
 
     return (
-        <Column alignItems="flex-end">
-            <Text variant="default" typographyStyle={typographyStyle}>
-                <FormattedCryptoAmount
-                    data-testid="@trading/quote/maximum-fee-amount"
-                    disableHiddenPlaceholder
-                    value={txMaximumFee}
-                    symbol={networkSymbol}
-                />
-            </Text>
+        <InlineLoader loading={areFeesLoading}>
+            <Column alignItems="flex-end">
+                <Text variant="default" typographyStyle={typographyStyle}>
+                    <FormattedCryptoAmount
+                        data-testid="@trading/quote/maximum-fee-amount"
+                        disableHiddenPlaceholder
+                        value={txMaxFee}
+                        symbol={networkSymbol}
+                    />
+                </Text>
 
-            <Text
-                data-testid="@trading/quote/maximum-fee-fiat-amount"
-                variant="tertiary"
-                typographyStyle="hint"
-            >
-                <BaseCurrencyValue
-                    disableHiddenPlaceholder
-                    amount={txMaximumFee}
-                    symbol={networkSymbol}
-                    showApproximationIndicator
-                />
-            </Text>
-        </Column>
+                <Text
+                    data-testid="@trading/quote/maximum-fee-fiat-amount"
+                    variant="tertiary"
+                    typographyStyle="hint"
+                >
+                    <BaseCurrencyValue
+                        disableHiddenPlaceholder
+                        amount={txMaxFee}
+                        symbol={networkSymbol}
+                        showApproximationIndicator
+                    />
+                </Text>
+            </Column>
+        </InlineLoader>
     );
-});
+}

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/hooks/useFetchFees.ts
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/hooks/useFetchFees.ts
@@ -1,4 +1,4 @@
-import { useFormContext } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { useFetchFeesOnce, useRefetchFees } from '@suite-common/wallet-core';
@@ -10,8 +10,7 @@ import { useSelector } from 'src/hooks/suite';
 
 function useIsRefetchDisabled() {
     const modal = useSelector(state => state.modal);
-    const { getValues } = useFormContext<FormState>();
-    const setMaxOutputId = getValues('setMaxOutputId');
+    const setMaxOutputId = useWatch<FormState, 'setMaxOutputId'>({ name: 'setMaxOutputId' });
 
     if (setMaxOutputId !== undefined) {
         return true;

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/hooks/useTransactionMaxFee.ts
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/hooks/useTransactionMaxFee.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+
+import { getNetwork } from '@suite-common/wallet-config';
+import {
+    asAmountSubunit,
+    roundToNonZeroFractionDigits,
+    subunitsToUnits,
+} from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { FeesContextType } from '../../context/FeesContext';
+
+export type TransactionMaxFeeProps = Pick<FeesContextType, 'networkSymbol' | 'composedLevels'> & {
+    selectedFeeLevel?: FeesContextType['selectedFeeLevel'];
+};
+
+export function useTransactionMaxFee({
+    networkSymbol,
+    composedLevels,
+    selectedFeeLevel,
+}: TransactionMaxFeeProps) {
+    const transactionInfo = selectedFeeLevel ? composedLevels?.[selectedFeeLevel.label] : null;
+    const txFee = transactionInfo?.type !== 'error' ? transactionInfo?.fee : null;
+
+    return useMemo(() => {
+        if (!txFee) return null;
+
+        return roundToNonZeroFractionDigits(
+            subunitsToUnits({
+                value: asAmountSubunit(new BigNumber(txFee)),
+                symbol: networkSymbol,
+                decimals: getNetwork(networkSymbol)?.decimals,
+            }),
+            4,
+        ).toString();
+    }, [networkSymbol, txFee]);
+}
+
+export type TransactionMaxFee = ReturnType<typeof useTransactionMaxFee>;

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -1756,7 +1756,6 @@ type FeeChangeFixture = {
 export const feeChange: FeeChangeFixture[] = [
     {
         description: 'BTC fee changes',
-        skip: false,
         store: {
             send: {
                 drafts: getDraft(),
@@ -1790,6 +1789,10 @@ export const feeChange: FeeChangeFixture[] = [
             },
         },
         actionSequence: [
+            {
+                type: 'click',
+                element: 'outputs.0.setMax',
+            },
             {
                 type: 'click',
                 element: '@wallet/fees/collapsible-fees-toggle',
@@ -2137,28 +2140,32 @@ export const feeChange: FeeChangeFixture[] = [
         actionSequence: [
             {
                 type: 'click',
+                element: 'outputs.0.setMax',
+            },
+            {
+                type: 'click',
                 element: '@wallet/fees/collapsible-fees-toggle',
             },
             {
                 type: 'click',
                 element: '@wallet/fees/select-custom-fee',
                 result: {
-                    getAccountInfoCalls: 1,
+                    getAccountInfoCalls: 2,
                     formValues: {
                         selectedFee: 'custom' as const,
                         feePerUnit: '12',
                     },
                     composedLevels: {
                         normal: {
-                            type: 'error', // not enough to cover reserve
+                            type: 'final',
                         },
                     },
                     errors: {
-                        outputs: [
-                            {
-                                amount: { type: 'compose' }, // AMOUNT_IS_LESS_THAN_RESERVE
-                            },
-                        ],
+                        // outputs: [
+                        //     {
+                        //         amount: { type: 'compose' }, // AMOUNT_IS_LESS_THAN_RESERVE
+                        //     },
+                        // ],
                     },
                 },
             },
@@ -2167,7 +2174,7 @@ export const feeChange: FeeChangeFixture[] = [
                 element: 'feePerUnit',
                 value: '', // reset value
                 result: {
-                    getAccountInfoCalls: 1,
+                    getAccountInfoCalls: 2,
                     formValues: {
                         feePerUnit: '',
                     },
@@ -2182,7 +2189,7 @@ export const feeChange: FeeChangeFixture[] = [
                 element: 'feePerUnit',
                 value: '10',
                 result: {
-                    getAccountInfoCalls: 2,
+                    getAccountInfoCalls: 3,
                     formValues: {
                         feePerUnit: '10',
                     },
@@ -2203,7 +2210,7 @@ export const feeChange: FeeChangeFixture[] = [
             },
         ],
         finalResult: {
-            getAccountInfoCalls: 2,
+            getAccountInfoCalls: 3,
         },
     },
 ];

--- a/suite-common/wallet-utils/src/bigNumberUtils.ts
+++ b/suite-common/wallet-utils/src/bigNumberUtils.ts
@@ -1,0 +1,43 @@
+import { BigNumber } from '@trezor/utils/src/bigNumber';
+
+/**
+ * Rounds a value to a given number of non-zero fractional digits.
+ * @example
+ * roundToNonZeroFractionDigits(new BigNumber('0.000000012367'), 4) // 0.0001237
+ * roundToNonZeroFractionDigits(new BigNumber('1.23456789'), 4) // 1.2346
+ * roundToNonZeroFractionDigits(new BigNumber('1.23400000'), 4) // 1.234
+ * roundToNonZeroFractionDigits(new BigNumber('1.00000000'), 4) // 1
+ */
+export function roundToNonZeroFractionDigits(
+    value: BigNumber,
+    nonZeroFractionDigits: number,
+): BigNumber {
+    if (value.isZero()) {
+        return value;
+    }
+
+    // Get the fractional part as a string without scientific notation
+    const [, fractionDigits] = value.toString().split('.');
+
+    // Find index (1-based) of the 4th non-zero digit after the decimal point
+    let nonZeroDigits = 0;
+    // Decimal places we'll round to
+    let decimalPlaces = 0;
+
+    for (let i = 0; i < fractionDigits.length; i++) {
+        if (fractionDigits[i] !== '0') nonZeroDigits++;
+
+        if (nonZeroDigits === nonZeroFractionDigits) {
+            decimalPlaces = i + 1;
+            break;
+        }
+    }
+
+    // If the number has < nonZeroFractionDigits non-zero fractional digits leave it as is
+    if (nonZeroDigits < nonZeroFractionDigits) {
+        return value;
+    }
+
+    // Round *up* at the calculated decimal place
+    return value.decimalPlaces(decimalPlaces, BigNumber.ROUND_UP);
+}

--- a/suite-common/wallet-utils/src/index.ts
+++ b/suite-common/wallet-utils/src/index.ts
@@ -32,3 +32,4 @@ export * from './hooks/useExcludedUtxos';
 export * from './hooks/useFilteredUtxos';
 export * from './cardanoStakingUtils';
 export * from './amountUtils';
+export * from './bigNumberUtils';


### PR DESCRIPTION
## Description

-  add loader
- display max fee with specific precision
- disable collapsible element if max fee null
- adjust collapsible box padding

## Related Issue

Resolve #21683

## Screenshots:


https://github.com/user-attachments/assets/9f381e7c-8cd6-4397-9f77-6faf81efeb7a




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/21683-collpase-network-fees-2&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/21683-collpase-network-fees-2&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/21683-collpase-network-fees-2&lookback=7)