### PR TITLE
refactor(suite-native): bottom sheet flashlist warning

### DIFF
--- a/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
@@ -6,9 +6,9 @@ import {
     BottomSheetBackdrop,
     BottomSheetModal,
     BottomSheetProps,
-    BottomSheetFlashList as FlashList,
+    useBottomSheetScrollableCreator,
 } from '@gorhom/bottom-sheet';
-import { FlashListProps } from '@shopify/flash-list';
+import { FlashList, FlashListProps } from '@shopify/flash-list';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
@@ -90,6 +90,8 @@ export const BottomSheetFlashList = <TItem,>({
         }
     }, [isVisible]);
 
+    const BottomSheetListScrollComponent = useBottomSheetScrollableCreator();
+
     return (
         <BottomSheetModal
             ref={bottomSheetModalRef}
@@ -114,6 +116,7 @@ export const BottomSheetFlashList = <TItem,>({
             keyboardBehavior="fillParent"
         >
             <FlashList
+                renderScrollComponent={BottomSheetListScrollComponent}
                 key={flashListKey}
                 {...flashListProps}
                 contentContainerStyle={applyStyle(sheetContentContainerStyle, {

--- a/suite-native/test-utils/src/expoMock.js
+++ b/suite-native/test-utils/src/expoMock.js
@@ -417,4 +417,12 @@ jest.mock('react-native-keyboard-controller', () =>
     require('react-native-keyboard-controller/jest'),
 );
 
-jest.mock('@gorhom/bottom-sheet', () => require('@gorhom/bottom-sheet/mock'));
+jest.mock('@gorhom/bottom-sheet', () => {
+    require('@gorhom/bottom-sheet/mock');
+    const ReactNative = require('react-native');
+    const GorhomBottomSheetMock = require('@gorhom/bottom-sheet/mock');
+
+    GorhomBottomSheetMock.useBottomSheetScrollableCreator = () => ReactNative.ScrollView;
+
+    return GorhomBottomSheetMock;
+});


### PR DESCRIPTION
## Description
- fix console waring from `'@gorhom/bottom-sheet'` library: 
```WARN  BottomSheetFlashList is deprecated, please use useBottomSheetScrollableCreator instead.``` 
(the author of the lib is trying to get rid of direct import of third party list libraries to his package)

## Notes for QA
Please test that all the bottom sheet in the trading section are rendering correctly.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/nativebottom-sheet-flashlist-warning&lookback=7)