### PR TITLE
Random Connect fixes

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -474,7 +474,7 @@ const initCoreInPopup = async (
     // dynamically load core module
     reactEventBus.dispatch({ type: 'loading', message: 'loading core' });
 
-    const { initCoreState, initTransport } = await import(
+    const { initCoreState } = await import(
         // @ts-expect-error - core is built in a separate build step.
         /* webpackIgnore: true */ `./core.js`
     ).catch(_err => {
@@ -520,15 +520,6 @@ const initCoreInPopup = async (
 
     setState({ core });
     log.debug('initiated core');
-
-    // init transport - deprecated, here for backward compatibility
-    if (initTransport) {
-        log.debug('initiating transport with settings: ', payload.settings);
-        reactEventBus.dispatch({ type: 'loading', message: 'initiating transport' });
-        await initTransport(payload.settings);
-        if (disposed) return;
-    }
-    log.debug('initiated transport');
 
     // done, in popup, we are ready to handle incoming messages
     // todo: would it make sense to unify this with IFRAME.LOADED?

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -205,29 +205,6 @@ export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsP
         });
     }
 
-    private initSettings = (settings: Partial<ConnectSettings> = {}) => {
-        this._settings = parseConnectSettings({
-            ...this._settings,
-            ...settings,
-            popup: false,
-        });
-
-        if (!this._settings.manifest) {
-            throw ERRORS.TypedError('Init_ManifestMissing');
-        }
-
-        if (!this._settings.transports?.length) {
-            // default fallback for node
-            this._settings.transports = ['BridgeTransport'];
-        }
-    };
-
-    public initCore() {
-        this.initSettings({ lazyLoad: false });
-
-        return this._coreManager.getOrInit(this._settings, this.boundOnCoreEvent);
-    }
-
     public async call(params: CallMethodPayload) {
         try {
             const { promiseId, promise } = this._messagePromises.create();

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -61,7 +61,7 @@ export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsP
 
         if (!importResult) {
             this._log.error(`importResult is empty! Cannot load "${connectCorePath}"`);
-            throw new Error(`importResult is empty! Cannot load "${connectCorePath}js/core.js"`);
+            throw new Error(`importResult is empty! Cannot load "${connectCorePath}"`);
         }
 
         const { initCoreState } = importResult;

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -64,14 +64,9 @@ export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsP
             throw new Error(`importResult is empty! Cannot load "${connectCorePath}js/core.js"`);
         }
 
-        const { initCoreState, initTransport } = importResult;
+        const { initCoreState } = importResult;
 
         if (!initCoreState) return;
-
-        if (initTransport) {
-            this._log.debug('initiating transport with settings: ', this._settings);
-            await initTransport(this._settings);
-        }
 
         this._coreManager = initCoreState();
 

--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -84,18 +84,15 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
                     dispatch(markDeviceAsRecentlyConnectedThunk(device));
                 },
                 [UI.INVALID_PIN_ATTEMPTS_DEPLETED]: () => {
-                    dispatch(
-                        modalActions.openModal({
-                            type: UI.INVALID_PIN_ATTEMPTS_DEPLETED,
-                        }),
-                    );
+                    dispatch(modalActions.openModal({ type: UI.INVALID_PIN_ATTEMPTS_DEPLETED }));
                     dispatch(modalActions.preserve());
                 },
             }),
         ).unwrap();
     } catch (err) {
         dispatch({ type: SUITE.ERROR, error: err.message });
-        throw err;
+
+        return;
     }
 
     // 7. init backends


### PR DESCRIPTION
## Description

While debugging Sentry stuff, I was tinkering here and there.

1) Errors from init thunk are now not thrown, as a) they were serialized by `createThunk` anyway so they're practically useless, and b) their messages are rethrown and reported to Sentry from higher levels.
2) Deprecated `initTransport` method removed from importing Connect core.
3) `initCore` and `initSettings` removed from `core-in-module` as they seem unused.
4) Fixed error message thrown from `core-in-module`

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/fixing&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/fixing&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/fixing&lookback=7)