### PR TITLE
Suite native: Fix trading tests

### DIFF
--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailFooter.comp.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailFooter.comp.test.tsx
@@ -6,7 +6,7 @@ import { TradeDetailFooter } from '../TradeDetailFooter';
 
 const mockCopyToClipboard = jest.fn();
 
-jest.mock('@suite-native/helpers', () => ({
+jest.mock('@suite-native/clipboard', () => ({
     useCopyToClipboard: () => mockCopyToClipboard,
 }));
 

--- a/suite-native/module-trading/src/components/sell/__tests__/SellTab.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellTab.comp.test.tsx
@@ -34,7 +34,32 @@ describe('SellTab', () => {
             featureFlags: {
                 [FeatureFlag.IsTradingSellEnabled]: false,
             },
-        });
+            messageSystem: {
+                validMessages: {
+                    feature: ['actionId'],
+                    banner: [],
+                    context: [],
+                    modal: [],
+                },
+                dismissedMessages: [],
+                config: {
+                    actions: [
+                        {
+                            message: {
+                                id: 'actionId',
+                                category: ['feature'],
+                                feature: [
+                                    {
+                                        domain: 'trading.sell',
+                                        flag: false,
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            },
+        } as unknown as PreloadedState);
 
         expect(getByText('Sell disabled')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
@@ -99,6 +99,7 @@ describe('useBuyFlow', () => {
                     btcAccount.addresses?.used?.[0]?.address ?? btcAccount.descriptor;
 
                 const { result } = await renderUseTradingBuyFlow();
+                dispatchSpy.mockClear();
 
                 act(() => {
                     result.current.selectQuote();
@@ -111,7 +112,7 @@ describe('useBuyFlow', () => {
                     nextStep();
                 });
 
-                expect(store.dispatch).toHaveBeenCalledWith(
+                expect(dispatchSpy).toHaveBeenCalledWith(
                     expect.objectContaining({
                         type: 'confirmTradeThunkMock',
                         payload: expect.objectContaining({

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
@@ -204,6 +204,8 @@ describe('useBuyQuotes', () => {
         const store = await getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
         const { result, rerender } = await renderUseBuyQuotes(store);
+        dispatchSpy.mockClear();
+
         act(() => {
             result.current.setValue('asset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -191,6 +191,7 @@ describe('useExchangeSelectQuote', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
 
             const { result } = await renderUseExchangeSelectQuote();
+            dispatchSpy.mockClear();
 
             act(() => {
                 result.current.selectQuote();
@@ -225,6 +226,7 @@ describe('useExchangeSelectQuote', () => {
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             const { result } = await renderUseExchangeSelectQuote();
+            dispatchSpy.mockClear();
 
             act(() => {
                 result.current.selectQuote();
@@ -253,6 +255,7 @@ describe('useExchangeSelectQuote', () => {
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             const { result } = await renderUseExchangeSelectQuote();
+            dispatchSpy.mockClear();
 
             act(() => {
                 result.current.selectQuote();
@@ -277,6 +280,7 @@ describe('useExchangeSelectQuote', () => {
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             const { result } = await renderUseExchangeSelectQuote();
+            dispatchSpy.mockClear();
 
             act(() => {
                 result.current.selectQuote();
@@ -307,6 +311,7 @@ describe('useExchangeSelectQuote', () => {
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             const { result } = await renderUseExchangeSelectQuote();
+            dispatchSpy.mockClear();
 
             act(() => {
                 result.current.selectQuote();
@@ -338,6 +343,7 @@ describe('useExchangeSelectQuote', () => {
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             const { result } = await renderUseExchangeSelectQuote();
+            dispatchSpy.mockClear();
 
             act(() => {
                 result.current.selectQuote();

--- a/suite-native/module-trading/src/hooks/general/__tests__/useQuotesInvalidator.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useQuotesInvalidator.test.ts
@@ -131,7 +131,7 @@ describe('useQuotesInvalidator', () => {
                 anyQuotesLoaded: false,
             });
 
-            expect(dispatchSpy).not.toHaveBeenCalled();
+            expect(dispatchSpy).not.toHaveBeenCalledWith({ type: 'clearStateAction' });
         });
 
         it('should not dispatch clear request when form is valid', async () => {
@@ -141,7 +141,7 @@ describe('useQuotesInvalidator', () => {
                 anyQuotesLoaded: true,
             });
 
-            expect(dispatchSpy).not.toHaveBeenCalled();
+            expect(dispatchSpy).not.toHaveBeenCalledWith({ type: 'clearStateAction' });
         });
     });
 

--- a/suite-native/module-trading/src/screens/__tests__/TradingScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingScreen.comp.test.tsx
@@ -76,6 +76,10 @@ const stateWithDisabledTrading = {
                                 domain: 'trading.exchange',
                                 flag: false,
                             },
+                            {
+                                domain: 'trading.sell',
+                                flag: false,
+                            },
                         ],
                     },
                 },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed some of failing trading tests (`@suite-native/module-trading` - `yarn test:unit:memory-heavy`)

## Notes for QA

Nothing to test.



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-mobile-trading-tests&lookback=7)