### PR TITLE
fix(suite): reload app after enabling autoForget

### DIFF
--- a/packages/suite/src/actions/suite/autoForgetDeviceDataThunks.ts
+++ b/packages/suite/src/actions/suite/autoForgetDeviceDataThunks.ts
@@ -4,6 +4,7 @@ import { setAutoForgetDeviceDataThunk as setAutoForgetDeviceDataThunkCore } from
 import * as storageActions from 'src/actions/suite/storageActions';
 
 import { setAutoEjectEnabledThunk } from './autoEjectThunks';
+import { reloadApp } from '../../utils/suite/reload';
 
 const AUTO_FORGET_PREFIX = '@suite/autoForgetDeviceData';
 
@@ -23,6 +24,10 @@ export const setAutoForgetDeviceDataThunk = createThunk<
     await dispatch(setAutoEjectEnabledThunk({ shouldEnable: true }));
 
     // Finally, having purged the data in Bluetooth and THP reducers, simply sync BT and THP to persistent storage.
-    dispatch(storageActions.saveKnownDevices());
-    dispatch(storageActions.saveThpCredentials());
+    await dispatch(storageActions.saveKnownDevices());
+    await dispatch(storageActions.saveThpCredentials());
+
+    // Reload to ensure all local state is cleared, especially Connect session, which would otherwise reconnect THP.
+    // Delay for two reasons: make sure IDB operations are complete, and give some time for the UI success notification to be seen
+    reloadApp(1000);
 });

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -1,6 +1,8 @@
+import { selectKnownDevices } from '@suite-common/bluetooth';
 import { MetadataState } from '@suite-common/metadata-types';
 import { createThunk } from '@suite-common/redux-utils/';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
+import { selectThp } from '@suite-common/thp';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { DefinitionType, TokenManagementAction } from '@suite-common/token-definitions';
 import type { TradingTransaction } from '@suite-common/trading';
@@ -124,39 +126,45 @@ export const saveCoinjoinDebugSettings = () => (_dispatch: Dispatch, getState: G
     db.addItem('coinjoinDebugSettings', debug || {}, 'debug', true);
 };
 
-export const saveThpCredentials = () => (_dispatch: Dispatch, getState: GetState) => {
-    if (!db.isAccessible()) return;
-    const { credentials, staticKey } = getState().thp;
-    db.addItem('thp', { credentials, staticKey }, 'value', true);
-};
+export const saveThpCredentials = createThunk(
+    `${STORAGE.MODULE_PREFIX}/saveThpCredentials`,
+    async (_, { getState }) => {
+        if (!db.isAccessible()) return;
+        const { credentials, staticKey } = selectThp(getState());
+        await db.addItem('thp', { credentials, staticKey }, 'value', true);
+    },
+);
 
-export const saveKnownDevices = () => (_dispatch: Dispatch, getState: GetState) => {
-    if (!db.isAccessible()) return;
-    const { knownDevices } = getState().bluetooth;
+export const saveKnownDevices = createThunk(
+    `${STORAGE.MODULE_PREFIX}/saveKnownDevices`,
+    async (_, { getState }) => {
+        if (!db.isAccessible()) return;
+        const knownDevices = selectKnownDevices<DesktopBluetoothDevice>(getState());
 
-    db.addItem(
-        'bluetooth',
-        {
-            knownDevices: knownDevices.map(
-                (it): DesktopBluetoothDevice => ({
-                    id: it.id,
-                    name: it.name,
-                    macAddress: it.macAddress,
-                    manufacturerData: it.manufacturerData,
-                    lastUpdatedTimestamp: it.lastUpdatedTimestamp,
-                    paired: it.paired,
-                    rssi: it.rssi,
-                    deviceId: it.deviceId,
+        await db.addItem(
+            'bluetooth',
+            {
+                knownDevices: knownDevices.map(
+                    (it): DesktopBluetoothDevice => ({
+                        id: it.id,
+                        name: it.name,
+                        macAddress: it.macAddress,
+                        manufacturerData: it.manufacturerData,
+                        lastUpdatedTimestamp: it.lastUpdatedTimestamp,
+                        paired: it.paired,
+                        rssi: it.rssi,
+                        deviceId: it.deviceId,
 
-                    // Those fields are reset to prevent some state-inconsistency and UI flickering
-                    connectionStatus: { type: 'disconnected' },
-                }),
-            ),
-        },
-        'value',
-        true,
-    );
-};
+                        // Those fields are reset to prevent some state-inconsistency and UI flickering
+                        connectionStatus: { type: 'disconnected' },
+                    }),
+                ),
+            },
+            'value',
+            true,
+        );
+    },
+);
 
 export const saveAccountFormDraft =
     (prefix: FormDraftKeyPrefix, accountKey: string) => (_: Dispatch, getState: GetState) => {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2873,7 +2873,7 @@ export default defineMessages({
     TR_STORE_DEVICE_DATA_MODAL_DISABLED_WARNING: {
         id: 'TR_STORE_DEVICE_DATA_MODAL_DISABLED_WARNING',
         defaultMessage:
-            'All wallets will be automatically ejected when your Trezor is disconnected.',
+            'All wallets will be ejected. Trezor Suite will automatically restart once the process is complete',
     },
     TR_LANGUAGE: {
         defaultMessage: 'Language',

--- a/suite-common/thp/src/index.ts
+++ b/suite-common/thp/src/index.ts
@@ -1,6 +1,11 @@
 export { prepareThpReducer, initialThpState } from './thpReducer';
 export type { ThpStep, ThpState } from './thpReducer';
-export { selectIsThpInProgress, selectThpStep, selectThpCredentials } from './thpSelectors';
+export {
+    selectThp,
+    selectIsThpInProgress,
+    selectThpStep,
+    selectThpCredentials,
+} from './thpSelectors';
 export { thpActions } from './thpActions';
 export * from './thpUtils';
 export { THP_BUTTON_REQUESTS_NAMES } from './thpConstants';

--- a/suite-common/thp/src/thpSelectors.ts
+++ b/suite-common/thp/src/thpSelectors.ts
@@ -4,6 +4,8 @@ export type WithThpState = {
     thp: ThpState;
 };
 
+export const selectThp = (state: WithThpState) => state.thp;
+
 export const selectIsThpInProgress = (state: WithThpState) => state.thp.step !== null;
 
 export const selectThpStep = (state: WithThpState) => state.thp.step;


### PR DESCRIPTION
## Description

Reload app after disabling device data storage (a.k.a. enabling auto forget), to ensure that Connect session is cleared.
That's because Connect keeps actie THP sessions, would reconnect the device (Suite can't prevent it from doing so), and Suite "gets a new device" so it becomes remembered again.

## Related Issue

Resolve #22738

## Screenshots:

Web:

[Screencast from 2025-11-11 14-07-23.webm](https://github.com/user-attachments/assets/56c9741d-5c3e-404a-96ee-6529af6f83a3)

Desktop: (I forgot to update copy in this video, but it'll be there..)

[Screencast from 2025-11-11 14-16-14.webm](https://github.com/user-attachments/assets/203259e4-d54d-48e9-be6d-8fbb1e1f475e)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/reload-suite-when-enable-autoForget&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/reload-suite-when-enable-autoForget&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/reload-suite-when-enable-autoForget&lookback=7)