### PR TITLE
refactor(suite-desktop): handling of auto-updater errors

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -53,7 +53,7 @@ export interface RendererChannels {
     'update/checking': void;
     'update/available': UpdateInfo;
     'update/not-available': UpdateInfo;
-    'update/error': Error;
+    'update/error': void;
     'update/downloading': UpdateProgress;
     'update/downloaded': UpdateInfo;
     'update/allow-prerelease': boolean;

--- a/packages/suite-desktop-core/src/libs/update-checker.ts
+++ b/packages/suite-desktop-core/src/libs/update-checker.ts
@@ -11,30 +11,26 @@ if (signingKey === undefined) {
     throw new Error('APP_PUBKEY is undefined.');
 }
 
-type GetSignatureFileProps = { feedURL: string; filename: string };
+type GetSignatureFileProps = { feedURL: string; downloadedFile: string };
 
-const getSignatureFile = async ({ filename, feedURL }: GetSignatureFileProps) => {
-    /**
-     * Signature files are available next to installation files.
-     */
-    const signatureFileURL = `${removeTrailingSlashes(feedURL)}/${filename}.asc`;
+/**
+ * Get signature files, which are available next to installation files.
+ */
+export const getSignatureFile = async ({ downloadedFile, feedURL }: GetSignatureFileProps) => {
+    try {
+        const filename = path.basename(downloadedFile);
+        const signatureFileURL = `${removeTrailingSlashes(feedURL)}/${filename}.asc`;
+        const signatureFile = await fetch(signatureFileURL);
 
-    const signatureFile = await fetch(signatureFileURL);
-
-    return signatureFile.text();
+        return signatureFile.text();
+    } catch {
+        return null;
+    }
 };
 
-type VerifySignatureProps = { feedURL: string; downloadedFile: string };
+type VerifySignatureProps = { downloadedFile: string; signatureFile: string };
 
-export const verifySignature = async ({ downloadedFile, feedURL }: VerifySignatureProps) => {
-    // Find the right signature for the downloaded file
-    const filename = path.basename(downloadedFile);
-
-    const signatureFile = await getSignatureFile({
-        filename,
-        feedURL,
-    });
-
+export const verifySignature = async ({ downloadedFile, signatureFile }: VerifySignatureProps) => {
     // Read downloaded file and create message to verify
     const file = await fs.promises.readFile(downloadedFile);
     const message = await createMessage({ binary: file });

--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -1,3 +1,4 @@
+import { captureMessage } from '@sentry/electron/main';
 import {
     CancellationToken,
     ProgressInfo,
@@ -9,10 +10,10 @@ import { unlinkSync } from 'fs';
 
 import { isDevEnv, isFeatureFlagEnabled } from '@suite-common/suite-utils';
 import { HandshakeElectron } from '@trezor/suite-desktop-api';
-import { bytesToHumanReadable } from '@trezor/utils';
+import { bytesToHumanReadable, serializeError } from '@trezor/utils';
 
 import { getSwitchValue, hasSwitch } from '../libs/process-switches';
-import { verifySignature } from '../libs/update-checker';
+import { getSignatureFile, verifySignature } from '../libs/update-checker';
 import { b2t } from '../libs/utils';
 import { app, ipcMain } from '../typed-electron';
 import { ModuleInit, mainThreadEmitter } from './module';
@@ -161,8 +162,9 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
     });
 
     autoUpdater.on('error', (err: Error) => {
+        captureMessage(serializeError(err));
         logger.error(SERVICE_NAME, `An error happened: ${err.toString()}`);
-        mainWindowProxy.getInstance()?.webContents.send('update/error', err);
+        mainWindowProxy.getInstance()?.webContents.send('update/error');
     });
 
     autoUpdater.on('download-progress', (progressObj: ProgressInfo) => {
@@ -188,11 +190,27 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
 
         mainWindowProxy.getInstance()?.webContents.send('update/downloading', { verifying: true });
 
+        const abortUpdate = () => {
+            autoUpdater.autoInstallOnAppQuit = false;
+            unlinkSync(downloadedFile);
+            logger.info(SERVICE_NAME, `Unlink downloaded file ${downloadedFile}`);
+            mainWindowProxy.getInstance()?.webContents.send('update/error');
+        };
+
         try {
+            // Find the right signature for the downloaded file
+            const signatureFile = await getSignatureFile({ downloadedFile, feedURL });
+            // If fetching of signature file has failed, abort the update, but do not log it as an error
+            if (signatureFile === null) {
+                abortUpdate();
+
+                return;
+            }
+
             // check downloaded file
             await verifySignature({
                 downloadedFile,
-                feedURL,
+                signatureFile,
             });
 
             logger.info(SERVICE_NAME, 'Signature of update file is valid');
@@ -203,12 +221,9 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
                 downloadedFile,
             });
         } catch (err) {
-            autoUpdater.autoInstallOnAppQuit = false;
-            unlinkSync(downloadedFile);
-            mainWindowProxy.getInstance()?.webContents.send('update/error', err);
-
+            captureMessage(serializeError(err));
+            abortUpdate();
             logger.error(SERVICE_NAME, `Signature check of update file failed: ${err.message}`);
-            logger.info(SERVICE_NAME, `Unlink downloaded file ${downloadedFile}`);
         }
 
         logger.info(

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater.tsx
@@ -51,7 +51,7 @@ export const DesktopUpdater = ({ children }: DesktopUpdaterProps) => {
         desktopApi.on('update/not-available', params => dispatch(notAvailable(params)));
         desktopApi.on('update/downloaded', params => dispatch(ready(params)));
         desktopApi.on('update/downloading', params => dispatch(downloading(params)));
-        desktopApi.on('update/error', params => dispatch(error(params)));
+        desktopApi.on('update/error', () => dispatch(error()));
 
         // Initial check for updates
         desktopApi.checkForUpdates({ isManual: false });

--- a/packages/suite/src/actions/suite/desktopUpdateActions.ts
+++ b/packages/suite/src/actions/suite/desktopUpdateActions.ts
@@ -126,10 +126,7 @@ export const installUpdate =
         }
     };
 
-export const error = (err: Error) => (dispatch: Dispatch, getState: GetState) => {
-    // TODO: Properly display error
-    console.error('auto-updater', err);
-
+export const error = () => (dispatch: Dispatch, getState: GetState) => {
     const { state, latest, allowPrerelease } = getState().desktopUpdate;
 
     // Ignore displaying errors while checking


### PR DESCRIPTION
## Description

Refactor a try-catch in Desktop auto-updater to only catch errors from signature verification as it should, and does not mix in errors from HTTP fetch for the signature file.

:information_source:  Note that I'm talking about fetching only the small file with signature, _after_ the big installation file is successfully downloaded.

## Notes for QA

Desktop update on all platforms

## Related Issue

Resolve [Sentry issue](https://satoshilabs.sentry.io/issues/4744718734/?environment=production&project=5193825&query=is:unresolved&referrer=issue-stream) 

## Screenshots:

Signature file fetch error: under the hood it does **not** log to Sentry, and does **not** delete the installation file, so you can try again without having to redownload the installation file (note that in this video I start already with the cache, so the download resolves instantly)
`stat ~/.cache/@trezorsuite-desktop-dev-updater/pending/Trezor-Suite-25.10.2-linux-x86_64.AppImage` :heavy_check_mark: 

https://github.com/user-attachments/assets/eac0da11-2093-4f76-af5c-9062b3890a2f

Verification error: under the hood [logs to Sentry](https://satoshilabs.sentry.io/issues/7015966376), and deletes the file (stat not there), because the file is considered damaged or compromised

https://github.com/user-attachments/assets/91c726ea-5f99-47c2-8770-7c2ab6b3d036



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/unhandled-desktop-update-errors&lookback=7)