### PR TITLE
Failed accounts handling

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -60,7 +60,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
     async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState }) => {
         const account = selectAccountByKey(getState(), accountKey);
 
-        if (!account) return;
+        if (!account || account.failed) return;
 
         if (!isTrezorConnectBackendType(account.backendType)) return; // skip unsupported backend type
         // first basic check, traffic optimization

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -119,6 +119,9 @@ export const initBlockchainThunk = createThunk(
     },
 );
 
+const isAccountSubscribable = (account: Account) =>
+    !account.failed && isTrezorConnectBackendType(account.backendType);
+
 // called from WalletMiddleware after ACCOUNT.ADD/UPDATE action
 // or after BLOCKCHAIN.CONNECT event (blockchainActions.onConnect)
 export const subscribeBlockchainThunk = createThunk(
@@ -140,7 +143,7 @@ export const subscribeBlockchainThunk = createThunk(
         const accountsToSubscribe = findAccountsByNetwork(
             symbol,
             selectAccounts(getState()),
-        ).filter(a => isTrezorConnectBackendType(a.backendType)); // do not subscribe accounts with unsupported backend type
+        ).filter(isAccountSubscribable); // do not subscribe accounts with unsupported backend type
         if (!accountsToSubscribe.length) return;
 
         const paramsArray = useIdentities
@@ -171,8 +174,8 @@ export const unsubscribeBlockchainThunk = createThunk(
             blocks?: boolean;
             accounts: Account[];
         }>(symbol => {
-            const accountsToSubscribe = findAccountsByNetwork(symbol, allAccounts).filter(a =>
-                isTrezorConnectBackendType(a.backendType),
+            const accountsToSubscribe = findAccountsByNetwork(symbol, allAccounts).filter(
+                isAccountSubscribable,
             ); // do not unsubscribe accounts with unsupported backend type
 
             if (shouldUseIdentities(symbol)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Failed accounts should never be subject to `getAccountInfo` or `blockchainSubscribe` as they may not have proper descriptor.

As a followup we should finish related #23304 as well.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/dont-sync-failed-accounts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/dont-sync-failed-accounts&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/dont-sync-failed-accounts&lookback=7)