### PR TITLE
Fix 25.10 / 25.11 migrations

### DIFF
--- a/packages/suite/src/storage/migrations/networks/removeNetwork.ts
+++ b/packages/suite/src/storage/migrations/networks/removeNetwork.ts
@@ -7,37 +7,23 @@ export async function removeNetwork(
     tx: IDBPTransaction<SuiteDBSchema, StoreNames<SuiteDBSchema>[], 'versionchange'>,
     removedNetworkSymbol: string,
 ) {
-    // remove a network transactions, change token address to contract
+    // remove a network transactions
     if (tx.objectStoreNames.contains('txs')) {
         await updateAll(tx, 'txs', tx => {
             if (tx.tx.symbol === removedNetworkSymbol) {
                 return null;
             }
 
-            tx.tx.tokens.forEach(token => {
-                // @ts-expect-error
-                token.contract = token.address;
-                // @ts-expect-error
-                delete token.address;
-            });
-
             return tx;
         });
     }
 
-    // remove a network accounts, change token address to contract
+    // remove a network accounts
     if (tx.objectStoreNames.contains('accounts')) {
         await updateAll(tx, 'accounts', account => {
             if (account.symbol === removedNetworkSymbol) {
                 return null;
             }
-
-            account.tokens?.forEach(token => {
-                // @ts-expect-error
-                token.contract = token.address;
-                // @ts-expect-error
-                delete token.address;
-            });
 
             return account;
         });

--- a/packages/suite/src/storage/migrations/versions/25.10.0.ts
+++ b/packages/suite/src/storage/migrations/versions/25.10.0.ts
@@ -4,8 +4,6 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { SuiteDBSchema } from 'src/storage/definitions';
 
-import { removeNetwork } from '../networks/removeNetwork';
-
 type DeletedSecurityType =
     | {
           devicesWithFailedEntropyCheck?: (string | null)[];
@@ -47,7 +45,4 @@ export default createMigration<SuiteDBSchema>('25.10.0', async (db, tx) => {
         // @ts-expect-error security no longer exists
         db.deleteObjectStore('security');
     }
-
-    // Remove Holesky test network. Now there's Hoodi (tHOD) test network.
-    await removeNetwork(tx, 'thol');
 });

--- a/packages/suite/src/storage/migrations/versions/25.11.0.1.ts
+++ b/packages/suite/src/storage/migrations/versions/25.11.0.1.ts
@@ -2,7 +2,9 @@ import { createMigration } from '@suite/idb-migration-utils';
 
 import { SuiteDBSchema } from 'src/storage/definitions';
 
-export default createMigration<SuiteDBSchema>('25.11.0.1', (db, tx) => {
+import { removeNetwork } from '../networks/removeNetwork';
+
+export default createMigration<SuiteDBSchema>('25.11.0.1', async (db, tx) => {
     // @ts-expect-error
     if (!db.objectStoreNames.contains('labelingSettings')) {
         // @ts-expect-error
@@ -19,4 +21,8 @@ export default createMigration<SuiteDBSchema>('25.11.0.1', (db, tx) => {
             'labelingSettings',
         );
     }
+
+    // Remove Holesky test network. Now there's Hoodi (tHOD) test network.
+    // Note: Moved to 25.11.0.1 from 25.10.0 as it was added there after 25.10 release
+    await removeNetwork(tx, 'thol');
 });


### PR DESCRIPTION
## Description

There was part of 25.10.0 migration which was a) wrong and b) added there after 25.10 freeze and not cherrypicked, therefore it causes fatal error when upgrading from <=25.9 to 25.11.

<img width="642" height="279" alt="image" src="https://github.com/user-attachments/assets/c4cf5611-2f84-4645-bb5a-c7cf4e2b3b59" />


I've fixed it and moved to 25.11.0.1 migration, which should theoretically cause no harm.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/hoodi-migration&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/hoodi-migration&lookback=7)