### PR TITLE
wip(connect-iframe): allow local-network-access

### DIFF
--- a/packages/connect-popup/e2e/support/helpers.ts
+++ b/packages/connect-popup/e2e/support/helpers.ts
@@ -61,6 +61,7 @@ const getExtensionPage = async () => {
             process.env.HEADLESS === 'true' ? `--headless=new` : '', // the new headless arg for chrome v109+. Use '--headless=chrome' as arg for browsers v94-108.
             `--disable-extensions-except=${pathToExtension}`,
             `--load-extension=${pathToExtension}`,
+            `--disable-local-network-access-check`,
         ],
     });
 
@@ -96,9 +97,17 @@ export const getContexts = async (
     isWebExtension: boolean,
 ) => {
     if (!isWebExtension) {
+        const browser = await chromium.launch({
+            headless: false,
+            args: [`--disable-local-network-access-check`],
+        });
+
+        const context = await browser.newContext();
+        const page = await context.newPage();
+
         return {
             explorerUrl: originalUrl,
-            explorerPage: originalPage,
+            explorerPage: page,
         };
     }
     const { page, url, browserContext } = await getExtensionPage();

--- a/packages/connect-popup/e2e/tests/analytics.test.ts
+++ b/packages/connect-popup/e2e/tests/analytics.test.ts
@@ -4,7 +4,7 @@ import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { waitAndClick } from '../support/helpers';
 
-const url = process.env.URL || 'http://localhost:8088/';
+const url = process.env.URL || 'https://dev.suite.sldev.cz/connect/local-permissions/';
 
 test.beforeAll(async () => {
     await TrezorUserEnvLink.connect();

--- a/packages/connect-popup/e2e/tests/permissions.test.ts
+++ b/packages/connect-popup/e2e/tests/permissions.test.ts
@@ -4,7 +4,7 @@ import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { setConnectSettings, waitAndClick } from '../support/helpers';
 
-const url = process.env.URL || 'http://localhost:8088/';
+const url = 'https://dev.suite.sldev.cz/connect/local-permissions/';
 const isCoreInPopup = process.env.CORE_IN_POPUP === 'true';
 
 let popup: Page;

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -44,6 +44,7 @@
     "dependencies": {
         "@trezor/connect": "workspace:*",
         "@trezor/connect-common": "workspace:*",
+        "@trezor/dom-utils": "workspace:^",
         "@trezor/utils": "workspace:*",
         "@trezor/websocket-client": "workspace:*"
     },

--- a/packages/connect-web/src/iframe/index.ts
+++ b/packages/connect-web/src/iframe/index.ts
@@ -74,6 +74,10 @@ export const init = async (settings: ConnectSettings) => {
         instance.id = 'trezorconnect';
     }
 
+    // this does not seem to make any difference (works without this), although here https://docs.google.com/document/d/1QQkqehw8umtAgz5z0um7THx-aoU251p705FbIQjDuGs they state:
+    // _Making a local network request from inside of an iframe requires that the embedding document specify the local-network-access permissions policy flag on the iframe._
+    instance.setAttribute('allow', 'local-network-access');
+
     let src: string;
     if (settings.env === 'web') {
         const manifestString = settings.manifest ? JSON.stringify(settings.manifest) : 'undefined'; // note: btoa(undefined) === btoa('undefined') === "dW5kZWZpbmVk"
@@ -90,7 +94,7 @@ export const init = async (settings: ConnectSettings) => {
     }
     instance.setAttribute('src', src);
     if (navigator.usb) {
-        instance.setAttribute('allow', 'usb');
+        instance.setAttribute('allow', instance.getAttribute('allow') + '; usb');
     }
 
     origin = getOrigin(instance.src);

--- a/packages/connect-web/src/impl/core-in-iframe.ts
+++ b/packages/connect-web/src/impl/core-in-iframe.ts
@@ -29,6 +29,7 @@ import type {
 } from '@trezor/connect/src/types';
 import { InitFullSettings } from '@trezor/connect/src/types/api/init';
 import { Log, initLog } from '@trezor/connect/src/utils/debug';
+import { waitForPermissionGranted } from '@trezor/dom-utils/src/localNetworkAccessPermission';
 import { DeferredManager, createDeferredManager } from '@trezor/utils/src/createDeferredManager';
 
 import { parseConnectSettings } from '../connectSettings';
@@ -192,10 +193,27 @@ export class CoreInIframe implements ConnectFactoryDependencies<ConnectSettingsW
 
         await iframe.init(this._settings);
 
+        // with iframe, it makes sense to check that we are able to communicate with trezor-bridge before we open popup.
+        const permissionResult = await waitForPermissionGranted(() => {
+            // in theory, bridge can live on 2 ports now, 21325 is considered legacy but is more likely to happen in this setup
+            // old standalone bridge installed, no suite-desktop running
+            fetch('http://127.0.0.1:21325/', { method: 'POST' }).catch(() => {});
+            fetch('http://127.0.0.1:21328/', { method: 'POST' }).catch(() => {});
+        });
+
+        // iframe mode does not support webusb so at this moment we are pretty sure that iframe mode will not work
+
+        // todo: maybe we should throw throw ERRORS.TypedError('Transport_Missing'); to force fallback to popup mode?
+
+        if (!permissionResult) {
+            throw ERRORS.TypedError('Browser_LocalNetworkPermissionMissing');
+        }
+
         if (this._settings.coreMode === 'auto') {
             // Checking bridge availability
             const { promiseId, promise } = this._messagePromises.create();
             this._log.debug('coreMode = auto, Checking bridge availability');
+
             iframe.postMessage({ id: promiseId, type: TRANSPORT.GET_INFO });
             const response = await promise;
             this._log.debug('Bridge availability response', response);

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -74,6 +74,7 @@ const impl = new TrezorConnectDynamic<
 
         // Handle desktop errors
         if (
+            isCoreModeAuto && // todo:....
             impl.getTargetType() === 'core-in-suite-desktop' &&
             (errorCode === 'Desktop_ConnectionMissing' || errorCode === 'Method_Unsupported')
         ) {

--- a/packages/connect-web/tsconfig.json
+++ b/packages/connect-web/tsconfig.json
@@ -24,6 +24,7 @@
     "references": [
         { "path": "../connect" },
         { "path": "../connect-common" },
+        { "path": "../dom-utils" },
         { "path": "../utils" },
         { "path": "../websocket-client" },
         { "path": "../eslint" },

--- a/packages/connect-web/tsconfig.lib.json
+++ b/packages/connect-web/tsconfig.lib.json
@@ -13,6 +13,9 @@
             "path": "../connect-common"
         },
         {
+            "path": "../dom-utils"
+        },
+        {
             "path": "../utils"
         },
         {

--- a/packages/dom-utils/package.json
+++ b/packages/dom-utils/package.json
@@ -8,5 +8,8 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@trezor/utils": "workspace:^"
     }
 }

--- a/packages/dom-utils/src/index.ts
+++ b/packages/dom-utils/src/index.ts
@@ -3,3 +3,4 @@ export { download } from './download';
 export { moveCaretToEndOfContentEditable } from './moveCaretToEndOfContentEditable';
 export { selectText } from './selectText';
 export { setCaretPosition } from './setCaretPosition';
+export { waitForPermissionGranted } from './localNetworkAccessPermission';

--- a/packages/dom-utils/src/localNetworkAccessPermission.ts
+++ b/packages/dom-utils/src/localNetworkAccessPermission.ts
@@ -1,0 +1,40 @@
+import { createDeferred } from '@trezor/utils';
+
+export const waitForPermissionGranted = async (triggerCallback: () => any) => {
+    if (window.location.hostname === 'localhost') return true;
+    const permission = await navigator.permissions
+        // @ts-expect-error outdated type definitions
+        .query({ name: 'local-network-access' })
+        .then(p => p)
+        .catch(() => undefined);
+
+    console.log('Permission:', permission);
+
+    // we don't know, permission API is not supported
+    if (!permission) return true;
+
+    // already either granted or denied, no user prompt is shown
+    if (permission.state === 'granted') return true;
+    if (permission.state === 'denied') return false;
+
+    // permission.state === 'prompt' -> lets wait for user to decide
+
+    const dfd = createDeferred<boolean>();
+    permission.onchange = ev => {
+        // @ts-expect-error outdated type definitions
+        if (ev.target?.state !== 'prompt') {
+            // @ts-expect-error outdated type definitions
+            dfd.resolve(ev.target!.state === 'granted');
+        }
+    };
+
+    triggerCallback();
+
+    console.log('==== waiting for permission prompt response ====');
+
+    return Promise.race([
+        dfd.promise,
+        // todo: add timeout? but how long? maybe user does not notice the dialogue, from this POV timeout makes sense
+        new Promise<boolean>(resolve => setTimeout(() => resolve(false), 60_000)),
+    ]);
+};

--- a/packages/dom-utils/tsconfig.json
+++ b/packages/dom-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": []
+    "references": [{ "path": "../utils" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13834,6 +13834,7 @@ __metadata:
     "@playwright/test": "npm:^1.55.0"
     "@trezor/connect": "workspace:*"
     "@trezor/connect-common": "workspace:*"
+    "@trezor/dom-utils": "workspace:^"
     "@trezor/eslint": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
@@ -13978,9 +13979,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/dom-utils@workspace:*, @trezor/dom-utils@workspace:packages/dom-utils":
+"@trezor/dom-utils@workspace:*, @trezor/dom-utils@workspace:^, @trezor/dom-utils@workspace:packages/dom-utils":
   version: 0.0.0-use.local
   resolution: "@trezor/dom-utils@workspace:packages/dom-utils"
+  dependencies:
+    "@trezor/utils": "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
- when using iframe mode, bridge is running but permission is denied 
<img width="551" height="156" alt="image" src="https://github.com/user-attachments/assets/6b43f365-cf66-49bc-9554-cad6b1e61f6b" />

- when using iframe mode and bridge is not running, permission does not matter - in this case, it should behave the same way as before since permission restriction does not kick in when the target endpoint is not available.

- what about iframe? _"Making a local network request from inside of an iframe requires that the embedding document specify the local-network-access [permissions policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Permissions_Policy) flag on the iframe." For example, if domainA.example includes an iframe for domainB.example, you will need to explicitly delegate the permission to the iframe as follows_ [source](https://docs.google.com/document/d/1QQkqehw8umtAgz5z0um7THx-aoU251p705FbIQjDuGs/edit?tab=t.0) 
```
<iframe src="domainB.example" allow="local-network-access"></iframe>
```


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=local-permissions-iframe&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=local-permissions-iframe&lookback=7)