### PR TITLE
fix(suite-common): include non-hex plaform contracts too in updateIcon

### DIFF
--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -82,8 +82,7 @@ const updateIcon = async (coin: CoinListData) => {
 
         const originImageBuffer = await originImage.arrayBuffer();
         const platforms = Object.entries(coinData.platforms).filter(
-            // filter out platforms that don't have a contract address (e.g. KASPY had instead of contract address some debug message which caused "too long name" error)
-            ([platform, contract]) => platform && contract && contract.startsWith('0x'),
+            ([platform, contract]) => platform && contract,
         );
 
         // Legacy naming – Make sure it's backwards compatible for older versions of the Trezor Suite


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I made a stupid mistake. Prev. I wanted to exclude invalid contracts and excluded all non-hex contracts. It fixed the error with KASPY but introduce another one. For example `pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn` wouldn't be include too. So better to leave as it was and I'll add specific filter exclusion if the KASPY error occurs again. 

## Related Issue

Resolve #22832


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/22832-download-icons-2&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/22832-download-icons-2&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/22832-download-icons-2&lookback=7)