### PR TITLE
chore(suite): unify cardano full/entire balance strings

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx
@@ -26,7 +26,7 @@ export const StakeRegistrationDepositCard = ({ account }: StakeRegistrationDepos
                     <Translation id="AMOUNT" />
                 </Paragraph>
                 <Paragraph typographyStyle="highlight">
-                    <Translation id="TR_STAKE_ENTIRE_BALANCE" />
+                    <Translation id="TR_STAKE_FULL_BALANCE" />
                 </Paragraph>
             </Row>
             {isUpdateProviderFlow ? (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeModal.tsx
@@ -46,7 +46,13 @@ export const UnstakeModalLoaded = ({ onCancel, selectedAccount }: UnstakeModalMo
                         values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
                     />
                 }
-                description={<Translation id="TR_STAKE_CLAIM_AFTER_UNSTAKING" />}
+                description={
+                    account.networkType === 'cardano' ? (
+                        <Translation id="TR_STAKE_UNSTAKE_WITH_REWARDS" />
+                    ) : (
+                        <Translation id="TR_STAKE_CLAIM_AFTER_UNSTAKING" />
+                    )
+                }
                 onCancel={onCancelClick}
                 bottomContent={<UnstakeButton />}
             >

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -8205,10 +8205,6 @@ export default defineMessages({
         id: 'TR_STAKE_DEREGISTERED',
         defaultMessage: 'Deregistration of a stake address',
     },
-    TR_STAKE_ENTIRE_BALANCE: {
-        id: 'TR_STAKE_ENTIRE_BALANCE',
-        defaultMessage: 'Entire balance',
-    },
     TR_STAKE_REGISTRATION_DEPOSIT: {
         id: 'TR_STAKE_REGISTRATION_DEPOSIT',
         defaultMessage: 'Registration deposit',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9897,6 +9897,10 @@ export default defineMessages({
         id: 'TR_STAKE_CLAIM_AFTER_UNSTAKING',
         defaultMessage: 'You can claim once the unstaking period is complete.',
     },
+    TR_STAKE_UNSTAKE_WITH_REWARDS: {
+        id: 'TR_STAKE_UNSTAKE_WITH_REWARDS',
+        defaultMessage: 'Your rewards are automatically claimed when you unstake.',
+    },
     TR_STAKE_UNSTAKING_APPROXIMATE: {
         id: 'TR_STAKE_UNSTAKING_APPROXIMATE',
         defaultMessage: 'Approximate amount of {symbol} available instantly',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- unifying balance strings 
- there is nothing to be claimed on cardano after unstake

## Related Issue

Resolve #23180

## Screenshots:
Before:
<img width="559" height="418" alt="Screenshot 2025-11-15 at 8 04 36" src="https://github.com/user-attachments/assets/59937086-2609-4908-85d2-cfb480e7669c" />

After:
<img width="1028" height="476" alt="Screenshot 2025-11-15 at 8 14 33" src="https://github.com/user-attachments/assets/72c42a88-2bf1-402e-ad19-66bbec2460ef" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/entire-full-balance&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/entire-full-balance&lookback=7)