### PR TITLE
fix(nix): disable electron sandbox for nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
             pkgs.python3
             pkgs.python3Packages.pip
             pkgs.jre
-            pkgs.electron_36
+            pkgs.electron_39
             pkgs.pkg-config
             pkgs.pixman # build dependencies for node-canvas
             pkgs.cairo # build dependencies for node-canvas
@@ -74,6 +74,7 @@
             export CURDIR="$(pwd)"
             export PATH="$PATH:$CURDIR/node_modules/.bin"
             export ELECTRON_BUILDER_CACHE="$CURDIR/.cache/electron-builder"
+            export ELECTRON_DISABLE_SANDBOX=1
             export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
             export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
             export PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright-driver.browsers}"
@@ -85,9 +86,9 @@
             echo "- Playwright $(playwright --version)"
             
           '' + pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
-            export ELECTRON_OVERRIDE_DIST_PATH="${pkgs.electron_36}/Applications/"
+            export ELECTRON_OVERRIDE_DIST_PATH="${pkgs.electron_39}/Applications/"
           '' + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
-            export ELECTRON_OVERRIDE_DIST_PATH="${pkgs.electron_36}/bin/"
+            export ELECTRON_OVERRIDE_DIST_PATH="${pkgs.electron_39}/bin/"
             export npm_config_build_from_source=true
           '';
         };

--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,14 @@
-# pinned to nixos-unstable on commit https://github.com/NixOS/nixpkgs/commit/467a36d9f02926bf8388b62eb82f0e6234b40851
+# pinned to nixos-unstable on commit https://github.com/NixOS/nixpkgs/commit/9ea478ee24f110ac3b20800a10903989b03e4bf2
 # we need to use nixos-unstable to be able to use nodejs_24, once there is a stable release with it we can change.
 with import
   (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/467a36d9f02926bf8388b62eb82f0e6234b40851.tar.gz";
-    sha256 = "17cana4hwz4a23p2lmqfp1szxihbgib9a4dqwf6xmbjz1w1kxxlh";
+    url = "https://github.com/NixOS/nixpkgs/archive/9ea478ee24f110ac3b20800a10903989b03e4bf2.tar.gz";
+    sha256 = "0b4bhjkcvdlaacydcaf1v4jmzp22mpxc16wwn3y6p12k3n5zkyj7";
    }) { system = builtins.currentSystem; };
 
 let
   # unstable packages
-  electron = electron_36;
+  electron = electron_39;
   nodejs = nodejs_24;
   # use older gcc. 10.2.0 with glibc 2.32 for node_modules bindings.
   # electron-builder is packing the app with glibc 2.32, bindings should not be compiled with newer version.
@@ -62,6 +62,7 @@ in
       export ELECTRON_OVERRIDE_DIST_PATH="${electron}/Applications/"
     '' + lib.optionalString stdenv.isLinux ''
       export ELECTRON_OVERRIDE_DIST_PATH="${electron}/bin/"
+      export ELECTRON_DISABLE_SANDBOX=1
       export npm_config_build_from_source=true  # tell yarn to not download binaries, but build from source
       export PLAYWRIGHT_BROWSERS_PATH="$CURDIR/.cache/ms-playwright"
     '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When using electron with nix as package manager there is issue with electron sandboxing. I am always solving it locally but this would make it easier. 


Also updated electron to version used in Suite: https://github.com/trezor/trezor-suite/blob/develop/package.json#L104

## Notes for QA

Nothing to test.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/electron-with-nix&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/electron-with-nix&lookback=7)