### PR TITLE
Store failed accounts as well

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -13,13 +13,9 @@ import {
     selectDevices,
     selectPersistentDeviceData,
 } from '@suite-common/wallet-core';
-import type { FormState, RatesByTimestamps, SuccessfulAccount } from '@suite-common/wallet-types';
+import type { FormState, RatesByTimestamps } from '@suite-common/wallet-types';
 import { FormDraftKeyPrefix } from '@suite-common/wallet-types';
-import {
-    getFormDraftKey,
-    isAccountSuccessful,
-    selectHistoricRatesByTransactions,
-} from '@suite-common/wallet-utils';
+import { getFormDraftKey, selectHistoricRatesByTransactions } from '@suite-common/wallet-utils';
 import { cloneObject } from '@trezor/utils';
 
 import { selectCoinjoinAccountByKey } from 'src/reducers/wallet/coinjoinReducer';
@@ -259,7 +255,7 @@ export const forgetDevice = (device: TrezorDevice) => (_: Dispatch, getState: Ge
     ]);
 };
 
-export const saveAccounts = (accounts: SuccessfulAccount[]) => {
+export const saveAccounts = (accounts: Account[]) => {
     if (!db.isAccessible()) return;
 
     return db.addItems('accounts', accounts, true);
@@ -307,9 +303,9 @@ export const rememberDevice =
         if (!isDeviceAcquired(device) || !device.state?.staticSessionId) return;
 
         const { wallet } = getState();
-        const accounts = wallet.accounts
-            .filter(isAccountSuccessful)
-            .filter(a => a.deviceState === device.state?.staticSessionId);
+        const accounts = wallet.accounts.filter(
+            a => a.deviceState === device.state?.staticSessionId,
+        );
 
         const graphData = wallet.graph.data.filter(d =>
             deviceGraphDataFilterFn(d, device.state?.staticSessionId),

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -32,7 +32,7 @@ import {
     transactionsActions,
     updateTxsFiatRatesThunk,
 } from '@suite-common/wallet-core';
-import { findAccountDevice, isAccountSuccessful } from '@suite-common/wallet-utils';
+import { findAccountDevice } from '@suite-common/wallet-utils';
 import { walletConnectActions } from '@suite-common/walletconnect';
 
 import { METADATA, STORAGE, SUITE } from 'src/actions/suite/constants';
@@ -65,7 +65,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 const device = findAccountDevice(newAccount, selectDevices(state));
 
                 // update only transactions for remembered device
-                if (isDeviceRemembered(device) && isAccountSuccessful(newAccount)) {
+                if (isDeviceRemembered(device)) {
                     storageActions.saveAccounts([newAccount]);
                     api.dispatch(storageActions.saveCoinjoinAccount(newAccount.key));
                 }
@@ -81,7 +81,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     const accounts = selectAccountsByDeviceState(
                         api.getState(),
                         action.payload.state,
-                    ).filter(isAccountSuccessful);
+                    );
 
                     storageActions.saveAccounts(accounts);
                 }
@@ -94,7 +94,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
             if (isAnyOf(metadataActions.setAccountAdd)(action)) {
                 const device = findAccountDevice(action.payload, selectDevices(api.getState()));
                 // if device is remembered, and there is a change in account.metadata (metadataActions.setAccountLoaded), update database
-                if (isDeviceRemembered(device) && isAccountSuccessful(action.payload)) {
+                if (isDeviceRemembered(device)) {
                     storageActions.saveAccounts([action.payload]);
                 }
             }

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -23,7 +23,6 @@ import {
     PrecomposedTransactionFinal,
     RatesByKey,
     ReceiveInfo,
-    SuccessfulAccount,
     TokenAddress,
 } from '@suite-common/wallet-types';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
@@ -54,9 +53,6 @@ import { isRbfBumpFeeTransaction } from './transactionUtils';
 
 export const isUtxoBased = (account: Account) =>
     account.networkType === 'bitcoin' || account.networkType === 'cardano';
-
-export const isAccountSuccessful = (account: Account): account is SuccessfulAccount =>
-    !account.failed;
 
 export const isAccountFailed = (account: Account): account is FailedAccount => !!account.failed;
 


### PR DESCRIPTION
## Description

In order to make new discovery work properly, we should store even failed accounts into DB. Yet we should find a proper way how to replace failed accounts with proper ones as they have different descriptors instead of placeholders. Maybe replace descriptor in account table key with type + index?

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/persist-failed-accounts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/persist-failed-accounts&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/persist-failed-accounts&lookback=7)