### PR TITLE
Feat: power state notification

### DIFF
--- a/packages/connect/src/device/workflow/trezorPushNotification.ts
+++ b/packages/connect/src/device/workflow/trezorPushNotification.ts
@@ -72,6 +72,7 @@ export const trezorPushNotificationHandler = async ({ device, message }: TpnWork
     switch (type) {
         case TrezorPushNotificationType.SETTING_CHANGE:
         case TrezorPushNotificationType.PIN_CHANGE:
+        case TrezorPushNotificationType.NOTIFY_POWER_STATUS_CHANGE:
             if (!device.isUsed()) {
                 await device.acquire();
                 await device.getFeatures();

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -171,6 +171,8 @@ export type KnownDevice = BaseDevice & {
     hid?: undefined;
     /** @deprecated  use descriptor.id in combination with descriptor.apiType */
     bluetoothProps?: BluetoothDeviceProps;
+    usb_connected?: boolean; // true if the device is powered/charged from USB, regardless of transport selection.
+    wireless_connected?: boolean;
 };
 
 export type UnknownDevice = BaseDevice & {

--- a/packages/protocol/src/protocol-tpn/decode.ts
+++ b/packages/protocol/src/protocol-tpn/decode.ts
@@ -17,6 +17,7 @@ export enum TrezorPushNotificationType {
     PIN_CHANGE = 7 /**< Pin changed on the device */,
     WIPE = 8 /**< Factory reset (wipe) invoked */,
     UNPAIR = 9 /**< BLE bonding for current connection deleted */,
+    NOTIFY_POWER_STATUS_CHANGE = 10 /**< Power status changed, i.e. charging started */,
 }
 
 export enum TrezorPushNotificationMode {

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -184,10 +184,28 @@ export const selectIsThpDevice = createMemoizedSelector(
 
 export const selectIsDeviceConnectedViaBluetoothLowOnBattery = createMemoizedSelector(
     [selectIsDeviceConnectedViaBluetooth, selectDeviceFeatures],
-    (isDeviceConnectedViaBluetooth, features) =>
-        isDeviceConnectedViaBluetooth &&
-        typeof features?.soc === 'number' &&
-        features.soc < DEVICE_LOW_BATTERY_PERCENTAGE_THRESHOLD,
+    (isDeviceConnectedViaBluetooth, features) => {
+        const { usb_connected, wireless_connected, soc } = features || {};
+
+        // If not connected via Bluetooth, then there is no low battery.
+        if (!isDeviceConnectedViaBluetooth) {
+            return false;
+        }
+
+        // If it is connected via USB or wireless charger, we assume it's charging/fine,
+        if (usb_connected || wireless_connected) {
+            return false;
+        }
+
+        const isBatteryDataValid = typeof soc === 'number';
+
+        if (!isBatteryDataValid) {
+            // If we cannot read battery status, we assume the worst.
+            return true;
+        }
+
+        return soc < DEVICE_LOW_BATTERY_PERCENTAGE_THRESHOLD;
+    },
 );
 
 export const selectDeviceBluetoothId = createMemoizedSelector(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Using new notification `NOTIFY_POWER_STATUS_CHANGE` that let us know that device has been started to be charged or otherwise. 

## Notes for QA

When trying to do FW update in TS7 over Ble and there is less than 40% of battery charged Suite should not allow user to update FW. If user connect it to power USB and try to update the FW it should be allowed even if battery level is lower than 40%.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22809

## Screenshots:
Maybe we want to change the message here:

<img width="1410" height="583" alt="image" src="https://github.com/user-attachments/assets/061289f9-2c72-4658-a8e6-bf227e946da3" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/power-state-notification&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/power-state-notification&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/power-state-notification&lookback=7)