### PR TITLE
fix(device-authenticity): use @noble/curves for universal ed25519 support

### DIFF
--- a/packages/connect-iframe/jest.config.js
+++ b/packages/connect-iframe/jest.config.js
@@ -3,4 +3,5 @@ const { ...baseConfig } = require('../../jest.config.base');
 module.exports = {
     ...baseConfig,
     testEnvironment: 'jsdom',
+    setupFiles: ['../../suite-common/test-utils/src/jsdomGlobalPolyfills.js'],
 };

--- a/packages/device-authenticity/package.json
+++ b/packages/device-authenticity/package.json
@@ -33,6 +33,7 @@
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
+        "@noble/curves": "^1.9.7",
         "@trezor/crypto-utils": "workspace:*",
         "@trezor/protobuf": "workspace:*",
         "@trezor/schema-utils": "workspace:*",

--- a/packages/device-authenticity/src/types.ts
+++ b/packages/device-authenticity/src/types.ts
@@ -7,7 +7,7 @@ export type VerifySignature = (
     rawKey: Buffer,
     data: Uint8Array,
     signature: Uint8Array,
-) => Promise<boolean>;
+) => boolean | Promise<boolean>;
 
 export type VerifyAuthenticityProofParams = {
     challenge: Buffer;

--- a/packages/device-authenticity/src/verifyAuthenticityProof.ts
+++ b/packages/device-authenticity/src/verifyAuthenticityProof.ts
@@ -1,3 +1,4 @@
+import { ed25519 } from '@noble/curves/ed25519.js';
 import * as crypto from 'crypto';
 
 import { getSubtleCrypto } from '@trezor/crypto-utils';
@@ -15,12 +16,12 @@ import { AlgorithmName, parseCertificate } from './x509certificate';
 // window.crypto.subtle.importKey (CryptoKey) cannot be used by `crypto-browserify`.Verify
 // The only common format of publicKey is PEM.
 const verifySignatureP256: VerifySignature = async (rawKey, data, signature) => {
+    const signer = crypto.createVerify('sha256');
+    signer.update(Buffer.from(data));
+
+    const SubtleCrypto = getSubtleCrypto();
+
     try {
-        const signer = crypto.createVerify('sha256');
-        signer.update(Buffer.from(data));
-
-        const SubtleCrypto = getSubtleCrypto();
-
         // get ECDSA P-256 (secp256r1) key from RAW key
         const ecPubKey = await SubtleCrypto.importKey(
             'raw',
@@ -42,25 +43,20 @@ const verifySignatureP256: VerifySignature = async (rawKey, data, signature) => 
         return signer.verify({ key }, Buffer.from(signature));
     } catch {
         // invalid inputs shall be considered unsuccessful verification, rather than runtime error
-        // (e.g. attempting to verify a Ed25519 signature signature here)
+        // (e.g. calling this with a P-256 signature and an Ed25519 key)
         return false;
     }
 };
 
-// Verifies Ed25519 signature using SubtleCrypto (browser or Node.js)
-const verifySignatureEd25519: VerifySignature = async (rawKey, data, signature) => {
+// Verifies Ed25519 signature using @noble/curves, because SubtleCrypto Ed25519 is still not broadly supported.
+// We can revert to SubtleCrypto when we stop supporting Chromium < 137 https://caniuse.com/mdn-api_subtlecrypto_sign_ed25519
+// Also must be verified react-native javascript runtime (unknown support matrix).
+const verifySignatureEd25519: VerifySignature = (rawKey, data, signature) => {
     try {
-        const SubtleCrypto = getSubtleCrypto();
-        // get Ed25519 key from RAW key
-        const edPubKey = await SubtleCrypto.importKey('raw', rawKey, { name: 'Ed25519' }, true, [
-            'verify',
-        ]);
-
-        // Verify signature
-        return await SubtleCrypto.verify({ name: 'Ed25519' }, edPubKey, signature, data);
+        return ed25519.verify(signature, data, rawKey);
     } catch {
         // invalid inputs shall be considered unsuccessful verification, rather than runtime error
-        // (e.g. attempting to verify a P-256 signature signature here)
+        // @noble/hashes correctly returns false when calling this with an Ed25519 signature and a P-256 key, but malformed signature sometimes throws
         return false;
     }
 };

--- a/scripts/list-outdated-dependencies/foundation-dependencies.txt
+++ b/scripts/list-outdated-dependencies/foundation-dependencies.txt
@@ -14,6 +14,7 @@
 @evolu/common
 @evolu/react-native
 @evolu/web
+@noble/curves
 @sentry/browser
 @sentry/core
 @sentry/electron

--- a/suite-common/message-system/jest.config.js
+++ b/suite-common/message-system/jest.config.js
@@ -3,4 +3,5 @@ const baseConfig = require('../../jest.config.base');
 module.exports = {
     ...baseConfig,
     testEnvironment: 'jsdom',
+    setupFiles: ['../../suite-common/test-utils/src/jsdomGlobalPolyfills.js'],
 };

--- a/suite-common/test-utils/src/jsdomGlobalPolyfills.js
+++ b/suite-common/test-utils/src/jsdomGlobalPolyfills.js
@@ -1,0 +1,8 @@
+import { TextDecoder, TextEncoder } from 'node:util';
+
+// TextEncoder/TextDecoder polyfill for jsdom environment in Jest, which doesn't provide them, even though they are part of both Node and Web APIs
+// See https://github.com/jsdom/jsdom/issues/2524
+
+global.TextEncoder = TextEncoder;
+// @ts-expect-error slight type incompatibility between DOM and node:util, but for test polyfill it works
+global.TextDecoder = TextDecoder;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6181,7 +6181,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:^1.0.0, @noble/curves@npm:^1.6.0, @noble/curves@npm:^1.9.6, @noble/curves@npm:~1.9.0":
+"@noble/curves@npm:^1.0.0, @noble/curves@npm:^1.6.0, @noble/curves@npm:^1.9.6, @noble/curves@npm:^1.9.7, @noble/curves@npm:~1.9.0":
   version: 1.9.7
   resolution: "@noble/curves@npm:1.9.7"
   dependencies:
@@ -13949,6 +13949,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/device-authenticity@workspace:packages/device-authenticity"
   dependencies:
+    "@noble/curves": "npm:^1.9.7"
     "@trezor/crypto-utils": "workspace:*"
     "@trezor/protobuf": "workspace:*"
     "@trezor/schema-utils": "workspace:*"


### PR DESCRIPTION
## Description

Use `@noble/curves` for ed25519 cryptographical verification used in Tropic Device Authenticiy Check, because window.crypto.subtle does not have broad support yet.

 `@noble/curves` was chosen over alternatives, particularly the standalone `@noble/ed25519` by the same author:
- We already have it installed in our repo as subdep of various crypto libs
- Looking at [the implementation](https://github.com/paulmillr/noble-curves/blob/main/src/ed25519.ts), it's pure JS with no dependence on `window.crypto` → promising compatibility
  - Meanwhile, the standalone [partially relies](https://github.com/paulmillr/noble-ed25519/blob/0f2958a572556588dfb8c6dcfaaec7c1602c3af2/index.js#L104-L105) on crypto.subtle :confused:  

## Notes for QA

Please test production TS7 DAC on various environments to be really sure.
Doesn't matter whether it's onboarding check or device settings check, under the hood it does the same.
- Web:
  - current chromium-based browser
  - outdated chromium-based browser (between 109 and 136)
  - current firefox
  - outdated firefox (between 115 and 128)
    - but FF is not so important as it's useless without bridge anyways
- Desktop:
  - windows, macOS, linux
    - (OS version should not matter because Suite Desktop carries the javascript runtime with it)
- Mobile:
  - physical Android, iOS
    - Does it make sense to test older OS versions?? I don't how JS runtime works on mobile, but should be like Desktop?

## Related Issue

Resolve #22955

## Screenshots

Web & Mobile success :tada: 

<img width="246" height="392" alt="web success" src="https://github.com/user-attachments/assets/7d2b142f-5248-4339-9d81-c4098511784c" />
<img width="408" height="306" alt="mobile success" src="https://github.com/user-attachments/assets/dee7fbad-cb26-4c46-8cab-6ccb24b7f432" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ed25519-compatibility&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ed25519-compatibility&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/ed25519-compatibility&lookback=7)