### PR TITLE
feat(suite): Prevent initial app flashing in dark/light mode

### DIFF
--- a/packages/suite-desktop-ui/src/static/index.html
+++ b/packages/suite-desktop-ui/src/static/index.html
@@ -4,6 +4,11 @@
         <meta charset="utf-8" />
         <title>Trezor Suite</title>
 
+        <style>
+            :root {
+                color-scheme: light dark;
+            }
+        </style>
         <link media="all" rel="stylesheet" href="<%= assetPrefix %>/static/fonts/fonts.css" />
     </head>
     <body>

--- a/packages/suite-web/src/static/index.html
+++ b/packages/suite-web/src/static/index.html
@@ -13,6 +13,11 @@
             http-equiv="onion-location"
             content="http://suite.trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion/web"
         />
+        <style>
+            :root {
+                color-scheme: light dark;
+            }
+        </style>
         <% } %> <% if(isCrowdinEnabled) { %>
         <script type="text/javascript">
             if (localStorage.getItem('translation_mode') === 'true') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When you reload the app, first background should reflect your system settings. This didn't happen until now.

So if you have dark mode in the system and dark mode in the app, you shouldn't see white background. 
But if you have dark mode in the system and light mode in the app, you will see dark background first, but this is still better than previous solution.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before


https://github.com/user-attachments/assets/9d7465a4-c390-4e0f-9fa0-e74f7d8e5183

after


https://github.com/user-attachments/assets/1278ff36-da10-4f2e-ae95-b8b18b1821c1



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=prevent-initial-app-flashing&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=prevent-initial-app-flashing&lookback=7)