### PR TITLE
Network Reserve

### DIFF
--- a/packages/suite/src/constants/suite/anchors.ts
+++ b/packages/suite/src/constants/suite/anchors.ts
@@ -25,6 +25,7 @@ export const SettingsAnchor = {
     AutomaticUpdate: '@general-settings/automatic-update',
     AutoEject: '@general-settings/auto-eject',
     MevProtection: '@general-settings/mev-protection',
+    NetworkReserve: '@general-settings/network-reserve',
     StoreDeviceData: '@general-settings/store-device-data',
 
     BackupFailed: '@device-settings/backup-failed',

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -6,16 +6,24 @@ import {
     TRADING_FORM_OUTPUT_AMOUNT,
     type TradingExchangeFormProps,
     type TradingSellFormProps,
+    getCryptoMaxAmountWithReserve,
     tradingActions,
 } from '@suite-common/trading';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 import {
     selectAccounts,
+    selectIsNetworkReserveEnabled,
     selectRawNetworkFeeInfo,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
-import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
+import {
+    asAmountSubunit,
+    findToken,
+    getConvertedOrDefaultFeeInfo,
+    subunitsToUnits,
+} from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
 
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { useCompose } from 'src/hooks/wallet/form/useCompose';
@@ -36,12 +44,14 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     network,
     values,
     methods,
+    setShowReserveBanner,
 }: TradingUseComposeTransactionProps<T>): TradingUseComposeTransactionReturnProps => {
     const dispatch = useDispatch();
     const accounts = useSelector(selectAccounts);
     const device = useSelector(selectSelectedDevice);
     const addressDisplayType = useSelector(selectAddressDisplayType);
     const { translationString } = useTranslation();
+    const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
 
     const { getValues, setValue, setError, clearErrors } = methods as unknown as UseFormReturn<
         TradingSellFormProps | TradingExchangeFormProps
@@ -82,6 +92,14 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
         composeRequest,
         ...methods,
     });
+
+    // when Max amount has been set and quotes are done loading
+    // reset shouldUpdateMaxAmount so that subsequent click on Max works
+    useEffect(() => {
+        if (!isComposing) {
+            setShouldUpdateMaxAmount(true);
+        }
+    }, [isComposing]);
 
     useEffect(() => {
         const setStateAsync = async () => {
@@ -154,7 +172,30 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
             if (typeof setMaxOutputId === 'number' && composed.max && shouldUpdateMaxAmount) {
                 setShouldUpdateMaxAmount(false);
 
-                setValue(TRADING_FORM_OUTPUT_AMOUNT, composed.max, {
+                const feeInUnits = composed.fee
+                    ? subunitsToUnits({
+                          value: asAmountSubunit(new BigNumber(composed.fee)),
+                          symbol: account.symbol,
+                      })
+                    : undefined;
+
+                const output = values.outputs?.[setMaxOutputId];
+                const token = findToken(account.tokens, output?.token);
+
+                const maxValue = isNetworkReserveEnabled
+                    ? getCryptoMaxAmountWithReserve({
+                          symbol: account.symbol,
+                          contractAddress: token?.contract,
+                          balance: account.formattedBalance,
+                          amount: composed.max,
+                          fee: feeInUnits?.toString() || '0',
+                          isNetworkReserveEnabled,
+                      })
+                    : composed.max;
+
+                setShowReserveBanner(maxValue !== composed.max);
+
+                setValue(TRADING_FORM_OUTPUT_AMOUNT, maxValue, {
                     shouldValidate: true,
                     shouldDirty: true,
                 });

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -14,9 +14,14 @@ import {
     type TradingExchangeFormProps,
     type TradingSellFormProps,
     cryptoIdToSymbol,
+    getCryptoAmountWithReserve,
     tradingExchangeActions,
 } from '@suite-common/trading';
-import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
+import {
+    selectAccounts,
+    selectIsNetworkReserveEnabled,
+    selectSelectedDevice,
+} from '@suite-common/wallet-core';
 import { TokenAddress } from '@suite-common/wallet-types';
 import {
     convertAmountSubunitsToUnits,
@@ -37,6 +42,7 @@ import {
 } from 'src/types/trading/tradingForm';
 import {
     getAddressAndTokenFromAccountOptionsGroupProps,
+    getFeeInUnits,
     getTradingNetworkDecimals,
     tradingGetSortedAccounts,
 } from 'src/utils/wallet/trading/tradingUtils';
@@ -58,12 +64,16 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
     composeRequest,
     setAccountOnChange,
     setComposedLevels,
+    composedLevels,
+    composedTransactionInfo,
+    setShowReserveBanner,
 }: TradingUseFormActionsProps<T>): TradingUseFormActionsReturnProps => {
     const dispatch = useDispatch();
     const { symbol } = account;
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
     const accounts = useSelector(selectAccounts);
     const device = useSelector(selectSelectedDevice);
+    const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
     const accountsSorted = tradingGetSortedAccounts({
         accounts,
         deviceState: device?.state?.staticSessionId,
@@ -88,6 +98,12 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
     });
     const networkDecimals = getTradingNetworkDecimals({
         sendCryptoSelect,
+    });
+
+    const feeInUnits = getFeeInUnits({
+        symbol: account.symbol,
+        composedLevels,
+        selectedFee: composedTransactionInfo?.selectedFee,
     });
 
     const setFractionButton = (fraction: number | undefined) => {
@@ -195,7 +211,21 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
             ? convertAmountUnitsToSubunits(amount, networkDecimals)
             : amount;
         clearErrors([TRADING_FORM_OUTPUT_FIAT, TRADING_FORM_OUTPUT_AMOUNT]);
-        setValue(TRADING_FORM_OUTPUT_AMOUNT, cryptoInputValue, { shouldDirty: true });
+
+        const cryptoAmountWithReserve = isNetworkReserveEnabled
+            ? getCryptoAmountWithReserve({
+                  symbol: account.symbol,
+                  contractAddress: tokenAddress,
+                  balance: account.formattedBalance,
+                  amount: cryptoInputValue,
+                  fee: feeInUnits?.toString(),
+                  isNetworkReserveEnabled,
+              })
+            : cryptoInputValue;
+
+        setShowReserveBanner(cryptoAmountWithReserve !== cryptoInputValue);
+
+        setValue(TRADING_FORM_OUTPUT_AMOUNT, cryptoAmountWithReserve, { shouldDirty: true });
         setFractionButton(divisor);
     };
 

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -107,6 +107,7 @@ export const useTradingExchangeForm = ({
     // used for disabling approve/revoke controls when
     // quotes are scheduled to refresh after changing swap form inputs
     const [isScheduledQuotesRefresh, setIsScheduledQuotesRefresh] = useState(false);
+    const [showReserveBanner, setShowReserveBanner] = useState<boolean>(false);
 
     const isTradingTermsDismissed = useSelector(state =>
         selectIsTradingTermsDismissed(state, type),
@@ -231,6 +232,7 @@ export const useTradingExchangeForm = ({
         network,
         values: values as TradingExchangeFormProps,
         methods,
+        setShowReserveBanner,
     });
 
     const { toggleAmountInCrypto } = useTradingCurrencySwitcher({
@@ -268,6 +270,9 @@ export const useTradingExchangeForm = ({
         setAccountOnChange: newAccount => {
             dispatch(tradingExchangeActions.setTradingAccountKey(newAccount.key));
         },
+        composedLevels,
+        composedTransactionInfo,
+        setShowReserveBanner,
     });
 
     const selectQuote = async (quote: ExchangeTrade) => {
@@ -942,5 +947,7 @@ export const useTradingExchangeForm = ({
         setIsLoadingQuote,
         isApproval,
         setIsApproval,
+        showReserveBanner,
+        setShowReserveBanner,
     };
 };

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
 import type { BankAccount, SellFiatTrade, SellFiatTradeResponse } from 'invity-api';
@@ -86,6 +86,9 @@ export const useTradingSellForm = ({
     const paymentMethods = useSelector(selectTradingPaymentMethods);
 
     const isPreviousRouteFromTradeSection = useTradingPreviousRoute(type);
+
+    const [showReserveBanner, setShowReserveBanner] = useState<boolean>(false);
+
     const [accountKey, setAccountKey] = useTradingAccountKey({
         type,
         tradingAccountKey,
@@ -197,6 +200,7 @@ export const useTradingSellForm = ({
         network,
         values: values as TradingSellFormProps,
         methods,
+        setShowReserveBanner,
     });
 
     const { toggleAmountInCrypto } = useTradingCurrencySwitcher<TradingSellFormProps>({
@@ -235,6 +239,9 @@ export const useTradingSellForm = ({
             dispatch(tradingSellActions.setTradingAccountKey(newAccount.key));
             setAccountKey(newAccount.key);
         },
+        composedLevels,
+        composedTransactionInfo,
+        setShowReserveBanner,
     });
 
     const getCommonFunctions = async (quote: SellFiatTrade) => {
@@ -618,5 +625,7 @@ export const useTradingSellForm = ({
         goToOffers,
         selectQuote,
         sendTransaction,
+        showReserveBanner,
+        setShowReserveBanner,
     };
 };

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -100,6 +100,9 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     const [state, setState] = useState<UseSendFormState>(
         getStateFromProps({ selectedAccount, localCurrency, online, metadataEnabled }),
     );
+
+    const [showReserveBanner, setShowReserveBanner] = useState<boolean>(false);
+
     // private variables, used inside sendForm hook
     const draft = useRef<FormState | undefined>(undefined);
 
@@ -185,6 +188,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         updateContext,
         setLoading,
         setAmount: sendFormUtils.setAmount,
+        setShowReserveBanner,
     });
 
     const changeHandlers = useSendFormChangeHandlers({
@@ -416,6 +420,8 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         ...sendFormUtils,
         ...sendFormOutputs,
         ...changeHandlers,
+        showReserveBanner,
+        setShowReserveBanner,
     };
 };
 

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -4,8 +4,12 @@ import { useDispatch } from 'react-redux';
 
 import { isFulfilled } from '@reduxjs/toolkit';
 
+import { getCryptoMaxAmountWithReserve } from '@suite-common/trading';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
-import { composeSendFormTransactionFeeLevelsThunk } from '@suite-common/wallet-core';
+import {
+    composeSendFormTransactionFeeLevelsThunk,
+    selectIsNetworkReserveEnabled,
+} from '@suite-common/wallet-core';
 import {
     ExcludedUtxos,
     FeeInfo,
@@ -15,15 +19,20 @@ import {
     PrecomposedTransaction,
     PrecomposedTransactionCardano,
 } from '@suite-common/wallet-types';
-import { findComposeErrors } from '@suite-common/wallet-utils';
+import {
+    asAmountSubunit,
+    findComposeErrors,
+    findToken,
+    subunitsToUnits,
+} from '@suite-common/wallet-utils';
 import { FeeLevel } from '@trezor/connect';
 import { useDebounce } from '@trezor/react-utils';
-import { isChanged } from '@trezor/utils';
+import { BigNumber, isChanged } from '@trezor/utils';
 
 import { TranslationKey } from 'src/components/suite/Translation';
 import { SendContextValues, UseSendFormState } from 'src/types/wallet/sendForm';
 
-import { useTranslation } from '../suite';
+import { useSelector, useTranslation } from '../suite';
 import { useSolanaSubscribeBlocks } from './form/useSolanaSubscribeBlocks';
 
 type Props = UseFormReturn<FormState> & {
@@ -36,6 +45,7 @@ type Props = UseFormReturn<FormState> & {
     setAmount: (index: number, amount: string) => void;
     targetAnonymity?: number;
     prison?: Record<string, unknown>;
+    setShowReserveBanner: SendContextValues['setShowReserveBanner'];
 };
 
 // This hook should be used only as a sub-hook of `useSendForm`
@@ -53,6 +63,7 @@ export const useSendFormCompose = ({
     setLoading,
     setAmount,
     prison,
+    setShowReserveBanner,
 }: Props) => {
     const [composedLevels, setComposedLevels] =
         useState<SendContextValues['composedLevels']>(undefined);
@@ -60,8 +71,8 @@ export const useSendFormCompose = ({
     const [draftSaveRequest, setDraftSaveRequest] = useState(false);
 
     const dispatch = useDispatch();
-
     const { translationString } = useTranslation();
+    const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
 
     const composeRequestID = useRef(0); // compose ID, incremented with every compose request
 
@@ -223,7 +234,30 @@ export const useSendFormCompose = ({
             const { setMaxOutputId } = values;
             // set calculated and formatted "max" value to `Amount` input
             if (typeof setMaxOutputId === 'number' && composed.max) {
-                setAmount(setMaxOutputId, composed.max);
+                const feeInUnits = composed.fee
+                    ? subunitsToUnits({
+                          value: asAmountSubunit(new BigNumber(composed.fee)),
+                          symbol: account.symbol,
+                      })
+                    : undefined;
+
+                const output = values.outputs?.[setMaxOutputId];
+                const token = findToken(account.tokens, output?.token);
+
+                const maxValue = isNetworkReserveEnabled
+                    ? getCryptoMaxAmountWithReserve({
+                          symbol: account.symbol,
+                          contractAddress: token?.contract,
+                          balance: account.formattedBalance,
+                          amount: composed.max,
+                          fee: feeInUnits?.toString() || '0',
+                          isNetworkReserveEnabled,
+                      })
+                    : composed.max;
+
+                setShowReserveBanner(maxValue !== composed.max);
+
+                setAmount(setMaxOutputId, maxValue);
                 setDraftSaveRequest(true);
             }
             setLoading(false);
@@ -238,6 +272,11 @@ export const useSendFormCompose = ({
             setValue,
             setLoading,
             translationString,
+            account.formattedBalance,
+            account.symbol,
+            account.tokens,
+            isNetworkReserveEnabled,
+            setShowReserveBanner,
         ],
     );
 

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -293,6 +293,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case setBaseCurrency.type:
                 case WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS:
                 case WALLET_SETTINGS.SET_MEV_PROTECTION:
+                case WALLET_SETTINGS.SET_NETWORK_RESERVE:
                 case WALLET_SETTINGS.AUTO_FORGET_DEVICE_DATA:
                 case WALLET_SETTINGS.SET_AUTO_EJECT:
                     api.dispatch(storageActions.saveWalletSettings());

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2818,6 +2818,19 @@ export default defineMessages({
         defaultMessage: 'Available on {supportedNetworks}.',
         id: 'TR_MEV_AVAILABLE_ON',
     },
+    TR_NETWORKS: {
+        defaultMessage: 'Networks',
+        id: 'TR_NETWORKS',
+    },
+    TR_NETWORK_RESERVE: {
+        defaultMessage: 'Network reserve',
+        id: 'TR_NETWORK_RESERVE',
+    },
+    TR_NETWORK_RESERVE_DESCRIPTION: {
+        defaultMessage:
+            'We reserve a small amount of native token on {supportedNetworks} to cover extra network fees when you send, swap, or sell your assets.',
+        id: 'TR_NETWORK_RESERVE_DESCRIPTION',
+    },
     TR_CONFIRM_AUTO_EJECT: {
         defaultMessage: 'Enable auto-eject',
         id: 'TR_CONFIRM_AUTO_EJECT',
@@ -5886,6 +5899,10 @@ export default defineMessages({
         defaultMessage:
             'Insufficient {networkDisplaySymbol} to cover the transaction fee ({feeAmount} {networkDisplaySymbol}).',
         id: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
+    },
+    AMOUNT_EXCEEDS_NETWORK_RESERVE: {
+        defaultMessage: 'Not enough funds left after we reserve for network fees',
+        id: 'AMOUNT_EXCEEDS_NETWORK_RESERVE',
     },
     REMAINING_BALANCE_LESS_THAN_RENT: {
         defaultMessage:
@@ -10828,6 +10845,16 @@ export default defineMessages({
     TR_SIMULATION_NO_ASSETS: {
         id: 'TR_SIMULATION_NO_ASSETS',
         defaultMessage: 'No changes to your assets were detected.',
+    },
+    TR_NETWORK_RESERVE_BANNER: {
+        id: 'TR_NETWORK_RESERVE_BANNER',
+        defaultMessage:
+            'We reserve up to {amount} {displaySymbol} in case extra network fees apply.',
+    },
+    TR_NETWORK_RESERVE_MANAGE: {
+        defaultMessage: 'Manage',
+        description: 'Link to manage network reserve.',
+        id: 'TR_NETWORK_RESERVE_MANAGE',
     },
     TR_EXCHANGE_DETAIL_FEEDBACK_TITLE: {
         id: 'TR_EXCHANGE_DETAIL_FEEDBACK_TITLE',

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -178,6 +178,8 @@ export interface TradingSellFormContextProps
     sendTransaction: () => Promise<boolean>;
     selectQuote: (quote: SellFiatTrade) => void;
     methods: UseFormReturn<TradingSellFormProps>;
+    showReserveBanner: boolean;
+    setShowReserveBanner: (showReserveBanner: boolean) => void;
 }
 
 export type TradingExchangeConfirmTradeProps = {
@@ -250,6 +252,9 @@ export interface TradingExchangeFormContextProps
     isApproval: boolean;
     setIsApproval: (isApproval: boolean) => void;
     methods: UseFormReturn<TradingExchangeFormProps>;
+
+    showReserveBanner: boolean;
+    setShowReserveBanner: (showReserveBanner: boolean) => void;
 }
 
 export type TradingExchangeApprovalType = 'APPROVE' | 'REVOKE';
@@ -320,6 +325,9 @@ export interface TradingUseFormActionsProps<T extends TradingSellExchangeFormPro
     composeRequest: SendContextValues<TradingSellExchangeFormProps>['composeTransaction'];
     setAccountOnChange: (account: Account) => void;
     setComposedLevels: (levels: PrecomposedLevels | PrecomposedLevelsCardano | undefined) => void;
+    composedLevels: PrecomposedLevels | PrecomposedLevelsCardano | undefined;
+    composedTransactionInfo: TradingComposedTransactionInfo;
+    setShowReserveBanner: (showReserveBanner: boolean) => void;
 }
 
 export interface TradingUseFormActionsReturnProps {
@@ -340,6 +348,7 @@ export interface TradingUseComposeTransactionProps<T extends TradingSellExchange
     network: Network;
     methods: UseFormReturn<T>;
     values: T;
+    setShowReserveBanner: (showReserveBanner: boolean) => void;
 }
 
 export interface TradingUseComposeTransactionStateProps {

--- a/packages/suite/src/types/wallet/sendForm.ts
+++ b/packages/suite/src/types/wallet/sendForm.ts
@@ -100,6 +100,8 @@ export type SendContextValues<TFormValues extends FormState = FormState> =
             setDraftSaveRequest: Dispatch<SetStateAction<boolean>>;
             // UTXO selection
             utxoSelection: UtxoSelectionContext;
+            showReserveBanner: boolean;
+            setShowReserveBanner: (show: boolean) => void;
         };
 
 export type RbfLabelsToBeUpdated = Record<

--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -91,6 +91,7 @@ export const getSuiteReadyPayload = async (
         experimentVariants: experimentVariants.map(({ name, variant }) => `${name}:${variant}`),
 
         mevProtection: state.wallet.settings.mevProtection,
+        networkReserve: state.wallet.settings.networkReserve,
     };
 };
 

--- a/packages/suite/src/utils/suite/validation.ts
+++ b/packages/suite/src/utils/suite/validation.ts
@@ -242,3 +242,26 @@ export const validateReserveOrBalance =
 
         return undefined;
     };
+
+interface ValidateNetworkReserveOptions {
+    reserve?: string;
+    balance?: string;
+    fee?: string;
+}
+
+export const validateNetworkReserve =
+    (
+        translationString: TranslationFunction,
+        { reserve, balance, fee = '0' }: ValidateNetworkReserveOptions,
+    ) =>
+    (value: string) => {
+        if (!reserve || !balance) return undefined;
+
+        const accountBalance = new BigNumber(balance);
+        const networkReserve = new BigNumber(reserve);
+        const networkFee = new BigNumber(fee);
+
+        if (new BigNumber(value).gt(accountBalance.minus(networkReserve).minus(networkFee))) {
+            return translationString('AMOUNT_EXCEEDS_NETWORK_RESERVE');
+        }
+    };

--- a/packages/suite/src/utils/wallet/trading/tradingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingUtils.ts
@@ -10,18 +10,22 @@ import {
 } from '@suite-common/trading';
 import {
     Network,
+    NetworkSymbol,
     getNetwork,
     getNetworkDisplaySymbol,
     getNetworkDisplaySymbolName,
     getNetworkFeatures,
     getNetworkType,
 } from '@suite-common/wallet-config';
+import { PrecomposedLevels, PrecomposedLevelsCardano } from '@suite-common/wallet-types';
 import {
+    asAmountSubunit,
     getContractAddressForNetworkSymbol,
     sortByCoin,
     substituteBip43Path,
+    subunitsToUnits,
 } from '@suite-common/wallet-utils';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { FeeLevel } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
 import { Route, TrezorDevice } from 'src/types/suite';
@@ -390,4 +394,33 @@ export const getTradeTypeByRoute = (
     if (routeName?.startsWith('wallet-trading-exchange')) {
         return 'exchange';
     }
+};
+
+interface GetFeeInUnitsProps {
+    symbol: NetworkSymbol;
+    composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
+    selectedFee?: FeeLevel['label'];
+}
+
+export const getFeeInUnits = ({
+    symbol,
+    composedLevels,
+    selectedFee = 'normal',
+}: GetFeeInUnitsProps): string => {
+    if (!composedLevels) return '0';
+
+    const selectedFeeLevel = composedLevels[selectedFee];
+
+    if (selectedFeeLevel.type !== 'final' && selectedFeeLevel.type !== 'nonfinal') {
+        return '0';
+    }
+
+    const { fee } = selectedFeeLevel;
+
+    const feeInUnits = subunitsToUnits({
+        value: asAmountSubunit(new BigNumber(fee)),
+        symbol,
+    }).toString();
+
+    return feeInUnits;
 };

--- a/packages/suite/src/views/settings/SettingsGeneral/MevProtection.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/MevProtection.tsx
@@ -1,7 +1,7 @@
 import { FormattedList } from 'react-intl';
 
 import { networksCollection } from '@suite-common/wallet-config';
-import { WALLET_SETTINGS, selectIsMevProtectionEnabled } from '@suite-common/wallet-core';
+import { selectIsMevProtectionEnabled, setMevProtection } from '@suite-common/wallet-core';
 import { Switch } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
@@ -19,19 +19,16 @@ export const MevProtection = () => {
         .filter(network => network.features.includes('mev-protection'))
         .map(network => network.name);
 
-    function handleSwitchChange() {
+    const handleSwitchChange = () => {
         const nextIsMevProtectionEnabled = !isMevProtectionEnabled;
 
-        dispatch({
-            type: WALLET_SETTINGS.SET_MEV_PROTECTION,
-            payload: nextIsMevProtectionEnabled,
-        });
+        dispatch(setMevProtection(nextIsMevProtectionEnabled));
 
         analytics.report({
             type: EventType.SettingsGeneralMevProtection,
             payload: { value: nextIsMevProtectionEnabled },
         });
-    }
+    };
 
     return (
         <SettingsSectionItem anchorId={SettingsAnchor.MevProtection}>

--- a/packages/suite/src/views/settings/SettingsGeneral/NetworkReserve.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/NetworkReserve.tsx
@@ -1,0 +1,53 @@
+import { FormattedList } from 'react-intl';
+
+import { networksCollection } from '@suite-common/wallet-config';
+import { selectIsNetworkReserveEnabled, setNetworkReserve } from '@suite-common/wallet-core';
+import { Switch } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
+
+import { SettingsSectionItem } from 'src/components/settings/SettingsSectionItem';
+import { ActionColumn, TextColumn } from 'src/components/suite';
+import { Translation } from 'src/components/suite/Translation';
+import { SettingsAnchor } from 'src/constants/suite/anchors';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+export const NetworkReserve = () => {
+    const dispatch = useDispatch();
+    const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
+
+    const supportedNetworks = networksCollection
+        .filter(network => !!network.nativeTokenReserve)
+        .map(network => network.name);
+
+    const handleSwitchChange = () => {
+        const nextIsNetworkReserveEnabled = !isNetworkReserveEnabled;
+
+        dispatch(setNetworkReserve(nextIsNetworkReserveEnabled));
+
+        analytics.report({
+            type: EventType.SettingsGeneralNetworkReserve,
+            payload: { value: nextIsNetworkReserveEnabled },
+        });
+    };
+
+    return (
+        <SettingsSectionItem anchorId={SettingsAnchor.NetworkReserve}>
+            <TextColumn
+                title={<Translation id="TR_NETWORK_RESERVE" />}
+                description={
+                    <Translation
+                        id="TR_NETWORK_RESERVE_DESCRIPTION"
+                        values={{
+                            supportedNetworks: (
+                                <FormattedList type="conjunction" value={supportedNetworks} />
+                            ),
+                        }}
+                    />
+                }
+            />
+            <ActionColumn>
+                <Switch isChecked={isNetworkReserveEnabled} onChange={handleSwitchChange} />
+            </ActionColumn>
+        </SettingsSectionItem>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -3,6 +3,7 @@ import { getNetwork } from '@suite-common/wallet-config';
 import {
     selectEnabledNetworks,
     selectIsMevProtectionSettingsVisible,
+    selectIsNetworkReserveSettingsVisible,
 } from '@suite-common/wallet-core';
 import { isDesktop, isLinux, isWeb } from '@trezor/env-utils';
 
@@ -39,6 +40,7 @@ import { Experimental } from './Experimental';
 import { Labeling } from './Labeling';
 import { Language } from './Language';
 import { MevProtection } from './MevProtection';
+import { NetworkReserve } from './NetworkReserve';
 import { ShowApplicationLog } from './ShowApplicationLog';
 import { ShowOnTray } from './ShowOnTray';
 import { StoreDeviceData } from './StoreDeviceData';
@@ -72,6 +74,7 @@ export const SettingsGeneral = () => {
 
     const isProviderConnected = useSelector(selectSelectedProviderForLabels);
     const isMevProtectionSettingsVisible = useSelector(selectIsMevProtectionSettingsVisible);
+    const isNetworkReserveSettingsVisible = useSelector(selectIsNetworkReserveSettingsVisible);
 
     return (
         <SettingsLayout data-testid="@settings/index">
@@ -125,6 +128,12 @@ export const SettingsGeneral = () => {
             {isMevProtectionSettingsVisible && (
                 <SettingsSection title={<Translation id="TR_SECURITY" />} icon="shield">
                     <MevProtection />
+                </SettingsSection>
+            )}
+
+            {isNetworkReserveSettingsVisible && (
+                <SettingsSection title={<Translation id="TR_NETWORKS" />} icon="graph">
+                    <NetworkReserve />
                 </SettingsSection>
             )}
 

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -1,5 +1,9 @@
+import { useEffect } from 'react';
+
+import { getNetworkReserve } from '@suite-common/trading';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
 import { Output, TokenAddress } from '@suite-common/wallet-types';
 import {
     convertAmountUnitsToSubunits,
@@ -25,8 +29,11 @@ import {
     validateDecimals,
     validateInteger,
     validateMin,
+    validateNetworkReserve,
     validateReserveOrBalance,
 } from 'src/utils/suite/validation';
+import { getFeeInUnits } from 'src/utils/wallet/trading/tradingUtils';
+import { TradingNetworkReserveBanner } from 'src/views/wallet/trading/common/TradingForm/TradingNetworkReserveBanner';
 
 import { BaseCurrencyInput } from './BaseCurrencyInput';
 import { SendMaxSwitch } from './SendMaxSwitch';
@@ -44,18 +51,23 @@ export const Amount = ({ output, outputId }: AmountProps) => {
         feeInfo,
         control,
         getDefaultValue,
+        getValues,
         handleAmountChange,
         formState: { errors },
         setMax,
         composeTransaction,
         getCurrentFiatRate,
         watch,
+        composedLevels,
+        showReserveBanner,
+        setShowReserveBanner,
     } = useSendFormContext();
     const { symbol, tokens } = account;
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
     const { isBelowLaptop } = useLayoutSize();
 
     const locale = useSelector(selectLanguage);
+    const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
 
     const amountName = `outputs.${outputId}.amount` as const;
     const tokenInputName = `outputs.${outputId}.token`;
@@ -102,6 +114,18 @@ export const Amount = ({ output, outputId }: AmountProps) => {
 
     const handleInputChange = (value: string) => handleAmountChange({ outputId, value });
 
+    const feeInUnits = getFeeInUnits({
+        symbol: account.symbol,
+        composedLevels,
+        selectedFee: getValues().selectedFee,
+    });
+
+    const isNetworkReserveError = error?.type === 'networkReserve';
+
+    useEffect(() => {
+        setShowReserveBanner(isNetworkReserveError);
+    }, [isNetworkReserveError, setShowReserveBanner]);
+
     const cryptoAmountRules = {
         required: translationString('AMOUNT_IS_NOT_SET'),
         validate: {
@@ -133,6 +157,17 @@ export const Amount = ({ output, outputId }: AmountProps) => {
                 areSatsUsed: !!shouldSendInSats,
                 contractAddress: tokenValue,
             }),
+            networkReserve: isNetworkReserveEnabled
+                ? validateNetworkReserve(translationString, {
+                      reserve: getNetworkReserve({
+                          symbol: account.symbol,
+                          contractAddress: tokenValue,
+                          isEnabled: isNetworkReserveEnabled,
+                      }),
+                      balance: account.formattedBalance,
+                      fee: feeInUnits?.toString(),
+                  })
+                : () => undefined,
         },
     };
 
@@ -222,6 +257,13 @@ export const Amount = ({ output, outputId }: AmountProps) => {
                     </BaseCurrencyValue>
                 )}
             </Flex>
+
+            {showReserveBanner && (
+                <TradingNetworkReserveBanner
+                    symbol={network.symbol}
+                    contractAddress={tokenValue ?? undefined}
+                />
+            )}
 
             {isLowAnonymity && (
                 <Banner icon margin={{ top: spacings.sm }}>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -25,6 +25,7 @@ import { TradingFormInputFiatCrypto } from 'src/views/wallet/trading/common/Trad
 import { TradingFormSwitcherExchangeRates } from 'src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormSwitcherExchangeRates';
 
 import { TradingFormFeesDisclamer } from './TradingFormFeeDisclamer';
+import { TradingNetworkReserveBanner } from './TradingNetworkReserveBanner';
 import { generateFractionButtons } from './tradingFormInputsUtils';
 import { TradingReceiveAddress } from '../TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress';
 
@@ -43,6 +44,7 @@ export const TradingExchangeFormInputs = () => {
         setValue,
         changeFeeLevel,
         shouldSendInSats,
+        showReserveBanner,
     } = context;
     const { rateType, sendCryptoSelect, receiveCryptoSelect, outputs, amountInCrypto } =
         getValues();
@@ -118,6 +120,14 @@ export const TradingExchangeFormInputs = () => {
                         </Row>
                     )}
                 </Column>
+
+                {showReserveBanner && (
+                    <TradingNetworkReserveBanner
+                        symbol={account.symbol}
+                        contractAddress={tokenAddress}
+                    />
+                )}
+
                 <TradingFormInputCryptoSelect<TradingExchangeFormProps>
                     placeholder="TR_SELECT_TOKEN"
                     label="TR_TO"

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputCryptoAmount.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { FieldErrors } from 'react-hook-form';
 
 import { useFormatters } from '@suite-common/formatters';
@@ -6,10 +7,12 @@ import {
     TRADING_FORM_OUTPUT_MAX,
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
     TradingBuyFormProps,
+    getNetworkReserve,
     useTradingInfo,
 } from '@suite-common/trading';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
 import { FormState } from '@suite-common/wallet-types';
 import { getInputState } from '@suite-common/wallet-utils';
 import { NumberInput } from '@trezor/product-components';
@@ -33,6 +36,7 @@ import {
     validateDecimals,
     validateInteger,
     validateMin,
+    validateNetworkReserve,
     validateReserveOrBalance,
 } from 'src/utils/suite/validation';
 import {
@@ -41,6 +45,7 @@ import {
     isTradingSellContext,
 } from 'src/utils/wallet/trading/tradingTypingUtils';
 import {
+    getFeeInUnits,
     getTradingNetworkDecimals,
     tradingGetAccountLabel,
 } from 'src/utils/wallet/trading/tradingUtils';
@@ -56,9 +61,20 @@ export const TradingFormInputCryptoAmount = <TFieldValues extends TradingAllForm
     const { translationString } = useTranslation();
     const { CryptoAmountFormatter } = useFormatters();
     const locale = useSelector(selectLanguage);
+    const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
 
     const context = useTradingFormContext();
     const { amountLimits, account, network } = context;
+
+    const feeInUnits =
+        isTradingSellContext(context) || isTradingExchangeContext(context)
+            ? getFeeInUnits({
+                  symbol: account.symbol,
+                  composedLevels: context.composedLevels,
+                  selectedFee: context.composedTransactionInfo?.selectedFee,
+              })
+            : undefined;
+
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const { cryptoIdToSymbolAndContractAddress } = useTradingInfo();
     const {
@@ -89,6 +105,18 @@ export const TradingFormInputCryptoAmount = <TFieldValues extends TradingAllForm
         network,
     });
 
+    const isNetworkReserveError =
+        (isTradingExchangeContext(context) || isTradingSellContext(context)) &&
+        cryptoInputError?.type === 'networkReserve';
+    const setShowReserveBanner =
+        isTradingExchangeContext(context) || isTradingSellContext(context)
+            ? context.setShowReserveBanner
+            : undefined;
+
+    useEffect(() => {
+        setShowReserveBanner?.(isNetworkReserveError);
+    }, [isNetworkReserveError, setShowReserveBanner]);
+
     const cryptoInputRules = {
         validate: {
             min: validateMin(translationString),
@@ -99,7 +127,6 @@ export const TradingFormInputCryptoAmount = <TFieldValues extends TradingAllForm
                 areSatsUsed: !!shouldSendInSats,
                 formatter: CryptoAmountFormatter,
             }),
-
             ...(!isTradingBuyContext(context)
                 ? {
                       reserveOrBalance: validateReserveOrBalance(translationString, {
@@ -107,6 +134,17 @@ export const TradingFormInputCryptoAmount = <TFieldValues extends TradingAllForm
                           areSatsUsed: !!shouldSendInSats,
                           contractAddress: (getValues() as FormState).outputs?.[0]?.token,
                       }),
+                      networkReserve: isNetworkReserveEnabled
+                          ? validateNetworkReserve(translationString, {
+                                reserve: getNetworkReserve({
+                                    symbol: account.symbol,
+                                    contractAddress,
+                                    isEnabled: isNetworkReserveEnabled,
+                                }),
+                                balance: account.formattedBalance,
+                                fee: feeInUnits?.toString(),
+                            })
+                          : () => undefined,
                   }
                 : {}),
         },

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { FieldErrors, UseControllerProps, UseFormReturn } from 'react-hook-form';
 
 import {
@@ -5,9 +6,10 @@ import {
     TRADING_FORM_OUTPUT_CURRENCY,
     TRADING_FORM_OUTPUT_FIAT,
     TradingBuyFormProps,
+    getNetworkReserve,
 } from '@suite-common/trading';
 import { formInputsMaxLength } from '@suite-common/validators';
-import { selectCurrentFiatRates } from '@suite-common/wallet-core';
+import { selectCurrentFiatRates, selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
 import { TokenAddress } from '@suite-common/wallet-types';
 import {
     buildCurrencyShortOption,
@@ -29,12 +31,12 @@ import {
     TradingFormInputFiatCryptoProps,
     TradingSellExchangeFormProps,
 } from 'src/types/trading/tradingForm';
-import { validateDecimals, validateMin } from 'src/utils/suite/validation';
+import { validateDecimals, validateMin, validateNetworkReserve } from 'src/utils/suite/validation';
 import {
     isTradingExchangeContext,
     isTradingSellContext,
 } from 'src/utils/wallet/trading/tradingTypingUtils';
-import { tradingGetRoundedFiatAmount } from 'src/utils/wallet/trading/tradingUtils';
+import { getFeeInUnits, tradingGetRoundedFiatAmount } from 'src/utils/wallet/trading/tradingUtils';
 import { TradingFormInputCurrency } from 'src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency';
 
 export const TradingFormInputFiat = <TFieldValues extends TradingAllFormProps>({
@@ -46,6 +48,7 @@ export const TradingFormInputFiat = <TFieldValues extends TradingAllFormProps>({
 }: TradingFormInputFiatCryptoProps<TFieldValues>) => {
     const { translationString } = useTranslation();
     const locale = useSelector(selectLanguage);
+    const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
 
     const context = useTradingFormContext();
     const { account, amountLimits, network } = context;
@@ -57,10 +60,40 @@ export const TradingFormInputFiat = <TFieldValues extends TradingAllFormProps>({
         getValues,
     } = methods as unknown as UseFormReturn<TradingAllFormProps>;
 
-    const tokenAddress = getValues('sendCryptoSelect')?.contractAddress as TokenAddress | undefined;
+    const sendCryptoSelect = getValues('sendCryptoSelect');
+    const tokenAddress = sendCryptoSelect?.contractAddress as TokenAddress | undefined;
 
     const { fiatAmount } = useFiatFromCryptoValue({
         amount: account.formattedBalance || '',
+        symbol: account.symbol,
+        tokenAddress,
+        rateType: 'current',
+    });
+
+    const networkReserve = getNetworkReserve({
+        symbol: account.symbol,
+        contractAddress: tokenAddress,
+        isEnabled: isNetworkReserveEnabled,
+    });
+
+    const { fiatAmount: networkReserveFiatAmount } = useFiatFromCryptoValue({
+        amount: networkReserve || '',
+        symbol: account.symbol,
+        tokenAddress,
+        rateType: 'current',
+    });
+
+    const feeInUnits =
+        isTradingSellContext(context) || isTradingExchangeContext(context)
+            ? getFeeInUnits({
+                  symbol: account.symbol,
+                  composedLevels: context.composedLevels,
+                  selectedFee: context.composedTransactionInfo?.selectedFee,
+              })
+            : undefined;
+
+    const { fiatAmount: feeFiatAmount } = useFiatFromCryptoValue({
+        amount: feeInUnits?.toString() || '',
         symbol: account.symbol,
         tokenAddress,
         rateType: 'current',
@@ -82,6 +115,18 @@ export const TradingFormInputFiat = <TFieldValues extends TradingAllFormProps>({
             ? (errors as FieldErrors<TradingSellExchangeFormProps>)?.outputs?.[0]?.amount
             : undefined;
 
+    const isNetworkReserveError =
+        (isTradingExchangeContext(context) || isTradingSellContext(context)) &&
+        fiatInputError?.type === 'networkReserve';
+    const setShowReserveBanner =
+        isTradingExchangeContext(context) || isTradingSellContext(context)
+            ? context.setShowReserveBanner
+            : undefined;
+
+    useEffect(() => {
+        setShowReserveBanner?.(isNetworkReserveError);
+    }, [isNetworkReserveError, setShowReserveBanner]);
+
     const fiatInputRules: UseControllerProps['rules'] = {
         ...(isTradingExchangeContext(context)
             ? {
@@ -96,6 +141,13 @@ export const TradingFormInputFiat = <TFieldValues extends TradingAllFormProps>({
                               return translationString('AMOUNT_IS_NOT_ENOUGH');
                           }
                       },
+                      networkReserve: isNetworkReserveEnabled
+                          ? validateNetworkReserve(translationString, {
+                                reserve: networkReserveFiatAmount?.toString(),
+                                balance: fiatAmount?.toString(),
+                                fee: feeFiatAmount?.toString(),
+                            })
+                          : () => undefined,
                       minFiat: () => {
                           if (
                               cryptoAmount &&
@@ -138,6 +190,17 @@ export const TradingFormInputFiat = <TFieldValues extends TradingAllFormProps>({
                   validate: {
                       min: validateMin(translationString),
                       decimals: validateDecimals(translationString, { decimals: 2 }),
+                      ...(isTradingSellContext(context)
+                          ? {
+                                networkReserve: isNetworkReserveEnabled
+                                    ? validateNetworkReserve(translationString, {
+                                          reserve: networkReserveFiatAmount?.toString(),
+                                          balance: fiatAmount?.toString(),
+                                          fee: feeFiatAmount?.toString(),
+                                      })
+                                    : () => undefined,
+                            }
+                          : {}),
                       minFiat: (value: string) => {
                           if (
                               value &&

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingNetworkReserveBanner.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingNetworkReserveBanner.tsx
@@ -1,0 +1,61 @@
+import { getNetworkReserve } from '@suite-common/trading';
+import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
+import { Banner } from '@trezor/components';
+
+import { goto } from 'src/actions/suite/routerActions';
+import { Translation } from 'src/components/suite/Translation';
+import { SettingsAnchor } from 'src/constants/suite/anchors';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+interface TradingNetworkReserveBannerProps {
+    symbol: NetworkSymbol;
+    contractAddress?: string;
+}
+
+export const TradingNetworkReserveBanner = ({
+    symbol,
+    contractAddress,
+}: TradingNetworkReserveBannerProps) => {
+    const dispatch = useDispatch();
+    const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
+
+    const onManageClick = () => {
+        dispatch(
+            goto('settings-index', {
+                preserveParams: true,
+                anchor: SettingsAnchor.NetworkReserve,
+            }),
+        );
+    };
+
+    if (!isNetworkReserveEnabled) return null;
+
+    const networkReserve = getNetworkReserve({
+        symbol,
+        contractAddress,
+        isEnabled: isNetworkReserveEnabled,
+    });
+    if (!networkReserve) return null;
+
+    const network = getNetwork(symbol);
+
+    return (
+        <Banner
+            intent="info"
+            rightContent={
+                <Banner.Button onClick={onManageClick}>
+                    <Translation id="TR_NETWORK_RESERVE_MANAGE" />
+                </Banner.Button>
+            }
+        >
+            <Translation
+                id="TR_NETWORK_RESERVE_BANNER"
+                values={{
+                    amount: networkReserve,
+                    displaySymbol: network.displaySymbol,
+                }}
+            />
+        </Banner>
+    );
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -20,6 +20,7 @@ import { TradingFormInputFiatCrypto } from 'src/views/wallet/trading/common/Trad
 import { TradingFormInputPaymentMethod } from 'src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod';
 
 import { TradingFormFeesDisclamer } from './TradingFormFeeDisclamer';
+import { TradingNetworkReserveBanner } from './TradingNetworkReserveBanner';
 import { generateFractionButtons } from './tradingFormInputsUtils';
 
 export const TradingSellFormInputs = () => {
@@ -33,6 +34,7 @@ export const TradingSellFormInputs = () => {
         shouldSendInSats,
         getValues,
         changeFeeLevel,
+        showReserveBanner,
     } = context;
     const { outputs, sendCryptoSelect, amountInCrypto } = getValues();
     const output = outputs[0];
@@ -82,6 +84,13 @@ export const TradingSellFormInputs = () => {
                         </Row>
                     )}
                 </Column>
+
+                {showReserveBanner && (
+                    <TradingNetworkReserveBanner
+                        symbol={account.symbol}
+                        contractAddress={tokenAddress}
+                    />
+                )}
             </Column>
             <Divider margin={0} />
             <Fees

--- a/suite-common/analytics/src/events/suite/constants.ts
+++ b/suite-common/analytics/src/events/suite/constants.ts
@@ -122,6 +122,7 @@ export enum EventType {
     SettingsGeneralAutoEject = 'settings/general/auto-eject',
     SettingsGeneralStoreDeviceData = 'settings/general/store-device-data',
     SettingsGeneralMevProtection = 'settings/general/mev-protection',
+    SettingsGeneralNetworkReserve = 'settings/general/network-reserve',
     SettingsCoinsBackend = 'settings/coins/backend',
     SettingsCoins = 'settings/coins',
     SettingsTor = 'settings/tor',

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -39,6 +39,7 @@ export type SuiteAnalyticsEventSuiteReady = {
         isAutomaticUpdateEnabled: boolean;
         experimentVariants: string[];
         mevProtection: boolean;
+        networkReserve: boolean;
     };
 };
 
@@ -713,6 +714,12 @@ export type SuiteAnalyticsEvent =
       }
     | {
           type: EventType.SettingsGeneralMevProtection;
+          payload: {
+              value: boolean;
+          };
+      }
+    | {
+          type: EventType.SettingsGeneralNetworkReserve;
           payload: {
               value: boolean;
           };

--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -1,7 +1,8 @@
 import { CryptoId, ExchangeProviderInfo, ExchangeTrade, SellFiatTrade } from 'invity-api';
 
-import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { NetworkSymbol, getNetwork, networksCollection } from '@suite-common/wallet-config';
 import type { Account } from '@suite-common/wallet-types';
+import { BigNumber } from '@trezor/utils';
 
 import * as BUY_FIXTURE from '../__fixtures__/buyUtils';
 import * as EXCHANGE_FIXTURE from '../__fixtures__/exchangeUtils';
@@ -19,6 +20,8 @@ import {
     cryptoIdToSymbol,
     filterQuotesAccordingTags,
     getBestRatedQuote,
+    getCryptoAmountWithReserve,
+    getCryptoMaxAmountWithReserve,
     getDefaultCountry,
     getTagAndInfoNote,
     getTradingFormState,
@@ -798,4 +801,257 @@ describe('getTradingFormState', () => {
             });
         });
     });
+});
+
+describe('getCryptoAmountWithReserve', () => {
+    const NETWORKS_WITH_RESERVE = networksCollection.filter(
+        network => !!network.nativeTokenReserve,
+    );
+    const NETWORKS_WITHOUT_RESERVE = networksCollection.filter(
+        network => !network.nativeTokenReserve,
+    );
+
+    it.each(NETWORKS_WITHOUT_RESERVE)(
+        'should return unchanged amount for %s (networks without reserve)',
+        network => {
+            const balance = '100';
+            const amount = '95';
+            const fee = '10';
+
+            const adjustedAmount = getCryptoAmountWithReserve({
+                symbol: network.symbol,
+                contractAddress: undefined,
+                balance,
+                amount,
+                fee,
+                isNetworkReserveEnabled: true,
+            });
+
+            expect(adjustedAmount).toBe(amount);
+        },
+    );
+
+    it.each(NETWORKS_WITH_RESERVE)(
+        'should return unchanged amount for %s when network reserve is not enabled',
+        network => {
+            const balance = '100';
+            const amount = '95';
+            const fee = '10';
+
+            const adjustedAmount = getCryptoAmountWithReserve({
+                symbol: network.symbol,
+                contractAddress: undefined,
+                balance,
+                amount,
+                fee,
+                isNetworkReserveEnabled: false,
+            });
+
+            expect(adjustedAmount).toBe(amount);
+        },
+    );
+
+    it.each(NETWORKS_WITH_RESERVE)('should return unchanged amount for %s (tokens)', network => {
+        const balance = '100';
+        const amount = '95';
+        const fee = '10';
+
+        const adjustedAmount = getCryptoAmountWithReserve({
+            symbol: network.symbol,
+            contractAddress: '0x123',
+            balance,
+            amount,
+            fee,
+            isNetworkReserveEnabled: true,
+        });
+
+        expect(adjustedAmount).toBe(amount);
+    });
+
+    it.each(NETWORKS_WITH_RESERVE)(
+        'should return unchanged amount when amount is less than balance - reserve - fee',
+        network => {
+            const amount = '10';
+            const fee = '10';
+
+            const reserve = network.nativeTokenReserve;
+            expect(reserve).toBeDefined();
+
+            const balance = new BigNumber(amount)
+                .plus(reserve ?? '0')
+                .plus(fee)
+                .plus('1')
+                .toString();
+
+            const adjustedAmount = getCryptoAmountWithReserve({
+                symbol: network.symbol,
+                contractAddress: undefined,
+                balance,
+                amount,
+                fee,
+                isNetworkReserveEnabled: true,
+            });
+
+            expect(adjustedAmount).toBe(amount);
+        },
+    );
+
+    it.each(NETWORKS_WITH_RESERVE)(
+        'should return adjusted amount when amount is greater than balance - reserve - fee',
+        network => {
+            const balance = '100';
+            const fee = '10';
+
+            const reserve = network.nativeTokenReserve;
+            expect(reserve).toBeDefined();
+
+            const amount = new BigNumber(balance)
+                .minus(reserve ?? '0')
+                .minus(fee)
+                .plus('1')
+                .toString();
+
+            const adjustedAmount = getCryptoAmountWithReserve({
+                symbol: network.symbol,
+                contractAddress: undefined,
+                balance,
+                amount,
+                fee,
+                isNetworkReserveEnabled: true,
+            });
+
+            expect(adjustedAmount).toBe(
+                new BigNumber(balance)
+                    .minus(reserve ?? '0')
+                    .minus(fee)
+                    .toString(),
+            );
+        },
+    );
+
+    it.each(NETWORKS_WITH_RESERVE)(
+        'should return zero when account balance is less than reserve + fee',
+        network => {
+            const balance = '10';
+            const amount = '5';
+
+            const reserve = network.nativeTokenReserve;
+            expect(reserve).toBeDefined();
+
+            const fee = new BigNumber(balance)
+                .minus(reserve ?? '0')
+                .plus('1')
+                .toString();
+
+            const adjustedAmount = getCryptoAmountWithReserve({
+                symbol: network.symbol,
+                contractAddress: undefined,
+                balance,
+                amount,
+                fee,
+                isNetworkReserveEnabled: true,
+            });
+
+            expect(adjustedAmount).toBe('0');
+        },
+    );
+});
+
+describe('getCryptoMaxAmountWithReserve', () => {
+    const NETWORKS_WITH_RESERVE = networksCollection.filter(
+        network => !!network.nativeTokenReserve,
+    );
+    const NETWORKS_WITHOUT_RESERVE = networksCollection.filter(
+        network => !network.nativeTokenReserve,
+    );
+
+    it.each(NETWORKS_WITHOUT_RESERVE)(
+        'should return unchanged amount for %s (networks without reserve)',
+        network => {
+            const balance = '100';
+            const amount = '95';
+            const fee = '10';
+
+            const adjustedAmount = getCryptoMaxAmountWithReserve({
+                symbol: network.symbol,
+                contractAddress: undefined,
+                balance,
+                amount,
+                fee,
+                isNetworkReserveEnabled: true,
+            });
+
+            expect(adjustedAmount).toBe(amount);
+        },
+    );
+
+    it.each(NETWORKS_WITH_RESERVE)(
+        'should return unchanged amount when network reserve is not enabled',
+        network => {
+            const balance = '100';
+            const amount = '95';
+            const fee = '10';
+
+            const adjustedAmount = getCryptoMaxAmountWithReserve({
+                symbol: network.symbol,
+                contractAddress: undefined,
+                balance,
+                amount,
+                fee,
+                isNetworkReserveEnabled: false,
+            });
+
+            expect(adjustedAmount).toBe(amount);
+        },
+    );
+
+    it.each(NETWORKS_WITH_RESERVE)('should return unchanged amount for %s (tokens)', network => {
+        const balance = '100';
+        const amount = '95';
+        const fee = '10';
+
+        const adjustedAmount = getCryptoMaxAmountWithReserve({
+            symbol: network.symbol,
+            contractAddress: '0x123',
+            balance,
+            amount,
+            fee,
+            isNetworkReserveEnabled: true,
+        });
+
+        expect(adjustedAmount).toBe(amount);
+    });
+
+    it.each(NETWORKS_WITH_RESERVE)(
+        'should return adjusted amount when amount is greater than balance - reserve - fee',
+        network => {
+            const balance = '100';
+            const fee = '10';
+
+            const reserve = network.nativeTokenReserve;
+            expect(reserve).toBeDefined();
+
+            const amount = new BigNumber(balance)
+                .minus(reserve ?? '0')
+                .minus(fee)
+                .plus('1')
+                .toString();
+
+            const adjustedAmount = getCryptoMaxAmountWithReserve({
+                symbol: network.symbol,
+                contractAddress: undefined,
+                balance,
+                amount,
+                fee,
+                isNetworkReserveEnabled: true,
+            });
+
+            expect(adjustedAmount).toBe(
+                new BigNumber(balance)
+                    .minus(reserve ?? '0')
+                    .minus(fee)
+                    .toString(),
+            );
+        },
+    );
 });

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -439,3 +439,94 @@ export const getTradingPrefilledFromAccountData = (
         key,
     };
 };
+
+interface GetNetworkReserveProps {
+    symbol: NetworkSymbol;
+    contractAddress: string | undefined | null;
+    isEnabled?: boolean;
+}
+
+/**
+ * Reserve defined in networksConfig.ts applies to the native token only
+ */
+export const getNetworkReserve = ({
+    symbol,
+    contractAddress,
+    isEnabled,
+}: GetNetworkReserveProps) => {
+    if ((!!contractAddress && contractAddress !== CONTRACT_ADDRESS_FOR_NATIVE_TOKEN) || !isEnabled)
+        return undefined;
+    const network = getNetwork(symbol);
+
+    return network.nativeTokenReserve;
+};
+
+interface GetCryptoAmountWithReserveProps {
+    symbol: NetworkSymbol;
+    contractAddress: string | undefined | null;
+    balance: string;
+    amount: string;
+    fee?: string;
+    isNetworkReserveEnabled?: boolean;
+}
+
+export const getCryptoAmountWithReserve = ({
+    symbol,
+    contractAddress,
+    balance,
+    amount,
+    fee = '0',
+    isNetworkReserveEnabled,
+}: GetCryptoAmountWithReserveProps) => {
+    const networkReserve = getNetworkReserve({
+        symbol,
+        contractAddress,
+        isEnabled: isNetworkReserveEnabled,
+    });
+    if (!networkReserve) return amount;
+
+    const accountBalance = new BigNumber(balance);
+    const reservePlusFee = new BigNumber(networkReserve).plus(fee);
+
+    if (accountBalance.minus(amount).gt(reservePlusFee)) {
+        return amount;
+    }
+
+    const maxAmount = accountBalance.minus(reservePlusFee);
+
+    return maxAmount.lt(0) ? '0' : maxAmount.toString();
+};
+
+interface GetCryptoMaxAmountWithReserveProps {
+    symbol: NetworkSymbol;
+    contractAddress: string | undefined | null;
+    balance: string;
+    amount: string;
+    fee?: string;
+    isNetworkReserveEnabled?: boolean;
+}
+
+export const getCryptoMaxAmountWithReserve = ({
+    symbol,
+    contractAddress,
+    balance,
+    amount,
+    fee = '0',
+    isNetworkReserveEnabled,
+}: GetCryptoMaxAmountWithReserveProps) => {
+    const networkReserve = getNetworkReserve({
+        symbol,
+        contractAddress,
+        isEnabled: isNetworkReserveEnabled,
+    });
+    if (!networkReserve) return amount;
+
+    const accountBalance = new BigNumber(balance);
+    const reservePlusFee = new BigNumber(networkReserve).plus(fee);
+
+    if (new BigNumber(amount).plus(reservePlusFee).gt(accountBalance)) {
+        return accountBalance.minus(reservePlusFee).toString();
+    }
+
+    return amount;
+};

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -219,6 +219,7 @@ export const networks = {
         coingeckoId: 'base',
         tradeCryptoId: 'base--0x0000000000000000000000000000000000000000',
         caipId: 'eip155:8453',
+        nativeTokenReserve: '0.0002',
     },
     op: {
         symbol: 'op',
@@ -254,6 +255,7 @@ export const networks = {
         coingeckoId: 'optimistic-ethereum',
         tradeCryptoId: 'optimistic-ethereum--0x0000000000000000000000000000000000000000',
         caipId: 'eip155:10',
+        nativeTokenReserve: '0.0002',
     },
     avax: {
         symbol: 'avax',
@@ -319,6 +321,7 @@ export const networks = {
         coingeckoId: 'solana',
         tradeCryptoId: 'solana',
         caipId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        nativeTokenReserve: '0.003',
     },
     ada: {
         // icarus derivation

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -130,6 +130,7 @@ type NetworkWithSpecificKey<TKey extends NetworkSymbol> = {
     coingeckoId?: string;
     tradeCryptoId?: string;
     caipId?: string; // CAIP-2 chain id, used by WalletConnect
+    nativeTokenReserve?: string;
 };
 export type Network = NetworkWithSpecificKey<NetworkSymbol>;
 

--- a/suite-common/wallet-core/src/settings/walletSettingsActions.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsActions.ts
@@ -30,6 +30,11 @@ export const setMevProtection = createAction(
     }),
 );
 
+export const setNetworkReserve = createAction(
+    WALLET_SETTINGS.SET_NETWORK_RESERVE,
+    (enabled: boolean) => ({ payload: enabled }),
+);
+
 export const toggleHideSuspiciousTransactions = createAction(
     WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS,
 );
@@ -52,11 +57,6 @@ export type ChangeCoinVisibilityAction = {
     };
 };
 
-export type SetMevProtectionAction = {
-    type: typeof WALLET_SETTINGS.SET_MEV_PROTECTION;
-    payload: boolean;
-};
-
 export type SetHideBalanceAction = {
     type: typeof WALLET_SETTINGS.SET_HIDE_BALANCE;
     toggled: boolean;
@@ -73,10 +73,11 @@ export type WalletSettingsAction =
     | ReturnType<typeof toggleHideSuspiciousTransactions>
     | ReturnType<typeof setAutoForgetDeviceData>
     | ReturnType<typeof setAutoEjectEnabled>
+    | ReturnType<typeof setMevProtection>
+    | ReturnType<typeof setNetworkReserve>
     | ChangeCoinVisibilityAction
     | SetHideBalanceAction
-    | SetBitcoinAmountUnitsAction
-    | SetMevProtectionAction;
+    | SetBitcoinAmountUnitsAction;
 
 export const setDiscreetMode = (toggled: boolean): WalletSettingsAction => ({
     type: WALLET_SETTINGS.SET_HIDE_BALANCE,

--- a/suite-common/wallet-core/src/settings/walletSettingsConstants.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsConstants.ts
@@ -7,6 +7,7 @@ const TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS = '@wallet-settings/toggle-hide-suspic
 const SET_DISCREET_MODE = '@wallet-settings/set-discreet-mode';
 const CHANGE_COIN_VISIBILITY = '@wallet-settings/change-coin-visibility';
 const SET_MEV_PROTECTION = '@wallet-settings/set-mev-protection';
+const SET_NETWORK_RESERVE = '@wallet-settings/set-network-reserve';
 const AUTO_FORGET_DEVICE_DATA = '@wallet-settings/set-auto-forget-device-data';
 const SET_AUTO_EJECT = '@wallet-settings/set-auto-eject';
 
@@ -20,6 +21,7 @@ export const WALLET_SETTINGS = {
     SET_DISCREET_MODE,
     CHANGE_COIN_VISIBILITY,
     SET_MEV_PROTECTION,
+    SET_NETWORK_RESERVE,
     AUTO_FORGET_DEVICE_DATA,
     SET_AUTO_EJECT,
 } as const;

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -47,6 +47,7 @@ const initialState: WalletSettingsState = {
     hideSuspiciousTransactions: false,
     bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
     mevProtection: true,
+    networkReserve: true,
     isAutoForgetDeviceDataEnabled: false,
     isAutoEjectEnabled: false,
 };
@@ -59,6 +60,7 @@ export const walletSettingsPersistedWhitelist: Array<keyof WalletSettingsState> 
     'hideSuspiciousTransactions',
     'bitcoinAmountUnit',
     'mevProtection',
+    'networkReserve',
     'isAutoForgetDeviceDataEnabled',
     'isAutoEjectEnabled',
 ];
@@ -97,8 +99,14 @@ export const prepareWalletSettingsReducer = createReducerWithExtraDeps(
         );
         builder.addCase(
             WALLET_SETTINGS.SET_MEV_PROTECTION,
-            (state, action: walletSettingsActions.SetMevProtectionAction) => {
+            (state, action: ReturnType<typeof walletSettingsActions.setMevProtection>) => {
                 state.mevProtection = action.payload;
+            },
+        );
+        builder.addCase(
+            WALLET_SETTINGS.SET_NETWORK_RESERVE,
+            (state, action: ReturnType<typeof walletSettingsActions.setNetworkReserve>) => {
+                state.networkReserve = action.payload;
             },
         );
         builder.addCase(WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS, state => {
@@ -169,6 +177,9 @@ export const selectIsBaseCurrencyInSats = (state: WalletSettingsRootState) => {
     return isBaseCurrencyWithSats(baseCurrency) && areSatsAmountUnit;
 };
 
+export const selectIsNetworkReserveEnabled = (state: WalletSettingsRootState) =>
+    state.wallet.settings.networkReserve;
+
 export const selectIsMevProtectionEnabled = (state: WalletSettingsRootState) =>
     state.wallet.settings.mevProtection;
 
@@ -186,4 +197,10 @@ export const selectIsMevProtectionSettingsVisible = createMemoizedSelector(
         enabledNetworks.some(enabledNetwork =>
             MEV_PROTECTION_SUPPORTED_NETWORK_SYMBOLS.includes(enabledNetwork),
         ),
+);
+
+export const selectIsNetworkReserveSettingsVisible = createMemoizedSelector(
+    [selectEnabledNetworks],
+    enabledNetworks =>
+        enabledNetworks.some(enabledNetwork => !!getNetwork(enabledNetwork)?.nativeTokenReserve),
 );

--- a/suite-common/wallet-types/src/settings.ts
+++ b/suite-common/wallet-types/src/settings.ts
@@ -24,6 +24,7 @@ export interface WalletSettings {
     hideSuspiciousTransactions: boolean;
     bitcoinAmountUnit: PROTO.AmountUnit;
     mevProtection: boolean;
+    networkReserve: boolean;
     isAutoForgetDeviceDataEnabled: boolean;
     isAutoEjectEnabled: boolean;
 }


### PR DESCRIPTION
## Description

Introduce network reserve for SOL and ETH (Base, Optimism).
Consider this reserve in send/swap/sell.

## Notes for QA

- network reserve can be turned on/off in application settings
- if enabled, ETH on Base and Optimism and SOL on Solana count with hardcoded network reserve
  - `0.0002 ETH`
  - `0.003 SOL`
- in send/swap/sell, the user cannot go below this reserve
- `10%`, `25%`, `50%` and `Max` buttons count with the reserve and if the value would go below the reserve, they adjust the amount to highest possible amount within the reserve (plus network fees)
- if the user types in amount manually, the input field shows an error if the amount is greater than balance minus reserve minus fee

## Related Issue

Resolve #22736 

## Screenshots

No banner is shown when amount is not set.

<img width="1512" height="860" alt="Screenshot 2025-11-14 at 11 03 22" src="https://github.com/user-attachments/assets/b003412c-127a-4ebb-b19d-2185243379d1" />

No banner is shown when amount is within network reserve.

<img width="1512" height="860" alt="Screenshot 2025-11-14 at 11 03 29" src="https://github.com/user-attachments/assets/c7c7a519-e985-492c-9e6f-6d742c429135" />

`50%` is not within the reserve, so the amount is adjusted and banner is shown.

<img width="1512" height="860" alt="Screenshot 2025-11-14 at 11 03 35" src="https://github.com/user-attachments/assets/6165c26d-5a6b-49de-b5cd-07c692ce83d1" />

`Max` is adjusted and banner is shown.

<img width="1512" height="860" alt="Screenshot 2025-11-14 at 11 03 40" src="https://github.com/user-attachments/assets/cf8f38cf-e997-4be5-94f0-ce736a421744" />

Manually inputted amount that is not within reserve is not allowed and banner is shown.

<img width="1512" height="860" alt="Screenshot 2025-11-14 at 11 03 51" src="https://github.com/user-attachments/assets/93cbdd7b-2ec7-4444-b6d0-b5201f92eca0" />

`Max` is adjusted and banner is shown.

<img width="1512" height="860" alt="Screenshot 2025-11-14 at 11 07 42" src="https://github.com/user-attachments/assets/e4868de6-5d25-40bd-a1ce-37b09cf47ac0" />

Manually inputted amount that is not within reserve is not allowed and banner is shown.

<img width="1512" height="860" alt="Screenshot 2025-11-14 at 11 04 27" src="https://github.com/user-attachments/assets/ca3fb526-f93e-4eec-bc05-1df1d50443ec" />

Clicking on the `Manage` button takes the user to application settings, where they can disable network reserve.

<img width="1512" height="860" alt="Screenshot 2025-11-14 at 11 11 45" src="https://github.com/user-attachments/assets/4477d761-fedf-4a17-b632-b59f6a2ea3ce" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/network-reserve&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/network-reserve&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/network-reserve&lookback=7)