### PR TITLE
feat(connect): add connect-cli script

### DIFF
--- a/packages/connect-cli/.gitignore
+++ b/packages/connect-cli/.gitignore
@@ -1,0 +1,1 @@
+thp-state.dat

--- a/packages/connect-cli/README.md
+++ b/packages/connect-cli/README.md
@@ -1,0 +1,7 @@
+# Connect CLI
+
+Nodejs client for `@trezor/connect`
+
+Run `yarn workspace @trezor/connect-cli cli --help`
+
+[HELP](./src/args.ts)

--- a/packages/connect-cli/package.json
+++ b/packages/connect-cli/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "@trezor/connect-cli",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build",
+        "cli": "tsx ./src/index.ts"
+    },
+    "dependencies": {
+        "@trezor/connect": "workspace:*",
+        "@trezor/protobuf": "workspace:*",
+        "@trezor/transport": "workspace:*",
+        "@trezor/transport-bluetooth": "workspace:*"
+    },
+    "devDependencies": {
+        "tsx": "^4.20.3"
+    }
+}

--- a/packages/connect-cli/src/args.ts
+++ b/packages/connect-cli/src/args.ts
@@ -1,0 +1,63 @@
+export const HELP = `@trezor/connect CLI arguments:
+
+  Transport options (default: usb)
+    --usb | --bridge | --udp | --bluetooth
+
+  TrezorConnect logs (default: disabled)
+    --debug                                   Enable TrezorConnect logs
+
+  Interaction options (default: disabled)
+    --debuglink                               Enable DebugLink decisions
+                                                --debuglink           All decisions resolved
+                                                --debuglink=pairing   THP pairing resolved
+                                                --debuglink=button    Button_Request resolved
+
+  THP Credentials options (default: none)
+    --credentials                             Use THP credentials no autoconnect
+    --autoconnect                             Use THP autoconnect credentials
+                                                Run --test=get-credentials to create autoconnect credentials
+                                                Credentials are stored in "thp-state.dat"
+
+  THP Pairing methods (default: code)
+    --pairing=code | qr | nfc | skip
+
+  Passphrase
+    --passphrase=<value>                      Use passphrase (default: empty)
+
+  Method (default: GetAddress)
+    --method <name>                           Run TrezorConnect method
+                                                --method=none (retrieve device Features and exit)
+                                                --method=fw-update
+                                                --method=get-credentials
+`;
+
+// read and parse application arguments
+const parseArgv = () => {
+    const argv = process.argv.slice(2);
+    const keys: string[] = [];
+    const result: Record<string, any> = { _: keys };
+
+    const add = (key: string, next?: string) =>
+        next && !next.startsWith('-') && keys.push(key) > -1
+            ? ((result[key] = next), true)
+            : ((result[key] = true), false);
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg.startsWith('--')) {
+            const key = arg.slice(2);
+            if (key.includes('=')) {
+                const [k, v] = key.split('=');
+                add(k, v.toLowerCase());
+            } else if (add(key, argv[i + 1])) i++;
+        } else if (arg.startsWith('-') && arg.length === 2) {
+            if (add(arg[1], argv[i + 1])) i++;
+        } else {
+            keys.push(arg);
+        }
+    }
+
+    return result;
+};
+
+export const args = parseArgv();

--- a/packages/connect-cli/src/index.ts
+++ b/packages/connect-cli/src/index.ts
@@ -1,0 +1,254 @@
+import fs from 'fs';
+import path from 'path';
+
+import TrezorConnect, { Device, ThpPairingMethod, UiRequestThpPairing } from '@trezor/connect';
+
+import { HELP, args } from './args';
+import { stdioManager } from './stdio';
+import {
+    debugLinkDecision,
+    debugLinkState,
+    getTransport,
+    initDebugLink,
+    isDebugLinkInteraction,
+} from './transport';
+
+/* eslint-disable no-console */
+
+const waitForStdio = stdioManager();
+
+const waitForPairingTag = async (uiEvent: UiRequestThpPairing) => {
+    const { selectedMethod } = uiEvent.payload;
+    if (!isDebugLinkInteraction('pairing')) {
+        const resp = await waitForStdio('Enter pairing code or type [C] for Cancel:').promise;
+        if (resp === 'c') {
+            return;
+        }
+
+        return resp;
+    } else {
+        const state = await debugLinkState(uiEvent.payload);
+        if (!state?.success) {
+            throw new Error('DebugLinkState missing: ' + state.error);
+        }
+        const { payload } = state;
+        if (payload.type !== 'DebugLinkPairingInfo') {
+            throw new Error(
+                'DebugLinkState missing, received ' + state.payload.type,
+                // state.payload.message,
+            );
+        }
+        const { code_entry_code, code_qr_code, nfc_secret_trezor } = payload.message;
+        if (selectedMethod === ThpPairingMethod.CodeEntry && code_entry_code) {
+            return Number(code_entry_code).toString().padStart(6, '0');
+        }
+        if (selectedMethod === ThpPairingMethod.QrCode && code_qr_code) {
+            // NOTE: qrcode throws from firmware: Pairing tag cancelled (Failure) ?
+            return code_qr_code;
+        }
+        if (selectedMethod === ThpPairingMethod.NFC && nfc_secret_trezor) {
+            return nfc_secret_trezor;
+        }
+
+        return 'unknown-tag';
+    }
+};
+
+const cliStatePath = path.join(__dirname, 'thp-state.dat');
+const readCliState = (): { credentials: NonNullable<Device['thp']>['credentials'] } => {
+    try {
+        return JSON.parse(fs.readFileSync(cliStatePath, 'utf8'));
+    } catch {
+        return { credentials: [] };
+    }
+};
+
+const writeCliState = (data: any) => {
+    fs.writeFileSync(cliStatePath, JSON.stringify(data, null, 2), 'utf8');
+};
+
+const getThpCredentials = () => {
+    const data = readCliState();
+    if (args.credentials) {
+        return data.credentials.filter(c => !c.autoconnect);
+    }
+    if (args.autoconnect) {
+        return data.credentials;
+    }
+
+    return [];
+};
+
+const getFeatures = (device: Device) =>
+    TrezorConnect.getFeatures({
+        device,
+    });
+
+const fwUpdate = (device: Device) =>
+    TrezorConnect.firmwareUpdate({
+        device,
+        baseUrl: path.resolve(__dirname, '../connect-common/files'),
+    });
+
+const runTestCase = async (device: Device) => {
+    const { method } = args;
+    if (method === 'none') {
+        console.log('Missing method. Exiting');
+        process.exit(1);
+    }
+
+    // device is ready, start workflow
+    let result;
+    if (method === 'fw-update') {
+        result = await fwUpdate(device);
+    } else if (method === 'get-credentials') {
+        result = await TrezorConnect.thpGetCredentials({ device });
+    } else {
+        result = await TrezorConnect.getAddress({
+            device,
+            path: "m/44'/0'/0'/0/0",
+        });
+    }
+
+    console.warn(result);
+    process.exit(1);
+};
+
+const run = async () => {
+    if (args.help || args.h) {
+        console.log(HELP);
+
+        return;
+    }
+
+    let testIsRunning = false;
+
+    console.log('Running @trezor/connect CLI with args', args);
+
+    TrezorConnect.on('DEVICE_EVENT', async event => {
+        if (event.type === 'device-connect_unacquired' || event.type === 'device-connect') {
+            if (testIsRunning) {
+                return;
+            }
+
+            const device = event.payload;
+            if (device.features && device.mode === 'initialize') {
+                await new Promise(resolve => setTimeout(resolve, 2000));
+                await TrezorConnect.loadDevice({
+                    device,
+                    pin: '',
+                    label: 'THP device',
+                    passphrase_protection: true,
+                    mnemonics: ['all all all all all all all all all all all all'],
+                    skip_checksum: true,
+                });
+            }
+
+            if (!device.features && device.thp?.properties) {
+                // start pairing
+                const result = await getFeatures(device);
+                if (!result.success) {
+                    process.exit(1);
+                }
+            } else {
+                testIsRunning = true;
+                runTestCase(device);
+            }
+        }
+
+        if (event.type === 'device-thp_credentials_changed') {
+            const { credentials } = event.payload;
+            console.log('THP credentials', event.payload.credentials);
+            const state = readCliState();
+            if (!state.credentials.find(c => c.credential === credentials.credential)) {
+                state.credentials.push(credentials);
+                writeCliState(state);
+            }
+        }
+    });
+
+    TrezorConnect.on('UI_EVENT', async event => {
+        console.warn('UI_EVENT', event.type);
+
+        if (event.type === 'ui-request_confirmation') {
+            return TrezorConnect.uiResponse({
+                type: 'ui-receive_confirmation',
+                payload: true,
+            });
+        }
+
+        if (event.type === 'ui-request_passphrase') {
+            if (args['cancel-passphrase']) {
+                return TrezorConnect.cancel();
+            }
+            if (args['cancel-passphrase-ui']) {
+                // respond with no passphrase
+                // @ts-expect-error
+                return TrezorConnect.uiResponse({
+                    type: 'ui-receive_passphrase',
+                });
+            }
+
+            const value = args.passphrase || '';
+            TrezorConnect.uiResponse({
+                type: 'ui-receive_passphrase',
+                payload: { value, passphraseOnDevice: args['passphrase-on-device'] },
+            });
+        }
+
+        if (event.type === 'ui-request_thp_pairing') {
+            const tag = await waitForPairingTag(event);
+            if (tag) {
+                TrezorConnect.uiResponse({
+                    type: 'ui-receive_thp_pairing_tag',
+                    payload: { tag },
+                });
+            } else {
+                return TrezorConnect.cancel();
+            }
+        }
+
+        if (event.type === 'ui-button') {
+            if (!isDebugLinkInteraction('button')) {
+                const resp = await waitForStdio(
+                    `Confirm ${event.payload.code} (${event.payload.name}) on device or type [c] for Cancel:`,
+                ).promise;
+                if (resp === 'c') {
+                    TrezorConnect.cancel();
+                }
+            } else {
+                await debugLinkDecision();
+            }
+        }
+    });
+
+    let pairingMethods: any[] = ['CodeEntry', 'QrCode', 'NFC', 'SkipPairing'];
+    if (args.pairing === 'none') {
+        pairingMethods = ['SkipPairing'].concat(pairingMethods.filter(m => m === 'SkipPairing'));
+    }
+    if (args.pairing === 'qr') {
+        pairingMethods = ['QrCode'].concat(pairingMethods.filter(m => m === 'QrCode'));
+    }
+    if (args.pairing === 'nfc') {
+        pairingMethods = ['NFC'].concat(pairingMethods.filter(m => m === 'NFC'));
+    }
+
+    await initDebugLink();
+    const transport = await getTransport();
+
+    await TrezorConnect.init({
+        manifest: { appUrl: 'a', appName: 'TrezorConnect Cli', email: 'b' },
+        transports: [transport],
+        pendingTransportEvent: false,
+        debug: args.debug,
+        thp: {
+            appName: 'TrezorConnect Cli',
+            hostName: 'localhost',
+            staticKey: '0007070707070707070707070707070707070707070707070707070707070747',
+            knownCredentials: getThpCredentials(),
+            pairingMethods,
+        },
+    });
+};
+
+run();

--- a/packages/connect-cli/src/stdio.ts
+++ b/packages/connect-cli/src/stdio.ts
@@ -1,0 +1,30 @@
+import readline from 'readline';
+
+export const stdioManager = () => {
+    let readInterface: readline.Interface | undefined;
+
+    return (promptText: string) => {
+        if (readInterface) {
+            readInterface.close();
+        }
+
+        readInterface = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+        });
+
+        const rl = readInterface;
+
+        return {
+            promise: new Promise<string>(resolve => {
+                setTimeout(() => {
+                    rl.question(promptText + ' ', (answer: any) => {
+                        rl.close();
+                        resolve(answer);
+                    });
+                }, 10);
+            }),
+            abort: () => rl.close(),
+        };
+    };
+};

--- a/packages/connect-cli/src/transport.ts
+++ b/packages/connect-cli/src/transport.ts
@@ -1,0 +1,149 @@
+import { ConnectSettingsTransport, UiRequestThpPairing } from '@trezor/connect';
+import * as protobufDefinitions from '@trezor/protobuf/messages.json';
+import { NodeUsbTransport, UdpTransport } from '@trezor/transport';
+import { BluetoothTransport, TrezorBluetooth } from '@trezor/transport-bluetooth';
+
+import { args } from './args';
+
+/* eslint-disable no-console */
+
+// get Transport from args
+export const getCurrentTransport = () => {
+    if (args._.includes('bridge') || args.bridge) return 'bridge';
+    if (args._.includes('udp') || args.udp) return 'udp';
+    if (args._.includes('bluetooth') || args.bluetooth) return 'bluetooth';
+
+    return 'usb';
+};
+
+// if interaction is done by the user or resolved by DebugLink decision
+export const isDebugLinkInteraction = (type: string) =>
+    (typeof args.debuglink === 'boolean' && args.debuglink) ||
+    (typeof args.debuglink === 'string' && ['all', type].includes(args.debuglink));
+
+const debugTransport =
+    getCurrentTransport() === 'udp'
+        ? new UdpTransport({ id: 'udp', messages: protobufDefinitions, debugLink: true })
+        : new NodeUsbTransport({ id: 'usb', messages: protobufDefinitions, debugLink: true });
+
+export const initDebugLink = async () => {
+    if (args['interactive']) return;
+
+    console.log('init', debugTransport.name, 'in DebugLink mode');
+    await debugTransport.init();
+
+    const enumerate = await debugTransport.enumerate();
+    if (!enumerate.success) {
+        throw new Error(enumerate.error);
+    }
+};
+
+const waitForDebugDevice = async () => {
+    let device;
+    let attempt = 0;
+    while (!device && attempt < 10) {
+        const enumerate = await debugTransport.enumerate();
+        console.log('DebugLink enumerate attempt', attempt);
+        if (!enumerate.success) {
+            throw new Error(enumerate.error);
+        }
+        if (enumerate.payload.length > 0) {
+            device = enumerate.payload[0];
+        }
+        attempt++;
+    }
+
+    return device;
+};
+
+export const debugLinkState = async (uiEvent: UiRequestThpPairing['payload']) => {
+    const descriptor = await waitForDebugDevice();
+    if (!descriptor || !uiEvent.device.thp) {
+        throw new Error('Debug device not found');
+    }
+    const input = { ...descriptor, previous: descriptor.session };
+    const acquire = await debugTransport.acquire({ input });
+    if (!acquire.success) {
+        throw new Error(acquire.error);
+    }
+
+    const { channel } = uiEvent.device.thp;
+    let nfc_secret_host, handshake_hash;
+    if (uiEvent.nfcData) {
+        const nfcData = Buffer.from(uiEvent.nfcData, 'hex');
+        nfc_secret_host = nfcData.subarray(0, 16);
+        handshake_hash = nfcData.subarray(16);
+    }
+
+    const session = acquire.payload;
+    const response = await debugTransport.call({
+        name: 'DebugLinkGetPairingInfo',
+        data: {
+            channel_id: Buffer.from(channel, 'hex'),
+            handshake_hash,
+            nfc_secret_host,
+        },
+        session,
+    });
+
+    await debugTransport.release({ ...descriptor, session });
+    await debugTransport.enumerate();
+
+    return response;
+};
+
+export const debugLinkDecision = async () => {
+    if (!isDebugLinkInteraction('button')) return;
+
+    const enumerate = await debugTransport.enumerate();
+    if (!enumerate.success) {
+        throw new Error(enumerate.error);
+    }
+    const descriptor = enumerate.payload[0];
+    const input = { ...descriptor, previous: descriptor.session };
+
+    const acquire = await debugTransport.acquire({ input });
+    if (!acquire.success) {
+        throw new Error(acquire.error);
+    }
+
+    const session = acquire.payload;
+    await debugTransport.send({
+        name: 'DebugLinkDecision',
+        data: { button: 1 },
+        session,
+    });
+
+    await debugTransport.release({ ...enumerate.payload[0], session });
+    await debugTransport.enumerate();
+};
+
+export const getTransport = async (): Promise<ConnectSettingsTransport> => {
+    const transportName = getCurrentTransport();
+
+    const bluetoothApi = new TrezorBluetooth({ url: `ws://localhost:21327/` });
+    if (transportName === 'bluetooth') {
+        await bluetoothApi.connect();
+        const enumerate = await bluetoothApi.send('start_scan');
+        const bluetoothDevice = enumerate.devices.find(d => d.paired);
+        if (!bluetoothDevice) {
+            throw new Error('Bluetooth Device is missing');
+        }
+
+        await bluetoothApi.send('connect_device', { id: bluetoothDevice.id, timeout: 5000 });
+
+        await bluetoothApi.send('start_scan');
+
+        return new BluetoothTransport({
+            url: 'ws://127.0.0.1:21327',
+            messages: protobufDefinitions,
+            id: 'ble',
+        });
+    } else if (transportName === 'bridge') {
+        return 'BridgeTransport';
+    } else if (transportName === 'udp') {
+        return 'UdpTransport';
+    }
+
+    return 'NodeUsbTransport';
+};

--- a/packages/connect-cli/tsconfig.json
+++ b/packages/connect-cli/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../connect" },
+        { "path": "../protobuf" },
+        { "path": "../transport" },
+        { "path": "../transport-bluetooth" }
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14345,6 +14345,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@trezor/connect-cli@workspace:packages/connect-cli":
+  version: 0.0.0-use.local
+  resolution: "@trezor/connect-cli@workspace:packages/connect-cli"
+  dependencies:
+    "@trezor/connect": "workspace:*"
+    "@trezor/protobuf": "workspace:*"
+    "@trezor/transport": "workspace:*"
+    "@trezor/transport-bluetooth": "workspace:*"
+    tsx: "npm:^4.20.3"
+  languageName: unknown
+  linkType: soft
+
 "@trezor/connect-common@workspace:*, @trezor/connect-common@workspace:packages/connect-common":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-common@workspace:packages/connect-common"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding handy script for testing `@trezor/connect` workflows in nodejs.

The intention is to have fast and accessible setup without need to run suite or connect-explorer in order to test some scenarios.

Initially it was created as THP pairing test but while working on other features it evolved into something useful across all branches.

Key features:
- CLI works with udp, usb, bridge and bluetooth transports
- CLI works with THP pairing and credentials
- CLI works with button requests (DebugLink support)

for more info run:

`yarn workspace @trezor/connect-cli cli --help`

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-cli&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-cli&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-cli&lookback=7)