### PR TITLE
ci: simplify yarn build:essential

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "postinstall": "yarn run patch-package && husky",
         "_______ Library Scripts #####": "Some libraries have their own build scripts.",
         "build:libs": "yarn nx run-many --skip-nx-cache --target=build:lib",
-        "build:essential": "yarn message-system-sign-config & yarn workspace @trezor/suite-data build:lib & yarn workspace @trezor/transport-bridge build:lib & wait",
+        "build:essential": "yarn message-system-sign-config & yarn workspace @trezor/suite-data build:lib & yarn workspace @trezor/transport-bridge build:lib",
         "suite:build:web": "yarn workspace @trezor/suite-web build",
         "_______ Start Scripts _______": "Here are standalone scripts for running individual applications for development.",
         "suite:dev": "yarn workspace @trezor/suite-web dev",


### PR DESCRIPTION
## Description

Remove `wait` from `yarn build:essential`, because it's not available on all platforms, only in linux bash.
I found out it's actually not needed, running through yarn is different than running directly in shell. Even with `&` yarn wraps the parallel processes in its own node process, taking care of blocking/releasing shell when all of them are finished, which is just what I inteded with the `wait` :heavy_check_mark: 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/simplify-build-essential&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/simplify-build-essential&lookback=7)