### PR TITLE
Unskip deviceOnboarding tests since latest FW is available on TENV

### DIFF
--- a/suite-native/app/e2e/tests/deviceOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/deviceOnboarding.test.ts
@@ -58,7 +58,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device onboarding [@fix
         await proceedToCreateOrRecoverCrossroads();
     });
 
-    it.skip('Create Wallet', async () => {
+    it('Create Wallet', async () => {
         await onDeviceOnboarding.selectCreateWalletOption();
 
         await onDeviceOnboarding.waitForCreateWalletLoadingScreen();
@@ -94,7 +94,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device onboarding [@fix
         await finishOnboardingFlow();
     });
 
-    it.skip('Recover Wallet', async () => {
+    it('Recover Wallet', async () => {
         await onDeviceOnboarding.selectRecoverWalletOption();
         await onDeviceOnboarding.confirmRecoveryInstructions();
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

The test was failing because there is a new FW available for update, which was not available in the Trezor User Env.
FW 2.9.4 is now the latest one on TENV, so the tests should pass.

[Let's discuss](https://satoshilabs.slack.com/archives/C09QFM647UY/p1763717537443319) how to properly avoid this situation in the future. 

## Notes for QA

No need for manual QA, just check if E2E tests pass.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23286

## Screenshots:
Was failing on 
<img width="350" alt="image" src="https://github.com/user-attachments/assets/4e00eba5-b2b2-4b53-b0f0-eee7a4646bfb" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/unskip-device-onboarding-test&lookback=7)