### PR TITLE
fix(suite): fetch sell quote when sell form opened from token overview

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -287,8 +287,8 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
                 handleSubmit(() => {
                     handleChange();
                 })();
+                previousValues.current = values;
             }
-            previousValues.current = values;
         },
         500,
         [values, previousValues, pageType],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes an issue where no sell offers were fetched if user went to sell form via Account -> Tokens -> Sell.

## Notes for QA
-
## Related Issue

Resolve #22481

## Screenshots:

https://github.com/user-attachments/assets/afe8c77b-3067-439d-a8a2-6b23c0fc9679



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sell-offers&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sell-offers&lookback=7)