### PR TITLE
ci: increase timeout on release-suite-desktop-web-staging

### DIFF
--- a/.github/workflows/release-suite-desktop-web-staging.yml
+++ b/.github/workflows/release-suite-desktop-web-staging.yml
@@ -217,7 +217,7 @@ jobs:
       - suite-desktop-autoupdate-release
       - build-web
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

Increase timeout on `release-suite-desktop-web-staging.yml`
because it repeatedly exceeds it, idk?
https://github.com/trezor/trezor-suite-release/actions/runs/19469347609/attempts/1