### PR TITLE
fix(suite): a newly recovered device withtout an instance id cannot u…

### DIFF
--- a/suite-common/local-first-storage/src/storage/initEvoluKeysThunk.ts
+++ b/suite-common/local-first-storage/src/storage/initEvoluKeysThunk.ts
@@ -23,7 +23,6 @@ export const initEvoluKeysThunk = createThunk<void, InitCipherKeyThunkParams, vo
         if (
             device === undefined ||
             device.state === undefined ||
-            device.instance === undefined ||
             device.localFirstStorageSecret?.evoluKeys !== undefined ||
             // We are already getting the keys in different "await"
             // This may happen if selectedDeviceThunk is called concurrently.
@@ -42,7 +41,7 @@ export const initEvoluKeysThunk = createThunk<void, InitCipherKeyThunkParams, vo
                 device: {
                     path: device.path,
                     state: device.state,
-                    instance: device.instance,
+                    ...(device.instance !== undefined ? { instance: device.instance } : {}),
                 },
                 useEmptyPassphrase: device.useEmptyPassphrase ?? false,
             });


### PR DESCRIPTION
…se evolu

<!--- Provide a general summary of your changes in the Title above -->

## Description

If you recover a device with all seed, the `instance` is `undefined` for some reason. 
I am not sure about this fix though, because there may be multiple wallets there.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-cannot-use-evolu-new-device&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-cannot-use-evolu-new-device&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-cannot-use-evolu-new-device&lookback=7)