### PR TITLE
Trading - Remove Buy default values

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
@@ -5,12 +5,12 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import messages from '@trezor/suite/src/support/messages';
 
+import { Fees } from './fees';
 import { getCompanyNameFromList, invityEndpoint } from '../../../fixtures/invity';
 import { calculatePercentageOfBalance, getCountryLabel, step } from '../../common';
 import { expect } from '../../testExtends/customMatchers';
 import { PaymentMethods, PercentageOfBalanceParams } from '../../types';
 import { DevicePrompt } from '../devicePrompt';
-import { Fees } from './fees';
 
 const quoteProviderLocator = '@trading/offers/quote/provider';
 
@@ -379,7 +379,7 @@ export class TradingPage {
         selectReceiveAddress?: () => Promise<void>;
     }) {
         const inputField = wantCrypto ? this.youPayCryptoInput : this.youPayFiatInput;
-        await expect(inputField).not.toHaveValue('');
+        await expect(inputField).toHaveValue('');
         if (wantCrypto) {
             // The desired value is already set due to sideeffect of mocked response,
             // We clear it so we can intercept and verify request payload that is triggered by filling value.

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-negative.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-negative.test.ts
@@ -13,13 +13,14 @@ test.describe('Trading - Buy Negative scenarios', { tag: ['@group=trading', '@we
     }) => {
         await walletPage.openTradingGlobalButton.click();
         // waits for trading form to load
-        await expect(tradingPage.youPayFiatInput).not.toHaveValue('');
+        await expect(tradingPage.youPayFiatInput).toHaveValue('');
         await tradingPage.selectFiatCurrency('eur');
 
         await test.step('Input amount above maximum', async () => {
             await page.route(invityEndpoint.buyQuotes, async route => {
                 await route.fulfill({ json: buyQuotesNegativeMax });
             });
+            await expect(page.getByText('Receive account')).toBeVisible();
             await tradingPage.youPayFiatInput.fill('1000000000');
             await expect(page.getByText('Maximum is 5000000 EUR')).toBeVisible();
             await expect(tradingPage.buyBestOfferButton).toBeDisabled();
@@ -29,6 +30,7 @@ test.describe('Trading - Buy Negative scenarios', { tag: ['@group=trading', '@we
             await page.route(invityEndpoint.buyQuotes, async route => {
                 await route.fulfill({ json: buyQuotesNegativeMin });
             });
+            await expect(page.getByText('Receive account')).toBeVisible();
             await tradingPage.youPayFiatInput.fill('0.01');
             await expect(page.getByText('Minimum is 96.61 EUR')).toBeVisible();
             await expect(tradingPage.buyBestOfferButton).toBeDisabled();
@@ -38,6 +40,7 @@ test.describe('Trading - Buy Negative scenarios', { tag: ['@group=trading', '@we
             await page.route(invityEndpoint.buyQuotes, async route => {
                 await route.fulfill({ json: {} });
             });
+            await expect(page.getByText('Receive account')).toBeVisible();
             await tradingPage.youPayFiatInput.fill('5000');
             await expect(page.getByTestId('trading-offer-found-none')).toBeVisible();
             await expect(tradingPage.buyBestOfferButton).toBeDisabled();

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -114,10 +114,7 @@ export const useTradingBuyForm = ({
     const draftUpdated: TradingBuyFormProps | null = draft
         ? {
               ...draft,
-              fiatInput:
-                  draft.fiatInput && draft.fiatInput !== ''
-                      ? draft.fiatInput
-                      : buyInfo?.buyInfo?.defaultAmountsOfFiatCurrencies.get(suggestedFiatCurrency),
+              fiatInput: draft.fiatInput && draft.fiatInput !== '' ? draft.fiatInput : undefined,
               // remember only for offers page
               cryptoSelect: isPreviousRouteFromTradeSection
                   ? draft.cryptoSelect
@@ -150,11 +147,10 @@ export const useTradingBuyForm = ({
     const isReceiveAddressFormValid =
         Object.keys(tradingReceiveAddress.form.formState.errors).length === 0;
 
-    const isInitialDataLoading = !buyInfo || !buyInfo?.buyInfo;
-    const noProviders = !isInitialDataLoading && buyInfo?.buyInfo?.providers.length === 0;
+    const noProviders = buyInfo?.buyInfo?.providers.length === 0;
     const formIsValid = Object.keys(formState.errors).length === 0;
     const hasValues = (values.fiatInput || values.cryptoInput) && !!values.currencySelect?.value;
-    const isFormLoading = isInitialDataLoading || formState.isSubmitting || isLoading;
+    const isFormLoading = formState.isSubmitting || isLoading;
     const isFormInvalid = !(formIsValid && hasValues) || !isReceiveAddressFormValid;
     const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
 

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts
@@ -62,7 +62,7 @@ export const useTradingBuyFormDefaultValues = (
     );
     const defaultValues = useMemo(
         () => ({
-            fiatInput: buyInfo?.buyInfo.defaultAmountsOfFiatCurrencies.get(suggestedFiatCurrency),
+            fiatInput: undefined,
             cryptoInput: undefined,
             currencySelect: defaultCurrency,
             cryptoSelect: defaultCrypto,
@@ -71,14 +71,7 @@ export const useTradingBuyFormDefaultValues = (
             amountInCrypto: false,
             receiveAddress: undefined,
         }),
-        [
-            buyInfo?.buyInfo.defaultAmountsOfFiatCurrencies,
-            defaultCountry,
-            defaultCrypto,
-            defaultCurrency,
-            defaultPaymentMethod,
-            suggestedFiatCurrency,
-        ],
+        [defaultCountry, defaultCrypto, defaultCurrency, defaultPaymentMethod],
     );
 
     return {

--- a/suite-common/trading/src/reducers/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/tradingReducer.ts
@@ -172,6 +172,7 @@ export const tradingSlice = createSliceWithExtraDeps({
                 state.buy.amountLimits = undefined;
                 state.buy.quotes = [];
                 state.buy.quotesRequest = undefined;
+                state.buy.isLoading = false;
                 state.info.paymentMethods = [];
             })
             .addCase(exchangeThunks.handleRequestThunk.pending, state => {


### PR DESCRIPTION
## Description

Remove default values in trading buy form.

## Related Issue

Resolve #22893 

## Screenshots:

<img width="1512" height="860" alt="Screenshot 2025-11-14 at 13 46 10" src="https://github.com/user-attachments/assets/6b7a76a8-d9ca-40a9-ab2e-73cd861ca5cc" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/remove-buy-default-values&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/remove-buy-default-values&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/remove-buy-default-values&lookback=7)