### PR TITLE
Fix/22832 download crypto icons 2

### DIFF
--- a/suite-common/icons/scripts/constants/index.ts
+++ b/suite-common/icons/scripts/constants/index.ts
@@ -11,5 +11,5 @@ export const UPDATED_ICONS_LIST_URL = join(ICONS_URL_BASE, 'icons.json');
 export const COIN_LIST_URL = 'https://pro-api.coingecko.com/api/v3/coins/list';
 export const COIN_DATA_URL = 'https://pro-api.coingecko.com/api/v3/coins/';
 
-export const RATE_LIMIT_PER_MINUTE = 90;
-export const RUN_LIMIT_SECONDS = 60 * 60; // 1 hour
+export const RATE_LIMIT_PER_MINUTE = 200;
+export const RUN_LIMIT_SECONDS = 2 * 60 * 60; // 2 hour

--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -156,6 +156,6 @@ async function ensureDirectoryExists(path: string) {
             break;
         }
 
-        await sleep((60 / RATE_LIMIT_PER_MINUTE) * 1000);
+        await sleep(Math.ceil((60 / RATE_LIMIT_PER_MINUTE) * 1000));
     }
 })();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The prev. adjustment `RATE_LIMIT_PER_MINUTE` did help: more crypto icons have been downloaded but there're still some missing. Therefore I attempted to increased:
- `RUN_LIMIT_SECONDS` to 2h
- `RATE_LIMIT_PER_MINUTE` to 200

## Related Issue

Resolve #22832


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/22913-download-crypto-icons-2&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/22913-download-crypto-icons-2&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/22913-download-crypto-icons-2&lookback=7)