### PR TITLE
fix(suite-native): select locale hook missing

### DIFF
--- a/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/WalletBackupRecapStep2.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/WalletBackupRecapStep2.tsx
@@ -1,8 +1,9 @@
 import { useDerivedValue } from 'react-native-reanimated';
+import { useSelector } from 'react-redux';
 
 import { Box, Text, VStack } from '@suite-native/atoms';
 import { useIsMultiline } from '@suite-native/helpers';
-import { Translation, useLocale } from '@suite-native/intl';
+import { Translation, selectLocale } from '@suite-native/intl';
 import { SwipeableWalkthroughStep } from '@suite-native/swipeable-walkthrough';
 
 import { Underline } from './Underline';
@@ -15,7 +16,7 @@ const CURRENT_STEP_INDEX = 1;
 export const WalletBackupRecapStep2 = ({
     currentStepIndex,
 }: WalletBackupTutorialNumberedStepProps) => {
-    const locale = useLocale();
+    const locale = useSelector(selectLocale);
     const isFocused = useDerivedValue(() => currentStepIndex.value === CURRENT_STEP_INDEX);
 
     const { onTextLayout, numberOfLines } = useIsMultiline('titleMedium');


### PR DESCRIPTION
## Description
- poorly rebased [PR](https://github.com/trezor/trezor-suite/pull/23008) is crashing app because of :
```
src/components/WalletBackupRecap/create/WalletBackupRecapStep2.tsx:5:23 - error TS2305: Module '"@suite-native/intl"' has no exported member 'useLocale'.

5 import { Translation, useLocale } from '@suite-native/intl';
```

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/use-locale-missing&lookback=7)