### PR TITLE
fix(wallet-core): evm balance should never be reduced without mined tx

### DIFF
--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -274,23 +274,16 @@ const synchronizeSentTransactionThunk = createThunk(
                 }),
             );
         } else if (selectedAccount.networkType === 'ethereum') {
-            const pendingAccount = getPendingAccount({
-                account: selectedAccount,
-                tx: precomposedTransaction,
-                txid,
-            });
-            if (pendingAccount) {
-                // manually add fake pending tx as we don't have the data about mempool txs
-                dispatch(
-                    addFakePendingEvmTxThunk({
-                        precomposedTransaction,
-                        precomposedForm,
-                        txid,
-                        account: selectedAccount,
-                    }),
-                );
-                dispatch(accountsActions.updateAccount(pendingAccount));
-            }
+            // manually add fake pending tx as we don't have the data about mempool txs
+            dispatch(
+                addFakePendingEvmTxThunk({
+                    precomposedTransaction,
+                    precomposedForm,
+                    txid,
+                    account: selectedAccount,
+                }),
+            );
+            dispatch(accountsActions.updateAccount(selectedAccount));
         } else {
             // there is no point in fetching account data right after tx submit
             //  as the account will update only after the tx is confirmed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- evm balance no longer changes before pending tx is mined

## Notes for QA

## Related Issue

Resolve https://satoshilabs.slack.com/archives/C07CNUB6HGC/p1762773565281999

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/negative-evm-balance&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/negative-evm-balance&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/negative-evm-balance&lookback=7)