### PR TITLE
fix(suite): Set max-height for suite banners

### DIFF
--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -32,6 +32,8 @@ import { SafetyChecksBanner } from './SafetyChecksBanner';
 const Container = styled.div<{ $fill?: boolean }>`
     width: 100%;
     max-width: ${({ $fill }) => ($fill ? 'none' : MAX_CONTENT_WIDTH)};
+    max-height: 20vh;
+    overflow: auto;
     padding: ${spacingsPx.sm} ${spacingsPx.md};
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

banners in the top of the app should be scrollable in case there are too many of them and they occupy more than 20% of viewport height
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=set-max-height-for-suite-banners&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=set-max-height-for-suite-banners&lookback=7)