### PR TITLE
fix(e2e): Fixed Solana account selection to always pick the first one

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
@@ -461,6 +461,7 @@ export class TradingPage {
     async fillSwapForm(params: {
         amount: string;
         sendCurrency: string;
+        accountIndex?: number;
         sendTicker: string;
         receiveCurrency: string;
         receiveSymbol: NetworkSymbol;
@@ -471,7 +472,7 @@ export class TradingPage {
     }) {
         await this.page.selectDropdownOptionWithRetry(
             this.swapFromAccountInput,
-            this.swapFromAccountOption(params.sendCurrency),
+            this.swapFromAccountOption(params.sendCurrency).nth(params.accountIndex ?? 0),
         );
         await this.selectAccount(params.receiveCurrency, params.receiveSymbol);
         // We should not fill in amount until account change takes effect = correct ticker is displayed

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
@@ -99,7 +99,7 @@ test.describe('Trading - Sell inputs', { tag: ['@group=trading', '@webOnly'] }, 
         await test.step('Try all % inputs on Solana', async () => {
             await page.selectDropdownOptionWithRetry(
                 tradingPage.accountDropdown,
-                tradingPage.accountOption('solana'),
+                tradingPage.accountOption('solana').first(),
             );
             await expect(tradingPage.swapAmountInputCurrencyTicker).toHaveText('SOL');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-solana-selectors&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-solana-selectors&lookback=7)