### PR TITLE
refactor(e2e-suite): change hardcoded strings in asserts to references

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/recoveryModal.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/recoveryModal.ts
@@ -1,6 +1,7 @@
-import { Locator, Page, expect } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 
 import { step } from '../common';
+import { expect } from '../testExtends/customMatchers';
 
 export class RecoveryModal {
     readonly selectRecoveryButton = (type: 'standard' | 'advanced') =>
@@ -38,9 +39,7 @@ export class RecoveryModal {
 
     @step()
     async verifyDryCheckPrompt() {
-        await expect(this.header).toHaveText('Check wallet backup', { timeout: 30_000 });
-        await expect(this.prompt).toHaveText(
-            'Enter the words directly on your Trezor device in the correct order.',
-        );
+        await expect(this.header).toHaveTranslation('TR_CHECK_RECOVERY_SEED', { timeout: 30_000 });
+        await expect(this.prompt).toHaveTranslation('TR_ENTER_SEED_WORDS_ON_DEVICE');
     }
 }

--- a/packages/suite-desktop-core/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/settings/settingsPage.ts
@@ -143,7 +143,7 @@ export class SettingsPage {
         const notInSettings = !(await this.settingsHeader.isVisible());
         if (notInSettings) {
             await this.settingsMenuButton.click();
-            await expect(this.settingsHeader).toHaveText('Settings', { timeout: 10000 });
+            await expect(this.settingsHeader).toHaveTranslation('TR_SETTINGS', { timeout: 10000 });
         }
         const tabNavigation: { [key: string]: () => Promise<void> } = {
             application: () => this.applicationTabButton.click(),

--- a/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
@@ -1,4 +1,6 @@
 /* eslint-disable playwright/no-standalone-expect */
+import { createIntl, createIntlCache } from 'react-intl';
+
 import { Locator, Request, expect as baseExpect, test } from '@playwright/test';
 import { diff } from 'jest-diff';
 import { isEqual } from 'lodash';
@@ -13,6 +15,7 @@ type LineFormats = 'fourTetragrams' | 'fullLine';
 
 const DISPLAY_CHAR_LIMIT = 18;
 const STRING_UP_TO_DISPLAY_LIMIT = new RegExp(`.{1,${DISPLAY_CHAR_LIMIT}}`, 'g');
+const intlEn = createIntl({ locale: 'en', messages: {} }, createIntlCache());
 
 const compareTextAndNumber = async (
     locator: Locator,
@@ -89,18 +92,6 @@ export const splitStringByDisplayLimit = (text: string) => {
     // Add a newline item into array after each item except the last one
     return splitLines.flatMap((line, index) =>
         index < splitLines.length - 1 ? [line.trim(), '\n'] : [line.trim()],
-    );
-};
-
-const applyPlaceholderValues = (
-    template: string,
-    placeholderValues: string[] | undefined,
-): string => {
-    if (!placeholderValues || placeholderValues.length === 0) return template;
-    let i = 0;
-
-    return template.replace(/\{[^}]+\}/g, () =>
-        i < placeholderValues.length ? placeholderValues[i++] : '',
     );
 };
 
@@ -216,15 +207,26 @@ export const expect = baseExpect.extend({
     async toHaveTranslation(
         locator: Locator,
         translationKey: TranslationKey,
-        // Some translations have placeholders like 'Maximum {decimals} decimals allowed'
-        options?: { isValue?: boolean; placeholderValues?: string[]; timeout?: number },
+        // Use ICU values for placeholders (e.g., { amount, symbol, days })
+        options?: {
+            isValueElement?: boolean;
+            values?: Record<string, string | number>;
+            timeout?: number;
+        },
     ) {
-        const expectedTranslation = applyPlaceholderValues(
-            messages[translationKey].defaultMessage,
-            options?.placeholderValues,
-        );
+        const template = messages[translationKey].defaultMessage;
+        const values = options?.values;
+        const expectedTranslation =
+            values && Object.keys(values).length > 0
+                ? String(
+                      intlEn.formatMessage(
+                          { id: translationKey, defaultMessage: template },
+                          options.values,
+                      ),
+                  )
+                : template;
 
-        if (options?.isValue) {
+        if (options?.isValueElement) {
             await baseExpect(locator).toHaveValue(expectedTranslation, {
                 timeout: options?.timeout,
             });
@@ -243,14 +245,25 @@ export const expect = baseExpect.extend({
     async toContainTranslation(
         locator: Locator,
         translationKey: TranslationKey,
-        // Some translations have placeholders like 'Maximum {decimals} decimals allowed'
-        options?: { isValue?: boolean; placeholderValues?: string[]; timeout?: number },
+        // Use ICU values for placeholders (e.g., { amount, symbol, days })
+        options?: {
+            isValueElement?: boolean;
+            values?: Record<string, string | number>;
+            timeout?: number;
+        },
     ) {
-        const expectedTranslation = applyPlaceholderValues(
-            messages[translationKey].defaultMessage,
-            options?.placeholderValues,
-        );
-        if (options?.isValue) {
+        const template = messages[translationKey].defaultMessage;
+        const values = options?.values;
+        const expectedTranslation =
+            values && Object.keys(values).length > 0
+                ? String(
+                      intlEn.formatMessage(
+                          { id: translationKey, defaultMessage: template },
+                          options.values,
+                      ),
+                  )
+                : template;
+        if (options?.isValueElement) {
             await baseExpect
                 .poll(async () => await locator.inputValue(), {
                     timeout: options?.timeout,

--- a/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
@@ -20,6 +20,8 @@ test(
 
         await settingsPage.navigateTo('application');
         await settingsPage.joinEarlyAccessProgram();
-        await expect(settingsPage.earlyAccessJoinButton).toHaveText('Opt out');
+        await expect(settingsPage.earlyAccessJoinButton).toHaveTranslation(
+            'TR_EARLY_ACCESS_DISABLE',
+        );
     },
 );

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-numbering.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-numbering.test.ts
@@ -20,9 +20,17 @@ test.describe('Passphrase numbering', { tag: ['@group=passphrase'] }, () => {
 
         await test.step('verify wallet labels are correct', async () => {
             await dashboardPage.openDeviceSwitcher();
-            await expect(dashboardPage.walletAtIndex(0)).toContainText('Standard wallet');
-            await expect(dashboardPage.walletAtIndex(1)).toContainText('Passphrase wallet #1');
-            await expect(dashboardPage.walletAtIndex(2)).toContainText('Passphrase wallet #2');
+            await expect(dashboardPage.walletAtIndex(0)).toContainTranslation(
+                'TR_NO_PASSPHRASE_WALLET',
+            );
+            await expect(dashboardPage.walletAtIndex(1)).toContainTranslation(
+                'TR_PASSPHRASE_WALLET',
+                { values: { id: '1' } },
+            );
+            await expect(dashboardPage.walletAtIndex(2)).toContainTranslation(
+                'TR_PASSPHRASE_WALLET',
+                { values: { id: '2' } },
+            );
         });
 
         await test.step('eject standard and the first passphrase wallet', async () => {
@@ -38,9 +46,17 @@ test.describe('Passphrase numbering', { tag: ['@group=passphrase'] }, () => {
 
         await test.step('verify passphrase wallet labels are correct', async () => {
             await dashboardPage.openDeviceSwitcher();
-            await expect(dashboardPage.walletAtIndex(0)).toContainText('Passphrase wallet #2');
-            await expect(dashboardPage.walletAtIndex(1)).toContainText('Standard wallet');
-            await expect(dashboardPage.walletAtIndex(2)).toContainText('Passphrase wallet #3');
+            await expect(dashboardPage.walletAtIndex(0)).toContainTranslation(
+                'TR_PASSPHRASE_WALLET',
+                { values: { id: '2' } },
+            );
+            await expect(dashboardPage.walletAtIndex(1)).toContainTranslation(
+                'TR_NO_PASSPHRASE_WALLET',
+            );
+            await expect(dashboardPage.walletAtIndex(2)).toContainTranslation(
+                'TR_PASSPHRASE_WALLET',
+                { values: { id: '3' } },
+            );
         });
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-reconnection.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-reconnection.test.ts
@@ -64,7 +64,12 @@ test.describe('Passphrase reconnection', { tag: ['@group=passphrase'] }, () => {
                 await dashboardPage.openDeviceSwitcher();
             }
 
-            await expect(dashboardPage.walletAtIndex(1)).toContainText('Passphrase wallet #1');
+            await expect(dashboardPage.walletAtIndex(1)).toContainTranslation(
+                'TR_PASSPHRASE_WALLET',
+                {
+                    values: { id: '1' },
+                },
+            );
         });
 
         await test.step('Displaying receive address should prompt for passphrase', async () => {

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
@@ -169,7 +169,12 @@ test.describe('Passphrase', { tag: ['@group=passphrase'] }, () => {
 
             await dashboardPage.modal.waitFor({ state: 'detached' });
             await dashboardPage.openDeviceSwitcher();
-            await expect(dashboardPage.walletAtIndex(1)).toContainText('Passphrase wallet #1');
+            await expect(dashboardPage.walletAtIndex(1)).toContainTranslation(
+                'TR_PASSPHRASE_WALLET',
+                {
+                    values: { id: '1' },
+                },
+            );
         });
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/recovery/dry-run.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/recovery/dry-run.test.ts
@@ -45,8 +45,8 @@ test.describe('Recovery - dry run', { tag: ['@group=device-management'] }, () =>
 
             await test.step('Verify success in suite', async () => {
                 await trezorUserEnvLink.pressYes();
-                await expect(recoveryModal.successTitle).toHaveText(
-                    'Wallet backup checked successfully',
+                await expect(recoveryModal.successTitle).toHaveTranslation(
+                    'TR_SEED_CHECK_SUCCESS_TITLE',
                 );
             });
         },
@@ -95,8 +95,8 @@ test.describe('Recovery - dry run', { tag: ['@group=device-management'] }, () =>
                 await trezorUserEnvLink.pressYes();
                 await trezorInput.inputMnemonicT2T1(MNEMONICS.mnemonic_all);
                 await trezorUserEnvLink.pressYes();
-                await expect(recoveryModal.successTitle).toHaveText(
-                    'Wallet backup checked successfully',
+                await expect(recoveryModal.successTitle).toHaveTranslation(
+                    'TR_SEED_CHECK_SUCCESS_TITLE',
                 );
             });
         },
@@ -139,8 +139,8 @@ test.describe('Recovery - dry run', { tag: ['@group=device-management'] }, () =>
                 await trezorUserEnvLink.pressYes();
                 await trezorInput.inputMnemonicT2T1(MNEMONICS.mnemonic_all);
                 await trezorUserEnvLink.pressYes();
-                await expect(recoveryModal.successTitle).toHaveText(
-                    'Wallet backup checked successfully',
+                await expect(recoveryModal.successTitle).toHaveTranslation(
+                    'TR_SEED_CHECK_SUCCESS_TITLE',
                 );
             });
         },

--- a/packages/suite-desktop-core/e2e/tests/recovery/t1b1-dry-run.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/recovery/t1b1-dry-run.test.ts
@@ -42,9 +42,7 @@ test.describe(
                 await recoveryModal.initDryCheck('standard', 24);
                 await trezorInput.enterPinOnBlindMatrix(pin);
                 await trezorInput.inputMnemonicT1B1(mnemonic);
-                await expect(devicePrompt.modal).toContainText(
-                    "Follow the instructions on your Trezor's screen",
-                );
+                await expect(devicePrompt.modal).toContainTranslation('TR_CONFIRM_ACTION_ON_YOUR');
                 await trezorUserEnvLink.pressYes();
                 await expect(recoveryModal.successTitle).toHaveText(
                     'Wallet backup checked successfully',

--- a/packages/suite-desktop-core/e2e/tests/settings/autodetect.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/autodetect.test.ts
@@ -1,7 +1,8 @@
+import messages from '@trezor/suite/src/support/messages';
 import { colorVariants } from '@trezor/theme';
 import { hexToRgba } from '@trezor/utils';
 
-import { TR_ALLOW_ANALYTICS } from '../../../../suite-data/files/translations/es-ES.json';
+import { TR_ONBOARDING_DATA_COLLECTION_HEADING as SPANISH_TR_ONBOARDING_DATA_COLLECTION_HEADING } from '../../../../suite-data/files/translations/es-ES.json';
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
@@ -14,21 +15,21 @@ const testCases = [
     {
         testName: 'Light English',
         userPreferences: { colorScheme: ColorScheme.Light },
-        text: 'Anonymous data collection',
+        text: messages['TR_ONBOARDING_DATA_COLLECTION_HEADING'].defaultMessage,
         textColor: colorVariants.standard.textDefault,
         bodyBackgroundColor: colorVariants.standard.backgroundSurfaceElevation0,
     },
     {
         testName: 'Dark English',
         userPreferences: { colorScheme: ColorScheme.Dark },
-        text: 'Anonymous data collection',
+        text: messages['TR_ONBOARDING_DATA_COLLECTION_HEADING'].defaultMessage,
         textColor: colorVariants.dark.textDefault,
         bodyBackgroundColor: colorVariants.dark.backgroundSurfaceElevation0,
     },
     {
         testName: 'Dark Spanish',
         userPreferences: { locale: 'es-ES', colorScheme: ColorScheme.Dark },
-        text: TR_ALLOW_ANALYTICS,
+        text: SPANISH_TR_ONBOARDING_DATA_COLLECTION_HEADING,
         textColor: colorVariants.dark.textDefault,
         bodyBackgroundColor: colorVariants.dark.backgroundSurfaceElevation0,
     },

--- a/packages/suite-desktop-core/e2e/tests/staking/initial-stake.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/initial-stake.test.ts
@@ -68,14 +68,24 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                 await stakingSection.stakingTabButton.click();
                 await expect(stakingSection.stakingDashboardCard).toBeHidden();
                 await expect(stakingSection.stakingEmptyCard).toBeVisible();
-                await expect(stakingSection.stakingEmptyCard).toContainText('Stake ETH');
+                await expect(stakingSection.stakingEmptyCard).toContainTranslation(
+                    'TR_STAKE_STAKE_TOKEN',
+                    {
+                        values: { symbol: 'ETH' },
+                    },
+                );
             });
 
             await test.step('Open and fill staking form', async () => {
                 await stakingSection.startStakingButton.click();
-                await expect(page.getByTestId('@modal/header')).toHaveText('Staking in a nutshell');
+                await expect(page.getByTestId('@modal/header')).toHaveTranslation(
+                    'TR_STAKE_STAKING_IN_A_NUTSHELL',
+                );
                 await stakingSection.continueButton.click();
-                await expect(page.getByTestId('@modal/header')).toHaveText('Stake ETH');
+                await expect(page.getByTestId('@modal/header')).toHaveTranslation(
+                    'TR_STAKE_STAKE_TOKEN',
+                    { values: { symbol: 'ETH' } },
+                );
                 await stakingSection.everstakeAcknowledgeCheckbox.click();
                 await stakingSection.confirmButton.click();
                 await expect(stakingSection.availableBalanceWithSymbol).toHaveText('1,234 ETH');
@@ -87,8 +97,9 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                 await stakingSection.acknowledgeCheckbox.click();
                 await stakingSection.confirmAndStakeButton.click();
 
-                await expect(devicePrompt.outputValueOf('data')).toHaveText(
-                    'Stake ETH on Everstake?',
+                await expect(devicePrompt.outputValueOf('data')).toHaveTranslation(
+                    'TR_STAKE_ON_EVERSTAKE',
+                    { values: { symbol: 'ETH' } },
                 );
                 await expect(devicePrompt).toDisplayOnEmulator({
                     header: { title: 'Stake' },
@@ -144,7 +155,9 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
 
             await test.step('Verify pending transaction', async () => {
                 await expect(stakingSection.pendingTransactionText).toBeVisible();
-                await expect(stakingSection.transactionStatus).toHaveText('Confirming transaction');
+                await expect(stakingSection.transactionStatus).toHaveTranslation(
+                    'TR_TX_CONFIRMING',
+                );
                 await stakingSection.expectProgressIndicatorsToMatchPhase('pendingTransaction');
                 await expect(stakingSection.speedUpButton).toBeEnabled();
                 await stakingSection.expectStakingAmounts({
@@ -174,7 +187,7 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                     ],
                 });
                 await page.clock.fastForward(stakingSection.watchPeriod);
-                await expect(stakingSection.transactionStatus).toHaveText('Transaction confirmed');
+                await expect(stakingSection.transactionStatus).toHaveTranslation('TR_TX_CONFIRMED');
                 await stakingSection.expectProgressIndicatorsToMatchPhase('addingToPool');
                 await stakingSection.expectStakingAmounts({
                     pending: '0.100204158497493752',

--- a/packages/suite-desktop-core/e2e/tests/staking/stake-more.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/stake-more.test.ts
@@ -81,8 +81,9 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                 await stakingSection.acknowledgeCheckbox.click();
                 await stakingSection.confirmAndStakeButton.click();
 
-                await expect(devicePrompt.outputValueOf('data')).toHaveText(
-                    'Stake ETH on Everstake?',
+                await expect(devicePrompt.outputValueOf('data')).toHaveTranslation(
+                    'TR_STAKE_ON_EVERSTAKE',
+                    { values: { symbol: 'ETH' } },
                 );
                 await expect(devicePrompt).toDisplayOnEmulator({
                     header: { title: 'Stake' },
@@ -138,7 +139,9 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
 
             await test.step('Verify pending transaction', async () => {
                 await expect(stakingSection.pendingTransactionText).toBeVisible();
-                await expect(stakingSection.transactionStatus).toHaveText('Confirming transaction');
+                await expect(stakingSection.transactionStatus).toHaveTranslation(
+                    'TR_TX_CONFIRMING',
+                );
                 await stakingSection.expectProgressIndicatorsToMatchPhase('pendingTransaction');
                 await expect(stakingSection.speedUpButton).toBeEnabled();
                 await stakingSection.expectStakingAmounts({
@@ -168,7 +171,7 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                     ],
                 });
                 await page.clock.fastForward(stakingSection.watchPeriod);
-                await expect(stakingSection.transactionStatus).toHaveText('Transaction confirmed');
+                await expect(stakingSection.transactionStatus).toHaveTranslation('TR_TX_CONFIRMED');
                 await stakingSection.expectProgressIndicatorsToMatchPhase('addingToPool');
                 await stakingSection.expectStakingAmounts({
                     pending: '0.100204158497493752',
@@ -207,11 +210,17 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
             });
 
             await test.step('Verify banner about instant staking', async () => {
-                await expect(stakingSection.instantBannerHeader).toHaveText(
-                    '0.100204158497493752 ETH staked instantly!',
+                await expect(stakingSection.instantBannerHeader).toHaveTranslation(
+                    'TR_STAKING_AMOUNT_STAKED_INSTANTLY',
+                    {
+                        values: { amount: '0.100204158497493752', symbol: 'ETH' },
+                    },
                 );
-                await expect(stakingSection.instantBannerParagraph).toHaveText(
-                    "You've instantly staked 0.100204158497493752 ETH. The remaining ETH will be staked within 1 day.",
+                await expect(stakingSection.instantBannerParagraph).toHaveTranslation(
+                    'TR_STAKING_INSTANTLY_STAKED',
+                    {
+                        values: { amount: '0.100204158497493752', symbol: 'ETH', days: '1' },
+                    },
                 );
                 await stakingSection.instantBannerGotItButton.click();
                 await expect(stakingSection.instantBanner).toBeHidden();

--- a/packages/suite-desktop-core/e2e/tests/staking/staking-form.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/staking-form.test.ts
@@ -60,14 +60,20 @@ test.describe('ETH staking form', { tag: ['@group=staking'] }, () => {
 
                     await expect
                         .soft(stakingSection.cryptoInputBottomText)
-                        .toHaveText('Minimum is 0.1 ETH', { timeout: 15_000 });
+                        .toHaveTranslation('TR_BUY_VALIDATION_ERROR_MINIMUM_CRYPTO', {
+                            values: { minimum: '0.1 ETH' },
+                            timeout: 15_000,
+                        });
                 });
 
                 await test.step('Too many decimal digits', async () => {
                     await stakingSection.cryptoInput.fill('0.0000000000000000001');
                     await expect
                         .soft(stakingSection.cryptoInputBottomText)
-                        .toHaveText('Maximum 18 decimals allowed', { timeout: 15_000 });
+                        .toHaveTranslation('AMOUNT_IS_NOT_IN_RANGE_DECIMALS', {
+                            values: { decimals: '18' },
+                            timeout: 15_000,
+                        });
                 });
 
                 await test.step('Not enough funds', async () => {
@@ -115,9 +121,9 @@ test.describe('ETH staking form', { tag: ['@group=staking'] }, () => {
                         .click();
                     await expect
                         .soft(stakingSection.withdrawalWarning)
-                        .toHaveText(
-                            'We’ve left 0.03 ETH in your account so you can pay for withdrawal fees.',
-                        );
+                        .toHaveTranslation('TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL', {
+                            values: { amount: '0.03', networkDisplaySymbol: 'ETH' },
+                        });
                     const expectedMax = new BigNumber(ethereumStakingBalance!)
                         .minus(WITHDRAWAL_BUFFER)
                         .minus(MOCKED_FEE_AMOUNT);

--- a/packages/suite-desktop-core/e2e/tests/staking/unstake.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/unstake.test.ts
@@ -63,8 +63,9 @@ test.describe('ETH unstaking and claim', { tag: ['@group=staking'] }, () => {
 
             await test.step('Initiate unstaking and confirm on device', async () => {
                 await stakingSection.unstakeButton.click();
-                await expect(devicePrompt.outputValueOf('data')).toHaveText(
-                    'Unstake ETH from Everstake?',
+                await expect(devicePrompt.outputValueOf('data')).toHaveTranslation(
+                    'TR_UNSTAKE_FROM_EVERSTAKE',
+                    { values: { symbol: 'ETH' } },
                 );
                 await expect(devicePrompt).toDisplayOnEmulator({
                     header: { title: 'Unstake' },
@@ -176,8 +177,9 @@ test.describe('ETH unstaking and claim', { tag: ['@group=staking'] }, () => {
             await test.step('Finish claiming', async () => {
                 await expect(stakingSection.claimModalAmount).toHaveText('3,234 ETH');
                 await stakingSection.claimModalButton.click();
-                await expect(devicePrompt.outputValueOf('data')).toHaveText(
-                    'Claim ETH from Everstake?',
+                await expect(devicePrompt.outputValueOf('data')).toHaveTranslation(
+                    'TR_CLAIM_FROM_EVERSTAKE',
+                    { values: { symbol: 'ETH' } },
                 );
                 await expect(devicePrompt).toDisplayOnEmulator({
                     header: { title: 'Claim' },

--- a/packages/suite-desktop-core/e2e/tests/suite/db-migration.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/db-migration.test.ts
@@ -77,7 +77,7 @@ test.describe(
                         .click();
                     await expect(
                         page.locator('[data-test="@theme/color-scheme-select/input"]'),
-                    ).toContainText('Dark');
+                    ).toContainTranslation('TR_COLOR_SCHEME_DARK');
                 });
 
                 await test.step('Add passphrase wallet', async () => {
@@ -140,8 +140,11 @@ test.describe(
                             .getByTestId('@menu/switch-device')
                             .getByTestId('@deviceStatus-disconnected'),
                     ).toBeVisible();
-                    await expect(dashboardPage.walletAtIndex(0)).toContainText(
-                        'Passphrase wallet #1',
+                    await expect(dashboardPage.walletAtIndex(0)).toContainTranslation(
+                        'TR_PASSPHRASE_WALLET',
+                        {
+                            values: { id: '1' },
+                        },
                     );
                 });
 

--- a/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
@@ -48,10 +48,12 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
 
             await test.step('Take Bridge session back', async () => {
                 await dashboardPage.solveIssuesButton.click();
-                await expect(dashboardPage.deviceStatusOnSwitchDevice).toHaveText('Connected');
+                await expect(dashboardPage.deviceStatusOnSwitchDevice).toHaveTranslation(
+                    'TR_CONNECTED',
+                );
                 await expect(dashboardPage.walletAtIndex(0)).toBeVisible();
                 await dashboardPage.deviceSwitchingCloseButton.click();
-                await expect(dashboardPage.deviceStatus).toHaveText('Connected');
+                await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_CONNECTED');
             });
 
             await test.step('Reload inactive suite session', async () => {
@@ -107,7 +109,7 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
             );
             await onboardingPageTwo.completeOnboarding();
             const dashboardPageTwo = new DashboardPage(pageTwo, devicePromptTwo);
-            await expect(dashboardPageTwo.deviceStatus).toHaveText('Connected');
+            await expect(dashboardPageTwo.deviceStatus).toHaveTranslation('TR_CONNECTED');
             await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE');
 
             await pageTwo.close();

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
@@ -103,8 +103,8 @@ test.describe('Trading - Buy BTC', { tag: ['@group=trading', '@webOnly'] }, () =
             await expect.soft(watchRequestPromise).toHavePayload(invityRequest.buyWatchPayload, {
                 omit: ['partnerData', 'orderId', 'paymentId'],
             });
-            await expect(tradingPage.transactionDetailStatus).toHaveText(
-                'Waiting for your payment...',
+            await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                'TR_BUY_DETAIL_SUBMITTED_TITLE',
             );
             await expect(tradingPage.proceedToPayButton).toBeVisible();
         });

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
@@ -117,7 +117,7 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
             });
 
         await test.step('Verify fees on modal and emulator', async () => {
-            await expect(devicePrompt.ethereumGasLimit).toHaveText(`Gas limit: ${gasLimit}`);
+            await expect(devicePrompt.ethereumGasLimit).toHaveText(`${messages['TR_GAS_LIMIT'].defaultMessage}: ${gasLimit}`);
             await expect(devicePrompt.ethereumFeeRate).toHaveText(`${maxFeePerGasRounded} Gwei`);
             await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(
                 `${maxPriorityFeePerGasRounded} Gwei`,

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
@@ -43,7 +43,7 @@ test.describe('Trading - Sell inputs', { tag: ['@group=trading', '@webOnly'] }, 
                 await expect
                     .soft(tradingPage.cryptoInputBottomText)
                     .toHaveTranslation('AMOUNT_IS_NOT_IN_RANGE_DECIMALS', {
-                        placeholderValues: ['8'],
+                        values: { decimals: '8' },
                         timeout: 15_000,
                     });
             });

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -23,7 +23,6 @@ const formattedCryptoAmount = `${cryptoAmount} SOL`;
 const formattedFiatAmount = `€${fiatAmount}`;
 const { paymentMethodName } = sellTradeSolana.trade;
 const formattedAddress = formatAddress(sellWatchSolana.destinationAddress);
-const toastText = `${formattedCryptoAmount} sent from Solana #1`;
 
 test.describe('Trading - Sell Solana', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({
@@ -108,11 +107,15 @@ test.describe('Trading - Sell Solana', { tag: ['@group=trading', '@webOnly'] }, 
         await test.step('Send crypto to provider', async () => {
             await page.clock.install();
             await devicePrompt.sendButton.click();
-            await expect(tradingPage.transactionDetailStatus).toHaveText('Trade in progress...');
+            await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                'TR_SELL_DETAIL_PENDING_TITLE',
+            );
             await expect(
                 page.getByRole('link', { name: "Open partner's support site" }),
             ).toBeVisible();
-            await expect(page.getByTestId('@toast/tx-sent')).toContainText(toastText);
+            await expect(page.getByTestId('@toast/tx-sent')).toContainTranslation('TOAST_TX_SENT', {
+                values: { amount: formattedCryptoAmount, account: 'Solana #1' },
+            });
         });
 
         await test.step('Wait 30s for watch refresh and status change to Success', async () => {

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -78,14 +78,14 @@ test.describe('Trading - Swap coin to token', { tag: ['@group=trading', '@webOnl
             await expect(page.getByTestId('@toast/tx-exchange')).toHaveTranslation(
                 'TOAST_TX_EXCHANGE_BROADCASTED',
                 {
-                    placeholderValues: [
+                    values: {
                         sendAmount,
-                        'SOL',
-                        'Solana #1',
+                        sendAsset: 'SOL',
+                        sendAccount: 'Solana #1',
                         receiveAmount,
-                        'USDC',
-                        'Ethereum #1',
-                    ],
+                        receiveAsset: 'USDC',
+                        receiveAccount: 'Ethereum #1',
+                    },
                 },
             );
             await expect(tradingPage.transactionDetailStatus).toHaveTranslation(

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
@@ -1,5 +1,5 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
-import messages from '@trezor/suite/src/support/messages';
+import type { TranslationKey } from '@trezor/suite/src/components/suite/Translation';
 
 import {
     getCompanyNameFromList,
@@ -13,11 +13,17 @@ import { transformAddress } from '../../support/testExtends/customMatchers';
 
 // In beforeEach, We set initial status to 'SENDING'
 const transactionStates = [
-    { transactionStatus: 'CONFIRMING', displayedText: 'Pending' },
-    { transactionStatus: 'CONVERTING', displayedText: 'Converting' },
+    {
+        transactionStatus: 'CONFIRMING',
+        displayedText: 'TR_EXCHANGE_STATUS_CONFIRMING',
+    },
+    {
+        transactionStatus: 'CONVERTING',
+        displayedText: 'TR_EXCHANGE_DETAIL_CONVERTING_TITLE',
+    },
     {
         transactionStatus: 'SUCCESS',
-        displayedText: messages['TR_EXCHANGE_DETAIL_SUCCESS_TITLE'].defaultMessage,
+        displayedText: 'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
     },
 ];
 
@@ -125,18 +131,20 @@ test.describe('Trading - Swap coins', { tag: ['@group=trading', '@webOnly'] }, (
         await test.step('Send crypto to provider', async () => {
             await page.clock.install();
             await devicePrompt.sendButton.click();
-            await expect(tradingPage.transactionDetailStatus).toHaveText('Pending');
+            await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                'TR_EXCHANGE_STATUS_CONFIRMING',
+            );
             await expect(page.getByTestId('@toast/tx-exchange')).toHaveTranslation(
                 'TOAST_TX_EXCHANGE_BROADCASTED',
                 {
-                    placeholderValues: [
+                    values: {
                         sendAmount,
-                        'SOL',
-                        'Solana #1',
+                        sendAsset: 'SOL',
+                        sendAccount: 'Solana #1',
                         receiveAmount,
-                        'BTC',
-                        'Bitcoin #1',
-                    ],
+                        receiveAsset: 'BTC',
+                        receiveAccount: 'Bitcoin #1',
+                    },
                 },
             );
         });
@@ -157,7 +165,9 @@ test.describe('Trading - Swap coins', { tag: ['@group=trading', '@webOnly'] }, (
                     status: transactionStatus,
                     sendAddress,
                 });
-                await expect(tradingPage.transactionDetailStatus).toHaveText(displayedText);
+                await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                    displayedText as TranslationKey,
+                );
             });
         }
 

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -75,14 +75,14 @@ test.describe('Trading - Swap token to coin', { tag: ['@group=trading', '@webOnl
             await expect(page.getByTestId('@toast/tx-exchange')).toHaveTranslation(
                 'TOAST_TX_EXCHANGE_BROADCASTED',
                 {
-                    placeholderValues: [
+                    values: {
                         sendAmount,
-                        'USDT',
-                        'Solana #1',
+                        sendAsset: 'USDT',
+                        sendAccount: 'Solana #1',
                         receiveAmount,
-                        'BTC',
-                        'Bitcoin #1',
-                    ],
+                        receiveAsset: 'BTC',
+                        receiveAccount: 'Bitcoin #1',
+                    },
                 },
             );
             await expect(tradingPage.transactionDetailStatus).toHaveTranslation(

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
@@ -75,14 +75,14 @@ test.describe('Trading - Swap tokens', { tag: ['@group=trading', '@webOnly'] }, 
             await expect(page.getByTestId('@toast/tx-exchange')).toHaveTranslation(
                 'TOAST_TX_EXCHANGE_BROADCASTED',
                 {
-                    placeholderValues: [
+                    values: {
                         sendAmount,
-                        'USDT',
-                        'Solana #1',
+                        sendAsset: 'USDT',
+                        sendAccount: 'Solana #1',
                         receiveAmount,
-                        'USDC',
-                        'Solana #1',
-                    ],
+                        receiveAsset: 'USDC',
+                        receiveAccount: 'Solana #1',
+                    },
                 },
             );
             await expect(tradingPage.transactionDetailStatus).toHaveTranslation(

--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/getAddress.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/getAddress.test.ts
@@ -85,7 +85,7 @@ test.describe('TrezorConnect.getAddress', { tag: ['@group=connect', '@desktopOnl
             ).toBeDisabled();
             await expect(
                 page.getByTestId('@connect-address-confirmation/verify-button/1'),
-            ).toHaveText('Verifying');
+            ).toHaveTranslation('TR_VERIFYING');
 
             // TODO: 'verifying' is not enough to ensure device call is already in progress, it is only set right after clicking the button.
             await page.waitForTimeout(1000);
@@ -108,7 +108,7 @@ test.describe('TrezorConnect.getAddress', { tag: ['@group=connect', '@desktopOnl
             ).toBeDisabled();
             await expect(
                 page.getByTestId('@connect-address-confirmation/verify-button/0'),
-            ).toHaveText('Verifying');
+            ).toHaveTranslation('TR_VERIFYING');
 
             // TODO: 'verifying' is not enough to ensure device call is already in progress, it is only set right after clicking the button.
             await page.waitForTimeout(1000);

--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/permissions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/permissions.test.ts
@@ -1,4 +1,5 @@
 import TrezorConnect from '@trezor/connect-web';
+import messages from '@trezor/suite/src/support/messages';
 
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
@@ -39,8 +40,8 @@ test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () =
             });
 
             await expect(connectPermissionsModal.processParagraph).toHaveText('node');
-            await expect(connectPermissionsModal.rememberCheckbox).toHaveText(
-                'Always allow for this app',
+            await expect(connectPermissionsModal.rememberCheckbox).toHaveTranslation(
+                'TR_CONNECT_MODAL_REMEMBER',
             );
             await connectPermissionsModal.rememberCheckbox.click();
             await connectPermissionsModal.confirmButton.click();
@@ -58,7 +59,8 @@ test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () =
             await page.getByTestId(`@settings/connect-apps/0/dropdown`).click();
 
             // todo: it looks like data-test is not passed down to list items in dropdown
-            await page.getByText('Forget').click();
+            const forgetButtonTranslation = messages['TR_FORGET'].defaultMessage;
+            await page.getByText(forgetButtonTranslation).click();
             await page.getByTestId('@settings/connect-apps/no-apps').waitFor({ state: 'visible' });
 
             // permissions modal appears again

--- a/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
@@ -107,10 +107,14 @@ test.describe(
                 );
                 await expect(
                     pendingTransactionsAccount1.getByTestId('@transaction-item/0/heading'),
-                ).toContainText('Sending REGTEST to myself');
+                ).toContainTranslation('TR_SENDING_SYMBOL_TO_SELF', {
+                    values: { multiple: 'false', symbol: 'REGTEST' },
+                });
                 await expect(
                     pendingTransactionsAccount1.getByTestId('@transaction-item/1/heading'),
-                ).toContainText('Sending REGTEST');
+                ).toContainTranslation('TR_SENDING_SYMBOL', {
+                    values: { multiple: 'false', symbol: 'REGTEST' },
+                });
             });
 
             await test.step('Verify account #2 has 1 pending transaction (receive)', async () => {
@@ -122,7 +126,9 @@ test.describe(
                 );
                 await expect(
                     pendingTransactionsAccount2.getByTestId('@transaction-item/0/heading'),
-                ).toContainText('Receiving REGTEST');
+                ).toContainTranslation('TR_RECEIVING_SYMBOL', {
+                    values: { multiple: 'false', symbol: 'REGTEST' },
+                });
             });
 
             await test.step('Generate empty Block and verify account #1 transaction has NOT changed', async () => {
@@ -139,10 +145,14 @@ test.describe(
                 );
                 await expect(
                     pendingTransactionsAccount1AfterMine.getByTestId('@transaction-item/0/heading'),
-                ).toContainText('Sending REGTEST to myself');
+                ).toContainTranslation('TR_SENDING_SYMBOL_TO_SELF', {
+                    values: { multiple: 'false', symbol: 'REGTEST' },
+                });
                 await expect(
                     pendingTransactionsAccount1AfterMine.getByTestId('@transaction-item/1/heading'),
-                ).toContainText('Sending REGTEST');
+                ).toContainTranslation('TR_SENDING_SYMBOL', {
+                    values: { multiple: 'false', symbol: 'REGTEST' },
+                });
             });
 
             await test.step('Mine the "not-self" transaction', async () => {
@@ -160,7 +170,9 @@ test.describe(
                     pendingTransactionsAccount1AfterMine2.getByTestId(
                         '@transaction-item/0/heading',
                     ),
-                ).toContainText('Sending REGTEST to myself');
+                ).toContainTranslation('TR_SENDING_SYMBOL_TO_SELF', {
+                    values: { multiple: 'false', symbol: 'REGTEST' },
+                });
                 await expect(page.getByTestId('@transaction-group/pending/count')).toContainText(
                     '1',
                 );
@@ -173,7 +185,9 @@ test.describe(
                 );
                 await expect(
                     confirmedTransactionsAccount1.getByTestId('@transaction-item/0/heading'),
-                ).toContainText('Sent REGTEST');
+                ).toContainTranslation('TR_SENT_SYMBOL', {
+                    values: { multiple: 'false', symbol: 'REGTEST' },
+                });
             });
 
             await test.step('Verify receive pending transaction on account #2 is now mined as well', async () => {
@@ -185,7 +199,9 @@ test.describe(
                 );
                 await expect(
                     confirmedTransactionsAccount2.getByTestId('@transaction-item/0/heading'),
-                ).toContainText('Received REGTEST');
+                ).toContainTranslation('TR_RECEIVED_SYMBOL', {
+                    values: { multiple: 'false', symbol: 'REGTEST' },
+                });
             });
 
             await test.step('Verify account #3 is visible', async () => {

--- a/packages/suite-desktop-core/e2e/tests/wallet/send-eth.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/send-eth.test.ts
@@ -1,4 +1,5 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
+import messages from '@trezor/suite/src/support/messages';
 import { BigNumber } from '@trezor/utils';
 
 import { formatAddress } from '../../support/common';
@@ -73,7 +74,8 @@ test.describe('Send Eth', { tag: ['@group=wallet'] }, () => {
 
         await test.step('Verify Total including fee', async () => {
             await devicePrompt.waitForPromptAndClick();
-            await expect(devicePrompt.ethereumGasLimit).toHaveText(`Gas limit: ${gasLimit}`);
+            const gasLimitTranslation = `${messages['TR_GAS_LIMIT'].defaultMessage}: ${gasLimit}`;
+            await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitTranslation);
             await expect(devicePrompt.ethereumFeeRate).toHaveText(`${maxFeePerGasRounded} Gwei`);
             await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(
                 `${maxPriorityFeePerGasRounded} Gwei`,

--- a/packages/suite-desktop-core/e2e/tests/wallet/transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/transactions.test.ts
@@ -1,12 +1,14 @@
+import messages from '@trezor/suite/src/support/messages';
+
 import { expect, test } from '../../support/fixtures';
 import { graphRangeOptions } from '../../support/pageObjects/dashboardPage';
 
 const rangeData: { range: graphRangeOptions; label: string }[] = [
-    { range: 'day', label: '1 day' },
-    { range: 'week', label: '1 week' },
-    { range: 'month', label: '1 month' },
-    { range: 'year', label: '1 year' },
-    { range: 'all', label: 'All' },
+    { range: 'day', label: messages['TR_DATE_DAY_LONG'].defaultMessage },
+    { range: 'week', label: messages['TR_DATE_WEEK_LONG'].defaultMessage },
+    { range: 'month', label: messages['TR_DATE_MONTH_LONG'].defaultMessage },
+    { range: 'year', label: messages['TR_DATE_YEAR_LONG'].defaultMessage },
+    { range: 'all', label: messages['TR_ALL'].defaultMessage },
 ];
 
 test.describe('Account transactions overview', { tag: ['@group=wallet'] }, () => {

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -83,6 +83,7 @@
         "glob": "^11.0.3",
         "jest-diff": "^29.7.0",
         "lodash": "^4.17.21",
+        "react-intl": "^7.1.14",
         "terser-webpack-plugin": "^5.3.14",
         "tsx": "^4.20.3",
         "webpack": "5.102.1",

--- a/scripts/list-outdated-dependencies/qa-dependencies.txt
+++ b/scripts/list-outdated-dependencies/qa-dependencies.txt
@@ -22,4 +22,5 @@ jest-expo
 jest-extended
 jest-junit
 jest-watch-typeahead
+react-intl
 ts-jest

--- a/yarn.lock
+++ b/yarn.lock
@@ -4515,6 +4515,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@formatjs/ecma402-abstract@npm:2.3.6":
+  version: 2.3.6
+  resolution: "@formatjs/ecma402-abstract@npm:2.3.6"
+  dependencies:
+    "@formatjs/fast-memoize": "npm:2.2.7"
+    "@formatjs/intl-localematcher": "npm:0.6.2"
+    decimal.js: "npm:^10.4.3"
+    tslib: "npm:^2.8.0"
+  checksum: 10/30b1b5cd6b62ba46245f934429936592df5500bc1b089dc92dd49c826757b873dd92c305dcfe370701e4df6b057bf007782113abb9b65db550d73be4961718bc
+  languageName: node
+  linkType: hard
+
 "@formatjs/fast-memoize@npm:2.2.7":
   version: 2.2.7
   resolution: "@formatjs/fast-memoize@npm:2.2.7"
@@ -4535,6 +4547,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@formatjs/icu-messageformat-parser@npm:2.11.4":
+  version: 2.11.4
+  resolution: "@formatjs/icu-messageformat-parser@npm:2.11.4"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.6"
+    "@formatjs/icu-skeleton-parser": "npm:1.8.16"
+    tslib: "npm:^2.8.0"
+  checksum: 10/2acb100c06c2ade666d72787fb9f9795b1ace41e8e73bfadc2b1a7b8562e81f655e484f0f33d8c39473aa17bf0ad96fb2228871806a9b3dc4f5f876754a0de3a
+  languageName: node
+  linkType: hard
+
 "@formatjs/icu-skeleton-parser@npm:1.8.14":
   version: 1.8.14
   resolution: "@formatjs/icu-skeleton-parser@npm:1.8.14"
@@ -4545,12 +4568,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@formatjs/icu-skeleton-parser@npm:1.8.16":
+  version: 1.8.16
+  resolution: "@formatjs/icu-skeleton-parser@npm:1.8.16"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.6"
+    tslib: "npm:^2.8.0"
+  checksum: 10/428001e5bed81889b276a2356a1393157af91dc59220b765a1a132f6407ac5832b7ac6ae9737674ac38e44035295c0c1c310b2630f383f2b5779ea90bf2849e6
+  languageName: node
+  linkType: hard
+
 "@formatjs/intl-localematcher@npm:0.6.1":
   version: 0.6.1
   resolution: "@formatjs/intl-localematcher@npm:0.6.1"
   dependencies:
     tslib: "npm:^2.8.0"
   checksum: 10/c7b3bc8395d18670677f207b2fd107561fff5d6394a9b4273c29e0bea920300ec3a2eefead600ebb7761c04a770cada28f78ac059f84d00520bfb57a9db36998
+  languageName: node
+  linkType: hard
+
+"@formatjs/intl-localematcher@npm:0.6.2":
+  version: 0.6.2
+  resolution: "@formatjs/intl-localematcher@npm:0.6.2"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10/eb12a7f5367bbecdfafc20d7f005559ce840f420e970f425c5213d35e94e86dfe75bde03464971a26494bf8427d4961269db22ecad2834f2a19d888b5d9cc064
   languageName: node
   linkType: hard
 
@@ -4569,6 +4611,24 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/10ebdce088898ad7de59c10890f7c02fa9f5aa50518ed3fae7e0ae1c392f3973da00464d2a42229cce97916c2eff1e41630e95c18bab01713d2b6ef5c7fd80c1
+  languageName: node
+  linkType: hard
+
+"@formatjs/intl@npm:3.1.8":
+  version: 3.1.8
+  resolution: "@formatjs/intl@npm:3.1.8"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.6"
+    "@formatjs/fast-memoize": "npm:2.2.7"
+    "@formatjs/icu-messageformat-parser": "npm:2.11.4"
+    intl-messageformat: "npm:10.7.18"
+    tslib: "npm:^2.8.0"
+  peerDependencies:
+    typescript: ^5.6.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/2e8b992606b8377dc4496fcc06ea0370b4f2b3fb27f4f086172cf618c9d981176831baff6a2b5bffb4a06e7aa580e28a8bda2d71ad2cb51d19f3d4bc4609e90e
   languageName: node
   linkType: hard
 
@@ -14396,6 +14456,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     node-loader: "npm:^2.1.0"
     openpgp: "npm:^6.2.2"
+    react-intl: "npm:^7.1.14"
     terser-webpack-plugin: "npm:^5.3.14"
     tsx: "npm:^4.20.3"
     webpack: "npm:5.102.1"
@@ -28492,6 +28553,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"intl-messageformat@npm:10.7.18":
+  version: 10.7.18
+  resolution: "intl-messageformat@npm:10.7.18"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.6"
+    "@formatjs/fast-memoize": "npm:2.2.7"
+    "@formatjs/icu-messageformat-parser": "npm:2.11.4"
+    tslib: "npm:^2.8.0"
+  checksum: 10/96650d673912763d21bbfa14b50749b992d45f1901092a020e3155961e3c70f4644dd1731c3ecb1207a1eb94d84bedf4c34b1ac8127c29ad6b015b6a2a4045cb
+  languageName: node
+  linkType: hard
+
 "intl-pluralrules@npm:^2.0.1":
   version: 2.0.1
   resolution: "intl-pluralrules@npm:2.0.1"
@@ -38428,17 +38501,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-intl@npm:^7.1.11":
-  version: 7.1.11
-  resolution: "react-intl@npm:7.1.11"
+"react-intl@npm:^7.1.11, react-intl@npm:^7.1.14":
+  version: 7.1.14
+  resolution: "react-intl@npm:7.1.14"
   dependencies:
-    "@formatjs/ecma402-abstract": "npm:2.3.4"
-    "@formatjs/icu-messageformat-parser": "npm:2.11.2"
-    "@formatjs/intl": "npm:3.1.6"
+    "@formatjs/ecma402-abstract": "npm:2.3.6"
+    "@formatjs/icu-messageformat-parser": "npm:2.11.4"
+    "@formatjs/intl": "npm:3.1.8"
     "@types/hoist-non-react-statics": "npm:^3.3.1"
     "@types/react": "npm:16 || 17 || 18 || 19"
     hoist-non-react-statics: "npm:^3.3.2"
-    intl-messageformat: "npm:10.7.16"
+    intl-messageformat: "npm:10.7.18"
     tslib: "npm:^2.8.0"
   peerDependencies:
     react: 16 || 17 || 18 || 19
@@ -38446,7 +38519,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/ea642c0e04f8186d9141a36a4804afe24810f8b6a96a47c8dc4388663f03c9acfa7b1d093fa65b47bd3f3b62217b8d33f90a7bb5d74d1a420aa1ecd3c6a88014
+  checksum: 10/74b1d9a2f6e6fa964503a08a56e0d27d52344ad5495dca875e08a146d16418d29bd12769273a479f3adf9ab445fc28a322421a8afaed4a4d040a0e9e3bedb79c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
To solve once for all problems with changes in translation, we have finally adopted the new toHave/ContainTransaltion to rest of tests. Because some template were too complicated, I had to rework the matchers a bit. Now they are more robust and work with key-value params.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-e2e-suite-refferemce-translation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-e2e-suite-refferemce-translation&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor-e2e-suite-refferemce-translation&lookback=7)