### PR TITLE
fix(suite): display loading state while feeInfo is loading

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
@@ -58,10 +58,6 @@ export function CollapsibleFees({
         selectedFeeLevel,
     });
 
-    if (!selectedFeeLevel) {
-        return null;
-    }
-
     return (
         <FeesContext.Provider
             value={{

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFee.tsx
@@ -28,7 +28,7 @@ type CustomFeeProps = {
 
 export const CustomFee = ({ showCurrentFee }: CustomFeeProps) => {
     const { composedLevels, selectedFeeLevel, networkType } = useFeesContext();
-    const transactionInfo = composedLevels?.[selectedFeeLevel.label];
+    const transactionInfo = selectedFeeLevel ? composedLevels?.[selectedFeeLevel.label] : null;
     const cachedBytes =
         transactionInfo && transactionInfo.type !== 'error' && transactionInfo.bytes;
     const shouldShowTxSize =

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/BitcoinFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/BitcoinFeeCards.tsx
@@ -30,7 +30,7 @@ export const BitcoinFeeCards = ({ feeOptions }: BitcoinFeeCardsProps) => {
     const locale = useLocales();
     const areFeesLoading = useSelector(state => selectAreFeesLoading(state, networkSymbol));
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(networkSymbol);
-    const transactionInfo = composedLevels?.[selectedFeeLevel.label];
+    const transactionInfo = selectedFeeLevel ? composedLevels?.[selectedFeeLevel.label] : null;
 
     const getTimeEstimate = (fee: FeeOptionType) => {
         if (fee.blocks) {
@@ -39,6 +39,10 @@ export const BitcoinFeeCards = ({ feeOptions }: BitcoinFeeCardsProps) => {
 
         return undefined;
     };
+
+    if (!selectedFeeLevel) {
+        return null;
+    }
 
     return (
         <>
@@ -82,7 +86,7 @@ export const BitcoinFeeCards = ({ feeOptions }: BitcoinFeeCardsProps) => {
                 ))}
             </FeeCardsWrapper>
             <DustPreventionNotice
-                chosenFeePerByte={selectedFeeLevel.feePerUnit}
+                chosenFeePerByte={selectedFeeLevel!.feePerUnit}
                 composedFeePerByte={
                     transactionInfo?.type === 'final' ? transactionInfo.feePerByte : undefined
                 }

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/EthereumFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/EthereumFeeCards.tsx
@@ -39,7 +39,7 @@ export const EthereumFeeCards = ({ feeOptions }: EthereumFeeCardsProps) => {
     const areFeesLoading = useSelector(state => selectAreFeesLoading(state, symbol));
 
     const [cachedGasLimit, setCachedGasLimit] = useState<string | undefined>(undefined);
-    const transactionInfo = composedLevels?.[selectedFeeLevel.label];
+    const transactionInfo = selectedFeeLevel ? composedLevels?.[selectedFeeLevel.label] : null;
 
     useEffect(() => {
         if (transactionInfo && transactionInfo.type !== 'error' && transactionInfo.feeLimit) {
@@ -57,6 +57,10 @@ export const EthereumFeeCards = ({ feeOptions }: EthereumFeeCardsProps) => {
 
         return undefined;
     };
+
+    if (!selectedFeeLevel) {
+        return null;
+    }
 
     return (
         <>

--- a/packages/suite/src/components/wallet/Fees/context/FeesContext.ts
+++ b/packages/suite/src/components/wallet/Fees/context/FeesContext.ts
@@ -7,7 +7,7 @@ import { FeeLevel } from '@trezor/connect';
 export type FeesContextType = {
     networkSymbol: NetworkSymbol;
     networkType: NetworkType;
-    selectedFeeLevel: FeeLevel;
+    selectedFeeLevel?: FeeLevel;
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano | null;
     feeInfo: FeeInfo;
     changeFeeLevel: (level: FeeLevel['label']) => void;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Display loading state while feeInfo is loading.

## Related Issue


Before:


<img width="1235" height="895" alt="Screenshot 2025-11-18 at 12 58 12" src="https://github.com/user-attachments/assets/64dbb7fc-3816-4c85-89b0-871d7e7dbb99" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/21683-fees-loader&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/21683-fees-loader&lookback=7)