### PR TITLE
fix(suite): connect popup various issues

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
@@ -99,7 +99,8 @@ export const ConnectErrorModal = () => {
         popupCall.error?.code === 'Device_InvalidState';
     const isNoTransportError = prerequisite === 'no-transport';
 
-    if (isDeviceReconnectError && !prerequisite) return <ConnectSelectDeviceModal />;
+    if (isDeviceReconnectError && (!prerequisite || prerequisite === 'device-disconnected'))
+        return <ConnectSelectDeviceModal />;
 
     const getVariant = () => {
         if (isCancelled) return 'warning';

--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -31,12 +31,16 @@ export const useConnectPopupWeb = () => {
     const lifecycle = useSelector(state => state.suite.lifecycle);
     const manifest = useRef<ManifestPartial | undefined>(undefined);
     const [pendingHandshake, setPendingHandshake] = useState<string | undefined>();
+    const [responseSent, setResponseSent] = useState(false);
 
     useEffect(() => {
         const onMessage = async (event: MessageEvent) => {
             if (event.data?.type === 'channel-handshake-request') {
                 postMessageToParent({ type: 'channel-handshake-confirm' });
-            } else if (event.data.type === POPUP.HANDSHAKE) {
+            } else if (
+                event.data.type === POPUP.HANDSHAKE &&
+                event.data.payload?.settings?.manifest
+            ) {
                 manifest.current = event.data.payload.settings.manifest;
                 setPendingHandshake(event.data.id);
             } else if (event.data?.type === IFRAME.CALL) {
@@ -67,6 +71,7 @@ export const useConnectPopupWeb = () => {
                     type: RESPONSE_EVENT,
                     payload: response,
                 });
+                setResponseSent(true);
             } else if (event.data?.type === POPUP.CLOSED) {
                 dispatch(connectPopupCancelThunk(event.data.payload));
             }
@@ -97,8 +102,12 @@ export const useConnectPopupWeb = () => {
 
     // Window close control
     useEffect(() => {
-        if (popupCall?.state === 'finished' && popupCall?.source.type === CALL_SOURCE_WEB) {
+        if (
+            popupCall?.state === 'finished' &&
+            popupCall?.source.type === CALL_SOURCE_WEB &&
+            responseSent
+        ) {
             window.close();
         }
-    }, [popupCall]);
+    }, [popupCall, responseSent]);
 };

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -90,7 +90,8 @@ const preCallHook = async <M extends keyof typeof TrezorConnect>({
 
         if (
             (method === 'ethereumSignTransaction' || method === 'ethereumSignTypedData') &&
-            source.type !== 'desktop-ws'
+            source.type !== 'desktop-ws' &&
+            source.type !== 'web'
         ) {
             // Display simulation
             const device = selectSelectedDevice(getState());

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -66,7 +66,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
     async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState }) => {
         const account = selectAccountByKey(getState(), accountKey);
 
-        if (!account || account.failed) return;
+        if (!account || account.failed || account.accountType === 'placeholder') return;
 
         if (!isTrezorConnectBackendType(account.backendType)) return; // skip unsupported backend type
         // first basic check, traffic optimization


### PR DESCRIPTION
## Description

Various issues in Connect Popup flows on web, found when testing with Metamask and Rabby:

- Unknown error in Rabby → caused by race condition with response message and window closing
- “Select ETH account” → collision with account refresh when using placeholder account (ETH is not enabled in Suite coins)
- Device disconnected → unhandled case if you don't have any remembered devices
- TX simulation should not be enabled outside of WalletConnect (yet)

## Notes for QA

Test with Metamask, Rabby custom builds.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-suite-web-flows&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-suite-web-flows&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-suite-web-flows&lookback=7)