### PR TITLE
fix(connect): update current release when bootloader mode

### DIFF
--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -356,7 +356,7 @@ export type CurrentVersion = {
     firmwareVersion: VersionArray | null;
 };
 
-const getCurrentVersion = (features: Features): CurrentVersion => {
+export const getCurrentVersion = (features: Features): CurrentVersion => {
     if (!isStrictFeatures(features)) {
         throw new Error('Features of unexpected shape provided.');
     }

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -22,6 +22,7 @@ import { abortThpWorkflow, getThpChannel } from './thp';
 import { checkFirmwareHashWithRetries } from './workflow/checkFirmwareHashWithRetries';
 import { getAllNetworks } from '../data/coinInfo';
 import {
+    getCurrentVersion,
     getFirmwareReleaseConfigInfo,
     getFirmwareStatus,
     getLanguage,
@@ -876,22 +877,23 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     private async _updateCurrentRelease(feat: Features) {
-        const newVersion = [
-            feat.major_version,
-            feat.minor_version,
-            feat.patch_version,
-        ] satisfies VersionArray;
+        const { firmwareVersion } = getCurrentVersion(feat);
         const newFirmwareType = getFirmwareType(feat);
+
+        // We need firmwareVersion to lookup the release.
+        if (!firmwareVersion) {
+            return;
+        }
 
         if (
             this._currentRelease &&
             newFirmwareType === this.firmwareType &&
-            versionUtils.isEqual(this._currentRelease.version, newVersion)
+            versionUtils.isEqual(this._currentRelease.version, firmwareVersion)
         ) {
             return;
         }
 
-        const release = await getReleaseByVersion(feat, newVersion, newFirmwareType);
+        const release = await getReleaseByVersion(feat, firmwareVersion, newFirmwareType);
         this._currentRelease = release;
         this.availableTranslations = this._currentRelease?.translations ?? {};
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As described in https://github.com/trezor/trezor-suite/pull/23313 there was a situation when Device was connected in bootloader mode that Connect tries to get the current release of the device using the bootloader version. But in most devices we know the version of the device when in bootloader mode, so using `getCurrentVersion` we can check if firmwareVersion is known and if so then we use it to request current release.


## Notes for QA

There is nothing that can be tested by QA

## Related Issue

Related to https://github.com/trezor/trezor-suite/pull/23313


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/update-current-release-in-bootloader-mode&lookback=7)