### PR TITLE
fix(suite): Tx review details

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewDetails.tsx
@@ -21,7 +21,7 @@ export interface TransactionReviewDetailsProps {
 const prettify = (json: Record<any, any>) => JSON.stringify(json, null, 2);
 
 export const TransactionReviewDetails = ({ tx, txHash }: TransactionReviewDetailsProps) => {
-    if (tx.inputs.length === 0) return null; // BTC-only, TODO: eth/ripple
+    if (tx.inputs.length === 0) return null; // only for BTC-like and ADA (UTXO-based chains), TODO ETH and other account-based?
 
     return (
         <Card>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -248,7 +248,7 @@ export const TransactionReviewModalBodyInner = ({
                 }
                 onBackClick={areDetailsVisible ? () => setAreDetailsVisible(false) : undefined}
                 description={
-                    !areDetailsVisible && (
+                    areDetailsVisible ? null : (
                         <TransactionReviewSummary
                             tx={precomposedTx}
                             account={account}
@@ -271,23 +271,24 @@ export const TransactionReviewModalBodyInner = ({
                     )
                 }
                 bottomContent={
-                    <TransactionReviewModalBottomContent
-                        decision={decision}
-                        isSending={isSending}
-                        onSend={setIsSending}
-                        onCancel={onCancel}
-                        handleTryAgain={handleTryAgain}
-                        txInfoState={txInfoState}
-                        areDetailsVisible={areDetailsVisible}
-                        actionTranslation={actionTranslation('button')}
-                        isTxExpired={isTxExpired}
-                        hasTxExpired={hasTxExpired}
-                        stakeType={stakeType || undefined}
-                        isRbfConfirmedError={isRbfConfirmedError}
-                        account={account}
-                        precomposedForm={precomposedForm}
-                        outputs={outputs}
-                    />
+                    areDetailsVisible ? null : (
+                        <TransactionReviewModalBottomContent
+                            decision={decision}
+                            isSending={isSending}
+                            onSend={setIsSending}
+                            onCancel={onCancel}
+                            handleTryAgain={handleTryAgain}
+                            txInfoState={txInfoState}
+                            actionTranslation={actionTranslation('button')}
+                            isTxExpired={isTxExpired}
+                            hasTxExpired={hasTxExpired}
+                            stakeType={stakeType || undefined}
+                            isRbfConfirmedError={isRbfConfirmedError}
+                            account={account}
+                            precomposedForm={precomposedForm}
+                            outputs={outputs}
+                        />
+                    )
                 }
                 size="small"
             >
@@ -300,6 +301,7 @@ export const TransactionReviewModalBodyInner = ({
                     reviewStep={reviewStep}
                     isRbfConfirmedError={isRbfConfirmedError}
                     onTryAgain={handleTryAgain}
+                    areDetailsVisible={areDetailsVisible}
                 />
             </Modal.ModalBase>
         </ConnectModalBackdrop>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx
@@ -28,7 +28,6 @@ type TransactionReviewModalBottomContentProps = {
     onCancel: () => void;
     handleTryAgain: (close: boolean) => void;
     txInfoState: SendState | StakeState;
-    areDetailsVisible: boolean;
     actionTranslation: ExtendedMessageDescriptor;
     isTxExpired: boolean;
     hasTxExpired: boolean;
@@ -47,7 +46,6 @@ export const TransactionReviewModalBottomContent = ({
     onCancel,
     handleTryAgain,
     txInfoState,
-    areDetailsVisible,
     actionTranslation,
     isTxExpired,
     hasTxExpired,
@@ -150,10 +148,6 @@ export const TransactionReviewModalBottomContent = ({
                 </Modal.Button>
             </>
         );
-    }
-
-    if (areDetailsVisible) {
-        return null;
     }
 
     if (connectPopupCall?.state === 'ongoing') {

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
@@ -33,7 +33,7 @@ type TransactionReviewModalContentProps = {
     onTryAgain: (cancel: boolean) => void;
     reviewStep: number;
     serializedTx?: SerializedTx;
-    areDetailsVisible?: boolean;
+    areDetailsVisible: boolean;
     isRbfConfirmedError?: boolean;
 };
 


### PR DESCRIPTION
## Description

Bring back forgotten `TransactionReviewDetails` component, which is currently never rendered.
Small code tweaks along the way.

## Related Issue

Resolve #23027

## Screenshots:

### Before

https://github.com/user-attachments/assets/b12fb51c-154b-4db8-9b33-a2878d31dac4

### After

at first not signed, then signed

[AFTER.webm](https://github.com/user-attachments/assets/e0ab6e2c-7044-4130-8dda-6285fd9199ce)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tx-review-details&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tx-review-details&lookback=7)