### PR TITLE
chore(connect): remove unused UI.IFRAME_FAILURE

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -252,16 +252,6 @@ const handleMessageInIframeMode = (
         handleResponseEvent(data);
     }
 
-    // This is message from the window.opener
-    if (data.type === UI_REQUEST.IFRAME_FAILURE) {
-        fail({
-            type: 'error',
-            detail: 'iframe-failure',
-        });
-
-        return;
-    }
-
     // ignore messages from origin other then MessagePort (iframe)
     const isMessagePort =
         event.target instanceof MessagePort ||

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -479,34 +479,6 @@ export class PopupManager extends EventEmitter {
         }
     }
 
-    async postMessage(message: CoreEventMessage) {
-        // NOTE: This method only seems to be used in one case to show UI.IFRAME_FAILURE
-        // Maybe we could handle this in a simpler way?
-
-        // device needs interaction but there is no popup/ui
-        // maybe popup request wasn't handled
-        // ignore "ui_request_window" type
-        if (!this.popupWindow && message.type !== UI.REQUEST_UI_WINDOW && this.openTimeout) {
-            this.clear();
-            showPopupRequest(this.open.bind(this), () => {
-                this.emitClosed();
-            });
-
-            return;
-        }
-
-        // post message before popup request finalized
-        if (this.popupPromise) {
-            await this.popupPromise.promise;
-        }
-        // post message to popup window
-        if (this.popupWindow?.mode === 'window') {
-            this.popupWindow.window.postMessage(message, this.origin);
-        } else if (this.popupWindow?.mode === 'tab') {
-            this.channel.postMessage(message);
-        }
-    }
-
     private isWebExtensionWithTab() {
         // Check if webextension actually has access to chrome.tabs API
         // This is not the case when used in offscreen context

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -68,7 +68,6 @@ export const UI_REQUEST = {
     LOGIN_CHALLENGE_REQUEST: 'ui-login_challenge_request',
     BUNDLE_PROGRESS: 'ui-bundle_progress',
     ADDRESS_VALIDATION: 'ui-address_validation',
-    IFRAME_FAILURE: 'ui-iframe_failure',
 } as const;
 
 export type UiRequestWithoutPayload =
@@ -78,10 +77,6 @@ export type UiRequestWithoutPayload =
       }
     | {
           type: typeof UI_REQUEST.REQUEST_UI_WINDOW;
-          payload?: typeof undefined;
-      }
-    | {
-          type: typeof UI_REQUEST.IFRAME_FAILURE;
           payload?: typeof undefined;
       }
     | {


### PR DESCRIPTION
was it really unused? Or did I miss anything? I hope tests would find out..

found while iterating on #23468

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=remove-iframe-failure&lookback=7)