### PR TITLE
fix(suite): pushy ada staking top banner only for fb pools

### DIFF
--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -4,13 +4,12 @@ import styled from 'styled-components';
 
 import { selectBannerMessage } from '@suite-common/message-system';
 import {
-    selectCardanoPoolsInfo,
     selectIsDeviceBackupRequired,
     selectIsDeviceBackupUnfinished,
     selectSelectedDevice,
     selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
-import { isCardanoStakedOutsideEverstake } from '@suite-common/wallet-utils';
+import { isCardanoStakedWithFiveBinaries } from '@suite-common/wallet-utils';
 import { isWeb } from '@trezor/env-utils';
 import { spacingsPx } from '@trezor/theme';
 
@@ -61,7 +60,6 @@ export const SuiteBanners = ({ isOnboarding, fill }: SuiteBannersProps) => {
     const isDeviceBackupRequired = useSelector(selectIsDeviceBackupRequired);
     const transport = useSelector(state => state.suite.transport);
     const accounts = useSelector(selectVisibleDeviceAccounts);
-    const cardanoStakingPools = useSelector(selectCardanoPoolsInfo);
     const { localNetworkAccessPermission } = useLocalNetworkAccessPermission();
 
     // The dismissal doesn't need to outlive the session. Use local state.
@@ -116,9 +114,7 @@ export const SuiteBanners = ({ isOnboarding, fill }: SuiteBannersProps) => {
     } else if (bridge?.outdated) {
         banner = <BridgeDeprecated />;
         priority = 30;
-    } else if (
-        accounts.some(account => isCardanoStakedOutsideEverstake(account, cardanoStakingPools))
-    ) {
+    } else if (accounts.some(account => isCardanoStakedWithFiveBinaries(account))) {
         banner = <CardanoOutdatedStakingBanner />;
         priority = 20;
     }

--- a/suite-common/wallet-constants/src/cardanoConstants.ts
+++ b/suite-common/wallet-constants/src/cardanoConstants.ts
@@ -28,3 +28,11 @@ export const CARDANO_EVERSTAKE_DREP = {
 export const CARDANO_POOL_SATURATION_SAFE_THRESHOLD = 80; // in percentage
 
 export const MIN_CARDANO_AMOUNT_FOR_SEND = new BigNumber(1_000_000);
+
+export const FIVE_BINARIES_POOLS = [
+    'pool1k2qhlrrweu8fecd4hx4hn22lv00nrd3rjdxj6durax7m78q7ynu',
+    'pool1nhhsh9yhlrvj9e3nce0zpx0xm2xlt6tx7gqakhr6hjc8wy84sat',
+    'pool1z5rt6kn6yvuczj44qla73mfyln9l55lw0jkz6x4kjw00u32zec3',
+    'pool1398lzhvtaa0hgz305d2jz4urfkwkkt66yv476wqe6att2f7dphh',
+    'pool1z9m2kxeat06t30yf6ar7sqpert0cjdgxzcv2dv36dcwcqcqtgk4',
+];

--- a/suite-common/wallet-utils/src/cardanoStakingUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoStakingUtils.ts
@@ -4,6 +4,7 @@ import { NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
 import {
     CARDANO_EVERSTAKE_STAKING_POOL,
     CARDANO_POOL_SATURATION_SAFE_THRESHOLD,
+    FIVE_BINARIES_POOLS,
 } from '@suite-common/wallet-constants';
 import {
     Account,
@@ -66,6 +67,13 @@ export const isCardanoStakedOutsideEverstake = (
     if (!accountPoolId) return false;
 
     return cardanoStakingPools.every(pool => pool.id !== accountPoolId);
+};
+
+export const isCardanoStakedWithFiveBinaries = (account: Account) => {
+    const accountPoolId = getAccountPoolId(account);
+    if (!accountPoolId) return false;
+
+    return FIVE_BINARIES_POOLS.includes(accountPoolId);
 };
 
 export const poolBech32ToHex = (poolId: string): string => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- pushy staking cardano banner at the top of app should be visible only when staking with FB not with anybody else

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

When staking with FB

<img width="1435" height="918" alt="Screenshot 2025-11-29 at 20 45 40" src="https://github.com/user-attachments/assets/2f96d0ba-23f0-4037-83e0-fc0a0a83fce1" />
<img width="1457" height="1023" alt="Screenshot 2025-11-29 at 20 44 48" src="https://github.com/user-attachments/assets/565fd7e0-7215-4844-b1eb-e41234db56f7" />

When staking with e.g. Nufi or Adalite
<img width="1150" height="923" alt="Screenshot 2025-11-29 at 16 49 40" src="https://github.com/user-attachments/assets/b9b63ff7-e63e-48a9-9a40-75fe2f42668f" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/staked-with-fb&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/staked-with-fb&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/staked-with-fb&lookback=7)