### PR TITLE
fix(e2e-suite): fix setting test by introducing scroll

### DIFF
--- a/suite-native/app/e2e/pageObjects/homeActions.ts
+++ b/suite-native/app/e2e/pageObjects/homeActions.ts
@@ -17,8 +17,12 @@ class HomeActions {
         await waitForElementByIdToBeVisible('@home/portfolio/graph');
     }
 
-    async tapSyncCoinsButton() {
+    async scrollScreenToBottom() {
         await element(by.id('@screen/mainScrollView')).scrollTo('bottom');
+    }
+
+    async tapSyncCoinsButton() {
+        await this.scrollScreenToBottom();
         await element(by.id('@home/portfolio/sync-coins-button')).tap();
 
         await detoxExpect(element(by.id('@screen/SelectNetwork'))).toBeVisible();

--- a/suite-native/app/e2e/pageObjects/trading/TradingActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/TradingActions.ts
@@ -29,10 +29,6 @@ export class TradingActions {
         return element(by.id(this.getTestId(suffix)));
     }
 
-    async scrollScreenToBottom() {
-        await element(by.id('@screen/mainScrollView')).scrollTo('bottom');
-    }
-
     async closeBottomSheet() {
         await element(by.id('@bottom-sheet/header/close-button')).tap();
         await wait(this.BOTTOM_SHEET_ANIMATION_DURATION);

--- a/suite-native/app/e2e/tests/appSettings.test.ts
+++ b/suite-native/app/e2e/tests/appSettings.test.ts
@@ -16,6 +16,7 @@ describe('App Settings - without device interactions [@noDevice]', () => {
     beforeEach(async () => {
         await openApp({ args: { preloadedState } });
         await onHome.assertIsPortfolioGraphVisible();
+        await onHome.scrollScreenToBottom();
     });
 
     it('Localization - Currency', async () => {

--- a/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
@@ -26,7 +26,7 @@ describe('Trade Buy [@noDevice]', () => {
         await tradingBuyActions.selectCountry('Polan', '🇵🇱 Poland');
         await tradingBuyActions.setFiatAmount('100');
 
-        await tradingBuyActions.scrollScreenToBottom();
+        await onHome.scrollScreenToBottom();
         await tradingBuyActions.viewPaymentMethods();
         await tradingBuyActions.viewProviders();
         await tradingBuyActions.expectValidBuyForm();

--- a/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
@@ -4,6 +4,7 @@ import { MNEMONICS, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import { ethCoinEnabled } from '../fixtures/ethCoinEnabled';
 import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
 import { portfolioTrackerBtcAccountState } from '../fixtures/portfolioTrackerBtcAccountState';
+import { onHome } from '../pageObjects/homeActions';
 import { onPassphrase } from '../pageObjects/passphraseModule';
 import { onTabBar } from '../pageObjects/tabBarActions';
 // import { exchangePreviewActions } from '../pageObjects/trading/exchangePreviewActions';
@@ -94,7 +95,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Trade Exchange', () => 
             await tradingExchangeActions.setSendCryptoAmount('10');
             await tradingExchangeActions.waitForQuotesToLoad();
 
-            await tradingExchangeActions.scrollScreenToBottom();
+            await onHome.scrollScreenToBottom();
             await tradingExchangeActions.viewProviders();
             await tradingExchangeActions.expectValidExchangeForm();
 


### PR DESCRIPTION
sometimes graph is not loaded correctly, there is then an error which is bigger then correctly loaded graph and prolongs the screen. Which moves our test elements out of view

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-e2e-native-appsettings&lookback=7)