### PR TITLE
feat(message-system): add conditional logic for THP devices

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemDevices.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemDevices.tsx
@@ -42,9 +42,16 @@ export const MessageSystemDevices = ({ devices }: MessageSystemDevicesProps) => 
                 <Collapsible.Content>
                     {devices.map((device, index) => (
                         <div key={`${device.model}_${index}`}>
-                            <strong>{device.model}</strong> (firmware: {device.firmware},
-                            bootloader: {device.bootloader}, variant: {device.variant},
-                            firmwareRevision: {device.firmwareRevision}, vendor: {device.vendor})
+                            <strong>{device.model}</strong>{' '}
+                            {JSON.stringify(
+                                device,
+                                (key, value) => {
+                                    if (key === 'model') return undefined;
+
+                                    return value;
+                                },
+                                2,
+                            )}
                         </div>
                     ))}
                 </Collapsible.Content>

--- a/suite-common/message-system/schema/config.schema.v1.json
+++ b/suite-common/message-system/schema/config.schema.v1.json
@@ -477,6 +477,39 @@
                                     "description": "Eligible authorized vendors.",
                                     "type": "string",
                                     "enum": ["*", "trezor.io"]
+                                },
+                                "thpProperties": {
+                                    "title": "Trezor-Host-Protocol (THP) properties",
+                                    "type": "object",
+                                    "properties": {
+                                        "internalModel": {
+                                            "type": "string"
+                                        },
+                                        "modelVariant": {
+                                            "type": "number"
+                                        },
+                                        "protocolVersionMajor": {
+                                            "type": "number"
+                                        },
+                                        "protocolVersionMinor": {
+                                            "type": "number"
+                                        },
+                                        "pairingMethods": {
+                                            "type": "array",
+                                            "items": {
+                                                "title": "Pairing Method",
+                                                "type": "string",
+                                                "enum": [
+                                                    "SkipPairing",
+                                                    "CodeEntry",
+                                                    "QrCode",
+                                                    "NFC"
+                                                ],
+                                                "description": "Supported THP pairing methods: 1=SkipPairing, 2=CodeEntry, 3=QrCode, 4=NFC."
+                                            }
+                                        }
+                                    },
+                                    "additionalProperties": false
                                 }
                             },
                             "additionalProperties": false

--- a/suite-common/message-system/src/messageSystemConstants.ts
+++ b/suite-common/message-system/src/messageSystemConstants.ts
@@ -5,6 +5,7 @@ import {
     CountryCode,
     FirmwareVariant,
     Model,
+    PairingMethod,
     Variant,
     Vendor,
 } from '@suite-common/suite-types';
@@ -89,6 +90,8 @@ export const FW_VARIANT_ENUM = schema.definitions.conditions.items.properties.de
     .properties.variant.enum as readonly FirmwareVariant[];
 export const VENDOR_ENUM = schema.definitions.conditions.items.properties.devices.items.properties
     .vendor.enum as readonly Vendor[];
+export const PAIRING_METHOD_ENUM = schema.definitions.conditions.items.properties.devices.items
+    .properties.thpProperties.properties.pairingMethods.items.enum as readonly PairingMethod[];
 
 export const CATEGORY_OPTIONS = toMessageSystemOptions(CATEGORY_ENUM);
 export const CATEGORY_FILTER_OPTIONS = toMessageSystemOptions([

--- a/suite-common/message-system/src/messageSystemUtils.ts
+++ b/suite-common/message-system/src/messageSystemUtils.ts
@@ -16,6 +16,7 @@ import type {
     Settings,
     Transport,
     TrezorDevice,
+    TrezorHostProtocolTHPProperties,
     Version,
 } from '@suite-common/suite-types';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
@@ -154,6 +155,50 @@ export const isTransportCompatible = (
         })
         .some(({ type, version }) => isVersionCompatible(transportCondition, type, version));
 
+const isThpPropertiesCompatible = (
+    condition?: TrezorHostProtocolTHPProperties,
+    device?: NonNullable<TrezorDevice['thp']>['properties'],
+) => {
+    if (!condition) return true;
+
+    if (!device) return false;
+
+    if (
+        condition.internalModel &&
+        device.internal_model?.toLowerCase() !== condition.internalModel.toLowerCase()
+    ) {
+        return false;
+    }
+
+    if (condition.modelVariant !== undefined && device.model_variant !== condition.modelVariant) {
+        return false;
+    }
+
+    if (
+        condition.protocolVersionMajor !== undefined &&
+        device.protocol_version_major !== condition.protocolVersionMajor
+    ) {
+        return false;
+    }
+
+    if (
+        condition.protocolVersionMinor !== undefined &&
+        device.protocol_version_minor !== condition.protocolVersionMinor
+    ) {
+        return false;
+    }
+
+    if (condition.pairingMethods?.length) {
+        if (!device.pairing_methods?.length) return false;
+
+        if (!condition.pairingMethods.every(method => device.pairing_methods.includes(method))) {
+            return false;
+        }
+    }
+
+    return true;
+};
+
 export const isDeviceCompatible = (deviceConditions: Device[], device?: TrezorDevice): boolean => {
     // if device conditions are empty, then device should be empty
     if (!deviceConditions.length) {
@@ -178,6 +223,7 @@ export const isDeviceCompatible = (deviceConditions: Device[], device?: TrezorDe
             firmware: firmwareCondition,
             bootloader: bootloaderCondition,
             variant: variantCondition,
+            thpProperties: thpPropertiesCondition,
         } = deviceCondition;
 
         return (
@@ -189,7 +235,8 @@ export const isDeviceCompatible = (deviceConditions: Device[], device?: TrezorDe
             (semver.satisfies(deviceFwVersion, createVersionRange(firmwareCondition)!) ||
                 firmwareCondition === '*') &&
             (semver.satisfies(deviceBootloaderVersion, createVersionRange(bootloaderCondition)!) ||
-                bootloaderCondition === '*')
+                bootloaderCondition === '*') &&
+            isThpPropertiesCompatible(thpPropertiesCondition, device.thp?.properties)
         );
     });
 };
@@ -466,12 +513,19 @@ export const getDefaultConditionValue = (key: keyof Condition): Condition[keyof 
         case 'devices':
             return [
                 {
-                    model: 'T3T1',
+                    model: 'T3W1',
                     firmwareRevision: '*',
                     firmware: '*',
                     bootloader: '*',
                     variant: '*',
                     vendor: '*',
+                    thpProperties: {
+                        internalModel: 'T3W1',
+                        modelVariant: 2,
+                        protocolVersionMajor: 2,
+                        protocolVersionMinor: 0,
+                        pairingMethods: ['CodeEntry'],
+                    },
                 },
             ];
 

--- a/suite-common/message-system/src/messageSystemValidation.ts
+++ b/suite-common/message-system/src/messageSystemValidation.ts
@@ -4,6 +4,7 @@ import type {
     CountryCode,
     FirmwareVariant,
     Model,
+    PairingMethod,
     Variant,
     Vendor,
 } from '@suite-common/suite-types';
@@ -17,6 +18,7 @@ import {
     FEATURE_LIST,
     FW_VARIANT_ENUM,
     MODEL_ENUM,
+    PAIRING_METHOD_ENUM,
     VARIANT_ENUM,
     VENDOR_ENUM,
 } from './messageSystemConstants';
@@ -254,6 +256,16 @@ const settingsSchema = yup.array(
         .noUnknown(false),
 );
 
+const thpPropertiesSchema = yup
+    .object({
+        internalModel: yup.string().optional(),
+        modelVariant: yup.number().optional(),
+        protocolVersionMajor: yup.number().optional(),
+        protocolVersionMinor: yup.number().optional(),
+        pairingMethods: yup.array(yup.mixed<PairingMethod>().oneOf(PAIRING_METHOD_ENUM)).optional(),
+    })
+    .noUnknown(true);
+
 const deviceSchema = yup
     .object({
         model: yup.mixed<Model>().oneOf(MODEL_ENUM).required(),
@@ -262,6 +274,7 @@ const deviceSchema = yup
         bootloader: versionSchema,
         variant: yup.mixed<FirmwareVariant>().oneOf(FW_VARIANT_ENUM).required(),
         vendor: yup.mixed<Vendor>().oneOf(VENDOR_ENUM).required(),
+        thpProperties: thpPropertiesSchema.optional(),
     })
     .noUnknown(true);
 

--- a/suite-common/suite-types/src/messageSystem.ts
+++ b/suite-common/suite-types/src/messageSystem.ts
@@ -23,6 +23,10 @@ export type FirmwareVariant = '*' | 'bitcoin-only' | 'universal';
  */
 export type Vendor = '*' | 'trezor.io';
 /**
+ * Supported THP pairing methods: 1=SkipPairing, 2=CodeEntry, 3=QrCode, 4=NFC.
+ */
+export type PairingMethod = 'SkipPairing' | 'CodeEntry' | 'QrCode' | 'NFC';
+/**
  * This interface was referenced by `MessageSystem`'s JSON-Schema
  * via the `definition` "countryCodes".
  */
@@ -378,6 +382,14 @@ export interface Device {
     bootloader: Version;
     variant: FirmwareVariant;
     vendor: Vendor;
+    thpProperties?: TrezorHostProtocolTHPProperties;
+}
+export interface TrezorHostProtocolTHPProperties {
+    internalModel?: string;
+    modelVariant?: number;
+    protocolVersionMajor?: number;
+    protocolVersionMinor?: number;
+    pairingMethods?: PairingMethod[];
 }
 export interface Message {
     id: string;


### PR DESCRIPTION
## Description

Add THP property conditions to the message system.

Also fixed the typing of `ThpPairingMethod` from numeric enums to string union.

## Notes for QA

Test message:

```
{
  "message": {
    "id": "ec0a5afc-ef4c-4913-9a8e-d5c051701624",
    "priority": 100,
    "dismissible": true,
    "variant": "info",
    "category": "banner",
    "content": {
      "en": "test",
      "cs": "",
      "es": "",
      "de": "",
      "fr": "",
      "pt": ""
    }
  },
  "conditions": [
    {
      "devices": [
        {
          "model": "T3W1",
          "firmwareRevision": "*",
          "firmware": "*",
          "bootloader": "*",
          "variant": "*",
          "vendor": "*",
          "thpProperties": {
            "internalModel": "T3W1",
            "modelVariant": 2,
            "protocolVersionMajor": 2,
            "protocolVersionMinor": 0,
            "pairingMethods": [
              "CodeEntry"
            ]
          }
        }
      ]
    }
  ]
}
```

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23141

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/message-system-thp&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/message-system-thp&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/message-system-thp&lookback=7)