### PR TITLE
fix(protobuf): add patch for ThpDeviceProperties.pairing_methods

### DIFF
--- a/packages/connect/src/types/api/__tests__/events.ts
+++ b/packages/connect/src/types/api/__tests__/events.ts
@@ -129,6 +129,20 @@ export const events = (api: TrezorConnect) => {
                 //
             }
         }
+
+        if (event.type === 'ui-request_thp_pairing') {
+            if (event.payload.device.thp?.properties?.pairing_methods[0] === 'CodeEntry') {
+                api.uiResponse({
+                    type: 'ui-receive_thp_pairing_tag',
+                    payload: { selectedMethod: 1 },
+                });
+
+                api.uiResponse({
+                    type: 'ui-receive_thp_pairing_tag',
+                    payload: { source: 'code-entry', tag: '0000' },
+                });
+            }
+        }
     });
     api.off(UI_EVENT, () => {});
 

--- a/packages/protobuf/scripts/protobuf-patches/index.ts
+++ b/packages/protobuf/scripts/protobuf-patches/index.ts
@@ -272,6 +272,7 @@ export const TYPE_PATCH = {
     'MoneroTransferDetails.out_key': 'Uint8Array',
     'MoneroTransferDetails.tx_pub_key': 'Uint8Array',
     'MoneroTransferDetails.additional_tx_pub_keys': 'Uint8Array',
+    'ThpDeviceProperties.pairing_methods': '(keyof typeof ThpPairingMethod)',
 };
 
 export const readPatch = (file: string) =>

--- a/packages/protocol/src/protocol-thp/messages/messageTypes.ts
+++ b/packages/protocol/src/protocol-thp/messages/messageTypes.ts
@@ -5,6 +5,7 @@
 import type {
     ThpCredentialResponse,
     ThpDeviceProperties,
+    ThpPairingMethod,
     ThpProtobufMessageType,
 } from './protobufTypes';
 
@@ -66,7 +67,7 @@ export type ThpMessageType = ThpProtobufMessageType & {
 };
 
 export type ThpHandshakeCredentials = {
-    pairingMethods: ThpDeviceProperties['pairing_methods'];
+    pairingMethods: ThpPairingMethod[];
     handshakeHash: Buffer;
     handshakeCommitment: Buffer;
     codeEntryChallenge: Buffer;

--- a/packages/protocol/src/protocol-thp/messages/protobufTypes.ts
+++ b/packages/protocol/src/protocol-thp/messages/protobufTypes.ts
@@ -12,7 +12,7 @@ export type ThpDeviceProperties = {
     model_variant: number;
     protocol_version_major: number;
     protocol_version_minor: number;
-    pairing_methods: ThpPairingMethod[];
+    pairing_methods: (keyof typeof ThpPairingMethod)[];
 };
 
 export type ThpHandshakeCompletionReqNoisePayload = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`ThpDeviceProperties.pairing_methods` are parsed and returned to suite as string but types are set to numbers


related to:

https://github.com/trezor/trezor-suite/issues/5299

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thppairingmethods-type&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thppairingmethods-type&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thppairingmethods-type&lookback=7)