### PR TITLE
Prevent TypeError on missing contractAddress in getContractAddressForNetworkSymbol

### DIFF
--- a/suite-common/wallet-utils/src/__fixtures__/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/tokenUtils.ts
@@ -35,4 +35,16 @@ export const getContractAddressForNetworkSymbolFixtures = [
         contractAddress: 'f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958',
         expected: 'f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc535',
     },
+    {
+        testName: 'Handles undefined contract address',
+        symbol: 'eth' as const,
+        contractAddress: undefined,
+        expected: '',
+    },
+    {
+        testName: 'Handles null contract address',
+        symbol: 'sol' as const,
+        contractAddress: null,
+        expected: '',
+    },
 ];

--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -9,8 +9,12 @@ import { parseAsset } from '@trezor/blockchain-link-utils/src/blockfrost';
 
 export const getContractAddressForNetworkSymbol = (
     symbol: NetworkSymbolExtended, // unknown symbols will result to lowerCase
-    contractAddress: string,
+    contractAddress?: string | null,
 ) => {
+    if (!contractAddress) {
+        return '';
+    }
+
     switch (symbol) {
         case 'eth':
             // Specifying most common network as first case improves performance little bit


### PR DESCRIPTION
## Description

When some tokens don't provide `contractAddress`, the helper tried to call `.toLowerCase()` on `undefined`, which resulted in a runtime error.

**Update**: The problem was with the migration.

## Notes for QA
No changes - no need to test.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23273


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/contract-address-lowercase&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/contract-address-lowercase&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/contract-address-lowercase&lookback=7)