### PR TITLE
fix(connect): broken noble import in e2e

### DIFF
--- a/packages/connect/e2e/jest.config.ts
+++ b/packages/connect/e2e/jest.config.ts
@@ -16,6 +16,7 @@ export default {
             },
         ],
     },
+    transformIgnorePatterns: ['node_modules/(?!(@noble)/)'],
     verbose: true,
     bail: true,
     testEnvironment: 'node',


### PR DESCRIPTION
## Description

Fix issue in node E2E with importing Noble lib

```
    SyntaxError: Cannot use import statement outside a module

    > 1 | import { ed25519 } from '@noble/curves/ed25519.js';
        | ^
      2 | import * as crypto from 'crypto';
      3 |
      4 | import { getSubtleCrypto } from '@trezor/crypto-utils';

      at Runtime.createScriptFromCode (../../node_modules/jest-runtime/build/index.js:1505:14)
      at Object.<anonymous> (../device-authenticity/src/verifyAuthenticityProof.ts:1:1)
      at Object.<anonymous> (../device-authenticity/src/index.ts:1:1)
      at Object.<anonymous> (src/api/authenticateDevice.ts:1:1)
      at Object.<anonymous> (src/api/index.ts:3:1)
      at Object.<anonymous> (src/core/method.ts:1:1)
      at Object.<anonymous> (src/core/index.ts:10:1)
      at Object.<anonymous> (src/index.ts:6:1)
      at Object.<anonymous> (e2e/tests/device/thpPairing.test.ts:1:1)
```

Before: https://github.com/trezor/trezor-suite/actions/runs/19619657647/job/56177673866
After: https://github.com/trezor/trezor-suite/actions/runs/19629373862/job/56205336843

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-e2e-noble-import&lookback=7)