### PR TITLE
fix(suite): use deeplink when navigating from buy provider for desktop app

### DIFF
--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -61,6 +61,13 @@ export const initBackground: ModuleInitBackground = ({
         ipcMain.handle('server/request-address', (ipcEvent, pathname) => {
             validateIpcMessage({ ipcEvent });
             try {
+                if (pathname === '/buy-redirect') {
+                    receiver.activateRoute(pathname);
+
+                    return `trezorsuite:/${pathname}`;
+                }
+
+                // For other routes, return the HTTP address
                 const address = receiver.getRouteAddress(pathname);
                 if (address) {
                     receiver.activateRoute(pathname);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Notes for QA

`return_url` param when navigating to buy provider (Mercuryo in this case) should not include `127.0.0.1:21335` but rather deeplink `trezorsuite://`. The functionality should remain unchanged. The changes should only affect desktop app.

Please test all operating systems and more providers

## Related Issue

Resolve #22684

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/deeplink-callback-for-desktop-app-buys&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/deeplink-callback-for-desktop-app-buys&lookback=7)