### PR TITLE
Speed up fee of evm token & approval tx

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -8,8 +8,10 @@ import { BTC_LOCKTIME_VALUE } from '@suite-common/wallet-constants';
 import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
 import { EvmTransactionPurpose, ReviewOutput, StakeType } from '@suite-common/wallet-types';
 import {
+    EvmApprovalPurpose,
     findAccountsByAddress,
     isApprovalFlowSupported,
+    isEvmApprovalTxByTextSignature,
     isTestnet,
 } from '@suite-common/wallet-utils';
 import { exhaustive } from '@trezor/type-utils';
@@ -64,11 +66,8 @@ const getStakeTranslations = (
     return translations[stakeType];
 };
 
-const approvalStrings: Record<
-    Exclude<EvmTransactionPurpose, 'transfer'>,
-    Record<'value' | 'label', TranslationKey>
-> = {
-    approval: {
+const approvalStrings: Record<EvmApprovalPurpose, Record<'value' | 'label', TranslationKey>> = {
+    approve: {
         value: 'TR_APPROVE_DESCRIPTION',
         label: 'TR_APPROVE_TITLE',
     },
@@ -81,15 +80,17 @@ const approvalStrings: Record<
 const getTranslationValues = (
     networkType: NetworkType,
     stakeType?: StakeType,
-    evmApprovalType?: Exclude<EvmTransactionPurpose, 'transfer'>,
+    evmTxType?: EvmTransactionPurpose,
     device?: TrezorDevice,
 ): Record<'value' | 'label', TranslationKey> | null => {
-    if (evmApprovalType && !isApprovalFlowSupported(device)) {
+    const isEvmApproval = isEvmApprovalTxByTextSignature(evmTxType);
+
+    if (isEvmApproval && !isApprovalFlowSupported(device)) {
         return null;
     }
 
-    if (evmApprovalType) {
-        return approvalStrings[evmApprovalType];
+    if (isEvmApproval) {
+        return approvalStrings[evmTxType];
     }
 
     if (stakeType) {
@@ -102,12 +103,12 @@ const getTranslationValues = (
 const getContractTitle = (
     networkType: NetworkType,
     isApprovalFlowSupported: boolean,
-    evmApprovalType?: Exclude<EvmTransactionPurpose, 'transfer'>,
+    evmTxType?: EvmTransactionPurpose,
 ): TranslationKey => {
-    if (evmApprovalType && isApprovalFlowSupported) {
-        return evmApprovalType === 'approval'
-            ? 'TR_CONTRACT_APPROVE_TITLE'
-            : 'TR_CONTRACT_REVOKE_TITLE';
+    const isEvmApproval = isEvmApprovalTxByTextSignature(evmTxType);
+
+    if (isEvmApproval && isApprovalFlowSupported) {
+        return evmTxType === 'approve' ? 'TR_CONTRACT_APPROVE_TITLE' : 'TR_CONTRACT_REVOKE_TITLE';
     }
 
     return networkType === 'solana' ? 'TR_TOKEN' : 'TR_CONTRACT_ADDRESS';
@@ -119,15 +120,11 @@ const getOutputTitle = (
     value: string,
     isRbf: boolean,
     stakeType: StakeType | undefined,
-    evmApprovalType: Exclude<EvmTransactionPurpose, 'transfer'> | undefined,
+    evmTxType?: EvmTransactionPurpose,
     device?: TrezorDevice,
 ): ReactNode | undefined => {
-    const translation = getTranslationValues(networkType, stakeType, evmApprovalType, device);
-    const contractTitle = getContractTitle(
-        networkType,
-        isApprovalFlowSupported(device),
-        evmApprovalType,
-    );
+    const translation = getTranslationValues(networkType, stakeType, evmTxType, device);
+    const contractTitle = getContractTitle(networkType, isApprovalFlowSupported(device), evmTxType);
 
     switch (type) {
         case 'locktime': {
@@ -170,11 +167,7 @@ const getOutputTitle = (
         case 'approve_data':
             return (
                 <Translation
-                    id={
-                        evmApprovalType === 'approval'
-                            ? 'TR_APPROVE_DATA_TITLE'
-                            : 'TR_REVOKE_DATA_TITLE'
-                    }
+                    id={evmTxType === 'approve' ? 'TR_APPROVE_DATA_TITLE' : 'TR_REVOKE_DATA_TITLE'}
                 />
             );
         case 'recipient_name':
@@ -194,7 +187,7 @@ interface GetOutputLinesParams {
     label?: string;
     symbol: NetworkSymbol;
     stakeType?: StakeType;
-    evmTxType?: Exclude<EvmTransactionPurpose, 'transfer'>;
+    evmTxType?: EvmTransactionPurpose;
     device?: TrezorDevice;
     token?: ReviewOutput['token'];
     translationString: TranslationFunction;
@@ -282,7 +275,8 @@ const getOutputLines = ({
                 return defaultOutput;
             }
 
-            if (evmTxType) {
+            const isEvmApproval = isEvmApprovalTxByTextSignature(evmTxType);
+            if (isEvmApproval) {
                 return [
                     {
                         id: 'data',
@@ -332,7 +326,7 @@ const getOutputLines = ({
             ];
         case 'approve_data': {
             const isMaxApproval = new BigNumber(value).eq(UINT256_MAX);
-            const isApprovalTx = evmTxType === 'approval';
+            const isApprovalTx = evmTxType === 'approve';
             const type = isMaxApproval || !isApprovalTx ? 'data' : 'amount';
             const getValue = () => {
                 if (!isApprovalTx && token?.symbol) {
@@ -408,7 +402,7 @@ export const TransactionReviewOutput = ({
         value,
         isRbf,
         stakeType,
-        evmTxType !== 'transfer' ? evmTxType : undefined,
+        evmTxType,
         device,
     );
 
@@ -420,7 +414,7 @@ export const TransactionReviewOutput = ({
         label,
         symbol,
         stakeType,
-        evmTxType: evmTxType !== 'transfer' ? evmTxType : undefined,
+        evmTxType,
         device,
         token,
         translationString,

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -9,7 +9,11 @@ import type {
     StakeFormState,
 } from '@suite-common/wallet-types';
 import { ReviewOutput, StakeType } from '@suite-common/wallet-types';
-import { findAccountsByAddress, getEvmTransactionTextSignature } from '@suite-common/wallet-utils';
+import {
+    findAccountsByAddress,
+    getEvmTransactionTextSignature,
+    isEvmApprovalTx,
+} from '@suite-common/wallet-utils';
 import { Column, H4 } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
 
@@ -88,11 +92,13 @@ export const TransactionReviewOutputList = ({
         lastButtonRequestCode,
     });
 
-    const { trading } = precomposedForm;
+    const { trading: isTrading } = precomposedForm;
 
     const isFirstStep = buttonRequestsCount <= 1;
 
     const isStaking = stakeType;
+
+    const isApprovalTx = isEvmApprovalTx(precomposedForm.transactionData);
 
     const isInternalTransfer =
         isFirstOutputAddress &&
@@ -116,7 +122,8 @@ export const TransactionReviewOutputList = ({
         isFirstOutputAddress &&
         isFirstStep &&
         !isStaking &&
-        !trading &&
+        !isApprovalTx &&
+        !isTrading &&
         !isInternalTransfer &&
         !signedTx
     ) {
@@ -160,7 +167,7 @@ export const TransactionReviewOutputList = ({
                                 })}
                                 account={account}
                                 isRbf={isRbfAction}
-                                isTrading={!!trading}
+                                isTrading={!!isTrading}
                                 stakeType={stakeType}
                                 evmTxType={getEvmTransactionTextSignature(
                                     precomposedForm.transactionData,

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -52,7 +52,7 @@ export const getTransactionReviewModalActionTranslation = ({
         const transactionPurpose = getEvmTransactionTextSignature(precomposedForm.transactionData);
 
         switch (transactionPurpose) {
-            case 'approval':
+            case 'approve':
                 return {
                     id:
                         source === 'heading'

--- a/packages/suite/src/views/wallet/send/TotalSent/CardanoSentTokenInfo.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/CardanoSentTokenInfo.tsx
@@ -34,7 +34,7 @@ export const CardanoSentTokenInfo = () => {
             .map(token => [token.symbol?.toUpperCase(), tokenAmountsMap.get(token.contract)]);
     }, [tokens, formOutputs]);
 
-    if (networkType !== 'cardano' && !hasTransactionInfo) return null;
+    if (networkType !== 'cardano' || !hasTransactionInfo) return null;
 
     return sentTokenList?.map(([tokenSymbol, amount]) => (
         <FormattedCryptoAmount

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -364,7 +364,7 @@ export const pushSendFormTransactionThunk = createThunk<
 
                 dispatch(
                     notificationsActions.addToast({
-                        type: evmApprovalData.type === 'approval' ? 'tx-approved' : 'tx-revoked',
+                        type: evmApprovalData.type === 'approve' ? 'tx-approved' : 'tx-revoked',
                         isInfiniteApproval,
                         formattedAmount: amount,
                         tokenSymbol: token.symbol?.toUpperCase(),

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -205,7 +205,7 @@ export interface RbfTransactionParamsBitcoin {
     locktime?: number;
 }
 
-export type EvmTransactionPurpose = 'transfer' | 'approval' | 'revoke';
+export type EvmTransactionPurpose = 'transfer' | 'approve' | 'revoke' | 'unknown' | '';
 
 export interface RbfTransactionParamsEthereum {
     type: 'ethereum';

--- a/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
@@ -2,6 +2,7 @@ import {
     decimalToHex,
     getEvmApprovalTxData,
     getEvmTransactionTextSignature,
+    getEvmTransferTxData,
     hexToDecimal,
     padLeftEven,
     sanitizeHex,
@@ -59,7 +60,7 @@ describe('eth utils', () => {
             const result = getEvmApprovalTxData(approveData);
 
             expect(result).toEqual({
-                type: 'approval',
+                type: 'approve',
                 spender: '0x742d35cc6634c0532925a3b8d40e592e43a73654',
                 amount: '1000000000000000000',
             });
@@ -86,7 +87,7 @@ describe('eth utils', () => {
                 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'; // max uint256
 
             const result = getEvmApprovalTxData(maxApprovalData);
-            expect(result?.type).toBe('approval');
+            expect(result?.type).toBe('approve');
         });
 
         it('should handle data without 0x prefix', () => {
@@ -97,7 +98,7 @@ describe('eth utils', () => {
 
             const result = getEvmApprovalTxData(dataWithoutPrefix);
 
-            expect(result?.type).toEqual('approval');
+            expect(result?.type).toEqual('approve');
         });
 
         it('should handle uppercase hex data', () => {
@@ -108,17 +109,46 @@ describe('eth utils', () => {
 
             expect(getEvmApprovalTxData(uppercaseData)?.type).toBe('revoke');
         });
+
+        it('returns null for invalid hex input', () => {
+            expect(getEvmApprovalTxData('0xZZZ')).toBeNull();
+            expect(getEvmApprovalTxData('ZZZ')).toBeNull();
+        });
+
+        it('returns null for data shorter than selector', () => {
+            expect(getEvmApprovalTxData('0x09')).toBeNull();
+            expect(getEvmApprovalTxData('09')).toBeNull();
+        });
+
+        it('returns null for selector present but parameters too short', () => {
+            const tooShort = '0x095ea7b3' + '00'.repeat(10); // way less than 2 * 32 bytes
+            expect(getEvmApprovalTxData(tooShort)).toBeNull();
+        });
+
+        it('returns null when decoded parameter types are invalid (garbage after selector)', () => {
+            // not enough bytes to form valid address+uint256
+            const invalidParams = '0x095ea7b3' + 'ff'.repeat(31);
+            expect(getEvmApprovalTxData(invalidParams)).toBeNull();
+        });
+
+        it('handles uppercase without 0x prefix', () => {
+            const data =
+                '095EA7B3' +
+                '000000000000000000000000742D35CC6634C0532925A3B8D40E592E43A73654' +
+                '0000000000000000000000000000000000000000000000000DE0B6B3A7640000';
+            expect(getEvmApprovalTxData(data)?.type).toBe('approve');
+        });
     });
 
     describe('getEvmTransactionTextSignature', () => {
-        it('should return "transfer" when data is undefined or empty string', () => {
-            expect(getEvmTransactionTextSignature(undefined)).toBe('transfer');
-            expect(getEvmTransactionTextSignature('')).toBe('transfer');
+        it('should return "" when data is undefined or empty string', () => {
+            expect(getEvmTransactionTextSignature(undefined)).toBe('');
+            expect(getEvmTransactionTextSignature('')).toBe('');
         });
 
         it('should return "transfer" for non-approval transaction data', () => {
             const randomData = '0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b8d40e5';
-            expect(getEvmTransactionTextSignature(randomData)).toBe('transfer');
+            expect(getEvmTransactionTextSignature(randomData)).toBe('unknown');
         });
 
         it('should return "approval" for approve transaction with non-zero amount', () => {
@@ -127,7 +157,7 @@ describe('eth utils', () => {
                 '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' + // spender
                 '0000000000000000000000000000000000000000000000000de0b6b3a7640000'; // amount (32 bytes) - 1 ETH in wei
 
-            expect(getEvmTransactionTextSignature(approveData)).toBe('approval');
+            expect(getEvmTransactionTextSignature(approveData)).toBe('approve');
         });
 
         it('should return "revoke" for approve transaction with zero amount', () => {
@@ -145,17 +175,17 @@ describe('eth utils', () => {
                 '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' + // spender
                 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'; // max uint256
 
-            expect(getEvmTransactionTextSignature(maxApprovalData)).toBe('approval');
+            expect(getEvmTransactionTextSignature(maxApprovalData)).toBe('approve');
         });
 
-        it('should return "transfer" for data that starts with approve selector but is too short', () => {
+        it('should return "unknown" for data that starts with approve selector but is too short', () => {
             const shortData = '0x095ea7b3';
-            expect(getEvmTransactionTextSignature(shortData)).toBe('transfer');
+            expect(getEvmTransactionTextSignature(shortData)).toBe('unknown');
         });
 
-        it('should return "transfer" for data that starts with approve selector but has invalid parameters', () => {
+        it('should return "unknown" for data that starts with approve selector but has invalid parameters', () => {
             const invalidData = '0x095ea7b3' + '000000000000000000000000742d35cc';
-            expect(getEvmTransactionTextSignature(invalidData)).toBe('transfer');
+            expect(getEvmTransactionTextSignature(invalidData)).toBe('unknown');
         });
 
         it('should handle data without 0x prefix', () => {
@@ -164,7 +194,7 @@ describe('eth utils', () => {
                 '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' +
                 '0000000000000000000000000000000000000000000000000de0b6b3a7640000';
 
-            expect(getEvmTransactionTextSignature(dataWithoutPrefix)).toBe('approval');
+            expect(getEvmTransactionTextSignature(dataWithoutPrefix)).toBe('approve');
         });
 
         it('should handle uppercase hex data', () => {
@@ -176,13 +206,104 @@ describe('eth utils', () => {
             expect(getEvmTransactionTextSignature(uppercaseData)).toBe('revoke');
         });
 
-        it('should return "transfer" for similar but different function selectors', () => {
+        it('should return "unknown" text signature for unknown method call', () => {
             const similarData =
                 '0x095ea7b4' +
                 '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' +
                 '0000000000000000000000000000000000000000000000000de0b6b3a7640000';
 
-            expect(getEvmTransactionTextSignature(similarData)).toBe('transfer');
+            expect(getEvmTransactionTextSignature(similarData)).toBe('unknown');
+        });
+
+        it('returns "transfer" for valid transfer call', () => {
+            const data =
+                '0xa9059cbb' +
+                '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' +
+                '00000000000000000000000000000000000000000000000000000000000003e8';
+            expect(getEvmTransactionTextSignature(data)).toBe('transfer');
+        });
+
+        it('returns "unknown" for selector-only transfer (too short)', () => {
+            expect(getEvmTransactionTextSignature('0xa9059cbb')).toBe('unknown');
+        });
+
+        it('returns "unknown" for "0x" input (not empty but no known selector)', () => {
+            expect(getEvmTransactionTextSignature('0x')).toBe('unknown');
+        });
+
+        it('returns "unknown" for random data not matching known selectors', () => {
+            const random =
+                '0x12345678' +
+                '0000000000000000000000001111111111111111111111111111111111111111' +
+                '0000000000000000000000000000000000000000000000000000000000000001';
+            expect(getEvmTransactionTextSignature(random)).toBe('unknown');
+        });
+
+        it('handles uppercase without 0x prefix for transfer', () => {
+            const upperNoPrefix =
+                'A9059CBB' +
+                '000000000000000000000000742D35CC6634C0532925A3B8D40E592E43A73654' +
+                '00000000000000000000000000000000000000000000000000000000000003E8';
+            expect(getEvmTransactionTextSignature(upperNoPrefix)).toBe('transfer');
+        });
+    });
+
+    describe('getEvmTransferTxData', () => {
+        it('returns transfer for valid ERC-20 transfer', () => {
+            const data =
+                '0xa9059cbb' +
+                '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' + // to
+                '00000000000000000000000000000000000000000000000000000000000003e8'; // 1000
+            const res = getEvmTransferTxData(data);
+            expect(res).toEqual({
+                type: 'transfer',
+                recipient: '0x742d35cc6634c0532925a3b8d40e592e43a73654',
+                amount: '1000',
+            });
+        });
+
+        it('handles zero-amount transfer', () => {
+            const data =
+                '0xa9059cbb' +
+                '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' +
+                '0000000000000000000000000000000000000000000000000000000000000000';
+            const res = getEvmTransferTxData(data);
+            expect(res).toEqual({
+                type: 'transfer',
+                recipient: '0x742d35cc6634c0532925a3b8d40e592e43a73654',
+                amount: '0',
+            });
+        });
+
+        it('returns null for data without 0x prefix (still valid)', () => {
+            const noPrefix =
+                'a9059cbb' +
+                '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' +
+                '00000000000000000000000000000000000000000000000000000000000003e8';
+            const res = getEvmTransferTxData(noPrefix);
+            expect(res?.type).toBe('transfer');
+        });
+
+        it('handles uppercase hex (with 0X prefix)', () => {
+            const upper =
+                '0XA9059CBB' +
+                '000000000000000000000000742D35CC6634C0532925A3B8D40E592E43A73654' +
+                '00000000000000000000000000000000000000000000000000000000000003E8';
+            expect(getEvmTransferTxData(upper)?.type).toBe('transfer');
+        });
+
+        it('returns null for selector only (too short)', () => {
+            expect(getEvmTransferTxData('0xa9059cbb')).toBeNull();
+        });
+
+        it('returns null for invalid hex payload', () => {
+            expect(
+                getEvmTransferTxData(
+                    '0xa9059cbb' +
+                        '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' +
+                        'GGGG000000000000000000000000000000000000000000000000000000000000',
+                ),
+            ).toBeNull();
         });
     });
 });

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -37,16 +37,26 @@ export const strip = (str: string): string => {
     return padLeftEven(str);
 };
 
-interface EvmApprovalTxData {
-    type: Exclude<EvmTransactionPurpose, 'transfer'>;
-    spender: string;
+interface EvmTxData {
+    type: EvmTransactionPurpose;
     amount: string;
 }
 
-export const getEvmApprovalTxData = (data?: string): EvmApprovalTxData | null => {
+interface EvmTxApprovalData extends EvmTxData {
+    spender: string;
+}
+
+interface EvmTxTransferData extends EvmTxData {
+    recipient: string;
+}
+
+const normalizeHex = (data: string) =>
+    data.toLowerCase().startsWith('0x') ? data.toLowerCase() : `0x${data.toLowerCase()}`;
+
+export const getEvmApprovalTxData = (data?: string): EvmTxApprovalData | null => {
     if (!data) return null;
 
-    const dataWithPrefix = data.toLowerCase().startsWith('0x') ? data : `0x${data}`;
+    const dataWithPrefix = normalizeHex(data);
     const dataLowercase = dataWithPrefix.toLowerCase();
     try {
         const approvalPrefix = sha3('approve(address,uint256)')?.slice(0, 10);
@@ -59,7 +69,7 @@ export const getEvmApprovalTxData = (data?: string): EvmApprovalTxData | null =>
         if (typeof decodedData[0] !== 'string' || typeof decodedData[1] !== 'bigint') return null;
 
         return {
-            type: decodedData[1] === 0n ? 'revoke' : 'approval',
+            type: decodedData[1] === 0n ? 'revoke' : 'approve',
             spender: decodedData[0].toLowerCase(),
             amount: decodedData[1].toString(),
         };
@@ -68,13 +78,46 @@ export const getEvmApprovalTxData = (data?: string): EvmApprovalTxData | null =>
     }
 };
 
+export const getEvmTransferTxData = (data?: string): EvmTxTransferData | null => {
+    if (!data) return null;
+
+    const d = normalizeHex(data);
+
+    try {
+        const transferPrefix = sha3('transfer(address,uint256)')?.slice(0, 10); // '0xa9059cbb'
+        if (!transferPrefix || !d.startsWith(transferPrefix)) return null;
+
+        const decoded = decodeParameters(['address', 'uint256'], d.slice(10)); // [to, amount]
+
+        if (typeof decoded[0] !== 'string' || typeof decoded[1] !== 'bigint') return null;
+
+        return {
+            type: 'transfer',
+            recipient: decoded[0].toLowerCase(),
+            amount: decoded[1].toString(),
+        };
+    } catch {
+        return null;
+    }
+};
+
 export const getEvmTransactionTextSignature = (data?: string): EvmTransactionPurpose => {
-    if (!data) return 'transfer';
+    // no data -> no method > no text signature
+    if (!data) {
+        return '';
+    }
 
-    const result = getEvmApprovalTxData(data);
-    if (result === null) return 'transfer';
+    const tokenTransferTxData = getEvmTransferTxData(data);
+    if (tokenTransferTxData?.type) {
+        return tokenTransferTxData.type;
+    }
 
-    return result.type;
+    const approvalTxData = getEvmApprovalTxData(data);
+    if (approvalTxData?.type) {
+        return approvalTxData.type;
+    }
+
+    return 'unknown';
 };
 
 export const isEvmApprovalTx = (data?: string): boolean => {
@@ -82,6 +125,12 @@ export const isEvmApprovalTx = (data?: string): boolean => {
 
     return result !== null;
 };
+
+export type EvmApprovalPurpose = Extract<EvmTransactionPurpose, 'approve' | 'revoke'>;
+
+export const isEvmApprovalTxByTextSignature = (
+    textSignature?: EvmTransactionPurpose,
+): textSignature is EvmApprovalPurpose => textSignature === 'approve' || textSignature === 'revoke';
 
 export const ensureHexPrefix = (hex?: string): string => {
     if (!hex) return '';

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -52,7 +52,12 @@ import {
     networkAmountToSmallestUnit,
 } from './accountUtils';
 import { isBaseCurrencyWithSats } from './baseCurrency';
-import { getEvmTransactionTextSignature, isEip1559, sanitizeHex } from './ethUtils';
+import {
+    getEvmTransactionTextSignature,
+    isEip1559,
+    isEvmApprovalTxByTextSignature,
+    sanitizeHex,
+} from './ethUtils';
 
 export const calculateTotal = (amount: string, fee: string): string => {
     try {
@@ -170,8 +175,6 @@ export const prepareEthereumTransaction = (
 ): EthereumTransaction | EthereumTransactionEIP1559 => {
     let result: EthereumTransaction | EthereumTransactionEIP1559;
 
-    const txType = getEvmTransactionTextSignature(txInfo.data);
-
     const commonTxData = {
         to: txInfo.to,
         value: getSerializedAmount(txInfo.amount),
@@ -206,10 +209,12 @@ export const prepareEthereumTransaction = (
     // Build erc20 'transfer' method or use provided data in case of approve/revoke transaction
     if (txInfo.token) {
         // join data
-        result.data =
-            txType === 'transfer'
-                ? getSerializedErc20Transfer(txInfo.token, txInfo.to, txInfo.amount)
-                : txInfo.data;
+        const evmTxTextSignature = getEvmTransactionTextSignature(txInfo.data);
+
+        result.data = isEvmApprovalTxByTextSignature(evmTxTextSignature)
+            ? txInfo.data
+            : getSerializedErc20Transfer(txInfo.token, txInfo.to, txInfo.amount);
+
         // replace tx recipient to smart contract address
         result.to = txInfo.token.contract;
         // replace tx value

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -37,6 +37,7 @@ import {
     isTokenTransferMatchesSearch,
 } from './accountUtils';
 import { asBaseCurrencyAmount } from './baseCurrency';
+import { getEvmApprovalTxData, getEvmTransactionTextSignature } from './ethUtils';
 import { getFiatRateKey, roundTimestampToNearestPastHour } from './fiatRatesUtils';
 import { getMyInputsFromTransaction } from './getMyInputsFromTransaction';
 import { toFiatCurrency } from '../src/fiatConverterUtils';
@@ -608,32 +609,60 @@ const getEthereumRbfParams = (
         account.networkType !== 'ethereum' ||
         tx.type === 'recv' ||
         !tx.ethereumSpecific ||
-        !isPending(tx)
-    )
+        !isPending(tx) ||
+        !tx.rbf
+    ) {
         return; // ignore non rbf and mined transactions
+    }
 
     const { vout } = tx.details;
-    // The standard transfer method ERC-20 tokens is limited to sending to one recipient per tx
-    // TODO: limit this method just for standard transfers
-    const token = tx.tokens[0];
-
-    const output = token
-        ? {
-              address: token.to,
-              token: token.contract,
-              amount: token.amount,
-              formattedAmount: convertAmountSubunitsToUnits(token.amount, token.decimals),
-          }
-        : {
-              address: vout[0].addresses![0],
-              amount: vout[0].value!,
-              formattedAmount: formatNetworkAmount(vout[0].value!, account.symbol),
-          };
 
     const { data, nonce, gasPrice, maxFeePerGas, maxPriorityFeePerGas } = tx.ethereumSpecific;
 
     // ignore empty calldata represented as '0x'
     const transactionData = !data || data === '0x' ? '' : data;
+
+    const txSignature = getEvmTransactionTextSignature(transactionData);
+
+    const toAddress = vout[0].addresses![0];
+
+    let output;
+    switch (txSignature) {
+        case 'transfer': {
+            const token = tx.tokens[0];
+
+            output = {
+                address: token.to,
+                token: token.contract,
+                amount: token.amount,
+                formattedAmount: convertAmountSubunitsToUnits(token.amount, token.decimals),
+            };
+            break;
+        }
+        case 'approve':
+        case 'revoke': {
+            const approvalData = getEvmApprovalTxData(data);
+
+            const token = account.tokens?.find(t => t.contract === toAddress);
+
+            output = {
+                address: toAddress,
+                token: toAddress, // approval is send to token address
+                amount: approvalData?.amount || '0',
+                formattedAmount: convertAmountSubunitsToUnits(
+                    approvalData?.amount || '0',
+                    token?.decimals || 0,
+                ),
+            };
+            break;
+        }
+        default:
+            output = {
+                address: toAddress,
+                amount: vout[0].value!,
+                formattedAmount: formatNetworkAmount(vout[0].value!, account.symbol),
+            };
+    }
 
     return {
         type: 'ethereum',
@@ -645,7 +674,7 @@ const getEthereumRbfParams = (
             },
         ],
         ethereumNonce: nonce,
-        transactionData,
+        transactionData: txSignature === 'transfer' ? '' : transactionData,
         gasPrice: gasPrice ? fromWei(gasPrice, 'gwei') : '',
         maxFeePerGas: maxFeePerGas ? fromWei(maxFeePerGas, 'gwei') : '',
         maxPriorityFeePerGas: maxPriorityFeePerGas ? fromWei(maxPriorityFeePerGas, 'gwei') : '',
@@ -714,8 +743,16 @@ const getBitcoinRbfParams = (
 export const getRbfParams = (
     tx: AccountTransaction,
     account: Account,
-): WalletAccountTransaction['rbfParams'] =>
-    getBitcoinRbfParams(tx, account) || getEthereumRbfParams(tx, account);
+): WalletAccountTransaction['rbfParams'] => {
+    switch (account.networkType) {
+        case 'bitcoin':
+            return getBitcoinRbfParams(tx, account);
+        case 'ethereum':
+            return getEthereumRbfParams(tx, account);
+        default:
+            return undefined;
+    }
+};
 
 /**
  * Attaches fields from the account (descriptor, deviceState, symbol) to the tx object


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

⚠️ THIS PR fixes the issues but it does not make Suite perfect. I think we should stop using `token` on tx and just use tx data. It is a huge mess ⚠️ 

- remove double token in total in sent total
- fix speed up of approval/revoke tx
- fix speed up of token tx

## Notes for QA

- check all kinds of EVM txs
- check all kinds of speed ups on EVM (token, staking, swap, classic)

Replace tx of sending token does not show token amount, the logic should be improved. Now it is a mess

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/22601
Resolve #22871 

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/approve-bump-fee&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/approve-bump-fee&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/approve-bump-fee&lookback=7)