### PR TITLE
refactor(e2e-native): refactor and unite all waitFor methods to one

### DIFF
--- a/suite-native/app/e2e/pageObjects/accountDetailActions.ts
+++ b/suite-native/app/e2e/pageObjects/accountDetailActions.ts
@@ -1,10 +1,10 @@
 import { expect as detoxExpect } from 'detox';
 
+import { waitForVisible } from '../support/utils';
+
 class AccountDetailActions {
     async waitForScreen() {
-        await waitFor(element(by.id('@screen/AccountDetail')))
-            .toBeVisible()
-            .withTimeout(5000);
+        await waitForVisible(by.id('@screen/AccountDetail'));
     }
 
     async openSettings() {
@@ -19,7 +19,7 @@ class AccountDetailActions {
 
     async openReceive() {
         const receiveButton = element(by.id('@account-detail/receive-button'));
-        await waitFor(receiveButton).toBeVisible().withTimeout(10000);
+        await waitForVisible(receiveButton);
         await receiveButton.tap();
     }
 }

--- a/suite-native/app/e2e/pageObjects/accountImportActions.ts
+++ b/suite-native/app/e2e/pageObjects/accountImportActions.ts
@@ -1,7 +1,7 @@
 import { expect as detoxExpect } from 'detox';
 
 import { onTabBar } from './tabBarActions';
-import { inputTextToElement, scrollUntilVisible } from '../support/utils';
+import { inputTextToElement, scrollUntilVisible, waitForVisible } from '../support/utils';
 
 class AccountImportActions {
     async importAccountAndVerifyVisibility({
@@ -30,7 +30,7 @@ class AccountImportActions {
         );
         await scrollUntilVisible(coinItemElement);
         await coinItemElement.tap();
-        await detoxExpect(element(by.id('`@screen/XpubScan`')));
+        await detoxExpect(element(by.id('@screen/XpubScan'))).toBeVisible();
     }
 
     async submitXpub({ xpub, isValid }: { xpub: string; isValid: boolean }) {
@@ -42,9 +42,7 @@ class AccountImportActions {
         await xpubSubmitButton.tap();
 
         if (isValid) {
-            await waitFor(element(by.id('@screen/AccountImportSummary')))
-                .toBeVisible()
-                .withTimeout(20000); // it may take a while to load data from blockchain
+            await waitForVisible(by.id('@screen/AccountImportSummary'));
         }
     }
 
@@ -58,8 +56,7 @@ class AccountImportActions {
         const confirmButton = element(by.id('@account-import/coin-synced/confirm-button'));
         await scrollUntilVisible(confirmButton);
         await confirmButton.tap();
-
-        await detoxExpect(element(by.id('@screen/Home')));
+        await detoxExpect(element(by.id('@screen/Accounts'))).toBeVisible();
     }
 }
 

--- a/suite-native/app/e2e/pageObjects/accountReceiveActions.ts
+++ b/suite-native/app/e2e/pageObjects/accountReceiveActions.ts
@@ -1,14 +1,16 @@
 import { expect as detoxExpect } from 'detox';
 
+import { waitForVisible } from '../support/utils';
+
 class AccountReceiveActions {
     async waitForScreen() {
-        await waitFor(element(by.id('@screen/ReceiveAccount'))).toBeVisible();
+        await waitForVisible(by.id('@screen/ReceiveAccount'));
     }
 
     async tapShowAddressButton() {
         const showAddressButton = element(by.id('@receive/show-address-button'));
 
-        await waitFor(showAddressButton).toBeVisible().withTimeout(30000);
+        await waitForVisible(showAddressButton);
         await showAddressButton.tap();
 
         // button should be hidden after tap
@@ -18,7 +20,7 @@ class AccountReceiveActions {
     async verifyReceiveAddress(address: string) {
         const receiveAddressText = element(by.id('@receive/confirmed-receive-address'));
 
-        await waitFor(receiveAddressText).toBeVisible().withTimeout(30000);
+        await waitForVisible(receiveAddressText);
         await detoxExpect(receiveAddressText).toHaveText(address);
     }
 }

--- a/suite-native/app/e2e/pageObjects/alertSheetActions.ts
+++ b/suite-native/app/e2e/pageObjects/alertSheetActions.ts
@@ -1,15 +1,17 @@
+import { waitForVisible } from '../support/utils';
+
 class AlertSheetActions {
     async tapPrimaryButton() {
         const primaryButtonElement = element(by.id('@alert-sheet/primary-button'));
 
-        await waitFor(primaryButtonElement).toBeVisible().withTimeout(10000);
+        await waitForVisible(primaryButtonElement);
         await primaryButtonElement.tap();
     }
 
     async tapSecondaryButton() {
         const secondaryButtonElement = element(by.id('@alert-sheet/secondary-button'));
 
-        await waitFor(secondaryButtonElement).toBeVisible().withTimeout(10000);
+        await waitForVisible(secondaryButtonElement);
         await secondaryButtonElement.tap();
     }
 }

--- a/suite-native/app/e2e/pageObjects/coinEnablingActions.ts
+++ b/suite-native/app/e2e/pageObjects/coinEnablingActions.ts
@@ -1,12 +1,10 @@
 import { onDeviceConnecting } from './deviceConnectingActions';
 import { onHome } from './homeActions';
-import { scrollUntilVisible } from '../support/utils';
+import { scrollUntilVisible, waitForVisible } from '../support/utils';
 
 class CoinEnablingActions {
     async waitForInitScreen() {
-        await waitFor(element(by.id('@screen/CoinEnablingInit')))
-            .toBeVisible()
-            .withTimeout(10000);
+        await waitForVisible(by.id('@screen/CoinEnablingInit'));
     }
 
     async toggleNetwork(symbol: string) {

--- a/suite-native/app/e2e/pageObjects/deviceAuthenticitySuccess.ts
+++ b/suite-native/app/e2e/pageObjects/deviceAuthenticitySuccess.ts
@@ -1,14 +1,14 @@
+import { waitForVisible } from '../support/utils';
+
 class DeviceAuthenticitySuccess {
     async waitForScreen() {
-        await waitFor(element(by.id('@screen/AuthenticitySuccess')))
-            .toBeVisible()
-            .withTimeout(10000);
+        await waitForVisible(by.id('@screen/AuthenticitySuccess'));
     }
 
     async tapCloseButton() {
         const closeButton = element(by.id('@device-authenticity/close-button'));
 
-        await waitFor(closeButton).toBeVisible().withTimeout(10000);
+        await waitForVisible(closeButton);
         await closeButton.tap();
     }
 }

--- a/suite-native/app/e2e/pageObjects/deviceConnectingActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceConnectingActions.ts
@@ -1,10 +1,10 @@
+import { waitForVisible } from '../support/utils';
+
 class DeviceConnectingActions {
     async waitForDeviceConnectingScreen() {
         // Connecting screen is rendered when discovery is running in the background so we need to disable synchronization to reliably test its presence
         await device.disableSynchronization();
-        await waitFor(element(by.id('@screen/ConnectingDevice')))
-            .toBeVisible()
-            .withTimeout(10000);
+        await waitForVisible(by.id('@screen/ConnectingDevice'));
         await device.enableSynchronization();
     }
 }

--- a/suite-native/app/e2e/pageObjects/deviceManagerActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceManagerActions.ts
@@ -1,8 +1,10 @@
+import { waitForVisible } from '../support/utils';
+
 class DeviceManagerActions {
     async tapDeviceSwitch() {
         const deviceSwitch = element(by.id('@device-manager/device-switch'));
 
-        await waitFor(deviceSwitch).toBeVisible().withTimeout(30_000);
+        await waitForVisible(deviceSwitch);
         await waitFor(element(by.id('@screen/ConnectingDevice')))
             .not.toBeVisible()
             .withTimeout(30_000);
@@ -12,14 +14,14 @@ class DeviceManagerActions {
     async tapDeviceSettingsButton() {
         const deviceSettingsButton = element(by.id('@device-manager/device-settings-button'));
 
-        await waitFor(deviceSettingsButton).toBeVisible().withTimeout(30000);
+        await waitForVisible(deviceSettingsButton);
         await deviceSettingsButton.tap();
     }
 
     async tapOpenPassphraseButton() {
         const openPassphraseButton = element(by.id('@device-manager/passphrase/add'));
 
-        await waitFor(openPassphraseButton).toBeVisible().withTimeout(30000);
+        await waitForVisible(openPassphraseButton);
         await openPassphraseButton.tap();
     }
 
@@ -28,11 +30,9 @@ class DeviceManagerActions {
     }: {
         title: 'Connected' | 'Disconnected' | 'Hi there!';
     }) {
-        await waitFor(
+        await waitForVisible(
             element(by.id('@device-manager/device-switch').withDescendant(by.text(title))),
-        )
-            .toBeVisible()
-            .withTimeout(10000);
+        );
     }
 }
 

--- a/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
@@ -1,78 +1,78 @@
 import { BackupType } from '@suite-common/suite-types';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { scrollUntilVisible, waitForElementByIdToBeVisible } from '../support/utils';
+import { scrollUntilVisible, waitForVisible } from '../support/utils';
 
 class DeviceOnboardingActions {
     async selectCreateWalletOption() {
         const buttonId = '@deviceOnboarding/CreateOrRecoverCrossroadsScreen/createWalletBtn';
-        await waitForElementByIdToBeVisible(buttonId);
+        await waitForVisible(by.id(buttonId));
         await element(by.id(buttonId)).tap();
     }
 
     async selectRecoverWalletOption() {
         const buttonId = '@deviceOnboarding/CreateOrRecoverCrossroadsScreen/recoverWalletBtn';
-        await waitForElementByIdToBeVisible(buttonId);
+        await waitForVisible(by.id(buttonId));
         await element(by.id(buttonId)).tap();
     }
 
     async confirmRecoveryInstructions() {
         const buttonId = '@deviceOnboarding/RecoveryInstructionsScreen/continueButton';
-        await waitForElementByIdToBeVisible(buttonId);
+        await waitForVisible(by.id(buttonId));
         await element(by.id(buttonId)).tap();
     }
 
     async waitForCreateOrRecoverCrossroadsScreen() {
-        await waitForElementByIdToBeVisible('@screen/CreateOrRecoverCrossroads');
+        await waitForVisible(by.id('@screen/CreateOrRecoverCrossroads'));
     }
 
     async waitForCreateWalletLoadingScreen() {
-        await waitForElementByIdToBeVisible('@screen/CreateWalletLoading');
+        await waitForVisible(by.id('@screen/CreateWalletLoading'));
     }
 
     async waitForWalletBackupTutorialScreen() {
-        await waitForElementByIdToBeVisible('@screen/WalletBackupTutorial');
+        await waitForVisible(by.id('@screen/WalletBackupTutorial'));
     }
 
     async waitForWalletCreationScreen() {
-        await waitForElementByIdToBeVisible('@screen/WalletCreation');
+        await waitForVisible(by.id('@screen/WalletCreation'));
     }
 
     async gotToNextWalletBackupTutorialStep(step: number) {
         const buttonId = `@swipeableWalkthroughStep/walletBackupTutorialStep${step}/nextButton`;
-        await waitForElementByIdToBeVisible(buttonId);
+        await waitForVisible(by.id(buttonId));
         await element(by.id(buttonId)).tap();
     }
 
     async goToNextWalletBackupRecapStep(step: number) {
         const buttonId = `@swipeableWalkthroughStep/walletBackupRecapStep${step}/nextButton`;
-        await waitForElementByIdToBeVisible(buttonId);
+        await waitForVisible(by.id(buttonId));
         await element(by.id(buttonId)).tap();
     }
 
     async goToNextWalletRecoveryRecapStep(step: number) {
         const buttonId = `@swipeableWalkthroughStep/walletRecoveryRecapStep${step}/nextButton`;
-        await waitForElementByIdToBeVisible(buttonId);
+        await waitForVisible(by.id(buttonId));
         await element(by.id(buttonId)).tap();
     }
 
     async waitForWalletBackupRecapScreen() {
-        await waitForElementByIdToBeVisible('@screen/WalletBackupRecap');
+        await waitForVisible(by.id('@screen/WalletBackupRecap'));
     }
 
     async waitForWalletRecoveryRecapScreen() {
-        await waitForElementByIdToBeVisible('@screen/WalletRecoveryRecap');
+        await waitForVisible(by.id('@screen/WalletRecoveryRecap'));
     }
 
     async openWalletBackupTypeMenu() {
         const buttonId = '@deviceOnboarding/WalletBackupTutorialStep5/moreOptionsButton';
-        await waitForElementByIdToBeVisible(buttonId);
+        await waitForVisible(by.id(buttonId));
         await element(by.id(buttonId)).tap();
     }
 
     async validateSelectedBackupType(selectedType: BackupType) {
-        await waitForElementByIdToBeVisible(
-            `onboarding/WalletBackupTutorialStep5/selectedType=${selectedType}`,
+        await waitForVisible(
+            by.id(`onboarding/WalletBackupTutorialStep5/selectedType=${selectedType}`),
         );
     }
 
@@ -89,22 +89,22 @@ class DeviceOnboardingActions {
 
     async pressHoldToConfirmButton() {
         const buttonId = '@holdToConfirmButton';
-        await waitForElementByIdToBeVisible(buttonId);
+        await waitForVisible(by.id(buttonId));
         const holdToConfirmButton = element(by.id(buttonId));
         await holdToConfirmButton.longPress(3000);
     }
 
     async waitForUninitializedDeviceLanding() {
-        await waitForElementByIdToBeVisible('@screen/UninitializedDeviceLanding');
+        await waitForVisible(by.id('@screen/UninitializedDeviceLanding'));
     }
 
     async waitForDeviceAuthenticitySuccess() {
-        await waitForElementByIdToBeVisible('@screen/DeviceAuthenticitySuccess');
+        await waitForVisible(by.id('@screen/DeviceAuthenticitySuccess'));
     }
 
     async dismissDeviceAuthenticitySuccess() {
         const buttonId = '@device-authenticity/continue-button';
-        await waitForElementByIdToBeVisible(buttonId);
+        await waitForVisible(by.id(buttonId));
         await element(by.id(buttonId)).tap();
     }
 
@@ -115,7 +115,7 @@ class DeviceOnboardingActions {
     async skipFirmwareUpdate() {
         const testId = '@firmware/skip-button';
         try {
-            await waitForElementByIdToBeVisible(testId, 5000);
+            await waitForVisible(by.id(testId));
             await element(by.id(testId)).tap();
         } catch {
             console.warn(
@@ -125,10 +125,13 @@ class DeviceOnboardingActions {
     }
 
     async enterTHPPairingCode() {
-        await waitForElementByIdToBeVisible('@screen/ThpCodeEntry');
+        await waitForVisible(by.id('@screen/ThpCodeEntry'));
         const screenContent = await TrezorUserEnvLink.getScreenContent();
         const screenContentBody = screenContent.body as string;
-        const code = screenContentBody.match(/(\d\s*){6}$/)?.[0].replace(/\s+/g, '') ?? '';
+        const code = screenContentBody.match(/(\d\s*){6}$/)?.[0].replace(/\s+/g, '');
+        if (!code) {
+            throw new Error(`Screen content did not contain pairing code\n${screenContentBody}`);
+        }
         await element(by.id('@thpSecurityCode/Input')).replaceText(code);
     }
 }

--- a/suite-native/app/e2e/pageObjects/devicePromptActions.ts
+++ b/suite-native/app/e2e/pageObjects/devicePromptActions.ts
@@ -1,10 +1,10 @@
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { waitForElementByIdToBeVisible } from '../support/utils';
+import { waitForVisible } from '../support/utils';
 
 class DevicePromptActions {
     async allowConnectToTrezor() {
-        await waitForElementByIdToBeVisible('@screen/ThpConfirmation');
+        await waitForVisible(by.id('@screen/ThpConfirmation'));
         await TrezorUserEnvLink.pressYes();
     }
 }

--- a/suite-native/app/e2e/pageObjects/deviceSettingsActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceSettingsActions.ts
@@ -1,13 +1,12 @@
 import { MNEMONICS, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { scrollUntilVisible, wait, waitForElementByIdToBeVisible } from '../support/utils';
+import { scrollUntilVisible, wait, waitForVisible } from '../support/utils';
 
 const insertSeed = async (seed: string = MNEMONICS.mnemonic_immune) => {
     const seedWords = seed.split(' ');
-
-    await seedWords.forEach(async word => {
+    for (const word of seedWords) {
         await TrezorUserEnvLink.inputEmu(word);
-    });
+    }
 };
 
 export const redirectToDeviceAuthenticityScreenButton = element(
@@ -16,43 +15,31 @@ export const redirectToDeviceAuthenticityScreenButton = element(
 
 class DeviceSettingsActions {
     async waitForSettingsScreen() {
-        await waitFor(element(by.id('@screen/DeviceSettings')))
-            .toBeVisible()
-            .withTimeout(10000);
+        await waitForVisible(by.id('@screen/DeviceSettings'));
     }
 
     async waitForHomeScreenAndUninitializedTitle() {
-        await waitFor(element(by.id('@screen/Home')))
-            .toBeVisible()
-            .withTimeout(10000);
-        await waitFor(element(by.id('@homescreen/uninitializedConnectedDeviceText')))
-            .toBeVisible()
-            .withTimeout(10000);
+        await waitForVisible(by.id('@screen/Home'));
+        await waitForVisible(by.id('@homescreen/uninitializedConnectedDeviceText'));
     }
 
     async waitForPinProtectionScreen() {
-        await waitFor(element(by.id('@screen/PinProtection')))
-            .toBeVisible()
-            .withTimeout(10000);
+        await waitForVisible(by.id('@screen/PinProtection'));
     }
 
     async waitForWipeDeviceContinueOnTrezor() {
-        await waitFor(element(by.id('@screen/ContinueOnTrezor')))
-            .toBeVisible()
-            .withTimeout(10000);
+        await waitForVisible(by.id('@screen/ContinueOnTrezor'));
     }
 
     async waitForDeviceAuthenticityScreen() {
-        await waitFor(element(by.id('@screen/DeviceAuthenticity')))
-            .toBeVisible()
-            .withTimeout(10000);
+        await waitForVisible(by.id('@screen/DeviceAuthenticity'));
     }
 
     async redirectToPinProtectionScreen() {
         const redirectToPinScreenButton = element(
             by.id('@device-pin-protection/redirectToPinScreen'),
         );
-        await waitFor(redirectToPinScreenButton).toBeVisible().withTimeout(10000);
+        await waitForVisible(redirectToPinScreenButton);
         await redirectToPinScreenButton.tap();
     }
 
@@ -62,12 +49,10 @@ class DeviceSettingsActions {
     }
 
     async tapEnablePinProtectionButton() {
-        await waitFor(element(by.id('@screen/PinProtection')))
-            .toBeVisible()
-            .withTimeout(10000);
+        await waitForVisible(by.id('@screen/PinProtection'));
 
         const enablePinProtectionButton = element(by.id('@device-pin-protection/enable-button'));
-        await waitFor(enablePinProtectionButton).toBeVisible().withTimeout(10000);
+        await waitForVisible(enablePinProtectionButton);
 
         await enablePinProtectionButton.tap();
     }
@@ -75,21 +60,21 @@ class DeviceSettingsActions {
     async tapChangePinProtectionButton() {
         const changePinProtectionButton = element(by.id('@device-pin-protection/change-button'));
 
-        await waitFor(changePinProtectionButton).toBeVisible().withTimeout(10000);
+        await waitForVisible(changePinProtectionButton);
         await changePinProtectionButton.tap();
     }
 
     async tapDisablePinProtectionButton() {
         const disablePinProtectionButton = element(by.id('@device-pin-protection/disable-button'));
 
-        await waitFor(disablePinProtectionButton).toBeVisible().withTimeout(10000);
+        await waitForVisible(disablePinProtectionButton);
         await disablePinProtectionButton.tap();
     }
 
     async tapChangeDeviceNameButton() {
         const changeDeviceNameButton = element(by.id('@device-name/change-button'));
 
-        await waitFor(changeDeviceNameButton).toBeVisible().withTimeout(10000);
+        await waitForVisible(changeDeviceNameButton);
         await changeDeviceNameButton.tap();
     }
 
@@ -124,13 +109,13 @@ class DeviceSettingsActions {
 
     async tapUpdateFirmwareBottomSheet() {
         const updateFirmwareButton = element(by.id('@device-firmware/update-button'));
-        await waitFor(updateFirmwareButton).toBeVisible().withTimeout(10000);
+        await waitForVisible(updateFirmwareButton);
         await updateFirmwareButton.tap();
     }
 
     async tapCheckBackupButtonFromFirmwareUpdate() {
         const checkBackupButton = element(by.id('@device-firmware/sheet/check-backup'));
-        await waitFor(checkBackupButton).toBeVisible().withTimeout(10000);
+        await waitForVisible(checkBackupButton);
         await checkBackupButton.tap();
     }
 
@@ -138,7 +123,7 @@ class DeviceSettingsActions {
         const changeDeviceNameInput = element(by.id('@device-name/input'));
         const changeDeviceNameSubmitButton = element(by.id('@device-name/submit-button'));
 
-        await waitFor(changeDeviceNameInput).toBeVisible().withTimeout(10000);
+        await waitForVisible(changeDeviceNameInput);
         await changeDeviceNameInput.tap();
         await changeDeviceNameInput.replaceText(value);
         await changeDeviceNameSubmitButton.tap();
@@ -146,28 +131,28 @@ class DeviceSettingsActions {
 
     async tapCheckAuthenticityButton() {
         const checkDeviceAuthenticityButton = element(by.id('@device-authenticity/check-button'));
-        await waitFor(checkDeviceAuthenticityButton).toBeVisible().withTimeout(5_000);
+        await waitForVisible(checkDeviceAuthenticityButton);
         await checkDeviceAuthenticityButton.tap();
     }
 
-    async confirmStepperItems(items: number) {
+    async confirmStepperItems(count: number) {
         const confirmButton = element(by.id('@cardStepper/confirm-button'));
 
-        for (let i = 0; i < items; i++) {
-            await waitFor(confirmButton).toBeVisible().withTimeout(10000);
+        for (let i = 0; i < count; i++) {
+            await waitForVisible(confirmButton);
             await confirmButton.tap();
         }
     }
 
     async goToNextDeviceCheckBackupTutorialStep(step: number) {
         const buttonId = `@swipeableWalkthroughStep/checkBackupTutorialStep${step}/nextButton`;
-        await waitForElementByIdToBeVisible(buttonId);
+        await waitForVisible(by.id(buttonId));
         await element(by.id(buttonId)).tap();
     }
 
     async tapDeviceCheckBackupContinueButton() {
         const continueButton = element(by.id('@device-check-backup/continue-button'));
-        await waitFor(continueButton).toBeVisible().withTimeout(10000);
+        await waitForVisible(continueButton);
         await continueButton.tap();
     }
 
@@ -182,9 +167,7 @@ class DeviceSettingsActions {
         await insertSeed();
         await TrezorUserEnvLink.pressYes();
 
-        await waitFor(element(by.text('Your backup is valid')))
-            .toBeVisible()
-            .withTimeout(10000);
+        await waitForVisible(by.text('Your backup is valid'));
     }
 }
 

--- a/suite-native/app/e2e/pageObjects/homeActions.ts
+++ b/suite-native/app/e2e/pageObjects/homeActions.ts
@@ -1,6 +1,6 @@
 import { expect as detoxExpect } from 'detox';
 
-import { waitForElementByIdToBeVisible } from '../support/utils';
+import { waitForVisible } from '../support/utils';
 
 const graphHeaderDiscreetTextElement = element(
     by.id('@screen/Home').withDescendant(by.id('discreet-text')),
@@ -8,13 +8,11 @@ const graphHeaderDiscreetTextElement = element(
 
 class HomeActions {
     async waitForScreen() {
-        await waitFor(element(by.id('@screen/Home')))
-            .toBeVisible()
-            .withTimeout(10000);
+        await waitForVisible(by.id('@screen/Home'));
     }
 
     async assertIsPortfolioGraphVisible() {
-        await waitForElementByIdToBeVisible('@home/portfolio/graph');
+        await waitForVisible(by.id('@home/portfolio/graph'));
     }
 
     async scrollScreenToBottom() {
@@ -33,7 +31,7 @@ class HomeActions {
     }
 
     async assertIsDiscreetModeEnabled() {
-        await waitFor(graphHeaderDiscreetTextElement).toBeVisible().withTimeout(10000);
+        await waitForVisible(graphHeaderDiscreetTextElement);
     }
 }
 

--- a/suite-native/app/e2e/pageObjects/myAssetsActions.ts
+++ b/suite-native/app/e2e/pageObjects/myAssetsActions.ts
@@ -1,29 +1,23 @@
 import { expect as detoxExpect } from 'detox';
 
-import { waitForElementByIdToBeVisible } from '../support/utils';
+import { waitForVisible } from '../support/utils';
 
 class MyAssetsActions {
     async waitForScreen() {
-        await waitFor(element(by.id('@screen/MyAssets')))
-            .toBeVisible()
-            .withTimeout(5000);
+        await waitForVisible(by.id('@screen/MyAssets'));
     }
 
     async addAccount() {
-        await waitForElementByIdToBeVisible('@screen/mainScrollView');
+        await waitForVisible(by.id('@screen/mainScrollView'));
         await element(by.id('@screen/mainScrollView')).scrollTo('top');
         const addAccountButtonId = '@myAssets/addAccountButton/import';
-        await waitForElementByIdToBeVisible(addAccountButtonId);
+        await waitForVisible(by.id(addAccountButtonId));
         await element(by.id(addAccountButtonId)).tap();
-
-        await waitFor(element(by.id('@screen/SelectNetwork')))
-            .toBeVisible()
-            .withTimeout(5000);
+        await waitForVisible(by.id('@screen/SelectNetwork'));
     }
 
     async openAccountDetail({ accountName }: { accountName: string }) {
         await element(by.text(accountName)).tap();
-
         await detoxExpect(element(by.id('@screen/AccountDetail'))).toBeVisible();
     }
 }

--- a/suite-native/app/e2e/pageObjects/onboardingActions.ts
+++ b/suite-native/app/e2e/pageObjects/onboardingActions.ts
@@ -1,12 +1,10 @@
-import { waitForElementByIdToBeVisible } from '../support/utils';
+import { waitForVisible } from '../support/utils';
 class OnOnboardingActions {
     async finishOnboarding() {
         const testId = '@onboarding/Welcome/nextBtn';
-        await waitForElementByIdToBeVisible(testId, 30000);
+        await waitForVisible(by.id(testId), { timeout: 30000 });
         await element(by.id(testId)).tap();
-
         await element(by.id('@onboarding/AnalyticsConsent/nextBtn')).tap();
-
         await element(by.id('@onboarding/Biometrics/skipBtn')).tap();
     }
 }

--- a/suite-native/app/e2e/pageObjects/passphraseModule.ts
+++ b/suite-native/app/e2e/pageObjects/passphraseModule.ts
@@ -4,7 +4,7 @@ import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { onDeviceManager } from './deviceManagerActions';
 import { getModelFromEnv } from '../support/setup';
-import { waitForElementByIdToBeVisible, waitForElementByTextToBeVisible } from '../support/utils';
+import { waitForVisible } from '../support/utils';
 
 class PassphraseModule {
     public async openNewPassphraseFlow() {
@@ -18,13 +18,13 @@ class PassphraseModule {
     }
 
     public async expectEnterPassphraseScreen() {
-        await waitForElementByIdToBeVisible('@screen/PassphraseForm');
+        await waitForVisible(by.id('@screen/PassphraseForm'));
     }
 
     public async enterPassphrase(passphrase: string) {
-        const inputTestId = '@passphrase/passphraseInput';
-        await element(by.id(inputTestId)).tap();
-        await element(by.id(inputTestId)).replaceText(passphrase);
+        const passphraseInput = element(by.id('@passphrase/passphraseInput'));
+        await passphraseInput.tap();
+        await passphraseInput.replaceText(passphrase);
         await element(by.id('@passphrase/confirmButton')).tap();
     }
 
@@ -42,7 +42,7 @@ class PassphraseModule {
     }
 
     public async expectConfirmPassphraseOnDeviceRequest() {
-        await waitForElementByIdToBeVisible('@screen/PassphraseConfirmOnTrezor');
+        await waitForVisible(by.id('@screen/PassphraseConfirmOnTrezor'));
     }
 
     public async confirmPassphraseOnEmu() {
@@ -59,22 +59,22 @@ class PassphraseModule {
     }
 
     public async expectEmptyPassphraseWalletScreen() {
-        await waitForElementByIdToBeVisible('@screen/PassphraseEmptyWallet');
+        await waitForVisible(by.id('@screen/PassphraseEmptyWallet'));
     }
 
     public async openEmptyPassphraseWalletAndConfirmBestPractices() {
         await element(by.id('@passphrase/emptyPassphraseWallet/confirmButton')).tap();
-        await waitForElementByTextToBeVisible('Passphrase best practices');
+        await waitForVisible(by.text('Passphrase best practices'));
         await element(by.text('Got it')).tap();
     }
 
     public async expectEmptyPassphraseWalletConfirmationScreen() {
-        await waitForElementByIdToBeVisible('@screen/PassphraseVerifyEmptyWallet');
+        await waitForVisible(by.id('@screen/PassphraseVerifyEmptyWallet'));
     }
 
     public async expectSwitcherSubheader(expectedText: string) {
         const subheaderTestID = '@deviceManager/walletDetail/subheader';
-        await waitForElementByIdToBeVisible(subheaderTestID);
+        await waitForVisible(by.id(subheaderTestID));
         await detoxExpect(element(by.id(subheaderTestID))).toHaveText(expectedText);
     }
 
@@ -89,7 +89,7 @@ class PassphraseModule {
 
         try {
             // If trying to open an already open passphrase wallet, just confirm the alert.
-            await waitForElementByTextToBeVisible('Passphrase duplicate', 5000);
+            await waitForVisible(by.text('Passphrase duplicate'));
             await element(by.id('@alert-sheet/primary-button')).tap();
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (error) {

--- a/suite-native/app/e2e/pageObjects/send/sendFeesActions.ts
+++ b/suite-native/app/e2e/pageObjects/send/sendFeesActions.ts
@@ -1,46 +1,33 @@
 import { FeeLevelLabel } from '@suite-common/wallet-types';
 
+import { waitForVisible } from '../../support/utils';
+
 export type FeeValues =
     | { feeType: Exclude<FeeLevelLabel, 'custom'>; customFeePerUnit?: never }
     | { feeType: 'custom'; customFeePerUnit: string };
 class SendFeesActions {
     async waitForScreen() {
-        await waitFor(element(by.id('@screen/SendFees')))
-            .toBeVisible()
-            .withTimeout(5000);
+        await waitForVisible(by.id('@screen/SendFees'));
     }
 
     async setCustomFee(customFeePerUnit: string) {
         await element(by.id('@transactionManagement/fees-level-custom')).tap();
-        await waitFor(element(by.id('@transactionManagement/custom-fee-bottom-sheet')))
-            .toBeVisible()
-            .withTimeout(5000);
+        await waitForVisible(by.id('@transactionManagement/custom-fee-bottom-sheet'));
         await element(by.id(`@transactionManagement/customFeePerUnit-input`)).replaceText(
             customFeePerUnit,
         );
 
         const submitButton = element(by.id('@transactionManagement/custom-fee-submit-button'));
-        await waitFor(submitButton).toBeVisible().withTimeout(5000);
+        await waitForVisible(submitButton);
         await submitButton.tap();
     }
     async selectFee({ feeType, customFeePerUnit }: FeeValues) {
         await this.waitForScreen();
 
-        switch (feeType) {
-            case 'low':
-                await element(by.id('@transactionManagement/fees-level-radio-low')).tap();
-                break;
-            case 'normal':
-                await element(by.id('@transactionManagement/fees-level-radio-normal')).tap();
-                break;
-            case 'high':
-                await element(by.id('@transactionManagement/fees-level-radio-high')).tap();
-                break;
-            case 'custom':
-                await this.setCustomFee(customFeePerUnit);
-                break;
-            default:
-                throw new Error(`SendFeesActions.selectFee(): Unsupported fee type: ${feeType}`);
+        if (feeType === 'custom') {
+            await this.setCustomFee(customFeePerUnit);
+        } else {
+            await element(by.id(`@transactionManagement/fees-level-radio-${feeType}`)).tap();
         }
     }
 

--- a/suite-native/app/e2e/pageObjects/send/sendOutputsFormActions.ts
+++ b/suite-native/app/e2e/pageObjects/send/sendOutputsFormActions.ts
@@ -1,8 +1,10 @@
 import { expect as detoxExpect } from 'detox';
 
+import { waitForVisible } from '../../support/utils';
+
 class SendOutputsFormActions {
     async waitForScreen() {
-        await waitFor(element(by.id('@screen/SendOutputs'))).toBeVisible();
+        await waitForVisible(by.id('@screen/SendOutputs'));
     }
 
     async fillForm(values: { address?: string; amount?: string }[]) {
@@ -11,10 +13,10 @@ class SendOutputsFormActions {
         for (const [index, value] of values.entries()) {
             const { address, amount } = value;
             if (address) {
-                await element(by.id(`outputs.${index}.address`)).replaceText(address);
+                await element(by.id(`outputs.${index}.address`)).typeText(address);
             }
             if (amount) {
-                await element(by.id(`outputs.${index}.amount`)).replaceText(amount);
+                await element(by.id(`outputs.${index}.amount`)).typeText(amount);
             }
         }
     }

--- a/suite-native/app/e2e/pageObjects/send/sendOutputsReviewActions.ts
+++ b/suite-native/app/e2e/pageObjects/send/sendOutputsReviewActions.ts
@@ -1,12 +1,12 @@
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
+import { waitForVisible } from '../../support/utils';
+
 const sendButton = element(by.id('@send/send-transaction-button'));
 
 class SendOutputsReviewActions {
     async waitForScreen() {
-        await waitFor(element(by.id('@screen/SendOutputsReview')))
-            .toBeVisible()
-            .withTimeout(10000);
+        await waitForVisible(by.id('@screen/SendOutputsReview'));
     }
 
     async confirmTransactionOutputs() {
@@ -15,7 +15,7 @@ class SendOutputsReviewActions {
             await TrezorUserEnvLink.pressYes();
 
             try {
-                await waitFor(sendButton).toBeVisible().withTimeout(3000);
+                await waitForVisible(sendButton);
                 isTransactionReviewInProgress = false;
             } catch {
                 // continue loop, there are more outputs to review
@@ -24,12 +24,10 @@ class SendOutputsReviewActions {
     }
 
     async clickSendTransaction() {
-        await waitFor(sendButton).toBeVisible().withTimeout(15000);
+        await waitForVisible(sendButton);
         await sendButton.tap();
 
-        await waitFor(element(by.id('@screen/TransactionDetail')))
-            .toBeVisible()
-            .withTimeout(3000);
+        await waitForVisible(by.id('@screen/TransactionDetail'));
     }
 }
 

--- a/suite-native/app/e2e/pageObjects/settingsActions.ts
+++ b/suite-native/app/e2e/pageObjects/settingsActions.ts
@@ -1,19 +1,18 @@
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { PROTO } from '@trezor/connect';
 
-import { scrollUntilVisible, wait } from '../support/utils';
+import { scrollUntilVisible, wait, waitForVisible } from '../support/utils';
 
 class SettingsActions {
     async tapPreferences() {
         const preferencesSettingsElement = element(by.id('@settings/preferences'));
-        await waitFor(preferencesSettingsElement).toBeVisible().withTimeout(10000);
+        await waitForVisible(preferencesSettingsElement);
         await preferencesSettingsElement.tap();
     }
 
     async tapPrivacyAndSecurity() {
         const privacyAndSecurityElement = element(by.id('@settings/privacy'));
-
-        await waitFor(privacyAndSecurityElement).toBeVisible().withTimeout(10000);
+        await waitForVisible(privacyAndSecurityElement);
         await privacyAndSecurityElement.tap();
     }
 
@@ -25,8 +24,7 @@ class SettingsActions {
 
     async tapEjectWallets() {
         const ejectWalletsElement = element(by.id('@settings/eject-wallets'));
-
-        await waitFor(ejectWalletsElement).toBeVisible().withTimeout(10000);
+        await waitForVisible(ejectWalletsElement);
         await ejectWalletsElement.tap();
     }
 
@@ -34,7 +32,7 @@ class SettingsActions {
         const discreetModeToggleElement = element(
             by.id('@settings/privacy-and-security/discreet-mode-toggle'),
         );
-        await waitFor(discreetModeToggleElement).toBeVisible().withTimeout(10000);
+        await waitForVisible(discreetModeToggleElement);
         await discreetModeToggleElement.tap();
     }
 
@@ -42,7 +40,7 @@ class SettingsActions {
         const currencySelectorTriggerElement = element(
             by.id('@settings/localization/currency-selector'),
         );
-        await waitFor(currencySelectorTriggerElement).toBeVisible().withTimeout(10000);
+        await waitForVisible(currencySelectorTriggerElement);
         await currencySelectorTriggerElement.tap();
 
         await wait(1000); // wait for the currency selector to open
@@ -58,7 +56,7 @@ class SettingsActions {
         const currencySelectorTriggerElement = element(
             by.id('@settings/localization/bitcoin-units-selector'),
         );
-        await waitFor(currencySelectorTriggerElement).toBeVisible().withTimeout(10000);
+        await waitForVisible(currencySelectorTriggerElement);
         await currencySelectorTriggerElement.tap();
 
         const currencySelectorItemElement = element(by.id(`@select/item/${unit}/content`));
@@ -69,13 +67,13 @@ class SettingsActions {
 
     async toggleAutoEject() {
         const autoEjectElement = element(by.id('@settings/auto-eject-toggle'));
-        await waitFor(autoEjectElement).toBeVisible().withTimeout(10000);
+        await waitForVisible(autoEjectElement);
         await autoEjectElement.tap();
     }
 
     async ejectSingleWallet() {
         const ejectWalletElement = element(by.id(`@settings/eject-single-wallet`));
-        await waitFor(ejectWalletElement).toBeVisible().withTimeout(10000);
+        await waitForVisible(ejectWalletElement);
         await ejectWalletElement.tap();
     }
 }

--- a/suite-native/app/e2e/pageObjects/tabBarActions.ts
+++ b/suite-native/app/e2e/pageObjects/tabBarActions.ts
@@ -1,16 +1,18 @@
 import { expect as detoxExpect } from 'detox';
 
+import { waitForVisible } from '../support/utils';
+
 class TabBarActions {
     async navigateToHome() {
         const homeTabBarItem = element(by.id('@tabBar/HomeStack'));
-        await waitFor(homeTabBarItem).toBeVisible().withTimeout(10000);
+        await waitForVisible(homeTabBarItem);
         await homeTabBarItem.tap();
 
         await detoxExpect(element(by.id('@screen/Home'))).toBeVisible();
     }
     async navigateToMyAssets() {
         const AccountsTabBarItem = element(by.id('@tabBar/AccountsStack'));
-        await waitFor(AccountsTabBarItem).toBeVisible().withTimeout(10000);
+        await waitForVisible(AccountsTabBarItem);
         await AccountsTabBarItem.tap();
 
         await detoxExpect(element(by.id('@screen/Accounts'))).toBeVisible();
@@ -18,7 +20,7 @@ class TabBarActions {
 
     async navigateToSettings() {
         const settingsTabBarItem = element(by.id('@tabBar/Settings'));
-        await waitFor(settingsTabBarItem).toBeVisible().withTimeout(10000);
+        await waitForVisible(settingsTabBarItem);
         await settingsTabBarItem.tap();
 
         await detoxExpect(element(by.id('@screen/Settings'))).toBeVisible();
@@ -26,13 +28,13 @@ class TabBarActions {
 
     async tapBackButton() {
         const backButton = element(by.id('@screen/sub-header/go-back-button'));
-        await waitFor(backButton).toBeVisible().withTimeout(10000);
+        await waitForVisible(backButton);
         await backButton.tap();
     }
 
     async navigateToTrade() {
         const tradeTabBarItem = element(by.id('@tabBar/TradeStack'));
-        await waitFor(tradeTabBarItem).toBeVisible().withTimeout(10000);
+        await waitForVisible(tradeTabBarItem);
         await tradeTabBarItem.tap();
 
         await detoxExpect(element(by.id('@screen/Trading'))).toBeVisible();

--- a/suite-native/app/e2e/pageObjects/trading/TradingActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/TradingActions.ts
@@ -2,7 +2,6 @@ import { wait } from '../../support/utils';
 
 export class TradingActions {
     readonly DOUBLE_LONG_TIMEOUT = 60_000;
-    readonly LONG_TIMEOUT = 30_000;
     readonly SHORT_TIMEOUT = 5_000;
     readonly BOTTOM_SHEET_ANIMATION_DURATION = 1_000;
 

--- a/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
@@ -1,11 +1,7 @@
 import { expect as detoxExpect } from 'detox';
 
 import { TradingActions } from './TradingActions';
-import {
-    wait,
-    waitForElementByIdToBeVisible,
-    waitForElementByTextToBeVisible,
-} from '../../support/utils';
+import { wait, waitForVisible } from '../../support/utils';
 
 export abstract class TradingFormActions extends TradingActions {
     abstract waitForQuotesToLoad(): Promise<void>;
@@ -31,13 +27,13 @@ export abstract class TradingFormActions extends TradingActions {
     }
 
     async waitForTradeDataToLoad() {
-        await waitForElementByIdToBeVisible(this.getTestId('form'), this.LONG_TIMEOUT);
+        await waitForVisible(this.getElementById('form'));
     }
 
     async expectSheetHeaderTitle(title: string) {
-        await waitFor(element(by.text(title).withAncestor(by.id('@trading/sheet-header-title'))))
-            .toBeVisible()
-            .withTimeout(this.SHORT_TIMEOUT);
+        await waitForVisible(
+            element(by.text(title).withAncestor(by.id('@trading/sheet-header-title'))),
+        );
     }
 
     async selectFiatCurrency(fiatCurrency: string) {
@@ -64,10 +60,10 @@ export abstract class TradingFormActions extends TradingActions {
 
     async selectReceiveAccount(accountName: string, derivationPath?: string) {
         await this.getElementById('receive-account').tap();
-        await waitForElementByTextToBeVisible(accountName);
+        await waitForVisible(by.text(accountName));
         await element(by.text(accountName)).tap();
         if (derivationPath) {
-            await waitForElementByTextToBeVisible(derivationPath);
+            await waitForVisible(by.text(derivationPath));
             await element(by.text(derivationPath)).tap();
         }
 
@@ -105,7 +101,7 @@ export abstract class TradingFormActions extends TradingActions {
         await this.getElementById('provider-picker').tap();
         await this.expectSheetHeaderTitle('Providers');
         await element(by.label('Close')).tap();
-        await waitForElementByIdToBeVisible(this.getTestId('provider-picker'), this.SHORT_TIMEOUT);
+        await waitForVisible(this.getElementById('provider-picker'));
     }
 
     async selectReceiveAsset(asset: string, network?: string) {
@@ -117,10 +113,10 @@ export abstract class TradingFormActions extends TradingActions {
             const networkFilterTab = element(
                 by.text(network).withAncestor(by.id(this.getTestId('receive-asset-sheet/header'))),
             );
-            await waitFor(networkFilterTab).toBeVisible().withTimeout(this.SHORT_TIMEOUT);
+            await waitForVisible(networkFilterTab);
             await networkFilterTab.tap();
         }
-        await waitForElementByTextToBeVisible(asset, this.BOTTOM_SHEET_ANIMATION_DURATION);
+        await waitForVisible(by.text(asset), { timeout: this.BOTTOM_SHEET_ANIMATION_DURATION });
         await element(by.text(asset)).tap();
 
         await waitFor(this.getElementById('asset-receive-button/symbol'))

--- a/suite-native/app/e2e/pageObjects/trading/exchangePreviewActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/exchangePreviewActions.ts
@@ -1,4 +1,5 @@
 import { TradingActions } from './TradingActions';
+import { waitForVisible } from '../../support/utils';
 
 class ExchangePreviewActions extends TradingActions {
     constructor() {
@@ -10,13 +11,14 @@ class ExchangePreviewActions extends TradingActions {
     }
 
     async expectExchangePreviewScreenToBeVisible() {
-        await waitFor(this.getScreen()).toBeVisible().withTimeout(this.SHORT_TIMEOUT);
+        await waitForVisible(this.getScreen());
     }
 
     async waitForFeesToLoad() {
-        await waitFor(element(by.text('≈').withAncestor(by.id('@trading/fees/fee-picker'))))
-            .toBeVisible()
-            .withTimeout(this.DOUBLE_LONG_TIMEOUT);
+        await waitForVisible(
+            element(by.text('≈').withAncestor(by.id('@trading/fees/fee-picker'))),
+            { timeout: this.DOUBLE_LONG_TIMEOUT },
+        );
     }
 
     async goToFees() {

--- a/suite-native/app/e2e/pageObjects/trading/outputsReviewActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/outputsReviewActions.ts
@@ -3,6 +3,7 @@ import { expect as detoxExpect } from 'detox';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { TradingActions } from './TradingActions';
+import { waitForVisible } from '../../support/utils';
 
 class OutputsReviewActions extends TradingActions {
     constructor() {
@@ -14,20 +15,16 @@ class OutputsReviewActions extends TradingActions {
     }
 
     async expectOutputsReviewScreenToBeVisible() {
-        await waitFor(this.getScreen()).toBeVisible().withTimeout(this.SHORT_TIMEOUT);
+        await waitForVisible(this.getScreen());
     }
 
     async expectAndConfirmRecipientAddress() {
-        await waitFor(element(by.text('Recipient address')))
-            .toBeVisible()
-            .withTimeout(this.DOUBLE_LONG_TIMEOUT);
+        await waitForVisible(by.text('Recipient address'), { timeout: this.DOUBLE_LONG_TIMEOUT });
         await TrezorUserEnvLink.pressYes();
     }
 
     async expectAndConfirmTotalFee() {
-        await waitFor(element(by.text('Total including fee')))
-            .toBeVisible()
-            .withTimeout(this.SHORT_TIMEOUT);
+        await waitForVisible(by.text('Total including fee'));
         await detoxExpect(element(by.text('Amount'))).toBeVisible();
         await detoxExpect(element(by.text('Maximum fee'))).toBeVisible();
         await TrezorUserEnvLink.pressYes();
@@ -38,9 +35,7 @@ class OutputsReviewActions extends TradingActions {
     }
 
     async expectSendTransactionButton() {
-        await waitFor(this.getElementById('footer/submit-button'))
-            .toBeVisible()
-            .withTimeout(this.SHORT_TIMEOUT);
+        await waitForVisible(this.getElementById('footer/submit-button'));
     }
 
     async cancelTransaction() {

--- a/suite-native/app/e2e/pageObjects/trading/tradingBuyActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/tradingBuyActions.ts
@@ -1,7 +1,7 @@
 import { expect as detoxExpect } from 'detox';
 
 import { TradingFormActions } from './TradingFormActions';
-import { wait, waitForElementByIdToBeVisible } from '../../support/utils';
+import { wait, waitForVisible } from '../../support/utils';
 
 class TradingBuyActions extends TradingFormActions {
     constructor() {
@@ -9,11 +9,8 @@ class TradingBuyActions extends TradingFormActions {
     }
 
     async waitForQuotesToLoad() {
-        await waitForElementByIdToBeVisible(this.getTestId('fiat-amount-input'), this.LONG_TIMEOUT);
-        await waitForElementByIdToBeVisible(
-            this.getTestId('crypto-amount-input'),
-            this.LONG_TIMEOUT,
-        );
+        await waitForVisible(this.getElementById('fiat-amount-input'));
+        await waitForVisible(this.getElementById('crypto-amount-input'));
     }
 
     async viewPaymentMethods() {
@@ -22,10 +19,7 @@ class TradingBuyActions extends TradingFormActions {
         await this.expectSheetHeaderTitle('Payment method');
         await element(by.label('Close')).tap();
         await wait(this.BOTTOM_SHEET_ANIMATION_DURATION);
-        await waitForElementByIdToBeVisible(
-            this.getTestId('payment-method-picker'),
-            this.SHORT_TIMEOUT,
-        );
+        await waitForVisible(this.getElementById('payment-method-picker'));
     }
 
     async expectValidBuyForm() {
@@ -35,9 +29,9 @@ class TradingBuyActions extends TradingFormActions {
     }
 
     async closePaymentWebview() {
-        await waitForElementByIdToBeVisible('@screen/TradingWebView', this.LONG_TIMEOUT);
+        await waitForVisible(by.id('@screen/TradingWebView'));
         await element(by.id('@trading/webview/close')).tap();
-        await waitForElementByIdToBeVisible('@screen/Trading', this.SHORT_TIMEOUT);
+        await waitForVisible(by.id('@screen/Trading'));
     }
 }
 

--- a/suite-native/app/e2e/pageObjects/trading/tradingExchangeActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/tradingExchangeActions.ts
@@ -1,7 +1,7 @@
 import { expect as detoxExpect } from 'detox';
 
 import { TradingFormActions } from './TradingFormActions';
-import { waitForElementByIdToBeVisible } from '../../support/utils';
+import { waitForVisible } from '../../support/utils';
 import { onTabBar } from '../tabBarActions';
 
 class TradingExchangeActions extends TradingFormActions {
@@ -10,11 +10,8 @@ class TradingExchangeActions extends TradingFormActions {
     }
 
     async waitForQuotesToLoad() {
-        await waitForElementByIdToBeVisible(this.getTestId('send-amount-input'), this.LONG_TIMEOUT);
-        await waitForElementByIdToBeVisible(
-            this.getTestId('receive-amount-input'),
-            this.LONG_TIMEOUT,
-        );
+        await waitForVisible(this.getElementById('send-amount-input'));
+        await waitForVisible(this.getElementById('receive-amount-input'));
     }
 
     async expectValidExchangeForm() {

--- a/suite-native/app/e2e/pageObjects/trading/tradingFeeActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/tradingFeeActions.ts
@@ -1,4 +1,5 @@
 import { TradingActions } from './TradingActions';
+import { waitForVisible } from '../../support/utils';
 
 class TradingFeeActions extends TradingActions {
     constructor() {
@@ -10,7 +11,7 @@ class TradingFeeActions extends TradingActions {
     }
 
     async expectFeesScreenToBeVisible() {
-        await waitFor(this.getScreen()).toBeVisible().withTimeout(this.SHORT_TIMEOUT);
+        await waitForVisible(this.getScreen());
     }
 
     async goBack() {

--- a/suite-native/app/e2e/support/utils.ts
+++ b/suite-native/app/e2e/support/utils.ts
@@ -1,3 +1,11 @@
+const isIndexableNativeElement = (
+    v: Detox.IndexableNativeElement | Detox.NativeMatcher,
+): v is Detox.IndexableNativeElement => {
+    const anyV = v as any;
+
+    return !!anyV && (typeof anyV.tap === 'function' || typeof anyV.atIndex === 'function');
+};
+
 export const platform = device.getPlatform();
 
 // There is inconsistency between platforms. Android needs to have 100% of an element visible to be able to interact with it.
@@ -8,10 +16,18 @@ export const wait = async (ms: number) => {
     await new Promise(resolve => setTimeout(resolve, ms));
 };
 
+export const waitForVisible = async (
+    elementOrMatcher: Detox.IndexableNativeElement | Detox.NativeMatcher,
+    { timeout = 30_000 }: { timeout?: number } = {},
+) => {
+    const target = isIndexableNativeElement(elementOrMatcher)
+        ? elementOrMatcher
+        : element(elementOrMatcher);
+    await waitFor(target).toBeVisible().withTimeout(timeout);
+};
+
 export const appIsFullyLoaded = async () => {
-    await waitFor(element(by.id('@screen/mainScrollView')))
-        .toBeVisible()
-        .withTimeout(35000);
+    await waitForVisible(by.id('@screen/mainScrollView'), { timeout: 35_000 });
 };
 
 export const scrollUntilVisible = async (
@@ -23,16 +39,6 @@ export const scrollUntilVisible = async (
         .whileElement(by.id(scrollViewTestId))
         .scroll(300, 'down', 0.5, 0.5);
 };
-
-export const waitForElementByTextToBeVisible = (text: string, timeout = 30000) =>
-    waitFor(element(by.text(text)))
-        .toBeVisible()
-        .withTimeout(timeout);
-
-export const waitForElementByIdToBeVisible = (testId: string, timeout = 30000) =>
-    waitFor(element(by.id(testId)))
-        .toBeVisible()
-        .withTimeout(timeout);
 
 export const inputTextToElement = async (element: Detox.IndexableNativeElement, text: string) => {
     // on Android it is very slow to type text symbol by symbol, for performance reasons `replaceText` is used instead.

--- a/suite-native/app/e2e/tests/coinEnabling.test.ts
+++ b/suite-native/app/e2e/tests/coinEnabling.test.ts
@@ -1,3 +1,5 @@
+import { expect as detoxExpect } from 'detox';
+
 import { conditionalDescribe } from '@suite-common/test-utils';
 
 import { deviceChecksDisabledState } from '../fixtures/deviceChecksDisabledState';
@@ -14,6 +16,7 @@ import {
     preparePreloadedReduxState,
     prepareTrezorEmulator,
 } from '../support/setup';
+import { waitForVisible } from '../support/utils';
 
 const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
@@ -33,10 +36,8 @@ conditionalDescribe(device.getPlatform() === 'android', 'Coin enabling [@fixT3W1
 
         await onDeviceConnecting.waitForDeviceConnectingScreen();
         await onHome.waitForScreen();
-
-        const bitcoinTextElement = element(by.text('Bitcoin'));
-
-        await waitFor(bitcoinTextElement).toExist().withTimeout(10000);
+        await onHome.scrollScreenToBottom();
+        await waitForVisible(by.text('Bitcoin'));
 
         await onTabBar.navigateToSettings();
         await onSettings.tapCoinEnabling();
@@ -45,8 +46,8 @@ conditionalDescribe(device.getPlatform() === 'android', 'Coin enabling [@fixT3W1
         await device.pressBack();
         await onTabBar.navigateToHome();
 
-        const ethereumTextElement = element(by.text('Ethereum'));
-        await waitFor(ethereumTextElement).toExist().withTimeout(10000);
+        await onHome.scrollScreenToBottom();
+        await waitForVisible(by.text('Ethereum'));
 
         await onTabBar.navigateToSettings();
         await onSettings.tapCoinEnabling();
@@ -54,6 +55,6 @@ conditionalDescribe(device.getPlatform() === 'android', 'Coin enabling [@fixT3W1
         await device.pressBack();
         await onTabBar.navigateToHome();
 
-        await waitFor(ethereumTextElement).not.toExist().withTimeout(10000);
+        await detoxExpect(element(by.text('Ethereum'))).not.toExist();
     });
 });

--- a/suite-native/app/e2e/tests/deeplinkPopup.test.ts
+++ b/suite-native/app/e2e/tests/deeplinkPopup.test.ts
@@ -18,6 +18,7 @@ import {
     preparePreloadedReduxState,
     prepareTrezorEmulator,
 } from '../support/setup';
+import { waitForVisible } from '../support/utils';
 
 const deepLinkServer = new DeepLinkServer();
 
@@ -80,14 +81,14 @@ conditionalDescribe(
                 coin: 'btc',
             });
 
-            await element(by.id('@popup/deeplink-info'));
+            await waitForVisible(by.id('@popup/deeplink-info'));
 
             const permissionButton = element(by.id('@popup/call-device'));
-            await waitFor(permissionButton).toBeVisible().withTimeout(30000);
+            await waitForVisible(permissionButton);
             await permissionButton.tap();
 
             const confirmButton = element(by.id('@popup/confirm-addresses'));
-            await waitFor(confirmButton).toBeVisible().withTimeout(10000);
+            await waitForVisible(confirmButton);
             await confirmButton.tap();
 
             await TrezorUserEnvLink.pressYes();

--- a/suite-native/app/e2e/tests/deviceSettingsT1B1.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettingsT1B1.test.ts
@@ -5,6 +5,7 @@ import { regtestDiscoveryFinishedStateT1B1 } from '../fixtures/regtestDiscoveryF
 import { onDeviceManager } from '../pageObjects/deviceManagerActions';
 import { onDeviceSettings } from '../pageObjects/deviceSettingsActions';
 import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
+import { waitForVisible } from '../support/utils';
 
 const preloadedStateT1B1 = preparePreloadedReduxState(
     onboardingCompletedState,
@@ -18,17 +19,13 @@ conditionalDescribe(
         beforeEach(async () => {
             await openApp({ args: { preloadedState: preloadedStateT1B1 } });
             await prepareTrezorEmulator({ model: 'T1B1' });
-
             await onDeviceManager.tapDeviceSwitch();
             await onDeviceManager.tapDeviceSettingsButton();
         });
 
         test('Device Check Backup with unsupported Device Model', async () => {
             await onDeviceSettings.tapDeviceCheckBackupButton();
-
-            await waitFor(element(by.text('To check your backup, use the web application.')))
-                .toBeVisible()
-                .withTimeout(10000);
+            await waitForVisible(by.text('To check your backup, use the web application.'));
         });
     },
 );

--- a/suite-native/app/e2e/tests/deviceSettingsT3T1.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettingsT3T1.test.ts
@@ -8,6 +8,7 @@ import { onDeviceAuthenticitySuccess } from '../pageObjects/deviceAuthenticitySu
 import { onDeviceManager } from '../pageObjects/deviceManagerActions';
 import { onDeviceSettings } from '../pageObjects/deviceSettingsActions';
 import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
+import { waitForVisible } from '../support/utils';
 
 const preloadedStateT3T1 = preparePreloadedReduxState(
     onboardingCompletedState,
@@ -21,7 +22,6 @@ conditionalDescribe(
         beforeEach(async () => {
             await openApp({ args: { preloadedState: preloadedStateT3T1 } });
             await prepareTrezorEmulator({ model: 'T3T1' });
-
             await onDeviceManager.tapDeviceSwitch();
             await onDeviceManager.tapDeviceSettingsButton();
         });
@@ -75,29 +75,22 @@ conditionalDescribe(
             await onDeviceSettings.tapChangeDeviceNameButton();
             await onDeviceSettings.submitNewDeviceName('new name');
             await TrezorUserEnvLink.pressYes();
-
             await onDeviceSettings.waitForSettingsScreen();
-
-            await waitFor(element(by.text('new name')))
-                .toBeVisible()
-                .withTimeout(10000);
+            await waitForVisible(by.text('new name'));
         });
 
         test('Wipe device', async () => {
             await onDeviceSettings.tapWipeDevice();
-
             await onDeviceSettings.confirmStepperItems(2);
             await onDeviceSettings.waitForWipeDeviceContinueOnTrezor();
             await TrezorUserEnvLink.pressNo();
             await onDeviceSettings.confirmStepperItems(1);
             await TrezorUserEnvLink.pressYes();
-
             await onDeviceSettings.waitForHomeScreenAndUninitializedTitle();
         });
 
         test('Device Check Backup', async () => {
             await onDeviceSettings.tapDeviceCheckBackupButton();
-
             await onDeviceSettings.passCheckBackupFlow();
         });
     },

--- a/suite-native/app/e2e/tests/invalidAccountsImport.test.ts
+++ b/suite-native/app/e2e/tests/invalidAccountsImport.test.ts
@@ -33,7 +33,9 @@ describe('Import invalid accounts [@noDevice]', () => {
         await goToBtcImportXpubScreen();
         await onAccountImport.submitXpub({ xpub: xpubs.btc.legacySegwit, isValid: true });
 
-        await detoxExpect(element(by.id('@account-import/summary/account-already-imported')));
+        await detoxExpect(
+            element(by.id('@account-import/summary/account-already-imported')),
+        ).toBeVisible();
     });
 
     it('Import BTC receive address', async () => {
@@ -42,6 +44,6 @@ describe('Import invalid accounts [@noDevice]', () => {
         await onAccountImport.selectCoin({ networkSymbol: 'btc' });
         await onAccountImport.submitXpub({ xpub: btcReceiveAddress, isValid: false });
 
-        await detoxExpect(element(by.id('@alert-sheet/error/invalidXpub')));
+        await detoxExpect(element(by.text('This is your receive address'))).toBeVisible();
     });
 });

--- a/suite-native/app/e2e/tests/onboardAndConnect.test.ts
+++ b/suite-native/app/e2e/tests/onboardAndConnect.test.ts
@@ -1,3 +1,5 @@
+import { expect as detoxExpect } from 'detox';
+
 import { conditionalDescribe } from '@suite-common/test-utils';
 
 import { onCoinEnabling } from '../pageObjects/coinEnablingActions';
@@ -23,11 +25,10 @@ conditionalDescribe(
                 await onDeviceOnboarding.enterTHPPairingCode();
             }
 
-            await waitFor(element(by.id('@screen/CoinEnablingInit')))
-                .toBeVisible()
-                .withTimeout(10000);
-
+            await onCoinEnabling.waitForInitScreen();
             await onCoinEnabling.handleCoinEnablingInit(['btc', 'eth']);
+            const bitcoinTextElement = element(by.text('Bitcoin'));
+            await detoxExpect(bitcoinTextElement).toBeVisible();
         });
     },
 );

--- a/suite-native/app/e2e/tests/send.test.ts
+++ b/suite-native/app/e2e/tests/send.test.ts
@@ -1,3 +1,5 @@
+import { expect as detoxExpect } from 'detox';
+
 import { conditionalDescribe } from '@suite-common/test-utils';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
@@ -27,7 +29,7 @@ const SEND_FORM_ERROR_MESSAGES = {
     dustAmount: 'The value is lower than the dust limit.',
     higherThanBalance: 'You don’t have enough balance to send this amount.',
     tooManyDecimals: 'Too many decimals.',
-    addressRequired: 'Address is required.',
+    addressRequired: 'Field is mandatory',
     amountRequired: 'Amount is required.',
 };
 
@@ -111,20 +113,21 @@ conditionalDescribe(device.getPlatform() === 'android', 'Send transaction flow. 
     it('Validate send form input errors.', async () => {
         await onSendOutputsForm.fillForm([{ address: 'wrong address', amount: '200' }]);
 
-        await waitFor(element(by.text(SEND_FORM_ERROR_MESSAGES.invalidAddress))).toBeVisible();
-        await waitFor(element(by.text(SEND_FORM_ERROR_MESSAGES.higherThanBalance))).toBeVisible();
+        await detoxExpect(element(by.text(SEND_FORM_ERROR_MESSAGES.invalidAddress))).toBeVisible();
+        await detoxExpect(
+            element(by.text(SEND_FORM_ERROR_MESSAGES.higherThanBalance)),
+        ).toBeVisible();
 
         await onSendOutputsForm.clearForm();
-
-        await waitFor(element(by.text(SEND_FORM_ERROR_MESSAGES.addressRequired))).toBeVisible();
-        await waitFor(element(by.text(SEND_FORM_ERROR_MESSAGES.amountRequired))).toBeVisible();
+        await detoxExpect(element(by.text(SEND_FORM_ERROR_MESSAGES.addressRequired))).toBeVisible();
+        await detoxExpect(element(by.text(SEND_FORM_ERROR_MESSAGES.amountRequired))).toBeVisible();
 
         await onSendOutputsForm.fillForm([{ amount: '0.00000001' }]);
-        await waitFor(element(by.text(SEND_FORM_ERROR_MESSAGES.dustAmount))).toBeVisible();
+        await detoxExpect(element(by.text(SEND_FORM_ERROR_MESSAGES.dustAmount))).toBeVisible();
 
         await onSendOutputsForm.clearForm();
 
         await onSendOutputsForm.fillForm([{ amount: '0.10000000000' }]);
-        await waitFor(element(by.text(SEND_FORM_ERROR_MESSAGES.tooManyDecimals))).toBeVisible();
+        await detoxExpect(element(by.text(SEND_FORM_ERROR_MESSAGES.tooManyDecimals))).toBeVisible();
     });
 });

--- a/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
@@ -122,6 +122,7 @@ export const XpubScanScreen = ({
         ) {
             showDelayedAlert({
                 title: <Translation id="moduleAccountImport.xpubScanScreen.alert.address.title" />,
+                testID: '@alert-sheet/error/invalidXpub',
                 description: (
                     <Translation id="moduleAccountImport.xpubScanScreen.alert.address.description" />
                 ),

--- a/suite-native/module-settings/src/components/LanguageSelector.tsx
+++ b/suite-native/module-settings/src/components/LanguageSelector.tsx
@@ -42,7 +42,7 @@ export const LanguageSelector = () => {
                 selectLabel={<Translation id="moduleSettings.preferences.languageLabel" />}
                 items={languageItems}
                 onSelectItem={handleSelectLanguage}
-                testID="@settings/localization/bitcoin-units-selector"
+                testID="@settings/localization/language-selector"
             />
         </PreferencesSettingsCard>
     );


### PR DESCRIPTION
Introduces universal waitForElement method that accespts, element or detox native matcher (by.Id / by.text ...). This way we can use it everywhere, have better readability, easier maintenance.
This unites also timeout to just one with ability to override. Please feel free to challenge that.

Contains minor refactorings
Contains several minor fixes where asserts or waitFor did not do anything  Cases:
detoxExpect without toBe<something> does not do anything
```
-        await detoxExpect(element(by.id('@screen/Home')));
+        await detoxExpect(element(by.id('@screen/Home'))).toBeVisible()
```

default waitFor without .withTimeout() also does nothing
```
-        await waitFor(receiveButton).toBeVisible();
+        await waitForVisible(receiveButton);
```

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor-native-e2e-cleanup&lookback=7)