### PR TITLE
`Invalid passphrase` followup

### DIFF
--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -127,6 +127,25 @@ export const setup = async (
     );
 };
 
+export const restartEmu = async (controller: TrezorUserEnvLinkClass) => {
+    await controller.stopEmu();
+    await new Promise<void>(resolve => {
+        const onDeviceDisconnected = () => {
+            TrezorConnect.off('device-disconnect', onDeviceDisconnected);
+            resolve();
+        };
+        TrezorConnect.on('device-disconnect', onDeviceDisconnected);
+    });
+    await controller.startEmu({ ...emulatorStartOpts, wipe: false });
+    await new Promise<void>(resolve => {
+        const onDeviceConnected = () => {
+            TrezorConnect.off('device-connect', onDeviceConnected);
+            resolve();
+        };
+        TrezorConnect.on('device-connect', onDeviceConnected);
+    });
+};
+
 type InitParams = Partial<Parameters<typeof TrezorConnect.init>[0]> & { autoConfirm?: boolean };
 
 export const initTrezorConnect = async (

--- a/packages/connect/e2e/tests/device/passphrase.test.ts
+++ b/packages/connect/e2e/tests/device/passphrase.test.ts
@@ -1,5 +1,11 @@
 import TrezorConnect from '../../../src';
-import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
+import {
+    conditionalTest,
+    getController,
+    initTrezorConnect,
+    restartEmu,
+    setup,
+} from '../../common.setup';
 
 const controller = getController();
 
@@ -163,6 +169,42 @@ describe('TrezorConnect passphrase', () => {
         expect(invalidState.payload).toMatchObject({
             error: 'Passphrase is incorrect',
         });
+    });
+
+    it('Using multiple passphrases with device restart', async () => {
+        // get standard wallet state
+        const standard = await TrezorConnect.getDeviceState({
+            device: { instance: 0, state: undefined },
+            useEmptyPassphrase: true,
+        });
+        if (!standard.success) throw new Error(standard.payload.error);
+
+        // get passphrase wallet state
+        TrezorConnect.on('ui-request_passphrase', passphraseHandler('a'));
+        const passphrase = await TrezorConnect.getDeviceState({
+            device: { instance: 1, state: undefined },
+        });
+        if (!passphrase.success) throw new Error(passphrase.payload.error);
+
+        // restart the device
+        await restartEmu(controller);
+
+        // try to get passphrase wallet state, with now invalid sessionId
+        TrezorConnect.on('ui-request_passphrase', passphraseHandler('a'));
+        const passphrase2 = await TrezorConnect.getDeviceState({
+            device: { instance: 1, state: passphrase.payload._state },
+        });
+        if (!passphrase2.success) throw new Error(passphrase2.payload.error);
+
+        // try to get standard wallet state, with sessionId now used for passphrase wallet
+        const standard2 = await TrezorConnect.getDeviceState({
+            device: { instance: 0, state: standard.payload._state },
+            useEmptyPassphrase: true,
+        });
+        if (!standard2.success) throw new Error(standard2.payload.error);
+
+        expect(passphrase2.payload.state).toEqual(passphrase.payload.state);
+        expect(standard2.payload.state).toEqual(standard.payload.state);
     });
 
     it('Passphrase encoding', async () => {

--- a/packages/connect/e2e/tests/device/thpPairing.test.ts
+++ b/packages/connect/e2e/tests/device/thpPairing.test.ts
@@ -1,5 +1,5 @@
 import TrezorConnect, { ConnectSettings, Device, UiEvent } from '../../../src';
-import { getController, initTrezorConnect, setup } from '../../common.setup';
+import { getController, initTrezorConnect, restartEmu, setup } from '../../common.setup';
 
 describe('THP pairing', () => {
     const controller = getController();
@@ -156,25 +156,7 @@ describe('THP pairing', () => {
         TrezorConnect.removeAllListeners('ui-button');
 
         // restart the device
-        await controller.stopEmu();
-        await new Promise<void>(resolve => {
-            const onDeviceDisconnected = () => {
-                TrezorConnect.off('device-disconnect', onDeviceDisconnected);
-                resolve();
-            };
-            TrezorConnect.on('device-disconnect', onDeviceDisconnected);
-        });
-        await controller.startEmu({
-            model: 'T3W1',
-            version: '2-main',
-        });
-        await new Promise<void>(resolve => {
-            const onDeviceConnected = () => {
-                TrezorConnect.off('device-connect', onDeviceConnected);
-                resolve();
-            };
-            TrezorConnect.on('device-connect', onDeviceConnected);
-        });
+        await restartEmu(controller);
 
         const address = await TrezorConnect.getAddress({
             device,

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -708,17 +708,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
             this.state[this.instance] = newState;
             this.stateStorage?.saveState(this, newState);
-
-            // special THP case: new sessionId was assigned to a wallet but there already was another remembered wallet with the same sessionId.
-            // In that case, remove the sessionId from the existing wallet as it can't be valid anymore.
-            // TODO: resolve in a more elegant way
-            if (!!this.thp && state.sessionId) {
-                this.state.forEach((s, instance) => {
-                    if (instance !== this.instance && s?.sessionId === state.sessionId) {
-                        delete s.sessionId;
-                    }
-                });
-            }
         }
     }
 

--- a/packages/connect/src/device/workflow/validateState.ts
+++ b/packages/connect/src/device/workflow/validateState.ts
@@ -29,6 +29,10 @@ const preauthorizeState = ({ device, method }: WorkflowContext) => {
     }
 };
 
+const isUnexpectedState = (expected?: StaticSessionId, current?: StaticSessionId) =>
+    // Ignore instance ID, it doesn't necessarily need to match the current instance
+    expected && current && expected.split(':')[0] !== current.split(':')[0];
+
 const getState = async (context: WorkflowContext) => {
     const { device } = context;
     if (!device.features) return;
@@ -45,8 +49,8 @@ const getState = async (context: WorkflowContext) => {
     if (device.features.session_id) {
         device.setState({ sessionId: device.features.session_id });
     }
-    // Ignore instance ID, it doesn't necessarily need to match the current instance
-    if (expectedState && expectedState.split(':')[0] !== uniqueState.split(':')[0]) {
+
+    if (isUnexpectedState(expectedState, uniqueState)) {
         return uniqueState;
     }
     if (!expectedState || expectedState !== uniqueState) {
@@ -133,7 +137,7 @@ const getInvalidThpDeviceState = async (context: WorkflowContext) => {
         });
     }
 
-    if (expectedState && expectedState !== uniqueState) {
+    if (isUnexpectedState(expectedState, uniqueState)) {
         return uniqueState;
     }
 

--- a/packages/connect/src/device/workflow/validateState.ts
+++ b/packages/connect/src/device/workflow/validateState.ts
@@ -109,21 +109,27 @@ const getInvalidThpDeviceState = async (context: WorkflowContext) => {
         // validate that expected ThpSession still exists
         thpState.setSessionId(expectedSessionId);
         uniqueState = await getStaticSessionId(device).catch(e => {
-            if (e.code === 'Failure_InvalidSession') {
-                // requested sessionId is not valid, reset setSessionId
-                device.setState({
-                    sessionId: undefined,
-                    deriveCardano: undefined,
-                });
-                thpState?.setSessionId(Buffer.alloc(1));
-
-                return undefined;
-            }
-            // user cancelled pin on device
-            if (e.code === 'Failure_PinCancelled') {
-                throw e;
+            switch (e.code) {
+                case 'Failure_PinCancelled':
+                    // user cancelled pin on device
+                    throw e;
+                case 'Failure_InvalidSession':
+                default:
+                    // TODO why not to throw?
+                    return undefined;
             }
         });
+
+        if (isUnexpectedState(expectedState, uniqueState)) {
+            // there is unexpected passphrase on given sessionId, ignore returned state
+            uniqueState = undefined;
+        }
+
+        if (!uniqueState) {
+            // requested sessionId is unknown or there was another passphrase, reset sessionId
+            device.setState({ sessionId: undefined, deriveCardano: undefined });
+            thpState?.setSessionId(Buffer.alloc(1));
+        }
     }
 
     if (!uniqueState || (!currentState?.deriveCardano && method.useCardanoDerivation)) {

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -101,7 +101,7 @@ const merge = (
     >,
 ): TrezorDevice => ({
     ...device,
-    ...upcoming,
+    ...(({ _state, ...rest }) => rest)(upcoming),
     id: upcoming.id ?? device.id,
     state: mergeDeviceState(device, upcoming),
     instance: device.instance,
@@ -126,7 +126,7 @@ const merge = (
  */
 const connectDevice = (
     draft: DeviceReducerState,
-    device: Device,
+    { _state, ...device }: Device,
     { isAutoEjectEnabled }: { isAutoEjectEnabled: boolean },
 ) => {
     const currentTime = new Date().getTime();
@@ -204,7 +204,7 @@ const connectDevice = (
     const newDevice: TrezorDevice = {
         ...device,
         ...deviceCommonFields,
-        state: device._state,
+        state: _state,
         useEmptyPassphrase: undefined,
         remember: shouldDeviceBeRemembered({ isAutoEjectEnabled, device }),
         temporaryRemember: false,

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -77,27 +77,14 @@ const mergeDeviceState = (
     const currentState = device.state;
     const upcomingState = typeof upcoming.state === 'string' ? upcoming._state : upcoming.state;
 
-    if (currentState && upcomingState) {
-        if (
-            currentState.staticSessionId === upcomingState.staticSessionId &&
-            currentState.sessionId !== upcomingState.sessionId
-        ) {
-            // update sessionId for the same staticSessionId
-            return { ...currentState, sessionId: upcomingState.sessionId };
-        }
-
-        if (
-            currentState.staticSessionId !== upcomingState.staticSessionId &&
-            currentState.sessionId === upcomingState.sessionId
-        ) {
-            // special THP case: new sessionId was assigned to a wallet but there already was another remembered wallet with the same sessionId.
-            // In that case, remove the sessionId from the existing wallet as it can't be valid anymore.
-            return { ...currentState, sessionId: undefined };
-        }
-    }
-
-    // ignore device state updates. we set device state explicitly using addAuthorizedDevice or setDeviceState
-    return currentState;
+    return currentState &&
+        upcomingState &&
+        currentState.staticSessionId === upcomingState.staticSessionId &&
+        currentState.sessionId !== upcomingState.sessionId
+        ? // update sessionId for the same staticSessionId
+          { ...currentState, sessionId: upcomingState.sessionId }
+        : // ignore device state updates. we set device state explicitly using addAuthorizedDevice or setDeviceState
+          currentState;
 };
 
 /**


### PR DESCRIPTION
## Description

This is a followup of #23457. It should fix the same issue in a more robust way so the previous fixes may not be needed anymore.

### Deep dive

In `getInvalidThpDeviceState` when you try to access wallet by already obtained `sessionId` (from couple of seconds ago or persisted from last month, doesn't matter) and it gives you invalid `staticSessionId`, instead of throwing `Invalid passphrase` (which is current behavior) Connect now behaves as if no `sessionId` was passed and lets you create a new session (e.g. insert passphrase...). Of course the error is then thrown as soon as you type incorrect passphrase.

With this fix, it's not needed to throw away remembered `sessionId`s when the same one is assigned to another wallet neither in Suite (https://github.com/trezor/trezor-suite/pull/23457/commits/c2e5f4c24503b4edabb7e89e2a833f3dab60e5c8) nor in Connect (https://github.com/trezor/trezor-suite/pull/23457/commits/591e347327d7aea6007237cd43582cd3ff391881). Anyway, both fixes may stay as well, so let's discuss it.

### Other small improvements

- `staticSessionId`s are now compared without instance parts in THP as well
  - eventually we should get rid of instance part completely
- `device._state` (which is coming from `DEVICE.CONNECT`/`DEVICE.CHANGED`) was removed from redux

## Notes for QA

Please test basically the same cases as in #23457:
- multiple passphrases on TS7, use them in different order after restarting device/suite/...
- you should never get `Invalid passphrase` unless you really type incorrect passphrase for selected wallet

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/invalid-passphrase-followup&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/invalid-passphrase-followup&lookback=7)