### PR TITLE
feat(suite): parametrize verifyAuthenticityProof

### DIFF
--- a/packages/device-authenticity/src/types.ts
+++ b/packages/device-authenticity/src/types.ts
@@ -17,6 +17,7 @@ export type VerifyAuthenticityProofParams = {
     config: DeviceAuthenticityConfig;
     blacklistConfig: DeviceAuthenticityBlacklistConfig;
     allowDebugKeys?: boolean;
+    challengePrefix?: string;
 };
 
 export type VerifyAuthenticityProofResult =

--- a/packages/device-authenticity/src/verifyAuthenticityProof.ts
+++ b/packages/device-authenticity/src/verifyAuthenticityProof.ts
@@ -111,6 +111,7 @@ export const verifyAuthenticityProof = async ({
     allowDebugKeys,
     config,
     blacklistConfig,
+    challengePrefix = 'AuthenticateDevice:',
 }: VerifyAuthenticityProofParams): Promise<VerifyAuthenticityProofResult> => {
     // Parse config with given device model, type of secure element and debug mode.
     const allRootPubKeys = getRootPubKeys({
@@ -198,10 +199,10 @@ export const verifyAuthenticityProof = async ({
     );
 
     // 5. validate that the signature from AuthenticityProof was created using prefixed challenge **and** if DEVICES pubKey is not on blacklist
-    const challengePrefix = Buffer.from('AuthenticateDevice:');
+    const challengePrefixBuffer = Buffer.from(challengePrefix);
     const prefixedChallenge = Buffer.concat([
-        bufferUtils.getChunkSize(challengePrefix.length),
-        challengePrefix,
+        bufferUtils.getChunkSize(challengePrefixBuffer.length),
+        challengePrefixBuffer,
         bufferUtils.getChunkSize(challenge.length),
         challenge,
     ]);


### PR DESCRIPTION
In order to check the evolu relay challenge, we need parametrized function.

## Notes for QA

not testable

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23136


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/parametrize-verify-authenticity-proof-append&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/parametrize-verify-authenticity-proof-append&lookback=7)