### PR TITLE
feat: output lables to use account descriptor and symbol

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
@@ -187,6 +187,8 @@ const addAccountMetadata: Fixture<(typeof metadataLabelingActions)['addAccountMe
                 txid: 'TXID',
                 outputIndex: 0,
                 value: 'Foo',
+                accountDescriptor: 'xpub...',
+                networkSymbol: 'btc',
             },
         ],
         result: undefined,
@@ -206,6 +208,8 @@ const addAccountMetadata: Fixture<(typeof metadataLabelingActions)['addAccountMe
                 txid: 'TXID',
                 outputIndex: 0,
                 value: 'Foo',
+                accountDescriptor: 'xpub...',
+                networkSymbol: 'btc',
             },
         ],
         result: undefined,
@@ -251,6 +255,8 @@ const addAccountMetadata: Fixture<(typeof metadataLabelingActions)['addAccountMe
                 txid: 'TXID',
                 outputIndex: 0,
                 value: 'Foo',
+                accountDescriptor: 'xpub...',
+                networkSymbol: 'btc',
             },
         ],
         result: [
@@ -318,6 +324,8 @@ const addAccountMetadata: Fixture<(typeof metadataLabelingActions)['addAccountMe
                 txid: 'TXID',
                 outputIndex: 0,
                 value: '', // empty string removes value
+                accountDescriptor: 'xpub...',
+                networkSymbol: 'btc',
             },
         ],
         result: [

--- a/packages/suite/src/actions/wallet/moveLabelsForRbf/moveLabelsForRbfOldMetadataThunk.ts
+++ b/packages/suite/src/actions/wallet/moveLabelsForRbf/moveLabelsForRbfOldMetadataThunk.ts
@@ -1,5 +1,7 @@
 import { AccountLabels, AccountOutputLabels } from '@suite-common/metadata-types';
 import { createThunk } from '@suite-common/redux-utils';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { selectAccountByKey } from '@suite-common/wallet-core';
 import { AccountKey } from '@suite-common/wallet-types';
 
 import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
@@ -13,6 +15,8 @@ type DeleteAllOutputLabelsParams = {
     labels: AccountLabels['outputLabels']['labels'];
     dispatch: Dispatch;
     accountKey: AccountKey;
+    accountDescriptor: string;
+    networkSymbol: NetworkSymbol;
     txid: string;
 };
 
@@ -20,6 +24,8 @@ export const deleteDanglingLabels = async ({
     labels,
     dispatch,
     accountKey,
+    accountDescriptor,
+    networkSymbol,
     txid,
 }: DeleteAllOutputLabelsParams) => {
     for (const outputIndex of Object.keys(labels)) {
@@ -31,6 +37,8 @@ export const deleteDanglingLabels = async ({
                 outputIndex: Number(outputIndex),
                 defaultValue: '',
                 value: '',
+                accountDescriptor,
+                networkSymbol,
             }),
         );
     }
@@ -41,12 +49,16 @@ type MoveLabelToNewTransactionParams = {
     dispatch: Dispatch;
     accountKey: AccountKey;
     newTxid: string;
+    accountDescriptor: string;
+    networkSymbol: NetworkSymbol;
 };
 
 export const copyLabelToNewTransaction = async ({
     accountOutputLabels,
     dispatch,
     accountKey,
+    accountDescriptor,
+    networkSymbol,
     newTxid,
 }: MoveLabelToNewTransactionParams) => {
     for (const outputIndex of Object.keys(accountOutputLabels)) {
@@ -60,6 +72,8 @@ export const copyLabelToNewTransaction = async ({
                 outputIndex: Number(outputIndex),
                 defaultValue: '',
                 value,
+                accountDescriptor,
+                networkSymbol,
             }),
         );
     }
@@ -78,14 +92,21 @@ export const moveLabelsForRbfOldMetadataThunk = createThunk<
 >(
     `${MODULE_PREFIX}/applyMetadataLabelsThunk`,
     async ({ accountKey, data, newTxid }, { dispatch, getState }) => {
+        const account = selectAccountByKey(getState(), accountKey);
         const accountMetadata = selectLabelingDataForAccount(getState(), accountKey);
         const accountOutputLabelsToBeMoved: AccountOutputLabels =
             accountMetadata?.outputLabels?.[data.toBeMoved.txid] ?? {};
+
+        if (!account) {
+            return;
+        }
 
         await copyLabelToNewTransaction({
             accountKey,
             accountOutputLabels: accountOutputLabelsToBeMoved,
             newTxid,
+            accountDescriptor: account.descriptor,
+            networkSymbol: account.symbol,
             dispatch,
         });
 
@@ -98,6 +119,8 @@ export const moveLabelsForRbfOldMetadataThunk = createThunk<
                 dispatch,
                 labels: accountOutputLabelsToBeDeleted,
                 txid: transactionToDrop.txid,
+                accountDescriptor: account.descriptor,
+                networkSymbol: account.symbol,
             };
 
             await deleteDanglingLabels(deleteParams);

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -151,6 +151,8 @@ const applySendFormMetadataLabelsThunk = createThunk<
                     outputIndex,
                     value: label,
                     defaultValue: '',
+                    networkSymbol: selectedAccount.symbol,
+                    accountDescriptor: selectedAccount.descriptor,
                 };
 
                 return outputMetadata;

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -228,6 +228,8 @@ export const TransactionTarget = ({
                             suiteSyncOutputLabels.find(
                                 it => it.txId === transaction.txid && it.outputIndex == metadataId,
                             )?.label ?? targetMetadata,
+                        networkSymbol: transaction.symbol,
+                        accountDescriptor: transaction.descriptor,
                     }}
                 />
             }

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -322,6 +322,8 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                                                 it.txId === utxo.txid &&
                                                 it.outputIndex == utxo.vout,
                                         )?.label ?? outputLabel,
+                                    networkSymbol: account.symbol,
+                                    accountDescriptor: account.descriptor,
                                 }}
                             />
                         </LabelPart>

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -480,6 +480,8 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                                 outputIndex: outputId,
                                 defaultValue: `${outputId}`,
                                 value: label,
+                                networkSymbol: symbol,
+                                accountDescriptor: descriptor,
                             }}
                             onSubmit={(value: string | undefined) => {
                                 setValue(`outputs.${outputId}.label`, value || '');

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -23,6 +23,8 @@ export type MetadataAddPayload = { skipSave?: boolean } & (
           outputIndex: number | string;
           defaultValue?: string;
           value?: string;
+          networkSymbol: string;
+          accountDescriptor: string;
       }
     | {
           type: 'addressLabel';

--- a/suite-common/suite-sync-evolu/src/labeling/outputLabels.ts
+++ b/suite-common/suite-sync-evolu/src/labeling/outputLabels.ts
@@ -9,6 +9,8 @@ import {
 } from '@evolu/common';
 
 import { OutputLabel, OutputLabelsStore } from '@suite-common/suite-sync-storage';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import type { AccountDescriptor } from '@suite-common/wallet-types';
 
 import { UnwrapQuery } from '../evoluUtils';
 import { normalizeLabel } from './normalizeLabel';
@@ -25,13 +27,15 @@ export const OutputLabelSchema = {
         label: nullOr(NonEmptyString1000),
         txId: NonEmptyString1000,
         outputIndex: NonNegativeNumber,
+        accountDescriptor: NonEmptyString1000,
+        networkSymbol: NonEmptyString1000,
     },
 };
 
 export class OutputLabels implements OutputLabelsStore {
     constructor(private evolu: Evolu<typeof OutputLabelSchema>) {}
 
-    update = ({ txId, outputIndex, label }: OutputLabel) => {
+    update = ({ txId, outputIndex, label, accountDescriptor, networkSymbol }: OutputLabel) => {
         const idResult = createOutputLabelId(txId, outputIndex);
 
         if (!idResult.ok) {
@@ -45,6 +49,8 @@ export class OutputLabels implements OutputLabelsStore {
             txId,
             outputIndex,
             label: normalizeLabel(label),
+            accountDescriptor: accountDescriptor as AccountDescriptor,
+            networkSymbol: networkSymbol as NetworkSymbol,
         });
 
         if (!result.ok) {
@@ -69,6 +75,8 @@ export class OutputLabels implements OutputLabelsStore {
                     txId: label.txId,
                     outputIndex: label.outputIndex,
                     label: label.label,
+                    accountDescriptor: label.accountDescriptor!,
+                    networkSymbol: label.networkSymbol as NetworkSymbol,
                 });
             }
         };

--- a/suite-common/suite-sync-storage/src/labeling/OutputLabelsStore.ts
+++ b/suite-common/suite-sync-storage/src/labeling/OutputLabelsStore.ts
@@ -1,7 +1,11 @@
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+
 export type OutputLabel = {
     txId: string;
     outputIndex: number;
     label: string | null;
+    accountDescriptor: string;
+    networkSymbol: NetworkSymbol;
 };
 
 export type OutputLabelsStore = {

--- a/suite-common/suite-sync/src/labeling/labelingActions.ts
+++ b/suite-common/suite-sync/src/labeling/labelingActions.ts
@@ -46,6 +46,8 @@ export const setOutputLabel = createAction(
         txId: string;
         outputIndex: number;
         label: string | null;
+        accountDescriptor: string;
+        networkSymbol: NetworkSymbol;
     }) => ({ payload }),
 );
 

--- a/suite-common/suite-sync/src/labeling/processMetadataMessageThunk.ts
+++ b/suite-common/suite-sync/src/labeling/processMetadataMessageThunk.ts
@@ -67,6 +67,8 @@ export const processMetadataMessageThunk = createThunk<
                         txId: payload.txid,
                         outputIndex: Number(payload.outputIndex),
                         label: value ?? null,
+                        accountDescriptor: payload.accountDescriptor,
+                        networkSymbol: payload.networkSymbol as NetworkSymbol,
                     }),
                 );
                 break;

--- a/suite-common/suite-sync/src/labeling/updateOutputLabelThunk.ts
+++ b/suite-common/suite-sync/src/labeling/updateOutputLabelThunk.ts
@@ -1,4 +1,5 @@
 import { createThunk } from '@suite-common/redux-utils';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectDevices } from '@suite-common/wallet-core';
 import type { StaticSessionId } from '@trezor/connect';
 
@@ -9,11 +10,16 @@ type UpdateOutputLabelThunkParams = {
     txId: string;
     outputIndex: number;
     label: string | null;
+    accountDescriptor: string;
+    networkSymbol: NetworkSymbol;
 };
 
 export const updateOutputLabelThunk = createThunk<void, UpdateOutputLabelThunkParams, void>(
     `${LABELING_PREFIX}/updateOutputLabelThunk`,
-    ({ deviceStaticSessionId, txId, outputIndex, label }, { getState, extra: { services } }) => {
+    (
+        { deviceStaticSessionId, txId, outputIndex, label, accountDescriptor, networkSymbol },
+        { getState, extra: { services } },
+    ) => {
         const device = selectDevices(getState())?.find(
             it => it.state?.staticSessionId === deviceStaticSessionId,
         );
@@ -31,6 +37,6 @@ export const updateOutputLabelThunk = createThunk<void, UpdateOutputLabelThunkPa
 
         services.suiteSync.suiteSyncStorageRepository
             .get(owner)
-            .outputLabels.update({ txId, outputIndex, label });
+            .outputLabels.update({ txId, outputIndex, label, accountDescriptor, networkSymbol });
     },
 );

--- a/suite-common/suite-sync/tests/labeling/labelingReducer.test.ts
+++ b/suite-common/suite-sync/tests/labeling/labelingReducer.test.ts
@@ -296,6 +296,8 @@ describe('labelingReducer', () => {
                 txId: 'deadbeefcafebabe',
                 outputIndex: 0,
                 label: 'Output 0',
+                accountDescriptor: 'xpub...',
+                networkSymbol: 'btc',
             }),
         );
 
@@ -316,6 +318,8 @@ describe('labelingReducer', () => {
                 txId: 'deadbeefcafebabe',
                 outputIndex: 0,
                 label: 'Output 0 Updated',
+                accountDescriptor: 'xpub...',
+                networkSymbol: 'btc',
             }),
         );
 
@@ -357,6 +361,8 @@ describe('labelingReducer', () => {
                     txId: 'deadbeefcafebabe',
                     outputIndex: 0,
                     label: 'Output 0',
+                    accountDescriptor: 'xpub...',
+                    networkSymbol: 'btc',
                 },
             ],
         };

--- a/suite-native/labeling/src/components/TransactionOutputLabelEditable.tsx
+++ b/suite-native/labeling/src/components/TransactionOutputLabelEditable.tsx
@@ -5,6 +5,7 @@ import {
     selectOutputLabel,
     updateOutputLabelThunk,
 } from '@suite-common/suite-sync';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { StaticSessionId } from '@trezor/connect';
 
 import { EditableLabelLayout } from './EditableLabelLayout';
@@ -15,12 +16,16 @@ type TransactionOutputLabelEditableProps = {
     txId: string;
     outputIndex: number;
     deviceStaticSessionId: StaticSessionId;
+    accountDescriptor: string;
+    networkSymbol: NetworkSymbol;
 };
 
 export const TransactionOutputLabelEditable = ({
     txId,
     outputIndex,
     deviceStaticSessionId,
+    accountDescriptor,
+    networkSymbol,
 }: TransactionOutputLabelEditableProps) => {
     const isLabelingEnabled = useSelector(selectIsLabelingEnabled);
     const dispatch = useDispatch();
@@ -50,6 +55,8 @@ export const TransactionOutputLabelEditable = ({
                                 txId,
                                 outputIndex,
                                 label: value,
+                                accountDescriptor,
+                                networkSymbol,
                             }),
                         );
                         onClose();

--- a/suite-native/transaction-management/src/addTransactionLabelingThunk.ts
+++ b/suite-native/transaction-management/src/addTransactionLabelingThunk.ts
@@ -63,6 +63,8 @@ export const addTransactionLabelingThunk = createThunk<
                         txId,
                         outputIndex: label.outputIndex,
                         label: label.value,
+                        accountDescriptor: selectedAccount.descriptor,
+                        networkSymbol: selectedAccount.symbol,
                     }),
                 );
             }

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailAddressesSection.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailAddressesSection.tsx
@@ -115,6 +115,8 @@ export const TransactionDetailAddressesSection = ({
                                 //       of the previous transaction. So for inputs we would need to pass previous txid
                                 //       (and figure out correct `n` output index of the utxo on the previous transaction)
                                 showLabels={addressesType === 'outputs'}
+                                accountDescriptor={transaction.descriptor}
+                                networkSymbol={transaction.symbol}
                             />
                         ))}
                     </Box>
@@ -162,6 +164,8 @@ export const TransactionDetailAddressesSection = ({
                                         //       of the previous transaction. So for inputs we would need to pass previous txid
                                         //       (and figure out correct `n` output index of the utxo on the previous transaction)
                                         showLabels={addressesType === 'outputs'}
+                                        accountDescriptor={transaction.descriptor}
+                                        networkSymbol={transaction.symbol}
                                     />
                                 ))}
                             </Box>

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionUtxoAddress.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionUtxoAddress.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux';
 
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { HStack, Text, VStack } from '@suite-native/atoms';
 import { isDebugEnv } from '@suite-native/config';
 import { AccountAddressFormatter } from '@suite-native/formatters';
@@ -21,6 +22,8 @@ type TransactionUtxoAddressProps = {
     txId: string;
     deviceStaticSessionId: StaticSessionId;
     showLabels?: boolean;
+    accountDescriptor: string;
+    networkSymbol: NetworkSymbol;
 };
 
 export const TransactionUtxoAddress = ({
@@ -28,6 +31,8 @@ export const TransactionUtxoAddress = ({
     txId,
     outputIndex,
     address,
+    accountDescriptor,
+    networkSymbol,
     showLabels,
 }: TransactionUtxoAddressProps) => {
     const { applyStyle } = useNativeStyles();
@@ -56,6 +61,8 @@ export const TransactionUtxoAddress = ({
                     txId={txId}
                     outputIndex={outputIndex}
                     deviceStaticSessionId={deviceStaticSessionId}
+                    accountDescriptor={accountDescriptor}
+                    networkSymbol={networkSymbol}
                 />
             )}
         </VStack>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding account descriptor and network symbol to the `outputLabels` table in Suite Sync so the output can be easily query based on account.

## Notes for QA

Nothing to test for QA.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23161


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/output-lables-to-use-account-descriptor-and-symbol&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/output-lables-to-use-account-descriptor-and-symbol&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/output-lables-to-use-account-descriptor-and-symbol&lookback=7)