### PR TITLE
Chore: re-export ThpPairingMethod enum

### DIFF
--- a/packages/connect/e2e/tests/device/thpPairing.test.ts
+++ b/packages/connect/e2e/tests/device/thpPairing.test.ts
@@ -72,7 +72,7 @@ describe('THP pairing', () => {
             TrezorConnect.removeAllListeners('ui-request_thp_pairing');
             TrezorConnect.uiResponse({
                 type: 'ui-receive_thp_pairing_tag',
-                payload: { source: 'nfc', tag: state.nfc_secret_trezor },
+                payload: { tag: state.nfc_secret_trezor },
             });
         });
 
@@ -137,7 +137,7 @@ describe('THP pairing', () => {
             const state = await getPairingInfo(event);
             TrezorConnect.uiResponse({
                 type: 'ui-receive_thp_pairing_tag',
-                payload: { source: 'code-entry', tag: state.code_entry_code },
+                payload: { tag: state.code_entry_code },
             });
         });
 
@@ -254,7 +254,7 @@ describe('THP pairing', () => {
             const state = await getPairingInfo(event);
             TrezorConnect.uiResponse({
                 type: 'ui-receive_thp_pairing_tag',
-                payload: { source: 'code-entry', tag: state.code_entry_code },
+                payload: { tag: state.code_entry_code },
             });
         });
         result = await TrezorConnect.getFeatures({ device });

--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -9,17 +9,15 @@ import { DataManager } from '../../data/DataManager';
 import type { Device } from '../Device';
 
 // intersection of device acceptable methods and host acceptable methods
-const enumFromString = (dm: ThpPairingMethod | keyof typeof ThpPairingMethod) =>
-    typeof dm === 'string' ? protocolThp.ThpPairingMethod[dm] : dm;
-
 const getPairingMethods = (
     deviceMethods?: (ThpPairingMethod | keyof typeof ThpPairingMethod)[],
     settingsMethods?: (ThpPairingMethod | keyof typeof ThpPairingMethod)[],
 ) =>
     deviceMethods?.flatMap(dm => {
-        const value = enumFromString(dm);
+        const value = protocolThp.getThpPairingMethod(dm);
         const isRequested =
-            settingsMethods && settingsMethods.find(sm => value === enumFromString(sm));
+            settingsMethods &&
+            settingsMethods.find(sm => value === protocolThp.getThpPairingMethod(sm));
 
         return isRequested ? value : [];
     });

--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes } from 'crypto';
 
-import { thp as protocolThp } from '@trezor/protocol';
+import { ThpPairingMethod, thp as protocolThp } from '@trezor/protocol';
 import { createDeferred } from '@trezor/utils';
 
 import { ERRORS } from '../../constants';
@@ -96,26 +96,28 @@ const processCodeEntry = async (device: Device, value: string) => {
 const processThpPairingResponse = (device: Device, payload: UiResponseThpPairingTag['payload']) => {
     if ('selectedMethod' in payload) {
         // change pairing method
-        device.getThpState()?.setPairingMethod(payload.selectedMethod);
+        const selectedMethod = protocolThp.getThpPairingMethod(payload.selectedMethod);
+        device.getThpState()?.setPairingMethod(selectedMethod);
 
         return thpCall(device, 'ThpSelectMethod', {
-            selected_pairing_method: payload.selectedMethod,
+            selected_pairing_method: selectedMethod,
         });
     }
 
-    if (payload.source === 'qr-code') {
+    const selectedMethod = device.getThpState()?.pairingMethod;
+    if (selectedMethod === ThpPairingMethod.QrCode) {
         return processQrCodeTag(device, payload.tag);
     }
 
-    if (payload.source === 'nfc') {
+    if (selectedMethod === ThpPairingMethod.NFC) {
         return processNfcTag(device, payload.tag);
     }
 
-    if (payload.source === 'code-entry') {
+    if (selectedMethod === ThpPairingMethod.CodeEntry) {
         return processCodeEntry(device, payload.tag);
     }
 
-    throw new Error(`Unknown THP pairing source ${payload.source}`);
+    throw ERRORS.TypedError('Device_ThpPairingMethodsException');
 };
 
 const waitForPairingCancel = (device: Device) => {
@@ -133,6 +135,9 @@ const waitForPairingTag = async (device: Device) => {
     const thpState = device.getThpState();
     if (!thpState?.handshakeCredentials) {
         throw ERRORS.TypedError('Device_ThpStateMissing');
+    }
+    if (thpState.pairingMethod === undefined) {
+        throw ERRORS.TypedError('Device_ThpPairingMethodsException');
     }
 
     const dfd = createDeferred<UiResponseThpPairingTag['payload'] | { error: string }>();

--- a/packages/connect/src/events/device.ts
+++ b/packages/connect/src/events/device.ts
@@ -66,8 +66,8 @@ export type DeviceThpCredentialsChangedPayload = {
 
 export type DeviceThpPairingPayload = {
     availableMethods: ThpPairingMethod[];
-    selectedMethod?: ThpPairingMethod; // expected pairing response data
-    nfcData?: string; // data for NFC module, if selected_method === ThpPairingMethod.NFC
+    selectedMethod: ThpPairingMethod; // expected pairing method
+    nfcData?: string; // data for NFC module, if selectedMethod === ThpPairingMethod.NFC
 };
 
 export interface DeviceThpCredentialsChanged {

--- a/packages/connect/src/events/ui-response.ts
+++ b/packages/connect/src/events/ui-response.ts
@@ -1,3 +1,5 @@
+import type { ThpPairingMethod } from '@trezor/protocol';
+
 import { POPUP } from './popup';
 import { UI_EVENT } from './ui-request';
 import type { Device } from '../types/device';
@@ -78,11 +80,10 @@ export interface UiResponseThpPairingTag {
     type: typeof UI_RESPONSE.RECEIVE_THP_PAIRING_TAG;
     payload:
         | {
-              source: 'code-entry' | 'qr-code' | 'nfc';
               tag: string;
           }
         | {
-              selectedMethod: number; // change pairing method ThpPairingMethod;
+              selectedMethod: ThpPairingMethod | keyof typeof ThpPairingMethod;
           };
 }
 

--- a/packages/connect/src/types/api/__tests__/events.ts
+++ b/packages/connect/src/types/api/__tests__/events.ts
@@ -6,6 +6,7 @@ import {
     DEVICE_EVENT,
     TRANSPORT,
     TRANSPORT_EVENT,
+    ThpPairingMethod,
     TrezorConnect,
     UI,
     UI_EVENT,
@@ -134,12 +135,35 @@ export const events = (api: TrezorConnect) => {
             if (event.payload.device.thp?.properties?.pairing_methods[0] === 'CodeEntry') {
                 api.uiResponse({
                     type: 'ui-receive_thp_pairing_tag',
-                    payload: { selectedMethod: 1 },
+                    payload: { selectedMethod: ThpPairingMethod.NFC },
                 });
 
                 api.uiResponse({
                     type: 'ui-receive_thp_pairing_tag',
-                    payload: { source: 'code-entry', tag: '0000' },
+                    payload: { selectedMethod: 'SkipPairing' },
+                });
+
+                api.uiResponse({
+                    type: 'ui-receive_thp_pairing_tag',
+                    // @ts-expect-error invalid string
+                    payload: { selectedMethod: 'unknown method' },
+                });
+
+                api.uiResponse({
+                    type: 'ui-receive_thp_pairing_tag',
+                    // @ts-expect-error invalid enum
+                    payload: { selectedMethod: 7 },
+                });
+
+                api.uiResponse({
+                    type: 'ui-receive_thp_pairing_tag',
+                    payload: { tag: '0000' },
+                });
+
+                api.uiResponse({
+                    type: 'ui-receive_thp_pairing_tag',
+                    // @ts-expect-error invalid tag
+                    payload: { tag: 1234 },
                 });
             }
         }

--- a/packages/connect/src/types/index.ts
+++ b/packages/connect/src/types/index.ts
@@ -44,3 +44,4 @@ export type {
 } from '@trezor/blockchain-link';
 
 export { FirmwareType, type VersionArray } from '@trezor/device-utils';
+export { ThpPairingMethod } from '@trezor/protocol/src/protocol-thp/messages';

--- a/packages/protocol/src/protocol-thp/index.ts
+++ b/packages/protocol/src/protocol-thp/index.ts
@@ -15,5 +15,6 @@ export {
 } from './crypto/pairing';
 export { ThpState } from './ThpState';
 export { getCurve25519KeyPair } from './crypto/curve25519';
+export { getThpPairingMethod } from './utils';
 
 export const name = 'thp';

--- a/packages/protocol/src/protocol-thp/utils.ts
+++ b/packages/protocol/src/protocol-thp/utils.ts
@@ -12,7 +12,7 @@ import {
     THP_HANDSHAKE_INIT_RESPONSE,
     THP_READ_ACK_HEADER_BYTE,
 } from './constants';
-import type { ThpMessageSyncBit } from './messages';
+import { ThpMessageSyncBit, ThpPairingMethod } from './messages';
 
 export const addAckBit = (magic: number, ackBit: number) => {
     const result = Buffer.alloc(1);
@@ -154,3 +154,6 @@ export const isThpMessageName = (name: string) =>
         'ThpHandshakeCompletionRequest',
         'ThpReadAck',
     ].includes(name);
+
+export const getThpPairingMethod = (dm: ThpPairingMethod | keyof typeof ThpPairingMethod) =>
+    typeof dm === 'string' ? ThpPairingMethod[dm] : dm;

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -1,7 +1,7 @@
-export type {
-    ThpDeviceProperties,
+export {
     ThpPairingMethod,
-    ThpCredentials,
+    type ThpDeviceProperties,
+    type ThpCredentials,
 } from './protocol-thp/messages';
 export type { ThpState, ThpStateSerialized, ThpChannelState } from './protocol-thp/ThpState';
 

--- a/packages/suite/src/components/connection/thp/ThpPairingCodeEntry.tsx
+++ b/packages/suite/src/components/connection/thp/ThpPairingCodeEntry.tsx
@@ -27,7 +27,7 @@ export const ThpPairingCodeEntry = ({ disabled, lastCode }: ThpPairingPinEntryPr
             dispatch(thpActions.setLastThpCode({ code: tag }));
             TrezorConnect.uiResponse({
                 type: 'ui-receive_thp_pairing_tag',
-                payload: { source: 'code-entry', tag },
+                payload: { tag },
             });
         },
         [dispatch],

--- a/suite-native/thp/src/components/ThpCodeEntryScreenContent.tsx
+++ b/suite-native/thp/src/components/ThpCodeEntryScreenContent.tsx
@@ -20,14 +20,11 @@ export const ThpCodeEntryScreenContent = ({ onRetry }: ThpCodeEntryScreenContent
 
     const [isLoading, setIsLoading] = useState(false);
 
-    const onSubmit = (code: string) => {
+    const onSubmit = (tag: string) => {
         setIsLoading(true);
         TrezorConnect.uiResponse({
             type: 'ui-receive_thp_pairing_tag',
-            payload: {
-                source: 'code-entry',
-                tag: code,
-            },
+            payload: { tag },
         });
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- re-export ThpPairingMethod enum from `@trezor/connect` package
- simplify `ui-request_thp_pairing`
  1. fix `selectedMethod` type (ThpPairingMethod as number)
- simplify `ui-receive_thp_pairing_tag`
  - fix `selectedMethod` type (ThpPairingMethod could be received as number or as string)
  - remove unnecessary `source` - source should be taken from inner ThpState


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/export-thp-pairing-method&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/export-thp-pairing-method&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/export-thp-pairing-method&lookback=7)