### PR TITLE
Fix incorrect rounding of the maximum unstaking fiat value

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
@@ -171,7 +171,11 @@ export const UnstakeInputs = () => {
                                     symbol={symbol}
                                 />
                                 <Text typographyStyle="hint">
-                                    <BaseCurrencyValue amount={depositedBalance} symbol={symbol}>
+                                    <BaseCurrencyValue
+                                        amount={depositedBalance}
+                                        symbol={symbol}
+                                        fiatAmountFormatterOptions={{ roundingMode: 'floor' }}
+                                    >
                                         {({ value }) => value && <span>{value}</span>}
                                     </BaseCurrencyValue>
                                     {isRewardsVisible && (

--- a/packages/suite/src/hooks/wallet/useUnstakeForm.ts
+++ b/packages/suite/src/hooks/wallet/useUnstakeForm.ts
@@ -204,7 +204,10 @@ export const useUnstakeForm = ({ selectedAccount }: UseUnstakeFormsProps): Unsta
     const onCryptoAmountChange = useCallback(
         async (amount: string) => {
             if (currentRate) {
-                const fiatValue = toFiatCurrency({ amount, rate: currentRate?.rate })?.toFixed(2);
+                const fiatValue = toFiatCurrency({ amount, rate: currentRate?.rate })?.toFixed(
+                    2,
+                    BigNumber.ROUND_FLOOR,
+                );
                 setValue(FIAT_INPUT, fiatValue || '', {
                     shouldDirty: true,
                     shouldValidate: true,


### PR DESCRIPTION
## Description

Previously, the value was rounded using `toFixed(2)` default behavior, which could produce a number higher than the actual maximum available for unstaking (e.g. **23.46700604763 → 23.47**).

Switched to `toFixed(2, BigNumber.ROUND_FLOOR)` so the value is always rounded down and never exceeds the maximum amount the user can unstake.

Also updated the Max button tooltip to use the same rounding logic for consistency.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23526


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/max-staking-fiat-rounding-down&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/max-staking-fiat-rounding-down&lookback=7)