### PR TITLE
fix(suite): use deeplink when navigating from sell/swap provider on desktop

### DIFF
--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -11,6 +11,12 @@ import { ModuleInitBackground } from './module';
 
 export const SERVICE_NAME = 'http-receiver';
 
+export const TRADING_REDIRECT_PATHS = [
+    '/buy-redirect',
+    '/sell-redirect',
+    '/exchange-redirect',
+] as const;
+
 export const initBackground: ModuleInitBackground = ({
     mainWindowProxy,
     mainThreadEmitter,
@@ -61,7 +67,8 @@ export const initBackground: ModuleInitBackground = ({
         ipcMain.handle('server/request-address', (ipcEvent, pathname) => {
             validateIpcMessage({ ipcEvent });
             try {
-                if (pathname === '/buy-redirect') {
+                // For trading redirect routes, return deeplink URL instead of localhost
+                if (TRADING_REDIRECT_PATHS.some(path => path === pathname)) {
                     receiver.activateRoute(pathname);
 
                     return `trezorsuite:/${pathname}`;

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -1,3 +1,4 @@
+import { ExtraDependencies } from '@suite-common/redux-utils';
 import { Protocol } from '@suite-common/suite-constants';
 import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -5,6 +6,7 @@ import * as walletConnectActions from '@suite-common/walletconnect';
 import {
     SUITE_ANCHOR_DEEPLINK_PREFIX,
     SUITE_BRIDGE_DEEPLINK,
+    SUITE_TRADING_REDIRECT_DEEPLINKS,
     SUITE_WALLETCONNECT_DEEPLINK,
 } from '@trezor/urls';
 import { isArrayMember } from '@trezor/utils';
@@ -12,7 +14,7 @@ import { isArrayMember } from '@trezor/utils';
 import * as routerActions from 'src/actions/suite/routerActions';
 import { goto } from 'src/actions/suite/routerActions';
 import type { SendFormState } from 'src/reducers/suite/protocolReducer';
-import { Dispatch } from 'src/types/suite';
+import { Dispatch, GetState } from 'src/types/suite';
 import { parseUri } from 'src/utils/suite/parseUri';
 import { CoinProtocolInfo, getProtocolInfo } from 'src/utils/suite/protocol';
 
@@ -44,50 +46,68 @@ const saveCoinProtocol = (scheme: Protocol, address: string, amount?: number): P
     payload: { scheme, address, amount },
 });
 
-export const handleProtocolRequest = (uri: string) => (dispatch: Dispatch) => {
-    const protocol = getProtocolInfo(uri);
+export const handleProtocolRequest =
+    (uri: string) => (dispatch: Dispatch, _getState: GetState, extra: ExtraDependencies) => {
+        const protocol = getProtocolInfo(uri);
 
-    if (protocol && !('error' in protocol) && getNetworkSymbolForProtocol(protocol.scheme)) {
-        const { scheme, amount, address } = protocol as CoinProtocolInfo;
+        if (protocol && !('error' in protocol) && getNetworkSymbolForProtocol(protocol.scheme)) {
+            const { scheme, amount, address } = protocol as CoinProtocolInfo;
 
-        dispatch(saveCoinProtocol(scheme, address, amount));
-        dispatch(
-            notificationsActions.addToast({
-                type: 'coin-scheme-protocol',
-                address,
-                scheme,
-                amount,
-                autoClose: false,
-            }),
-        );
-    } else if (uri?.startsWith(SUITE_BRIDGE_DEEPLINK)) {
-        dispatch(routerActions.goto('suite-bridge-requested', { params: { cancelable: true } }));
-    } else if (uri?.startsWith(SUITE_WALLETCONNECT_DEEPLINK)) {
-        const parsedUri = parseUri(uri);
-        const wcUri = parsedUri?.searchParams?.get('uri');
-        if (wcUri) {
-            dispatch(walletConnectActions.walletConnectPairThunk({ uri: wcUri }))
-                .unwrap()
-                .catch(error => {
-                    dispatch(
-                        notificationsActions.addToast({
-                            type: 'error',
-                            error: error.message,
-                        }),
-                    );
-                });
+            dispatch(saveCoinProtocol(scheme, address, amount));
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'coin-scheme-protocol',
+                    address,
+                    scheme,
+                    amount,
+                    autoClose: false,
+                }),
+            );
+        } else if (uri?.startsWith(SUITE_BRIDGE_DEEPLINK)) {
+            dispatch(
+                routerActions.goto('suite-bridge-requested', { params: { cancelable: true } }),
+            );
+        } else if (uri?.startsWith(SUITE_WALLETCONNECT_DEEPLINK)) {
+            const parsedUri = parseUri(uri);
+            const wcUri = parsedUri?.searchParams?.get('uri');
+            if (wcUri) {
+                dispatch(walletConnectActions.walletConnectPairThunk({ uri: wcUri }))
+                    .unwrap()
+                    .catch(error => {
+                        dispatch(
+                            notificationsActions.addToast({
+                                type: 'error',
+                                error: error.message,
+                            }),
+                        );
+                    });
+            }
+        } else if (uri?.startsWith(SUITE_ANCHOR_DEEPLINK_PREFIX)) {
+            const anchor = uri.replace(SUITE_ANCHOR_DEEPLINK_PREFIX, '');
+
+            if (isArrayMember(anchor, Object.values(SettingsAnchor))) {
+                const [domain] = anchor.split('/');
+
+                const targetRoute =
+                    mapAnchorToRoute[domain.replace(/^@/, '') as AnchorSettingSection];
+                dispatch(goto(targetRoute, { anchor }));
+            }
+        } else if (SUITE_TRADING_REDIRECT_DEEPLINKS.some(deeplink => uri?.startsWith(deeplink))) {
+            const parsedUri = parseUri(decodeURIComponent(uri));
+            const redirectPath = parsedUri?.searchParams?.get('p');
+
+            if (redirectPath) {
+                const decodedPath = decodeURIComponent(redirectPath);
+                const [, hash] = decodedPath.split('/coinmarket-redirect/');
+                if (hash) {
+                    const fullUrl = `/coinmarket-redirect#${hash}`;
+
+                    extra.routerServices.navigate(fullUrl);
+                    dispatch(routerActions.onLocationChange(fullUrl));
+                }
+            }
         }
-    } else if (uri?.startsWith(SUITE_ANCHOR_DEEPLINK_PREFIX)) {
-        const anchor = uri.replace(SUITE_ANCHOR_DEEPLINK_PREFIX, '');
-
-        if (isArrayMember(anchor, Object.values(SettingsAnchor))) {
-            const [domain] = anchor.split('/');
-
-            const targetRoute = mapAnchorToRoute[domain.replace(/^@/, '') as AnchorSettingSection];
-            dispatch(goto(targetRoute, { anchor }));
-        }
-    }
-};
+    };
 
 export const resetProtocol = (): ProtocolAction => ({
     type: PROTOCOL.RESET,

--- a/packages/suite/src/components/suite/ReadMoreLink.tsx
+++ b/packages/suite/src/components/suite/ReadMoreLink.tsx
@@ -5,7 +5,7 @@ import { Translation } from 'src/components/suite/Translation';
 import { ExtendedMessageDescriptor } from 'src/types/suite';
 
 interface ReadMoreLinkProps {
-    url: keyof Omit<typeof URLS, 'TOR_URLS'>;
+    url: keyof Omit<typeof URLS, 'TOR_URLS' | 'SUITE_TRADING_REDIRECT_DEEPLINKS'>;
     linkLabel?: ExtendedMessageDescriptor['id'];
     message?: ExtendedMessageDescriptor['id'];
 }

--- a/packages/urls/src/deeplinks.ts
+++ b/packages/urls/src/deeplinks.ts
@@ -3,3 +3,9 @@ import { SuiteDeeplink } from './types';
 export const SUITE_BRIDGE_DEEPLINK: SuiteDeeplink = 'trezorsuite://bridge-requested-by-a-3rd-party';
 export const SUITE_WALLETCONNECT_DEEPLINK: SuiteDeeplink = 'trezorsuite://walletconnect';
 export const SUITE_ANCHOR_DEEPLINK_PREFIX: SuiteDeeplink = 'trezorsuite://anchor-';
+
+export const SUITE_TRADING_REDIRECT_DEEPLINKS: SuiteDeeplink[] = [
+    'trezorsuite://buy-redirect',
+    'trezorsuite://sell-redirect',
+    'trezorsuite://exchange-redirect',
+];


### PR DESCRIPTION
## Description


## Notes for QA

`return_url` param when navigating to sell/swap provider should not include 127.0.0.1:21335 but rather deeplink `trezorsuite://`. The functionality should remain unchanged. The changes should only affect desktop app.

## Related Issue

Resolve #23069

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/deeplink-redirect-for-swap-sell-on-desktop&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/deeplink-redirect-for-swap-sell-on-desktop&lookback=7)