### PR TITLE
chore(e2e): skip flaky localization currency test

### DIFF
--- a/suite-native/app/e2e/tests/appSettings.test.ts
+++ b/suite-native/app/e2e/tests/appSettings.test.ts
@@ -23,7 +23,7 @@ describe('App Settings - without device interactions [@noDevice]', () => {
         await onHome.scrollScreenToBottom();
     });
 
-    it('Localization - Currency', async () => {
+    it.skip('Localization - Currency', async () => {
         await detoxExpect(element(by.text(/^.*\$.*$/i))).toBeVisible();
         await onTabBar.navigateToSettings();
         await onSettings.tapPreferences();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The test pass locally, but on CI it mostly fails.

Followup https://github.com/trezor/trezor-suite/issues/23438

## Screenshots:
https://github.com/trezor/trezor-suite/actions/runs/19721146885/job/56504132935#step:13:273

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/skip-flaky-localization-currency-test&lookback=7)