### PR TITLE
Rerun discovery on account first use

### DIFF
--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -66,8 +66,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         ) {
             if (isDeviceReady && isUIReady) {
                 const shouldRediscover = selectShouldRediscover(getState(), device);
-                const noDiscoveryYet = device?.state?.staticSessionId === undefined;
-                if (noDiscoveryYet || shouldRediscover) {
+                if (shouldRediscover) {
                     dispatch(startOrRestartDiscoveryThunk());
                 }
             }

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -62,6 +62,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             connectPopupCallThunkInner.fulfilled.match(action) ||
             deviceActions.selectDevice.match(action) ||
             changeNetworks.match(action) ||
+            accountsActions.updateAccount.match(action) || // empty account can become nonempty
             accountsActions.changeAccountVisibility.match(action)
         ) {
             if (isDeviceReady && isUIReady) {

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -65,11 +65,7 @@ const rootReducer = combineReducers({
 
 export type AppState = ReturnType<typeof rootReducer>;
 
-const loggerExcludedActions = [
-    addLog.type,
-    accountsActions.updateAccount.type,
-    accountsActions.updateAccountRefreshTimestamp.type,
-];
+const loggerExcludedActions = [addLog.type, accountsActions.updateAccountRefreshTimestamp.type];
 
 const getCustomMiddleware = () => {
     const middleware = [

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -1,7 +1,7 @@
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { NetworkSymbol, networks, networksCollection } from '@suite-common/wallet-config';
-import { ReviewOutput } from '@suite-common/wallet-types';
+import { Account, ReviewOutput } from '@suite-common/wallet-types';
 import {
     findAccountsByAddress,
     isAccountDiscoverable,
@@ -78,34 +78,42 @@ export const selectAllSuccessfulAccountsToList = createMemoizedSelector(
 
 type DiscoveryAccountsParam = Parameters<TrezorConnect['discoverAccounts']>[0]['coins'];
 
+const getDeviceAccountsPerEnabledNetwork = (
+    state: WalletCoreCompoundRootState,
+    deviceState: StaticSessionId,
+): { symbol: NetworkSymbol; accounts: Account[] | undefined }[] => {
+    const symbols = selectEnabledSupportedNetworks(state);
+    const knownAccounts = selectAccountsByDeviceState(state, deviceState);
+    const discoverableAccounts = knownAccounts.filter(isAccountDiscoverable);
+    const symbolMap = arrayToDictionary(discoverableAccounts, acc => acc.symbol, true);
+
+    return symbols.map(symbol => ({ symbol, accounts: symbolMap[symbol] }));
+};
+
+const getLastAccountsPerAccountType = (accounts: Account[]) =>
+    Object.entries(arrayToDictionary(accounts, acc => acc.accountType, true)).map(
+        ([type, accs]) => ({
+            type,
+            // account with the highest index
+            lastAccount: accs.reduce((last, current) =>
+                current.index > last.index ? current : last,
+            ),
+        }),
+    );
+
 export const selectDiscoveryAccountsParam = (
     state: WalletCoreCompoundRootState,
     deviceState: StaticSessionId,
     knownOnly?: boolean,
-): DiscoveryAccountsParam => {
-    const symbols = selectEnabledSupportedNetworks(state);
-    const knownAccounts = selectAccountsByDeviceState(state, deviceState);
-    const discoverableAccounts = knownAccounts.filter(isAccountDiscoverable);
-
-    const symbolMap = arrayToDictionary(discoverableAccounts, acc => acc.symbol, true);
-
-    return symbols.map(symbol => {
-        const symbolAccounts = symbolMap[symbol];
+): DiscoveryAccountsParam =>
+    getDeviceAccountsPerEnabledNetwork(state, deviceState).map(({ symbol, accounts }) => {
         const { networkType } = networks[symbol];
         const identity = tryGetAccountIdentity({ networkType, deviceState });
 
         // undiscovered network; discover as a whole
-        if (!symbolAccounts) return { symbol, identity };
+        if (!accounts) return { symbol, identity };
 
-        // discovered network; separate by account type
-        const typeMap = arrayToDictionary(symbolAccounts, acc => acc.accountType, true);
-
-        const known = Object.entries(typeMap).map(([type, accs]) => {
-            // account with the highest index
-            const lastAccount = accs.reduce((last, current) =>
-                current.index > last.index ? current : last,
-            );
-
+        const known = getLastAccountsPerAccountType(accounts).map(({ type, lastAccount }) => {
             // last account is a failed one; try to discover it again
             if (lastAccount.failed) return { type, skip: lastAccount.index };
             // last account is a used one; skip it and try to discover next one
@@ -116,48 +124,19 @@ export const selectDiscoveryAccountsParam = (
 
         return { symbol, identity, known, knownOnly } as DiscoveryAccountsParam[number];
     });
-};
 
 export const selectShouldAccountsBeRediscovered = (
     state: WalletCoreCompoundRootState,
     deviceState?: StaticSessionId,
-): boolean | null => {
-    if (!deviceState) return null;
-
-    const networkSymbols = selectEnabledSupportedNetworks(state);
-    const deviceDiscoveredAccounts = selectAccountsByDeviceState(state, deviceState);
-    const discoverableAccounts = deviceDiscoveredAccounts.filter(isAccountDiscoverable);
-
-    const networkSymbolToAccountsMap = arrayToDictionary(
-        discoverableAccounts,
-        acc => acc.symbol,
-        true,
+) =>
+    !!deviceState &&
+    getDeviceAccountsPerEnabledNetwork(state, deviceState).some(
+        ({ accounts }) =>
+            !accounts ||
+            getLastAccountsPerAccountType(accounts).some(
+                ({ lastAccount }) => lastAccount.failed || !lastAccount.empty,
+            ),
     );
-
-    return networkSymbols.some(symbol => {
-        const networkSymbolsAccounts = networkSymbolToAccountsMap[symbol];
-
-        // undiscovered network; needs discovery
-        if (!networkSymbolsAccounts) return true;
-
-        // discovered network; check each account type
-        const networkSymbolAccountTypeToAccountMap = arrayToDictionary(
-            networkSymbolsAccounts,
-            acc => acc.accountType,
-            true,
-        );
-
-        return Object.values(networkSymbolAccountTypeToAccountMap).some(accounts => {
-            // account with the highest index
-            const lastAccount = accounts.reduce((last, current) =>
-                current.index > last.index ? current : last,
-            );
-            if (lastAccount.failed || !lastAccount.empty) return true;
-
-            return false;
-        });
-    });
-};
 
 const selectShouldRediscoverHelper = (
     state: WalletCoreCompoundRootState,

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -134,7 +134,7 @@ export const selectShouldAccountsBeRediscovered = (
         ({ accounts }) =>
             !accounts ||
             getLastAccountsPerAccountType(accounts).some(
-                ({ lastAccount }) => lastAccount.failed || !lastAccount.empty,
+                ({ lastAccount }) => !lastAccount.failed && !lastAccount.empty,
             ),
     );
 

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -125,30 +125,14 @@ export const selectDiscoveryAccountsParam = (
         return { symbol, identity, known, knownOnly } as DiscoveryAccountsParam[number];
     });
 
-export const selectShouldAccountsBeRediscovered = (
+export const selectShowRediscoverButton = (
     state: WalletCoreCompoundRootState,
-    deviceState?: StaticSessionId,
-) =>
-    !!deviceState &&
-    getDeviceAccountsPerEnabledNetwork(state, deviceState).some(
-        ({ accounts }) =>
-            !accounts ||
-            getLastAccountsPerAccountType(accounts).some(
-                ({ lastAccount }) => !lastAccount.failed && !lastAccount.empty,
-            ),
-    );
-
-const selectShouldRediscoverHelper = (
-    state: WalletCoreCompoundRootState,
-    device: TrezorDevice | undefined,
-    allowUndiscovered: boolean,
+    device?: TrezorDevice,
 ) => {
     const staticSessionId = device?.state?.staticSessionId;
     if (!staticSessionId) return false;
 
     if (selectHasRunningDiscovery(state)) return false;
-
-    if (allowUndiscovered && !device.discovered) return true;
 
     const symbols = selectEnabledSupportedNetworks(state);
     const accounts = selectAccountsByDeviceState(state, staticSessionId);
@@ -157,13 +141,25 @@ const selectShouldRediscoverHelper = (
     return symbols.some(symbol => !discoveredNetworks.has(symbol));
 };
 
-export const selectShowRediscoverButton = (
+export const selectShouldRediscover = (
     state: WalletCoreCompoundRootState,
-    device?: TrezorDevice,
-) => selectShouldRediscoverHelper(state, device, false);
+    device: TrezorDevice,
+) => {
+    if (selectHasRunningDiscovery(state)) return false;
 
-export const selectShouldRediscover = (state: WalletCoreCompoundRootState, device?: TrezorDevice) =>
-    selectShouldRediscoverHelper(state, device, true);
+    const staticSessionId = device.state?.staticSessionId;
+    if (!staticSessionId) return true;
+
+    if (!device.discovered) return true;
+
+    return getDeviceAccountsPerEnabledNetwork(state, staticSessionId).some(
+        ({ accounts }) =>
+            !accounts ||
+            getLastAccountsPerAccountType(accounts).some(
+                ({ lastAccount }) => !lastAccount.failed && !lastAccount.empty,
+            ),
+    );
+};
 
 export const selectAccountsToBeForgotten = (
     state: DiscoveryRootState & AccountsRootState & WalletSettingsRootState,

--- a/suite-native/discovery/src/components/AccountsRediscoveryNeededWarning.tsx
+++ b/suite-native/discovery/src/components/AccountsRediscoveryNeededWarning.tsx
@@ -7,7 +7,6 @@ import {
     selectIsDeviceConnected,
     selectIsPortfolioTrackerDevice,
     selectSelectedDevice,
-    selectShouldAccountsBeRediscovered,
     selectShouldRediscover,
 } from '@suite-common/wallet-core';
 import { Box, InlineAlertBox } from '@suite-native/atoms';
@@ -28,17 +27,13 @@ export const AccountsRediscoveryNeededWarning = ({
         selectDeviceModelById(state, device?.id),
     );
 
-    const shouldRediscover = useSelector((state: WalletCoreCompoundRootState) =>
-        selectShouldRediscover(state, device),
-    );
-    const shouldAccountsBeRediscovered = useSelector((state: WalletCoreCompoundRootState) =>
-        selectShouldAccountsBeRediscovered(state, device?.state?.staticSessionId),
+    const shouldRediscover = useSelector(
+        (state: WalletCoreCompoundRootState) => device && selectShouldRediscover(state, device),
     );
 
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
-    const shouldUserBePromptedToReconnectDevice =
-        !shouldRediscover && !shouldAccountsBeRediscovered;
+    const shouldUserBePromptedToReconnectDevice = !shouldRediscover;
 
     if (
         shouldUserBePromptedToReconnectDevice ||

--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -71,8 +71,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
                 isDeviceAcquired(device)
             ) {
                 const shouldRediscover = selectShouldRediscover(getState(), device);
-                const noDiscoveryYet = device?.state?.staticSessionId === undefined;
-                if (noDiscoveryYet || shouldRediscover) {
+                if (shouldRediscover) {
                     dispatch(startOrRestartDiscoveryThunk());
                 }
             }

--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -58,6 +58,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             action.type === DEVICE.CONNECT ||
             deviceActions.selectDevice.match(action) ||
             changeCoinVisibility.fulfilled.match(action) ||
+            accountsActions.updateAccount.match(action) || // empty account can become nonempty
             accountsActions.changeAccountVisibility.match(action) ||
             createAndBackupWalletThunk.fulfilled.match(action) ||
             recoverWalletThunk.fulfilled.match(action)


### PR DESCRIPTION
## Description

Discovery conditions were improved in order to not encounter some incorrect states. Specifically, when a previously empty account became non-empty, discovery wasn't triggered and therefore it wasn't possible to add a new account. Also, it slightly changes mobile logic recently added in https://github.com/trezor/trezor-suite/pull/22725.

## Commits

- Don't ignore `updateAccount` action in dev logs (it was ignored [here](https://github.com/trezor/trezor-suite/commit/39c71a19dd173ba5f5d8a490163b8e3cd8dfe552#diff-f6cbd9448cc861419263766f38aab404421e1d4aea98af18f7e09f78f9722cbd), probably by mistake )
- Pure refactoring; Extract common logic from `selectDiscoveryAccountsParam` and `selectShouldAccountsBeRediscovered`
- Don't consider account sequences ending with failed account as a reason to rediscover; first fix the account issue
- Unify `selectShouldRediscover` with `selectShouldAccountsBeRediscovered`; previous lighter check ("is there an enabled coin without any account?") is now used only for showing rediscover button, otherwise it was replaced by heavier check ("is there an enabled coin with an account type sequence not ending with non-failed empty account?").
- Check rediscover condition on `updateAccount` action as well; previously empty account could've become non-empty and therefore a new one may be needed

## Notes for QA

Please test that:.

- Discovery in general works great as always :trollface: 
- When there is an unused account, it may not be possible to add a next one of the same type, but as soon as it becomes used, discovery is triggered and a new empty account is discovered to be added later (regtest to the rescue).
- When there is a failed account (e.g. nonexistent custom backend is set), discovery is **not** triggered every time something happens (e.g. switching between dashboard/accounts/settings)

## Related Issue

Resolve <!--- link the issue here -->

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/discovery-add-account&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/discovery-add-account&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/discovery-add-account&lookback=7)