### PR TITLE
Stabilize module-send/useAddressValidationAlerts test suite

### DIFF
--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/__tests__/useAddressValidationAlerts.test.tsx
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/__tests__/useAddressValidationAlerts.test.tsx
@@ -85,13 +85,26 @@ describe('useAddressValidationAlerts', () => {
     const renderHookWithForm = async (
         preloadedState: PreloadedState = defaultPreloadedState,
         { inputIndex = 0 } = {},
-    ) =>
-        await renderHookWithStoreProviderAsync(() => useAddressValidationAlerts({ inputIndex }), {
-            preloadedState,
-            wrapper: ({ children }) => (
-                <Form form={{ setValue: mockSetValue, watch: mockWatch } as any}>{children}</Form>
-            ),
+    ) => {
+        const result = await renderHookWithStoreProviderAsync(
+            () => useAddressValidationAlerts({ inputIndex }),
+            {
+                preloadedState,
+                wrapper: ({ children }) => (
+                    <Form form={{ setValue: mockSetValue, watch: mockWatch } as any}>
+                        {children}
+                    </Form>
+                ),
+            },
+        );
+
+        // allow async TrezorConnect.getAccountInfo to resolve
+        await act(async () => {
+            await Promise.resolve();
         });
+
+        return result;
+    };
 
     beforeEach(() => {
         jest.clearAllMocks();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Stabilize module-send/useAddressValidationAlerts test suite by waiting for mocked async action.
<!--- Describe your changes in detail -->

## Notes for QA

Nothing to test.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=stabilize-module-send-useAddressValidationAlerts-tests&lookback=7)