### PR TITLE
fix(connect): always use iframe mode for tests

### DIFF
--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -179,6 +179,7 @@ export const initTrezorConnect = async (
             email: 'tests@connect.trezor.io',
         },
         transports: ['BridgeTransport'],
+        coreMode: 'iframe',
         debug: false,
         popup: false,
         pendingTransportEvent: true,


### PR DESCRIPTION
## Description

This was causing some issues with override tests. 
Before it was also checking if Suite desktop is running, which can add latency. 

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-test-use-iframe&lookback=7)