### PR TITLE
fix(suite): update condition for checking account eligibility in trading form

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.ts
@@ -71,9 +71,10 @@ export const useTradingFormAccount = () => {
                     : undefined;
 
             if (isNativeToken) {
-                return tokens
-                    ? tokens.shownWithBalance.length > 0
-                    : new BigNumber(account.balance).gt(0);
+                const hasTokensWithBalance = tokens ? tokens.shownWithBalance.length > 0 : false;
+                const hasAccountBalance = new BigNumber(account.balance).gt(0);
+
+                return hasTokensWithBalance || hasAccountBalance;
             }
 
             return tokens?.shownWithBalance.some(token => {


### PR DESCRIPTION
## Description

Fixed account eligibility check in trading form to properly evaluate native token balance when account only has hidden tokens.

The problem was that the condition would resolve to `false` if there was a `tokens` object, but `tokens.shownWithBalance` was empty. Now we properly check for `tokens` OR native balance.

## Notes for QA

Testable on an account with some native balance and only hidden tokens. The account should be selectable now

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/global-swap-account-select&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/global-swap-account-select&lookback=7)