### PR TITLE
chore: separate suite-sync and labeling a bit more (reducer) in common

### DIFF
--- a/packages/suite/src/actions/labeling/labelingSelectors.ts
+++ b/packages/suite/src/actions/labeling/labelingSelectors.ts
@@ -1,4 +1,0 @@
-import { DesktopLabelingRootState } from './labelingSlice';
-
-export const selectShowEnableLocalFirstStorageModal = (state: DesktopLabelingRootState): boolean =>
-    state.labeling.showEnableLocalFirstStorageModal;

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -2,7 +2,7 @@
 // data provided by TrezorConnect are mocked
 import { connectInitThunk } from '@suite-common/connect-init';
 import { prepareFirmwareReducer } from '@suite-common/firmware';
-import { prepareLabelingReducer } from '@suite-common/suite-sync';
+import { prepareLabelingReducer, prepareSuiteSyncReducer } from '@suite-common/suite-sync';
 import { testMocks } from '@suite-common/test-utils';
 import {
     acquireDevice,
@@ -33,6 +33,7 @@ const { getSuiteDevice } = testMocks;
 const firmwareReducer = prepareFirmwareReducer(extraDependencies);
 const deviceReducer = prepareDeviceReducer(extraDependencies);
 const labelingReducer = prepareLabelingReducer(extraDependencies);
+const suiteSyncReducer = prepareSuiteSyncReducer(extraDependencies);
 
 const TrezorConnect = testMocks.getTrezorConnectMock();
 
@@ -92,6 +93,9 @@ const getInitialState = (
     labeling: {
         ...labelingReducer(undefined, { type: 'foo' } as any),
         ...labeling,
+    },
+    suiteSync: {
+        ...suiteSyncReducer(undefined, { type: 'foo' } as any),
     },
     wallet: {
         settings: {

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -477,20 +477,21 @@ export const saveMetadataSettings = () => async (_dispatch: Dispatch, getState: 
     });
 };
 
-export const saveLabelingSettings = () => (_dispatch: Dispatch, getState: GetState) => {
+export const saveSuiteSyncSettings = () => (_dispatch: Dispatch, getState: GetState) => {
     if (!db.isAccessible()) return;
 
-    const { labeling } = getState();
+    const { suiteSync } = getState();
 
     return db.addItem(
-        'labelingSettings',
+        'suiteSyncSettings',
         {
-            isFeatureLocalFirstStorageAvailable: labeling.isFeatureLocalFirstStorageAvailable,
-            isLocalFirstStorageEnabled: labeling.isLocalFirstStorageEnabled,
-            isLocalFirstStorageDebugEnabled: labeling.isLocalFirstStorageDebugEnabled,
-            localFirstStorageRelayUrl: labeling.localFirstStorageRelayUrl,
+            isFeatureLocalFirstStorageAvailable:
+                suiteSync.settings.isFeatureLocalFirstStorageAvailable,
+            isLocalFirstStorageEnabled: suiteSync.settings.isLocalFirstStorageEnabled,
+            isLocalFirstStorageDebugEnabled: suiteSync.settings.isLocalFirstStorageDebugEnabled,
+            localFirstStorageRelayUrl: suiteSync.settings.localFirstStorageRelayUrl,
         },
-        'labelingSettings',
+        'suiteSyncSettings',
         true,
     );
 };

--- a/packages/suite/src/actions/suiteSync/suiteSyncSelectors.ts
+++ b/packages/suite/src/actions/suiteSync/suiteSyncSelectors.ts
@@ -1,0 +1,4 @@
+import { DesktopSuiteSyncRootState } from './suiteSyncSlice';
+
+export const selectShowEnableLocalFirstStorageModal = (state: DesktopSuiteSyncRootState): boolean =>
+    state.suiteSync.showEnableLocalFirstStorageModal;

--- a/packages/suite/src/actions/suiteSync/suiteSyncSlice.ts
+++ b/packages/suite/src/actions/suiteSync/suiteSyncSlice.ts
@@ -1,37 +1,37 @@
 import { AnyAction, createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import {
-    LabelingState,
-    initialLabelingState as commonInitialState,
-    prepareLabelingReducer,
+    SuiteSyncState,
+    initialSuiteSyncState as commonInitialState,
+    prepareSuiteSyncReducer,
 } from '@suite-common/suite-sync';
 
 import { Action } from 'src/types/suite';
 
 import { STORAGE } from '../suite/constants';
 
-export type DesktopLabelingState = LabelingState & {
+export type DesktopSuiteSyncState = SuiteSyncState & {
     showEnableLocalFirstStorageModal: boolean;
 };
 
-export const initialLabelingState: DesktopLabelingState = {
+export const initialSuiteSyncState: DesktopSuiteSyncState = {
     ...commonInitialState,
     showEnableLocalFirstStorageModal: false,
 };
 
-export type DesktopLabelingRootState = {
-    labeling: DesktopLabelingState;
+export type DesktopSuiteSyncRootState = {
+    suiteSync: DesktopSuiteSyncState;
 };
 
-export const labelingSlice = createSliceWithExtraDeps({
-    name: 'labeling',
-    initialState: initialLabelingState,
+export const suiteSyncSlice = createSliceWithExtraDeps({
+    name: 'suiteSync',
+    initialState: initialSuiteSyncState,
     reducers: {
         updateShowEnableLocalFirstStorageModal: (state, action) => {
             state.showEnableLocalFirstStorageModal = action.payload.show;
         },
     },
     extraReducers: (builder, extra) => {
-        const commonReducer = prepareLabelingReducer(extra);
+        const commonReducer = prepareSuiteSyncReducer(extra);
 
         builder
             .addCase(STORAGE.LOAD, (state, action) => {
@@ -39,9 +39,15 @@ export const labelingSlice = createSliceWithExtraDeps({
 
                 if (
                     actionWithPayload.type === STORAGE.LOAD &&
-                    actionWithPayload.payload.labelingSettings
+                    actionWithPayload.payload.suiteSyncSettings
                 ) {
-                    return { ...state, ...actionWithPayload.payload.labelingSettings };
+                    return {
+                        ...state,
+                        settings: {
+                            ...state.settings,
+                            ...actionWithPayload.payload.suiteSyncSettings,
+                        },
+                    } satisfies SuiteSyncState;
                 }
             })
             .addDefaultCase((state, action) => {
@@ -50,4 +56,4 @@ export const labelingSlice = createSliceWithExtraDeps({
     },
 });
 
-export const { updateShowEnableLocalFirstStorageModal } = labelingSlice.actions;
+export const { updateShowEnableLocalFirstStorageModal } = suiteSyncSlice.actions;

--- a/packages/suite/src/components/suite/labeling/LabelingModalManager.tsx
+++ b/packages/suite/src/components/suite/labeling/LabelingModalManager.tsx
@@ -1,5 +1,5 @@
-import { selectShowEnableLocalFirstStorageModal } from 'src/actions/labeling/labelingSelectors';
-import { updateShowEnableLocalFirstStorageModal } from 'src/actions/labeling/labelingSlice';
+import { selectShowEnableLocalFirstStorageModal } from 'src/actions/suiteSync/suiteSyncSelectors';
+import { updateShowEnableLocalFirstStorageModal } from 'src/actions/suiteSync/suiteSyncSlice';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { TurnOnSecureSyncModal } from './TurnOnSecureSyncModal';

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -8,8 +8,8 @@ import { StaticSessionId } from '@trezor/connect';
 import { spacingsPx } from '@trezor/theme';
 import { TimerId } from '@trezor/type-utils';
 
-import { updateShowEnableLocalFirstStorageModal } from 'src/actions/labeling/labelingSlice';
 import { addMetadata, init, setEditing } from 'src/actions/suite/metadataLabelingActions';
+import { updateShowEnableLocalFirstStorageModal } from 'src/actions/suiteSync/suiteSyncSlice';
 import { Translation } from 'src/components/suite/Translation';
 import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
 import {

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -1,5 +1,5 @@
 import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
-import { labelingActions } from '@suite-common/suite-sync';
+import { suiteSyncActions } from '@suite-common/suite-sync';
 import { Route } from '@suite-common/suite-types';
 import { networksCollection } from '@suite-common/wallet-config';
 import { isDesktop } from '@trezor/env-utils';
@@ -81,7 +81,7 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
         description: { id: 'TR_EXPERIMENTAL_SUITE_SYNC_DESCRIPTION' },
         onToggle: ({ newValue, dispatch }) => {
             dispatch(
-                labelingActions.updateIsFeatureLocalFirstStorageAvailable({
+                suiteSyncActions.updateIsFeatureLocalFirstStorageAvailable({
                     isShownInSettings: newValue,
                 }),
             );

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -1,6 +1,6 @@
 import { combineReducers, createReducer } from '@reduxjs/toolkit';
 
-import { LabelingState } from '@suite-common/suite-sync';
+import { LabelingState, SuiteSyncState } from '@suite-common/suite-sync';
 import { testMocks } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { Network, getNetwork } from '@suite-common/wallet-config';
@@ -415,11 +415,18 @@ export const getRootReducer = (selectedAccount = BTC_ACCOUNT, fees = DEFAULT_FEE
         labeling: createReducer(
             {
                 walletsLabels: {},
-                isFeatureLocalFirstStorageAvailable: false,
-                isLocalFirstStorageEnabled: false,
-                isLocalFirstStorageDebugEnabled: false,
-                localFirstStorageRelayUrl: null,
             } satisfies LabelingState,
+            state => state,
+        ),
+        suiteSync: createReducer(
+            {
+                settings: {
+                    isFeatureLocalFirstStorageAvailable: false,
+                    isLocalFirstStorageEnabled: false,
+                    isLocalFirstStorageDebugEnabled: false,
+                    localFirstStorageRelayUrl: null,
+                },
+            } satisfies SuiteSyncState,
             state => state,
         ),
         connectPopup: createReducer({}, () => ({})),

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -6,7 +6,7 @@ import { bluetoothActions } from '@suite-common/bluetooth';
 import { connectPopupActions } from '@suite-common/connect-popup';
 import { firmwareActions } from '@suite-common/firmware';
 import { messageSystemActions } from '@suite-common/message-system';
-import { labelingActions } from '@suite-common/suite-sync';
+import { suiteSyncActions } from '@suite-common/suite-sync';
 import { isDeviceRemembered } from '@suite-common/suite-utils';
 import { thpActions } from '@suite-common/thp';
 import { TokenManagementAction } from '@suite-common/token-definitions';
@@ -178,13 +178,13 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
 
             if (
                 isAnyOf(
-                    labelingActions.updateLocalFirstStorageDebugEnabled,
-                    labelingActions.updateLocalFirstStorageEnabled,
-                    labelingActions.updateIsFeatureLocalFirstStorageAvailable,
-                    labelingActions.setLocalFirstStorageRelayUrl,
+                    suiteSyncActions.updateLocalFirstStorageDebugEnabled,
+                    suiteSyncActions.updateLocalFirstStorageEnabled,
+                    suiteSyncActions.updateIsFeatureLocalFirstStorageAvailable,
+                    suiteSyncActions.setLocalFirstStorageRelayUrl,
                 )(action)
             ) {
-                api.dispatch(storageActions.saveLabelingSettings());
+                api.dispatch(storageActions.saveSuiteSyncSettings());
             }
 
             if (deviceActions.setRememberDevice.match(action)) {

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -17,7 +17,7 @@ import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions'
 import { prepareFirmwareReducer } from '@suite-common/firmware';
 import { prepareThpReducer } from '@suite-common/thp';
 import { accountsActions } from '@suite-common/wallet-core';
-import { labelingSlice } from 'src/actions/labeling/labelingSlice';
+import { suiteSyncSlice } from 'src/actions/suiteSync/suiteSyncSlice';
 
 import { suiteMiddlewares } from 'src/middlewares/suite';
 import walletMiddlewares from 'src/middlewares/wallet';
@@ -40,12 +40,14 @@ import { OPEN_USER_CONTEXT } from 'src/actions/suite/constants/modalConstants';
 import { geolocationReducer } from '@suite-common/geolocation';
 import { bluetoothSlice } from '../actions/bluetooth/desktopBluetoothReducer';
 import { ExtraDependencies } from '@suite-common/redux-utils';
+import { prepareLabelingReducer } from '@suite-common/suite-sync';
 
 const firmwareReducer = prepareFirmwareReducer(extraDependencies);
 const tokenDefinitionsReducer = prepareTokenDefinitionsReducer(extraDependencies);
 const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependencies);
 const thpReducer = prepareThpReducer(extraDependencies);
-const labelingReducer = labelingSlice.prepareReducer(extraDependencies);
+const labelingReducer = prepareLabelingReducer(extraDependencies);
+const suiteSyncReducer = suiteSyncSlice.prepareReducer(extraDependencies);
 
 const rootReducer = combineReducers({
     ...suiteReducers,
@@ -60,6 +62,7 @@ const rootReducer = combineReducers({
     bluetooth: bluetoothReducer,
     thp: thpReducer,
     labeling: labelingReducer,
+    suiteSync: suiteSyncReducer,
     geolocation: geolocationReducer,
 });
 

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -14,7 +14,6 @@ import { AccountKey } from '@suite-common/wallet-types';
 import { DeviceState, StaticSessionId } from '@trezor/connect';
 
 import { DesktopDeviceRootState } from 'src/actions/device/deviceSlice';
-import { DesktopLabelingRootState } from 'src/actions/labeling/labelingSlice';
 import {
     METADATA,
     METADATA_LABELING,
@@ -25,6 +24,7 @@ import {
     DEFAULT_ACCOUNT_METADATA,
     DEFAULT_WALLET_METADATA,
 } from 'src/actions/suite/constants/metadataLabelingConstants';
+import { DesktopSuiteSyncRootState } from 'src/actions/suiteSync/suiteSyncSlice';
 import { Action, TrezorDevice } from 'src/types/suite';
 import {
     AccountLabels,
@@ -53,7 +53,7 @@ type MetadataRootState = {
 } & DesktopDeviceRootState &
     SuiteRootState &
     AccountsRootState &
-    DesktopLabelingRootState;
+    DesktopSuiteSyncRootState;
 
 const metadataReducer = (state = initialState, action: Action): MetadataState =>
     produce(state, draft => {

--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -5,7 +5,7 @@ import type { DBSchema } from 'idb';
 import { AnalyticsState } from '@suite-common/analytics';
 import { AppRememberedPermission } from '@suite-common/connect-popup/src/connectPopupTypes';
 import type { MessageState } from '@suite-common/message-system';
-import { LabelingSettings } from '@suite-common/suite-sync';
+import { SuiteSyncSettings } from '@suite-common/suite-sync';
 import type {
     DeviceWithEmptyPath,
     MessageSystem,
@@ -140,9 +140,9 @@ export interface SuiteDBSchema extends DBSchema {
         key: 'state';
         value: MetadataState;
     };
-    labelingSettings: {
-        key: 'labelingSettings';
-        value: LabelingSettings;
+    suiteSyncSettings: {
+        key: 'suiteSyncSettings';
+        value: SuiteSyncSettings;
     };
     messageSystem: {
         key: string;

--- a/packages/suite/src/storage/migrations/versions/25.11.0.1.ts
+++ b/packages/suite/src/storage/migrations/versions/25.11.0.1.ts
@@ -3,9 +3,12 @@ import { createMigration } from '@suite/idb-migration-utils';
 import { SuiteDBSchema } from 'src/storage/definitions';
 
 export default createMigration<SuiteDBSchema>('25.11.0.1', (db, tx) => {
+    // @ts-expect-error
     if (!db.objectStoreNames.contains('labelingSettings')) {
+        // @ts-expect-error
         db.createObjectStore('labelingSettings');
 
+        // @ts-expect-error
         tx.objectStore('labelingSettings').put(
             {
                 isFeatureLocalFirstStorageAvailable: false,

--- a/packages/suite/src/storage/migrations/versions/25.12.0.ts
+++ b/packages/suite/src/storage/migrations/versions/25.12.0.ts
@@ -1,0 +1,25 @@
+import { createMigration } from '@suite/idb-migration-utils';
+
+import { SuiteDBSchema } from 'src/storage/definitions';
+
+export default createMigration<SuiteDBSchema>('25.12.0', (db, tx) => {
+    // @ts-expect-error `suiteSyncSettings` no longer exists, migrates to `suiteSyncSettings`
+    if (db.objectStoreNames.contains('labelingSettings')) {
+        // @ts-expect-error
+        db.deleteObjectStore('labelingSettings');
+    }
+
+    if (!db.objectStoreNames.contains('suiteSyncSettings')) {
+        db.createObjectStore('suiteSyncSettings');
+
+        tx.objectStore('suiteSyncSettings').put(
+            {
+                isFeatureLocalFirstStorageAvailable: false,
+                isLocalFirstStorageEnabled: false,
+                isLocalFirstStorageDebugEnabled: false,
+                localFirstStorageRelayUrl: null,
+            },
+            'suiteSyncSettings',
+        );
+    }
+});

--- a/packages/suite/src/storage/migrations/versions/index.ts
+++ b/packages/suite/src/storage/migrations/versions/index.ts
@@ -9,3 +9,4 @@ export { default as m25_9_2 } from './25.9.2';
 export { default as m25_10_0 } from './25.10.0';
 export { default as m25_11_0 } from './25.11.0';
 export { default as m25_11_0_1 } from './25.11.0.1';
+export { default as m25_12_0 } from './25.12.0';

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -99,7 +99,7 @@ export const extraDependencies: ExtraDependencies = {
             state.suite.settings.debug.invityServerEnvironment,
         selectIsViewOnlyByDefaultEnabled: (_: AppState) => true,
         selectIsLocalFirstStorageEnabled: (state: AppState) =>
-            state.labeling.isLocalFirstStorageEnabled,
+            state.suiteSync.settings.isLocalFirstStorageEnabled,
         selectThpSettings: (state: AppState) => ({
             appName: 'Trezor Suite', // NOTE: this is displayed on Trezor. not the same as manifest.appName
             pairingMethods: ['CodeEntry'],

--- a/packages/suite/src/support/suite/preloadStore.ts
+++ b/packages/suite/src/support/suite/preloadStore.ts
@@ -51,7 +51,7 @@ export const preloadStore = async () => {
             explorer,
             bioAuth,
             firmware,
-            labelingSettings,
+            suiteSyncSettings,
         ] = await Promise.all([
             db.getItemByPK('suiteSettings', 'suite'),
             db.getItemsExtended('devices'),
@@ -77,7 +77,7 @@ export const preloadStore = async () => {
             db.getItemsExtended('explorer'),
             db.getItemByPK('bioAuth', 'bioAuth'),
             db.getItemByPK('firmware', 'firmware'),
-            db.getItemByPK('labelingSettings', 'labelingSettings'),
+            db.getItemByPK('suiteSyncSettings', 'suiteSyncSettings'),
         ]);
 
         return {
@@ -107,7 +107,7 @@ export const preloadStore = async () => {
                 connect,
                 explorer,
                 firmware,
-                labelingSettings,
+                suiteSyncSettings,
             },
         } as const;
     } catch (error) {

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -1,10 +1,11 @@
 import { FirmwareUpdateState } from '@suite-common/firmware';
 import { messageSystemInitialState } from '@suite-common/message-system';
 import { MetadataState } from '@suite-common/metadata-types';
+import { initialLabelingState } from '@suite-common/suite-sync';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { initialState } from 'src/actions/device/deviceSlice';
-import { initialLabelingState } from 'src/actions/labeling/labelingSlice';
+import { initialSuiteSyncState } from 'src/actions/suiteSync/suiteSyncSlice';
 import { BackupState } from 'src/reducers/backup/backupReducer';
 import { OnboardingState } from 'src/reducers/onboarding/onboardingReducer';
 import { AppState } from 'src/reducers/store';
@@ -26,6 +27,7 @@ export const initialAppState: AppState = {
         credentials: [],
     },
     labeling: initialLabelingState,
+    suiteSync: initialSuiteSyncState,
     window: {
         isVisible: true,
         isBelowMobile: false,

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -8,7 +8,7 @@ import { firmwareActions } from '@suite-common/firmware';
 import { geolocationActions } from '@suite-common/geolocation';
 import { addLog } from '@suite-common/logger';
 import { messageSystemActions } from '@suite-common/message-system';
-import { labelingActions } from '@suite-common/suite-sync';
+import { labelingActions, suiteSyncActions } from '@suite-common/suite-sync';
 import type { Route } from '@suite-common/suite-types';
 import { thpActions } from '@suite-common/thp';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -23,7 +23,6 @@ import { FilterOutFromUnionByTypeProperty } from '@trezor/type-utils';
 
 import type { BackupAction } from 'src/actions/backup/backupActions';
 import { deviceSlice } from 'src/actions/device/deviceSlice';
-import { labelingSlice } from 'src/actions/labeling/labelingSlice';
 import type { OnboardingAction } from 'src/actions/onboarding/onboardingActions';
 import type { RecoveryAction } from 'src/actions/recovery/recoveryActions';
 import { BioAuthAction } from 'src/actions/suite/bioAuthActions';
@@ -36,6 +35,7 @@ import type { RouterAction } from 'src/actions/suite/routerActions';
 import type { StorageAction } from 'src/actions/suite/storageActions';
 import type { SuiteAction } from 'src/actions/suite/suiteActions';
 import type { WindowAction } from 'src/actions/suite/windowActions';
+import { suiteSyncSlice } from 'src/actions/suiteSync/suiteSyncSlice';
 import type { AppState } from 'src/reducers/store';
 import type { WalletAction } from 'src/types/wallet';
 
@@ -85,8 +85,9 @@ type BluetoothAction = ReturnType<(typeof bluetoothActions)[keyof typeof bluetoo
 type BluetoothActionDesktop = ReturnType<
     (typeof bluetoothSlice.actions)[keyof typeof bluetoothSlice.actions]
 >;
-type LabelingActionDesktop = ReturnType<
-    (typeof labelingSlice.actions)[keyof typeof labelingSlice.actions]
+type SuiteSyncAction = ReturnType<(typeof suiteSyncActions)[keyof typeof suiteSyncActions]>;
+type SuiteSyncActionDesktop = ReturnType<
+    (typeof suiteSyncSlice.actions)[keyof typeof suiteSyncSlice.actions]
 >;
 type DeviceActionDesktop = ReturnType<
     (typeof deviceSlice.actions)[keyof typeof deviceSlice.actions]
@@ -98,38 +99,39 @@ type FeeAction = ReturnType<(typeof feesActions)[keyof typeof feesActions]>;
 
 // all actions from all apps used to properly type Dispatch.
 export type Action =
-    | TrezorConnectEvents
-    | RouterAction
-    | WindowAction
-    | StorageAction
-    | SuiteAction
-    | TransactionAction
-    | ModalAction
-    | NotificationAction
     | AnalyticsAction
-    | MetadataAction
-    | WalletAction
-    | OnboardingAction
-    | FirmwareAction
     | BackupAction
-    | RecoveryAction
-    | DesktopUpdateAction
-    | MessageSystemAction
-    | GuideAction
-    | ProtocolAction
-    | DiscoveryAction
-    | DeviceAction
-    | DeviceAuthenticityAction
-    | ReturnType<typeof addLog>
+    | BioAuthAction
     | BluetoothAction
     | BluetoothActionDesktop
+    | DesktopUpdateAction
+    | DeviceAction
     | DeviceActionDesktop
-    | LabelingActionDesktop
-    | ThpAction
-    | LabelingAction
+    | DeviceAuthenticityAction
+    | DiscoveryAction
+    | FeeAction
+    | FirmwareAction
     | GeolocationAction
-    | BioAuthAction
-    | FeeAction;
+    | GuideAction
+    | LabelingAction
+    | MessageSystemAction
+    | MetadataAction
+    | ModalAction
+    | NotificationAction
+    | OnboardingAction
+    | ProtocolAction
+    | RecoveryAction
+    | ReturnType<typeof addLog>
+    | RouterAction
+    | StorageAction
+    | SuiteAction
+    | SuiteSyncAction
+    | SuiteSyncActionDesktop
+    | ThpAction
+    | TransactionAction
+    | TrezorConnectEvents
+    | WalletAction
+    | WindowAction;
 
 export type ThunkAction = TAction<any, AppState, any, Action>;
 

--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -34,7 +34,7 @@ const resolveLabelingType = (state: AppState): 'legacy' | 'evolu' | string => {
         );
     }
 
-    return state.labeling.isLocalFirstStorageEnabled ? 'evolu' : '';
+    return state.suiteSync.settings.isLocalFirstStorageEnabled ? 'evolu' : '';
 };
 
 // redact transaction id from account transaction anchor

--- a/packages/suite/src/views/settings/SettingsDebug/LocalFirstStorageSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/LocalFirstStorageSettings.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import {
     DEFAULT_LOCAL_FIRST_STORAGE_RELAY_URL,
     changeRelayUrlThunk,
-    labelingActions,
     selectLocalFirstStorageRelayUrl,
+    suiteSyncActions,
 } from '@suite-common/suite-sync';
 import { Button, Checkbox, Code, Column, Input, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
@@ -31,7 +31,7 @@ export const LocalFirstStorageSettings = () => {
 
     const handleToggleLocalFirstStorageDebug = () => {
         dispatch(
-            labelingActions.updateLocalFirstStorageDebugEnabled({
+            suiteSyncActions.updateLocalFirstStorageDebugEnabled({
                 isEnabled: !isLocalFirstStorageDebugEnabled,
             }),
         );

--- a/suite-common/suite-sync/src/index.ts
+++ b/suite-common/suite-sync/src/index.ts
@@ -1,10 +1,21 @@
-// Local Storage initialization ond disposal
+// Suite Sync
 export { disposeAllLocalFirstStorageThunk } from './storage/disposeAllLocalFirstStorageThunk';
 export { initLocalFirstStorageThunkFactory } from './storage/initLocalFirstStorageThunk';
 export { subscribeLocalFirstStorageThunk } from './storage/subscribeLocalFirstStorageThunk';
 export { changeRelayUrlThunk } from './storage/changeRelayUrlThunk';
 export { unsubscribeAndDisposeLocalFirstStorageThunk } from './storage/unsubscribeAndDisposeLocalFirstStorageThunk';
 export { DEFAULT_SUITE_SYNC_RELAY_URL as DEFAULT_LOCAL_FIRST_STORAGE_RELAY_URL } from './storage/LocalFirstStorageProvider';
+export { suiteSyncActions } from './storage/suiteSyncActions';
+export { prepareSuiteSyncReducer, initialSuiteSyncState } from './storage/suiteSyncReducer';
+export type { SuiteSyncState, SuiteSyncSettings } from './storage/suiteSyncReducer';
+export {
+    selectIsLocalFirstStorageDebugEnabled,
+    selectIsLocalFirstStorageEnabled,
+    selectLocalFirstStorageRelayUrl,
+    selectShouldOfferSecureSync,
+    selectIsFeatureLocalFirstStorageAvailable,
+} from './storage/suiteSyncSelectors';
+export { useLocalFirstStorage } from './storage/useLocalFirstStorage';
 
 // Labeling
 export { updateWalletLabelThunk } from './labeling/updateWalletLabelThunk';
@@ -19,34 +30,10 @@ export {
     selectAccountLabel,
     selectOutputLabels,
     selectOutputLabel,
-    selectIsLocalFirstStorageDebugEnabled,
-    selectIsLocalFirstStorageEnabled,
-    selectLocalFirstStorageRelayUrl,
-    selectShouldOfferSecureSync,
-    selectIsFeatureLocalFirstStorageAvailable,
 } from './labeling/labelingSelectors';
 export { findAccountLabel, findOutputLabel, findAddressLabel } from './labeling/selectorUtils';
 export type { WithLabelingState } from './labeling/labelingSelectors';
-
-import { labelingActions as labelingActionsImported } from './labeling/labelingActions';
-
-// Todo: this shall be in LocalFirstStorage reducer, not labeling
-export const labelingActions = {
-    updateLocalFirstStorageEnabled: labelingActionsImported.updateLocalFirstStorageEnabled,
-    updateLocalFirstStorageDebugEnabled:
-        labelingActionsImported.updateLocalFirstStorageDebugEnabled,
-    updateIsFeatureLocalFirstStorageAvailable:
-        labelingActionsImported.updateIsFeatureLocalFirstStorageAvailable,
-
-    /** @deprecated This is exported only for the `storageMiddleware`, do not use anywhere else! */
-    setLocalFirstStorageRelayUrl: labelingActionsImported.setLocalFirstStorageRelayUrl,
-};
-
-export {
-    prepareLabelingReducer,
-    initialLabelingState,
-    type LabelingSettings,
-} from './labeling/labelingReducer';
+export { prepareLabelingReducer, initialLabelingState } from './labeling/labelingReducer';
 export type { LabelingState } from './labeling/labelingReducer';
 export { processMetadataMessageThunk } from './labeling/processMetadataMessageThunk';
-export { useLocalFirstStorage } from './labeling/hooks/useLocalFirstStorage';
+export { labelingActions } from './labeling/labelingActions';

--- a/suite-common/suite-sync/src/labeling/labelingActions.ts
+++ b/suite-common/suite-sync/src/labeling/labelingActions.ts
@@ -49,41 +49,10 @@ export const clearAllLabels = createAction(
     (payload: { walletDescriptor: WalletDescriptor }) => ({ payload }),
 );
 
-// Todo: this shall be in LocalFirstStorage reducer, not labeling
-export const updateLocalFirstStorageEnabled = createAction(
-    `${LABELING_PREFIX}/update-locale-first-storage-enabled`,
-    (payload: { isEnabled: boolean }) => ({ payload }),
-);
-
-// Todo: this shall be in LocalFirstStorage reducer, not labeling
-export const updateLocalFirstStorageDebugEnabled = createAction(
-    `${LABELING_PREFIX}/update-locale-first-storage-debug-enabled`,
-    (payload: { isEnabled: boolean }) => ({ payload }),
-);
-
-// Todo: this shall be in LocalFirstStorage reducer, not labeling
-export const updateIsFeatureLocalFirstStorageAvailable = createAction(
-    `${LABELING_PREFIX}/update-show-locale-first-storage`,
-    (payload: { isShownInSettings: boolean }) => ({ payload }),
-);
-
-// Todo: this shall be in LocalFirstStorage reducer, not labeling
-/** @deprecated this shall be called only from `changeRelayUrlThunk`, use the thunk only */
-export const setLocalFirstStorageRelayUrl = createAction(
-    `${LABELING_PREFIX}/set-local-first-storage-relay-url`,
-    (payload: { url: string | null }) => ({ payload }),
-);
-
 export const labelingActions = {
     setWalletLabel,
     setAccountLabel,
     setAddressLabel,
     setOutputLabel,
     clearAllLabels,
-
-    // Todo: this shall be in LocalFirstStorage reducer, not labeling
-    updateLocalFirstStorageEnabled,
-    updateLocalFirstStorageDebugEnabled,
-    updateIsFeatureLocalFirstStorageAvailable,
-    setLocalFirstStorageRelayUrl,
 };

--- a/suite-common/suite-sync/src/labeling/labelingReducer.ts
+++ b/suite-common/suite-sync/src/labeling/labelingReducer.ts
@@ -14,23 +14,12 @@ export type WalletLabelState = {
     outputLabels: OutputLabel[];
 };
 
-export type LabelingSettings = {
-    isFeatureLocalFirstStorageAvailable: boolean;
-    isLocalFirstStorageEnabled: boolean;
-    isLocalFirstStorageDebugEnabled: boolean;
-    localFirstStorageRelayUrl: string | null;
-};
-
-export type LabelingState = LabelingSettings & {
+export type LabelingState = {
     walletsLabels: Record<WalletDescriptor, WalletLabelState>; // key: WalletDescriptor = First btc testnet address
 };
 
 export const initialLabelingState: LabelingState = {
     walletsLabels: {},
-    isFeatureLocalFirstStorageAvailable: false,
-    isLocalFirstStorageEnabled: false,
-    isLocalFirstStorageDebugEnabled: false,
-    localFirstStorageRelayUrl: null,
 };
 
 const getOrCreateWalletsLabelsState = (
@@ -118,20 +107,5 @@ export const prepareLabelingReducer = createReducerWithExtraDeps<LabelingState>(
             })
             .addCase(labelingActions.clearAllLabels, (state, { payload }) => {
                 delete state.walletsLabels[payload.walletDescriptor];
-            })
-            .addCase(labelingActions.updateLocalFirstStorageEnabled, (state, { payload }) => {
-                state.isLocalFirstStorageEnabled = payload.isEnabled;
-            })
-            .addCase(labelingActions.updateLocalFirstStorageDebugEnabled, (state, { payload }) => {
-                state.isLocalFirstStorageDebugEnabled = payload.isEnabled;
-            })
-            .addCase(
-                labelingActions.updateIsFeatureLocalFirstStorageAvailable,
-                (state, { payload }) => {
-                    state.isFeatureLocalFirstStorageAvailable = payload.isShownInSettings;
-                },
-            )
-            .addCase(labelingActions.setLocalFirstStorageRelayUrl, (state, { payload }) => {
-                state.localFirstStorageRelayUrl = payload.url;
             }),
 );

--- a/suite-common/suite-sync/src/labeling/labelingSelectors.ts
+++ b/suite-common/suite-sync/src/labeling/labelingSelectors.ts
@@ -1,4 +1,3 @@
-import { DeviceRootState } from '@suite-common/wallet-core';
 import type { AccountKey, WalletDescriptor } from '@suite-common/wallet-types';
 import { parseAccountKey, parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import type { StaticSessionId } from '@trezor/connect';
@@ -9,25 +8,6 @@ import { findAccountLabel, findAddressLabel, findOutputLabel } from './selectorU
 export type WithLabelingState = {
     labeling: LabelingState;
 };
-
-export type WithLabelingAndDeviceState = WithLabelingState & DeviceRootState;
-
-export const selectIsLocalFirstStorageEnabled = (state: WithLabelingState): boolean =>
-    state.labeling.isLocalFirstStorageEnabled;
-
-export const selectIsLocalFirstStorageDebugEnabled = (state: WithLabelingState): boolean =>
-    state.labeling.isLocalFirstStorageDebugEnabled;
-
-export const selectIsFeatureLocalFirstStorageAvailable = (state: WithLabelingState): boolean =>
-    state.labeling.isFeatureLocalFirstStorageAvailable;
-
-export const selectLocalFirstStorageRelayUrl = (state: WithLabelingState) =>
-    state.labeling.localFirstStorageRelayUrl;
-
-export const selectShouldOfferSecureSync = (state: WithLabelingAndDeviceState): boolean =>
-    state.device.selectedDevice?.unavailableCapabilities?.evolu === undefined &&
-    state.labeling.isFeatureLocalFirstStorageAvailable &&
-    !state.labeling.isLocalFirstStorageEnabled;
 
 type SelectWalletLabelParams = {
     state: WithLabelingState;

--- a/suite-common/suite-sync/src/storage/changeRelayUrlThunk.ts
+++ b/suite-common/suite-sync/src/storage/changeRelayUrlThunk.ts
@@ -4,7 +4,7 @@ import { selectDevices } from '@suite-common/wallet-core';
 import { DEFAULT_SUITE_SYNC_RELAY_URL } from './LocalFirstStorageProvider';
 import { LOCAL_FIRST_STORAGE_PREFIX } from './constants';
 import { getLocalFirstStorageProvider } from './sharedObjects';
-import { labelingActions } from '../labeling/labelingActions';
+import { setLocalFirstStorageRelayUrl } from './suiteSyncActions';
 
 type ChangeRelayUrlThunkThunkParams = {
     relayUrl: string | null;
@@ -14,7 +14,7 @@ export const changeRelayUrlThunk = createThunk<void, ChangeRelayUrlThunkThunkPar
     `${LOCAL_FIRST_STORAGE_PREFIX}/changeRelayUrlThunk`,
     async ({ relayUrl }, { getState, dispatch }) => {
         const devices = selectDevices(getState());
-        dispatch(labelingActions.setLocalFirstStorageRelayUrl({ url: relayUrl }));
+        dispatch(setLocalFirstStorageRelayUrl({ url: relayUrl }));
 
         // We save empty, but we need to reconnect to DEFAULT in case user clears relay form to empty
         const normalizedUrl =

--- a/suite-common/suite-sync/src/storage/initLocalFirstStorageThunk.ts
+++ b/suite-common/suite-sync/src/storage/initLocalFirstStorageThunk.ts
@@ -8,7 +8,7 @@ import { setLocalFirstStorageProvider } from './sharedObjects';
 import {
     selectIsLocalFirstStorageEnabled,
     selectLocalFirstStorageRelayUrl,
-} from '../labeling/labelingSelectors';
+} from './suiteSyncSelectors';
 
 export const initLocalFirstStorageThunk = createThunk<void, void, void>(
     `${LOCAL_FIRST_STORAGE_PREFIX}/initLocalFirstStorageThunk`,

--- a/suite-common/suite-sync/src/storage/suiteSyncActions.ts
+++ b/suite-common/suite-sync/src/storage/suiteSyncActions.ts
@@ -1,0 +1,31 @@
+import { createAction } from '@reduxjs/toolkit';
+export const SUITE_SYNC_PREFIX = '@suite/suite-sync';
+
+export const updateLocalFirstStorageEnabled = createAction(
+    `${SUITE_SYNC_PREFIX}/update-locale-first-storage-enabled`,
+    (payload: { isEnabled: boolean }) => ({ payload }),
+);
+
+export const updateLocalFirstStorageDebugEnabled = createAction(
+    `${SUITE_SYNC_PREFIX}/update-locale-first-storage-debug-enabled`,
+    (payload: { isEnabled: boolean }) => ({ payload }),
+);
+
+export const updateIsFeatureLocalFirstStorageAvailable = createAction(
+    `${SUITE_SYNC_PREFIX}/update-show-locale-first-storage`,
+    (payload: { isShownInSettings: boolean }) => ({ payload }),
+);
+
+/** @deprecated this shall be called only from `changeRelayUrlThunk`, use the thunk only */
+export const setLocalFirstStorageRelayUrl = createAction(
+    `${SUITE_SYNC_PREFIX}/set-local-first-storage-relay-url`,
+    (payload: { url: string | null }) => ({ payload }),
+);
+
+export const suiteSyncActions = {
+    updateLocalFirstStorageEnabled,
+    updateLocalFirstStorageDebugEnabled,
+    updateIsFeatureLocalFirstStorageAvailable,
+    /** @deprecated this shall be called only from `changeRelayUrlThunk`, use the thunk only */
+    setLocalFirstStorageRelayUrl,
+};

--- a/suite-common/suite-sync/src/storage/suiteSyncReducer.ts
+++ b/suite-common/suite-sync/src/storage/suiteSyncReducer.ts
@@ -1,0 +1,69 @@
+import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+
+import { setLocalFirstStorageRelayUrl, suiteSyncActions } from './suiteSyncActions';
+
+export type SuiteSyncSettings = {
+    /**
+     * This is flag, that enables the Suite Sync Feature.
+     * On desktop, it is managed by Experimental Features.
+     * On mobile, it is managed by Debug Settings.
+     *
+     * It shall be removed once we release the Suite Sync feature.
+     */
+    isFeatureLocalFirstStorageAvailable: boolean;
+
+    /**
+     * This is flag to show some extra Debug UI.
+     */
+    isLocalFirstStorageDebugEnabled: boolean;
+
+    /**
+     * This flag enables Suite Sync. It is intended as Switch
+     * in the settings, so privacy focused users can simply
+     * switch whole feature off.
+     */
+    isLocalFirstStorageEnabled: boolean;
+
+    /**
+     * This is URL for backend/relay.
+     *
+     * Todo: This is kinda reladed to Evolu, and other libraries
+     *       can have different config. So this may better be in some
+     *       Provider-Config place in the future.
+     */
+    localFirstStorageRelayUrl: string | null;
+};
+
+export type SuiteSyncState = {
+    settings: SuiteSyncSettings;
+};
+
+export const initialSuiteSyncState: SuiteSyncState = {
+    settings: {
+        isFeatureLocalFirstStorageAvailable: false,
+        isLocalFirstStorageEnabled: false,
+        isLocalFirstStorageDebugEnabled: false,
+        localFirstStorageRelayUrl: null,
+    },
+};
+
+export const prepareSuiteSyncReducer = createReducerWithExtraDeps<SuiteSyncState>(
+    initialSuiteSyncState,
+    builder =>
+        builder
+            .addCase(suiteSyncActions.updateLocalFirstStorageEnabled, (state, { payload }) => {
+                state.settings.isLocalFirstStorageEnabled = payload.isEnabled;
+            })
+            .addCase(suiteSyncActions.updateLocalFirstStorageDebugEnabled, (state, { payload }) => {
+                state.settings.isLocalFirstStorageDebugEnabled = payload.isEnabled;
+            })
+            .addCase(
+                suiteSyncActions.updateIsFeatureLocalFirstStorageAvailable,
+                (state, { payload }) => {
+                    state.settings.isFeatureLocalFirstStorageAvailable = payload.isShownInSettings;
+                },
+            )
+            .addCase(setLocalFirstStorageRelayUrl, (state, { payload }) => {
+                state.settings.localFirstStorageRelayUrl = payload.url;
+            }),
+);

--- a/suite-common/suite-sync/src/storage/suiteSyncSelectors.ts
+++ b/suite-common/suite-sync/src/storage/suiteSyncSelectors.ts
@@ -1,0 +1,28 @@
+import { DeviceRootState } from '@suite-common/wallet-core';
+
+import { SuiteSyncState } from './suiteSyncReducer';
+
+export type WithSuiteSyncState = {
+    suiteSync: SuiteSyncState;
+};
+
+export type WithSuiteSyncAndDeviceState = WithSuiteSyncState & DeviceRootState;
+
+export const selectIsLocalFirstStorageEnabled = (state: WithSuiteSyncAndDeviceState): boolean =>
+    state.suiteSync.settings.isLocalFirstStorageEnabled;
+
+export const selectIsLocalFirstStorageDebugEnabled = (
+    state: WithSuiteSyncAndDeviceState,
+): boolean => state.suiteSync.settings.isLocalFirstStorageDebugEnabled;
+
+export const selectIsFeatureLocalFirstStorageAvailable = (
+    state: WithSuiteSyncAndDeviceState,
+): boolean => state.suiteSync.settings.isFeatureLocalFirstStorageAvailable;
+
+export const selectLocalFirstStorageRelayUrl = (state: WithSuiteSyncAndDeviceState) =>
+    state.suiteSync.settings.localFirstStorageRelayUrl;
+
+export const selectShouldOfferSecureSync = (state: WithSuiteSyncAndDeviceState): boolean =>
+    state.device.selectedDevice?.unavailableCapabilities?.evolu === undefined &&
+    state.suiteSync.settings.isFeatureLocalFirstStorageAvailable &&
+    !state.suiteSync.settings.isLocalFirstStorageEnabled;

--- a/suite-common/suite-sync/src/storage/useLocalFirstStorage.ts
+++ b/suite-common/suite-sync/src/storage/useLocalFirstStorage.ts
@@ -2,14 +2,14 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { TrezorDevice } from '@suite-common/suite-types';
 
-import { disposeAllLocalFirstStorageThunk } from '../../storage/disposeAllLocalFirstStorageThunk';
-import { initLocalFirstStorageThunk } from '../../storage/initLocalFirstStorageThunk';
-import { labelingActions } from '../labelingActions';
+import { disposeAllLocalFirstStorageThunk } from './disposeAllLocalFirstStorageThunk';
+import { initLocalFirstStorageThunk } from './initLocalFirstStorageThunk';
+import { suiteSyncActions } from './suiteSyncActions';
 import {
     selectIsFeatureLocalFirstStorageAvailable,
     selectIsLocalFirstStorageDebugEnabled,
     selectIsLocalFirstStorageEnabled,
-} from '../labelingSelectors';
+} from './suiteSyncSelectors';
 
 export type UseLocalStorageParams = {
     // This needs to be passed, as labeling can be attached to remembered wallets
@@ -28,7 +28,7 @@ export const useLocalFirstStorage = ({ device }: UseLocalStorageParams) => {
 
     const toggleIsFeatureLocalFirstStorageAvailable = () => {
         dispatch(
-            labelingActions.updateIsFeatureLocalFirstStorageAvailable({
+            suiteSyncActions.updateIsFeatureLocalFirstStorageAvailable({
                 isShownInSettings: !isFeatureLocalFirstStorageAvailable,
             }),
         );
@@ -36,14 +36,14 @@ export const useLocalFirstStorage = ({ device }: UseLocalStorageParams) => {
 
     const disableLocalFirstStorageIfNeeded = () => {
         if (isLocalFirstStorageEnabled) {
-            dispatch(labelingActions.updateLocalFirstStorageEnabled({ isEnabled: false }));
+            dispatch(suiteSyncActions.updateLocalFirstStorageEnabled({ isEnabled: false }));
             dispatch(disposeAllLocalFirstStorageThunk());
         }
     };
 
     const enableLocalFirstStorageIfNeeded = () => {
         if (!isLocalFirstStorageEnabled) {
-            dispatch(labelingActions.updateLocalFirstStorageEnabled({ isEnabled: true }));
+            dispatch(suiteSyncActions.updateLocalFirstStorageEnabled({ isEnabled: true }));
             dispatch(initLocalFirstStorageThunk());
         }
     };

--- a/suite-common/suite-sync/tests/labeling/labelingReducer.test.ts
+++ b/suite-common/suite-sync/tests/labeling/labelingReducer.test.ts
@@ -27,10 +27,6 @@ const labelingReducer = prepareLabelingReducer(extraDependenciesMock);
 
 const initialState: LabelingState = {
     walletsLabels: {},
-    isFeatureLocalFirstStorageAvailable: false,
-    isLocalFirstStorageEnabled: false,
-    isLocalFirstStorageDebugEnabled: false,
-    localFirstStorageRelayUrl: null,
 };
 
 const walletDescriptor = asWalletDescriptor('mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q');
@@ -61,10 +57,6 @@ describe('labelingReducer', () => {
                     outputLabels: [],
                 },
             },
-            isFeatureLocalFirstStorageAvailable: false,
-            isLocalFirstStorageEnabled: false,
-            isLocalFirstStorageDebugEnabled: false,
-            localFirstStorageRelayUrl: null,
         };
 
         const store = configureMockStore({
@@ -330,10 +322,6 @@ describe('labelingReducer', () => {
     it('clears all labels for a wallet (remove whole entry)', () => {
         const preloaded: LabelingState = {
             walletsLabels: {},
-            isFeatureLocalFirstStorageAvailable: false,
-            isLocalFirstStorageEnabled: false,
-            isLocalFirstStorageDebugEnabled: false,
-            localFirstStorageRelayUrl: null,
         };
         preloaded.walletsLabels[walletDescriptor] = {
             walletLabel: 'To be removed',

--- a/suite-native/module-dev-utils/src/components/LocalFirstRelaySettings.tsx
+++ b/suite-native/module-dev-utils/src/components/LocalFirstRelaySettings.tsx
@@ -4,9 +4,9 @@ import {
     DEFAULT_LOCAL_FIRST_STORAGE_RELAY_URL,
     changeRelayUrlThunk,
     disposeAllLocalFirstStorageThunk,
-    labelingActions,
     selectIsFeatureLocalFirstStorageAvailable,
     selectLocalFirstStorageRelayUrl,
+    suiteSyncActions,
 } from '@suite-common/suite-sync';
 import { yup } from '@suite-common/validators';
 import { Button, Card, CheckBox, HStack, Text, VStack } from '@suite-native/atoms';
@@ -44,7 +44,7 @@ export const LocalFirstRelaySettings = () => {
     const handleLocalFirstEnableToggle = () => {
         const originalIsLocalFirstStorageEnabled = isFeatureLocalFirstStorageEnabled;
         dispatch(
-            labelingActions.updateIsFeatureLocalFirstStorageAvailable({
+            suiteSyncActions.updateIsFeatureLocalFirstStorageAvailable({
                 isShownInSettings: !isFeatureLocalFirstStorageEnabled,
             }),
         );

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -9,7 +9,7 @@ import {
     messageSystemPersistedWhitelist,
     prepareMessageSystemReducer,
 } from '@suite-common/message-system';
-import { prepareLabelingReducer } from '@suite-common/suite-sync';
+import { prepareLabelingReducer, prepareSuiteSyncReducer } from '@suite-common/suite-sync';
 import { prepareThpReducer } from '@suite-common/thp';
 import { notificationsReducer } from '@suite-common/toast-notifications';
 import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions';
@@ -82,6 +82,7 @@ const walletSettingsReducer = prepareWalletSettingsReducer(extraDependencies);
 const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependencies);
 const thpReducer = prepareThpReducer(extraDependencies);
 const labelingReducer = prepareLabelingReducer(extraDependencies);
+const suiteSyncReducer = prepareSuiteSyncReducer(extraDependencies);
 
 export const prepareRootReducers = async () => {
     const appSettingsPersistedReducer = await preparePersistReducer({
@@ -261,43 +262,39 @@ export const prepareRootReducers = async () => {
         version: 1,
     });
 
-    const labelingPersistedReducer = await preparePersistReducer({
-        reducer: labelingReducer,
-        persistedKeys: [
-            'localFirstStorageRelayUrl',
-            'isLocalFirstStorageEnabled',
-            'isLocalFirstStorageDebugEnabled',
-            'isFeatureLocalFirstStorageAvailable',
-        ],
-        key: 'labeling',
+    const suiteSyncPersistedReducer = await preparePersistReducer({
+        reducer: suiteSyncReducer,
+        persistedKeys: ['settings'],
+        key: 'suiteSync',
         version: 1,
     });
 
     const rootReducer = await preparePersistReducer({
         reducer: combineReducers({
-            app: appReducer,
             analytics: analyticsPersistedReducer,
+            app: appReducer,
             appSettings: appSettingsPersistedReducer,
-            wallet: walletPersistedReducer,
-            featureFlags: featureFlagsPersistedReducer,
             bannerFlags: bannerFlagsPersistedReducer,
-            graph: graphReducer,
+            bluetooth: bluetoothPersistedReducer,
+            connectPopup: connectPopupPersistedReducer,
             device: devicePersistedReducer,
             deviceAuthorization: deviceAuthorizationReducer,
             deviceOnboarding: deviceOnboardingReducer,
+            featureFlags: featureFlagsPersistedReducer,
             firmware: firmwarePersistedReducer,
-            nativeFirmware: nativeFirmwareReducer,
-            logs: logsSlice.reducer,
-            notifications: notificationsReducer,
-            messageSystem: messageSystemPersistedReducer,
-            tokenDefinitions: tokenDefinitionsReducer,
-            connectPopup: connectPopupPersistedReducer,
-            walletConnect: walletConnectReducer,
-            bluetooth: bluetoothPersistedReducer,
             geolocation: geolocationReducer,
-            thp: thpPersistedReducer,
+            graph: graphReducer,
+            labeling: labelingReducer,
             locale: localePersistedReducer,
-            labeling: labelingPersistedReducer,
+            logs: logsSlice.reducer,
+            messageSystem: messageSystemPersistedReducer,
+            nativeFirmware: nativeFirmwareReducer,
+            notifications: notificationsReducer,
+            suiteSync: suiteSyncPersistedReducer,
+            thp: thpPersistedReducer,
+            tokenDefinitions: tokenDefinitionsReducer,
+            wallet: walletPersistedReducer,
+            walletConnect: walletConnectReducer,
         } as const),
         // 'wallet' and 'graph' need to be persisted at the top level to ensure device state
         // is accessible for transformation.


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/23032

Code-splitting and cleanup. 

SuiteSync settings are separated to different reducer from the labeling

## QA
If SuiteSync works on high-level, all shall be good.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=separate-suite-sync-reducer&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=separate-suite-sync-reducer&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=separate-suite-sync-reducer&lookback=7)