### PR TITLE
Mobile Trade: display card titles on single line

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyCard.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCard.tsx
@@ -23,12 +23,20 @@ const BUY_CARD_TEST_ID = '@trading/buyCard';
 
 const buySectionStyle = prepareNativeStyle<{ bottomBorder: boolean }>(
     ({ borders, colors, spacings }, { bottomBorder }) => ({
-        borderBottomWidth: bottomBorder ? borders.widths.small : 0,
+        borderBottomWidth: 0,
         borderBottomColor: colors.backgroundSurfaceElevation0,
         paddingHorizontal: spacings.sp12,
         paddingTop: spacings.sp16,
         paddingBottom: spacings.sp12,
         gap: spacings.sp8,
+        extend: [
+            {
+                condition: bottomBorder,
+                style: {
+                    borderBottomWidth: borders.widths.small,
+                },
+            },
+        ],
     }),
 );
 

--- a/suite-native/trading-atoms/src/components/CardTitle.tsx
+++ b/suite-native/trading-atoms/src/components/CardTitle.tsx
@@ -8,7 +8,7 @@ export type CardTitleProps = {
 
 export const CardTitle = ({ children }: CardTitleProps) => (
     <Box paddingHorizontal="sp8" flex={1}>
-        <Text variant="body" color="textDefault">
+        <Text variant="body" color="textDefault" numberOfLines={1}>
             {children}
         </Text>
     </Box>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Unify spacing for trading card title. Always display title on single line.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #21034


## Screenshots:

<img width="300" alt="Screenshot_1762435058" src="https://github.com/user-attachments/assets/c222de34-ed73-48cf-9060-7fe509bdcce4" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=21034-round-2&lookback=7)