### PR TITLE
chore(nix): update nix to nodejs 24

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747542820,
-        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
+        "lastModified": 1763283776,
+        "narHash": "sha256-Y7TDFPK4GlqrKrivOcsHG8xSGqQx3A6c+i7novT85Uk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
+        "rev": "50a96edd8d0db6cc8db57dab6bb6d6ee1f3dc49a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
             pkgs.xorg.xhost
             pkgs.docker
             pkgs.docker-compose
-            pkgs.nodejs_22
+            pkgs.nodejs_24
             (pkgs.yarn.override { nodejs = null; })
             pkgs.python3
             pkgs.python3Packages.pip

--- a/shell.nix
+++ b/shell.nix
@@ -1,15 +1,15 @@
-# pinned to nixos-unstable on commit https://github.com/NixOS/nixpkgs/commit/8d92119c540d78599ba208010c722a60958810f4
-# we need to use nixos-unstable to be able to use electron_36, once there is a stable release with it we can change.
+# pinned to nixos-unstable on commit https://github.com/NixOS/nixpkgs/commit/467a36d9f02926bf8388b62eb82f0e6234b40851
+# we need to use nixos-unstable to be able to use nodejs_24, once there is a stable release with it we can change.
 with import
   (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/8d92119c540d78599ba208010c722a60958810f4.tar.gz";
-    sha256 = "08w0arf23z6mdnipmpspmkwmmvskd9mjq6b5j8070ryqjpzwas05";
+    url = "https://github.com/NixOS/nixpkgs/archive/467a36d9f02926bf8388b62eb82f0e6234b40851.tar.gz";
+    sha256 = "17cana4hwz4a23p2lmqfp1szxihbgib9a4dqwf6xmbjz1w1kxxlh";
    }) { system = builtins.currentSystem; };
 
 let
   # unstable packages
   electron = electron_36;
-  nodejs = nodejs_22;
+  nodejs = nodejs_24;
   # use older gcc. 10.2.0 with glibc 2.32 for node_modules bindings.
   # electron-builder is packing the app with glibc 2.32, bindings should not be compiled with newer version.
   gccPkgs = import (builtins.fetchTarball {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update Nodejs to 24 for Nix users since it was updated for Suite https://github.com/trezor/trezor-suite/pull/23206

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/new-nodejs-version&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/new-nodejs-version&lookback=7)