### PR TITLE
fix(suite-desktop-core): allow data img-src for CSP

### DIFF
--- a/packages/suite-desktop-core/src/modules/csp.ts
+++ b/packages/suite-desktop-core/src/modules/csp.ts
@@ -20,7 +20,7 @@ const createCspRules = ({ nonce }: CreateCspRulesParams) => [
     // Allow all API calls (Can't be restricted bc of custom backends)
     'connect-src *',
     // Allow images from trezor.io
-    "img-src 'self' blob: *.trezor.io",
+    "img-src 'self' blob: data: *.trezor.io",
 ];
 
 export const init: ModuleInit = ({ cspNonce }) => {


### PR DESCRIPTION
## Description

Seems like #22671 broke app icons in Connect popup where we use `data:` urls

## Notes for QA

See if icons in Connect popup work

## Screenshots:

Before (broken)

<img width="732" height="296" alt="Screenshot 2025-11-11 at 12 50 37" src="https://github.com/user-attachments/assets/2db4a9bd-a261-459a-89bb-d61614e8f1f0" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/data-url-images&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/data-url-images&lookback=7)