### PR TITLE
Feat/evolu/analytics

### DIFF
--- a/packages/suite/src/hooks/suite/useLabelingCombined.ts
+++ b/packages/suite/src/hooks/suite/useLabelingCombined.ts
@@ -7,6 +7,7 @@ import {
 } from '@suite-common/local-first-storage';
 import { selectDeviceByStaticSessionId } from '@suite-common/wallet-core';
 import type { StaticSessionId } from '@trezor/connect';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { initSuiteLocalFirstStorageThunk } from '@trezor/suite-local-first-storage';
 
 import * as metadataActions from 'src/actions/suite/metadataActions';
@@ -64,6 +65,13 @@ export const useLabelingCombined = ({ deviceStaticSessionId }: UseLabelingCombin
         if (!isLocalFirstStorageEnabled) {
             dispatch(labelingActions.updateLocalFirstStorageEnabled({ isEnabled: true }));
             dispatch(initSuiteLocalFirstStorageThunk());
+
+            analytics.report({
+                type: EventType.SettingsGeneralLabelingProvider,
+                payload: {
+                    provider: 'evolu',
+                },
+            });
         }
     };
 

--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -25,6 +25,18 @@ import { AppState } from 'src/types/suite';
 
 import { getIsTorEnabled } from './tor';
 
+const resolveLabelingType = (state: AppState): 'legacy' | 'evolu' | string => {
+    if (state.metadata.enabled) {
+        return (
+            state.metadata.providers.find(
+                p => p.clientId === state.metadata.selectedProvider.labels,
+            )?.type || 'legacy'
+        );
+    }
+
+    return state.labeling.isLocalFirstStorageEnabled ? 'evolu' : '';
+};
+
 // redact transaction id from account transaction anchor
 export const redactTransactionIdFromAnchor = (anchor?: string) => {
     if (!anchor) {
@@ -56,12 +68,7 @@ export const getSuiteReadyPayload = async (
         screenHeight: getScreenHeight(),
         platformLanguages: getPlatformLanguages().join(','),
         tor: getIsTorEnabled(state.suite.torStatus),
-        // todo: duplicated with suite/src/utils/suite/logUtils
-        labeling: state.metadata.enabled
-            ? state.metadata.providers.find(
-                  p => p.clientId === state.metadata.selectedProvider.labels,
-              )?.type || 'missing-provider'
-            : '',
+        labeling: resolveLabelingType(state),
         rememberedStandardWallets: selectRememberedStandardWalletsCount(state),
         rememberedHiddenWallets: selectRememberedHiddenWalletsCount(state),
         theme: state.suite.settings.theme.variant,

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -84,7 +84,7 @@ export const Labeling = () => {
         analytics.report({
             type: EventType.SettingsGeneralLabeling,
             payload: {
-                value,
+                value: value === 'secure-sync' ? 'evolu' : value,
             },
         });
     };

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -706,6 +706,8 @@ export type SuiteAnalyticsEvent =
                   | 'missing-provider'
                   | 'inMemoryTest'
                   | 'closed'
+                  | 'evolu'
+                  | 'legacy'
                   | ''; // Todo: 'sdCard' not implemented yet
           };
       }


### PR DESCRIPTION
Added some missing analytics into suite.

**Changes**:
- extended labeling SuiteReady analytics event with `evolu` and `legacy` values
- extended SettingsGeneralLabelingProvider with `evolu` and `legacy` values
 
**Summary**:
- currently the SuiteReady sends labeling payload with `evolu` and `legacy` or labeling provider, eg. `dropbox`, etc. - same for SettingsGeneralLabelingProvider
- but there is also event called `settings/general/labeling` that sends `off` | `evolu` | `legacy`


<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22542

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/evolu/ANALytics&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/evolu/ANALytics&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/evolu/ANALytics&lookback=7)