### PR TITLE
chore(suite): secure sync moved back to debug

### DIFF
--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -1,5 +1,4 @@
 import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
-import { suiteSyncActions } from '@suite-common/suite-sync';
 import { Route } from '@suite-common/suite-types';
 import { networksCollection } from '@suite-common/wallet-config';
 import { isDesktop } from '@trezor/env-utils';
@@ -17,8 +16,8 @@ export type ExperimentalFeature =
     | 'password-manager'
     | 'tor-external'
     | 'nft-section'
-    | 'experimental-networks'
-    | 'suite-sync';
+    | 'experimental-networks';
+// | 'suite-sync';
 
 export type ExperimentalFeatureConfig = {
     title: ExtendedMessageDescriptor;
@@ -71,7 +70,8 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
             },
         },
     },
-    'suite-sync': {
+    // temporarily disabled, moved to debug
+    /*     'suite-sync': {
         title: { id: 'TR_EXPERIMENTAL_SUITE_SYNC_TITLE' },
         description: { id: 'TR_EXPERIMENTAL_SUITE_SYNC_DESCRIPTION' },
         onToggle: ({ newValue, dispatch }) => {
@@ -81,5 +81,5 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
                 }),
             );
         },
-    },
+    }, */
 };

--- a/packages/suite/src/views/settings/SettingsDebug/LocalFirstStorageSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/LocalFirstStorageSettings.tsx
@@ -17,11 +17,14 @@ import { useLabelingCombined } from 'src/hooks/suite/useLabelingCombined';
 export const LocalFirstStorageSettings = () => {
     const [isLoading, setIsLoading] = useState(false);
 
-    const { isLocalFirstStorageDebugEnabled, isFeatureLocalFirstStorageAvailable } =
-        useLabelingCombined({
-            // In debug, there may not be any device selected and it is in fact irrelevant
-            deviceStaticSessionId: undefined,
-        });
+    const {
+        isLocalFirstStorageDebugEnabled,
+        isFeatureLocalFirstStorageAvailable,
+        toggleIsFeatureLocalFirstStorageAvailable,
+    } = useLabelingCombined({
+        // In debug, there may not be any device selected and it is in fact irrelevant
+        deviceStaticSessionId: undefined,
+    });
 
     const localFirstStorageRelayUrl = useSelector(selectLocalFirstStorageRelayUrl);
 
@@ -49,6 +52,18 @@ export const LocalFirstStorageSettings = () => {
 
     return (
         <SettingsSection title="Local First Storage">
+            <SectionItem>
+                <TextColumn
+                    title="Local First Storage (Evolu)"
+                    description="This enables Local First Storage (Evolu) for labeling in the application settings. This is an experimental feature."
+                />
+                <ActionColumn>
+                    <Checkbox
+                        isChecked={isFeatureLocalFirstStorageAvailable}
+                        onClick={toggleIsFeatureLocalFirstStorageAvailable}
+                    />
+                </ActionColumn>
+            </SectionItem>
             {!isFeatureLocalFirstStorageAvailable && (
                 <p>
                     Enable Local First Storage is disabled. To use Local First Storage (Evolu),


### PR DESCRIPTION
Sneak suite-sync back to debug. :suspect: 



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/evolu/back-to-debug&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/evolu/back-to-debug&lookback=7)