### PR TITLE
fix(suite-native): ios e2e trading location ignored

### DIFF
--- a/suite-native/app/e2e/support/setup.ts
+++ b/suite-native/app/e2e/support/setup.ts
@@ -28,6 +28,7 @@ const INITIAL_LAUNCH_ARGS: LaunchArguments = {
     isDebugKeysAllowed: true,
     isTradingBuyEnabled: true,
     areDebugOnlyNetworksEnabled: true,
+    isTradingResidenceCheckEnabled: false,
 };
 
 const TREZOR_E2E_DEVICE_LABEL = 'Trezor T - Tester';


### PR DESCRIPTION
## Description
- fixed iOS e2e tests by disabling the trading location onboarding screen


## Screenshot
This screen was preventing iOS tests from running
<img width="200" height="942" alt="Screenshot 2025-11-11 at 10 53 54 AM" src="https://github.com/user-attachments/assets/606b6a25-fbad-4f89-a588-6e9a9be0a0e0" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/ios-e2e-trading-location-ignored&lookback=7)