### PR TITLE
chore(suite): updated DEFAULT_SUITE_SYNC_RELAY_URL

### DIFF
--- a/suite-common/local-first-storage/package.json
+++ b/suite-common/local-first-storage/package.json
@@ -16,6 +16,7 @@
         "@suite-common/metadata-types": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
+        "@suite-common/suite-utils": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",

--- a/suite-common/local-first-storage/src/index.ts
+++ b/suite-common/local-first-storage/src/index.ts
@@ -3,7 +3,7 @@ export { disposeAllLocalFirstStorageThunk } from './storage/disposeAllLocalFirst
 export { initLocalFirstStorageThunkFactory } from './storage/initLocalFirstStorageThunk';
 export { subscribeLocalFirstStorageThunk } from './storage/subscribeLocalFirstStorageThunk';
 export { unsubscribeAndDisposeLocalFirstStorageThunk } from './storage/unsubscribeAndDisposeLocalFirstStorageThunk';
-export { DEFAULT_LOCAL_FIRST_STORAGE_RELAY_URL } from './storage/LocalFirstStorageProvider';
+export { DEFAULT_SUITE_SYNC_RELAY_URL as DEFAULT_LOCAL_FIRST_STORAGE_RELAY_URL } from './storage/LocalFirstStorageProvider';
 
 // Labeling
 export { updateWalletLabelThunk } from './labeling/updateWalletLabelThunk';

--- a/suite-common/local-first-storage/src/storage/LocalFirstStorageProvider.ts
+++ b/suite-common/local-first-storage/src/storage/LocalFirstStorageProvider.ts
@@ -9,6 +9,7 @@ import {
 } from '@evolu/common';
 
 import { EvoluKeys } from '@suite-common/suite-types';
+import { isDevEnv } from '@suite-common/suite-utils';
 
 import { createAppOwnerFromTrezorNode } from '../evoluUtils';
 import { Schema } from '../schema';
@@ -71,8 +72,10 @@ const createEvoluInstance = ({ relayUrl, evoluKeys, evoluDeps }: CreateEvoluInst
 
 type SuiteOwnerId = string;
 
-// The `https://evolu.suite.sldev.cz/evolu/` MUST have the last `/` in the URL.
-export const DEFAULT_LOCAL_FIRST_STORAGE_RELAY_URL = 'https://evolu.suite.sldev.cz/evolu/';
+// The `https://suite-sync.trezor.io/` MUST have the last `/` in the URL.
+export const DEFAULT_SUITE_SYNC_RELAY_URL = isDevEnv
+    ? 'https://evolu.suite.sldev.cz/evolu/'
+    : 'https://suite-sync.trezor.io/';
 
 export class LocalFirstStorageProvider {
     private storages = new Map<SuiteOwnerId, LocalFirstStorage>();
@@ -88,7 +91,7 @@ export class LocalFirstStorageProvider {
         if (storage === undefined) {
             const relayUrl =
                 this.relayUrl === null || this.relayUrl.trim() === ''
-                    ? DEFAULT_LOCAL_FIRST_STORAGE_RELAY_URL
+                    ? DEFAULT_SUITE_SYNC_RELAY_URL
                     : this.relayUrl;
 
             const evolu = createEvoluInstance({

--- a/suite-common/local-first-storage/tsconfig.json
+++ b/suite-common/local-first-storage/tsconfig.json
@@ -8,6 +8,7 @@
         { "path": "../metadata-types" },
         { "path": "../redux-utils" },
         { "path": "../suite-types" },
+        { "path": "../suite-utils" },
         { "path": "../test-utils" },
         { "path": "../wallet-config" },
         { "path": "../wallet-core" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10658,6 +10658,7 @@ __metadata:
     "@suite-common/metadata-types": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
+    "@suite-common/suite-utils": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"


### PR DESCRIPTION
**changes**: 
- changed the default suite sync relay URL

**note:** other variables will be renamed from `local first storage` to `suite sync` after freeze.

## Notes for QA

nothing to test much here:
- suite sync works with prod relay

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23042


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/evolu/default-url-update&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/evolu/default-url-update&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/evolu/default-url-update&lookback=7)