### PR TITLE
refactor(e2e-suite): unites how emu model and version is get in tests

### DIFF
--- a/packages/suite/e2e/support/electron.ts
+++ b/packages/suite/e2e/support/electron.ts
@@ -2,10 +2,10 @@ import { ElectronApplication, Page, _electron as electron } from '@playwright/te
 import { createWriteStream, ensureDirSync } from 'fs-extra';
 import path from 'path';
 
-import { StartEmu, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { BRIDGE_VERSION } from './bridge';
-import { getModelFromEnv } from './helpers/modelFromEnv';
+import { LaunchSuiteParams, StartEmuModelRequired } from './types';
 
 const appDir = path.join(__dirname, '../../../suite-desktop');
 const disableHashChecksPatch = '--state.suite.settings.enabledSecurityChecks.firmwareHash=false';
@@ -22,17 +22,6 @@ const disableHWAccelerationArgument = '--disable-gpu'; // to fix chromium error 
 const removeUserDataArgument = '--remove-user-data-on-start';
 const exposeStoreArgument = '--expose-store';
 
-export type LaunchSuiteParams = {
-    keepUserData?: boolean;
-    bridgeDaemon?: boolean;
-    exposeConnectWs?: boolean;
-    locale?: string;
-    colorScheme?: 'light' | 'dark' | 'no-preference' | null | undefined;
-    artefactFolder: string;
-    viewport: { width: number; height: number };
-    disableAuthenticityCheck?: boolean;
-};
-
 export type Suite = {
     electronApp: ElectronApplication;
     window: Page;
@@ -48,7 +37,11 @@ const formatErrorLogMessage = (data: string) => {
     return `${timestamp} - ${bold}${red}ERROR${unbold}: ${data}${reset}`;
 };
 
-const buildArgs = (params: LaunchSuiteParams, emulatorStartConf: StartEmu) => {
+const buildArgs = (
+    params: LaunchSuiteParams,
+    emulatorStartConf: StartEmuModelRequired,
+    firmwareVersion: string,
+) => {
     const args = [
         // This needs to be just path to the app root, so it is same as for production builds,
         // electron will resolve the path to app.js from the package.json => "main": "dist/app.js",
@@ -80,11 +73,11 @@ const buildArgs = (params: LaunchSuiteParams, emulatorStartConf: StartEmu) => {
         args.push(removeUserDataArgument);
     }
 
-    if (emulatorStartConf.version?.endsWith('-main')) {
+    if (firmwareVersion.endsWith('-main')) {
         args.push(disableFirmwareRevisionChecksPatch);
     }
 
-    if (getModelFromEnv() === 'T3W1' || params.disableAuthenticityCheck) {
+    if (emulatorStartConf.model === 'T3W1' || params.disableAuthenticityCheck) {
         args.push(disableAuthenticityCheckPatch);
     }
 
@@ -107,7 +100,8 @@ const setupLoggingToFile = (electronApp: ElectronApplication, params: LaunchSuit
 
 export const launchSuiteElectronApp = async (
     params: LaunchSuiteParams,
-    emulatorStartConf: StartEmu,
+    emulatorStartConf: StartEmuModelRequired,
+    firmwareVersion: string,
 ) => {
     if (!params.bridgeDaemon) {
         await TrezorUserEnvLink.startBridge(BRIDGE_VERSION);
@@ -115,7 +109,7 @@ export const launchSuiteElectronApp = async (
 
     const electronApp = await electron.launch({
         cwd: appDir,
-        args: buildArgs(params, emulatorStartConf),
+        args: buildArgs(params, emulatorStartConf, firmwareVersion),
         env: {
             ...process.env,
             PLAYWRIGHT_RUN: 'true',
@@ -132,9 +126,10 @@ export const launchSuiteElectronApp = async (
 
 export const launchSuite = async (
     params: LaunchSuiteParams,
-    emulatorStartConf: StartEmu,
+    emulatorStartConf: StartEmuModelRequired,
+    firmwareVersion: string,
 ): Promise<Suite> => {
-    const electronApp = await launchSuiteElectronApp(params, emulatorStartConf);
+    const electronApp = await launchSuiteElectronApp(params, emulatorStartConf, firmwareVersion);
     const window = await electronApp.firstWindow();
 
     return { electronApp, window };

--- a/packages/suite/e2e/support/fixtures.ts
+++ b/packages/suite/e2e/support/fixtures.ts
@@ -60,7 +60,7 @@ const test = suiteBaseTest.extend<Fixtures>({
         await use(new WalletPage(page));
     },
     onboardingPage: async (
-        { page, model, devicePrompt, analyticsSection, settingsPage, emulatorStartConf },
+        { page, model, devicePrompt, analyticsSection, settingsPage, firmwareVersion },
         use,
         testInfo,
     ) => {
@@ -72,7 +72,7 @@ const test = suiteBaseTest.extend<Fixtures>({
                 devicePrompt,
                 analyticsSection,
                 settingsPage,
-                emulatorStartConf,
+                firmwareVersion,
             ),
         );
     },
@@ -125,8 +125,8 @@ const test = suiteBaseTest.extend<Fixtures>({
     stakingSection: async ({ page }, use) => {
         await use(new StakingSection(page));
     },
-    model: async ({ emulatorStartConf }, use) => {
-        await use(new ModelFixture(emulatorStartConf.model));
+    model: async ({ emulatorStartConf, firmwareVersion }, use) => {
+        await use(new ModelFixture(emulatorStartConf.model, firmwareVersion));
     },
 });
 

--- a/packages/suite/e2e/support/modelFixture.ts
+++ b/packages/suite/e2e/support/modelFixture.ts
@@ -4,5 +4,8 @@ export class ModelFixture {
     isModelWithSecureElement = () => ['T3B1', 'T3T1', 'T3W1'].includes(this.model);
     isModelWithTHP = () => ['T3W1'].includes(this.model);
 
-    constructor(readonly model: Model) {}
+    constructor(
+        readonly model: Model,
+        readonly version: string,
+    ) {}
 }

--- a/packages/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/packages/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -1,7 +1,5 @@
 import { Locator, Page, TestInfo, expect } from '@playwright/test';
 
-import { StartEmu } from '@trezor/trezor-user-env-link';
-
 import { SUITE as SuiteActions } from '../../../../src/actions/suite/constants';
 import { TrezorUserEnvLinkProxy, isWebProject, step } from '../../common';
 import { SeedType } from '../../enums/seedType';
@@ -11,7 +9,6 @@ import { BackupSection } from './backupSection';
 import { FirmwareSection } from './firmwareSection';
 import { PinSection } from './pinSection';
 import { TutorialSection } from './tutorialSection';
-import { getModelFromEnv } from '../../helpers/modelFromEnv';
 import { ModelFixture } from '../../modelFixture';
 import { SettingsPage } from '../settings/settingsPage';
 
@@ -48,7 +45,7 @@ export class OnboardingPage {
         private readonly devicePrompt: DevicePrompt,
         private readonly analyticsSection: AnalyticsSection,
         private readonly settingsPage: SettingsPage,
-        private readonly emulatorStartConf: StartEmu,
+        private readonly firmwareVersion: string,
     ) {
         this.backup = new BackupSection(page, devicePrompt);
         this.firmware = new FirmwareSection(page);
@@ -126,7 +123,7 @@ export class OnboardingPage {
         }
 
         await this.onboardingExitButton.click();
-        if (this.model.isModelWithSecureElement() && getModelFromEnv() !== 'T3W1') {
+        if (this.model.isModelWithSecureElement() && this.model.model !== 'T3W1') {
             await this.passThroughAuthenticityCheck();
         }
         // Enabled debug mode is needed for passing firmware checks but it also enables several hidden features
@@ -250,11 +247,11 @@ export class OnboardingPage {
     @step()
     async disableNecessaryFirmwareChecks(options?: { skipSuiteLoadedCheck?: boolean }) {
         await this.disableFirmwareHashCheck(options);
-        if (this.emulatorStartConf.version?.endsWith('-main')) {
+        if (this.firmwareVersion.endsWith('-main')) {
             await this.disableFirmwareRevisionCheck();
         }
 
-        if (getModelFromEnv() === 'T3W1') {
+        if (this.model.model === 'T3W1') {
             await this.disableAuthenticityCheck();
         }
     }

--- a/packages/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/packages/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -2,7 +2,7 @@
 import { BrowserContext, Page, TestInfo, test as base, mergeTests } from '@playwright/test';
 
 import { TestAnnotationType } from '@trezor/e2e-utils';
-import { Model, SetupEmu, StartEmu, TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
+import { SetupEmu, StartEmu, TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
 
 import {
     TrezorUserEnvLinkProxy,
@@ -11,23 +11,18 @@ import {
     isDesktopProject,
     mockRemoteMessageSystem,
 } from '../common';
-import { LaunchSuiteParams, Suite, launchSuite } from '../electron';
+import { Suite, launchSuite } from '../electron';
 import { currentsTest } from './currentsFixture';
 import { enhancePage } from './enhancePage';
 import { BRIDGE_VERSION } from '../bridge';
 import { getModelFromEnv } from '../helpers/modelFromEnv';
-
-type StartEmuModelRequired = StartEmu & { model: Model };
-
-type ElectronConf = Pick<
-    LaunchSuiteParams,
-    'keepUserData' | 'bridgeDaemon' | 'exposeConnectWs' | 'disableAuthenticityCheck'
->;
+import { ElectronConf, StartEmuModelRequired } from '../types';
 
 type suiteBaseFixture = {
     startEmulator: boolean;
     setupEmulator: boolean;
     emulatorStartConf: StartEmuModelRequired;
+    firmwareVersion: string;
     emulatorSetupConf: SetupEmu;
     electronConf: ElectronConf;
     ignoreJSExceptions: Array<string>;
@@ -42,7 +37,8 @@ const electronSetup = async (
     locale: string | undefined,
     colorScheme: any,
     electronConf: ElectronConf,
-    emulatorStartConf: StartEmu,
+    emulatorStartConf: StartEmuModelRequired,
+    firmwareVersion: string,
 ) => {
     const suite = await launchSuite(
         {
@@ -53,6 +49,7 @@ const electronSetup = async (
             ...electronConf,
         },
         emulatorStartConf,
+        firmwareVersion,
     );
 
     await suite.window
@@ -118,23 +115,12 @@ const webTeardown = async (page: Page, browserContext: BrowserContext, testInfo:
     }
 };
 
-const getDefaultEmuStartConf = (emulatorModel?: Model): StartEmuModelRequired => {
-    const model = emulatorModel ?? getModelFromEnv();
-    const DefaultFirmwareMajorVersion = model === 'T1B1' ? 1 : 2;
-    const defaultFirmwareType = process.env.CANARY_FIRMWARE ? '-main' : '-latest';
-
-    return {
-        model,
-        wipe: true,
-        version: `${DefaultFirmwareMajorVersion}${defaultFirmwareType}`,
-    };
-};
-
 const trezorEnvSetup = async (
     testInfo: TestInfo,
     startEmulator: boolean,
     setupEmulator: boolean,
     emulatorStartConf: StartEmu,
+    firmwareVersion: string,
     emulatorSetupConf: SetupEmu,
 ) => {
     const setupPromise = (async () => {
@@ -149,11 +135,11 @@ const trezorEnvSetup = async (
         await TrezorUserEnvLinkProxy.stopEmu();
         await TrezorUserEnvLinkProxy.connect();
 
-        const defaultEmulatorStartConf = getDefaultEmuStartConf(emulatorStartConf.model);
-        emulatorStartConf.version = emulatorStartConf.version || defaultEmulatorStartConf.version;
-
         if (startEmulator) {
-            await TrezorUserEnvLinkProxy.startEmu(emulatorStartConf);
+            await TrezorUserEnvLinkProxy.startEmu({
+                ...emulatorStartConf,
+                version: firmwareVersion,
+            });
         }
         if (startEmulator && setupEmulator) {
             await TrezorUserEnvLinkProxy.setupEmu(emulatorSetupConf);
@@ -176,10 +162,17 @@ const baseWithCurrents = mergeTests(base, currentsTest);
 const suiteBaseTest = baseWithCurrents.extend<suiteBaseFixture>({
     startEmulator: true,
     setupEmulator: true,
-    emulatorStartConf: getDefaultEmuStartConf(),
+    emulatorStartConf: { model: getModelFromEnv(), wipe: true },
     emulatorSetupConf: {},
     electronConf: {},
     ignoreJSExceptions: [],
+
+    firmwareVersion: async ({ emulatorStartConf }, use) => {
+        const defaultFirmwareMajorVersion = emulatorStartConf.model === 'T1B1' ? 1 : 2;
+        const defaultFirmwareType = process.env.CANARY_FIRMWARE ? '-main' : '-latest';
+        const version = `${defaultFirmwareMajorVersion}${defaultFirmwareType}`;
+        await use(version);
+    },
 
     url: async ({}, use, testInfo) => {
         await use(getUrl(testInfo));
@@ -196,6 +189,7 @@ const suiteBaseTest = baseWithCurrents.extend<suiteBaseFixture>({
             startEmulator,
             setupEmulator,
             emulatorStartConf,
+            firmwareVersion,
             emulatorSetupConf,
             electronConf,
         },
@@ -209,6 +203,7 @@ const suiteBaseTest = baseWithCurrents.extend<suiteBaseFixture>({
                 startEmulator,
                 setupEmulator,
                 emulatorStartConf,
+                firmwareVersion,
                 emulatorSetupConf,
             );
         });
@@ -220,6 +215,7 @@ const suiteBaseTest = baseWithCurrents.extend<suiteBaseFixture>({
                 colorScheme,
                 electronConf,
                 emulatorStartConf,
+                firmwareVersion,
             );
             enhancePage(suite.window);
             await use(suite.window);

--- a/packages/suite/e2e/support/types/index.ts
+++ b/packages/suite/e2e/support/types/index.ts
@@ -1,5 +1,7 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
-import { SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+import type { Model } from '@suite-common/suite-types';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import type { SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+import type { StartEmu } from '@trezor/trezor-user-env-link';
 
 import { urlSearchParams } from '../../../src/utils/suite/metadata';
 
@@ -24,6 +26,24 @@ export type PercentageOfBalanceParams = {
     balance: string | null;
     symbol: NetworkSymbol;
 };
+
+export type StartEmuModelRequired = Omit<StartEmu, 'version'> & { model: Model };
+
+export type LaunchSuiteParams = {
+    keepUserData?: boolean;
+    bridgeDaemon?: boolean;
+    exposeConnectWs?: boolean;
+    locale?: string;
+    colorScheme?: 'light' | 'dark' | 'no-preference' | null | undefined;
+    artefactFolder: string;
+    viewport: { width: number; height: number };
+    disableAuthenticityCheck?: boolean;
+};
+
+export type ElectronConf = Pick<
+    LaunchSuiteParams,
+    'keepUserData' | 'bridgeDaemon' | 'exposeConnectWs' | 'disableAuthenticityCheck'
+>;
 
 declare global {
     interface Window {

--- a/packages/suite/e2e/tests/analytics/events.test.ts
+++ b/packages/suite/e2e/tests/analytics/events.test.ts
@@ -13,7 +13,7 @@ test.describe(
     { tag: ['@group=suite', '@webOnly', '@specificFirmware'] },
     () => {
         const firmwareVersion = findLatestVersionForModel('T3T1');
-        test.use({ emulatorStartConf: { model: 'T3T1', version: firmwareVersion, wipe: true } });
+        test.use({ emulatorStartConf: { model: 'T3T1', wipe: true }, firmwareVersion });
         test.beforeEach(async ({ analytics, onboardingPage }) => {
             await analytics.interceptAnalytics();
             await onboardingPage.completeOnboarding();

--- a/packages/suite/e2e/tests/backup/t2t1-fail.test.ts
+++ b/packages/suite/e2e/tests/backup/t2t1-fail.test.ts
@@ -21,6 +21,7 @@ test.describe('Backup errors', { tag: ['@group=device-management', '@specificMod
         devicePrompt,
         trezorUserEnvLink,
         settingsPage,
+        model,
     }) => {
         await test.step('Start backup', async () => {
             await dashboardPage.notificationNoBackupButton.click();
@@ -39,7 +40,7 @@ test.describe('Backup errors', { tag: ['@group=device-management', '@specificMod
         });
 
         await test.step('Simulate reconnect and check errors', async () => {
-            await trezorUserEnvLink.startEmu();
+            await trezorUserEnvLink.startEmu({ model: model.model, version: model.version });
             await expect(page.getByTestId('@toast/backup-failed')).toBeVisible({ timeout: 30_000 });
             await dashboardPage.deviceSwitchingCloseButton.click();
         });

--- a/packages/suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
+++ b/packages/suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
@@ -20,6 +20,7 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
     test('App in daemon mode spawns node-bridge', async ({
         request,
         emulatorStartConf,
+        firmwareVersion,
     }, testInfo) => {
         await expectBridgeToBeStopped(request);
 
@@ -30,6 +31,7 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
                 viewport: testInfo.project.use.viewport!,
             },
             emulatorStartConf,
+            firmwareVersion,
         );
 
         await expect(async () => {
@@ -43,6 +45,7 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
                 viewport: testInfo.project.use.viewport!,
             },
             emulatorStartConf,
+            firmwareVersion,
         );
         const title = await suite.window.title();
         expect(title).toContain('Trezor Suite');

--- a/packages/suite/e2e/tests/bridge-tor/spawn-bridge.test.ts
+++ b/packages/suite/e2e/tests/bridge-tor/spawn-bridge.test.ts
@@ -29,6 +29,7 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
     test('App spawns bundled bridge and stops it after app quit', async ({
         request,
         emulatorStartConf,
+        firmwareVersion,
     }, testInfo) => {
         const suite = await launchSuite(
             {
@@ -37,6 +38,7 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
                 viewport: testInfo.project.use.viewport!,
             },
             emulatorStartConf,
+            firmwareVersion,
         );
         const title = await suite.window.title();
         enhancePage(suite.window);
@@ -66,9 +68,10 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
     test('App acquired device, EXTERNAL bridge is restarted, app reconnects', async ({
         trezorUserEnvLink,
         emulatorStartConf,
+        firmwareVersion,
         model,
     }, testInfo) => {
-        await trezorUserEnvLink.startEmu(emulatorStartConf);
+        await trezorUserEnvLink.startEmu({ ...emulatorStartConf, version: firmwareVersion });
         await trezorUserEnvLink.setupEmu({});
         await trezorUserEnvLink.startBridge(BRIDGE_VERSION);
 
@@ -78,6 +81,7 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
                 viewport: testInfo.project.use.viewport!,
             },
             emulatorStartConf,
+            firmwareVersion,
         );
         enhancePage(suite.window);
         await suite.window.title();
@@ -91,7 +95,7 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
             devicePrompt,
             new AnalyticsSection(suite.window),
             new SettingsPage(suite.window),
-            emulatorStartConf,
+            firmwareVersion,
         );
         await onboardingPage.completeOnboarding();
 

--- a/packages/suite/e2e/tests/bridge-tor/spawn-tor.test.ts
+++ b/packages/suite/e2e/tests/bridge-tor/spawn-tor.test.ts
@@ -36,20 +36,23 @@ const turnOnTorInSettings = async (window: Page, shouldEnableTor = true) => {
 };
 
 test.describe.skip('Tor loading screen', { tag: ['@group=suite', '@desktopOnly'] }, () => {
-    test('Tor loading screen: happy path', async ({ emulatorStartConf }, testInfo) => {
+    test('Tor loading screen: happy path', async ({
+        emulatorStartConf,
+        firmwareVersion,
+    }, testInfo) => {
         const suiteArgs = {
             artefactFolder: testInfo.outputDir,
             viewport: testInfo.project.use.viewport!,
         };
         test.setTimeout(timeout);
 
-        let suite = await launchSuite(suiteArgs, emulatorStartConf);
+        let suite = await launchSuite(suiteArgs, emulatorStartConf, firmwareVersion);
 
         await turnOnTorInSettings(suite.window);
 
         suite.electronApp.close();
 
-        suite = await launchSuite(suiteArgs, emulatorStartConf);
+        suite = await launchSuite(suiteArgs, emulatorStartConf, firmwareVersion);
 
         await suite.window.waitForSelector('[data-testid="@tor-loading-screen"]', {
             state: 'visible',
@@ -62,6 +65,7 @@ test.describe.skip('Tor loading screen', { tag: ['@group=suite', '@desktopOnly']
 
     test('Tor loading screen: making sure that all the request go throw Tor', async ({
         emulatorStartConf,
+        firmwareVersion,
     }, testInfo) => {
         const suiteArgs = {
             artefactFolder: testInfo.outputDir,
@@ -70,13 +74,13 @@ test.describe.skip('Tor loading screen', { tag: ['@group=suite', '@desktopOnly']
 
         const networkAnalyzer = new NetworkAnalyzer();
 
-        let suite = await launchSuite(suiteArgs, emulatorStartConf);
+        let suite = await launchSuite(suiteArgs, emulatorStartConf, firmwareVersion);
 
         await turnOnTorInSettings(suite.window);
 
         suite.electronApp.close();
 
-        suite = await launchSuite(suiteArgs, emulatorStartConf);
+        suite = await launchSuite(suiteArgs, emulatorStartConf, firmwareVersion);
         // Start network analyzer after making sure tor is going to be running.
         networkAnalyzer.start();
 
@@ -96,6 +100,7 @@ test.describe.skip('Tor loading screen', { tag: ['@group=suite', '@desktopOnly']
 
     test('Tor loading screen: disable tor while loading', async ({
         emulatorStartConf,
+        firmwareVersion,
     }, testInfo) => {
         const suiteArgs = {
             artefactFolder: testInfo.outputDir,
@@ -103,13 +108,13 @@ test.describe.skip('Tor loading screen', { tag: ['@group=suite', '@desktopOnly']
         };
         test.setTimeout(timeout);
 
-        let suite = await launchSuite(suiteArgs, emulatorStartConf);
+        let suite = await launchSuite(suiteArgs, emulatorStartConf, firmwareVersion);
 
         await turnOnTorInSettings(suite.window);
 
         suite.electronApp.close();
 
-        suite = await launchSuite(suiteArgs, emulatorStartConf);
+        suite = await launchSuite(suiteArgs, emulatorStartConf, firmwareVersion);
 
         await suite.window.waitForSelector('[data-testid="@tor-loading-screen"]', {
             state: 'visible',

--- a/packages/suite/e2e/tests/firmware/update-firmware.test.ts
+++ b/packages/suite/e2e/tests/firmware/update-firmware.test.ts
@@ -5,7 +5,7 @@ test.describe.skip(
     'Firmware update',
     { tag: ['@group=device-management', '@specificFirmware'] },
     () => {
-        test.use({ emulatorStartConf: { wipe: true, model: 'T2T1', version: '2.5.2' } });
+        test.use({ emulatorStartConf: { wipe: true, model: 'T2T1' }, firmwareVersion: '2.5.2' });
         test.beforeEach(async ({ onboardingPage }) => {
             await onboardingPage.completeOnboarding();
         });

--- a/packages/suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts
+++ b/packages/suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts
@@ -20,6 +20,7 @@ test.describe(
             recoveryModal,
             page,
             trezorUserEnvLink,
+            firmwareVersion,
         }) => {
             await test.step('Navigate through onboarding steps', async () => {
                 await analyticsSection.passThroughAnalytics();
@@ -49,7 +50,7 @@ test.describe(
             });
 
             await test.step('Restart emulator', async () => {
-                await trezorUserEnvLink.startEmu({ model: 'T1B1' });
+                await trezorUserEnvLink.startEmu({ model: 'T1B1', version: firmwareVersion });
             });
 
             await test.step('Retry recovery with basic type', async () => {

--- a/packages/suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts
+++ b/packages/suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts
@@ -19,6 +19,7 @@ test.describe(
             recoveryModal,
             devicePrompt,
             trezorUserEnvLink,
+            firmwareVersion,
         }) => {
             await analyticsSection.passThroughAnalytics();
 
@@ -33,7 +34,11 @@ test.describe(
             // Disconnect the device
             await trezorUserEnvLink.stopEmu();
             await devicePrompt.connectDevicePromptIsShown();
-            await trezorUserEnvLink.startEmu({ model: 'T1B1', wipe: false });
+            await trezorUserEnvLink.startEmu({
+                model: 'T1B1',
+                wipe: false,
+                version: firmwareVersion,
+            });
 
             // Retry recovery process
             await onboardingPage.retryRecoveryButton.click();

--- a/packages/suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
+++ b/packages/suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
@@ -22,7 +22,14 @@ test.describe(
                         'Verifies that if the device is disconnected during the recovery process, the user is given the option to retry the recovery.',
                 }),
             },
-            async ({ page, onboardingPage, analyticsSection, devicePrompt, trezorUserEnvLink }) => {
+            async ({
+                page,
+                firmwareVersion,
+                onboardingPage,
+                analyticsSection,
+                devicePrompt,
+                trezorUserEnvLink,
+            }) => {
                 await analyticsSection.passThroughAnalytics();
                 await onboardingPage.firmware.continueThroughFirmware();
 
@@ -36,7 +43,11 @@ test.describe(
                 await trezorUserEnvLink.stopEmu();
                 await page.waitForTimeout(500);
                 await devicePrompt.connectDevicePromptIsShown();
-                await trezorUserEnvLink.startEmu({ model: 'T2T1', wipe: false });
+                await trezorUserEnvLink.startEmu({
+                    model: 'T2T1',
+                    wipe: false,
+                    version: firmwareVersion,
+                });
 
                 // Check that you can retry
                 await onboardingPage.retryRecoveryButton.click();

--- a/packages/suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts
+++ b/packages/suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts
@@ -71,6 +71,7 @@ test.describe(
             analyticsSection,
             devicePrompt,
             indexedDb,
+            firmwareVersion,
         }) => {
             await test.step('Start recovery with some device', async () => {
                 await page.getByTestId('@onboarding/recovery/start-button').click();
@@ -91,7 +92,11 @@ test.describe(
             });
 
             await test.step('Restart emulator and disable firmware hash check and analytics', async () => {
-                await trezorUserEnvLink.startEmu({ wipe: false, model: 'T2T1' });
+                await trezorUserEnvLink.startEmu({
+                    wipe: false,
+                    model: 'T2T1',
+                    version: firmwareVersion,
+                });
                 await onboardingPage.disableNecessaryFirmwareChecks();
                 await analyticsSection.passThroughAnalytics();
             });
@@ -107,6 +112,7 @@ test.describe(
             page,
             trezorUserEnvLink,
             devicePrompt,
+            firmwareVersion,
         }) => {
             await test.step('Start recovery', async () => {
                 await page.getByTestId('@onboarding/recovery/start-button').click();
@@ -128,7 +134,11 @@ test.describe(
             await test.step('Disconnect and reconnect device', async () => {
                 await trezorUserEnvLink.stopEmu();
                 await devicePrompt.connectDevicePromptIsShown();
-                await trezorUserEnvLink.startEmu({ wipe: false, model: 'T2T1' });
+                await trezorUserEnvLink.startEmu({
+                    wipe: false,
+                    model: 'T2T1',
+                    version: firmwareVersion,
+                });
                 await devicePrompt.confirmOnDevicePromptIsShown({ timeout: 15_000 });
 
                 // This is needed, because there seem to be some weird refreshes on the emu

--- a/packages/suite/e2e/tests/passphrase/passphrase-cardano.test.ts
+++ b/packages/suite/e2e/tests/passphrase/passphrase-cardano.test.ts
@@ -19,12 +19,17 @@ test.describe('Passphrase with cardano', { tag: ['@group=passphrase'] }, () => {
         devicePrompt,
         trezorUserEnvLink,
         emulatorStartConf,
+        firmwareVersion,
     }) => {
         async function restartEmulator() {
             await test.step('Restart emulator', async () => {
                 await trezorUserEnvLink.stopEmu();
                 await expect(page.getByTestId('@deviceStatus-disconnected')).toBeVisible();
-                await trezorUserEnvLink.startEmu({ model: emulatorStartConf.model, wipe: false });
+                await trezorUserEnvLink.startEmu({
+                    model: emulatorStartConf.model,
+                    wipe: false,
+                    version: firmwareVersion,
+                });
                 await expect(page.getByTestId('@deviceStatus-connected')).toBeVisible({
                     timeout: 15_000,
                 });

--- a/packages/suite/e2e/tests/passphrase/passphrase-reconnection.test.ts
+++ b/packages/suite/e2e/tests/passphrase/passphrase-reconnection.test.ts
@@ -16,6 +16,7 @@ test.describe('Passphrase reconnection', { tag: ['@group=passphrase'] }, () => {
         devicePrompt,
         trezorUserEnvLink,
         emulatorStartConf,
+        firmwareVersion,
     }) => {
         await test.step('Add passphrase wallet "abc"', async () => {
             await dashboardPage.openDeviceSwitcher();
@@ -45,7 +46,11 @@ test.describe('Passphrase reconnection', { tag: ['@group=passphrase'] }, () => {
 
         await test.step('Disconnect and reconnect the device', async () => {
             await trezorUserEnvLink.stopEmu();
-            await trezorUserEnvLink.startEmu({ model: emulatorStartConf.model, wipe: false });
+            await trezorUserEnvLink.startEmu({
+                model: emulatorStartConf.model,
+                wipe: false,
+                version: firmwareVersion,
+            });
         });
 
         await test.step('Check passphrase wallet "abc" is still cached and connected', async () => {

--- a/packages/suite/e2e/tests/settings/t2t1-device-settings.test.ts
+++ b/packages/suite/e2e/tests/settings/t2t1-device-settings.test.ts
@@ -68,7 +68,10 @@ test.describe('T2T1 - Device settings', { tag: ['@group=settings', '@specificMod
         'T2T1 - older firmware < 2.5.4',
         { tag: ['@group=settings', '@specificFirmware'] },
         () => {
-            test.use({ emulatorStartConf: { wipe: true, model: 'T2T1', version: '2.5.3' } });
+            test.use({
+                emulatorStartConf: { wipe: true, model: 'T2T1' },
+                firmwareVersion: '2.5.3',
+            });
             test('Cannot change homescreen in firmware < 2.5.4', async ({ page }) => {
                 await expect(
                     page.getByTestId('@settings/device/homescreen-gallery'),

--- a/packages/suite/e2e/tests/settings/without-device.test.ts
+++ b/packages/suite/e2e/tests/settings/without-device.test.ts
@@ -25,6 +25,7 @@ test.describe(
             tradingPage,
             trezorUserEnvLink,
             emulatorStartConf,
+            firmwareVersion,
         }) => {
             await test.step('Go to send form and verify prompt to connect Trezor', async () => {
                 await settingsPage.navigateTo('application');
@@ -33,7 +34,11 @@ test.describe(
                 await settingsPage.navigateTo('coins');
                 await settingsPage.coins.enableNetwork('regtest');
 
-                await trezorUserEnvLink.startEmu({ ...emulatorStartConf, wipe: false });
+                await trezorUserEnvLink.startEmu({
+                    ...emulatorStartConf,
+                    wipe: false,
+                    version: firmwareVersion,
+                });
 
                 await trezorUserEnvLink.sendToAddressAndMineBlock({
                     address: ADDRESS_INDEX_1,

--- a/packages/suite/e2e/tests/suite/db-migration.test.ts
+++ b/packages/suite/e2e/tests/suite/db-migration.test.ts
@@ -54,6 +54,7 @@ test.describe(
                 walletPage,
                 devicePrompt,
                 trezorUserEnvLink,
+                model,
             }) => {
                 const discoveryBar = page.locator(
                     '[data-test="\\@wallet\\/discovery-progress-bar"] div',
@@ -169,7 +170,10 @@ test.describe(
                 });
 
                 await test.step('Reconnect Emulator', async () => {
-                    await trezorUserEnvLink.startEmu();
+                    await trezorUserEnvLink.startEmu({
+                        model: model.model,
+                        version: model.version,
+                    });
                     await onboardingPage.disableNecessaryFirmwareChecks({
                         skipSuiteLoadedCheck: true,
                     });

--- a/packages/suite/e2e/tests/suite/multiple-sessions.test.ts
+++ b/packages/suite/e2e/tests/suite/multiple-sessions.test.ts
@@ -87,7 +87,7 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
                 priority: TestPriority.Medium,
             }),
         },
-        async ({ context, model, onboardingPage, dashboardPage, emulatorStartConf }, testInfo) => {
+        async ({ context, model, onboardingPage, dashboardPage, firmwareVersion }, testInfo) => {
             await onboardingPage.completeOnboarding();
 
             const pageTwo = await context.newPage();
@@ -106,7 +106,7 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
                 devicePromptTwo,
                 analyticsSectionTwo,
                 settingsPageTwo,
-                emulatorStartConf,
+                firmwareVersion,
             );
             await onboardingPageTwo.completeOnboarding();
             const dashboardPageTwo = new DashboardPage(pageTwo, devicePromptTwo);


### PR DESCRIPTION
splits version off emulatorStartConf

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-e2e-model-version-setup&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-e2e-model-version-setup&lookback=7)