### PR TITLE
chore(suite): add lint to knowledge base bip 329

### DIFF
--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -6,7 +6,12 @@ import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
 import { getAccountTypeTech } from '@suite-common/wallet-utils';
 import { Button, Card, Column, InfoItem, Paragraph } from '@trezor/components';
 import { spacings, typography } from '@trezor/theme';
-import { HELP_CENTER_BIP32_URL, HELP_CENTER_XPUB_URL, Url } from '@trezor/urls';
+import {
+    HELP_CENTER_BIP329_URL,
+    HELP_CENTER_BIP32_URL,
+    HELP_CENTER_XPUB_URL,
+    Url,
+} from '@trezor/urls';
 
 import { exportMetadataToBip329File } from 'src/actions/suite/metadataActions';
 import { showXpub } from 'src/actions/wallet/publicKeyActions';
@@ -176,6 +181,7 @@ const Details = () => {
                             description={
                                 <Translation id="TR_ACCOUNT_DETAILS_EXPORT_LABELS_DESCRIPTION" />
                             }
+                            learnMoreUrl={HELP_CENTER_BIP329_URL}
                         >
                             <Button
                                 intent="neutral"

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -201,6 +201,9 @@ export const HELP_CENTER_ADVANCED_RECOVERY_URL: Url = withPlatformUtm(
 export const HELP_CENTER_XPUB_URL: Url = withPlatformUtm(
     'https://trezor.io/learn/supported-assets/bitcoin/what-is-a-public-key-xpub',
 );
+export const HELP_CENTER_BIP329_URL: Url = withPlatformUtm(
+    'https://trezor.io/learn/advanced/standards-proposals/what-is-bip329',
+);
 export const HELP_CENTER_BIP32_URL: Url = withPlatformUtm(
     'https://trezor.io/learn/advanced/standards-proposals/what-is-bip32',
 );

--- a/packages/urls/tests/urls.test.ts
+++ b/packages/urls/tests/urls.test.ts
@@ -10,6 +10,8 @@ const excluded = [
     URLS.LTC_ADDRESS_INFO_URL,
     // captcha, returning 403 in ci
     URLS.TREZOR_FORUM_URL,
+    // TODO: BIP329 article not live yet
+    URLS.HELP_CENTER_BIP329_URL,
     // TODO T3W1 - articles not live yet
     URLS.TREZOR_SUPPORT_BLUETOOTH_TROUBLESHOOTING,
     URLS.HELP_CENTER_DRY_RUN_T3W1_URL,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The new knowledge base article `https://trezor.io/learn/advanced/standards-proposals/what-is-bip329` will be available for Suite release. Including it now in the code.

## Notes for QA

Check that there is link to knowledge base article explaining BIP329 export labels when in account details in suite desktop.

## Screenshots:

<img width="819" height="117" alt="image" src="https://github.com/user-attachments/assets/070c531d-1429-4ba6-9b54-becfda5b77e5" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/add-link-to-knowledge-base-bip329&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/add-link-to-knowledge-base-bip329&lookback=7)