### PR TITLE
fix(suite-native): define node version for EAS explicitely

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,3 @@
 24.11.1
+
+# This needs to be consistent with node version defined in suite-native/app/eas.json file!

--- a/suite-native/app/eas.json
+++ b/suite-native/app/eas.json
@@ -6,6 +6,7 @@
     },
     "build": {
         "base": {
+            "node": "24.11.1",
             "env": {
                 "EAS_NO_FROZEN_LOCKFILE": "1"
             }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- It looks like Node.js 20.19.4 is the default on EAS, we need v24

It's supposed to fix crashes on develop.

Testing ad-hoc build: https://github.com/trezor/trezor-suite/actions/runs/19858755612

## Notes for QA

I'll check the CI if it is applied as expected, but then it can break basically anything in both Android and iOS apps, so it makes sense to keep that in mind during sanity tests, but doesn't make sense to test this separately.

## Screenshots

[EAS build logs mentioning Node.js 20.19.4
](https://expo.dev/accounts/trezorcompany/projects/trezor-suite-develop/builds/311732cb-db66-484b-bf36-99e9f49e7c16)



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/define-node-version-for-eas&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/define-node-version-for-eas&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/define-node-version-for-eas&lookback=7)