### PR TITLE
Cardano staking - outdated provider

### DIFF
--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -84,4 +84,4 @@ export const Badge = ({
     );
 };
 
-export type { BadgeSize };
+export type { BadgeSize, BadgeIntent };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -16,7 +16,7 @@ export { hexToRgbaArray } from '../../utils/src/hexToRgbaArray';
 export { hexToRgba } from '../../utils/src/hexToRgba';
 export * from './components/Flag/Flag';
 export * from './components/AutoScalingInput/AutoScalingInput';
-export { Badge, type BadgeProps, type BadgeSize } from './components/Badge/Badge';
+export { Badge, type BadgeProps, type BadgeSize, type BadgeIntent } from './components/Badge/Badge';
 export * from './components/buttons/ButtonGroup/ButtonGroup';
 export { Button, type ButtonProps } from './components/buttons/Button/Button';
 export { IconButton, type IconButtonProps } from './components/buttons/IconButton/IconButton';

--- a/packages/suite/src/components/suite/banners/SuiteBanners/CardanoOutdatedStakingBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/CardanoOutdatedStakingBanner.tsx
@@ -1,0 +1,31 @@
+import { selectPoolStatsApyData } from '@suite-common/wallet-core';
+import { Banner } from '@trezor/components';
+
+import { goto } from 'src/actions/suite/routerActions';
+import { Translation } from 'src/components/suite/Translation';
+import { DashboardAnchor } from 'src/constants/suite/anchors';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+export const CardanoOutdatedStakingBanner = () => {
+    const dispatch = useDispatch();
+    const apy = useSelector(state => selectPoolStatsApyData(state, 'ada'));
+
+    return (
+        <Banner
+            icon
+            intent="warning"
+            rightContent={
+                <Banner.Button
+                    onClick={() =>
+                        dispatch(goto('suite-index', { anchor: DashboardAnchor.Staking }))
+                    }
+                    data-testid="@notification/bridge-deprecated/button"
+                >
+                    <Translation id="TR_STAKING_MODAL_OUTDATED_BUTTON" />
+                </Banner.Button>
+            }
+        >
+            <Translation id="TR_STAKING_MODAL_OUTDATED" values={{ apy }} />
+        </Banner>
+    );
+};

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -7,7 +7,9 @@ import {
     selectIsDeviceBackupRequired,
     selectIsDeviceBackupUnfinished,
     selectSelectedDevice,
+    selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
+import { isCardanoStakedOutsideEverstake } from '@suite-common/wallet-utils';
 import { isWeb } from '@trezor/env-utils';
 import { spacingsPx } from '@trezor/theme';
 
@@ -22,6 +24,7 @@ import { selectTransportOfType } from 'src/selectors/suite/suiteSelectors';
 
 import { MessageSystemBanner } from '../MessageSystemBanner';
 import { BridgeDeprecated } from './BridgeDeprecatedBanner';
+import { CardanoOutdatedStakingBanner } from './CardanoOutdatedStakingBanner';
 import { FailedBackup } from './FailedBackupBanner';
 import { FirmwareAuthenticityCheckBanner } from './FirmwareAuthenticityCheckBanner';
 import { LocalNetworkAccessPermission } from './LocalNetworkAccessPermission';
@@ -56,6 +59,7 @@ export const SuiteBanners = ({ isOnboarding, fill }: SuiteBannersProps) => {
     const isDeviceBackupUnfinished = useSelector(selectIsDeviceBackupUnfinished);
     const isDeviceBackupRequired = useSelector(selectIsDeviceBackupRequired);
     const transport = useSelector(state => state.suite.transport);
+    const accounts = useSelector(selectVisibleDeviceAccounts);
     const { localNetworkAccessPermission } = useLocalNetworkAccessPermission();
 
     // The dismissal doesn't need to outlive the session. Use local state.
@@ -110,6 +114,9 @@ export const SuiteBanners = ({ isOnboarding, fill }: SuiteBannersProps) => {
     } else if (bridge?.outdated) {
         banner = <BridgeDeprecated />;
         priority = 30;
+    } else if (accounts.some(isCardanoStakedOutsideEverstake)) {
+        banner = <CardanoOutdatedStakingBanner />;
+        priority = 20;
     }
 
     // message system banners should always be visible in the app even if app body is blurred

--- a/packages/suite/src/constants/suite/anchors.ts
+++ b/packages/suite/src/constants/suite/anchors.ts
@@ -1,8 +1,16 @@
 import { Route } from '@suite-common/suite-types';
 
-export type AnchorSettingSection = 'general-settings' | 'device-settings' | 'coin-settings';
+export type AnchorSettingSection =
+    | 'general-settings'
+    | 'device-settings'
+    | 'coin-settings'
+    | 'dashboard';
 
 type Anchor = `@${AnchorSettingSection}/${string}`;
+
+export const DashboardAnchor = {
+    Staking: '@dashboard/staking',
+} satisfies { [key: string]: Anchor };
 
 export const SettingsAnchor = {
     Language: '@general-settings/language',
@@ -57,6 +65,7 @@ export const mapAnchorToRoute: Record<AnchorSettingSection, Route['name']> = {
     'general-settings': 'settings-index',
     'device-settings': 'settings-device',
     'coin-settings': 'settings-coins',
+    dashboard: 'suite-index',
 };
 
 export const AccountTransactionBaseAnchor = '@account/transaction';

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9393,6 +9393,15 @@ export default defineMessages({
         id: 'TR_STAKING_DASHBOARD_OUTDATED',
         defaultMessage: 'Outdated provider',
     },
+    TR_STAKING_MODAL_OUTDATED: {
+        id: 'TR_STAKING_MODAL_OUTDATED',
+        defaultMessage:
+            'Your ADA staking rewards will drop soon. Move to a new pool with {apy}% APY. Your funds and past rewards are safe.',
+    },
+    TR_STAKING_MODAL_OUTDATED_BUTTON: {
+        id: 'TR_STAKING_MODAL_OUTDATED_BUTTON',
+        defaultMessage: 'Update staking pool',
+    },
     TR_STAKING_DASHBOARD_TABLE_ACCOUNT_BALANCE: {
         id: 'TR_STAKING_DASHBOARD_TABLE_ACCOUNT_BALANCE',
         defaultMessage: 'Account',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9389,6 +9389,10 @@ export default defineMessages({
         id: 'TR_STAKING_DASHBOARD_NOT_ACTIVE',
         defaultMessage: 'Inactive',
     },
+    TR_STAKING_DASHBOARD_OUTDATED: {
+        id: 'TR_STAKING_DASHBOARD_OUTDATED',
+        defaultMessage: 'Outdated provider',
+    },
     TR_STAKING_DASHBOARD_TABLE_ACCOUNT_BALANCE: {
         id: 'TR_STAKING_DASHBOARD_TABLE_ACCOUNT_BALANCE',
         defaultMessage: 'Account',
@@ -9432,6 +9436,10 @@ export default defineMessages({
     TR_STAKING_DASHBOARD_STAKED: {
         id: 'TR_STAKING_DASHBOARD_STAKED',
         defaultMessage: '{amount} {displaySymbol} staked',
+    },
+    TR_STAKING_DASHBOARD_OUTDATED_PROVIDER: {
+        id: 'TR_STAKING_DASHBOARD_OUTDATED_PROVIDER',
+        defaultMessage: 'Update to Everstake and earn ~{apy}% APY',
     },
     TR_STAKING_BANNER_DETAIL_TITLE: {
         id: 'TR_STAKING_BANNER_DETAIL_TITLE',

--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboard.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboard.tsx
@@ -17,9 +17,12 @@ import { spacings } from '@trezor/theme';
 import { BigNumber, arrayPartition } from '@trezor/utils';
 
 import { setStakingDashboardCollapsed } from 'src/actions/suite/suiteActions';
+import { OutlineHighlight } from 'src/components/OutlineHighlight';
 import { DashboardSection } from 'src/components/dashboard';
 import { Translation, TranslationKey } from 'src/components/suite/Translation';
+import { DashboardAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 import { StakingDashboardAccountRow } from './StakingDashboardAccountRow';
@@ -61,6 +64,8 @@ export const StakingDashboard = () => {
     const dispatch = useDispatch();
 
     const collapsed = useSelector(state => state.suite.stakingDashboardCollapsed);
+
+    const { anchorRef, shouldHighlight } = useAnchor(DashboardAnchor.Staking);
 
     const ethCurrentRate = useCryptoCurrentRate('eth');
     const solCurrentRate = useCryptoCurrentRate('sol');
@@ -182,61 +187,64 @@ export const StakingDashboard = () => {
     const badge = getBadgeState(isStakingActive, stakingAccounts);
 
     return (
-        <DashboardSection
-            heading={
-                <>
-                    <Translation id="TR_STAKING_DASHBOARD_TITLE" />
-                    <Badge intent={badge.intent} margin={{ left: spacings.sm }}>
-                        <Translation id={badge.label} />
-                    </Badge>
-                </>
-            }
-            subheading={<Translation id="TR_STAKING_DASHBOARD_TEXT" />}
-            collapsible
-            defaultCollapsed={collapsed}
-            onCollapseChange={onCollapseChange}
-        >
-            <Card paddingType="none">
-                <Table isRowHighlightedOnHover margin={{ top: spacings.xs }}>
-                    <Table.Header>
-                        <Table.Row>
-                            <Table.Cell>
-                                <Translation id="TR_STAKING_DASHBOARD_TABLE_ACCOUNT_BALANCE" />
-                            </Table.Cell>
-                            <Table.Cell>
-                                <Translation id="TR_STAKING_DASHBOARD_TABLE_APY" />
-                            </Table.Cell>
-                            <Table.Cell>
-                                {!stakingAccountsNotActivated && (
-                                    <Translation id="TR_STAKING_DASHBOARD_TABLE_YEARLY_REWARDS" />
-                                )}
-                            </Table.Cell>
-                            <Table.Cell>
-                                {!stakingAccountsNotActivated && (
-                                    <Translation id="TR_STAKING_DASHBOARD_TABLE_POTENTIAL_REWARDS" />
-                                )}
-                            </Table.Cell>
-                            <Table.Cell></Table.Cell>
-                        </Table.Row>
-                    </Table.Header>
+        <OutlineHighlight shouldHighlight={shouldHighlight}>
+            <DashboardSection
+                heading={
+                    <>
+                        <Translation id="TR_STAKING_DASHBOARD_TITLE" />
+                        <Badge intent={badge.intent} margin={{ left: spacings.sm }}>
+                            <Translation id={badge.label} />
+                        </Badge>
+                    </>
+                }
+                subheading={<Translation id="TR_STAKING_DASHBOARD_TEXT" />}
+                collapsible
+                defaultCollapsed={collapsed}
+                onCollapseChange={onCollapseChange}
+                ref={anchorRef}
+            >
+                <Card paddingType="none">
+                    <Table isRowHighlightedOnHover margin={{ top: spacings.xs }}>
+                        <Table.Header>
+                            <Table.Row>
+                                <Table.Cell>
+                                    <Translation id="TR_STAKING_DASHBOARD_TABLE_ACCOUNT_BALANCE" />
+                                </Table.Cell>
+                                <Table.Cell>
+                                    <Translation id="TR_STAKING_DASHBOARD_TABLE_APY" />
+                                </Table.Cell>
+                                <Table.Cell>
+                                    {!stakingAccountsNotActivated && (
+                                        <Translation id="TR_STAKING_DASHBOARD_TABLE_YEARLY_REWARDS" />
+                                    )}
+                                </Table.Cell>
+                                <Table.Cell>
+                                    {!stakingAccountsNotActivated && (
+                                        <Translation id="TR_STAKING_DASHBOARD_TABLE_POTENTIAL_REWARDS" />
+                                    )}
+                                </Table.Cell>
+                                <Table.Cell></Table.Cell>
+                            </Table.Row>
+                        </Table.Header>
 
-                    <Table.Body>
-                        {sortedAccounts.map(account => (
-                            <StakingDashboardAccountRow account={account} key={account.key} />
-                        ))}
+                        <Table.Body>
+                            {sortedAccounts.map(account => (
+                                <StakingDashboardAccountRow account={account} key={account.key} />
+                            ))}
 
-                        {ethNotActivated && !isEthStakingDisabled && (
-                            <StakingDashboardActivateRow symbol="eth" />
-                        )}
-                        {solNotActivated && !isSolStakingDisabled && (
-                            <StakingDashboardActivateRow symbol="sol" />
-                        )}
-                        {adaNotActivated && !isAdaStakingDisabled && (
-                            <StakingDashboardActivateRow symbol="ada" />
-                        )}
-                    </Table.Body>
-                </Table>
-            </Card>
-        </DashboardSection>
+                            {ethNotActivated && !isEthStakingDisabled && (
+                                <StakingDashboardActivateRow symbol="eth" />
+                            )}
+                            {solNotActivated && !isSolStakingDisabled && (
+                                <StakingDashboardActivateRow symbol="sol" />
+                            )}
+                            {adaNotActivated && !isAdaStakingDisabled && (
+                                <StakingDashboardActivateRow symbol="ada" />
+                            )}
+                        </Table.Body>
+                    </Table>
+                </Card>
+            </DashboardSection>
+        </OutlineHighlight>
     );
 };

--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboard.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboard.tsx
@@ -9,20 +9,45 @@ import {
     getAccountTotalStakingBalance,
     getFiatRateKey,
     getStakingLimitsByNetworkSymbol,
+    isCardanoStakedOutsideEverstake,
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
-import { Badge, Card, Table } from '@trezor/components';
+import { Badge, BadgeIntent, Card, Table } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { BigNumber, arrayPartition } from '@trezor/utils';
 
 import { setStakingDashboardCollapsed } from 'src/actions/suite/suiteActions';
 import { DashboardSection } from 'src/components/dashboard';
-import { Translation } from 'src/components/suite/Translation';
+import { Translation, TranslationKey } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 import { StakingDashboardAccountRow } from './StakingDashboardAccountRow';
 import { StakingDashboardActivateRow } from './StakingDashboardActivateRow';
+
+const getBadgeState = (
+    isStakingActive: boolean,
+    accounts: Account[],
+): { intent: BadgeIntent; label: TranslationKey } => {
+    if (!isStakingActive) {
+        return {
+            intent: 'neutral',
+            label: 'TR_STAKING_DASHBOARD_NOT_ACTIVE',
+        };
+    }
+
+    if (accounts.some(isCardanoStakedOutsideEverstake)) {
+        return {
+            intent: 'warning',
+            label: 'TR_STAKING_DASHBOARD_OUTDATED',
+        };
+    }
+
+    return {
+        intent: 'brand',
+        label: 'TR_STAKING_DASHBOARD_ACTIVE',
+    };
+};
 
 const useCryptoCurrentRate = (symbol: NetworkSymbol) => {
     const baseCurrency = useSelector(selectBaseCurrency);
@@ -154,22 +179,15 @@ export const StakingDashboard = () => {
         dispatch(setStakingDashboardCollapsed(collapsed));
     };
 
+    const badge = getBadgeState(isStakingActive, stakingAccounts);
+
     return (
         <DashboardSection
             heading={
                 <>
                     <Translation id="TR_STAKING_DASHBOARD_TITLE" />
-                    <Badge
-                        intent={isStakingActive ? 'brand' : 'neutral'}
-                        margin={{ left: spacings.sm }}
-                    >
-                        <Translation
-                            id={
-                                isStakingActive
-                                    ? 'TR_STAKING_DASHBOARD_ACTIVE'
-                                    : 'TR_STAKING_DASHBOARD_NOT_ACTIVE'
-                            }
-                        />
+                    <Badge intent={badge.intent} margin={{ left: spacings.sm }}>
+                        <Translation id={badge.label} />
                     </Badge>
                 </>
             }

--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardAccountRow.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardAccountRow.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { useFormatters } from '@suite-common/formatters';
 import { getNetworkAdjustedStakingBalance } from '@suite-common/staking';
+import { StakingFlow } from '@suite-common/suite-types/src/staking';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { selectAccountIsStakingActive, selectPoolStatsApyData } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
@@ -9,11 +10,14 @@ import {
     calculateRewards,
     getAccountTotalStakingBalance,
     getStakingLimitsByNetworkSymbol,
+    isCardanoStakedOutsideEverstake,
 } from '@suite-common/wallet-utils';
 import { Button, Column, H4, Icon, Paragraph, Row, Table } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
+import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
+import { openModal } from 'src/actions/suite/modalActions';
 import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -85,6 +89,35 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
         });
     };
 
+    const openStakeInANutshellModal = () => {
+        dispatch(
+            goto('wallet-staking', {
+                preserveParams: true,
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+
+        dispatch(
+            openModal({
+                type: 'stake-in-a-nutshell',
+                flow: StakingFlow.Stake,
+            }),
+        );
+
+        analytics.report({
+            type: EventType.StakingUpdateProvider,
+            payload: {
+                action: 'continue',
+                step: 'staking-dashboard',
+                networkSymbol: account?.symbol,
+            },
+        });
+    };
+
     const formatCryptoAmount = (amount: string, withSymbol = false) =>
         CryptoAmountFormatter.format(amount, {
             symbol: account.symbol,
@@ -95,6 +128,10 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
         });
 
     const state = useMemo(() => {
+        if (isCardanoStakedOutsideEverstake(account)) {
+            return 'staking-outdated-provider';
+        }
+
         if (
             (accountBalance === '0' && stakingBalance !== '0') ||
             (isCardanoNetworkType && isStakingActive)
@@ -118,7 +155,14 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
         }
 
         return 'staking-inactive';
-    }, [accountBalance, stakingBalance, minStakingAmount, isCardanoNetworkType, isStakingActive]);
+    }, [
+        account,
+        accountBalance,
+        stakingBalance,
+        minStakingAmount,
+        isCardanoNetworkType,
+        isStakingActive,
+    ]);
 
     const CurrentRewardsCell = () => {
         const isStakingActive = stakingBalance !== '0';
@@ -183,7 +227,13 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
                 <StakingDashboardAccountCell account={account} />
             </Table.Cell>
 
-            <Table.Cell>~{apy}%</Table.Cell>
+            <Table.Cell>
+                {state === 'staking-outdated-provider' ? (
+                    <Translation id="TR_STAKE_UNKNOWN_APY" />
+                ) : (
+                    <>~{apy}%</>
+                )}
+            </Table.Cell>
 
             {state === 'insufficient-funds' && (
                 <>
@@ -278,6 +328,28 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
                             onClick={navigateToTradingBuy}
                         >
                             <Translation id="TR_BUY" />
+                        </Button>
+                    </Table.Cell>
+                </>
+            )}
+
+            {state === 'staking-outdated-provider' && (
+                <>
+                    <Table.Cell colSpan={2}>
+                        <Row gap={spacings.xxs}>
+                            <Icon name="warning" size={24} variant="warning" />
+                            <Paragraph typographyStyle="body" variant="warning">
+                                <Translation
+                                    id="TR_STAKING_DASHBOARD_OUTDATED_PROVIDER"
+                                    values={{ apy }}
+                                />
+                            </Paragraph>
+                        </Row>
+                    </Table.Cell>
+
+                    <Table.Cell align="end">
+                        <Button intent="brand" size="small" onClick={openStakeInANutshellModal}>
+                            <Translation id="TR_STAKING_UPDATE_PROVIDER" />
                         </Button>
                     </Table.Cell>
                 </>

--- a/suite-common/wallet-utils/src/cardanoStakingUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoStakingUtils.ts
@@ -39,6 +39,15 @@ export const isCardanoStakedWithEverstake = (account: Account) => {
     return account?.misc.staking.poolId === CARDANO_EVERSTAKE_STAKING_POOL.bech32;
 };
 
+export const isCardanoStakedOutsideEverstake = (account: Account) => {
+    if (account.networkType !== 'cardano') return false;
+
+    const poolId = account.misc?.staking?.poolId;
+    if (!poolId) return false;
+
+    return poolId !== CARDANO_EVERSTAKE_STAKING_POOL.bech32;
+};
+
 export const validateCardanoDrep = (drepId: string): boolean => {
     try {
         const { prefix, words } = bech32.decode(drepId);


### PR DESCRIPTION
## Description

- Added a new status badge (Outdated provider)
- Changed APY 0% to unknown
- Added the text: “Update to Everstake and earn ~2.4% APY”
- Added a warning banner
- Implemented scrolling to the staking dashboard section when the banner button is clicked

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23430

## Screenshots:

<img width="1755" height="853" alt="image" src="https://github.com/user-attachments/assets/f9c0516f-6feb-4936-9c64-7abd68627c36" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/cardano-staking-outdated-provider&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/cardano-staking-outdated-provider&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/cardano-staking-outdated-provider&lookback=7)