### PR TITLE
add account descriptor and account symbol the address labeling sync 

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -209,6 +209,8 @@ export const ConfirmValueModal = ({
                                                 type: 'addressLabel',
                                                 entityKey: account.key,
                                                 defaultValue: value,
+                                                networkSymbol: account.symbol,
+                                                accountDescriptor: account.descriptor,
                                                 value:
                                                     suiteSyncAddressLabels?.find(
                                                         it => it.address === value,

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -186,6 +186,8 @@ export const UsedAddresses = ({
                                     type: 'addressLabel',
                                     entityKey: account.key,
                                     defaultValue: addr.address,
+                                    networkSymbol: account.symbol,
+                                    accountDescriptor: account.descriptor,
                                     value:
                                         suiteSyncAddressLabels.find(
                                             it => it.address === addr.address,

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -267,6 +267,8 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                                 type: 'addressLabel',
                                 entityKey: account.key,
                                 defaultValue: utxo.address,
+                                accountDescriptor: account.descriptor,
+                                networkSymbol: account.symbol,
                                 value:
                                     suiteSyncAddressLabels.find(it => it.address === utxo.address)
                                         ?.label ?? addressLabels[utxo.address],

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -29,6 +29,8 @@ export type MetadataAddPayload = { skipSave?: boolean } & (
           entityKey: string;
           defaultValue: string;
           value?: string;
+          networkSymbol: string;
+          accountDescriptor: string;
       }
     | {
           type: 'accountLabel';

--- a/suite-common/suite-sync-evolu/src/labeling/addressLabels.ts
+++ b/suite-common/suite-sync-evolu/src/labeling/addressLabels.ts
@@ -8,9 +8,11 @@ import {
 } from '@evolu/common';
 
 import { AddressLabel, AddressLabelsStore } from '@suite-common/suite-sync-storage';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountDescriptor } from '@suite-common/wallet-types';
 
-import { UnwrapQuery } from '../evoluUtils';
 import { normalizeLabel } from './normalizeLabel';
+import { UnwrapQuery } from '../evoluUtils';
 
 export const AddressLabelId = id('AddressLabelId');
 export type AddressLabelId = typeof AddressLabelId.Type;
@@ -23,13 +25,15 @@ export const AddressLabelSchema = {
         id: AddressLabelId,
         label: nullOr(NonEmptyString1000),
         address: NonEmptyString1000,
+        accountDescriptor: NonEmptyString1000,
+        networkSymbol: NonEmptyString1000,
     },
 };
 
 export class AddressLabels implements AddressLabelsStore {
     constructor(private evolu: Evolu<typeof AddressLabelSchema>) {}
 
-    update = ({ address, label }: AddressLabel) => {
+    update = ({ address, label, accountDescriptor, networkSymbol }: AddressLabel) => {
         const idResult = createAddressLabelId(address);
 
         if (!idResult.ok) {
@@ -42,6 +46,8 @@ export class AddressLabels implements AddressLabelsStore {
             id: idResult.value,
             address,
             label: normalizeLabel(label),
+            accountDescriptor: accountDescriptor as AccountDescriptor,
+            networkSymbol: networkSymbol as NetworkSymbol,
         });
 
         if (!result.ok) {
@@ -59,13 +65,19 @@ export class AddressLabels implements AddressLabelsStore {
 
         const process = (labels: QueryRows<UnwrapQuery<typeof query>>) => {
             for (const label of labels) {
-                if (label.address === null) {
+                if (
+                    label.address === null ||
+                    label.accountDescriptor === null ||
+                    label.networkSymbol === null
+                ) {
                     continue;
                 }
 
                 onChange({
                     address: label.address,
                     label: label.label,
+                    accountDescriptor: label.accountDescriptor,
+                    networkSymbol: label.networkSymbol as NetworkSymbol,
                 });
             }
         };

--- a/suite-common/suite-sync-storage/src/labeling/AddressLabelsStore.ts
+++ b/suite-common/suite-sync-storage/src/labeling/AddressLabelsStore.ts
@@ -1,6 +1,10 @@
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+
 export type AddressLabel = {
     address: string;
     label: string | null;
+    accountDescriptor: string;
+    networkSymbol: NetworkSymbol;
 };
 
 export interface AddressLabelsStore {

--- a/suite-common/suite-sync/src/labeling/labelingActions.ts
+++ b/suite-common/suite-sync/src/labeling/labelingActions.ts
@@ -27,7 +27,13 @@ export const setAccountLabel = createAction(
 /** @deprecated This shall be used **ONLY ONCE** in Evolu Subscribe Query. */
 export const setAddressLabel = createAction(
     `${LABELING_PREFIX}/set-address-label`,
-    (payload: { walletDescriptor: WalletDescriptor; address: string; label: string | null }) => ({
+    (payload: {
+        walletDescriptor: WalletDescriptor;
+        address: string;
+        label: string | null;
+        accountDescriptor: string;
+        networkSymbol: NetworkSymbol;
+    }) => ({
         payload,
     }),
 );

--- a/suite-common/suite-sync/src/labeling/processMetadataMessageThunk.ts
+++ b/suite-common/suite-sync/src/labeling/processMetadataMessageThunk.ts
@@ -1,5 +1,6 @@
 import { MetadataAddPayload } from '@suite-common/metadata-types';
 import { createThunk } from '@suite-common/redux-utils';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import type { StaticSessionId } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -53,6 +54,8 @@ export const processMetadataMessageThunk = createThunk<
                         address: payload.defaultValue, // WTF, but this is the address. For example: `"bc1q9mnl3ae6dra54uu2n9hp3d4jwkt0c2ux5l79ja"`
                         // entityKey is for example `zpub6rY6av7j6m7Lnd6rgqw5jffjX2rgeirDWWivEmFDMCKxt7FkWD5XQSrXCSW2Vsh3vnqUo1r9XjoGZiW41jqfEBkrxxdPnS15QhwJFjwfZ1U-btc-momP8m1p6w1nteR3hNREZjNc48buvpPv8K@BCCD2503E021276E78A8EBB2:2`
                         label: value ?? null,
+                        accountDescriptor: payload.accountDescriptor,
+                        networkSymbol: payload.networkSymbol as NetworkSymbol,
                     }),
                 );
                 break;

--- a/suite-common/suite-sync/src/labeling/updateAddressLabelThunk.ts
+++ b/suite-common/suite-sync/src/labeling/updateAddressLabelThunk.ts
@@ -1,6 +1,8 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { getSuiteSyncStorageProvider } from '@suite-common/suite-sync-storage';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectDevices } from '@suite-common/wallet-core';
+import { Account } from '@suite-common/wallet-types';
 import type { StaticSessionId } from '@trezor/connect';
 
 import { LABELING_PREFIX } from './labelingActions';
@@ -9,11 +11,13 @@ type UpdateAddressLabelThunkParams = {
     deviceStaticSessionId: StaticSessionId;
     address: string;
     label: string | null;
+    accountDescriptor: Account['descriptor'];
+    networkSymbol: NetworkSymbol;
 };
 
 export const updateAddressLabelThunk = createThunk<void, UpdateAddressLabelThunkParams, void>(
     `${LABELING_PREFIX}/updateAddressLabelThunk`,
-    ({ deviceStaticSessionId, address, label }, { getState }) => {
+    ({ deviceStaticSessionId, address, label, accountDescriptor, networkSymbol }, { getState }) => {
         const device = selectDevices(getState())?.find(
             it => it.state?.staticSessionId === deviceStaticSessionId,
         );
@@ -31,6 +35,6 @@ export const updateAddressLabelThunk = createThunk<void, UpdateAddressLabelThunk
 
         const storage = getSuiteSyncStorageProvider(owner);
 
-        storage.addressLabels.update({ address, label });
+        storage.addressLabels.update({ address, label, accountDescriptor, networkSymbol });
     },
 );

--- a/suite-common/suite-sync/tests/labeling/labelingReducer.test.ts
+++ b/suite-common/suite-sync/tests/labeling/labelingReducer.test.ts
@@ -185,6 +185,8 @@ describe('labelingReducer', () => {
                 walletDescriptor,
                 address: 'tb1qexampleaddressxyz',
                 label: 'First Address',
+                accountDescriptor: 'test-descriptor-123',
+                networkSymbol: 'btc',
             }),
         );
 
@@ -206,6 +208,8 @@ describe('labelingReducer', () => {
                 walletDescriptor,
                 address: 'tb1qexampleaddressxyz',
                 label: 'First Address Updated',
+                accountDescriptor: 'test-descriptor-123',
+                networkSymbol: 'btc',
             }),
         );
 
@@ -235,6 +239,8 @@ describe('labelingReducer', () => {
                 walletDescriptor,
                 address: 'tb1qaddress1',
                 label: 'Address 1',
+                accountDescriptor: 'test-descriptor-123',
+                networkSymbol: 'btc',
             }),
         );
 
@@ -243,6 +249,8 @@ describe('labelingReducer', () => {
                 walletDescriptor,
                 address: 'tb1qaddress2',
                 label: 'Address 2',
+                accountDescriptor: 'test-descriptor-123',
+                networkSymbol: 'btc',
             }),
         );
 
@@ -259,6 +267,8 @@ describe('labelingReducer', () => {
                 walletDescriptor,
                 address: 'tb1qaddress2',
                 label: 'Address 2 Updated',
+                accountDescriptor: 'test-descriptor-123',
+                networkSymbol: 'btc',
             }),
         );
 
@@ -269,6 +279,8 @@ describe('labelingReducer', () => {
         expect(updatedAddrLabels).toHaveLength(2);
         expect(updatedAddrLabels[0].label).toBe('Address 1');
         expect(updatedAddrLabels[1].label).toBe('Address 2 Updated');
+        expect(updatedAddrLabels[0].accountDescriptor).toBe('test-descriptor-123');
+        expect(updatedAddrLabels[1].networkSymbol).toBe('btc');
     });
 
     it('adds and updates output label (insert then update path)', () => {
@@ -336,6 +348,8 @@ describe('labelingReducer', () => {
                 {
                     address: 'tb1qexampleaddressxyz',
                     label: 'Address',
+                    accountDescriptor: 'test-descriptor-123',
+                    networkSymbol: 'btc',
                 },
             ],
             outputLabels: [

--- a/suite-native/labeling/package.json
+++ b/suite-native/labeling/package.json
@@ -14,6 +14,7 @@
         "@reduxjs/toolkit": "2.10.1",
         "@suite-common/suite-sync": "workspace:*",
         "@suite-common/validators": "workspace:*",
+        "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",

--- a/suite-native/labeling/src/components/AddressLabelEditable.tsx
+++ b/suite-native/labeling/src/components/AddressLabelEditable.tsx
@@ -5,6 +5,7 @@ import {
     selectAddressLabel,
     updateAddressLabelThunk,
 } from '@suite-common/suite-sync';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { StaticSessionId } from '@trezor/connect';
 
 import { EditableLabelLayout } from './EditableLabelLayout';
@@ -14,11 +15,15 @@ import { useIsLabelingEnabled } from './useIsLabelingEnabled';
 type AddressLabelEditableProps = {
     address: string;
     deviceStaticSessionId: StaticSessionId;
+    accountDescriptor: string;
+    networkSymbol: NetworkSymbol;
 };
 
 export const AddressLabelEditable = ({
     address,
     deviceStaticSessionId,
+    accountDescriptor,
+    networkSymbol,
 }: AddressLabelEditableProps) => {
     const isLabelingEnabled = useIsLabelingEnabled();
     const dispatch = useDispatch();
@@ -37,6 +42,8 @@ export const AddressLabelEditable = ({
                 deviceStaticSessionId,
                 address,
                 label: newLabel,
+                accountDescriptor,
+                networkSymbol,
             }),
         );
     };

--- a/suite-native/labeling/tsconfig.json
+++ b/suite-native/labeling/tsconfig.json
@@ -9,6 +9,9 @@
             "path": "../../suite-common/validators"
         },
         {
+            "path": "../../suite-common/wallet-config"
+        },
+        {
             "path": "../../suite-common/wallet-core"
         },
         {

--- a/suite-native/qr-code/src/components/AddressQRCode.tsx
+++ b/suite-native/qr-code/src/components/AddressQRCode.tsx
@@ -1,5 +1,6 @@
 import { Alert, Pressable, Share } from 'react-native';
 
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { useCopyToClipboard } from '@suite-native/helpers';
 import { Translation, useTranslate } from '@suite-native/intl';
@@ -12,13 +13,20 @@ import { QRCode } from './QRCode';
 type AddressQRCodeProps = {
     address: string;
     deviceStaticSessionId: StaticSessionId;
+    accountDescriptor: string;
+    networkSymbol: NetworkSymbol;
 };
 
 const addressContainer = prepareNativeStyle(() => ({
     justifyContent: 'center',
     alignItems: 'center',
 }));
-export const AddressQRCode = ({ address, deviceStaticSessionId }: AddressQRCodeProps) => {
+export const AddressQRCode = ({
+    address,
+    deviceStaticSessionId,
+    accountDescriptor,
+    networkSymbol,
+}: AddressQRCodeProps) => {
     const copyToClipboard = useCopyToClipboard();
     const { translate } = useTranslate();
     const { applyStyle } = useNativeStyles();
@@ -49,7 +57,12 @@ export const AddressQRCode = ({ address, deviceStaticSessionId }: AddressQRCodeP
                     {address}
                 </Text>
             </Pressable>
-            <AddressLabelEditable address={address} deviceStaticSessionId={deviceStaticSessionId} />
+            <AddressLabelEditable
+                accountDescriptor={accountDescriptor}
+                address={address}
+                deviceStaticSessionId={deviceStaticSessionId}
+                networkSymbol={networkSymbol}
+            />
             <HStack spacing="sp8" justifyContent="center">
                 <Button
                     size="small"

--- a/suite-native/receive/src/components/ReceiveAddressCard.tsx
+++ b/suite-native/receive/src/components/ReceiveAddressCard.tsx
@@ -17,6 +17,7 @@ type ReceiveAddressCardProps = {
     address: string;
     deviceStaticSessionId: StaticSessionId;
     isReceiveApproved: boolean;
+    accountDescriptor: string;
     isUnverifiedAddressRevealed: boolean;
     symbol: NetworkSymbol;
     onShowAddress: () => void;
@@ -24,6 +25,7 @@ type ReceiveAddressCardProps = {
 };
 
 export const ReceiveAddressCard = ({
+    accountDescriptor,
     address,
     deviceStaticSessionId,
     isUnverifiedAddressRevealed,
@@ -75,8 +77,10 @@ export const ReceiveAddressCard = ({
                 <Box paddingVertical="sp8">
                     {isReceiveApproved ? (
                         <AddressQRCode
+                            accountDescriptor={accountDescriptor}
                             address={address}
                             deviceStaticSessionId={deviceStaticSessionId}
+                            networkSymbol={symbol}
                         />
                     ) : (
                         <UnverifiedAddress

--- a/suite-native/receive/src/screens/ReceiveAddressScreen.tsx
+++ b/suite-native/receive/src/screens/ReceiveAddressScreen.tsx
@@ -157,6 +157,7 @@ export const ReceiveAddressScreen = ({
                     </AnimatedBox>
                 )}
                 <ReceiveAddressCard
+                    accountDescriptor={account.descriptor}
                     symbol={account.symbol}
                     address={address}
                     deviceStaticSessionId={account.deviceState}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11905,6 +11905,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:2.10.1"
     "@suite-common/suite-sync": "workspace:*"
     "@suite-common/validators": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

Nothing to test.

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/23161

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=23161-add-account-reference-to-synced-labeling&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=23161-add-account-reference-to-synced-labeling&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=23161-add-account-reference-to-synced-labeling&lookback=7)