### PR TITLE
Small TPN fixes

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -9,7 +9,6 @@ import {
 } from '@trezor/protocol';
 import { Session, TRANSPORT, TRANSPORT_ERROR } from '@trezor/transport';
 import { type Descriptor, type Transport } from '@trezor/transport';
-import { OpenDeviceChannel } from '@trezor/transport/src/api/abstract';
 import { TransportDeviceEvent } from '@trezor/transport/src/transports/abstract';
 import { Deferred, TypedEmitter, createDeferred, isArrayMember, versionUtils } from '@trezor/utils';
 
@@ -147,11 +146,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
      * with and user needs to take some action. for example reconnect the device, update firmware or change transport type
      */
     private unreadableError?: string;
-
-    private channels: Record<Exclude<OpenDeviceChannel, 'read'>, boolean> = {
-        'battery-level': false,
-        'trezor-push-notification': false,
-    };
 
     // @ts-expect-error: strictPropertyInitialization
     private _firmwareStatus: DeviceFirmwareStatus;
@@ -347,7 +341,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this.busy = value;
     }
 
-    subscribe() {
+    private subscribe() {
         if (this.descriptor.id && this.descriptor.apiType === 'bluetooth') {
             this.transport
                 .subscribe({
@@ -355,18 +349,17 @@ export class Device extends TypedEmitter<DeviceEvents> {
                     channels: ['battery-level', 'trezor-push-notification'],
                 })
                 .then(result => {
-                    if (result.success) {
-                        this.channels = result.payload;
-                        this.lifecycle.emit(DEVICE.CHANGED);
-                    }
+                    if (!result.success) return;
 
-                    if (this.channels['battery-level']) {
+                    this.lifecycle.emit(DEVICE.CHANGED);
+
+                    if (result.payload['battery-level']) {
                         this.transport.on('battery-level', event => {
                             this._updateFeature('soc', event.data[0]);
                             this.lifecycle.emit(DEVICE.CHANGED);
                         });
                     }
-                    if (this.channels['trezor-push-notification']) {
+                    if (result.payload['trezor-push-notification']) {
                         this.transport.on('trezor-push-notification', ({ id, data }) => {
                             if (id === this.descriptor.id) {
                                 trezorPushNotificationHandler({ device: this, message: data });

--- a/packages/connect/src/device/workflow/trezorPushNotification.ts
+++ b/packages/connect/src/device/workflow/trezorPushNotification.ts
@@ -1,9 +1,4 @@
-import {
-    type DecodedTrezorPushNotification,
-    TrezorPushNotificationMode,
-    TrezorPushNotificationType,
-    tpn,
-} from '@trezor/protocol';
+import { TrezorPushNotificationMode, TrezorPushNotificationType, tpn } from '@trezor/protocol';
 import { resolveAfter } from '@trezor/utils';
 
 import { DEVICE } from '../../events/device';
@@ -48,7 +43,12 @@ const setupDeviceMode = async (
 };
 
 export const trezorPushNotificationHandler = async ({ device, message }: TpnWorkflowContext) => {
-    const decoded: DecodedTrezorPushNotification = tpn.decode(message);
+    const decodedResult = tpn.decode(message);
+
+    if (!decodedResult.success) return;
+
+    const decoded = decodedResult.payload;
+
     device.lifecycle.emit(DEVICE.TREZOR_PUSH_NOTIFICATION, decoded);
 
     const { type, mode } = decoded;

--- a/packages/protocol/src/protocol-tpn/decode.ts
+++ b/packages/protocol/src/protocol-tpn/decode.ts
@@ -30,23 +30,20 @@ export interface DecodedTrezorPushNotification {
     mode: TrezorPushNotificationMode;
 }
 
-export const decode = (message: number[]): DecodedTrezorPushNotification => {
+export const decode = (message: number[]) => {
     const [version, type, mode] = message;
     if (!version || version !== TPN_VERSION) {
-        throw new Error(PROTOCOL_MISSMATCH_VERSION);
+        return { success: false, error: PROTOCOL_MISSMATCH_VERSION } as const;
     }
 
     if (
-        message.length !== MESSAGE_LENGTH ||
+        message.length < MESSAGE_LENGTH ||
         !Object.values(Version).includes(version) ||
         !Object.values(TrezorPushNotificationType).includes(type) ||
         !Object.values(TrezorPushNotificationMode).includes(mode)
     ) {
-        throw new Error(PROTOCOL_MALFORMED);
+        return { success: false, error: PROTOCOL_MALFORMED } as const;
     }
 
-    return {
-        type,
-        mode,
-    };
+    return { success: true, payload: { type, mode } } as const;
 };

--- a/packages/protocol/tests/protocol-tpn.test.ts
+++ b/packages/protocol/tests/protocol-tpn.test.ts
@@ -13,10 +13,12 @@ describe('protocol-tpn', () => {
                 TrezorPushNotificationType.BOOT,
                 TrezorPushNotificationMode.NormalMode,
             ];
-            const result = tpn.decode(message);
-            expect(result).toEqual({
-                type: TrezorPushNotificationType.BOOT,
-                mode: TrezorPushNotificationMode.NormalMode,
+            expect(tpn.decode(message)).toEqual({
+                success: true,
+                payload: {
+                    type: TrezorPushNotificationType.BOOT,
+                    mode: TrezorPushNotificationMode.NormalMode,
+                },
             });
         });
 
@@ -26,40 +28,56 @@ describe('protocol-tpn', () => {
                 TrezorPushNotificationType.LOCK,
                 TrezorPushNotificationMode.BootloaderMode,
             ];
-            const result = tpn.decode(message);
-            expect(result).toEqual({
-                type: TrezorPushNotificationType.LOCK,
-                mode: TrezorPushNotificationMode.BootloaderMode,
+            expect(tpn.decode(message)).toEqual({
+                success: true,
+                payload: {
+                    type: TrezorPushNotificationType.LOCK,
+                    mode: TrezorPushNotificationMode.BootloaderMode,
+                },
             });
         });
 
-        it('should throw a protocol error for messages with incorrect version', () => {
+        it('should return a protocol error for messages with incorrect version', () => {
             const invalidVersionMessage = [
                 99,
                 TrezorPushNotificationType.BOOT,
                 TrezorPushNotificationMode.BootloaderMode,
             ];
-
-            expect(() => tpn.decode(invalidVersionMessage)).toThrow(PROTOCOL_MISSMATCH_VERSION);
+            expect(tpn.decode(invalidVersionMessage)).toEqual({
+                success: false,
+                error: PROTOCOL_MISSMATCH_VERSION,
+            });
         });
 
-        it('should throw a protocol error for messages with incorrect length', () => {
+        it('should correctly decode longer message but return a protocol error for shorter message', () => {
             const shortMessage = [1, 0];
             const longMessage = [1, 0, 1, 99];
 
-            expect(() => tpn.decode(shortMessage)).toThrow(PROTOCOL_MALFORMED);
-            expect(() => tpn.decode(longMessage)).toThrow(PROTOCOL_MALFORMED);
+            expect(tpn.decode(shortMessage)).toEqual({ success: false, error: PROTOCOL_MALFORMED });
+            expect(tpn.decode(longMessage)).toEqual({
+                success: true,
+                payload: {
+                    type: TrezorPushNotificationType.BOOT,
+                    mode: TrezorPushNotificationMode.BootloaderMode,
+                },
+            });
         });
 
-        it('should throw a protocol error for an unknown notification type', () => {
+        it('should return a protocol error for an unknown notification type', () => {
             const messageWithInvalidType = [Version.v1, 99, TrezorPushNotificationMode.NormalMode];
 
-            expect(() => tpn.decode(messageWithInvalidType)).toThrow(PROTOCOL_MALFORMED);
+            expect(tpn.decode(messageWithInvalidType)).toEqual({
+                success: false,
+                error: PROTOCOL_MALFORMED,
+            });
         });
 
-        it('should throw a protocol error for an unknown mode', () => {
+        it('should return a protocol error for an unknown mode', () => {
             const messageWithInvalidMode = [Version.v1, TrezorPushNotificationType.BOOT, 99];
-            expect(() => tpn.decode(messageWithInvalidMode)).toThrow(PROTOCOL_MALFORMED);
+            expect(tpn.decode(messageWithInvalidMode)).toEqual({
+                success: false,
+                error: PROTOCOL_MALFORMED,
+            });
         });
     });
 });


### PR DESCRIPTION
## Description

a) Stop remembering unused `channels` on device
b) Don't throw when unknown notification comes from THP; it caused a lot of `Malformed protocol format` errors in Sentry just because device knew more notification types than Suite

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tpn&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tpn&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tpn&lookback=7)