### PR TITLE
fix(suite-native): graph formatter without formatToParts

### DIFF
--- a/suite-native/formatters/src/hooks/useFormattedGraphHeaderValues.ts
+++ b/suite-native/formatters/src/hooks/useFormattedGraphHeaderValues.ts
@@ -3,52 +3,89 @@ import { useSelector } from 'react-redux';
 import { selectBaseCurrency, selectIsBaseCurrencyInSats } from '@suite-common/wallet-core';
 import { useLocale } from '@suite-native/intl';
 
-const FIAT_CURRENCY_DECIMALS_LENGTH = 2;
-const BTC_CURRENCY_DECIMALS_LENGTH = 0;
+const MAX_DECIMALS_LENGTH = 2;
 
-const getFormattedWholeNumber = (value: Intl.NumberFormatPart[]) =>
-    value
-        .filter(part => part.type === 'integer' || part.type === 'group')
-        ?.reduce((acc, part) => acc + part.value, '') ?? null;
+const getFormattedWholeNumber = ({ value, locale }: { value: string; locale: string }) => {
+    const formatter = new Intl.NumberFormat(locale);
 
-const getFormattedDecimalNumber = (value: Intl.NumberFormatPart[]) => {
-    const decimalDigits = value.find(part => part.type === 'fraction')?.value ?? null;
-    const decimalSeparator = value.find(part => part.type === 'decimal')?.value ?? '.';
-
-    return decimalDigits ? `${decimalSeparator}${decimalDigits}` : '';
+    return formatter.format(Number(value));
 };
 
-const getFormattedCurrencySymbol = (value: Intl.NumberFormatPart[], isSatsValue: boolean) =>
-    isSatsValue ? 'sat' : (value.find(part => part.type === 'currency')?.value ?? null);
+const getDecimalSeparator = (locale: string) => {
+    const formatter = new Intl.NumberFormat(locale, { minimumFractionDigits: 1 });
 
-export const useFormattedGraphHeaderValues = (value?: string) => {
+    // we can not use formatter.formatToParts because it is not supported on iOS
+    // for this reason we need to use a regex on a dummy 0.1 value to get the decimal separator.
+    const formattedValue = formatter.format(Number(0.1));
+    const numericRegex = /[\d]+/g;
+    const cleanedDecimalSeparator = formattedValue.replace(numericRegex, '');
+
+    return cleanedDecimalSeparator;
+};
+
+const getFormattedDecimalNumber = ({
+    value = '00',
+    locale,
+    isSatsValue,
+}: {
+    value: string | undefined;
+    locale: string;
+    isSatsValue: boolean;
+}) => {
+    if (isSatsValue) {
+        return '';
+    }
+
+    const decimalSeparator = getDecimalSeparator(locale);
+
+    return `${decimalSeparator}${value.slice(0, MAX_DECIMALS_LENGTH)}`;
+};
+
+const getFormattedCurrencySymbol = ({
+    locale,
+    currency,
+    isSatsValue,
+}: {
+    locale: string;
+    currency: string;
+    isSatsValue: boolean;
+}) => {
+    if (isSatsValue) {
+        return 'sat';
+    }
+
+    const formatter = new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currencyDisplay: 'symbol',
+        currency,
+        maximumFractionDigits: 0,
+    });
+
+    // we can not use formatter.formatToParts because it is not supported on iOS
+    // for this reason we need to use a regex on a dummy 0 value to get the currency symbol
+    const formattedValue = formatter.format(0);
+    const regex = /[\s0]+/g;
+    const cleanedCurrencySymbol = formattedValue.replace(regex, '');
+
+    return cleanedCurrencySymbol;
+};
+
+export const useFormattedGraphHeaderValues = (value: string = '0') => {
     const locale = useLocale();
     const baseCurrency = useSelector(selectBaseCurrency);
     const isBaseCurrencyInSats = useSelector(selectIsBaseCurrencyInSats);
 
     const isSatsValue = isBaseCurrencyInSats && baseCurrency === 'btc';
-    const minimumFractionDigits =
-        baseCurrency === 'btc' && !isBaseCurrencyInSats
-            ? FIAT_CURRENCY_DECIMALS_LENGTH
-            : BTC_CURRENCY_DECIMALS_LENGTH;
-    const maximumFractionDigits = isBaseCurrencyInSats
-        ? BTC_CURRENCY_DECIMALS_LENGTH
-        : FIAT_CURRENCY_DECIMALS_LENGTH;
-
-    const formatter = new Intl.NumberFormat(locale, {
-        currency: baseCurrency,
-        style: 'currency',
-        currencyDisplay: 'symbol',
-        minimumFractionDigits,
-        maximumFractionDigits,
-    });
 
     const numericValue = isSatsValue ? Number(value) * 100_000_000 : Number(value);
-    const formattedValueParts = formatter.formatToParts(numericValue);
+    const [integerPart, decimalPart] = numericValue
+        .toFixed(MAX_DECIMALS_LENGTH)
+        .toString()
+        .split('.');
 
     return {
-        wholeNumber: getFormattedWholeNumber(formattedValueParts),
-        currencySymbol: getFormattedCurrencySymbol(formattedValueParts, isSatsValue),
-        decimalNumber: getFormattedDecimalNumber(formattedValueParts),
+        currencySymbol: getFormattedCurrencySymbol({ locale, currency: baseCurrency, isSatsValue }),
+        wholeNumber: getFormattedWholeNumber({ value: integerPart, locale }),
+        decimalNumber: getFormattedDecimalNumber({ value: decimalPart, locale, isSatsValue }),
     };
 };

--- a/suite-native/formatters/src/tests/useFormattedGraphHeaderValues.hook.test.ts
+++ b/suite-native/formatters/src/tests/useFormattedGraphHeaderValues.hook.test.ts
@@ -76,7 +76,7 @@ describe(useFormattedGraphHeaderValues.name, () => {
         expect(result.current).toEqual({
             currencySymbol: '€',
             wholeNumber: '2,000',
-            decimalNumber: '',
+            decimalNumber: '.00',
         });
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The iOS version of Hermes does not support `Intl.NumberFormat.formatToParts()` I was trying to polyfill it, but it seems that we would need to include too much of polyfilled code (about 6MB to support all possible locales). For that reason is reimplementing the single place where is the `formatToParts` with our own logic a better solution.

## Notes for QA
Please test both iOS and Android app:
1. Connect device
2. Wait for discovery to finish
3. See if the portfolio graph balance is displayed correctly
4. Try to slide your finger over to graph to see if the value is changing based on the timestamp correctly


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/graph-formatter-without-format-to-parts&lookback=7)