### PR TITLE
chore: change "fail" in test names to "error" to find fails easier

### DIFF
--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -417,7 +417,7 @@ export const fixtures = {
     ],
     getTxType: [
         {
-            description: 'should return "failed" if the transaction has an error',
+            description: 'should return error if the transaction has an error',
             input: {
                 transaction: {
                     meta: {

--- a/packages/blockchain-link-utils/src/tests/fixtures/stellar.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/stellar.ts
@@ -1721,7 +1721,7 @@ export const fixtures = {
             },
         },
         {
-            description: 'failed transaction',
+            description: 'errored transaction',
             input: {
                 descriptor: 'GB635ARCRZOV7YZ5KC2BRIBFRHOCBJ5E35O76H3VUAMJP7UDTXFHG5C4',
                 tx: {

--- a/packages/coinjoin/tests/client/CoinjoinRound.test.ts
+++ b/packages/coinjoin/tests/client/CoinjoinRound.test.ts
@@ -100,7 +100,7 @@ describe(`CoinjoinRound`, () => {
         );
     });
 
-    it('catch failed Round', async () => {
+    it('catch errored Round', async () => {
         // create CoinjoinRound in phase 2 (OutputRegistration)
         const round = createCoinjoinRound(
             [
@@ -135,7 +135,7 @@ describe(`CoinjoinRound`, () => {
         );
     });
 
-    it('end Round if any input-registration fails and there is only one account', async () => {
+    it('end Round if any input-registration errors and there is only one account', async () => {
         server?.addListener('test-request', ({ url, data, resolve, reject }) => {
             if (url.endsWith('/input-registration') && data.Input === 'A2') {
                 // fail on second input
@@ -159,7 +159,7 @@ describe(`CoinjoinRound`, () => {
         expect(round.inputs.length).toBe(0); // all inputs are removed
     });
 
-    it('exclude all account inputs from the Round if any input-registration fails', async () => {
+    it('exclude all account inputs from the Round if any input-registration errors', async () => {
         server?.addListener('test-request', ({ url, data, resolve, reject }) => {
             if (url.endsWith('/input-registration') && data.Input === 'B2') {
                 // fail on second input of account-B

--- a/packages/coinjoin/tests/client/outputDecomposition.test.ts
+++ b/packages/coinjoin/tests/client/outputDecomposition.test.ts
@@ -19,7 +19,7 @@ describe('outputRegistration', () => {
         if (server) server.close();
     });
 
-    it('outputDecomposition fails. missing data in input', async () => {
+    it('outputDecomposition errors. missing data in input', async () => {
         await expect(
             outputDecomposition(
                 createCoinjoinRound([createInput('account-A', 'A1')], {

--- a/packages/coinjoin/tests/client/outputRegistration.test.ts
+++ b/packages/coinjoin/tests/client/outputRegistration.test.ts
@@ -31,7 +31,7 @@ describe('outputRegistration', () => {
         server?.close();
     });
 
-    it('fails on joining credentials (missing data in input)', async () => {
+    it('errors on joining credentials (missing data in input)', async () => {
         const response = await outputRegistration(
             createCoinjoinRound([createInput('account-A', 'A1')], {
                 ...server?.requestOptions,
@@ -45,7 +45,7 @@ describe('outputRegistration', () => {
         expect(response.inputs[0].error?.message).toMatch(/Missing confirmed credentials/);
     });
 
-    it('fails on insufficient amount of available change addresses', async () => {
+    it('errors on insufficient amount of available change addresses', async () => {
         server?.addListener('test-request', ({ url, resolve, reject }) => {
             if (url.endsWith('/output-registration')) {
                 // do not accept **any** output

--- a/packages/coinjoin/tests/client/selectRound.test.ts
+++ b/packages/coinjoin/tests/client/selectRound.test.ts
@@ -62,7 +62,7 @@ describe('selectRound', () => {
         expect(result).toEqual([]);
     });
 
-    it('CoinjoinRound creation failed on status Round without RoundCreated event', async () => {
+    it('CoinjoinRound creation errored on status Round without RoundCreated event', async () => {
         const result = await getRoundCandidates({
             roundGenerator,
             prison,

--- a/packages/coinjoin/tests/client/transactionSigning.test.ts
+++ b/packages/coinjoin/tests/client/transactionSigning.test.ts
@@ -352,7 +352,7 @@ describe('transactionSigning', () => {
         expect(response.isSignedSuccessfully()).toBe(true);
     });
 
-    it('failed to send signatures', async () => {
+    it('errors to send signatures', async () => {
         server?.addListener('test-request', ({ url, resolve, reject }) => {
             if (url.endsWith('/transaction-signature')) {
                 reject(500, { ErrorCode: 'WrongPhase' });

--- a/packages/connect/e2e/__fixtures__/signTransactionMultisigPubkeysOrder.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionMultisigPubkeysOrder.ts
@@ -63,7 +63,7 @@ export default {
             },
         },
         {
-            description: 'Testnet (multisig): 2 of 3 (fail when ordered gives wrong key))',
+            description: 'Testnet (multisig): 2 of 3 (errors when ordered gives wrong key))',
             params: {
                 coin: 'testnet',
                 inputs: [

--- a/packages/connect/src/device/__tests__/checkFirmwareHashWithRetries.test.ts
+++ b/packages/connect/src/device/__tests__/checkFirmwareHashWithRetries.test.ts
@@ -46,7 +46,7 @@ describe(checkFirmwareHashWithRetries.name, () => {
         });
     });
 
-    it('performs check with failure from initial state', async () => {
+    it('performs check with error from initial state', async () => {
         jest.spyOn(checkFirmwareHashModule, 'checkFirmwareHash').mockImplementation(() =>
             Promise.resolve({ success: false, error: 'hash-mismatch' }),
         );
@@ -76,7 +76,7 @@ describe(checkFirmwareHashWithRetries.name, () => {
         expect(device.setAuthenticityChecks).not.toHaveBeenCalled();
     });
 
-    it('does not retry the check after decisive failure', async () => {
+    it('does not retry the check after decisive error', async () => {
         const device = getMockedDevice();
         device.getAuthenticityChecks = jest.fn(() => ({
             firmwareRevision: null,
@@ -111,7 +111,7 @@ describe(checkFirmwareHashWithRetries.name, () => {
         });
     });
 
-    it('does a single retry with failure for a retriable error', async () => {
+    it('does a single retry with error for a retriable error', async () => {
         jest.spyOn(checkFirmwareHashModule, 'checkFirmwareHash').mockImplementation(() =>
             Promise.resolve({
                 success: false,

--- a/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
+++ b/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
@@ -50,14 +50,14 @@ describe.each(DeviceNames)(`${checkFirmwareRevision.name} for device %s`, intern
             expected: { success: true },
         },
         {
-            it: 'fails when firmware revision is NOT same as in static file',
+            it: 'errors when firmware revision is NOT same as in static file',
             params: createDeviceParams({
                 expectedRevision: 'cde8f31ec2ddcb7d35e36edbcf8a71dda983a9ea',
             }),
             expected: { success: false, error: 'revision-mismatch' },
         },
         {
-            it: 'fails when firmware revision is not provided',
+            it: 'errors when firmware revision is not provided',
             params: createDeviceParams({
                 deviceRevision: undefined,
                 expectedRevision: 'cde8f31ec2ddcb7d35e36edbcf8a71dda983a9ea',
@@ -73,7 +73,7 @@ describe.each(DeviceNames)(`${checkFirmwareRevision.name} for device %s`, intern
             expected: { success: true },
         },
         {
-            it: 'fails when firmware version is not found locally, found in the online release, but does NOT match',
+            it: 'errors when firmware version is not found locally, found in the online release, but does NOT match',
             httpRequestMock: () => Promise.resolve(ONLINE_RELEASES_JSON_MOCK),
             params: createDeviceParams({
                 deviceRevision: '1234567890987654321',
@@ -82,7 +82,7 @@ describe.each(DeviceNames)(`${checkFirmwareRevision.name} for device %s`, intern
             expected: { success: false, error: 'revision-mismatch' },
         },
         {
-            it: 'fails when firmware version is not found locally, and also not in the online release',
+            it: 'errors when firmware version is not found locally, and also not in the online release',
             httpRequestMock: () => Promise.resolve(ONLINE_RELEASES_JSON_MOCK),
             params: createDeviceParams({
                 deviceRevision: '1234567890987654321',
@@ -92,7 +92,7 @@ describe.each(DeviceNames)(`${checkFirmwareRevision.name} for device %s`, intern
             expected: { success: false, error: 'firmware-version-unknown' },
         },
         {
-            it: 'fails with a specific error message when the check cannot be performed because the revision is not found locally and the user is offline',
+            it: 'errors with a specific error message when the check cannot be performed because the revision is not found locally and the user is offline',
             httpRequestMock: () => {
                 throw new FetchError('You are offline!', 'network', {
                     code: 'ENOTFOUND',
@@ -106,7 +106,7 @@ describe.each(DeviceNames)(`${checkFirmwareRevision.name} for device %s`, intern
             expected: { success: false, error: 'cannot-perform-check-offline' },
         },
         {
-            it: 'fails with a generic error message when there is an error when reading the online version of releases.json',
+            it: 'errors with a generic error message when there is an error when reading the online version of releases.json',
             httpRequestMock: () => {
                 throw new Error('There is an unexpected error!');
             },

--- a/packages/connect/src/utils/__tests__/firmwareUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/firmwareUtils.test.ts
@@ -5,7 +5,7 @@ import { findBestCompatibleRelease, isStrictFeatures } from '../firmwareUtils';
 
 describe('firmwareUtils', () => {
     describe('isStrictFeatures()', () => {
-        it('fail on not matching pattern', () => {
+        it('errors on not matching pattern', () => {
             expect(
                 // @ts-expect-error
                 isStrictFeatures({ foo: 'bar' }),

--- a/packages/device-authenticity/src/tests/verifyAuthenticityProof.test.ts
+++ b/packages/device-authenticity/src/tests/verifyAuthenticityProof.test.ts
@@ -112,7 +112,7 @@ describe(`firmware/${verifyAuthenticityProof.name}`, () => {
         expect(verify.rootPubKey).toBe(T3W1rootPubKeyTropic);
     });
 
-    it('verify failed for optiga (debug keys not allowed)', async () => {
+    it('verify errored for optiga (debug keys not allowed)', async () => {
         const verify = await verifyAuthenticityProof({
             ...defaultOptigaProps,
             config: CONFIG_WITH_DEBUG_KEYS,
@@ -123,7 +123,7 @@ describe(`firmware/${verifyAuthenticityProof.name}`, () => {
         expect(verify.rootPubKey).toBe(undefined);
     });
 
-    it('verify failed for tropic (debug keys not allowed)', async () => {
+    it('verify errored for tropic (debug keys not allowed)', async () => {
         const verify = await verifyAuthenticityProof({
             ...defaultTropicProps,
             config: CONFIG_WITH_DEBUG_KEYS,
@@ -134,7 +134,7 @@ describe(`firmware/${verifyAuthenticityProof.name}`, () => {
         expect(verify.rootPubKey).toBe(undefined);
     });
 
-    it('verify failed for optiga (signature mismatch)', async () => {
+    it('verify errored for optiga (signature mismatch)', async () => {
         const verify = await verifyAuthenticityProof({
             ...defaultOptigaProps,
             signature:
@@ -148,7 +148,7 @@ describe(`firmware/${verifyAuthenticityProof.name}`, () => {
         expect(verify.rootPubKey).toBe(T2B1rootPubKeyOptiga);
     });
 
-    it('verify failed for tropic (signature mismatch)', async () => {
+    it('verify errored for tropic (signature mismatch)', async () => {
         const verify = await verifyAuthenticityProof({
             ...defaultTropicProps,
             signature:
@@ -162,7 +162,7 @@ describe(`firmware/${verifyAuthenticityProof.name}`, () => {
         expect(verify.rootPubKey).toBe(T3W1rootPubKeyTropic);
     });
 
-    it('verify failed for optiga (missing rootPubKey)', async () => {
+    it('verify errored for optiga (missing rootPubKey)', async () => {
         const verify = await verifyAuthenticityProof({
             ...defaultOptigaProps,
             config: {
@@ -181,7 +181,7 @@ describe(`firmware/${verifyAuthenticityProof.name}`, () => {
         expect(verify.rootPubKey).toBe(undefined);
     });
 
-    it('verify failed for tropic (missing rootPubKey)', async () => {
+    it('verify errored for tropic (missing rootPubKey)', async () => {
         const verify = await verifyAuthenticityProof({
             ...defaultTropicProps,
             config: {
@@ -197,7 +197,7 @@ describe(`firmware/${verifyAuthenticityProof.name}`, () => {
         expect(verify.rootPubKey).toBe(undefined);
     });
 
-    it('verify failed for tropic (no rootPubKeysTropic defined)', async () => {
+    it('verify errored for tropic (no rootPubKeysTropic defined)', async () => {
         const verify = await verifyAuthenticityProof({
             ...defaultTropicProps,
             config: { ...CONFIG, T3W1: { rootPubKeysOptiga: [] } },
@@ -207,7 +207,7 @@ describe(`firmware/${verifyAuthenticityProof.name}`, () => {
         expect(verify.rootPubKey).toBe(undefined);
     });
 
-    it('verify failed for optiga (device model mismatch)', async () => {
+    it('verify errored for optiga (device model mismatch)', async () => {
         const verify = await verifyAuthenticityProof({
             ...defaultOptigaProps,
             certificates: [
@@ -223,7 +223,7 @@ describe(`firmware/${verifyAuthenticityProof.name}`, () => {
 
     // device model mismatch case is not relevant for tropic (supported only by T3W1)
 
-    it('verify failed for optiga (caPubKey on blacklist)', async () => {
+    it('verify errored for optiga (caPubKey on blacklist)', async () => {
         const verify = await verifyAuthenticityProof({
             ...defaultOptigaProps,
             blacklistConfig: {
@@ -239,7 +239,7 @@ describe(`firmware/${verifyAuthenticityProof.name}`, () => {
         expect(verify.rootPubKey).toBe(T2B1rootPubKeyOptiga);
     });
 
-    it('verify failed for tropic (caPubKey on blacklist)', async () => {
+    it('verify errored for tropic (caPubKey on blacklist)', async () => {
         const verify = await verifyAuthenticityProof({
             ...defaultTropicProps,
             blacklistConfig: {

--- a/packages/ipc-proxy/src/__tests__/validateIpcMessage.test.ts
+++ b/packages/ipc-proxy/src/__tests__/validateIpcMessage.test.ts
@@ -54,7 +54,7 @@ describe(validateIpcMessage.name, () => {
         });
     });
 
-    it('fails when not in PROD environment and is on (localhost.8000)', () => {
+    it('errors when not in PROD environment and is on (localhost.8000)', () => {
         const original = process.env.NODE_ENV;
         process.env.NODE_ENV = 'production';
 
@@ -70,7 +70,7 @@ describe(validateIpcMessage.name, () => {
         process.env.NODE_ENV = original;
     });
 
-    it('fails for malicious URL', () => {
+    it('errors for malicious URL', () => {
         const subject = () => {
             validateIpcMessage({
                 ipcEvent: createSenderFrame('https://www.irs.gov/'),
@@ -81,7 +81,7 @@ describe(validateIpcMessage.name, () => {
         expect(subject).toThrow('Hostname www.irs.gov found, must be empty');
     });
 
-    it('fails for invalid senderFrame', () => {
+    it('errors for invalid senderFrame', () => {
         const subject = () => {
             validateIpcMessage({
                 ipcEvent: {} as ElectronIpcMainInvokeEvent,
@@ -92,7 +92,7 @@ describe(validateIpcMessage.name, () => {
         expect(subject).toThrow('Invalid ipcEvent: {}');
     });
 
-    it('fails when senderFrame has been destroyed', () => {
+    it('errors when senderFrame has been destroyed', () => {
         const subject = () => {
             validateIpcMessage({
                 ipcEvent: createSenderFrame('http://localhost:8000/', true),
@@ -103,7 +103,7 @@ describe(validateIpcMessage.name, () => {
         expect(subject).toThrow('ipcEvent.senderFrame is destroyed');
     });
 
-    it('fails when in production, you get different protocol to file:', () => {
+    it('errors when in production, you get different protocol to file:', () => {
         const original = process.env.NODE_ENV;
         process.env.NODE_ENV = 'production';
 

--- a/packages/suite-desktop-core/e2e/tests/backup/t2t1-fail.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/backup/t2t1-fail.test.ts
@@ -4,7 +4,7 @@ import { HELP_CENTER_RECOVERY_ISSUES_URL } from '@trezor/urls';
 
 import { expect, test } from '../../support/fixtures';
 
-test.describe('Backup fail', { tag: ['@group=device-management', '@specificModel'] }, () => {
+test.describe('Backup errors', { tag: ['@group=device-management', '@specificModel'] }, () => {
     test.use({
         emulatorStartConf: { model: 'T2T1', wipe: true },
         emulatorSetupConf: { needs_backup: true },
@@ -51,7 +51,7 @@ test.describe('Backup fail', { tag: ['@group=device-management', '@specificModel
             );
         });
 
-        await test.step('Check backup failed setting in device settings', async () => {
+        await test.step('Check backup errored setting in device settings', async () => {
             await settingsPage.navigateTo('device');
             await expect(onboardingPage.backup.failedBackupSetting).toBeVisible();
             await expect(onboardingPage.backup.failedBackupSetting).toContainTranslation(

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
@@ -113,7 +113,11 @@ test.describe('Passphrase', { tag: ['@group=passphrase'] }, () => {
         },
     );
 
-    test('Fail to confirm passphrase and retry', async ({ page, dashboardPage, devicePrompt }) => {
+    test('Errors to confirm passphrase and retry', async ({
+        page,
+        dashboardPage,
+        devicePrompt,
+    }) => {
         await test.step('Initiate adding passphrase wallet', async () => {
             await dashboardPage.openDeviceSwitcher();
             await dashboardPage.addHiddenWallet('abc', { skipDiscovery: true });

--- a/packages/suite-desktop-core/e2e/tests/settings/coins-custom-backend.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/coins-custom-backend.test.ts
@@ -83,7 +83,7 @@ test.describe('Coin Settings', { tag: ['@group=settings'] }, () => {
         );
 
         test(
-            `Enable ${coin.toUpperCase()} asset & connect to backend server ${customBackendUrlWrong} failes`,
+            `Enable ${coin.toUpperCase()} asset & connect to backend server ${customBackendUrlWrong} errors`,
             {
                 annotation: createTestAnnotation({
                     testCase: `Verifies that settings up a custom ${backendType} server for ${coin.toUpperCase()} with wrong url ${customBackendUrlWrong} will fail.`,
@@ -115,7 +115,7 @@ test.describe('Coin Settings', { tag: ['@group=settings'] }, () => {
                         page.discoveryShouldFinish(),
                     ]);
                 });
-                await test.step(`Open ${coin.toUpperCase()} account & verify it fails to load`, async () => {
+                await test.step(`Open ${coin.toUpperCase()} account & verify it errors to load`, async () => {
                     await walletPage.accountButton({ symbol: coin }).click();
                     await expect(walletPage.accountNotLoaded).toContainTranslation(
                         'TR_ACCOUNT_EXCEPTION_DISCOVERY_ERROR',

--- a/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
@@ -153,7 +153,7 @@ export const actions = [
         },
     },
     {
-        description: 'Fails for missing device',
+        description: 'Errors for missing device',
         action: () => firmwareUpdate({ firmwareType: FirmwareType.Universal }),
         initialState: {
             device: {
@@ -166,7 +166,7 @@ export const actions = [
         },
     },
     {
-        description: 'FirmwareUpdate call to connect fails',
+        description: 'FirmwareUpdate call to connect errors',
         action: () => firmwareUpdate({ firmwareType: FirmwareType.Universal }),
         initialState: {
             device: {
@@ -203,7 +203,7 @@ export const actions = [
         },
     },
     {
-        description: 'FirmwareUpdate call to connect fails due to cancelling on device',
+        description: 'FirmwareUpdate call to connect errors due to cancelling on device',
         action: () => firmwareUpdate({ firmwareType: FirmwareType.Universal }),
         initialState: {
             device: {

--- a/packages/suite/src/actions/settings/__fixtures__/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/deviceSettingsActions.ts
@@ -231,7 +231,7 @@ const fixture: Fixture[] = [
         },
     },
     {
-        description: 'Wipe device failed',
+        description: 'Wipe device errored',
         action: () => wipeDeviceThunk(),
         mocks: { success: false, payload: { error: 'fuuu' } },
         result: {
@@ -366,7 +366,7 @@ const fixture: Fixture[] = [
         },
     },
     {
-        description: 'Reset device - Entropy check fail - show Device compromised',
+        description: 'Reset device - Entropy check errored - show Device compromised',
         action: () => deviceSettingsActions.resetDevice(),
         mocks: {
             success: false,

--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -470,7 +470,7 @@ export const onConnect = [
         blockchainSubscribe: 1,
     },
     {
-        description: 'successful, blockchainEstimateFee failed',
+        description: 'successful, blockchainEstimateFee errored',
         initialState: {
             accounts: [{ symbol: 'btc', history: {} }],
         },
@@ -485,7 +485,7 @@ export const onConnect = [
         blockchainSubscribe: 1,
     },
     {
-        description: 'successful, ETH blockchainEstimateFee failed',
+        description: 'successful, ETH blockchainEstimateFee errored',
         initialState: {
             accounts: [{ symbol: 'eth', history: {}, deviceState: 'abc' }],
         },

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -240,7 +240,7 @@ export const stopCoinjoinSession = [
 
 export const restoreCoinjoinAccounts = [
     {
-        description: 'four accounts, two networks, one success, one failed',
+        description: 'four accounts, two networks, one success, one errored',
         state: {
             accounts: [
                 { key: 'account-1', symbol: 'regtest' }, // regtest is not supported in tests

--- a/packages/suite/src/actions/wallet/__fixtures__/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/publicKeyActions.ts
@@ -61,7 +61,7 @@ export default [
         },
     },
     {
-        description: 'Show public key failed, @trezor/connect method not specified',
+        description: 'Show public key errored, @trezor/connect method not specified',
         initialState: {
             networkType: 'ethereum',
         },

--- a/packages/suite/src/actions/wallet/__fixtures__/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/receiveActions.ts
@@ -119,7 +119,7 @@ export default [
         },
     },
     {
-        description: 'Show address failed, @trezor/connect method not specified',
+        description: 'Show address errored, @trezor/connect method not specified',
         initialState: {
             wallet: {
                 selectedAccount: {

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
@@ -247,7 +247,7 @@ describe('coinjoinClientActions', () => {
         expect(cli).toBe(undefined);
     });
 
-    it('initCoinjoinService and fail to enable', async () => {
+    it('initCoinjoinService and errors to enable', async () => {
         const store = initStore();
         const spy = jest.spyOn(CoinjoinService, 'createInstance').mockImplementationOnce(
             () =>

--- a/packages/suite/src/components/suite/Preloader/__tests__/selectShouldDisplayDeviceCompromisedOnRoute.test.ts
+++ b/packages/suite/src/components/suite/Preloader/__tests__/selectShouldDisplayDeviceCompromisedOnRoute.test.ts
@@ -46,7 +46,7 @@ const fixtures: Fixture[] = [
         result: false,
     },
     {
-        description: 'returns false if check fails, but on a skipped route',
+        description: 'returns false if check errors, but on a skipped route',
         state: {
             ...initialAppState,
             router: {
@@ -70,7 +70,7 @@ const fixtures: Fixture[] = [
         result: false,
     },
     {
-        description: 'returns true if firmware check failed and not dismissed',
+        description: 'returns true if firmware check errored and not dismissed',
         state: {
             ...initialAppState,
             messageSystem: messageSystemInitialState,
@@ -85,7 +85,7 @@ const fixtures: Fixture[] = [
         result: true,
     },
     {
-        description: 'returns false if firmware check failed and dismissed',
+        description: 'returns false if firmware check errored and dismissed',
         state: {
             ...initialAppState,
             messageSystem: messageSystemInitialState,
@@ -101,7 +101,7 @@ const fixtures: Fixture[] = [
         result: false,
     },
     {
-        description: 'returns false if a firmware check failed but is disabled',
+        description: 'returns false if a firmware check errored but is disabled',
         state: {
             ...initialAppState,
             messageSystem: messageSystemInitialState,
@@ -129,7 +129,7 @@ const fixtures: Fixture[] = [
         result: false,
     },
     {
-        description: 'returns true if entropy check failed',
+        description: 'returns true if entropy check errored',
         state: {
             ...initialAppState,
             messageSystem: messageSystemInitialState,
@@ -150,7 +150,7 @@ const fixtures: Fixture[] = [
         result: true,
     },
     {
-        description: 'returns false if entropy check failed but is disabled',
+        description: 'returns false if entropy check errored but is disabled',
         state: {
             ...initialAppState,
             messageSystem: messageSystemInitialState,

--- a/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
@@ -52,7 +52,7 @@ const deviceCompromisedFixtures: Array<{
     result: TranslationKey;
 }> = [
     {
-        description: 'Failed entropy check',
+        description: 'Errored entropy check',
         device: {
             ...deviceInitialState,
             persistentDeviceData: [
@@ -66,7 +66,7 @@ const deviceCompromisedFixtures: Array<{
         result: 'TR_DEVICE_COMPROMISED_ENTROPY_CHECK_TEXT',
     },
     {
-        description: 'Failed firmware hash check',
+        description: 'Errored firmware hash check',
         device: {
             ...deviceInitialState,
             selectedDevice: {
@@ -126,7 +126,7 @@ const deviceCompromisedFixtures: Array<{
         result: 'TR_FAILED_VERIFY_DEVICE_AGAIN_TEXT',
     },
     {
-        description: 'Failed firmware revision check',
+        description: 'Errored firmware revision check',
         device: {
             ...deviceInitialState,
             selectedDevice: {

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -1453,7 +1453,7 @@ export const signAndPush = [
         },
     },
     {
-        description: 'ETH failed',
+        description: 'ETH errored',
         store: {
             send: {
                 drafts: getDraft(),
@@ -1508,7 +1508,7 @@ export const signAndPush = [
         },
     },
     {
-        description: 'XRP failed',
+        description: 'XRP errored',
         store: {
             send: {
                 drafts: getDraft(),

--- a/packages/suite/src/storage/migrations/versions/__tests__/25.10.0.test.ts
+++ b/packages/suite/src/storage/migrations/versions/__tests__/25.10.0.test.ts
@@ -19,7 +19,7 @@ describe('migration 25.10.0', () => {
         await deleteDB(DB_NAME);
     });
 
-    test('migrates devicesWithFailedEntropyCheck to persistentDeviceData', async () => {
+    test('migrates devices with errored entropy check to persistentDeviceData', async () => {
         const db = await openDB(DB_NAME, INITIAL_VERSION, {
             upgrade(db) {
                 db.createObjectStore('security');

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/test/canLocktimeTxBeBroadcast.test.ts
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/test/canLocktimeTxBeBroadcast.test.ts
@@ -36,7 +36,7 @@ const data: Array<{
         result: true,
     },
     {
-        it: 'fails for locktime more then current hash',
+        it: 'errors for locktime more then current hash',
         input: {
             locktimeBlockHeight: 151,
             locktimeDatetime: undefined,
@@ -54,7 +54,7 @@ const data: Array<{
         result: true,
     },
     {
-        it: 'fails for datetime in the future',
+        it: 'errors for datetime in the future',
         input: {
             locktimeBlockHeight: undefined,
             locktimeDatetime: 2147483647,

--- a/packages/transport/tests/readWithExpectedHeaders.test.ts
+++ b/packages/transport/tests/readWithExpectedHeaders.test.ts
@@ -52,7 +52,7 @@ describe('readWithExpectedHeaders', () => {
         await expect(() => resultPromise).rejects.toThrow('Aborted by timeout');
     });
 
-    it('api.read failed', async () => {
+    it('api.read error', async () => {
         const read = readWithExpectedHeaders(() =>
             Promise.resolve({ success: false, error: 'unexpected error' }),
         );

--- a/packages/transport/tests/thp.test.ts
+++ b/packages/transport/tests/thp.test.ts
@@ -60,7 +60,7 @@ describe('thp', () => {
             expect(result).toMatchObject({ success: false, message: 'Aborted by signal in API' });
         });
 
-        it('api write failed', async () => {
+        it('api write error', async () => {
             const readResult = Buffer.from('200c22000471913136', 'hex');
             thpState.setChannel(readResult.subarray(1, 3));
             thpState.setExpectedResponses([0x20]);
@@ -192,7 +192,7 @@ describe('thp', () => {
             expect(apiWrite).toHaveBeenCalledTimes(10);
         });
 
-        it('api read failed', async () => {
+        it('api read error', async () => {
             jest.useFakeTimers();
 
             const apiRead = jest.fn(
@@ -222,7 +222,7 @@ describe('thp', () => {
             expect(apiRead).toHaveBeenCalledTimes(1);
         });
 
-        it('api write failed', async () => {
+        it('api write error', async () => {
             const apiWrite = jest.fn(
                 () =>
                     new Promise<any>(resolve => {

--- a/packages/utils/tests/promiseAllSequence.test.ts
+++ b/packages/utils/tests/promiseAllSequence.test.ts
@@ -35,7 +35,7 @@ describe('promiseAllSequence', () => {
         expect(args2).toEqual([[3], [2], [1]]); // but actionInnerProcess was called in different order
     });
 
-    it('one failed', async () => {
+    it('one errored', async () => {
         const action = (id: number, time: number) =>
             new Promise((resolve, reject) =>
                 setTimeout(() => {

--- a/packages/utils/tests/scheduleAction.test.ts
+++ b/packages/utils/tests/scheduleAction.test.ts
@@ -63,7 +63,7 @@ describe('scheduleAction', () => {
             aborter.abort();
         }));
 
-    it('deadline on always failing action', async () => {
+    it('deadline on always error action', async () => {
         const spy = jest.fn(() => {
             throw new Error('Runtime error');
         });
@@ -153,7 +153,7 @@ describe('scheduleAction', () => {
         expect(checkListeners()).toBeUndefined();
     });
 
-    it('attempt failure handler', async () => {
+    it('attempt error handler', async () => {
         const spy = jest.fn(
             (signal?: AbortSignal) =>
                 new Promise<any>((_, reject) => {

--- a/packages/utxo-lib/tests/__fixtures__/coinselect/accumulative.ts
+++ b/packages/utxo-lib/tests/__fixtures__/coinselect/accumulative.ts
@@ -270,7 +270,7 @@ export default [
         dustThreshold: 546,
     },
     {
-        description: '1 output, fails, skips (and finishes on) detrimental input',
+        description: '1 output, errors, skips (and finishes on) detrimental input',
         feeRate: 55,
         inputs: [
             {

--- a/packages/utxo-lib/tests/__fixtures__/coinselect/bnb.ts
+++ b/packages/utxo-lib/tests/__fixtures__/coinselect/bnb.ts
@@ -222,7 +222,7 @@ export default [
         dustThreshold: 546,
     },
     {
-        description: '1 output, fails, skips (and finishes on) detrimental input',
+        description: '1 output, errors, skips (and finishes on) detrimental input',
         feeRate: 55,
         inputs: [
             {

--- a/packages/utxo-lib/tests/__fixtures__/coinselect/coinselect-index.ts
+++ b/packages/utxo-lib/tests/__fixtures__/coinselect/coinselect-index.ts
@@ -497,7 +497,7 @@ export const coinselectIndexFixture = [
         dustThreshold: 546,
     },
     {
-        description: '1 output, fails, skips (and finishes on) detrimental input',
+        description: '1 output, errors, skips (and finishes on) detrimental input',
         feeRate: 55,
         inputs: [
             {

--- a/packages/utxo-lib/tests/__fixtures__/compose.ts
+++ b/packages/utxo-lib/tests/__fixtures__/compose.ts
@@ -130,7 +130,7 @@ export const composeTxFixture: Fixture[] = [
         },
     },
     {
-        description: 'fails on little funds',
+        description: 'errors on little funds',
         request: {
             changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
             dustThreshold: 546,

--- a/packages/utxo-lib/tests/address.test.ts
+++ b/packages/utxo-lib/tests/address.test.ts
@@ -47,7 +47,7 @@ describe('address', () => {
         });
 
         fixtures.invalid.bech32.forEach(f => {
-            it(`decode fails for ${f.address}(${f.exception})`, () => {
+            it(`decode errors for ${f.address}(${f.exception})`, () => {
                 expect(() => {
                     baddress.fromBech32(f.address);
                 }).toThrow(new RegExp(f.exception));
@@ -87,7 +87,7 @@ describe('address', () => {
         // TODO: These fixtures (according to TypeScript) have none of the data used below
         // fixtures.invalid.bech32.forEach((f, i) => {
         // eslint-disable-next-line jest/no-commented-out-tests
-        //     it(`encode fails (${f.exception}`, () => {
+        //     it(`encode errors (${f.exception}`, () => {
         //         expect(() => {
         //             baddress.toBech32(Buffer.from(f.data, 'hex'), f.version, f.prefix);
         //         }).toThrow(new RegExp(f.exception));

--- a/suite-common/device-authenticity/tests/deviceAuthenticityThunks.test.ts
+++ b/suite-common/device-authenticity/tests/deviceAuthenticityThunks.test.ts
@@ -111,7 +111,7 @@ const fixtures: Fixture[] = [
         expectedResult: undefined,
     },
     {
-        description: 'Fail - root pub key not found',
+        description: 'Error - root pub key not found',
         device: deviceWithLockedBootloader,
         mockedConnectResponse: verifyFailureResponseNotFound,
         expectedFulfilled: false,
@@ -119,7 +119,7 @@ const fixtures: Fixture[] = [
         expectedResult: { valid: false, ...verifyFailureResponseNotFound.payload },
     },
     {
-        description: 'Fail - caPubKey is blacklisted',
+        description: 'Error - caPubKey is blacklisted',
         device: deviceWithLockedBootloader,
         mockedConnectResponse: verifyFailureResponseBlacklisted,
         expectedFulfilled: false,
@@ -127,7 +127,7 @@ const fixtures: Fixture[] = [
         expectedResult: { valid: false, ...verifyFailureResponseBlacklisted.payload },
     },
     {
-        description: 'Fail - bootloader unlocked',
+        description: 'Error - bootloader unlocked',
         device: getDevice(false),
         mockedConnectResponse: connectCallFailResponse,
         expectedFulfilled: false,

--- a/suite-common/message-system/src/__tests__/messageSystemActions.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemActions.test.ts
@@ -105,7 +105,7 @@ describe('Message system actions', () => {
             expect(global.fetch).not.toHaveBeenCalled();
         });
 
-        it('fetches local jws if the remote one fails', async () => {
+        it('fetches local jws if the remote one errors', async () => {
             jest.spyOn(console, 'error').mockImplementation(() => {});
 
             global.fetch = jest.fn().mockImplementationOnce(() => undefined);

--- a/suite-common/staking/src/__fixtures__/ethereumStaking.ts
+++ b/suite-common/staking/src/__fixtures__/ethereumStaking.ts
@@ -114,7 +114,7 @@ export const stakeFailedFixture = [
         result: 'Min amount 0.1 ETH',
     },
     {
-        description: 'should throw an error when fee estimation is failed',
+        description: 'should throw an error when fee estimation is errored',
         args: {
             from: '0xfB0bc552ab5Fa1971E8530852753c957e29eEEFC',
             amount: '0.1',
@@ -172,7 +172,7 @@ export const unstakeFixture = [
 
 export const unstakeFailedFixture = [
     {
-        description: 'should throw an error when account info is failed',
+        description: 'should throw an error when account info is errored',
         args: {
             from: '0xfB0bc552ab5Fa1971E8530852753c957e29eEEFC',
             amount: '0.1', // eth
@@ -220,7 +220,7 @@ export const unstakeFailedFixture = [
         result: 'Failed to get the autocompound balance',
     },
     {
-        description: 'should throw an error when fee estimation is failed',
+        description: 'should throw an error when fee estimation is errored',
         args: {
             from: '0xfB0bc552ab5Fa1971E8530852753c957e29eEEFC',
             amount: '0.1', // eth
@@ -312,7 +312,7 @@ export const claimFixture = [
 
 export const claimFailedFixture = [
     {
-        description: 'should throw an error when account info is failed',
+        description: 'should throw an error when account info is errored',
         args: {
             from: '0xfB0bc552ab5Fa1971E8530852753c957e29eEEFC',
             symbol: 'thod',
@@ -327,7 +327,7 @@ export const claimFailedFixture = [
         result: 'Account info error',
     },
     {
-        description: 'should throw an error when fee estimation is failed',
+        description: 'should throw an error when fee estimation is errored',
         args: {
             from: '0xfB0bc552ab5Fa1971E8530852753c957e29eEEFC',
             symbol: 'eth',

--- a/suite-common/trading/src/thunks/common/__tests__/createPaymentRequestsThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/createPaymentRequestsThunk.test.ts
@@ -355,7 +355,7 @@ describe('createPaymentRequestsThunk', () => {
             });
         });
 
-        it('should reject when payment request creation fails', async () => {
+        it('should reject when payment request creation errors', async () => {
             invityAPI.getSignedTrade = () =>
                 Promise.resolve({
                     mockExchangeQuote,
@@ -462,7 +462,7 @@ describe('createPaymentRequestsThunk', () => {
             });
         });
 
-        it('should reject when sell payment request creation fails', async () => {
+        it('should reject when sell payment request creation errors', async () => {
             invityAPI.getSignedTrade = () =>
                 Promise.resolve({
                     ...mockSignedSellTrade,
@@ -569,7 +569,7 @@ describe('createPaymentRequestsThunk', () => {
 
     describe('error handling', () => {
         it('should handle invityAPI.getSignedTrade rejection', async () => {
-            invityAPI.getSignedTrade = () => Promise.reject('API request failed');
+            invityAPI.getSignedTrade = () => Promise.reject('API request errored');
 
             const mockExchangeQuote = {
                 orderId: 'exchange-order-123',

--- a/suite-common/trading/src/thunks/common/__tests__/getNonce.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/getNonce.test.ts
@@ -142,7 +142,7 @@ describe('getNonce thunk', () => {
             });
         });
 
-        it('should reject when TrezorConnect.getNonce fails', async () => {
+        it('should reject when TrezorConnect.getNonce errors', async () => {
             (selectSelectedDevice as jest.Mock).mockReturnValue(mockDevice);
             (TrezorConnect.getNonce as jest.Mock).mockResolvedValue({
                 success: false,

--- a/suite-common/trading/src/thunks/common/__tests__/getRefundAddress.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/getRefundAddress.test.ts
@@ -183,7 +183,7 @@ describe('getRefundAddress thunk', () => {
             });
         });
 
-        it('should reject when confirmAddressOnDeviceThunk fails', async () => {
+        it('should reject when confirmAddressOnDeviceThunk errors', async () => {
             (confirmAddressOnDeviceThunk as unknown as jest.Mock).mockImplementation(
                 createThunk('@suite/device/confirmAddressOnDeviceThunk', () => ({
                     success: false,

--- a/suite-common/wallet-core/src/discovery/__tests__/discoveryReducer.test.ts
+++ b/suite-common/wallet-core/src/discovery/__tests__/discoveryReducer.test.ts
@@ -295,7 +295,7 @@ describe('Discovery Reducer', () => {
         });
     });
 
-    it('should handle updateDiscovery action with failed status', () => {
+    it('should handle updateDiscovery action with errored status', () => {
         // Initialize store with existing discovery
         const store = initStore({
             preloadedState: {

--- a/suite-common/wallet-utils/src/__tests__/localizeNumber.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/localizeNumber.test.ts
@@ -13,7 +13,7 @@ describe('localizeNumber', () => {
         expect(localizeNumber(1.234832924423748, 'cs-CZ')).toStrictEqual('1,234832924423748');
     });
 
-    it('fails with wrong values', () => {
+    it('errors with wrong values', () => {
         expect(localizeNumber(NaN)).toStrictEqual('');
         expect(localizeNumber(Infinity)).toStrictEqual('');
         expect(localizeNumber('asadff')).toStrictEqual('');

--- a/suite-native/device-mutex/src/tests/DeviceAccessMutex.test.ts
+++ b/suite-native/device-mutex/src/tests/DeviceAccessMutex.test.ts
@@ -86,7 +86,7 @@ describe('RequestDeviceAccess', () => {
         expect(deviceAccessMutex.isLocked).toBe(false);
     });
 
-    test('mutex unlocked on deviceCallback failure', async () => {
+    test('mutex unlocked on deviceCallback error', async () => {
         const callbackError = 'Callback failed';
         const mockCallback = jest.fn().mockRejectedValue(callbackError);
 

--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/__tests__/useAddressValidationAlerts.test.tsx
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/__tests__/useAddressValidationAlerts.test.tsx
@@ -404,7 +404,7 @@ describe('useAddressValidationAlerts', () => {
     });
 
     describe('Error handling', () => {
-        it('should handle TrezorConnect.getAccountInfo failure gracefully', async () => {
+        it('should handle TrezorConnect.getAccountInfo error gracefully', async () => {
             mockWatch.mockReturnValue(contractAddressLowercase);
 
             getAccountInfoSpy.mockResolvedValue(mockAccountInfoResponses.networkError);

--- a/suite-native/module-trading/src/hooks/settings/__tests__/useMaxSlippageForm.test.ts
+++ b/suite-native/module-trading/src/hooks/settings/__tests__/useMaxSlippageForm.test.ts
@@ -21,7 +21,7 @@ describe('useMaxSlippageForm', () => {
     });
 
     it.each<string>(['-1', '0', '0.009', '50.1', '55', '', 'invalid_number'])(
-        'should fail validation for value %s',
+        'should error validation for value %s',
         async slippage => {
             const store = await initStore();
             const { result } = await renderUseMaxSlippageForm(store);

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
@@ -126,7 +126,7 @@ describe('TradingExchangePreviewScreen', () => {
     });
 
     describe('Error Alert Functionality', () => {
-        it('should show error alert when trade confirmation fails', async () => {
+        it('should show error alert when trade confirmation errors', async () => {
             const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
             // Mock confirmTrade to throw an error
             mockConfirmTrade.mockRejectedValueOnce(new Error('Trade confirmation failed'));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- when unit tests fail, it is hard to find failed ones because passing ones have fail in their name

## Screenshots:

Before:
<img width="1062" height="894" alt="Screenshot 2025-11-24 at 10 29 13" src="https://github.com/user-attachments/assets/4d7a0316-7ec1-43fa-a89a-af30aef9b553" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/rename-fails-in-tets&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/rename-fails-in-tets&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/rename-fails-in-tets&lookback=7)