### PR TITLE
fix(suite-native): got to payment for waiting status in buy history

### DIFF
--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAlert.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAlert.tsx
@@ -158,11 +158,10 @@ export const TradeDetailAlert = ({
     // Special handling for different alert types
     let handleButtonPress: (() => void) | undefined;
 
+    // even if there is support url, we still need to navigate to the webview for waiting and kyc alerts
     if ((['waiting', 'kyc'] as TradeStatusStep[]).includes(alertType) && orderId) {
         handleButtonPress = () => navigateToWebView();
-    }
-
-    if (supportUrl) {
+    } else if (supportUrl) {
         handleButtonPress = () => openLink(supportUrl);
     }
 


### PR DESCRIPTION
User was not able to go to payment from Buy history trade if if it was waiting for payment.

## Description

- I changed the decision tree to prioritise payment over support link

## Related Issue

This resolves mobile version of #23573



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/trade/buy-history-to-payment&lookback=7)