### PR TITLE
fix(suite-native): fix alert bottom offset

### DIFF
--- a/suite-native/alerts/package.json
+++ b/suite-native/alerts/package.json
@@ -18,6 +18,7 @@
         "jotai": "2.15.0",
         "react": "19.1.0",
         "react-native": "0.81.4",
-        "react-native-reanimated": "~4.1.3"
+        "react-native-reanimated": "~4.1.3",
+        "react-native-safe-area-context": "5.6.1"
     }
 }

--- a/suite-native/alerts/src/components/AlertSheet.tsx
+++ b/suite-native/alerts/src/components/AlertSheet.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { Modal, Pressable, StyleSheet } from 'react-native';
 import Animated from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
     Box,
@@ -25,16 +26,18 @@ type AlertSheetProps = {
 const SCREEN_WIDTH = getScreenWidth();
 const SCREEN_HEIGHT = getScreenHeight();
 
-const alertSheetContainerStyle = prepareNativeStyle(utils => ({
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: utils.spacings.sp24,
-    paddingVertical: utils.spacings.sp32,
-    marginBottom: utils.spacings.sp32,
-    marginHorizontal: utils.spacings.sp8,
-    borderRadius: utils.borders.radii.r16,
-    ...utils.boxShadows.small,
-}));
+const alertSheetContainerStyle = prepareNativeStyle<{ bottomInset: number }>(
+    (utils, { bottomInset }) => ({
+        justifyContent: 'center',
+        alignItems: 'center',
+        paddingHorizontal: utils.spacings.sp24,
+        paddingVertical: utils.spacings.sp32,
+        marginHorizontal: utils.spacings.sp16,
+        borderRadius: utils.borders.radii.r16,
+        marginBottom: bottomInset + utils.spacings.sp16,
+        ...utils.boxShadows.small,
+    }),
+);
 
 const alertSheetContentStyle = prepareNativeStyle(utils => ({
     width: '100%',
@@ -58,6 +61,7 @@ export const AlertSheet = ({ alert }: AlertSheetProps) => {
     const { hideAlert } = useAlert();
     const { applyStyle } = useNativeStyles();
     const { runShakeAnimation, shakeAnimatedStyle } = useShakeAnimation();
+    const { bottom } = useSafeAreaInsets();
 
     const {
         animatedSheetWithOverlayStyle,
@@ -109,7 +113,7 @@ export const AlertSheet = ({ alert }: AlertSheetProps) => {
                     style={shakeAnimatedStyle}
                     onStartShouldSetResponder={_ => true} // Stop the shake event trigger propagation.
                 >
-                    <Card style={applyStyle(alertSheetContainerStyle)}>
+                    <Card style={applyStyle(alertSheetContainerStyle, { bottomInset: bottom })}>
                         <VStack style={applyStyle(alertSheetContentStyle)}>
                             {pictogramVariant && (
                                 <Box alignItems="center">

--- a/yarn.lock
+++ b/yarn.lock
@@ -11153,6 +11153,7 @@ __metadata:
     react: "npm:19.1.0"
     react-native: "npm:0.81.4"
     react-native-reanimated: "npm:~4.1.3"
+    react-native-safe-area-context: "npm:5.6.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix Alert bottom offset

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23353

## Screenshots:

![IMG_2537](https://github.com/user-attachments/assets/34f35637-cca0-43bc-b3e1-512eb2733668)



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/overlaping-alert-nav-bar&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/overlaping-alert-nav-bar&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/overlaping-alert-nav-bar&lookback=7)