### PR TITLE
tests(connect): add passphrase encoding e2e test

### DIFF
--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -190,11 +190,12 @@ export const initTrezorConnect = async (
             hostName: 'tests:e2e',
             staticKey: '0007070707070707070707070707070707070707070707070707070707070747',
             knownCredentials: [
+                // all all seed credential generated from thpPairing.test
                 {
                     trezor_static_public_key:
-                        'f60b84cdb80a2139f80489c811dc129937a4f4f75ca7710c7570c5085f1ffe68',
+                        '566f6976fd42cafadf1b843ce4e6275c930d52efac878217df0ea2a23933b07d',
                     credential:
-                        '0a1c0a0974657374733a65326510011a0d5472657a6f72436f6e6e656374122098264da94889d9b3bd52a61f6e94da83795c83ffb7be34e7e3a06f1c90eb8cfc',
+                        '0a1c0a0974657374733a65326510011a0d5472657a6f72436f6e6e65637412203fa725f325ba34cce19e39e6c87f573a9db1a532c28f67a363f0ea8317f64af9',
                     autoconnect: true,
                 },
             ],

--- a/packages/connect/e2e/tests/device/passphrase.test.ts
+++ b/packages/connect/e2e/tests/device/passphrase.test.ts
@@ -165,6 +165,25 @@ describe('TrezorConnect passphrase', () => {
         });
     });
 
+    it('Passphrase encoding', async () => {
+        TrezorConnect.on('ui-request_passphrase', passphraseHandler('příliš žluťoučký kůň'));
+
+        const xpub = await TrezorConnect.getPublicKey({
+            device: {
+                instance: 0,
+                state: undefined,
+            },
+            path: "m/84'/0'/0'/0/0",
+        });
+
+        if (!xpub.success) {
+            throw new Error(`Passphrase exception: ${xpub.payload.error}`);
+        }
+        expect(xpub.payload).toMatchObject({
+            xpub: 'xpub6Gw8xpZ3YUTF7ebfnT3bGLHYrZ5mRQU14SXfGsjopTx1yVcZwkXSz2TPGyS7zqvzL9McXUjBG87FugyENjxpFCCv5W3ic1SWW5oQbRKx368',
+        });
+    });
+
     // passphrase on device not available on T1B1
     conditionalTest(['1'], 'Input passphrase on device', async () => {
         TrezorConnect.on('ui-request_passphrase', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

in addition to [passphrase issue](https://github.com/trezor/trezor-suite/pull/23349
) im adding passphrase encoding e2e case

testing locally:

### TS5

```
TESTS_PATTERN="passphrase" TESTS_FIRMWARE_MODEL="T3B1" TESTS_TRANSPORT="node-bridge" yarn workspace @trezor/connect test:e2e:node
```

### TS7

```
TESTS_PATTERN="passphrase" TESTS_FIRMWARE_MODEL="T3W1" TESTS_TRANSPORT="node-bridge" yarn workspace @trezor/connect test:e2e:node
```

it should be a part of nightly cross-model testing. is it running with TS7? cc @mroz22


Edit: https://github.com/trezor/trezor-suite/actions/runs/19619657647 turns out nightly jobs are failing (for a long time) because of invalid thp credentials 

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thp-passphrase&lookback=7)