### PR TITLE
test(connect): catch controller.getPairingInfo failure

### DIFF
--- a/packages/connect/e2e/tests/device/thpPairing.test.ts
+++ b/packages/connect/e2e/tests/device/thpPairing.test.ts
@@ -1,4 +1,4 @@
-import TrezorConnect, { ConnectSettings, Device } from '../../../src';
+import TrezorConnect, { ConnectSettings, Device, UiEvent } from '../../../src';
 import { getController, initTrezorConnect, setup } from '../../common.setup';
 
 describe('THP pairing', () => {
@@ -40,6 +40,16 @@ describe('THP pairing', () => {
         });
     };
 
+    const getPairingInfo = ({
+        device,
+        nfcData,
+    }: Extract<UiEvent, { type: 'ui-request_thp_pairing' }>['payload']) =>
+        controller.getPairingInfo(device.thp!.channel, nfcData).catch(e => {
+            console.error('DebugLinkGetPairingInfo', device.thp!.channel, e);
+
+            return { error: e.message };
+        });
+
     it('ThpPairing SkipPairing', async () => {
         const spy = typeof jest !== 'undefined' ? jest.fn() : jasmine.createSpy('on.button');
         const device = await waitForDevice({ pairingMethods: ['SkipPairing'] });
@@ -57,10 +67,8 @@ describe('THP pairing', () => {
     it('ThpPairing NFC', async () => {
         const device = await waitForDevice({ pairingMethods: ['NFC'] });
 
-        // eslint-disable-next-line @typescript-eslint/no-shadow
-        TrezorConnect.on('ui-request_thp_pairing', async ({ device, nfcData }) => {
-            // await new Promise(resolve => setTimeout(resolve, 1000));
-            const state = await controller.getPairingInfo(device.thp!.channel, nfcData);
+        TrezorConnect.on('ui-request_thp_pairing', async event => {
+            const state = await getPairingInfo(event);
             TrezorConnect.removeAllListeners('ui-request_thp_pairing');
             TrezorConnect.uiResponse({
                 type: 'ui-receive_thp_pairing_tag',
@@ -118,8 +126,8 @@ describe('THP pairing', () => {
             typeof jest !== 'undefined' ? jest.fn() : jasmine.createSpy('credentials');
         TrezorConnect.on('device-thp_credentials_changed', credentialsSpy);
 
-        TrezorConnect.on('ui-request_thp_pairing', async ({ nfcData }) => {
-            const state = await controller.getPairingInfo(device.thp!.channel, nfcData);
+        TrezorConnect.on('ui-request_thp_pairing', async event => {
+            const state = await getPairingInfo(event);
             TrezorConnect.uiResponse({
                 type: 'ui-receive_thp_pairing_tag',
                 payload: { source: 'code-entry', tag: state.code_entry_code },
@@ -235,8 +243,8 @@ describe('THP pairing', () => {
         TrezorConnect.removeAllListeners('ui-button');
         TrezorConnect.removeAllListeners('ui-request_thp_pairing');
         TrezorConnect.on('ui-button', buttonRequestHandler());
-        TrezorConnect.on('ui-request_thp_pairing', async ({ nfcData, ...rest }) => {
-            const state = await controller.getPairingInfo(rest.device.thp!.channel, nfcData);
+        TrezorConnect.on('ui-request_thp_pairing', async event => {
+            const state = await getPairingInfo(event);
             TrezorConnect.uiResponse({
                 type: 'ui-receive_thp_pairing_tag',
                 payload: { source: 'code-entry', tag: state.code_entry_code },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

if `user-env` throws error from `getPairingInfo` then the test is left hanging on pairing input and eventually timeouts.

this is happening because getPairingInfo is called inside TrezorConnect event handler - so if failue happens here  TrezorConnect.uiResponse is never called.

With this fix controller error is logged and test flow continues with empty data (empty pairing info) which leads to invalid pairing (and test failure)

I think there may be multiple other cases like that in connect or suite tests (calling controller methods inside event handler without catching error)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-e2e-contoller-failure&lookback=7)