### PR TITLE
chore(suite): Add eslint rule for prohibit classnames in custom compo…

### DIFF
--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -5,4 +5,4 @@ require('ts-node').register({
     },
 });
 
-module.exports = require('./rules').default;
+module.exports = require('./rules.js');

--- a/eslint-local-rules/rules.js
+++ b/eslint-local-rules/rules.js
@@ -1,0 +1,183 @@
+/** @typedef {import('eslint').Rule} Rule */
+
+function findNodeWithCalleeInSubTree(node, calleeName) {
+    if (!node) return null;
+
+    if (node.type === 'CallExpression' && node.callee && node.callee.name === calleeName) {
+        return node;
+    }
+
+    if (node.callee && typeof node.callee === 'object' && node.callee.object) {
+        return findNodeWithCalleeInSubTree(node.callee.object, calleeName);
+    }
+
+    return null;
+}
+
+function checkNodeForAvoidStyledComponent(node, context, nodeRef, importedComponents) {
+    if (node[nodeRef]?.type !== 'CallExpression') return;
+
+    const nodeWithCallee = findNodeWithCalleeInSubTree(node[nodeRef], 'styled');
+    if (!nodeWithCallee) return;
+
+    if (
+        nodeWithCallee.callee.name === 'styled' &&
+        nodeWithCallee.arguments[0] &&
+        nodeWithCallee.arguments[0].type === 'Identifier'
+    ) {
+        const componentName = nodeWithCallee.arguments[0].name;
+
+        for (const [pkgName, components] of importedComponents) {
+            if (components.has(componentName)) {
+                context.report({
+                    node,
+                    messageId: 'avoidStyledComponent',
+                    data: { packageName: pkgName },
+                });
+                break;
+            }
+        }
+    }
+}
+
+module.exports = {
+    'no-override-ds-component': {
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'Disallows overriding components imported from a specific package using styled-components',
+                category: 'Best Practices',
+                recommended: false,
+            },
+            messages: {
+                avoidStyledComponent:
+                    "Please do not override components imported from '{{packageName}}'. Use wrapper component or ask Growth team for help.",
+            },
+            schema: [
+                {
+                    type: 'object',
+                    properties: {
+                        packageNames: {
+                            type: 'array',
+                            items: { type: 'string' },
+                            minItems: 1,
+                        },
+                    },
+                    additionalProperties: false,
+                },
+            ],
+        },
+
+        create(context) {
+            const packageNames = context.options[0]?.packageNames || [];
+            if (packageNames.length === 0) return {};
+
+            const importedComponents = new Map();
+
+            return {
+                ImportDeclaration(node) {
+                    if (packageNames.includes(node.source.value)) {
+                        node.specifiers.forEach(specifier => {
+                            if (
+                                specifier.type === 'ImportSpecifier' ||
+                                specifier.type === 'ImportDefaultSpecifier'
+                            ) {
+                                if (!importedComponents.has(node.source.value)) {
+                                    importedComponents.set(node.source.value, new Set());
+                                }
+                                importedComponents.get(node.source.value).add(specifier.local.name);
+                            }
+                        });
+                    }
+                },
+
+                VariableDeclarator(node) {
+                    checkNodeForAvoidStyledComponent(node, context, 'init', importedComponents);
+                },
+
+                TaggedTemplateExpression(node) {
+                    checkNodeForAvoidStyledComponent(node, context, 'tag', importedComponents);
+                },
+            };
+        },
+    },
+
+    'no-classname-on-component': {
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'Disallows passing className to React components (non-DOM) including styled-components',
+                recommended: false,
+            },
+            messages: {
+                avoidClassName:
+                    "Do not pass 'className' to custom components or styled-components. Use wrappers or styling alternatives.",
+            },
+            schema: [
+                {
+                    type: 'object',
+                    properties: {
+                        excluded: {
+                            type: 'array',
+                            items: { type: 'string' },
+                        },
+                    },
+                    additionalProperties: false,
+                },
+            ],
+        },
+
+        create(context) {
+            const excluded = new Set(context.options[0]?.excluded || []);
+
+            function isDomElement(name) {
+                // <div>, <button>, <svg> -> OK
+                return /^[a-z]/.test(name);
+            }
+
+            function getComponentName(node) {
+                if (node.type === 'JSXIdentifier') return node.name;
+
+                if (node.type === 'JSXMemberExpression') {
+                    return node.object.name || null;
+                }
+
+                if (node.type === 'JSXNamespacedName') {
+                    return node.name.name;
+                }
+
+                return null;
+            }
+
+            return {
+                JSXAttribute(node) {
+                    if (node.name.name !== 'className') return;
+
+                    const jsxEl = node.parent;
+                    if (!jsxEl || jsxEl.type !== 'JSXOpeningElement') return;
+
+                    const tag = jsxEl.name;
+                    const componentName = getComponentName(tag);
+
+                    if (!componentName) return;
+
+                    if (isDomElement(componentName)) {
+                        return;
+                    }
+
+                    if (excluded.has(componentName)) {
+                        return;
+                    }
+
+
+                    context.report({
+                        node,
+                        messageId: 'avoidClassName',
+                    });
+                },
+            };
+        },
+    },
+};

--- a/packages/components/src/components/AutoScalingInput/AutoScalingInput.tsx
+++ b/packages/components/src/components/AutoScalingInput/AutoScalingInput.tsx
@@ -96,6 +96,7 @@ export const AutoScalingInput = forwardRef<HTMLInputElement, Props>(
         return (
             <>
                 <HiddenInputToMeasurePlaceholderScrollableWidth
+                    // eslint-disable-next-line local-rules/no-classname-on-component
                     className={props.className} // It is important to keep styles so the width is properly calculated
                     style={props.style} // It is important to keep styles so the width is properly calculated
                     type="text"

--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -186,6 +186,7 @@ export const Card = ({
                 $variant={variant}
                 onClick={onClick}
                 onMouseEnter={onMouseEnter}
+                // eslint-disable-next-line local-rules/no-classname-on-component
                 className={className}
                 onMouseLeave={onMouseLeave}
                 data-testid={dataTest}

--- a/packages/components/src/components/Flex/Flex.tsx
+++ b/packages/components/src/components/Flex/Flex.tsx
@@ -171,6 +171,7 @@ export const Flex = ({
 
     return (
         <Container
+            // eslint-disable-next-line local-rules/no-classname-on-component
             className={className}
             data-testid={dataTestId}
             {...makePropsTransient({

--- a/packages/components/src/components/Icon/Icon.tsx
+++ b/packages/components/src/components/Icon/Icon.tsx
@@ -179,6 +179,7 @@ export const Icon = forwardRef(
                 $variant={variant}
                 data-testid={dataTest}
                 onClick={onClick ? handleClick : undefined}
+                // eslint-disable-next-line local-rules/no-classname-on-component
                 className={className}
                 ref={ref}
                 {...frameProps}

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -122,7 +122,12 @@ export const Tooltip = ({
     const elType = isInline ? 'span' : 'div';
 
     return (
-        <Wrapper $isFullWidth={isFullWidth} className={className} as={elType}>
+        <Wrapper
+            $isFullWidth={isFullWidth}
+            // eslint-disable-next-line local-rules/no-classname-on-component
+            className={className}
+            as={elType}
+        >
             <TooltipFloatingUi
                 isActive={isActive}
                 placement={placement}

--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -129,6 +129,7 @@ export const Button = ({
             $priority={priority}
             $intent={intent}
             $isInverse={isInverse}
+            // eslint-disable-next-line local-rules/no-classname-on-component
             className={className}
             {...frameProps}
         >

--- a/packages/components/src/components/buttons/TextButton/TextButton.tsx
+++ b/packages/components/src/components/buttons/TextButton/TextButton.tsx
@@ -175,6 +175,7 @@ export const TextButton = ({
             $isUnderlined={isUnderlined}
             data-testid={dataTestId}
             onClick={onClick}
+            // eslint-disable-next-line local-rules/no-classname-on-component
             className={className}
             tabIndex={tabIndex}
             type={type}

--- a/packages/components/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.tsx
@@ -222,6 +222,7 @@ export const Checkbox = ({
             $verticalAlignment={verticalAlignment}
             onClick={isDisabled ? undefined : onClick}
             onKeyUp={handleKeyUp}
+            // eslint-disable-next-line local-rules/no-classname-on-component
             className={className}
             {...frameProps}
         >

--- a/packages/components/src/components/form/FormCell/FormCell.tsx
+++ b/packages/components/src/components/form/FormCell/FormCell.tsx
@@ -82,6 +82,7 @@ export const FormCell = ({
     return (
         <Wrapper
             {...frameProps}
+            // eslint-disable-next-line local-rules/no-classname-on-component
             className={className}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}

--- a/packages/components/src/components/form/Range/Range.tsx
+++ b/packages/components/src/components/form/Range/Range.tsx
@@ -362,7 +362,11 @@ export const Range = ({
     );
 
     return (
-        <StyledRange className={className} $fill={fill}>
+        <StyledRange
+            // eslint-disable-next-line local-rules/no-classname-on-component
+            className={className}
+            $fill={fill}
+        >
             <Input
                 {...props}
                 type="range"

--- a/packages/components/src/components/loaders/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/components/loaders/ProgressBar/ProgressBar.tsx
@@ -48,6 +48,7 @@ export const ProgressBar = ({
         <Wrapper
             $color={backgroundColor || theme.backgroundNeutralSubdued}
             data-testid={dataTestId}
+            // eslint-disable-next-line local-rules/no-classname-on-component
             className={className}
         >
             <Value $max={max} $value={value} $color={foregroundColor || theme.iconPrimaryDefault} />

--- a/packages/components/src/components/loaders/ProgressPie/ProgressPie.tsx
+++ b/packages/components/src/components/loaders/ProgressPie/ProgressPie.tsx
@@ -68,6 +68,7 @@ export const ProgressPie = ({
             $valueInPercents={valueInPercents}
             $backgroundColor={backgroundColor}
             $color={color}
+            // eslint-disable-next-line local-rules/no-classname-on-component
             className={className}
             $elevation={elevation}
             {...frameProps}

--- a/packages/components/src/components/loaders/Spinner/Spinner.tsx
+++ b/packages/components/src/components/loaders/Spinner/Spinner.tsx
@@ -151,6 +151,7 @@ export const Spinner = ({
         <StyledLottie
             size={size}
             $isGrey={isGrey}
+            // eslint-disable-next-line local-rules/no-classname-on-component
             className={className}
             data-testid={dataTest ?? '@spinner'}
             {...lottieProps}

--- a/packages/components/src/components/typography/Link/Link.tsx
+++ b/packages/components/src/components/typography/Link/Link.tsx
@@ -114,6 +114,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
                     }
                 }}
                 $variant={variant}
+                // eslint-disable-next-line local-rules/no-classname-on-component
                 className={className}
                 {...textProps}
                 $color={color}

--- a/packages/components/src/components/typography/Text/Text.tsx
+++ b/packages/components/src/components/typography/Text/Text.tsx
@@ -147,6 +147,7 @@ export const Text = ({
     return (
         <StyledText
             {...(variant !== undefined ? { $variant: variant } : { $color: color })}
+            // eslint-disable-next-line local-rules/no-classname-on-component
             className={className}
             as={as}
             onClick={onClick}

--- a/packages/connect-explorer/eslint.config.mjs
+++ b/packages/connect-explorer/eslint.config.mjs
@@ -24,6 +24,7 @@ export default [
         rules: {
             'react/no-unescaped-entities': 'off',
             'local-rules/no-override-ds-component': 'off',
+            'local-rules/no-classname-on-component': 'off',
         },
     },
     {

--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -7,7 +7,7 @@ import { globalNoExtraneousDependenciesDevDependencies, importConfig } from './i
 import { javascriptConfig } from './javascriptConfig.mjs';
 import { javascriptNodejsConfig } from './javascriptNodejsConfig.mjs';
 import { jestConfig } from './jestConfig.mjs';
-import { localRulesConfig } from './localRulesConfig.mjs';
+import localRulesConfig from './localRulesConfig.mjs';
 import { reactConfig } from './reactConfig.mjs';
 import { typescriptConfig } from './typescriptConfig.mjs';
 /**

--- a/packages/eslint/src/localRulesConfig.mjs
+++ b/packages/eslint/src/localRulesConfig.mjs
@@ -4,7 +4,7 @@ import pluginLocalRules from 'eslint-plugin-local-rules';
  */
 
 /** @type {Config[]} */
-export const localRulesConfig = [
+export default [
     {
         plugins: {
             'local-rules': pluginLocalRules,
@@ -14,6 +14,15 @@ export const localRulesConfig = [
                 'error',
                 { packageNames: ['@trezor/components', '@trezor/product-components'] },
             ],
+            'local-rules/no-classname-on-component': 'error',
+        },
+    },
+
+    {
+        files: ['packages/connect-explorer-theme/**/*'],
+        rules: {
+            'local-rules/no-classname-on-component': 'off',
+            'local-rules/no-override-ds-component': 'off',
         },
     },
 ];

--- a/packages/product-components/src/components/AssetShareIndicator/AssetShareIndicator.tsx
+++ b/packages/product-components/src/components/AssetShareIndicator/AssetShareIndicator.tsx
@@ -108,7 +108,10 @@ export const AssetShareIndicator = ({
     index,
     ...rest
 }: AssetShareIndicatorProps) => (
-    <Container className={className}>
+    <Container
+        // eslint-disable-next-line local-rules/no-classname-on-component
+        className={className}
+    >
         <CoinLogo symbol={symbol} size={size} {...rest} />
         <ProgressCircle
             symbol={symbol}

--- a/packages/product-components/src/components/CoinLogo/CoinLogo.tsx
+++ b/packages/product-components/src/components/CoinLogo/CoinLogo.tsx
@@ -89,7 +89,12 @@ export const CoinLogo = ({
     }
 
     return (
-        <SvgWrapper className={className} $size={size} {...rest}>
+        <SvgWrapper
+            // eslint-disable-next-line local-rules/no-classname-on-component
+            className={className}
+            $size={size}
+            {...rest}
+        >
             <ReactSVG
                 src={symbolSrc ?? COINS[symbol]}
                 beforeInjection={svg => {

--- a/packages/product-components/src/components/DataAnalytics.tsx
+++ b/packages/product-components/src/components/DataAnalytics.tsx
@@ -22,12 +22,7 @@ export const DataAnalytics = ({
     const [trackingEnabled, setTrackingEnabled] = useState<boolean>(isInitialTrackingEnabled);
 
     return (
-        <Card
-            data-testid="@analytics/consent"
-            className={className}
-            paddingType="large"
-            maxWidth={550}
-        >
+        <Card data-testid="@analytics/consent" paddingType="large" maxWidth={550}>
             <Column gap={spacings.md}>
                 <Column gap={spacings.md}>
                     <Text typographyStyle="callout" data-testid="@analytics/consent/heading">

--- a/packages/product-components/src/components/RotateDeviceImage/RotateDeviceImage.tsx
+++ b/packages/product-components/src/components/RotateDeviceImage/RotateDeviceImage.tsx
@@ -31,6 +31,7 @@ export const RotateDeviceImage = ({
     return (
         <DeviceAnimation
             loop={loop}
+            // eslint-disable-next-line local-rules/no-classname-on-component
             className={className}
             type="ROTATE"
             deviceModelInternal={

--- a/packages/suite/src/components/suite/BaseCurrencyValue.tsx
+++ b/packages/suite/src/components/suite/BaseCurrencyValue.tsx
@@ -111,7 +111,10 @@ export const BaseCurrencyValue = ({
 
     if (value) {
         const fiatValueComponent = (
-            <WrapperComponent className={className}>
+            <WrapperComponent
+                // eslint-disable-next-line local-rules/no-classname-on-component
+                className={className}
+            >
                 {showApproximationIndicator && <>≈&nbsp;</>}
                 <BaseCurrencyAmountFormatter
                     currency={baseCurrencyCode.toUpperCase()}

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -136,5 +136,12 @@ export const FormattedCryptoAmount = ({
         return content;
     }
 
-    return <HiddenPlaceholder className={className}>{content}</HiddenPlaceholder>;
+    return (
+        <HiddenPlaceholder
+            // eslint-disable-next-line local-rules/no-classname-on-component
+            className={className}
+        >
+            {content}
+        </HiddenPlaceholder>
+    );
 };

--- a/packages/suite/src/components/suite/FormattedNftAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedNftAmount.tsx
@@ -95,7 +95,10 @@ export const FormattedNftAmount = ({
     }
 
     return (
-        <Row className={className}>
+        <Row
+            // eslint-disable-next-line local-rules/no-classname-on-component
+            className={className}
+        >
             {signValue ? <Sign value={signValue} /> : null}
             <Box margin={{ right: spacings.xxs }}>
                 <Translation id="TR_TOKEN_ID_COLON" />

--- a/packages/suite/src/components/suite/HiddenPlaceholder.tsx
+++ b/packages/suite/src/components/suite/HiddenPlaceholder.tsx
@@ -125,6 +125,7 @@ export const HiddenPlaceholder = ({
             $discreetMode={discreetMode}
             $intensity={enforceIntensity !== undefined ? enforceIntensity : automaticIntensity}
             $minWidth={shouldEnforceMinWidth ? wrapperMinWidth : undefined}
+            // eslint-disable-next-line local-rules/no-classname-on-component
             className={className}
             ref={ref}
             data-testid={dataTestId}

--- a/packages/suite/src/components/suite/Loading.tsx
+++ b/packages/suite/src/components/suite/Loading.tsx
@@ -16,7 +16,10 @@ type LoadingProps = {
 };
 
 export const Loading = ({ className }: LoadingProps) => (
-    <LoaderWrapper data-testid="@suite/loading" className={className}>
+    <LoaderWrapper
+        data-testid="@suite/loading" // eslint-disable-next-line local-rules/no-classname-on-component
+        className={className}
+    >
         <Spinner size={80} isGrey={false} hasStartAnimation={true} />
     </LoaderWrapper>
 );

--- a/packages/suite/src/components/suite/QuestionTooltip.tsx
+++ b/packages/suite/src/components/suite/QuestionTooltip.tsx
@@ -25,7 +25,10 @@ interface QuestionTooltipProps {
 
 // TODO: remove or refactor this
 export const QuestionTooltip = ({ label, tooltip, className }: QuestionTooltipProps) => (
-    <Wrapper className={className}>
+    <Wrapper
+        // eslint-disable-next-line local-rules/no-classname-on-component
+        className={className}
+    >
         {label &&
             (tooltip ? (
                 <Tooltip

--- a/packages/suite/src/components/suite/StatusLight.tsx
+++ b/packages/suite/src/components/suite/StatusLight.tsx
@@ -55,7 +55,11 @@ interface StatusLightProps {
 }
 
 export const StatusLight = ({ variant, className }: StatusLightProps) => (
-    <Circle $variant={variant} className={className}>
+    <Circle
+        $variant={variant}
+        // eslint-disable-next-line local-rules/no-classname-on-component
+        className={className}
+    >
         <div />
     </Circle>
 );

--- a/packages/suite/src/components/suite/Ticker/NoRatesTooltip.tsx
+++ b/packages/suite/src/components/suite/Ticker/NoRatesTooltip.tsx
@@ -25,7 +25,10 @@ export const NoRatesTooltip = ({ customText, customTooltip, className }: NoRates
     const theme = useTheme();
 
     return (
-        <NoRatesMessage className={className}>
+        <NoRatesMessage
+            // eslint-disable-next-line local-rules/no-classname-on-component
+            className={className}
+        >
             <Translation id={customText || 'TR_FIAT_RATES_NOT_AVAILABLE'} />
             <TooltipSymbol
                 content={

--- a/packages/suite/src/components/suite/TooltipSymbol.tsx
+++ b/packages/suite/src/components/suite/TooltipSymbol.tsx
@@ -24,6 +24,7 @@ const TooltipSymbol = ({
         margin={{ horizontal: 4 }}
         content={content}
         maxWidth={250}
+        // eslint-disable-next-line local-rules/no-classname-on-component
         className={className}
     >
         <Icon name={icon} size={16} color={iconColor} />

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
@@ -140,6 +140,7 @@ export const NavItem = (props: NavigationItemProps) => {
             $isActive={isActive || isActiveRoute}
             onClick={handleClick}
             data-testid={dataTest || `@suite/menu/${goToRoute}`}
+            // eslint-disable-next-line local-rules/no-classname-on-component
             className={className}
             tabIndex={0}
             $elevation={elevation}

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -230,6 +230,7 @@ export const TransactionItem = memo(
                 onMouseLeave={() => setTxItemIsHovered(false)}
                 ref={anchorRef}
                 $isPhishingTransaction={isPhishingTransaction}
+                // eslint-disable-next-line local-rules/no-classname-on-component
                 className={className}
                 data-testid="@wallet/transaction-item"
             >

--- a/packages/suite/src/views/wallet/details/CoinjoinSetup/SetupSlider/SliderInput.tsx
+++ b/packages/suite/src/views/wallet/details/CoinjoinSetup/SetupSlider/SliderInput.tsx
@@ -124,7 +124,10 @@ export const SliderInput = forwardRef<
     const focusInput = () => inputRef.current?.focus();
 
     return (
-        <LevelContainer className={className}>
+        <LevelContainer
+            // eslint-disable-next-line local-rules/no-classname-on-component
+            className={className}
+        >
             <Level
                 value={String(inputValue)}
                 onChange={handleChange}

--- a/packages/suite/src/views/wallet/sign-verify/components/HiddenAddressRow.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/components/HiddenAddressRow.tsx
@@ -22,6 +22,7 @@ export const HiddenAddressRow = ({
 
     return (
         <Row
+            // eslint-disable-next-line local-rules/no-classname-on-component
             className={`${className} react-select__single-value`}
             gap={spacings.xxs}
             cursor="pointer"

--- a/packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx
@@ -18,7 +18,10 @@ export const TradingCoinLogo = ({
     const networkSymbol = cryptoIdToNativeCoinSymbol(cryptoId);
 
     return (
-        <Wrapper className={className}>
+        <Wrapper
+            // eslint-disable-next-line local-rules/no-classname-on-component
+            className={className}
+        >
             <AssetLogo
                 coingeckoId={networkId}
                 symbol={networkSymbol}

--- a/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeaderSummary.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeaderSummary.tsx
@@ -36,7 +36,10 @@ export const TradingHeaderSummary = ({
     const context = useTradingFormContext();
 
     return (
-        <SummaryWrap className={className}>
+        <SummaryWrap
+            // eslint-disable-next-line local-rules/no-classname-on-component
+            className={className}
+        >
             <Row alignItems="center">
                 {isTradingSellContext(context) && (
                     <>

--- a/packages/suite/src/views/wallet/trading/common/TradingTag.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTag.tsx
@@ -21,5 +21,10 @@ interface TradingTagProps {
 }
 
 export const TradingTag = ({ tag, className }: TradingTagProps) => (
-    <TagRow className={className}>{tag && <Tag>{tag}</Tag>}</TagRow>
+    <TagRow
+        // eslint-disable-next-line local-rules/no-classname-on-component
+        className={className}
+    >
+        {tag && <Tag>{tag}</Tag>}
+    </TagRow>
 );

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsProvider.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsProvider.tsx
@@ -26,7 +26,12 @@ export const TradingUtilsProvider = ({
     const provider = providers && exchange ? providers[exchange] : null;
 
     return (
-        <Row gap={spacings.xs} className={className} data-testid="@trading/offers/quote/provider">
+        <Row
+            gap={spacings.xs}
+            // eslint-disable-next-line local-rules/no-classname-on-component
+            className={className}
+            data-testid="@trading/offers/quote/provider"
+        >
             {provider ? (
                 <>
                     {provider.logo && (

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/BalancePrivacyBreakdown/CryptoAmountWithHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/BalancePrivacyBreakdown/CryptoAmountWithHeader.tsx
@@ -51,7 +51,10 @@ export const CryptoAmountWithHeader = ({
     color,
     className,
 }: CryptoAmountWithHeaderProps) => (
-    <Container className={className}>
+    <Container
+        // eslint-disable-next-line local-rules/no-classname-on-component
+        className={className}
+    >
         <Header>
             {headerIcon && headerIcon} {header}
         </Header>

--- a/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
@@ -110,7 +110,10 @@ export const SummaryCards = ({
     );
 
     return (
-        <InfoCardsWrapper className={className}>
+        <InfoCardsWrapper
+            // eslint-disable-next-line local-rules/no-classname-on-component
+            className={className}
+        >
             <InfoCard
                 title={getFormattedLabelLong(selectedRange.label)}
                 isLoading={isLoading}


### PR DESCRIPTION
…nents

<!--- Provide a general summary of your changes in the Title above -->

## Description

```jsx
const Container = styled.div`
   ...
`;

<Container className={className} /> // Error ❌

---

<div className={className} /> // OKish but why 🟡

---

const Container = styled.div`
   border: solld 10px salmon;
`;

<Container /> // Correct ✅

```


## Notes for QA

dev only

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-eslint-rule-for-prohibit-classname&lookback=7)