### PR TITLE
refactor: download crypto icons

### DIFF
--- a/packages/asset-utils/src/asset-logo-urls.ts
+++ b/packages/asset-utils/src/asset-logo-urls.ts
@@ -1,36 +1,41 @@
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import {
     COIN_IMAGE_SIZES,
-    CoinImageQuality,
     CoinImageSize,
     ICONS_URL_BASE,
-    concatCoinImageName,
     createCoinImageName,
 } from '@suite-common/icons/src/index';
 
 export interface GetAssetLogoUrlParams {
     coingeckoId: string;
     contractAddress?: string;
-    quality?: CoinImageQuality;
-    size?: CoinImageSize;
+    /**
+     * Pixel density of the image
+     */
+    density?: 1 | 2;
+    size?: number;
+}
+
+function resolveImageSize(
+    size: GetAssetLogoUrlParams['size'] = 24,
+    density: GetAssetLogoUrlParams['density'] = 1,
+) {
+    const targetSize = size * density;
+
+    return (
+        COIN_IMAGE_SIZES.find(s => s >= targetSize) ??
+        (Math.max(...COIN_IMAGE_SIZES) as CoinImageSize)
+    );
 }
 
 export const getAssetLogoUrl = ({
     coingeckoId,
     contractAddress,
-    quality = '1x',
-    size = 24,
+    density,
+    size,
 }: GetAssetLogoUrlParams) => {
-    const name = concatCoinImageName(coingeckoId, contractAddress);
-    const fileName = createCoinImageName(name, { quality, size });
+    const resolvedSize = resolveImageSize(size, density);
+    const fileName = createCoinImageName({ coingeckoId, contractAddress, size: resolvedSize });
 
     return `${ICONS_URL_BASE}/${fileName}` as const;
 };
-
-/**
- * - Coin images are generated only in specific sizes (defined in `COIN_IMAGE_SIZES` constant).
- * - This util. finds the `COIN_IMAGE_SIZES` size that is at least as big as the `size` parameter.
- */
-export function resolveAssetLogoSize(size: number, defaultSize: CoinImageSize = 24): CoinImageSize {
-    return COIN_IMAGE_SIZES.find(s => s >= size) ?? defaultSize;
-}

--- a/packages/components/src/components/AssetLogo/AssetLogo.tsx
+++ b/packages/components/src/components/AssetLogo/AssetLogo.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 // TODO: suite-common imports in non-suite packages should not be allowed
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { getNetwork, getNetworkByCoingeckoId, isNetworkSymbol } from '@suite-common/wallet-config';
-import { getAssetLogoUrl, resolveAssetLogoSize } from '@trezor/asset-utils';
+import { getAssetLogoUrl } from '@trezor/asset-utils';
 import { Elevation, borders, mapElevationToBackground, mapElevationToBorder } from '@trezor/theme';
 
 import { AssetInitials } from './AssetInitials';
@@ -144,14 +144,14 @@ export const AssetLogo = ({
             const url1x = getAssetLogoUrl({
                 coingeckoId: coingeckoIdLogo,
                 contractAddress: !hasNative ? address : undefined,
-                quality: '1x',
-                size: resolveAssetLogoSize(size),
+                density: 1,
+                size,
             });
             const url2x = getAssetLogoUrl({
                 coingeckoId: coingeckoIdLogo,
                 contractAddress: !hasNative ? address : undefined,
-                quality: '2x',
-                size: resolveAssetLogoSize(size),
+                density: 2,
+                size,
             });
 
             return { address, src: url1x, srcSet: `${url1x} 1x, ${url2x} 2x` };

--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -12,9 +12,8 @@ import {
 } from './constants';
 import { CoinListData } from './types';
 import {
-    COIN_IMAGE_QUALITIES,
     COIN_IMAGE_SIZES,
-    concatCoinImageName,
+    LEGACY_COIN_IMAGE_SIZES,
     createCoinImageName,
     createCoinImageNameLegacy,
 } from '../src/coinImages';
@@ -87,37 +86,38 @@ const updateIcon = async (coin: CoinListData) => {
             ([platform, contract]) => platform && contract && contract.startsWith('0x'),
         );
 
+        // Legacy naming – Make sure it's backwards compatible for older versions of the Trezor Suite
+        for (const size of LEGACY_COIN_IMAGE_SIZES) {
+            const finalImageBuffer = await resizeImage(originImageBuffer, size);
+
+            const fileNameLegacy = createCoinImageNameLegacy({ coingeckoId: coinData.id, size });
+            console.log(`[legacy] Writing image (${coin.id}):`, fileNameLegacy);
+            await writeImage(fileNameLegacy, finalImageBuffer);
+
+            for (const [coingeckoId, contractAddress] of platforms) {
+                const fileNameLegacyPlatform = createCoinImageNameLegacy({
+                    coingeckoId,
+                    contractAddress,
+                    size,
+                });
+                console.log(`[legacy] Writing image (${coin.id}):`, fileNameLegacyPlatform);
+                await writeImage(fileNameLegacyPlatform, finalImageBuffer);
+            }
+        }
+
+        // New naming
         for (const size of COIN_IMAGE_SIZES) {
             const finalImageBuffer = await resizeImage(originImageBuffer, size);
 
-            for (const quality of COIN_IMAGE_QUALITIES) {
-                for (const [platform, contract] of platforms) {
-                    const name = concatCoinImageName(platform, contract);
-                    const fileName = createCoinImageName(name, { size, quality });
-                    console.log(`Writing image (${coin.id}):`, fileName);
-                    await writeImage(fileName, finalImageBuffer);
-
-                    // Make sure it's backwards compatible for older versions of the Trezor Suite
-                    if (size === 24) {
-                        const fileNameLegacy = createCoinImageNameLegacy(name, quality);
-                        console.log(`Writing image - legacy (${coin.id}):`, fileNameLegacy);
-                        await writeImage(fileNameLegacy, finalImageBuffer);
-                    }
-                }
-
-                const name = coinData.id;
-
-                const fileName = createCoinImageName(name, { size, quality });
+            for (const [coingeckoId, contractAddress] of platforms) {
+                const fileName = createCoinImageName({ coingeckoId, contractAddress, size });
                 console.log(`Writing image (${coin.id}):`, fileName);
                 await writeImage(fileName, finalImageBuffer);
-
-                // Make sure it's backwards compatible for older versions of the Trezor Suite
-                if (size === 24) {
-                    const fileNameLegacy = createCoinImageNameLegacy(name, quality);
-                    console.log(`Writing image - legacy (${coin.id}):`, fileNameLegacy);
-                    await writeImage(fileNameLegacy, finalImageBuffer);
-                }
             }
+
+            const fileName = createCoinImageName({ coingeckoId: coinData.id, size });
+            console.log(`Writing image (${coin.id}):`, fileName);
+            await writeImage(fileName, finalImageBuffer);
         }
     } catch (error) {
         console.error(`Error (${coin.id}):`, error);

--- a/suite-common/icons/src/coinImages.ts
+++ b/suite-common/icons/src/coinImages.ts
@@ -1,28 +1,60 @@
 export const ICONS_URL_BASE = 'https://data.trezor.io/suite/icons/coins';
 
-export const COIN_IMAGE_SIZES = [24, 40] as const satisfies number[];
-export const COIN_IMAGE_QUALITIES = ['1x', '2x'] as const satisfies string[];
+/**
+ * @deprecated Use `COIN_IMAGE_SIZES` instead
+ */
+export const LEGACY_COIN_IMAGE_SIZES = [24, 48] as const satisfies number[];
+/**
+ * @deprecated Use `CoinImageSize` instead
+ */
+export type LegacyCoinImageSize = (typeof LEGACY_COIN_IMAGE_SIZES)[number];
+
+export const COIN_IMAGE_SIZES = [24, 40, 48, 80] as const satisfies number[];
 
 export type CoinImageSize = (typeof COIN_IMAGE_SIZES)[number];
-export type CoinImageQuality = (typeof COIN_IMAGE_QUALITIES)[number];
 
-export function createCoinImageName<
-    Name extends string,
-    Size extends CoinImageSize,
-    Quality extends CoinImageQuality,
->(name: Name, { size, quality }: { size: Size; quality: Quality }) {
-    const qualitySuffix =
-        quality !== '1x'
-            ? (`@${quality as Exclude<Quality, '1x'>}` as const)
-            : ('' as const satisfies string);
+const CRYPTO_ID_SEPARATOR = '--';
+const IMAGE_SIZE_SEPARATOR = '@';
 
-    return `${encodeURIComponent(name)}--${size}${qualitySuffix}.webp` as const;
+function createCryptoId(coingeckoId: string, contractAddress?: string) {
+    const cryptoId = contractAddress
+        ? (`${coingeckoId}${CRYPTO_ID_SEPARATOR}${contractAddress}` as const)
+        : coingeckoId;
+
+    return encodeURIComponent(cryptoId);
 }
 
-export function createCoinImageNameLegacy(name: string, quality: CoinImageQuality) {
-    return `${encodeURIComponent(name)}${quality !== '1x' ? `@${quality}` : ''}.webp` as const;
+export interface CreateCoinImageNameParams<Size extends CoinImageSize> {
+    coingeckoId: string;
+    contractAddress?: string;
+    size: Size;
 }
 
-export function concatCoinImageName(coingeckoId: string, contractAddress?: string) {
-    return contractAddress ? `${coingeckoId}--${contractAddress}` : coingeckoId;
+export function createCoinImageName<Size extends CoinImageSize>({
+    coingeckoId,
+    contractAddress,
+    size,
+}: CreateCoinImageNameParams<Size>) {
+    const cryptoId = createCryptoId(coingeckoId, contractAddress);
+
+    return `${cryptoId}${IMAGE_SIZE_SEPARATOR}${size}.webp` as const;
+}
+
+export interface CreateCoinImageNameLegacyParams {
+    coingeckoId: string;
+    contractAddress?: string;
+    size: LegacyCoinImageSize;
+}
+
+/**
+ * @deprecated Use `createCoinImageName` instead
+ */
+export function createCoinImageNameLegacy({
+    coingeckoId,
+    contractAddress,
+    size,
+}: CreateCoinImageNameLegacyParams) {
+    const cryptoId = createCryptoId(coingeckoId, contractAddress);
+
+    return `${cryptoId}${size === 24 ? '' : '@2x'}.webp` as const;
 }

--- a/suite-native/icons/src/CryptoIcon.tsx
+++ b/suite-native/icons/src/CryptoIcon.tsx
@@ -11,7 +11,7 @@ import {
 } from '@suite-common/wallet-config';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { useTranslate } from '@suite-native/intl';
-import { getAssetLogoUrl, resolveAssetLogoSize } from '@trezor/asset-utils';
+import { getAssetLogoUrl } from '@trezor/asset-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 export interface CryptoIconProps {
     symbol: NetworkSymbol | NetworkDisplaySymbol;
@@ -58,8 +58,8 @@ export const CryptoIcon = ({ symbol, contractAddress, size = 'small' }: CryptoIc
                 url = getAssetLogoUrl({
                     coingeckoId,
                     contractAddress: formattedAddress,
-                    quality: '2x',
-                    size: resolveAssetLogoSize(sizeNumber, 24),
+                    density: 2,
+                    size: sizeNumber,
                 });
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Don't store different image densities (qualities), store just different image size instead.
- Simplify usage of `getAssetLogoUrl` util

## QA Notes

- asset logos should be rendered
- they're now size in 40px too (e.g. in global send/receive)

## Related Issue


## After merge todos
- [x] Run https://github.com/trezor/trezor-suite/actions/workflows/release-suite-coin-icons.yml


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/22832-download-icons&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/22832-download-icons&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/22832-download-icons&lookback=7)