### PR TITLE
fix(e2e): Fixed Solana send max test

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/fees.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/fees.ts
@@ -23,6 +23,7 @@ export class Fees {
     readonly ethereumFeeLimit: Locator;
     readonly ethereumMaxFeePerGas: Locator;
     readonly ethereumMaxPriorityFeePerGas: Locator;
+    readonly networkReserveBanner: Locator;
 
     constructor(private readonly page: Page) {
         this.collapsibleFeesToggle = this.page.getByTestId('@wallet/fees/collapsible-fees-toggle');
@@ -35,6 +36,7 @@ export class Fees {
         this.ethereumFeeLimit = this.page.getByTestId('feeLimit');
         this.ethereumMaxFeePerGas = this.page.getByTestId('maxFeePerGas');
         this.ethereumMaxPriorityFeePerGas = this.page.getByTestId('maxPriorityFeePerGas');
+        this.networkReserveBanner = this.page.getByTestId('@send/network-reserve-banner');
     }
 
     @step()
@@ -211,5 +213,22 @@ before rounding: ${maxFeeInEthereum} ETH, after rounding: ${maxFeeRounded} ETH`;
         await this.ethereumFeeLimit.fill(input.gasLimit);
         await this.ethereumMaxFeePerGas.fill(input.maxFeePerGas);
         await this.ethereumMaxPriorityFeePerGas.fill(input.maxPriorityFeePerGas);
+    }
+
+    @step()
+    async getNetworkReserveAmount() {
+        const bannerText = await this.networkReserveBanner.textContent();
+        if (!bannerText) {
+            throw new Error('Network reserve banner text is undefined or null');
+        }
+
+        const regex = /(\d+(?:\.\d+)?)(?=\s*SOL)/;
+        const match = bannerText.match(regex);
+
+        if (!match || !match[1]) {
+            throw new Error(`Failed to extract network reserve amount from text: "${bannerText}"`);
+        }
+
+        return Number(match[1]);
     }
 }

--- a/packages/suite-desktop-core/e2e/tests/wallet/send-sol.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/send-sol.test.ts
@@ -40,9 +40,8 @@ test.describe('Send - Solana', { tag: ['@group=wallet'] }, () => {
             }),
         },
         async ({ model, walletPage, tradingPage, devicePrompt }) => {
-            let balance: number;
             let maxFee: number;
-            let sendMaxAmount: string;
+            let sendMaxAmountWithReserve: string;
 
             await test.step('Navigate to Solana Send form', async () => {
                 await walletPage.openSendFormButton.click();
@@ -56,11 +55,14 @@ test.describe('Send - Solana', { tag: ['@group=wallet'] }, () => {
 
                 await expect(tradingPage.fees.maxFee).not.toBeEmpty();
 
-                balance = Number(await tradingPage.sendBalance.textContent());
+                const balance = Number(await tradingPage.sendBalance.textContent());
                 maxFee = Number(await tradingPage.fees.maxFee.textContent());
-                sendMaxAmount = (balance - maxFee).toFixed(SOL_DECIMALS);
+                const reservedAmount = await tradingPage.fees.getNetworkReserveAmount();
+                sendMaxAmountWithReserve = (balance - maxFee - reservedAmount).toFixed(
+                    SOL_DECIMALS,
+                );
 
-                await expect(tradingPage.sendAmountInput).toHaveValue(sendMaxAmount);
+                await expect(tradingPage.sendAmountInput).toHaveValue(sendMaxAmountWithReserve);
                 await expect(walletPage.totalSent).toHaveText(`${balance}`);
                 await expect(tradingPage.sendButton).toBeEnabled();
             });
@@ -85,7 +87,9 @@ test.describe('Send - Solana', { tag: ['@group=wallet'] }, () => {
                 await devicePrompt.waitForPromptAndClick(model.model);
             });
             await test.step('Verify Amount & Transaction Fee', async () => {
-                await expect(devicePrompt.cryptoAmountOf('total')).toHaveText(`${sendMaxAmount}`);
+                await expect(devicePrompt.cryptoAmountOf('total')).toHaveText(
+                    `${sendMaxAmountWithReserve}`,
+                );
                 await expect(devicePrompt.cryptoAmountOf('fee')).toHaveText(`${maxFee}`);
 
                 // verify amount & fee
@@ -93,7 +97,7 @@ test.describe('Send - Solana', { tag: ['@group=wallet'] }, () => {
                     header: { title: 'Summary' },
                     body: [
                         ['Amount:'],
-                        [`${sendMaxAmount} SOL`],
+                        [`${sendMaxAmountWithReserve} SOL`],
                         [' '],
                         ['Transaction fee:'],
                         [`${maxFee} SOL`],

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingNetworkReserveBanner.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingNetworkReserveBanner.tsx
@@ -42,6 +42,7 @@ export const TradingNetworkReserveBanner = ({
 
     return (
         <Banner
+            data-testid="@send/network-reserve-banner"
             intent="info"
             rightContent={
                 <Banner.Button onClick={onManageClick}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There was a change in the calculation, which was not reflected in E2E and this fixes it in a way that change in the reserved amount doesn't break the test.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-send-max-sol-e2e&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-send-max-sol-e2e&lookback=7)