### PR TITLE
fix(connect): ignore yarn min age for install test

### DIFF
--- a/packages/connect/e2e/test-yarn-install.sh
+++ b/packages/connect/e2e/test-yarn-install.sh
@@ -15,6 +15,8 @@ cd connect-implementation
 npm init -y
 touch yarn.lock
 
+echo "npmMinimalAgeGate: 0" > .yarnrc.yml
+
 # install connect package
 yarn add @trezor/connect@"$1"
 # prepare minimal typescript implementation


### PR DESCRIPTION
## Description

Yarn minimum age gate property can break Connect install tests when we publish a new package

Before: https://github.com/trezor/trezor-suite/actions/runs/19619796219/job/56201077559
After: https://github.com/trezor/trezor-suite/actions/runs/19628251097/job/56201641016

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-yarn-test-min-age&lookback=7)