### PR TITLE
chore(suite): show all accounts in global send modal

### DIFF
--- a/packages/suite/src/components/suite/asset-picker/components/AssetsListEmpty/AssetsListEmpty.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetsListEmpty/AssetsListEmpty.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import { TranslationKey } from '@suite-common/intl-types';
 import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
-import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { selectHasRunningDiscovery, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Button, Column, Paragraph, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -29,6 +29,7 @@ export const AssetsListEmpty = ({
     const dispatch = useDispatch();
     const protocolScheme = useSelector(state => state.protocol.sendForm.scheme);
     const device = useSelector(selectSelectedDevice);
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const protocolSymbol = protocolScheme ? getNetworkSymbolForProtocol(protocolScheme) : undefined;
     const network = protocolSymbol ? getNetworkDisplaySymbolName(protocolSymbol) : undefined;
@@ -74,7 +75,9 @@ export const AssetsListEmpty = ({
                 <Button
                     onClick={openActivateNetworkModal}
                     margin={{ top: spacings.md }}
+                    isLoading={isDiscoveryRunning}
                     intent="neutral"
+                    priority="secondary"
                 >
                     <Translation id="TR_ACCOUNT_SEARCH_ACTIVATE_NETWORK_CTA" values={{ network }} />
                 </Button>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useThrottle } from 'react-use';
 
-import { TokenDefinitionsState, selectTokenDefinitions } from '@suite-common/token-definitions';
+import { selectTokenDefinitions } from '@suite-common/token-definitions';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
     selectAllAccountsToList,
@@ -14,7 +14,6 @@ import {
     findAccountsByNetwork,
 } from '@suite-common/wallet-utils';
 import { useCurrentRef } from '@trezor/react-utils';
-import { BigNumber } from '@trezor/utils';
 
 import {
     ASSET_ROW_ACCOUNT_HEIGHT,
@@ -26,7 +25,6 @@ import {
     TokensWithRates,
     enhanceTokensWithRates,
     getTokens,
-    hasVisibleTokens,
     sortTokensWithRates,
 } from 'src/utils/wallet/tokenUtils';
 
@@ -50,17 +48,6 @@ function filterAccountsByNetworkSymbol(
     return networkSymbol ? findAccountsByNetwork(networkSymbol, accounts) : accounts;
 }
 
-function getAccountsWithPositiveBalanceOrVisibleTokens(
-    accounts: Account[],
-    tokenDefinitions: TokenDefinitionsState,
-): Account[] {
-    return accounts.filter(
-        account =>
-            new BigNumber(account.availableBalance).gt(0) ||
-            hasVisibleTokens(account.symbol, account.tokens, tokenDefinitions),
-    );
-}
-
 export function useAccountWithTokensOptions(): AccountWithTokensOption[] {
     const networkSymbol = useSelector(globalSendReceiveFilters.selectors.selectNetworkSymbol);
     const accounts = useSelector(selectAllAccountsToList);
@@ -81,12 +68,7 @@ export function useAccountWithTokensOptions(): AccountWithTokensOption[] {
 
         const networkAccounts = filterAccountsByNetworkSymbol(throttledAccounts, networkSymbol);
 
-        const accountsWithPositiveBalanceOrTokens = getAccountsWithPositiveBalanceOrVisibleTokens(
-            networkAccounts,
-            tokenDefinitions,
-        );
-
-        const accountsAndTokensSortedByFiatBalance = accountsWithPositiveBalanceOrTokens
+        const accountsAndTokensSortedByFiatBalance = networkAccounts
             .toSorted(function sortByFiatBalanceInDescOrder(accountA, accountB) {
                 return accountsFiatBalanceInDescOrderComparator({
                     accountA,

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
@@ -8,6 +8,7 @@ import {
     getNetworkDisplaySymbolName,
 } from '@suite-common/wallet-config';
 import { selectDeviceAccountsByNetworkSymbol } from '@suite-common/wallet-core';
+import { isBech32AddressUppercase } from '@suite-common/wallet-utils';
 import { Text } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 import { BigNumber } from '@trezor/utils';
@@ -87,6 +88,14 @@ export const CoinProtocolRenderer = ({
         onCancel(false);
     };
 
+    const renderAddress = () => {
+        if (networkSymbol === 'btc' && isBech32AddressUppercase(notification.address)) {
+            return notification.address.toLowerCase();
+        }
+
+        return notification.address;
+    };
+
     return (
         <ConditionalActionRenderer
             render={render}
@@ -100,7 +109,7 @@ export const CoinProtocolRenderer = ({
             body={
                 <>
                     <Row>
-                        <Text typographyStyle="hint">{notification.address}</Text>
+                        <Text typographyStyle="hint">{renderAddress()}</Text>
                     </Row>
                     {notification.amount && (
                         <>

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/ConditionalActionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/ConditionalActionRenderer.tsx
@@ -29,7 +29,7 @@ export const ConditionalActionRenderer = ({
 }: ConditionalActionRendererProps) => {
     const actions: NotificationAction[] = [
         { onClick: onAction, label: actionLabel, position: 'bottom', variant: 'primary' },
-        { onClick: onCancel, label: 'TR_CANCEL', position: 'bottom' },
+        { onClick: onCancel, label: 'TR_CANCEL', position: 'bottom', priority: 'secondary' },
     ];
 
     return (

--- a/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView.tsx
+++ b/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView.tsx
@@ -3,6 +3,7 @@ import { JSX } from 'react';
 import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import type { NotificationEntry } from '@suite-common/toast-notifications';
 import { Button, ButtonProps, Column, Icon, IconName, Paragraph, Row } from '@trezor/components';
+import { ButtonPriority } from '@trezor/components/src/components/buttons/types';
 import { spacings } from '@trezor/theme';
 
 import { FormattedDateWithBullet } from 'src/components/suite';
@@ -18,6 +19,7 @@ export interface NotificationAction {
     label: ExtendedMessageDescriptor['id'];
     position?: 'bottom' | 'right';
     variant?: NotificationActionVariant;
+    priority?: ButtonPriority;
 }
 
 export interface NotificationViewProps {
@@ -84,6 +86,7 @@ export const NotificationView = ({
                 ) : (
                     <Button
                         intent={mapActionVariantToIntent(action.variant)}
+                        priority={action.priority}
                         size="small"
                         onClick={action.onClick}
                         minWidth={80}

--- a/packages/suite/src/components/suite/notifications/ToastNotification.tsx
+++ b/packages/suite/src/components/suite/notifications/ToastNotification.tsx
@@ -75,6 +75,7 @@ const ToastNotification = ({
         <Button
             key={a.label}
             intent={mapActionVariantToIntent(a.variant)}
+            priority={a.priority}
             onClick={a.onClick}
             size="small"
             margin={

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -298,6 +298,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
             protocol.sendForm.scheme &&
             selectedAccount.network.symbol === getNetworkSymbolForProtocol(protocol.sendForm.scheme)
         ) {
+            reset(getLoadedValues());
             // for now we always fill only first output
             const outputIndex = 0;
 
@@ -313,8 +314,13 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
 
             if (protocol.sendForm.address) {
                 setValue(`outputs.${outputIndex}.address`, protocol.sendForm.address, {
-                    shouldValidate: true,
+                    shouldDirty: true,
                 });
+
+                // Defer validation until after Address component renders and registers validators
+                setTimeout(() => {
+                    trigger(`outputs.${outputIndex}.address`);
+                }, 0);
             }
 
             dispatch(fillSendForm(false));
@@ -330,46 +336,35 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         composeRequest,
         shouldSendInSats,
         state.network.decimals,
+        reset,
+        getLoadedValues,
+        trigger,
     ]);
 
     // load draft from reducer and reset current form values, this should be only called once on mount
     useEffect(() => {
         const loadDraftValues = async () => {
-            // Check if we should fill from protocol data instead of draft
-            const shouldFillFromProtocol =
-                protocol.sendForm.shouldFill &&
-                protocol.sendForm.scheme &&
-                protocol.sendForm.address &&
-                selectedAccount.network.symbol ===
-                    getNetworkSymbolForProtocol(protocol.sendForm.scheme);
+            const storedState = await dispatch(getSendFormDraftThunk()).unwrap();
+            const values = getLoadedValues(storedState);
 
-            if (shouldFillFromProtocol) {
-                const values = getLoadedValues();
-                values.outputs[0].address = protocol.sendForm.address!;
+            reset(values, { keepDefaultValues: !!storedState });
 
-                if (protocol.sendForm.amount) {
-                    const amount = protocol.sendForm.amount.toString();
-                    values.outputs[0].amount = shouldSendInSats
-                        ? convertAmountUnitsToSubunits(amount, state.network.decimals)
-                        : amount;
-                }
-
-                reset(values);
-                dispatch(fillSendForm(false));
-                composeRequest();
-            } else {
-                const storedState = await dispatch(getSendFormDraftThunk()).unwrap();
-                const values = getLoadedValues(storedState);
-
-                reset(values, { keepDefaultValues: !!storedState });
-
-                if (storedState) {
-                    draft.current = storedState;
-                    composeDraft(storedState);
-                }
+            if (storedState) {
+                draft.current = storedState;
+                composeDraft(storedState);
             }
         };
-        loadDraftValues();
+        const shouldFillFromProtocol =
+            protocol.sendForm.shouldFill &&
+            protocol.sendForm.scheme &&
+            protocol.sendForm.address &&
+            selectedAccount.network.symbol ===
+                getNetworkSymbolForProtocol(protocol.sendForm.scheme);
+
+        if (!shouldFillFromProtocol) {
+            loadDraftValues();
+        }
+
         // composeDraft is excluded because its reference changes with each feeInfo update.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [dispatch, getLoadedValues, reset]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Global send modal "Activate {network}" button now has a loading state while the discovery is running
- All accounts are now included in global send modal, not just accounts with balance
- Changed button `priority` to `secondary` for `ConditionalActionRenderer`

<!--- Describe your changes in detail -->

## Notes for QA

- All accounts are visible in the global send modal
- "Activate {network}" button in global send modal now has a loading state while there is a running discovery
- validate all types of btc account types because some types are case sensitive

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

#### Notification - changed button `priority` to `secondary`
<img width="493" height="163" alt="image" src="https://github.com/user-attachments/assets/a69b9ac6-adc7-4192-85ea-d97dac0d09c0" />

#### Global send modal - change "Activate {network}" button `priority` to `secondary`
<img width="723" height="368" alt="image" src="https://github.com/user-attachments/assets/a5ef148f-cbbc-4908-b678-8fe2953051b2" />

#### Flow
https://github.com/user-attachments/assets/25b9e580-9f21-4a58-a288-ce7e14c7cd28




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/global-send-nits&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/global-send-nits&lookback=7)