### PR TITLE
Feat/22781 revert changes before freeze

### DIFF
--- a/packages/asset-utils/src/asset-logo-urls.ts
+++ b/packages/asset-utils/src/asset-logo-urls.ts
@@ -18,7 +18,6 @@ export const getAssetLogoUrl = ({
     coingeckoId,
     contractAddress,
     quality = '1x',
-    size = 24,
 }: GetAssetLogoUrlParams) => {
     const name = contractAddress ? `${coingeckoId}--${contractAddress}` : coingeckoId;
     const fileName = createCoinImageNameLegacy(name, quality);

--- a/packages/asset-utils/src/asset-logo-urls.ts
+++ b/packages/asset-utils/src/asset-logo-urls.ts
@@ -4,7 +4,7 @@ import {
     CoinImageQuality,
     CoinImageSize,
     ICONS_URL_BASE,
-    createCoinImageName,
+    createCoinImageNameLegacy,
 } from '@suite-common/icons/src/index';
 
 export interface GetAssetLogoUrlParams {
@@ -21,7 +21,7 @@ export const getAssetLogoUrl = ({
     size = 24,
 }: GetAssetLogoUrlParams) => {
     const name = contractAddress ? `${coingeckoId}--${contractAddress}` : coingeckoId;
-    const fileName = createCoinImageName(name, { size, quality });
+    const fileName = createCoinImageNameLegacy(name, quality);
 
     return `${ICONS_URL_BASE}/${fileName}` as const;
 };

--- a/packages/product-components/src/components/SelectAssetModal/SelectAssetModal.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/SelectAssetModal.tsx
@@ -56,7 +56,6 @@ export const SelectAssetModal = ({
     searchInput,
     noItemsAvailablePlaceholder,
     'data-testid': dataTestId,
-    renderOptionBalance,
 }: SelectAssetModalProps) => {
     const intl = useIntl();
 
@@ -96,11 +95,10 @@ export const SelectAssetModal = ({
                     badge={badge}
                     shouldTryToFetch={shouldTryToFetch}
                     handleClick={onSelectAsset}
-                    balance={renderOptionBalance(option)}
                 />
             );
         },
-        [dataTestId, onSelectAsset, renderOptionBalance],
+        [dataTestId, onSelectAsset],
     );
 
     return (

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/hooks/useBuildOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/hooks/useBuildOptions.ts
@@ -130,20 +130,6 @@ function getTokenBalance({
     };
 }
 
-function orderAssetOptionsByFiatBalanceInDesc(
-    assetA: SelectAssetOptionCurrencyProps,
-    assetB: SelectAssetOptionCurrencyProps,
-) {
-    if (
-        assetA.tokenBalance?.fiatAmount?.gt(assetB.tokenBalance?.fiatAmount ?? '0') ||
-        (assetA.tokenBalance?.baseAmount && !assetB.tokenBalance?.baseAmount)
-    ) {
-        return -1;
-    }
-
-    return 0;
-}
-
 /**
  * Take all `TradingCryptoSelectOptionProps[]`:
  * 1. Select only `currency` options
@@ -197,9 +183,7 @@ export function useBuildOptions(
             })
             .filter(option => option !== null);
 
-        return sortTokensByFiatBalanceInDesc
-            ? filteredOptions.toSorted(orderAssetOptionsByFiatBalanceInDesc)
-            : filteredOptions;
+        return filteredOptions;
     }, [
         rawOptions,
         currentRates,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/hooks/useNetworksTabs.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCryptoSelect/TradingSelectAssetModal/hooks/useNetworksTabs.ts
@@ -32,10 +32,7 @@ export function useNetworksTabs(options: SelectAssetOptionCurrencyProps[]) {
 
         return options.filter(
             option =>
-                option.coingeckoId === activeTab.coingeckoId &&
-                option.symbol === activeTab.symbol &&
-                // E.g. Don't show Solana network in Solana tab
-                option.ticker !== activeTab.displaySymbol,
+                option.coingeckoId === activeTab.coingeckoId && option.symbol === activeTab.symbol,
         );
     }, [activeTab, options]);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Rollback to `createCoinImageNameLegacy` to the `develop` isn't blocked by the #22913 before the freeze.
- Revert fiat rates in asset modal:
  - disable fiat rates
  - rollback the items order
  - return back the main network coin among filtered network tokens

## Related Issue

Relate #22781

## Screenshots:

**Send:**
<img width="735" height="1312" alt="Snímek obrazovky 2025-11-10 v 11 46 17" src="https://github.com/user-attachments/assets/d5d8cec5-ee01-4c95-9fae-1ef00dc9eeb7" />

**Swap:**
<img width="720" height="1360" alt="Snímek obrazovky 2025-11-10 v 11 46 48" src="https://github.com/user-attachments/assets/59491f67-119c-457c-8ef6-59073992f025" />
<img width="740" height="1384" alt="Snímek obrazovky 2025-11-10 v 11 47 32" src="https://github.com/user-attachments/assets/be75c2f5-1619-45df-93bf-af5f633e5e56" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/22781-revert-changes-before-freeze&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/22781-revert-changes-before-freeze&lookback=7)