### PR TITLE
fix(suite-desktop): release notes

### DIFF
--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/JustUpdated.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/JustUpdated.tsx
@@ -13,13 +13,16 @@ interface AvailableProps {
     onCancel: () => void;
 }
 
+const DEFAULT_ASSET_PREFIX = '.';
+
 export const JustUpdated = ({ onCancel }: AvailableProps) => {
     const [changelog, setChangelog] = useState<string | null>(null);
     const theme = useTheme();
     const suiteCurrentVersion = process.env.VERSION || '';
 
     const getReleaseNotes = useCallback(async () => {
-        const releaseNotesPath = process.env.ASSET_PREFIX + '/release-notes.md';
+        const releaseNotesPath =
+            (process.env.ASSET_PREFIX || DEFAULT_ASSET_PREFIX) + '/release-notes.md';
         const result = await (await fetch(releaseNotesPath)).text();
         setChangelog(result);
     }, []);


### PR DESCRIPTION
## Description

Fix link to Desktop update release notes after https://github.com/trezor/trezor-suite/pull/22671 

## Screenshots:

### Before

<img width="925" height="1046" alt="Screenshot from 2025-11-19 11-44-11" src="https://github.com/user-attachments/assets/b91c0b81-5962-494c-94a1-7f953be32292" />


### After

<img width="925" height="1046" alt="Screenshot from 2025-11-19 11-43-17" src="https://github.com/user-attachments/assets/cd0b1ae1-8f09-4411-9640-7f632dfe4e4b" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/release-notes&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/release-notes&lookback=7)