### PR TITLE
chore(suite): move logic out of TransactionReviewOutputElement

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -3,13 +3,14 @@ import { ReactNode } from 'react';
 import { TranslationKey } from '@suite-common/intl-types';
 import { UINT256_MAX } from '@suite-common/suite-constants';
 import { TrezorDevice } from '@suite-common/suite-types';
-import { NetworkSymbol, NetworkType, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { NetworkType, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { BTC_LOCKTIME_VALUE } from '@suite-common/wallet-constants';
 import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
 import { EvmTransactionPurpose, ReviewOutput, StakeType } from '@suite-common/wallet-types';
 import {
     EvmApprovalPurpose,
     findAccountsByAddress,
+    getCardanoFingerprint,
     isApprovalFlowSupported,
     isEvmApprovalTxByTextSignature,
     isTestnet,
@@ -181,11 +182,10 @@ const getOutputTitle = (
 
 interface GetOutputLinesParams {
     type: ReviewOutput['type'];
-    networkType: NetworkType;
+    account: Account;
     value: string;
     value2?: string;
     label?: string;
-    symbol: NetworkSymbol;
     stakeType?: StakeType;
     evmTxType?: EvmTransactionPurpose;
     device?: TrezorDevice;
@@ -195,17 +195,18 @@ interface GetOutputLinesParams {
 
 const getOutputLines = ({
     type,
-    networkType,
+    account,
     value,
     value2 = '',
     label = '',
-    symbol,
     stakeType,
     evmTxType,
     device,
     token,
     translationString,
 }: GetOutputLinesParams): OutputElementLine[] => {
+    const { networkType, symbol } = account;
+
     switch (type) {
         case 'gas':
         case 'fee':
@@ -315,15 +316,38 @@ const getOutputLines = ({
                     value,
                 },
             ];
-        case 'amount':
-            return [
+        case 'amount': {
+            const output: OutputElementLine[] = [
                 {
                     id: type,
                     label: <Translation id="AMOUNT" />,
                     value,
                     type: 'amount',
+                    token,
                 },
             ];
+            if (networkType === 'cardano' && token) {
+                const fingerprint = getCardanoFingerprint(account?.tokens, token?.symbol);
+                if (fingerprint) {
+                    output.push({
+                        id: 'cardano-fingerprint',
+                        label: <Translation id="TR_CARDANO_FINGERPRINT_HEADLINE" />,
+                        value: fingerprint,
+                        type: 'default',
+                    });
+                }
+                if (token.decimals !== 0) {
+                    output.push({
+                        id: 'cardano-trezor-amount',
+                        label: <Translation id="TR_CARDANO_TREZOR_AMOUNT_HEADLINE" />,
+                        value,
+                        type: 'default',
+                    });
+                }
+            }
+
+            return output;
+        }
         case 'approve_data': {
             const isMaxApproval = new BigNumber(value).eq(UINT256_MAX);
             const isApprovalTx = evmTxType === 'approve';
@@ -345,6 +369,7 @@ const getOutputLines = ({
                         />
                     ),
                     value: getValue(),
+                    token,
                     type,
                 },
                 {
@@ -408,11 +433,10 @@ export const TransactionReviewOutput = ({
 
     const outputLines = getOutputLines({
         type,
-        networkType,
+        account,
         value,
         value2,
         label,
-        symbol,
         stakeType,
         evmTxType,
         device,
@@ -477,7 +501,6 @@ export const TransactionReviewOutput = ({
             title={outputTitle}
             account={account}
             lines={outputLines}
-            token={token}
             state={state}
             fiatVisible={isFiatVisible}
         />

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -27,19 +27,6 @@ import { Translation } from 'src/components/suite/Translation';
 import { TransactionReviewOutputStatus } from 'src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputStatus';
 import { Account } from 'src/types/wallet';
 
-const getCardanoFingerprint = (
-    tokens: Account['tokens'],
-    symbol: string | undefined,
-): string | undefined => {
-    if (!tokens) {
-        return undefined;
-    }
-
-    const token = tokens.find(token => token.symbol?.toLowerCase() === symbol?.toLowerCase());
-
-    return token?.fingerprint;
-};
-
 const DataWrapper = styled.p<{ $isExpanded: boolean; $elevation: Elevation }>`
     word-break: break-all;
     font-variant-numeric: tabular-nums;
@@ -115,12 +102,11 @@ type ValueProps = {
     type: OutputElementLine['type'];
     symbol: NetworkSymbol;
     isFiatVisible: boolean;
-    isFee: boolean;
     state: TransactionReviewOutputElementProps['state'];
     token?: TokenInfo;
 };
 
-const Value = ({ value, type, symbol, token, isFee, isFiatVisible, state }: ValueProps) => {
+const Value = ({ value, type, symbol, token, isFiatVisible, state }: ValueProps) => {
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(symbol);
 
     switch (type) {
@@ -137,8 +123,7 @@ const Value = ({ value, type, symbol, token, isFee, isFiatVisible, state }: Valu
         case 'data':
             return <Data value={value} />;
         case 'amount': {
-            const isTokenAmount = !isFee && token;
-            const formattedValue = isTokenAmount
+            const formattedValue = token
                 ? convertAmountSubunitsToUnits(value, token.decimals)
                 : formatNetworkAmount(value, symbol);
 
@@ -148,11 +133,8 @@ const Value = ({ value, type, symbol, token, isFee, isFiatVisible, state }: Valu
                         data-testid="@modal/crypto-amount"
                         disableHiddenPlaceholder
                         value={formattedValue}
-                        symbol={
-                            // TX fee is so far always paid in network native coin
-                            isTokenAmount ? token.symbol : symbol
-                        }
-                        contractAddress={isTokenAmount ? token?.contract : undefined}
+                        symbol={token?.symbol ?? symbol}
+                        contractAddress={token?.contract}
                         isTabular={false}
                     />
                     {shallDisplayBaseCurrency && isFiatVisible && (
@@ -160,9 +142,7 @@ const Value = ({ value, type, symbol, token, isFee, isFiatVisible, state }: Valu
                             <BaseCurrencyValue
                                 disableHiddenPlaceholder
                                 amount={formattedValue}
-                                tokenAddress={
-                                    token && !isFee ? (token.contract as TokenAddress) : undefined
-                                }
+                                tokenAddress={token?.contract as TokenAddress}
                                 symbol={symbol}
                             />
                         </Text>
@@ -180,6 +160,7 @@ const Value = ({ value, type, symbol, token, isFee, isFiatVisible, state }: Valu
 export type OutputElementLine = {
     id: string;
     value: string;
+    token?: TokenInfo;
     type: 'default' | 'address' | 'safe-address' | 'data' | 'amount';
     label?: ReactNode;
 };
@@ -190,18 +171,16 @@ export type TransactionReviewOutputElementProps = {
     account: Pick<Account, 'networkType' | 'symbol' | 'tokens'>;
     state: 'active' | 'confirmed' | 'unconfirmed';
     fiatVisible?: boolean;
-    token?: TokenInfo;
 };
 
 export const TransactionReviewOutputElement = ({
     title,
     lines,
-    token,
     fiatVisible = false,
     account,
     state,
 }: TransactionReviewOutputElementProps) => {
-    const { networkType, symbol } = account;
+    const { symbol } = account;
 
     return (
         <Card
@@ -226,9 +205,8 @@ export const TransactionReviewOutputElement = ({
                             value={line.value}
                             type={line.type}
                             symbol={symbol}
-                            token={token}
+                            token={line.token}
                             isFiatVisible={fiatVisible}
-                            isFee={line.id === 'fee'}
                             state={state}
                         />
                     );
@@ -261,44 +239,6 @@ export const TransactionReviewOutputElement = ({
                                     <Text data-testid="@modal/output-value">{value}</Text>
                                 )}
                             </Text>
-                            {networkType === 'cardano' && token?.symbol && (
-                                <Text typographyStyle="hint" as="div">
-                                    <InfoItem
-                                        label={
-                                            <Text variant="default">
-                                                <Translation id="TR_CARDANO_FINGERPRINT_HEADLINE" />
-                                            </Text>
-                                        }
-                                        direction="row"
-                                    >
-                                        <Column
-                                            alignItems="flex-end"
-                                            data-testid="@modal/cardano-fingerprint"
-                                        >
-                                            {getCardanoFingerprint(account?.tokens, token?.symbol)}
-                                        </Column>
-                                    </InfoItem>
-                                </Text>
-                            )}
-                            {networkType === 'cardano' && token && token.decimals !== 0 && (
-                                <Text typographyStyle="hint" as="div">
-                                    <InfoItem
-                                        label={
-                                            <Text variant="default">
-                                                <Translation id="TR_CARDANO_TREZOR_AMOUNT_HEADLINE" />
-                                            </Text>
-                                        }
-                                        direction="row"
-                                    >
-                                        <Column
-                                            alignItems="flex-end"
-                                            data-testid="@modal/cardano-trezor-amount"
-                                        >
-                                            {line.value}
-                                        </Column>
-                                    </InfoItem>
-                                </Text>
-                            )}
                         </Column>
                     );
                 })}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -75,6 +75,7 @@ const getLines = (
             id: 'amount', // In updated ethereum send flow there is no total amount shown, only amount without fee
             label: <Translation id="AMOUNT" />,
             value: tokenInfo ? precomposedTx.totalSpent : amountWithoutFee,
+            token: tokenInfo,
             type: 'amount',
         };
 
@@ -98,6 +99,7 @@ const getLines = (
                 id: 'total',
                 label: <Translation id={showAmountWithoutFee ? 'AMOUNT' : 'TR_TOTAL_AMOUNT'} />,
                 value: tokenInfo ? precomposedTx.totalSpent : amount,
+                token: tokenInfo,
                 type: 'amount',
             },
             {
@@ -114,6 +116,7 @@ const getLines = (
             id: 'total',
             label: <Translation id="TR_TOTAL" />,
             value: precomposedTx.totalSpent,
+            token: tokenInfo,
             type: 'amount',
         },
     ];
@@ -158,7 +161,6 @@ export const TransactionReviewTotalOutput = ({
             lines={lines}
             state={state}
             fiatVisible={!isTestnet(symbol)}
-            token={precomposedTx?.token}
         />
     );
 };

--- a/suite-common/wallet-utils/src/cardanoUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoUtils.ts
@@ -197,3 +197,16 @@ export const formatMaxOutputAmount = (
 
     return convertAmountSubunitsToUnits(maxAmount, tokenDecimals);
 };
+
+export const getCardanoFingerprint = (
+    tokens: Account['tokens'],
+    symbol: string | undefined,
+): string | undefined => {
+    if (!tokens) {
+        return undefined;
+    }
+
+    const token = tokens.find(t => t.symbol?.toLowerCase() === symbol?.toLowerCase());
+
+    return token?.fingerprint;
+};


### PR DESCRIPTION
## Description

When trying to solve #23398 I found that the logic in Transaction modal outputs is rather difficult to work with, because it's spread across many different places. 
In this PR I'm refactoring TransactionReviewOutputElement to move logic away and make it a purely view component. 
Specifically, token needs to be passed to each line and moves Cardano-specific conditions.

## Notes for QA

Check that review modal is correct for token sending, especially for Cardano

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/transaction-review-refactor&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/transaction-review-refactor&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/transaction-review-refactor&lookback=7)