### PR TITLE
Refactor e2e-native remove try-catch from tests

### DIFF
--- a/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
@@ -113,15 +113,9 @@ class DeviceOnboardingActions {
     }
 
     async skipFirmwareUpdate() {
-        const testId = '@firmware/skip-button';
-        try {
-            await waitForVisible(by.id(testId));
-            await element(by.id(testId)).tap();
-        } catch {
-            console.warn(
-                'SKIPPING FIRMWARE UPDATE: Firmware update was not displayed, it is already latest version.',
-            );
-        }
+        const skipFirmwareUpdateButton = element(by.id('@firmware/skip-button'));
+        await waitForVisible(skipFirmwareUpdateButton);
+        await skipFirmwareUpdateButton.tap();
     }
 
     async enterTHPPairingCode() {

--- a/suite-native/app/e2e/pageObjects/passphraseModule.ts
+++ b/suite-native/app/e2e/pageObjects/passphraseModule.ts
@@ -78,7 +78,10 @@ class PassphraseModule {
         await detoxExpect(element(by.id(subheaderTestID))).toHaveText(expectedText);
     }
 
-    public async openPassphraseWallet(passphrase: string) {
+    public async openPassphraseWallet(
+        passphrase: string,
+        options?: { dismissDuplicatePassphraseAlert: boolean },
+    ) {
         await this.openNewPassphraseFlow();
 
         await this.expectEnterPassphraseScreen();
@@ -87,13 +90,9 @@ class PassphraseModule {
         await this.expectConfirmPassphraseOnDeviceRequest();
         await this.confirmPassphraseOnEmu();
 
-        try {
-            // If trying to open an already open passphrase wallet, just confirm the alert.
+        if (options?.dismissDuplicatePassphraseAlert) {
             await waitForVisible(by.text('Passphrase duplicate'));
             await element(by.id('@alert-sheet/primary-button')).tap();
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        } catch (error) {
-            // Newly opened wallet, do nothing.
         }
     }
 }

--- a/suite-native/app/e2e/pageObjects/send/sendOutputsReviewActions.ts
+++ b/suite-native/app/e2e/pageObjects/send/sendOutputsReviewActions.ts
@@ -10,17 +10,8 @@ class SendOutputsReviewActions {
     }
 
     async confirmTransactionOutputs() {
-        let isTransactionReviewInProgress = true;
-        do {
-            await TrezorUserEnvLink.pressYes();
-
-            try {
-                await waitForVisible(sendButton);
-                isTransactionReviewInProgress = false;
-            } catch {
-                // continue loop, there are more outputs to review
-            }
-        } while (isTransactionReviewInProgress);
+        await TrezorUserEnvLink.pressYes();
+        await waitForVisible(sendButton);
     }
 
     async clickSendTransaction() {

--- a/suite-native/app/e2e/support/utils.ts
+++ b/suite-native/app/e2e/support/utils.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 const isIndexableNativeElement = (
     v: Detox.IndexableNativeElement | Detox.NativeMatcher,
 ): v is Detox.IndexableNativeElement => {
@@ -16,6 +18,28 @@ export const wait = async (ms: number) => {
     await new Promise(resolve => setTimeout(resolve, ms));
 };
 
+function pruneToAppStack(invocationStack: string): string {
+    const thisFile = path.normalize(__filename);
+    const lines = invocationStack.split('\n');
+    const kept: string[] = [];
+
+    for (const l of lines) {
+        const m = l.match(/\s+at (?:.+ \()?(.*?):\d+:\d+\)?/);
+        if (!m) continue;
+        const file = path.normalize(m[1]);
+        if (
+            file.includes('node:') ||
+            file.includes(`${path.sep}node_modules${path.sep}`) ||
+            file === thisFile
+        ) {
+            continue;
+        }
+        kept.push(l);
+    }
+
+    return kept.length ? ['Error'].concat(kept).join('\n') : invocationStack;
+}
+
 export const waitForVisible = async (
     elementOrMatcher: Detox.IndexableNativeElement | Detox.NativeMatcher,
     { timeout = 30_000 }: { timeout?: number } = {},
@@ -23,7 +47,15 @@ export const waitForVisible = async (
     const target = isIndexableNativeElement(elementOrMatcher)
         ? elementOrMatcher
         : element(elementOrMatcher);
-    await waitFor(target).toBeVisible().withTimeout(timeout);
+    const invocationStack = new Error().stack || '';
+    try {
+        await waitFor(target).toBeVisible().withTimeout(timeout);
+    } catch (error) {
+        const details = `waitForVisible(): target not visible after ${timeout}ms`;
+        const appStackError = new Error(details, { cause: error as Error });
+        appStackError.stack = `${appStackError.name}: ${appStackError.message}\n${pruneToAppStack(invocationStack)}`;
+        throw appStackError;
+    }
 };
 
 export const appIsFullyLoaded = async () => {

--- a/suite-native/app/e2e/tests/deviceOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/deviceOnboarding.test.ts
@@ -15,10 +15,12 @@ import {
 } from '../support/setup';
 import { wait } from '../support/utils';
 
-const proceedToCreateOrRecoverCrossroads = async () => {
+const proceedToCreateOrRecoverCrossroads = async (options?: { skipFirmwareUpdate?: boolean }) => {
     await onDeviceOnboarding.waitForUninitializedDeviceLanding();
     await onDeviceOnboarding.dismissTheUninitializedDeviceLanding();
-    await onDeviceOnboarding.skipFirmwareUpdate();
+    if (options?.skipFirmwareUpdate) {
+        await onDeviceOnboarding.skipFirmwareUpdate();
+    }
 
     await TrezorUserEnvLink.pressYes();
 

--- a/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
@@ -12,6 +12,7 @@ import { onTabBar } from '../pageObjects/tabBarActions';
 import { tradingExchangeActions } from '../pageObjects/trading/tradingExchangeActions';
 // import { tradingFeeActions } from '../pageObjects/trading/tradingFeeActions';
 import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
+import { waitForVisible } from '../support/utils';
 
 const preloadedStateWithoutTrezor = preparePreloadedReduxState(
     portfolioTrackerBtcAccountState,
@@ -54,6 +55,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Trade Exchange', () => 
                 seed: MNEMONICS.mnemonic_academic,
                 passphrase_protection: true,
             });
+            await waitForVisible(by.id('@home/portfolio/receive-button'));
             await onPassphrase.openPassphraseWallet(passphrase);
             await tradingExchangeActions.openSwapForm();
         });

--- a/suite-native/atoms/src/Button/Button.tsx
+++ b/suite-native/atoms/src/Button/Button.tsx
@@ -367,7 +367,10 @@ export const Button = ({
             ]}
         >
             {isLoading ? (
-                <Animated.View entering={FadeIn.duration(LOADER_FADE_IN_DURATION)}>
+                <Animated.View
+                    testID={`${pressableProps.testID}/loading`}
+                    entering={FadeIn.duration(LOADER_FADE_IN_DURATION)}
+                >
                     <Loader color={textColor} />
                 </Animated.View>
             ) : (
@@ -380,6 +383,7 @@ export const Button = ({
                         />
                     )}
                     <Text
+                        testID={`${pressableProps.testID}/text`}
                         textAlign="center"
                         variant={buttonToTextSizeMap[size]}
                         color={textColor}

--- a/suite-native/atoms/src/SelectableItem.tsx
+++ b/suite-native/atoms/src/SelectableItem.tsx
@@ -53,6 +53,7 @@ type SelectableItemProps = {
     content?: ReactNode;
     isSelected: boolean;
     isDefault: boolean;
+    testID?: string;
     onSelected: () => void;
 };
 

--- a/suite-native/atoms/src/types.ts
+++ b/suite-native/atoms/src/types.ts
@@ -3,7 +3,8 @@ export type TestProps = {
     ['data-test']?: never;
     ['data-testid']?: never;
     ['data-testId']?: never;
-    ['data-testID']?: string;
+    ['data-testID']?: never;
+    ['testID']?: string;
 };
 
 export type SurfaceElevation = '0' | '1';

--- a/suite-native/module-accounts-import/src/components/DevXpub.tsx
+++ b/suite-native/module-accounts-import/src/components/DevXpub.tsx
@@ -86,7 +86,7 @@ export const DevXpub = ({ symbol, onSelect }: DevXpubProps) => {
                     return (
                         <Button
                             key={address}
-                            data-testID={`@accounts-import/sync-coins/dev-xpub/${symbol}${testIdSuffix}`}
+                            testID={`@accounts-import/sync-coins/dev-xpub/${symbol}${testIdSuffix}`}
                             onPress={() => onSelect({ xpubAddress: address })}
                             colorScheme="tertiaryElevation0"
                         >
@@ -100,7 +100,7 @@ export const DevXpub = ({ symbol, onSelect }: DevXpubProps) => {
 
     return (
         <Button
-            data-testID={`@accounts-import/sync-coins/dev-xpub/${symbol}`}
+            testID={`@accounts-import/sync-coins/dev-xpub/${symbol}`}
             onPress={() => onSelect({ xpubAddress: xpub })}
             colorScheme="tertiaryElevation0"
         >

--- a/suite-native/module-accounts-import/src/components/XpubHint.tsx
+++ b/suite-native/module-accounts-import/src/components/XpubHint.tsx
@@ -38,7 +38,7 @@ export const XpubHint = ({ networkType, handleOpen }: XpubScanHintSheet) => {
             <TextButton
                 viewLeft="question"
                 onPress={handleOpen}
-                data-testID="@accounts-import/sync-coins/xpub-help-link"
+                testID="@accounts-import/sync-coins/xpub-help-link"
             >
                 {buttonTitle}
             </TextButton>

--- a/suite-native/module-accounts-import/src/components/XpubHintBottomSheet.tsx
+++ b/suite-native/module-accounts-import/src/components/XpubHintBottomSheet.tsx
@@ -58,7 +58,7 @@ export const XpubHintBottomSheet = ({
                 </VStack>
                 <Box marginTop="sp32">
                     <Button
-                        data-testID="@accounts-import/xpub-help-modal/confirm-btn"
+                        testID="@accounts-import/xpub-help-modal/confirm-btn"
                         onPress={handleClose}
                     >
                         <Translation id="generic.buttons.gotIt" />

--- a/suite-native/module-add-accounts/src/screens/SelectAccountTypeScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/SelectAccountTypeScreen.tsx
@@ -144,7 +144,7 @@ export const SelectAccountTypeScreen = ({
                                 content={bulletsForKeyPath(descKey)}
                                 isSelected={selectedAccountType === item}
                                 isDefault={defaultType === item}
-                                data-testID={`@add-account/select-type/${item}`}
+                                testID={`@add-account/select-type/${item}`}
                                 onSelected={() => setSelectedAccountType(item)}
                             />
                         );

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
@@ -65,7 +65,7 @@ export const PortfolioContent = forwardRef<PortfolioGraphRef>((_props, ref) => {
                                 {showReceiveButton && (
                                     <Button
                                         flex={1}
-                                        data-testID="@home/portfolio/receive-button"
+                                        testID="@home/portfolio/receive-button"
                                         onPress={handleReceive}
                                         viewLeft="arrowDown"
                                     >
@@ -75,7 +75,7 @@ export const PortfolioContent = forwardRef<PortfolioGraphRef>((_props, ref) => {
                                 {showSendButton && (
                                     <Button
                                         flex={1}
-                                        data-testID="@home/portfolio/send-button"
+                                        testID="@home/portfolio/send-button"
                                         onPress={handleSend}
                                         viewLeft="arrowUp"
                                     >


### PR DESCRIPTION

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/ab2c29d0-72fc-4238-863d-c160c3bcdace" />

Refactors all try catch in tests as determinism is desired quality and we don't want false positive passes.

Also refactors `waitForVisible` errors. Now they contain clear message and callstack of the method for faster debugging and troubleshooting. Thx to that we will be able to see immediately in error trace what locator / element was not visible. Example:
```
    waitForVisible(): target not visible after 3000ms

      28 |
      29 |     async waitForCreateWalletLoadingScreen() {
    > 30 |         await waitForVisible(by.id('@screen/CreateWalletLoadingg'), { timeout: 3000 });
         |                             ^
      31 |     }
      32 |
      33 |     async waitForWalletBackupTutorialScreen() {

      at DeviceOnboardingActions.<anonymous> (e2e/pageObjects/deviceOnboardingActions.ts:30:29)
      at DeviceOnboardingActions.apply [as waitForCreateWalletLoadingScreen] (e2e/pageObjects/deviceOnboardingActions.ts:29:43)
      at Object.waitForCreateWalletLoadingScreen (e2e/tests/deviceOnboarding.test.ts:64:34)

    Cause:
```
and also followed by rest of original error
```
    Test Failed: 3.0sec timeout expired without matching of given matcher: (view has effective visibility <VISIBLE> and view.getGlobalVisibleRect() covers at least <75> percent of the view's area)

      49 |     const invocationStack = new Error().stack || '';
      50 |     try {
    > 51 |         await waitFor(target).toBeVisible().withTimeout(timeout);
         |                                             ^
      52 |     } catch (error) {
      53 |         const details = `waitForVisible(): target not visible after ${timeout}ms`;
      54 |         const appStackError = new Error(details, { cause: error as Error });

      at withTimeout (e2e/support/utils.ts:51:45)
      at asyncGeneratorStep (../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
      at _next (../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:17:9)
      at ../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:22:7
      at ../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:14:12
      at apply (e2e/support/utils.ts:42:28)
      at DeviceOnboardingActions.<anonymous> (e2e/pageObjects/deviceOnboardingActions.ts:30:29)
      at asyncGeneratorStep (../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
      at _next (../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:17:9)
      at ../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:22:7
      at DeviceOnboardingActions.<anonymous> (../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:14:12)
      at DeviceOnboardingActions.apply [as waitForCreateWalletLoadingScreen] (e2e/pageObjects/deviceOnboardingActions.ts:29:43)
      at Object.waitForCreateWalletLoadingScreen (e2e/tests/deviceOnboarding.test.ts:64:34)
      at asyncGeneratorStep (../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
      at _next (../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:17:9)
```


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor-native-no-try&lookback=7)