### PR TITLE
chore(suite-desktop): clean up ASSET_PREFIX for desktop vs. other apps

### DIFF
--- a/packages/env-utils/src/__tests__/resolveStaticPath.test.ts
+++ b/packages/env-utils/src/__tests__/resolveStaticPath.test.ts
@@ -13,18 +13,24 @@ describe(resolveStaticPath.name, () => {
 
     it('return default static path with empty ASSET_PREFIX', () => {
         process.env.ASSET_PREFIX = '';
-        expect(resolveStaticPath('mypath')).toBe('./static/mypath');
+        expect(resolveStaticPath('mypath')).toBe('/static/mypath');
     });
 
     it('return default static path with undefined ASSET_PREFIX', () => {
         process.env.ASSET_PREFIX = undefined;
-        expect(resolveStaticPath('mypath')).toBe('./static/mypath');
-        expect(resolveStaticPath('/mypath')).toBe('./static/mypath');
+        expect(resolveStaticPath('mypath')).toBe('/static/mypath');
+        expect(resolveStaticPath('/mypath')).toBe('/static/mypath');
     });
 
-    it('return static path prefixed with ASSET_PREFIX', () => {
+    it('return static path prefixed with branch name ASSET_PREFIX', () => {
         process.env.ASSET_PREFIX = 'branchName';
         expect(resolveStaticPath('mypath')).toBe('branchName/static/mypath');
         expect(resolveStaticPath('/mypath')).toBe('branchName/static/mypath');
+    });
+
+    it('return static path prefixed with ASSET_PREFIX that is used on Suite Desktop', () => {
+        process.env.ASSET_PREFIX = '.';
+        expect(resolveStaticPath('mypath')).toBe('./static/mypath');
+        expect(resolveStaticPath('/mypath')).toBe('./static/mypath');
     });
 });

--- a/packages/env-utils/src/resolveStaticPath.ts
+++ b/packages/env-utils/src/resolveStaticPath.ts
@@ -1,16 +1,21 @@
-const isWeb = () => process.env.SUITE_TYPE === 'web'; // duplicated with envUtils.ts to prevent importing it in mobile
-
-// This needs to be set as `.` so it loads from appDir of the Electron app.
-// For example (in case of AppImage): `file:///tmp/.mount_TrezorAvGo8g/resources/app.asar/build`,
-// where the requested asset (for example: `static/images/images/app-store-badge.svg`) is located.
-const getDefaultAssetPrefix = () => (isWeb() ? '' : '.');
+/*
+ Most apps use empty string as ASSET_PREFIX, which means loading assets from root of location.origin
+ e.g. https://suite.trezor.io/web/settings will load /static/images/logo.svg from https://suite.trezor.io/static/images/logo.svg
+ However on desktop, the app runs from file, for example AppImage: file:///tmp/.mount_TrezorAvGo8g/resources/app.asar/build
+ There is no location.origin, so using /path would incorrectly resolve as file:///path
+ On Desktop, we therefore need to use relative paths, e.g. ./static/images/logo.svg
+ Note that `process` may not be defined (e.g. in storybook), so accessing it without checking would crash.
+*/
+const getEnvAssetPrefix = () =>
+    typeof process !== 'undefined' ? process.env?.ASSET_PREFIX : undefined;
+const getDefaultPrefix = () => getEnvAssetPrefix() ?? '';
 
 export const resolveStaticPath = (
     path: string,
-    pathPrefix: string | undefined = process.env.ASSET_PREFIX,
-) => `${pathPrefix || getDefaultAssetPrefix()}/static/${path.replace(/^\/+/, '')}`;
+    pathPrefix: string | undefined = getDefaultPrefix(),
+) => `${pathPrefix}/static/${path.replace(/^\/+/, '')}`;
 
 export const resolveConnectPath = (
     path: string,
-    pathPrefix: string | undefined = process.env.ASSET_PREFIX,
-) => `${pathPrefix || getDefaultAssetPrefix()}/${path.replace(/^\/+/, '')}`;
+    pathPrefix: string | undefined = getDefaultPrefix(),
+) => `${pathPrefix}/${path.replace(/^\/+/, '')}`;

--- a/packages/suite-build/package.json
+++ b/packages/suite-build/package.json
@@ -17,7 +17,7 @@
         "dev:web": "yarn run web",
         "dev:web:vite": "vite",
         "build:web": "NODE_ENV=production yarn run web",
-        "desktop": "PROJECT=desktop yarn run base",
+        "desktop": "PROJECT=desktop ASSET_PREFIX=. yarn run base",
         "dev:desktop": "yarn run desktop",
         "build:desktop": "NODE_ENV=production yarn run desktop",
         "type-check": "yarn g:tsc --build tsconfig.json",

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/JustUpdated.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/JustUpdated.tsx
@@ -13,16 +13,13 @@ interface AvailableProps {
     onCancel: () => void;
 }
 
-const DEFAULT_ASSET_PREFIX = '.';
-
 export const JustUpdated = ({ onCancel }: AvailableProps) => {
     const [changelog, setChangelog] = useState<string | null>(null);
     const theme = useTheme();
     const suiteCurrentVersion = process.env.VERSION || '';
 
     const getReleaseNotes = useCallback(async () => {
-        const releaseNotesPath =
-            (process.env.ASSET_PREFIX || DEFAULT_ASSET_PREFIX) + '/release-notes.md';
+        const releaseNotesPath = process.env.ASSET_PREFIX + '/release-notes.md';
         const result = await (await fetch(releaseNotesPath)).text();
         setChangelog(result);
     }, []);


### PR DESCRIPTION
## Description

In [#22671](https://github.com/trezor/trezor-suite/pull/22671), a new way of loading assets in Desktop was introduced.
This broke a lot of things :scream: 
This shall be one final PR to properly fix all the hotfixes done in [#23215](https://github.com/trezor/trezor-suite/pull/23215), [#23222](https://github.com/trezor/trezor-suite/pull/23222), [#23260](https://github.com/trezor/trezor-suite/pull/23260)

## Notes for QA
 
:warning: This can break a lot of things!!

Please test what you can think of, if any files are missing (images, icons most likely).
Please [test desktop builds](https://github.com/trezor/trezor-suite/actions/runs/19644054418/)
Please do test trade flows both on desktop & web. There is some effect, it should work, but I don't understand it fully.
This can all be done as part of regular RC tests for 25.12...

I have tested:
- Suite Web local, sldev and Suite Desktop local, built AppImage:
  - Device image, network and token logos, homescreen gallery, images in Guide etc.
- `components` & `product-components` storybook working:
  - icons, flags, images, logos, spinner, I clicked through it all.
- Connect explorer logos, icons
- Desktop release notes

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/resolveStaticPath&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/resolveStaticPath&lookback=7)