### PR TITLE
chore(token-definitions): run script for more chains at once, reuse data

### DIFF
--- a/.github/workflows/release-suite-definitions.yml
+++ b/.github/workflows/release-suite-definitions.yml
@@ -42,26 +42,10 @@ jobs:
         run: |
           yarn install
           cd suite-common/token-definitions
-          yarn nfts simple ethereum
-          yarn nfts simple polygon-pos
-          yarn nfts simple binance-smart-chain
-          yarn nfts simple optimistic-ethereum
-          yarn nfts simple base
-          yarn nfts simple arbitrum-one
-          yarn nfts simple avalanche
-          yarn coins simple ethereum
-          yarn coins simple ethereum-classic
-          yarn coins simple polygon-pos
-          yarn coins simple binance-smart-chain
-          yarn coins simple optimistic-ethereum
-          yarn coins simple base
-          yarn coins simple arbitrum-one
-          yarn coins simple avalanche
-          yarn coins simple cardano
-          yarn coins simple solana
-          yarn coins advanced solana
-          yarn coins simple stellar
-          yarn coins advanced stellar
+
+          yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
+          yarn coins simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche cardano solana stellar
+          yarn coins advanced solana stellar
 
       - name: Build and sign ${{ github.event.inputs.environment }} token-definitions files
         if: ${{ github.event.inputs.environment == 'production-definitions' && github.ref == 'refs/heads/develop' }}
@@ -71,26 +55,10 @@ jobs:
         run: |
           yarn install
           cd suite-common/token-definitions
-          yarn nfts simple ethereum
-          yarn nfts simple polygon-pos
-          yarn nfts simple binance-smart-chain
-          yarn nfts simple optimistic-ethereum
-          yarn nfts simple base
-          yarn nfts simple arbitrum-one
-          yarn nfts simple avalanche
-          yarn coins simple ethereum
-          yarn coins simple ethereum-classic
-          yarn coins simple polygon-pos
-          yarn coins simple binance-smart-chain
-          yarn coins simple optimistic-ethereum
-          yarn coins simple base
-          yarn coins simple arbitrum-one
-          yarn coins simple avalanche
-          yarn coins simple cardano
-          yarn coins simple solana
-          yarn coins advanced solana
-          yarn coins simple stellar
-          yarn coins advanced stellar
+
+          yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
+          yarn coins simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche cardano solana stellar
+          yarn coins advanced solana stellar
 
       - name: Upload ${{ github.event.inputs.environment }} token-definitions files
         if: ${{ github.ref == 'refs/heads/develop' }}

--- a/suite-common/token-definitions/scripts/index.ts
+++ b/suite-common/token-definitions/scripts/index.ts
@@ -3,67 +3,119 @@ import fs from 'fs';
 import { join } from 'path';
 
 import { DEFINITIONS_FILENAME_SUFFIX, FILES_PATH } from './constants';
-import { fetchCoinData } from './utils/fetchCoins';
+import { buildCoinDataForPlatform, fetchAllCoins } from './utils/fetchCoins';
 import { fetchNftData } from './utils/fetchNft';
 import { signData } from './utils/sign';
 import { validateStructure } from './utils/validate';
-import { TokenStructure } from '../src/tokenDefinitionsTypes';
+import { DefinitionType, TokenStructure, TokenStructureType } from '../src/tokenDefinitionsTypes';
+
+const writeDefinitionFiles = (
+    assetPlatformId: string,
+    type: DefinitionType,
+    structure: TokenStructureType,
+    data: TokenStructure,
+) => {
+    const fileName = `${assetPlatformId}.${structure}.${type}.${DEFINITIONS_FILENAME_SUFFIX}`;
+    fs.mkdirSync(FILES_PATH, { recursive: true });
+    const signedData = signData(data);
+    fs.writeFileSync(join(FILES_PATH, `${fileName}.jws`), signedData);
+    fs.writeFileSync(join(FILES_PATH, `${fileName}.json`), JSON.stringify(data));
+    console.log('JSON definitions saved to ', join(FILES_PATH, fileName, '.[jws,json]'));
+};
+
+const countRecords = (data: TokenStructure, structure: TokenStructureType) =>
+    structure === TokenStructureType.SIMPLE
+        ? (data as string[]).length
+        : Object.keys(data as Record<string, unknown>).length;
+
+const printSummary = (
+    type: DefinitionType,
+    structure: TokenStructureType,
+    counts: Record<string, number>,
+) => {
+    const entries = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+    const total = entries.reduce((sum, [, n]) => sum + n, 0);
+
+    console.log('\n==================== SUMMARY ====================');
+    console.log(`Type: ${type}, Structure: ${structure}`);
+    for (const [platform, n] of entries) {
+        console.log(`${platform.padEnd(22, ' ')} : ${n}`);
+    }
+    console.log('-----------------------------------------------');
+    console.log(`TOTAL records: ${total}`);
+    console.log('================================================\n');
+};
 
 const main = async () => {
     const argv = process.argv.slice(2);
 
-    const type: string = argv[0];
-    const structure: string = argv[1];
-    const assetPlatformId: string = argv[2];
+    const rawType = argv[0];
+    const rawStructure = argv[1];
+    const assetPlatformIds = argv.slice(2);
 
-    if (!type || !['nft', 'coin'].includes(type)) {
-        throw new Error('Missing type, please specify "nft" or "coin"');
+    if (!rawType || !Object.values(DefinitionType).includes(rawType as DefinitionType)) {
+        throw new Error('Missing or invalid type, please specify "nft" or "coin"');
+    }
+    if (
+        !rawStructure ||
+        !Object.values(TokenStructureType).includes(rawStructure as TokenStructureType)
+    ) {
+        throw new Error('Missing or invalid structure, please specify "simple" or "advanced"');
     }
 
-    if (!structure || !['simple', 'advanced'].includes(structure)) {
-        throw new Error('Missing structure, please specify "simple" or "advanced"');
-    }
+    const type = rawType as DefinitionType;
+    const structure = rawStructure as TokenStructureType;
 
-    if (!assetPlatformId) {
+    if (!assetPlatformIds.length) {
         throw new Error(
-            'Missing platform id. Please enter "ethereum", "polygon-pos" or any other from https://pro-api.coingecko.com/api/v3/asset_platforms',
+            'Missing platform id(s). Provide one or more (e.g. "ethereum polygon-pos").',
         );
     }
 
-    let data: TokenStructure;
-    if (type === 'nft') {
-        data = await fetchNftData(assetPlatformId, structure);
-    } else {
-        data = await fetchCoinData(assetPlatformId, structure);
+    console.log(
+        `Type: ${type}, structure: ${structure}, platforms: ${assetPlatformIds.join(', ')}`,
+    );
+
+    const counts: Record<string, number> = {};
+
+    if (type === DefinitionType.COIN) {
+        const allCoins = await fetchAllCoins();
+
+        for (const assetPlatformId of assetPlatformIds) {
+            console.log('Building coin data for:', assetPlatformId);
+            const data = await buildCoinDataForPlatform(allCoins, assetPlatformId, structure);
+
+            const length = countRecords(data, structure);
+            console.log('Records for specific platform:', length);
+            if (!length)
+                throw new Error(`No definitions available for platform: ${assetPlatformId}`);
+
+            validateStructure(data, structure);
+            writeDefinitionFiles(assetPlatformId, type, structure, data);
+            counts[assetPlatformId] = length;
+        }
     }
 
-    if (structure === 'simple') {
-        const { length } = data;
-        console.log('Records for specific platform:', length);
+    if (type === DefinitionType.NFT) {
+        for (const assetPlatformId of assetPlatformIds) {
+            console.log('Fetching NFT data for:', assetPlatformId);
+            const data = await fetchNftData(assetPlatformId, structure);
 
-        if (!length) {
-            throw new Error(`No definitions available for platform: ${assetPlatformId}`);
-        }
-    } else {
-        const { length } = Object.keys(data);
-        console.log('Records for specific platform:', length);
+            const length = countRecords(data, structure);
+            console.log('Records for specific platform:', length);
+            if (!length)
+                throw new Error(`No definitions available for platform: ${assetPlatformId}`);
 
-        if (!length) {
-            throw new Error(`No definitions available for platform: ${assetPlatformId}`);
+            validateStructure(data, structure);
+            writeDefinitionFiles(assetPlatformId, type, structure, data);
+            counts[assetPlatformId] = length;
         }
     }
 
-    validateStructure(data, structure);
-
-    const fileName = `${assetPlatformId}.${structure}.${type}.${DEFINITIONS_FILENAME_SUFFIX}`;
-
-    fs.mkdirSync(FILES_PATH, { recursive: true });
-
-    const signedData = signData(data);
-    fs.writeFileSync(join(FILES_PATH, `${fileName}.jws`), signedData);
-    fs.writeFileSync(join(FILES_PATH, `${fileName}.json`), JSON.stringify(data));
-
-    console.log('JSON definitions saved to ', join(FILES_PATH, fileName, '.[jws,json]'));
+    printSummary(type, structure, counts);
 };
 
-main();
+main().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/suite-common/token-definitions/scripts/utils/fetchCoins.ts
+++ b/suite-common/token-definitions/scripts/utils/fetchCoins.ts
@@ -3,7 +3,11 @@ import * as toml from 'toml';
 
 import { blockfrostUtils } from '@trezor/blockchain-link-utils';
 
-import { AdvancedTokenStructure, SimpleTokenStructure } from '../../src/tokenDefinitionsTypes';
+import {
+    AdvancedTokenStructure,
+    SimpleTokenStructure,
+    TokenStructureType,
+} from '../../src/tokenDefinitionsTypes';
 import { COIN_LIST_URL, STELLAR_EXPERT_URL, STELLAR_HORIZON_URL } from '../constants';
 import { CoinData } from '../types';
 
@@ -150,65 +154,64 @@ const fetchStellarTokenRating = async (contractAddress: string): Promise<number 
     }
 };
 
-export const fetchCoinData = async (assetPlatformId: string, structure: string) => {
-    console.log('Start fetching coin data for:', assetPlatformId, 'platform');
+const options = {
+    method: 'GET',
+    headers: { 'x-cg-pro-api-key': process.env.COINGECKO_API_KEY! },
+};
 
-    const params = new URLSearchParams({
-        include_platform: true.toString(),
-    });
+export const fetchAllCoins = async (): Promise<CoinData[]> => {
+    const params = new URLSearchParams({ include_platform: String(true) });
+    const res = await fetch(`${COIN_LIST_URL}?${params.toString()}`, options);
 
-    const options = {
-        method: 'GET',
-        headers: { 'x-cg-pro-api-key': process.env.COINGECKO_API_KEY! },
-    };
-
-    let data: CoinData[];
-    try {
-        const response = await fetch(`${COIN_LIST_URL}?${params.toString()}`, options);
-        if (!response.ok) {
-            const { error } = await response.json();
-
-            throw new Error(`${error}, status: ${response.status}`);
+    if (!res.ok) {
+        let msg = `status: ${res.status}`;
+        try {
+            const { error } = await res.json();
+            if (error) msg = `${error}, ${msg}`;
+        } catch {
+            // ignore JSON parse error
         }
 
-        data = await response.json();
-    } catch (error) {
-        throw new Error(error);
+        throw new Error(`CoinGecko coins/list failed: ${msg}`);
     }
 
-    console.log('Number of coin records fetched:', data.length);
+    const data: CoinData[] = await res.json();
+    console.log('Number of coin records fetched (ALL):', data.length);
 
-    if (structure === 'advanced') {
+    return data;
+};
+
+export const buildCoinDataForPlatform = async (
+    allCoins: CoinData[],
+    assetPlatformId: string,
+    structure: TokenStructureType,
+): Promise<AdvancedTokenStructure | SimpleTokenStructure> => {
+    if (structure === TokenStructureType.ADVANCED) {
         const result: AdvancedTokenStructure = {};
 
-        for (const { platforms, symbol, name } of data) {
+        for (const { platforms, symbol, name } of allCoins) {
             const contractAddress = getContractAddress(assetPlatformId, platforms);
-            if (contractAddress) {
-                result[contractAddress] = { symbol, name };
+            if (!contractAddress) continue;
 
-                // For Stellar, add `home_domain` and `rating` if available
-                if (assetPlatformId === 'stellar') {
-                    const homeDomain = await getStellarHomeDomain(contractAddress);
-                    if (homeDomain) {
-                        result[contractAddress].home_domain = homeDomain;
-                    }
+            result[contractAddress] = { symbol, name };
 
-                    const rating = await fetchStellarTokenRating(contractAddress);
-                    if (rating !== undefined) {
-                        result[contractAddress].rating = rating;
-                    }
-                }
+            if (assetPlatformId === 'stellar') {
+                const homeDomain = await getStellarHomeDomain(contractAddress);
+                if (homeDomain) result[contractAddress].home_domain = homeDomain;
+
+                const rating = await fetchStellarTokenRating(contractAddress);
+                if (rating !== undefined) result[contractAddress].rating = rating;
             }
         }
 
         return result;
-    } else {
-        return [
-            ...new Set(
-                data
-                    .map(item => getContractAddress(assetPlatformId, item.platforms))
-                    .filter(item => item),
-            ),
-        ] as SimpleTokenStructure;
     }
+
+    return [
+        ...new Set(
+            allCoins
+                .map(item => getContractAddress(assetPlatformId, item.platforms))
+                .filter(Boolean),
+        ),
+    ] as SimpleTokenStructure;
 };

--- a/suite-common/token-definitions/scripts/utils/fetchNft.ts
+++ b/suite-common/token-definitions/scripts/utils/fetchNft.ts
@@ -1,5 +1,9 @@
 /* eslint-disable no-console */
-import { AdvancedTokenStructure, SimpleTokenStructure } from '../../src/tokenDefinitionsTypes';
+import {
+    AdvancedTokenStructure,
+    SimpleTokenStructure,
+    TokenStructureType,
+} from '../../src/tokenDefinitionsTypes';
 import { NFTS_PER_PAGE, NFT_LIST_URL } from '../constants';
 import { NftData } from '../types';
 
@@ -17,6 +21,7 @@ const fetchNftPage = async (page: number, assetPlatformId: string): Promise<NftD
 
     try {
         const response = await fetch(`${NFT_LIST_URL}?${params.toString()}`, options);
+
         if (!response.ok) {
             const { error } = await response.json();
 
@@ -29,7 +34,7 @@ const fetchNftPage = async (page: number, assetPlatformId: string): Promise<NftD
     }
 };
 
-export const fetchNftData = async (assetPlatformId: string, structure: string) => {
+export const fetchNftData = async (assetPlatformId: string, structure: TokenStructureType) => {
     console.log('Start fetching NFT data for:', assetPlatformId, 'platform');
 
     let page = 1;
@@ -37,24 +42,20 @@ export const fetchNftData = async (assetPlatformId: string, structure: string) =
 
     while (true) {
         const data = await fetchNftPage(page, assetPlatformId);
-
         allData = allData.concat(data);
         page++;
-
-        if (data.length < NFTS_PER_PAGE) {
-            break;
-        }
+        if (data.length < NFTS_PER_PAGE) break;
     }
 
     console.log('Number of NFT records fetched:', allData.length);
 
-    if (structure === 'advanced') {
+    if (structure === TokenStructureType.ADVANCED) {
         return allData.reduce<AdvancedTokenStructure>((acc, { contract_address, symbol, name }) => {
             acc[contract_address] = { symbol, name };
 
             return acc;
         }, {});
-    } else {
-        return [...new Set(allData.map(item => item.contract_address))] as SimpleTokenStructure;
     }
+
+    return [...new Set(allData.map(item => item.contract_address))] as SimpleTokenStructure;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

QA: check that token definitions still work on dev and production. it is deployed

- for unknown reason, CI started failing https://satoshilabs.slack.com/archives/C07CNUB6HGC/p1762936036087899
- added logs + all token data are fetched at once (nfts are not as there is no endpoint for it)

local testing
<img width="1125" height="383" alt="Screenshot 2025-11-12 at 14 51 24" src="https://github.com/user-attachments/assets/142dc1ad-a9e2-46ad-9095-fd99bec7f992" />

<img width="1079" height="191" alt="Screenshot 2025-11-12 at 14 51 44" src="https://github.com/user-attachments/assets/f068d5d6-8bc9-461e-aaaf-f7d7eb81d814" />
<img width="1165" height="608" alt="Screenshot 2025-11-12 at 14 52 03" src="https://github.com/user-attachments/assets/4140b0ea-cdbd-4211-aa56-1d3ff7d8aefe" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/token-definitions&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/token-definitions&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/token-definitions&lookback=7)