### PR TITLE
fix(suite-native): fix underlined title for foreign languages

### DIFF
--- a/suite-native/helpers/src/hooks/useIsMultiline.tsx
+++ b/suite-native/helpers/src/hooks/useIsMultiline.tsx
@@ -6,6 +6,7 @@ import { NativeTypographyStyle } from '@trezor/theme';
 
 export const useIsMultiline = (fontType: NativeTypographyStyle = 'titleMedium') => {
     const [isMultiline, setIsMultiline] = useState<boolean | null>(false);
+    const [numberOfLines, setNumberOfLines] = useState<number | null>(null);
     const {
         utils: { typography },
     } = useNativeStyles();
@@ -18,8 +19,9 @@ export const useIsMultiline = (fontType: NativeTypographyStyle = 'titleMedium') 
     const onTextLayout = (event: LayoutChangeEvent) => {
         const { height } = event.nativeEvent.layout;
         const numOfLines = Math.floor(height / scaledLineHeight);
+        setNumberOfLines(numOfLines);
         setIsMultiline(numOfLines > 1);
     };
 
-    return { onTextLayout, isMultiline };
+    return { onTextLayout, isMultiline, numberOfLines };
 };

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1616,8 +1616,7 @@ export const messages = {
             },
             step2: {
                 callout: 'Securing your wallet backup',
-                titleRegular: 'backup anywhere digital',
-                titleUnderlined: 'Never store your wallet',
+                title: 'Never store your wallet\nbackup anywhere digital',
             },
             step3: {
                 callout: 'Storing your wallet backup',

--- a/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/Underline.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/Underline.tsx
@@ -13,8 +13,8 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 const containerStyle = prepareNativeStyle(() => ({
     position: 'absolute',
-    bottom: 3,
-    left: 0,
+    bottom: 38,
+    left: 9,
     zIndex: -1,
 }));
 

--- a/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/WalletBackupRecapStep2.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/WalletBackupRecapStep2.tsx
@@ -2,7 +2,7 @@ import { useDerivedValue } from 'react-native-reanimated';
 
 import { Box, Text, VStack } from '@suite-native/atoms';
 import { useIsMultiline } from '@suite-native/helpers';
-import { Translation } from '@suite-native/intl';
+import { Translation, useLocale } from '@suite-native/intl';
 import { SwipeableWalkthroughStep } from '@suite-native/swipeable-walkthrough';
 
 import { Underline } from './Underline';
@@ -15,9 +15,13 @@ const CURRENT_STEP_INDEX = 1;
 export const WalletBackupRecapStep2 = ({
     currentStepIndex,
 }: WalletBackupTutorialNumberedStepProps) => {
+    const locale = useLocale();
     const isFocused = useDerivedValue(() => currentStepIndex.value === CURRENT_STEP_INDEX);
 
-    const { onTextLayout, isMultiline } = useIsMultiline('titleMedium');
+    const { onTextLayout, numberOfLines } = useIsMultiline('titleMedium');
+
+    // We can be sure that the underline word `Never` is at the beginning of the sentence for english locale only.
+    const isUnderlineVisible = numberOfLines === 2 && locale === 'en-US';
 
     return (
         <SwipeableWalkthroughStep
@@ -33,13 +37,10 @@ export const WalletBackupRecapStep2 = ({
                     <Box>
                         <Box alignSelf="center">
                             <Text variant="titleMedium" textAlign="center" onLayout={onTextLayout}>
-                                <Translation id="moduleDeviceOnboarding.walletBackupRecapScreen.step2.titleUnderlined" />
+                                <Translation id="moduleDeviceOnboarding.walletBackupRecapScreen.step2.title" />
                             </Text>
-                            {!isMultiline && <Underline isFocused={isFocused} />}
+                            {isUnderlineVisible && <Underline isFocused={isFocused} />}
                         </Box>
-                        <Text variant="titleMedium" textAlign="center">
-                            <Translation id="moduleDeviceOnboarding.walletBackupRecapScreen.step2.titleRegular" />
-                        </Text>
                     </Box>
                 </VStack>
             </WalletRecapStepContent>


### PR DESCRIPTION
## Description
This PR fixes two problems:
1. An onboarding screen title was divided into two translatable strings which brings confusion to translators who are preparing other foreign languages. It might potentionally brought unconsistent translations. See this message:

> Hi SatoshiLabs, I have a few questions for this string.
> If the whole text displayed to the user is like the full text on the screenshot, then this string "can't be accurately translated" for the simple reason, that in PTBR the "backup" has to come before the "wallet" in order to be grammatically correct in this sentence.
> The issue is, there is no backup mentioned on the original string, and translating "word by word" it would look like this "Nunca armazene a sua carteira" which makes no sense in PTBR. Assuming there is going to be another string for the "backup anywhere digital" part of the screenshot, and the idea is to join this 2, it will make absolutely no sense in PTBR.
> The current saved translation also doesn't exactly match the string, and if this is going to be the fist part of the whole text, then I'm 100% sure that whatever the 2nd part is translated to, it won't match.
> So should I make sure it's accurate with the string, or with the whole text on the screenshot?

2. the translation of word `Never` might not be at the beginning of the string for other languages. For this reason the underline will be displayed for `en-US` locale only.

## Notes for QA
- go through the onboarding and see if the screen behaves correctly for different languages.

## Screenshots:
<img width="356" height="753" alt="Screenshot 2025-11-10 at 8 13 19 AM" src="https://github.com/user-attachments/assets/e28057df-679e-4ef8-afaa-2fbf982d5c00" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/underlined-translations&lookback=7)