### PR TITLE
fix(suite): fix resolving contract address in TradingCoinLogo

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx
@@ -15,14 +15,14 @@ export const TradingCoinLogo = ({
     className,
 }: TradingCoinLogoProps) => {
     const { networkId, contractAddress } = parseCryptoId(cryptoId);
-    const { cryptoIdToSymbolAndContractAddress } = useTradingInfo();
-    const symbol = cryptoIdToSymbolAndContractAddress(cryptoId).coinSymbol;
+    const { cryptoIdToNativeCoinSymbol } = useTradingInfo();
+    const networkSymbol = cryptoIdToNativeCoinSymbol(cryptoId);
 
     return (
         <Wrapper className={className}>
             <AssetLogo
                 coingeckoId={networkId}
-                contractAddress={getAssetLogoContractAddresses(symbol, contractAddress)}
+                contractAddress={getAssetLogoContractAddresses(networkSymbol, contractAddress)}
                 size={size}
                 placeholder={networkId.toUpperCase()}
                 margin={margin}


### PR DESCRIPTION
## Description

Use network symbol instead of token symbol for resolving `contractAddress`.

## Related Issue

Resolve #14806

## Screenshots:

**Before:**
<img width="766" height="488" alt="Snímek obrazovky 2025-11-12 v 10 55 12" src="https://github.com/user-attachments/assets/7a11a9d5-c667-4ac8-832c-ff9bb77ea0a5" />

**After:**
<img width="769" height="499" alt="Snímek obrazovky 2025-11-12 v 10 54 54" src="https://github.com/user-attachments/assets/40d1d90d-b67e-4a21-8839-4d63debf5422" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/14806-trading-coin-logo&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/14806-trading-coin-logo&lookback=7)