### PR TITLE
fix(node-utils): unit test on node24

### DIFF
--- a/packages/node-utils/src/tests/findProcessFromIncomingPort.test.ts
+++ b/packages/node-utils/src/tests/findProcessFromIncomingPort.test.ts
@@ -22,7 +22,7 @@ describe('findProcessFromIncomingPort', () => {
             if (process.platform === 'win32') {
                 expect(processInfo?.name).toEqual('Node.js');
             } else {
-                expect(processInfo?.name).toEqual('node');
+                expect(processInfo?.name).toEqual('MainThread');
             }
         } finally {
             server.close();


### PR DESCRIPTION
## Description

Fix unit tests that started failing after https://github.com/trezor/trezor-suite/pull/23206
because sadly the unit test did not run.

## Notes

I created a minimal file for testing this in node 22 vs node 24, and confirmed that even outside of trezor-suite:
- Linux node22 `'node'`
- Linux node24 `'MainThread'`
- Windows is the same: `'Node.js'`


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/node24-unit-test&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/node24-unit-test&lookback=7)