### PR TITLE
fix(suite-native): improve keyboard handling in security code input

### DIFF
--- a/suite-native/thp/package.json
+++ b/suite-native/thp/package.json
@@ -10,6 +10,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@react-navigation/native": "7.1.18",
         "@reduxjs/toolkit": "2.10.1",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/thp": "workspace:*",
@@ -22,6 +23,7 @@
         "@trezor/styles": "workspace:*",
         "react": "19.1.0",
         "react-native": "0.81.4",
+        "react-native-keyboard-controller": "1.19.2",
         "react-redux": "9.2.0"
     }
 }

--- a/suite-native/thp/src/components/SecurityCodeInput.tsx
+++ b/suite-native/thp/src/components/SecurityCodeInput.tsx
@@ -1,5 +1,8 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { Pressable, TextInput } from 'react-native';
+import { KeyboardEvents } from 'react-native-keyboard-controller';
+
+import { useFocusEffect } from '@react-navigation/native';
 
 import { HStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -29,6 +32,10 @@ export const SecurityCodeInput = ({ length, onSubmit }: SecurityCodeInputProps) 
         inputRef.current?.focus();
     }, []);
 
+    const blurInput = useCallback(() => {
+        inputRef.current?.blur();
+    }, []);
+
     const onKeyPress = (key: string) => {
         if (key >= '0' && key <= '9' && code.length < length) {
             const newCode = code + key;
@@ -41,13 +48,19 @@ export const SecurityCodeInput = ({ length, onSubmit }: SecurityCodeInputProps) 
         }
     };
 
-    useEffect(() => {
-        const timeoutId = setTimeout(focusInput, 1);
+    useFocusEffect(
+        useCallback(() => {
+            // Need to wait a while with focusing otherwise the keyboard might not show up.
+            const timeoutId = setTimeout(focusInput, 100);
+            // In case the keyboard is hidden on Android, ensure it shows up again upon focus.
+            const subscription = KeyboardEvents.addListener('keyboardDidHide', blurInput);
 
-        return () => {
-            clearTimeout(timeoutId);
-        };
-    }, [focusInput]);
+            return () => {
+                clearTimeout(timeoutId);
+                subscription.remove();
+            };
+        }, [focusInput, blurInput]),
+    );
 
     return (
         <Pressable onPress={focusInput}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12951,6 +12951,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/thp@workspace:suite-native/thp"
   dependencies:
+    "@react-navigation/native": "npm:7.1.18"
     "@reduxjs/toolkit": "npm:2.10.1"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/thp": "workspace:*"
@@ -12963,6 +12964,7 @@ __metadata:
     "@trezor/styles": "workspace:*"
     react: "npm:19.1.0"
     react-native: "npm:0.81.4"
+    react-native-keyboard-controller: "npm:1.19.2"
     react-redux: "npm:9.2.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Better handling of keyboard events on Android.

## Related Issue

Resolve #23385


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/thp-security-code-input&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/thp-security-code-input&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/thp-security-code-input&lookback=7)