### PR TITLE
chore: reintroduce deeplink trading redirects for macos and windows

### DIFF
--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -1,6 +1,7 @@
 /**
  * Local web server for handling requests to app
  */
+import { isMacOs, isWindows } from '@trezor/env-utils';
 import { validateIpcMessage } from '@trezor/ipc-proxy';
 
 import { restartApp } from '../libs/app-utils';
@@ -67,6 +68,16 @@ export const initBackground: ModuleInitBackground = ({
         ipcMain.handle('server/request-address', (ipcEvent, pathname) => {
             validateIpcMessage({ ipcEvent });
             try {
+                // Use deeplink URLs for trading redirects on macOS/Windows only
+                if (
+                    TRADING_REDIRECT_PATHS.some(path => path === pathname) &&
+                    (isMacOs() || isWindows())
+                ) {
+                    receiver.activateRoute(pathname);
+
+                    return `trezorsuite:/${pathname}`;
+                }
+
                 const address = receiver.getRouteAddress(pathname);
                 if (address) {
                     receiver.activateRoute(pathname);

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -1,3 +1,4 @@
+import { ExtraDependencies } from '@suite-common/redux-utils';
 import { Protocol } from '@suite-common/suite-constants';
 import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -5,6 +6,7 @@ import * as walletConnectActions from '@suite-common/walletconnect';
 import {
     SUITE_ANCHOR_DEEPLINK_PREFIX,
     SUITE_BRIDGE_DEEPLINK,
+    SUITE_TRADING_REDIRECT_DEEPLINKS,
     SUITE_WALLETCONNECT_DEEPLINK,
 } from '@trezor/urls';
 import { isArrayMember } from '@trezor/utils';
@@ -12,7 +14,7 @@ import { isArrayMember } from '@trezor/utils';
 import * as routerActions from 'src/actions/suite/routerActions';
 import { goto } from 'src/actions/suite/routerActions';
 import type { SendFormState } from 'src/reducers/suite/protocolReducer';
-import { Dispatch } from 'src/types/suite';
+import { Dispatch, GetState } from 'src/types/suite';
 import { parseUri } from 'src/utils/suite/parseUri';
 import { CoinProtocolInfo, getProtocolInfo } from 'src/utils/suite/protocol';
 
@@ -44,50 +46,68 @@ const saveCoinProtocol = (scheme: Protocol, address: string, amount?: number): P
     payload: { scheme, address, amount },
 });
 
-export const handleProtocolRequest = (uri: string) => (dispatch: Dispatch) => {
-    const protocol = getProtocolInfo(uri);
+export const handleProtocolRequest =
+    (uri: string) => (dispatch: Dispatch, _getState: GetState, extra: ExtraDependencies) => {
+        const protocol = getProtocolInfo(uri);
 
-    if (protocol && !('error' in protocol) && getNetworkSymbolForProtocol(protocol.scheme)) {
-        const { scheme, amount, address } = protocol as CoinProtocolInfo;
+        if (protocol && !('error' in protocol) && getNetworkSymbolForProtocol(protocol.scheme)) {
+            const { scheme, amount, address } = protocol as CoinProtocolInfo;
 
-        dispatch(saveCoinProtocol(scheme, address, amount));
-        dispatch(
-            notificationsActions.addToast({
-                type: 'coin-scheme-protocol',
-                address,
-                scheme,
-                amount,
-                autoClose: false,
-            }),
-        );
-    } else if (uri?.startsWith(SUITE_BRIDGE_DEEPLINK)) {
-        dispatch(routerActions.goto('suite-bridge-requested', { params: { cancelable: true } }));
-    } else if (uri?.startsWith(SUITE_WALLETCONNECT_DEEPLINK)) {
-        const parsedUri = parseUri(uri);
-        const wcUri = parsedUri?.searchParams?.get('uri');
-        if (wcUri) {
-            dispatch(walletConnectActions.walletConnectPairThunk({ uri: wcUri }))
-                .unwrap()
-                .catch(error => {
-                    dispatch(
-                        notificationsActions.addToast({
-                            type: 'error',
-                            error: error.message,
-                        }),
-                    );
-                });
+            dispatch(saveCoinProtocol(scheme, address, amount));
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'coin-scheme-protocol',
+                    address,
+                    scheme,
+                    amount,
+                    autoClose: false,
+                }),
+            );
+        } else if (uri?.startsWith(SUITE_BRIDGE_DEEPLINK)) {
+            dispatch(
+                routerActions.goto('suite-bridge-requested', { params: { cancelable: true } }),
+            );
+        } else if (uri?.startsWith(SUITE_WALLETCONNECT_DEEPLINK)) {
+            const parsedUri = parseUri(uri);
+            const wcUri = parsedUri?.searchParams?.get('uri');
+            if (wcUri) {
+                dispatch(walletConnectActions.walletConnectPairThunk({ uri: wcUri }))
+                    .unwrap()
+                    .catch(error => {
+                        dispatch(
+                            notificationsActions.addToast({
+                                type: 'error',
+                                error: error.message,
+                            }),
+                        );
+                    });
+            }
+        } else if (uri?.startsWith(SUITE_ANCHOR_DEEPLINK_PREFIX)) {
+            const anchor = uri.replace(SUITE_ANCHOR_DEEPLINK_PREFIX, '');
+
+            if (isArrayMember(anchor, Object.values(SettingsAnchor))) {
+                const [domain] = anchor.split('/');
+
+                const targetRoute =
+                    mapAnchorToRoute[domain.replace(/^@/, '') as AnchorSettingSection];
+                dispatch(goto(targetRoute, { anchor }));
+            }
+        } else if (SUITE_TRADING_REDIRECT_DEEPLINKS.some(deeplink => uri?.startsWith(deeplink))) {
+            const parsedUri = parseUri(decodeURIComponent(uri));
+            const redirectPath = parsedUri?.searchParams?.get('p');
+
+            if (redirectPath) {
+                const decodedPath = decodeURIComponent(redirectPath);
+                const [, hash] = decodedPath.split('/coinmarket-redirect/');
+                if (hash) {
+                    const fullUrl = `/coinmarket-redirect#${hash}`;
+
+                    extra.routerServices.navigate(fullUrl);
+                    dispatch(routerActions.onLocationChange(fullUrl));
+                }
+            }
         }
-    } else if (uri?.startsWith(SUITE_ANCHOR_DEEPLINK_PREFIX)) {
-        const anchor = uri.replace(SUITE_ANCHOR_DEEPLINK_PREFIX, '');
-
-        if (isArrayMember(anchor, Object.values(SettingsAnchor))) {
-            const [domain] = anchor.split('/');
-
-            const targetRoute = mapAnchorToRoute[domain.replace(/^@/, '') as AnchorSettingSection];
-            dispatch(goto(targetRoute, { anchor }));
-        }
-    }
-};
+    };
 
 export const resetProtocol = (): ProtocolAction => ({
     type: PROTOCOL.RESET,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

`return_url` param when navigating to sell/swap/buy provider should not include `127.0.0.1:21335` but rather a deeplink `trezorsuite://`. The functionality should remain unchanged. The changes should only affect desktop app on **Windows** and **MacOS**

## Related Issue

Resolve #23174

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/reintroduce-deeplink-redirects&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/reintroduce-deeplink-redirects&lookback=7)