### PR TITLE
Fix incorrect rounding of the minimum staking fiat value.

### DIFF
--- a/packages/suite/src/hooks/wallet/useStakeForm.ts
+++ b/packages/suite/src/hooks/wallet/useStakeForm.ts
@@ -194,7 +194,7 @@ export const useStakeForm = ({ selectedAccount }: UseStakeFormsProps): StakeCont
                 toFiatCurrency({
                     amount: stakingLimits.MIN_AMOUNT_FOR_STAKING.toString(),
                     rate: currentRate?.rate,
-                })?.toFixed(2) ?? undefined,
+                })?.toFixed(2, BigNumber.ROUND_CEIL) ?? undefined,
             maxFiat:
                 toFiatCurrency({ amount: maxCrypto, rate: currentRate?.rate })?.toFixed(2) ??
                 undefined,


### PR DESCRIPTION
## Description

Previously, the value was truncated using `toFixed(2)`, which could produce a number lower than the required minimum (e.g. **301.183 → 301.18**). 
Switched to `toFixed(2, BigNumber.ROUND_CEIL)` so the value is always rounded up to ensure the minimum threshold is respected.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23371


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/min-staking-fiat-rounding-up&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/min-staking-fiat-rounding-up&lookback=7)