### PR TITLE
ci: do not collect coverage from unit tests

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -122,7 +122,7 @@ jobs:
       - name: "Minimal yarn install"
         uses: ./.github/actions/minimal-yarn-install
       - name: Unit Tests
-        run: yarn nx:test-unit --output-style=stream
+        run: yarn nx:test-unit --output-style=stream --coverage false
 
   build-libs-for-publishing:
     name: "Build libs for publishing"


### PR DESCRIPTION
It has been a while since we stopped requiring specific coverage treshold in CI. If this is true, it does not make sense to instrument code for collecting coverage.

With this change, unit tests in CI will run faster and test output will be more readable 
https://github.com/trezor/trezor-suite/actions/runs/19267666852/job/55087614361?pr=23067

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci-coverage&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci-coverage&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci-coverage&lookback=7)