### PR TITLE
fix(e2e-suite): start the test with wiped model

### DIFF
--- a/packages/suite/e2e/tests/general/check-links.test.ts
+++ b/packages/suite/e2e/tests/general/check-links.test.ts
@@ -11,25 +11,26 @@ async function getAllLinksFromAllPages(page: Page, paths: Array<string>): Promis
 
     for (const path of paths) {
         await page.goto(path, { waitUntil: 'domcontentloaded' });
-        // make sure the page is loaded by asserting the element visibility in DOM
-        await expect
-            .soft(
-                page
-                    .getByTestId('@suite-layout')
-                    .or(page.locator('[data-testid^="@onboarding"]'))
-                    .first(),
-                `Page element for route "${path}" is not visible`,
-            )
-            .toBeVisible();
+
+        // Ensure the page is loaded by asserting the element is attached to the DOM.
+        // For unknown reasons, this is the only available method to wait for the page to load.
+        await expect(
+            page
+                .locator('[data-testid^="@welcome"]')
+                .or(page.locator('[data-testid^="@suite-layout"]'))
+                .or(page.locator('[data-testid^="@onboarding"]'))
+                .first(),
+            `The page element for route "${path}" should be attached`,
+        ).toBeAttached();
 
         const links = page.locator('a');
         const allLinks = await links.all();
         const allHrefs = await Promise.all(allLinks.map(link => link.getAttribute('href')));
 
         for (const link of allHrefs) {
-            expect.soft(link, `${link} is not valid href`).toBeTruthy();
+            expect.soft(link, `${link} should be a valid href`).toBeTruthy();
 
-            // normalize the links
+            // Normalize the links.
             if (link) allValidHrefs.add(new URL(link, page.url()).href);
         }
     }
@@ -38,7 +39,7 @@ async function getAllLinksFromAllPages(page: Page, paths: Array<string>): Promis
 }
 
 test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@specificModel'] }, () => {
-    test.use({ emulatorStartConf: { model: 'T3T1' } });
+    test.use({ emulatorStartConf: { model: 'T3T1', wipe: true } });
 
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
@@ -55,12 +56,12 @@ test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@specificModel
             }),
         },
         async ({ page }) => {
-            // Test is slow due to opening the pages for all known routes
-            // Don't allow the test to finish on standard timeout.
+            // Test is slow due to opening the pages for all known routes.
+            // The standard timeout must be extended to ensure test completion.
             test.slow();
 
             // Create an array of all routes except those containing 4 segments
-            // to keep the list a bit shorter, and reduce execution time
+            // to keep the list a bit shorter, and reduce execution time.
             const allPaths = routes
                 .map(route => route.pattern)
                 .filter(pattern => {
@@ -76,7 +77,7 @@ test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@specificModel
                     await test.step(`Checking link: ${url}`, async () => {
                         const response = await page.request.get(url);
 
-                        expect.soft(response.ok(), `${url} has no green status code`).toBeTruthy();
+                        expect.soft(response.ok(), `${url} should be OK`).toBeTruthy();
                     });
                 }),
             );


### PR DESCRIPTION
## Description


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/test-check-broken-links&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/test-check-broken-links&lookback=7)