### PR TITLE
fix(suite-native): use 16px bottom padding for bottom sheet content

### DIFF
--- a/suite-native/atoms/src/Sheet/BottomSheetModalContent.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetModalContent.tsx
@@ -8,13 +8,11 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { AnimatedBox, BoxProps } from '../Box';
 
-const childWrapperStyle = prepareNativeStyle<{ bottomInset?: number }>(
-    (utils, { bottomInset }) => ({
-        flex: 1,
-        paddingBottom: bottomInset || utils.spacings.sp16,
-        paddingHorizontal: utils.spacings.sp16,
-    }),
-);
+const childWrapperStyle = prepareNativeStyle<{ bottomInset: number }>((utils, { bottomInset }) => ({
+    flex: 1,
+    paddingBottom: bottomInset + utils.spacings.sp16,
+    paddingHorizontal: utils.spacings.sp16,
+}));
 
 const containerStyle = prepareNativeStyle(() => ({
     flex: 1,


### PR DESCRIPTION
Ensure there's a 16px bottom padding for content in bottom sheets.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/bottom-sheet-bottom-padding&lookback=7)