### PR TITLE
fix(suite-common): update download crypto icons script

### DIFF
--- a/suite-common/icons/scripts/constants/index.ts
+++ b/suite-common/icons/scripts/constants/index.ts
@@ -11,5 +11,5 @@ export const UPDATED_ICONS_LIST_URL = join(ICONS_URL_BASE, 'icons.json');
 export const COIN_LIST_URL = 'https://pro-api.coingecko.com/api/v3/coins/list';
 export const COIN_DATA_URL = 'https://pro-api.coingecko.com/api/v3/coins/';
 
-export const RATE_LIMIT_PER_MINUTE = 200;
-export const RUN_LIMIT_SECONDS = 2 * 60 * 60; // 2 hour
+export const RATE_LIMIT_PER_MINUTE = 240;
+export const RUN_LIMIT_SECONDS = 4 * 60 * 60; // 4 hour

--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -140,6 +140,10 @@ async function ensureDirectoryExists(path: string) {
         (a, b) => (updatedIcons[a.id]?.updatedAt ?? 0) - (updatedIcons[b.id]?.updatedAt ?? 0),
     );
 
+    const newIconsCount = coins.length - Object.keys(updatedIcons).length;
+
+    console.log(`Total coins: ${coins.length}, new icons: ${newIconsCount}`);
+
     await ensureDirectoryExists(FILES_CRYPTOICONS_PATH);
 
     for (const coin of coins) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Logs from prev. runs:
- 3544 coins processed (90 rate, 1h max)
- 9821 coins processed (200 rate, 2h max)

## Description

- Add more logs
- Increase limits (to 240 req. / min). The avail. limit is 500 req. / min for all Coingecko requests.

## Related Issue

Resolve #22913



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/22913-download-crypto-icons-3&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/22913-download-crypto-icons-3&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/22913-download-crypto-icons-3&lookback=7)