### PR TITLE
chore(suite-native): Fix and enable onboardAndConnect e2e test

### DIFF
--- a/suite-native/app/e2e/tests/onboardAndConnect.test.ts
+++ b/suite-native/app/e2e/tests/onboardAndConnect.test.ts
@@ -1,12 +1,12 @@
-import { expect as detoxExpect } from 'detox';
-
 import { conditionalDescribe } from '@suite-common/test-utils';
 
 import { onCoinEnabling } from '../pageObjects/coinEnablingActions';
 import { onDeviceOnboarding } from '../pageObjects/deviceOnboardingActions';
 import { onDevicePrompt } from '../pageObjects/devicePromptActions';
+import { onHome } from '../pageObjects/homeActions';
 import { onOnboarding } from '../pageObjects/onboardingActions';
 import { getModelFromEnv, openApp, prepareTrezorEmulator } from '../support/setup';
+import { waitForVisible } from '../support/utils';
 
 conditionalDescribe(
     device.getPlatform() === 'android',
@@ -17,7 +17,7 @@ conditionalDescribe(
             await prepareTrezorEmulator();
         });
 
-        it.skip('Navigate to dashboard', async () => {
+        it('Navigate to dashboard', async () => {
             await onOnboarding.finishOnboarding();
 
             if (getModelFromEnv() === 'T3W1') {
@@ -27,8 +27,9 @@ conditionalDescribe(
 
             await onCoinEnabling.waitForInitScreen();
             await onCoinEnabling.handleCoinEnablingInit(['btc', 'eth']);
-            const bitcoinTextElement = element(by.text('Bitcoin'));
-            await detoxExpect(bitcoinTextElement).toBeVisible();
+            await waitForVisible(by.text('Connected'));
+            await onHome.scrollScreenToBottom();
+            await waitForVisible(by.text('Bitcoin'));
         });
     },
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Waits until dashboard is displayed and scrolls down before asserting `Bitcoin` string.

## Notes for QA

Nothing to test, just fix of E2E scenario.

## Related Issue

Resolve #23289



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=23289-fix-failing-onboarding-and-connect-e2e&lookback=7)