### PR TITLE
fix(suite): remove receive button from portfolio when wallet is empty

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3266,10 +3266,6 @@ export default defineMessages({
         defaultMessage: 'Select an account to receive funds',
         id: 'TR_RECEIVE',
     },
-    TR_RECEIVE_SELECT_ACCOUNT: {
-        defaultMessage: 'Select an account to receive funds',
-        id: 'TR_RECEIVE_SELECT_ACCOUNT',
-    },
     TR_RECEIVE_DESCRIPTION: {
         defaultMessage: 'How to <a>choose the right network</a> to receive your tokens',
         id: 'TR_RECEIVE_DESCRIPTION',

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -11,7 +11,6 @@ import { isAccountFailed } from '@suite-common/wallet-utils';
 import { Box, Card, Column, Dropdown, Switch } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { goto } from 'src/actions/suite/routerActions';
 import { setFlag } from 'src/actions/suite/suiteActions';
 import { DashboardSection } from 'src/components/dashboard';
 import { GraphScaleDropdownItem, GraphSkeleton } from 'src/components/suite';
@@ -46,7 +45,6 @@ export const PortfolioCard = memo(() => {
     const walletBalance = useTotalFiatBalance(accounts, baseCurrencyCode, currentFiatRates);
 
     const passphraseEntryCanceled = accounts.length === 0 && discoveryStatus === undefined;
-    const hasMultipleAccounts = accounts.length > 1;
 
     const hasNetworkWithEnabledGraph = networksCollection.some(
         network => network.features.includes('graph') && enabledNetworks.includes(network.symbol),
@@ -113,14 +111,6 @@ export const PortfolioCard = memo(() => {
         isGraphHidden,
     });
 
-    const goToReceive = () => {
-        if (hasMultipleAccounts) {
-            dispatch(goto('suite-index', { params: { modal: 'receive' } }));
-        } else {
-            dispatch(goto('wallet-receive'));
-        }
-    };
-
     const heading = <Translation id="TR_MY_PORTFOLIO" />;
 
     const header =
@@ -130,13 +120,10 @@ export const PortfolioCard = memo(() => {
                 showGraphControls={showGraphControls}
                 fiatAmount={walletBalance}
                 localCurrency={baseCurrencyCode}
-                isWalletEmpty={isWalletEmpty}
                 isWalletLoading={isWalletLoading}
                 isWalletError={isWalletError}
                 isDiscoveryRunning={isDiscoveryRunning}
                 passphraseEntryCanceled={passphraseEntryCanceled}
-                hasMultipleAccounts={hasMultipleAccounts}
-                receiveClickHandler={goToReceive}
             />
         );
 

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
@@ -1,11 +1,10 @@
 import { useCallback } from 'react';
 
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
-import { Button, SkeletonRectangle } from '@trezor/components';
+import { SkeletonRectangle } from '@trezor/components';
 
 import { updateGraphData } from 'src/actions/wallet/graphActions';
 import { GraphRangeSelector } from 'src/components/suite';
-import { Translation } from 'src/components/suite/Translation';
 import { FiatHeader } from 'src/components/wallet/FiatHeader';
 import { useSelector } from 'src/hooks/suite';
 import { Discovery } from 'src/types/wallet';
@@ -17,28 +16,22 @@ export type PortfolioCardHeaderProps = {
     discovery?: Discovery;
     fiatAmount: string;
     localCurrency: string;
-    isWalletEmpty: boolean;
     isWalletLoading: boolean;
     isWalletError: boolean;
     isDiscoveryRunning?: boolean;
     showGraphControls: boolean;
     passphraseEntryCanceled: boolean;
-    hasMultipleAccounts: boolean;
-    receiveClickHandler: () => void;
 };
 
 export const PortfolioCardHeader = ({
     discovery,
     fiatAmount,
     localCurrency,
-    isWalletEmpty,
     isWalletLoading,
     isWalletError,
     isDiscoveryRunning,
     showGraphControls,
     passphraseEntryCanceled,
-    hasMultipleAccounts,
-    receiveClickHandler,
 }: PortfolioCardHeaderProps) => {
     const accounts = useSelector(selectAllAccountsToList);
     const isContentBelowBreakpoint = useIsContentBelowBreakpoint();
@@ -52,20 +45,7 @@ export const PortfolioCardHeader = ({
 
     let actions = null;
     if (!isWalletLoading && !isWalletError && !passphraseEntryCanceled) {
-        if (isWalletEmpty) {
-            actions = (
-                <Button
-                    onClick={receiveClickHandler}
-                    data-testid="@dashboard/receive-button"
-                    minWidth={120}
-                    size={isContentBelowBreakpoint ? 'medium' : 'large'}
-                >
-                    <Translation
-                        id={hasMultipleAccounts ? 'TR_RECEIVE_SELECT_ACCOUNT' : 'TR_RECEIVE'}
-                    />
-                </Button>
-            );
-        } else if (showGraphControls) {
+        if (showGraphControls) {
             actions = (
                 <GraphRangeSelector
                     onSelectedRange={onSelectedRange}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removed "Select an account to receive funds" button from Dashboard

## Notes for QA

Button should not be visible

## Related Issue

Resolve #23476

## Screenshots:

### Before
<img width="1255" height="829" alt="Screenshot 2025-12-02 at 12 52 56" src="https://github.com/user-attachments/assets/40b34d1b-aa26-4ba4-b966-7e29343c05b5" />

### After
<img width="1255" height="827" alt="Screenshot 2025-12-02 at 12 53 16" src="https://github.com/user-attachments/assets/fb3b8a8c-448e-4c10-a354-5aaf080a39fa" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/empty-wallet-receive-cta&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/empty-wallet-receive-cta&lookback=7)