### PR TITLE
fix(suite-native): FW rev check abort error as offline

### DIFF
--- a/packages/connect/src/device/checkFirmwareRevision.ts
+++ b/packages/connect/src/device/checkFirmwareRevision.ts
@@ -14,6 +14,7 @@ const isNodeJSOfflineError = (e: Error) => ['FetchError', 'AbortError'].includes
 const isReactNativeOfflineError = (e: Error) =>
     e.name === 'TypeError' && e.message.includes('Network request failed');
 const isAbortControllerTimeout = (e: Error) =>
+    e.message.includes('Aborted') ||
     e.name === 'AbortError' ||
     (e.name === 'TimeoutError' && e.message.includes('signal timed out'));
 


### PR DESCRIPTION
## Description

Continuing the game of whack-a-mole to catch all kinds of offline errors on all environments.

## Related Issue

Resolve #22653

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/FW-rev-check-other-error&lookback=7)