### PR TITLE
fix(suite): fix default values in buy

### DIFF
--- a/packages/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -400,8 +400,7 @@ export class TradingPage {
             fiatCurrency: fiatCurrencyCode.toUpperCase(),
             receiveCurrency: cryptoCurrency,
             country,
-            fiatStringAmount: wantCrypto ? '' : amount,
-            ...(wantCrypto && { cryptoStringAmount: amount }),
+            ...(wantCrypto ? { cryptoStringAmount: amount } : { fiatStringAmount: amount }),
         });
         await quotesResponsePromise;
         await this.waitForOffersSync();

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -99,13 +99,8 @@ export const useTradingBuyForm = ({
           };
     useTradingFiatValues(fiatTradingValuesParams);
 
-    const {
-        defaultValues,
-        defaultCountry,
-        defaultCurrency,
-        defaultPaymentMethod,
-        suggestedFiatCurrency,
-    } = useTradingBuyFormDefaultValues(account.symbol, buyInfo);
+    const { defaultValues, defaultCountry, defaultCurrency, defaultPaymentMethod } =
+        useTradingBuyFormDefaultValues(account.symbol, buyInfo);
     const redirectValues = useTradingBuyFormRedirectValues(isFromRedirect, quotesRequest);
     const { saveDraft, draft, removeDraft } = useFormDraft<TradingBuyFormProps>(
         'trading-buy',
@@ -450,12 +445,7 @@ export const useTradingBuyForm = ({
             if (!formState.isValidating && Object.keys(formState.errors).length === 0 && buyInfo) {
                 saveDraft({
                     ...values,
-                    fiatInput:
-                        values.fiatInput !== ''
-                            ? values.fiatInput
-                            : buyInfo?.buyInfo.defaultAmountsOfFiatCurrencies.get(
-                                  suggestedFiatCurrency,
-                              ),
+                    fiatInput: values.fiatInput ?? '',
                 } as TradingBuyFormProps);
             }
         },

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
@@ -3,7 +3,6 @@ import { Control, Controller } from 'react-hook-form';
 
 import {
     TRADING_FORM_FIAT_CURRENCY_SELECT,
-    TRADING_FORM_FIAT_INPUT,
     TRADING_FORM_OUTPUT_CURRENCY,
     TradingFiatCurrencyOption,
 } from '@suite-common/trading';
@@ -48,10 +47,6 @@ export const TradingFormInputCurrency = ({
     );
 
     const onChangeAdditional = (option: TradingFiatCurrencyOption) => {
-        if (isTradingBuyContext(context)) {
-            context.setValue(TRADING_FORM_FIAT_INPUT, '');
-        }
-
         if (isTradingExchangeContext(context) || isTradingSellContext(context)) {
             context.form.helpers.onFiatCurrencyChange(option.value);
         }


### PR DESCRIPTION
## Description

- changing fiat currency in `Compare all offers` in buy navigated back to trading form with the original (unchanged) fiat currency
- default values were still applied in some cases


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/buy-default-values&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/buy-default-values&lookback=7)