### PR TITLE
chore: correct naming for SuiteSyncOwner (abstract-type) for Evolu [3]

### DIFF
--- a/packages/suite/src/hooks/suite/useLabelingCombined.ts
+++ b/packages/suite/src/hooks/suite/useLabelingCombined.ts
@@ -67,7 +67,7 @@ export const useLabelingCombined = ({ deviceStaticSessionId }: UseLabelingCombin
 
     const isEvoluSupportedByDevice = device?.unavailableCapabilities?.evolu === undefined;
 
-    const hasDeviceLocalFirstStorageKeys = device?.localFirstStorageSecret?.evoluKeys !== undefined;
+    const hasDeviceLocalFirstStorageKeys = device?.suiteSyncOwner !== undefined;
 
     return {
         /** New Labeling: LocalFirstStorage (Evolu) */

--- a/packages/suite/src/utils/suite/storage.ts
+++ b/packages/suite/src/utils/suite/storage.ts
@@ -19,10 +19,6 @@ export const serializeDevice = (device: AcquiredDevice): DeviceWithEmptyPath => 
     // instead persisted on `persistentDeviceData` as part of the effort to unlink device from wallet
     thp: undefined,
     bluetoothProps: undefined,
-    localFirstStorageSecret: {
-        evoluKeys: device.localFirstStorageSecret?.evoluKeys,
-        isRetrieving: false,
-    },
 });
 
 /**

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/LocalFirstStorageDebug.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/LocalFirstStorageDebug.tsx
@@ -31,7 +31,7 @@ export const LocalFirstStorageDebug = ({ device }: { device: AcquiredDevice }) =
     const handleResetKeysRequest = () => {
         if (!device?.id) return;
 
-        dispatch(deviceActions.setLocalFirstStorageSecret({ device, evoluKeys: undefined }));
+        dispatch(deviceActions.setLocalFirstStorageSecret({ device, owner: undefined }));
         dispatch(
             deviceActions.setDelegatedIdentityKey({
                 deviceId: device.id,
@@ -54,15 +54,11 @@ export const LocalFirstStorageDebug = ({ device }: { device: AcquiredDevice }) =
                         <Code>{deviceId.slice(-8)}</Code>
                     </Text>
                     <Tooltip
-                        content={
-                            <Code>{JSON.stringify(device.localFirstStorageSecret, null, 2)}</Code>
-                        }
+                        content={<Code>{JSON.stringify(device.suiteSyncOwner, null, 2)}</Code>}
                     >
                         <Text typographyStyle="hint" variant="purple">
                             E:
-                            <Code>
-                                {device.localFirstStorageSecret?.evoluKeys?.ownerId.slice(-8)}
-                            </Code>
+                            <Code>{device.suiteSyncOwner?.ownerId.slice(-8)}</Code>
                         </Text>
                     </Tooltip>
                 </>

--- a/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
+++ b/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
@@ -1,6 +1,6 @@
 import { EvoluDeps, SimpleName, createEvolu } from '@evolu/common';
 
-import { EvoluKeys } from '@suite-common/suite-types';
+import { SuiteSyncOwner } from '@suite-common/suite-types';
 
 import { createEvoluAppOwnerFromTrezorData } from './createEvoluAppOwnerFromTrezorData';
 import { Schema } from './schema';
@@ -11,12 +11,12 @@ import { Schema } from './schema';
 const VERSION = 5;
 
 type CreateEvoluInstanceProps = {
-    evoluKeys: EvoluKeys;
+    suiteSyncOwner: SuiteSyncOwner;
     evoluDeps: EvoluDeps;
 };
 
-export const createEvoluInstance = ({ evoluKeys, evoluDeps }: CreateEvoluInstanceProps) => {
-    const owner = createEvoluAppOwnerFromTrezorData({ data: evoluKeys.ownerSecret });
+export const createEvoluInstance = ({ suiteSyncOwner, evoluDeps }: CreateEvoluInstanceProps) => {
+    const owner = createEvoluAppOwnerFromTrezorData({ data: suiteSyncOwner.ownerSecret });
 
     if (!owner.ok) {
         console.error(owner.error);

--- a/suite-common/suite-sync-evolu/src/evoluStorage.ts
+++ b/suite-common/suite-sync-evolu/src/evoluStorage.ts
@@ -1,7 +1,7 @@
 import { Evolu, EvoluDeps, SyncOwner, createOwnerWebSocketTransport } from '@evolu/common';
 
 import { SuiteSyncStorage } from '@suite-common/suite-sync-storage';
-import { EvoluKeys } from '@suite-common/suite-types';
+import { SuiteSyncOwner } from '@suite-common/suite-types';
 
 import { createEvoluInstance } from './createEvoluInstance';
 import { AccountLabelSchema, AccountLabels } from './labeling/accountLabels';
@@ -12,7 +12,7 @@ import { Schema } from './schema';
 
 type LocalFirstStorageDeps = {
     relayUrl: string;
-    evoluKeys: EvoluKeys;
+    owner: SuiteSyncOwner;
     evoluDeps: EvoluDeps;
 };
 
@@ -34,13 +34,13 @@ export class EvoluStorage implements SuiteSyncStorage {
     outputLabels: OutputLabels;
     addressLabels: AddressLabels;
 
-    constructor({ relayUrl, evoluDeps, evoluKeys }: LocalFirstStorageDeps) {
+    constructor({ relayUrl, evoluDeps, owner }: LocalFirstStorageDeps) {
         // just to satisfy TS for initialization,
         // its then truly initialized in this.updateRelayUrl()
         this.#ownerDispose = () => {};
 
         this.#evolu = createEvoluInstance({
-            evoluKeys,
+            suiteSyncOwner: owner,
             evoluDeps,
         });
         this.updateRelayUrl(relayUrl); // This updates the relay

--- a/suite-common/suite-sync-storage/src/LocalFirstStorageProvider.ts
+++ b/suite-common/suite-sync-storage/src/LocalFirstStorageProvider.ts
@@ -1,35 +1,39 @@
-import { EvoluKeys } from '@suite-common/suite-types';
+import { SuiteSyncOwner, SuiteSyncOwnerId } from '@suite-common/suite-types';
 
 import { SuiteSyncStorage } from './SuiteSyncStorage';
 
-// Todo: Branded type, export probably
-type SuiteOwnerId = string;
+type SuiteStorageCreatorParams = {
+    owner: SuiteSyncOwner;
+    relayUrl: string | null;
+};
 
-export type SuiteStorageCreator = (
-    evoluKeys: EvoluKeys,
-    relayUrl: string | null,
-) => SuiteSyncStorage;
+/**
+ * This is a service responsible for creating the SuiteSyncStorage. Every Owner
+ * has its own Storage. Currently only Evolu storage is implemented, but in theory,
+ * you can have different one as well.
+ */
+export type SuiteStorageCreator = (params: SuiteStorageCreatorParams) => SuiteSyncStorage;
 
 export class LocalFirstStorageProvider {
-    private storages = new Map<SuiteOwnerId, SuiteSyncStorage>();
+    private storages = new Map<SuiteSyncOwnerId, SuiteSyncStorage>();
 
     constructor(
         private relayUrl: string | null, // null -> fallback to default
         private storageCreator: SuiteStorageCreator,
     ) {}
 
-    getStorage(evoluKeys: EvoluKeys): SuiteSyncStorage {
-        let storage = this.storages.get(evoluKeys.ownerId);
+    getStorage(owner: SuiteSyncOwner): SuiteSyncStorage {
+        let storage = this.storages.get(owner.ownerId);
 
         if (storage === undefined) {
-            storage = this.storageCreator(evoluKeys, this.relayUrl);
-            this.storages.set(evoluKeys.ownerId, storage);
+            storage = this.storageCreator({ owner, relayUrl: this.relayUrl });
+            this.storages.set(owner.ownerId, storage);
         }
 
         return storage;
     }
 
-    async deleteStorage(ownerId: SuiteOwnerId) {
+    async deleteStorage(ownerId: SuiteSyncOwnerId) {
         await this.storages.get(ownerId)?.dispose();
         this.storages.delete(ownerId);
     }

--- a/suite-common/suite-sync-storage/src/index.ts
+++ b/suite-common/suite-sync-storage/src/index.ts
@@ -1,4 +1,6 @@
 export { LocalFirstStorageProvider } from './LocalFirstStorageProvider';
+export type { SuiteStorageCreator } from './LocalFirstStorageProvider';
+export type { SuiteSyncStorage } from './SuiteSyncStorage';
 
 // Todo: this shared object shall be handled by Dependency Injection, this is madness
 export {
@@ -7,8 +9,6 @@ export {
     setLocalFirstStorageProvider,
     localFirstStorageProvider,
 } from './sharedObjects';
-
-export type { SuiteSyncStorage } from './SuiteSyncStorage';
 
 // Labeling
 export type { AddressLabelsStore, AddressLabel } from './labeling/AddressLabelsStore';

--- a/suite-common/suite-sync-storage/src/sharedObjects.ts
+++ b/suite-common/suite-sync-storage/src/sharedObjects.ts
@@ -1,4 +1,4 @@
-import { EvoluKeys } from '@suite-common/suite-types';
+import { SuiteSyncOwner } from '@suite-common/suite-types';
 import { WalletDescriptor } from '@suite-common/wallet-types';
 
 import { LocalFirstStorageProvider } from './LocalFirstStorageProvider';
@@ -16,10 +16,10 @@ export const setLocalFirstStorageProvider = (provider: LocalFirstStorageProvider
     localFirstStorageProvider = provider;
 };
 
-export const getLocalFirstStorageProvider = (evoluKeys: EvoluKeys) => {
+export const getLocalFirstStorageProvider = (owner: SuiteSyncOwner) => {
     if (localFirstStorageProvider === null) {
         throw Error('initLocalFirstStorageThunk() must be called before this!');
     }
 
-    return localFirstStorageProvider.getStorage(evoluKeys);
+    return localFirstStorageProvider.getStorage(owner);
 };

--- a/suite-common/suite-sync/src/changeRelayUrlThunk.ts
+++ b/suite-common/suite-sync/src/changeRelayUrlThunk.ts
@@ -20,13 +20,13 @@ export const changeRelayUrlThunk = createThunk<void, ChangeRelayUrlThunkThunkPar
             relayUrl === null || relayUrl.trim() === '' ? DEFAULT_SUITE_SYNC_RELAY_URL : relayUrl;
 
         for (const device of devices) {
-            const evoluKeys = device.localFirstStorageSecret?.evoluKeys;
+            const owner = device.suiteSyncOwner;
 
-            if (evoluKeys === undefined) {
+            if (owner === undefined) {
                 continue;
             }
 
-            await getLocalFirstStorageProvider(evoluKeys).updateRelayUrl(normalizedUrl);
+            await getLocalFirstStorageProvider(owner).updateRelayUrl(normalizedUrl);
         }
     },
 );

--- a/suite-common/suite-sync/src/initLocalFirstStorageThunk.ts
+++ b/suite-common/suite-sync/src/initLocalFirstStorageThunk.ts
@@ -4,9 +4,9 @@ import { createThunk } from '@suite-common/redux-utils';
 import { EvoluStorage } from '@suite-common/suite-sync-evolu';
 import {
     LocalFirstStorageProvider,
+    SuiteStorageCreator,
     setLocalFirstStorageProvider,
 } from '@suite-common/suite-sync-storage';
-import { EvoluKeys } from '@suite-common/suite-types';
 
 import { DEFAULT_SUITE_SYNC_RELAY_URL, LOCAL_FIRST_STORAGE_PREFIX } from './constants';
 import {
@@ -22,7 +22,8 @@ export const initLocalFirstStorageThunk = createThunk<void, void, void>(
 );
 
 const evoluStorageCreator =
-    (evoluDeps: EvoluDeps) => (evoluKeys: EvoluKeys, relayUrl: string | null) =>
+    (evoluDeps: EvoluDeps): SuiteStorageCreator =>
+    ({ owner, relayUrl }) =>
         // This is the place were we decide which storage we use
         new EvoluStorage({
             relayUrl:
@@ -30,7 +31,7 @@ const evoluStorageCreator =
                     ? DEFAULT_SUITE_SYNC_RELAY_URL
                     : relayUrl,
             evoluDeps,
-            evoluKeys,
+            owner,
         });
 
 export const initLocalFirstStorageThunkFactory = (evoluDeps: EvoluDeps) =>

--- a/suite-common/suite-sync/src/labeling/subscribeLabelingUpdatesThunk.ts
+++ b/suite-common/suite-sync/src/labeling/subscribeLabelingUpdatesThunk.ts
@@ -3,13 +3,13 @@ import {
     getLocalFirstStorageProvider,
     subscriptionStorage,
 } from '@suite-common/suite-sync-storage';
-import { EvoluKeys } from '@suite-common/suite-types';
+import { SuiteSyncOwner } from '@suite-common/suite-types';
 import { WalletDescriptor } from '@suite-common/wallet-types';
 
 import { LABELING_PREFIX, clearAllLabels, labelingActions } from './labelingActions';
 
 type SubscribeLabelingUpdatesThunkParams = {
-    evoluKeys: EvoluKeys;
+    owner: SuiteSyncOwner;
     walletDescriptor: WalletDescriptor;
 };
 
@@ -19,8 +19,8 @@ export const subscribeLabelingUpdatesThunk = createThunk<
     void
 >(
     `${LABELING_PREFIX}/subscribeLabelingUpdatesThunk`,
-    ({ evoluKeys, walletDescriptor }, { dispatch }) => {
-        const storage = getLocalFirstStorageProvider(evoluKeys);
+    ({ owner, walletDescriptor }, { dispatch }) => {
+        const storage = getLocalFirstStorageProvider(owner);
 
         const unsubscribeWalletLabels = storage.walletLabels.subscribe(payload => {
             if (walletDescriptor !== payload.walletDescriptor) {

--- a/suite-common/suite-sync/src/labeling/updateAccountLabelThunk.ts
+++ b/suite-common/suite-sync/src/labeling/updateAccountLabelThunk.ts
@@ -18,9 +18,9 @@ export const updateAccountLabelThunk = createThunk<void, UpdateAccountLabelThunk
             it => it.state?.staticSessionId === deviceStaticSessionId,
         );
 
-        const evoluKeys = device?.localFirstStorageSecret?.evoluKeys;
+        const owner = device?.suiteSyncOwner;
 
-        if (evoluKeys === undefined) {
+        if (owner === undefined) {
             console.error(
                 'Evolu: [updateAccountLabelThunk] no keys found on the selected device',
                 deviceStaticSessionId,
@@ -29,7 +29,7 @@ export const updateAccountLabelThunk = createThunk<void, UpdateAccountLabelThunk
             return;
         }
 
-        const storage = getLocalFirstStorageProvider(evoluKeys);
+        const storage = getLocalFirstStorageProvider(owner);
 
         const { accountDescriptor, networkSymbol } = parseAccountKey(accountKey);
 

--- a/suite-common/suite-sync/src/labeling/updateAddressLabelThunk.ts
+++ b/suite-common/suite-sync/src/labeling/updateAddressLabelThunk.ts
@@ -18,9 +18,9 @@ export const updateAddressLabelThunk = createThunk<void, UpdateAddressLabelThunk
             it => it.state?.staticSessionId === deviceStaticSessionId,
         );
 
-        const evoluKeys = device?.localFirstStorageSecret?.evoluKeys;
+        const owner = device?.suiteSyncOwner;
 
-        if (evoluKeys === undefined) {
+        if (owner === undefined) {
             console.error(
                 'Evolu: [updateAddressLabelThunk] no keys found on the selected device',
                 deviceStaticSessionId,
@@ -29,7 +29,7 @@ export const updateAddressLabelThunk = createThunk<void, UpdateAddressLabelThunk
             return;
         }
 
-        const storage = getLocalFirstStorageProvider(evoluKeys);
+        const storage = getLocalFirstStorageProvider(owner);
 
         storage.addressLabels.update({ address, label });
     },

--- a/suite-common/suite-sync/src/labeling/updateOutputLabelThunk.ts
+++ b/suite-common/suite-sync/src/labeling/updateOutputLabelThunk.ts
@@ -19,9 +19,9 @@ export const updateOutputLabelThunk = createThunk<void, UpdateOutputLabelThunkPa
             it => it.state?.staticSessionId === deviceStaticSessionId,
         );
 
-        const evoluKeys = device?.localFirstStorageSecret?.evoluKeys;
+        const owner = device?.suiteSyncOwner;
 
-        if (evoluKeys === undefined) {
+        if (owner === undefined) {
             console.error(
                 'Evolu: [updateOutputLabelThunk] no keys found on the selected device',
                 deviceStaticSessionId,
@@ -30,7 +30,7 @@ export const updateOutputLabelThunk = createThunk<void, UpdateOutputLabelThunkPa
             return;
         }
 
-        const storage = getLocalFirstStorageProvider(evoluKeys);
+        const storage = getLocalFirstStorageProvider(owner);
 
         storage.outputLabels.update({ txId, outputIndex, label });
     },

--- a/suite-common/suite-sync/src/labeling/updateWalletLabelThunk.ts
+++ b/suite-common/suite-sync/src/labeling/updateWalletLabelThunk.ts
@@ -18,9 +18,9 @@ export const updateWalletLabelThunk = createThunk<void, UpdateWalletLabelThunkPa
             it => it.state?.staticSessionId === deviceStaticSessionId,
         );
 
-        const evoluKeys = device?.localFirstStorageSecret?.evoluKeys;
+        const owner = device?.suiteSyncOwner;
 
-        if (evoluKeys === undefined) {
+        if (owner === undefined) {
             console.error(
                 'Evolu: [updateWalletLabelThunk] no keys found on the selected device',
                 deviceStaticSessionId,
@@ -29,7 +29,7 @@ export const updateWalletLabelThunk = createThunk<void, UpdateWalletLabelThunkPa
             return;
         }
 
-        const storage = getLocalFirstStorageProvider(evoluKeys);
+        const storage = getLocalFirstStorageProvider(owner);
 
         const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
 

--- a/suite-common/suite-sync/src/refreshSuiteSyncKeysThunk.ts
+++ b/suite-common/suite-sync/src/refreshSuiteSyncKeysThunk.ts
@@ -3,10 +3,11 @@ import { Dispatch } from '@reduxjs/toolkit';
 import { createEvoluAppOwnerFromTrezorData } from '@suite-common/suite-sync-evolu';
 import {
     DelegatedIdentityKey,
-    EvoluKeys,
+    SuiteSyncOwner,
     TrezorDevice,
     TrezorDeviceWithState,
-    asDeviceEvoluOwnerId,
+    asSuiteSyncOwnerId,
+    asSuiteSyncOwnerSecretHex,
 } from '@suite-common/suite-types';
 import {
     deviceActions,
@@ -56,12 +57,12 @@ const retrieveEvoluNode = async ({ device, delegatedKey }: RetrieveEvoluNodePara
             return ok();
         }
 
-        const evoluKeys: EvoluKeys = {
-            ownerId: asDeviceEvoluOwnerId(appOwnerResult.value.id),
-            ownerSecret: result.payload.data,
+        const owner: SuiteSyncOwner = {
+            ownerId: asSuiteSyncOwnerId(appOwnerResult.value.id),
+            ownerSecret: asSuiteSyncOwnerSecretHex(result.payload.data),
         };
 
-        return ok(evoluKeys);
+        return ok(owner);
     }
 
     if (isCanceledErrorMessage(result.payload.error)) {
@@ -92,26 +93,14 @@ export const refreshSuiteSyncKeysThunk =
             !device.connected || // disconnected device cannot resolve Evolu-Keys
             device.mode !== 'normal' || // bootloader,
             !isTrezorDeviceWithState(device) ||
-            device.localFirstStorageSecret?.evoluKeys !== undefined ||
-            // We are already getting the keys in different "await"
-            // This may happen if selectedDeviceThunk is called concurrently.
-            // Todo: This probably shall not happen, but it happens currently.
-            device.localFirstStorageSecret?.isRetrieving
+            device.suiteSyncOwner !== undefined
         ) {
             return ok(); // No action needed
         }
 
-        dispatch(
-            deviceActions.setLocalFirstStorageSecretRetrieving({ device, isRetrieving: true }),
-        );
-
         const delegatedKeyResult = await dispatch(retrieveDelegatedIdentityKeyThunk({ device }));
 
         if (!delegatedKeyResult.ok) {
-            dispatch(
-                deviceActions.setLocalFirstStorageSecretRetrieving({ device, isRetrieving: false }),
-            );
-
             return delegatedKeyResult;
         }
 
@@ -121,7 +110,7 @@ export const refreshSuiteSyncKeysThunk =
         });
 
         if (!evoluNodeResult.ok) {
-            dispatch(deviceActions.setLocalFirstStorageSecret({ device, evoluKeys: undefined }));
+            dispatch(deviceActions.setLocalFirstStorageSecret({ device, owner: undefined }));
             dispatch(
                 deviceActions.setDelegatedIdentityKey({ deviceId: device.id, delegatedKey: null }),
             );
@@ -129,11 +118,10 @@ export const refreshSuiteSyncKeysThunk =
             return evoluNodeResult;
         }
 
-        // This also sets the `isRetrieving` flag to `false`
         dispatch(
             deviceActions.setLocalFirstStorageSecret({
                 device,
-                evoluKeys: evoluNodeResult.value ?? undefined,
+                owner: evoluNodeResult.value ?? undefined,
             }),
         );
 

--- a/suite-common/suite-sync/src/subscribeLocalFirstStorageThunk.ts
+++ b/suite-common/suite-sync/src/subscribeLocalFirstStorageThunk.ts
@@ -30,7 +30,7 @@ export const subscribeLocalFirstStorageThunk =
 
         const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
 
-        if (device.localFirstStorageSecret?.evoluKeys === undefined) {
+        if (device.suiteSyncOwner === undefined) {
             const result = await dispatch(refreshSuiteSyncKeysThunk({ device }));
 
             if (!result.ok) {
@@ -53,18 +53,15 @@ export const subscribeLocalFirstStorageThunk =
             it => it.state?.staticSessionId === deviceStaticSessionId,
         );
 
-        const evoluKeys = reselectedDevice?.localFirstStorageSecret?.evoluKeys;
+        const owner = reselectedDevice?.suiteSyncOwner;
 
-        if (evoluKeys === undefined) {
-            console.error(
-                'Evolu: Keys set to reselectedDevice',
-                reselectedDevice?.localFirstStorageSecret,
-            );
+        if (owner === undefined) {
+            console.error('Evolu: Keys set to reselectedDevice', reselectedDevice?.suiteSyncOwner);
 
             return ok();
         }
 
-        dispatch(subscribeLabelingUpdatesThunk({ evoluKeys, walletDescriptor }));
+        dispatch(subscribeLabelingUpdatesThunk({ owner, walletDescriptor }));
 
         return ok();
     };

--- a/suite-common/suite-sync/src/unsubscribeAndDisposeLocalFirstStorageThunk.ts
+++ b/suite-common/suite-sync/src/unsubscribeAndDisposeLocalFirstStorageThunk.ts
@@ -1,5 +1,3 @@
-import { OwnerId } from '@evolu/common';
-
 import { createThunk } from '@suite-common/redux-utils';
 import { localFirstStorageProvider, subscriptionStorage } from '@suite-common/suite-sync-storage';
 import { TrezorDeviceWithState } from '@suite-common/suite-types';
@@ -16,32 +14,23 @@ export const unsubscribeAndDisposeLocalFirstStorageThunk = createThunk<
     void,
     UnsubscribeLocalFirstStorageThunkParams,
     void
->(
-    `${LOCAL_FIRST_STORAGE_PREFIX}/unsubscribeLocalFirstStorageThunk`,
-    async ({ device }, { rejectWithValue }) => {
-        if (localFirstStorageProvider === null) {
-            throw new Error("initLocalFirstStorageThunk() must be called before this!'");
-        }
+>(`${LOCAL_FIRST_STORAGE_PREFIX}/unsubscribeLocalFirstStorageThunk`, async ({ device }) => {
+    if (localFirstStorageProvider === null) {
+        throw new Error("initLocalFirstStorageThunk() must be called before this!'");
+    }
 
-        const deviceStaticSessionId = device.state.staticSessionId;
+    const deviceStaticSessionId = device.state.staticSessionId;
 
-        const evoluKeys = device.localFirstStorageSecret?.evoluKeys;
+    const owner = device.suiteSyncOwner;
 
-        if (evoluKeys === undefined) {
-            return;
-        }
+    if (owner === undefined) {
+        return;
+    }
 
-        const ownerIdResult = OwnerId.from(evoluKeys.ownerId);
+    const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
 
-        if (!ownerIdResult.ok) {
-            return rejectWithValue(ownerIdResult.error);
-        }
+    typedObjectValues(subscriptionStorage[walletDescriptor]).forEach(callback => callback?.());
 
-        const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
-
-        typedObjectValues(subscriptionStorage[walletDescriptor]).forEach(callback => callback?.());
-
-        delete subscriptionStorage[walletDescriptor];
-        await localFirstStorageProvider.deleteStorage(ownerIdResult.value);
-    },
-);
+    delete subscriptionStorage[walletDescriptor];
+    await localFirstStorageProvider.deleteStorage(owner.ownerId);
+});

--- a/suite-common/suite-sync/src/useLocalFirstStorage.ts
+++ b/suite-common/suite-sync/src/useLocalFirstStorage.ts
@@ -50,7 +50,7 @@ export const useLocalFirstStorage = ({ device }: UseLocalStorageParams) => {
     };
 
     const isEvoluSupportedByDevice = isSuiteSyncSupportedByDevice(device);
-    const hasDeviceLocalFirstStorageKeys = device?.localFirstStorageSecret?.evoluKeys !== undefined;
+    const hasDeviceLocalFirstStorageKeys = device?.suiteSyncOwner !== undefined;
 
     return {
         isLocalFirstStorageEnabled,

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -30,12 +30,26 @@ export type ButtonRequest = Omit<DeviceEvent['payload'], 'device' | 'code'> & {
         | NonNullable<PROTO.PinMatrixRequest>['type'];
 };
 
-export type DeviceEvoluOwnerId = string & Branded<DeviceEvoluOwnerId>;
-export const asDeviceEvoluOwnerId = (value: string) => value as DeviceEvoluOwnerId;
+/**
+ * This is identifier of the SuiteSync user. We generate an Owner for every
+ * wallet (seed+passphrase). It is deterministically derived from the secret
+ * in Trezor Device (seed+passphrase).
+ *
+ * This can be calculated from SuiteSyncOwnerSecretHex.
+ */
+export type SuiteSyncOwnerId = string & Branded<SuiteSyncOwnerId>;
+export const asSuiteSyncOwnerId = (value: string) => value as SuiteSyncOwnerId;
 
-export type EvoluKeys = {
-    ownerId: DeviceEvoluOwnerId;
-    ownerSecret: string; // hex
+/**
+ * This is an SLIP21 node, it is provided by Trezor Device
+ * (derived from the wallets secret)
+ */
+export type SuiteSyncOwnerSecretHex = string & Branded<SuiteSyncOwnerSecretHex>;
+export const asSuiteSyncOwnerSecretHex = (value: string) => value as SuiteSyncOwnerSecretHex;
+
+export type SuiteSyncOwner = {
+    ownerId: SuiteSyncOwnerId;
+    ownerSecret: SuiteSyncOwnerSecretHex;
 };
 
 /**
@@ -62,11 +76,7 @@ export interface ExtendedDevice {
     firstConnectedTimestamp: number;
     buttonRequests: ButtonRequest[];
     metadata: DeviceMetadata;
-    localFirstStorageSecret?: {
-        // To prevent consequential call of the TrezorConnect.evoluGetNode(...)
-        isRetrieving: boolean;
-        evoluKeys: EvoluKeys | undefined;
-    };
+    suiteSyncOwner: SuiteSyncOwner | undefined;
     walletNumber?: number; // number of passphrase wallet intended to be used in UI
     passwords: DeviceMetadata;
     reconnectRequested?: boolean; // currently only after wipeDevice

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -243,10 +243,7 @@ export const getSuiteDevice = (
             ts: 0,
             buttonRequests: [],
             metadata: {},
-            localFirstStorageSecret: {
-                evoluKeys: undefined,
-                isRetrieving: false,
-            },
+            suiteSyncOwner: undefined,
             ...dev,
             ...device,
             state: dev?.state

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -4,7 +4,7 @@ import {
     AcquiredDevice,
     ButtonRequest,
     DelegatedIdentityKey,
-    EvoluKeys,
+    SuiteSyncOwner,
     ThpSuiteCredentials,
     TrezorDevice,
 } from '@suite-common/suite-types';
@@ -143,8 +143,8 @@ const setThpCredentials = createAction(
 
 const setLocalFirstStorageSecret = createAction(
     `${DEVICE_MODULE_PREFIX}/setLocalFirstStorageSecret`,
-    ({ device, evoluKeys }: { device: TrezorDevice; evoluKeys: EvoluKeys | undefined }) => ({
-        payload: { device, evoluKeys },
+    ({ device, owner }: { device: TrezorDevice; owner: SuiteSyncOwner | undefined }) => ({
+        payload: { device, owner },
     }),
 );
 
@@ -157,13 +157,6 @@ const setDelegatedIdentityKey = createAction(
     `${DEVICE_MODULE_PREFIX}/setDelegatedIdentityKey`,
     ({ deviceId, delegatedKey }: SetDelegatedIdentityKeyParams) => ({
         payload: { deviceId, delegatedKey },
-    }),
-);
-
-const setLocalFirstStorageSecretRetrieving = createAction(
-    `${DEVICE_MODULE_PREFIX}/setLocalFirstStorageSecretRetrieving`,
-    ({ device, isRetrieving }: { device: TrezorDevice; isRetrieving: boolean }) => ({
-        payload: { device, isRetrieving },
     }),
 );
 
@@ -197,7 +190,6 @@ export const deviceActions = {
     setThpCredentials,
     setDelegatedIdentityKey,
     setLocalFirstStorageSecret,
-    setLocalFirstStorageSecretRetrieving,
     setDiscovered,
     devicePushNotification,
 };

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -133,7 +133,6 @@ const connectDevice = (
 
     const deviceCommonFields = {
         connected: true,
-
         buttonRequests: [],
         metadata: {},
         passwords: {},
@@ -142,6 +141,7 @@ const connectDevice = (
                 ? Number(device.firstConnectedTimestamp ?? currentTime)
                 : currentTime,
         ts: currentTime,
+        suiteSyncOwner: undefined,
     };
     // connected device is unacquired/unreadable
     if (!device.features) {
@@ -210,7 +210,7 @@ const connectDevice = (
         temporaryRemember: false,
         available: true,
         instance: deviceInstance,
-        localFirstStorageSecret: undefined,
+        suiteSyncOwner: undefined,
     };
 
     // update affected devices
@@ -353,7 +353,7 @@ const addAuthorizedDevice = (
         useEmptyPassphrase,
         remember: shouldDeviceBeRemembered({ isAutoEjectEnabled, device }),
         state,
-        localFirstStorageSecret: undefined,
+        suiteSyncOwner: undefined,
     };
 
     draft.devices.push(newDevice);
@@ -458,7 +458,7 @@ const createInstance = (draft: DeviceReducerState, device: TrezorDevice) => {
         buttonRequests: [],
         metadata: {},
         passwords: {},
-        localFirstStorageSecret: undefined,
+        suiteSyncOwner: undefined,
     };
     draft.devices.push(newDevice);
 };
@@ -724,26 +724,11 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
             )
             .addCase(
                 deviceActions.setLocalFirstStorageSecret,
-                (state, { payload: { device, evoluKeys } }) => {
+                (state, { payload: { device, owner } }) => {
                     if (!device.features) return;
                     const index = deviceUtils.findInstanceIndex(state.devices, device);
                     if (!state.devices[index]) return;
-                    state.devices[index].localFirstStorageSecret = {
-                        evoluKeys,
-                        isRetrieving: false,
-                    };
-                },
-            )
-            .addCase(
-                deviceActions.setLocalFirstStorageSecretRetrieving,
-                (state, { payload: { device, isRetrieving } }) => {
-                    if (!device.features) return;
-                    const index = deviceUtils.findInstanceIndex(state.devices, device);
-                    if (!state.devices[index]) return;
-                    state.devices[index].localFirstStorageSecret = {
-                        isRetrieving,
-                        evoluKeys: state.devices[index].localFirstStorageSecret?.evoluKeys,
-                    };
+                    state.devices[index].suiteSyncOwner = owner;
                 },
             )
             .addCase(deviceActions.setDiscovered, (state, { payload }) => {

--- a/suite-native/device-manager/src/components/WalletItemBase.tsx
+++ b/suite-native/device-manager/src/components/WalletItemBase.tsx
@@ -75,7 +75,7 @@ const LocalFirstStorageDebug = ({ device }: { device?: TrezorDevice }) => {
         ' @ ' +
         deviceId.slice(-8) +
         ' E: ' +
-        device.localFirstStorageSecret?.evoluKeys?.ownerId.slice(-8);
+        device.suiteSyncOwner?.ownerId.slice(-8);
 
     return <Text>{evoluDebug}</Text>;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR corrects the naming and introduces `SuteSyncOwner` type. Wraps the Evolu Owner and takes the structure from Evolu (noobish abstraction, but its a start).

Also it removes `isRetrying` probly its not needed anymore. :tada: 

## Notes for QA

Internal update for SuteSync, if it generally works, it shall be ok.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=suite-sync-owner-type-normalization&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=suite-sync-owner-type-normalization&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=suite-sync-owner-type-normalization&lookback=7)