### PR TITLE
feat(suite-native): Mobile trade: Set limits to approve

### DIFF
--- a/suite-native/atoms/src/Button/AsyncButton.tsx
+++ b/suite-native/atoms/src/Button/AsyncButton.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+import { Button, ButtonProps } from './Button';
+
+export type AsyncButtonProps = Exclude<ButtonProps, 'isLoading' | 'onPress'> & {
+    onPress: () => Promise<void>;
+    onReject?: (error: unknown) => void;
+};
+
+export const AsyncButton = ({ onPress, onReject, ...props }: AsyncButtonProps) => {
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handlePress = async () => {
+        setIsLoading(true);
+        try {
+            await onPress();
+        } catch (error) {
+            if (onReject) {
+                onReject(error);
+            }
+        }
+        setIsLoading(false);
+    };
+
+    return <Button {...props} isLoading={isLoading} onPress={handlePress} />;
+};

--- a/suite-native/atoms/src/Button/__tests__/AsyncButton.comp.test.tsx
+++ b/suite-native/atoms/src/Button/__tests__/AsyncButton.comp.test.tsx
@@ -1,0 +1,84 @@
+import { Text } from 'react-native';
+
+import { act, fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+
+import { AsyncButton, AsyncButtonProps } from '../AsyncButton';
+
+describe('AsyncButton', () => {
+    const renderAsyncButton = (props: Partial<AsyncButtonProps>) =>
+        renderWithBasicProvider(
+            <AsyncButton
+                onPress={() => new Promise(resolve => setTimeout(resolve, 1000))}
+                testID="async-button"
+                {...props}
+            >
+                <Text>Press me</Text>
+            </AsyncButton>,
+        );
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('should display loading indicator after press', async () => {
+        const { getByTestId, getByText } = renderAsyncButton({});
+
+        fireEvent.press(getByText('Press me'));
+
+        expect(getByTestId('async-button/loading')).toBeOnTheScreen();
+
+        await act(async () => {
+            jest.runAllTimers();
+            await Promise.resolve();
+        });
+    });
+
+    it('should hide loading indicator after async operation is complete', async () => {
+        const { getByText, queryByTestId } = renderAsyncButton({});
+
+        fireEvent.press(getByText('Press me'));
+        await act(async () => {
+            jest.runAllTimers();
+            await Promise.resolve();
+        });
+
+        expect(queryByTestId('async-button/loading')).toBeNull();
+    });
+
+    it('should handle onPress rejection gracefully', async () => {
+        const { getByText, queryByTestId } = renderAsyncButton({
+            onPress: () =>
+                new Promise((_, reject) => setTimeout(() => reject(new Error('Failed')), 1000)),
+        });
+
+        fireEvent.press(getByText('Press me'));
+        await act(async () => {
+            jest.runAllTimers();
+            await Promise.resolve();
+        });
+
+        expect(queryByTestId('async-button/loading')).toBeNull();
+    });
+
+    it('should call onReject on rejection', async () => {
+        const mockOnReject = jest.fn();
+        const { getByText } = renderAsyncButton({
+            onPress: () =>
+                new Promise((_, reject) => setTimeout(() => reject(new Error('Failed')), 1000)),
+            onReject: mockOnReject,
+        });
+
+        fireEvent.press(getByText('Press me'));
+
+        await act(async () => {
+            jest.runAllTimers();
+            await Promise.resolve();
+        });
+
+        expect(mockOnReject).toHaveBeenCalledWith(new Error('Failed'));
+    });
+});

--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -25,6 +25,7 @@ export * from './Sheet/BottomSheetFlashList';
 export * from './Sheet/BottomSheetGrabber';
 export * from './Sheet/useAlertAnimation';
 export * from './Button/Button';
+export * from './Button/AsyncButton';
 export * from './Button/IconButton';
 export * from './Button/TextButton';
 export * from './Select/Select';

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "lint:js:fix": "yarn lint:js --fix",
         "type-check": "yarn g:tsc --build",
         "test:unit:memory-heavy": "yarn g:jest --coverage"
     },

--- a/suite-native/module-trading/src/components/exchange/Approval/ApprovalButton.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ApprovalButton.tsx
@@ -1,0 +1,51 @@
+import { useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { selectTradingExchangePreselectedQuote } from '@suite-common/trading';
+import { AsyncButton, Box } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import {
+    StackNavigationProps,
+    TradingStackParamList,
+    TradingStackRoutes,
+} from '@suite-native/navigation';
+
+import { useExchangeFlow } from '../../../hooks/exchange/useExchangeFlow';
+
+export const ApprovalButton = () => {
+    const navigation =
+        useNavigation<
+            StackNavigationProps<TradingStackParamList, TradingStackRoutes.TradingExchangeApproval>
+        >();
+
+    const { confirmTrade } = useExchangeFlow();
+
+    const quote = useSelector(selectTradingExchangePreselectedQuote);
+
+    const handleContinue = async () => {
+        const success = await confirmTrade({
+            receiveAddress: quote?.receiveAddress ?? '',
+            trade: quote,
+            approvalFlow: true,
+            nextStep: () => {},
+        });
+
+        if (success) {
+            // TODO
+            navigation.navigate(TradingStackRoutes.TradingExchangePreview, { isApproved: true });
+        }
+    };
+
+    if (!quote) {
+        return null;
+    }
+
+    return (
+        <Box paddingTop="sp20">
+            <AsyncButton onPress={handleContinue}>
+                <Translation id="generic.buttons.continue" />
+            </AsyncButton>
+        </Box>
+    );
+};

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalDetailsCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalDetailsCard.tsx
@@ -1,6 +1,6 @@
-import type { ExchangeTrade } from 'invity-api';
+import { useSelector } from 'react-redux';
 
-import { cryptoIdToSymbol } from '@suite-common/trading';
+import { cryptoIdToSymbol, selectTradingExchangePreselectedQuote } from '@suite-common/trading';
 import { Card } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { TradeInfoHeader } from '@suite-native/trading-atoms';
@@ -9,11 +9,13 @@ import { LimitPicker } from './LimitPicker';
 import { FeePicker } from '../../fees/FeePicker';
 import { ProviderInfoRow } from '../../general/TradeInfo/ProviderInfoRow';
 
-export type ExchangeApprovalDetailsCardProps = {
-    quote: ExchangeTrade;
-};
+export const ExchangeApprovalDetailsCard = () => {
+    const quote = useSelector(selectTradingExchangePreselectedQuote);
 
-export const ExchangeApprovalDetailsCard = ({ quote }: ExchangeApprovalDetailsCardProps) => {
+    if (!quote) {
+        return null;
+    }
+
     // TODO 22293 - set real values
     const fee = '4.76';
     const areFeesLoading = false;
@@ -28,7 +30,7 @@ export const ExchangeApprovalDetailsCard = ({ quote }: ExchangeApprovalDetailsCa
                 }
             />
             <ProviderInfoRow exchange={quote.exchange} />
-            <LimitPicker quote={quote} />
+            <LimitPicker />
             <FeePicker
                 fee={fee}
                 symbol={networkSymbol}

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/ExchangeApprovalLimitCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/ExchangeApprovalLimitCard.tsx
@@ -5,7 +5,7 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Card, HStack, Radio, Text } from '@suite-native/atoms';
 import { CryptoIcon } from '@suite-native/icons';
 
-type ExchangeApprovalLimitCardProps = {
+export type ExchangeApprovalLimitCardProps = {
     title: ReactNode;
     description: ReactNode;
     symbol?: NetworkSymbol;
@@ -34,7 +34,7 @@ export const ExchangeApprovalLimitCard = memo(
                                 size="extraSmall"
                             />
                         )}
-                        <Text variant="callout">{title}</Text>
+                        {title}
                     </HStack>
                     <Radio value="option" isChecked={isChecked} onPress={onChange} />
                 </HStack>

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/ExchangeApprovalLimitSheet.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/ExchangeApprovalLimitSheet.tsx
@@ -9,13 +9,11 @@ import {
     selectTradingCoinSymbolByCryptoId,
     selectTradingProviderByNameAndTradeType,
 } from '@suite-common/trading';
-import { isNetworkSymbol } from '@suite-common/wallet-config';
-import { TokenSymbol } from '@suite-common/wallet-types';
-import { BottomSheetModal, VStack, useBottomSheetModal } from '@suite-native/atoms';
-import { CryptoAmountFormatter, TokenAmountFormatter } from '@suite-native/formatters';
+import { BottomSheetModal, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
 import { ExchangeApprovalLimitCard } from './ExchangeApprovalLimitCard';
+import { TradingCoinAmountFormatter } from '../../../general/TradingCoinAmountFormatter';
 
 export type ExchangeApprovalLimitSheetProps = {
     isVisible: boolean;
@@ -56,23 +54,6 @@ export const ExchangeApprovalLimitSheet = memo(
             return null;
         }
 
-        const formattedLimitAmount =
-            !!coinSymbol &&
-            (isNetworkSymbol(coinSymbol) ? (
-                <CryptoAmountFormatter
-                    value={quote.sendStringAmount ?? '0'}
-                    symbol={coinSymbol}
-                    isBalance={false}
-                    variant="callout"
-                />
-            ) : (
-                <TokenAmountFormatter
-                    value={quote.sendStringAmount ?? '0'}
-                    tokenSymbol={coinSymbol as TokenSymbol}
-                    variant="callout"
-                />
-            ));
-
         return (
             <BottomSheetModal
                 ref={bottomSheetRef}
@@ -84,7 +65,9 @@ export const ExchangeApprovalLimitSheet = memo(
                 <VStack spacing="sp12" paddingBottom="sp12">
                     <ExchangeApprovalLimitCard
                         title={
-                            <Translation id="moduleTrading.tradingExchangeApprovalScreen.unlimitedLabel" />
+                            <Text variant="callout" color="textDefault">
+                                <Translation id="moduleTrading.tradingExchangeApprovalScreen.unlimitedLabel" />
+                            </Text>
                         }
                         description={
                             <Translation
@@ -102,7 +85,14 @@ export const ExchangeApprovalLimitSheet = memo(
                     />
 
                     <ExchangeApprovalLimitCard
-                        title={formattedLimitAmount}
+                        title={
+                            <TradingCoinAmountFormatter
+                                cryptoId={quote.send}
+                                amount={quote.sendStringAmount}
+                                variant="callout"
+                                color="textDefault"
+                            />
+                        }
                         description={
                             <Translation
                                 id="moduleTrading.exchangeApprovalLimitSheet.limitedCard.description"

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitCard.comp.test.tsx
@@ -1,62 +1,60 @@
+import { Text } from 'react-native';
+
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { ExchangeApprovalLimitCard } from '../ExchangeApprovalLimitCard';
+import {
+    ExchangeApprovalLimitCard,
+    ExchangeApprovalLimitCardProps,
+} from '../ExchangeApprovalLimitCard';
 
 const mockOnChange = jest.fn();
 
-const defaultProps = {
-    title: 'Test limit',
-    description: 'Test description',
-    onChange: mockOnChange,
-};
-
 describe('ExchangeApprovalLimitCard', () => {
+    const renderExchangeApprovalLimitCard = (props: Partial<ExchangeApprovalLimitCardProps>) =>
+        renderWithBasicProvider(
+            <ExchangeApprovalLimitCard
+                title={<Text>Test limit</Text>}
+                description="Test description"
+                onChange={mockOnChange}
+                {...props}
+            />,
+        );
+
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
     it('should render title and description', () => {
-        const { getByText } = renderWithBasicProvider(
-            <ExchangeApprovalLimitCard {...defaultProps} />,
-        );
+        const { getByText } = renderExchangeApprovalLimitCard({});
 
         expect(getByText('Test limit')).toBeTruthy();
         expect(getByText('Test description')).toBeTruthy();
     });
 
     it('should render crypto icon when symbol is provided', () => {
-        const { getByLabelText } = renderWithBasicProvider(
-            <ExchangeApprovalLimitCard {...defaultProps} symbol="btc" />,
-        );
+        const { getByLabelText } = renderExchangeApprovalLimitCard({ symbol: 'btc' });
 
         expect(getByLabelText('btc')).toBeTruthy();
     });
 
     it('should render crypto icon with contract address when provided', () => {
-        const { getByLabelText } = renderWithBasicProvider(
-            <ExchangeApprovalLimitCard
-                {...defaultProps}
-                symbol="eth"
-                contractAddress="0x123456789"
-            />,
-        );
+        const { getByLabelText } = renderExchangeApprovalLimitCard({
+            symbol: 'eth',
+            contractAddress: '0x123456789',
+        });
 
         expect(getByLabelText('eth0x123456789')).toBeTruthy();
     });
 
     it('should call onChange when card is pressed', () => {
-        const { getByText } = renderWithBasicProvider(
-            <ExchangeApprovalLimitCard {...defaultProps} />,
-        );
+        const { getByText } = renderExchangeApprovalLimitCard({});
 
         fireEvent.press(getByText('Test limit'));
         expect(mockOnChange).toHaveBeenCalledTimes(1);
     });
 
     it('should call onChange when description is pressed', () => {
-        const { getByText } = renderWithBasicProvider(
-            <ExchangeApprovalLimitCard {...defaultProps} />,
-        );
+        const { getByText } = renderExchangeApprovalLimitCard({});
 
         fireEvent.press(getByText('Test description'));
         expect(mockOnChange).toHaveBeenCalledTimes(1);

--- a/suite-native/module-trading/src/components/exchange/Approval/LimitPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/LimitPicker.tsx
@@ -1,47 +1,47 @@
-import { useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import type { DexApprovalType, ExchangeProviderInfo, ExchangeTrade } from 'invity-api';
+import type { ExchangeProviderInfo } from 'invity-api';
 
 import {
     type TradingRootState,
     cryptoIdToNetworkAndContractAddress,
     selectTradingCoinSymbolByCryptoId,
+    selectTradingExchangePreselectedQuote,
     selectTradingProviderByNameAndTradeType,
 } from '@suite-common/trading';
 import { HStack, Text, VStack } from '@suite-native/atoms';
 import { CryptoIcon, Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { TradeInfoRow, useBottomSheetControls } from '@suite-native/trading-atoms';
+import { TradeInfoRow } from '@suite-native/trading-atoms';
 
 import { ExchangeApprovalLimitSheet } from './ExchangeApprovalLimitSheet/ExchangeApprovalLimitSheet';
+import { useApprovalTypeControls } from '../../../hooks/exchange/Approval/useApprovalTypeControls';
+import { TradingCoinAmountFormatter } from '../../general/TradingCoinAmountFormatter';
 
-export type LimitPickerProps = {
-    quote: ExchangeTrade;
-};
+export const LimitPicker = () => {
+    const quote = useSelector(selectTradingExchangePreselectedQuote);
 
-export const LimitPicker = ({ quote }: LimitPickerProps) => {
-    const [selectedApprovalType, setSelectedApprovalType] = useState<DexApprovalType>('INFINITE');
-    const { isSheetVisible, showSheet, hideSheet } = useBottomSheetControls();
+    const { approvalType, isSheetVisible, showSheet, hideSheet, handleApprovalTypeChange } =
+        useApprovalTypeControls(quote);
 
     const providerInfo = useSelector((state: TradingRootState) =>
-        selectTradingProviderByNameAndTradeType(state, quote.exchange, 'exchange'),
+        selectTradingProviderByNameAndTradeType(state, quote?.exchange, 'exchange'),
     ) as ExchangeProviderInfo | undefined;
 
     const coinSymbol = useSelector((state: TradingRootState) =>
-        selectTradingCoinSymbolByCryptoId(state, quote.send),
+        selectTradingCoinSymbolByCryptoId(state, quote?.send),
     );
 
-    const { network, contractAddress } = cryptoIdToNetworkAndContractAddress(quote.send);
+    if (!quote?.send) {
+        return null;
+    }
 
-    const handleApprovalTypeChange = (newType: DexApprovalType) => {
-        setSelectedApprovalType(newType);
-        hideSheet();
-    };
+    const { send, sendStringAmount } = quote;
+    const { network, contractAddress } = cryptoIdToNetworkAndContractAddress(send);
 
     // TODO 22293 those strings need update according to latest design
     const limitDescription =
-        selectedApprovalType === 'INFINITE' ? (
+        approvalType === 'INFINITE' ? (
             <Translation
                 id="moduleTrading.exchangeApprovalLimitSheet.unlimitedCard.description"
                 values={{
@@ -72,13 +72,19 @@ export const LimitPicker = ({ quote }: LimitPickerProps) => {
                                     size="extraSmall"
                                 />
                             )}
-                            <Text variant="hint" color="textSubdued">
-                                {selectedApprovalType === 'INFINITE' ? (
+                            {approvalType === 'INFINITE' ? (
+                                <Text variant="hint" color="textSubdued">
                                     <Translation id="moduleTrading.tradingExchangeApprovalScreen.unlimitedLabel" />
-                                ) : (
-                                    `${quote.sendStringAmount} ${coinSymbol}`
-                                )}
-                            </Text>
+                                </Text>
+                            ) : (
+                                <TradingCoinAmountFormatter
+                                    amount={sendStringAmount}
+                                    cryptoId={send}
+                                    variant="hint"
+                                    color="textSubdued"
+                                />
+                            )}
+
                             <Icon name="caretDown" size="medium" />
                         </HStack>
                     </HStack>
@@ -91,7 +97,7 @@ export const LimitPicker = ({ quote }: LimitPickerProps) => {
                 isVisible={isSheetVisible}
                 onDismiss={hideSheet}
                 onApprovalTypeSelect={handleApprovalTypeChange}
-                selectedApprovalType={selectedApprovalType}
+                selectedApprovalType={approvalType}
                 quote={quote}
             />
         </>

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/ApprovalButton.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/ApprovalButton.comp.test.tsx
@@ -1,0 +1,74 @@
+import { tradingExchangeActions } from '@suite-common/trading';
+import {
+    TestStore,
+    initStore,
+    renderWithStoreProviderAsync,
+    userEvent,
+} from '@suite-native/test-utils';
+import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
+
+import { ApprovalButton } from '../ApprovalButton';
+
+const mockNavigate = jest.fn();
+const mockConfirmTrade = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => ({
+        navigate: mockNavigate,
+    }),
+}));
+
+jest.mock('../../../../hooks/exchange/useExchangeFlow', () => ({
+    useExchangeFlow: () => ({
+        confirmTrade: mockConfirmTrade,
+    }),
+}));
+
+describe('ApprovalButton', () => {
+    let store: TestStore;
+
+    const renderApprovalButton = () => renderWithStoreProviderAsync(<ApprovalButton />, { store });
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        mockConfirmTrade.mockResolvedValue(true);
+
+        const preloadedState = {
+            wallet: getWalletState({
+                tradeType: 'exchange',
+            }),
+        };
+        preloadedState!.wallet!.trading!.exchange!.preselectedQuote = exchangeQuotes[0];
+        store = await initStore(preloadedState);
+    });
+
+    it('should render continue button', async () => {
+        const { getByText } = await renderApprovalButton();
+
+        expect(getByText('Continue')).toBeOnTheScreen();
+    });
+
+    it('should confirmTrade and navigate to TradingExchangePreview on press', async () => {
+        const { getByText } = await renderApprovalButton();
+
+        await userEvent.press(getByText('Continue'));
+
+        expect(mockConfirmTrade).toHaveBeenCalledWith({
+            receiveAddress: '',
+            trade: exchangeQuotes[0],
+            approvalFlow: true,
+            nextStep: expect.any(Function),
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith('TradingExchangePreview', { isApproved: true });
+    });
+
+    it('should render nothing when no preselected quote is provided', async () => {
+        store.dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
+
+        const { toJSON } = await renderApprovalButton();
+
+        expect(toJSON()).toBeNull();
+    });
+});

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeApprovalDetailsCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeApprovalDetailsCard.comp.test.tsx
@@ -1,0 +1,36 @@
+import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
+
+import { ExchangeApprovalDetailsCard } from '../ExchangeApprovalDetailsCard';
+
+describe('ExchangeApprovalDetailsCard', () => {
+    let preloadedState: PreloadedState;
+
+    const renderExchangeApprovalDetailsCard = () =>
+        renderWithStoreProviderAsync(<ExchangeApprovalDetailsCard />, { preloadedState });
+
+    beforeEach(() => {
+        preloadedState = {
+            wallet: getWalletState({
+                tradeType: 'exchange',
+            }),
+        };
+    });
+
+    it('should render card', async () => {
+        preloadedState!.wallet!.trading!.exchange!.preselectedQuote = exchangeQuotes[0];
+
+        const { getByText } = await renderExchangeApprovalDetailsCard();
+
+        expect(getByText('Approval details')).toBeTruthy();
+        expect(getByText('Provider')).toBeTruthy();
+        expect(getByText('Limit')).toBeTruthy();
+        expect(getByText('Fee')).toBeTruthy();
+    });
+
+    it('should render nothing without preselectedQuote', async () => {
+        const { toJSON } = await renderExchangeApprovalDetailsCard();
+
+        expect(toJSON()).toBeNull();
+    });
+});

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/LimitPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/LimitPicker.comp.test.tsx
@@ -1,23 +1,37 @@
-import { renderWithStoreProviderAsync, userEvent, within } from '@suite-native/test-utils';
+import {
+    selectTradingExchangePreselectedQuote,
+    tradingExchangeActions,
+} from '@suite-common/trading';
+import {
+    TestStore,
+    initStore,
+    renderWithStoreProviderAsync,
+    userEvent,
+    within,
+} from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
-import { LimitPicker, LimitPickerProps } from '../LimitPicker';
+import { LimitPicker } from '../LimitPicker';
 
 describe('LimitPicker', () => {
-    const renderLimitPicker = (props: Partial<LimitPickerProps> = {}) => {
+    let store: TestStore;
+
+    const renderLimitPicker = () => renderWithStoreProviderAsync(<LimitPicker />, { store });
+
+    beforeEach(async () => {
         const preloadedState = {
             wallet: getWalletState({
                 tradeType: 'exchange',
             }),
         };
 
-        return renderWithStoreProviderAsync(<LimitPicker quote={exchangeQuotes[0]} {...props} />, {
-            preloadedState,
-        });
-    };
+        preloadedState!.wallet!.trading.exchange.preselectedQuote = exchangeQuotes[0];
 
-    it('should render Unlimited', async () => {
-        const { getByTestId } = await renderLimitPicker({});
+        store = await initStore(preloadedState);
+    });
+
+    it('should render Unlimited when no limit is specified', async () => {
+        const { getByTestId } = await renderLimitPicker();
 
         const picker = getByTestId('ExchangeApproval/LimitPicker');
 
@@ -25,10 +39,13 @@ describe('LimitPicker', () => {
         expect(
             within(picker).getByText(/^Approve unlimited USDC to skip future approval requests/),
         ).toBeOnTheScreen();
+        expect(selectTradingExchangePreselectedQuote(store.getState())).toEqual(
+            expect.objectContaining({ approvalType: 'INFINITE' }),
+        );
     });
 
-    it('should render selected value', async () => {
-        const { getByTestId } = await renderLimitPicker({});
+    it('should update limit when users selects new value', async () => {
+        const { getByTestId } = await renderLimitPicker();
 
         const picker = getByTestId('ExchangeApproval/LimitPicker');
         const sheet = getByTestId('ExchangeApproval/LimitSheet');
@@ -39,5 +56,16 @@ describe('LimitPicker', () => {
         expect(
             within(picker).getByText(/^Approve only the amount needed for this swap/),
         ).toBeOnTheScreen();
+        expect(selectTradingExchangePreselectedQuote(store.getState())).toEqual(
+            expect.objectContaining({ approvalType: 'MINIMAL' }),
+        );
+    });
+
+    it('should render nothing without quote', async () => {
+        store.dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
+
+        const { toJSON } = await renderLimitPicker();
+
+        expect(toJSON()).toBeNull();
     });
 });

--- a/suite-native/module-trading/src/components/general/TradingCoinAmountFormatter.tsx
+++ b/suite-native/module-trading/src/components/general/TradingCoinAmountFormatter.tsx
@@ -1,0 +1,47 @@
+import { useSelector } from 'react-redux';
+
+import type { CryptoId } from 'invity-api';
+
+import { type TradingRootState, selectTradingCoinSymbolByCryptoId } from '@suite-common/trading';
+import { isNetworkSymbol } from '@suite-common/wallet-config';
+import type { TokenSymbol } from '@suite-common/wallet-types';
+import type { TextProps } from '@suite-native/atoms';
+import { CryptoAmountFormatter, TokenAmountFormatter } from '@suite-native/formatters';
+
+export type TradingCoinAmountFormatterProps = TextProps & {
+    cryptoId?: CryptoId;
+    amount?: string;
+};
+
+export const TradingCoinAmountFormatter = ({
+    amount,
+    cryptoId,
+    ...textProps
+}: TradingCoinAmountFormatterProps) => {
+    const coinSymbol = useSelector((state: TradingRootState) =>
+        selectTradingCoinSymbolByCryptoId(state, cryptoId),
+    );
+
+    if (!coinSymbol) {
+        return null;
+    }
+
+    if (isNetworkSymbol(coinSymbol)) {
+        return (
+            <CryptoAmountFormatter
+                value={amount ?? '0'}
+                symbol={coinSymbol}
+                isBalance={false}
+                {...textProps}
+            />
+        );
+    }
+
+    return (
+        <TokenAmountFormatter
+            value={amount ?? '0'}
+            tokenSymbol={coinSymbol as TokenSymbol}
+            {...textProps}
+        />
+    );
+};

--- a/suite-native/module-trading/src/components/general/__tests__/TradingCoinAmountFormatter.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingCoinAmountFormatter.comp.test.tsx
@@ -1,0 +1,58 @@
+import type { CryptoId } from 'invity-api';
+
+import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { btcAsset, getWalletState, usdcAsset } from '@suite-native/trading-fixtures';
+
+import {
+    TradingCoinAmountFormatter,
+    TradingCoinAmountFormatterProps,
+} from '../TradingCoinAmountFormatter';
+
+describe('TradingCoinAmountFormatter', () => {
+    const renderTradingCoinAmountFormatter = (
+        props: Partial<TradingCoinAmountFormatterProps> = {},
+    ) =>
+        renderWithStoreProviderAsync(<TradingCoinAmountFormatter {...props} />, {
+            preloadedState: { wallet: getWalletState() },
+        });
+
+    it('should render formatted value for network', async () => {
+        const { getByText } = await renderTradingCoinAmountFormatter({
+            amount: '123456',
+            cryptoId: btcAsset.cryptoId,
+        });
+
+        expect(getByText('123,456 BTC')).toBeOnTheScreen();
+    });
+
+    it('should render formatted value for token', async () => {
+        const { getByText } = await renderTradingCoinAmountFormatter({
+            amount: '123456',
+            cryptoId: usdcAsset.cryptoId,
+        });
+
+        expect(getByText('123,456 USDC')).toBeOnTheScreen();
+    });
+
+    it('should render null when cryptoId is undefined', async () => {
+        const { toJSON } = await renderTradingCoinAmountFormatter();
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render null when cryptoId is unknown', async () => {
+        const { toJSON } = await renderTradingCoinAmountFormatter({
+            cryptoId: 'unknown-crypto-id' as CryptoId,
+        });
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render 0 value when amount is undefined', async () => {
+        const { getByText } = await renderTradingCoinAmountFormatter({
+            cryptoId: btcAsset.cryptoId,
+        });
+
+        expect(getByText('0 BTC')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useApprovalTypeControls.hook.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useApprovalTypeControls.hook.test.ts
@@ -1,0 +1,96 @@
+import { useSelector } from 'react-redux';
+
+import {
+    selectTradingExchangePreselectedQuote,
+    tradingExchangeActions,
+} from '@suite-common/trading';
+import {
+    TestStore,
+    act,
+    initStore,
+    renderHookWithStoreProviderAsync,
+} from '@suite-native/test-utils';
+import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
+
+import { useApprovalTypeControls } from '../useApprovalTypeControls';
+
+describe('useApprovalTypeControls', () => {
+    let store: TestStore;
+
+    const renderUseApprovalTypeControls = () =>
+        renderHookWithStoreProviderAsync(
+            () => {
+                const quote = useSelector(selectTradingExchangePreselectedQuote)!;
+
+                return useApprovalTypeControls(quote);
+            },
+            { store },
+        );
+
+    beforeEach(async () => {
+        const preloadedState = {
+            wallet: getWalletState({
+                tradeType: 'exchange',
+            }),
+        };
+        store = await initStore(preloadedState);
+        store.dispatch(tradingExchangeActions.savePreselectedQuote(exchangeQuotes[0]));
+    });
+
+    it('should use INFINITE as default', async () => {
+        const { result } = await renderUseApprovalTypeControls();
+
+        expect(result.current).toEqual({
+            approvalType: 'INFINITE',
+            isSheetVisible: false,
+            showSheet: expect.any(Function),
+            hideSheet: expect.any(Function),
+            handleApprovalTypeChange: expect.any(Function),
+        });
+        expect(selectTradingExchangePreselectedQuote(store.getState())).toEqual(
+            expect.objectContaining({ approvalType: 'INFINITE' }),
+        );
+    });
+
+    it('should set new value with handleApprovalTypeChange', async () => {
+        const { result } = await renderUseApprovalTypeControls();
+
+        act(() => {
+            result.current.handleApprovalTypeChange('MINIMAL');
+        });
+
+        expect(result.current).toEqual(
+            expect.objectContaining({
+                approvalType: 'MINIMAL',
+            }),
+        );
+        expect(selectTradingExchangePreselectedQuote(store.getState())).toEqual(
+            expect.objectContaining({ approvalType: 'MINIMAL' }),
+        );
+    });
+
+    it('should do nothing when no preselected quote is provided', async () => {
+        store.dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
+        const { result } = await renderUseApprovalTypeControls();
+
+        expect(result.current).toEqual({
+            approvalType: 'INFINITE',
+            isSheetVisible: false,
+            showSheet: expect.any(Function),
+            hideSheet: expect.any(Function),
+            handleApprovalTypeChange: expect.any(Function),
+        });
+        expect(selectTradingExchangePreselectedQuote(store.getState())).toBeUndefined();
+
+        act(() => {
+            result.current.handleApprovalTypeChange('MINIMAL');
+        });
+
+        expect(result.current).toEqual(
+            expect.objectContaining({
+                approvalType: 'INFINITE',
+            }),
+        );
+        expect(selectTradingExchangePreselectedQuote(store.getState())).toBeUndefined();
+    });
+});

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalTypeControls.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalTypeControls.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+import type { DexApprovalType, ExchangeTrade } from 'invity-api';
+
+import { tradingExchangeActions } from '@suite-common/trading';
+import { useBottomSheetControls } from '@suite-native/trading-atoms';
+
+export const useApprovalTypeControls = (quote: ExchangeTrade | undefined) => {
+    const dispatch = useDispatch();
+    const { isSheetVisible, showSheet, hideSheet } = useBottomSheetControls();
+
+    useEffect(() => {
+        if (!!quote && !quote?.approvalType) {
+            dispatch(
+                tradingExchangeActions.savePreselectedQuote({
+                    ...quote,
+                    approvalType: 'INFINITE',
+                }),
+            );
+        }
+    }, [dispatch, quote]);
+
+    const handleApprovalTypeChange = useCallback(
+        (newApprovalType: DexApprovalType) => {
+            if (quote) {
+                dispatch(
+                    tradingExchangeActions.savePreselectedQuote({
+                        ...quote,
+                        approvalType: newApprovalType,
+                    }),
+                );
+            }
+            hideSheet();
+        },
+        [dispatch, hideSheet, quote],
+    );
+
+    return {
+        approvalType: quote?.approvalType ?? 'INFINITE',
+        isSheetVisible,
+        showSheet,
+        hideSheet,
+        handleApprovalTypeChange,
+    };
+};

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
@@ -1,3 +1,4 @@
+import { tradingExchangeActions } from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';
 import {
     PreloadedState,
@@ -205,17 +206,15 @@ describe('useExchangeFlow', () => {
         it('should return null when no trade is provided and no selectedQuote', async () => {
             const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
             // Mock the selector to return undefined for selectedQuote
-            const modifiedStore = await getInitializedStore();
-            modifiedStore.getState().wallet.trading.exchange.selectedQuote = undefined;
+            const store = await getInitializedStore();
+            store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
-            const { result: modifiedResult } = await renderUseExchangeFlow({
-                store: modifiedStore,
-            });
+            const { result } = await renderUseExchangeFlow({ store });
 
             // The getCommonFunctions is called internally, but we can test its effect
             // by calling confirmTrade without a trade parameter
             const resultValue = await act(() =>
-                modifiedResult.current.confirmTrade({
+                result.current.confirmTrade({
                     receiveAddress: 'test-address',
                     trade: undefined,
                     approvalFlow: false,
@@ -243,6 +242,30 @@ describe('useExchangeFlow', () => {
                 await result.current.confirmTrade({
                     receiveAddress: 'test-address',
                     trade: mockTrade,
+                    approvalFlow: false,
+                    nextStep: jest.fn(),
+                });
+            });
+
+            // If we get here without errors, getCommonFunctions worked correctly
+            expect(true).toBe(true);
+        });
+
+        it('should return common functions when preselected quote is provided', async () => {
+            const store = await getInitializedStore();
+            store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
+            store.dispatch(
+                tradingExchangeActions.savePreselectedQuote({
+                    exchange: 'test-exchange',
+                    orderId: 'test-order',
+                }),
+            );
+            const { result } = await renderUseExchangeFlow({ store });
+
+            // Test by calling confirmTrade which uses getCommonFunctions internally
+            await act(async () => {
+                await result.current.confirmTrade({
+                    receiveAddress: 'test-address',
                     approvalFlow: false,
                     nextStep: jest.fn(),
                 });

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -335,6 +335,10 @@ describe('useExchangeSelectQuote', () => {
             });
 
             expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangePreview', {});
+            expect(dispatchSpy).not.toHaveBeenCalledWith({
+                type: '@trading-exchange/savePreselectedQuote',
+                payload: expect.anything(),
+            });
         });
 
         it('should navigate to TradingExchangePreview when approval status is "not_needed"', async () => {
@@ -382,8 +386,11 @@ describe('useExchangeSelectQuote', () => {
                 nextStep();
             });
 
-            expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangeApproval', {
-                quote: exchangeQuotes[1],
+            expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangeApproval', {});
+
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: '@trading-exchange/savePreselectedQuote',
+                payload: exchangeQuotes[1],
             });
         });
 
@@ -410,8 +417,11 @@ describe('useExchangeSelectQuote', () => {
             });
 
             expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangeApproval', {
-                quote: exchangeQuotes[1],
                 shouldIncreaseLimit: true,
+            });
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: '@trading-exchange/savePreselectedQuote',
+                payload: exchangeQuotes[1],
             });
         });
 

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
@@ -7,6 +7,7 @@ import type { ExchangeTrade, FormResponse } from 'invity-api';
 import {
     TradingSendRejectedProps,
     exchangeThunks,
+    selectTradingExchangePreselectedQuote,
     selectTradingExchangeSelectedQuote,
 } from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';
@@ -40,6 +41,8 @@ export const useExchangeFlow = () => {
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
 
     const selectedQuote = useSelector(selectTradingExchangeSelectedQuote);
+    const preSelectedQuote = useSelector(selectTradingExchangePreselectedQuote);
+    const quote = selectedQuote ?? preSelectedQuote;
 
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);
 
@@ -62,7 +65,7 @@ export const useExchangeFlow = () => {
 
     const getCommonFunctions = useCallback(
         (trade?: ExchangeTrade) => {
-            const tradeToUse = trade ?? selectedQuote;
+            const tradeToUse = trade ?? quote;
 
             if (!tradeToUse) {
                 console.error('Trade or selectedQuote is required to getCommonFunctions');
@@ -95,7 +98,7 @@ export const useExchangeFlow = () => {
                 processResponseData,
             };
         },
-        [handleWebview, selectedQuote],
+        [handleWebview, quote],
     );
 
     const {

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
@@ -9,6 +9,7 @@ import {
     selectTradingExchangeIsLoading,
     selectTradingMaxSlippagePercentage,
     tokenSupportsIncreasingAllowance,
+    tradingExchangeActions,
 } from '@suite-common/trading';
 import {
     RootStackParamList,
@@ -108,9 +109,10 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
                     const isIncreasingAllowanceSupported =
                         tokenSupportsIncreasingAllowance(contractAddress);
 
+                    dispatch(tradingExchangeActions.savePreselectedQuote(candidateQuote));
+
                     if (approvalStatus === 'needs_increase' && isIncreasingAllowanceSupported) {
                         return navigation.navigate(TradingStackRoutes.TradingExchangeApproval, {
-                            quote: candidateQuote,
                             shouldIncreaseLimit: true,
                         });
                     }
@@ -122,9 +124,7 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
                         });
                     }
 
-                    return navigation.navigate(TradingStackRoutes.TradingExchangeApproval, {
-                        quote: candidateQuote,
-                    });
+                    return navigation.navigate(TradingStackRoutes.TradingExchangeApproval, {});
                 },
                 onCancel: () => {},
             }),

--- a/suite-native/module-trading/src/screens/TradingExchangeApprovalScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangeApprovalScreen.tsx
@@ -1,27 +1,27 @@
-import { useSelector } from 'react-redux';
-
-import { useNavigation } from '@react-navigation/native';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
 import {
     TradingRootState,
     selectTradingCoinSymbolByCryptoId,
+    selectTradingExchangePreselectedQuote,
     selectTradingProviderByNameAndTradeType,
+    tradingExchangeActions,
 } from '@suite-common/trading';
-import { Box, Button, InlineAlertBox, VStack } from '@suite-native/atoms';
+import { InlineAlertBox, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DynamicScreenHeader,
     RootStackParamList,
     Screen,
-    StackNavigationProps,
     StackToStackCompositeScreenProps,
     TradingStackParamList,
     TradingStackRoutes,
 } from '@suite-native/navigation';
 
+import { ApprovalButton } from '../components/exchange/Approval/ApprovalButton';
 import { ExchangeApprovalDetailsCard } from '../components/exchange/Approval/ExchangeApprovalDetailsCard';
 import { ExchangeApprovalForCard } from '../components/exchange/Approval/ExchangeApprovalForCard';
-import { useExchangeFlow } from '../hooks/exchange/useExchangeFlow';
 
 type TradingExchangeApprovalScreenProps = StackToStackCompositeScreenProps<
     TradingStackParamList,
@@ -32,40 +32,29 @@ type TradingExchangeApprovalScreenProps = StackToStackCompositeScreenProps<
 export const TradingExchangeApprovalScreen = ({
     route: { params },
 }: TradingExchangeApprovalScreenProps) => {
-    const { quote, shouldIncreaseLimit, isRevoked } = params;
-    const navigation =
-        useNavigation<
-            StackNavigationProps<TradingStackParamList, TradingStackRoutes.TradingExchangeApproval>
-        >();
+    const { shouldIncreaseLimit, isRevoked } = params;
+    const dispatch = useDispatch();
+
+    const quote = useSelector(selectTradingExchangePreselectedQuote);
 
     const providerInfo = useSelector((state: TradingRootState) =>
-        selectTradingProviderByNameAndTradeType(state, quote.exchange, 'exchange'),
+        selectTradingProviderByNameAndTradeType(state, quote?.exchange, 'exchange'),
     );
 
     const coinSymbol = useSelector((state: TradingRootState) =>
         selectTradingCoinSymbolByCryptoId(state, quote?.send),
     );
 
-    const { confirmTrade } = useExchangeFlow();
+    useEffect(
+        () => () => {
+            dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
+        },
+        [dispatch],
+    );
 
-    const handleContinue = async () => {
-        const updatedQuote = {
-            ...quote,
-            // approvalType: selectedApprovalType, // TODO 22293
-        };
-
-        const success = await confirmTrade({
-            receiveAddress: quote.receiveAddress ?? '',
-            trade: updatedQuote,
-            approvalFlow: true,
-            nextStep: () => {},
-        });
-
-        if (success) {
-            // TODO
-            navigation.navigate(TradingStackRoutes.TradingExchangePreview, { isApproved: true });
-        }
-    };
+    if (!quote) {
+        return null;
+    }
 
     return (
         <Screen
@@ -107,14 +96,9 @@ export const TradingExchangeApprovalScreen = ({
                 )}
 
                 <ExchangeApprovalForCard />
-                <ExchangeApprovalDetailsCard quote={quote} />
+                <ExchangeApprovalDetailsCard />
             </VStack>
-
-            <Box paddingTop="sp20">
-                <Button onPress={handleContinue}>
-                    <Translation id="generic.buttons.continue" />
-                </Button>
-            </Box>
+            <ApprovalButton />
         </Screen>
     );
 };

--- a/suite-native/module-trading/src/screens/TradingExchangeRevokeScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangeRevokeScreen.tsx
@@ -9,15 +9,9 @@ import {
     selectTradingCoinSymbolByCryptoId,
     selectTradingProviderByNameAndTradeType,
 } from '@suite-common/trading';
-import { isNetworkSymbol } from '@suite-common/wallet-config';
-import { TokenSymbol } from '@suite-common/wallet-types';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-utils';
 import { Box, Button, Card, HStack, InlineAlertBox, Text, VStack } from '@suite-native/atoms';
-import {
-    BaseCurrencyAmountFormatter,
-    CryptoAmountFormatter,
-    TokenAmountFormatter,
-} from '@suite-native/formatters';
+import { BaseCurrencyAmountFormatter } from '@suite-native/formatters';
 import { CryptoIcon, Icon, NetworkIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import {
@@ -32,6 +26,8 @@ import {
 import { ProviderLogo, TradeInfoHeader, TradeInfoRow } from '@suite-native/trading-atoms';
 import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
 import { BigNumber } from '@trezor/utils';
+
+import { TradingCoinAmountFormatter } from '../components/general/TradingCoinAmountFormatter';
 
 type TradingExchangeRevokeScreenProps = StackToStackCompositeScreenProps<
     TradingStackParamList,
@@ -58,7 +54,6 @@ export const TradingExchangeRevokeScreen = ({
         // TODO
         if (shouldIncreaseLimit) {
             return navigation.replace(TradingStackRoutes.TradingExchangeApproval, {
-                quote,
                 isRevoked: true,
             });
         }
@@ -167,23 +162,12 @@ export const TradingExchangeRevokeScreen = ({
                                 />
                             )}
                             <Text variant="hint" color="textSubdued">
-                                {!!coinSymbol &&
-                                    (isNetworkSymbol(coinSymbol) ? (
-                                        <CryptoAmountFormatter
-                                            value={quote.preapprovedStringAmount || '0'}
-                                            symbol={coinSymbol}
-                                            isBalance={false}
-                                            variant="hint"
-                                            color="textSubdued"
-                                        />
-                                    ) : (
-                                        <TokenAmountFormatter
-                                            value={quote.preapprovedStringAmount || '0'}
-                                            tokenSymbol={coinSymbol as TokenSymbol}
-                                            variant="hint"
-                                            color="textSubdued"
-                                        />
-                                    ))}
+                                <TradingCoinAmountFormatter
+                                    amount={quote.preapprovedStringAmount}
+                                    cryptoId={quote.send}
+                                    variant="hint"
+                                    color="textSubdued"
+                                />
                             </Text>
                         </HStack>
                     </TradeInfoRow>
@@ -199,23 +183,12 @@ export const TradingExchangeRevokeScreen = ({
                                     size="extraSmall"
                                 />
                             )}
-                            {!!coinSymbol &&
-                                (isNetworkSymbol(coinSymbol) ? (
-                                    <CryptoAmountFormatter
-                                        value={0}
-                                        symbol={coinSymbol}
-                                        isBalance={false}
-                                        variant="hint"
-                                        color="textSubdued"
-                                    />
-                                ) : (
-                                    <TokenAmountFormatter
-                                        value={0}
-                                        tokenSymbol={coinSymbol as TokenSymbol}
-                                        variant="hint"
-                                        color="textSubdued"
-                                    />
-                                ))}
+                            <TradingCoinAmountFormatter
+                                amount="0"
+                                cryptoId={quote.send}
+                                variant="hint"
+                                color="textSubdued"
+                            />
                         </HStack>
                     </TradeInfoRow>
                     <TradeInfoRow>

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.comp.test.tsx
@@ -1,7 +1,16 @@
 import { RouteProp } from '@react-navigation/native';
 
+import {
+    selectTradingExchangePreselectedQuote,
+    tradingExchangeActions,
+} from '@suite-common/trading';
 import { TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
-import { PreloadedState, fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import {
+    TestStore,
+    fireEvent,
+    initStore,
+    renderWithStoreProviderAsync,
+} from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import { TradingExchangeApprovalScreen } from '../TradingExchangeApprovalScreen';
@@ -35,36 +44,27 @@ jest.mock('@suite-native/trading-atoms', () => ({
 
 const testQuote = exchangeQuotes[0];
 
-let preloadedState: PreloadedState;
-
-const renderScreen = () =>
-    renderWithStoreProviderAsync(
-        <TradingExchangeApprovalScreen
-            route={
-                { params: { quote: testQuote } } as RouteProp<
-                    TradingStackParamList,
-                    TradingStackRoutes.TradingExchangeApproval
-                >
-            }
-            navigation={{} as any}
-        />,
-        {
-            preloadedState,
-        },
-    );
-
 describe('TradingExchangeApprovalScreen', () => {
-    beforeEach(() => {
+    let store: TestStore;
+
+    const renderScreen = () =>
+        renderWithStoreProviderAsync(
+            <TradingExchangeApprovalScreen route={{ params: {} } as any} navigation={{} as any} />,
+            { store },
+        );
+
+    beforeEach(async () => {
         jest.clearAllMocks();
 
-        preloadedState = {
+        const preloadedState = {
             wallet: getWalletState({
                 tradeType: 'exchange',
             }),
         };
 
-        preloadedState!.wallet!.trading!.exchange!.selectedQuote = testQuote;
-        preloadedState!.wallet!.trading!.exchange!.tradingAccountKey = 'eth-account-1';
+        store = await initStore(preloadedState);
+        store.dispatch(tradingExchangeActions.savePreselectedQuote(testQuote));
+        store.dispatch(tradingExchangeActions.setTradingAccountKey('eth-account-1'));
     });
 
     it('should render the approval screen with quote details', async () => {
@@ -100,5 +100,22 @@ describe('TradingExchangeApprovalScreen', () => {
 
         const buttons = getByText('Continue');
         expect(buttons).toBeTruthy();
+    });
+
+    it('should render nothing when no preselected quote is provided', async () => {
+        store.dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
+
+        const { toJSON } = await renderScreen();
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should clear preselected quote on unmount', async () => {
+        const { unmount } = await renderScreen();
+
+        unmount();
+
+        const preselectedQuote = selectTradingExchangePreselectedQuote(store.getState());
+        expect(preselectedQuote).toBeUndefined();
     });
 });

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -359,7 +359,6 @@ export type TradingStackParamList = {
         isApproved?: boolean;
     };
     [TradingStackRoutes.TradingExchangeApproval]: {
-        quote: ExchangeTrade;
         shouldIncreaseLimit?: boolean;
         isRevoked?: boolean;
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Another intermediate PR about mobile DEX approval flow.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22293-mobile-swap-prepare-and-send-approval-transaction&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=22293-mobile-swap-prepare-and-send-approval-transaction&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=22293-mobile-swap-prepare-and-send-approval-transaction&lookback=7)