### PR TITLE
fix(suite): exit bridge requested modal on connect popup flow

### DIFF
--- a/packages/suite/src/views/suite/bridge-requested/index.tsx
+++ b/packages/suite/src/views/suite/bridge-requested/index.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
+import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { Card, Column, H3, Modal, Paragraph, Text } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
@@ -8,7 +9,7 @@ import { spacings } from '@trezor/theme';
 import { goto } from 'src/actions/suite/routerActions';
 import { Metadata } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
-import { useDispatch, useLayout } from 'src/hooks/suite';
+import { useDispatch, useLayout, useSelector } from 'src/hooks/suite';
 import { AutoStart } from 'src/views/settings/SettingsGeneral/AutoStart';
 
 import { ErrorPage } from '../ErrorPage';
@@ -18,10 +19,18 @@ import { ErrorPage } from '../ErrorPage';
  */
 export const BridgeRequested = () => {
     const [confirmGoToWallet, setConfirmGoToWallet] = useState(false);
+    const popupCall = useSelector(selectConnectPopupCall);
 
     const dispatch = useDispatch();
 
-    const goToWallet = () => dispatch(goto('wallet-index'));
+    const goToWallet = useCallback(() => dispatch(goto('wallet-index')), [dispatch]);
+
+    useEffect(() => {
+        // Popup flow started, exit the bridge requested foreground app
+        if (popupCall?.state && popupCall.state !== 'finished') {
+            goToWallet();
+        }
+    }, [popupCall, goToWallet]);
 
     const handleKeepInBackground = () => {
         if (desktopApi.available) {


### PR DESCRIPTION
## Description

As mentioned in #22908

>if Suite is on the bridge requested modal, it's not possible to start the Connect flow and the user is stuck


## Notes for QA

Testing flow: 
1. Don't have Suite open, make any Connect call
2. Click the "Try Trezor Suite" button in popup
3. Wait for Suite to open with bridge requested modal
4. Restart new Connect call in browser
5. Now Suite should open with Connect flow

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bridge-requested-connect-flow&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bridge-requested-connect-flow&lookback=7)