### PR TITLE
fix(suite-native): move footer and fix infinite fee fetching in sell

### DIFF
--- a/suite-native/module-trading/src/components/general/Footer.tsx
+++ b/suite-native/module-trading/src/components/general/Footer.tsx
@@ -53,6 +53,7 @@ const FooterProviderContent = ({ provider }: FooterProviderContentProps) => {
                             href={termsUrl}
                             label={parts}
                             isUnderlined
+                            key={parts.join('|')}
                         />
                     ),
                 }}

--- a/suite-native/module-trading/src/components/history/TradeHistoryListItem/TradeHistoryListItem.tsx
+++ b/suite-native/module-trading/src/components/history/TradeHistoryListItem/TradeHistoryListItem.tsx
@@ -52,8 +52,8 @@ export const TradeHistoryListItem = memo(({ transaction, onPress }: TradeHistory
                             <Translation
                                 id="moduleTrading.tradeHistory.timeAt"
                                 values={{
-                                    date: <DateFormatter value={date} />,
-                                    time: <TimeFormatter value={date} />,
+                                    date: <DateFormatter value={date} key="date" />,
+                                    time: <TimeFormatter value={date} key="time" />,
                                 }}
                             />
                         </Text>

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.tsx
@@ -12,7 +12,6 @@ import { SellFeePickerCard } from './SellFeePickerCard';
 import { SellFromAccountTradePreviewCard } from './SellFromAccountTradePreviewCard';
 import { SellToFiatTradePreviewCard } from './SellToFiatTradePreviewCard';
 import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
-import { Footer } from '../../general/Footer';
 
 export type SellPreviewViewProps = {
     quote: SellFiatTrade | undefined;
@@ -56,8 +55,6 @@ export const SellPreviewView = memo(({ quote, txnErrorString }: SellPreviewViewP
                     onBankAccountSelect={handleBankAccountSelect}
                 />
             )}
-
-            <Footer type="sell" />
         </VStack>
     );
 });

--- a/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -9,6 +9,7 @@ import {
 } from '@suite-common/trading';
 import { Screen } from '@suite-native/navigation';
 
+import { Footer } from '../components/general/Footer';
 import {
     SellPreviewContinueButton,
     SellPreviewScreenHeader,
@@ -23,6 +24,7 @@ export const TradingSellPreviewScreen = () => {
     const { txnErrorString, doBankAccountVerificationCheck, fetchFeesAndCompose } = useSellFlow();
     const { trade } = useTradingDetailData<TradingSellType>('sell');
     const selectedQuote = useSelector(selectTradingSellSelectedQuote);
+    const [shouldFetchFees, setShouldFetchFees] = useState(false);
 
     const currentQuote = trade?.data ? trade.data : selectedQuote;
     const isFinalized = isFinalStatus('sell', currentQuote?.status);
@@ -41,9 +43,17 @@ export const TradingSellPreviewScreen = () => {
     // Fetch fees and compose when status is SEND_CRYPTO
     useEffect(() => {
         if (currentQuote?.status === 'SEND_CRYPTO') {
+            setShouldFetchFees(true);
+        }
+    }, [currentQuote?.status, currentQuote?.orderId]);
+
+    // unfortunately fetchFeesAndCompose is too unstable to be used directly in above useEffect
+    useEffect(() => {
+        if (shouldFetchFees) {
+            setShouldFetchFees(false);
             fetchFeesAndCompose();
         }
-    }, [currentQuote?.status, currentQuote?.orderId, fetchFeesAndCompose]);
+    }, [shouldFetchFees, fetchFeesAndCompose]);
 
     // clear trading state on unmount
     useEffect(
@@ -69,6 +79,7 @@ export const TradingSellPreviewScreen = () => {
                     onSignTransactionNavigation={onSignTransactionNavigation}
                 />
             )}
+            <Footer type="sell" />
         </Screen>
     );
 };

--- a/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.comp.test.tsx
@@ -164,4 +164,21 @@ describe('TradingSellPreviewScreen', () => {
 
         expect(mockFetchFeesAndCompose).not.toHaveBeenCalled();
     });
+
+    it('should call fetchFeesAndCompose only once per orderId', async () => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'sell' }),
+        };
+        const quoteWithSendCryptoStatus = {
+            ...sellQuotes[0],
+            status: 'SEND_CRYPTO' as const,
+            orderId: 'test_order_id_1',
+        };
+        preloadedState.wallet!.trading!.sell!.selectedQuote = quoteWithSendCryptoStatus;
+
+        await renderTradingSellPreviewScreen(preloadedState);
+
+        // Should be called exactly once for this orderId
+        expect(mockFetchFeesAndCompose).toHaveBeenCalledTimes(1);
+    });
 });


### PR DESCRIPTION
Fixes native sell issues

## Description

- moves footer in sell to correct place
- stops infinite calls of `fetchFeesAndCompose` in `TradingSellPreviewScreen`

## Notes for QA

Test sell flow
## Related Issue



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/sell-issues&lookback=7)