### PR TITLE
mobile: Send sell txn

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/useTradingDetail.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingDetail.ts
@@ -1,113 +1,44 @@
-import { createContext, useContext, useEffect } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 
 import {
-    type TradingTransaction,
-    type TradingTransactionBuy,
     type TradingType,
-    selectTrading,
-    selectTradingBuyInfo,
-    selectTradingExchangeInfo,
-    selectTradingSellInfo,
-    tradingThunks,
+    type TradingUseDetailOutputProps,
+    type TradingUseDetailProps,
+    useTradingDetail as useTradingDetailCommon,
 } from '@suite-common/trading';
 
-import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useServerEnvironment } from 'src/hooks/wallet/trading/useServerEnviroment';
 import { useTradingWatchTrade } from 'src/hooks/wallet/trading/useTradingWatchTrade';
-import {
-    TradingGetDetailDataProps,
-    TradingGetTypedTradeProps,
-    TradingTradeInfoMapProps,
-    TradingTradeMapProps,
-} from 'src/types/trading/trading';
-import {
-    TradingDetailContextValues,
-    TradingGetDetailDataOutputProps,
-    TradingUseDetailOutputProps,
-    TradingUseDetailProps,
-} from 'src/types/trading/tradingDetail';
+import type { TradingDetailContextValues } from 'src/types/trading/tradingDetail';
 
 import { useTradingFormAccount } from './form/useTradingFormAccount';
 
-const isBuyTrade = (trade: TradingTransaction): trade is TradingTransactionBuy =>
-    trade.tradeType === 'buy';
+/**
+ * Suite-specific wrapper around the common useTradingDetail hook
+ * Adds platform-specific functionality like server environment setup and trade watching
+ */
+export const useTradingDetail = <T extends TradingType>(
+    props: TradingUseDetailProps & { tradeType: T },
+): TradingUseDetailOutputProps<T> => {
+    const { tradeType, account: accountProps } = props;
+    const { account: formAccount } = useTradingFormAccount();
 
-const getTypedTrade = <T extends TradingType>({
-    trades,
-    tradeType,
-    transactionId,
-}: TradingGetTypedTradeProps): TradingTradeMapProps[T] | undefined => {
-    const trade = trades.find(
-        trade =>
-            trade.tradeType === tradeType &&
-            (trade.key == transactionId ||
-                (isBuyTrade(trade) && trade.data?.originalPaymentId === transactionId)),
+    // For exchange trades, use the account from the trading form context
+    // For buy/sell trades, use the account passed as a prop
+    const account = useMemo(
+        () => (tradeType === 'exchange' ? formAccount : accountProps),
+        [tradeType, formAccount, accountProps],
     );
 
-    if (!trade) {
-        return undefined;
-    }
+    const result = useTradingDetailCommon<T>({ tradeType });
 
-    return trade as TradingTradeMapProps[T];
-};
-
-const getTradingDetailData = <T extends TradingType>({
-    trading,
-    tradeType,
-    infos,
-}: TradingGetDetailDataProps): TradingGetDetailDataOutputProps<T> => {
-    const info = infos[tradeType] as TradingTradeInfoMapProps[T];
-
-    const { trades } = trading;
-    const { transactionId } = trading[tradeType];
-
-    const trade = getTypedTrade<T>({
-        trades,
-        tradeType,
-        transactionId,
-    });
-
-    return {
-        transactionId,
-        info,
-        trade,
-    };
-};
-
-export const useTradingDetail = <T extends TradingType>({
-    selectedAccount,
-    tradeType,
-}: TradingUseDetailProps): TradingUseDetailOutputProps<T> => {
-    const trading = useSelector(selectTrading);
-    const { account: exchangeAccount } = useTradingFormAccount();
-    const buyInfo = useSelector(selectTradingBuyInfo);
-    const sellInfo = useSelector(selectTradingSellInfo);
-    const exchangeInfo = useSelector(selectTradingExchangeInfo);
-    const { info, transactionId, trade } = getTradingDetailData<T>({
-        trading,
-        tradeType,
-        infos: {
-            buy: buyInfo,
-            sell: sellInfo,
-            exchange: exchangeInfo,
-        },
-    });
-
-    const account = tradeType === 'exchange' ? exchangeAccount : selectedAccount.account;
-    const dispatch = useDispatch();
-
-    useEffect(() => {
-        dispatch(tradingThunks.loadInitialDataThunk({ activeSection: tradeType }));
-    }, [dispatch, tradeType]);
+    // Setup server environment from suite settings
     useServerEnvironment();
-    useTradingWatchTrade({ account, trade });
 
-    return {
-        account,
-        trade,
-        transactionId,
-        info,
-    };
+    // Watch for trade updates
+    useTradingWatchTrade({ account, trade: result.trade });
+
+    return { ...result, account };
 };
 
 export const TradingDetailContext = createContext<TradingDetailContextValues<any> | null>(null);

--- a/packages/suite/src/types/trading/tradingDetail.ts
+++ b/packages/suite/src/types/trading/tradingDetail.ts
@@ -1,5 +1,4 @@
 import type { TradingType } from '@suite-common/trading';
-import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 
 import { TradingTradeInfoMapProps, TradingTradeMapProps } from 'src/types/trading/trading';
 import type { Account } from 'src/types/wallet';
@@ -8,22 +7,4 @@ export interface TradingDetailContextValues<T extends TradingType> {
     account: Account;
     trade: TradingTradeMapProps[T] | undefined;
     info?: TradingTradeInfoMapProps[T] | undefined;
-}
-
-export interface TradingGetDetailDataOutputProps<T extends TradingType> {
-    transactionId?: string;
-    info?: TradingTradeInfoMapProps[T] | undefined;
-    trade?: TradingTradeMapProps[T] | undefined;
-}
-
-export interface TradingUseDetailProps {
-    selectedAccount: SelectedAccountLoaded;
-    tradeType: TradingType;
-}
-
-export interface TradingUseDetailOutputProps<T extends TradingType> {
-    transactionId: string | undefined;
-    info: TradingTradeInfoMapProps[T] | undefined;
-    trade: TradingTradeMapProps[T] | undefined;
-    account: Account;
 }

--- a/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail.tsx
+++ b/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail.tsx
@@ -5,7 +5,7 @@ import { TradingDetailBuy } from 'src/views/wallet/trading/common/TradingDetail/
 
 const TradingBuyDetailComponent = ({ selectedAccount }: UseTradingProps) => {
     const tradingDetailContext = useTradingDetail({
-        selectedAccount,
+        account: selectedAccount.account,
         tradeType: 'buy',
     });
 

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail.tsx
@@ -5,7 +5,7 @@ import { TradingDetailExchange } from 'src/views/wallet/trading/common/TradingDe
 
 const TradingExchangeDetailComponent = ({ selectedAccount }: UseTradingProps) => {
     const tradingDetailContext = useTradingDetail({
-        selectedAccount,
+        account: selectedAccount.account,
         tradeType: 'exchange',
     });
 

--- a/packages/suite/src/views/wallet/trading/sell/TradingSellDetail.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingSellDetail.tsx
@@ -5,7 +5,7 @@ import { TradingDetailSell } from 'src/views/wallet/trading/common/TradingDetail
 
 const TradingSellDetailComponent = ({ selectedAccount }: UseTradingProps) => {
     const tradingDetailContext = useTradingDetail({
-        selectedAccount,
+        account: selectedAccount.account,
         tradeType: 'sell',
     });
 

--- a/suite-common/trading/src/hooks/useTradingDetail.ts
+++ b/suite-common/trading/src/hooks/useTradingDetail.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+import type { TradingType } from '@suite-common/suite-types';
+
+import { useSelector } from './useSelector';
+import { selectTradingDetailData } from '../selectors/tradingSelectors';
+import { tradingThunks } from '../thunks';
+import type {
+    TradingTradeInfoMapProps,
+    TradingTradeTransactionMapProps,
+    TradingUseDetailOutputWithoutAccountProps,
+    TradingUseDetailPropsWithoutAccount,
+} from '../types/tradingDetail';
+
+export const useTradingDetailData = <T extends TradingType>(
+    tradeType: TradingType,
+): TradingUseDetailOutputWithoutAccountProps<T> => {
+    const { info, transactionId, trade } = useSelector(state =>
+        selectTradingDetailData(state, tradeType),
+    ) as {
+        info: TradingTradeInfoMapProps[T] | undefined;
+        transactionId: string | undefined;
+        trade: TradingTradeTransactionMapProps[T] | undefined;
+    };
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        dispatch(tradingThunks.loadInitialDataThunk({ activeSection: tradeType }));
+    }, [dispatch, tradeType]);
+
+    return {
+        trade,
+        transactionId,
+        info,
+    };
+};
+
+export const useTradingDetail = <T extends TradingType>({
+    tradeType,
+}: TradingUseDetailPropsWithoutAccount): TradingUseDetailOutputWithoutAccountProps<T> => {
+    const { info, transactionId, trade } = useTradingDetailData(tradeType);
+
+    return {
+        info: info as TradingTradeInfoMapProps[T] | undefined,
+        transactionId,
+        trade: trade as TradingTradeTransactionMapProps[T] | undefined,
+    };
+};

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -17,4 +17,6 @@ export * from './selectors/tradingSelectors';
 export * from './selectors/settingsSelectors';
 export * from './thunks';
 export * from './hooks/useTradingInfo';
+export * from './hooks/useTradingDetail';
+export * from './types/tradingDetail';
 export * from './currency';

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -27,6 +27,7 @@ import {
     cryptoIdToNetwork,
     getBestRatedQuote,
     getTradingQuotesByPaymentMethod,
+    isBuyTrade,
     isExchangeProvider,
     testnetToProdCryptoId,
 } from '../utils';
@@ -649,6 +650,9 @@ export const selectTradingExchangeTransactionId = (state: TradingRootState) =>
 export const selectTradingSellTransactionId = (state: TradingRootState) =>
     state.wallet.trading.sell.transactionId;
 
+export const selectTradingBuyTransactionId = (state: TradingRootState) =>
+    state.wallet.trading.buy.transactionId;
+
 export const selectTradingVerifiedAddress = (state: TradingRootState) =>
     state.wallet.trading.verifiedAddress;
 
@@ -667,5 +671,56 @@ export const selectTradingIsSlip24Allowed = createMemoizedSelectorWithDeviceAndA
         const isNetworkSupported = supportedNetworks.includes(account.networkType);
 
         return isSlip24Active && isFirmwareVersionSlip24Compatible && isNetworkSupported;
+    },
+);
+
+export const selectTradingDetailData = createMemoizedSelector(
+    [
+        selectTradingBuyInfo,
+        selectTradingSellInfo,
+        selectTradingExchangeInfo,
+        selectTradingBuyTransactionId,
+        selectTradingSellTransactionId,
+        selectTradingExchangeTransactionId,
+        selectTradingTrades,
+        (_: TradingRootState, tradeType: TradingType) => tradeType,
+    ],
+    (
+        buyInfo,
+        sellInfo,
+        exchangeInfo,
+        buyTransactionId,
+        sellTransactionId,
+        exchangeTransactionId,
+        trades,
+        tradeType,
+    ) => {
+        const infos = {
+            buy: buyInfo,
+            sell: sellInfo,
+            exchange: exchangeInfo,
+        };
+        const transactionIds = {
+            buy: buyTransactionId,
+            sell: sellTransactionId,
+            exchange: exchangeTransactionId,
+        };
+        const info = infos[tradeType];
+        const transactionId = transactionIds[tradeType];
+
+        const trade = trades.find(
+            t =>
+                t.tradeType === tradeType &&
+                (t.key == transactionId ||
+                    (tradeType === 'buy' &&
+                        isBuyTrade(t.data) &&
+                        t.data?.originalPaymentId === transactionId)),
+        );
+
+        return {
+            transactionId,
+            info,
+            trade,
+        };
     },
 );

--- a/suite-common/trading/src/thunks/common/watchTradeThunk.ts
+++ b/suite-common/trading/src/thunks/common/watchTradeThunk.ts
@@ -4,7 +4,9 @@ import { exhaustive } from '@trezor/type-utils';
 
 import { TRADING_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
+import { tradingSellActions } from '../../reducers/sellReducer';
 import { tradingActions } from '../../reducers/tradingReducer';
+import { selectTradingSellSelectedQuote } from '../../selectors/tradingSelectors';
 import {
     TradingTradeMapProps,
     TradingTransaction,
@@ -50,7 +52,7 @@ const watchTradeData = async <T extends TradingType>({
 
 export const watchTradeThunk = createThunk(
     `${TRADING_THUNK_PREFIX}/watchTrade`,
-    async ({ account, trade, refreshCount }: WatchTradeThunk, { dispatch }) => {
+    async ({ account, trade, refreshCount }: WatchTradeThunk, { dispatch, getState }) => {
         invityAPI.createInvityAPIKey(account.descriptor);
 
         const { tradeType } = trade;
@@ -93,6 +95,12 @@ export const watchTradeThunk = createThunk(
 
                 if (data.response.cryptoStringAmount) {
                     data.tradeData.cryptoStringAmount = data.response.cryptoStringAmount;
+                }
+
+                const selectedQuote = selectTradingSellSelectedQuote(getState());
+
+                if (data.tradeData && selectedQuote?.orderId === data.tradeData.orderId) {
+                    dispatch(tradingSellActions.saveSelectedQuote(data.tradeData));
                 }
 
                 dispatch(

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellTradeThunk.test.ts
@@ -83,7 +83,6 @@ describe('handleSellTradeThunk', () => {
 
     describe('should return undefined', () => {
         it.each([
-            ['when quotesRequest is undefined', { quotesRequest: undefined }, {}],
             ['when provider is undefined', { sellInfo: {} }, {}],
             [
                 'when quote`s provider was not found',

--- a/suite-common/trading/src/thunks/sell/handleSellTradeThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellTradeThunk.ts
@@ -8,10 +8,7 @@ import { TRADING_SELL_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
 import { tradingSellActions } from '../../reducers/sellReducer';
 import { tradingActions } from '../../reducers/tradingReducer';
-import {
-    selectTradingSellInfo,
-    selectTradingSellQuotesRequest,
-} from '../../selectors/tradingSelectors';
+import { selectTradingSellInfo } from '../../selectors/tradingSelectors';
 import { getUnusedAddressFromAccount } from '../../utils';
 
 export type HandleSellTradeThunkProps = {
@@ -29,12 +26,17 @@ export const handleSellTradeThunk = createThunk(
         { dispatch, getState, fulfillWithValue },
     ) => {
         const sellInfo = selectTradingSellInfo(getState());
-        const quotesRequest = selectTradingSellQuotesRequest(getState());
+
         const provider =
             sellInfo?.providerInfos && trade.exchange
                 ? sellInfo.providerInfos[trade.exchange]
                 : undefined;
-        if (!quotesRequest || !provider) return;
+
+        if (!provider) {
+            console.warn('doSellTrade: No provider found');
+
+            return;
+        }
 
         const response = await invityAPI.doSellTrade({
             trade: { ...trade, refundAddress: getUnusedAddressFromAccount(account).address },

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -35,7 +35,7 @@ import { Timer } from '@trezor/react-utils';
 import { PrimitiveType } from '@trezor/type-utils';
 
 import * as constants from './constants';
-import { TradingState } from './reducers/tradingReducer';
+import type { TradingState } from './reducers/tradingReducer';
 
 export type InvityServerEnvironment = 'production' | 'staging' | 'dev' | 'localhost';
 export type InvityServers = Record<InvityServerEnvironment, string>;

--- a/suite-common/trading/src/types/tradingDetail.ts
+++ b/suite-common/trading/src/types/tradingDetail.ts
@@ -1,0 +1,54 @@
+import type { Account } from '@suite-common/wallet-types';
+
+import type {
+    TradingBuyInfoSelector,
+    TradingExchangeInfoSelector,
+    TradingSellInfoSelector,
+} from '../selectors/tradingSelectors';
+import type {
+    TradingTransactionBuy,
+    TradingTransactionExchange,
+    TradingTransactionSell,
+    TradingType,
+} from '../types';
+
+export type TradingTradeTransactionMapProps = {
+    buy: TradingTransactionBuy;
+    sell: TradingTransactionSell;
+    exchange: TradingTransactionExchange;
+};
+
+export type TradingTradeInfoMapProps = {
+    buy: TradingBuyInfoSelector;
+    sell: TradingSellInfoSelector;
+    exchange: TradingExchangeInfoSelector;
+};
+
+export interface TradingGetDetailDataOutputProps<T extends TradingType> {
+    transactionId?: string;
+    info?: TradingTradeInfoMapProps[T] | undefined;
+    trade?: TradingTradeTransactionMapProps[T] | undefined;
+}
+
+export interface TradingUseDetailProps {
+    account: Account;
+    tradeType: TradingType;
+}
+
+export type TradingUseDetailPropsWithoutAccount = Omit<TradingUseDetailProps, 'account'>;
+export interface TradingUseDetailOutputProps<T extends TradingType> {
+    transactionId: string | undefined;
+    info: TradingTradeInfoMapProps[T] | undefined;
+    trade: TradingTradeTransactionMapProps[T] | undefined;
+    account: Account;
+}
+
+export type TradingUseDetailOutputWithoutAccountProps<T extends TradingType> = Omit<
+    TradingUseDetailOutputProps<T>,
+    'account'
+>;
+
+export interface TradingUseWatchTradeProps<T extends TradingType> {
+    account: Account | undefined;
+    trade: TradingTradeTransactionMapProps[T] | undefined;
+}

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2452,6 +2452,13 @@ export const messages = {
             paymentMethods: {
                 bankTransfer: 'Bank Transfer',
                 creditCard: 'Credit/Debit Card',
+                sepa: 'SEPA',
+                ach: 'Automated Clearing House',
+                skrill: 'Skrill',
+                neteller: 'Neteller',
+                payid: 'PayID',
+                dcinterac: 'Interac',
+                fasterPayment: 'Faster Payment System',
             },
             bankAccount: 'Bank account',
             verified: 'Verified',

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.tsx
@@ -57,9 +57,8 @@ export const ExchangePreviewContinueButton = memo(
                 : undefined;
 
             navigation.navigate({
-                name: TradingStackRoutes.TradingOutputsReview,
+                name: TradingStackRoutes.TradingExchangeOutputsReview,
                 params: {
-                    tradingType: 'exchange',
                     accountKey: fromAccount.key,
                     tokenContract,
                     orderId: quote.orderId ?? '',

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewContinueButton.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewContinueButton.comp.test.tsx
@@ -113,7 +113,7 @@ describe('ExchangePreviewContinueButton', () => {
         expect(mockOnSignTransactionNavigation).not.toHaveBeenCalled();
     });
 
-    it('should navigate to TradingOutputsReview on continue press', async () => {
+    it('should navigate to TradingExchangeOutputsReview on continue press', async () => {
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
         const mockOnSignTransactionNavigation = jest.fn();
         const { getByText } = await renderExchangePreviewContinueButton(
@@ -125,9 +125,8 @@ describe('ExchangePreviewContinueButton', () => {
 
         expect(consoleWarnSpy).not.toHaveBeenCalled();
         expect(mockNavigate).toHaveBeenCalledWith({
-            name: 'TradingOutputsReview',
+            name: 'TradingExchangeOutputsReview',
             params: {
-                tradingType: 'exchange',
                 accountKey: 'btc-account-1',
                 orderId: exchangeQuotes[0].orderId,
                 tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',

--- a/suite-native/module-trading/src/components/general/TradeInfo/TradeFiatSideCard.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/TradeFiatSideCard.tsx
@@ -1,33 +1,42 @@
 import { ReactNode } from 'react';
 
-import type { SellCryptoPaymentMethod } from 'invity-api';
-
 import { Card, HStack, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { TradeInfoHeader, TradeInfoRow } from '@suite-native/trading-atoms';
-import { exhaustive } from '@trezor/type-utils';
+import type { ExtendedSellCryptoPaymentMethod } from '@suite-native/trading-types';
 
 import { FiatCurrencyIcon } from '../FiatCurrencyIcon';
 
 export type TradeFiatSideCardProps = {
-    paymentMethod: SellCryptoPaymentMethod;
+    paymentMethod: ExtendedSellCryptoPaymentMethod;
     amount: ReactNode;
     title: ReactNode;
 };
+const paymentMethodNamesMap: Record<ExtendedSellCryptoPaymentMethod, ReactNode> = {
+    bankTransfer: (
+        <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.bankTransfer" />
+    ),
+    creditCard: (
+        <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.creditCard" />
+    ),
+    sepa: <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.sepa" />,
+    ach: <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.ach" />,
+    skrill: <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.skrill" />,
 
-const getPaymentMethodTranslation = (paymentMethod: SellCryptoPaymentMethod) => {
-    switch (paymentMethod) {
-        case 'bankTransfer':
-            return (
-                <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.bankTransfer" />
-            );
-        case 'creditCard':
-            return (
-                <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.creditCard" />
-            );
-        default:
-            exhaustive(paymentMethod);
+    neteller: <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.neteller" />,
+    payid: <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.payid" />,
+    dcinterac: <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.dcinterac" />,
+    fasterPayment: (
+        <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.fasterPayment" />
+    ),
+};
+
+const getPaymentMethodTranslation = (paymentMethod: ExtendedSellCryptoPaymentMethod | string) => {
+    if (paymentMethod in paymentMethodNamesMap) {
+        return paymentMethodNamesMap[paymentMethod as ExtendedSellCryptoPaymentMethod];
     }
+
+    return paymentMethod;
 };
 
 export const TradeFiatSideCard = ({ paymentMethod, amount, title }: TradeFiatSideCardProps) => (

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAlert.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAlert.tsx
@@ -149,6 +149,7 @@ export const TradeDetailAlert = ({
                     orderId,
                     exchange: trade.data.partnerData,
                 }),
+                tradingType: trade.tradeType,
                 source: { uri: trade.data.partnerData },
             });
         }

--- a/suite-native/module-trading/src/components/sell/SellConfirmation.tsx
+++ b/suite-native/module-trading/src/components/sell/SellConfirmation.tsx
@@ -4,8 +4,8 @@ import { AnimatedBox, Button } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
 import { SellLegalSheet } from './SellLegalSheet';
-import { useSellFlow } from '../../hooks/sell/useSellFlow';
 import { useSellFormContext } from '../../hooks/sell/useSellFormContext';
+import { useSellSelectQuote } from '../../hooks/sell/useSellSelectQuote';
 
 export type ConfirmationProps = {
     enteringAnimation?: AnimatedProps<any>['entering'];
@@ -21,7 +21,7 @@ export const SellConfirmation = ({ enteringAnimation }: ConfirmationProps) => {
         cancelLegalTermsConsent,
         giveLegalTermsConsent,
         selectQuote,
-    } = useSellFlow(form);
+    } = useSellSelectQuote(form);
 
     const [quote, sendAsset] = form.watch(['quote', 'sendAsset']);
 

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountPicker.tsx
@@ -3,18 +3,13 @@ import { useSelector } from 'react-redux';
 
 import type { BankAccount } from 'invity-api';
 
-import {
-    TradingRootState,
-    selectTradingAccountKeyByTradeType,
-    selectTradingTradeByOrderId,
-} from '@suite-common/trading';
+import { TradingRootState, selectTradingTradeByOrderId } from '@suite-common/trading';
 import { AnimatedCard, useBottomSheetModal } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { TradeInfoHeader } from '@suite-native/trading-atoms';
 
 import { SellBankAccountItem } from './SellBankAccountItem';
 import { SellBankAccountSheet } from './SellBankAccountSheet';
-import { useWatchTrade } from '../../../../hooks/general/useWatchTrade';
 
 type SellBankAccountPickerProps = {
     orderId: string | undefined;
@@ -53,15 +48,6 @@ export const SellBankAccountPicker = ({
         selectTradingTradeByOrderId(state, orderId),
     );
 
-    const accountKey = useSelector((state: TradingRootState) =>
-        selectTradingAccountKeyByTradeType(state, 'sell'),
-    );
-
-    useWatchTrade({
-        accountKey,
-        orderId,
-        isInProgress: true,
-    });
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
 
     if (

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountPicker.comp.test.tsx
@@ -5,11 +5,6 @@ import { bankAccounts, getWalletState } from '@suite-native/trading-fixtures';
 
 import { SellBankAccountPicker } from '../SellBankAccountPicker';
 
-// Mock the useWatchTrade hook since it's complex and not the focus of this test
-jest.mock('../../../../../hooks/general/useWatchTrade', () => ({
-    useWatchTrade: jest.fn(),
-}));
-
 // Mock the SellBankAccountSheet component to isolate the picker component
 jest.mock('../SellBankAccountSheet', () => ({
     SellBankAccountSheet: jest.fn().mockImplementation(() => <div>Bank Account Sheet</div>),

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewContinueButton.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewContinueButton.tsx
@@ -1,0 +1,80 @@
+import { memo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+import type { SellFiatTrade } from 'invity-api';
+
+import { parseCryptoId } from '@suite-common/trading';
+import { selectSendPrecomposedTx } from '@suite-common/wallet-core';
+import { TokenAddress } from '@suite-common/wallet-types';
+import { Button } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import {
+    type AppTabsParamList,
+    type StackToTabCompositeNavigationProp,
+    type TradingStackParamList,
+    TradingStackRoutes,
+} from '@suite-native/navigation';
+import { selectSellSelectedSendAccount } from '@suite-native/trading-state';
+
+export type SellPreviewContinueButtonProps = {
+    isDisabled: boolean;
+    quote?: SellFiatTrade;
+    onSignTransactionNavigation: () => void;
+};
+
+type NavigationProp = StackToTabCompositeNavigationProp<
+    TradingStackParamList,
+    TradingStackRoutes.TradingSellPreview,
+    AppTabsParamList
+>;
+
+const SELL_PREVIEW_CONTINUE_BUTTON_TEST_ID = '@trading/sell-preview/continue-button';
+
+export const SellPreviewContinueButton = memo(
+    ({ isDisabled, quote, onSignTransactionNavigation }: SellPreviewContinueButtonProps) => {
+        const navigation = useNavigation<NavigationProp>();
+
+        const precomposedTransaction = useSelector(selectSendPrecomposedTx);
+        const fromAccount = useSelector(selectSellSelectedSendAccount);
+
+        if (precomposedTransaction?.type !== 'final') {
+            return null;
+        }
+
+        const handleSignTransaction = () => {
+            if (!quote || !fromAccount) {
+                console.warn('quote or fromAccount is not defined', {
+                    hasQuote: !!quote,
+                    hasFromAccount: !!fromAccount,
+                });
+
+                return;
+            }
+
+            const tokenContract = quote.cryptoCurrency
+                ? (parseCryptoId(quote.cryptoCurrency)?.contractAddress as TokenAddress)
+                : undefined;
+
+            navigation.navigate({
+                name: TradingStackRoutes.TradingSellOutputsReview,
+                params: {
+                    accountKey: fromAccount.key,
+                    tokenContract,
+                    orderId: quote.orderId ?? '',
+                },
+            });
+            onSignTransactionNavigation();
+        };
+
+        return (
+            <Button
+                onPress={handleSignTransaction}
+                isDisabled={isDisabled}
+                testID={SELL_PREVIEW_CONTINUE_BUTTON_TEST_ID}
+            >
+                <Translation id="generic.buttons.continue" />
+            </Button>
+        );
+    },
+);

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.tsx
@@ -1,10 +1,10 @@
-import { memo, useState } from 'react';
+import { type ReactNode, memo, useState } from 'react';
 import Animated from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
-import type { BankAccount } from 'invity-api';
+import type { BankAccount, SellFiatTrade } from 'invity-api';
 
-import { selectTradingSellFormStep, selectTradingSellSelectedQuote } from '@suite-common/trading';
+import { selectTradingSellFormStep } from '@suite-common/trading';
 import { InlineAlertBox, VStack } from '@suite-native/atoms';
 
 import { SellBankAccountPicker } from './BankAccount/SellBankAccountPicker';
@@ -13,15 +13,16 @@ import { SellToFiatTradePreviewCard } from './SellToFiatTradePreviewCard';
 import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
 
 export type SellPreviewViewProps = {
-    txnErrorString: string | null;
+    quote: SellFiatTrade | undefined;
+    txnErrorString: ReactNode;
 };
 
-export const SellPreviewView = memo(({ txnErrorString }: SellPreviewViewProps) => {
+export const SellPreviewView = memo(({ quote, txnErrorString }: SellPreviewViewProps) => {
     const formStep = useSelector(selectTradingSellFormStep);
-    const selectedQuote = useSelector(selectTradingSellSelectedQuote);
-    const { fromStringValue, toStringValue } = useChangeStringsExtractor(selectedQuote);
+
+    const { fromStringValue, toStringValue } = useChangeStringsExtractor(quote);
     const [selectedBankAccountIban, setSelectedBankAccountIban] = useState(
-        selectedQuote?.bankAccounts?.[0].bankAccount,
+        quote?.bankAccounts?.[0].bankAccount,
     );
 
     const isTxnError = !!txnErrorString;
@@ -41,13 +42,13 @@ export const SellPreviewView = memo(({ txnErrorString }: SellPreviewViewProps) =
                 </Animated.View>
             )}
             <SellFromAccountTradePreviewCard
-                cryptoId={selectedQuote?.cryptoCurrency}
+                cryptoId={quote?.cryptoCurrency}
                 fromStringValue={fromStringValue}
             />
-            <SellToFiatTradePreviewCard quote={selectedQuote} toStringValue={toStringValue} />
+            <SellToFiatTradePreviewCard quote={quote} toStringValue={toStringValue} />
             {showBankAccountPicker && (
                 <SellBankAccountPicker
-                    orderId={selectedQuote?.orderId}
+                    orderId={quote?.orderId}
                     selectedBankAccountIban={selectedBankAccountIban}
                     onBankAccountSelect={handleBankAccountSelect}
                 />

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewContinueButton.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewContinueButton.comp.test.tsx
@@ -1,0 +1,137 @@
+import { GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { PreloadedState, renderWithStoreProviderAsync, userEvent } from '@suite-native/test-utils';
+import { getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
+
+import {
+    SellPreviewContinueButton,
+    SellPreviewContinueButtonProps,
+} from '../SellPreviewContinueButton';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => ({
+        navigate: mockNavigate,
+    }),
+}));
+
+describe('SellPreviewContinueButton', () => {
+    const renderSellPreviewContinueButton = (
+        props: Partial<SellPreviewContinueButtonProps> = {},
+        preloadedState: PreloadedState = {},
+    ) =>
+        renderWithStoreProviderAsync(
+            <SellPreviewContinueButton
+                isDisabled={false}
+                quote={sellQuotes[0]}
+                onSignTransactionNavigation={jest.fn()}
+                {...props}
+            />,
+            { preloadedState },
+        );
+
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    const getPreloadedState = (): PreloadedState => {
+        const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
+        preloadedState.wallet!.trading!.sell!.tradingAccountKey = 'eth-account-1';
+        preloadedState.wallet!.send!.precomposedTx = {
+            type: 'final',
+            totalSpent: '1100',
+            fee: '1000',
+            feePerByte: '100',
+            bytes: 1,
+        } as GeneralPrecomposedTransactionFinal;
+
+        return preloadedState;
+    };
+
+    it('should render nothing when precomposed transaction is not in final state', async () => {
+        const preloadedState = getPreloadedState();
+        preloadedState!.wallet!.send!.precomposedTx = {
+            type: 'composing',
+        } as any;
+        const { toJSON } = await renderSellPreviewContinueButton({}, preloadedState);
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render continue button', async () => {
+        const { getByText } = await renderSellPreviewContinueButton({}, getPreloadedState());
+
+        expect(getByText('Continue')).toBeOnTheScreen();
+    });
+
+    it('should render disabled button when isDisabled prop is specified', async () => {
+        const { getByText } = await renderSellPreviewContinueButton(
+            { isDisabled: true },
+            getPreloadedState(),
+        );
+
+        expect(getByText('Continue')).toBeDisabled();
+    });
+
+    it('should fire console.warn and do not navigate when quote is not specified', async () => {
+        const mockOnSignTransactionNavigation = jest.fn();
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const { getByText } = await renderSellPreviewContinueButton(
+            { quote: undefined, onSignTransactionNavigation: mockOnSignTransactionNavigation },
+            getPreloadedState(),
+        );
+
+        await userEvent.press(getByText('Continue'));
+
+        expect(consoleWarnSpy).toHaveBeenCalledWith('quote or fromAccount is not defined', {
+            hasQuote: false,
+            hasFromAccount: true,
+        });
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockOnSignTransactionNavigation).not.toHaveBeenCalled();
+    });
+
+    it('should fire console.warn and do not navigate when fromAccount is not found', async () => {
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const preloadedState = getPreloadedState();
+        preloadedState!.wallet!.trading!.sell!.tradingAccountKey = 'non-existing-key';
+        const mockOnSignTransactionNavigation = jest.fn();
+        const { getByText } = await renderSellPreviewContinueButton(
+            { onSignTransactionNavigation: mockOnSignTransactionNavigation },
+            preloadedState,
+        );
+
+        await userEvent.press(getByText('Continue'));
+
+        expect(consoleWarnSpy).toHaveBeenCalledWith('quote or fromAccount is not defined', {
+            hasQuote: true,
+            hasFromAccount: false,
+        });
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockOnSignTransactionNavigation).not.toHaveBeenCalled();
+    });
+
+    it('should navigate to TradingOutputsReview on continue press', async () => {
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const mockOnSignTransactionNavigation = jest.fn();
+        const { getByText } = await renderSellPreviewContinueButton(
+            { onSignTransactionNavigation: mockOnSignTransactionNavigation },
+            getPreloadedState(),
+        );
+
+        await userEvent.press(getByText('Continue'));
+
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith({
+            name: 'TradingOutputsReview',
+            params: {
+                tradingType: 'sell',
+                accountKey: 'eth-account-1',
+                orderId: sellQuotes[0].orderId,
+                tokenContract: undefined,
+            },
+        });
+        expect(mockOnSignTransactionNavigation).toHaveBeenCalledTimes(1);
+    });
+});

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewView.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewView.comp.test.tsx
@@ -34,9 +34,12 @@ describe('SellPreviewView', () => {
     ) => {
         const preloadedState = getPreloadedSellState(preloadedStateOverrides ?? {});
 
-        return renderWithStoreProviderAsync(<SellPreviewView txnErrorString={null} {...props} />, {
-            preloadedState,
-        });
+        return renderWithStoreProviderAsync(
+            <SellPreviewView quote={sellQuotes[1]} txnErrorString={null} {...props} />,
+            {
+                preloadedState,
+            },
+        );
     };
 
     it('should render all sections except alert', async () => {
@@ -80,5 +83,16 @@ describe('SellPreviewView', () => {
         );
 
         expect(getAllByTestId(BANK_ACCOUNT_ITEM_TEST_ID).length).toBeGreaterThan(0);
+    });
+
+    it('should use quote prop instead of selector', async () => {
+        const differentQuote = sellQuotes[0];
+        const { getByText } = await renderSellPreviewView({
+            quote: differentQuote,
+        });
+
+        // Verify component renders with the passed quote
+        expect(getByText('From')).toBeOnTheScreen();
+        expect(getByText('To')).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/sell/SellPreview/index.ts
+++ b/suite-native/module-trading/src/components/sell/SellPreview/index.ts
@@ -3,3 +3,4 @@ export { SellPreviewView } from './SellPreviewView';
 export { SellFromAccountTradePreviewCard } from './SellFromAccountTradePreviewCard';
 export { SellToFiatTradePreviewCard } from './SellToFiatTradePreviewCard';
 export { SellBankAccountPicker } from './BankAccount/SellBankAccountPicker';
+export { SellPreviewContinueButton } from './SellPreviewContinueButton';

--- a/suite-native/module-trading/src/components/sell/__tests__/SellConfirmation.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellConfirmation.comp.test.tsx
@@ -3,18 +3,31 @@ import { getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixt
 
 import { SellConfirmation } from '../SellConfirmation';
 
-jest.mock('../../../hooks/sell/useSellFlow', () => ({
-    useSellFlow: jest.fn(),
+jest.mock('../../../hooks/sell/useSellSelectQuote', () => ({
+    useSellSelectQuote: jest.fn(),
 }));
 
 jest.mock('../../../hooks/sell/useSellFormContext', () => ({
     useSellFormContext: () => ({
-        watch: () => [{ exchange: 'test-provider' }, { symbol: 'btc' }],
+        watch: (fields: any) => {
+            if (Array.isArray(fields)) {
+                return fields.map((field: string) => {
+                    if (field === 'quote') return { exchange: 'test-provider' };
+
+                    if (field === 'sendAsset') return { symbol: 'btc' };
+
+                    return null;
+                });
+            }
+
+            return null;
+        },
     }),
 }));
 
 describe('SellConfirmation', () => {
-    const mockUseSellFlow = require('../../../hooks/sell/useSellFlow').useSellFlow;
+    const mockUseSellSelectQuote = require('../../../hooks/sell/useSellSelectQuote')
+        .useSellSelectQuote;
 
     const renderConfirmation = () =>
         renderWithStoreProviderAsync(<SellConfirmation />, {
@@ -22,12 +35,12 @@ describe('SellConfirmation', () => {
         });
 
     it('should render continue button when canProceed is true', async () => {
-        mockUseSellFlow.mockReturnValue({
+        mockUseSellSelectQuote.mockReturnValue({
             canProceed: true,
             selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
+            isLegalTermsConsentRequested: false,
+            giveLegalTermsConsent: jest.fn(),
+            cancelLegalTermsConsent: jest.fn(),
         });
 
         const { getByText } = await renderConfirmation();
@@ -36,12 +49,12 @@ describe('SellConfirmation', () => {
     });
 
     it('should not render continue button when canProceed is false', async () => {
-        mockUseSellFlow.mockReturnValue({
+        mockUseSellSelectQuote.mockReturnValue({
             canProceed: false,
             selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
+            isLegalTermsConsentRequested: false,
+            giveLegalTermsConsent: jest.fn(),
+            cancelLegalTermsConsent: jest.fn(),
         });
 
         const { queryByText } = await renderConfirmation();

--- a/suite-native/module-trading/src/components/sell/__tests__/SellConfirmation.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellConfirmation.comp.test.tsx
@@ -26,8 +26,8 @@ jest.mock('../../../hooks/sell/useSellFormContext', () => ({
 }));
 
 describe('SellConfirmation', () => {
-    const mockUseSellSelectQuote = require('../../../hooks/sell/useSellSelectQuote')
-        .useSellSelectQuote;
+    const mockUseSellSelectQuote =
+        require('../../../hooks/sell/useSellSelectQuote').useSellSelectQuote;
 
     const renderConfirmation = () =>
         renderWithStoreProviderAsync(<SellConfirmation />, {

--- a/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
@@ -122,6 +122,7 @@ export const useBuyFlow = (form: BuyFormType) => {
 
         rootNavigation.navigate(RootStackRoutes.TradingWebView, {
             closeCallbackUrl: returnUrl,
+            tradingType: 'buy',
             source,
             orderId: candidateQuote?.orderId,
         });

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
@@ -56,6 +56,7 @@ export const useExchangeFlow = () => {
 
             rootNavigation.navigate(RootStackRoutes.TradingWebView, {
                 closeCallbackUrl: returnUrl,
+                tradingType: 'exchange',
                 source,
                 orderId: trade?.orderId,
             });

--- a/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { ReactNode, useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { isFulfilled, isRejected } from '@reduxjs/toolkit';
@@ -21,6 +21,7 @@ import {
     AccountsRootState,
     FeesRootState,
     FormDraftRootState,
+    SerializedTx,
     WalletSettingsRootState,
     selectAccountByKey,
     selectConvertedNetworkFeeInfo,
@@ -61,12 +62,29 @@ export type UseTradingTransactionProps = {
     triggerAnalyticsTradeConfirmation?: () => void;
 };
 
+export type UseTradingTransactionReturnProps = {
+    txnErrorString: ReactNode;
+    composeRequest: (props: TradingTransactionComposeProps) => Promise<unknown>;
+    fetchFeesAndCompose: () => Promise<void>;
+    signAndSendTransaction: (props: TradingTransactionSignAndSendProps) => Promise<boolean>;
+    signAndPushSendFormTransaction: (
+        props: TradingSignAndPushSendFormTransactionProps,
+    ) => Promise<TradingFulfillValue>;
+    serializedTx: SerializedTx | undefined;
+    resolveTransactionSendConsent: (approved: boolean) => void;
+    isTransactionSendConsentRequested: boolean;
+    waitForTransactionSendConsent: () => Promise<boolean>;
+    tokenDecimals: number | null;
+    shouldSendInSats: boolean;
+    isSlip24Active: boolean;
+};
+
 export const useTradingTransaction = ({
     tradeType,
     returnUrl,
     processResponseData,
     triggerAnalyticsTradeConfirmation,
-}: UseTradingTransactionProps) => {
+}: UseTradingTransactionProps): UseTradingTransactionReturnProps => {
     const dispatch = useDispatch();
 
     const sendAccountKey = useSelector((state: TradingRootState) =>
@@ -298,7 +316,14 @@ export const useTradingTransaction = ({
                 feeLimit: feeLimitDraft,
             });
         }
-    }, [selectedFee, composeRequest, feePerUnitDraft, feeLimitDraft, networkFeeInfo]);
+    }, [
+        selectedFee,
+        composeRequest,
+        feePerUnitDraft,
+        feeLimitDraft,
+        networkFeeInfo,
+        selectedQuote,
+    ]);
 
     return {
         txnErrorString,

--- a/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewScreenControls.hook.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewScreenControls.hook.test.ts
@@ -12,11 +12,7 @@ import { transactionManagementActions } from '@suite-native/transaction-manageme
 import { TradingExchangeSignAndSendTransactionProps } from '../../exchange/useExchangeFlow';
 import { useTradingOutputsReviewScreenControls } from '../useTradingOutputsReviewScreenControls';
 
-const mockUseExchangeFlow = {
-    signAndSendTransaction: jest.fn(() => Promise.resolve(true)),
-    isTransactionSendConsentRequested: false,
-    resolveTransactionSendConsent: jest.fn(),
-};
+const mockSignAndSendTransaction = jest.fn(() => Promise.resolve(true));
 
 const mockUseConfirmOnTrezorController = {
     confirmOnTrezorRef: { current: null },
@@ -27,10 +23,6 @@ const mockPopToTop = jest.fn();
 const mockPop = jest.fn();
 const mockUseOutputsReviewBackInterceptor = jest.fn();
 const mockShowAlert = jest.fn();
-
-jest.mock('../../exchange/useExchangeFlow', () => ({
-    useExchangeFlow: () => mockUseExchangeFlow,
-}));
 
 jest.mock('@suite-native/device', () => ({
     ...jest.requireActual('@suite-native/device'),
@@ -63,7 +55,12 @@ describe('useTradingOutputsReviewScreenControls', () => {
 
     const renderUseTradingOutputsReviewScreenControls = () =>
         renderHookWithStoreProviderAsync(
-            () => useTradingOutputsReviewScreenControls('orderId', 'btc-account-1'),
+            () =>
+                useTradingOutputsReviewScreenControls({
+                    orderId: 'orderId',
+                    accountKey: 'btc-account-1',
+                    signAndSendTransaction: mockSignAndSendTransaction,
+                }),
             {
                 store,
             },
@@ -72,17 +69,6 @@ describe('useTradingOutputsReviewScreenControls', () => {
     beforeEach(async () => {
         jest.clearAllMocks();
         store = (await initStore({ wallet: getWalletState({ tradeType: 'exchange' }) })).store;
-    });
-
-    it('should return values from useExchangeFlow', async () => {
-        const { result } = await renderUseTradingOutputsReviewScreenControls();
-
-        expect(result.current.isConsentRequested).toBe(
-            mockUseExchangeFlow.isTransactionSendConsentRequested,
-        );
-        expect(result.current.resolveConsent).toBe(
-            mockUseExchangeFlow.resolveTransactionSendConsent,
-        );
     });
 
     it('should return confirmOnTrezorRef', async () => {
@@ -97,7 +83,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
         it('should call signAndSendTransaction on mount', async () => {
             await renderUseTradingOutputsReviewScreenControls();
 
-            expect(mockUseExchangeFlow.signAndSendTransaction).toHaveBeenCalledTimes(1);
+            expect(mockSignAndSendTransaction).toHaveBeenCalledTimes(1);
         });
 
         it('should not call closeSheet', async () => {
@@ -109,7 +95,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
         it('should navigate to trade detail', async () => {
             await renderUseTradingOutputsReviewScreenControls();
 
-            expect(mockUseExchangeFlow.signAndSendTransaction).toHaveBeenCalledWith(
+            expect(mockSignAndSendTransaction).toHaveBeenCalledWith(
                 expect.objectContaining({
                     nextStep: expect.any(Function),
                 }),
@@ -118,7 +104,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
             // call the nextStep callback to simulate thunk behavior
             act(() => {
                 const { nextStep } = (
-                    mockUseExchangeFlow.signAndSendTransaction.mock.lastCall as unknown as [
+                    mockSignAndSendTransaction.mock.lastCall as unknown as [
                         TradingExchangeSignAndSendTransactionProps,
                     ]
                 )[0];
@@ -138,7 +124,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
         it('should display alert on thunk error', async () => {
             await renderUseTradingOutputsReviewScreenControls();
 
-            expect(mockUseExchangeFlow.signAndSendTransaction).toHaveBeenCalledWith(
+            expect(mockSignAndSendTransaction).toHaveBeenCalledWith(
                 expect.objectContaining({
                     nextStep: expect.any(Function),
                 }),
@@ -147,7 +133,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
             // call the onError callback to simulate thunk behavior
             act(() => {
                 const { onError } = (
-                    mockUseExchangeFlow.signAndSendTransaction.mock.lastCall as unknown as [
+                    mockSignAndSendTransaction.mock.lastCall as unknown as [
                         TradingExchangeSignAndSendTransactionProps,
                     ]
                 )[0];
@@ -168,7 +154,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             await renderUseTradingOutputsReviewScreenControls();
 
-            expect(mockUseExchangeFlow.signAndSendTransaction).toHaveBeenCalledWith(
+            expect(mockSignAndSendTransaction).toHaveBeenCalledWith(
                 expect.objectContaining({
                     nextStep: expect.any(Function),
                 }),
@@ -177,7 +163,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
             // call the onError callback to simulate thunk behavior
             act(() => {
                 const { onError } = (
-                    mockUseExchangeFlow.signAndSendTransaction.mock.lastCall as unknown as [
+                    mockSignAndSendTransaction.mock.lastCall as unknown as [
                         TradingExchangeSignAndSendTransactionProps,
                     ]
                 )[0];
@@ -236,7 +222,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
         it('should not call signAndSendTransaction', async () => {
             await renderUseTradingOutputsReviewScreenControls();
 
-            expect(mockUseExchangeFlow.signAndSendTransaction).not.toHaveBeenCalled();
+            expect(mockSignAndSendTransaction).not.toHaveBeenCalled();
         });
 
         it('should closeSheet', async () => {

--- a/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.ts
@@ -21,28 +21,34 @@ import {
 
 import { useTradingOutputsReviewErrorAlert } from './useTradingOutputsReviewErrorAlert';
 import { useExchangeAnalyticReportCallback } from '../exchange/useExchangeAnalyticReportCallback';
-import {
-    TradingExchangeSignAndSendTransactionProps,
-    useExchangeFlow,
-} from '../exchange/useExchangeFlow';
+import { TradingExchangeSignAndSendTransactionProps } from '../exchange/useExchangeFlow';
+import { UseTradingTransactionReturnProps } from '../general/useTradingTransaction';
 
 type TradingOutputsReviewScreenNavigationProp = StackToTabCompositeNavigationProp<
     TradingStackParamList,
-    TradingStackRoutes.TradingOutputsReview,
+    TradingStackRoutes.TradingSellOutputsReview | TradingStackRoutes.TradingExchangeOutputsReview,
     AppTabsParamList
 >;
 
-export const useTradingOutputsReviewScreenControls = (orderId: string, accountKey: AccountKey) => {
+export type UseTradingOutputsReviewScreenControlsProps = Pick<
+    UseTradingTransactionReturnProps,
+    'signAndSendTransaction'
+> & {
+    orderId: string;
+    accountKey: AccountKey;
+};
+
+export const useTradingOutputsReviewScreenControls = ({
+    orderId,
+    accountKey,
+    signAndSendTransaction,
+}: UseTradingOutputsReviewScreenControlsProps) => {
     const allowAlertRef = useRef(true);
     const signingExecutedRef = useRef(false);
 
     const navigation = useNavigation<TradingOutputsReviewScreenNavigationProp>();
     const dispatch = useDispatch();
-    const {
-        signAndSendTransaction,
-        isTransactionSendConsentRequested: isConsentRequested,
-        resolveTransactionSendConsent: resolveConsent,
-    } = useExchangeFlow();
+
     const { confirmOnTrezorRef, closeSheet } = useConfirmOnTrezorController();
     const showOutputsReviewErrorAlert = useTradingOutputsReviewErrorAlert(accountKey);
 
@@ -108,8 +114,6 @@ export const useTradingOutputsReviewScreenControls = (orderId: string, accountKe
 
     return {
         isTransactionAlreadySigned,
-        isConsentRequested,
-        resolveConsent,
         confirmOnTrezorRef,
     };
 };

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
@@ -1,3 +1,5 @@
+import type { SellFiatTrade, SellFiatTradeResponse } from 'invity-api';
+
 import { tradingSellActions } from '@suite-common/trading';
 import {
     TestStore,
@@ -5,280 +7,359 @@ import {
     initStore,
     renderHookWithStoreProviderAsync,
 } from '@suite-native/test-utils';
-import { getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
-import { SellFormType } from '@suite-native/trading-types';
+import { bankAccounts, getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 
 import { useSellFlow } from '../useSellFlow';
-import { useSellForm } from '../useSellForm';
 
-// Store the thunk arguments for testing
-let capturedThunkArgs: any = null;
+// Store captured arguments for testing side effects (processResponseData callback)
+let capturedHandleTradeArgs:
+    | Parameters<typeof import('@suite-common/trading').sellThunks.handleTradeThunk>[0]
+    | null = null;
 
 jest.mock('@suite-common/trading', () => ({
     ...jest.requireActual('@suite-common/trading'),
     sellThunks: {
-        selectQuoteThunk: (args: any) => {
-            capturedThunkArgs = args;
+        handleTradeThunk: (args: unknown) => {
+            capturedHandleTradeArgs = args as typeof capturedHandleTradeArgs;
 
-            return () => args;
+            return {
+                type: 'handleTradeThunkMock',
+                payload: args,
+            };
         },
-        handleTradeThunk: (args: unknown) => () => args,
-        confirmTradeThunk: (args: unknown) => () => args,
+        confirmTradeThunk: (args: unknown) => ({
+            type: 'confirmTradeThunkMock',
+            payload: args,
+        }),
     },
+    sellUtils: {
+        needToRegisterOrVerifyBankAccount: jest.fn(
+            ({ quote }) =>
+                // Mock logic: return true if exchange is 'banxa-sell' and quote has no quoteId
+                quote?.exchange === 'banxa-sell' && !quote?.quoteId,
+        ),
+    },
+}));
+
+const mockNavigation = {
+    navigate: jest.fn(),
+};
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => mockNavigation,
 }));
 
 describe('useSellFlow', () => {
     let store: TestStore;
-    let sellForm: SellFormType;
-
-    const renderSellForm = () => renderHookWithStoreProviderAsync(() => useSellForm(), { store });
 
     const renderUseSellFlow = () =>
-        renderHookWithStoreProviderAsync(() => useSellFlow(sellForm), { store });
+        renderHookWithStoreProviderAsync(() => useSellFlow(), { store });
 
     beforeEach(async () => {
         store = (await initStore({ wallet: getWalletState({ tradeType: 'sell' }) })).store;
 
-        const { result } = await renderSellForm();
-        sellForm = result.current;
-        capturedThunkArgs = null; // Reset before each test
+        capturedHandleTradeArgs = null;
+        mockNavigation.navigate.mockClear();
+        jest.clearAllMocks();
     });
 
-    describe('canProceed', () => {
-        it('should be false when no quote is selected in form', async () => {
-            const { result } = await renderUseSellFlow();
-
-            expect(result.current.canProceed).toEqual(false);
-        });
-
-        it('should be false when quotes are being fetched', async () => {
-            act(() => {
-                sellForm.setValue('quote', sellQuotes[0]);
-                store.dispatch(tradingSellActions.setIsLoading(true));
-            });
-
-            const { result } = await renderUseSellFlow();
-
-            expect(result.current.canProceed).toEqual(false);
-        });
-
-        it('should be true when quote is selected', async () => {
-            act(() => {
-                sellForm.setValue('quote', sellQuotes[0]);
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
-            });
-
-            const { result } = await renderUseSellFlow();
-
-            expect(result.current.canProceed).toEqual(true);
-        });
-    });
-
-    describe('selectQuote', () => {
-        it('should do nothing when no quote is selected', async () => {
-            const { result } = await renderUseSellFlow();
-
-            act(() => {
-                result.current.selectQuote();
-            });
-
-            expect(result.current.isLegalTermsConsentRequested).toEqual(false);
-        });
-
-        it('should request consent', async () => {
-            act(() => {
-                sellForm.setValue('quote', sellQuotes[0]);
-                store.dispatch(
-                    tradingSellActions.saveQuoteRequest({
-                        cryptoCurrency: sellQuotes[0].cryptoCurrency!,
-                        amountInCrypto: sellQuotes[0].amountInCrypto!,
-                        fiatCurrency: sellQuotes[0].fiatCurrency!,
-                    }),
-                );
-            });
-            const { result } = await renderUseSellFlow();
-
-            act(() => {
-                result.current.selectQuote();
-            });
-
-            const { userConsent } = capturedThunkArgs;
-
-            act(() => {
-                userConsent({
-                    provider: 'Banxa',
-                    cryptoCurrency: sellQuotes[0].cryptoCurrency,
-                });
-            });
-
-            expect(result.current.isLegalTermsConsentRequested).toEqual(true);
-        });
-    });
-
-    describe('giveConsent', () => {
-        beforeEach(() => {
-            act(() => {
-                sellForm.setValue('quote', sellQuotes[0]);
-                store.dispatch(
-                    tradingSellActions.saveQuoteRequest({
-                        cryptoCurrency: sellQuotes[0].cryptoCurrency!,
-                        amountInCrypto: sellQuotes[0].amountInCrypto!,
-                        fiatCurrency: sellQuotes[0].fiatCurrency!,
-                    }),
-                );
-            });
-        });
-
-        it('should resolve consent', async () => {
-            const { result } = await renderUseSellFlow();
-
-            act(() => {
-                result.current.selectQuote();
-            });
-
-            const { userConsent } = capturedThunkArgs;
-
-            act(() => {
-                userConsent({
-                    provider: 'Banxa',
-                    cryptoCurrency: sellQuotes[0].cryptoCurrency,
-                });
-            });
-
-            expect(result.current.isLegalTermsConsentRequested).toEqual(true);
-
-            act(() => {
-                result.current.giveLegalTermsConsent();
-            });
-
-            expect(result.current.isLegalTermsConsentRequested).toEqual(false);
-        });
-    });
-
-    describe('cancelConsent', () => {
-        beforeEach(() => {
-            act(() => {
-                sellForm.setValue('quote', sellQuotes[0]);
-                store.dispatch(
-                    tradingSellActions.saveQuoteRequest({
-                        cryptoCurrency: sellQuotes[0].cryptoCurrency!,
-                        amountInCrypto: sellQuotes[0].amountInCrypto!,
-                        fiatCurrency: sellQuotes[0].fiatCurrency!,
-                    }),
-                );
-            });
-        });
-
-        it('should resolve consent (with false value)', async () => {
-            const { result } = await renderUseSellFlow();
-
-            act(() => {
-                result.current.selectQuote();
-            });
-
-            const { userConsent } = capturedThunkArgs;
-
-            act(() => {
-                userConsent({
-                    provider: 'Banxa',
-                    cryptoCurrency: sellQuotes[0].cryptoCurrency,
-                });
-            });
-
-            expect(result.current.isLegalTermsConsentRequested).toEqual(true);
-
-            act(() => {
-                result.current.cancelLegalTermsConsent();
-            });
-
-            expect(result.current.isLegalTermsConsentRequested).toEqual(false);
-        });
-
-        it('should reset consent when quote provider changes', async () => {
-            const { result, rerender } = await renderUseSellFlow();
-
-            act(() => {
-                result.current.selectQuote();
-            });
-
-            const { userConsent } = capturedThunkArgs;
-
-            act(() => {
-                userConsent({
-                    provider: 'Banxa',
-                    cryptoCurrency: sellQuotes[0].cryptoCurrency,
-                });
-            });
-
-            expect(result.current.isLegalTermsConsentRequested).toEqual(true);
-
-            // Change quote to one with different provider
-            act(() => {
-                sellForm.setValue('quote', { ...sellQuotes[0], exchange: 'invity-sell' });
-            });
-            rerender({});
-
-            expect(result.current.isLegalTermsConsentRequested).toEqual(false);
-        });
-    });
-
-    describe('Form Step Logic', () => {
-        it('should set form step to BANK_ACCOUNT when provider flow is BANK_ACCOUNT', async () => {
+    describe('doSellTrade', () => {
+        it('should dispatch handleTradeThunk with correct parameters', async () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const trade = sellQuotes[0];
 
+            // Set up required state
             act(() => {
-                sellForm.setValue('quote', sellQuotes[1]); // banxa-sell provider with BANK_ACCOUNT flow
-                store.dispatch(
-                    tradingSellActions.saveQuoteRequest({
-                        cryptoCurrency: sellQuotes[1].cryptoCurrency!,
-                        amountInCrypto: sellQuotes[1].amountInCrypto!,
-                        fiatCurrency: sellQuotes[1].fiatCurrency!,
-                    }),
-                );
+                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
             const { result } = await renderUseSellFlow();
 
-            act(() => {
-                result.current.selectQuote();
+            await act(async () => {
+                await result.current.doSellTrade(trade);
             });
 
-            // Check that setFormStep was called with BANK_ACCOUNT
-            expect(dispatchSpy).toHaveBeenCalledWith(
-                tradingSellActions.setFormStep('BANK_ACCOUNT'),
+            // Verify dispatch was called with the thunk
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: 'handleTradeThunkMock',
+                payload: expect.objectContaining({
+                    trade,
+                    account: expect.objectContaining({
+                        key: 'btc-account-1',
+                    }),
+                    returnUrl: expect.stringContaining('trezorsuite://trading'),
+                    processResponseData: expect.any(Function),
+                }),
+            });
+        });
+
+        it('should not dispatch thunk if sendAccount is missing', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const trade = sellQuotes[0];
+
+            // Set up quote but not account
+            act(() => {
+                store.dispatch(tradingSellActions.saveSelectedQuote(trade));
+                // Explicitly clear trading account key
+                store.dispatch(tradingSellActions.setTradingAccountKey(undefined));
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            await act(async () => {
+                await result.current.doSellTrade(trade);
+            });
+
+            // Verify dispatch was NOT called with handleTradeThunk
+            expect(dispatchSpy).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'handleTradeThunkMock',
+                }),
             );
         });
 
-        it('should set form step to SEND_TRANSACTION when provider flow is not BANK_ACCOUNT', async () => {
+        it('should dispatch thunk even when selectedQuote is not set (uses passed trade)', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const trade = sellQuotes[0];
+
+            // Set up account but not selectedQuote
+            act(() => {
+                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.saveSelectedQuote(undefined));
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            await act(async () => {
+                await result.current.doSellTrade(trade);
+            });
+
+            // Should still work because trade is passed as parameter
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: 'handleTradeThunkMock',
+                payload: expect.objectContaining({
+                    trade,
+                }),
+            });
+        });
+    });
+
+    describe('confirmTrade', () => {
+        it('should dispatch confirmTradeThunk with bank account and correct parameters', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const trade = sellQuotes[0];
+            const bankAccount = bankAccounts[0];
+
+            // Set up required state
+            act(() => {
+                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.saveSelectedQuote(trade));
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            await act(async () => {
+                await result.current.confirmTrade(bankAccount);
+            });
+
+            // Verify dispatch was called
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: 'confirmTradeThunkMock',
+                payload: expect.objectContaining({
+                    bankAccount,
+                    account: expect.objectContaining({
+                        key: 'btc-account-1',
+                    }),
+                    returnUrl: expect.stringContaining('trezorsuite://trading'),
+                    triggerAnalyticsTradeConfirmation: expect.any(Function),
+                    processResponseData: expect.any(Function),
+                }),
+            });
+        });
+
+        it('should not dispatch thunk if selectedQuote is missing', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const bankAccount = bankAccounts[0];
+
+            // Set up account but not quote
+            act(() => {
+                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.saveSelectedQuote(undefined));
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            await act(async () => {
+                await result.current.confirmTrade(bankAccount);
+            });
+
+            expect(dispatchSpy).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'confirmTradeThunkMock',
+                }),
+            );
+        });
+
+        it('should not dispatch thunk if sendAccount is missing', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const trade = sellQuotes[0];
+            const bankAccount = bankAccounts[0];
+
+            // Set up quote but not account
+            act(() => {
+                store.dispatch(tradingSellActions.saveSelectedQuote(trade));
+                store.dispatch(tradingSellActions.setTradingAccountKey(undefined));
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            await act(async () => {
+                await result.current.confirmTrade(bankAccount);
+            });
+
+            expect(dispatchSpy).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'confirmTradeThunkMock',
+                }),
+            );
+        });
+    });
+
+    describe('doBankAccountVerificationCheck', () => {
+        it('should call doSellTrade when needToRegisterOrVerifyBankAccount returns true', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const trade = { ...sellQuotes[0], exchange: 'banxa-sell', quoteId: undefined };
+
+            act(() => {
+                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.saveSelectedQuote(trade));
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            await act(async () => {
+                await result.current.doBankAccountVerificationCheck();
+            });
+
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: 'handleTradeThunkMock',
+                payload: expect.objectContaining({
+                    trade,
+                }),
+            });
+        });
+
+        it('should call doSellTrade when quoteId is empty', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const trade = { ...sellQuotes[0], quoteId: '' };
+
+            act(() => {
+                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.saveSelectedQuote(trade));
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            await act(async () => {
+                await result.current.doBankAccountVerificationCheck();
+            });
+
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: 'handleTradeThunkMock',
+                payload: expect.objectContaining({
+                    trade,
+                }),
+            });
+        });
+
+        it('should not call doSellTrade when verification is not needed', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            // Use a trade with a quoteId to avoid triggering doSellTrade
+            const trade = { ...sellQuotes[0], quoteId: 'test-quote-id' };
+
+            act(() => {
+                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.saveSelectedQuote(trade));
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            await act(async () => {
+                await result.current.doBankAccountVerificationCheck();
+            });
+
+            expect(dispatchSpy).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'handleTradeThunkMock',
+                }),
+            );
+        });
+
+        it('should not call doSellTrade if selectedQuote is missing', async () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-            // Create a quote with a provider that doesn't have BANK_ACCOUNT flow
-            const customQuote = {
-                ...sellQuotes[0],
-                exchange: 'custom-provider', // This provider won't be in providerInfos
+            act(() => {
+                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.saveSelectedQuote(undefined));
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            await act(async () => {
+                await result.current.doBankAccountVerificationCheck();
+            });
+
+            expect(dispatchSpy).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'handleTradeThunkMock',
+                }),
+            );
+        });
+    });
+
+    describe('handleWebview', () => {
+        it('should navigate to webview when processResponseData is called with form data', async () => {
+            const trade = sellQuotes[0];
+
+            act(() => {
+                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.saveSelectedQuote(trade));
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            await act(async () => {
+                await result.current.doSellTrade(trade);
+            });
+
+            const mockResponse: SellFiatTradeResponse = {
+                tradeForm: {
+                    form: {
+                        formMethod: 'GET',
+                        formAction: 'https://example.com/form',
+                        fields: {},
+                    },
+                },
+                trade: {
+                    orderId: 'order_id_0',
+                    exchange: 'banxa-sell',
+                } as SellFiatTrade,
             };
 
+            // Call processResponseData - capturedHandleTradeArgs is set during mock
+            expect(capturedHandleTradeArgs).toBeTruthy();
             act(() => {
-                sellForm.setValue('quote', customQuote);
-                store.dispatch(
-                    tradingSellActions.saveQuoteRequest({
-                        cryptoCurrency: customQuote.cryptoCurrency!,
-                        amountInCrypto: customQuote.amountInCrypto!,
-                        fiatCurrency: customQuote.fiatCurrency!,
-                    }),
-                );
+                capturedHandleTradeArgs!.processResponseData(mockResponse);
             });
 
-            const { result } = await renderUseSellFlow();
-
-            act(() => {
-                result.current.selectQuote();
+            expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingWebView', {
+                closeCallbackUrl: expect.stringContaining('trezorsuite://trading'),
+                source: { uri: 'https://example.com/form' },
+                orderId: 'order_id_0',
+                tradingType: 'sell',
             });
-
-            // Check that setFormStep was called with SEND_TRANSACTION
-            expect(dispatchSpy).toHaveBeenCalledWith(
-                tradingSellActions.setFormStep('SEND_TRANSACTION'),
-            );
         });
     });
 });

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
@@ -50,6 +50,18 @@ jest.mock('@react-navigation/native', () => ({
     useNavigation: () => mockNavigation,
 }));
 
+jest.mock('../../general/useTradingTransaction', () => ({
+    useTradingTransaction: () => ({
+        txnErrorString: null,
+        composeRequest: jest.fn(),
+        fetchFeesAndCompose: jest.fn(),
+        signAndSendTransaction: jest.fn(),
+        serializedTx: undefined,
+        resolveTransactionSendConsent: jest.fn(),
+        isTransactionSendConsentRequested: false,
+    }),
+}));
+
 describe('useSellFlow', () => {
     let store: TestStore;
 

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellSelectQuote.test.ts
@@ -1,0 +1,221 @@
+import { tradingSellActions } from '@suite-common/trading';
+import {
+    TestStore,
+    act,
+    initStore,
+    renderHookWithStoreProviderAsync,
+} from '@suite-native/test-utils';
+import { getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
+import { SellFormType } from '@suite-native/trading-types';
+
+import { useSellForm } from '../useSellForm';
+import { useSellSelectQuote } from '../useSellSelectQuote';
+// Store the thunk arguments for testing
+let capturedThunkArgs: any = null;
+
+jest.mock('@suite-common/trading', () => ({
+    ...jest.requireActual('@suite-common/trading'),
+    sellThunks: {
+        selectQuoteThunk: (args: any) => {
+            capturedThunkArgs = args;
+
+            return () => args;
+        },
+    },
+}));
+
+describe('useSellSelectQuote', () => {
+    let store: TestStore;
+    let sellForm: SellFormType;
+
+    const renderSellForm = () => renderHookWithStoreProviderAsync(() => useSellForm(), { store });
+
+    const renderUseSellSelectQuote = () =>
+        renderHookWithStoreProviderAsync(() => useSellSelectQuote(sellForm), { store });
+
+    beforeEach(async () => {
+        store = (await initStore({ wallet: getWalletState({ tradeType: 'sell' }) })).store;
+
+        const { result } = await renderSellForm();
+        sellForm = result.current;
+        capturedThunkArgs = null; // Reset before each test
+    });
+
+    describe('canProceed', () => {
+        it('should be false when no quote is selected in form', async () => {
+            const { result } = await renderUseSellSelectQuote();
+
+            expect(result.current.canProceed).toEqual(false);
+        });
+
+        it('should be false when quotes are being fetched', async () => {
+            act(() => {
+                sellForm.setValue('quote', sellQuotes[0]);
+                store.dispatch(tradingSellActions.setIsLoading(true));
+            });
+
+            const { result } = await renderUseSellSelectQuote();
+
+            expect(result.current.canProceed).toEqual(false);
+        });
+
+        it('should be true when quote is selected', async () => {
+            act(() => {
+                sellForm.setValue('quote', sellQuotes[0]);
+                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+            });
+
+            const { result } = await renderUseSellSelectQuote();
+
+            expect(result.current.canProceed).toEqual(true);
+        });
+    });
+
+    describe('selectQuote', () => {
+        it('should do nothing when no quote is selected', async () => {
+            const { result } = await renderUseSellSelectQuote();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            expect(result.current.isLegalTermsConsentRequested).toEqual(false);
+        });
+
+        it('should request consent', async () => {
+            act(() => {
+                sellForm.setValue('quote', sellQuotes[0]);
+                store.dispatch(
+                    tradingSellActions.saveQuoteRequest({
+                        cryptoCurrency: sellQuotes[0].cryptoCurrency!,
+                        amountInCrypto: sellQuotes[0].amountInCrypto!,
+                        fiatCurrency: sellQuotes[0].fiatCurrency!,
+                    }),
+                );
+            });
+            const { result } = await renderUseSellSelectQuote();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            const { userConsent } = capturedThunkArgs;
+
+            act(() => {
+                userConsent({
+                    provider: 'Banxa',
+                    cryptoCurrency: sellQuotes[0].cryptoCurrency,
+                });
+            });
+
+            expect(result.current.isLegalTermsConsentRequested).toEqual(true);
+        });
+    });
+
+    describe('giveConsent', () => {
+        beforeEach(() => {
+            act(() => {
+                sellForm.setValue('quote', sellQuotes[0]);
+                store.dispatch(
+                    tradingSellActions.saveQuoteRequest({
+                        cryptoCurrency: sellQuotes[0].cryptoCurrency!,
+                        amountInCrypto: sellQuotes[0].amountInCrypto!,
+                        fiatCurrency: sellQuotes[0].fiatCurrency!,
+                    }),
+                );
+            });
+        });
+
+        it('should resolve consent', async () => {
+            const { result } = await renderUseSellSelectQuote();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            const { userConsent } = capturedThunkArgs;
+
+            act(() => {
+                userConsent({
+                    provider: 'Banxa',
+                    cryptoCurrency: sellQuotes[0].cryptoCurrency,
+                });
+            });
+
+            expect(result.current.isLegalTermsConsentRequested).toEqual(true);
+
+            act(() => {
+                result.current.giveLegalTermsConsent();
+            });
+
+            expect(result.current.isLegalTermsConsentRequested).toEqual(false);
+        });
+    });
+
+    describe('cancelConsent', () => {
+        beforeEach(() => {
+            act(() => {
+                sellForm.setValue('quote', sellQuotes[0]);
+                store.dispatch(
+                    tradingSellActions.saveQuoteRequest({
+                        cryptoCurrency: sellQuotes[0].cryptoCurrency!,
+                        amountInCrypto: sellQuotes[0].amountInCrypto!,
+                        fiatCurrency: sellQuotes[0].fiatCurrency!,
+                    }),
+                );
+            });
+        });
+
+        it('should resolve consent (with false value)', async () => {
+            const { result } = await renderUseSellSelectQuote();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            const { userConsent } = capturedThunkArgs;
+
+            act(() => {
+                userConsent({
+                    provider: 'Banxa',
+                    cryptoCurrency: sellQuotes[0].cryptoCurrency,
+                });
+            });
+
+            expect(result.current.isLegalTermsConsentRequested).toEqual(true);
+
+            act(() => {
+                result.current.cancelLegalTermsConsent();
+            });
+
+            expect(result.current.isLegalTermsConsentRequested).toEqual(false);
+        });
+
+        it('should reset consent when quote provider changes', async () => {
+            const { result, rerender } = await renderUseSellSelectQuote();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            const { userConsent } = capturedThunkArgs;
+
+            act(() => {
+                userConsent({
+                    provider: 'Banxa',
+                    cryptoCurrency: sellQuotes[0].cryptoCurrency,
+                });
+            });
+
+            expect(result.current.isLegalTermsConsentRequested).toEqual(true);
+
+            // Change quote to one with different provider
+            act(() => {
+                sellForm.setValue('quote', { ...sellQuotes[0], exchange: 'invity-sell' });
+            });
+            rerender({});
+
+            expect(result.current.isLegalTermsConsentRequested).toEqual(false);
+        });
+    });
+});

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellSelectQuote.test.ts
@@ -110,6 +110,55 @@ describe('useSellSelectQuote', () => {
 
             expect(result.current.isLegalTermsConsentRequested).toEqual(true);
         });
+
+        it('should clear form quote data when quote is selected and consent is given', async () => {
+            act(() => {
+                sellForm.setValue('quote', sellQuotes[0]);
+                sellForm.setValue('cryptoStringAmount', '0.001');
+                sellForm.setValue('fiatStringAmount', '100');
+                sellForm.setValue('generalAlert', 'test error message');
+                store.dispatch(
+                    tradingSellActions.saveQuoteRequest({
+                        cryptoCurrency: sellQuotes[0].cryptoCurrency!,
+                        amountInCrypto: sellQuotes[0].amountInCrypto!,
+                        fiatCurrency: sellQuotes[0].fiatCurrency!,
+                    }),
+                );
+            });
+
+            const { result } = await renderUseSellSelectQuote();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            const { userConsent, nextStep } = capturedThunkArgs;
+
+            act(() => {
+                userConsent({
+                    provider: 'Banxa',
+                    cryptoCurrency: sellQuotes[0].cryptoCurrency,
+                });
+            });
+
+            expect(result.current.isLegalTermsConsentRequested).toEqual(true);
+
+            // Give consent to proceed
+            act(() => {
+                result.current.giveLegalTermsConsent();
+            });
+
+            // Call nextStep which should clear the form data
+            act(() => {
+                nextStep();
+            });
+
+            // Verify form values are cleared
+            expect(sellForm.watch('quote')).toBeUndefined();
+            expect(sellForm.watch('cryptoStringAmount')).toBeUndefined();
+            expect(sellForm.watch('fiatStringAmount')).toBeUndefined();
+            expect(sellForm.watch('generalAlert')).toBeUndefined();
+        });
     });
 
     describe('giveConsent', () => {

--- a/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
@@ -18,14 +18,9 @@ import {
 import { selectSellSelectedSendAccount } from '@suite-native/trading-state';
 
 import { buildTradingUrl, getSourceForForm } from '../../utils/general/formUtils';
+import { useTradingTransaction } from '../general/useTradingTransaction';
 
-type SellFlowReturn = {
-    doSellTrade: (trade: SellFiatTrade) => Promise<void>;
-    confirmTrade: (bankAccount: BankAccount) => Promise<void>;
-    doBankAccountVerificationCheck: () => Promise<void>;
-};
-
-export const useSellFlow = (): SellFlowReturn => {
+export const useSellFlow = () => {
     const dispatch = useDispatch();
     const rootNavigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
@@ -85,6 +80,22 @@ export const useSellFlow = (): SellFlowReturn => {
         },
         [handleWebview, selectedQuote],
     );
+
+    const {
+        txnErrorString,
+        composeRequest,
+        fetchFeesAndCompose,
+        signAndSendTransaction,
+        serializedTx,
+        resolveTransactionSendConsent,
+        isTransactionSendConsentRequested,
+    } = useTradingTransaction({
+        tradeType: 'sell',
+        returnUrl: getCommonFunctions(selectedQuote)?.returnUrl,
+        processResponseData: getCommonFunctions(selectedQuote)?.processResponseData,
+        triggerAnalyticsTradeConfirmation:
+            getCommonFunctions(selectedQuote)?.triggerAnalyticsTradeConfirmation,
+    });
 
     const doSellTrade = useCallback(
         async (trade: SellFiatTrade) => {
@@ -163,6 +174,13 @@ export const useSellFlow = (): SellFlowReturn => {
     }, [selectedQuote, sellInfo, doSellTrade]);
 
     return {
+        txnErrorString,
+        composeRequest,
+        fetchFeesAndCompose,
+        signAndSendTransaction,
+        serializedTx,
+        resolveTransactionSendConsent,
+        isTransactionSendConsentRequested,
         doSellTrade,
         confirmTrade,
         doBankAccountVerificationCheck,

--- a/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
@@ -6,64 +6,34 @@ import type { BankAccount, FormResponse, SellFiatTrade, SellFiatTradeResponse } 
 
 import {
     selectTradingSellInfo,
-    selectTradingSellIsLoading,
     selectTradingSellSelectedQuote,
     sellThunks,
     sellUtils,
-    tradingSellActions,
 } from '@suite-common/trading';
 import {
     RootStackParamList,
     RootStackRoutes,
     StackNavigationProps,
-    StackToStackCompositeNavigationProps,
-    TradingStackParamList,
-    TradingStackRoutes,
 } from '@suite-native/navigation';
 import { selectSellSelectedSendAccount } from '@suite-native/trading-state';
-import { SellFormType } from '@suite-native/trading-types';
-import { useNullTimer } from '@trezor/react-utils';
 
 import { buildTradingUrl, getSourceForForm } from '../../utils/general/formUtils';
-import { useConsent } from '../general/useConsent';
-import { useConsentDenier } from '../general/useConsentDenier';
-
-type NavigationProps = StackToStackCompositeNavigationProps<
-    TradingStackParamList,
-    TradingStackRoutes.TradingSellPreview,
-    RootStackParamList
->;
 
 type SellFlowReturn = {
-    canProceed: boolean;
-    isLegalTermsConsentRequested: boolean;
-    selectQuote: () => Promise<void>;
-    giveLegalTermsConsent: () => void;
-    cancelLegalTermsConsent: () => void;
     doSellTrade: (trade: SellFiatTrade) => Promise<void>;
     confirmTrade: (bankAccount: BankAccount) => Promise<void>;
+    doBankAccountVerificationCheck: () => Promise<void>;
 };
 
-export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
+export const useSellFlow = (): SellFlowReturn => {
     const dispatch = useDispatch();
     const rootNavigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
-    const navigation = useNavigation<NavigationProps>();
-    const timer = useNullTimer();
-    const candidateQuote = watch('quote');
-    const isLoading = useSelector(selectTradingSellIsLoading);
     const sellInfo = useSelector(selectTradingSellInfo);
 
     const selectedQuote = useSelector(selectTradingSellSelectedQuote);
 
     const sendAccount = useSelector(selectSellSelectedSendAccount);
-
-    const {
-        isConsentRequested: isLegalTermsConsentRequested,
-        waitForConsent: waitForLegalTermsConsent,
-        resolveConsent: resolveLegalTermsConsent,
-    } = useConsent();
-    useConsentDenier(candidateQuote?.exchange, resolveLegalTermsConsent);
 
     // whenever we get a form from the webview, we need to navigate to the webview screen
     const handleWebview = useCallback(
@@ -75,6 +45,7 @@ export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
 
             rootNavigation.navigate(RootStackRoutes.TradingWebView, {
                 closeCallbackUrl: returnUrl,
+                tradingType: 'sell',
                 source,
                 orderId: trade.orderId,
             });
@@ -87,6 +58,8 @@ export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
             const tradeToUse = trade ?? selectedQuote;
 
             if (!tradeToUse) {
+                console.warn('No trade to use for get common functions');
+
                 return;
             }
 
@@ -113,20 +86,12 @@ export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
         [handleWebview, selectedQuote],
     );
 
-    const canProceed = !!candidateQuote && !!sendAccount && !isLoading;
-
-    const giveLegalTermsConsent = useCallback(() => {
-        resolveLegalTermsConsent(true);
-    }, [resolveLegalTermsConsent]);
-
-    const cancelLegalTermsConsent = useCallback(() => {
-        resolveLegalTermsConsent(false);
-    }, [resolveLegalTermsConsent]);
-
     const doSellTrade = useCallback(
         async (trade: SellFiatTrade) => {
             const commonFunctions = getCommonFunctions(trade);
             if (!commonFunctions || !sendAccount) {
+                console.warn('No common functions or send account for do sell trade');
+
                 return;
             }
 
@@ -147,6 +112,8 @@ export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
     const confirmTrade = useCallback(
         async (bankAccount: BankAccount) => {
             if (!selectedQuote) {
+                console.warn('No selected quote for confirm trade');
+
                 return;
             }
 
@@ -154,6 +121,8 @@ export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
 
             const commonFunctions = getCommonFunctions(quote);
             if (!commonFunctions || !sendAccount) {
+                console.warn('No common functions or send account for confirm trade');
+
                 return;
             }
 
@@ -173,63 +142,29 @@ export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
         [dispatch, getCommonFunctions, selectedQuote, sendAccount],
     );
 
-    const selectQuote = useCallback(async () => {
-        if (!candidateQuote || isLoading) {
+    const doBankAccountVerificationCheck = useCallback(async () => {
+        if (!selectedQuote) {
+            console.warn('No selected quote for bank account check');
+
             return;
         }
 
-        const provider = candidateQuote.exchange
-            ? sellInfo?.providerInfos[candidateQuote.exchange]
-            : undefined;
-
-        if (provider?.flow === 'BANK_ACCOUNT') {
-            dispatch(tradingSellActions.setFormStep('BANK_ACCOUNT'));
-        } else {
-            dispatch(tradingSellActions.setFormStep('SEND_TRANSACTION'));
+        // empty quoteId means the partner requests login first, requestTrade to get login screen
+        if (
+            (sellInfo &&
+                sellUtils.needToRegisterOrVerifyBankAccount({
+                    quote: selectedQuote,
+                    sellInfo,
+                })) ||
+            !selectedQuote.quoteId
+        ) {
+            await doSellTrade(selectedQuote);
         }
-
-        const nextStep = () => {
-            // empty quoteId means the partner requests login first, requestTrade to get login screen
-            if (
-                (sellInfo &&
-                    sellUtils.needToRegisterOrVerifyBankAccount({
-                        quote: candidateQuote,
-                        sellInfo,
-                    })) ||
-                !candidateQuote.quoteId
-            ) {
-                doSellTrade(candidateQuote);
-            }
-            navigation.navigate(TradingStackRoutes.TradingSellPreview);
-        };
-
-        await dispatch(
-            sellThunks.selectQuoteThunk({
-                quote: candidateQuote,
-                timer,
-                userConsent: waitForLegalTermsConsent,
-                nextStep,
-                onCancel: () => {},
-            }),
-        );
-    }, [
-        candidateQuote,
-        isLoading,
-        navigation,
-        dispatch,
-        timer,
-        waitForLegalTermsConsent,
-        sellInfo,
-        doSellTrade,
-    ]);
+    }, [selectedQuote, sellInfo, doSellTrade]);
 
     return {
-        canProceed,
-        isLegalTermsConsentRequested,
-        giveLegalTermsConsent,
-        cancelLegalTermsConsent,
         doSellTrade,
         confirmTrade,
-        selectQuote,
+        doBankAccountVerificationCheck,
     };
 };

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.ts
@@ -225,3 +225,10 @@ export const useSellForm = (): SellFormType => {
 
     return form;
 };
+
+export const clearSellFormQuoteData = (form: SellFormType) => {
+    form.setValue('quote', undefined);
+    form.setValue('cryptoStringAmount', undefined, { shouldValidate: true });
+    form.setValue('fiatStringAmount', undefined, { shouldValidate: true });
+    form.setValue('generalAlert', undefined);
+};

--- a/suite-native/module-trading/src/hooks/sell/useSellSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellSelectQuote.ts
@@ -19,6 +19,7 @@ import { selectSellSelectedSendAccount } from '@suite-native/trading-state';
 import { SellFormType } from '@suite-native/trading-types';
 import { useNullTimer } from '@trezor/react-utils';
 
+import { clearSellFormQuoteData } from './useSellForm';
 import { useConsent } from '../general/useConsent';
 import { useConsentDenier } from '../general/useConsentDenier';
 
@@ -36,10 +37,11 @@ type SellSelectQuoteReturn = {
     cancelLegalTermsConsent: () => void;
 };
 
-export const useSellSelectQuote = ({ watch }: SellFormType): SellSelectQuoteReturn => {
+export const useSellSelectQuote = (form: SellFormType): SellSelectQuoteReturn => {
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
     const timer = useNullTimer();
+    const { watch } = form;
     const candidateQuote = watch('quote');
     const isLoading = useSelector(selectTradingSellIsLoading);
     const sellInfo = useSelector(selectTradingSellInfo);
@@ -81,6 +83,7 @@ export const useSellSelectQuote = ({ watch }: SellFormType): SellSelectQuoteRetu
         const nextStep = () => {
             // bank account and txn handling will be done in the next step
             navigation.navigate(TradingStackRoutes.TradingSellPreview);
+            clearSellFormQuoteData(form);
         };
 
         await dispatch(
@@ -95,11 +98,12 @@ export const useSellSelectQuote = ({ watch }: SellFormType): SellSelectQuoteRetu
     }, [
         candidateQuote,
         isLoading,
-        navigation,
+        sellInfo?.providerInfos,
         dispatch,
         timer,
         waitForLegalTermsConsent,
-        sellInfo,
+        navigation,
+        form,
     ]);
 
     return {

--- a/suite-native/module-trading/src/hooks/sell/useSellSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellSelectQuote.ts
@@ -1,0 +1,112 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import {
+    selectTradingSellInfo,
+    selectTradingSellIsLoading,
+    sellThunks,
+    tradingSellActions,
+} from '@suite-common/trading';
+import {
+    RootStackParamList,
+    StackToStackCompositeNavigationProps,
+    TradingStackParamList,
+    TradingStackRoutes,
+} from '@suite-native/navigation';
+import { selectSellSelectedSendAccount } from '@suite-native/trading-state';
+import { SellFormType } from '@suite-native/trading-types';
+import { useNullTimer } from '@trezor/react-utils';
+
+import { useConsent } from '../general/useConsent';
+import { useConsentDenier } from '../general/useConsentDenier';
+
+type NavigationProps = StackToStackCompositeNavigationProps<
+    TradingStackParamList,
+    TradingStackRoutes.TradingSellPreview,
+    RootStackParamList
+>;
+
+type SellSelectQuoteReturn = {
+    canProceed: boolean;
+    isLegalTermsConsentRequested: boolean;
+    selectQuote: () => Promise<void>;
+    giveLegalTermsConsent: () => void;
+    cancelLegalTermsConsent: () => void;
+};
+
+export const useSellSelectQuote = ({ watch }: SellFormType): SellSelectQuoteReturn => {
+    const dispatch = useDispatch();
+    const navigation = useNavigation<NavigationProps>();
+    const timer = useNullTimer();
+    const candidateQuote = watch('quote');
+    const isLoading = useSelector(selectTradingSellIsLoading);
+    const sellInfo = useSelector(selectTradingSellInfo);
+
+    const sendAccount = useSelector(selectSellSelectedSendAccount);
+
+    const {
+        isConsentRequested: isLegalTermsConsentRequested,
+        waitForConsent: waitForLegalTermsConsent,
+        resolveConsent: resolveLegalTermsConsent,
+    } = useConsent();
+    useConsentDenier(candidateQuote?.exchange, resolveLegalTermsConsent);
+
+    const canProceed = !!candidateQuote && !!sendAccount && !isLoading;
+
+    const giveLegalTermsConsent = useCallback(() => {
+        resolveLegalTermsConsent(true);
+    }, [resolveLegalTermsConsent]);
+
+    const cancelLegalTermsConsent = useCallback(() => {
+        resolveLegalTermsConsent(false);
+    }, [resolveLegalTermsConsent]);
+
+    const selectQuote = useCallback(async () => {
+        if (!candidateQuote || isLoading) {
+            return;
+        }
+
+        const provider = candidateQuote.exchange
+            ? sellInfo?.providerInfos[candidateQuote.exchange]
+            : undefined;
+
+        if (provider?.flow === 'BANK_ACCOUNT') {
+            dispatch(tradingSellActions.setFormStep('BANK_ACCOUNT'));
+        } else {
+            dispatch(tradingSellActions.setFormStep('SEND_TRANSACTION'));
+        }
+
+        const nextStep = () => {
+            // bank account and txn handling will be done in the next step
+            navigation.navigate(TradingStackRoutes.TradingSellPreview);
+        };
+
+        await dispatch(
+            sellThunks.selectQuoteThunk({
+                quote: candidateQuote,
+                timer,
+                userConsent: waitForLegalTermsConsent,
+                nextStep,
+                onCancel: () => {},
+            }),
+        );
+    }, [
+        candidateQuote,
+        isLoading,
+        navigation,
+        dispatch,
+        timer,
+        waitForLegalTermsConsent,
+        sellInfo,
+    ]);
+
+    return {
+        canProceed,
+        isLegalTermsConsentRequested,
+        giveLegalTermsConsent,
+        cancelLegalTermsConsent,
+        selectQuote,
+    };
+};

--- a/suite-native/module-trading/src/navigation/TradingStackNavigator.tsx
+++ b/suite-native/module-trading/src/navigation/TradingStackNavigator.tsx
@@ -11,7 +11,10 @@ import { TradingExchangePreviewScreen } from '../screens/TradingExchangePreviewS
 import { TradingExchangeRevokeScreen } from '../screens/TradingExchangeRevokeScreen';
 import { TradingFeesScreen } from '../screens/TradingFeesScreen';
 import { TradingHistoryScreen } from '../screens/TradingHistoryScreen';
-import { TradingOutputsReviewScreen } from '../screens/TradingOutputsReviewScreen';
+import {
+    TradingExchangeOutputsReviewScreen,
+    TradingSellOutputsReviewScreen,
+} from '../screens/TradingOutputsReviewScreen';
 import { TradingReceiveAccountsPickerScreen } from '../screens/TradingReceiveAccountsPickerScreen';
 import { TradingScreen } from '../screens/TradingScreen';
 import { TradingSellPreviewScreen } from '../screens/TradingSellPreviewScreen';
@@ -64,9 +67,14 @@ export const TradingStackNavigator = () => (
             component={TradingFeesScreen}
         />
         <TradingStack.Screen
-            options={{ title: TradingStackRoutes.TradingOutputsReview }}
-            name={TradingStackRoutes.TradingOutputsReview}
-            component={TradingOutputsReviewScreen}
+            options={{ title: TradingStackRoutes.TradingSellOutputsReview }}
+            name={TradingStackRoutes.TradingSellOutputsReview}
+            component={TradingSellOutputsReviewScreen}
+        />
+        <TradingStack.Screen
+            options={{ title: TradingStackRoutes.TradingExchangeOutputsReview }}
+            name={TradingStackRoutes.TradingExchangeOutputsReview}
+            component={TradingExchangeOutputsReviewScreen}
         />
     </TradingStack.Navigator>
 );

--- a/suite-native/module-trading/src/screens/TradingOutputsReviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingOutputsReviewScreen.tsx
@@ -1,3 +1,5 @@
+import { TradingType } from '@suite-common/trading';
+import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { Box, VStack } from '@suite-native/atoms';
 import { ConfirmOnTrezorWrapper } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
@@ -12,22 +14,47 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { ReviewOutputsFooter } from '../components/reviewOutputs/ReviewOutputsFooter';
 import { ReviewOutputsSkeleton } from '../components/reviewOutputs/ReviewOutputsSkeleton';
+import { useExchangeFlow } from '../hooks/exchange/useExchangeFlow';
+import type { UseTradingTransactionReturnProps } from '../hooks/general/useTradingTransaction';
 import { useDelayedReviewOutputListDisplayFlag } from '../hooks/reviewOutputs/useDelayedReviewOutputListDisplayFlag';
-import { useTradingOutputsReviewScreenControls } from '../hooks/reviewOutputs/useTradingOutputsReviewScreenControls';
+import {
+    UseTradingOutputsReviewScreenControlsProps,
+    useTradingOutputsReviewScreenControls,
+} from '../hooks/reviewOutputs/useTradingOutputsReviewScreenControls';
+import { useSellFlow } from '../hooks/sell/useSellFlow';
 import { getFormDraftKeyPrefixFromTradingType } from '../utils/general/utils';
 
 const spacerStyle = prepareNativeStyle(_ => ({
     height: 150,
 }));
 
-export const TradingOutputsReviewScreen = ({
-    route,
-}: StackProps<TradingStackParamList, TradingStackRoutes.TradingOutputsReview>) => {
-    const { accountKey, tokenContract, tradingType, orderId } = route.params;
+type TradingOutputsBaseReviewScreenParams = UseTradingOutputsReviewScreenControlsProps &
+    Pick<
+        UseTradingTransactionReturnProps,
+        'isTransactionSendConsentRequested' | 'resolveTransactionSendConsent'
+    > & {
+        accountKey: AccountKey;
+        tokenContract?: TokenAddress;
+        orderId: string;
+        tradingType: TradingType;
+    };
 
+const TradingOutputsBaseReviewScreen = ({
+    accountKey,
+    tokenContract,
+    orderId,
+    tradingType,
+    signAndSendTransaction,
+    isTransactionSendConsentRequested,
+    resolveTransactionSendConsent,
+}: TradingOutputsBaseReviewScreenParams) => {
     const { applyStyle } = useNativeStyles();
-    const { isTransactionAlreadySigned, isConsentRequested, resolveConsent, confirmOnTrezorRef } =
-        useTradingOutputsReviewScreenControls(orderId, accountKey);
+    const { isTransactionAlreadySigned, confirmOnTrezorRef } =
+        useTradingOutputsReviewScreenControls({
+            orderId,
+            accountKey,
+            signAndSendTransaction,
+        });
     const shouldDisplayReviewList = useDelayedReviewOutputListDisplayFlag();
 
     const prefix = getFormDraftKeyPrefixFromTradingType(tradingType);
@@ -55,8 +82,8 @@ export const TradingOutputsReviewScreen = ({
                 )}
                 {isTransactionAlreadySigned ? (
                     <ReviewOutputsFooter
-                        isConsentRequested={isConsentRequested}
-                        resolveConsent={resolveConsent}
+                        isConsentRequested={isTransactionSendConsentRequested}
+                        resolveConsent={resolveTransactionSendConsent}
                         testID="@trading/outputs-review/footer"
                     />
                 ) : (
@@ -64,5 +91,51 @@ export const TradingOutputsReviewScreen = ({
                 )}
             </VStack>
         </ConfirmOnTrezorWrapper>
+    );
+};
+
+export const TradingExchangeOutputsReviewScreen = ({
+    route,
+}: StackProps<TradingStackParamList, TradingStackRoutes.TradingExchangeOutputsReview>) => {
+    const { accountKey, tokenContract, orderId } = route.params;
+    const {
+        signAndSendTransaction,
+        isTransactionSendConsentRequested,
+        resolveTransactionSendConsent,
+    } = useExchangeFlow();
+
+    return (
+        <TradingOutputsBaseReviewScreen
+            accountKey={accountKey}
+            tokenContract={tokenContract}
+            orderId={orderId}
+            tradingType="exchange"
+            signAndSendTransaction={signAndSendTransaction}
+            isTransactionSendConsentRequested={isTransactionSendConsentRequested}
+            resolveTransactionSendConsent={resolveTransactionSendConsent}
+        />
+    );
+};
+
+export const TradingSellOutputsReviewScreen = ({
+    route,
+}: StackProps<TradingStackParamList, TradingStackRoutes.TradingSellOutputsReview>) => {
+    const { accountKey, tokenContract, orderId } = route.params;
+    const {
+        signAndSendTransaction,
+        isTransactionSendConsentRequested,
+        resolveTransactionSendConsent,
+    } = useSellFlow();
+
+    return (
+        <TradingOutputsBaseReviewScreen
+            accountKey={accountKey}
+            tokenContract={tokenContract}
+            orderId={orderId}
+            tradingType="sell"
+            signAndSendTransaction={signAndSendTransaction}
+            isTransactionSendConsentRequested={isTransactionSendConsentRequested}
+            resolveTransactionSendConsent={resolveTransactionSendConsent}
+        />
     );
 };

--- a/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
@@ -1,20 +1,53 @@
-import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useCallback, useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
+import {
+    TradingSellType,
+    selectTradingSellSelectedQuote,
+    useTradingDetailData,
+} from '@suite-common/trading';
 import { Screen } from '@suite-native/navigation';
 
-import { SellPreviewScreenHeader, SellPreviewView } from '../components/sell/SellPreview';
+import {
+    SellPreviewContinueButton,
+    SellPreviewScreenHeader,
+    SellPreviewView,
+} from '../components/sell/SellPreview';
+import { useWatchTrade } from '../hooks/general/useWatchTrade';
 import { useSellFlow } from '../hooks/sell/useSellFlow';
 import { clearTradingStateThunk } from '../thunks';
 
 export const TradingSellPreviewScreen = () => {
     const dispatch = useDispatch();
-    const { doBankAccountVerificationCheck } = useSellFlow();
+    const { txnErrorString, doBankAccountVerificationCheck, fetchFeesAndCompose } = useSellFlow();
+    const { trade } = useTradingDetailData<TradingSellType>('sell');
+    const selectedQuote = useSelector(selectTradingSellSelectedQuote);
+
+    const currentQuote = trade?.data ? trade.data : selectedQuote;
+    const currentStatus = useRef(currentQuote?.status);
+
+    useWatchTrade({
+        accountKey: trade?.sendAccountKey,
+        orderId: currentQuote?.orderId,
+        isInProgress: false,
+    });
 
     useEffect(() => {
         doBankAccountVerificationCheck();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    useEffect(() => {
+        // only fetch fees and compose if the form step has changed to SEND_TRANSACTION
+        // dependencies are not stable, so we use useRef to store the previous form step
+        if (
+            currentStatus.current !== currentQuote?.status &&
+            currentQuote?.status === 'SEND_CRYPTO'
+        ) {
+            currentStatus.current = currentQuote?.status;
+            fetchFeesAndCompose();
+        }
+    }, [fetchFeesAndCompose, currentQuote]);
 
     // clear trading state on unmount
     useEffect(
@@ -24,9 +57,20 @@ export const TradingSellPreviewScreen = () => {
         [dispatch],
     );
 
+    const onSignTransactionNavigation = useCallback(() => {
+        // TODO: Add analytics if needed
+    }, []);
+
+    const errorString = txnErrorString ?? currentQuote?.error;
+
     return (
         <Screen header={<SellPreviewScreenHeader />}>
-            <SellPreviewView txnErrorString={null} />
+            <SellPreviewView quote={currentQuote} txnErrorString={errorString} />
+            <SellPreviewContinueButton
+                quote={currentQuote}
+                isDisabled={!!errorString}
+                onSignTransactionNavigation={onSignTransactionNavigation}
+            />
         </Screen>
     );
 };

--- a/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
@@ -4,10 +4,17 @@ import { useDispatch } from 'react-redux';
 import { Screen } from '@suite-native/navigation';
 
 import { SellPreviewScreenHeader, SellPreviewView } from '../components/sell/SellPreview';
+import { useSellFlow } from '../hooks/sell/useSellFlow';
 import { clearTradingStateThunk } from '../thunks';
 
 export const TradingSellPreviewScreen = () => {
     const dispatch = useDispatch();
+    const { doBankAccountVerificationCheck } = useSellFlow();
+
+    useEffect(() => {
+        doBankAccountVerificationCheck();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     // clear trading state on unmount
     useEffect(

--- a/suite-native/module-trading/src/screens/TradingWebViewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingWebViewScreen.tsx
@@ -4,7 +4,7 @@ import { WebView } from 'react-native-webview';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation, useRoute } from '@react-navigation/native';
-import { useURL } from 'expo-linking';
+import { useLinkingURL } from 'expo-linking';
 import { WebViewSource } from 'react-native-webview/lib/WebViewTypes';
 
 import { TradingRootState, selectTradingTradeByOrderId } from '@suite-common/trading';
@@ -31,12 +31,12 @@ const webViewStyle = prepareNativeStyle(_ => ({ flex: 1 }));
 
 export const TradingWebViewScreen = () => {
     const {
-        params: { source, closeCallbackUrl, orderId },
+        params: { source, tradingType, closeCallbackUrl, orderId },
     } = useRoute<RouteProps>();
     const navigation = useNavigation();
     const { applyStyle } = useNativeStyles();
     const dispatch = useDispatch();
-    const receivedDeeplinkUrl = useURL();
+    const receivedDeeplinkUrl = useLinkingURL();
     const trade = useSelector((state: TradingRootState) =>
         selectTradingTradeByOrderId(state, orderId ?? ''),
     );
@@ -61,12 +61,12 @@ export const TradingWebViewScreen = () => {
         isInProgress: true,
     });
 
-    // when url contains closeCallbackUrl or TRADING_URL_DEFAULT_BACK, go back and mark the trade to be opened
+    // when url contains closeCallbackUrl or TRADING_URL_DEFAULT_BACK, go back and mark the trade to be opened for buy
     const checkForGoBackOnUrl = useCallback(
         (url: string | null) => {
             const urlString = url ?? '';
             if (doesUrlContainCloseCallbackUrl(urlString, closeCallbackUrl)) {
-                if (orderId) {
+                if (orderId && tradingType === 'buy') {
                     dispatch(tradingActions.setTradeOrderIdToBeOpened(orderId));
                 }
                 navigation.goBack();
@@ -76,7 +76,7 @@ export const TradingWebViewScreen = () => {
 
             return true;
         },
-        [closeCallbackUrl, dispatch, navigation, orderId],
+        [closeCallbackUrl, dispatch, navigation, orderId, tradingType],
     );
 
     useEffect(() => {

--- a/suite-native/module-trading/src/screens/__tests__/TradingOutputsReviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingOutputsReviewScreen.comp.test.tsx
@@ -1,0 +1,144 @@
+import { RouteProp } from '@react-navigation/native';
+
+import { TokenAddress } from '@suite-common/wallet-types';
+import { TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
+import { TestStore, initStore, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { getWalletState } from '@suite-native/trading-fixtures';
+
+import {
+    TradingExchangeOutputsReviewScreen,
+    TradingSellOutputsReviewScreen,
+} from '../TradingOutputsReviewScreen';
+
+const mockSignAndSendTransaction = jest.fn();
+const mockResolveTransactionSendConsent = jest.fn();
+const mockUseExchangeFlow = {
+    signAndSendTransaction: mockSignAndSendTransaction,
+    isTransactionSendConsentRequested: false,
+    resolveTransactionSendConsent: mockResolveTransactionSendConsent,
+};
+
+const mockUseSellFlow = {
+    signAndSendTransaction: mockSignAndSendTransaction,
+    isTransactionSendConsentRequested: false,
+    resolveTransactionSendConsent: mockResolveTransactionSendConsent,
+};
+
+const mockNavigation = {
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    popToTop: jest.fn(),
+} as any;
+
+jest.mock('@suite-native/device', () => ({
+    ...jest.requireActual('@suite-native/device'),
+    useConfirmOnTrezorController: () => ({
+        confirmOnTrezorRef: { current: null },
+        closeSheet: jest.fn(),
+    }),
+    ConfirmOnTrezorWrapper: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockUseExchangeFlowFn = jest.fn(() => mockUseExchangeFlow);
+const mockUseSellFlowFn = jest.fn(() => mockUseSellFlow);
+
+jest.mock('../../hooks/exchange/useExchangeFlow', () => ({
+    useExchangeFlow: () => mockUseExchangeFlowFn(),
+}));
+
+jest.mock('../../hooks/sell/useSellFlow', () => ({
+    useSellFlow: () => mockUseSellFlowFn(),
+}));
+
+jest.mock('../../hooks/reviewOutputs/useTradingOutputsReviewScreenControls', () => ({
+    useTradingOutputsReviewScreenControls: jest.fn(() => ({
+        isTransactionAlreadySigned: false,
+        isConsentRequested: false,
+        resolveConsent: jest.fn(),
+        confirmOnTrezorRef: { current: null },
+    })),
+}));
+
+jest.mock('../../hooks/reviewOutputs/useDelayedReviewOutputListDisplayFlag', () => ({
+    useDelayedReviewOutputListDisplayFlag: () => false,
+}));
+
+// Test constants
+const TEST_ACCOUNT_KEY = 'btc-account-1';
+const TEST_ORDER_ID = 'test-order-id';
+
+// Helper function to create route params for sell
+const createSellRouteParams = (tokenContract?: TokenAddress) => ({
+    accountKey: TEST_ACCOUNT_KEY,
+    tokenContract,
+    orderId: TEST_ORDER_ID,
+});
+
+// Helper function to create route params for exchange
+const createExchangeRouteParams = (tokenContract?: TokenAddress) => ({
+    accountKey: TEST_ACCOUNT_KEY,
+    tokenContract,
+    orderId: TEST_ORDER_ID,
+});
+
+// Helper function to create route for sell
+const createSellRoute = (params: ReturnType<typeof createSellRouteParams>) =>
+    ({
+        params,
+    }) as RouteProp<TradingStackParamList, TradingStackRoutes.TradingSellOutputsReview>;
+
+// Helper function to create route for exchange
+const createExchangeRoute = (params: ReturnType<typeof createExchangeRouteParams>) =>
+    ({
+        params,
+    }) as RouteProp<TradingStackParamList, TradingStackRoutes.TradingExchangeOutputsReview>;
+
+describe('TradingSellOutputsReviewScreen', () => {
+    let store: TestStore;
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        store = (await initStore({ wallet: getWalletState({ tradeType: 'sell' }) })).store;
+        mockNavigation.navigate.mockClear();
+        mockNavigation.goBack.mockClear();
+        mockNavigation.popToTop.mockClear();
+    });
+
+    it('should render TradingSellOutputsReviewScreen', async () => {
+        const params = createSellRouteParams();
+        const route = createSellRoute(params);
+
+        const { toJSON } = await renderWithStoreProviderAsync(
+            <TradingSellOutputsReviewScreen route={route} navigation={mockNavigation} />,
+            { store },
+        );
+
+        expect(toJSON()).not.toBeNull();
+        expect(mockUseSellFlowFn).toHaveBeenCalled();
+    });
+});
+
+describe('TradingExchangeOutputsReviewScreen', () => {
+    let store: TestStore;
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        store = (await initStore({ wallet: getWalletState({ tradeType: 'exchange' }) })).store;
+        mockNavigation.navigate.mockClear();
+        mockNavigation.goBack.mockClear();
+        mockNavigation.popToTop.mockClear();
+    });
+
+    it('should render TradingExchangeOutputsReviewScreen', async () => {
+        const params = createExchangeRouteParams();
+        const route = createExchangeRoute(params);
+
+        const { toJSON } = await renderWithStoreProviderAsync(
+            <TradingExchangeOutputsReviewScreen route={route} navigation={mockNavigation} />,
+            { store },
+        );
+
+        expect(toJSON()).not.toBeNull();
+        expect(mockUseExchangeFlowFn).toHaveBeenCalled();
+    });
+});

--- a/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.comp.test.tsx
@@ -8,9 +8,39 @@ jest.mock('@react-navigation/native', () => ({
     useRoute: () => ({ name: 'TradingSellPreviewScreen' }),
 }));
 
+const mockDoBankAccountVerificationCheck = jest.fn();
+const mockFetchFeesAndCompose = jest.fn();
+const mockTxnErrorString = null;
+
+jest.mock('../../hooks/sell/useSellFlow', () => ({
+    useSellFlow: () => ({
+        txnErrorString: mockTxnErrorString,
+        doBankAccountVerificationCheck: mockDoBankAccountVerificationCheck,
+        fetchFeesAndCompose: mockFetchFeesAndCompose,
+    }),
+}));
+
+const mockUseTradingDetailData = {
+    trade: undefined,
+};
+
+jest.mock('@suite-common/trading', () => ({
+    ...jest.requireActual('@suite-common/trading'),
+    useTradingDetailData: () => mockUseTradingDetailData,
+}));
+
+jest.mock('../../hooks/general/useWatchTrade', () => ({
+    useWatchTrade: jest.fn(),
+}));
+
 describe('TradingSellPreviewScreen', () => {
     const renderTradingSellPreviewScreen = (preloadedState?: PreloadedState) =>
         renderWithStoreProviderAsync(<TradingSellPreviewScreen />, { preloadedState });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseTradingDetailData.trade = undefined;
+    });
 
     it('should render screen with header and preview view', async () => {
         const preloadedState: PreloadedState = {
@@ -23,5 +53,69 @@ describe('TradingSellPreviewScreen', () => {
         expect(getByText('Sell')).toBeOnTheScreen();
         expect(getByText('To')).toBeOnTheScreen();
         expect(getByText('Credit/Debit Card')).toBeOnTheScreen();
+    });
+
+    it('should call doBankAccountVerificationCheck on mount', async () => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'sell' }),
+        };
+        preloadedState.wallet!.trading!.sell!.selectedQuote = sellQuotes[0];
+
+        await renderTradingSellPreviewScreen(preloadedState);
+
+        expect(mockDoBankAccountVerificationCheck).toHaveBeenCalledTimes(1);
+    });
+
+    it('should use selectedQuote when trade data is not available', async () => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'sell' }),
+        };
+        preloadedState.wallet!.trading!.sell!.selectedQuote = sellQuotes[0];
+
+        const { getByText } = await renderTradingSellPreviewScreen(preloadedState);
+
+        // Should render with selectedQuote
+        expect(getByText('To')).toBeOnTheScreen();
+    });
+
+    it('should use trade data when available', async () => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'sell' }),
+        };
+        preloadedState.wallet!.trading!.sell!.selectedQuote = sellQuotes[0];
+
+        // Add trade to trades array so SellBankAccountPicker can find it
+        const tradeData = sellQuotes[1];
+        preloadedState.wallet!.trading!.trades = [
+            {
+                tradeType: 'sell',
+                data: tradeData,
+                sendAccountKey: 'eth-account-1',
+            } as any,
+        ];
+
+        mockUseTradingDetailData.trade = {
+            tradeType: 'sell',
+            data: tradeData,
+            sendAccountKey: 'eth-account-1',
+        } as any;
+
+        const { getByText } = await renderTradingSellPreviewScreen(preloadedState);
+
+        // Should render with trade data
+        expect(getByText('To')).toBeOnTheScreen();
+    });
+
+    it('should render SellPreviewContinueButton with correct props', async () => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'sell' }),
+        };
+        preloadedState.wallet!.trading!.sell!.selectedQuote = sellQuotes[0];
+
+        const { getByText } = await renderTradingSellPreviewScreen(preloadedState);
+
+        // SellPreviewContinueButton should be rendered (it's part of the screen)
+        // We can verify by checking that the screen renders without errors
+        expect(getByText('To')).toBeOnTheScreen();
     });
 });

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -382,8 +382,12 @@ export type TradingStackParamList = {
         accountKey: AccountKey;
         tradingType: TradingType;
     };
-    [TradingStackRoutes.TradingOutputsReview]: {
-        tradingType: TradingType;
+    [TradingStackRoutes.TradingSellOutputsReview]: {
+        accountKey: AccountKey;
+        tokenContract?: TokenAddress;
+        orderId: string;
+    };
+    [TradingStackRoutes.TradingExchangeOutputsReview]: {
         accountKey: AccountKey;
         tokenContract?: TokenAddress;
         orderId: string;

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -351,6 +351,7 @@ export type RootStackParamList = {
     [RootStackRoutes.DeviceCompromisedModal]: undefined;
     [RootStackRoutes.TradingWebView]: {
         closeCallbackUrl: string;
+        tradingType: TradingType;
         source?: { uri?: string; html?: string };
         orderId?: string;
     };

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -227,5 +227,6 @@ export enum TradingStackRoutes {
     TradingExchangeRevoke = 'TradingExchangeRevoke',
     TradingSellPreview = 'TradingSellPreview',
     TradingFees = 'TradingFees',
-    TradingOutputsReview = 'TradingOutputsReview',
+    TradingSellOutputsReview = 'TradingSellOutputsReview',
+    TradingExchangeOutputsReview = 'TradingExchangeOutputsReview',
 }

--- a/suite-native/trading-fixtures/src/__fixtures__/sellProviders.ts
+++ b/suite-native/trading-fixtures/src/__fixtures__/sellProviders.ts
@@ -63,7 +63,7 @@ export const sellBanxa = {
     tradedCoins: ['bitcoin', 'ethereum'] as CryptoId[],
     tradedFiatCurrencies: ['EUR', 'USD', 'AUD'],
     supportedCountries: ['AU', 'EU', 'US'],
-    paymentMethods: ['bankTransfer', 'creditCard'],
+    paymentMethods: ['bankTransfer', 'creditCard', 'SEPA'],
     statusUrl: 'https://checkout.banxa.com/sell/status/{{orderId}}',
     supportUrl: 'https://banxa.com/support',
     flow: 'BANK_ACCOUNT',

--- a/suite-native/trading-types/src/sell.ts
+++ b/suite-native/trading-types/src/sell.ts
@@ -1,4 +1,4 @@
-import type { SellFiatTrade } from 'invity-api';
+import type { SellCryptoPaymentMethod, SellFiatTrade } from 'invity-api';
 
 import type { UseFormReturn } from '@suite-native/forms';
 
@@ -7,6 +7,16 @@ import type {
     FormWithFiatCurrencyValues,
     FormWithSendAccountValues,
 } from './general';
+
+export type ExtendedSellCryptoPaymentMethod =
+    | SellCryptoPaymentMethod
+    | 'sepa'
+    | 'ach'
+    | 'skrill'
+    | 'neteller'
+    | 'payid'
+    | 'dcinterac'
+    | 'fasterPayment';
 
 export type SellFormValues = BaseFormValues<
     'cryptoStringAmount' | 'fiatStringAmount',


### PR DESCRIPTION
This PR allows Sell trade to be finalised with sent txn using default (normal) txn fee.

## Notes for QA

this is WIP, do not test

## Related Issue

Resolve #22711

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=22711-mobile-sell-prepare-txn-to-be-sent-with-normal-fee&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=22711-mobile-sell-prepare-txn-to-be-sent-with-normal-fee&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22711-mobile-sell-prepare-txn-to-be-sent-with-normal-fee&lookback=7)