### PR TITLE
fix(suite-native): move self address button

### DIFF
--- a/suite-native/module-send/src/components/AddressInput.tsx
+++ b/suite-native/module-send/src/components/AddressInput.tsx
@@ -72,11 +72,6 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
                 <Text variant="hint">
                     <Translation id="moduleSend.outputs.recipients.addressLabel" />
                 </Text>
-                {isDebugEnv() && (
-                    <Button size="small" colorScheme="tertiaryElevation0" onPress={fillSelfAddress}>
-                        DEV: self address
-                    </Button>
-                )}
                 <SendFormLabelEditable
                     label={utxoLabel ?? null}
                     onLabelChange={newUtxoLabel => {
@@ -84,6 +79,11 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
                     }}
                 />
             </HStack>
+            {isDebugEnv() && (
+                <Button size="small" colorScheme="tertiaryElevation0" onPress={fillSelfAddress}>
+                    DEV: self address
+                </Button>
+            )}
             <TextInputField
                 multiline
                 name={addressFieldName}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Tiny PR to move self address button on send form meant for development. No change for users.

## Screenshots:
Before
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/852c9f2a-4aea-49b8-86d0-402d2298761c" />

After
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/4ade13da-8f98-49d6-90aa-373e7659d76f" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/move-self-address-button&lookback=7)