### PR TITLE
fix(suite): display correct native token for external EVMs

### DIFF
--- a/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
@@ -202,6 +202,17 @@ export default class EthereumSignTransaction extends AbstractMethod<
                 max: undefined,
                 isTokenKnown: !!token,
                 token,
+                nativeToken: this.params.network
+                    ? {
+                          type: 'NATIVE',
+                          standard: 'NATIVE',
+                          contract: '',
+                          name: this.params.network.name,
+                          symbol: this.params.network.shortcut,
+                          decimals: this.params.network.decimals,
+                      }
+                    : undefined,
+                network: this.params.network,
             };
         } catch (e) {
             // Don't throw errors from this method

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -15,6 +15,7 @@ import {
     isEvmApprovalTxByTextSignature,
     isTestnet,
 } from '@suite-common/wallet-utils';
+import type { TokenInfo } from '@trezor/blockchain-link-types';
 import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
@@ -190,6 +191,7 @@ interface GetOutputLinesParams {
     evmTxType?: EvmTransactionPurpose;
     device?: TrezorDevice;
     token?: ReviewOutput['token'];
+    nativeToken?: TokenInfo;
     translationString: TranslationFunction;
 }
 
@@ -203,6 +205,7 @@ const getOutputLines = ({
     evmTxType,
     device,
     token,
+    nativeToken,
     translationString,
 }: GetOutputLinesParams): OutputElementLine[] => {
     const { networkType, symbol } = account;
@@ -216,6 +219,7 @@ const getOutputLines = ({
                     type: 'amount',
                     label: <Translation id="AMOUNT" />,
                     value,
+                    token: nativeToken,
                 },
             ];
         case 'fee-replace':
@@ -323,7 +327,7 @@ const getOutputLines = ({
                     label: <Translation id="AMOUNT" />,
                     value,
                     type: 'amount',
-                    token,
+                    token: token || nativeToken,
                 },
             ];
             if (networkType === 'cardano' && token) {
@@ -395,6 +399,7 @@ export type TransactionReviewOutputProps = {
     stakeType?: StakeType;
     isTrading?: boolean;
     evmTxType?: EvmTransactionPurpose;
+    nativeToken?: TokenInfo;
 } & ReviewOutput;
 
 export const TransactionReviewOutput = ({
@@ -411,6 +416,7 @@ export const TransactionReviewOutput = ({
     isRbf,
     isTrading,
     evmTxType,
+    nativeToken,
 }: TransactionReviewOutputProps) => {
     const { networkType, symbol } = account;
     const accounts = useSelector(selectAccounts);
@@ -419,7 +425,8 @@ export const TransactionReviewOutput = ({
     const { translationString } = useTranslation();
     const isFiatVisible =
         ['fee', 'amount', 'gas', 'fee-replace', 'reduce-output'].includes(type) &&
-        !isTestnet(symbol);
+        !isTestnet(symbol) &&
+        !nativeToken;
 
     const outputTitle = getOutputTitle(
         type,
@@ -442,6 +449,7 @@ export const TransactionReviewOutput = ({
         device,
         token,
         translationString,
+        nativeToken,
     }).map(line => {
         if (line.type === 'address') {
             const relevantAccounts = findAccountsByAddress(symbol, line.value, accounts);

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -109,6 +109,11 @@ export const TransactionReviewOutputList = ({
         ({ type }) => !['address', 'amount', 'opreturn'].includes(type),
     );
 
+    const nativeToken =
+        account.accountType === 'placeholder' && 'nativeToken' in precomposedTx
+            ? precomposedTx.nativeToken
+            : undefined;
+
     useEffect(() => {
         if (reviewStep === outputs.length || signedTx) {
             // When the tx is signed, the outputs are updated, so we use instant scroll to prevent jumping
@@ -172,6 +177,7 @@ export const TransactionReviewOutputList = ({
                                 evmTxType={getEvmTransactionTextSignature(
                                     precomposedForm.transactionData,
                                 )}
+                                nativeToken={nativeToken}
                             />
                         </Column>
                     </Wrapper>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -14,6 +14,7 @@ import {
     isEvmApprovalTx,
     isTestnet,
 } from '@suite-common/wallet-utils';
+import type { TokenInfo } from '@trezor/blockchain-link-types';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Translation } from 'src/components/suite/Translation';
@@ -26,14 +27,25 @@ import {
     TransactionReviewOutputElementProps,
 } from './TransactionReviewOutputElement';
 
-const getLines = (
-    device: TrezorDevice,
-    networkType: NetworkType,
-    precomposedTx: GeneralPrecomposedTransactionFinal,
-    precomposedForm: FormState | StakeFormState,
-    isRbfAction?: boolean,
-    stakeType?: StakeType,
-): OutputElementLine[] => {
+interface GetLinesParams {
+    device: TrezorDevice;
+    networkType: NetworkType;
+    precomposedTx: GeneralPrecomposedTransactionFinal;
+    precomposedForm: FormState | StakeFormState;
+    isRbfAction?: boolean;
+    stakeType?: StakeType;
+    nativeToken?: TokenInfo;
+}
+
+const getLines = ({
+    device,
+    networkType,
+    precomposedTx,
+    precomposedForm,
+    isRbfAction,
+    stakeType,
+    nativeToken,
+}: GetLinesParams): OutputElementLine[] => {
     const isUpdatedSendFlow = getIsUpdatedSendFlow(device);
     const isUpdatedEthereumSendFlow = getIsUpdatedEthereumSendFlow(device, networkType, stakeType);
     const isEthereum = networkType === 'ethereum';
@@ -75,7 +87,7 @@ const getLines = (
             id: 'amount', // In updated ethereum send flow there is no total amount shown, only amount without fee
             label: <Translation id="AMOUNT" />,
             value: tokenInfo ? precomposedTx.totalSpent : amountWithoutFee,
-            token: tokenInfo,
+            token: tokenInfo ?? nativeToken,
             type: 'amount',
         };
 
@@ -83,6 +95,7 @@ const getLines = (
             id: 'fee',
             label: <Translation id="MAX_FEE" />,
             value: precomposedTx.fee,
+            token: nativeToken,
             type: 'amount',
         };
 
@@ -145,8 +158,21 @@ export const TransactionReviewTotalOutput = ({
         return null;
     }
 
-    const { networkType, symbol } = account;
-    const lines = getLines(device, networkType, precomposedTx, precomposedForm, isRbf, stakeType);
+    const { networkType } = account;
+    const nativeToken =
+        account.accountType === 'placeholder' && 'nativeToken' in precomposedTx
+            ? precomposedTx.nativeToken
+            : undefined;
+    const isFiatVisible = !isTestnet(account.symbol) && account.accountType !== 'placeholder';
+    const lines = getLines({
+        device,
+        networkType,
+        precomposedTx,
+        precomposedForm,
+        isRbfAction: isRbf,
+        stakeType,
+        nativeToken,
+    });
 
     return (
         <TransactionReviewOutputElement
@@ -160,7 +186,7 @@ export const TransactionReviewTotalOutput = ({
             account={account}
             lines={lines}
             state={state}
-            fiatVisible={!isTestnet(symbol)}
+            fiatVisible={isFiatVisible}
         />
     );
 };

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -122,6 +122,9 @@ type PrecomposedTransactionBase = PrecomposedTransactionConnectResponseFinal & {
     feeLimit?: string;
     estimatedFeeLimit?: string;
     token?: TokenInfo;
+    /** override the network's native token
+     * used with EVMs that are used via Connect, but not natively supported in Suite */
+    nativeToken?: TokenInfo;
     isTokenKnown?: boolean;
     createdTimestamp?: number;
     maxFeePerGas?: string;

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -205,6 +205,8 @@ export const getAccountTypeName = ({ path, accountType, networkType }: getAccoun
                 return 'TR_ACCOUNT_TYPE_LEGACY';
             case 'normal':
                 return 'TR_ACCOUNT_TYPE_DEFAULT';
+            case 'placeholder':
+                return 'TR_ACCOUNT_TYPE_DEFAULT';
         }
     }
 


### PR DESCRIPTION
## Description

Added new `nativeToken` field to PrecomposedTransaction, which can be used to override the network's native token. 
This is to display correct native token for EVMs that are used via Connect, but not natively supported in Suite

## Notes for QA

Import an unsupported chain into Metamask etc. and do a transaction via Connect. 

## Related Issue

Resolve #23398

## Screenshots:

With Monad chain (MON native token)

|Before|After|
|-|-|
|<img width="683" height="506" alt="Screenshot 2025-11-28 at 16 06 17" src="https://github.com/user-attachments/assets/b373c10c-a5f5-42bb-b348-3b65943f3dec" />|<img width="683" height="506" alt="Screenshot 2025-11-28 at 16 05 31" src="https://github.com/user-attachments/assets/a88d8819-a795-457a-820a-dff0639c7afb" />|


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-unsupported-evms-native-token&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-unsupported-evms-native-token&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-unsupported-evms-native-token&lookback=7)