### PR TITLE
Resolve `Invalid passphrase`

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -707,6 +707,17 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
             this.state[this.instance] = newState;
             this.stateStorage?.saveState(this, newState);
+
+            // special THP case: new sessionId was assigned to a wallet but there already was another remembered wallet with the same sessionId.
+            // In that case, remove the sessionId from the existing wallet as it can't be valid anymore.
+            // TODO: resolve in a more elegant way
+            if (!!this.thp && state.sessionId) {
+                this.state.forEach((s, instance) => {
+                    if (instance !== this.instance && s?.sessionId === state.sessionId) {
+                        delete s.sessionId;
+                    }
+                });
+            }
         }
     }
 

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -74,17 +74,30 @@ const mergeDeviceState = (
         AcquiredDevice & { state?: DeviceState | StaticSessionId; _state?: DeviceState }
     >,
 ): DeviceState | undefined => {
+    const currentState = device.state;
     const upcomingState = typeof upcoming.state === 'string' ? upcoming._state : upcoming.state;
-    if (
-        // state was previously not defined, we can set it
-        device.state === undefined ||
-        // update sessionId for the same staticSessionId
-        (upcomingState &&
-            device.state?.staticSessionId === upcomingState.staticSessionId &&
-            device.state?.sessionId !== upcomingState.sessionId)
-    ) {
-        return upcomingState;
+
+    if (currentState && upcomingState) {
+        if (
+            currentState.staticSessionId === upcomingState.staticSessionId &&
+            currentState.sessionId !== upcomingState.sessionId
+        ) {
+            // update sessionId for the same staticSessionId
+            return { ...currentState, sessionId: upcomingState.sessionId };
+        }
+
+        if (
+            currentState.staticSessionId !== upcomingState.staticSessionId &&
+            currentState.sessionId === upcomingState.sessionId
+        ) {
+            // special THP case: new sessionId was assigned to a wallet but there already was another remembered wallet with the same sessionId.
+            // In that case, remove the sessionId from the existing wallet as it can't be valid anymore.
+            return { ...currentState, sessionId: undefined };
+        }
     }
+
+    // ignore device state updates. we set device state explicitly using addAuthorizedDevice or setDeviceState
+    return currentState;
 };
 
 /**
@@ -103,7 +116,7 @@ const merge = (
     ...device,
     ...upcoming,
     id: upcoming.id ?? device.id,
-    state: mergeDeviceState(device, upcoming) ?? device.state,
+    state: mergeDeviceState(device, upcoming),
     instance: device.instance,
     features: {
         // Don't override features if upcoming device is locked.
@@ -262,25 +275,6 @@ const changeDevice = (
         });
 
         return;
-    }
-
-    // this is not nice - during passphrase/discovery refactor, I made a decision that we are not going to update device.state in reducer
-    // in any other case than as a result of device authorization (passphrase+discovery). But later we realized that we need to update device.state.sessionId
-    // for saved devices too https://github.com/trezor/trezor-suite/issues/19411 so I am adding this as a quick fix that should work until we come up with a better solution.
-    const staticSessionId = device?.state;
-    const deviceBeforeUpdate = staticSessionId
-        ? draft.devices.find(d => d.state?.staticSessionId === staticSessionId)
-        : undefined;
-    const shouldUpdateState =
-        !!deviceBeforeUpdate &&
-        deviceBeforeUpdate.remember &&
-        !deviceBeforeUpdate.useEmptyPassphrase;
-
-    if (!shouldUpdateState) {
-        // ignore device state updates. we set device state explicitly using addAuthorizedDevice or setDeviceState
-        delete device.state;
-        // @ts-expect-error - connect feeds this but we don't work with it
-        delete device._state;
     }
 
     // find devices with the same "device_id"


### PR DESCRIPTION
## Description

Hopefully ok?

## Notes for QA

How to reproduce:
- TS7, e.g. web and cable (doesn't matter)
- add **standard** wallet, discover
- add **passphrase** wallet, discover
- restart device (so session cache is cleared)
- get receive address on **passphrase** wallet (should work)
- get receive address on **standard** wallet (previously Invalid passphrase, now it should work)

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/invalid-passphrase&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/invalid-passphrase&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/invalid-passphrase&lookback=7)