### PR TITLE
fix(suite): fix flaky send form test

### DIFF
--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -715,7 +715,6 @@ export const composeDebouncedTransaction = [
             ],
         },
         actions: [{ type: 'input', element: 'outputs.0.amount', value: '111', delay: 100 }],
-        expectRerender: true, // The unit test will break otherwise
         finalResult: {
             composeTransactionCalls: 1,
             composedLevels: {

--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -372,18 +372,6 @@ describe('useSendForm hook', () => {
             async () => {
                 testMocks.setTrezorConnectFixtures(f.connect);
 
-                jest.mock('@trezor/react-utils', () => {
-                    const originalModule = jest.requireActual('@trezor/react-utils');
-
-                    return {
-                        ...originalModule,
-                        __esModule: true,
-                        useDebounce: () => async (fn: any) => {
-                            await fn();
-                        },
-                    };
-                });
-
                 const store = initStore(f.store as Args);
                 const callback: TestCallback = {};
                 const { unmount } = renderWithProviders(


### PR DESCRIPTION
PR that tries to fix flaky `BTC fee changes` by removing mock for debounce hook introduced in `795bc73` - it appears that it was try to mock the hook only for this specific case, but Jest mocks are hoisted and mocked for the whole test file.

## Related Issue

Resolve <!--- link the issue here -->



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/send-form-test&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/send-form-test&lookback=7)