### PR TITLE
Update eslint ignores

### DIFF
--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -34,6 +34,7 @@ export const eslint = [
             '**/.expo/*',
             'eslint-local-rules/*',
             '**/.cache/*',
+            '**/playwright-report/*',
         ],
     },
     { files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'] },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Running `yarn lint:js` caused lots of false positives (over 9000) from playwright reports.

Udates eslint configuration to Ignore `playwright-report` directory

## Notes for QA

Nothing to test

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=update-eslint-ignored-paths&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=update-eslint-ignored-paths&lookback=7)