### PR TITLE
feat(analytics): reuse settings/device/wipe event on mobile

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/WipeDevice/WipeDeviceModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/WipeDevice/WipeDeviceModal.tsx
@@ -5,7 +5,7 @@ import { isFulfilled } from '@reduxjs/toolkit';
 import { wipeDeviceThunk } from '@suite-common/wallet-core';
 import { Card, Column, H3, Modal, Paragraph } from '@trezor/components';
 import { isDeviceInBootloaderMode } from '@trezor/device-utils';
-import { EventType, analytics } from '@trezor/suite-analytics';
+import { EventTypeShared, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import * as routerActions from 'src/actions/suite/routerActions';
@@ -35,7 +35,7 @@ export const WipeDeviceModal = ({ onCancel }: WipeDeviceModalProps) => {
 
         if (isFulfilled(response)) {
             analytics.report({
-                type: EventType.SettingsDeviceWipe,
+                type: EventTypeShared.SettingsDeviceWipe,
             });
             if (appRoute === 'settings') {
                 // redirect to the index to close the settings and show initial device setup

--- a/suite-common/analytics/src/events/shared/constants.ts
+++ b/suite-common/analytics/src/events/shared/constants.ts
@@ -8,6 +8,7 @@ export enum EventType {
     WalletConnectError = 'wallet-connect/error',
 
     SettingsDeviceChangeLabel = 'settings/device/change-label',
+    SettingsDeviceWipe = 'settings/device/wipe',
 
     ConnectPopupInit = 'connect-popup/init',
     ConnectPopupPermissions = 'connect-popup/permissions',

--- a/suite-common/analytics/src/events/shared/types.ts
+++ b/suite-common/analytics/src/events/shared/types.ts
@@ -42,6 +42,7 @@ export type SuiteSharedAnalyticsEvent =
           };
       }
     | { type: EventType.SettingsDeviceChangeLabel }
+    | { type: EventType.SettingsDeviceWipe }
     | {
           type: EventType.ConnectPopupInit;
       }

--- a/suite-common/analytics/src/events/suite/constants.ts
+++ b/suite-common/analytics/src/events/suite/constants.ts
@@ -102,7 +102,6 @@ export enum EventType {
     SettingsDeviceChangeHapticFeedback = 'settings/device/change-haptic-feedback',
     SettingsDeviceChangeBrightness = 'settings/device/change-brightness',
     SettingsMultiShareBackup = 'settings/device/multi-share-backup',
-    SettingsDeviceWipe = 'settings/device/wipe',
     SettingsDeviceChangePassphraseProtection = 'settings/device/change-passphrase-protection',
 
     SettingsGeneralBioAuth = 'settings/general/bio-auth',

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -621,7 +621,6 @@ export type SuiteAnalyticsEvent =
               value?: number;
           };
       }
-    | { type: EventType.SettingsDeviceWipe }
     | {
           type: EventType.SettingsDeviceChangePassphraseProtection;
           payload: {

--- a/suite-native/device/src/hooks/useWipeDevice.tsx
+++ b/suite-native/device/src/hooks/useWipeDevice.tsx
@@ -5,6 +5,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { isFulfilled } from '@reduxjs/toolkit';
 
 import { selectSelectedDevice, wipeDeviceThunk } from '@suite-common/wallet-core';
+import { EventTypeShared, analytics } from '@suite-native/analytics';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { setWasDeviceOnboardingCancelled } from '@suite-native/device-onboarding';
 import {
@@ -49,6 +50,9 @@ export const useWipeDevice = () => {
         });
 
         if (response.success && isFulfilled(response.payload)) {
+            analytics.report({
+                type: EventTypeShared.SettingsDeviceWipe,
+            });
             navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
                 screen: DeviceSettingsStackRoutes.WipeDeviceStack,
                 params: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reports only on success (same as on desktop)

Notion link https://www.notion.so/satoshilabs/settings-device-wipe-2a4dc526060680b79c5ed79d8794d647?source=copy_link

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21489



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/add-device-wipe-analytic-event&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/add-device-wipe-analytic-event&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/add-device-wipe-analytic-event&lookback=7)