### PR TITLE
fix(e2e-native): return try catch that resolves firmware mismatch

### DIFF
--- a/suite-native/app/e2e/support/utils.ts
+++ b/suite-native/app/e2e/support/utils.ts
@@ -83,3 +83,19 @@ export const inputTextToElement = async (element: Detox.IndexableNativeElement, 
         await element.typeText(text);
     }
 };
+
+// Use this method in absolute necessity only! Try-catch in tests is discouraged because it may hide real issues.
+export const isElementVisible = async (
+    elementOrMatcher: Detox.IndexableNativeElement | Detox.NativeMatcher,
+): Promise<boolean> => {
+    const target = isIndexableNativeElement(elementOrMatcher)
+        ? elementOrMatcher
+        : element(elementOrMatcher);
+    try {
+        await waitFor(target).toBeVisible().withTimeout(5_000);
+
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/suite-native/app/e2e/tests/deviceOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/deviceOnboarding.test.ts
@@ -13,13 +13,22 @@ import {
     preparePreloadedReduxState,
     prepareTrezorEmulator,
 } from '../support/setup';
-import { wait } from '../support/utils';
+import { isElementVisible, wait } from '../support/utils';
 
-const proceedToCreateOrRecoverCrossroads = async (options?: { skipFirmwareUpdate?: boolean }) => {
+const proceedToCreateOrRecoverCrossroads = async () => {
     await onDeviceOnboarding.waitForUninitializedDeviceLanding();
     await onDeviceOnboarding.dismissTheUninitializedDeviceLanding();
-    if (options?.skipFirmwareUpdate) {
+    // During our release process, the TrezorUserEnv might not have the latest firmware version.
+    // In such cases, the firmware update screen appears here.
+    // We want to skip the update in e2e tests as it is not supported.
+    const isFirmwareUpdateScreenPresent = await isElementVisible(
+        by.id('@device-firmware/update-button'),
+    );
+    if (isFirmwareUpdateScreenPresent) {
         await onDeviceOnboarding.skipFirmwareUpdate();
+        console.warn(
+            'SKIPPING FIRMWARE UPDATE: Firmware update was displayed, make sure it was only due to TrezorUserEnv not having latest firmware version.',
+        );
     }
 
     await TrezorUserEnvLink.pressYes();
@@ -58,7 +67,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device onboarding [@fix
         await proceedToCreateOrRecoverCrossroads();
     });
 
-    it.skip('Create Wallet', async () => {
+    it('Create Wallet', async () => {
         await onDeviceOnboarding.selectCreateWalletOption();
 
         await onDeviceOnboarding.waitForCreateWalletLoadingScreen();
@@ -94,7 +103,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device onboarding [@fix
         await finishOnboardingFlow();
     });
 
-    it.skip('Recover Wallet', async () => {
+    it('Recover Wallet', async () => {
         await onDeviceOnboarding.selectRecoverWalletOption();
         await onDeviceOnboarding.confirmRecoveryInstructions();
 


### PR DESCRIPTION
In past PR I removed try-catch that solved firmware version mismatch. I am "reverting" that approach in slightly nice way.

Resolve https://github.com/trezor/trezor-suite/issues/23286

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-native-e2e-device-onboarding&lookback=7)