### PR TITLE
Nitpicks 6

### DIFF
--- a/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
@@ -20,7 +20,7 @@ export const TROUBLESHOOTING_TIP_WEBUSB_ENVIRONMENT: TroubleshootingTipsItem = {
     key: 'webusb-environment',
     heading: <Translation id="TR_TROUBLESHOOTING_TIP_BROWSER_WEBUSB_TITLE" />,
     description: <Translation id="TR_TROUBLESHOOTING_TIP_BROWSER_WEBUSB_DESCRIPTION" />,
-    hide: !isWeb(),
+    hide: !isWeb() || 'usb' in navigator,
 };
 
 export const TROUBLESHOOTING_TIP_UNREADABLE_HID: TroubleshootingTipsItem = {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/DeviceUnavailable.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/DeviceUnavailable.tsx
@@ -8,7 +8,7 @@ export const DeviceUnavailable = () => {
     const dispatch = useDispatch();
     const { device, isLocked } = useDevice();
 
-    if (!device?.connected || device.available) return null;
+    if (!device?.connected || device.available || !device.features) return null;
 
     const handleButtonClick = () => dispatch(applySettings({ use_passphrase: true }));
 

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -247,7 +247,7 @@ export const HELP_CENTER_TRANSACTION_FEES_URL: Url = withPlatformUtm(
     'https://trezor.io/guides/trezor-suite/trezor-suite-desktop/transaction-fees-in-trezor-suite',
 );
 export const HELP_CENTER_EVM_ADDRESS_CHECKSUM: Url = withPlatformUtm(
-    'https://trezor.io/guides/trezor-suite/trezor-suite-desktop/experimental-features-in-trezor-suite',
+    'https://trezor.io/learn/a/evm-address-checksum-in-trezor-suite',
 );
 export const HELP_CENTER_EVM_SEND_TO_CONTRACT_URL = withPlatformUtm(
     'https://trezor.io/support/troubleshooting/coins-tokens/where-is-my-ethereum',


### PR DESCRIPTION
- 348894c191 fix(urls): eth checksum link pointing at experimental features. bug introduced in 10112c2ec8faf4f72a4ea258710a20488734665c
- 4421551b09 fix(suite): dont show enable passphrase banner when device is unacquired. It doesn't make sense to prompt users to turn on passphrase in settings when we don't know features yet.
- f0fb93da3f chore(suite): hide use chrome if already using chrome troubleshooting tip. It doesnt make sense to tell user that is using webusb-enabled browser to start using webusb enabled browser.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=nitpicks-6&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=nitpicks-6&lookback=7)