### PR TITLE
fix(suite): fees fixups

### DIFF
--- a/packages/components/src/components/Collapsible/CollapsibleToggle.tsx
+++ b/packages/components/src/components/Collapsible/CollapsibleToggle.tsx
@@ -4,21 +4,23 @@ import styled from 'styled-components';
 
 import { useCollapsible } from './CollapsibleContext';
 
-const Container = styled.div`
+const Container = styled.div<{ $disabled?: boolean }>`
     display: contents;
-    cursor: pointer;
+    cursor: ${({ $disabled }) => ($disabled ? 'default' : 'pointer')};
 `;
 
 type CollapsibleToggleProps = {
     children: ReactNode;
     onClick?: () => void;
     'data-testid'?: string;
+    disabled?: boolean;
 };
 
 export const CollapsibleToggle = ({
     children,
     onClick,
     'data-testid': dataTestId,
+    disabled,
 }: CollapsibleToggleProps) => {
     const { toggle, isOpen, contentId } = useCollapsible();
 
@@ -33,10 +35,12 @@ export const CollapsibleToggle = ({
         <Container
             role="button"
             tabIndex={0}
+            aria-disabled={disabled}
             aria-expanded={isOpen}
             aria-controls={contentId}
             data-testid={dataTestId}
             onClick={clickHandler}
+            $disabled={disabled}
         >
             {children}
         </Container>

--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/fees.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/fees.ts
@@ -14,6 +14,7 @@ export class Fees {
         this.page.getByTestId(`@fee-card/${feeType}-fiat-amount`);
     readonly rateOnCard = (feeType: FeeTypes) => this.page.getByTestId(`@fee-card/${feeType}-rate`);
     readonly collapsibleFeesToggle: Locator;
+    readonly maxFeeLoading: Locator;
     readonly customInput: Locator;
     readonly maxFee: Locator;
     readonly maxFeeFiat: Locator;
@@ -25,6 +26,7 @@ export class Fees {
 
     constructor(private readonly page: Page) {
         this.collapsibleFeesToggle = this.page.getByTestId('@wallet/fees/collapsible-fees-toggle');
+        this.maxFeeLoading = this.page.getByTestId('@trading/quote/maximum-fee-amount-loading');
         this.customInput = this.page.getByTestId('feePerUnit');
         this.maxFee = this.page.getByTestId('@trading/quote/maximum-fee-amount');
         this.maxFeeFiat = this.page.getByTestId('@trading/quote/maximum-fee-fiat-amount');
@@ -69,6 +71,19 @@ export class Fees {
             return;
         }
 
+        // Wait for maximum fee to be calculated
+        await this.maxFeeLoading.waitFor({ state: 'hidden', timeout: 5000 });
+
+        const isDisabled = await this.collapsibleFeesToggle.getAttribute('aria-disabled');
+
+        if (isDisabled === 'true') {
+            console.error(
+                new Error(
+                    `Can't open collapsible fees because it is disabled. Make sure 'to' and 'amount' fields are filled so that maximum fee is calculated.`,
+                ),
+            );
+        }
+
         await expect(this.collapsibleFeesToggle).toHaveAttribute('aria-expanded', 'false');
         await this.collapsibleFeesToggle.click();
         await expect(this.collapsibleFeesToggle).toHaveAttribute('aria-expanded', 'true');
@@ -92,7 +107,7 @@ export class Fees {
 
     @step()
     async expectBitcoinFeeCalculated() {
-        this.openCollapsibleFees();
+        await this.openCollapsibleFees();
 
         const feePattern = /[≈~]\s*\$\s*\d+\.\d+/;
         await expect(this.valueOnCard('economy')).toHaveText(feePattern);
@@ -102,7 +117,7 @@ export class Fees {
 
     @step()
     async expectEthereumFeeCalculated() {
-        this.openCollapsibleFees();
+        await this.openCollapsibleFees();
 
         const feePattern = /\d+\.\d+\s*Gwei/;
         await expect(this.rateOnCard('low')).toHaveText(feePattern);

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
@@ -130,8 +130,9 @@ test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () 
                 });
 
                 await test.step(`Fill in a sell form with ${feeType} fee`, async () => {
-                    await feeSwitchFunction();
                     await tradingPage.fillSellForm({ cryptoAmount });
+                    await tradingPage.fees.openCollapsibleFees();
+                    await feeSwitchFunction();
                     feeRate = await tradingPage.fees.getBitcoinFeeRate(feeType);
                 });
 

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
@@ -69,15 +69,15 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
 
     test('Sell Ethereum', async ({ tradingPage, devicePrompt }) => {
         await test.step('Fill in a sell request', async () => {
-            await tradingPage.fees.setEthereumCustomFees({
-                gasLimit,
-                maxFeePerGas,
-                maxPriorityFeePerGas,
-            });
             await tradingPage.fillSellForm({
                 cryptoAmount,
                 networkSymbolOrTokenId: 'eth',
                 cryptoCurrency: 'ethereum',
+            });
+            await tradingPage.fees.setEthereumCustomFees({
+                gasLimit,
+                maxFeePerGas,
+                maxPriorityFeePerGas,
             });
             await expect(tradingPage.bestOfferAmount).toHaveText(fiatAmount);
             await expect(tradingPage.quoteProvider).toHaveText(capitalizeFirstLetter(provider));

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
@@ -60,9 +60,6 @@ test.describe('Trading - Sell inputs', { tag: ['@group=trading', '@webOnly'] }, 
         });
 
         await test.step('Try all % inputs for Bitcoin', async () => {
-            await tradingPage.fees.switchToCustom();
-            await tradingPage.fees.customInput.fill(customFeeRate.toString());
-
             for (const percentage of [10, 25, 50]) {
                 await test.step(`${percentage}% of BTC balance`, async () => {
                     await tradingPage.cryptoInputFractionButtons
@@ -75,6 +72,8 @@ test.describe('Trading - Sell inputs', { tag: ['@group=trading', '@webOnly'] }, 
                     });
                 });
             }
+            await tradingPage.fees.switchToCustom();
+            await tradingPage.fees.customInput.fill(customFeeRate.toString());
 
             await test.step('Max of BTC balance', async () => {
                 await tradingPage.cryptoInputFractionButtons

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-fees-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-fees-bitcoin.test.ts
@@ -28,8 +28,6 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@group=trading', '@webOnly
     test('Swap custom fees for Bitcoin', async ({ page, tradingPage, devicePrompt }) => {
         let feeRate: string;
         await test.step('Fill in a Swap form', async () => {
-            await tradingPage.fees.switchToCustom();
-            await tradingPage.fees.customInput.fill(customFee);
             await tradingPage.fillSwapForm({
                 amount: sendAmount,
                 sendCurrency: 'bitcoin',
@@ -39,7 +37,12 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@group=trading', '@webOnly
                 receiveNetwork: 'ethereum',
                 receiveAddress,
             });
+            await tradingPage.fees.switchToCustom();
+            await tradingPage.fees.customInput.fill(customFee);
             feeRate = await tradingPage.fees.getBitcoinFeeRate('custom');
+
+            // Wait for TX precomposition to avoid
+            await new Promise(resolve => setTimeout(resolve, 2500));
         });
 
         await test.step('Continue Swap flow towards Send section', async () => {

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-fees-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-fees-ethereum.test.ts
@@ -38,11 +38,6 @@ test.describe('Trading - Swap fees', { tag: ['@group=trading', '@webOnly'] }, ()
 
     test('Swap custom fees for Ethereum', async ({ page, tradingPage, devicePrompt }) => {
         await test.step('Fill in a Swap form', async () => {
-            await tradingPage.fees.setEthereumCustomFees({
-                gasLimit,
-                maxFeePerGas,
-                maxPriorityFeePerGas,
-            });
             await tradingPage.fillSwapForm({
                 amount: sendAmount,
                 sendCurrency: 'ethereum',
@@ -52,6 +47,14 @@ test.describe('Trading - Swap fees', { tag: ['@group=trading', '@webOnly'] }, ()
                 receiveNetwork: 'bitcoin',
                 receiveAddress,
             });
+            await tradingPage.fees.setEthereumCustomFees({
+                gasLimit,
+                maxFeePerGas,
+                maxPriorityFeePerGas,
+            });
+
+            // Wait for TX precomposition to avoid
+            await new Promise(resolve => setTimeout(resolve, 2500));
         });
 
         await test.step('Continue Swap flow towards Send section', async () => {

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
@@ -5,7 +5,7 @@ import { TranslationKey } from '@suite-common/intl-types';
 import { NetworkSymbol, NetworkType } from '@suite-common/wallet-config';
 import { FormState } from '@suite-common/wallet-types';
 import { Button, Collapsible, Column, Row, TextButton } from '@trezor/components';
-import { TypographyStyle } from '@trezor/theme';
+import { TypographyStyle, spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite/Translation';
 
@@ -14,6 +14,7 @@ import { CustomFee } from './CustomFee/CustomFee';
 import { MaximumFee } from './MaximumFee';
 import { StandardFee } from './StandardFee/StandardFee';
 import { FeesContext, FeesContextType } from '../context/FeesContext';
+import { useTransactionMaxFee } from './hooks/useTransactionMaxFee';
 
 export type CollapsibleFeesProps = {
     networkType: NetworkType;
@@ -51,6 +52,12 @@ export function CollapsibleFees({
         [feeInfo.levels, selectedFee],
     );
 
+    const txMaxFee = useTransactionMaxFee({
+        networkSymbol,
+        composedLevels,
+        selectedFeeLevel,
+    });
+
     if (!selectedFeeLevel) {
         return null;
     }
@@ -69,11 +76,15 @@ export function CollapsibleFees({
             <Collapsible gap={20}>
                 <Row justifyContent="space-between" gap={12}>
                     <CollapsibleFeesHeader label={label} typographyStyle={headerTypographyStyle} />
-                    <Collapsible.Toggle data-testid="@wallet/fees/collapsible-fees-toggle">
+                    <Collapsible.Toggle
+                        data-testid="@wallet/fees/collapsible-fees-toggle"
+                        disabled={!supportsAdjustableFees}
+                    >
                         <Row gap={10}>
-                            {composedLevels === null ? null : (
-                                <MaximumFee typographyStyle={headerTypographyStyle} />
-                            )}
+                            <MaximumFee
+                                typographyStyle={headerTypographyStyle}
+                                txMaxFee={txMaxFee}
+                            />
                             {supportsAdjustableFees && (
                                 <Collapsible.ToggleIcon iconName="caretDown" size="mediumLarge" />
                             )}
@@ -81,14 +92,14 @@ export function CollapsibleFees({
                     </Collapsible.Toggle>
                 </Row>
                 {supportsAdjustableFees && (
-                    <Collapsible.Content>
+                    <Collapsible.Content overflow="unset">
                         <Column gap={16}>
                             <Column gap={16}>
                                 {!isCustomFee && <StandardFee />}
                                 {isCustomFee && <CustomFee showCurrentFee={!rbfForm} />}
                             </Column>
 
-                            <Row justifyContent="center">
+                            <Row justifyContent="center" margin={{ bottom: spacings.xs }}>
                                 {isCustomFee && (
                                     <Button
                                         intent="neutral"

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/InlineLoader.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/InlineLoader.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react';
+
+import { Row, Spinner, SpinnerProps } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+interface InlineLoaderProps {
+    children: ReactNode;
+    loading: boolean;
+    size?: SpinnerProps['size'];
+    testId?: string;
+}
+
+export function InlineLoader({ children, loading, size = 20, testId }: InlineLoaderProps) {
+    if (!loading) {
+        return <>{children}</>;
+    }
+
+    return (
+        <Row gap={spacings.sm} data-testid={testId}>
+            <Spinner size={size} />
+            {children}
+        </Row>
+    );
+}

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/MaximumFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/MaximumFee.tsx
@@ -1,72 +1,65 @@
-import { memo, useEffect, useMemo, useState } from 'react';
-
-import { getNetwork } from '@suite-common/wallet-config';
-import { AmountUnit, asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
+import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import { Column, Text } from '@trezor/components';
 import { TypographyStyle } from '@trezor/theme';
-import { BigNumber } from '@trezor/utils';
 
 import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { useSelector } from 'src/hooks/suite';
 
+import { InlineLoader } from './InlineLoader';
 import { useFeesContext } from '../context/FeesContext';
+import { TransactionMaxFee } from './hooks/useTransactionMaxFee';
 
 export type MaximumFeeProps = {
     typographyStyle: TypographyStyle;
+    txMaxFee: TransactionMaxFee;
 };
 
-export const MaximumFee = memo(function MaximumFeeInner({ typographyStyle }: MaximumFeeProps) {
-    const { networkSymbol, composedLevels, selectedFeeLevel } = useFeesContext();
-    const transactionInfo = composedLevels?.[selectedFeeLevel.label];
-    const txFee = transactionInfo?.type !== 'error' ? transactionInfo?.fee : null;
-    const [txMaximumFee, setTxMaximumFee] = useState<AmountUnit | null>(null);
-    const txMaxFee = useMemo(() => {
-        if (!txFee) return null;
+export function MaximumFee({ typographyStyle, txMaxFee }: MaximumFeeProps) {
+    const { networkSymbol } = useFeesContext();
+    const areFeesLoading = useSelector(state => selectAreFeesLoading(state, networkSymbol));
 
-        return subunitsToUnits({
-            value: asAmountSubunit(new BigNumber(txFee)),
-            symbol: networkSymbol,
-            decimals: getNetwork(networkSymbol)?.decimals,
-        }) as AmountUnit;
-    }, [networkSymbol, txFee]);
-
-    useEffect(() => {
-        if (txMaxFee) {
-            setTxMaximumFee(txMaxFee);
-        }
-    }, [txMaxFee]);
-
-    if (!txMaximumFee) {
+    if (!txMaxFee) {
         return (
-            <Text variant="tertiary" typographyStyle={typographyStyle}>
-                <Translation id="TO_BE_CALCULATED" />
-            </Text>
+            <InlineLoader
+                loading={areFeesLoading}
+                data-testid="@trading/quote/maximum-fee-amount-loading"
+            >
+                <Text variant="tertiary" typographyStyle={typographyStyle}>
+                    <Translation id="TO_BE_CALCULATED" />
+                </Text>
+            </InlineLoader>
         );
     }
 
     return (
-        <Column alignItems="flex-end">
-            <Text variant="default" typographyStyle={typographyStyle}>
-                <FormattedCryptoAmount
-                    data-testid="@trading/quote/maximum-fee-amount"
-                    disableHiddenPlaceholder
-                    value={txMaximumFee}
-                    symbol={networkSymbol}
-                />
-            </Text>
+        <InlineLoader
+            loading={areFeesLoading}
+            data-testid="@trading/quote/maximum-fee-amount-loading"
+        >
+            <Column alignItems="flex-end">
+                <Text variant="default" typographyStyle={typographyStyle}>
+                    <FormattedCryptoAmount
+                        data-testid="@trading/quote/maximum-fee-amount"
+                        disableHiddenPlaceholder
+                        value={txMaxFee}
+                        symbol={networkSymbol}
+                    />
+                </Text>
 
-            <Text
-                data-testid="@trading/quote/maximum-fee-fiat-amount"
-                variant="tertiary"
-                typographyStyle="hint"
-            >
-                <BaseCurrencyValue
-                    disableHiddenPlaceholder
-                    amount={txMaximumFee}
-                    symbol={networkSymbol}
-                    showApproximationIndicator
-                />
-            </Text>
-        </Column>
+                <Text
+                    data-testid="@trading/quote/maximum-fee-fiat-amount"
+                    variant="tertiary"
+                    typographyStyle="hint"
+                >
+                    <BaseCurrencyValue
+                        disableHiddenPlaceholder
+                        amount={txMaxFee}
+                        symbol={networkSymbol}
+                        showApproximationIndicator
+                    />
+                </Text>
+            </Column>
+        </InlineLoader>
     );
-});
+}

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/hooks/useFetchFees.ts
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/hooks/useFetchFees.ts
@@ -1,4 +1,4 @@
-import { useFormContext } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { useFetchFeesOnce, useRefetchFees } from '@suite-common/wallet-core';
@@ -10,8 +10,7 @@ import { useSelector } from 'src/hooks/suite';
 
 function useIsRefetchDisabled() {
     const modal = useSelector(state => state.modal);
-    const { getValues } = useFormContext<FormState>();
-    const setMaxOutputId = getValues('setMaxOutputId');
+    const setMaxOutputId = useWatch<FormState, 'setMaxOutputId'>({ name: 'setMaxOutputId' });
 
     if (setMaxOutputId !== undefined) {
         return true;

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/hooks/useTransactionMaxFee.ts
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/hooks/useTransactionMaxFee.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+
+import { getNetwork } from '@suite-common/wallet-config';
+import {
+    asAmountSubunit,
+    roundToNonZeroFractionDigits,
+    subunitsToUnits,
+} from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { FeesContextType } from '../../context/FeesContext';
+
+export type TransactionMaxFeeProps = Pick<FeesContextType, 'networkSymbol' | 'composedLevels'> & {
+    selectedFeeLevel?: FeesContextType['selectedFeeLevel'];
+};
+
+export function useTransactionMaxFee({
+    networkSymbol,
+    composedLevels,
+    selectedFeeLevel,
+}: TransactionMaxFeeProps) {
+    const transactionInfo = selectedFeeLevel ? composedLevels?.[selectedFeeLevel.label] : null;
+    const txFee = transactionInfo?.type !== 'error' ? transactionInfo?.fee : null;
+
+    return useMemo(() => {
+        if (!txFee) {
+            return null;
+        }
+
+        return roundToNonZeroFractionDigits(
+            subunitsToUnits({
+                value: asAmountSubunit(new BigNumber(txFee)),
+                symbol: networkSymbol,
+                decimals: getNetwork(networkSymbol)?.decimals,
+            }),
+            4,
+        ).toString();
+    }, [networkSymbol, txFee]);
+}
+
+export type TransactionMaxFee = ReturnType<typeof useTransactionMaxFee>;

--- a/suite-common/wallet-utils/src/bigNumberUtils.ts
+++ b/suite-common/wallet-utils/src/bigNumberUtils.ts
@@ -1,0 +1,43 @@
+import { BigNumber } from '@trezor/utils/src/bigNumber';
+
+/**
+ * Rounds a value to a given number of non-zero fractional digits.
+ * @example
+ * roundToNonZeroFractionDigits(new BigNumber('0.000000012367'), 4) // 0.0001237
+ * roundToNonZeroFractionDigits(new BigNumber('1.23456789'), 4) // 1.2346
+ * roundToNonZeroFractionDigits(new BigNumber('1.23400000'), 4) // 1.234
+ * roundToNonZeroFractionDigits(new BigNumber('1.00000000'), 4) // 1
+ */
+export function roundToNonZeroFractionDigits(
+    value: BigNumber,
+    nonZeroFractionDigits: number,
+): BigNumber {
+    if (value.isZero()) {
+        return value;
+    }
+
+    // Get the fractional part as a string without scientific notation
+    const [, fractionDigits] = value.toString().split('.');
+
+    // Find index (1-based) of the 4th non-zero digit after the decimal point
+    let nonZeroDigits = 0;
+    // Decimal places we'll round to
+    let decimalPlaces = 0;
+
+    for (let i = 0; i < fractionDigits.length; i++) {
+        if (fractionDigits[i] !== '0') nonZeroDigits++;
+
+        if (nonZeroDigits === nonZeroFractionDigits) {
+            decimalPlaces = i + 1;
+            break;
+        }
+    }
+
+    // If the number has < nonZeroFractionDigits non-zero fractional digits leave it as is
+    if (nonZeroDigits < nonZeroFractionDigits) {
+        return value;
+    }
+
+    // Round *up* at the calculated decimal place
+    return value.decimalPlaces(decimalPlaces, BigNumber.ROUND_UP);
+}

--- a/suite-common/wallet-utils/src/index.ts
+++ b/suite-common/wallet-utils/src/index.ts
@@ -32,3 +32,4 @@ export * from './hooks/useExcludedUtxos';
 export * from './hooks/useFilteredUtxos';
 export * from './cardanoStakingUtils';
 export * from './amountUtils';
+export * from './bigNumberUtils';


### PR DESCRIPTION
## Description

- add loader
- display max fee with specific precision
- ~~disable collapsible element if max fee null~~ I had reverted this. Because when you set a custom fee, the max. fee might be null at some time during recalculation. 
- adjust collapsible box padding
- fix fees content overflow

<!--- Provide a general summary of your changes in the Title above -->

## Related Issue

Resolve #21683

## Screenshots:



https://github.com/user-attachments/assets/d33eb991-b7c2-4c8b-825b-c9cd4521b1d6






🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/21683-collpase-network-fees-3&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/21683-collpase-network-fees-3&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/21683-collpase-network-fees-3&lookback=7)