### PR TITLE
Translation simplification

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareWipeWarning.tsx
+++ b/packages/suite/src/components/firmware/FirmwareWipeWarning.tsx
@@ -1,6 +1,7 @@
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { Banner, Paragraph, Text } from '@trezor/components';
 
-import { ExtendedMessageDescriptor, Translation } from 'src/components/suite/Translation';
+import { Translation } from 'src/components/suite/Translation';
 
 export const FirmwareWipeWarning = () => {
     const warningTranslationValues: ExtendedMessageDescriptor['values'] = {

--- a/packages/suite/src/components/suite/QuestionTooltip.tsx
+++ b/packages/suite/src/components/suite/QuestionTooltip.tsx
@@ -2,10 +2,10 @@ import { JSX } from 'react';
 
 import styled from 'styled-components';
 
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { H3, Tooltip } from '@trezor/components';
 
 import { Translation } from 'src/components/suite/Translation';
-import { ExtendedMessageDescriptor } from 'src/types/suite';
 
 const Wrapper = styled.div`
     display: flex;

--- a/packages/suite/src/components/suite/ReadMoreLink.tsx
+++ b/packages/suite/src/components/suite/ReadMoreLink.tsx
@@ -1,8 +1,8 @@
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import * as URLS from '@trezor/urls';
 
 import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
-import { ExtendedMessageDescriptor } from 'src/types/suite';
 
 interface ReadMoreLinkProps {
     url: keyof Omit<typeof URLS, 'TOR_URLS' | 'SUITE_TRADING_REDIRECT_DEEPLINKS'>;

--- a/packages/suite/src/components/suite/Translation.tsx
+++ b/packages/suite/src/components/suite/Translation.tsx
@@ -12,26 +12,23 @@ import messages from '../../support/messages';
 
 export type TranslationKey = keyof typeof messages;
 
-type OwnProps = {
-    isNested?: boolean;
-};
-
 export type ExtendedMessageDescriptor = CommonExtendedMessageDescriptor;
-type MsgType = OwnProps & ExtendedMessageDescriptor;
 
 export const isMsgType = (
-    props: MsgType | ReactNode | ExtendedMessageDescriptor | Date | FormatXMLElementFn,
-): props is MsgType =>
-    typeof props === 'object' && props !== null && (props as MsgType).id !== undefined;
+    props: ReactNode | ExtendedMessageDescriptor | Date | FormatXMLElementFn,
+): props is ExtendedMessageDescriptor =>
+    typeof props === 'object' &&
+    props !== null &&
+    (props as ExtendedMessageDescriptor).id !== undefined;
 
-export const Translation = (props: MsgType) => {
+export const Translation = (props: ExtendedMessageDescriptor) => {
     const values: Record<string, any> = {};
     // message passed via props (id, defaultMessage, values)
     Object.keys(props.values || []).forEach(key => {
         // Iterates through all values. The entry may also contain a MessageDescriptor.
         // If so, Renders MessageDescriptor by passing it to `Translation` component
         const maybeMsg = props.values![key];
-        values[key] = isMsgType(maybeMsg) ? <Translation {...maybeMsg} isNested /> : maybeMsg;
+        values[key] = isMsgType(maybeMsg) ? <Translation {...maybeMsg} /> : maybeMsg;
     });
 
     // prevent runtime errors
@@ -43,12 +40,10 @@ export const Translation = (props: MsgType) => {
         return <>{`Unknown translation id: ${props.id}`}</>;
     }
 
-    const defaultTagName = props.isNested ? undefined : 'span';
-
     return (
         <FormattedMessage
             id={props.id}
-            {...(defaultTagName === undefined ? {} : { tagName: defaultTagName })} // needed due to: "exactOptionalPropertyTypes": true
+            tagName="span"
             defaultMessage={props.defaultMessage || messages[props.id].defaultMessage}
             // pass undefined to a 'values' prop in case of an empty values object
             {...(Object.keys(values).length === 0 ? {} : { values })} // needed due to: "exactOptionalPropertyTypes": true

--- a/packages/suite/src/components/suite/Translation.tsx
+++ b/packages/suite/src/components/suite/Translation.tsx
@@ -1,10 +1,6 @@
-import { ReactNode } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import {
-    ExtendedMessageDescriptor as CommonExtendedMessageDescriptor,
-    FormatXMLElementFn,
-} from '@suite-common/intl-types';
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 
 // We cannot use aliases here because this file is directly imported by the @suite-common/intl-types
 // It's little hacky by this will be solved when PR for refactor intl will be merged.
@@ -12,41 +8,18 @@ import messages from '../../support/messages';
 
 export type TranslationKey = keyof typeof messages;
 
-export type ExtendedMessageDescriptor = CommonExtendedMessageDescriptor;
-
-export const isMsgType = (
-    props: ReactNode | ExtendedMessageDescriptor | Date | FormatXMLElementFn,
-): props is ExtendedMessageDescriptor =>
-    typeof props === 'object' &&
-    props !== null &&
-    (props as ExtendedMessageDescriptor).id !== undefined;
-
-export const Translation = (props: ExtendedMessageDescriptor) => {
-    const values: Record<string, any> = {};
-    // message passed via props (id, defaultMessage, values)
-    Object.keys(props.values || []).forEach(key => {
-        // Iterates through all values. The entry may also contain a MessageDescriptor.
-        // If so, Renders MessageDescriptor by passing it to `Translation` component
-        const maybeMsg = props.values![key];
-        values[key] = isMsgType(maybeMsg) ? <Translation {...maybeMsg} /> : maybeMsg;
-    });
-
+export const Translation = ({ defaultMessage, id, values }: ExtendedMessageDescriptor) => {
     // prevent runtime errors
-    if (
-        !props.defaultMessage &&
-        Object.prototype.hasOwnProperty.call(props, 'id') &&
-        !messages[props.id]
-    ) {
-        return <>{`Unknown translation id: ${props.id}`}</>;
+    if (!defaultMessage && id !== undefined && !messages[id]) {
+        return <>{`Unknown translation id: ${id}`}</>;
     }
 
     return (
         <FormattedMessage
-            id={props.id}
+            id={id}
             tagName="span"
-            defaultMessage={props.defaultMessage || messages[props.id].defaultMessage}
-            // pass undefined to a 'values' prop in case of an empty values object
-            {...(Object.keys(values).length === 0 ? {} : { values })} // needed due to: "exactOptionalPropertyTypes": true
+            defaultMessage={defaultMessage || messages[id].defaultMessage}
+            {...(values !== undefined && Object.keys(values).length === 0 ? {} : { values })} // needed due to: "exactOptionalPropertyTypes": true
         />
     );
 };

--- a/packages/suite/src/components/suite/__tests__/Translation.test.tsx
+++ b/packages/suite/src/components/suite/__tests__/Translation.test.tsx
@@ -38,11 +38,12 @@ describe('Translation component', () => {
 
     test('renders message with nested messages', () => {
         renderWithIntl(
+            // @ts-expect-error: fake id for testing
             <Translation
                 {...messages.TR_HELLO_NAME}
                 values={{
                     // @ts-expect-error: fake id for testing
-                    TR_NAME: { ...messages.TR_NAME, values: { name: 'John' } },
+                    TR_NAME: <Translation {...messages.TR_NAME} values={{ name: 'John' }} />,
                     TR_AGE: 100,
                 }}
             />,

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/ConditionalActionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/ConditionalActionRenderer.tsx
@@ -1,9 +1,9 @@
 import { JSX, ReactNode } from 'react';
 
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { Paragraph } from '@trezor/components';
 
 import type { NotificationRendererProps } from 'src/components/suite';
-import type { ExtendedMessageDescriptor } from 'src/types/suite';
 
 type ConditionalActionRendererProps = NotificationRendererProps & {
     header: ReactNode;

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -1,6 +1,7 @@
 import { ComponentType, JSX } from 'react';
 import { useSelector } from 'react-redux';
 
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { AUTH_DEVICE, type NotificationEntry } from '@suite-common/toast-notifications';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
@@ -8,13 +9,13 @@ import { DEVICE } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
 import { NotificationViewProps } from 'src/components/suite';
-import type { ExtendedMessageDescriptor } from 'src/types/suite';
 
 import { ActionRenderer } from './ActionRenderer';
 import { AutoEjectRenderer } from './AutoEjectRenderer';
 import { CoinProtocolRenderer } from './CoinProtocolRenderer';
 import { ExchangeInfoRenderer } from './ExchangeInfoRenderer';
 import { TransactionRenderer } from './TransactionRenderer';
+import { Translation } from '../../Translation';
 
 const simple = (
     View: NotificationRendererProps['render'],
@@ -78,7 +79,7 @@ export const NotificationRenderer = ({
             return error(render, notification, 'TOAST_ACQUIRE_ERROR');
         case 'auth-confirm-error':
             return error(render, notification, 'TOAST_AUTH_CONFIRM_ERROR', {
-                error: notification.error || { id: 'TOAST_AUTH_CONFIRM_ERROR_DEFAULT' },
+                error: notification.error || <Translation id="TOAST_AUTH_CONFIRM_ERROR_DEFAULT" />,
             });
         case 'discovery-error':
             return error(render, notification, 'TOAST_DISCOVERY_ERROR');
@@ -295,7 +296,7 @@ export const NotificationRenderer = ({
                     variant="warning"
                     message="EVENT_DEVICE_CONNECT_UNACQUIRED"
                     messageValues={{
-                        label: { id: 'TR_UNACQUIRED' },
+                        label: <Translation id="TR_UNACQUIRED" />,
                     }}
                 />
             );

--- a/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView.tsx
+++ b/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView.tsx
@@ -1,5 +1,6 @@
 import { JSX } from 'react';
 
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import type { NotificationEntry } from '@suite-common/toast-notifications';
 import { Button, ButtonProps, Column, Icon, IconName, Paragraph, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
@@ -7,7 +8,7 @@ import { spacings } from '@trezor/theme';
 import { FormattedDateWithBullet } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { useLayoutSize } from 'src/hooks/suite';
-import type { ExtendedMessageDescriptor, ToastNotificationVariant } from 'src/types/suite';
+import type { ToastNotificationVariant } from 'src/types/suite';
 import { getNotificationIcon } from 'src/utils/suite/notification';
 
 export type NotificationActionVariant = 'primary' | 'info' | 'warning' | 'destructive' | 'tertiary';

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionRow.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionRow.tsx
@@ -1,3 +1,4 @@
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { SignOperator } from '@suite-common/suite-types';
 import { selectBaseCurrency, selectHistoricFiatRatesByTimestamp } from '@suite-common/wallet-core';
 import { Timestamp } from '@suite-common/wallet-types';
@@ -12,7 +13,6 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
-import { ExtendedMessageDescriptor } from 'src/types/suite';
 import { WalletAccountTransaction } from 'src/types/wallet';
 
 import { TransactionTargetLayout } from './TransactionTargetLayout';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
@@ -78,7 +78,7 @@ export const RefreshAfterDiscoveryNeeded = () => {
                     ) : (
                         <DiscoveryButtonContainer {...animationConfig}>
                             <AccountsMenuNotice>
-                                <Translation id="TR_DISCOVERY_NEW_COINS_TEXT" isNested={false} />
+                                <Translation id="TR_DISCOVERY_NEW_COINS_TEXT" />
                             </AccountsMenuNotice>
 
                             <Button

--- a/packages/suite/src/hooks/suite/useTranslation.ts
+++ b/packages/suite/src/hooks/suite/useTranslation.ts
@@ -1,10 +1,10 @@
 import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
 
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { PrimitiveType } from '@trezor/type-utils';
 
 import messages from 'src/support/messages';
-import { ExtendedMessageDescriptor } from 'src/types/suite';
 
 export type TranslationFunction = (
     id: ExtendedMessageDescriptor['id'],

--- a/packages/suite/src/hooks/wallet/sign-verify/useSignAddressOptions.ts
+++ b/packages/suite/src/hooks/wallet/sign-verify/useSignAddressOptions.ts
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
 
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { getStakingPath } from '@suite-common/wallet-utils';
 
 import { useTranslation } from 'src/hooks/suite';
 import type { State as RevealedAddresses } from 'src/reducers/wallet/receiveReducer';
-import type { ExtendedMessageDescriptor } from 'src/types/suite';
 import type { Account } from 'src/types/wallet';
 
 export type AddressItem = {

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -51,7 +51,6 @@ export type {
     UnknownDevice,
     UnreadableDevice,
 } from '@suite-common/suite-types';
-export type { ExtendedMessageDescriptor } from 'src/components/suite/Translation';
 export type { AppState } from 'src/reducers/store';
 export type { PrerequisiteType } from 'src/utils/suite/prerequisites';
 export type { Route };

--- a/packages/suite/src/types/trading/trading.ts
+++ b/packages/suite/src/types/trading/trading.ts
@@ -8,6 +8,7 @@ import {
     SellProviderInfo,
 } from 'invity-api';
 
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { TokenDefinitionsState } from '@suite-common/token-definitions';
 import type {
     TradingBuyInfoSelector,
@@ -32,7 +33,6 @@ import { StaticSessionId } from '@trezor/connect';
 import { AssetLogoProps, AssetOptionBaseProps } from '@trezor/product-components';
 
 import { GetDefaultAccountLabelParams } from 'src/hooks/suite/useDefaultAccountLabel';
-import { ExtendedMessageDescriptor } from 'src/types/suite';
 
 export type TradingPageType = 'form' | 'offers' | 'confirm' | 'retry';
 

--- a/packages/suite/src/types/trading/tradingVerify.ts
+++ b/packages/suite/src/types/trading/tradingVerify.ts
@@ -3,9 +3,9 @@ import { UseFormReturn } from 'react-hook-form';
 
 import { CryptoId } from 'invity-api';
 
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { AccountAddress } from '@trezor/connect';
 
-import { ExtendedMessageDescriptor } from 'src/types/suite';
 import type { Account } from 'src/types/wallet';
 
 export interface TradingVerifyFormProps {

--- a/packages/suite/src/utils/firmware/index.ts
+++ b/packages/suite/src/utils/firmware/index.ts
@@ -1,9 +1,10 @@
 import { satisfies, valid } from 'semver';
 
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { FirmwareType } from '@trezor/connect';
 import { DeviceModelInternal, getFirmwareVersion } from '@trezor/device-utils';
 
-import { type ExtendedMessageDescriptor, type TrezorDevice } from 'src/types/suite';
+import { type TrezorDevice } from 'src/types/suite';
 
 export const getFormattedFingerprint = (fingerprint: string) =>
     [

--- a/packages/suite/src/utils/wallet/trading/tradingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingUtils.ts
@@ -1,5 +1,6 @@
 import { CryptoId, FiatCurrencyCode } from 'invity-api';
 
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { DefinitionType, isTokenDefinitionKnown } from '@suite-common/token-definitions';
 import {
     TradingCryptoSelectItemProps,
@@ -23,7 +24,7 @@ import {
 import TrezorConnect from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
-import { ExtendedMessageDescriptor, Route, TrezorDevice } from 'src/types/suite';
+import { Route, TrezorDevice } from 'src/types/suite';
 import {
     TradingAccountOptionsGroupOptionProps,
     TradingAccountsOptionsGroupProps,

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/TrezorExpertBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/TrezorExpertBanner.tsx
@@ -54,7 +54,6 @@ const Title = () => {
                     rest: text => text,
                     underline: text => <UnderlinedBlock>{text}</UnderlinedBlock>,
                 }}
-                isNested={true}
             />
         </Text>
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeader.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { INVITY_API_RELOAD_QUOTES_AFTER_SECONDS } from '@suite-common/trading';
 import { H2 } from '@trezor/components';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
@@ -7,7 +8,6 @@ import { spacingsPx } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite/Translation';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
-import { ExtendedMessageDescriptor } from 'src/types/suite';
 import {
     getCryptoQuoteAmountProps,
     isTradingExchangeContext,

--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersExchangeQuotesByTypeSection.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersExchangeQuotesByTypeSection.tsx
@@ -1,10 +1,11 @@
 import { ExchangeTrade } from 'invity-api';
 import styled from 'styled-components';
 
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { H3, Icon, Row, Tooltip } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
 
-import { ExtendedMessageDescriptor, Translation } from 'src/components/suite/Translation';
+import { Translation } from 'src/components/suite/Translation';
 import { TradingOffersItem } from 'src/views/wallet/trading/common/TradingOffers/TradingOffersItem';
 
 const OffersContainer = styled.div`

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferStepper.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferStepper.tsx
@@ -1,10 +1,10 @@
 import { Fragment, JSX } from 'react';
 
+import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { Icon, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite/Translation';
-import { ExtendedMessageDescriptor } from 'src/types/suite';
 
 export interface TradingSelectedOfferStepperItemProps {
     step: string;

--- a/suite-common/intl-types/package.json
+++ b/suite-common/intl-types/package.json
@@ -10,7 +10,6 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@trezor/type-utils": "workspace:*",
         "react": "19.1.0",
         "react-intl": "^7.1.11"
     }

--- a/suite-common/intl-types/src/types.ts
+++ b/suite-common/intl-types/src/types.ts
@@ -1,9 +1,7 @@
 // IMPORTANT! This package is just temporary solution until https://github.com/trezor/trezor-suite/pull/5647 will be merged.
 // Then we won't need this package anymore and can be deleted.
-import { ReactElement } from 'react';
-import { MessageDescriptor } from 'react-intl';
-
-import { PrimitiveType } from '@trezor/type-utils';
+import { ComponentProps } from 'react';
+import { FormattedMessage } from 'react-intl';
 
 // Warning, very hacky import solution, do not use this anywhere else than in this file.
 import type { TranslationKey as SuiteTranslationKey } from '../../../packages/suite/src/components/suite/Translation';
@@ -11,15 +9,10 @@ import type { TranslationKey as SuiteTranslationKey } from '../../../packages/su
 // reexport for easier usage, without need to have hacky solutions
 export type TranslationKey = SuiteTranslationKey;
 
-// Add MessageDescriptor type to values entry
-export type FormatXMLElementFn = (...args: any[]) => string | object;
-export interface ExtendedMessageDescriptor extends MessageDescriptor {
+// Add values to MessageDescriptor type, types are copied from react-intl because they are not exported from the package.
+export type ExtendedMessageDescriptor = Pick<
+    ComponentProps<typeof FormattedMessage>,
+    'defaultMessage' | 'values'
+> & {
     id: TranslationKey;
-    values?: {
-        [key: string]:
-            | PrimitiveType
-            | ReactElement
-            | ExtendedMessageDescriptor
-            | FormatXMLElementFn;
-    };
-}
+};

--- a/suite-common/intl-types/tsconfig.json
+++ b/suite-common/intl-types/tsconfig.json
@@ -4,9 +4,7 @@
         "outDir": "libDev",
         "rootDir": "../../../"
     },
-    "references": [
-        { "path": "../../packages/type-utils" }
-    ],
+    "references": [],
     "include": [
         "suite-common/intl-types/**/*",
         "packages/suite/src/components/suite/Translation"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10615,7 +10615,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/intl-types@workspace:suite-common/intl-types"
   dependencies:
-    "@trezor/type-utils": "workspace:*"
     react: "npm:19.1.0"
     react-intl: "npm:^7.1.11"
   languageName: unknown


### PR DESCRIPTION
Cleanup around `Translation` component. See comments to code below.

I originally wanted to fix console warnings, but it is a `formatjs` bug and should be solved on [their side](https://github.com/formatjs/formatjs/issues/5135) eventually.
<img width="453" height="74" alt="Screenshot 2025-11-25 at 17 52 07" src="https://github.com/user-attachments/assets/410195b7-0d80-4eb9-ba2d-3a02cbd72f57" />

**QA:** Related to translations. Nothing should change in the app.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/is-nested-translation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/is-nested-translation&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/is-nested-translation&lookback=7)