### PR TITLE
Update radio and checkbox border color for better visibility

### DIFF
--- a/suite-native/atoms/src/CheckBox.tsx
+++ b/suite-native/atoms/src/CheckBox.tsx
@@ -28,7 +28,7 @@ const checkBoxStyle = prepareNativeStyle<CheckBoxStyleProps>(
         justifyContent: 'center',
         borderRadius: utils.borders.radii.r4,
         borderWidth: utils.borders.widths.medium,
-        borderColor: utils.colors.borderElevation2,
+        borderColor: utils.colors.iconSubdued,
         backgroundColor: isDisabled
             ? utils.colors.backgroundNeutralDisabled
             : utils.colors.backgroundNeutralSubtleOnElevation1,

--- a/suite-native/atoms/src/Radio.tsx
+++ b/suite-native/atoms/src/Radio.tsx
@@ -35,7 +35,7 @@ const radioStyle = prepareNativeStyle<RadioStyleProps>(
         justifyContent: 'center',
         borderRadius: utils.borders.radii.round,
         borderWidth: isChecked ? utils.borders.widths.large : utils.borders.widths.medium,
-        borderColor: utils.colors.borderElevation2,
+        borderColor: utils.colors.iconSubdued,
         extend: {
             condition: isChecked && !isDisabled,
             style: { borderColor: utils.colors[activeColor] },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update radio and checkbox border color for better visibility.

## Notes for QA

Please check ideally all of the places where we have radio or checkbox. Would be nice to check also darkmode.

Radio:
- fee options
- country list
- trading module
- wallet backup selection
- demo account questionnaire (new)
- device switcher
- bitcoin units settings
- currency selection
- language selection

Checkbox:
- Advanced settings - turn off checks
- coin control
- connect popup: permission confirmation and tx simulation banner

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23354

## Screenshots:
<img width="330" alt="Simulator Screenshot - iPhone 11 - 2025-11-26 at 14 54 32" src="https://github.com/user-attachments/assets/c09627ed-1063-44bf-b1f6-216a7fd047a7" />
<img width="330"  alt="Simulator Screenshot - iPhone 11 - 2025-11-26 at 14 52 10" src="https://github.com/user-attachments/assets/f8fc806c-6f91-485b-b8cd-24e2011ecca9" />
<img width="330" alt="image" src="https://github.com/user-attachments/assets/a562a4b3-35a1-4351-a9c1-173cea854ce6" />

<img width="330"  alt="image" src="https://github.com/user-attachments/assets/3fff8062-683a-4e78-9d47-72eacdca9d35" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/radio-and-checkbox-border-color&lookback=7)