### PR TITLE
fix(suite): connect select account index

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/getAccountInfo.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/getAccountInfo.test.ts
@@ -30,8 +30,8 @@ test.describe('TrezorConnect.getAccountInfo', { tag: ['@group=connect', '@deskto
 
         await connectPermissionsModal.confirmButton.click();
 
-        await page.getByTestId('@select-account-modal/subtab/p2sh').click();
-        await page.getByTestId(`@select-account-modal/accounts/p2sh/1`).click();
+        await page.getByTestId('@select-account-modal/subtab/p2wpkh').click();
+        await page.getByTestId(`@select-account-modal/accounts/p2wpkh/1`).click();
 
         expect(await res).toMatchObject({ success: true });
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectAccountModal.tsx
@@ -61,7 +61,10 @@ export const SelectAccountModal = ({ data }: SelectAccountModalProps) => {
         p2sh: <Translation id="TR_LEGACY_SEGWIT_ACCOUNTS" />,
         p2pkh: <Translation id="TR_LEGACY_ACCOUNTS" />,
     };
-    const filteredAccounts = accounts?.filter(account => account.type === selectedAccountType);
+    const indexedAccounts = accounts?.map((account, index) => ({ ...account, index }));
+    const filteredAccounts = indexedAccounts?.filter(
+        account => account.type === selectedAccountType,
+    );
 
     return (
         <ConnectModalBackdrop onClick={close} canSwitchDevice>
@@ -113,7 +116,7 @@ export const SelectAccountModal = ({ data }: SelectAccountModalProps) => {
                                 </Table.Row>
                             </Table.Header>
                             <Table.Body>
-                                {filteredAccounts?.map((account, index) => {
+                                {filteredAccounts?.map(account => {
                                     const symbol = data.coinInfo.shortcut.toLowerCase();
                                     const suiteAccount = suiteAccounts.find(
                                         a =>
@@ -124,8 +127,8 @@ export const SelectAccountModal = ({ data }: SelectAccountModalProps) => {
                                     return (
                                         <Table.Row
                                             key={account.descriptor}
-                                            onClick={() => confirm(index)}
-                                            data-testid={`@select-account-modal/accounts/${account.type}/${index}`}
+                                            onClick={() => confirm(account.index)}
+                                            data-testid={`@select-account-modal/accounts/${account.type}/${account.index}`}
                                         >
                                             <Table.Cell>
                                                 <Row gap={spacings.sm}>


### PR DESCRIPTION
## Description

Fix indexing in select account modal in Suite, which caused an issue with the account type selection. 

## Related Issue

Resolve #22982

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/getaccountinfo-type&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/getaccountinfo-type&lookback=7)