### PR TITLE
fix(suite): on finished goToPayment in buy enable button again

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentWaitingForUserStep.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentWaitingForUserStep.tsx
@@ -72,6 +72,7 @@ export const TradingDetailBuyPaymentWaitingForUserStep = ({
         if (response) {
             dispatch(submitRequestForm(response.form));
         }
+        setIsWorking(false);
     };
 
     return (


### PR DESCRIPTION
After opening web for buy, the Go to payment button remained disabled. This PR enables it again.

## Notes for QA

After going to web, the button should be enabled again

## Related Issue

Resolve #23573


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=23573-buy---proceed-to-pay-links-invalid-or-cannot-connect-to-trade-partner&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=23573-buy---proceed-to-pay-links-invalid-or-cannot-connect-to-trade-partner&lookback=7)