### PR TITLE
Bridge deprecation ci

### DIFF
--- a/.github/workflows/test-trezor-user-env-link-e2e.yml
+++ b/.github/workflows/test-trezor-user-env-link-e2e.yml
@@ -39,5 +39,5 @@ jobs:
 
       - name: Run e2e tests
         run: |
-          docker run -d --network=host ghcr.io/trezor/trezor-user-env:d699116aef887c0a9094442d0b230e8ff4831dfe
+          docker run -d --network=host ghcr.io/trezor/trezor-user-env:d7a5fd453668207fdf537f1dc038a2e0bc8e4b92
           yarn workspace @trezor/trezor-user-env-link test:e2e

--- a/docker/docker-compose.connect-popup-ci.yml
+++ b/docker/docker-compose.connect-popup-ci.yml
@@ -1,6 +1,6 @@
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:d699116aef887c0a9094442d0b230e8ff4831dfe
+    image: ghcr.io/trezor/trezor-user-env:d7a5fd453668207fdf537f1dc038a2e0bc8e4b92
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -1,6 +1,6 @@
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:d699116aef887c0a9094442d0b230e8ff4831dfe
+    image: ghcr.io/trezor/trezor-user-env:d7a5fd453668207fdf537f1dc038a2e0bc8e4b92
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -1,6 +1,6 @@
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:d699116aef887c0a9094442d0b230e8ff4831dfe
+    image: ghcr.io/trezor/trezor-user-env:d7a5fd453668207fdf537f1dc038a2e0bc8e4b92
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-webextension-test.yml
+++ b/docker/docker-compose.connect-webextension-test.yml
@@ -1,6 +1,6 @@
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:d699116aef887c0a9094442d0b230e8ff4831dfe
+    image: ghcr.io/trezor/trezor-user-env:d7a5fd453668207fdf537f1dc038a2e0bc8e4b92
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-ci-e2e.yml
+++ b/docker/docker-compose.suite-ci-e2e.yml
@@ -1,6 +1,6 @@
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:d699116aef887c0a9094442d0b230e8ff4831dfe
+    image: ghcr.io/trezor/trezor-user-env:d7a5fd453668207fdf537f1dc038a2e0bc8e4b92
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-desktop-ci.yml
+++ b/docker/docker-compose.suite-desktop-ci.yml
@@ -1,6 +1,6 @@
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:d699116aef887c0a9094442d0b230e8ff4831dfe
+    image: ghcr.io/trezor/trezor-user-env:d7a5fd453668207fdf537f1dc038a2e0bc8e4b92
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-dev.yml
+++ b/docker/docker-compose.suite-dev.yml
@@ -3,7 +3,7 @@
 
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:d699116aef887c0a9094442d0b230e8ff4831dfe
+    image: ghcr.io/trezor/trezor-user-env:d7a5fd453668207fdf537f1dc038a2e0bc8e4b92
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.suite-native-ci.yml
+++ b/docker/docker-compose.suite-native-ci.yml
@@ -2,7 +2,7 @@ services:
   trezor-user-env-unix:
     network_mode: "host"
     container_name: trezor-user-env.unix
-    image: ghcr.io/trezor/trezor-user-env:d699116aef887c0a9094442d0b230e8ff4831dfe
+    image: ghcr.io/trezor/trezor-user-env:d7a5fd453668207fdf537f1dc038a2e0bc8e4b92
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.transport-test-ci.yml
+++ b/docker/docker-compose.transport-test-ci.yml
@@ -1,6 +1,6 @@
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:d699116aef887c0a9094442d0b230e8ff4831dfe
+    image: ghcr.io/trezor/trezor-user-env:d7a5fd453668207fdf537f1dc038a2e0bc8e4b92
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-connect-test.sh
+++ b/docker/docker-connect-test.sh
@@ -58,7 +58,7 @@ USE_WS_CACHE=true
 PATTERN=""
 FIRMWARE_MODEL=""
 RANDOMIZE=false
-TRANSPORT="2.0.33"
+TRANSPORT="node-bridge"
 
 # echo $OPTARG
 # user options

--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -103,7 +103,6 @@ Available flags:
 | `--updater-url=URL`           | Set custom URL for auto-updater (default is github)                                                                                                                                    |
 | `--bridge-legacy`             | Use Legacy (trezord-go) Bridge implementation                                                                                                                                          |
 | `--bridge-test`               | Use Legacy (trezord-go) Bridge implementation in Testing mode                                                                                                                          |
-| `--bridge-dev`                | Instruct Bridge to support emulator on port 21324                                                                                                                                      |
 | `--bridge-daemon`             | Start Suite in daemon mode (no UI initially)                                                                                                                                           |
 | `--bridge-daemon-show-ui`     | Start Suite in daemon mode with UI right away                                                                                                                                          |
 | `--log-level=NAME`            | Set the logging level. Available levels are [name (value)]: error (1), warn (2), info(3), debug (4). All logs with a value equal or lower to the selected log level will be displayed. |

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -65,7 +65,8 @@ const setup = async ({
         needs_backup: false,
     });
     log('beforeEach', 'startBridge');
-    await TrezorUserEnvLink.startBridge();
+    // todo: with node-bridge, this test fails, investigate
+    await TrezorUserEnvLink.startBridge('2.0.33');
 
     const contexts = await getContexts(page, url, isWebExtension);
 

--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -95,9 +95,20 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
     private readonly emitter: TypedEmitter<BaseEvents> = this;
     private ports: number[] = [];
     private port: number | undefined;
+    private address: string;
     private sockets: Record<number, net.Socket> = {};
 
-    constructor({ logger, port, ports }: { logger: Log; port?: number; ports?: number[] }) {
+    constructor({
+        logger,
+        port,
+        ports,
+        address = '127.0.0.1',
+    }: {
+        logger: Log;
+        port?: number;
+        ports?: number[];
+        address?: string;
+    }) {
         super();
 
         if (ports && ports.length > 0) {
@@ -110,6 +121,7 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
 
         this.logger = logger;
         this.server = http.createServer(this.onRequest);
+        this.address = address;
     }
 
     get logName() {
@@ -212,7 +224,7 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
                 };
             });
 
-            this.server.listen(port, '127.0.0.1', undefined, () => {
+            this.server.listen(port, this.address, undefined, () => {
                 this.logger.info('Server started, listening on port: ', port);
                 const address = this.getServerAddress();
                 if (address) {

--- a/packages/suite-desktop-core/src/libs/process-switches.ts
+++ b/packages/suite-desktop-core/src/libs/process-switches.ts
@@ -7,7 +7,6 @@ export type SuiteSwitch =
     | 'updater-url'
     | 'bridge-legacy'
     | 'bridge-test'
-    | 'bridge-dev'
     | 'bridge-daemon'
     | 'bridge-daemon-show-ui'
     | 'log-level'

--- a/packages/suite-desktop-core/src/libs/processes/BridgeProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BridgeProcess.ts
@@ -37,10 +37,6 @@ export class BridgeProcess extends BaseProcess {
         };
     }
 
-    async startDev(): Promise<void> {
-        await this.start(['-e', '21324']);
-    }
-
     async startTest(): Promise<void> {
         await this.start(['-e', '21324', '-u=false']);
     }

--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -13,14 +13,12 @@ import { b2t } from '../libs/utils';
 import { ipcMain } from '../typed-electron';
 import type { Dependencies } from './module';
 
-const bridgeLegacy = hasSwitch('bridge-legacy');
 // bridge node is intended for internal testing
 const bridgeTest = hasSwitch('bridge-test');
-const bridgeDev = hasSwitch('bridge-dev');
 
 export const SERVICE_NAME = 'bridge';
 
-type BridgeInterface = Pick<BridgeProcess, 'start' | 'startDev' | 'startTest' | 'stop' | 'status'>;
+type BridgeInterface = Pick<BridgeProcess, 'start' | 'startTest' | 'stop' | 'status'>;
 
 /** Wrapper around TrezordNode ThreadProxy which unifies its api with legacy BridgeProcess */
 class TrezordNodeProcess implements BridgeInterface {
@@ -30,9 +28,9 @@ class TrezordNodeProcess implements BridgeInterface {
         this.proxy = new ThreadProxy<TrezordNode>({ name: 'bridge', keepAlive: true });
     }
 
-    private async startProxy(mode: 'start' | 'startDev' | 'startTest') {
+    private async startProxy(mode: 'start' | 'startTest') {
         if (this.proxy.running) return;
-        await this.proxy.run({ api: bridgeDev || bridgeTest ? 'udp' : 'usb' });
+        await this.proxy.run({ api: bridgeTest ? 'udp' : 'usb' });
         // Call `start` again in case of respawning due to keepAlive
         this.proxy.watch('started', () => this.proxy.request(mode, []));
         await this.proxy.request(mode, []);
@@ -40,10 +38,6 @@ class TrezordNodeProcess implements BridgeInterface {
 
     start() {
         return this.startProxy('start');
-    }
-
-    startDev() {
-        return this.startProxy('startDev');
     }
 
     startTest() {
@@ -56,23 +50,36 @@ class TrezordNodeProcess implements BridgeInterface {
         this.proxy.dispose();
     }
 
-    status() {
-        if (!this.proxy.running) {
-            return Promise.resolve({ service: false, process: false });
+    async status() {
+        try {
+            const resp = await fetch(`http://127.0.0.1:21328/`, {
+                method: 'POST',
+                headers: {
+                    Origin: 'https://electron.trezor.io',
+                },
+            });
+            if (resp.status === 200) {
+                const data = await resp.json();
+                if (data?.version) {
+                    return {
+                        service: true,
+                        process: Boolean(this.proxy.running),
+                    };
+                }
+            }
+        } catch {
+            // empty
         }
 
-        return this.proxy
-            .request('status', [])
-            .catch(() => ({ service: false, process: this.proxy.running }));
+        return {
+            service: false,
+            process: Boolean(this.proxy.running),
+        };
     }
 }
 
 const start = async (bridge: BridgeInterface) => {
-    if (bridgeLegacy) {
-        await bridge.start();
-    } else if (bridgeDev) {
-        await bridge.startDev();
-    } else if (bridgeTest) {
+    if (bridgeTest) {
         await bridge.startTest();
     } else {
         await bridge.start();
@@ -81,9 +88,9 @@ const start = async (bridge: BridgeInterface) => {
 
 const shouldUseLegacyBridge = (store: Dependencies['store']) => {
     const legacyRequestedBySettings = store.getBridgeSettings().legacy;
-
+    const legacyRequestedBySwitch = hasSwitch('bridge-legacy');
     // Legacy bridge explicitly requested
-    if (bridgeLegacy || legacyRequestedBySettings) return true;
+    if (legacyRequestedBySwitch || legacyRequestedBySettings) return true;
 
     return false;
 };
@@ -92,12 +99,24 @@ let bridge: BridgeInterface;
 let legacyBridge: BridgeInterface;
 let nodeBridge: BridgeInterface;
 
-const loadBridge = async (store: Dependencies['store']) => {
+const handleBridgeStatus = async ({
+    mainThreadEmitter,
+    mainWindowProxy,
+}: Pick<Dependencies, 'mainThreadEmitter' | 'mainWindowProxy'>) => {
     const { logger } = global;
-    legacyBridge = new BridgeProcess();
-    nodeBridge = new TrezordNodeProcess();
 
-    bridge = shouldUseLegacyBridge(store) ? legacyBridge : nodeBridge;
+    logger.info('bridge', `Getting status`);
+    const status = await bridge.status();
+    logger.info('bridge', `Toggling bridge. Status: ${JSON.stringify(status)}`);
+
+    mainWindowProxy.getInstance()?.webContents.send('bridge/status', status);
+    mainThreadEmitter.emit('module/bridge/status', status);
+
+    return status;
+};
+
+const loadBridge = async ({ store }: Pick<Dependencies, 'store'>) => {
+    const { logger } = global;
 
     if (store.getBridgeSettings().doNotStartOnStartup) {
         return;
@@ -106,7 +125,7 @@ const loadBridge = async (store: Dependencies['store']) => {
     try {
         logger.info(
             SERVICE_NAME,
-            `Starting (Legacy: ${b2t(shouldUseLegacyBridge(store))}, Test: ${b2t(bridgeTest)}, Dev: ${b2t(bridgeDev)})`,
+            `Starting (Legacy: ${b2t(shouldUseLegacyBridge(store))}, Test: ${b2t(bridgeTest)})`,
         );
         await start(bridge);
     } catch (err) {
@@ -115,12 +134,20 @@ const loadBridge = async (store: Dependencies['store']) => {
     }
 };
 
-export const initBackground = ({ store }: Pick<Dependencies, 'store'>) => {
+let watchInterval: NodeJS.Timeout | undefined;
+
+export const initBackground = ({
+    store,
+    mainThreadEmitter,
+    mainWindowProxy,
+}: Pick<Dependencies, 'store' | 'mainThreadEmitter' | 'mainWindowProxy'>) => {
     let loaded = false;
 
-    let watchInterval: NodeJS.Timeout | undefined;
+    legacyBridge = new BridgeProcess();
+    nodeBridge = new TrezordNodeProcess();
+    bridge = shouldUseLegacyBridge(store) ? legacyBridge : nodeBridge;
 
-    const onLoad = () => {
+    const onLoad = async () => {
         if (loaded) return;
         loaded = true;
 
@@ -136,15 +163,29 @@ export const initBackground = ({ store }: Pick<Dependencies, 'store'>) => {
             if (!isBridgeRunning.service && !isStartingLocalBridge) {
                 isStartingLocalBridge = true;
                 logger.info(SERVICE_NAME, 'Detected that no bridge is running, starting it');
-                await loadBridge(store)
+                await loadBridge({
+                    store,
+                })
                     .catch(() => {})
                     .finally(() => {
                         isStartingLocalBridge = false;
+                        handleBridgeStatus({
+                            mainThreadEmitter,
+                            mainWindowProxy,
+                        });
                     });
             }
         }, 30_000);
 
-        return scheduleAction(() => loadBridge(store), { timeout: 3000 }).catch(err => {
+        const status = await bridge.status();
+
+        if (status.service) {
+            return;
+        }
+
+        return scheduleAction(() => loadBridge({ store }), {
+            timeout: 3000,
+        }).catch(err => {
             // Error ignored, user will see transport error afterwards
             logger.error(SERVICE_NAME, `Failed to load: ${err.message}`);
         });
@@ -174,6 +215,7 @@ export const init = ({ store, mainWindowProxy, mainThreadEmitter }: Dependencies
                 return { success: false, error };
             } finally {
                 const newSettings = store.getBridgeSettings();
+                mainWindowProxy?.getInstance()?.webContents.send('bridge/settings', newSettings);
 
                 if (oldSettings.legacy !== payload.legacy) {
                     const wasBridgeRunning = await bridge.status();
@@ -185,8 +227,6 @@ export const init = ({ store, mainWindowProxy, mainThreadEmitter }: Dependencies
                         await start(bridge);
                     }
                 }
-
-                mainWindowProxy?.getInstance()?.webContents.send('bridge/settings', newSettings);
             }
         },
     );
@@ -201,21 +241,8 @@ export const init = ({ store, mainWindowProxy, mainThreadEmitter }: Dependencies
         }
     });
 
-    const handleBridgeStatus = async () => {
-        const { logger } = global;
-
-        logger.info('bridge', `Getting status`);
-        const status = await bridge.status();
-        logger.info('bridge', `Toggling bridge. Status: ${JSON.stringify(status)}`);
-
-        mainWindowProxy.getInstance()?.webContents.send('bridge/status', status);
-        mainThreadEmitter.emit('module/bridge/status', status);
-
-        return status;
-    };
-
     const toggleBridge = async (): Promise<InvokeResult> => {
-        const status = await handleBridgeStatus();
+        const status = await handleBridgeStatus({ mainThreadEmitter, mainWindowProxy });
         try {
             if (status.service) {
                 await bridge.stop();
@@ -227,11 +254,17 @@ export const init = ({ store, mainWindowProxy, mainThreadEmitter }: Dependencies
         } catch (error) {
             return { success: false, error };
         } finally {
-            handleBridgeStatus();
+            handleBridgeStatus({ mainThreadEmitter, mainWindowProxy });
         }
     };
+
     ipcMain.handle('bridge/toggle', async ipcEvent => {
         validateIpcMessage({ ipcEvent });
+
+        // turning bridge on and off disables watchdog. this watchdog handles quite an edge-case anyway so trying to reconcile both functionalities
+        if (watchInterval) {
+            clearInterval(watchInterval);
+        }
 
         return await toggleBridge();
     });

--- a/packages/suite/e2e/support/bridge.ts
+++ b/packages/suite/e2e/support/bridge.ts
@@ -4,16 +4,22 @@ export const BRIDGE_VERSION = 'node-bridge';
 
 export const BRIDGE_URL = 'http://127.0.0.1:21328';
 const BRIDGE_STATUS_URL = `${BRIDGE_URL}/status/`;
-
+const HEADERS = {
+    Origin: 'https://wallet.trezor.io',
+};
 export const expectBridgeToBeRunning = async (request: APIRequestContext) => {
-    const bridgeResponse = await request.get(BRIDGE_STATUS_URL);
+    const bridgeResponse = await request.get(BRIDGE_STATUS_URL, {
+        headers: HEADERS,
+    });
     await expect(bridgeResponse).toBeOK();
 };
 
 export const expectBridgeToBeStopped = async (request: APIRequestContext) => {
     await expect(async () => {
-        await request.get(BRIDGE_STATUS_URL);
-    }).rejects.toThrow('ECONNREFUSED');
+        await request.get(BRIDGE_STATUS_URL, {
+            headers: HEADERS,
+        });
+    }).rejects.toThrow();
 };
 
 // We wait for `@welcome-layout/body` or `@dashboard/graph` since

--- a/packages/suite/src/actions/suite/bioAuthThunks.ts
+++ b/packages/suite/src/actions/suite/bioAuthThunks.ts
@@ -26,31 +26,25 @@ const handleError = (error: string, dispatch: Dispatch, message: string) => {
 export const init = createThunk(`${BIO_AUTH_PREFIX}/init`, (_args, { dispatch }) => {
     // settings
     desktopApi.getBioAuthSettings().then(settings => {
-        console.log('get settings', settings);
         dispatch(bioAuthActions.setBioAuthEnabled(settings.enabled));
     });
     desktopApi.on('bio-auth/settings-changed', settings => {
-        console.log('bio-auth/settings-changed', settings);
         dispatch(bioAuthActions.setBioAuthEnabled(settings.enabled));
     });
 
     // api availability
     desktopApi.isBioAuthAvailable().then(available => {
-        console.log('initial availability', available);
         dispatch(bioAuthActions.setIsBioAuthAvailable(available));
     });
 
     // validation status
     desktopApi.getBioAuthStatus().then(validated => {
-        console.log('initial validation status', validated);
         dispatch(bioAuthActions.setIsBioAuthValidationRequired(!validated));
     });
     desktopApi.on('bio-auth/validation-status-changed', validated => {
-        console.log('validation status changed', validated);
         dispatch(bioAuthActions.setIsBioAuthValidationRequired(!validated));
     });
     desktopApi.on('bio-auth/bio-auth-availability-changed', available => {
-        console.log('bio-auth availability changed', available);
         dispatch(bioAuthActions.setIsBioAuthAvailable(available));
     });
 });
@@ -114,7 +108,6 @@ export const requestBioAuthValidationThunk = createThunk(
         const result = await desktopApi.validateBioAuth({
             message: messageSuccess,
         });
-        console.log('result of bio-auth validation', result);
         if (!result.success) {
             dispatch(bioAuthActions.setCancelled(true));
 

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -577,11 +577,6 @@ export class TrezordNode {
     }
 
     // compatibility with "BridgeProcess" type
-    public startDev() {
-        return this.start();
-    }
-
-    // compatibility with "BridgeProcess" type
     public startTest() {
         return this.start();
     }

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -220,11 +220,13 @@ export class TrezordNode {
         const primaryApp = new HttpServer({
             ports: [this.requestedPort],
             logger: this.logger,
+            address: ADDRESS.replace('http://', ''),
         });
 
         const compatibilityApp = new HttpServer({
             ports: [COMPATIBILITY_PORT],
             logger: this.logger,
+            address: ADDRESS.replace('http://', ''),
         });
 
         const bindHandlers = (app: HttpServer<any>) => {

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -80,6 +80,7 @@ const validateProtocolMessageBody =
     };
 
 const COMPATIBILITY_PORT = 21325;
+const ADDRESS = 'http://127.0.0.1';
 
 export class TrezordNode {
     version = '3.1.0';
@@ -234,7 +235,7 @@ export class TrezordNode {
                         !req.headers.origin &&
                         req.headers.host &&
                         [
-                            `127.0.0.1:${app.getServerAddress().port}`,
+                            `${ADDRESS}:${app.getServerAddress().port}`,
                             `localhost:${app.getServerAddress().port}`,
                         ].includes(req.headers.host)
                     ) {
@@ -458,7 +459,7 @@ export class TrezordNode {
             app.get('/', [
                 (_req, res) => {
                     res.writeHead(301, {
-                        Location: `http://127.0.0.1:${app.getServerAddress().port}/status`,
+                        Location: `${ADDRESS}:${app.getServerAddress().port}/status`,
                     });
                     res.end();
                 },
@@ -489,7 +490,7 @@ export class TrezordNode {
                     const signal = this.createAbortSignal(res);
                     await this.core.enumerate({ signal });
                     const props = {
-                        intro: `To download full logs go to http://127.0.0.1:${app.getServerAddress().port}/logs`,
+                        intro: `To download full logs go to ${ADDRESS}:${app.getServerAddress().port}/logs`,
                         version: this.version,
                         bundledVersion: this.bundledVersion,
                         devices: this.descriptors,
@@ -566,7 +567,7 @@ export class TrezordNode {
     }
 
     public async status() {
-        const running = await fetch(`http://127.0.0.1:${this.port ?? this.requestedPort}/`)
+        const running = await fetch(`${ADDRESS}:${this.port ?? this.requestedPort}/`)
             .then(resp => resp.ok)
             .catch(() => false);
 

--- a/packages/transport-test/e2e/bridge/bridge.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge.test.ts
@@ -8,6 +8,7 @@ import { assertSuccess } from '../api/utils';
 
 const emulatorStartOpts = { model: 'T2T1', version: '2-latest', wipe: true } as const;
 
+// todo: these test were focused on testing feature parity between old and new bridge implementations. since old bridge is now deprecated, we might get rid of them, or at least stop testing the old bridge behavior
 describe('bridge', () => {
     let bridge: BridgeTransport;
     let descriptors: Descriptor[];

--- a/packages/transport-test/e2e/bridge/controller.ts
+++ b/packages/transport-test/e2e/bridge/controller.ts
@@ -52,8 +52,7 @@ class Controller extends TrezorUserEnvLinkClass {
 
         this.startBridge =
             !env.USE_HW && !env.USE_NODE_BRIDGE
-                ? (version?: Parameters<TrezorUserEnvLinkClass['startBridge']>[0]) =>
-                      this.originalApi.startBridge(version)
+                ? () => this.originalApi.startBridge('2.0.33')
                 : env.USE_NODE_BRIDGE
                   ? async () => {
                         this.nodeBridge = new TrezordNode({

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -77,7 +77,7 @@ interface ReadAndConfirmShamirMnemonicEmu {
     threshold: number;
 }
 
-type StartBridgeVersion = '2.0.32' | '2.0.33' | 'node-bridge';
+type StartBridgeVersion = '2.0.33' | 'node-bridge';
 
 export const MNEMONICS = {
     mnemonic_all: 'all all all all all all all all all all all all',
@@ -89,7 +89,7 @@ export const MNEMONICS = {
         'academic again academic academic academic academic academic academic academic academic academic academic academic academic academic academic academic pecan provide remember',
 };
 
-export const DEFAULT_BRIDGE_VERSION = '2.0.33';
+export const DEFAULT_BRIDGE_VERSION = 'node-bridge';
 
 // There's an ongoing problem with debug link & button requests race conditions
 // Adding a delay to workaround this issue temporarily

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -110,7 +110,7 @@ const inputs = [
     },
     {
         key: 'transport',
-        value: ['2.0.32', '2.0.33', 'node-bridge'],
+        value: ['node-bridge', '2.0.33'],
     },
     {
         key: 'groups',


### PR DESCRIPTION
Changes in this PR make node-bridge even more default across the codebase:

- related tenv branch https://github.com/trezor/trezor-user-env/pull/336 where node-bridge is set to default, mac-proxy is removed
- in connect CI, node-bridge has been default for some time, so no changes here. 
- ...


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bridge-deprecation-ci&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bridge-deprecation-ci&lookback=7)