### PR TITLE
ci(suite-data): run update.sh after updating Tor version

### DIFF
--- a/.github/workflows/update-tor.yml
+++ b/.github/workflows/update-tor.yml
@@ -110,6 +110,6 @@ jobs:
           branch: chore/update-tor-binaries
           title: "Update TOR binaries"
           body: ${{ steps.pr_body.outputs.body }}
-          base: "develop"
+          base: ${{ github.ref_name }}
           delete-branch: true
           labels: tor, ci

--- a/.github/workflows/update-tor.yml
+++ b/.github/workflows/update-tor.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-tor:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     env:
       UPDATE_FILE: packages/suite-data/files/bin/tor/update.sh
     steps:
@@ -66,11 +66,16 @@ jobs:
         if: steps.check_crx.outputs.new_crx == 'true' || steps.check_arm.outputs.new_arm == 'true'
         run: |
           if [ "${{ steps.check_crx.outputs.new_crx }}" = "true" ]; then
-            sed -i "s/^CRX_VER=.*/CRX_VER=${{ steps.versions.outputs.crx_next }}/" "$UPDATE_FILE"
+            sed -i '' "s/^CRX_VER=.*/CRX_VER=${{ steps.versions.outputs.crx_next }}/" "$UPDATE_FILE"
           fi
           if [ "${{ steps.check_arm.outputs.new_arm }}" = "true" ]; then
-            sed -i "s/^CRX_LINUX_ARM_VER=.*/CRX_LINUX_ARM_VER=${{ steps.versions.outputs.arm_next }}/" "$UPDATE_FILE"
+            sed -i '' "s/^CRX_LINUX_ARM_VER=.*/CRX_LINUX_ARM_VER=${{ steps.versions.outputs.arm_next }}/" "$UPDATE_FILE"
           fi
+
+      - name: Run update.sh
+        if: steps.check_crx.outputs.new_crx == 'true' || steps.check_arm.outputs.new_arm == 'true'
+        run: |
+          bash "$UPDATE_FILE"
 
       - name: Build PR body
         id: pr_body

--- a/.github/workflows/update-tor.yml
+++ b/.github/workflows/update-tor.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update-tor:
+    if: github.repository == 'trezor/trezor-suite'
     runs-on: macos-latest
     env:
       UPDATE_FILE: packages/suite-data/files/bin/tor/update.sh

--- a/packages/suite-data/files/bin/tor/linux-arm64/tor
+++ b/packages/suite-data/files/bin/tor/linux-arm64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b28a7ca0caff7bc264b104f6d0702e080993442d89b3199c55c381622ff6bd2a
-size 18523504
+oid sha256:d881d01da89ffec4a7ba934efbd0a2479755293d15a796ff924a1891acb48899
+size 19184896

--- a/packages/suite-data/files/bin/tor/linux-x64/tor
+++ b/packages/suite-data/files/bin/tor/linux-x64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9cbf2ba586ae087df01e43e5624fb7f42207e5a982811e0d3cad7cbce96c9dce
-size 19094608
+oid sha256:28febb73579b7148bccc552e699ccf7a682cd7d618f3a6c24c7407a4a17438e8
+size 19765304

--- a/packages/suite-data/files/bin/tor/mac-arm64/tor
+++ b/packages/suite-data/files/bin/tor/mac-arm64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4abe5676e7f4cba6e1083e3e02e172bf8971a53e33d948b81551c82f7fef03dd
-size 6558224
+oid sha256:e0204c3d8f15bab9daec2aba725050a77082b5d82fc2143bd05bb513ade52690
+size 7565568

--- a/packages/suite-data/files/bin/tor/mac-x64/tor
+++ b/packages/suite-data/files/bin/tor/mac-x64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e38458e276d77afa75ca7b65ab922fcd7e8f9574e8eac9fdec7dd191600f60d
-size 7086640
+oid sha256:b2933d6503c01fc365b78e259a7859cb78e46147fdca7c1f8cfaa706196e30b1
+size 9299344

--- a/packages/suite-data/files/bin/tor/update.sh
+++ b/packages/suite-data/files/bin/tor/update.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
+
+# If you are going to make changes to the script, make sure it stays compatible with update-tor.yml
+
 set -e
 
-# !!! If you are going to change this, change update-tor workflow as well !!!
 CRX_VER=1_0_39
 CRX_LINUX_ARM_VER=1_0_8
 

--- a/packages/suite-data/files/bin/tor/update.sh
+++ b/packages/suite-data/files/bin/tor/update.sh
@@ -4,6 +4,10 @@
 
 set -e
 
+# Ensure the script runs from its own directory so it can be invoked from repo root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
 CRX_VER=1_0_39
 CRX_LINUX_ARM_VER=1_0_8
 

--- a/packages/suite-data/files/bin/tor/win-x64/tor.exe
+++ b/packages/suite-data/files/bin/tor/win-x64/tor.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f62c93694d1e723a3e6a91cd788d4de9205a192e6c3b4102fd728468bf7be0f6
-size 18173920
+oid sha256:d64b412f52f02e5948a3ae0efa1df2c1f5588eb37ca119ae5b0b9a709c4715ae
+size 18741616


### PR DESCRIPTION
Fixes for https://github.com/trezor/trezor-suite/pull/20825

- After updating the script, it should be run as well. I changed the runner to `macos-latest` so that the `lipo` commands work.
- It should only run in the public repo, not private or release repos, otherwise it creates redundant PRs in those repos.
- Enabled executing the script from any directory (previously it was necessary to `cd` to its directory before executing it).
- Updated Tor as it was missed in https://github.com/trezor/trezor-suite/pull/22815.
- Replaced hard-coded `develop` base branch with the branch the workflow was executed from, in case it is executed manually.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/run-script-when-updating-tor-versions&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/run-script-when-updating-tor-versions&lookback=7)