### PR TITLE
Discovery passphrase error

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletExistsFlow.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletExistsFlow.tsx
@@ -48,6 +48,7 @@ export const PassphraseWalletExistsFlow = ({
             case 'empty-wallet':
                 return (
                     <PassphraseWalletIsEmpty
+                        accountFailed={discovery.accountFailed}
                         onCancel={onCancel}
                         onNext={() => {
                             // Navigate to best practices

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletIsEmpty.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletIsEmpty.tsx
@@ -19,6 +19,7 @@ type PassphraseWalletIsEmptyProps = {
     device: TrezorDevice;
     onNext: () => void;
     onBack: () => void;
+    accountFailed?: boolean;
 };
 
 type PassphraseWalletIsEmptyContentProps = {
@@ -26,6 +27,7 @@ type PassphraseWalletIsEmptyContentProps = {
     onRetry: () => void;
     onCancel: () => void;
     'data-testid'?: string;
+    accountFailed?: boolean;
 };
 
 const PassphraseWalletIsEmptyContent = ({
@@ -33,6 +35,7 @@ const PassphraseWalletIsEmptyContent = ({
     onRetry,
     onCancel,
     'data-testid': dataTest,
+    accountFailed,
 }: PassphraseWalletIsEmptyContentProps) => {
     const { supportedMainnets } = useNetworkSupport();
     const enabledNetworks = useSelector(selectEnabledNetworks);
@@ -45,7 +48,9 @@ const PassphraseWalletIsEmptyContent = ({
     return (
         <Column gap={spacings.sm}>
             <H3>
-                <Translation id="TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_TITLE" />
+                <Translation
+                    id={`TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_TITLE${accountFailed ? '_ERROR' : ''}`}
+                />
             </H3>
             <Card
                 paddingType="small"
@@ -69,7 +74,9 @@ const PassphraseWalletIsEmptyContent = ({
             >
                 <Column gap={spacings.sm} alignItems="center">
                     <Paragraph typographyStyle="highlight">
-                        <Translation id="TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_OPEN_UNUSED_WALLET_DESCRIPTION" />
+                        <Translation
+                            id={`TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_OPEN_UNUSED_WALLET_DESCRIPTION${accountFailed ? '_ERROR' : ''}`}
+                        />
                     </Paragraph>
                     <Button
                         width="100%"
@@ -135,10 +142,16 @@ export const PassphraseWalletIsEmpty = ({
     onBack,
     onRetry,
     onNext,
+    accountFailed,
 }: PassphraseWalletIsEmptyProps) => (
     <SwitchDeviceModal onCancel={onCancel}>
         <CardWithDevice onCancel={onCancel} device={device} onBackButtonClick={onBack}>
-            <PassphraseWalletIsEmptyContent onNext={onNext} onRetry={onRetry} onCancel={onCancel} />
+            <PassphraseWalletIsEmptyContent
+                onNext={onNext}
+                onRetry={onRetry}
+                onCancel={onCancel}
+                accountFailed={accountFailed}
+            />
         </CardWithDevice>
     </SwitchDeviceModal>
 );

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10032,10 +10032,19 @@ export default defineMessages({
         id: 'TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_TITLE',
         defaultMessage: 'This Passphrase wallet is empty',
     },
+    TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_TITLE_ERROR: {
+        id: 'TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_TITLE_ERROR',
+        defaultMessage: "Passphrase wallet couldn't be loaded",
+    },
     TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_OPEN_UNUSED_WALLET_DESCRIPTION: {
         id: 'TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_OPEN_UNUSED_WALLET_DESCRIPTION',
         defaultMessage:
             "This Passphrase wallet is empty and hasn't been used before. Do you want to open it?",
+    },
+    TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_OPEN_UNUSED_WALLET_DESCRIPTION_ERROR: {
+        id: 'TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_OPEN_UNUSED_WALLET_DESCRIPTION_ERROR',
+        defaultMessage:
+            'Your wallet may appear empty until the internet connection is restored. Do you want to open it?',
     },
     TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_OPEN_UNUSED_WALLET_BUTTON: {
         id: 'TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_OPEN_UNUSED_WALLET_BUTTON',

--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -34,7 +34,6 @@ export const useConnectPopupWeb = () => {
 
     useEffect(() => {
         const onMessage = async (event: MessageEvent) => {
-            console.log('onMessage', event.data);
             if (event.data?.type === 'channel-handshake-request') {
                 postMessageToParent({ type: 'channel-handshake-confirm' });
             } else if (event.data.type === POPUP.HANDSHAKE) {

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -486,7 +486,7 @@ export const runDiscoveryThunk = createThunk(
 
             dispatch(
                 discoveryActions.updateDiscovery(
-                    { status: 'confirm-empty-passphrase' },
+                    { status: 'confirm-empty-passphrase', accountFailed: !!result.payload.failed },
                     device.path,
                 ),
             );

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -38,6 +38,7 @@ export type DiscoveryStatus = CommonDiscoveryStatus &
           }
         | {
               status: 'confirm-empty-passphrase';
+              accountFailed?: boolean;
           }
         | {
               status: 'complete';


### PR DESCRIPTION
## Description

Show different copy when discovered passphrase, expected to be used, is empty but with some failed accounts (as it may not be in fact empty).
<img width="398" height="515" alt="image" src="https://github.com/user-attachments/assets/4c76f411-cd24-4df4-9d20-3abb3215c217" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/discovery-passphrase-error&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/discovery-passphrase-error&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/discovery-passphrase-error&lookback=7)