### PR TITLE
chore(suite-native): skip failing buy flow test

### DIFF
--- a/suite-native/app/e2e/tests/manual/currencyChange.test.ts
+++ b/suite-native/app/e2e/tests/manual/currencyChange.test.ts
@@ -2,6 +2,7 @@ import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 
 import { it } from '../../support/wrappedIt';
 
+// FIXME https://github.com/trezor/trezor-suite/issues/23438
 describe.skip('Settings', () => {
     it(
         'Change currency',

--- a/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
@@ -11,7 +11,8 @@ const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
 );
 
-describe('Trade Buy [@noDevice]', () => {
+// FIXME https://github.com/trezor/trezor-suite/issues/23518
+describe.skip('Trade Buy [@noDevice]', () => {
     beforeEach(async () => {
         await openApp({ args: { preloadedState } });
         await onHome.assertIsPortfolioGraphVisible();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

followup issue https://github.com/trezor/trezor-suite/issues/23518

failed on develop here https://github.com/trezor/trezor-suite/actions/runs/19807179691

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/flaky-buy-e2e-test&lookback=7)