### PR TITLE
fix(suite): one-time AutoForget all persistentDeviceData

### DIFF
--- a/packages/suite/src/actions/suite/autoForgetDeviceDataThunks.ts
+++ b/packages/suite/src/actions/suite/autoForgetDeviceDataThunks.ts
@@ -26,6 +26,7 @@ export const setAutoForgetDeviceDataThunk = createThunk<
     // Finally, having purged the data in Bluetooth and THP reducers, simply sync BT and THP to persistent storage.
     await dispatch(storageActions.saveKnownDevices());
     await dispatch(storageActions.saveThpCredentials());
+    await storageActions.clearPersistentDeviceData();
 
     // Reload to ensure all local state is cleared, especially Connect session, which would otherwise reconnect THP.
     // Delay for two reasons: make sure IDB operations are complete, and give some time for the UI success notification to be seen

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -518,15 +518,18 @@ export const saveMessageSystem = () => (_dispatch: Dispatch, getState: GetState)
     );
 };
 
-export const savePersistentDeviceData = createThunk(
-    `${STORAGE.MODULE_PREFIX}/savePersistentDeviceData`,
-    (_, { getState }) => {
-        if (!db.isAccessible()) return;
-        const data = selectPersistentDeviceData(getState());
+export const savePersistentDeviceData = () => async (_dispatch: Dispatch, getState: GetState) => {
+    if (!db.isAccessible()) return;
+    const data = selectPersistentDeviceData(getState());
 
-        db.addItem('persistentDeviceData', data, 'persistentDeviceData', true);
-    },
-);
+    await db.addItem('persistentDeviceData', data, 'persistentDeviceData', true);
+};
+
+// BEWARE This is not a thunk (most functions in this file are thunks, but are not named as such TODO rename them to "thunk"
+export const clearPersistentDeviceData = async () => {
+    if (!db.isAccessible()) return;
+    await db.removeItemByPK('persistentDeviceData', 'persistentDeviceData');
+};
 
 export const saveConnectSettings = () => (_dispatch: Dispatch, getState: GetState) => {
     if (!db.isAccessible()) return;

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -283,6 +283,10 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
             ) {
                 api.dispatch(storageActions.savePersistentDeviceData());
             }
+            // just a safeguard, nothing should be persisted in the first place
+            if (isAutoForgetEnabled && deviceActions.deviceDisconnect.match(action)) {
+                storageActions.clearPersistentDeviceData();
+            }
 
             switch (action.type) {
                 case WALLET_SETTINGS.SET_HIDE_BALANCE:


### PR DESCRIPTION
## Description

Fix auto forgetting devices when disabling device storage.

## Notes for QA

Needs to be verified in IDB, that when you disable device data storage, all data is cleared, even when the device is still connected. Connecting a new device does not persist anything.

And that persistence works when the device data storage is enabled.

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/168

## Screenshots:

[fixed.webm](https://github.com/user-attachments/assets/d2ec6a1d-2e00-46dd-8088-a8596fb2d5dc)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/auto-forget&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/auto-forget&lookback=7)