### PR TITLE
feat(e2e): Allow using -main FW via fixture

### DIFF
--- a/packages/suite-desktop-core/e2e/support/electron.ts
+++ b/packages/suite-desktop-core/e2e/support/electron.ts
@@ -2,7 +2,7 @@ import { ElectronApplication, Page, _electron as electron } from '@playwright/te
 import { createWriteStream, ensureDirSync } from 'fs-extra';
 import path from 'path';
 
-import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+import { StartEmu, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { BRIDGE_VERSION } from './bridge';
 import { getModelFromEnv } from './helpers/modelFromEnv';
@@ -48,7 +48,7 @@ const formatErrorLogMessage = (data: string) => {
     return `${timestamp} - ${bold}${red}ERROR${unbold}: ${data}${reset}`;
 };
 
-const buildArgs = (params: LaunchSuiteParams) => {
+const buildArgs = (params: LaunchSuiteParams, emulatorStartConf: StartEmu) => {
     const args = [
         // This needs to be just path to the app root, so it is same as for production builds,
         // electron will resolve the path to app.js from the package.json => "main": "dist/app.js",
@@ -80,7 +80,7 @@ const buildArgs = (params: LaunchSuiteParams) => {
         args.push(removeUserDataArgument);
     }
 
-    if (process.env.CANARY_FIRMWARE) {
+    if (emulatorStartConf.version?.endsWith('-main')) {
         args.push(disableFirmwareRevisionChecksPatch);
     }
 
@@ -105,14 +105,17 @@ const setupLoggingToFile = (electronApp: ElectronApplication, params: LaunchSuit
     });
 };
 
-export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
+export const launchSuiteElectronApp = async (
+    params: LaunchSuiteParams,
+    emulatorStartConf: StartEmu,
+) => {
     if (!params.bridgeDaemon) {
         await TrezorUserEnvLink.startBridge(BRIDGE_VERSION);
     }
 
     const electronApp = await electron.launch({
         cwd: appDir,
-        args: buildArgs(params),
+        args: buildArgs(params, emulatorStartConf),
         env: {
             ...process.env,
             PLAYWRIGHT_RUN: 'true',
@@ -127,8 +130,11 @@ export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
     return electronApp;
 };
 
-export const launchSuite = async (params: LaunchSuiteParams): Promise<Suite> => {
-    const electronApp = await launchSuiteElectronApp(params);
+export const launchSuite = async (
+    params: LaunchSuiteParams,
+    emulatorStartConf: StartEmu,
+): Promise<Suite> => {
+    const electronApp = await launchSuiteElectronApp(params, emulatorStartConf);
     const window = await electronApp.firstWindow();
 
     return { electronApp, window };

--- a/packages/suite-desktop-core/e2e/support/fixtures.ts
+++ b/packages/suite-desktop-core/e2e/support/fixtures.ts
@@ -60,12 +60,20 @@ const test = suiteBaseTest.extend<Fixtures>({
         await use(new WalletPage(page));
     },
     onboardingPage: async (
-        { page, model, devicePrompt, analyticsSection, settingsPage },
+        { page, model, devicePrompt, analyticsSection, settingsPage, emulatorStartConf },
         use,
         testInfo,
     ) => {
         await use(
-            new OnboardingPage(page, model, testInfo, devicePrompt, analyticsSection, settingsPage),
+            new OnboardingPage(
+                page,
+                model,
+                testInfo,
+                devicePrompt,
+                analyticsSection,
+                settingsPage,
+                emulatorStartConf,
+            ),
         );
     },
     analyticsSection: async ({ page }, use) => {

--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -1,6 +1,7 @@
 import { Locator, Page, TestInfo, expect } from '@playwright/test';
 
 import { SUITE as SuiteActions } from '@trezor/suite/src/actions/suite/constants';
+import { StartEmu } from '@trezor/trezor-user-env-link';
 
 import { TrezorUserEnvLinkProxy, isWebProject, step } from '../../common';
 import { SeedType } from '../../enums/seedType';
@@ -47,6 +48,7 @@ export class OnboardingPage {
         private readonly devicePrompt: DevicePrompt,
         private readonly analyticsSection: AnalyticsSection,
         private readonly settingsPage: SettingsPage,
+        private readonly emulatorStartConf: StartEmu,
     ) {
         this.backup = new BackupSection(page, devicePrompt);
         this.firmware = new FirmwareSection(page);
@@ -252,7 +254,7 @@ export class OnboardingPage {
     @step()
     async disableNecessaryFirmwareChecks(options?: { skipSuiteLoadedCheck?: boolean }) {
         await this.disableFirmwareHashCheck(options);
-        if (process.env.CANARY_FIRMWARE) {
+        if (this.emulatorStartConf.version?.endsWith('-main')) {
             await this.disableFirmwareRevisionCheck();
         }
 

--- a/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
@@ -42,14 +42,18 @@ const electronSetup = async (
     locale: string | undefined,
     colorScheme: any,
     electronConf: ElectronConf,
+    emulatorStartConf: StartEmu,
 ) => {
-    const suite = await launchSuite({
-        locale,
-        colorScheme,
-        artefactFolder: testInfo.outputDir,
-        viewport: testInfo.project.use.viewport!,
-        ...electronConf,
-    });
+    const suite = await launchSuite(
+        {
+            locale,
+            colorScheme,
+            artefactFolder: testInfo.outputDir,
+            viewport: testInfo.project.use.viewport!,
+            ...electronConf,
+        },
+        emulatorStartConf,
+    );
 
     await suite.window
         .context()
@@ -114,6 +118,18 @@ const webTeardown = async (page: Page, browserContext: BrowserContext, testInfo:
     }
 };
 
+const getDefaultEmuStartConf = (): StartEmuModelRequired => {
+    const model = getModelFromEnv();
+    const DefaultFirmwareMajorVersion = model === 'T1B1' ? 1 : 2;
+    const defaultFirmwareType = process.env.CANARY_FIRMWARE ? '-main' : '-latest';
+
+    return {
+        model,
+        wipe: true,
+        version: `${DefaultFirmwareMajorVersion}${defaultFirmwareType}`,
+    };
+};
+
 const trezorEnvSetup = async (
     testInfo: TestInfo,
     startEmulator: boolean,
@@ -149,7 +165,7 @@ const baseWithCurrents = mergeTests(base, currentsTest);
 const suiteBaseTest = baseWithCurrents.extend<suiteBaseFixture>({
     startEmulator: true,
     setupEmulator: true,
-    emulatorStartConf: { model: getModelFromEnv(), wipe: true },
+    emulatorStartConf: getDefaultEmuStartConf(),
     emulatorSetupConf: {},
     electronConf: {},
     ignoreJSExceptions: [],
@@ -185,7 +201,13 @@ const suiteBaseTest = baseWithCurrents.extend<suiteBaseFixture>({
         );
 
         if (isDesktopProject(testInfo)) {
-            const suite = await electronSetup(testInfo, locale, colorScheme, electronConf);
+            const suite = await electronSetup(
+                testInfo,
+                locale,
+                colorScheme,
+                electronConf,
+                emulatorStartConf,
+            );
             enhancePage(suite.window);
             await use(suite.window);
             await electronTeardown(suite, testInfo, electronConf);

--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
@@ -17,24 +17,33 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
         await trezorUserEnvLink.stopBridge();
     });
 
-    test('App in daemon mode spawns node-bridge', async ({ request }, testInfo) => {
+    test('App in daemon mode spawns node-bridge', async ({
+        request,
+        emulatorStartConf,
+    }, testInfo) => {
         await expectBridgeToBeStopped(request);
 
-        const daemonApp = await launchSuiteElectronApp({
-            bridgeDaemon: true,
-            artefactFolder: testInfo.outputDir,
-            viewport: testInfo.project.use.viewport!,
-        });
+        const daemonApp = await launchSuiteElectronApp(
+            {
+                bridgeDaemon: true,
+                artefactFolder: testInfo.outputDir,
+                viewport: testInfo.project.use.viewport!,
+            },
+            emulatorStartConf,
+        );
 
         await expect(async () => {
             await expectBridgeToBeRunning(request);
         }).toPass({ timeout: 3_000 });
 
         // launch UI, with node-bridge already running in background
-        const suite = await launchSuite({
-            artefactFolder: testInfo.outputDir,
-            viewport: testInfo.project.use.viewport!,
-        });
+        const suite = await launchSuite(
+            {
+                artefactFolder: testInfo.outputDir,
+                viewport: testInfo.project.use.viewport!,
+            },
+            emulatorStartConf,
+        );
         const title = await suite.window.title();
         expect(title).toContain('Trezor Suite');
 

--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge.test.ts
@@ -26,12 +26,18 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
         await trezorUserEnvLink.stopBridge();
     });
 
-    test('App spawns bundled bridge and stops it after app quit', async ({ request }, testInfo) => {
-        const suite = await launchSuite({
-            bridgeDaemon: true,
-            artefactFolder: testInfo.outputDir,
-            viewport: testInfo.project.use.viewport!,
-        });
+    test('App spawns bundled bridge and stops it after app quit', async ({
+        request,
+        emulatorStartConf,
+    }, testInfo) => {
+        const suite = await launchSuite(
+            {
+                bridgeDaemon: true,
+                artefactFolder: testInfo.outputDir,
+                viewport: testInfo.project.use.viewport!,
+            },
+            emulatorStartConf,
+        );
         const title = await suite.window.title();
         enhancePage(suite.window);
         expect(title).toContain('Trezor Suite');
@@ -59,16 +65,20 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
 
     test('App acquired device, EXTERNAL bridge is restarted, app reconnects', async ({
         trezorUserEnvLink,
+        emulatorStartConf,
         model,
     }, testInfo) => {
-        await trezorUserEnvLink.startEmu({ wipe: true, model: model.model });
+        await trezorUserEnvLink.startEmu(emulatorStartConf);
         await trezorUserEnvLink.setupEmu({});
         await trezorUserEnvLink.startBridge(BRIDGE_VERSION);
 
-        const suite = await launchSuite({
-            artefactFolder: testInfo.outputDir,
-            viewport: testInfo.project.use.viewport!,
-        });
+        const suite = await launchSuite(
+            {
+                artefactFolder: testInfo.outputDir,
+                viewport: testInfo.project.use.viewport!,
+            },
+            emulatorStartConf,
+        );
         enhancePage(suite.window);
         await suite.window.title();
 
@@ -81,6 +91,7 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
             devicePrompt,
             new AnalyticsSection(suite.window),
             new SettingsPage(suite.window),
+            emulatorStartConf,
         );
         await onboardingPage.completeOnboarding();
 

--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-tor.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-tor.test.ts
@@ -36,20 +36,20 @@ const turnOnTorInSettings = async (window: Page, shouldEnableTor = true) => {
 };
 
 test.describe.skip('Tor loading screen', { tag: ['@group=suite', '@desktopOnly'] }, () => {
-    test('Tor loading screen: happy path', async ({}, testInfo) => {
+    test('Tor loading screen: happy path', async ({ emulatorStartConf }, testInfo) => {
         const suiteArgs = {
             artefactFolder: testInfo.outputDir,
             viewport: testInfo.project.use.viewport!,
         };
         test.setTimeout(timeout);
 
-        let suite = await launchSuite(suiteArgs);
+        let suite = await launchSuite(suiteArgs, emulatorStartConf);
 
         await turnOnTorInSettings(suite.window);
 
         suite.electronApp.close();
 
-        suite = await launchSuite(suiteArgs);
+        suite = await launchSuite(suiteArgs, emulatorStartConf);
 
         await suite.window.waitForSelector('[data-testid="@tor-loading-screen"]', {
             state: 'visible',
@@ -60,7 +60,9 @@ test.describe.skip('Tor loading screen', { tag: ['@group=suite', '@desktopOnly']
         suite.electronApp.close();
     });
 
-    test('Tor loading screen: making sure that all the request go throw Tor', async ({}, testInfo) => {
+    test('Tor loading screen: making sure that all the request go throw Tor', async ({
+        emulatorStartConf,
+    }, testInfo) => {
         const suiteArgs = {
             artefactFolder: testInfo.outputDir,
             viewport: testInfo.project.use.viewport!,
@@ -68,13 +70,13 @@ test.describe.skip('Tor loading screen', { tag: ['@group=suite', '@desktopOnly']
 
         const networkAnalyzer = new NetworkAnalyzer();
 
-        let suite = await launchSuite(suiteArgs);
+        let suite = await launchSuite(suiteArgs, emulatorStartConf);
 
         await turnOnTorInSettings(suite.window);
 
         suite.electronApp.close();
 
-        suite = await launchSuite(suiteArgs);
+        suite = await launchSuite(suiteArgs, emulatorStartConf);
         // Start network analyzer after making sure tor is going to be running.
         networkAnalyzer.start();
 
@@ -92,20 +94,22 @@ test.describe.skip('Tor loading screen', { tag: ['@group=suite', '@desktopOnly']
         suite.electronApp.close();
     });
 
-    test('Tor loading screen: disable tor while loading', async ({}, testInfo) => {
+    test('Tor loading screen: disable tor while loading', async ({
+        emulatorStartConf,
+    }, testInfo) => {
         const suiteArgs = {
             artefactFolder: testInfo.outputDir,
             viewport: testInfo.project.use.viewport!,
         };
         test.setTimeout(timeout);
 
-        let suite = await launchSuite(suiteArgs);
+        let suite = await launchSuite(suiteArgs, emulatorStartConf);
 
         await turnOnTorInSettings(suite.window);
 
         suite.electronApp.close();
 
-        suite = await launchSuite(suiteArgs);
+        suite = await launchSuite(suiteArgs, emulatorStartConf);
 
         await suite.window.waitForSelector('[data-testid="@tor-loading-screen"]', {
             state: 'visible',

--- a/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
@@ -87,7 +87,7 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
                 priority: TestPriority.Medium,
             }),
         },
-        async ({ context, model, onboardingPage, dashboardPage }, testInfo) => {
+        async ({ context, model, onboardingPage, dashboardPage, emulatorStartConf }, testInfo) => {
             await onboardingPage.completeOnboarding();
 
             const pageTwo = await context.newPage();
@@ -106,6 +106,7 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
                 devicePromptTwo,
                 analyticsSectionTwo,
                 settingsPageTwo,
+                emulatorStartConf,
             );
             await onboardingPageTwo.completeOnboarding();
             const dashboardPageTwo = new DashboardPage(pageTwo, devicePromptTwo);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reworked how the setup handles FW. Now you can start with -main FW on demand, while CANARY_FIRMWARE env variable still works as before.  This is done by updating the emulatorstartconf FW version with default values, so that it is always available even when not explicitly defined and then use this value instead of reading it from ENV.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-e2e-fw-main&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-e2e-fw-main&lookback=7)