### PR TITLE
fix(suite-native): prevent errors if oldState is undefined

### DIFF
--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -101,10 +101,14 @@ export const prepareRootReducers = async () => {
         key: 'trading',
         version: 2,
         migrations: {
-            2: (oldState: any /* FIXME */) => ({
-                ...oldState,
-                residence: tradingInitialState.residence,
-            }),
+            2: (oldState: any /* FIXME */) => {
+                if (!oldState) return oldState;
+
+                return {
+                    ...oldState,
+                    residence: tradingInitialState.residence,
+                };
+            },
         },
     });
 
@@ -304,6 +308,8 @@ export const prepareRootReducers = async () => {
         version: 3,
         migrations: {
             2: (oldState: any /* FIXME */) => {
+                if (!oldState?.wallet) return oldState;
+
                 const oldStateWallet = oldState.wallet;
                 const migratedAccounts = migrateAccountBnbToBsc(oldStateWallet.accounts);
 
@@ -326,6 +332,8 @@ export const prepareRootReducers = async () => {
                 return migratedState;
             },
             3: (oldState: any /* FIXME */) => {
+                if (!oldState?.wallet) return oldState;
+
                 const oldStateWallet = oldState.wallet;
                 const migratedAccounts = migrateAccountsDeprecateNetworks(oldStateWallet.accounts);
                 const migratedTransactions = migrateTransactionsDeprecateNetworks(

--- a/suite-native/storage/src/transforms/bluetoothTransforms.ts
+++ b/suite-native/storage/src/transforms/bluetoothTransforms.ts
@@ -3,11 +3,15 @@ import { createTransform } from 'redux-persist';
 import { BluetoothDevice } from '@trezor/transport-native-bluetooth';
 
 export const bluetoothPersistTransform = createTransform<BluetoothDevice[], BluetoothDevice[]>(
-    inboundState =>
-        inboundState.map(device => ({
+    inboundState => {
+        if (!inboundState) return inboundState;
+
+        return inboundState.map(device => ({
             ...device,
             connectionStatus: { type: 'disconnected' },
-        })),
+        }));
+    },
+
     undefined,
     { whitelist: ['knownDevices'] },
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Just to be sure. With old createMigrate migration were not running with undefined oldState but now it can run (with only _persist key prefilled).

## Related Issue

Followup for https://github.com/trezor/trezor-suite/pull/22912




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/handle-undefined-old-states-in-migrations&lookback=7)