### PR TITLE
fix(suite-native): trading tests

### DIFF
--- a/suite-native/module-trading/src/components/general/TradeInfo/__tests__/TradeFiatSideCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/__tests__/TradeFiatSideCard.comp.test.tsx
@@ -1,4 +1,5 @@
 import { renderWithBasicProvider } from '@suite-native/test-utils';
+import type { ExtendedSellCryptoPaymentMethod } from '@suite-native/trading-types';
 
 import { TradeFiatSideCard, type TradeFiatSideCardProps } from '../TradeFiatSideCard';
 
@@ -28,15 +29,14 @@ describe('TradeFiatSideCard', () => {
         expect(getByText('Bank Transfer')).toBeOnTheScreen();
     });
 
-    it('should handle exhaustive case for unknown payment method', () => {
-        // This test ensures the exhaustive function is called for unknown payment methods
-        // The exhaustive function will throw an error for unknown values
-        expect(() => {
-            renderTradeFiatSideCard({
-                paymentMethod: 'unknown' as any,
-                amount: '+90.17',
-                title: 'To',
-            });
-        }).toThrow();
+    it('should render unknown payment method', () => {
+        const { getByText } = renderTradeFiatSideCard({
+            paymentMethod: 'customMethod' as ExtendedSellCryptoPaymentMethod,
+            amount: '+100.00',
+            title: 'To',
+        });
+
+        expect(getByText('To')).toBeOnTheScreen();
+        expect(getByText('customMethod')).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewContinueButton.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewContinueButton.comp.test.tsx
@@ -124,9 +124,8 @@ describe('SellPreviewContinueButton', () => {
 
         expect(consoleWarnSpy).not.toHaveBeenCalled();
         expect(mockNavigate).toHaveBeenCalledWith({
-            name: 'TradingOutputsReview',
+            name: 'TradingSellOutputsReview',
             params: {
-                tradingType: 'sell',
                 accountKey: 'eth-account-1',
                 orderId: sellQuotes[0].orderId,
                 tokenContract: undefined,


### PR DESCRIPTION
tests for `suite-native/module-trading` are broken by my previous PR. This fixes them

## Notes for QA

do not test



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/module-trading-tests&lookback=7)