### PR TITLE
ci: add script build:essential to save time

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Welcome to the Trezor Suite repository! This repository contains the source code
 - `git lfs pull`
 - `nvm install`
 - `yarn`
-- `yarn build:libs`
+- `yarn build:essential`
 
 It's recommended to enable `git config --global submodule.recurse true` so you don't need to run `git submodule update --init --recursive` every time when submodules are updated.
 

--- a/docs/misc/development-on-windows.md
+++ b/docs/misc/development-on-windows.md
@@ -9,13 +9,14 @@ Running the dev environment natively on Windows is not most straightforward, but
 
 ### Prerequisites
 
-- Install Python either via the [Python for Windows installer](https://www.python.org/downloads/windows/), or from Microsoft Store
+- Install Python preferably via the [Python for Windows installer](https://www.python.org/downloads/windows/), maybe Microsoft Store could work too
 - Install [latest Visual Studio Community](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community) with C++ build tools
     - **Make sure** to install the "Desktop development with C++" workload
     - _FYI: it's necessary so that yarn packages with native code can be built, `node-gyp` depends on it: [details](https://github.com/nodejs/node-gyp?tab=readme-ov-file#on-windows)_
 - Install [git](https://git-scm.com/downloads/win) using the installer and make sure to include git bash for Windows
 - Install nodeJS version as per [.nvmrc](https://github.com/trezor/trezor-suite/blob/develop/.nvmrc)
-    - You may use nvm, but it's not officially supported on Windows; manual nodeJS installation will work
+    - nvm is not supported on Windows, forks exists but manual nodeJS installation from `.msi` will work.
+        - Do **not** check build tools with Chocolatey (already installed with Visual Studio)
 - Enable [Yarn](https://yarnpkg.com/getting-started/install) through npm
 - Install [Git LFS](https://git-lfs.com/)
 - It is **imperative** that all further commands are run in bash for Windows, **not** in cmd or powershell!

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "postinstall": "yarn run patch-package && husky",
         "_______ Library Scripts #####": "Some libraries have their own build scripts.",
         "build:libs": "yarn nx run-many --skip-nx-cache --target=build:lib",
+        "build:essential": "yarn message-system-sign-config & yarn workspace @trezor/suite-data build:lib & yarn workspace @trezor/transport-bridge build:lib & wait",
         "suite:build:web": "yarn workspace @trezor/suite-web build",
         "_______ Start Scripts _______": "Here are standalone scripts for running individual applications for development.",
         "suite:dev": "yarn workspace @trezor/suite-web dev",


### PR DESCRIPTION
## Description

Add `yarn build:essential` as minimal setup for Suite development, because `yarn build:libs` is unnecessary.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/build-essential&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/build-essential&lookback=7)