### PR TITLE
chore(suite): bump beta version to 26.1.0

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite",
-    "suiteVersion": "25.12.0",
+    "suiteVersion": "26.1.0",
     "version": "1.0.0",
     "private": true,
     "scripts": {


### PR DESCRIPTION
## Description,

Bumping beta version after freeze

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bump-suite-version-26.1.0&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bump-suite-version-26.1.0&lookback=7)