### PR TITLE
feat(suite): remove "Stake X" headline on the staking account detail

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/staking/eth/initial-stake.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/eth/initial-stake.test.ts
@@ -68,12 +68,6 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                 await stakingSection.stakingTabButton.click();
                 await expect(stakingSection.stakingDashboardCard).toBeHidden();
                 await expect(stakingSection.stakingEmptyCard).toBeVisible();
-                await expect(stakingSection.stakingEmptyCard).toContainTranslation(
-                    'TR_STAKE_STAKE_TOKEN',
-                    {
-                        values: { symbol: 'ETH' },
-                    },
-                );
             });
 
             await test.step('Open and fill staking form', async () => {

--- a/packages/suite-desktop-core/e2e/tests/staking/sol/initial-stake.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/sol/initial-stake.test.ts
@@ -36,10 +36,6 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
                 await stakingSection.stakingTabButton.click();
                 await expect(stakingSection.stakingDashboardCard).toBeHidden();
                 await expect(stakingSection.stakingEmptyCard).toBeVisible();
-                await expect(stakingSection.stakingEmptyCard).toContainTranslation(
-                    'TR_STAKE_STAKE_TOKEN',
-                    { values: { symbol: 'SOL' } },
-                );
                 await expect(stakingSection.stakeMoreButton).toBeHidden();
                 await expect(stakingSection.unstakeToClaimButton).toBeHidden();
             });

--- a/packages/suite/src/components/dashboard/DashboardSection.tsx
+++ b/packages/suite/src/components/dashboard/DashboardSection.tsx
@@ -4,7 +4,7 @@ import { Collapsible, Column, H3, IconButton, Row, Text } from '@trezor/componen
 import { useCurrentRef } from '@trezor/react-utils';
 
 type DashboardSectionProps = HTMLAttributes<HTMLDivElement> & {
-    heading: ReactElement;
+    heading?: ReactElement;
     subheading?: ReactElement;
     actions?: ReactElement;
     collapsible?: boolean;
@@ -35,31 +35,37 @@ export const DashboardSection = forwardRef(
             collapseChangeRef.current?.(collapsed);
         }, [collapseChangeRef, collapsed]);
 
+        const renderHeader = heading || subheading || actions || collapsible;
+
         return (
             <div ref={ref} {...rest}>
                 <Collapsible isOpen={!collapsed}>
                     <Column data-testid={dataTestId} gap={16}>
-                        <Column width="100%" gap={2}>
-                            <Row as="header" justifyContent="space-between">
-                                {heading && (
-                                    <H3>
-                                        <Row as="span">{heading}</Row>
-                                    </H3>
-                                )}
+                        {renderHeader && (
+                            <Column width="100%" gap={2}>
+                                <Row as="header" justifyContent="space-between">
+                                    {heading && (
+                                        <H3>
+                                            <Row as="span">{heading}</Row>
+                                        </H3>
+                                    )}
 
-                                {actions && <div>{actions}</div>}
-                                {collapsible && (
-                                    <Collapsible.Toggle onClick={() => setCollapsed(prev => !prev)}>
-                                        <IconButton
-                                            icon={collapsed ? 'caretDown' : 'caretUp'}
-                                            intent="neutral"
-                                            priority="secondary"
-                                        />
-                                    </Collapsible.Toggle>
-                                )}
-                            </Row>
-                            {subheading && <Text variant="tertiary">{subheading}</Text>}
-                        </Column>
+                                    {actions && <div>{actions}</div>}
+                                    {collapsible && (
+                                        <Collapsible.Toggle
+                                            onClick={() => setCollapsed(prev => !prev)}
+                                        >
+                                            <IconButton
+                                                icon={collapsed ? 'caretDown' : 'caretUp'}
+                                                intent="neutral"
+                                                priority="secondary"
+                                            />
+                                        </Collapsible.Toggle>
+                                    )}
+                                </Row>
+                                {subheading && <Text variant="tertiary">{subheading}</Text>}
+                            </Column>
+                        )}
                         <Collapsible.Content overflow="unset">{children}</Collapsible.Content>
                     </Column>
                 </Collapsible>

--- a/packages/suite/src/views/wallet/staking/components/CardanoStakingDashboard/NewCardanoStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/CardanoStakingDashboard/NewCardanoStakingDashboard.tsx
@@ -1,4 +1,3 @@
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { CARDANO_EPOCH_DAYS } from '@suite-common/wallet-constants';
 import {
     StakeRootState,
@@ -13,7 +12,6 @@ import { Column, Flex, Grid } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { DashboardSection } from 'src/components/dashboard';
-import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 
@@ -57,14 +55,7 @@ export const NewCardanoStakingDashboard = ({
             dashboard={
                 <Column alignItems="normal" gap={spacings.xxxxl}>
                     {shouldShowStakingDashboard ? (
-                        <DashboardSection
-                            heading={
-                                <Translation
-                                    id="TR_STAKE_STAKE_TOKEN"
-                                    values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
-                                />
-                            }
-                        >
+                        <DashboardSection>
                             <Column alignItems="normal" gap={spacings.sm}>
                                 {!isDeviceConnected && <ConnectDeviceGenericPromo />}
                                 {isDiscoveryRunning && <DiscoveryWarning />}

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EthStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EthStakingDashboard.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo } from 'react';
 
 import { getDaysToAddToPool, getDaysToUnstake } from '@suite-common/staking';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     fetchAllTransactionsForAccountThunk,
     selectAccountIsStakingActive,
@@ -18,7 +17,6 @@ import { Column, Flex, Grid } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { DashboardSection } from 'src/components/dashboard';
-import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 
@@ -84,14 +82,7 @@ export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProp
             dashboard={
                 <Column gap={spacings.xxxxl}>
                     {isStakingActive ? (
-                        <DashboardSection
-                            heading={
-                                <Translation
-                                    id="TR_STAKE_STAKE_TOKEN"
-                                    values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
-                                />
-                            }
-                        >
+                        <DashboardSection>
                             <Column gap={spacings.sm}>
                                 {!isDeviceConnected && <ConnectDeviceGenericPromo />}
                                 {isDiscoveryRunning && <DiscoveryWarning />}

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
@@ -1,4 +1,3 @@
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
 import {
     StakeRootState,
@@ -12,7 +11,6 @@ import { Column, Flex, Grid } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { DashboardSection } from 'src/components/dashboard';
-import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { useSolanaRewards } from 'src/hooks/wallet/useSolanaRewards';
 import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
@@ -61,14 +59,7 @@ export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProp
                 <Column alignItems="normal" gap={spacings.xxxxl}>
                     {isStakingActive ? (
                         <>
-                            <DashboardSection
-                                heading={
-                                    <Translation
-                                        id="TR_STAKE_STAKE_TOKEN"
-                                        values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
-                                    />
-                                }
-                            >
+                            <DashboardSection>
                                 <Column alignItems="normal" gap={spacings.sm}>
                                     {!isDeviceConnected && <ConnectDeviceGenericPromo />}
                                     {isDiscoveryRunning && <DiscoveryWarning />}

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
@@ -148,10 +148,7 @@ export const EmptyStakingCard = () => {
     };
 
     return (
-        <DashboardSection
-            data-testid="@wallet/staking/empty-card"
-            heading={<Translation id="TR_STAKE_STAKE_TOKEN" values={{ symbol: displaySymbol }} />}
-        >
+        <DashboardSection data-testid="@wallet/staking/empty-card">
             <Column gap={16}>
                 {!isDeviceConnected && <ConnectDeviceGenericPromo />}
                 {isDiscoveryRunning && <DiscoveryWarning />}


### PR DESCRIPTION
## Description

Removed the **"Stake X"** headline from the staking account detail pages across all supported networks
- Ethereum
- Solana
- Cardano

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23414

## Screenshots:

<img width="1174" height="750" alt="image" src="https://github.com/user-attachments/assets/258f4af1-d886-4092-b822-efee66b2d9b8" />

<img width="1172" height="671" alt="image" src="https://github.com/user-attachments/assets/81474675-754a-4402-a654-17105554a4ce" />

<img width="1176" height="629" alt="image" src="https://github.com/user-attachments/assets/c15bfbb0-c730-4697-b6c5-43a6d934abf2" />

### Empty: 
<img width="1181" height="729" alt="image" src="https://github.com/user-attachments/assets/c3295d9f-cbc3-479e-9ece-dcf38cbed410" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/remove-staking-heading&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/remove-staking-heading&lookback=7)