### PR TITLE
feat(suite): prefill send form with protocol scheme values

### DIFF
--- a/packages/suite/src/components/suite/asset-picker/components/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
@@ -1,6 +1,7 @@
 import { RefObject, memo } from 'react';
 
 import { TranslationKey } from '@suite-common/intl-types';
+import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
 import { selectEnabledNetworks } from '@suite-common/wallet-core';
 import { GlobalSendReceiveType } from '@suite-common/wallet-types';
 import { Box } from '@trezor/components';
@@ -30,6 +31,12 @@ export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetwork
         resetSearch: () => setSearch(''),
     });
     const enabledNetworks = useSelector(selectEnabledNetworks);
+    const protocolScheme = useSelector(state => state.protocol.sendForm.scheme);
+
+    const protocolSymbol = protocolScheme ? getNetworkSymbolForProtocol(protocolScheme) : undefined;
+
+    const networks = protocolSymbol ? [protocolSymbol] : enabledNetworks;
+
     const { translationString } = useTranslation();
 
     return (
@@ -39,10 +46,10 @@ export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetwork
                 search={search}
                 setSearch={setSearch}
                 selectConfig={{
-                    networks: enabledNetworks,
+                    networks,
                     selectedNetwork: networkFilter,
                     onChange: setNetworkFilter,
-                    includeAllOption: true,
+                    includeAllOption: !protocolSymbol,
                     allLabel: translationString('TR_ALL_NETWORKS', {
                         networkCount: enabledNetworks?.length,
                     }),

--- a/packages/suite/src/components/suite/asset-picker/components/AssetsListEmpty/AssetsListEmpty.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetsListEmpty/AssetsListEmpty.tsx
@@ -1,10 +1,15 @@
 import { ReactNode } from 'react';
 
 import { TranslationKey } from '@suite-common/intl-types';
-import { Column, Paragraph, Text } from '@trezor/components';
+import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
+import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { Button, Column, Paragraph, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
+import { openModal } from 'src/actions/suite/modalActions';
 import { Translation } from 'src/components/suite/Translation';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 interface AssetsListEmptyProps {
     heading: TranslationKey;
@@ -21,8 +26,60 @@ export const AssetsListEmpty = ({
     children,
     height,
 }: AssetsListEmptyProps) => {
+    const dispatch = useDispatch();
+    const protocolScheme = useSelector(state => state.protocol.sendForm.scheme);
+    const device = useSelector(selectSelectedDevice);
+
+    const protocolSymbol = protocolScheme ? getNetworkSymbolForProtocol(protocolScheme) : undefined;
+    const network = protocolSymbol ? getNetworkDisplaySymbolName(protocolSymbol) : undefined;
+
+    const openActivateNetworkModal = () => {
+        if (!protocolSymbol || !device) return;
+
+        dispatch(openModal({ type: 'add-account', symbol: protocolSymbol, device }));
+    };
+
     if (!isEmpty) {
         return <>{children}</>;
+    }
+
+    if (isEmpty && protocolScheme) {
+        return (
+            <Column
+                alignItems="center"
+                justifyContent="center"
+                height="auto"
+                margin={{ vertical: spacings.md }}
+            >
+                <Paragraph typographyStyle="body">
+                    <Translation
+                        id="TR_ACCOUNT_SEARCH_ACTIVATE_NETWORK_TITLE"
+                        values={{ network }}
+                    />
+                </Paragraph>
+                <Paragraph
+                    typographyStyle="hint"
+                    variant="tertiary"
+                    align="center"
+                    maxWidth={400}
+                    margin={{
+                        top: spacings.xxxs,
+                        left: 'auto',
+                        right: 'auto',
+                    }}
+                >
+                    <Translation id="TR_ACCOUNT_SEARCH_ACTIVATE_NETWORK_DESC" />
+                </Paragraph>
+
+                <Button
+                    onClick={openActivateNetworkModal}
+                    margin={{ top: spacings.md }}
+                    intent="neutral"
+                >
+                    <Translation id="TR_ACCOUNT_SEARCH_ACTIVATE_NETWORK_CTA" values={{ network }} />
+                </Button>
+            </Column>
+        );
     }
 
     return (

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 
 import { Account } from '@suite-common/wallet-types';
 
+import { resetProtocol } from 'src/actions/suite/protocolActions';
 import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
@@ -39,6 +40,7 @@ export const GlobalSendReceive = memo(function GlobalSendReceiveInner() {
     const handleSendCancel = (filledSearch: boolean) => {
         sendAnalytics.close(filledSearch);
         closeModal();
+        dispatch(resetProtocol());
         dispatch(globalSendReceiveFilters.actions.resetFilters());
     };
 

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
@@ -1,15 +1,24 @@
 import styled from 'styled-components';
 
 import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import {
+    NetworkSymbol,
+    getNetworkDisplaySymbol,
+    getNetworkDisplaySymbolName,
+} from '@suite-common/wallet-config';
+import { selectDeviceAccountsByNetworkSymbol } from '@suite-common/wallet-core';
+import { Text } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
-import { capitalizeFirstLetter } from '@trezor/utils';
+import { BigNumber } from '@trezor/utils';
 
 import { fillSendForm, resetProtocol } from 'src/actions/suite/protocolActions';
+import { goto } from 'src/actions/suite/routerActions';
 import type { NotificationRendererProps } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectRouteName } from 'src/reducers/suite/routerReducer';
+import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
 
 import { ConditionalActionRenderer } from './ConditionalActionRenderer';
 
@@ -19,42 +28,98 @@ const Row = styled.span`
 
 const getIcon = (symbol?: NetworkSymbol) => symbol && <CoinLogo symbol={symbol} size={24} />;
 
-const useActionAllowed = (symbol?: NetworkSymbol) => {
-    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
-    const routeName = useSelector(selectRouteName);
-
-    return routeName === 'wallet-send' && selectedAccount?.network?.symbol === symbol;
-};
-
 export const CoinProtocolRenderer = ({
     render,
     notification,
 }: NotificationRendererProps<'coin-scheme-protocol'>) => {
     const dispatch = useDispatch();
-    const allowed = useActionAllowed(getNetworkSymbolForProtocol(notification.scheme));
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const routeName = useSelector(selectRouteName);
 
-    const onAction = () => dispatch(fillSendForm(true));
-    const onCancel = () => dispatch(resetProtocol());
+    const networkSymbol = getNetworkSymbolForProtocol(notification.scheme) ?? null;
+    const displaySymbol = networkSymbol && getNetworkDisplaySymbol(networkSymbol);
+    const networkName = networkSymbol && getNetworkDisplaySymbolName(networkSymbol);
+    const networkAccounts = useSelector(state =>
+        selectDeviceAccountsByNetworkSymbol(state, networkSymbol),
+    ).filter(a => new BigNumber(a.balance).gt(0));
+    const isOnSendPage =
+        routeName === 'wallet-send' && selectedAccount?.network?.symbol === networkSymbol;
+
+    const onCancel = (reset: boolean = true) => {
+        dispatch(notificationsActions.close(notification.id));
+        if (reset) {
+            dispatch(resetProtocol());
+        }
+    };
+
+    const handleContinue = () => {
+        if (isOnSendPage) {
+            dispatch(fillSendForm(true));
+        } else {
+            if (networkSymbol) {
+                dispatch(fillSendForm(true));
+
+                if (networkAccounts.length === 1) {
+                    const account = networkAccounts[0];
+                    dispatch(
+                        goto('wallet-send', {
+                            params: {
+                                symbol: account.symbol,
+                                accountIndex: account.index,
+                                accountType: account.accountType,
+                            },
+                        }),
+                    );
+                } else {
+                    dispatch(globalSendReceiveFilters.actions.setNetworkSymbol(networkSymbol));
+                    dispatch(
+                        goto('suite-index', {
+                            params: {
+                                modal: 'send',
+                                networkSymbol,
+                            },
+                        }),
+                    );
+                }
+            }
+        }
+
+        onCancel(false);
+    };
 
     return (
         <ConditionalActionRenderer
             render={render}
             notification={notification}
-            header={<Translation id="TOAST_COIN_SCHEME_PROTOCOL_HEADER" />}
+            header={
+                <Translation
+                    id="TOAST_COIN_SCHEME_PROTOCOL_HEADER"
+                    values={{ symbol: networkName?.toLowerCase() }}
+                />
+            }
             body={
                 <>
                     <Row>
-                        {notification.amount && `${notification.amount} `}
-                        {capitalizeFirstLetter(notification.scheme)}
+                        <Text typographyStyle="hint">{notification.address}</Text>
                     </Row>
-                    <Row>{notification.address}</Row>
+                    {notification.amount && (
+                        <>
+                            <Text variant="tertiary" typographyStyle="hint">
+                                <Translation id="TOAST_COIN_SCHEME_PROTOCOL_AMOUNT" />
+                            </Text>
+                            &nbsp;
+                            <Text typographyStyle="hint">
+                                {notification.amount} {displaySymbol}
+                            </Text>
+                        </>
+                    )}
                 </>
             }
-            actionLabel="TOAST_COIN_SCHEME_PROTOCOL_ACTION"
-            actionAllowed={allowed}
-            onAction={onAction}
+            actionLabel="TR_CONTINUE"
+            actionAllowed
+            onAction={handleContinue}
             onCancel={onCancel}
-            icon={getIcon(getNetworkSymbolForProtocol(notification.scheme))}
+            icon={getIcon(networkSymbol ?? undefined)}
         />
     );
 };

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/ConditionalActionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/ConditionalActionRenderer.tsx
@@ -5,6 +5,8 @@ import { Paragraph } from '@trezor/components';
 
 import type { NotificationRendererProps } from 'src/components/suite';
 
+import { NotificationAction } from '../Notifications/NotificationGroup/NotificationList/NotificationView';
+
 type ConditionalActionRendererProps = NotificationRendererProps & {
     header: ReactNode;
     body: ReactNode;
@@ -25,14 +27,10 @@ export const ConditionalActionRenderer = ({
     render: View,
     ...rest
 }: ConditionalActionRendererProps) => {
-    const action = actionAllowed
-        ? ({
-              onClick: onAction,
-              label: actionLabel,
-              position: 'bottom',
-              variant: 'primary',
-          } as const)
-        : undefined;
+    const actions: NotificationAction[] = [
+        { onClick: onAction, label: actionLabel, position: 'bottom', variant: 'primary' },
+        { onClick: onCancel, label: 'TR_CANCEL', position: 'bottom' },
+    ];
 
     return (
         <View
@@ -41,7 +39,7 @@ export const ConditionalActionRenderer = ({
             message="TOAST_COIN_SCHEME_PROTOCOL"
             messageValues={{
                 header: (
-                    <Paragraph typographyStyle="body" margin={{ top: 2 }} variant="tertiary">
+                    <Paragraph typographyStyle="highlight" margin={{ top: 2 }}>
                         {header}
                     </Paragraph>
                 ),
@@ -51,7 +49,7 @@ export const ConditionalActionRenderer = ({
                     </Paragraph>
                 ),
             }}
-            action={action}
+            action={actions}
             onCancel={onCancel}
         />
     );

--- a/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView.tsx
+++ b/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView.tsx
@@ -13,18 +13,20 @@ import { getNotificationIcon } from 'src/utils/suite/notification';
 
 export type NotificationActionVariant = 'primary' | 'info' | 'warning' | 'destructive' | 'tertiary';
 
+export interface NotificationAction {
+    onClick: () => void;
+    label: ExtendedMessageDescriptor['id'];
+    position?: 'bottom' | 'right';
+    variant?: NotificationActionVariant;
+}
+
 export interface NotificationViewProps {
     notification: NotificationEntry;
     variant: ToastNotificationVariant;
     icon?: IconName | JSX.Element;
     message: ExtendedMessageDescriptor['id'];
     messageValues: ExtendedMessageDescriptor['values'];
-    action?: {
-        onClick: () => void;
-        label: ExtendedMessageDescriptor['id'];
-        position?: 'bottom' | 'right';
-        variant?: NotificationActionVariant;
-    };
+    action?: NotificationAction | NotificationAction[];
 }
 
 export const mapActionVariantToIntent = (
@@ -48,7 +50,7 @@ export const mapActionVariantToIntent = (
 export const NotificationView = ({
     message,
     messageValues,
-    action,
+    action: actionProp,
     icon,
     variant,
     notification: { seen, id },
@@ -56,6 +58,9 @@ export const NotificationView = ({
     const { isBelowTablet } = useLayoutSize();
     const defaultIcon = icon ?? getNotificationIcon(variant);
     const colorVariant = seen ? 'tertiary' : 'default';
+
+    // NotificationView only supports a single action so even if an array is passed, only the first action is used
+    const action = Array.isArray(actionProp) ? actionProp[0] : actionProp;
 
     return (
         <Row gap={spacings.sm}>

--- a/packages/suite/src/components/suite/notifications/ToastNotification.tsx
+++ b/packages/suite/src/components/suite/notifications/ToastNotification.tsx
@@ -1,9 +1,9 @@
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 
 import styled, { useTheme } from 'styled-components';
 
 import { NotificationEntry, notificationsActions } from '@suite-common/toast-notifications';
-import { Button, Icon } from '@trezor/components';
+import { Button, Column, Icon, Row } from '@trezor/components';
 import { spacings, typography } from '@trezor/theme';
 
 import {
@@ -16,22 +16,22 @@ import { useDispatch } from 'src/hooks/suite';
 import { getNotificationIcon, getVariantColor } from 'src/utils/suite/notification';
 
 import { ToastNotificationVariant } from '../../../types/suite';
+import { NotificationAction } from './Notifications/NotificationGroup/NotificationList/NotificationView';
 
-const Wrapper = styled.div<{ $variant: ToastNotificationVariant; $isTall: boolean }>`
+const Wrapper = styled.div<{ $variant: ToastNotificationVariant }>`
     display: flex;
-    align-items: ${({ $isTall }) => ($isTall ? 'start' : 'center')};
+    align-items: center;
     font-size: ${typography.hint};
     height: 100%;
-    padding: ${({ $isTall }) => ($isTall ? '16px 16px 12px 12px' : '12px 16px 12px 12px')};
+    padding: 8px 16px;
     border-left: 4px solid ${({ $variant }) => getVariantColor($variant)};
     overflow-wrap: anywhere;
     word-break: normal;
     max-width: 430px;
 `;
 
-const BodyWrapper = styled.div<{ $isTall: boolean }>`
+const BodyWrapper = styled.div`
     flex: 1;
-    margin-top: ${({ $isTall }) => $isTall && '-4px'};
     margin-left: 14px;
 `;
 
@@ -55,19 +55,9 @@ const ToastNotification = ({
     onCancel,
     notification: { type, id },
 }: ToastNotificationProps) => {
-    const [isTall, setIsTall] = useState(false);
     const theme = useTheme();
     const dispatch = useDispatch();
     const wrapperRef = useRef<HTMLDivElement>(null);
-
-    useLayoutEffect(() => {
-        const height = wrapperRef.current?.getBoundingClientRect().height ?? 0;
-
-        // more than 2 lines of text
-        if (height > 70) {
-            setIsTall(true);
-        }
-    }, []);
 
     const dataTestBase = `@toast/${type}`;
     const defaultIcon = icon ?? getNotificationIcon(variant);
@@ -77,22 +67,26 @@ const ToastNotification = ({
         onCancel?.();
     };
 
-    const actionButton = action && (
+    const actions = Array.isArray(action)
+        ? action
+        : [action].filter((a): a is NotificationAction => a !== undefined);
+
+    const renderActionButton = (a: NotificationAction) => (
         <Button
-            intent={mapActionVariantToIntent(action.variant)}
-            onClick={action.onClick}
+            key={a.label}
+            intent={mapActionVariantToIntent(a.variant)}
+            onClick={a.onClick}
             size="small"
-            width={action.position === 'bottom' ? '100%' : undefined}
             margin={
                 // eslint-disable-next-line no-nested-ternary
-                !action.position || action.position === 'right'
+                !a.position || a.position === 'right'
                     ? { left: 16 }
-                    : action.position === 'bottom'
+                    : a.position === 'bottom'
                       ? { top: 12 }
                       : undefined
             }
         >
-            <Translation id={action.label} />
+            <Translation id={a.label} />
         </Button>
     );
 
@@ -101,7 +95,6 @@ const ToastNotification = ({
             data-testid={dataTestBase}
             data-testid-alt="@toast"
             $variant={variant}
-            $isTall={isTall}
             ref={wrapperRef}
         >
             {defaultIcon && typeof defaultIcon === 'string' ? (
@@ -109,19 +102,23 @@ const ToastNotification = ({
             ) : (
                 defaultIcon
             )}
-            <BodyWrapper $isTall={isTall}>
+            <BodyWrapper>
                 <Message>
                     <Translation id={message} values={messageValues} />
                 </Message>
 
-                {action?.position === 'bottom' && actionButton}
+                <Row gap={spacings.xs}>
+                    {actions.map(a => a.position === 'bottom' && renderActionButton(a))}
+                </Row>
             </BodyWrapper>
 
-            {(action?.position === 'right' || !action?.position) && actionButton}
+            <Column gap={spacings.xs}>
+                {actions.map(a => (a.position === 'right' || !a.position) && renderActionButton(a))}
+            </Column>
 
             {cancelable && (
                 <Icon
-                    size={16}
+                    size={20}
                     name="x"
                     hoverColor={theme.iconSubdued}
                     onClick={handleCancelClick}

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -22,7 +22,7 @@ import {
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { useDidUpdate } from '@trezor/react-utils';
 
-import { fillSendForm } from 'src/actions/suite/protocolActions';
+import { fillSendForm, resetProtocol } from 'src/actions/suite/protocolActions';
 import { goto } from 'src/actions/suite/routerActions';
 import {
     getSendFormDraftThunk,
@@ -318,6 +318,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
             }
 
             dispatch(fillSendForm(false));
+            dispatch(resetProtocol());
             composeRequest();
         }
     }, [
@@ -334,15 +335,38 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     // load draft from reducer and reset current form values, this should be only called once on mount
     useEffect(() => {
         const loadDraftValues = async () => {
-            const storedState = await dispatch(getSendFormDraftThunk()).unwrap();
-            const values = getLoadedValues(storedState);
+            // Check if we should fill from protocol data instead of draft
+            const shouldFillFromProtocol =
+                protocol.sendForm.shouldFill &&
+                protocol.sendForm.scheme &&
+                protocol.sendForm.address &&
+                selectedAccount.network.symbol ===
+                    getNetworkSymbolForProtocol(protocol.sendForm.scheme);
 
-            // keepDefaultValues will set `isDirty` flag to true
-            reset(values, { keepDefaultValues: !!storedState });
+            if (shouldFillFromProtocol) {
+                const values = getLoadedValues();
+                values.outputs[0].address = protocol.sendForm.address!;
 
-            if (storedState) {
-                draft.current = storedState;
-                composeDraft(storedState);
+                if (protocol.sendForm.amount) {
+                    const amount = protocol.sendForm.amount.toString();
+                    values.outputs[0].amount = shouldSendInSats
+                        ? convertAmountUnitsToSubunits(amount, state.network.decimals)
+                        : amount;
+                }
+
+                reset(values);
+                dispatch(fillSendForm(false));
+                composeRequest();
+            } else {
+                const storedState = await dispatch(getSendFormDraftThunk()).unwrap();
+                const values = getLoadedValues(storedState);
+
+                reset(values, { keepDefaultValues: !!storedState });
+
+                if (storedState) {
+                    draft.current = storedState;
+                    composeDraft(storedState);
+                }
             }
         };
         loadDraftValues();

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4061,13 +4061,13 @@ export default defineMessages({
         description: 'Required for current notifications. Do not change.',
         defaultMessage: '{header}{body}',
     },
-    TOAST_COIN_SCHEME_PROTOCOL_ACTION: {
-        id: 'TOAST_COIN_SCHEME_PROTOCOL_ACTION',
-        defaultMessage: 'Autofill send form',
-    },
     TOAST_COIN_SCHEME_PROTOCOL_HEADER: {
         id: 'TOAST_COIN_SCHEME_PROTOCOL_HEADER',
-        defaultMessage: 'Go to an account to send',
+        defaultMessage: 'Send {symbol} to this address',
+    },
+    TOAST_COIN_SCHEME_PROTOCOL_AMOUNT: {
+        id: 'TOAST_COIN_SCHEME_PROTOCOL_AMOUNT',
+        defaultMessage: 'Amount:',
     },
     TOAST_ACQUIRE_ERROR: {
         id: 'TOAST_ACQUIRE_ERROR',
@@ -6938,6 +6938,18 @@ export default defineMessages({
     TR_RECOVERY_FAILED: {
         id: 'TR_RECOVERY_FAILED',
         defaultMessage: 'Wallet recovery failed',
+    },
+    TR_ACCOUNT_SEARCH_ACTIVATE_NETWORK_TITLE: {
+        id: 'TR_ACCOUNT_SEARCH_ACTIVATE_NETWORK_TITLE',
+        defaultMessage: 'No {network} account found',
+    },
+    TR_ACCOUNT_SEARCH_ACTIVATE_NETWORK_DESC: {
+        id: 'TR_ACCOUNT_SEARCH_ACTIVATE_NETWORK_DESC',
+        defaultMessage: 'Activate an account to continue with this transaction.',
+    },
+    TR_ACCOUNT_SEARCH_ACTIVATE_NETWORK_CTA: {
+        id: 'TR_ACCOUNT_SEARCH_ACTIVATE_NETWORK_CTA',
+        defaultMessage: 'Activate {network}',
     },
     TR_ACCOUNT_SEARCH_NO_RESULTS: {
         id: 'TR_ACCOUNT_SEARCH_NO_RESULTS',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR implements `bitcoin://` deeplink usage. It redirects user to the send form and prefills `address` and `amount`

## Notes for QA

Navigating to `bitcoin://bc1qj2xcxn8kc59042f9n6dpag7le89y44luh6hqj0?amount=0.0003` should:
1. Show notification
2. On "Continue" show global send modal if user has more than one bitcoin account with some balance. In case just one account has balance, redirect user to send form directly with this account selected.
3. Prefill send form values

What's not handled in this PR is when user has bitcoin network activated, but doesn't have any account with balance. It will have to be handled in a separate PR, no designs for it yet.

## Related Issue

Resolve #14700

## Screenshots:

### Notification
<img width="491" height="161" alt="Screenshot 2025-12-02 at 11 37 39" src="https://github.com/user-attachments/assets/becc218a-a487-4072-ab58-d60b105c0fcb" />

### Global send modal - empty state
<img width="722" height="365" alt="Screenshot 2025-12-02 at 12 08 01" src="https://github.com/user-attachments/assets/45b2ae6b-dbe3-4cb3-8657-ffddf39ac85f" />

### Single address flow
https://github.com/user-attachments/assets/ccfdf319-3286-4302-99a6-320280fe88e6

### Multiple addresses flow
https://github.com/user-attachments/assets/b59e2ca9-a4ed-48ea-9564-c788442d69d9

### Activate network flow
https://github.com/user-attachments/assets/34da0985-c59f-4235-92ba-382534fc324e



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bitcoin-protocol-scheme-send&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bitcoin-protocol-scheme-send&lookback=7)