### PR TITLE
FW release fetching cleanup

### DIFF
--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -651,7 +651,7 @@ export const getFirmwareReleaseConfigInfo = (features: Features, firmwareType: F
     });
 };
 
-export const getFirmwareStatus = (features: Features, firmwareType: FirmwareType) => {
+export const getFirmwareStatus = (features: Features, releaseInfo?: FirmwareReleaseConfigInfo) => {
     // indication that firmware is not installed at all. This information is set to false in bl mode. Otherwise it is null.
     if (features.firmware_present === false) {
         return 'none';
@@ -661,8 +661,6 @@ export const getFirmwareStatus = (features: Features, firmwareType: FirmwareType
     if (features.major_version === 1 && features.bootloader_mode) {
         return 'unknown';
     }
-
-    const releaseInfo = getFirmwareReleaseConfigInfo(features, firmwareType);
 
     // should never happen for official firmware, see getInfo
     if (!releaseInfo) return 'custom';

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -158,9 +158,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     private _currentRelease?: FirmwareRelease;
-    public get currentRelease() {
-        return this._currentRelease;
-    }
 
     private _firmwareReleaseConfigInfo?: FirmwareReleaseConfigInfo;
     public get firmwareReleaseConfigInfo() {
@@ -213,8 +210,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
     private name = 'Trezor';
 
     private color?: string;
-
-    private availableTranslations: Record<string, string> = {};
 
     private authenticityChecks: KnownDevice['authenticityChecks'] = {
         firmwareRevision: null,
@@ -891,9 +886,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             return;
         }
 
-        const release = await getReleaseByVersion(feat, newVersion, newFirmwareType);
-        this._currentRelease = release;
-        this.availableTranslations = this._currentRelease?.translations ?? {};
+        this._currentRelease = await getReleaseByVersion(feat, newVersion, newFirmwareType);
     }
 
     private _updateFeatures(feat: Features) {
@@ -948,7 +941,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 newVersion,
                 getFirmwareType(feat),
             );
-            this.availableTranslations = this._currentRelease?.translations ?? {};
         }
 
         this._features = feat;
@@ -1168,7 +1160,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             firmwareType: this.firmwareType,
             features: this.features,
             unavailableCapabilities: this.unavailableCapabilities,
-            availableTranslations: this.availableTranslations,
+            availableTranslations: this._currentRelease?.translations ?? {},
             authenticityChecks: this.authenticityChecks,
             bluetoothProps,
             thp: this.thp?.serialize(),

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -928,19 +928,14 @@ export class Device extends TypedEmitter<DeviceEvents> {
                     device: this.toMessageObject(),
                 });
             }
+            const firmwareType = getFirmwareType(feat);
             this._unavailableCapabilities = getUnavailableCapabilities(feat, getAllNetworks());
-            this._firmwareStatus = getFirmwareStatus(feat, getFirmwareType(feat));
-            this._firmwareReleaseConfigInfo = getFirmwareReleaseConfigInfo(
-                feat,
-                getFirmwareType(feat),
-            );
+            this._firmwareReleaseConfigInfo = getFirmwareReleaseConfigInfo(feat, firmwareType);
+            this._firmwareStatus = getFirmwareStatus(feat, this._firmwareReleaseConfigInfo);
+
             // Here we update `currentRelease` in case of a release JSON that was bundled.
             // In case it was not bundled it will be fetched after `_updateFeatures` by `_updateCurrentRelease`.
-            this._currentRelease = getReleaseAsset(
-                feat.internal_model,
-                newVersion,
-                getFirmwareType(feat),
-            );
+            this._currentRelease = getReleaseAsset(feat.internal_model, newVersion, firmwareType);
         }
 
         this._features = feat;


### PR DESCRIPTION
## Description

**WORK IN PROGRESS**

I believe there's a bug that we sometimes try to fetch firmware binary for bootloader version instead of fw one, which naturally fails. (there isn't the fix yet, just some refactoring along the way)

<img width="768" height="145" alt="image" src="https://github.com/user-attachments/assets/4d02f71f-eb8f-4f23-973c-dd959c0793e7" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/fetch-bl-releases&lookback=7)