### PR TITLE
feat(connect): show hash option for ethereumSignTypedData

### DIFF
--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignTypedData.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignTypedData.mdx
@@ -33,6 +33,8 @@ export const paramDescriptions = {
         "set to `true` for compatibility with [MetaMask's signTypedData_v4](https://docs.metamask.io/guide/signing-data.html#sign-typed-data-v4).",
     domain_separator_hash: 'hex-encoded 32-byte hash of the EIP-712 domain.',
     message_hash: 'hex-encoded 32-byte hash of the EIP-712 message.',
+    show_message_hash:
+        'set to `true` to also display the message hash on the device for additional confirmation on newer Trezor models.',
 };
 
 ## Ethereum: Sign Typed Data

--- a/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
@@ -99,6 +99,13 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
                 );
             }
         }
+
+        if (payload.show_message_hash !== undefined) {
+            this.params.show_message_hash = payload.show_message_hash;
+        } else if (this.params.data.primaryType === 'SafeTx') {
+            // Show hashes for Safe transactions by default unless specified otherwise
+            this.params.show_message_hash = true;
+        }
     }
 
     async initAsync() {
@@ -127,6 +134,7 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
                     'should_show_struct',
                     'should_show_array',
                     'confirm_typed_value',
+                    'confirm_message_hash',
                     'confirm_empty_typed_message',
                     'confirm_typed_data_final',
                 ].includes(name)) ||
@@ -191,6 +199,9 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
                 primary_type: primaryType as string,
                 metamask_v4_compat,
                 definitions,
+                show_message_hash: this.params.show_message_hash
+                    ? this.params.message_hash
+                    : undefined,
             },
         );
 

--- a/packages/connect/src/types/api/ethereum/index.ts
+++ b/packages/connect/src/types/api/ethereum/index.ts
@@ -123,6 +123,7 @@ export interface EthereumSignTypedData<T extends EthereumSignTypedDataTypes> {
     metamask_v4_compat: boolean;
     domain_separator_hash?: undefined;
     message_hash?: undefined;
+    show_message_hash?: boolean;
 }
 export const EthereumSignTypedData = Type.Object({
     path: DerivationPath,
@@ -130,6 +131,7 @@ export const EthereumSignTypedData = Type.Object({
     metamask_v4_compat: Type.Boolean(),
     domain_separator_hash: Type.Optional(Type.Undefined()),
     message_hash: Type.Optional(Type.Undefined()),
+    show_message_hash: Type.Optional(Type.Boolean()),
 });
 
 /**
@@ -145,6 +147,7 @@ export interface EthereumSignTypedHash<T extends EthereumSignTypedDataTypes> {
     domain_separator_hash: string;
     /** Not required for domain-only signing, when EIP712Domain is the `primaryType` */
     message_hash?: string;
+    show_message_hash?: boolean;
 }
 export const EthereumSignTypedHash = Type.Object({
     path: DerivationPath,
@@ -152,6 +155,7 @@ export const EthereumSignTypedHash = Type.Object({
     metamask_v4_compat: Type.Boolean(),
     domain_separator_hash: Type.String(),
     message_hash: Type.Optional(Type.String()),
+    show_message_hash: Type.Optional(Type.Boolean()),
 });
 
 // ethereumVerifyMessage


### PR DESCRIPTION
## Description

Adding a new option - `show_message_hash` for the `ethereumSignTypedData` method, to align with the current firmware capabilities.

We enable it by default for Safe multisig. 

## Notes for QA

Connect to Safe using WalletConnect, do any EIP712 signing operation there, see that hash is displayed on device as last signing step

## Related Issue

Resolve #22720


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/ethereumsigntypeddata-show-hash&lookback=7)