### PR TITLE
Refactor/global send receive

### DIFF
--- a/packages/components/src/components/Box/Box.tsx
+++ b/packages/components/src/components/Box/Box.tsx
@@ -58,7 +58,7 @@ const Container = styled.div<
     border: 0 solid
         ${({ $borderColor, $elevation, theme }) =>
             $borderColor ?? mapElevationToBorder({ theme, $elevation })};
-    transition: background 0.2s ease;
+    transition: background 0.3s ease;
 
     ${({ $borderWidth }) =>
         $borderWidth &&
@@ -120,6 +120,7 @@ export type BoxProps = AllowedFrameProps & {
     hasBackground?: boolean;
     // TODO: type to token names
     backgroundColor?: CSSColor;
+    // TODO: type to token names
     backgroundColorOnInteraction?: CSSColor;
     // TODO: type to token names
     borderColor?: CSSColor;

--- a/packages/components/src/components/VirtualizedList/VirtualizedList.tsx
+++ b/packages/components/src/components/VirtualizedList/VirtualizedList.tsx
@@ -4,6 +4,17 @@ import styled from 'styled-components';
 
 import { TimerId } from '@trezor/type-utils';
 
+import {
+    FrameProps,
+    FramePropsKeys,
+    pickAndPrepareFrameProps,
+    withFrameProps,
+} from '../../utils/frameProps';
+import { TransientProps } from '../../utils/transientProps';
+
+export const allowedVirtualizedListFrameProps: FramePropsKeys[] = ['padding'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedVirtualizedListFrameProps)[number]>;
+
 function debounce<T extends (...args: unknown[]) => void>(
     func: T,
     wait: number,
@@ -20,10 +31,10 @@ function debounce<T extends (...args: unknown[]) => void>(
     };
 }
 
-interface ContainerProps {
+type ContainerProps = TransientProps<AllowedFrameProps> & {
     $height: number | string;
     $minHeight: number | string;
-}
+};
 
 const Container = styled.div<ContainerProps>`
     height: ${({ $height }) => (typeof $height === 'number' ? `${$height}px` : $height)};
@@ -33,6 +44,7 @@ const Container = styled.div<ContainerProps>`
     width: 100%;
     overflow-y: auto;
     position: relative;
+    ${withFrameProps};
 `;
 const Content = styled.div`
     position: relative;
@@ -51,7 +63,7 @@ export type BaseItemProps = {
 
 const calculateItemHeight = <T extends BaseItemProps>(item: T): number => item.height;
 
-type VirtualizedListProps<T extends BaseItemProps> = {
+type VirtualizedListProps<T extends BaseItemProps> = AllowedFrameProps & {
     items: Array<T>;
     itemsFingerprint: string;
     onScroll?: (e: Event) => void;
@@ -103,6 +115,7 @@ export function VirtualizedListComponent<T extends BaseItemProps>({
     estimatedItemHeight = 40,
 
     resetScrollOnItemsChange = true,
+    ...rest
 }: VirtualizedListProps<T>) {
     const newRef = useRef<HTMLDivElement>(null);
     const containerRef = (ref as React.RefObject<HTMLDivElement>) || newRef;
@@ -207,13 +220,18 @@ export function VirtualizedListComponent<T extends BaseItemProps>({
         }
     }, [containerRef, handleScroll]);
 
+    const frameProps = pickAndPrepareFrameProps(
+        rest,
+        allowedVirtualizedListFrameProps,
+    ) as TransientProps<AllowedFrameProps>;
+
     const firstItemTop = useMemo(
         () => itemHeights.slice(0, indexes.startIndex).reduce((acc, h) => acc + h, 0),
         [itemHeights, indexes.startIndex],
     );
 
     return (
-        <Container ref={ref} $height={listHeight} $minHeight={listMinHeight}>
+        <Container ref={ref} $height={listHeight} $minHeight={listMinHeight} {...frameProps}>
             <Content style={{ height: `${totalHeight}px` }}>
                 {/* TODO: use https://react-window.vercel.app/list/variable-row-height or something that's already optimized */}
                 {itemHeights.slice(indexes.startIndex, indexes.endIndex).map((height, index) => {

--- a/packages/components/src/utils/useScrollShadow.tsx
+++ b/packages/components/src/utils/useScrollShadow.tsx
@@ -52,14 +52,13 @@ const ShadowContainer = styled.div`
 const Gradient = styled.div<GradientProps>`
     ${({ $direction }) => $direction && `${$direction}: 0;`}
     width: ${({ $direction }) =>
-        $direction === 'left' || $direction === 'right' ? '60px' : '100%'};
+        $direction === 'left' || $direction === 'right' ? '60px' : 'calc(100% - 15px)'};
     height: ${({ $direction }) =>
         $direction === 'left' || $direction === 'right' ? '100%' : '60px'};
     z-index: 1;
     position: absolute;
     pointer-events: none;
     opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
-    transition: all 0.2s ease-in;
     background: ${({ $direction, $backgroundColor, $elevation, theme }) =>
         mapDirectionToGradient({ $direction, $backgroundColor, $elevation, theme })};
 `;

--- a/packages/product-components/src/components/SelectAssetModal/SearchAsset.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/SearchAsset.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
-import { Icon, Input, Select } from '@trezor/components';
-import { spacingsPx } from '@trezor/theme';
+import { Icon, Input, Row, Select, Text } from '@trezor/components';
 
 import { CoinLogo } from '../CoinLogo/CoinLogo';
 import { SearchAssetSelectConfig, useNetworkSelect } from './hooks/useNetworkSelect';
@@ -39,20 +38,14 @@ const SelectWrapper = styled.div`
     /* stylelint-enable selector-class-pattern */
 `;
 
-const Option = styled.div`
-    display: flex;
-    align-items: center;
-    gap: ${spacingsPx.xs};
-`;
-
-export interface SearchAssetProps {
+export type SearchAssetProps = {
     searchPlaceholder: string;
     search: string;
     setSearch: (value: string) => void;
     'data-testid'?: string;
     selectConfig?: SearchAssetSelectConfig;
     autoFocus?: boolean;
-}
+};
 
 export const SearchAsset = ({
     searchPlaceholder,
@@ -71,8 +64,10 @@ export const SearchAsset = ({
                 value={selectedOption}
                 onChange={option => selectConfig.onChange(option.value)}
                 size="small"
+                isClean
                 formatOptionLabel={(option, meta) => (
-                    <Option
+                    <Row
+                        gap={8}
                         data-testid={
                             meta.context === 'menu'
                                 ? `${dataTestId}/select-option/${option.value ?? 'all-networks'}`
@@ -82,8 +77,8 @@ export const SearchAsset = ({
                         {option.value && (
                             <CoinLogo size={20} symbol={option.value} type="network" />
                         )}
-                        <span>{option.label}</span>
-                    </Option>
+                        <Text typographyStyle="hint">{option.label}</Text>
+                    </Row>
                 )}
                 width="auto"
                 minValueWidth="170px"

--- a/packages/product-components/src/components/TopAssets/TopAssets.tsx
+++ b/packages/product-components/src/components/TopAssets/TopAssets.tsx
@@ -1,21 +1,10 @@
 import { useTheme } from 'styled-components';
 
-import {
-    Box,
-    Column,
-    FrameProps,
-    FramePropsKeys,
-    Row,
-    Text,
-    pickAndPrepareFrameProps,
-} from '@trezor/components';
+import { Box, Column, Row, Text } from '@trezor/components';
 import { mapElevationToBackground, mapElevationToBorder } from '@trezor/theme';
 
 import { AssetLogo, AssetLogoProps, shouldShowNetworkIcon } from '../AssetLogo/AssetLogo';
 import { CoinLogo } from '../CoinLogo/CoinLogo';
-
-const allowedTopAssetsFrameProps = ['margin'] as const satisfies FramePropsKeys[];
-type AllowedTopAssetsFrameProps = Pick<FrameProps, (typeof allowedTopAssetsFrameProps)[number]>;
 
 export type Asset = {
     id: string;
@@ -30,17 +19,15 @@ export type TopAssetsProps = {
     onAssetClick: (asset: Asset) => void;
     logoSize?: AssetLogoProps['size'];
     'data-testid'?: string;
-} & AllowedTopAssetsFrameProps;
+};
 
 export function TopAssets({
     assets,
     logoSize = 40,
     onAssetClick,
     'data-testid': dataTestId,
-    ...rest
 }: TopAssetsProps) {
     const theme = useTheme();
-    const frameProps = pickAndPrepareFrameProps(rest, allowedTopAssetsFrameProps, false);
 
     return (
         <Box
@@ -51,7 +38,6 @@ export function TopAssets({
             as="button"
             overflow="hidden"
             data-testid={dataTestId}
-            {...frameProps}
         >
             <Row hasDivider alignItems="stretch">
                 {assets.map(asset => {

--- a/packages/suite/src/components/suite/AccountLabel.tsx
+++ b/packages/suite/src/components/suite/AccountLabel.tsx
@@ -1,7 +1,10 @@
+import { selectAccountLabel } from '@suite-common/suite-sync';
 import { Account } from '@suite-common/wallet-types';
+import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { BadgeSize, Row, Text } from '@trezor/components';
 
-import { useDefaultAccountLabel } from 'src/hooks/suite';
+import { useDefaultAccountLabel, useSelector } from 'src/hooks/suite';
+import { selectLabelingDataForAccount } from 'src/reducers/suite/metadataReducer';
 
 import { AccountTypeBadge } from './AccountTypeBadge';
 
@@ -17,15 +20,27 @@ export const AccountLabel = ({
     account,
 }: AccountLabelProps) => {
     const { getDefaultAccountLabel } = useDefaultAccountLabel();
-    const { symbol, accountType, index, path, networkType, accountLabel } = account;
+    const { walletDescriptor } = parseDeviceStaticSessionId(account.deviceState);
+    const suiteSyncAccountLabel = useSelector(state =>
+        selectAccountLabel({
+            state,
+            walletDescriptor,
+            accountKey: account.key,
+        }),
+    );
+    const { accountLabel: legacyAccountLabel } = useSelector(state =>
+        selectLabelingDataForAccount(state, account.key),
+    );
+    const { symbol, accountType, index, path, networkType } = account;
+    const accountLabel =
+        suiteSyncAccountLabel ||
+        legacyAccountLabel ||
+        account.accountLabel ||
+        getDefaultAccountLabel({ accountType, symbol, index });
 
     return (
-        <Row gap={12} overflow="hidden">
-            <Text ellipsisLineCount={1}>
-                {accountLabel
-                    ? accountLabel
-                    : getDefaultAccountLabel({ accountType, symbol, index })}
-            </Text>
+        <Row gap={12} overflow="hidden" maxWidth="100%">
+            <Text ellipsisLineCount={1}>{accountLabel}</Text>
             {showAccountTypeBadge && (
                 <AccountTypeBadge
                     accountType={accountType}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetDetails.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetDetails.tsx
@@ -5,11 +5,6 @@ import { Badge, Column, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { hasOwn } from '@trezor/utils';
 
-const TextWrapper = styled.div`
-    overflow: hidden;
-    text-overflow: ellipsis;
-`;
-
 const BadgeWrapper = styled.div`
     flex: none;
 `;
@@ -32,12 +27,10 @@ export function AssetDetails({ name, symbol, ...props }: AssetDetailsProps) {
         : props.networkName;
 
     return (
-        <Column alignItems="flex-start" justifyContent="flex-start">
-            <TextWrapper>
-                <Text typographyStyle="body" textWrap="nowrap">
-                    {name}
-                </Text>
-            </TextWrapper>
+        <Column overflow="hidden" alignItems="flex-start" justifyContent="flex-start">
+            <Text typographyStyle="body" ellipsisLineCount={1}>
+                {name}
+            </Text>
             <Row gap={spacings.xs} alignItems="center">
                 <Text typographyStyle="hint" variant="tertiary">
                     {getDisplaySymbol(symbol)}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetGroupLabel.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetGroupLabel.tsx
@@ -1,11 +1,8 @@
 import { ReactNode } from 'react';
 
-import { Text } from '@trezor/components';
-import { spacings } from '@trezor/theme';
+import { Row, Text } from '@trezor/components';
 
 import { Translation, TranslationKey, isTranslationKey } from 'src/components/suite/Translation';
-
-export const ASSET_ROW_GROUP_LABEL_HEIGHT = 24;
 
 export type AssetGroupLabelProps = {
     label: ReactNode | TranslationKey;
@@ -13,13 +10,10 @@ export type AssetGroupLabelProps = {
 
 export function AssetGroupLabel({ label }: AssetGroupLabelProps) {
     return (
-        <Text
-            typographyStyle="hint"
-            variant="default"
-            margin={{ bottom: spacings.xxs, left: spacings.md }}
-            as="div"
-        >
-            {isTranslationKey(label) ? <Translation id={label} /> : label}
-        </Text>
+        <Row padding={{ horizontal: 8 }}>
+            <Text typographyStyle="hint" variant="default" as="div" ellipsisLineCount={1}>
+                {isTranslationKey(label) ? <Translation id={label} /> : label}
+            </Text>
+        </Row>
     );
 }

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetGroupSpace.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetGroupSpace.tsx
@@ -1,19 +1,12 @@
-import styled from 'styled-components';
+import { Box } from '@trezor/components';
 
-const RowSpace = styled.div<{ height: number }>`
-    height: ${({ height }) => height}px;
-`;
+import { ASSET_ROW_HEIGHTS_BY_SIZE } from 'src/components/suite/asset-picker/constants';
+import { AssetGroupSpaceSize } from 'src/components/suite/asset-picker/types';
 
-type AssetGroupSpaceSize = 'md' | 'lg';
-export interface AssetGroupSpaceProps {
+export type AssetGroupSpaceProps = {
     size: AssetGroupSpaceSize;
-}
-
-export const ASSET_ROW_HEIGHTS_BY_SIZE = {
-    md: 24,
-    lg: 32,
-} as const satisfies Record<AssetGroupSpaceSize, number>;
+};
 
 export function AssetGroupSpace({ size }: AssetGroupSpaceProps) {
-    return <RowSpace height={ASSET_ROW_HEIGHTS_BY_SIZE[size]} />;
+    return <Box height={ASSET_ROW_HEIGHTS_BY_SIZE[size]} />;
 }

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowAccountWithBalance.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowAccountWithBalance.tsx
@@ -24,10 +24,10 @@ export function AssetRowAccountWithBalance({
                 data-testid={`${dataTestId}/${account.symbol}`}
                 gap={spacings.sm}
                 alignItems="center"
+                overflow="hidden"
             >
                 <CoinLogo symbol={account.symbol} size={40} type="tokenWithNetwork" />
-
-                <Column alignItems="flex-start" justifyContent="flex-start">
+                <Column overflow="hidden" alignItems="flex-start" justifyContent="flex-start">
                     <Text variant="default" typographyStyle="body">
                         {getNetworkDisplaySymbolName(account.symbol)}
                     </Text>

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowReceiveToAccount.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowReceiveToAccount.tsx
@@ -29,19 +29,16 @@ export function AssetRowReceiveToAccount({
 
     return (
         <ItemClickableContainer onClick={() => onClick(account)}>
-            <Row data-testid={dataTestId} gap={spacings.sm} alignItems="center">
+            <Row data-testid={dataTestId} gap={spacings.sm} alignItems="center" overflow="hidden">
                 <CoinLogo symbol={account.symbol} size={40} type="token" />
-
-                <Column alignItems="flex-start" justifyContent="flex-start">
-                    <Text variant="default" typographyStyle="body">
-                        <AccountLabel
-                            account={account}
-                            accountTypeBadgeSize="medium"
-                            showAccountTypeBadge={true}
-                        />
-                    </Text>
+                <Column overflow="hidden" alignItems="flex-start" justifyContent="flex-start">
+                    <AccountLabel
+                        account={account}
+                        accountTypeBadgeSize="medium"
+                        showAccountTypeBadge={true}
+                    />
                     {supportsTokens && (
-                        <Text typographyStyle="hint" as="div" variant="tertiary">
+                        <Text typographyStyle="hint" variant="tertiary">
                             <Translation id="TR_INCLUDING_TOKENS" />
                         </Text>
                     )}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/constants/index.ts
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/constants/index.ts
@@ -1,1 +1,0 @@
-export const ASSET_ROW_ACCOUNT_HEIGHT = 68;

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/index.ts
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/index.ts
@@ -1,3 +1,2 @@
-export * from './constants';
 export * from './AssetRowReceiveToAccount';
 export * from './AssetRowAccountWithBalance';

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx
@@ -6,8 +6,6 @@ import { spacings } from '@trezor/theme';
 import { AssetDetails } from '../AssetDetails';
 import { ItemClickableContainer } from '../ItemClickableContainer';
 
-export const ASSET_ROW_ASSET_HEIGHT = 68;
-
 export type AssetRowAssetProps = {
     asset: TradingAssetOption;
     onClick: (asset: TradingAssetOption) => void;
@@ -21,7 +19,12 @@ export function AssetRowAsset({ asset, dataTestId, onClick }: AssetRowAssetProps
                 onClick(asset);
             }}
         >
-            <Row data-testid={`${dataTestId}/${asset.id}`} gap={spacings.sm}>
+            <Row
+                data-testid={`${dataTestId}/${asset.id}`}
+                gap={spacings.sm}
+                overflow="hidden"
+                maxWidth="100%"
+            >
                 {asset.isNativeToken ? (
                     <CoinLogo size={40} symbol={asset.symbol} type="tokenWithNetwork" />
                 ) : (

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
@@ -10,8 +10,6 @@ import { ItemClickableContainer } from '../ItemClickableContainer';
 import { AssetAmount } from './AssetAmount';
 import { AssetDetails } from '../AssetDetails';
 
-export const ASSET_ROW_TOKEN_HEIGHT = 68;
-
 export type AssetRowTokenProps = {
     token: TokensWithRates;
     account: Account;
@@ -26,7 +24,11 @@ export function AssetRowToken({ token, account, dataTestId, onClick }: AssetRowT
                 onClick(token, account);
             }}
         >
-            <Row data-testid={`${dataTestId}/${account.symbol}/${token.symbol}`} gap={spacings.sm}>
+            <Row
+                data-testid={`${dataTestId}/${account.symbol}/${token.symbol}`}
+                gap={spacings.sm}
+                overflow="hidden"
+            >
                 <AssetLogo
                     size={40}
                     coingeckoId={getCoingeckoId(account.symbol)!}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/ItemClickableContainer.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/ItemClickableContainer.tsx
@@ -1,46 +1,34 @@
-import styled from 'styled-components';
+import { useTheme } from 'styled-components';
 
-import { Row } from '@trezor/components';
-import { spacings, spacingsPx } from '@trezor/theme';
+import { Box, Row } from '@trezor/components';
 
-const ClickableContainer = styled.button`
-    border: unset;
-    background: unset;
-    box-shadow: unset;
+import { ASSET_ROW_HEIGHT } from '../../constants';
 
-    width: calc(100% - ${spacings.xxs * 2}px);
-
-    cursor: pointer;
-    padding: ${spacingsPx.xs} 0;
-    margin: ${spacingsPx.xxs} ${spacingsPx.xxs};
-    border-radius: 4px;
-    transition: background-color 150ms ease-in-out;
-
-    &:hover {
-        background-color: ${({ theme }) => theme.backgroundTertiaryPressedOnElevation0};
-    }
-`;
-
-interface ItemClickableContainerProps {
+type ItemClickableContainerProps = {
     children: React.ReactNode;
     onClick: () => void;
-}
+};
 
 export function ItemClickableContainer({ children, onClick }: ItemClickableContainerProps) {
+    const theme = useTheme();
+
     return (
-        <ClickableContainer
+        <Box
+            borderRadius={10}
+            width="100%"
+            height={ASSET_ROW_HEIGHT - 8}
+            padding={8}
             onClick={e => {
                 e.stopPropagation();
                 onClick();
             }}
+            as="button"
+            cursor="pointer"
+            backgroundColorOnInteraction={theme.backgroundTertiaryPressedOnElevation0}
         >
-            <Row
-                justifyContent="space-between"
-                gap={spacings.sm}
-                padding={{ horizontal: spacings.md }}
-            >
+            <Row justifyContent="space-between" gap={12} height="100%">
                 {children}
             </Row>
-        </ClickableContainer>
+        </Box>
     );
 }

--- a/packages/suite/src/components/suite/asset-picker/components/AssetsList/AssetsList.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetsList/AssetsList.tsx
@@ -33,6 +33,7 @@ function AssetsListInner<T extends BaseItemProps>({
             <ShadowTop backgroundColor={shadowColor} />
             <VirtualizedList
                 items={items}
+                padding={8}
                 itemsFingerprint={itemsFingerprint}
                 ref={ref}
                 onScroll={onScroll}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetsModal/AssetsModal.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetsModal/AssetsModal.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react';
 
 import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { Modal, ModalSize } from '@trezor/components';
-import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite/Translation';
 
@@ -12,6 +11,7 @@ interface AssetsModalProps {
     description?: ExtendedMessageDescriptor;
     onClose: () => void;
     size?: ModalSize;
+    bottomContent?: ReactNode;
 }
 
 export function AssetsModal({
@@ -20,6 +20,7 @@ export function AssetsModal({
     description,
     onClose,
     size = 'small',
+    bottomContent,
 }: AssetsModalProps) {
     return (
         <Modal
@@ -28,10 +29,8 @@ export function AssetsModal({
             onCancel={onClose}
             size={size}
             height="unset"
-            padding={{
-                horizontal: 0,
-                vertical: spacings.md,
-            }}
+            padding={{ horizontal: 0, top: 16 }}
+            bottomContent={bottomContent}
         >
             {children}
         </Modal>

--- a/packages/suite/src/components/suite/asset-picker/constants/index.ts
+++ b/packages/suite/src/components/suite/asset-picker/constants/index.ts
@@ -1,0 +1,8 @@
+import type { AssetGroupSpaceSize } from 'src/components/suite/asset-picker/types';
+
+export const ASSET_ROW_HEIGHT = 68;
+export const ASSET_ROW_GROUP_LABEL_HEIGHT = 28;
+export const ASSET_ROW_HEIGHTS_BY_SIZE = {
+    md: 24,
+    lg: 32,
+} as const satisfies Record<AssetGroupSpaceSize, number>;

--- a/packages/suite/src/components/suite/asset-picker/types/index.ts
+++ b/packages/suite/src/components/suite/asset-picker/types/index.ts
@@ -1,0 +1,1 @@
+export type AssetGroupSpaceSize = 'md' | 'lg';

--- a/packages/suite/src/components/suite/labeling/AccountLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/AccountLabeling.tsx
@@ -5,7 +5,6 @@ import { BadgeProps } from '@trezor/components';
 
 import { AccountLabel } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
-import { selectLabelingDataForAccount } from 'src/reducers/suite/metadataReducer';
 import { Account as WalletAccount } from 'src/types/wallet';
 
 import { WalletLabeling } from './WalletLabeling';
@@ -26,16 +25,11 @@ export const AccountLabeling = ({
 
     const accounts = !Array.isArray(account) ? [account] : account;
 
-    const labels = useSelector(state => selectLabelingDataForAccount(state, accounts[0].key));
-
     if (accounts.length < 1) return null;
 
     const accountLabel = (
         <AccountLabel
-            account={{
-                ...accounts[0],
-                accountLabel: labels.accountLabel,
-            }}
+            account={accounts[0]}
             showAccountTypeBadge={showAccountTypeBadge}
             accountTypeBadgeSize={accountTypeBadgeSize}
         />

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
@@ -6,18 +6,17 @@ import { selectEnabledNetworks } from '@suite-common/wallet-core';
 import { GlobalSendReceiveType } from '@suite-common/wallet-types';
 import { Box } from '@trezor/components';
 import { SearchAsset } from '@trezor/product-components';
-import { spacings } from '@trezor/theme';
 
 import { useSelector, useTranslation } from 'src/hooks/suite';
 
 import { useNetworkFilter } from './hooks/useNetworkFilter';
 import { useSearchFilter } from './hooks/useSearchFilter';
 
-export interface AssetSearchWithNetworkFilterProps {
+export type AssetSearchWithNetworkFilterProps = {
     placeholder: TranslationKey;
     listRef: RefObject<HTMLDivElement | null>;
     modal?: NonNullable<GlobalSendReceiveType>;
-}
+};
 
 export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetworkFilterInner({
     placeholder,
@@ -40,7 +39,7 @@ export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetwork
     const { translationString } = useTranslation();
 
     return (
-        <Box padding={{ horizontal: spacings.md }}>
+        <Box padding={{ horizontal: 16 }}>
             <SearchAsset
                 searchPlaceholder={translationString(placeholder)}
                 search={search}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx
@@ -2,9 +2,8 @@ import { useCallback, useRef } from 'react';
 
 import { useTheme } from 'styled-components';
 
-import { Divider, Link, Row } from '@trezor/components';
+import { Divider, Link } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
-import { spacings } from '@trezor/theme';
 import { HOW_TO_CHOOSE_RIGHT_NETWORK_URL } from '@trezor/urls';
 
 import {
@@ -73,32 +72,7 @@ export const GlobalReceiveModal = ({ onCancel, onSubmit }: GlobalReceiveModalPro
                     },
                 }}
                 onClose={() => onCancel(filledSearch)}
-            >
-                <AssetSearchWithNetworkFilter
-                    placeholder="TR_RECEIVE_SEARCH"
-                    listRef={listRef}
-                    modal="receive"
-                />
-
-                <Divider />
-
-                <AssetsListEmpty
-                    isEmpty={filteredAccounts.length === 0}
-                    heading={
-                        filledSearch ? 'TR_ACCOUNT_SEARCH_NO_RESULTS' : 'TR_ACCOUNT_NO_ACCOUNTS'
-                    }
-                    height={LIST_HEIGHT}
-                >
-                    <AssetsList
-                        items={filteredAccounts}
-                        itemsFingerprint={filteredAccountsFingerprint}
-                        renderItem={renderItem}
-                        height={LIST_HEIGHT}
-                        ref={listRef}
-                    />
-                </AssetsListEmpty>
-
-                <Row justifyContent="center" margin={{ top: spacings.xs }}>
+                bottomContent={
                     <AddAccountButton
                         data-testid="@global-send-receive/add-account"
                         device={device}
@@ -115,7 +89,31 @@ export const GlobalReceiveModal = ({ onCancel, onSubmit }: GlobalReceiveModalPro
                         }}
                         isIconOnly={false}
                     />
-                </Row>
+                }
+            >
+                <AssetSearchWithNetworkFilter
+                    placeholder="TR_RECEIVE_SEARCH"
+                    listRef={listRef}
+                    modal="receive"
+                />
+
+                <Divider margin={{ top: 16 }} />
+
+                <AssetsListEmpty
+                    isEmpty={filteredAccounts.length === 0}
+                    heading={
+                        filledSearch ? 'TR_ACCOUNT_SEARCH_NO_RESULTS' : 'TR_ACCOUNT_NO_ACCOUNTS'
+                    }
+                    height={LIST_HEIGHT}
+                >
+                    <AssetsList
+                        items={filteredAccounts}
+                        itemsFingerprint={filteredAccountsFingerprint}
+                        renderItem={renderItem}
+                        height={LIST_HEIGHT}
+                        ref={listRef}
+                    />
+                </AssetsListEmpty>
             </AssetsModal>
             {acccountModal.open && device && (
                 <AddAccountModal

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useAccountsOptions.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useAccountsOptions.ts
@@ -4,7 +4,7 @@ import { useThrottle } from 'react-use';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { sortByCoin } from '@suite-common/wallet-utils';
 
-import { ASSET_ROW_ACCOUNT_HEIGHT } from 'src/components/suite/asset-picker/components';
+import { ASSET_ROW_HEIGHT } from 'src/components/suite/asset-picker/constants';
 import { useSelector } from 'src/hooks/suite';
 
 export function useAccountsOptions() {
@@ -15,7 +15,7 @@ export function useAccountsOptions() {
         () =>
             sortByCoin(throttledAccounts).map(account => ({
                 account,
-                height: ASSET_ROW_ACCOUNT_HEIGHT,
+                height: ASSET_ROW_HEIGHT,
             })),
         [throttledAccounts],
     );

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx
@@ -98,7 +98,7 @@ export function GlobalSendModal({ onCancel, onSubmit }: GlobalSendModalProps) {
                 modal="send"
             />
 
-            <Divider />
+            <Divider margin={{ top: 16 }} />
 
             <AssetsListEmpty
                 isEmpty={filteredAccountsWithTokens.length === 0}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts
@@ -15,10 +15,7 @@ import {
 } from '@suite-common/wallet-utils';
 import { useCurrentRef } from '@trezor/react-utils';
 
-import {
-    ASSET_ROW_ACCOUNT_HEIGHT,
-    ASSET_ROW_TOKEN_HEIGHT,
-} from 'src/components/suite/asset-picker/components';
+import { ASSET_ROW_HEIGHT } from 'src/components/suite/asset-picker/constants';
 import { useSelector } from 'src/hooks/suite';
 import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
 import {
@@ -104,7 +101,7 @@ export function useAccountWithTokensOptions(): AccountWithTokensOption[] {
                 {
                     type: 'account',
                     account,
-                    height: ASSET_ROW_ACCOUNT_HEIGHT,
+                    height: ASSET_ROW_HEIGHT,
                 },
                 ...(account.tokens ?? []).map(
                     token =>
@@ -112,7 +109,7 @@ export function useAccountWithTokensOptions(): AccountWithTokensOption[] {
                             type: 'token',
                             account,
                             token,
-                            height: ASSET_ROW_TOKEN_HEIGHT,
+                            height: ASSET_ROW_HEIGHT,
                         }) satisfies AccountWithTokensOption,
                 ),
             ]);

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useInsertGroupLabelsAndSpaces.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useInsertGroupLabelsAndSpaces.tsx
@@ -6,7 +6,7 @@ import { AccountLabel } from 'src/components/suite/AccountLabel';
 import {
     ASSET_ROW_GROUP_LABEL_HEIGHT,
     ASSET_ROW_HEIGHTS_BY_SIZE,
-} from 'src/components/suite/asset-picker/components';
+} from 'src/components/suite/asset-picker/constants';
 
 import { AccountWithTokensOption } from './useAccountWithTokensOptions';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -71,7 +71,7 @@ export const ConfirmValueModal = ({
     const modalContext = useSelector(state => state.modal.context);
     const isActionAbortable = useSelector(selectIsActionAbortable);
     const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
-    const { accountLabel, addressLabels } = useSelector(selectLabelingDataForSelectedAccount);
+    const { addressLabels } = useSelector(selectLabelingDataForSelectedAccount);
     const dispatch = useDispatch();
     const { openNodeById } = useGuideOpenNode();
     const { translationString } = useTranslation();
@@ -142,10 +142,7 @@ export const ConfirmValueModal = ({
                         <Row gap={spacings.xxs}>
                             <CoinLogo size={14} symbol={account.symbol} />
                             <AccountLabel
-                                account={{
-                                    ...account,
-                                    accountLabel,
-                                }}
+                                account={account}
                                 accountTypeBadgeSize="small"
                                 showAccountTypeBadge
                             />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
-import { Button, H3, Modal, Paragraph, Tooltip } from '@trezor/components';
+import { H3, Modal, Paragraph, Tooltip } from '@trezor/components';
 
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { onCancel } from 'src/actions/suite/modalActions';
@@ -69,9 +69,9 @@ export const ConfirmUnverifiedModal = ({
             onCancel={handleClose}
             bottomContent={
                 <>
-                    <Button intent="warning" onClick={handleEvent}>
+                    <Modal.Button intent="warning" onClick={handleEvent}>
                         <Translation id={action.title} />
-                    </Button>
+                    </Modal.Button>
                     {isPassphraseRequired && (
                         <Tooltip
                             isActive={isDeviceLocked}
@@ -79,18 +79,18 @@ export const ConfirmUnverifiedModal = ({
                                 <Translation id="TR_SETTINGS_DEVICE_BANNER_TITLE_REMEMBERED" />
                             }
                         >
-                            <Button
+                            <Modal.Button
                                 intent="brand"
                                 onClick={enablePassphraseAndContinue}
                                 isDisabled={isDeviceLocked}
                             >
                                 <Translation id="TR_ACCOUNT_ENABLE_PASSPHRASE" />
-                            </Button>
+                            </Modal.Button>
                         </Tooltip>
                     )}
-                    <Button onClick={handleClose} intent="neutral" priority="secondary">
+                    <Modal.Button onClick={handleClose} intent="neutral" priority="secondary">
                         <Translation id="TR_DISMISS" />
-                    </Button>
+                    </Modal.Button>
                 </>
             }
         >

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerModal/AssetPickerModal.tsx
@@ -1,17 +1,17 @@
 import { memo, useCallback, useState } from 'react';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { Divider } from '@trezor/components';
+import { Box, Divider } from '@trezor/components';
 import { TopAssets } from '@trezor/product-components';
 
 import {
-    ASSET_ROW_ASSET_HEIGHT,
     AssetGroupLabel,
     AssetRowAccountWithBalance,
     AssetRowAsset,
     AssetRowToken,
     AssetsModal,
 } from 'src/components/suite/asset-picker/components';
+import { ASSET_ROW_HEIGHT } from 'src/components/suite/asset-picker/constants';
 
 import { AssetListWrapper } from './AssetListWrapper';
 import { AssetSearchWithNetworkFilter } from './AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter';
@@ -40,18 +40,19 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
             switch (item.type) {
                 case 'top-five-assets':
                     return (
-                        <TopAssets
-                            assets={item.assets}
-                            onAssetClick={topAsset =>
-                                handleAssetClick({
-                                    type: 'asset',
-                                    asset: item.assets.find(asset => asset.id === topAsset.id)!,
-                                    height: ASSET_ROW_ASSET_HEIGHT,
-                                })
-                            }
-                            data-testid={`${dataTestId}/top-five-assets`}
-                            margin={{ horizontal: 16 }}
-                        />
+                        <Box margin={{ horizontal: 8, top: 8 }}>
+                            <TopAssets
+                                assets={item.assets}
+                                onAssetClick={topAsset =>
+                                    handleAssetClick({
+                                        type: 'asset',
+                                        asset: item.assets.find(asset => asset.id === topAsset.id)!,
+                                        height: ASSET_ROW_HEIGHT,
+                                    })
+                                }
+                                data-testid={`${dataTestId}/top-five-assets`}
+                            />
+                        </Box>
                     );
 
                 case 'account':
@@ -103,7 +104,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                 setNetworkFilter={setNetworkFilter}
             />
 
-            <Divider />
+            <Divider margin={{ top: 16 }} />
 
             <AssetListWrapper
                 search={throttledSearch}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
@@ -7,12 +7,10 @@ import { Account } from '@suite-common/wallet-types';
 import { accountSearchFn, isTokenMatchesSearch } from '@suite-common/wallet-utils';
 
 import {
-    ASSET_ROW_ACCOUNT_HEIGHT,
-    ASSET_ROW_ASSET_HEIGHT,
     ASSET_ROW_GROUP_LABEL_HEIGHT,
+    ASSET_ROW_HEIGHT,
     ASSET_ROW_HEIGHTS_BY_SIZE,
-    ASSET_ROW_TOKEN_HEIGHT,
-} from 'src/components/suite/asset-picker/components';
+} from 'src/components/suite/asset-picker/constants';
 import { TokensWithRates } from 'src/utils/wallet/tokenUtils';
 
 import { useAssetsContext } from '../../AssetOptionsContext';
@@ -139,7 +137,7 @@ export function useBuildTradingAssetOptions({
                     listItems.push({
                         type: 'account',
                         account: accountOrToken.account,
-                        height: ASSET_ROW_ACCOUNT_HEIGHT,
+                        height: ASSET_ROW_HEIGHT,
                     });
                     break;
 
@@ -148,7 +146,7 @@ export function useBuildTradingAssetOptions({
                         type: 'token',
                         token: accountOrToken.token,
                         account: accountOrToken.account,
-                        height: ASSET_ROW_TOKEN_HEIGHT,
+                        height: ASSET_ROW_HEIGHT,
                     });
                     break;
             }
@@ -178,7 +176,7 @@ export function useBuildTradingAssetOptions({
             listItems.push({
                 type: 'asset',
                 asset,
-                height: ASSET_ROW_ASSET_HEIGHT,
+                height: ASSET_ROW_HEIGHT,
             });
         }
 


### PR DESCRIPTION
## Notes for QA
Slight UI changes to the global send and receive, and asset picker modal. Fixed to show account labeling.

### Before
<img width="634" height="772" alt="Screenshot 2025-12-16 at 15 11 38" src="https://github.com/user-attachments/assets/3e0441a8-9a94-4155-b6f0-9f6a0d72dee7" />
<img width="634" height="835" alt="Screenshot 2025-12-16 at 15 12 23" src="https://github.com/user-attachments/assets/41d7c064-0d6b-42a5-bb55-79e5cbe6169a" />
<img width="634" height="713" alt="Screenshot 2025-12-16 at 15 12 03" src="https://github.com/user-attachments/assets/6b719198-95c0-4f09-baf5-30d2492772f6" />

### After
<img width="634" height="765" alt="Screenshot 2025-12-16 at 15 09 30" src="https://github.com/user-attachments/assets/521a87d1-bf54-4920-8b81-8a1b8199ab6e" />
<img width="634" height="800" alt="Screenshot 2025-12-16 at 15 10 03" src="https://github.com/user-attachments/assets/e0e09f6e-cad8-463b-85b9-ed4bdcabdafb" />
<img width="634" height="678" alt="Screenshot 2025-12-16 at 15 09 48" src="https://github.com/user-attachments/assets/42f9ef61-605a-4630-95e6-ec5362cff884" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/global-send-receive&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/global-send-receive&lookback=7)