### PR TITLE
fix(suite-native): adjust trading e2e after legal sheet removal

### DIFF
--- a/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
@@ -150,17 +150,8 @@ export abstract class TradingFormActions extends TradingActions {
         await detoxExpect(this.getElementById('asset-send-button/symbol')).toHaveText(asset);
     }
 
-    async openLegalSheet() {
-        await this.getElementById('continue-button').tap();
-        await wait(this.BOTTOM_SHEET_ANIMATION_DURATION);
-    }
-
     async confirmTradingForm() {
-        await this.openLegalSheet();
-        await element(by.id('@bottom-sheet/scroll-view')).scrollTo('bottom', 0.5, 0.5);
-        await this.waitForBottomSheetAnimation();
-        await this.getElementById('confirm-button').tap();
-        await this.waitForBottomSheetAnimation();
+        await this.getElementById('continue-button').tap();
     }
 
     async tapTradingSectionHeaderTab() {

--- a/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
@@ -32,9 +32,6 @@ describe.skip('Trade Buy [@noDevice]', () => {
         await tradingBuyActions.viewProviders();
         await tradingBuyActions.expectValidBuyForm();
 
-        await tradingBuyActions.openLegalSheet();
-        await tradingBuyActions.closeBottomSheet();
-        await tradingBuyActions.expectValidBuyForm();
         await tradingBuyActions.confirmTradingForm();
         await tradingBuyActions.closePaymentWebview();
 

--- a/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
@@ -70,9 +70,6 @@ conditionalDescribe(device.getPlatform() === 'android', 'Trade Exchange', () => 
             await tradingExchangeActions.viewProviders();
             await tradingExchangeActions.expectValidExchangeForm();
 
-            await tradingExchangeActions.openLegalSheet();
-            await tradingExchangeActions.closeBottomSheet();
-            await tradingExchangeActions.expectValidExchangeForm();
             await tradingExchangeActions.confirmTradingForm();
 
             await exchangePreviewActions.expectExchangePreviewScreenToBeVisible();


### PR DESCRIPTION
After #23339 was merged, e2e tests started to fail, because it was not adjusted to removed Legal Terms sheet.

This fixes the tests

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/trading-e2e-after-removed-legal-sheet&lookback=7)