### PR TITLE
feat(suite): update troubleshooting tips and connection flow

### DIFF
--- a/packages/components/src/components/Image/Image.tsx
+++ b/packages/components/src/components/Image/Image.tsx
@@ -58,6 +58,7 @@ const getSourceProps = (imageKey: ImageKey) => {
 };
 
 const StyledImage = styled.img<TransientProps<AllowedFrameProps>>`
+    display: block;
     max-width: 100%;
 
     ${withFrameProps}

--- a/packages/suite/src/components/connection/CantSeeTrezorModal.tsx
+++ b/packages/suite/src/components/connection/CantSeeTrezorModal.tsx
@@ -1,31 +1,23 @@
 import { useMemo } from 'react';
 
-import { Card, Column, H3, Modal, Paragraph } from '@trezor/components';
+import { Column, H3, Modal, Paragraph } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
-import { isDesktop } from '@trezor/env-utils';
 import { DeviceAnimation } from '@trezor/product-components';
 import { EventType, analytics } from '@trezor/suite-analytics';
-import { TREZOR_SUPPORT_URL } from '@trezor/urls';
+import { TREZOR_SUPPORT_DEVICE_URL } from '@trezor/urls';
 
 import { Translation } from 'src/components/suite/Translation';
 import { TroubleshootingTipsItem } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import { TroubleshootingTipsList } from 'src/components/suite/troubleshooting/TroubleshootingTipsList';
 import {
-    TROUBLESHOOTING_ALL_BLUETOOTH_TIPS,
-    TROUBLESHOOTING_TIP_BRIDGE_STATUS,
     TROUBLESHOOTING_TIP_CABLE,
+    TROUBLESHOOTING_TIP_DEVICE_TURNED_ON_UNLOCKED,
     TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER,
     TROUBLESHOOTING_TIP_SUITE_DESKTOP,
-    TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE,
     TROUBLESHOOTING_TIP_UDEV,
-    TROUBLESHOOTING_TIP_USB,
 } from 'src/components/suite/troubleshooting/tips';
 import { useSelector } from 'src/hooks/suite';
-import { useBridgeDesktopApi } from 'src/hooks/suite/useBridgeDesktopApi';
-import {
-    selectHasTransportOfType,
-    selectTransportOfType,
-} from 'src/selectors/suite/suiteSelectors';
+import { selectHasTransportOfType } from 'src/selectors/suite/suiteSelectors';
 
 import { AnimationCard } from './AnimationCard';
 import { useConnectionGlobalModalContext } from './context/ConnectionGlobalModalContext';
@@ -35,9 +27,10 @@ type DontSeeYourTrezorModalProps = {
 };
 
 const commonCableTips = [
+    TROUBLESHOOTING_TIP_DEVICE_TURNED_ON_UNLOCKED,
     TROUBLESHOOTING_TIP_UDEV,
     TROUBLESHOOTING_TIP_CABLE,
-    TROUBLESHOOTING_TIP_USB,
+    TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER,
 ];
 
 export const CantSeeTrezorModal = ({ onClose }: DontSeeYourTrezorModalProps) => {
@@ -50,43 +43,22 @@ export const CantSeeTrezorModal = ({ onClose }: DontSeeYourTrezorModalProps) => 
     } = useConnectionGlobalModalContext();
 
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
-    const bridge = useSelector(selectTransportOfType('BridgeTransport'));
-
-    const bridgeDesktopApi = useBridgeDesktopApi();
 
     const allowPairAgain =
         notConnectedNearbyDevices?.length === 0 && notConnectedKnownDevices.length > 0;
 
     const openTrezorSupport = () => {
-        window.open(TREZOR_SUPPORT_URL, '_blank');
+        window.open(TREZOR_SUPPORT_DEVICE_URL, '_blank');
         toggleShowHints();
     };
 
     const cableItem: TroubleshootingTipsItem[] = useMemo(() => {
         const items = isWebUsbTransport
             ? [...commonCableTips, TROUBLESHOOTING_TIP_SUITE_DESKTOP]
-            : [
-                  TROUBLESHOOTING_TIP_BRIDGE_STATUS,
-                  ...commonCableTips,
-                  TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER,
-              ];
-
-        if (bridgeDesktopApi?.bridgeProcess?.process && bridge) {
-            items.push(TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE);
-        } else {
-            // TODO: here we are going to put instruction to uninstall standalone bridge
-        }
+            : commonCableTips;
 
         return items;
-    }, [isWebUsbTransport, bridgeDesktopApi, bridge]);
-
-    const tipItems = useMemo(() => {
-        if (isBluetoothMode && isDesktop()) {
-            return TROUBLESHOOTING_ALL_BLUETOOTH_TIPS;
-        }
-
-        return cableItem;
-    }, [isBluetoothMode, cableItem]);
+    }, [isWebUsbTransport]);
 
     if (isBluetoothMode) {
         return (
@@ -115,17 +87,19 @@ export const CantSeeTrezorModal = ({ onClose }: DontSeeYourTrezorModalProps) => 
                 }
             >
                 <Column gap={32}>
-                    <H3 typographyStyle="titleMedium" align="center" textWrap="balance">
-                        <Translation id="TR_TREZOR_NEEDS_TO_BE_IN_PAIRING_MODE" />
-                    </H3>
-                    <Paragraph
-                        variant="tertiary"
-                        typographyStyle="hint"
-                        align="center"
-                        textWrap="pretty"
-                    >
-                        <Translation id="TR_WINDOW_WILL_CLOSE_WHEN_TREZOR_IS_PAIRED" />
-                    </Paragraph>
+                    <Column gap={24} padding={{ horizontal: 8 }}>
+                        <H3 typographyStyle="titleMedium" align="center" textWrap="pretty">
+                            <Translation id="TR_TREZOR_NEEDS_TO_BE_IN_PAIRING_MODE" />
+                        </H3>
+                        <Paragraph
+                            variant="tertiary"
+                            typographyStyle="hint"
+                            align="center"
+                            textWrap="balance"
+                        >
+                            <Translation id="TR_WINDOW_WILL_CLOSE_WHEN_TREZOR_IS_PAIRED" />
+                        </Paragraph>
+                    </Column>
                     <AnimationCard aspectRatio="1">
                         <DeviceAnimation
                             type="PAIRING_MODE"
@@ -140,25 +114,29 @@ export const CantSeeTrezorModal = ({ onClose }: DontSeeYourTrezorModalProps) => 
 
     return (
         <Modal
+            size="small"
             bottomContent={
-                <Modal.Button
-                    intent="neutral"
-                    priority="secondary"
-                    onClick={() => {
-                        openTrezorSupport();
-                        onClose();
-                    }}
-                >
-                    <Translation id="TR_CONTACT_TREZOR_SUPPORT" />
-                </Modal.Button>
+                <>
+                    <Modal.Button onClick={toggleShowHints}>
+                        <Translation id="TR_GOT_IT" />
+                    </Modal.Button>
+                    <Modal.Button
+                        intent="neutral"
+                        priority="secondary"
+                        onClick={() => {
+                            openTrezorSupport();
+                            onClose();
+                        }}
+                    >
+                        <Translation id="TR_CONTACT_TREZOR_SUPPORT" />
+                    </Modal.Button>
+                </>
             }
             heading={<Translation id="TR_STILL_DONT_SEE_YOUR_TREZOR" />}
             onCancel={toggleShowHints}
             variant="info"
         >
-            <Card paddingType="large">
-                <TroubleshootingTipsList items={tipItems} />
-            </Card>
+            <TroubleshootingTipsList items={cableItem} />
         </Modal>
     );
 };

--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -1,8 +1,27 @@
+import { useState } from 'react';
+
+import { AnimatePresence, motion } from 'framer-motion';
 import { useTheme } from 'styled-components';
 
 import { selectAdapterStatus, selectIsDeviceOsUnpairingRequired } from '@suite-common/bluetooth';
-import { Box, Button, Column, H3, Modal, Row, Spinner, Text } from '@trezor/components';
+import {
+    Box,
+    Button,
+    Card,
+    Column,
+    Divider,
+    H3,
+    IconCircle,
+    Image,
+    Modal,
+    Row,
+    Spinner,
+    Text,
+    motionEasing,
+} from '@trezor/components';
+import { DeviceModelInternal } from '@trezor/device-utils';
 import { isDesktop } from '@trezor/env-utils';
+import { getLargeModelImagePath } from '@trezor/product-components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
 import {
@@ -48,15 +67,151 @@ type ConnectModalContentProps = {
 const ConnectModalContent = ({ children, isBluetoothMode }: ConnectModalContentProps) => (
     <Column alignItems="center" gap={32} overflow="hidden">
         <H3 typographyStyle="titleMedium" align="center" textWrap="balance">
-            <Translation id="TR_CONNECT_UNLOCK_YOUR_DEVICE" />
+            <Translation
+                id={
+                    isBluetoothMode
+                        ? 'TR_CONNECT_UNLOCK_BLUETOOTH_DEVICE'
+                        : 'TR_CONNECT_UNLOCK_YOUR_DEVICE'
+                }
+            />
         </H3>
+        <Row gap={8} alignItems="center" justifyContent="center" height={36}>
+            <Spinner size={16} isGrey={false} />
+            <Text variant="primary">
+                <Translation
+                    id={isBluetoothMode ? 'TR_SCAN_TREZORS_NEARBY' : 'TR_CHECK_CONNECTED_TREZORS'}
+                />
+            </Text>
+        </Row>
         {children}
         <CableConnectionAnimation isBluetoothMode={isBluetoothMode} />
     </Column>
 );
 
+type ConnectionModeCardProps = {
+    onClick: () => void;
+};
+
+const ViaBluetoothCard = ({ onClick }: ConnectionModeCardProps) => (
+    <Card onClick={onClick} paddingType="large">
+        <Column alignItems="center" gap={24}>
+            <Image image={getLargeModelImagePath(DeviceModelInternal.T3W1)} height={128} />
+            <H3>
+                <Column alignItems="center">
+                    <Text>
+                        <Translation
+                            id="TR_CONNECT_DEVICE_NAME"
+                            values={{
+                                deviceName: 'Trezor Safe 7',
+                                b: chunks => (
+                                    <Text textWrap="nowrap">
+                                        <strong>{chunks}</strong>
+                                    </Text>
+                                ),
+                            }}
+                        />
+                    </Text>
+                    <Row gap={8}>
+                        <Text>
+                            <Translation id="TR_VIA_BLUETOOTH" />
+                        </Text>
+                        <IconCircle
+                            variant="tertiary"
+                            hasBorder={false}
+                            name="bluetooth"
+                            size={28}
+                            paddingType="small"
+                        />
+                    </Row>
+                </Column>
+            </H3>
+        </Column>
+    </Card>
+);
+
+const ViaCableCard = ({ onClick }: ConnectionModeCardProps) => (
+    <Card onClick={onClick} paddingType="large">
+        <Column alignItems="center" gap={24}>
+            <Row justifyContent="center">
+                {[
+                    DeviceModelInternal.T2T1,
+                    DeviceModelInternal.T3T1,
+                    DeviceModelInternal.T3W1,
+                    DeviceModelInternal.T2B1,
+                    DeviceModelInternal.T1B1,
+                ].map((model, index, array) => {
+                    const distanceFromEdge = Math.min(index, array.length - 1 - index);
+
+                    return (
+                        <Box
+                            key={index}
+                            position={{ type: 'relative' }}
+                            // T1B1 is narrower than other models, so we skip the negative margin
+                            margin={
+                                model !== DeviceModelInternal.T1B1 ? { horizontal: -8 } : undefined
+                            }
+                            zIndex={distanceFromEdge}
+                        >
+                            <AnimatePresence>
+                                <motion.div
+                                    initial={
+                                        index !== Math.floor(array.length / 2)
+                                            ? {
+                                                  x: index < array.length / 2 ? 20 : -20,
+                                              }
+                                            : undefined
+                                    }
+                                    animate={{ x: 0 }}
+                                    transition={{
+                                        duration: 1,
+                                        ease: motionEasing.enter,
+                                    }}
+                                >
+                                    <Image
+                                        image={getLargeModelImagePath(model)}
+                                        height={80 + distanceFromEdge * 24}
+                                    />
+                                </motion.div>
+                            </AnimatePresence>
+                        </Box>
+                    );
+                })}
+            </Row>
+            <H3>
+                <Column alignItems="center">
+                    <Text>
+                        <Translation
+                            id="TR_CONNECT_DEVICE_NAME"
+                            values={{
+                                deviceName: 'any Trezor',
+                                b: chunks => (
+                                    <Text textWrap="nowrap">
+                                        <strong>{chunks}</strong>
+                                    </Text>
+                                ),
+                            }}
+                        />
+                    </Text>
+                    <Row gap={8}>
+                        <Text>
+                            <Translation id="TR_VIA_CABLE" />
+                        </Text>
+                        <IconCircle
+                            variant="tertiary"
+                            hasBorder={false}
+                            name="cableUsbC"
+                            size={28}
+                            paddingType="small"
+                        />
+                    </Row>
+                </Column>
+            </H3>
+        </Column>
+    </Card>
+);
+
 export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void }) => {
-    const theme = useTheme();
+    const [isModeSelected, setIsModeSelected] = useState(false);
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
     const {
         toggleBluetoothMode,
@@ -150,18 +305,37 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
                     data-testid="@suite/connection-modal"
                     size="tiny"
                     onCancel={onCancel}
-                    onBackClick={toggleBluetoothMode}
+                    onBackClick={() => {
+                        setIsModeSelected(false);
+                        toggleBluetoothMode();
+                    }}
                 >
-                    <ConnectModalContent isBluetoothMode={true}>
-                        <Row gap={8} alignItems="center" justifyContent="center" height={36}>
-                            <Spinner size={16} bodyColor={theme.iconAlertBlue} isGrey={false} />
-                            <Text variant="info">
-                                <Translation id="TR_SCAN_TREZORS_NEARBY" />
-                            </Text>
-                        </Row>
-                    </ConnectModalContent>
+                    <ConnectModalContent isBluetoothMode={true} />
                 </Modal.ModalBase>
             </Modal.Backdrop>
+        );
+    }
+
+    if (isDesktop() && !isModeSelected) {
+        return (
+            <Modal data-testid="@suite/connection-modal" size="tiny" onCancel={onCancel}>
+                <Column gap={16}>
+                    <ViaBluetoothCard
+                        onClick={() => {
+                            setIsModeSelected(true);
+                            toggleBluetoothMode();
+                        }}
+                    />
+                    <Row gap={24}>
+                        <Divider margin={0} />
+                        <Text typographyStyle="hint" variant="tertiary" case="uppercase">
+                            or
+                        </Text>
+                        <Divider margin={0} />
+                    </Row>
+                    <ViaCableCard onClick={() => setIsModeSelected(true)} />
+                </Column>
+            </Modal>
         );
     }
 
@@ -169,23 +343,13 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
     return (
         <Modal.Backdrop onClick={onCancel}>
             <DontSeeTrezorPill onClick={toggleShowHints} />
-            <Modal.ModalBase data-testid="@suite/connection-modal" size="tiny" onCancel={onCancel}>
+            <Modal.ModalBase
+                data-testid="@suite/connection-modal"
+                size="tiny"
+                onCancel={onCancel}
+                onBackClick={() => setIsModeSelected(false)}
+            >
                 <ConnectModalContent isBluetoothMode={false}>
-                    {isDesktop() && (
-                        <Button
-                            iconLeft="bluetooth"
-                            onClick={() => {
-                                analytics.report({
-                                    type: EventType.DeviceConnectionConnectModal,
-                                    payload: {},
-                                });
-                                toggleBluetoothMode();
-                            }}
-                            intent="info"
-                        >
-                            <Translation id="TR_PAIR_NEW_BLUETOOTH_DEVICE" />
-                        </Button>
-                    )}
                     {isWebUsbTransport && <WebUsbButton intent="brand" size="medium" />}
                 </ConnectModalContent>
             </Modal.ModalBase>

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -1,6 +1,6 @@
 import '@suite-common/test-utils/src/globalOverrides';
 
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 
 import { AnalyticsState } from '@suite-common/analytics';
 import { TransportInfo } from '@trezor/connect';
@@ -228,7 +228,7 @@ describe(`${Preloader.name} component`, () => {
 
         expect(findByTestId('@connect-device-prompt')).not.toBeNull();
         fireEvent.click(findByTestId('@onboarding/troubleshooting-tips/button'));
-        expect(screen.getAllByText('TR_ACQUIRE_DEVICE_TITLE').length).toBe(2);
+        expect(findByTestId('TR_ACQUIRE_DEVICE_TITLE')).not.toBeNull();
 
         unmount();
     });
@@ -381,7 +381,6 @@ describe(`${Preloader.name} component`, () => {
 
         expect(findByTestId('@connect-device-prompt')).not.toBeNull();
         fireEvent.click(findByTestId('@onboarding/troubleshooting-tips/button'));
-        expect(findByTestId(/TR_YOUR_DEVICE_IS_SEEDLESS/)).not.toBeNull();
         expect(findByTestId('TR_SEEDLESS_SETUP_IS_NOT_SUPPORTED_TITLE')).not.toBeNull();
 
         unmount();

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceBootloader.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceBootloader.tsx
@@ -18,11 +18,13 @@ export const DeviceBootloader = () => {
             key: 'device-bootloader',
             heading: <Translation id="TR_DEVICE_CONNECTED_BOOTLOADER_RECONNECT" />,
             description: tipDescription !== null ? <Translation id={tipDescription} /> : null,
+            icon: 'trezorBody',
         },
         {
             key: 'wipe-or-update',
             heading: <Translation id="TR_WIPE_OR_UPDATE" />,
             description: <UpdateGoToSettingsDescription />,
+            icon: 'arrowsClockwise',
         },
     ];
 

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceDisconnectRequired.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceDisconnectRequired.tsx
@@ -4,13 +4,13 @@ import { Translation } from 'src/components/suite/Translation';
 export const DeviceDisconnectRequired = () => (
     <TroubleshootingTips
         initiallyIsOpen={true}
-        label={<Translation id="TR_DISCONNECT_YOUR_DEVICE" />}
         intent="warning"
         items={[
             {
                 key: 'disconnect-your-device',
                 heading: <Translation id="TR_DISCONNECT_YOUR_DEVICE" />,
                 description: <Translation id="DISCONNECT_DEVICE_DESCRIPTION" />,
+                icon: 'plugs',
             },
         ]}
     />

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceFirmwareCorrupted.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceFirmwareCorrupted.tsx
@@ -29,6 +29,7 @@ export const DeviceFirmwareCorrupted = () => {
                     key: 'device-firmware-corrupted',
                     heading: <Translation id="FW_CORRUPTED_REINSTALL_REQUIRED" />,
                     description: <Translation id="TR_FIRMWARE_CORRUPTED_REQUIRED_EXPLAINED" />,
+                    icon: 'cpu',
                 },
             ]}
         />

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
@@ -41,6 +41,7 @@ export const DeviceInitialize = () => {
                     key: 'device-initialize',
                     heading: <Translation id="TR_DEVICE_NOT_INITIALIZED" />,
                     description: <Translation id="TR_DEVICE_NOT_INITIALIZED_TEXT" />,
+                    icon: 'trezorBody',
                 },
             ]}
         />

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx
@@ -29,6 +29,7 @@ export const DeviceNoFirmware = () => {
                     key: 'device-firmware-missing',
                     heading: <Translation id="TR_NO_FIRMWARE" />,
                     description: <Translation id="TR_NO_FIRMWARE_EXPLAINED" />,
+                    icon: 'cpu',
                 },
             ]}
         />

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceRecoveryMode.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceRecoveryMode.tsx
@@ -36,6 +36,7 @@ export const DeviceRecoveryMode = () => {
                     key: 'recovery-mode',
                     heading: <Translation id="TR_DEVICE_IN_RECOVERY_MODE" />,
                     description: <Translation id="TR_DEVICE_IN_RECOVERY_MODE_DESC" />,
+                    icon: 'trezorBody',
                 },
             ]}
         />

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceSeedless.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceSeedless.tsx
@@ -4,13 +4,13 @@ import { Translation } from 'src/components/suite/Translation';
 // Seedless devices are not supported by Trezor Suite
 export const DeviceSeedless = () => (
     <TroubleshootingTips
-        label={<Translation id="TR_YOUR_DEVICE_IS_SEEDLESS" />}
         intent="info"
         items={[
             {
                 key: 'device-seedless',
                 heading: <Translation id="TR_SEEDLESS_SETUP_IS_NOT_SUPPORTED_TITLE" />,
                 description: <Translation id="TR_SEEDLESS_SETUP_IS_NOT_SUPPORTED_DESCRIPTION" />,
+                icon: 'trezorBody',
             },
         ]}
     />

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnknown.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnknown.tsx
@@ -10,6 +10,7 @@ export const DeviceUnknown = () => (
                 key: 'device-unknown',
                 heading: <Translation id="TR_UNKNOWN_DEVICE" />,
                 description: 'This is a very rare case. Please contact our support team.',
+                icon: 'questionSimple',
             },
         ]}
     />

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
@@ -2,10 +2,8 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { isLinux } from '@trezor/env-utils';
 
 import { TroubleshootingTips } from 'src/components/suite';
-import { Translation } from 'src/components/suite/Translation';
 import {
     TROUBLESHOOTING_TIP_CLOSE_ALL_TABS,
-    TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER,
     TROUBLESHOOTING_TIP_RECONNECT,
     TROUBLESHOOTING_TIP_SUITE_DESKTOP,
     TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE,
@@ -58,19 +56,10 @@ export const DeviceUnreadable = () => {
         items.push(TROUBLESHOOTING_TIP_RECONNECT);
         // if on web - try installing desktop. this takes you to using bridge which should be more powerful than WebUSB
         items.push(TROUBLESHOOTING_TIP_SUITE_DESKTOP);
-        // unfortunately we have seen reports that even old bridge might not be enough for some Windows users. So the only chance
-        // is using another computer, or maybe it would be better to say another OS
-        items.push(TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER);
     }
 
     return (
         <TroubleshootingTips
-            label={
-                <Translation
-                    id="TR_TROUBLESHOOTING_UNREADABLE_UNKNOWN"
-                    values={{ error: selectedDevice?.error }}
-                />
-            }
             intent="warning"
             items={items}
             data-testid="@connect-device-prompt/unreadable-unknown"

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUpdateRequired.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUpdateRequired.tsx
@@ -29,6 +29,7 @@ export const DeviceUpdateRequired = () => {
                     key: 'device-firmware-required',
                     heading: <Translation id="FW_CAPABILITY_UPDATE_REQUIRED" />,
                     description: <Translation id="TR_FIRMWARE_UPDATE_REQUIRED_EXPLAINED" />,
+                    icon: 'arrowsClockwise',
                 },
             ]}
         />

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUsedElsewhere.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUsedElsewhere.tsx
@@ -11,6 +11,7 @@ import {
 import { useDevice } from 'src/hooks/suite';
 
 import { AcquireDeviceButton } from '../AcquireDeviceButton';
+import { TroubleshootingTipsItem } from '../troubleshooting/TroubleshootingTips';
 
 export const DeviceUsedElsewhere = () => {
     const { device } = useDevice();
@@ -19,7 +20,7 @@ export const DeviceUsedElsewhere = () => {
         e.stopPropagation();
     };
 
-    const tips = [
+    const tips: TroubleshootingTipsItem[] = [
         {
             key: 'device-used-elsewhere',
             heading: <Translation id="TR_DEVICE_CONNECTED_UNACQUIRED" />,
@@ -31,6 +32,7 @@ export const DeviceUsedElsewhere = () => {
                     }}
                 />
             ),
+            icon: 'trezorBody',
         },
         TROUBLESHOOTING_TIP_CLOSE_ALL_TABS,
         TROUBLESHOOTING_TIP_RECONNECT,

--- a/packages/suite/src/components/suite/PrerequisitesGuide/MultiShareBackupInProgress.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/MultiShareBackupInProgress.tsx
@@ -10,6 +10,7 @@ export const MultiShareBackupInProgress = () => (
                 key: 'multi-share-backup-in-progress',
                 heading: <Translation id="TR_MULTI_SHARE_BACKUP_IN_PROGRESS_HEADING" />,
                 description: <Translation id="TR_MULTI_SHARE_BACKUP_IN_PROGRESS_DESCRIPTION" />,
+                icon: 'recoverySeed',
             },
         ]}
     />

--- a/packages/suite/src/components/suite/PrerequisitesGuide/NoTransport.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/NoTransport.tsx
@@ -1,7 +1,6 @@
 import { isDesktop } from '@trezor/env-utils';
 
 import { TroubleshootingTips } from 'src/components/suite';
-import { Translation } from 'src/components/suite/Translation';
 import {
     TROUBLESHOOTING_ENABLE_IN_DEBUG,
     TROUBLESHOOTING_TIP_RESTART_COMPUTER,
@@ -28,7 +27,6 @@ const Tips = ({ items }: { items: TroubleshootingTipsItem[] }) => (
     // - use a browser that supports WebUSB
     // Desktop app should have Bridge transport layer available as it is built-in, if it is not available we fucked up something.
     <TroubleshootingTips
-        label={<Translation id="TR_TROUBLESHOOTING_DEVICE_NOT_DETECTED" />}
         intent="warning"
         items={items}
         data-testid="@connect-device-prompt/bridge-not-running"

--- a/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
@@ -1,21 +1,8 @@
 import { ReactNode, useState } from 'react';
 
-import {
-    Banner,
-    BannerIntent,
-    Box,
-    Button,
-    Card,
-    Column,
-    IconName,
-    Modal,
-    Row,
-    Text,
-} from '@trezor/components';
-import { spacings } from '@trezor/theme';
+import { Banner, BannerIntent, Box, Button, Column, IconName, Modal } from '@trezor/components';
 
 import { TroubleshootingTipsList } from './TroubleshootingTipsList';
-import { useLayoutSize } from '../../../hooks/suite';
 import { Translation } from '../Translation';
 import { TroubleshootingTipsFooter } from './TroubleshootingTipsFooter';
 
@@ -48,28 +35,6 @@ export const TroubleshootingTips = ({
     intent = 'warning',
     'data-testid': dataTest,
 }: TroubleshootingTipsBaseProps) => {
-    // @TODO isn't `labelRow` duplicate information? If not, where to show it?
-    const labelRow =
-        label !== undefined ? (
-            <Row
-                justifyContent="space-between"
-                alignItems="center"
-                margin={{ horizontal: spacings.sm }}
-            >
-                <Text typographyStyle="body">{label}</Text>
-            </Row>
-        ) : null;
-
-    const ActionBanner = () => {
-        const { isBelowMobile } = useLayoutSize();
-
-        return (
-            <Banner rightContent={cta} intent={intent} minWidth={isBelowMobile ? undefined : 400}>
-                {ctaLabel ?? label}
-            </Banner>
-        );
-    };
-
     // todo: this filter is duplicated with TroubleshootingTipsList
     const visibleTips = items.filter(item => !item.hide);
 
@@ -106,9 +71,7 @@ export const TroubleshootingTips = ({
                         bottomContent={<TroubleshootingTipsFooter />}
                         data-testid="@onboarding/troubleshooting-tips/modal"
                     >
-                        <Card header={labelRow}>
-                            <TroubleshootingTipsList items={visibleTips} />
-                        </Card>
+                        <TroubleshootingTipsList items={visibleTips} />
                     </Modal>
                 )}
             </Column>
@@ -117,7 +80,9 @@ export const TroubleshootingTips = ({
 
     return cta ? (
         <Column gap={80} alignItems="center">
-            <ActionBanner />
+            <Banner rightContent={cta} intent={intent} maxWidth={600}>
+                {ctaLabel ?? label}
+            </Banner>
             {visibleTips.length > 0 && <TroubleshootingButton />}
         </Column>
     ) : (

--- a/packages/suite/src/components/suite/troubleshooting/TroubleshootingTipsFooter.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/TroubleshootingTipsFooter.tsx
@@ -21,7 +21,7 @@ export const TroubleshootingTipsFooter = () => {
                 <Translation id="TR_ONBOARDING_TROUBLESHOOTING_FAILED" />
             </Text>
 
-            <Button intent="neutral" priority="secondary" size="small" href={href}>
+            <Button intent="neutral" priority="secondary" href={href}>
                 <Translation id="TR_CONTACT_SUPPORT" />
             </Button>
         </Flex>

--- a/packages/suite/src/components/suite/troubleshooting/TroubleshootingTipsItemComponent.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/TroubleshootingTipsItemComponent.tsx
@@ -1,4 +1,4 @@
-import { BulletList, Column, IconCircle, List, Paragraph, Text } from '@trezor/components';
+import { Column, IconCircle, List, Paragraph } from '@trezor/components';
 
 import { TroubleshootingTipsItem } from './TroubleshootingTips';
 
@@ -6,31 +6,25 @@ type TroubleshootingTipsItemProps = {
     item: TroubleshootingTipsItem;
 };
 
-export const TroubleshootingTipsItemComponent = ({ item }: TroubleshootingTipsItemProps) => {
-    const isBulletList = item.icon == undefined;
-
-    return isBulletList ? (
-        <BulletList.Item title={item.heading}>
-            <Text variant="tertiary">{item.description}</Text>
-        </BulletList.Item>
-    ) : (
-        <List.Item
-            bulletComponent={
-                <IconCircle
-                    variant="info"
-                    hasBorder={false}
-                    paddingType="medium"
-                    name={item.icon ?? 'dotOutlineFilled'}
-                    size={40}
-                />
-            }
-        >
-            <Column gap={2}>
-                <Paragraph typographyStyle="body">{item.heading}</Paragraph>
+export const TroubleshootingTipsItemComponent = ({ item }: TroubleshootingTipsItemProps) => (
+    <List.Item
+        bulletComponent={
+            <IconCircle
+                variant="info"
+                hasBorder={false}
+                paddingType="medium"
+                name={item.icon ?? 'dotOutlineFilled'}
+                size={40}
+            />
+        }
+    >
+        <Column>
+            <Paragraph typographyStyle="body">{item.heading}</Paragraph>
+            {item.description && (
                 <Paragraph typographyStyle="hint" variant="tertiary">
                     {item.description}
                 </Paragraph>
-            </Column>
-        </List.Item>
-    );
-};
+            )}
+        </Column>
+    </List.Item>
+);

--- a/packages/suite/src/components/suite/troubleshooting/TroubleshootingTipsList.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/TroubleshootingTipsList.tsx
@@ -1,4 +1,4 @@
-import { BulletList, List } from '@trezor/components';
+import { List } from '@trezor/components';
 
 import { TroubleshootingTipsItem } from './TroubleshootingTips';
 import { TroubleshootingTipsItemComponent } from './TroubleshootingTipsItemComponent';
@@ -11,13 +11,6 @@ export const TroubleshootingTipsList = ({ items }: TroubleshootingTipsListCardPr
     const visibleItems = items
         .filter(item => !item.hide)
         .map(item => <TroubleshootingTipsItemComponent item={item} key={item.key} />);
-    const isBulletList = items.every(item => item.icon == undefined);
 
-    return isBulletList ? (
-        <BulletList bulletSize="medium" titleGap={2} gap={20} bulletGap={16}>
-            {visibleItems}
-        </BulletList>
-    ) : (
-        <List gap={20}>{visibleItems}</List>
-    );
+    return <List gap={20}>{visibleItems}</List>;
 };

--- a/packages/suite/src/components/suite/troubleshooting/tips/BridgeTip.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/BridgeTip.tsx
@@ -1,7 +1,3 @@
-import styled from 'styled-components';
-
-import { typography } from '@trezor/theme';
-
 import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
@@ -9,49 +5,22 @@ import { useBridgeDesktopApi } from 'src/hooks/suite/useBridgeDesktopApi';
 import { useOpenSuiteDesktop } from 'src/hooks/suite/useOpenSuiteDesktop';
 import { selectTransportOfType } from 'src/selectors/suite/suiteSelectors';
 
-export const Wrapper = styled.div`
-    a {
-        ${typography.hint};
-    }
-`;
-
 export const SuiteDesktopTip = () => {
     const handleClick = useOpenSuiteDesktop();
 
     return (
-        <Wrapper>
-            <Translation
-                id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_DESCRIPTION"
-                values={{
-                    a: chunks => (
-                        <TrezorLink icon="arrowUpRight" variant="underline" onClick={handleClick}>
-                            {chunks}
-                        </TrezorLink>
-                    ),
-                }}
-            />
-        </Wrapper>
-    );
-};
-
-export const BridgeStatus = () => (
-    <Wrapper>
         <Translation
-            id="TR_TROUBLESHOOTING_TIP_TRANSPORT_STATUS_DESCRIPTION"
+            id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_DESCRIPTION"
             values={{
                 a: chunks => (
-                    <TrezorLink
-                        icon="arrowUpRight"
-                        variant="underline"
-                        href="http://127.0.0.1:21325/status/"
-                    >
+                    <TrezorLink variant="underline" onClick={handleClick}>
                         {chunks}
                     </TrezorLink>
                 ),
             }}
         />
-    </Wrapper>
-);
+    );
+};
 
 /**
  * should only be rendered for desktop when built-in bridge is running
@@ -64,36 +33,34 @@ export const BridgeToggle = () => {
     if (!bridgeSettings) return null;
 
     return (
-        <Wrapper>
-            <Translation
-                id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_ALT_DESCRIPTION"
-                values={{
-                    currentVersion: bridge?.version || 'unknown', // unknown should not happen, if bridge process is running
-                    a: chunks => (
-                        <TrezorLink
-                            variant="underline"
-                            onClick={() => {
-                                changeBridgeSettings({
-                                    ...bridgeSettings,
-                                    legacy: !bridgeSettings?.legacy,
-                                });
+        <Translation
+            id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_ALT_DESCRIPTION"
+            values={{
+                currentVersion: bridge?.version || 'unknown', // unknown should not happen, if bridge process is running
+                a: chunks => (
+                    <TrezorLink
+                        variant="underline"
+                        onClick={() => {
+                            changeBridgeSettings({
+                                ...bridgeSettings,
+                                legacy: !bridgeSettings?.legacy,
+                            });
 
-                                // if bridge process is not running it might make sense to toggle it on and also
-                                // try to switch between legacy and node implementation (= who knows why it didn't start?)
-                                if (!bridgeProcess.process) {
-                                    // to get some sentry insights
-                                    console.error(
-                                        'Bridge process was not running and user toggled it in troubleshooting tips',
-                                    );
-                                    toggleBridge();
-                                }
-                            }}
-                        >
-                            {chunks}
-                        </TrezorLink>
-                    ),
-                }}
-            />
-        </Wrapper>
+                            // if bridge process is not running it might make sense to toggle it on and also
+                            // try to switch between legacy and node implementation (= who knows why it didn't start?)
+                            if (!bridgeProcess.process) {
+                                // to get some sentry insights
+                                console.error(
+                                    'Bridge process was not running and user toggled it in troubleshooting tips',
+                                );
+                                toggleBridge();
+                            }
+                        }}
+                    >
+                        {chunks}
+                    </TrezorLink>
+                ),
+            }}
+        />
     );
 };

--- a/packages/suite/src/components/suite/troubleshooting/tips/UdevDescription.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/UdevDescription.tsx
@@ -1,17 +1,7 @@
-import styled from 'styled-components';
-
-import { typography } from '@trezor/theme';
-
 import { goto } from 'src/actions/suite/routerActions';
 import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
-
-const Wrapper = styled.div`
-    a {
-        ${typography.hint};
-    }
-`;
 
 export const UdevDescription = () => {
     const dispatch = useDispatch();
@@ -19,7 +9,7 @@ export const UdevDescription = () => {
     const handleClick = () => dispatch(goto('suite-udev'));
 
     return (
-        <Wrapper data-testid="@connect-device-prompt/unreadable-udev">
+        <div data-testid="@connect-device-prompt/unreadable-udev">
             <Translation
                 id="TR_TROUBLESHOOTING_TIP_UDEV_INSTALL_DESCRIPTION"
                 values={{
@@ -34,6 +24,6 @@ export const UdevDescription = () => {
                     ),
                 }}
             />
-        </Wrapper>
+        </div>
     );
 };

--- a/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
@@ -1,20 +1,12 @@
-import { Text } from '@trezor/components';
 import { isAndroid, isDesktop, isLinux, isWeb } from '@trezor/env-utils';
-import { TREZOR_SUPPORT_DEVICE_URL, TREZOR_SUPPORT_RESET_PIN } from '@trezor/urls';
+import { TREZOR_SUPPORT_DEVICE_URL } from '@trezor/urls';
 
 import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 
-import { BridgeStatus, BridgeToggle, SuiteDesktopTip, Wrapper } from './BridgeTip';
+import { BridgeToggle, SuiteDesktopTip } from './BridgeTip';
 import { UdevDescription } from './UdevDescription';
 import { TroubleshootingTipsItem } from '../TroubleshootingTips';
-
-export const TROUBLESHOOTING_TIP_BRIDGE_STATUS: TroubleshootingTipsItem = {
-    key: 'bridge-status',
-    heading: <Translation id="TR_TROUBLESHOOTING_TIP_TRANSPORT_STATUS_TITLE" />,
-    description: <BridgeStatus />,
-    hide: !isWeb(),
-};
 
 export const TROUBLESHOOTING_TIP_WEBUSB_ENVIRONMENT: TroubleshootingTipsItem = {
     key: 'webusb-environment',
@@ -27,79 +19,59 @@ export const TROUBLESHOOTING_TIP_UNREADABLE_HID: TroubleshootingTipsItem = {
     key: 'unreadable-hid',
     heading: <Translation id="TR_TROUBLESHOOTING_TIP_UNREADABLE_HID_TITLE" />,
     description: (
-        <Wrapper>
-            <Translation
-                id="TR_TROUBLESHOOTING_TIP_UNREADABLE_HID_DESCRIPTION"
-                values={{
-                    a: chunks => (
-                        <TrezorLink variant="underline" href={TREZOR_SUPPORT_DEVICE_URL}>
-                            {chunks}
-                        </TrezorLink>
-                    ),
-                }}
-            />
-        </Wrapper>
-    ),
-};
-
-export const TROUBLESHOOTING_TIP_SUITE_DESKTOP: TroubleshootingTipsItem = {
-    key: 'suite-desktop',
-    heading: <Translation id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TITLE" />,
-    description: <SuiteDesktopTip />,
-    hide: !isWeb(),
-};
-
-export const TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE: TroubleshootingTipsItem = {
-    key: 'suite-desktop-toggle',
-    heading: <Translation id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_ALT_TITLE" />,
-    description: <BridgeToggle />,
-    hide: isWeb() || isAndroid(),
-};
-
-export const TROUBLESHOOTING_TIP_CABLE: TroubleshootingTipsItem = {
-    key: 'cable',
-    heading: <Translation id="TR_TROUBLESHOOTING_TIP_CABLE_TITLE" />,
-    description: <Translation id="TR_TROUBLESHOOTING_TIP_CABLE_DESCRIPTION" />,
-};
-
-export const TROUBLESHOOTING_TIP_USB: TroubleshootingTipsItem = {
-    key: 'usbPort',
-    heading: <Translation id="TR_TROUBLESHOOTING_TIP_USB_PORT_TITLE" />,
-    description: <Translation id="TR_TROUBLESHOOTING_TIP_USB_PORT_DESCRIPTION" />,
-    hide: isAndroid(),
-};
-
-export const TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER: TroubleshootingTipsItem = {
-    key: 'lostPin',
-    heading: <Translation id="TR_TROUBLESHOOTING_TIP_PIN_LOST_TITLE" />,
-    description: (
         <Translation
-            id="TR_TROUBLESHOOTING_TIP_PIN_LOST_DESCRIPTION"
+            id="TR_TROUBLESHOOTING_TIP_UNREADABLE_HID_DESCRIPTION"
             values={{
                 a: chunks => (
-                    <TrezorLink variant="underline" href={TREZOR_SUPPORT_RESET_PIN}>
+                    <TrezorLink variant="underline" href={TREZOR_SUPPORT_DEVICE_URL}>
                         {chunks}
                     </TrezorLink>
                 ),
             }}
         />
     ),
+    icon: 'cpu',
+};
+
+export const TROUBLESHOOTING_TIP_SUITE_DESKTOP: TroubleshootingTipsItem = {
+    key: 'suite-desktop',
+    heading: <SuiteDesktopTip />,
+    hide: !isWeb(),
+    icon: 'desktop',
+};
+
+export const TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE: TroubleshootingTipsItem = {
+    key: 'suite-desktop-toggle',
+    description: <BridgeToggle />,
+    heading: <Translation id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_ALT_TITLE" />,
+    icon: 'bridge',
+    hide: isWeb() || isAndroid(),
+};
+
+export const TROUBLESHOOTING_TIP_CABLE: TroubleshootingTipsItem = {
+    key: 'cable',
+    heading: <Translation id="TR_TROUBLESHOOTING_TIP_CABLE_TITLE" />,
+    icon: 'cableUsbC',
+};
+
+export const TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER: TroubleshootingTipsItem = {
+    key: 'different-computer',
+    heading: <Translation id="TR_TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER_TITLE" />,
+    icon: 'arrowsClockwise',
 };
 
 export const TROUBLESHOOTING_TIP_RESTART_COMPUTER: TroubleshootingTipsItem = {
     key: 'restartComputer',
     heading: <Translation id="TR_TROUBLESHOOTING_TIP_RESTART_COMPUTER_TITLE" />,
     description: <Translation id="TR_TROUBLESHOOTING_TIP_RESTART_COMPUTER_DESCRIPTION" />,
+    icon: 'arrowsClockwise',
 };
 
 export const TROUBLESHOOTING_ENABLE_IN_DEBUG: TroubleshootingTipsItem = {
     key: 'enableInDebug',
-    heading: (
-        <>
-            You may have <Text variant="destructive">disabled bridge in the debug</Text> settings.
-        </>
-    ),
+    heading: <>You may have disabled bridge in the debug settings.</>,
     description: <>Try to enable it. You know, ... with the switch.</>,
+    icon: 'gear',
     hide: isWeb(),
 };
 
@@ -107,6 +79,7 @@ export const TROUBLESHOOTING_TIP_UDEV: TroubleshootingTipsItem = {
     key: 'udev',
     heading: <Translation id="TR_UDEV_DOWNLOAD_TITLE" />,
     description: <UdevDescription />,
+    icon: 'arrowLineDown',
     hide: !isLinux(),
 };
 
@@ -122,6 +95,7 @@ export const TROUBLESHOOTING_TIP_RECONNECT: TroubleshootingTipsItem = {
             }
         />
     ),
+    icon: 'arrowsClockwise',
 };
 
 export const TROUBLESHOOTING_TIP_CLOSE_ALL_TABS: TroubleshootingTipsItem = {
@@ -136,15 +110,16 @@ export const TROUBLESHOOTING_TIP_CLOSE_ALL_TABS: TroubleshootingTipsItem = {
             }
         />
     ),
+    icon: 'tabs',
 };
 
-const TROUBLESHOOTING_TIP_DEVICE_TURNED_ON_UNLOCKED: TroubleshootingTipsItem = {
+export const TROUBLESHOOTING_TIP_DEVICE_TURNED_ON_UNLOCKED: TroubleshootingTipsItem = {
     key: 'trezor-turned-on-unlocked',
     heading: <Translation id="TR_BLUETOOTH_DEVICE_TURNED_ON_UNLOCKED_HEADING" />,
-    icon: 'power',
+    icon: 'trezorPassword',
 };
 
-const TROUBLESHOOTING_TIP_MANUAL_PAIRING_GUIDE: TroubleshootingTipsItem = {
+export const TROUBLESHOOTING_TIP_MANUAL_PAIRING_GUIDE: TroubleshootingTipsItem = {
     key: 'manually-pair-device-guide',
     heading: <Translation id="TR_BLUETOOTH_MANUAL_PAIR_DEVICE_GUIDE_HEADING" />,
     description: <Translation id="TR_BLUETOOTH_MANUAL_PAIR_DEVICE_GUIDE_DESCRIPTION" />,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2104,6 +2104,22 @@ export default defineMessages({
         description: 'Prompt to user to connect and unlock device in modal.',
         id: 'TR_CONNECT_UNLOCK_YOUR_DEVICE',
     },
+    TR_CONNECT_UNLOCK_BLUETOOTH_DEVICE: {
+        defaultMessage: 'Turn on & unlock your Trezor Safe 7',
+        id: 'TR_CONNECT_UNLOCK_BLUETOOTH_DEVICE',
+    },
+    TR_CONNECT_DEVICE_NAME: {
+        defaultMessage: 'Connect <b>{deviceName}</b>',
+        id: 'TR_CONNECT_DEVICE_NAME',
+    },
+    TR_VIA_CABLE: {
+        defaultMessage: 'via cable',
+        id: 'TR_VIA_CABLE',
+    },
+    TR_VIA_BLUETOOTH: {
+        defaultMessage: 'via Bluetooth',
+        id: 'TR_VIA_BLUETOOTH',
+    },
     TR_CONNECT_YOUR_DEVICE: {
         defaultMessage: 'Connect & unlock your Trezor',
         description: 'Prompt to user to connect his device.',
@@ -7929,12 +7945,16 @@ export default defineMessages({
     },
     TR_TROUBLESHOOTING_TIP_CABLE_TITLE: {
         id: 'TR_TROUBLESHOOTING_TIP_CABLE_TITLE',
-        defaultMessage: 'Use a different USB cable',
+        defaultMessage: 'Try using a different USB cable or port.',
     },
     TR_TROUBLESHOOTING_TIP_CABLE_DESCRIPTION: {
         id: 'TR_TROUBLESHOOTING_TIP_CABLE_DESCRIPTION',
         defaultMessage:
             'The cable must be fully inserted. For USB-C devices, ensure the cable clicks securely into place.',
+    },
+    TR_TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER_TITLE: {
+        id: 'TR_TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER_TITLE',
+        defaultMessage: 'Connect your Trezor to a different computer or phone.',
     },
     TR_TROUBLESHOOTING_TIP_USB_PORT_TITLE: {
         id: 'TR_TROUBLESHOOTING_TIP_USB_PORT_TITLE',
@@ -10414,6 +10434,10 @@ export default defineMessages({
     TR_SCAN_TREZORS_NEARBY: {
         id: 'TR_SCAN_TREZORS_NEARBY',
         defaultMessage: 'Scanning for nearby Trezors',
+    },
+    TR_CHECK_CONNECTED_TREZORS: {
+        id: 'TR_CHECK_CONNECTED_TREZORS',
+        defaultMessage: 'Checking for connected Trezors',
     },
     TR_BLUETOOTH_CANNOT_OPEN_BLUETOOTH_SETTINGS_REMOVE_DEVICE: {
         id: 'TR_BLUETOOTH_CANNOT_OPEN_BLUETOOTH_SETTINGS_REMOVE_DEVICE',


### PR DESCRIPTION

## Notes for QA

Adds another step to the connect flow where user first has to pick either a cable or bluetooth connection. Unlike before where it opened on cable connection with a button to switch to bluetooth, which confused users without Safe 7. Now it's clearly stated which devices support bluetooth and which not.

Also updated the various troubleshooting scenarios with icons instead of the bullets.

## Screenshots:

https://github.com/user-attachments/assets/44996c4c-1ea4-4a22-8e50-0714a2647962

### Before
<img width="1458" height="858" alt="Screenshot 2025-11-21 at 9 59 11" src="https://github.com/user-attachments/assets/ee2fe549-68a6-4dfc-aa3f-05550c9f1d2e" />
<img width="1458" height="926" alt="Screenshot 2025-11-21 at 10 18 01" src="https://github.com/user-attachments/assets/6cf9ad82-8317-46f8-b16e-4508a0262607" />
<img width="1458" height="926" alt="Screenshot 2025-11-21 at 10 18 24" src="https://github.com/user-attachments/assets/d1e8134d-a19d-4016-8aba-e6ce1eeacb1d" />
<img width="1458" height="926" alt="Screenshot 2025-11-21 at 10 18 48" src="https://github.com/user-attachments/assets/4b7348b3-58e6-4938-a887-6888ac240e14" />
<img width="1458" height="926" alt="Screenshot 2025-11-21 at 10 19 10" src="https://github.com/user-attachments/assets/51b4a60a-609e-472d-8ebb-23ba15b31606" />
<img width="1458" height="926" alt="Screenshot 2025-11-21 at 10 19 35" src="https://github.com/user-attachments/assets/427ee7d3-1bc8-4a6f-8b82-36455d0f81d3" />
<img width="1458" height="926" alt="Screenshot 2025-11-21 at 10 21 06" src="https://github.com/user-attachments/assets/87158a30-8ea0-4e86-9920-4b6e5995101a" />
<img width="1458" height="926" alt="Screenshot 2025-11-21 at 10 21 29" src="https://github.com/user-attachments/assets/7dacbafb-0684-426f-9a8c-c250633d17f2" />
<img width="1458" height="926" alt="Screenshot 2025-11-21 at 10 21 51" src="https://github.com/user-attachments/assets/b86da3d5-89e2-4d8b-b225-f4c60795ae0a" />
<img width="1458" height="926" alt="Screenshot 2025-11-21 at 10 22 14" src="https://github.com/user-attachments/assets/f6f548ac-f1ef-4db4-ab05-82884a711b4d" />

### After
<img width="740" height="389" alt="Screenshot 2025-11-24 at 9 01 36" src="https://github.com/user-attachments/assets/03f3171e-9005-4029-84cf-9faed71b1ef0" />
<img width="740" height="293" alt="Screenshot 2025-11-24 at 9 07 22" src="https://github.com/user-attachments/assets/d12e45d2-2e40-4457-90a8-612c4f4fa227" />
<img width="740" height="293" alt="Screenshot 2025-11-24 at 9 07 03" src="https://github.com/user-attachments/assets/945ade46-839e-47fd-a433-6f46decdbd8e" />
<img width="740" height="293" alt="Screenshot 2025-11-24 at 9 06 46" src="https://github.com/user-attachments/assets/4210ccc0-1da5-4571-8d35-224d4172c6e1" />
<img width="740" height="293" alt="Screenshot 2025-11-24 at 9 06 22" src="https://github.com/user-attachments/assets/23e0e4d8-1a7a-4b2f-a6f8-8ad029eabcf9" />
<img width="740" height="343" alt="Screenshot 2025-11-24 at 9 06 00" src="https://github.com/user-attachments/assets/3fabd010-7ec1-473b-873c-88e33a4fa4b1" />
<img width="740" height="291" alt="Screenshot 2025-11-24 at 9 05 36" src="https://github.com/user-attachments/assets/495954a4-a895-4426-9abf-81271e2c8b24" />
<img width="740" height="291" alt="Screenshot 2025-11-24 at 9 05 11" src="https://github.com/user-attachments/assets/c320b22b-4686-407e-ae17-1bbb69dbcf0c" />
<img width="740" height="291" alt="Screenshot 2025-11-24 at 9 04 45" src="https://github.com/user-attachments/assets/a84eaf64-9505-4be2-afee-2f9bba58fb02" />
<img width="740" height="286" alt="Screenshot 2025-11-24 at 9 04 21" src="https://github.com/user-attachments/assets/9e2d0c06-3295-453a-9bdc-faf028be3753" />
<img width="740" height="428" alt="Screenshot 2025-11-24 at 9 03 09" src="https://github.com/user-attachments/assets/564fc337-78b1-40a8-a031-dfa0bdeb64e2" />
<img width="740" height="353" alt="Screenshot 2025-11-24 at 9 02 37" src="https://github.com/user-attachments/assets/afb5814c-9ea7-4175-92a9-edba04c07c99" />
<img width="740" height="284" alt="Screenshot 2025-11-24 at 9 02 07" src="https://github.com/user-attachments/assets/648b191e-54d3-4e36-87b3-6d4a36f9fdac" />




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/update-connect-flow&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/update-connect-flow&lookback=7)