### PR TITLE
fix(components): show only placeholder when all asset logo candidates fail

### DIFF
--- a/packages/components/src/components/AssetLogo/AssetLogo.tsx
+++ b/packages/components/src/components/AssetLogo/AssetLogo.tsx
@@ -129,6 +129,7 @@ export const AssetLogo = ({
     );
 
     const [candidateIndex, setCandidateIndex] = useState(0);
+    const [showPlaceholder, setShowPlaceholder] = useState(!shouldTryToFetch);
 
     const candidates = useMemo<LogoCandidate[]>(() => {
         if (!shouldTryToFetch || !canonicalAddresses.length) return [];
@@ -158,14 +159,20 @@ export const AssetLogo = ({
     }, [shouldTryToFetch, canonicalAddresses, coingeckoIdLogo, size]);
 
     const hasCandidates = candidates.length > 0;
-    const currentIndex = hasCandidates ? Math.min(candidateIndex, candidates.length - 1) : -1;
-    const current = hasCandidates ? candidates[currentIndex] : undefined;
-    const showPlaceholder = !hasCandidates;
+    const hasValidIndex = candidateIndex >= 0 && candidateIndex < candidates.length;
+    const current = hasCandidates && hasValidIndex ? candidates[candidateIndex] : undefined;
 
     useEffect(() => {
+        if (!hasCandidates) {
+            setShowPlaceholder(true);
+
+            return;
+        }
+
         const cachedResult = resolvedLogoCache.get(cacheKey);
         if (!cachedResult) {
             setCandidateIndex(0);
+            setShowPlaceholder(false);
 
             return;
         }
@@ -174,7 +181,8 @@ export const AssetLogo = ({
             c => c.src === cachedResult.src && c.srcSet === cachedResult.srcSet,
         );
         setCandidateIndex(idx >= 0 ? idx : 0);
-    }, [cacheKey, candidates]);
+        setShowPlaceholder(false);
+    }, [cacheKey, candidates, hasCandidates]);
 
     const frameProps = pickAndPrepareFrameProps(rest, allowedAssetLogoFrameProps);
 
@@ -182,7 +190,13 @@ export const AssetLogo = ({
         if (!current) return;
 
         failedAddressesCache.add(makeAddressKey(coingeckoIdLogo, current.address));
-        setCandidateIndex(prev => Math.min(prev + 1, candidates.length - 1));
+
+        const nextIndex = candidateIndex + 1;
+        if (nextIndex >= candidates.length) {
+            setShowPlaceholder(true);
+        } else {
+            setCandidateIndex(nextIndex);
+        }
     };
 
     const handleOnLoad = () => {


### PR DESCRIPTION
## Description

This PR fixes showing of `AssetLogo` placeholder. Now user no longer sees failed img load icon but just the placeholder.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

### Before

https://github.com/user-attachments/assets/d0029e1a-929a-4a53-9ffc-e6249b2a69d0

### After

https://github.com/user-attachments/assets/e849dbc5-2413-484d-8580-26d025152979



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/asset-logo-placeholder-fallback&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/asset-logo-placeholder-fallback&lookback=7)