### PR TITLE
chore(suite): staking rewards frequency & next rewards

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9881,6 +9881,10 @@ export default defineMessages({
         id: 'TR_STAKE_NEXT_PAYOUT',
         defaultMessage: 'Next reward payout',
     },
+    TR_STAKE_NEXT_PAYOUT_FREQUENCY: {
+        id: 'TR_STAKE_NEXT_PAYOUT_FREQUENCY',
+        defaultMessage: 'Reward cycle',
+    },
     TR_STAKE_STAKE_MORE: {
         id: 'TR_STAKE_STAKE_MORE',
         defaultMessage: 'Stake more',

--- a/packages/suite/src/views/wallet/staking/components/CardanoStakingDashboard/NewCardanoStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/CardanoStakingDashboard/NewCardanoStakingDashboard.tsx
@@ -23,7 +23,7 @@ import { ApyCard } from '../StakingDashboard/components/ApyCard';
 import { ClaimCard } from '../StakingDashboard/components/ClaimCard';
 import { DiscoveryWarning } from '../StakingDashboard/components/DiscoveryWarning';
 import { EmptyStakingCard } from '../StakingDashboard/components/EmptyStakingCard';
-import { PayoutCard } from '../StakingDashboard/components/PayoutCard';
+import { PayoutCardFrequencyRewards } from '../StakingDashboard/components/PayoutCardFrequencyRewards';
 import { StakingCard } from '../StakingDashboard/components/StakingCard';
 interface NewCardanoStakingDashboardProps {
     selectedAccount: SelectedAccountLoaded;
@@ -78,10 +78,8 @@ export const NewCardanoStakingDashboard = ({
                                     <ClaimCard />
                                     <Flex direction={canClaim ? 'column' : 'row'} gap={spacings.sm}>
                                         <ApyCard apy={isStakedWithEverstake ? apy : undefined} />
-                                        <PayoutCard
-                                            nextRewardPayout={CARDANO_EPOCH_DAYS}
-                                            daysToAddToPool={CARDANO_EPOCH_DAYS}
-                                            validatorWithdrawTime={0}
+                                        <PayoutCardFrequencyRewards
+                                            rewardFrequency={CARDANO_EPOCH_DAYS}
                                         />
                                     </Flex>
                                 </Grid>

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EthStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EthStakingDashboard.tsx
@@ -28,7 +28,7 @@ import { ApyCard } from '../../StakingDashboard/components/ApyCard';
 import { ClaimCard } from '../../StakingDashboard/components/ClaimCard';
 import { DiscoveryWarning } from '../../StakingDashboard/components/DiscoveryWarning';
 import { EmptyStakingCard } from '../../StakingDashboard/components/EmptyStakingCard';
-import { PayoutCard } from '../../StakingDashboard/components/PayoutCard';
+import { PayoutCardNextRewards } from '../../StakingDashboard/components/PayoutCardNextRewards';
 import { StakingCard } from '../../StakingDashboard/components/StakingCard';
 import { Transactions } from '../../StakingDashboard/components/Transactions';
 
@@ -108,7 +108,7 @@ export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProp
                                     <ClaimCard />
                                     <Flex direction={canClaim ? 'column' : 'row'} gap={spacings.sm}>
                                         <ApyCard apy={apy} />
-                                        <PayoutCard
+                                        <PayoutCardNextRewards
                                             nextRewardPayout={nextRewardPayout}
                                             daysToAddToPool={daysToAddToPool}
                                             validatorWithdrawTime={data?.validatorWithdrawTime}

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
@@ -25,7 +25,7 @@ import { ApyCard } from '../StakingDashboard/components/ApyCard';
 import { ClaimCard } from '../StakingDashboard/components/ClaimCard';
 import { DiscoveryWarning } from '../StakingDashboard/components/DiscoveryWarning';
 import { EmptyStakingCard } from '../StakingDashboard/components/EmptyStakingCard';
-import { PayoutCard } from '../StakingDashboard/components/PayoutCard';
+import { PayoutCardFrequencyRewards } from '../StakingDashboard/components/PayoutCardFrequencyRewards';
 import { StakingCard } from '../StakingDashboard/components/StakingCard';
 
 interface SolStakingDashboardProps {
@@ -84,10 +84,8 @@ export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProp
                                             gap={spacings.sm}
                                         >
                                             <ApyCard apy={apy} />
-                                            <PayoutCard
-                                                nextRewardPayout={SOLANA_EPOCH_DAYS}
-                                                daysToAddToPool={SOLANA_EPOCH_DAYS}
-                                                validatorWithdrawTime={0}
+                                            <PayoutCardFrequencyRewards
+                                                rewardFrequency={SOLANA_EPOCH_DAYS}
                                             />
                                         </Flex>
                                     </Grid>

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/PayoutCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/PayoutCard.tsx
@@ -1,63 +1,17 @@
-import { useMemo } from 'react';
+import { ReactNode } from 'react';
 
-import { BACKUP_REWARD_PAYOUT_DAYS } from '@suite-common/wallet-constants';
-import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
-import { Card, Column, Icon, Paragraph } from '@trezor/components';
+import { Card, Column, Icon } from '@trezor/components';
 import { spacings } from '@trezor/theme';
-import { BigNumber } from '@trezor/utils/src/bigNumber';
-
-import { Translation } from 'src/components/suite/Translation';
-import { useSelector } from 'src/hooks/suite';
-import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 
 interface PayoutCardProps {
-    nextRewardPayout?: number | null;
-    daysToAddToPool?: number;
-    validatorWithdrawTime?: number;
+    children: ReactNode;
 }
 
-export const PayoutCard = ({
-    nextRewardPayout,
-    daysToAddToPool,
-    validatorWithdrawTime,
-}: PayoutCardProps) => {
-    const selectedAccount = useSelector(selectSelectedAccount);
-
-    const { autocompoundBalance = '0' } = getStakingDataForNetwork(selectedAccount) ?? {};
-
-    const payout = useMemo(() => {
-        if (!nextRewardPayout || !daysToAddToPool) return undefined;
-
-        if (new BigNumber(autocompoundBalance).gt(0) || daysToAddToPool <= nextRewardPayout) {
-            return nextRewardPayout;
-        }
-
-        if (!validatorWithdrawTime) return undefined;
-
-        return Math.round(validatorWithdrawTime / 60 / 60 / 24) + nextRewardPayout;
-    }, [autocompoundBalance, daysToAddToPool, nextRewardPayout, validatorWithdrawTime]);
-
-    return (
-        <Card paddingType="small" flex="1">
-            <Column alignItems="flex-start" flex="1" gap={spacings.lg}>
-                <Icon name="calendar" variant="tertiary" />
-
-                <Column margin={{ top: 'auto' }}>
-                    <Paragraph typographyStyle="titleMedium">
-                        {payout === undefined ? (
-                            <Translation
-                                id="TR_STAKE_MAX_REWARD_DAYS"
-                                values={{ count: BACKUP_REWARD_PAYOUT_DAYS }}
-                            />
-                        ) : (
-                            <Translation id="TR_STAKE_DAYS" values={{ count: payout }} />
-                        )}
-                    </Paragraph>
-                    <Paragraph typographyStyle="hint" variant="tertiary">
-                        <Translation id="TR_STAKE_NEXT_PAYOUT" />
-                    </Paragraph>
-                </Column>
-            </Column>
-        </Card>
-    );
-};
+export const PayoutCard = ({ children }: PayoutCardProps) => (
+    <Card paddingType="small" flex="1">
+        <Column alignItems="flex-start" flex="1" gap={spacings.lg}>
+            <Icon name="calendar" variant="tertiary" />
+            <Column margin={{ top: 'auto' }}>{children}</Column>
+        </Column>
+    </Card>
+);

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/PayoutCardFrequencyRewards.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/PayoutCardFrequencyRewards.tsx
@@ -1,0 +1,24 @@
+import { Paragraph } from '@trezor/components';
+
+import { Translation } from 'src/components/suite/Translation';
+
+import { PayoutCard } from './PayoutCard';
+
+interface PayoutCardFrequencyRewardsProps {
+    rewardFrequency: number;
+}
+
+export const PayoutCardFrequencyRewards = ({
+    rewardFrequency,
+}: PayoutCardFrequencyRewardsProps) => (
+    <PayoutCard>
+        <>
+            <Paragraph typographyStyle="titleMedium">
+                <Translation id="TR_STAKE_DAYS" values={{ count: rewardFrequency }} />
+            </Paragraph>
+            <Paragraph typographyStyle="hint" variant="tertiary">
+                <Translation id="TR_STAKE_NEXT_PAYOUT_FREQUENCY" />
+            </Paragraph>
+        </>
+    </PayoutCard>
+);

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/PayoutCardNextRewards.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/PayoutCardNextRewards.tsx
@@ -1,0 +1,60 @@
+import { useMemo } from 'react';
+
+import { BACKUP_REWARD_PAYOUT_DAYS } from '@suite-common/wallet-constants';
+import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
+import { Paragraph } from '@trezor/components';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
+
+import { Translation } from 'src/components/suite/Translation';
+import { useSelector } from 'src/hooks/suite';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+
+import { PayoutCard } from './PayoutCard';
+
+interface PayoutCardNextRewardsProps {
+    nextRewardPayout?: number | null;
+    daysToAddToPool?: number;
+    validatorWithdrawTime?: number;
+}
+
+export const PayoutCardNextRewards = ({
+    nextRewardPayout,
+    daysToAddToPool,
+    validatorWithdrawTime,
+}: PayoutCardNextRewardsProps) => {
+    const selectedAccount = useSelector(selectSelectedAccount);
+
+    const { autocompoundBalance = '0' } = getStakingDataForNetwork(selectedAccount) ?? {};
+
+    const payout = useMemo(() => {
+        if (!nextRewardPayout || !daysToAddToPool) return undefined;
+
+        if (new BigNumber(autocompoundBalance).gt(0) || daysToAddToPool <= nextRewardPayout) {
+            return nextRewardPayout;
+        }
+
+        if (!validatorWithdrawTime) return undefined;
+
+        return Math.round(validatorWithdrawTime / 60 / 60 / 24) + nextRewardPayout;
+    }, [autocompoundBalance, daysToAddToPool, nextRewardPayout, validatorWithdrawTime]);
+
+    return (
+        <PayoutCard>
+            <>
+                <Paragraph typographyStyle="titleMedium">
+                    {payout === undefined ? (
+                        <Translation
+                            id="TR_STAKE_MAX_REWARD_DAYS"
+                            values={{ count: BACKUP_REWARD_PAYOUT_DAYS }}
+                        />
+                    ) : (
+                        <Translation id="TR_STAKE_DAYS" values={{ count: payout }} />
+                    )}
+                </Paragraph>
+                <Paragraph typographyStyle="hint" variant="tertiary">
+                    <Translation id="TR_STAKE_NEXT_PAYOUT" />
+                </Paragraph>
+            </>
+        </PayoutCard>
+    );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- we know exact time when you get rewards on Ethereum
- we do not know exact time when you get rewards on Solana and Cardano so frequency is shown


## Screenshots:

<img width="483" height="282" alt="Screenshot 2025-11-25 at 13 28 16" src="https://github.com/user-attachments/assets/6a211456-989e-493d-9d77-edc520c2b850" />
<img width="481" height="413" alt="Screenshot 2025-11-25 at 13 28 08" src="https://github.com/user-attachments/assets/6409c239-d43e-422a-a711-1202c96e078e" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/payout&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/payout&lookback=7)