### PR TITLE
Mobile Trade: Remove bottom border from country selector

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
@@ -13,6 +13,7 @@ import { EventType, analytics } from '@suite-native/analytics';
 import { HStack, Text } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import { OverviewRow, OverviewValueSkeleton, ProviderLogo } from '@suite-native/trading-atoms';
+import { ResidenceCheckAwareAnimatedBox } from '@suite-native/trading-residence';
 import {
     TradingRootState,
     selectBuyQuotesByPaymentMethodNative,
@@ -106,18 +107,20 @@ export const BuyProviderPicker = () => {
 
     return (
         <>
-            <OverviewRow
-                title={translate('moduleTrading.tradingScreen.provider')}
-                noBottomBorder
-                onPress={handleProviderPress}
-                testID={PROVIDER_PICKER_TEST_ID}
-                noCaret={isLoading}
-                warning={
-                    isLoading ? undefined : translate('moduleTrading.tradingScreen.kycWarning')
-                }
-            >
-                <BuyProviderPickerRight isLoading={isLoading} selectedValue={selectedValue} />
-            </OverviewRow>
+            <ResidenceCheckAwareAnimatedBox>
+                <OverviewRow
+                    title={translate('moduleTrading.tradingScreen.provider')}
+                    noBottomBorder
+                    onPress={handleProviderPress}
+                    testID={PROVIDER_PICKER_TEST_ID}
+                    noCaret={isLoading}
+                    warning={
+                        isLoading ? undefined : translate('moduleTrading.tradingScreen.kycWarning')
+                    }
+                >
+                    <BuyProviderPickerRight isLoading={isLoading} selectedValue={selectedValue} />
+                </OverviewRow>
+            </ResidenceCheckAwareAnimatedBox>
             <ProviderSheet
                 quotes={quotes}
                 isVisible={isSheetVisible}

--- a/suite-native/module-trading/src/components/general/TradingCountryOfResidencePicker.tsx
+++ b/suite-native/module-trading/src/components/general/TradingCountryOfResidencePicker.tsx
@@ -1,10 +1,16 @@
 import { useSelector } from 'react-redux';
 
 import { TradingType } from '@suite-common/trading';
-import { CountryOfResidencePicker } from '@suite-native/trading-residence';
+import {
+    CountryOfResidencePicker,
+    type CountryOfResidencePickerProps,
+} from '@suite-native/trading-residence';
 import { selectIsTradingResidenceCheckEnabled } from '@suite-native/trading-state';
 
-export type TradingCountryOfResidencePickerProps = {
+export type TradingCountryOfResidencePickerProps = Omit<
+    CountryOfResidencePickerProps,
+    'context'
+> & {
     context: Exclude<TradingType, 'exchange'>;
     testID: string;
 };

--- a/suite-native/module-trading/src/components/sell/payment/SellProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/SellProviderPicker.tsx
@@ -1,4 +1,3 @@
-import { StretchInY, StretchOutY } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import type { SellFiatTrade } from 'invity-api';
@@ -11,11 +10,11 @@ import {
     selectTradingSellProviders,
 } from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';
-import { AnimatedBox, HStack, Text } from '@suite-native/atoms';
+import { HStack, Text } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import { OverviewRow, OverviewValueSkeleton, ProviderLogo } from '@suite-native/trading-atoms';
+import { ResidenceCheckAwareAnimatedBox } from '@suite-native/trading-residence';
 import { TradingRootState, selectSellQuotesByPaymentMethod } from '@suite-native/trading-state';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { useSheetControls } from '../../../hooks/general/useSheetControls';
 import { useSellFormContext } from '../../../hooks/sell/useSellFormContext';
@@ -27,11 +26,6 @@ type SellProviderPickerRightProps = {
     isLoading: boolean;
     selectedValue: SellFiatTrade | undefined;
 };
-
-const pickerStyle = prepareNativeStyle(({ borders, colors }) => ({
-    borderTopWidth: borders.widths.small,
-    borderTopColor: colors.backgroundSurfaceElevation0,
-}));
 
 const SellProviderPickerRight = ({ isLoading, selectedValue }: SellProviderPickerRightProps) => {
     const { translate } = useTranslate();
@@ -65,7 +59,6 @@ const SellProviderPickerRight = ({ isLoading, selectedValue }: SellProviderPicke
 
 export const SellProviderPicker = () => {
     const { translate } = useTranslate();
-    const { applyStyle } = useNativeStyles();
     const form = useSellFormContext();
     const providers = useSelector(selectTradingSellProviders);
     const isLoading = useSelector(selectTradingSellIsLoading);
@@ -111,11 +104,7 @@ export const SellProviderPicker = () => {
 
     return (
         <>
-            <AnimatedBox
-                style={applyStyle(pickerStyle)}
-                entering={StretchInY}
-                exiting={StretchOutY}
-            >
+            <ResidenceCheckAwareAnimatedBox>
                 <OverviewRow
                     title={translate('moduleTrading.tradingScreen.provider')}
                     onPress={handleProviderPress}
@@ -128,7 +117,7 @@ export const SellProviderPicker = () => {
                 >
                     <SellProviderPickerRight isLoading={isLoading} selectedValue={selectedValue} />
                 </OverviewRow>
-            </AnimatedBox>
+            </ResidenceCheckAwareAnimatedBox>
             <ProviderSheet
                 quotes={quotes}
                 isVisible={isSheetVisible}

--- a/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.tsx
@@ -55,6 +55,7 @@ export const CountryOfResidencePicker = ({ testID, context }: CountryOfResidence
                 title={translate('tradingResidence.locationSettings.countryOfResidence')}
                 onPress={showSheet}
                 testID={testID}
+                noBottomBorder
             >
                 {selectedValue ? (
                     <HStack>

--- a/suite-native/trading-residence/src/components/ResidenceCheckAwareAnimatedBox.tsx
+++ b/suite-native/trading-residence/src/components/ResidenceCheckAwareAnimatedBox.tsx
@@ -1,0 +1,36 @@
+import { StretchInY, StretchOutY } from 'react-native-reanimated';
+import { useSelector } from 'react-redux';
+
+import { AnimatedBox, BoxProps } from '@suite-native/atoms';
+import { selectIsTradingResidenceCheckEnabled } from '@suite-native/trading-state';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+export type ResidenceCheckAwareAnimatedBoxProps = Omit<BoxProps, 'style'>;
+
+const pickerStyle = prepareNativeStyle<{ hasBorder: boolean }>(
+    ({ borders, colors }, { hasBorder }) => ({
+        extend: [
+            {
+                condition: hasBorder,
+                style: {
+                    borderTopWidth: borders.widths.small,
+                    borderTopColor: colors.backgroundSurfaceElevation0,
+                },
+            },
+        ],
+    }),
+);
+
+export const ResidenceCheckAwareAnimatedBox = (props: ResidenceCheckAwareAnimatedBoxProps) => {
+    const { applyStyle } = useNativeStyles();
+    const isTradingResidenceCheckEnabled = useSelector(selectIsTradingResidenceCheckEnabled);
+
+    return (
+        <AnimatedBox
+            style={applyStyle(pickerStyle, { hasBorder: !isTradingResidenceCheckEnabled })}
+            entering={StretchInY}
+            exiting={StretchOutY}
+            {...props}
+        />
+    );
+};

--- a/suite-native/trading-residence/src/components/__tests__/ResidenceCheckAwareAnimatedBox.comp.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/ResidenceCheckAwareAnimatedBox.comp.test.tsx
@@ -1,0 +1,30 @@
+import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { ResidenceCheckAwareAnimatedBox } from '../ResidenceCheckAwareAnimatedBox';
+
+describe('ResidenceCheckAwareAnimatedBox', () => {
+    const renderResidenceCheckAwareAnimatedBox = (preloadedState: PreloadedState = {}) =>
+        renderWithStoreProviderAsync(<ResidenceCheckAwareAnimatedBox testID="TEST_ID" />, {
+            preloadedState,
+        });
+
+    it('should have no border when residence check is enabled', async () => {
+        const { getByTestId } = await renderResidenceCheckAwareAnimatedBox({
+            featureFlags: { isTradingResidenceCheckEnabled: true },
+        });
+
+        expect(getByTestId('TEST_ID')).not.toHaveStyle({
+            borderTopWidth: 1,
+        });
+    });
+
+    it('should have border when residence check is disabled', async () => {
+        const { getByTestId } = await renderResidenceCheckAwareAnimatedBox({
+            featureFlags: { isTradingResidenceCheckEnabled: false },
+        });
+
+        expect(getByTestId('TEST_ID')).toHaveStyle({
+            borderTopWidth: 1,
+        });
+    });
+});

--- a/suite-native/trading-residence/src/index.ts
+++ b/suite-native/trading-residence/src/index.ts
@@ -3,6 +3,7 @@ export * from './types/tradingLocationForm';
 export * from './components/CountrySheet/CountryOfResidencePicker';
 export * from './components/TradingLocationSettings';
 export * from './components/OnboardingButtons';
+export * from './components/ResidenceCheckAwareAnimatedBox';
 
 export * from './screens/TradingLocationModalScreen';
 export * from './screens/SettingsTradingLocationScreen';


### PR DESCRIPTION

## Description

Fixes when border is and when it is not displayed under the country picker.

## Notes for QA

Please check borders for both android and iOS on buy, sell and country picking screen.

## Related Issue

Resolve #22950

## Screenshots:

### Before
(in addition to originally reported visual fix)
<img width="300" alt="before1" src="https://github.com/user-attachments/assets/8622aff3-b939-4a53-90a0-13eeb5f402fd" />

### After
<img width="300" alt="after1" src="https://github.com/user-attachments/assets/e1c4c57f-593d-4907-8fdf-1dec8c380cef" />
<img width="300" alt="after2" src="https://github.com/user-attachments/assets/5ab945fc-1f25-4d71-ab2c-042f5a88b9d4" />
<img width="300" alt="after3" src="https://github.com/user-attachments/assets/e3e87ed6-2faa-4c5d-b1a6-93fa38ce15ab" />




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22950-remove-bottom-border-from-country-selector&lookback=7)