### PR TITLE
feat(suite): send form DEV: self address

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -34,9 +34,11 @@ import { InputError } from 'src/components/wallet';
 import { InputErrorProps } from 'src/components/wallet/InputError';
 import { useDevice, useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 import { getProtocolInfo } from 'src/utils/suite/protocol';
 import { captureSentryMessage } from 'src/utils/suite/sentry';
 
+import { DevSelfAddress } from './DevSelfAddress';
 import { Translation } from '../../../../components/suite/Translation';
 
 type AddressProps = {
@@ -83,6 +85,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
     const options = getDefaultValue('options', []);
     const broadcastEnabled = options.includes('broadcast');
     const isOnline = useSelector(state => state.suite.online);
+    const isDebug = useSelector(selectIsDebugModeActive);
 
     const [isExternalAddressCheckWarningDismissed, setIsExternalAddressCheckWarningDismissed] =
         useState(false);
@@ -464,6 +467,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                         }
                         values={{ index: recipientId }}
                     />
+                    {isDebug && <DevSelfAddress outputId={outputId} account={account} />}
                 </p>
             }
             labelRight={

--- a/packages/suite/src/views/wallet/send/Outputs/DevSelfAddress.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/DevSelfAddress.tsx
@@ -1,0 +1,29 @@
+import { Account } from '@suite-common/wallet-types';
+import { getFirstFreshAddress, isUtxoBased } from '@suite-common/wallet-utils';
+import { Button } from '@trezor/components';
+
+import { useSendFormContext } from 'src/hooks/wallet';
+
+type DevSelfAddressProps = {
+    account: Account;
+    outputId: number;
+};
+
+// Debug helper to fill opened account address.
+export const DevSelfAddress = ({ account, outputId }: DevSelfAddressProps) => {
+    const { setValue } = useSendFormContext();
+    const inputName = `outputs.${outputId}.address` as const;
+
+    const fillSelfAddress = () => {
+        const selfAddress = getFirstFreshAddress(account, [], [], isUtxoBased(account));
+        if (selfAddress) {
+            setValue(inputName, selfAddress.address, { shouldValidate: true });
+        }
+    };
+
+    return (
+        <Button size="small" priority="secondary" intent="neutral" onClick={fillSelfAddress}>
+            DEV: self address
+        </Button>
+    );
+};


### PR DESCRIPTION
## Description

Add a dev-only tweak (hidden behind debug mode) to fill out self address in Send form, [inspired by mobile](https://github.com/user-attachments/assets/7cd4eeac-fbf3-48e0-8a0b-1b49d15e9c3c). 

## Screenshots:

### Debug mode off (unchanged)

<img width="925" height="522" alt="Screenshot from 2025-11-16 22-37-10" src="https://github.com/user-attachments/assets/1e30d14d-be20-45b3-954d-ad129fbe2ebf" />

### Debug mode on

[Screencast from 2025-11-16 22-37-28.webm](https://github.com/user-attachments/assets/0b92d95b-9247-4f20-816b-9a287aa9771a)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/dev-send-to-thyself&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/dev-send-to-thyself&lookback=7)