### PR TITLE
fix(message-system): fix circular dependency in message system (TradingType)

### DIFF
--- a/suite-common/message-system/schema/config.schema.v1.json
+++ b/suite-common/message-system/schema/config.schema.v1.json
@@ -749,6 +749,10 @@
                 "ZM",
                 "ZW"
             ]
+        },
+        "tradingType": {
+            "type": "string",
+            "enum": ["buy", "sell", "exchange"]
         }
     }
 }

--- a/suite-common/message-system/scripts/generate-types.ts
+++ b/suite-common/message-system/scripts/generate-types.ts
@@ -6,6 +6,7 @@ import { SCHEMA_PATH, TYPES_PATH } from './constants';
 const options = {
     style: { singleQuote: true, tabWidth: 4 },
     ignoreMinAndMaxItems: true,
+    unreachableDefinitions: true,
     bannerComment: `/**
             * DO NOT MODIFY BY HAND! This file was automatically generated.
             * Instead, modify the original JSONSchema file in /message-system/schema, and run yarn build:libs.

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -1,4 +1,9 @@
-import type { Category, ExperimentsItem, MessageSystem } from '@suite-common/suite-types';
+import type {
+    Category,
+    ExperimentsItem,
+    MessageSystem,
+    TradingType,
+} from '@suite-common/suite-types';
 import type { AccountType, NetworkSymbol, StakingNetworkSymbol } from '@suite-common/wallet-config';
 
 export type MessageState = { [key in Category]: boolean };
@@ -104,8 +109,7 @@ const getAccountContext = (networkSymbol: NetworkSymbol, accountType?: AccountTy
 const getStakingContext = (networkSymbol: StakingNetworkSymbol) =>
     `accounts.${networkSymbol}.staking` as const;
 
-// Todo: fix TradingType see: https://github.com/trezor/trezor-suite/pull/21265
-const getTradingContext = (type: 'buy' | 'sell' | 'exchange') => `trading.${type}` as const;
+const getTradingContext = (type: TradingType) => `trading.${type}` as const;
 
 export type SettingsCategory = 'general' | 'device' | 'networks' | 'debug';
 const getSettingsContext = (category: SettingsCategory) => `settings.${category}` as const;

--- a/suite-common/suite-types/src/messageSystem.ts
+++ b/suite-common/suite-types/src/messageSystem.ts
@@ -5,8 +5,15 @@
 
 /**
  * ISO 8601 date-time format.
+ *
+ * This interface was referenced by `MessageSystem`'s JSON-Schema
+ * via the `definition` "date-time".
  */
 export type DateTime = string;
+/**
+ * This interface was referenced by `MessageSystem`'s JSON-Schema
+ * via the `definition` "version".
+ */
 export type Version = string | string[];
 export type Model = '1' | 'T' | 'T1B1' | 'T2T1' | 'T2B1' | 'Safe 3' | 'T3B1' | 'T3T1' | 'T3W1' | '';
 export type FirmwareRevision = string;
@@ -15,6 +22,10 @@ export type FirmwareVariant = '*' | 'bitcoin-only' | 'universal';
  * Eligible authorized vendors.
  */
 export type Vendor = '*' | 'trezor.io';
+/**
+ * This interface was referenced by `MessageSystem`'s JSON-Schema
+ * via the `definition` "countryCodes".
+ */
 export type CountryCodes =
     | 'AD'
     | 'AE'
@@ -271,10 +282,23 @@ export type CountryCodes =
  * @minItems 1
  */
 export type CountryCode = CountryCodes[];
+/**
+ * This interface was referenced by `MessageSystem`'s JSON-Schema
+ * via the `definition` "conditions".
+ */
 export type Conditions = Condition[];
 export type Variant = 'info' | 'warning' | 'critical';
+/**
+ * This interface was referenced by `MessageSystem`'s JSON-Schema
+ * via the `definition` "category".
+ */
 export type Category = 'banner' | 'context' | 'modal' | 'feature';
 export type CTAAction = 'internal-link' | 'external-link';
+/**
+ * This interface was referenced by `MessageSystem`'s JSON-Schema
+ * via the `definition` "tradingType".
+ */
+export type TradingType = 'buy' | 'sell' | 'exchange';
 
 /**
  * JSON schema of the Trezor Suite messaging system.
@@ -373,6 +397,9 @@ export interface Message {
 }
 /**
  * A multilingual text localization.
+ *
+ * This interface was referenced by `MessageSystem`'s JSON-Schema
+ * via the `definition` "localization".
  */
 export interface Localization {
     en: string;


### PR DESCRIPTION
## Description

Added `TradingType` to the message system JSON schema so the enum is defined directly in the schema. This prevents circular dependency issues.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21552


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/message-system-circular-dependency&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/message-system-circular-dependency&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/message-system-circular-dependency&lookback=7)