### PR TITLE
fix(connect): PaymentRequest amount

### DIFF
--- a/packages/connect/e2e/__fixtures__/signTransactionPaymentRequest.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionPaymentRequest.ts
@@ -13,7 +13,7 @@ export default {
     tests: [
         {
             description: 'Testnet (Bech32/P2WPKH): Payment request success',
-            skip: ['1', '<2.9.3'], // payment requests are not implemented in T1B1 and EC used for signing was changed in 2.9.3
+            skip: ['1', '<2.9.4'], // payment requests are not implemented in T1B1 and proto was changed in 2.9.4
             params: {
                 coin: 'Testnet',
                 inputs: [

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -136,11 +136,26 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
                 );
             }
         }
+        const paymentRequests =
+            payload.paymentRequests?.map(p => {
+                if (typeof p.amount === 'number') {
+                    // convert int to hex string (little endian)
+                    const buffer = Buffer.allocUnsafe(8);
+                    buffer.writeIntLE(p.amount, 0, 6);
+
+                    return {
+                        ...p,
+                        amount: buffer.toString('hex'),
+                    };
+                }
+
+                return { ...p, amount: p.amount };
+            }) ?? [];
 
         this.params = {
             inputs,
             outputs,
-            paymentRequests: payload.paymentRequests ?? [],
+            paymentRequests,
             refTxs,
             addresses: payload.account ? payload.account.addresses : undefined,
             options: {

--- a/packages/connect/src/types/api/bitcoin/index.ts
+++ b/packages/connect/src/types/api/bitcoin/index.ts
@@ -66,10 +66,14 @@ export interface TransactionOptions {
     chunkify?: boolean;
 }
 
+export interface PaymentRequest extends Omit<PROTO.PaymentRequest, 'amount'> {
+    amount?: string | number;
+}
+
 export interface SignTransaction {
     inputs: ProtoWithDerivationPath<PROTO.TxInputType>[];
     outputs: ProtoWithDerivationPath<PROTO.TxOutputType>[];
-    paymentRequests?: PROTO.PaymentRequest[];
+    paymentRequests?: PaymentRequest[];
     refTxs?: RefTransaction[];
     account?: {
         addresses: AccountAddresses;

--- a/packages/protobuf/scripts/protobuf-patches/index.ts
+++ b/packages/protobuf/scripts/protobuf-patches/index.ts
@@ -273,6 +273,7 @@ export const TYPE_PATCH = {
     'MoneroTransferDetails.tx_pub_key': 'Uint8Array',
     'MoneroTransferDetails.additional_tx_pub_keys': 'Uint8Array',
     'ThpDeviceProperties.pairing_methods': '(keyof typeof ThpPairingMethod)',
+    'PaymentRequest.amount': 'string',
 };
 
 export const readPatch = (file: string) =>

--- a/packages/protobuf/src/messages-schema.ts
+++ b/packages/protobuf/src/messages-schema.ts
@@ -108,7 +108,7 @@ export const PaymentRequest = Type.Object(
         nonce: Type.Optional(Type.String()),
         recipient_name: Type.String(),
         memos: Type.Optional(Type.Array(PaymentRequestMemo)),
-        amount: Type.Optional(Type.Uint()),
+        amount: Type.Optional(Type.String()),
         signature: Type.String(),
     },
     { $id: 'PaymentRequest' },

--- a/packages/protobuf/src/messages.ts
+++ b/packages/protobuf/src/messages.ts
@@ -78,7 +78,7 @@ export type PaymentRequest = {
     nonce?: string;
     recipient_name: string;
     memos?: PaymentRequestMemo[];
-    amount?: UintType;
+    amount?: string;
     signature: string;
 };
 


### PR DESCRIPTION
## Description

The type for PaymentRequest amount has been changed [in FW](https://github.com/trezor/trezor-firmware/pull/5996), we updated the protobuf, but the encoding was broken. We need to fix that manually here. 
Fortunately this is shouldn't be used in production anywhere. 

## Notes for QA

Fixes methods-btc-sign in Connect E2E - but after we merge updated TENV

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/paymentrequest-amount&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/paymentrequest-amount&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/paymentrequest-amount&lookback=7)