### PR TITLE
fix: pass THP props into evoluGetDelegatedIdentityKey

### DIFF
--- a/packages/connect/src/api/evoluGetDelegatedIdentityKey.ts
+++ b/packages/connect/src/api/evoluGetDelegatedIdentityKey.ts
@@ -1,4 +1,5 @@
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
+import { thp } from '@trezor/protocol';
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../core/AbstractMethod';
@@ -18,10 +19,16 @@ export default class EvoluGetDelegatedIdentityKey extends AbstractMethod<
 
         Assert(PROTO.EvoluGetDelegatedIdentityKey, payload);
 
-        this.params = {
-            thp_credential: payload.thp_credential,
-            host_static_public_key: payload.host_static_public_key,
-        };
+        if (payload.thp !== undefined) {
+            const staticKey = Buffer.from(payload.thp.staticHostKey, 'hex');
+            const hostStaticKeys = thp.getCurve25519KeyPair(staticKey);
+            this.params = {
+                thp_credential: payload.thp.credential,
+                host_static_public_key: hostStaticKeys.publicKey.toString('hex'),
+            };
+        } else {
+            this.params = {};
+        }
     }
 
     get info() {

--- a/packages/connect/src/types/api/evoluGetDelegatedIdentityKey.ts
+++ b/packages/connect/src/types/api/evoluGetDelegatedIdentityKey.ts
@@ -2,5 +2,10 @@ import { PROTO } from '../../constants';
 import { Params, Response } from '../params';
 
 export declare function evoluGetDelegatedIdentityKey(
-    params: Params<PROTO.EvoluGetDelegatedIdentityKey>,
+    params: Params<{
+        thp?: {
+            staticHostKey: string;
+            credential: string;
+        };
+    }>,
 ): Response<PROTO.EvoluDelegatedIdentityKey>;

--- a/suite-common/suite-sync/src/storage/LocalFirstStorageProvider.ts
+++ b/suite-common/suite-sync/src/storage/LocalFirstStorageProvider.ts
@@ -16,7 +16,7 @@ import { LocalFirstStorage } from '../storage';
 // This is a way how to force change of the SQL files. It was useful for development
 // so not everybody had to delete SQLite file manually:
 // See: https://www.evolu.dev/docs/faq#how-to-delete-opfs-sqlite-in-browser
-const VERSION = 3;
+const VERSION = 4;
 
 type CreateEvoluInstanceProps = {
     relayUrl: string;

--- a/suite-common/thp/src/thpReducer.ts
+++ b/suite-common/thp/src/thpReducer.ts
@@ -39,8 +39,10 @@ export type ThpState = {
     step: ThpStep;
     lastThpCode?: string;
     credentials: ThpSuiteCredentials[];
-    // staticKey for the application.
-    // this value is generated at first THP pairing and should never change. will be used for all future pairings
+
+    // StaticKey for the application.
+    // This value is generated at first THP pairing and should never change. will be used for all future pairings
+    // This is basically Identity of the Host
     staticKey?: string;
 };
 

--- a/suite-common/wallet-core/src/device/delegatedIdentityKey/retrieveDelegatedIdentityKeyThunk.ts
+++ b/suite-common/wallet-core/src/device/delegatedIdentityKey/retrieveDelegatedIdentityKeyThunk.ts
@@ -1,6 +1,8 @@
 import { Dispatch } from '@reduxjs/toolkit';
 
 import { TrezorDeviceWithState, asDelegatedIdentityKey } from '@suite-common/suite-types';
+// Circular issue, see: https://github.com/trezor/trezor-suite/issues/21553
+import { selectThp } from '@suite-common/thp/src/thpSelectors';
 import TrezorConnect from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
@@ -10,9 +12,15 @@ import { isCanceledErrorMessage } from '../deviceUtils';
 
 type RetrieveDelegatedIdentityKeyParams = {
     device: TrezorDeviceWithState;
+    thpStaticHostKey: string | undefined;
 };
 
-const retrieveDelegatedIdentityKey = async ({ device }: RetrieveDelegatedIdentityKeyParams) => {
+const retrieveDelegatedIdentityKey = async ({
+    device,
+    thpStaticHostKey,
+}: RetrieveDelegatedIdentityKeyParams) => {
+    const thpCredential = device.thp?.credentials?.[0].credential;
+
     const result = await TrezorConnect.evoluGetDelegatedIdentityKey({
         device: {
             path: device.path,
@@ -20,6 +28,13 @@ const retrieveDelegatedIdentityKey = async ({ device }: RetrieveDelegatedIdentit
             instance: device.instance ?? 0,
         },
         useEmptyPassphrase: device.useEmptyPassphrase ?? false,
+        thp:
+            thpStaticHostKey !== undefined && thpCredential !== undefined
+                ? {
+                      credential: thpCredential,
+                      staticHostKey: thpStaticHostKey,
+                  }
+                : undefined,
     });
 
     if (result.success) {
@@ -52,8 +67,10 @@ export const retrieveDelegatedIdentityKeyThunk =
         const devicePersistedData = persistedData.find(it => it.device_id === device.id);
         const currentDelegatedKey = devicePersistedData?.delegatedIdentityKey ?? null;
 
+        const thpStaticHostKey = selectThp(getState()).staticKey;
+
         if (currentDelegatedKey === null) {
-            const result = await retrieveDelegatedIdentityKey({ device });
+            const result = await retrieveDelegatedIdentityKey({ device, thpStaticHostKey });
 
             if (!result.ok) {
                 dispatch(


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/23229

## QA:

Secure Sync (get keys flow) shall work for THP devices (TS7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-evoluGetDelegatedIdentityKey-thp&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-evoluGetDelegatedIdentityKey-thp&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-evoluGetDelegatedIdentityKey-thp&lookback=7)