### PR TITLE
Feat/native/delete unused translations script

### DIFF
--- a/.github/workflows/bot-crowdin-sync.yml
+++ b/.github/workflows/bot-crowdin-sync.yml
@@ -11,7 +11,7 @@ on:
         description: Should be synced desktop or mobile crowdin project?
         required: true
       remove_unused_translations:
-        description: "Confirm removal of unused translations. Check them first in misc tests pipeline. (works for desktop only)"
+        description: "Confirm removal of unused translations. Check them first in misc tests pipeline."
         required: true
         default: false
         type: boolean
@@ -77,6 +77,9 @@ jobs:
         run: |
           yarn workspace @suite-native/intl translations:download --token=${{ secrets.CROWDIN_PERSONAL_TOKEN_MOBILE }}
           yarn workspace @suite-native/intl translations:backport-en
+          if [ "${{ github.event.inputs.remove_unused_translations }}" = "true" ]; then
+            yarn workspace @suite-native/intl translations:remove-unused
+          fi
           yarn workspace @suite-native/intl translations:format
           yarn workspace @suite-native/intl translations:extract
           cat suite-native/intl/translations/master.json

--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -19,6 +19,7 @@
     },
     "dependencies": {
         "@suite-common/suite-types": "workspace:*",
+        "@suite-common/suite-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "semver": "^7.7.1"
     },

--- a/packages/suite-data/src/translations/list-unused.ts
+++ b/packages/suite-data/src/translations/list-unused.ts
@@ -2,6 +2,7 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
+import { getGrepCommandOfTranslationKey } from '@suite-common/suite-utils';
 // See comment in list-duplicates.ts
 import messages from '@trezor/suite/src/support/messages';
 
@@ -18,31 +19,6 @@ function execLocal(cmd: string) {
 
 const unused: string[] = [];
 
-const ignore = [
-    'docs',
-    'node_modules',
-    'lib',
-    'libDev',
-    'build',
-    'build-electron',
-    '.next',
-    '__fixtures__',
-    'fixtures',
-    'test',
-    'tests',
-    '__test__',
-    '__tests__',
-    'coverage',
-    '.git',
-    'suite-data',
-    'connect-common',
-    '.yarn',
-    'screenshots',
-    'e2e',
-];
-
-const extensions = ['.ts', '.tsx'];
-
 for (const message in messages) {
     if (Object.prototype.hasOwnProperty.call(messages, message)) {
         // some messages might be 'dynamic' which means they are not present
@@ -50,13 +26,7 @@ for (const message in messages) {
         if (messages[message].dynamic) {
             continue;
         }
-
-        const includeExtensions = extensions
-            .map(extension => `--include="*${extension}"`)
-            .join(' ');
-        const excludeDir = ignore.map(folder => `--exclude-dir="${folder}"`).join(' ');
-
-        const cmd = `grep ${includeExtensions} ${excludeDir} --exclude=messages.ts -r "${message}" -w ./`;
+        const cmd = getGrepCommandOfTranslationKey(message);
 
         try {
             execLocal(cmd);

--- a/packages/suite-data/tsconfig.json
+++ b/packages/suite-data/tsconfig.json
@@ -9,6 +9,9 @@
         {
             "path": "../../suite-common/suite-types"
         },
+        {
+            "path": "../../suite-common/suite-utils"
+        },
         { "path": "../env-utils" },
         { "path": "../eslint" }
     ]

--- a/suite-common/suite-utils/src/index.ts
+++ b/suite-common/suite-utils/src/index.ts
@@ -9,3 +9,4 @@ export * from './invariant';
 export * from './jws';
 export * from './pollingController';
 export * from './triggerWebDownloadFile';
+export * from './translations';

--- a/suite-common/suite-utils/src/translations.ts
+++ b/suite-common/suite-utils/src/translations.ts
@@ -1,0 +1,35 @@
+const TRANSLATED_FILE_EXTENSIONS = ['.ts', '.tsx'] as const;
+
+const IGNORED_TRANSLATION_PATHS = [
+    'docs',
+    'node_modules',
+    'lib',
+    'libDev',
+    'build',
+    'build-electron',
+    '.next',
+    '__fixtures__',
+    'fixtures',
+    'test',
+    'tests',
+    '__test__',
+    '__tests__',
+    'coverage',
+    '.git',
+    'suite-data',
+    'connect-common',
+    '.yarn',
+    'screenshots',
+    'e2e',
+] as const;
+
+export const getGrepCommandOfTranslationKey = (message: string) => {
+    const includeExtensions = TRANSLATED_FILE_EXTENSIONS.map(
+        extension => `--include="*${extension}"`,
+    ).join(' ');
+    const excludeDir = IGNORED_TRANSLATION_PATHS.map(folder => `--exclude-dir="${folder}"`).join(
+        ' ',
+    );
+
+    return `grep ${includeExtensions} ${excludeDir} --exclude=messages.ts -r "${message}" -w ./`;
+};

--- a/suite-native/intl/package.json
+++ b/suite-native/intl/package.json
@@ -12,14 +12,17 @@
         "type-check": "yarn g:tsc --build",
         "test:unit": "yarn g:jest",
         "translations:format": "yarn g:prettier --write \"translations/*\"",
-        "translations:extract": "tsx ./scripts/extractTranslations.ts",
-        "translations:backport-en": "tsx ./scripts/backportEnglish.ts && yarn g:prettier --write src/messages.ts",
+        "translations:extract": "yarn g:tsx ./scripts/extractTranslations.ts",
+        "translations:backport-en": "yarn g:tsx ./scripts/backportEnglish.ts && yarn g:prettier --write src/messages.ts",
+        "translations:list-unused": "yarn g:tsx ./scripts/listUnused.ts",
+        "translations:remove-unused": "yarn g:tsx ./scripts/listUnused.ts --cleanup",
         "translations:upload": "crowdin upload",
         "translations:download": "crowdin download --all -l en -l cs -l de -l pt-BR -l ja"
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.11.0",
         "@suite-common/suite-types": "workspace:*",
+        "@suite-common/suite-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "expo-localization": "~17.0.7",
         "intl-pluralrules": "^2.0.1",
@@ -29,7 +32,6 @@
         "react-redux": "9.2.0"
     },
     "devDependencies": {
-        "@crowdin/cli": "4.8.0",
-        "tsx": "^4.20.3"
+        "@crowdin/cli": "4.8.0"
     }
 }

--- a/suite-native/intl/scripts/backportEnglish.ts
+++ b/suite-native/intl/scripts/backportEnglish.ts
@@ -11,11 +11,12 @@
  */
 
 import fs from 'fs';
+import path from 'path';
 
 import { mergeDeepObject } from '@trezor/utils';
 
 import { messages } from '../src/messages';
-import { unflatten } from '../src/utils';
+import { unflatten, writeMessagesObjectToFile } from '../src/utils';
 
 const source: { [key in keyof typeof messages]: string } = JSON.parse(
     fs.readFileSync('translations/en-US.json', 'utf8'),
@@ -24,13 +25,6 @@ const source: { [key in keyof typeof messages]: string } = JSON.parse(
 const unflattenedSource = unflatten(source);
 const updatedMessages = mergeDeepObject(messages, unflattenedSource);
 
-fs.writeFileSync(
-    'src/messages.ts',
-    `
-    // Few rules:
-    // 1. Never use dynamic keys IDs for example: translate(\`module.graph.coin.\${symbol}\`) instead map it to static key: { btc: translate('module.graph.coin.btc') }
-    // 2. Don't split string because of formatting or nested components use Rich Text Formatting instead https://formatjs.io/docs/react-intl/components#rich-text-formatting
-    // 3. Always wrap keys per module/screen/feature for example: module.graph.legend
-    
-    export const messages = ${JSON.stringify(updatedMessages, null, 2)};`,
-);
+const messagesPath = path.join(__dirname, '..', '..', 'intl', 'src', 'messages.ts');
+
+writeMessagesObjectToFile(updatedMessages, messagesPath);

--- a/suite-native/intl/scripts/backportEnglish.ts
+++ b/suite-native/intl/scripts/backportEnglish.ts
@@ -15,8 +15,9 @@ import path from 'path';
 
 import { mergeDeepObject } from '@trezor/utils';
 
+import { writeMessagesObjectToFile } from './utils';
 import { messages } from '../src/messages';
-import { unflatten, writeMessagesObjectToFile } from '../src/utils';
+import { unflatten } from '../src/utils';
 
 const source: { [key in keyof typeof messages]: string } = JSON.parse(
     fs.readFileSync('translations/en-US.json', 'utf8'),

--- a/suite-native/intl/scripts/listUnused.ts
+++ b/suite-native/intl/scripts/listUnused.ts
@@ -1,0 +1,63 @@
+/* eslint-disable no-console */
+import { execSync } from 'child_process';
+import path from 'path';
+
+import { getGrepCommandOfTranslationKey } from '@suite-common/suite-utils';
+
+import { messages } from '../src/messages';
+import { deleteNestedTranslationKey, flatten, writeMessagesObjectToFile } from '../src/utils';
+
+const suiteNativeRoot = path.join(__dirname, '..', '..');
+const messagesPath = path.join(suiteNativeRoot, 'intl', 'src', 'messages.ts');
+
+function execLocal(cmd: string) {
+    return execSync(cmd, {
+        encoding: 'utf-8',
+        cwd: suiteNativeRoot,
+    });
+}
+
+const unused: string[] = [];
+
+const flatMessages = flatten(messages);
+const numberOfMessages = Object.keys(flatMessages).length;
+
+console.log('Looking up for unused translation keys... 🔎');
+
+for (let i = 0; i < numberOfMessages; i++) {
+    const message = Object.keys(flatMessages)[i];
+    process.stdout.write(`\r\x1b[KProcessing translation ${i}/${numberOfMessages}: ${message}`);
+
+    if (Object.prototype.hasOwnProperty.call(flatMessages, message)) {
+        const cmd = getGrepCommandOfTranslationKey(message);
+
+        try {
+            execLocal(cmd);
+        } catch {
+            unused.push(message);
+        }
+    }
+}
+
+if (unused.length > 0) {
+    console.log('\n');
+    for (const unusedId of unused) {
+        console.log(unusedId);
+    }
+    console.log(`${unused.length} unused messages found. ⚠️`);
+
+    if (process.argv.includes('--cleanup')) {
+        console.log('cleaning up unused translation keys...');
+
+        for (const unusedId of unused) {
+            deleteNestedTranslationKey(messages, unusedId);
+        }
+        writeMessagesObjectToFile(messages, messagesPath);
+        execLocal(`yarn prettier --write ${messagesPath}`);
+        console.log('Unused translation keys cleaned up! 🎉');
+    } else {
+        process.exit(1);
+    }
+} else {
+    console.log('No unused translation keys found! 🎉');
+}

--- a/suite-native/intl/scripts/listUnused.ts
+++ b/suite-native/intl/scripts/listUnused.ts
@@ -4,8 +4,9 @@ import path from 'path';
 
 import { getGrepCommandOfTranslationKey } from '@suite-common/suite-utils';
 
+import { writeMessagesObjectToFile } from './utils';
 import { messages } from '../src/messages';
-import { deleteNestedTranslationKey, flatten, writeMessagesObjectToFile } from '../src/utils';
+import { deleteNestedTranslationKey, flatten } from '../src/utils';
 
 const suiteNativeRoot = path.join(__dirname, '..', '..');
 const messagesPath = path.join(suiteNativeRoot, 'intl', 'src', 'messages.ts');

--- a/suite-native/intl/scripts/utils.ts
+++ b/suite-native/intl/scripts/utils.ts
@@ -1,0 +1,13 @@
+import fs from 'fs';
+export const writeMessagesObjectToFile = (messages: Record<string, any>, filePath: string) => {
+    fs.writeFileSync(
+        filePath,
+        `
+        // Few rules:
+        // 1. Never use dynamic keys IDs for example: translate(\`module.graph.coin.\${symbol}\`) instead map it to static key: { btc: translate('module.graph.coin.btc') }
+        // 2. Don't split string because of formatting or nested components use Rich Text Formatting instead https://formatjs.io/docs/react-intl/components#rich-text-formatting
+        // 3. Always wrap keys per module/screen/feature for example: module.graph.legend
+        
+        export const messages = ${JSON.stringify(messages, null, 2)};`,
+    );
+};

--- a/suite-native/intl/src/__tests__/utils.test.ts
+++ b/suite-native/intl/src/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { flatten, unflatten } from '../utils';
+import { deleteNestedTranslationKey, flatten, unflatten } from '../utils';
 
 describe('flatten', () => {
     it('should flatten nested translation object to dot notation', () => {
@@ -111,5 +111,121 @@ describe('unflatten', () => {
         };
 
         expect(unflatten(input)).toEqual(expected);
+    });
+});
+
+describe('deleteNestedTranslationKey', () => {
+    it('removes nested key and prunes empty parents', () => {
+        const messages = {
+            generic: {
+                trezorSuite: 'Trezor Suite',
+                buttons: {
+                    yes: 'Yes',
+                    no: 'No',
+                },
+            },
+            moduleSend: {
+                fees: {
+                    custom: {
+                        openButton: 'Open',
+                    },
+                },
+                low: 'Low',
+                normal: 'Normal',
+                high: 'High',
+            },
+        };
+
+        deleteNestedTranslationKey(messages, 'moduleSend.fees.custom.openButton');
+
+        expect(messages).toEqual({
+            generic: {
+                trezorSuite: 'Trezor Suite',
+                buttons: {
+                    yes: 'Yes',
+                    no: 'No',
+                },
+            },
+            moduleSend: {
+                low: 'Low',
+                normal: 'Normal',
+                high: 'High',
+            },
+        });
+    });
+
+    it('keeps parent when siblings still exist', () => {
+        const messages = {
+            moduleSend: {
+                fees: {
+                    custom: {
+                        openButton: 'Open',
+                        closeButton: 'Close',
+                    },
+                },
+            },
+        };
+
+        deleteNestedTranslationKey(messages, 'moduleSend.fees.custom.openButton');
+
+        expect(messages).toEqual({
+            moduleSend: {
+                fees: {
+                    custom: {
+                        closeButton: 'Close',
+                    },
+                },
+            },
+        });
+    });
+
+    it('removes entire branch when nothing remains', () => {
+        const messages = {
+            moduleSend: {
+                fees: {
+                    custom: {
+                        openButton: 'Open',
+                    },
+                },
+            },
+        };
+
+        deleteNestedTranslationKey(messages, 'moduleSend.fees.custom.openButton');
+
+        expect(messages).toEqual({});
+    });
+
+    it('does nothing when path does not exist', () => {
+        const messages = {
+            moduleSend: {
+                fees: {
+                    custom: {
+                        openButton: 'Open',
+                    },
+                },
+            },
+        };
+
+        const clone = structuredClone(messages);
+
+        deleteNestedTranslationKey(messages, 'moduleSend.fees.custom.invalid');
+
+        expect(messages).toEqual(clone);
+    });
+
+    it('exits early when intermediate key missing', () => {
+        const messages = {
+            moduleSend: {
+                fees: {},
+            },
+        };
+
+        deleteNestedTranslationKey(messages, 'moduleSend.fees.custom.openButton');
+
+        expect(messages).toEqual({
+            moduleSend: {
+                fees: {},
+            },
+        });
     });
 });

--- a/suite-native/intl/src/utils.ts
+++ b/suite-native/intl/src/utils.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+
 import { DEFAULT_LOCALE, LANGUAGES } from './languages';
 import { SupportedLocaleCode } from './types';
 
@@ -49,4 +51,50 @@ export const findClosestOfficiallySupportedLanguageLocale = (
     )?.[0] as SupportedLocaleCode | undefined;
 
     return matchingOfficialLanguageLocale ?? DEFAULT_LOCALE;
+};
+
+export const deleteNestedTranslationKey = (obj: Record<string, any>, path: string) => {
+    const keys = path.split('.');
+    let currentNode: Record<string, any> = obj;
+    const parents: Array<{ node: Record<string, any>; key: string }> = [];
+
+    for (let i = 0; i < keys.length - 1; i++) {
+        const nextNode = currentNode[keys[i]];
+        parents.push({ node: currentNode, key: keys[i] });
+        currentNode = nextNode;
+        if (!currentNode) return;
+    }
+
+    const lastKey = keys[keys.length - 1];
+    if (!(lastKey in currentNode)) return;
+
+    delete currentNode[lastKey];
+
+    if (Object.keys(currentNode).length > 0) {
+        return;
+    }
+
+    while (parents.length) {
+        const { node, key } = parents.pop()!;
+        delete node[key];
+
+        if (Object.keys(node).length > 0) {
+            break;
+        }
+
+        currentNode = node;
+    }
+};
+
+export const writeMessagesObjectToFile = (messages: Record<string, any>, filePath: string) => {
+    fs.writeFileSync(
+        filePath,
+        `
+        // Few rules:
+        // 1. Never use dynamic keys IDs for example: translate(\`module.graph.coin.\${symbol}\`) instead map it to static key: { btc: translate('module.graph.coin.btc') }
+        // 2. Don't split string because of formatting or nested components use Rich Text Formatting instead https://formatjs.io/docs/react-intl/components#rich-text-formatting
+        // 3. Always wrap keys per module/screen/feature for example: module.graph.legend
+        
+        export const messages = ${JSON.stringify(messages, null, 2)};`,
+    );
 };

--- a/suite-native/intl/src/utils.ts
+++ b/suite-native/intl/src/utils.ts
@@ -1,5 +1,3 @@
-import fs from 'fs';
-
 import { DEFAULT_LOCALE, LANGUAGES } from './languages';
 import { SupportedLocaleCode } from './types';
 
@@ -84,17 +82,4 @@ export const deleteNestedTranslationKey = (obj: Record<string, any>, path: strin
 
         currentNode = node;
     }
-};
-
-export const writeMessagesObjectToFile = (messages: Record<string, any>, filePath: string) => {
-    fs.writeFileSync(
-        filePath,
-        `
-        // Few rules:
-        // 1. Never use dynamic keys IDs for example: translate(\`module.graph.coin.\${symbol}\`) instead map it to static key: { btc: translate('module.graph.coin.btc') }
-        // 2. Don't split string because of formatting or nested components use Rich Text Formatting instead https://formatjs.io/docs/react-intl/components#rich-text-formatting
-        // 3. Always wrap keys per module/screen/feature for example: module.graph.legend
-        
-        export const messages = ${JSON.stringify(messages, null, 2)};`,
-    );
 };

--- a/suite-native/intl/tsconfig.json
+++ b/suite-native/intl/tsconfig.json
@@ -5,6 +5,9 @@
         {
             "path": "../../suite-common/suite-types"
         },
+        {
+            "path": "../../suite-common/suite-utils"
+        },
         { "path": "../../packages/utils" }
     ]
 }

--- a/suite-native/module-connect-popup/src/components/PermissionConfirmation.tsx
+++ b/suite-native/module-connect-popup/src/components/PermissionConfirmation.tsx
@@ -17,9 +17,17 @@ import {
     VStack,
 } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
-import { Translation } from '@suite-native/intl';
+import { Translation, TxKeyPath } from '@suite-native/intl';
+import { MethodPermission } from '@trezor/connect/src/core/AbstractMethod';
 
 import { ConnectAppIcon } from '../components/ConnectAppIcon';
+
+const permissionTranslationKeysMap = {
+    read: 'moduleConnectPopup.permissions.read',
+    write: 'moduleConnectPopup.permissions.write',
+    management: 'moduleConnectPopup.permissions.management',
+    push_tx: 'moduleConnectPopup.permissions.push_tx',
+} as const satisfies Record<MethodPermission, TxKeyPath>;
 
 export const PermissionConfirmation = () => {
     const dispatch = useDispatch();
@@ -84,7 +92,7 @@ export const PermissionConfirmation = () => {
                         <HStack key={permission} alignItems="center" spacing="sp8">
                             <Icon name="checkCircle" color="iconPrimaryDefault" />
                             <Text color="textSubdued" variant="hint" style={{ flex: 1 }}>
-                                <Translation id={`moduleConnectPopup.permissions.${permission}`} />
+                                <Translation id={permissionTranslationKeysMap[permission]} />
                             </Text>
                         </HStack>
                     ))}

--- a/suite-native/module-connect-popup/src/components/TxSimulation/FeeInfoBottomSheet.tsx
+++ b/suite-native/module-connect-popup/src/components/TxSimulation/FeeInfoBottomSheet.tsx
@@ -48,7 +48,9 @@ export const FeeInfoBottomSheet = ({
             ),
         },
         {
-            label: <Translation id="moduleSend.fees.custom.bottomSheet.label.maxFeePerGas" />,
+            label: (
+                <Translation id="transactionManagement.fees.custom.bottomSheet.label.maxFeePerGas" />
+            ),
             value:
                 popupCall.payload?.transaction?.maxFeePerGas &&
                 fromWei(popupCall.payload?.transaction?.maxFeePerGas, 'gwei').toLocaleString() +
@@ -57,7 +59,7 @@ export const FeeInfoBottomSheet = ({
         },
         {
             label: (
-                <Translation id="moduleSend.fees.custom.bottomSheet.label.maxPriorityFeePerGas" />
+                <Translation id="transactionManagement.fees.custom.bottomSheet.label.maxPriorityFeePerGas" />
             ),
             value:
                 popupCall.payload?.transaction?.maxPriorityFeePerGas &&
@@ -69,7 +71,9 @@ export const FeeInfoBottomSheet = ({
                     getFeeUnits(network.networkType),
         },
         {
-            label: <Translation id="moduleSend.fees.custom.bottomSheet.label.gasPrice" />,
+            label: (
+                <Translation id="transactionManagement.fees.custom.bottomSheet.label.gasPrice" />
+            ),
             value:
                 popupCall.payload?.transaction?.gasPrice &&
                 fromWei(Number(popupCall.payload?.transaction?.gasPrice), 'gwei').toLocaleString() +
@@ -77,7 +81,9 @@ export const FeeInfoBottomSheet = ({
                     getFeeUnits(network.networkType),
         },
         {
-            label: <Translation id="moduleSend.fees.custom.bottomSheet.label.gasLimit" />,
+            label: (
+                <Translation id="transactionManagement.fees.custom.bottomSheet.label.gasLimit" />
+            ),
             value: formattedGasLimit,
         },
     ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -11968,6 +11968,7 @@ __metadata:
     "@crowdin/cli": "npm:4.8.0"
     "@reduxjs/toolkit": "npm:2.11.0"
     "@suite-common/suite-types": "workspace:*"
+    "@suite-common/suite-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     expo-localization: "npm:~17.0.7"
     intl-pluralrules: "npm:^2.0.1"
@@ -11975,7 +11976,6 @@ __metadata:
     react-intl: "npm:^7.1.11"
     react-native: "npm:0.81.4"
     react-redux: "npm:9.2.0"
-    tsx: "npm:^4.20.3"
   languageName: unknown
   linkType: soft
 
@@ -14525,6 +14525,7 @@ __metadata:
   dependencies:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@suite-common/suite-types": "workspace:*"
+    "@suite-common/suite-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/eslint": "workspace:*"
     "@types/fs-extra": "npm:^11.0.4"


### PR DESCRIPTION
## Description
- adds a script that will remove all unused translation keys and sync it changes with Crowdin. The implementation is close as possible to desktop to avoid any platform specific confusion. Part of the script code is even shared with desktop script.
- there is about 120  unsused translations but they are not removed in this PR yet. I want to test the removal from the CI workflow. Will be done after all the release 25.12 related Crowdin syncs will be done. 
## Notes for QA
Nothing to test, this code is running in CI workflow.

## Related Issue

Resolve #21380 



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/delete-unused-translations-script&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/delete-unused-translations-script&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/delete-unused-translations-script&lookback=7)