### PR TITLE
fix(suite-native): condition for accounts rediscovery

### DIFF
--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -152,7 +152,7 @@ export const selectShouldAccountsBeRediscovered = (
             const lastAccount = accounts.reduce((last, current) =>
                 current.index > last.index ? current : last,
             );
-            if (lastAccount.failed || lastAccount.empty) return true;
+            if (lastAccount.failed || !lastAccount.empty) return true;
 
             return false;
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- the condition was incorrect. We need to show rediscovery when last account is either non-empty or failed.

Fix for https://github.com/trezor/trezor-suite/issues/20547

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/rediscovery-warning-condition&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/rediscovery-warning-condition&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/rediscovery-warning-condition&lookback=7)