### PR TITLE
fix(components): broken SSR in select due to cspNonce

### DIFF
--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -329,12 +329,11 @@ export const Select = ({
 
     const [selectedOption, setSelectedOption] = useState<Option | undefined>(rest.value);
 
-    const { cspNonce } = window;
-
     // Todo: hack to workaround the issue, see: https://github.com/JedWatson/react-select/issues/4631
     const cache: EmotionCache = createCache({
         key: 'react-select-nonce-hack',
-        nonce: cspNonce ?? '',
+        // window may be undefined during SSR, for example in Connect Explorer
+        nonce: typeof window !== 'undefined' && window?.cspNonce ? window.cspNonce : '',
     });
 
     const handleOnChange = useCallback<Required<ReactSelectProps<Option>>['onChange']>(


### PR DESCRIPTION
## Description

A change in the Select component in #22671 broke our Connect Explorer build, since window object is not defined when doing server-side rendering

Fixed build run here: https://github.com/trezor/trezor-suite/actions/runs/19129222704/job/54665722519

## Notes for QA

QA not needed

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/select-breaks-ssr&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/select-breaks-ssr&lookback=7)