### PR TITLE
test(suite): increase useSendForm test timeout

### DIFF
--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -23,7 +23,7 @@ import SendIndex from 'src/views/wallet/send';
 import * as fixtures from '../__fixtures__/useSendForm';
 import { useSendFormContext } from '../useSendForm';
 
-const TEST_TIMEOUT = 30000;
+const TEST_TIMEOUT = 35000;
 
 global.ResizeObserver = class MockedResizeObserver {
     observe = jest.fn();


### PR DESCRIPTION
This test is flaky due to exceeding timeout.  I can't tell what change has cased it.

Examples of failing pipelines:
https://github.com/trezor/trezor-suite/actions/runs/19679289047/job/56369118280?pr=23375 - with a successful re-run
https://github.com/trezor/trezor-suite/actions/runs/19676968809/job/56361023186

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/increase-sendform-test-timeout&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/increase-sendform-test-timeout&lookback=7)