### PR TITLE
Suite nativ: Skip failing e2e

### DIFF
--- a/suite-native/app/e2e/tests/deviceOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/deviceOnboarding.test.ts
@@ -58,7 +58,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device onboarding [@fix
         await proceedToCreateOrRecoverCrossroads();
     });
 
-    it('Create Wallet', async () => {
+    it.skip('Create Wallet', async () => {
         await onDeviceOnboarding.selectCreateWalletOption();
 
         await onDeviceOnboarding.waitForCreateWalletLoadingScreen();
@@ -94,7 +94,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device onboarding [@fix
         await finishOnboardingFlow();
     });
 
-    it('Recover Wallet', async () => {
+    it.skip('Recover Wallet', async () => {
         await onDeviceOnboarding.selectRecoverWalletOption();
         await onDeviceOnboarding.confirmRecoveryInstructions();
 

--- a/suite-native/app/e2e/tests/onboardAndConnect.test.ts
+++ b/suite-native/app/e2e/tests/onboardAndConnect.test.ts
@@ -17,7 +17,7 @@ conditionalDescribe(
             await prepareTrezorEmulator();
         });
 
-        it('Navigate to dashboard', async () => {
+        it.skip('Navigate to dashboard', async () => {
             await onOnboarding.finishOnboarding();
 
             if (getModelFromEnv() === 'T3W1') {

--- a/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
@@ -60,7 +60,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Trade Exchange', () => 
             await tradingExchangeActions.openSwapForm();
         });
 
-        it('Basic exchange USDC to USDT', async () => {
+        it.skip('Basic exchange USDC to USDT', async () => {
             await tradingExchangeActions.selectSendAsset('USDC');
             await tradingExchangeActions.selectReceiveAsset('USDT', 'Ethereum');
             await tradingExchangeActions.selectReceiveAccount('Ethereum #1');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Skiping failing e2es.

## Issues with failing tests
- https://github.com/trezor/trezor-suite/issues/23286
- https://github.com/trezor/trezor-suite/issues/23287
- https://github.com/trezor/trezor-suite/issues/23289

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=disable-failing-tests&lookback=7)