### PR TITLE
ci: dependabot minimum package age check

### DIFF
--- a/.github/ISSUE_TEMPLATE/07_deps_maintenance_task.md
+++ b/.github/ISSUE_TEMPLATE/07_deps_maintenance_task.md
@@ -24,6 +24,8 @@ assignees: ''
 
 See [notion page](https://www.notion.so/satoshilabs/Dependency-Management-1b5bf845aa1f4ca7b9d57ea9ccd3fe63) for more details.
 
+💡 _Hint:_ `ncu --deep -u -c 14 -t greatest --pre 0 -f DEP_NAME` to honor the [npmMinimalAgeGate](https://github.com/trezor/trezor-suite/blob/develop/.yarnrc.yml) when using [ncu](https://www.npmjs.com/package/npm-check-updates)
+
 ## QA instructions
 
 🚧 not known yet, will be discovered – it depends on specific list of updated dependencies.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Note that this just limits age of the versions that dependabot suggests, not a limit for installation (that's in .yarnrc.yml)
+    cooldown:
+      default-days: 14
+      include:
+        - "*"
+      exclude:
+        - "@evolu/*"
+        - "@types/invity-api"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,6 +8,13 @@ logFilters:
 
 nodeLinker: node-modules
 
+# Allow only packages older than 14 days (in minutes). Schema declares that "14d" can be entered, but that doesn't have any effect.
+npmMinimalAgeGate: 20160
+# Skip age gate for experimental, rapidly changing packages
+npmPreapprovedPackages:
+  - "@evolu/*"
+  - "@types/invity-api@*"
+
 plugins:
   - checksum: 5e73a1acbb9741fce1e8335e243c9480ea2107b9b4b65ed7643785ddea9e3019aee254a92a853b1cd71023b16fff5b7d3afd5256fe57cd35a54f8785b8c30281
     path: .yarn/plugins/@yarnpkg/plugin-outdated.cjs


### PR DESCRIPTION
## Description

- **Mainly,** add yarn "age gate", meaning that yarn won't let you install a version younger than 14 days
  - see [yarn docs](https://yarnpkg.com/configuration/yarnrc/#npmMinimalAgeGate), or [the PR](https://github.com/yarnpkg/berry/pull/6901) for more info
- Add "cooldown" to dependabot, so that it doesn't suggest versions younger than that
  - see [dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-)
  - that' less impactful because we don't check it that often, this is just to prevent nuissance where dependabot would require us to install a version that yarn forbids.

### Exclusions
Exclusions are ofc possible for experimental, rapidly changing packages. Adding a few that we know about right away.

### How to bump deps now?
When you run for example `yarn list-outdated TEAM`, the age gate is honored. So for example it suggests eslint 9.38 (old enough), not 9.39.1 (too young), which is amazing, otherwise it'd be really annoying :slightly_smiling_face:
- `yarn up` honors the age gate automatically
- `ncu` doesn't do it automatically, but since [19.1.0](https://github.com/raineorshine/npm-check-updates/releases/tag/v19.1.0) you can specify `-c` alias `--cooldown` yourself, so for example:
`ncu --deep -u -c 14 -t greatest --pre 0 -f @eslint/js`
will update `eslint` to the age gated version in all package.jsons :rocket: :slightly_smiling_face: 
  - target `greatest` must be specified; default `latest` may not match anything with `-c` ([more on that here](https://www.npmjs.com/package/npm-check-updates#cooldown))

## Related Issue

Resolve #22681

## Screenshots

I installed eslint 9.39.1, which is 9 days old as of writing this PR, and it won't let me install:

<img width="1203" height="545" alt="age gate blocked me" src="https://github.com/user-attachments/assets/de83423d-a95c-4574-bd6e-ed8b52d39b64" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/yarn-min-age&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/yarn-min-age&lookback=7)