### PR TITLE
fix(suite-native): format of phishing transactions value

### DIFF
--- a/suite-native/formatters/src/components/TokenAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/TokenAmountFormatter.tsx
@@ -10,7 +10,7 @@ type TokenAmountFormatterProps = {
     tokenSymbol: TokenSymbol | null;
     isDiscreetText?: boolean;
     decimals?: number;
-    isForcedDiscreetMode?: boolean;
+    isPhishingTransaction?: boolean;
 } & FormatterProps<number | string> &
     TextProps;
 
@@ -21,11 +21,14 @@ export const TokenAmountFormatter = ({
     decimals = 0,
     variant = 'hint',
     color = 'textSubdued',
+    isPhishingTransaction = false,
     ...rest
 }: TokenAmountFormatterProps) => {
-    const decimalValue = convertTokenValueToDecimal(value, decimals);
-    const { CryptoAmountFormatter: formatter } = useFormatters();
+    // Phishing transactions values may be equal to empty string, so we replace it with 0.
+    // These values are hidden by discreet mode , so the exact value does not matter anyway.
+    const decimalValue = isPhishingTransaction ? 0 : convertTokenValueToDecimal(value, decimals);
 
+    const { CryptoAmountFormatter: formatter } = useFormatters();
     const formattedValue = formatter.format(decimalValue.toString(), {
         symbol: tokenSymbol ?? undefined,
     });
@@ -36,6 +39,7 @@ export const TokenAmountFormatter = ({
             isDiscreetText={isDiscreetText}
             variant={variant}
             color={color}
+            isForcedDiscreetMode={isPhishingTransaction}
             {...rest}
         />
     );

--- a/suite-native/transactions/src/components/TransactionsList/TokenTransferListItem.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TokenTransferListItem.tsx
@@ -80,7 +80,7 @@ export const TokenTransferListItemValues = ({
                 decimals={tokenTransfer.decimals}
                 numberOfLines={1}
                 ellipsizeMode="tail"
-                isForcedDiscreetMode={isPhishingTransaction}
+                isPhishingTransaction={isPhishingTransaction}
                 variant="hint"
                 color="textSubdued"
             />


### PR DESCRIPTION
## Description
-A phishing transaction might contain a value equal to empty string `""`, which causes a crash when attempting to convert it to a number. This PR fixes that.

## Issue
closes #23247 


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/format-of-phishing-transaction&lookback=7)