### PR TITLE
feat(suite-native): migrate autoEject from device to walletSettings

### DIFF
--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -48,6 +48,7 @@ import {
     migrateAccountBnbToBsc,
     migrateAccountLabel,
     migrateAccountsDeprecateNetworks,
+    migrateAutoEjectToWalletSettings,
     migrateDeviceState,
     migrateTransactionsBnbToBsc,
     migrateTransactionsDeprecateNetworks,
@@ -114,6 +115,7 @@ export const prepareRootReducers = async () => {
         version: 1,
         migrations: {
             1: initialMigrateAppSettingsAndDiscoveryConfig,
+            2: migrateAutoEjectToWalletSettings,
         },
     });
 

--- a/suite-native/storage/src/createAsyncMigrate.ts
+++ b/suite-native/storage/src/createAsyncMigrate.ts
@@ -1,43 +1,27 @@
 import { DEFAULT_VERSION, PersistedState } from 'redux-persist';
 
-// unknown is here just for explicitness, it's the same as PersistedState
-export type UnknownPersistedState = unknown & PersistedState;
+import { MigrationsManifest } from './migrationTypes';
 
-export type MigrationsManifest = {
-    [key: number]: (
-        state: UnknownPersistedState,
-    ) => UnknownPersistedState | Promise<UnknownPersistedState> | undefined;
-};
-
-type MigratedState<TReducerInitialState> =
-    | (Partial<TReducerInitialState> & PersistedState)
-    | undefined;
+type MigratedState<TReducerInitialState> = Partial<TReducerInitialState> & PersistedState;
 
 /**
  * This is a replacement of createMigrate helper from redux-persist that allows to use async migrations
- * and also allows initial migration from empty state.
+ * and also allows migration with empty persisted state (if you need to get the initial data from other source).
  *
  * Debug config is not implemented, but it can be added if needed.
  */
 export const createAsyncMigrate =
     <TReducerInitialState>(migrations: MigrationsManifest) =>
     async (
-        oldState: UnknownPersistedState,
+        oldState: PersistedState,
         currentVersion: number,
     ): Promise<MigratedState<TReducerInitialState>> => {
-        if (
-            !oldState &&
-            // If migration for version 1 exists, undefined oldState is allowed - do not early return.
-            // Migration for version 1 is considered as "initial migration" from an empty state.
-            !migrations[1]
-        ) {
-            return Promise.resolve(undefined);
+        if (!oldState) {
+            // This allows to use migration that gets the initial data from other sources.
+            oldState = { _persist: { version: DEFAULT_VERSION /* -1 */, rehydrated: true } };
         }
 
-        const inboundVersion: number =
-            oldState?._persist?.version !== undefined
-                ? oldState._persist.version
-                : DEFAULT_VERSION; /* -1 */
+        const inboundVersion: number = oldState._persist?.version ?? DEFAULT_VERSION;
 
         if (inboundVersion === currentVersion) {
             // `as` because we do no migration here

--- a/suite-native/storage/src/index.ts
+++ b/suite-native/storage/src/index.ts
@@ -13,6 +13,7 @@ export * from './migrations/wallet/accounts/v2';
 export * from './migrations/wallet/accounts/v3';
 export * from './migrations/wallet/transactions/v3';
 export * from './migrations/walletSettings/v1';
+export * from './migrations/walletSettings/v2';
 
 export * from './transforms/bluetoothTransforms';
 export * from './transforms/deviceTransforms';

--- a/suite-native/storage/src/migrationTypes.ts
+++ b/suite-native/storage/src/migrationTypes.ts
@@ -1,0 +1,17 @@
+import { PersistedState } from 'redux-persist';
+
+export type MigrationsManifest = {
+    [key: number]: (state: PersistedState) => PersistedState | Promise<PersistedState>;
+};
+
+export const isPersistedState = (state: unknown): state is PersistedState =>
+    typeof state === 'undefined' ||
+    (typeof state === 'object' &&
+        state !== null &&
+        '_persist' in state &&
+        typeof state._persist === 'object' &&
+        state._persist !== null &&
+        'version' in state._persist &&
+        typeof state._persist.version === 'number' &&
+        'rehydrated' in state._persist &&
+        typeof state._persist.rehydrated === 'boolean');

--- a/suite-native/storage/src/migrations/walletSettings/v1.ts
+++ b/suite-native/storage/src/migrations/walletSettings/v1.ts
@@ -82,9 +82,6 @@ const migrateDiscoveryConfigToWalletSettings = (
 };
 
 export const initialMigrateAppSettingsAndDiscoveryConfig = async (walletSettingsState: unknown) => {
-    // This is supposed to be initial migration from an empty state.
-    if (typeof walletSettingsState !== 'undefined') return undefined;
-
     const storage = await initMmkvStorage();
     const appSettings = await getStoredState({
         key: 'appSettings',
@@ -95,9 +92,9 @@ export const initialMigrateAppSettingsAndDiscoveryConfig = async (walletSettings
         storage,
     });
 
-    if (!appSettings && !discoveryConfig) return undefined;
+    const newState = walletSettingsState as Partial<WalletSettings> & PersistedState;
 
-    const newState = {} as Partial<WalletSettings> & PersistedState;
+    if (!appSettings && !discoveryConfig) return newState;
 
     if (appSettings) {
         const localCurrency = migrateLocalCurrency(appSettings);

--- a/suite-native/storage/src/migrations/walletSettings/v2.ts
+++ b/suite-native/storage/src/migrations/walletSettings/v2.ts
@@ -1,0 +1,30 @@
+import { PersistedState, getStoredState } from 'redux-persist';
+
+import { WalletSettings } from '@suite-common/wallet-types';
+
+import { isPersistedState } from '../../migrationTypes';
+import { initMmkvStorage } from '../../storage';
+
+type MigratedState = Partial<WalletSettings> & PersistedState;
+
+export const migrateAutoEjectToWalletSettings = async (
+    oldState: unknown,
+): Promise<MigratedState> => {
+    if (!oldState || !isPersistedState(oldState)) {
+        return oldState as MigratedState;
+    }
+
+    const devicesState = await getStoredState({
+        key: 'devices',
+        storage: await initMmkvStorage(),
+    });
+
+    if (!devicesState || !('isDeviceAutoEjectEnabled' in devicesState)) {
+        return oldState as MigratedState; // no new migration, just pass the previous one
+    }
+
+    return {
+        ...oldState,
+        isAutoEjectEnabled: devicesState.isDeviceAutoEjectEnabled === true,
+    };
+};

--- a/suite-native/storage/src/tests/createAsyncMigrate.test.ts
+++ b/suite-native/storage/src/tests/createAsyncMigrate.test.ts
@@ -13,16 +13,19 @@ describe('createAsyncMigrate', () => {
     });
 
     describe('empty state handling', () => {
-        it('should return undefined when oldState is null and no migration for version 1', async () => {
+        const emptyPersistedState = {
+            _persist: { rehydrated: true, version: -1 },
+        };
+        it('should return empty persisted state when oldState is null and no migration for version 1', async () => {
             const migrations = {};
             const migrate = createAsyncMigrate(migrations);
             // @ts-expect-error
             const result = await migrate(null, 0);
 
-            expect(result).toBeUndefined();
+            expect(result).toEqual(emptyPersistedState);
         });
 
-        it('should run initial migration when oldState is null and migration for version 1 exists', async () => {
+        it('should run migration when oldState is null and migration for version 1 exists', async () => {
             const mockMigration = jest.fn().mockResolvedValue({ migrated: true });
             const migrations = {
                 '1': mockMigration,
@@ -31,7 +34,7 @@ describe('createAsyncMigrate', () => {
             // @ts-expect-error
             const result = await migrate(null, 1);
 
-            expect(mockMigration).toHaveBeenCalledWith(null);
+            expect(mockMigration).toHaveBeenCalledWith(emptyPersistedState);
             expect(result).toEqual({ migrated: true });
         });
     });

--- a/suite-native/storage/src/tests/migrations/walletSettingsV1.test.ts
+++ b/suite-native/storage/src/tests/migrations/walletSettingsV1.test.ts
@@ -31,7 +31,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             return Promise.resolve(undefined);
         });
 
-        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig(undefined);
+        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({});
 
         expect(migratedState).toEqual({
             localCurrency: 'czk',
@@ -49,7 +49,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             return Promise.resolve(undefined);
         });
 
-        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig(undefined);
+        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({});
 
         expect(migratedState).toEqual({});
     });
@@ -65,7 +65,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             return Promise.resolve(undefined);
         });
 
-        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig(undefined);
+        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({});
 
         expect(migratedState).toEqual({
             localCurrency: 'czk',
@@ -83,7 +83,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             return Promise.resolve(undefined);
         });
 
-        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig(undefined);
+        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({});
 
         expect(migratedState).toEqual({
             bitcoinAmountUnit: 3,
@@ -101,7 +101,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             return Promise.resolve(undefined);
         });
 
-        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig(undefined);
+        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({});
 
         expect(migratedState).toEqual({});
     });
@@ -117,7 +117,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             return Promise.resolve(undefined);
         });
 
-        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig(undefined);
+        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({});
 
         expect(migratedState).toEqual({});
     });
@@ -140,7 +140,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             return Promise.resolve(undefined);
         });
 
-        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig(undefined);
+        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({});
 
         expect(migratedState).toEqual({
             enabledNetworks: ['btc', 'eth', 'bsc', 'test'],
@@ -171,22 +171,14 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             return Promise.resolve(undefined);
         });
 
-        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig(undefined);
+        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({});
 
         expect(migratedState).toEqual({
             enabledNetworks: ['btc', 'eth', 'test', 'bsc'],
         });
     });
 
-    it('should not migrate if both appSettings and discoveryConfig are missing', async () => {
-        mockGetStoredState.mockImplementation(() => Promise.resolve(undefined));
-
-        const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig(undefined);
-
-        expect(migratedState).toEqual(undefined); // undefined means nothing to migrate, initial state will be used
-    });
-
-    it('should not migrate if it is not an initial migration (something already persisted)', async () => {
+    it('should keep previous state if both appSettings and discoveryConfig are missing', async () => {
         mockGetStoredState.mockImplementation(() => Promise.resolve(undefined));
 
         const walletSettingsState = { someProperty: 'value' };
@@ -194,6 +186,6 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
         const migratedState =
             await initialMigrateAppSettingsAndDiscoveryConfig(walletSettingsState);
 
-        expect(migratedState).toEqual(undefined); // undefined means nothing to migrate, initial state will be used
+        expect(migratedState).toEqual(walletSettingsState);
     });
 });

--- a/suite-native/storage/src/tests/migrations/walletSettingsV1.test.ts
+++ b/suite-native/storage/src/tests/migrations/walletSettingsV1.test.ts
@@ -3,6 +3,8 @@ import { getStoredState } from 'redux-persist';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { PROTO } from '@trezor/connect';
 
+import { initialMigrateAppSettingsAndDiscoveryConfig } from '../../migrations/walletSettings/v1';
+
 jest.mock('../../storage', () => ({
     initMmkvStorage: jest.fn().mockResolvedValue({}),
 }));
@@ -10,8 +12,6 @@ jest.mock('../../storage', () => ({
 jest.mock('redux-persist', () => ({
     getStoredState: jest.fn(),
 }));
-
-import { initialMigrateAppSettingsAndDiscoveryConfig } from '../../migrations/walletSettings/v1';
 
 const mockGetStoredState = getStoredState as jest.MockedFunction<typeof getStoredState>;
 

--- a/suite-native/storage/src/tests/migrations/walletSettingsV2.test.ts
+++ b/suite-native/storage/src/tests/migrations/walletSettingsV2.test.ts
@@ -1,0 +1,53 @@
+import { getStoredState } from 'redux-persist';
+
+import { migrateAutoEjectToWalletSettings } from '../../migrations/walletSettings/v2';
+
+jest.mock('../../storage', () => ({
+    initMmkvStorage: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('redux-persist', () => ({
+    getStoredState: jest.fn(),
+}));
+
+const mockGetStoredState = getStoredState as jest.MockedFunction<typeof getStoredState>;
+
+describe(migrateAutoEjectToWalletSettings.name, () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('migrates value from devices.isDeviceAutoEjectEnabled to walletSettings.autoEject', async () => {
+        mockGetStoredState.mockImplementation(({ key }) => {
+            if (key === 'devices') {
+                return Promise.resolve({
+                    isDeviceAutoEjectEnabled: true,
+                });
+            }
+
+            return Promise.resolve(undefined);
+        });
+
+        const oldWalletSettings = {
+            isAutoEjectEnabled: false,
+            _persist: { version: 1, rehydrated: true },
+        };
+
+        const migrated = await migrateAutoEjectToWalletSettings(oldWalletSettings);
+
+        expect(migrated.isAutoEjectEnabled).toBe(true);
+    });
+
+    it('pass previous state if no migration is needed', async () => {
+        mockGetStoredState.mockImplementation(() => Promise.resolve(undefined));
+
+        const oldWalletSettings = {
+            enabledNetworks: ['btc', 'eth'],
+            _persist: { version: 1, rehydrated: true },
+        };
+
+        const migrated = await migrateAutoEjectToWalletSettings(oldWalletSettings);
+
+        expect(migrated).toEqual(oldWalletSettings);
+    });
+});

--- a/suite-native/storage/src/typedPersistReducer.ts
+++ b/suite-native/storage/src/typedPersistReducer.ts
@@ -3,7 +3,8 @@ import { Transform, persistReducer } from 'redux-persist';
 import autoMergeLevel1 from 'redux-persist/lib/stateReconciler/autoMergeLevel1';
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 
-import { MigrationsManifest, createAsyncMigrate } from './createAsyncMigrate';
+import { createAsyncMigrate } from './createAsyncMigrate';
+import { MigrationsManifest } from './migrationTypes';
 import { initMmkvStorage } from './storage';
 
 export const preparePersistReducer = async <TReducerInitialState>({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Mobile migration for this change https://github.com/trezor/trezor-suite/pull/21639

This migration was waiting for https://github.com/trezor/trezor-suite/pull/22912

## Notes for QA

- Test migration of auto-eject setting from 25.10 to 25.11



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/add-missing-wallet-settings-migration&lookback=7)