### PR TITLE
ci: add dry-run check for mdBook

### DIFF
--- a/.github/workflows/check-mdbook-build.yml
+++ b/.github/workflows/check-mdbook-build.yml
@@ -1,0 +1,24 @@
+name: "[Check]: mdBook dry-run build validation"
+# Only a dry-run check if the mdBook docs are buildable; the deploy pipeline onto trezor.io is not here in github actions.
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  mdbook-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: mdbook build
+        run: |
+          mkdir bin
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.52/mdbook-v0.4.52-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
+          mkdir temp-output
+          ./bin/mdbook build ./docs -d ./temp-output

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
 # Trezor Suite documentation
 
-This documentation provides technical information for Suite developers, third-party wallet developers integrating Trezor, and users interested in implementation details. It is available at [docs.trezor.io/trezor-suite](https://docs.trezor.io/trezor-suite) in an HTML version compiled using [mdBook](https://github.com/rust-lang/mdBook). More guidance on Suite development can be found in package READMEs of the [trezor-suite](https://github.com/trezor/trezor-suite/tree/develop/packages) monorepo.
+This documentation provides technical information for Suite developers, third-party wallet developers integrating Trezor, and users interested in implementation details.
+It is available at [docs.trezor.io/trezor-suite](https://docs.trezor.io/trezor-suite) in an HTML version compiled using [mdBook](https://github.com/rust-lang/mdBook).
+More guidance on Suite development can be found in package READMEs of the [trezor-suite](https://github.com/trezor/trezor-suite/tree/develop/packages) monorepo.


### PR DESCRIPTION
## Description

Create a new CI check running on changes in `/docs/**`, which will check if mdBook build successfully.
- On this PR, it passes as it should :heavy_check_mark: 
- Meanwhile, on [that branch](https://github.com/trezor/trezor-suite/actions/runs/19107577130/job/54595574630?pr=22935) I've tested it fails for broken md :heavy_check_mark: 

:information_source: recently #22851 I have found out that the docs were outdated for at least half a year, maybe longer, who knows. The pipeline does not run in Github actions, so it has been silently failing, and docs were not updated. In that PR I fixed the docs, but this will ensure it doesn't happen again.