### PR TITLE
fix(suite-desktop-core): prevent fallbacking to file:// protocol

### DIFF
--- a/packages/suite-desktop-core/src/modules/csp.ts
+++ b/packages/suite-desktop-core/src/modules/csp.ts
@@ -20,7 +20,7 @@ const createCspRules = ({ nonce }: CreateCspRulesParams) => [
     // Allow all API calls (Can't be restricted bc of custom backends)
     'connect-src *',
     // Allow images from trezor.io
-    "img-src 'self' blob: data: *.trezor.io",
+    "img-src 'self' blob: data: https://*.trezor.io",
 ];
 
 export const init: ModuleInit = ({ cspNonce }) => {


### PR DESCRIPTION
## Description

- Fix the CSP for desktop app by explicitly setting `https://` protocol.

## Related Issue

Resolve #22671



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/22671-desktop-csp&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/22671-desktop-csp&lookback=7)