### PR TITLE
fix(suite): cardano update provider when having rewards

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -205,17 +205,15 @@ export const calculateOutputAmount = (
     stakeType: StakeType,
     totalSpent?: string,
 ) => {
-    const accountBalance = new BigNumber(account.balance ?? '0');
-
-    let amount: BigNumber;
+    let amount;
 
     switch (stakeType) {
         case 'stake':
         case 'unstake':
-            amount = accountBalance.minus(totalSpent ?? '0');
+            amount = new BigNumber(account.availableBalance ?? '0').minus(totalSpent ?? '0');
             break;
         case 'claim':
-            amount = accountBalance.minus(account.availableBalance ?? '0');
+            amount = new BigNumber(account.balance ?? '0').minus(account.availableBalance ?? '0');
             break;
         default:
             return '0';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- there are no accounts with available rewards, so you have to trust me that it works
- the problem is that balance includes rewards, available balance does not and compose transaction uses available balance so it fails on not enough native token to pay fees

## Notes for QA

- Update provider should now work (calculate fee and show review tx modal) even when you have rewards on your account

## Related Issue

Resolve [23004](https://github.com/trezor/trezor-suite/issues/23004)

## Screenshots:

<img width="1047" height="551" alt="Screenshot 2025-11-12 at 16 26 52" src="https://github.com/user-attachments/assets/00b99274-b411-4b15-9db8-a20ba29df3a1" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/cardano-update-provider&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/cardano-update-provider&lookback=7)