### PR TITLE
chore: bump eslint packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
         "@types/node-fetch": "^2.6.12",
         "babel-jest": "30.0.0",
         "depcheck": "^1.4.7",
-        "eslint": "^9.37.0",
+        "eslint": "^9.38.0",
         "husky": "^9.1.7",
         "jest": "29.7.0",
         "jest-environment-node": "^29.7.0",

--- a/packages/connect-explorer-theme/src/components/menu.tsx
+++ b/packages/connect-explorer-theme/src/components/menu.tsx
@@ -273,6 +273,7 @@ export function FolderImpl({ item, anchors }: FolderProps): ReactElement {
                 routeFromChildren,
             ]),
         );
+        // eslint-disable-next-line react-hooks/immutability
         item.children = Object.entries(menu.items || {}).map(([key, menuItem]) => {
             const routeMenuItem = routes[key] || {
                 name: key,

--- a/packages/connect-explorer-theme/src/mdx-components.tsx
+++ b/packages/connect-explorer-theme/src/mdx-components.tsx
@@ -35,6 +35,7 @@ function HeadingLink({
         if (!id) return;
         const heading = obRef.current;
         if (!heading) return;
+        // eslint-disable-next-line react-hooks/immutability
         slugs.set(heading, [id, (context.index += 1)]);
         observer?.observe(heading);
 

--- a/packages/connect-explorer/src/components/CodeEditor.tsx
+++ b/packages/connect-explorer/src/components/CodeEditor.tsx
@@ -15,6 +15,7 @@ export const CodeEditor = ({ code, codeChange, schema }: CodeEditorProps) => {
 
     const [codeKey, setCodeKey] = useState(0);
     const extensions = useMemo(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-render
         setCodeKey(prev => prev + 1);
 
         const patchedSchema = schema ? { ...schema } : { properties: {} };

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -10,8 +10,8 @@
         "type-check": "yarn g:tsc --build"
     },
     "devDependencies": {
-        "@eslint/js": "^9.37.0",
-        "eslint": "^9.37.0",
+        "@eslint/js": "^9.38.0",
+        "eslint": "^9.38.0",
         "eslint-plugin-chai-friendly": "^1.1.0",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jest": "^29.0.1",
@@ -19,8 +19,8 @@
         "eslint-plugin-local-rules": "^3.0.2",
         "eslint-plugin-playwright": "^2.2.0",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^6.1.1",
+        "eslint-plugin-react-hooks": "^7.0.1",
         "globals": "^16.4.0",
-        "typescript-eslint": "^8.46.0"
+        "typescript-eslint": "^8.46.2"
     }
 }

--- a/packages/eslint/src/chaiFriendlyConfig.mjs
+++ b/packages/eslint/src/chaiFriendlyConfig.mjs
@@ -1,5 +1,9 @@
 import pluginChaiFriendly from 'eslint-plugin-chai-friendly';
+/**
+ * @typedef {import('eslint').Linter.Config} Config
+ */
 
+/** @type {Config[]} */
 export const chaiFriendlyConfig = [
     {
         plugins: { 'chai-friendly': pluginChaiFriendly },

--- a/packages/eslint/src/importConfig.mjs
+++ b/packages/eslint/src/importConfig.mjs
@@ -2,6 +2,10 @@ import pluginImport from 'eslint-plugin-import';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+/**
+ * @typedef {import('eslint').Linter.Config} Config
+ */
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -17,6 +21,7 @@ export const globalNoExtraneousDependenciesDevDependencies = [
     '**/*e2e/**', // Todo: This shall be only in packages that has e2e tests
 ];
 
+/** @type {Config[]} */
 export const importConfig = [
     pluginImport.flatConfigs.recommended,
     {

--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -10,9 +10,13 @@ import { jestConfig } from './jestConfig.mjs';
 import { localRulesConfig } from './localRulesConfig.mjs';
 import { reactConfig } from './reactConfig.mjs';
 import { typescriptConfig } from './typescriptConfig.mjs';
+/**
+ * @typedef {import('eslint').Linter.Config} Config
+ */
 
 export { globalNoExtraneousDependenciesDevDependencies };
 
+/** @type {Config[]} */
 export const eslint = [
     {
         ignores: [
@@ -71,6 +75,7 @@ export const eslint = [
     },
 ];
 
+/** @type {Config} */
 export const playwrightEslint = {
     ...playwright.configs['flat/recommended'],
     files: ['e2e/**'],

--- a/packages/eslint/src/javascriptConfig.mjs
+++ b/packages/eslint/src/javascriptConfig.mjs
@@ -1,5 +1,9 @@
 import pluginJs from '@eslint/js';
+/**
+ * @typedef {import('eslint').Linter.Config} Config
+ */
 
+/** @type {Config[]} */
 export const javascriptConfig = [
     pluginJs.configs.recommended,
     {

--- a/packages/eslint/src/javascriptNodejsConfig.mjs
+++ b/packages/eslint/src/javascriptNodejsConfig.mjs
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import('eslint').Linter.Config} Config
+ */
+
+/** @type {Config[]} */
 export const javascriptNodejsConfig = [
     {
         // These rules are specific to JavaScript running on Node.js.

--- a/packages/eslint/src/jestConfig.mjs
+++ b/packages/eslint/src/jestConfig.mjs
@@ -1,5 +1,9 @@
 import pluginJest from 'eslint-plugin-jest';
+/**
+ * @typedef {import('eslint').Linter.Config} Config
+ */
 
+/** @type {Config[]} */
 export const jestConfig = [
     pluginJest.configs['flat/recommended'],
     {

--- a/packages/eslint/src/localRulesConfig.mjs
+++ b/packages/eslint/src/localRulesConfig.mjs
@@ -1,5 +1,9 @@
 import pluginLocalRules from 'eslint-plugin-local-rules';
+/**
+ * @typedef {import('eslint').Linter.Config} Config
+ */
 
+/** @type {Config[]} */
 export const localRulesConfig = [
     {
         plugins: {

--- a/packages/eslint/src/reactConfig.mjs
+++ b/packages/eslint/src/reactConfig.mjs
@@ -1,13 +1,15 @@
 import pluginReact from 'eslint-plugin-react';
 import pluginReactHooks from 'eslint-plugin-react-hooks';
+/**
+ * @typedef {import('eslint').Linter.Config} Config
+ */
 
+/** @type {Config[]} */
 export const reactConfig = [
     // React
     pluginReact.configs.flat.recommended,
     {
-        languageOptions: {
-            ...pluginReact.configs.flat.recommended.languageOptions,
-        },
+        languageOptions: pluginReact.configs.flat.recommended.languageOptions,
         settings: { react: { version: 'detect' } },
         rules: {
             // Additions
@@ -23,12 +25,18 @@ export const reactConfig = [
     },
 
     // React Hooks
-    ...pluginReactHooks.configs.recommended,
+    pluginReactHooks.configs.flat.recommended,
     {
         plugins: { 'react-hooks': pluginReactHooks },
         rules: {
             'react-hooks/rules-of-hooks': 'error',
             'react-hooks/exhaustive-deps': 'error',
+            'react-hooks/static-components': 'off', // TODO fix & reenable
+            'react-hooks/set-state-in-effect': 'off', // TODO fix & reenable, though this anti-pattern is unfortunately quite widespread
+            'react-hooks/refs': 'off', // Too restrictive. Reading ref in render is often desired, though must be carefully considered
+            'react-hooks/incompatible-library': 'off', // Rule for React Compiler; it's unlikely we'll use it anytime soon
+            'react-hooks/preserve-manual-memoization': 'off', // Rule for React Compiler; it's unlikely we'll use it anytime soon
+            'react-hooks/use-memo': 'off', // Too restrictive: enforces inline function in useMemo (forbids using variable)
         },
     },
 ];

--- a/packages/suite/src/components/connection/context/ConnectionGlobalModalContext.tsx
+++ b/packages/suite/src/components/connection/context/ConnectionGlobalModalContext.tsx
@@ -99,6 +99,8 @@ const useConnectionGlobalModal = () => {
 
     const allDevices = useSelector(selectAllDevices);
 
+    // TODO shall be refactored, now it isn't reactive on Date.now() → can render outdated result. Maybe a setInterval?
+    // eslint-disable-next-line react-hooks/purity
     const lastUpdatedBoundaryTimestamp = Date.now() - NEARBY_DEVICES_LAST_UPDATED_LIMIT;
 
     const devices = allDevices.filter(it => {

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -451,6 +451,8 @@ export const MetadataLabeling = ({
             await dispatch(processMetadataMessageThunk({ payload, deviceStaticSessionId, value }));
 
             setShowSuccess(true);
+            // Intentional pattern how to use timers with useEffect
+            // eslint-disable-next-line react-hooks/immutability
             timeout = setTimeout(() => {
                 setShowSuccess(false);
             }, 2000);

--- a/packages/suite/src/components/wallet/CoinjoinAccountDiscoveryProgress/RotatingFacts.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinAccountDiscoveryProgress/RotatingFacts.tsx
@@ -53,6 +53,8 @@ const factsCount = FACTS.length;
 const selectNextHint = (currentIndex: number) => (currentIndex + 1) % factsCount;
 
 export const RotatingFacts = () => {
+    // Intentionally impure, non-deterministic rendering
+    // eslint-disable-next-line react-hooks/purity
     const firstHintIndex = Math.floor(Math.random() * (factsCount - 1));
     const [factIndex, setFactIndex] = useState(firstHintIndex);
 

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -128,6 +128,7 @@ interface TestCallback {
 // getContextValues returns actual state of SendFormContext
 const Component = ({ callback }: { callback: TestCallback }) => {
     const values = useRbfContext();
+    // eslint-disable-next-line react-hooks/immutability
     callback.getContextValues = () => values;
 
     return values.isLoading ? <div>Loading</div> : null;

--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -92,6 +92,7 @@ interface TestCallback {
 // getContextValues returns actual state of SendFormContext
 const Component = ({ callback }: { callback: TestCallback }) => {
     const values = useSendFormContext();
+    // eslint-disable-next-line react-hooks/immutability
     callback.getContextValues = () => values;
 
     // NOTE: rendering briefly explanation:

--- a/suite-native/atoms/src/Accordion/AccordionItem.tsx
+++ b/suite-native/atoms/src/Accordion/AccordionItem.tsx
@@ -64,6 +64,7 @@ export const AccordionItem = ({
 
     const handlePress = () => {
         if (currentIndexOpened.value === index) {
+            // eslint-disable-next-line react-hooks/immutability
             currentIndexOpened.value = null;
         } else {
             currentIndexOpened.value = index;

--- a/suite-native/atoms/src/Button/TextButton.tsx
+++ b/suite-native/atoms/src/Button/TextButton.tsx
@@ -96,6 +96,7 @@ export const TextButton = ({
     );
 
     const interpolatePressColor = () => {
+        // eslint-disable-next-line react-hooks/immutability
         animatedColor.value = interpolateColor(
             textPressedColorValue.value,
             [0, 1],

--- a/suite-native/atoms/src/Sheet/useAlertAnimation.ts
+++ b/suite-native/atoms/src/Sheet/useAlertAnimation.ts
@@ -70,6 +70,7 @@ export const useAlertAnimation = ({ onClose }: { onClose?: () => void }) => {
     const openSheetAnimated = useCallback(() => {
         'worklet';
 
+        // eslint-disable-next-line react-hooks/immutability
         translatePanY.value = withTiming(0, {
             duration: 300,
             easing: Easing.out(Easing.cubic),

--- a/suite-native/atoms/src/SwipeableWalkthrough/SwipeableWalkthroughScreenHeader.tsx
+++ b/suite-native/atoms/src/SwipeableWalkthrough/SwipeableWalkthroughScreenHeader.tsx
@@ -85,6 +85,7 @@ export const SwipeableWalkthroughScreenHeader = ({
         if (currentStepIndex.value === 0) {
             onPressBack();
         } else {
+            // eslint-disable-next-line react-hooks/immutability
             currentStepIndex.value -= 1;
         }
     }, [currentStepIndex, onPressBack]);

--- a/suite-native/atoms/src/SwipeableWalkthrough/SwipeableWalkthroughStep.tsx
+++ b/suite-native/atoms/src/SwipeableWalkthrough/SwipeableWalkthroughStep.tsx
@@ -73,6 +73,7 @@ export const SwipeableWalkthroughStep = ({
 
     const handleNextButtonPress = () => {
         if (currentStepIndex.value < totalSteps - 1) {
+            // eslint-disable-next-line react-hooks/immutability
             currentStepIndex.value += 1;
         }
     };

--- a/suite-native/firmware/src/hooks/useFirmwareAnalytics.ts
+++ b/suite-native/firmware/src/hooks/useFirmwareAnalytics.ts
@@ -43,6 +43,7 @@ export const useFirmwareAnalytics = ({
     // Use refs to avoid any re-renders because of analytics and to make useCallback dependencies stable
     // so it won't trigger any useEffect which could interfere with other business logic.
     const analyticsPayload = useRef<FirmwareUpdatePayload>(prepareAnalyticsPayload());
+    // eslint-disable-next-line react-hooks/purity
     const timeStarted = useRef<number>(Date.now());
 
     useEffect(() => {

--- a/suite-native/icons/src/PizzaIcon.tsx
+++ b/suite-native/icons/src/PizzaIcon.tsx
@@ -26,6 +26,7 @@ export const usePizzaAnimation = ({
     const [displayedPizzaIndex, setDisplayedPizzaIndex] = useState<0 | PIZZA_INDEX>(1);
 
     const handleChangePizza = () => {
+        // eslint-disable-next-line react-hooks/immutability
         animationProgress.value = 0;
         setDisplayedPizzaIndex(currentPizzaIndex => ((currentPizzaIndex + 1) % 4) as PIZZA_INDEX);
         animationProgress.value = withTiming(percentage / 100, {

--- a/suite-native/link/src/components/Link.tsx
+++ b/suite-native/link/src/components/Link.tsx
@@ -64,11 +64,13 @@ export const Link = ({
     }));
 
     const handlePressIn = (e: GestureResponderEvent) => {
+        // eslint-disable-next-line react-hooks/immutability
         isPressed.value = withTiming(IS_PRESSED_VALUE, { duration: ANIMATION_DURATION });
         e.stopPropagation();
     };
 
     const handlePressOut = (e: GestureResponderEvent) => {
+        // eslint-disable-next-line react-hooks/immutability
         isPressed.value = withTiming(IS_NOT_PRESSED_VALUE, { duration: ANIMATION_DURATION });
         if (href) openLink(href);
 

--- a/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
@@ -70,6 +70,8 @@ export const WalletCreationScreen = () => {
             }
         }
         // repeat the attempt if error was not one of the DEFINITIVE_ERRORS
+        // This code is OK, but the eslint plugin crashes on recursive calls
+        // eslint-disable-next-line react-hooks/immutability
         handleCreateAndBackupWallet();
     }, [dispatch, walletBackupType, navigation, isEntropyCheckEnabled]);
 

--- a/suite-native/module-device-onboarding/src/screens/WalletRecoveryScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletRecoveryScreen.tsx
@@ -26,6 +26,8 @@ export const WalletRecoveryScreen = ({
         // Do not retry if user cancelled the flow via the app UI
         if (response.payload.code && response.payload.code === 'Method_Interrupted') return;
 
+        // This code is OK, but the eslint plugin crashes on recursive calls
+        // eslint-disable-next-line react-hooks/immutability
         handleRecoverWallet();
     }, [dispatch, navigation]);
 

--- a/suite-native/navigation/src/hooks/useDisableIOSGesture.ts
+++ b/suite-native/navigation/src/hooks/useDisableIOSGesture.ts
@@ -10,6 +10,8 @@ export const useDisableIOSGesture = () => {
         nav?.setOptions({ gestureEnabled: enable });
         const parent = nav?.getParent?.();
         if (parent) {
+            // This code is OK, but the eslint plugin crashes on recursive calls
+            // eslint-disable-next-line react-hooks/immutability
             toggleGestures(parent, enable);
         }
     }, []);

--- a/suite-native/react-native-graph/src/SelectionDot.tsx
+++ b/suite-native/react-native-graph/src/SelectionDot.tsx
@@ -25,6 +25,7 @@ export function SelectionDot({
 
     const setIsActive = useCallback(
         (active: boolean) => {
+            // eslint-disable-next-line react-hooks/immutability
             circleRadius.value = withSpring(active ? CIRCLE_RADIUS : 0, {
                 mass: 1,
                 stiffness: 1000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2946,23 +2946,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/config-array@npm:^0.21.0":
-  version: 0.21.0
-  resolution: "@eslint/config-array@npm:0.21.0"
+"@eslint/config-array@npm:^0.21.1":
+  version: 0.21.1
+  resolution: "@eslint/config-array@npm:0.21.1"
   dependencies:
-    "@eslint/object-schema": "npm:^2.1.6"
+    "@eslint/object-schema": "npm:^2.1.7"
     debug: "npm:^4.3.1"
     minimatch: "npm:^3.1.2"
-  checksum: 10/f5a499e074ecf4b4a5efdca655418a12079d024b77d02fd35868eeb717c5bfdd8e32c6e8e1dd125330233a878026edda8062b13b4310169ba5bfee9623a67aa0
+  checksum: 10/6eaa0435972f735ce52d581f355a0b616e50a9b8a73304a7015398096e252798b9b3b968a67b524eefb0fdeacc57c4d960f0ec6432abe1c1e24be815b88c5d18
   languageName: node
   linkType: hard
 
-"@eslint/config-helpers@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@eslint/config-helpers@npm:0.4.0"
+"@eslint/config-helpers@npm:^0.4.1":
+  version: 0.4.2
+  resolution: "@eslint/config-helpers@npm:0.4.2"
   dependencies:
-    "@eslint/core": "npm:^0.16.0"
-  checksum: 10/d5fdbf927a77b98d2462f025f8b1a5b610609201f8d1dd47032a2937842f02bf3bdf9cb672025c83a00f3255dfd218172f989caa724853c4a8f434124a6d79ff
+    "@eslint/core": "npm:^0.17.0"
+  checksum: 10/3f2b4712d8e391c36ec98bc200f7dea423dfe518e42956569666831b89ede83b33120c761dfd3ab6347d8e8894a6d4af47254a18d464a71c6046fd88065f6daf
   languageName: node
   linkType: hard
 
@@ -2972,6 +2972,15 @@ __metadata:
   dependencies:
     "@types/json-schema": "npm:^7.0.15"
   checksum: 10/3cea45971b2d0114267b6101b673270b5d8047448cc7a8cbfdca0b0245e9d5e081cb25f13551dc7d55a090f98c13b33f0c4999f8ee8ab058537e6037629a0f71
+  languageName: node
+  linkType: hard
+
+"@eslint/core@npm:^0.17.0":
+  version: 0.17.0
+  resolution: "@eslint/core@npm:0.17.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+  checksum: 10/f9a428cc651ec15fb60d7d60c2a7bacad4666e12508320eafa98258e976fafaa77d7be7be91519e75f801f15f830105420b14a458d4aab121a2b0a59bc43517b
   languageName: node
   linkType: hard
 
@@ -2992,17 +3001,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.37.0, @eslint/js@npm:^9.37.0":
-  version: 9.37.0
-  resolution: "@eslint/js@npm:9.37.0"
-  checksum: 10/2ead426ed47af0b914c7d7064eb59fede858483cf9511f78ded840708aca578138f2a6c375916d520f4f2ecf25945f4bd47b8a84e42106b4eb46f7708a36db1d
+"@eslint/js@npm:9.38.0, @eslint/js@npm:^9.38.0":
+  version: 9.38.0
+  resolution: "@eslint/js@npm:9.38.0"
+  checksum: 10/08ba53e3e631e2815ff33e0f48dccf87daf3841eb5605fa5980d18b88cd6dd4cd63b5829ac015e97eeb85807bf91efe7d4e1d4eaf6beb586bc01549b7660c4a2
   languageName: node
   linkType: hard
 
-"@eslint/object-schema@npm:^2.1.6":
-  version: 2.1.6
-  resolution: "@eslint/object-schema@npm:2.1.6"
-  checksum: 10/266085c8d3fa6cd99457fb6350dffb8ee39db9c6baf28dc2b86576657373c92a568aec4bae7d142978e798b74c271696672e103202d47a0c148da39154351ed6
+"@eslint/object-schema@npm:^2.1.7":
+  version: 2.1.7
+  resolution: "@eslint/object-schema@npm:2.1.7"
+  checksum: 10/946ef5d6235b4d1c0907c6c6e6429c8895f535380c562b7705c131f63f2e961b06e8785043c86a293da48e0a60c6286d98ba395b8b32ea55561fe6e4417cb7e4
   languageName: node
   linkType: hard
 
@@ -14024,8 +14033,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/eslint@workspace:packages/eslint"
   dependencies:
-    "@eslint/js": "npm:^9.37.0"
-    eslint: "npm:^9.37.0"
+    "@eslint/js": "npm:^9.38.0"
+    eslint: "npm:^9.38.0"
     eslint-plugin-chai-friendly: "npm:^1.1.0"
     eslint-plugin-import: "npm:^2.32.0"
     eslint-plugin-jest: "npm:^29.0.1"
@@ -14033,9 +14042,9 @@ __metadata:
     eslint-plugin-local-rules: "npm:^3.0.2"
     eslint-plugin-playwright: "npm:^2.2.0"
     eslint-plugin-react: "npm:^7.37.5"
-    eslint-plugin-react-hooks: "npm:^6.1.1"
+    eslint-plugin-react-hooks: "npm:^7.0.1"
     globals: "npm:^16.4.0"
-    typescript-eslint: "npm:^8.46.0"
+    typescript-eslint: "npm:^8.46.2"
   languageName: unknown
   linkType: soft
 
@@ -16346,106 +16355,106 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.46.0":
-  version: 8.46.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.46.0"
+"@typescript-eslint/eslint-plugin@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.46.2"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.46.0"
-    "@typescript-eslint/type-utils": "npm:8.46.0"
-    "@typescript-eslint/utils": "npm:8.46.0"
-    "@typescript-eslint/visitor-keys": "npm:8.46.0"
+    "@typescript-eslint/scope-manager": "npm:8.46.2"
+    "@typescript-eslint/type-utils": "npm:8.46.2"
+    "@typescript-eslint/utils": "npm:8.46.2"
+    "@typescript-eslint/visitor-keys": "npm:8.46.2"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^7.0.0"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.46.0
+    "@typescript-eslint/parser": ^8.46.2
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/415afd894a5fec9cfe2c327c8b26377045979cc6bdf720aeecb32af335b9e6865c70fa6a355dd16f52a36dc38f50755df3eb1466d5822c53c80465ff824c9881
+  checksum: 10/00c659fcc04c185e6cdfb6c7e52beae1935f1475fef4079193a719f93858b6255e07b4764fc7104e9524a4d0b7652e63616b93e7f112f1cba4e983d10383e224
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.46.0":
-  version: 8.46.0
-  resolution: "@typescript-eslint/parser@npm:8.46.0"
+"@typescript-eslint/parser@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/parser@npm:8.46.2"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.46.0"
-    "@typescript-eslint/types": "npm:8.46.0"
-    "@typescript-eslint/typescript-estree": "npm:8.46.0"
-    "@typescript-eslint/visitor-keys": "npm:8.46.0"
+    "@typescript-eslint/scope-manager": "npm:8.46.2"
+    "@typescript-eslint/types": "npm:8.46.2"
+    "@typescript-eslint/typescript-estree": "npm:8.46.2"
+    "@typescript-eslint/visitor-keys": "npm:8.46.2"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/6838fde776fd2b2932b259a20cc89b517e0c94a2cfa363a5e8531095c23fb35d8f803196f6594026d0510bf2a8ec003c67181bb2c407904685a64c97602da65f
+  checksum: 10/2ee394d880b5a9372ecf50ddbf70f66e9ecc16691a210dd40b5b152310a539005dfed13105e0adc81f1a9f49d86f7b78ddf3bf8d777fe84c179eb6a8be2fa56c
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.46.0":
-  version: 8.46.0
-  resolution: "@typescript-eslint/project-service@npm:8.46.0"
+"@typescript-eslint/project-service@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/project-service@npm:8.46.2"
   dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.46.0"
-    "@typescript-eslint/types": "npm:^8.46.0"
+    "@typescript-eslint/tsconfig-utils": "npm:^8.46.2"
+    "@typescript-eslint/types": "npm:^8.46.2"
     debug: "npm:^4.3.4"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/de11af23ae6b82769b667e8d6e81d47ce039c7817465b99c1e29c8fbcac58af898bebe70368a274cd7b3c7232354134d53ceba0415b8d7e18317037bc4a4a2f7
+  checksum: 10/76ba446f86e83b4afd6dacbebc9a0737b5a3e0500a0712b37fea4f0141dcf4c9238e8e5a9a649cf609a4624cc575431506a2a56432aaa18d4c3a8cf2df9d1480
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.46.0":
-  version: 8.46.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.46.0"
+"@typescript-eslint/scope-manager@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/scope-manager@npm:8.46.2"
   dependencies:
-    "@typescript-eslint/types": "npm:8.46.0"
-    "@typescript-eslint/visitor-keys": "npm:8.46.0"
-  checksum: 10/ed85abd08c0edf088b1b11757c658acf593cf84051bddde651304a609d3a6cd9e331149e88653676606a565c3f92c191d4af049f540f6e3bb692a4f38305fd71
+    "@typescript-eslint/types": "npm:8.46.2"
+    "@typescript-eslint/visitor-keys": "npm:8.46.2"
+  checksum: 10/6a8a9b644ff57ca9e992348553f19f6e010d76ff4872d972d333a16952e93cce4bf5096a1fefe1af8b452bce963fde6c78410d15817e673b75176ec3241949e9
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.46.0, @typescript-eslint/tsconfig-utils@npm:^8.46.0":
-  version: 8.46.0
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.46.0"
+"@typescript-eslint/tsconfig-utils@npm:8.46.2, @typescript-eslint/tsconfig-utils@npm:^8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.46.2"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/e78a66a854322423aca835070c5ee9489975c4d80d2f8ffe9cf4d6e3f67a1646ddc05b086f7156599c90ad521670ca572a4315f2b49a5922c33d6e49723558e4
+  checksum: 10/e459d131ca646cca6ad164593ca7e8c45ad3daa103a24e1e57fd47b5c1e5b5418948b749f02baa42e61103a496fc80d32ddd1841c11495bbcf37808b88bb0ef4
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.46.0":
-  version: 8.46.0
-  resolution: "@typescript-eslint/type-utils@npm:8.46.0"
+"@typescript-eslint/type-utils@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/type-utils@npm:8.46.2"
   dependencies:
-    "@typescript-eslint/types": "npm:8.46.0"
-    "@typescript-eslint/typescript-estree": "npm:8.46.0"
-    "@typescript-eslint/utils": "npm:8.46.0"
+    "@typescript-eslint/types": "npm:8.46.2"
+    "@typescript-eslint/typescript-estree": "npm:8.46.2"
+    "@typescript-eslint/utils": "npm:8.46.2"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/5405b71b91d02ed4eac1028fc156c053953403b9f48393d92340b15a8b05bee5bf1281324c6283ac31a0e03cc1a19baf94768cb3fd70b4621f8c07a4243837db
+  checksum: 10/db5d3d782b44d31f828ebdbec44550c6f94fdcfac1164f59e3922f6413feed749d93df3977625fd5949aaff5c691cf4603a7cd93eaf7b19b9cf6fd91537fb8c7
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.46.0, @typescript-eslint/types@npm:^8.46.0":
-  version: 8.46.0
-  resolution: "@typescript-eslint/types@npm:8.46.0"
-  checksum: 10/0118b0dd592bf4beaf41e8c6be812980dd0adea44d48c90d8b0272777b58d4cfd6326b8bc363efa3c640be476a6bf3632aee2d97052d5e34071e6576b9c28264
+"@typescript-eslint/types@npm:8.46.2, @typescript-eslint/types@npm:^8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/types@npm:8.46.2"
+  checksum: 10/c641453c868b730ef64bd731cc47b19e1a5e45c090dfe9542ecd15b24c5a7b6dc94a8ef4e548b976aabcd1ca9dec1b766e417454b98ea59079795eb008226b38
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.46.0":
-  version: 8.46.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.46.0"
+"@typescript-eslint/typescript-estree@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/typescript-estree@npm:8.46.2"
   dependencies:
-    "@typescript-eslint/project-service": "npm:8.46.0"
-    "@typescript-eslint/tsconfig-utils": "npm:8.46.0"
-    "@typescript-eslint/types": "npm:8.46.0"
-    "@typescript-eslint/visitor-keys": "npm:8.46.0"
+    "@typescript-eslint/project-service": "npm:8.46.2"
+    "@typescript-eslint/tsconfig-utils": "npm:8.46.2"
+    "@typescript-eslint/types": "npm:8.46.2"
+    "@typescript-eslint/visitor-keys": "npm:8.46.2"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -16454,32 +16463,32 @@ __metadata:
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/61053bd0c35a1fe5c82aef00cb70dbe0878ab28e55550cc1e2d6e7d4a0520c81947eb7505227c85a742a93db905d7e7376aed7d958dc257507b9bdda1daf0b00
+  checksum: 10/4d2149ad97e7f7e2e4cf466932f52f38e90414d47341c5938e497fd0826d403db9896bbd5cc08e7488ad0d0ffb3817e6f18e9f0c623d8a8cda09af204f81aab8
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.46.0, @typescript-eslint/utils@npm:^8.0.0":
-  version: 8.46.0
-  resolution: "@typescript-eslint/utils@npm:8.46.0"
+"@typescript-eslint/utils@npm:8.46.2, @typescript-eslint/utils@npm:^8.0.0":
+  version: 8.46.2
+  resolution: "@typescript-eslint/utils@npm:8.46.2"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.7.0"
-    "@typescript-eslint/scope-manager": "npm:8.46.0"
-    "@typescript-eslint/types": "npm:8.46.0"
-    "@typescript-eslint/typescript-estree": "npm:8.46.0"
+    "@typescript-eslint/scope-manager": "npm:8.46.2"
+    "@typescript-eslint/types": "npm:8.46.2"
+    "@typescript-eslint/typescript-estree": "npm:8.46.2"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/4e0da60de389799afdd36249fd4bcf9e085a4d6f119e241e436a701b45cdf10becc3f1e3cdef29ebbf147a81f40d9a4800d428cb4a66799d3e4aa80b879c9ee2
+  checksum: 10/91f6216f858161c3f59b2e035e0abce68fcdc9fbe45cb693a111c11ce5352c42fe0b1145a91e538c5459ff81b5e3741a4b38189b97e0e1a756567b6467c7b6c9
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.46.0":
-  version: 8.46.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.46.0"
+"@typescript-eslint/visitor-keys@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/visitor-keys@npm:8.46.2"
   dependencies:
-    "@typescript-eslint/types": "npm:8.46.0"
+    "@typescript-eslint/types": "npm:8.46.2"
     eslint-visitor-keys: "npm:^4.2.1"
-  checksum: 10/37e6145b6a5e960c59777d7fc86f722ff696e76c627106ac4577b945ca35744a5f96525d77bde50fe8c328503e9392e21e3adb7cf9899ae0efc054d63f4c3916
+  checksum: 10/4352629a33bc1619dc78d55eaec382be4c7e1059af02660f62bfdb22933021deaf98504d4030b8db74ec122e6d554e9015341f87aed729fb70fae613f12f55a4
   languageName: node
   linkType: hard
 
@@ -24137,17 +24146,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:^6.1.1":
-  version: 6.1.1
-  resolution: "eslint-plugin-react-hooks@npm:6.1.1"
+"eslint-plugin-react-hooks@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "eslint-plugin-react-hooks@npm:7.0.1"
   dependencies:
     "@babel/core": "npm:^7.24.4"
     "@babel/parser": "npm:^7.24.4"
-    zod: "npm:^3.22.4 || ^4.0.0"
-    zod-validation-error: "npm:^3.0.3 || ^4.0.0"
+    hermes-parser: "npm:^0.25.1"
+    zod: "npm:^3.25.0 || ^4.0.0"
+    zod-validation-error: "npm:^3.5.0 || ^4.0.0"
   peerDependencies:
     eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
-  checksum: 10/dcd74dbff0f18ba5aa1d36f0e414628f99c25f14e5bd7ce8205d719dd488adca7530d15ea429ffbc94b09ab6d499160a2e3d2a9a9d9a72f9d517c79e6b472ba6
+  checksum: 10/12e96c68d58c6588305fd17d660524a1ef1e872650ec591d5b138f059431290831c373d4b1c9ae8991fb25f96c43935497d2149678c027e65d0417d3d99ecc85
   languageName: node
   linkType: hard
 
@@ -24213,23 +24223,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.37.0":
-  version: 9.37.0
-  resolution: "eslint@npm:9.37.0"
+"eslint@npm:^9.38.0":
+  version: 9.38.0
+  resolution: "eslint@npm:9.38.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.8.0"
     "@eslint-community/regexpp": "npm:^4.12.1"
-    "@eslint/config-array": "npm:^0.21.0"
-    "@eslint/config-helpers": "npm:^0.4.0"
+    "@eslint/config-array": "npm:^0.21.1"
+    "@eslint/config-helpers": "npm:^0.4.1"
     "@eslint/core": "npm:^0.16.0"
     "@eslint/eslintrc": "npm:^3.3.1"
-    "@eslint/js": "npm:9.37.0"
+    "@eslint/js": "npm:9.38.0"
     "@eslint/plugin-kit": "npm:^0.4.0"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
     "@humanwhocodes/retry": "npm:^0.4.2"
     "@types/estree": "npm:^1.0.6"
-    "@types/json-schema": "npm:^7.0.15"
     ajv: "npm:^6.12.4"
     chalk: "npm:^4.0.0"
     cross-spawn: "npm:^7.0.6"
@@ -24259,7 +24268,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10/c7530470c9cafe9a7f768477f7894d9b9d28e92995186223e99fbd9edeb391119e2a70678a2e98e213ae37cbb41de89403b510f5f33df2340aa65dd6f2a3c0bb
+  checksum: 10/fb8971572dfedd1fd67a35a746d2ab399bef320a7f131fdccaec6416f4b4a028e762663c32ccf1a88f715aec6d1c5da066fdb11e20219a0156f1f3fc1a726713
   languageName: node
   linkType: hard
 
@@ -27545,6 +27554,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hermes-estree@npm:0.25.1":
+  version: 0.25.1
+  resolution: "hermes-estree@npm:0.25.1"
+  checksum: 10/7b1eca98b264a25632064cffa5771360d30cf452e77db1e191f9913ee45cf78c292b2dbca707e92fb71b0870abb97e94b506a5ab80abd96ba237fee169b601fe
+  languageName: node
+  linkType: hard
+
 "hermes-estree@npm:0.29.1":
   version: 0.29.1
   resolution: "hermes-estree@npm:0.29.1"
@@ -27574,6 +27590,15 @@ __metadata:
   dependencies:
     hermes-estree: "npm:0.32.0"
   checksum: 10/496210490cb45e97df14796d94aec6c817c4cefa20f1dbe3ba1df323cc58c930033cfec93f3ecfad6b90e09166fc9ffc4f665843d25b4862523aa70dacbae81f
+  languageName: node
+  linkType: hard
+
+"hermes-parser@npm:^0.25.1":
+  version: 0.25.1
+  resolution: "hermes-parser@npm:0.25.1"
+  dependencies:
+    hermes-estree: "npm:0.25.1"
+  checksum: 10/805efc05691420f236654349872c70731121791fa54de521c7ee51059eae34f84dd19f22ee846741dcb60372f8fb5335719b96b4ecb010d2aed7d872f2eff9cc
   languageName: node
   linkType: hard
 
@@ -43051,7 +43076,7 @@ __metadata:
     "@types/node-fetch": "npm:^2.6.12"
     babel-jest: "npm:30.0.0"
     depcheck: "npm:^1.4.7"
-    eslint: "npm:^9.37.0"
+    eslint: "npm:^9.38.0"
     husky: "npm:^9.1.7"
     jest: "npm:29.7.0"
     jest-environment-node: "npm:^29.7.0"
@@ -43525,18 +43550,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.46.0":
-  version: 8.46.0
-  resolution: "typescript-eslint@npm:8.46.0"
+"typescript-eslint@npm:^8.46.2":
+  version: 8.46.2
+  resolution: "typescript-eslint@npm:8.46.2"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.46.0"
-    "@typescript-eslint/parser": "npm:8.46.0"
-    "@typescript-eslint/typescript-estree": "npm:8.46.0"
-    "@typescript-eslint/utils": "npm:8.46.0"
+    "@typescript-eslint/eslint-plugin": "npm:8.46.2"
+    "@typescript-eslint/parser": "npm:8.46.2"
+    "@typescript-eslint/typescript-estree": "npm:8.46.2"
+    "@typescript-eslint/utils": "npm:8.46.2"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/fd74aab1d21d661299a64107236b5c3515d6d955eb1764b56c5c9505b8cef5f2600e8290d251f1379138333573df94a1fe1fd7fef23952b5ab9f12ff2b774f92
+  checksum: 10/cd1bbc5d33c0369f70032165224badf1a8a9f95f39c891e4f71c78ceea9e7b2d71e0516d8b38177a11217867f387788f3fa126381418581409e7a76cdfdfe909
   languageName: node
   linkType: hard
 
@@ -46402,7 +46427,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-validation-error@npm:^3.0.3 || ^4.0.0":
+"zod-validation-error@npm:^3.5.0 || ^4.0.0":
   version: 4.0.2
   resolution: "zod-validation-error@npm:4.0.2"
   peerDependencies:
@@ -46418,7 +46443,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.22.4 || ^4.0.0":
+"zod@npm:^3.25.0 || ^4.0.0":
   version: 4.1.12
   resolution: "zod@npm:4.1.12"
   checksum: 10/c5f04e6ac306515c4db6ef73cf7705f521c7a2107c8c8912416a0658d689f361db9bee829b0bf01ef4a22492f1065c5cbcdb523ce532606ac6792fd714f3c326


### PR DESCRIPTION
## Description

:information_source: I've developed this rebased on #23118, so even though that one isn't merged yet, this PR honors the age gate :heavy_check_mark: 

`eslint` now has stricter TS validation on configs, so I added [JSDoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) to the eslint config files.

Lot of new rules introduced in `eslint-plugin-react-hooks@7`:
- Some rules I have disabled in [reactConfig.mjs](https://github.com/trezor/trezor-suite/pull/23131/files#diff-4e8104ff8421a63c6662d73efffac09f42512b4bc336eea6d9e5a1edecc2a231), see there for rationale
- `react-hooks/immutability` is good :+1: but it crashes on recursive calls, probably a bug in the plugin? It's just three cases, so I put an ignore there rather than disable this rule globally because of those false positives 

## Related Issue

Part of #22351