### PR TITLE
fix: enable SuiteSync work differently on Mobile

### DIFF
--- a/suite-native/module-dev-utils/src/components/SuiteSyncRelaySettings.tsx
+++ b/suite-native/module-dev-utils/src/components/SuiteSyncRelaySettings.tsx
@@ -16,7 +16,7 @@ import { useToast } from '@suite-native/toasts';
 
 const DEFAULT_CUSTOM_RELAY_URL = '';
 
-export const LocalFirstRelaySettings = () => {
+export const SuiteSyncRelaySettings = () => {
     const localFirstStorageRelayUrl = useSelector(selectLocalFirstStorageRelayUrl);
     const isFeatureLocalFirstStorageEnabled = useSelector(
         selectIsFeatureLocalFirstStorageAvailable,
@@ -43,9 +43,16 @@ export const LocalFirstRelaySettings = () => {
 
     const handleLocalFirstEnableToggle = () => {
         const originalIsLocalFirstStorageEnabled = isFeatureLocalFirstStorageEnabled;
+        // This is probably irrelevant for native
         dispatch(
             suiteSyncActions.updateIsFeatureLocalFirstStorageAvailable({
                 isShownInSettings: !isFeatureLocalFirstStorageEnabled,
+            }),
+        );
+        // Here, we need this as well,as we don't have experimental feature in Native
+        dispatch(
+            suiteSyncActions.updateLocalFirstStorageEnabled({
+                isEnabled: !isFeatureLocalFirstStorageEnabled,
             }),
         );
 

--- a/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
@@ -20,9 +20,9 @@ import { getCommitHash, getSuiteVersion } from '@trezor/env-utils';
 
 import { FeatureFlags } from '../components/FeatureFlags';
 import { FirmwareUpdateEnvironmentSelect } from '../components/FirmwareUpdateEnvironmentSelect';
-import { LocalFirstRelaySettings } from '../components/LocalFirstRelaySettings';
 import { MessageSystemInfo } from '../components/MessageSystemInfo';
 import { RenderingUtils } from '../components/RenderingUtils';
+import { SuiteSyncRelaySettings } from '../components/SuiteSyncRelaySettings';
 import { TestnetsToggle } from '../components/TestnetsToggle';
 import { TradingDeeplinks } from '../components/TradingDeeplinks';
 import { TradingEnvironmentSelect } from '../components/TradingEnvironmentSelect';
@@ -103,7 +103,7 @@ export const DevUtilsScreen = () => {
                         <FirmwareUpdateEnvironmentSelect />
                     </VStack>
                 </Card>
-                <LocalFirstRelaySettings />
+                <SuiteSyncRelaySettings />
             </VStack>
         </Screen>
     );


### PR DESCRIPTION
Fix: Suite Sync on Mobile

(experimental features are not in mobile)

## QA

If Suite Sync can be turned on and off on mobile, its ok.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-mobile-suite-sync&lookback=7)