### PR TITLE
feat(suite): move global send/receive out of experimental features

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
@@ -1,11 +1,6 @@
-import { useSelector } from 'react-redux';
-
-import { selectHasBitcoinOnlyFirmware } from '@suite-common/wallet-core';
 import { GlobalSendReceiveType } from '@suite-common/wallet-types';
 import { ButtonGroup, ButtonProps } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
-
-import { ExperimentalFeatureFlag } from 'src/support/suite/ExperimentalFeatureFlag';
 
 import { Translation } from '../../../../Translation';
 import { HeaderActionButton } from '../HeaderActionButton';
@@ -19,38 +14,32 @@ export const GlobalSendReceiveButtons = ({
     setActiveModal,
     intent,
     priority,
-}: GlobalSendReceiveButtonsProps) => {
-    const btcOnlyFw = useSelector(selectHasBitcoinOnlyFirmware);
+}: GlobalSendReceiveButtonsProps) => (
+    <ButtonGroup intent={intent} priority={priority}>
+        <HeaderActionButton
+            key="wallet-send"
+            icon="arrowUp"
+            onClick={() => {
+                setActiveModal('send');
 
-    return (
-        <ExperimentalFeatureFlag feature="global-send-receive" featureFlagDisabled={btcOnlyFw}>
-            <ButtonGroup intent={intent} priority={priority}>
-                <HeaderActionButton
-                    key="wallet-send"
-                    icon="arrowUp"
-                    onClick={() => {
-                        setActiveModal('send');
+                analytics.report({ type: EventType.DashboardSendModal });
+            }}
+            data-testid="@wallet/menu/wallet-global-send"
+        >
+            <Translation id="TR_NAV_SEND" />
+        </HeaderActionButton>
 
-                        analytics.report({ type: EventType.DashboardSendModal });
-                    }}
-                    data-testid="@wallet/menu/wallet-global-send"
-                >
-                    <Translation id="TR_NAV_SEND" />
-                </HeaderActionButton>
+        <HeaderActionButton
+            key="wallet-receive"
+            icon="arrowDown"
+            onClick={() => {
+                setActiveModal('receive');
 
-                <HeaderActionButton
-                    key="wallet-receive"
-                    icon="arrowDown"
-                    onClick={() => {
-                        setActiveModal('receive');
-
-                        analytics.report({ type: EventType.DashboardReceiveModal });
-                    }}
-                    data-testid="@wallet/menu/wallet-global-receive"
-                >
-                    <Translation id="TR_NAV_RECEIVE" />
-                </HeaderActionButton>
-            </ButtonGroup>
-        </ExperimentalFeatureFlag>
-    );
-};
+                analytics.report({ type: EventType.DashboardReceiveModal });
+            }}
+            data-testid="@wallet/menu/wallet-global-receive"
+        >
+            <Translation id="TR_NAV_RECEIVE" />
+        </HeaderActionButton>
+    </ButtonGroup>
+);

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -17,7 +17,6 @@ export type ExperimentalFeature =
     | 'password-manager'
     | 'tor-external'
     | 'nft-section'
-    | 'global-send-receive'
     | 'experimental-networks'
     | 'suite-sync';
 
@@ -55,10 +54,6 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
     'nft-section': {
         title: { id: 'TR_EXPERIMENTAL_NFT_SECTION' },
         description: { id: 'TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION' },
-    },
-    'global-send-receive': {
-        title: { id: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE' },
-        description: { id: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION' },
     },
     'experimental-networks': {
         title: {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5335,15 +5335,6 @@ export default defineMessages({
         defaultMessage:
             'For experienced users only. Use at your own risk. These features are in testing, may be unstable, and might not have long-term support.',
     },
-    TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE: {
-        id: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE',
-        defaultMessage: 'Global send & receive',
-    },
-    TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION: {
-        id: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION',
-        defaultMessage:
-            'Send and receive transactions from your dashboard directly to any account.',
-    },
     TR_GO_TO_EXP_FEATURE: {
         id: 'TR_GO_TO_EXP_FEATURE',
         defaultMessage: 'Open',


### PR DESCRIPTION
## Description

So here we go again: Move global send/receive out of experimental features.


## Related Issue

Resolve #22737


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/22737-global-receive-send&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/22737-global-receive-send&lookback=7)