### PR TITLE
Fix receive flow for zero-balance accounts and correct dashboard state with no active accounts

### DIFF
--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -1617,7 +1617,7 @@
   "TR_RBF_ORIGINAL_AMOUNT": "Original amount",
   "TR_READ_AND_UNDERSTOOD": "I've read and understand the warnings above.",
   "TR_REBOOT_INTO_BOOTLOADER": "Update Trezor firmware",
-  "TR_RECEIVE": "Select an account to receive funds",
+  "TR_RECEIVE": "Receive",
   "TR_RECEIVED": "Received",
   "TR_RECEIVED_SYMBOL": "Received {multiple, select, true {multiple tokens} false {{symbol}} other {{symbol}}}",
   "TR_RECEIVE_ACCOUNT_NOT_SELECTED": "Not selected",

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3213,8 +3213,12 @@ export default defineMessages({
         id: 'TR_RANDOM_SEED_WORDS_DISCLAIMER',
     },
     TR_RECEIVE: {
-        defaultMessage: 'Select an account to receive funds',
+        defaultMessage: 'Receive',
         id: 'TR_RECEIVE',
+    },
+    TR_RECEIVE_SELECT_ACCOUNT: {
+        defaultMessage: 'Select an account to receive funds',
+        id: 'TR_RECEIVE_SELECT_ACCOUNT',
     },
     TR_RECEIVE_NETWORK: {
         defaultMessage: 'Receive {networkDisplaySymbol}',

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -39,6 +39,7 @@ export const PortfolioCard = memo(() => {
     const walletBalance = useTotalFiatBalance(accounts, baseCurrencyCode, currentFiatRates);
 
     const passphraseEntryCanceled = accounts.length === 0 && discoveryStatus === undefined;
+    const hasMultipleAccounts = accounts.length > 1;
 
     // TODO: DashboardGraph will get mounted twice (thus triggering data processing twice)
     // 1. DashboardGraph gets mounted
@@ -90,7 +91,7 @@ export const PortfolioCard = memo(() => {
     });
 
     const goToReceive = () => {
-        if (accounts.length > 1) {
+        if (hasMultipleAccounts) {
             dispatch(goto('suite-index', { params: { modal: 'receive' } }));
         } else {
             dispatch(goto('wallet-receive'));
@@ -111,6 +112,7 @@ export const PortfolioCard = memo(() => {
                 isWalletError={isWalletError}
                 isDiscoveryRunning={isDiscoveryRunning}
                 passphraseEntryCanceled={passphraseEntryCanceled}
+                hasMultipleAccounts={hasMultipleAccounts}
                 receiveClickHandler={goToReceive}
             />
         );

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -38,6 +38,8 @@ export const PortfolioCard = memo(() => {
     const failedAccounts = useMemo(() => accounts.filter(isAccountFailed), [accounts]);
     const walletBalance = useTotalFiatBalance(accounts, baseCurrencyCode, currentFiatRates);
 
+    const passphraseEntryCanceled = accounts.length === 0 && discoveryStatus === undefined;
+
     // TODO: DashboardGraph will get mounted twice (thus triggering data processing twice)
     // 1. DashboardGraph gets mounted
     // 2. Discovery starts, DashboardGraph is unmounted, Loading mounts
@@ -48,6 +50,17 @@ export const PortfolioCard = memo(() => {
         body = (
             <PortfolioCardException
                 exception={discoveryStatus}
+                discovery={discovery}
+                failed={failedAccounts}
+            />
+        );
+    } else if (passphraseEntryCanceled) {
+        body = (
+            <PortfolioCardException
+                exception={{
+                    status: 'exception',
+                    type: 'discovery-failed',
+                }}
                 discovery={discovery}
                 failed={failedAccounts}
             />
@@ -97,6 +110,7 @@ export const PortfolioCard = memo(() => {
                 isWalletLoading={isWalletLoading}
                 isWalletError={isWalletError}
                 isDiscoveryRunning={isDiscoveryRunning}
+                passphraseEntryCanceled={passphraseEntryCanceled}
                 receiveClickHandler={goToReceive}
             />
         );

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -76,7 +76,14 @@ export const PortfolioCard = memo(() => {
         dashboardGraphHidden,
     });
 
-    const goToReceive = () => dispatch(goto('wallet-receive'));
+    const goToReceive = () => {
+        if (accounts.length > 1) {
+            dispatch(goto('suite-index', { params: { modal: 'receive' } }));
+        } else {
+            dispatch(goto('wallet-receive'));
+        }
+    };
+
     const heading = <Translation id="TR_MY_PORTFOLIO" />;
 
     const header =

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
@@ -20,6 +20,7 @@ export type PortfolioCardHeaderProps = {
     isWalletError: boolean;
     isDiscoveryRunning?: boolean;
     showGraphControls: boolean;
+    passphraseEntryCanceled: boolean;
     receiveClickHandler: () => void;
 };
 
@@ -32,6 +33,7 @@ export const PortfolioCardHeader = ({
     isWalletError,
     isDiscoveryRunning,
     showGraphControls,
+    passphraseEntryCanceled,
     receiveClickHandler,
 }: PortfolioCardHeaderProps) => {
     const accounts = useSelector(selectAllAccountsToList);
@@ -44,7 +46,7 @@ export const PortfolioCardHeader = ({
     );
 
     let actions = null;
-    if (!isWalletLoading && !isWalletError) {
+    if (!isWalletLoading && !isWalletError && !passphraseEntryCanceled) {
         if (isWalletEmpty) {
             actions = (
                 <Button

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
@@ -21,6 +21,7 @@ export type PortfolioCardHeaderProps = {
     isDiscoveryRunning?: boolean;
     showGraphControls: boolean;
     passphraseEntryCanceled: boolean;
+    hasMultipleAccounts: boolean;
     receiveClickHandler: () => void;
 };
 
@@ -34,6 +35,7 @@ export const PortfolioCardHeader = ({
     isDiscoveryRunning,
     showGraphControls,
     passphraseEntryCanceled,
+    hasMultipleAccounts,
     receiveClickHandler,
 }: PortfolioCardHeaderProps) => {
     const accounts = useSelector(selectAllAccountsToList);
@@ -55,7 +57,9 @@ export const PortfolioCardHeader = ({
                     minWidth={120}
                     size="large"
                 >
-                    <Translation id="TR_RECEIVE" />
+                    <Translation
+                        id={hasMultipleAccounts ? 'TR_RECEIVE_SELECT_ACCOUNT' : 'TR_RECEIVE'}
+                    />
                 </Button>
             );
         } else if (showGraphControls) {


### PR DESCRIPTION
## Description

### 1) Zero-balance accounts: offer proper account selection

When multiple accounts are activated but all have zero balance, clicking **“Receive funds”** now opens the **global receive modal**.  

### 2) No active accounts: hide the receive button

If the user has **no active accounts**, the dashboard now shows the correct empty state **without the receive button**.

### 3) Translation update

Restored **TR_RECEIVE** ("Receive") and added **TR_RECEIVE_SELECT_ACCOUNT** ("Select an account to receive funds") for cases with multiple zero-balance accounts.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23114

## Screenshots:


https://github.com/user-attachments/assets/e16a834b-0f1e-4c48-9238-45097cf7bef2

<img width="1279" height="652" alt="image" src="https://github.com/user-attachments/assets/a9ea032c-5a37-45b1-9dfc-5a0e65cf8a78" />

<img width="1279" height="663" alt="image" src="https://github.com/user-attachments/assets/4dbbafe7-3c12-421b-9039-dd87fae5007a" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/empty-accounts-receive-flow&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/empty-accounts-receive-flow&lookback=7)