### PR TITLE
fix(tests): maxlistenerwarning in unit tests

### DIFF
--- a/JestCustomEnv.js
+++ b/JestCustomEnv.js
@@ -13,6 +13,11 @@ class CustomEnvironment extends NodeEnvironment {
             }
         });
     }
+
+    async teardown() {
+        process.removeAllListeners('warning');
+        await super.teardown();
+    }
 }
 
 module.exports = CustomEnvironment;


### PR DESCRIPTION
## Description

It turns out the MaxListenersExceededWarning was happenning because of the listener that was supposed to be handling it! 🤣

## Notes for QA

Nothing to test

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/maxlistenerswarning-unit-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/maxlistenerswarning-unit-tests&lookback=7)