### PR TITLE
fix: Sentry in Desktop renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,12 @@
         "### We need promise to be same version in mobile unless it produces undefined behavior, check PR #15815": "1.0.0",
         "promise": "8.3.0",
         "elliptic": "6.6.1",
-        "@headlessui/react": "^2.2.0"
+        "@headlessui/react": "^2.2.0",
+        "### Align versions of sentry internal packages, because electron & native use different versions of @core": "1.0.0",
+        "@sentry/core": "10.17.0",
+        "@sentry/browser": "10.17.0",
+        "@sentry/react": "10.17.0",
+        "@sentry/types": "10.17.0"
     },
     "devDependencies": {
         "@babel/cli": "7.28.3",

--- a/packages/suite-desktop-ui/src/sentry.ts
+++ b/packages/suite-desktop-ui/src/sentry.ts
@@ -5,7 +5,7 @@ import { SENTRY_CONFIG } from '@suite-common/sentry';
 const ELECTRON_RENDERER_SENTRY_CONFIG = {
     ...SENTRY_CONFIG,
     // BrowserSession is not present in Electron renderer process so we don't have to remove it
-    integrations: () => [captureConsoleIntegration({ levels: ['error'] })],
+    integrations: defaults => [...defaults, captureConsoleIntegration({ levels: ['error'] })],
 } as BrowserOptions;
 
 export const initSentry = () => {

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -13,7 +13,7 @@
         "build": "yarn rimraf ./build && yarn workspace @trezor/suite-build run build:web"
     },
     "dependencies": {
-        "@sentry/browser": "10.20.0",
+        "@sentry/browser": "10.17.0",
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -26,7 +26,7 @@
         "@mobily/ts-belt": "^3.13.1",
         "@noble/hashes": "^2.0.1",
         "@reduxjs/toolkit": "2.10.1",
-        "@sentry/core": "10.20.0",
+        "@sentry/core": "10.17.0",
         "@solana/kit": "^2.3.0",
         "@suite-common/analytics": "workspace:*",
         "@suite-common/assets": "workspace:*",

--- a/suite-common/sentry/package.json
+++ b/suite-common/sentry/package.json
@@ -10,7 +10,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@sentry/core": "10.20.0",
+        "@sentry/core": "10.17.0",
         "@suite-common/suite-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/utils": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8981,30 +8981,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/browser-utils@npm:10.20.0":
-  version: 10.20.0
-  resolution: "@sentry-internal/browser-utils@npm:10.20.0"
-  dependencies:
-    "@sentry/core": "npm:10.20.0"
-  checksum: 10/28daf5ba680bc769432c834dc8c104fcd6c61285854ebbd993444f06fede5c72a139345145c0ac325cb6a125e9d4cc113e5f129e20696c9a55de0f0b684f7b71
-  languageName: node
-  linkType: hard
-
 "@sentry-internal/feedback@npm:10.17.0":
   version: 10.17.0
   resolution: "@sentry-internal/feedback@npm:10.17.0"
   dependencies:
     "@sentry/core": "npm:10.17.0"
   checksum: 10/f6753f11b06809109a5d5189720370a78a66859738a1e8c9285db4fd7871030927458e92909e9729a6cd94c216de3d578b3bb836f39cbd697da972922960b57a
-  languageName: node
-  linkType: hard
-
-"@sentry-internal/feedback@npm:10.20.0":
-  version: 10.20.0
-  resolution: "@sentry-internal/feedback@npm:10.20.0"
-  dependencies:
-    "@sentry/core": "npm:10.20.0"
-  checksum: 10/7f8545b0c851128fd6547abef3b6409877b27f0e273f18746871b0a326ff543f06378ab6988376f1838ce04523bc71266faa81b30bc7937097a673956955bdd9
   languageName: node
   linkType: hard
 
@@ -9018,16 +9000,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/replay-canvas@npm:10.20.0":
-  version: 10.20.0
-  resolution: "@sentry-internal/replay-canvas@npm:10.20.0"
-  dependencies:
-    "@sentry-internal/replay": "npm:10.20.0"
-    "@sentry/core": "npm:10.20.0"
-  checksum: 10/f37a96a2c2d31f9507f704ec3933bf462da92787ed71ad596f77f338017eb99367c069018cd10f44133aad3359a2a976ef4242248401db0833d8341dbc67967b
-  languageName: node
-  linkType: hard
-
 "@sentry-internal/replay@npm:10.17.0":
   version: 10.17.0
   resolution: "@sentry-internal/replay@npm:10.17.0"
@@ -9035,16 +9007,6 @@ __metadata:
     "@sentry-internal/browser-utils": "npm:10.17.0"
     "@sentry/core": "npm:10.17.0"
   checksum: 10/b9cce490dd0840f6284f9fecd1ec00f77c7e7a39daeffc8da25622ae4006ceaa20bd1dbb94756db20438dd2e60f341dbb3f5348a4839fcde59f508d13e5c097a
-  languageName: node
-  linkType: hard
-
-"@sentry-internal/replay@npm:10.20.0":
-  version: 10.20.0
-  resolution: "@sentry-internal/replay@npm:10.20.0"
-  dependencies:
-    "@sentry-internal/browser-utils": "npm:10.20.0"
-    "@sentry/core": "npm:10.20.0"
-  checksum: 10/ae4340e013cc30932770af318637da4cf204ca861be22d7841f14ae0ad3039d3c70a34366eaf417fc08ec08afb4f23bdee5580b63429a8038503f981a995d0ca
   languageName: node
   linkType: hard
 
@@ -9072,19 +9034,6 @@ __metadata:
     "@sentry-internal/replay-canvas": "npm:10.17.0"
     "@sentry/core": "npm:10.17.0"
   checksum: 10/6bfc8ae92d988b79a4f2ced0be438f389fbf8d7d0ee82cbce1cbac02693b02a9a76df8375582bfca7578ec856c025d074f49de2c3e1f75a2185f9d52d2a61f65
-  languageName: node
-  linkType: hard
-
-"@sentry/browser@npm:10.20.0":
-  version: 10.20.0
-  resolution: "@sentry/browser@npm:10.20.0"
-  dependencies:
-    "@sentry-internal/browser-utils": "npm:10.20.0"
-    "@sentry-internal/feedback": "npm:10.20.0"
-    "@sentry-internal/replay": "npm:10.20.0"
-    "@sentry-internal/replay-canvas": "npm:10.20.0"
-    "@sentry/core": "npm:10.20.0"
-  checksum: 10/0b48d8d6529d22a24694d27fa7a78ad15197b50c0ef83e430c7e68aebb71fc531406d03266d8e7102d90d259db51b54d59cf3aca493b7482ff4cfd6d40bc3af2
   languageName: node
   linkType: hard
 
@@ -9293,13 +9242,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:10.20.0":
-  version: 10.20.0
-  resolution: "@sentry/core@npm:10.20.0"
-  checksum: 10/7c87a27bd8aedc25e4bf449a094b10d60c536485d099bb47efdbb2d5b7af5c87fbe55ede62cca9c4110a5a183c7d302e637af6344935699b992c8c56a3c83653
-  languageName: node
-  linkType: hard
-
 "@sentry/electron@npm:^7.2.0":
   version: 7.2.0
   resolution: "@sentry/electron@npm:7.2.0"
@@ -9416,25 +9358,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/react@npm:10.20.0":
-  version: 10.20.0
-  resolution: "@sentry/react@npm:10.20.0"
+"@sentry/react@npm:10.17.0":
+  version: 10.17.0
+  resolution: "@sentry/react@npm:10.17.0"
   dependencies:
-    "@sentry/browser": "npm:10.20.0"
-    "@sentry/core": "npm:10.20.0"
+    "@sentry/browser": "npm:10.17.0"
+    "@sentry/core": "npm:10.17.0"
     hoist-non-react-statics: "npm:^3.3.2"
   peerDependencies:
     react: ^16.14.0 || 17.x || 18.x || 19.x
-  checksum: 10/cfe7addb2f00664cb0233f30a13f802c2f617f33d2e0dbf9c00af88ed65b8c7c66c862ef0ad309dae493230fb72fc3ecc90282195e027f6520ac79f04defe1db
+  checksum: 10/ba560c9c0e27d1c18860efe14a8d138b3e818e47c87655003063f022c9056c08ac6a1cb62c433fd1e39626b193baf26fe570aa21b922e5522f7fe127ad0a57f6
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:10.20.0":
-  version: 10.20.0
-  resolution: "@sentry/types@npm:10.20.0"
+"@sentry/types@npm:10.17.0":
+  version: 10.17.0
+  resolution: "@sentry/types@npm:10.17.0"
   dependencies:
-    "@sentry/core": "npm:10.20.0"
-  checksum: 10/95e612b5f5f167fd1e51fcc77e7633ddea4368c41ed0bfc9dab48654dac08d659cfbf914da350ad3526509406b929c1f28b489d848e941d6e470bfce60c70966
+    "@sentry/core": "npm:10.17.0"
+  checksum: 10/b6a6d1d60ca2088f911624a339546c5ffa3c9e2bf1a316911a8d160abd4d6ded5b30bb1d9f657822c757e79e2c10fa3bf202b63599dd8edfc8f75804ec20b962
   languageName: node
   linkType: hard
 
@@ -10732,7 +10674,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/sentry@workspace:suite-common/sentry"
   dependencies:
-    "@sentry/core": "npm:10.20.0"
+    "@sentry/core": "npm:10.17.0"
     "@suite-common/suite-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
@@ -14492,7 +14434,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-web@workspace:packages/suite-web"
   dependencies:
-    "@sentry/browser": "npm:10.20.0"
+    "@sentry/browser": "npm:10.17.0"
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite/suite-sync": "workspace:*"
@@ -14526,7 +14468,7 @@ __metadata:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@noble/hashes": "npm:^2.0.1"
     "@reduxjs/toolkit": "npm:2.10.1"
-    "@sentry/core": "npm:10.20.0"
+    "@sentry/core": "npm:10.17.0"
     "@solana/kit": "npm:^2.3.0"
     "@suite-common/analytics": "workspace:*"
     "@suite-common/assets": "workspace:*"


### PR DESCRIPTION
## Description

Fix Sentry in Desktop rendered, which was broken by me in a fixup in https://github.com/trezor/trezor-suite/pull/22817

- align versions of `@sentry/core`, which are mismatched between electron & react-native SDKs
  - see comment [here](https://github.com/trezor/trezor-suite/pull/22817#discussion_r2486345723) in the bump PR but I did not act on it then. Now I thought it might be the problem. Turns out it did not fix it, but let's do it anyway since I have it ready.
- **the fix**: default integrations dropped by accident from `suite-desktop-ui`
  - (only this shall be cherrypicked)

## Notes for QA

Sentry testing error must work on Desktop, Web and Native.
I tested that in dev environments and Desktop build :heavy_check_mark: 

## Related Issue

Resolve #23149

## Screenshots:

[Testing error thrown from desktop](https://satoshilabs.sentry.io/issues/7027640356/?project=5193825&query=TESTING&referrer=issue-stream)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sentry-desktop&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sentry-desktop&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/sentry-desktop&lookback=7)