### PR TITLE
Refactor lock for formal try lock

### DIFF
--- a/packages/suite/src/actions/suite/autoForgetDeviceDataThunks.ts
+++ b/packages/suite/src/actions/suite/autoForgetDeviceDataThunks.ts
@@ -26,6 +26,7 @@ export const setAutoForgetDeviceDataThunk = createThunk<
     // Finally, having purged the data in Bluetooth and THP reducers, simply sync BT and THP to persistent storage.
     await dispatch(storageActions.saveKnownDevices());
     await dispatch(storageActions.saveThpCredentials());
+    await dispatch(storageActions.savePersistentDeviceData());
 
     // Reload to ensure all local state is cleared, especially Connect session, which would otherwise reconnect THP.
     // Delay for two reasons: make sure IDB operations are complete, and give some time for the UI success notification to be seen

--- a/packages/suite/src/utils/suite/storage.ts
+++ b/packages/suite/src/utils/suite/storage.ts
@@ -21,7 +21,6 @@ export const serializeDevice = (device: AcquiredDevice): DeviceWithEmptyPath => 
     bluetoothProps: undefined,
     localFirstStorageSecret: {
         evoluKeys: device.localFirstStorageSecret?.evoluKeys,
-        isRetrieving: false,
     },
 });
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -9,6 +9,7 @@ export * from './arrayShuffle';
 export * from './arrayToDictionary';
 export * from './asciiUtils';
 export * from './bigNumber';
+export { createTryLock } from './tryLock';
 export * from './bytesToHumanReadable';
 export * from './cache';
 export * from './capitalizeFirstLetter';

--- a/packages/utils/src/tryLock.ts
+++ b/packages/utils/src/tryLock.ts
@@ -1,0 +1,31 @@
+/**
+ * Non-blocking implementation of the lock. If two task are trying to run at the same time,
+ * only one is allowed to pass.
+ *
+ * In contrast with `getMutex.ts`, where all tasks are expected to wait and run once lock is released.
+ */
+export const createTryLock = () => {
+    let acquired = false;
+
+    const acquire = (): boolean => {
+        if (acquired) {
+            return false;
+        }
+
+        acquired = true;
+
+        return true;
+    };
+
+    const release = (): void => {
+        acquired = false;
+    };
+
+    return <T>(task: () => Promise<T>): Promise<T | null> => {
+        if (acquire()) {
+            return task().finally(release);
+        }
+
+        return Promise.resolve(null);
+    };
+};

--- a/packages/utils/tests/getMutex.test.ts
+++ b/packages/utils/tests/getMutex.test.ts
@@ -7,7 +7,7 @@ const fail = (reason: string) => {
     throw new Error(reason);
 };
 
-describe('getMutex', () => {
+describe(getMutex.name, () => {
     let state: any;
     let lock: ReturnType<typeof getMutex>;
 

--- a/packages/utils/tests/getSynchronize.test.ts
+++ b/packages/utils/tests/getSynchronize.test.ts
@@ -7,7 +7,7 @@ const fail = (reason: string) => {
     throw new Error(reason);
 };
 
-describe('getSynchronize', () => {
+describe(getSynchronize.name, () => {
     let state: any;
     let synchronize: ReturnType<typeof getSynchronize>;
 

--- a/packages/utils/tests/tryLock.test.ts
+++ b/packages/utils/tests/tryLock.test.ts
@@ -1,0 +1,41 @@
+import { createTryLock } from '../src/tryLock';
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe(createTryLock.name, () => {
+    it('skips the task if already locked', async () => {
+        const tryLock = createTryLock();
+
+        let a = 0;
+
+        const task = async (ms: number) => {
+            a += 1;
+            await wait(ms);
+        };
+
+        await Promise.all([
+            tryLock(() => task(10)),
+            tryLock(() => task(3)),
+            tryLock(() => task(5)),
+        ]);
+
+        expect(a).toBe(1);
+    });
+
+    it('running tasks in sequence runs them all', async () => {
+        const tryLock = createTryLock();
+
+        let a = 0;
+
+        const task = async (ms: number) => {
+            a += 1;
+            await wait(ms);
+        };
+
+        await tryLock(() => task(10));
+        await tryLock(() => task(3));
+        await tryLock(() => task(5));
+
+        expect(a).toBe(3);
+    });
+});

--- a/suite-common/suite-sync/src/storage/refreshSuiteSyncKeysThunk.ts
+++ b/suite-common/suite-sync/src/storage/refreshSuiteSyncKeysThunk.ts
@@ -17,6 +17,7 @@ import {
 import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
+import { createTryLock } from '@trezor/utils';
 
 import { createEvoluAppOwnerFromTrezorData } from '../createEvoluAppOwnerFromTrezorData';
 
@@ -72,6 +73,13 @@ const retrieveEvoluNode = async ({ device, delegatedKey }: RetrieveEvoluNodePara
     return err({ type: 'DeviceError' as const, message: result.payload.error });
 };
 
+/**
+ * Ideally, this shall be done per-physical device. But practically,
+ * it is not needed. We won't run `refreshSuiteSyncKeysThunk`
+ * in parallel on multiple physical devices.
+ */
+const tryLock = createTryLock();
+
 type RefreshSuiteSyncKeysThunkParams = {
     device: TrezorDevice;
 };
@@ -84,59 +92,63 @@ type RefreshSuiteSyncKeysThunkParams = {
 export const refreshSuiteSyncKeysThunk =
     ({ device: originalDevice }: RefreshSuiteSyncKeysThunkParams) =>
     async (dispatch: Dispatch, getState: () => any) => {
-        const device = selectDevices(getState())?.find(
-            it => it.state?.staticSessionId === originalDevice.state?.staticSessionId,
-        );
-
-        if (
-            device === undefined ||
-            !device.connected || // disconnected device cannot resolve Evolu-Keys
-            device.mode !== 'normal' || // bootloader,
-            !isTrezorDeviceWithState(device) ||
-            device.localFirstStorageSecret?.evoluKeys !== undefined ||
-            // We are already getting the keys in different "await"
-            // This may happen if selectedDeviceThunk is called concurrently.
-            // Todo: This probably shall not happen, but it happens currently.
-            device.localFirstStorageSecret?.isRetrieving
-        ) {
-            return ok(); // No action needed
-        }
-
-        dispatch(
-            deviceActions.setLocalFirstStorageSecretRetrieving({ device, isRetrieving: true }),
-        );
-
-        const delegatedKeyResult = await dispatch(retrieveDelegatedIdentityKeyThunk({ device }));
-
-        if (!delegatedKeyResult.ok) {
-            dispatch(
-                deviceActions.setLocalFirstStorageSecretRetrieving({ device, isRetrieving: false }),
+        const inner = async () => {
+            const device = selectDevices(getState())?.find(
+                it => it.state?.staticSessionId === originalDevice.state?.staticSessionId,
             );
 
-            return delegatedKeyResult;
-        }
+            if (
+                device === undefined ||
+                !device.connected || // disconnected device cannot resolve Evolu-Keys
+                device.mode !== 'normal' || // bootloader,
+                !isTrezorDeviceWithState(device) ||
+                device.localFirstStorageSecret?.evoluKeys !== undefined
+            ) {
+                return ok(); // No action needed
+            }
 
-        const evoluNodeResult = await retrieveEvoluNode({
-            device,
-            delegatedKey: delegatedKeyResult.value,
-        });
-
-        if (!evoluNodeResult.ok) {
-            dispatch(deviceActions.setLocalFirstStorageSecret({ device, evoluKeys: undefined }));
-            dispatch(
-                deviceActions.setDelegatedIdentityKey({ deviceId: device.id, delegatedKey: null }),
+            const delegatedKeyResult = await dispatch(
+                retrieveDelegatedIdentityKeyThunk({ device }),
             );
 
-            return evoluNodeResult;
-        }
+            if (!delegatedKeyResult.ok) {
+                return delegatedKeyResult;
+            }
 
-        // This also sets the `isRetrieving` flag to `false`
-        dispatch(
-            deviceActions.setLocalFirstStorageSecret({
+            const evoluNodeResult = await retrieveEvoluNode({
                 device,
-                evoluKeys: evoluNodeResult.value ?? undefined,
-            }),
-        );
+                delegatedKey: delegatedKeyResult.value,
+            });
 
-        return ok();
+            if (!evoluNodeResult.ok) {
+                dispatch(
+                    deviceActions.setLocalFirstStorageSecret({ device, evoluKeys: undefined }),
+                );
+                dispatch(
+                    deviceActions.setDelegatedIdentityKey({
+                        deviceId: device.id,
+                        delegatedKey: null,
+                    }),
+                );
+
+                return evoluNodeResult;
+            }
+
+            dispatch(
+                deviceActions.setLocalFirstStorageSecret({
+                    device,
+                    evoluKeys: evoluNodeResult.value ?? undefined,
+                }),
+            );
+
+            return ok();
+        };
+
+        // Hack: We are already getting the keys in different "await". This may happen
+        // if selectedDeviceThunk is called concurrently. So we run it under
+        // try-lock to prevent double-calling of the device.
+        // Todo: This probably shall not happen, but it happens currently.
+        const lockedResult = await tryLock(inner);
+
+        return lockedResult !== null ? lockedResult : ok();
     };

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -63,8 +63,6 @@ export interface ExtendedDevice {
     buttonRequests: ButtonRequest[];
     metadata: DeviceMetadata;
     localFirstStorageSecret?: {
-        // To prevent consequential call of the TrezorConnect.evoluGetNode(...)
-        isRetrieving: boolean;
         evoluKeys: EvoluKeys | undefined;
     };
     walletNumber?: number; // number of passphrase wallet intended to be used in UI

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -245,7 +245,6 @@ export const getSuiteDevice = (
             metadata: {},
             localFirstStorageSecret: {
                 evoluKeys: undefined,
-                isRetrieving: false,
             },
             ...dev,
             ...device,

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -160,13 +160,6 @@ const setDelegatedIdentityKey = createAction(
     }),
 );
 
-const setLocalFirstStorageSecretRetrieving = createAction(
-    `${DEVICE_MODULE_PREFIX}/setLocalFirstStorageSecretRetrieving`,
-    ({ device, isRetrieving }: { device: TrezorDevice; isRetrieving: boolean }) => ({
-        payload: { device, isRetrieving },
-    }),
-);
-
 const setDiscovered = createAction(
     `${DEVICE_MODULE_PREFIX}/setDiscovered`,
     (staticSessionId: StaticSessionId, success: boolean) => ({
@@ -197,7 +190,6 @@ export const deviceActions = {
     setThpCredentials,
     setDelegatedIdentityKey,
     setLocalFirstStorageSecret,
-    setLocalFirstStorageSecretRetrieving,
     setDiscovered,
     devicePushNotification,
 };

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -728,22 +728,7 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
                     if (!device.features) return;
                     const index = deviceUtils.findInstanceIndex(state.devices, device);
                     if (!state.devices[index]) return;
-                    state.devices[index].localFirstStorageSecret = {
-                        evoluKeys,
-                        isRetrieving: false,
-                    };
-                },
-            )
-            .addCase(
-                deviceActions.setLocalFirstStorageSecretRetrieving,
-                (state, { payload: { device, isRetrieving } }) => {
-                    if (!device.features) return;
-                    const index = deviceUtils.findInstanceIndex(state.devices, device);
-                    if (!state.devices[index]) return;
-                    state.devices[index].localFirstStorageSecret = {
-                        isRetrieving,
-                        evoluKeys: state.devices[index].localFirstStorageSecret?.evoluKeys,
-                    };
+                    state.devices[index].localFirstStorageSecret = { evoluKeys };
                 },
             )
             .addCase(deviceActions.setDiscovered, (state, { payload }) => {


### PR DESCRIPTION
Do not use Redux for locking. This PR

- adds a formal try-lock to do non-blocking locking
- uses it for `refreshSuiteSyncKeysThunk` wehre `isRetrieving` flag was used in the Reducx.

This shall be more simple, less complex solution for local locking. 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-lock-for-formal-try-lock&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-lock-for-formal-try-lock&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor-lock-for-formal-try-lock&lookback=7)