### PR TITLE
fix(suite-native): Stabilize mobile trade E2E - part 2

### DIFF
--- a/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
@@ -59,7 +59,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Trade Exchange', () => 
             await tradingExchangeActions.openSwapForm();
         });
 
-        it.skip('Basic exchange USDC to USDT', async () => {
+        it('Basic exchange USDC to USDT', async () => {
             await tradingExchangeActions.selectSendAsset('USDC');
             await tradingExchangeActions.selectReceiveAsset('USDT', 'Ethereum');
             await tradingExchangeActions.selectReceiveAccount('Ethereum #1');
@@ -76,6 +76,10 @@ conditionalDescribe(device.getPlatform() === 'android', 'Trade Exchange', () => 
             await tradingExchangeActions.confirmTradingForm();
 
             await exchangePreviewActions.expectExchangePreviewScreenToBeVisible();
+
+            // TODO remove after https://github.com/trezor/trezor-trade-api/issues/386 is resolved
+            const is386Resolved = false;
+            if (!is386Resolved) return;
 
             await exchangePreviewActions.waitForFeesToLoad();
             await exchangePreviewActions.scrollScreenToBottom();

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback } from 'react';
+import { Keyboard } from 'react-native';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { BottomSheetSectionList, ItemRenderConfig } from '@suite-native/trading-atoms';
@@ -43,6 +44,8 @@ export const TradeableAssetSheet = memo(
         testID,
     }: TradeableAssetsSheetProps) => {
         const onAssetSelectCallback = (asset: TradeableAsset) => {
+            // has to be before onAssetSelect callback call to allow focusing another input from it
+            Keyboard.dismiss();
             onAssetSelect(asset);
             onClose();
         };

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.comp.test.tsx
@@ -1,3 +1,5 @@
+import { Keyboard } from 'react-native';
+
 import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 import { adaAsset, btcAsset, usdcAsset } from '@suite-native/trading-fixtures';
 import { TradeableAsset } from '@suite-native/trading-types';
@@ -21,9 +23,10 @@ describe('TradeableAssetSheet', () => {
             />,
         );
 
-    it('should call both onAssetSelect and onClose when an item is pressed', async () => {
+    it('should call Keyboard.dismiss, onAssetSelect and onClose when an item is pressed', async () => {
         const closeMock = jest.fn();
         const selectMock = jest.fn();
+        const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
         const { getByText } = await renderTradeableAssetsSheet({
             onClose: closeMock,
@@ -32,6 +35,7 @@ describe('TradeableAssetSheet', () => {
 
         fireEvent.press(getByText('BTC'));
 
+        expect(keyboardDismissSpy).toHaveBeenCalledTimes(1);
         expect(selectMock).toHaveBeenCalledTimes(1);
         expect(closeMock).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { isFulfilled } from '@reduxjs/toolkit';
+import { isFulfilled, isRejected } from '@reduxjs/toolkit';
 import type { ExchangeTrade, SellFiatTrade } from 'invity-api';
 
 import {
@@ -176,7 +176,13 @@ export const useTradingTransaction = ({
             return;
         }
 
-        await dispatch(updateFeeInfoThunk({ networkSymbol: sendAccount.symbol }));
+        const feesResult = await dispatch(
+            updateFeeInfoThunk({ networkSymbol: sendAccount.symbol }),
+        );
+        if (isRejected(feesResult)) {
+            console.error('Failed to fetch fees for trading transaction');
+        }
+
         await composeRequest({
             selectedFeeLevel: selectedFee as NativeSupportedFeeLevel,
             feePerUnit: feePerUnitDraft,


### PR DESCRIPTION
## Description
Make sure no input has focus, when selecting tradeable asset from modal.

## Notes for QA
### Scenario 1
1. open buy / swap
2. select send asset (in case of swap)
3. open receive asset
4. focus filter input
5. Select second asset

#### Expected behaviour
- no input is focused
- account is selected

### Scenario 2
1. open buy
3. press on receive amount (`0.0` placeholder)
4. asset modal should be opened
5. focus filter input
6. Select second asset

#### Expected behaviour
- receive amount input is focused
- account is selected

## Related Issue
Resolve #23287




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=23287-fix-failing-trading-exchange-e2es&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=23287-fix-failing-trading-exchange-e2es&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=23287-fix-failing-trading-exchange-e2es&lookback=7)