### PR TITLE
fix(suite-desktop): partially revert #22911 to fix Windows

### DIFF
--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -22,12 +22,6 @@ const config: webpack.Configuration = {
     target: 'browserslist:Chrome >= 138',
     entry: [path.join(baseDirUI, 'src', 'index.tsx')],
     output: {
-        // This builds JS directly `dist/` (instead `dist/js/`)
-        // without this, Evolu worker import won't (for unknow reason) work
-        // Todo: Issue is probably in combination of @evolu/sqlite-wasm which wraps `mjs` files and our webpack config
-        filename: '[name].[contenthash:8].js',
-        chunkFilename: '[id].[contenthash:8].js',
-        // ---
         path: path.join(baseDir, 'build'),
         publicPath: './',
     },

--- a/packages/suite-build/configs/dev.webpack.config.ts
+++ b/packages/suite-build/configs/dev.webpack.config.ts
@@ -18,12 +18,8 @@ const config: webpack.Configuration = {
     devtool: 'eval-source-map',
     entry: ['webpack-plugin-serve/client'],
     output: {
-        // This builds JS directly `dist/` (instead `dist/js/`)
-        // without this, Evolu worker import won't (for unknow reason) work
-        // Todo: Issue is probably in combination of @evolu/sqlite-wasm which wraps `mjs` files and our webpack config
-        filename: '[name].js',
-        chunkFilename: '[id].js',
-        // ---
+        filename: 'js/[name].js',
+        chunkFilename: 'js/[id].js',
     },
     watchOptions: {
         // reduce number of file watchers; for HMR it is not necessary to watch both source code & node_modules


### PR DESCRIPTION
## Description

Partially revert the webpack config from #22911 to fix Windows build in time for freeze.

## Screenshots:

<img width="1138" height="475" alt="Screenshot from 2025-11-11 12-36-11" src="https://github.com/user-attachments/assets/8ae21f88-85cf-4e26-b00b-528ffa3e0e4d" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/partially-revert-22911&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/partially-revert-22911&lookback=7)