### PR TITLE
test(suite-native): language settings e2e

### DIFF
--- a/suite-native/app/e2e/pageObjects/settingsActions.ts
+++ b/suite-native/app/e2e/pageObjects/settingsActions.ts
@@ -1,3 +1,4 @@
+import { LocaleTag } from '@suite-native/intl';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { PROTO } from '@trezor/connect';
 
@@ -34,6 +35,22 @@ class SettingsActions {
         );
         await waitForVisible(discreetModeToggleElement);
         await discreetModeToggleElement.tap();
+    }
+
+    async changeLanguage(localeTag: LocaleTag) {
+        const languageSelectorTriggerElement = element(
+            by.id('@settings/localization/language-selector'),
+        );
+        await waitForVisible(languageSelectorTriggerElement);
+        await languageSelectorTriggerElement.tap();
+
+        await wait(1000); // wait for the language selector to open
+
+        const languageSelectorItemElement = element(by.id(`@select/item/${localeTag}`));
+        await scrollUntilVisible(languageSelectorItemElement, '@bottom-sheet/scroll-view');
+
+        await languageSelectorItemElement.tap();
+        await wait(1000); // wait for the language selector to close
     }
 
     async changeLocalizationCurrency(currencyCode: BaseCurrencyCode) {

--- a/suite-native/app/e2e/pageObjects/tabBarActions.ts
+++ b/suite-native/app/e2e/pageObjects/tabBarActions.ts
@@ -39,6 +39,10 @@ class TabBarActions {
 
         await detoxExpect(element(by.id('@screen/Trading'))).toBeVisible();
     }
+
+    async assertHomeTabBarItemTitle(title: string) {
+        await detoxExpect(element(by.id('@tabBar/HomeStack/title'))).toHaveText(title);
+    }
 }
 
 export const onTabBar = new TabBarActions();

--- a/suite-native/app/e2e/tests/appSettings.test.ts
+++ b/suite-native/app/e2e/tests/appSettings.test.ts
@@ -1,5 +1,7 @@
 import { expect as detoxExpect } from 'detox';
 
+import CS_TRANSLATIONS from '@suite-native/intl/translations/cs-CZ.json';
+import EN_TRANSLATIONS from '@suite-native/intl/translations/en-US.json';
 import { PROTO } from '@trezor/connect';
 
 import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
@@ -41,6 +43,17 @@ describe('App Settings - without device interactions [@noDevice]', () => {
         await onTabBar.navigateToHome();
 
         await detoxExpect(element(by.text('0 sat'))).toBeVisible();
+    });
+
+    it('Localization - Language', async () => {
+        await onTabBar.assertHomeTabBarItemTitle(EN_TRANSLATIONS['navigation.tabs.home']);
+        await onTabBar.navigateToSettings();
+        await onSettings.tapPreferences();
+        await onSettings.changeLanguage('cs-CZ');
+        await onTabBar.tapBackButton();
+        await onTabBar.navigateToHome();
+
+        await onTabBar.assertHomeTabBarItemTitle(CS_TRANSLATIONS['navigation.tabs.home']);
     });
 
     it('Privacy & Security - Discreet Mode', async () => {

--- a/suite-native/navigation/src/components/TabBarItem.tsx
+++ b/suite-native/navigation/src/components/TabBarItem.tsx
@@ -67,6 +67,7 @@ export const TabBarItem = ({
                         variant="label"
                         textAlign="center"
                         color={isFocused ? 'textPrimaryDefault' : 'textDisabled'}
+                        testID={`@tabBar/${testID}/title`}
                     >
                         {title}
                     </Text>


### PR DESCRIPTION
## Description
Adds E2E test for switching a langugage between english and czech.

## Related Issue

Resolve #21341 


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native/language-settings-e2e&lookback=7)