### PR TITLE
fix(analytics): fix naming and trigger for device onboarding start

### DIFF
--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -167,13 +167,6 @@ const SecurityCheckContent = ({
 
     const toggleView = () => setIsFailed(current => !current);
     const handleContinueButtonClick = () => {
-        analytics.report({
-            type: EventType.OnboardingSetupStart,
-            payload: {
-                deviceModel,
-            },
-        });
-
         if (shouldAuthenticateSelectedDevice) {
             goToDeviceAuthentication();
         } else {
@@ -183,7 +176,7 @@ const SecurityCheckContent = ({
 
     const handleSetupButtonClick = () => {
         analytics.report({
-            type: EventType.OnboardingSetupStart,
+            type: EventType.DeviceSetupStarted,
             payload: {
                 deviceModel,
             },

--- a/suite-common/analytics/src/events/suite/constants.ts
+++ b/suite-common/analytics/src/events/suite/constants.ts
@@ -26,6 +26,7 @@ export enum EventType {
     DeviceDisconnect = 'device-disconnect',
     DeviceUpdateFirmware = 'device-update-firmware',
     DeviceSetupCompleted = 'device-setup-completed',
+    DeviceSetupStarted = 'device-setup-started',
 
     DeviceConnectionConnectButton = 'device-connection/connect-button',
     DeviceConnectionConnectModal = 'device-connection/connect-modal',
@@ -33,7 +34,6 @@ export enum EventType {
     DeviceConnectionDeviceFound = 'device-connection/device-found',
     DeviceConnectionDevicePaired = 'device-connection/device-paired',
     DeviceConnectionDeviceConfirmation = 'device-connection/device-confirmation',
-    OnboardingSetupStart = 'onboarding/setup-start',
 
     FirmwareValidateHashError = 'firmware-validate-hash-error',
     FirmwareValidateHashMismatch = 'firmware-validate-hash-mismatch',

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -845,7 +845,7 @@ export type SuiteAnalyticsEvent =
           };
       }
     | {
-          type: EventType.OnboardingSetupStart;
+          type: EventType.DeviceSetupStarted;
           payload: {
               deviceModel: DeviceModelInternal;
           };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Better aligned naming of the event for device onboarding start.
- Do not report device onboarding start for devices that are already initialialized.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19916



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/analytics-device-setup-started&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/analytics-device-setup-started&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/analytics-device-setup-started&lookback=7)