### PR TITLE
feat(suite-native): open correct modal tab

### DIFF
--- a/suite-native/transactions/src/components/TransactionDetail/NetworkTransactionDetailSummary.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/NetworkTransactionDetailSummary.tsx
@@ -11,6 +11,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { TransactionDetailAddressesSection } from './TransactionDetailAddressesSection';
 import { selectTransactionAddresses } from '../../selectors';
+import { AddressesType } from '../../types';
 
 type VerticalSeparatorProps = { inputsCount: number };
 
@@ -54,7 +55,7 @@ export const VerticalSeparator = ({ inputsCount }: VerticalSeparatorProps) => {
 type NetworkTransactionDetailSummaryProps = {
     transaction: WalletAccountTransaction;
     accountKey: AccountKey;
-    onShowMore: () => void;
+    onShowMore: (addressesType: AddressesType) => void;
 };
 
 export const NetworkTransactionDetailSummary = ({
@@ -77,7 +78,7 @@ export const NetworkTransactionDetailSummary = ({
                 <TransactionDetailAddressesSection
                     addressesType="inputs"
                     addresses={transactionInputAddresses}
-                    onShowMore={onShowMore}
+                    onShowMore={() => onShowMore('inputs')}
                     symbol={transaction.symbol}
                     transaction={transaction}
                 />
@@ -86,7 +87,7 @@ export const NetworkTransactionDetailSummary = ({
                 <TransactionDetailAddressesSection
                     addressesType="outputs"
                     addresses={transactionOutputAddresses}
-                    onShowMore={onShowMore}
+                    onShowMore={() => onShowMore('outputs')}
                     transaction={transaction}
                 />
             )}

--- a/suite-native/transactions/src/components/TransactionDetail/TokenTransactionDetailSummary.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TokenTransactionDetailSummary.tsx
@@ -7,13 +7,13 @@ import { TypedTokenTransfer, WalletAccountTransaction } from '@suite-native/toke
 
 import { VerticalSeparator } from './NetworkTransactionDetailSummary';
 import { TransactionDetailAddressesSection } from './TransactionDetailAddressesSection';
-import { VinVoutAddress } from '../../types';
+import { AddressesType, VinVoutAddress } from '../../types';
 
 type TokenTransactionDetailSummaryProps = {
     transaction: WalletAccountTransaction;
     accountKey: AccountKey;
     tokenTransfer: TypedTokenTransfer;
-    onShowMore: () => void;
+    onShowMore: (addressesType: AddressesType) => void;
 };
 
 export const TokenTransactionDetailSummary = ({
@@ -41,13 +41,13 @@ export const TokenTransactionDetailSummary = ({
                 addresses={inputAddresses}
                 symbol={symbol ?? undefined}
                 contractAddress={tokenTransfer.contract}
-                onShowMore={onShowMore}
+                onShowMore={() => onShowMore('inputs')}
             />
             <TransactionDetailAddressesSection
                 transaction={transaction}
                 addressesType="outputs"
                 addresses={outputAddresses}
-                onShowMore={onShowMore}
+                onShowMore={() => onShowMore('outputs')}
             />
             <VerticalSeparator inputsCount={inputAddresses.length} />
         </VStack>

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailAddressesSheet.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailAddressesSheet.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { useSelector } from 'react-redux';
 
@@ -31,6 +31,8 @@ type TransactionDetailAddressesSheetProps = {
     accountKey: AccountKey;
     onClose: () => void;
     ref: BottomSheetModalRef;
+    displayedAddressesType: AddressesType;
+    toggleAddresses: () => void;
 };
 
 const addressStyle = prepareNativeStyle(_ => ({ maxWidth: '90%' }));
@@ -88,9 +90,9 @@ export const TransactionDetailAddressesSheet = ({
     txid,
     accountKey,
     ref,
+    toggleAddresses,
+    displayedAddressesType,
 }: TransactionDetailAddressesSheetProps) => {
-    const [displayedAddressesType, setDisplayedAddressesType] = useState<AddressesType>('inputs');
-
     const inputAddresses = useSelector((state: TransactionsRootState & TokenDefinitionsRootState) =>
         selectTransactionAddresses(state, accountKey, txid, 'inputs'),
     );
@@ -109,10 +111,6 @@ export const TransactionDetailAddressesSheet = ({
         }),
         [displayedAddresses],
     );
-
-    const toggleAddresses = () => {
-        setDisplayedAddressesType(displayedAddressesType === 'inputs' ? 'outputs' : 'inputs');
-    };
 
     return (
         <BottomSheetModal

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailSummary.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailSummary.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { AccountKey } from '@suite-common/wallet-types';
 import { Card, useBottomSheetModal } from '@suite-native/atoms';
 import { TypedTokenTransfer, WalletAccountTransaction } from '@suite-native/tokens';
@@ -6,6 +8,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { NetworkTransactionDetailSummary } from './NetworkTransactionDetailSummary';
 import { TokenTransactionDetailSummary } from './TokenTransactionDetailSummary';
 import { TransactionDetailAddressesSheet } from './TransactionDetailAddressesSheet';
+import { AddressesType } from '../../types';
 
 type TransactionDetailSummaryProps = {
     transaction: WalletAccountTransaction;
@@ -25,8 +28,18 @@ export const TransactionDetailSummary = ({
 }: TransactionDetailSummaryProps) => {
     const { applyStyle } = useNativeStyles();
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
+    const [displayedAddressesType, setDisplayedAddressesType] = useState<AddressesType>('inputs');
 
     const isTokenTransferDetail = !!tokenTransfer;
+
+    const handleOpenModal = (addressesType: AddressesType) => {
+        setDisplayedAddressesType(addressesType);
+        openModal();
+    };
+
+    const toggleAddresses = () => {
+        setDisplayedAddressesType(displayedAddressesType === 'inputs' ? 'outputs' : 'inputs');
+    };
 
     return (
         <Card style={applyStyle(cardStyle)} borderColor="borderElevation1">
@@ -35,13 +48,13 @@ export const TransactionDetailSummary = ({
                     accountKey={accountKey}
                     transaction={transaction}
                     tokenTransfer={tokenTransfer}
-                    onShowMore={openModal}
+                    onShowMore={handleOpenModal}
                 />
             ) : (
                 <NetworkTransactionDetailSummary
                     accountKey={accountKey}
                     transaction={transaction}
-                    onShowMore={openModal}
+                    onShowMore={handleOpenModal}
                 />
             )}
             <TransactionDetailAddressesSheet
@@ -49,6 +62,8 @@ export const TransactionDetailSummary = ({
                 txid={transaction.txid}
                 accountKey={accountKey}
                 onClose={closeModal}
+                displayedAddressesType={displayedAddressesType}
+                toggleAddresses={toggleAddresses}
             />
         </Card>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When opening transaction outputs or inputs modal, it didn't take into account whether I clicked on `Show more` from inputs or outputs. This PR fixes that. 

There's still weird behavior in that toggling happens even when you click on already selected toggle within the toggle component, but I didn't want to look too much into it in this PR and could be fixed in some follow up, so I'll [create an issue for it](https://github.com/trezor/trezor-suite/issues/23405).

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Screenshots:

https://github.com/user-attachments/assets/8a7cd7da-8cab-46f8-849f-7d09ba19761c



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/open-correct-modal-tx-detail&lookback=7)