### PR TITLE
chore(suite): split qr code scan and deeplink usage analytics call

### DIFF
--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -3,6 +3,7 @@ import { Protocol } from '@suite-common/suite-constants';
 import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import * as walletConnectActions from '@suite-common/walletconnect';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import {
     SUITE_ANCHOR_DEEPLINK_PREFIX,
     SUITE_BRIDGE_DEEPLINK,
@@ -49,6 +50,16 @@ const saveCoinProtocol = (scheme: Protocol, address: string, amount?: number): P
 export const handleProtocolRequest =
     (uri: string) => (dispatch: Dispatch, _getState: GetState, extra: ExtraDependencies) => {
         const protocol = getProtocolInfo(uri);
+
+        if (protocol) {
+            analytics.report({
+                type: EventType.AppUriHandler,
+                payload: {
+                    scheme: protocol.scheme,
+                    isAmountPresent: 'amount' in protocol && protocol.amount !== undefined,
+                },
+            });
+        }
 
         if (protocol && !('error' in protocol) && getNetworkSymbolForProtocol(protocol.scheme)) {
             const { scheme, amount, address } = protocol as CoinProtocolInfo;

--- a/packages/suite/src/utils/suite/protocol.ts
+++ b/packages/suite/src/utils/suite/protocol.ts
@@ -1,6 +1,5 @@
 import { Protocol } from '@suite-common/suite-constants';
 import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
-import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { parseQuery, parseUri } from './parseUri';
 
@@ -21,14 +20,6 @@ export const getProtocolInfo = (
         const { protocol, pathname, host, search } = url;
         const scheme = protocol.slice(0, -1) as Protocol; // slice ":" from protocol
         const params = parseQuery(search);
-
-        analytics.report({
-            type: EventType.AppUriHandler,
-            payload: {
-                scheme,
-                isAmountPresent: params.amount !== undefined,
-            },
-        });
 
         if (!getNetworkSymbolForProtocol(scheme)) {
             return { error: 'Unknown protocol', scheme };

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -19,6 +19,7 @@ import { SYSTEM_PROGRAM_PUBLIC_KEY } from '@trezor/blockchain-link-utils/src/sol
 import { Icon, IconButton, Input, Link, Row } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
 import { CoinLogo } from '@trezor/product-components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 import { TimerId } from '@trezor/type-utils';
 import * as URLS from '@trezor/urls';
@@ -119,6 +120,17 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
         }
 
         const protocol = getProtocolInfo(uri);
+
+        if (protocol) {
+            analytics.report({
+                type: EventType.SendQrScan,
+                payload: {
+                    scheme: protocol.scheme,
+                    isAmountPresent: 'amount' in protocol && protocol.amount !== undefined,
+                    networkSymbol: symbol,
+                },
+            });
+        }
 
         if (protocol && 'error' in protocol) {
             dispatch(

--- a/suite-common/analytics/src/events/suite/constants.ts
+++ b/suite-common/analytics/src/events/suite/constants.ts
@@ -45,6 +45,7 @@ export enum EventType {
     SendInitialised = 'send/initialised',
     SendConfirmerOnDevice = 'send/confirmed-on-device',
     SendDetailOpened = 'send/detail-opened',
+    SendQrScan = 'send/qr-scan',
 
     AccountsStatus = 'accounts/status',
     AccountsTokensStatus = 'accounts/tokens-status',

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -200,6 +200,14 @@ export type SuiteAnalyticsEvent =
           };
       }
     | {
+          type: EventType.SendQrScan;
+          payload: {
+              scheme: string;
+              isAmountPresent: boolean;
+              networkSymbol: string;
+          };
+      }
+    | {
           type: EventType.AccountsStatus;
           payload: Record<string, number>;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

**New `EventType` added: `SendQrScan`**

This PR splits analytics call for **deeplink** usage and **QR code scans**. Before they were sent as one event and it wasn't possible to differentiate between them. Now `EventType.AppUriHandler` is used for deeplinks and `EventType.SendQrScan` for QR code scans.

## Notes for QA

There should be 2 separate analytics logs for these actions:
- `send/qr-scan` for QR code scans
- `app/uri-handler` for deeplinks

## Related Issue

Resolve #23242

## Screenshots:

### QR code scan call
<img width="470" height="258" alt="image" src="https://github.com/user-attachments/assets/b436862b-48fd-4dff-b63c-c14044835bdd" />

### Deeplink call
<img width="587" height="234" alt="image" src="https://github.com/user-attachments/assets/8cf527e4-c557-4e76-ab1b-aee05e69b728" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/split-protocol-analytics-call&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/split-protocol-analytics-call&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/split-protocol-analytics-call&lookback=7)