### PR TITLE
feat(suite): move FF for Suite Sync into experimental features

### DIFF
--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -1,4 +1,5 @@
 import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
+import { labelingActions } from '@suite-common/local-first-storage';
 import { Route } from '@suite-common/suite-types';
 import { networksCollection } from '@suite-common/wallet-config';
 import { isDesktop } from '@trezor/env-utils';
@@ -16,7 +17,8 @@ export type ExperimentalFeature =
     | 'password-manager'
     | 'tor-external'
     | 'nft-section'
-    | 'experimental-networks';
+    | 'experimental-networks'
+    | 'suite-sync';
 
 export type ExperimentalFeatureConfig = {
     title: ExtendedMessageDescriptor;
@@ -67,6 +69,17 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
                 networkNames: experimentalNetworkNames.join(', '),
                 count: experimentalNetworks.length,
             },
+        },
+    },
+    'suite-sync': {
+        title: { id: 'TR_EXPERIMENTAL_SUITE_SYNC_TITLE' },
+        description: { id: 'TR_EXPERIMENTAL_SUITE_SYNC_DESCRIPTION' },
+        onToggle: ({ newValue, dispatch }) => {
+            dispatch(
+                labelingActions.updateIsFeatureLocalFirstStorageAvailable({
+                    isShownInSettings: newValue,
+                }),
+            );
         },
     },
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5344,6 +5344,15 @@ export default defineMessages({
         defaultMessage:
             'Send and receive transactions on the {networkNames} {count, plural, one {network} other {networks}}.',
     },
+    TR_EXPERIMENTAL_SUITE_SYNC_TITLE: {
+        id: 'TR_EXPERIMENTAL_SUITE_SYNC_TITLE',
+        defaultMessage: 'Suite Sync',
+    },
+    TR_EXPERIMENTAL_SUITE_SYNC_DESCRIPTION: {
+        id: 'TR_EXPERIMENTAL_SUITE_SYNC_DESCRIPTION',
+        defaultMessage:
+            'Sync your labels across multiple devices using local-first encrypted storage.',
+    },
     TR_EARLY_ACCESS: {
         id: 'TR_EARLY_ACCESS',
         defaultMessage: 'Early Access Program',

--- a/packages/suite/src/views/settings/SettingsDebug/LocalFirstStorageSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/LocalFirstStorageSettings.tsx
@@ -18,14 +18,11 @@ import { useLabelingCombined } from 'src/hooks/suite/useLabelingCombined';
 export const LocalFirstStorageSettings = () => {
     const [isLoading, setIsLoading] = useState(false);
 
-    const {
-        isLocalFirstStorageDebugEnabled,
-        toggleIsFeatureLocalFirstStorageAvailable,
-        isFeatureLocalFirstStorageAvailable,
-    } = useLabelingCombined({
-        // In debug, there may not be any device selected and it is in fact irrelevant
-        deviceStaticSessionId: undefined,
-    });
+    const { isLocalFirstStorageDebugEnabled, isFeatureLocalFirstStorageAvailable } =
+        useLabelingCombined({
+            // In debug, there may not be any device selected and it is in fact irrelevant
+            deviceStaticSessionId: undefined,
+        });
 
     const localFirstStorageRelayUrl = useSelector(selectLocalFirstStorageRelayUrl);
 
@@ -58,18 +55,12 @@ export const LocalFirstStorageSettings = () => {
 
     return (
         <SettingsSection title="Local First Storage">
-            <SectionItem>
-                <TextColumn
-                    title="Local First Storage (Evolu)"
-                    description="This enables Local First Storage (Evolu) for labeling in the application settings. This is an experimental feature."
-                />
-                <ActionColumn>
-                    <Checkbox
-                        isChecked={isFeatureLocalFirstStorageAvailable}
-                        onClick={toggleIsFeatureLocalFirstStorageAvailable}
-                    />
-                </ActionColumn>
-            </SectionItem>
+            {!isFeatureLocalFirstStorageAvailable && (
+                <p>
+                    Enable Local First Storage is disabled. To use Local First Storage (Evolu),
+                    enable Suite Sync experimental feature in the Experimental settings section.
+                </p>
+            )}
             {isFeatureLocalFirstStorageAvailable && (
                 <>
                     <SectionItem>


### PR DESCRIPTION
Moved Suite Sync FF into experimental settings from debug settings. Suite Sync Debug flag and Relay URL is kept in debug settings.

**Changes**:
- moved Suite Sync FF to experimental
- added translations for Suite Sync FF experimental

## Notes for QA

- now you should be able to enable Suite Sync in experimental instead of debug settings

 
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22998

## Screenshots:
<img width="1216" height="924" alt="Screenshot 2025-11-07 at 17 54 12" src="https://github.com/user-attachments/assets/60cbfe5e-eff3-4e03-a46a-370e7537e7b9" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/evolut/propagate-to-experiemental&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/evolut/propagate-to-experiemental&lookback=7)