### PR TITLE
fix(suite): add staking validation for not enough balance to cover fees

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeInputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeInputs.tsx
@@ -105,6 +105,19 @@ export const StakeInputs = () => {
             .lte(stakingLimits.MIN_AMOUNT_FOR_STAKING);
     };
 
+    const balance = new BigNumber(account.formattedBalance || '0');
+    const maxCrypto = new BigNumber(amountLimits?.maxCrypto ?? '0');
+
+    const isBalanceBelowMinStake = balance.lt(
+        stakingLimits.MIN_AMOUNT_FOR_STAKING.plus(stakingLimits.MIN_BALANCE_FOR_FEE_BUFFER),
+    );
+
+    const missingAmount =
+        balance.gte(stakingLimits.MIN_AMOUNT_FOR_STAKING) &&
+        maxCrypto.lte(stakingLimits.MIN_AMOUNT_FOR_STAKING)
+            ? stakingLimits.MIN_AMOUNT_FOR_STAKING.minus(amountLimits?.maxCrypto ?? '0')
+            : null;
+
     const tooltip = (
         <Translation
             id="TR_STAKE_MIN_AMOUNT_TOOLTIP"
@@ -115,8 +128,17 @@ export const StakeInputs = () => {
         />
     );
 
-    const isBalanceBelowMinStake = new BigNumber(account.formattedBalance || '0').lt(
-        stakingLimits.MIN_AMOUNT_FOR_STAKING.plus(stakingLimits.MIN_BALANCE_FOR_FEE_BUFFER),
+    const maxTooltip = missingAmount && (
+        <Translation
+            id="TR_STAKING_VALIDATION_ERROR_NOT_ENOUGH_FOR_FEES_CRYPTO"
+            values={{
+                missingAmount: CryptoAmountFormatter.format(missingAmount.toString(), {
+                    isBalance: true,
+                    symbol: account.symbol,
+                    maxDisplayedDecimals: network.decimals,
+                }),
+            }}
+        />
     );
 
     return (
@@ -208,8 +230,8 @@ export const StakeInputs = () => {
                     {
                         id: 'TR_FRACTION_BUTTONS_MAX',
                         children: <Translation id="TR_FRACTION_BUTTONS_MAX" />,
-                        tooltip: isBalanceBelowMinStake && tooltip,
-                        isDisabled: isBalanceBelowMinStake,
+                        tooltip: maxTooltip || (isBalanceBelowMinStake && tooltip),
+                        isDisabled: isBalanceBelowMinStake || !!missingAmount,
                         onClick: () => setMax(),
                     },
                 ]}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1060,6 +1060,16 @@ export default defineMessages({
         defaultMessage: 'Maximum is {maximum} {currency}',
         id: 'TR_BUY_VALIDATION_ERROR_MAXIMUM_FIAT',
     },
+    TR_STAKING_VALIDATION_ERROR_NOT_ENOUGH_FOR_FEES_CRYPTO: {
+        defaultMessage:
+            'Balance is enough for the minimum, but not enough to cover network fees. Missing {missingAmount}',
+        id: 'TR_STAKING_VALIDATION_ERROR_NOT_ENOUGH_FOR_FEES_CRYPTO',
+    },
+    TR_STAKING_VALIDATION_ERROR_NOT_ENOUGH_FOR_FEES_FIAT: {
+        defaultMessage:
+            'Balance is enough for the minimum, but not enough to cover network fees. Missing {missingAmount} {currency}',
+        id: 'TR_STAKING_VALIDATION_ERROR_NOT_ENOUGH_FOR_FEES_FIAT',
+    },
     TR_BUY_STATUS_PENDING_GO_TO_GATEWAY: {
         defaultMessage: 'Pending',
         id: 'TR_BUY_STATUS_PENDING_GO_TO_GATEWAY',

--- a/packages/suite/src/utils/suite/validation.ts
+++ b/packages/suite/src/utils/suite/validation.ts
@@ -99,6 +99,22 @@ export const validateCryptoLimits =
             }
 
             if (amountLimits.maxCrypto && new BigNumber(value).gt(maxCrypto)) {
+                if (minCrypto.lte(new BigNumber(value))) {
+                    const missingAmount = new BigNumber(value).minus(maxCrypto);
+
+                    return translationString(
+                        'TR_STAKING_VALIDATION_ERROR_NOT_ENOUGH_FOR_FEES_CRYPTO',
+                        {
+                            missingAmount: formatter.format(missingAmount.toString(), {
+                                isBalance: true,
+                                symbol: currency,
+                                shouldRedactNumbers: false,
+                                maxDisplayedDecimals: 18,
+                            }),
+                        },
+                    );
+                }
+
                 return translationString('TR_BUY_VALIDATION_ERROR_MAXIMUM_CRYPTO', {
                     maximum: formatter.format(amountLimits.maxCrypto, {
                         isBalance: true,
@@ -152,6 +168,18 @@ export const validateFiatLimits =
             }
 
             if (amountLimits.maxFiat && new BigNumber(value).gt(amountLimits.maxFiat)) {
+                if (new BigNumber(amountLimits.minCrypto ?? '0').lte(new BigNumber(value))) {
+                    const missingAmount = new BigNumber(value).minus(amountLimits.maxFiat);
+
+                    return translationString(
+                        'TR_STAKING_VALIDATION_ERROR_NOT_ENOUGH_FOR_FEES_FIAT',
+                        {
+                            missingAmount: missingAmount.toString(),
+                            currency: localCurrency.toUpperCase(),
+                        },
+                    );
+                }
+
                 return translationString('TR_BUY_VALIDATION_ERROR_MAXIMUM_FIAT', {
                     maximum: amountLimits.maxFiat,
                     currency: localCurrency.toUpperCase(),

--- a/suite-common/wallet-constants/src/solanaStakingConstants.ts
+++ b/suite-common/wallet-constants/src/solanaStakingConstants.ts
@@ -3,7 +3,7 @@ import { BigNumber } from '@trezor/utils';
 export const BACKUP_SOL_APY = 6.87;
 export const MIN_SOL_AMOUNT_FOR_STAKING = new BigNumber(0.01);
 export const MAX_SOL_AMOUNT_FOR_STAKING = new BigNumber(10_000_000);
-export const MIN_SOL_FOR_WITHDRAWALS = new BigNumber(0.05);
+export const MIN_SOL_FOR_WITHDRAWALS = new BigNumber(0.02);
 export const MIN_SOL_BALANCE_FOR_FEE_BUFFER = new BigNumber(0.005);
 export const MIN_SOL_BALANCE_FOR_STAKING = MIN_SOL_AMOUNT_FOR_STAKING.plus(MIN_SOL_FOR_WITHDRAWALS);
 export const SOL_STAKING_OPERATION_FEE = new BigNumber(70_000); // 0.00007 SOL


### PR DESCRIPTION
## Description

Improved staking validation logic to detect situations where the balance meets the advertised minimum amount but part of it must remain for fees. Users now see an informative error - **Balance is enough for the minimum, but not enough to cover network fees. Missing ??? SOL**

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20270

## Screenshots:

<img width="603" height="671" alt="image" src="https://github.com/user-attachments/assets/120c2092-00f7-40a4-8103-2de73323ea83" />

<img width="570" height="545" alt="image" src="https://github.com/user-attachments/assets/0931b92d-2929-4aa2-b7f4-65ab1d873f82" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/staking-validation-not-enough-for-fees&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/staking-validation-not-enough-for-fees&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/staking-validation-not-enough-for-fees&lookback=7)