### PR TITLE
Suite Connect device selection flow improvements 

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
@@ -11,7 +11,7 @@ import { spacings } from '@trezor/theme';
 import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
 import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { Translation } from 'src/components/suite/Translation';
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
 import { useOpenSuiteDesktop } from 'src/hooks/suite/useOpenSuiteDesktop';
 import { selectPrerequisite } from 'src/selectors/suite/suiteSelectors';
 import { SwitchDeviceContent } from 'src/views/suite/SwitchDevice/SwitchDevice';
@@ -23,6 +23,8 @@ export const ConnectSelectDeviceModal = () => {
     const selectedDevice = useSelector(selectSelectedDevice);
     const hasConnectedDevice = devices.some(d => d.connected);
     const selectedDeviceConnected = selectedDevice?.connected;
+    const { isDiscoveryRunning } = useDiscovery();
+    const isLoading = isDiscoveryRunning;
 
     const onCancel = () => {
         dispatch(connectPopupActions.finishCall());
@@ -53,7 +55,7 @@ export const ConnectSelectDeviceModal = () => {
                 }
                 bottomContent={
                     selectedDeviceConnected && (
-                        <Modal.Button onClick={onResume} size="medium">
+                        <Modal.Button onClick={onResume} size="medium" isLoading={isLoading}>
                             <Translation id="TR_CONTINUE" />
                         </Modal.Button>
                     )

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
@@ -34,6 +34,11 @@ export const ConnectSelectDeviceModal = () => {
             dispatch(
                 connectPopupCallThunkInner({
                     ...popupCall,
+                    payload: {
+                        ...popupCall.payload,
+                        // override previously selected device
+                        device: selectedDevice,
+                    },
                 }),
             );
     };


### PR DESCRIPTION
## Description

Handle a few issues with device selection: 

- Discovery loading would block continuation of the flow, but the button didn't show loading state

- Override original device parameter if it was specified in the payload. This previously led to issues with password mismatch.

## Notes for QA

Start connect call with disconnected device, wait for device selection step, plug in device and add a different passphrase

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-popup-improvements&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-popup-improvements&lookback=7)