### PR TITLE
Fix/14806 asset logo

### DIFF
--- a/packages/components/src/components/AssetLogo/AssetLogo.tsx
+++ b/packages/components/src/components/AssetLogo/AssetLogo.tsx
@@ -68,22 +68,21 @@ const resolvedLogoCache = new Map<string, LogoCandidate>();
 const failedAddressesCache = new Set<string>();
 
 const makeCacheKey = (coingeckoId: string, addressesKey: string) =>
-    `${coingeckoId.toLowerCase()}::${addressesKey}`;
+    `${coingeckoId}::${addressesKey}`;
 
-const makeAddressKey = (coingeckoId: string, address: string) =>
-    `${coingeckoId.toLowerCase()}::${address.toLowerCase()}`;
+const makeAddressKey = (coingeckoId: string, address: string) => `${coingeckoId}::${address}`;
 
 export const getCoingeckoIdAndContractAddressIncludesNativeTokens = (
     coingeckoId: string,
     contractAddress: string[] | undefined,
 ) => {
-    const mainNetworkSymbol = getNetworkByCoingeckoId(coingeckoId)?.displaySymbol.toLowerCase();
+    const mainNetworkSymbol = getNetworkByCoingeckoId(coingeckoId)?.displaySymbol;
 
     const addresses = ([] as Array<string | undefined>)
         .concat(contractAddress ?? [])
         .map(addr => addr ?? ZERO_ADDRESS);
 
-    const hasNative = addresses.some(addr => addr.toLowerCase() === ZERO_ADDRESS);
+    const hasNative = addresses.some(addr => addr === ZERO_ADDRESS);
 
     const shouldUseTradeId = hasNative && !!mainNetworkSymbol && isNetworkSymbol(mainNetworkSymbol);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Names of stored logo assets are not lowercased. 
- Fixed git blame by adding empty `.git-blame-ignore-revs` file. [Context](https://github.com/gitkraken/vscode-gitlens/issues/1143#issuecomment-758947995)

## Related Issue

Resolve #14806

## Screenshots:

<img width="1102" height="804" alt="Snímek obrazovky 2025-11-11 v 14 11 28" src="https://github.com/user-attachments/assets/7ef18725-bdb3-44e6-ae28-767ca2fefb7f" />
<img width="811" height="544" alt="Snímek obrazovky 2025-11-11 v 14 11 37" src="https://github.com/user-attachments/assets/2b4161a3-782d-4137-9274-503781a30bfb" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/14806-asset-logo&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/14806-asset-logo&lookback=7)