### PR TITLE
fix(suite-native): add shims for Set needed for evolu

### DIFF
--- a/scripts/list-outdated-dependencies/foundation-dependencies.txt
+++ b/scripts/list-outdated-dependencies/foundation-dependencies.txt
@@ -64,6 +64,13 @@ react-native-ble-plx
 react-native-mmkv
 react-freeze
 react-native-nitro-modules
+set.prototype.difference
+set.prototype.intersection
+set.prototype.isdisjointfrom
+set.prototype.issubsetof
+set.prototype.issupersetof
+set.prototype.symmetricdifference
+set.prototype.union
 sort-package-json
 terser-webpack-plugin
 typescript-eslint

--- a/suite-native/app/globalPolyfills.js
+++ b/suite-native/app/globalPolyfills.js
@@ -6,6 +6,14 @@ import { install } from 'react-native-quick-crypto';
 import { CustomEvent } from '@whatwg-node/events'; // to work with @solana/kit
 import { Event, EventTarget } from 'event-target-shim'; // to work with @solana/kit
 import 'abortcontroller-polyfill/dist/polyfill-patch-fetch'; // to work with @solana/kit
+// Shimming Set prototype methods
+import difference from 'set.prototype.difference';
+import intersection from 'set.prototype.intersection';
+import isDisjointFrom from 'set.prototype.isdisjointfrom';
+import isSubsetOf from 'set.prototype.issubsetof';
+import isSupersetOf from 'set.prototype.issupersetof';
+import symmetricDifference from 'set.prototype.symmetricdifference';
+import union from 'set.prototype.union';
 
 // Event, EventTarget and CustomEvent are needed for @solana/kit to work
 globalThis.Event = Event;
@@ -22,6 +30,14 @@ install();
 
 // The Buffer implementation from react-native-quick-crypto is not compatible with Trezor Connect.
 global.Buffer = require('buffer').Buffer;
+
+difference.shim();
+intersection.shim();
+isDisjointFrom.shim();
+isSubsetOf.shim();
+isSupersetOf.shim();
+symmetricDifference.shim();
+union.shim();
 
 global.process = {
     ...require('process'),

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -146,7 +146,14 @@
         "react-native-webview": "13.16.0",
         "react-native-worklets": "^0.5.2",
         "react-redux": "9.2.0",
-        "redux-persist": "6.0.0"
+        "redux-persist": "6.0.0",
+        "set.prototype.difference": "^1.1.7",
+        "set.prototype.intersection": "^1.1.7",
+        "set.prototype.isdisjointfrom": "^1.1.5",
+        "set.prototype.issubsetof": "^1.1.4",
+        "set.prototype.issupersetof": "^1.1.3",
+        "set.prototype.symmetricdifference": "^1.1.3",
+        "set.prototype.union": "^1.1.3"
     },
     "devDependencies": {
         "@babel/core": "7.28.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11469,6 +11469,13 @@ __metadata:
     react-native-worklets: "npm:^0.5.2"
     react-redux: "npm:9.2.0"
     redux-persist: "npm:6.0.0"
+    set.prototype.difference: "npm:^1.1.7"
+    set.prototype.intersection: "npm:^1.1.7"
+    set.prototype.isdisjointfrom: "npm:^1.1.5"
+    set.prototype.issubsetof: "npm:^1.1.4"
+    set.prototype.issupersetof: "npm:^1.1.3"
+    set.prototype.symmetricdifference: "npm:^1.1.3"
+    set.prototype.union: "npm:^1.1.3"
     ts-jest: "npm:29.4.1"
     ts-node: "npm:^10.9.2"
     typescript: "npm:5.8.3"
@@ -18518,6 +18525,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async-function@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "async-function@npm:1.0.0"
+  checksum: 10/1a09379937d846f0ce7614e75071c12826945d4e417db634156bf0e4673c495989302f52186dfa9767a1d9181794554717badd193ca2bbab046ef1da741d8efd
+  languageName: node
+  linkType: hard
+
+"async-generator-function@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "async-generator-function@npm:1.0.0"
+  checksum: 10/3d49e7acbeee9e84537f4cb0e0f91893df8eba976759875ae8ee9e3d3c82f6ecdebdb347c2fad9926b92596d93cdfc78ecc988bcdf407e40433e8e8e6fe5d78e
+  languageName: node
+  linkType: hard
+
 "async-limiter@npm:~1.0.0":
   version: 1.0.1
   resolution: "async-limiter@npm:1.0.1"
@@ -23754,6 +23775,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-get-iterator@npm:^1.0.2, es-get-iterator@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "es-get-iterator@npm:1.1.3"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    get-intrinsic: "npm:^1.1.3"
+    has-symbols: "npm:^1.0.3"
+    is-arguments: "npm:^1.1.1"
+    is-map: "npm:^2.0.2"
+    is-set: "npm:^2.0.2"
+    is-string: "npm:^1.0.7"
+    isarray: "npm:^2.0.5"
+    stop-iteration-iterator: "npm:^1.0.0"
+  checksum: 10/bc2194befbe55725f9489098626479deee3c801eda7e83ce0dff2eb266a28dc808edb9b623ff01d31ebc1328f09d661333d86b601036692c2e3c1a6942319433
+  languageName: node
+  linkType: hard
+
 "es-iterator-helpers@npm:^1.2.1":
   version: 1.2.1
   resolution: "es-iterator-helpers@npm:1.2.1"
@@ -23775,6 +23813,25 @@ __metadata:
     iterator.prototype: "npm:^1.1.4"
     safe-array-concat: "npm:^1.1.3"
   checksum: 10/802e0e8427a05ff4a5b0c70c7fdaaeff37cdb81a28694aeb7bfb831c6ab340d8f3deeb67b96732ff9e9699ea240524d5ea8a9a6a335fcd15aa3983b27b06113f
+  languageName: node
+  linkType: hard
+
+"es-map@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "es-map@npm:1.0.6"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.3"
+    es-get-iterator: "npm:^1.1.3"
+    es-set-tostringtag: "npm:^2.0.3"
+    for-each: "npm:^0.3.3"
+    get-intrinsic: "npm:^1.2.4"
+    globalthis: "npm:^1.0.4"
+    has-symbols: "npm:^1.0.3"
+    internal-slot: "npm:^1.0.7"
+    object.entries: "npm:^1.1.8"
+  checksum: 10/db975222eacceeabeb3294bcb672352e0afe2d0ea4916c78dfc63fb09b094f9a59596284a65387c6fd4849b235b9d07586d235490f1e3b62b9bcb3edeb5880c0
   languageName: node
   linkType: hard
 
@@ -23803,6 +23860,30 @@ __metadata:
     has-tostringtag: "npm:^1.0.2"
     hasown: "npm:^2.0.2"
   checksum: 10/86814bf8afbcd8966653f731415888019d4bc4aca6b6c354132a7a75bb87566751e320369654a101d23a91c87a85c79b178bcf40332839bd347aff437c4fb65f
+  languageName: node
+  linkType: hard
+
+"es-set@npm:^1.1.1, es-set@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "es-set@npm:1.1.2"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.3"
+    es-map: "npm:^1.0.6"
+    es-set-tostringtag: "npm:^2.0.3"
+    for-each: "npm:^0.3.3"
+    functions-have-names: "npm:^1.2.3"
+    get-intrinsic: "npm:^1.2.4"
+    globalthis: "npm:^1.0.4"
+    gopd: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.2"
+    has-symbols: "npm:^1.0.3"
+    internal-slot: "npm:^1.0.7"
+    iterate-value: "npm:^1.0.2"
+    object.entries: "npm:^1.1.8"
+    stop-iteration-iterator: "npm:^1.0.0"
+  checksum: 10/56d56897e51cd6729d53c79377723bc29ac0afa9a8278256da1d297f48f05d921834b32885d6b0def7e90c10a70b9075a4e20e4b9b8eb1a4db054f97f482835f
   languageName: node
   linkType: hard
 
@@ -26796,6 +26877,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"generator-function@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "generator-function@npm:2.0.1"
+  checksum: 10/eb7e7eb896c5433f3d40982b2ccacdb3dd990dd3499f14040e002b5d54572476513be8a2e6f9609f6e41ab29f2c4469307611ddbfc37ff4e46b765c326663805
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -26817,21 +26905,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "get-intrinsic@npm:1.3.0"
+"get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
+  version: 1.3.1
+  resolution: "get-intrinsic@npm:1.3.1"
   dependencies:
+    async-function: "npm:^1.0.0"
+    async-generator-function: "npm:^1.0.0"
     call-bind-apply-helpers: "npm:^1.0.2"
     es-define-property: "npm:^1.0.1"
     es-errors: "npm:^1.3.0"
     es-object-atoms: "npm:^1.1.1"
     function-bind: "npm:^1.1.2"
+    generator-function: "npm:^2.0.0"
     get-proto: "npm:^1.0.1"
     gopd: "npm:^1.2.0"
     has-symbols: "npm:^1.1.0"
     hasown: "npm:^2.0.2"
     math-intrinsics: "npm:^1.1.0"
-  checksum: 10/6e9dd920ff054147b6f44cb98104330e87caafae051b6d37b13384a45ba15e71af33c3baeac7cb630a0aaa23142718dcf25b45cfdd86c184c5dcb4e56d953a10
+  checksum: 10/bb579dda84caa4a3a41611bdd483dade7f00f246f2a7992eb143c5861155290df3fdb48a8406efa3dfb0b434e2c8fafa4eebd469e409d0439247f85fc3fa2cc1
   languageName: node
   linkType: hard
 
@@ -28639,7 +28730,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"internal-slot@npm:^1.1.0":
+"internal-slot@npm:^1.0.7, internal-slot@npm:^1.1.0":
   version: 1.1.0
   resolution: "internal-slot@npm:1.1.0"
   dependencies:
@@ -28780,13 +28871,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-arguments@npm:^1.0.4":
-  version: 1.1.1
-  resolution: "is-arguments@npm:1.1.1"
+"is-arguments@npm:^1.0.4, is-arguments@npm:^1.1.1":
+  version: 1.2.0
+  resolution: "is-arguments@npm:1.2.0"
   dependencies:
-    call-bind: "npm:^1.0.2"
-    has-tostringtag: "npm:^1.0.0"
-  checksum: 10/a170c7e26082e10de9be6e96d32ae3db4d5906194051b792e85fae3393b53cf2cb5b3557863e5c8ccbab55e2fd8f2f75aa643d437613f72052cf0356615c34be
+    call-bound: "npm:^1.0.2"
+    has-tostringtag: "npm:^1.0.2"
+  checksum: 10/471a8ef631b8ee8829c43a8ab05c081700c0e25180c73d19f3bf819c1a8448c426a9e8e601f278973eca68966384b16ceb78b8c63af795b099cd199ea5afc457
   languageName: node
   linkType: hard
 
@@ -29040,7 +29131,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-map@npm:^2.0.3":
+"is-map@npm:^2.0.2, is-map@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-map@npm:2.0.3"
   checksum: 10/8de7b41715b08bcb0e5edb0fb9384b80d2d5bcd10e142188f33247d19ff078abaf8e9b6f858e2302d8d05376a26a55cd23a3c9f8ab93292b02fcd2cc9e4e92bb
@@ -29185,7 +29276,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-set@npm:^2.0.3":
+"is-set@npm:^2.0.2, is-set@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-set@npm:2.0.3"
   checksum: 10/5685df33f0a4a6098a98c72d94d67cad81b2bc72f1fb2091f3d9283c4a1c582123cd709145b02a9745f0ce6b41e3e43f1c944496d1d74d4ea43358be61308669
@@ -29499,6 +29590,23 @@ __metadata:
     html-escaper: "npm:^2.0.0"
     istanbul-lib-report: "npm:^3.0.0"
   checksum: 10/135c178e509b21af5c446a6951fc01c331331bb0fdb1ed1dd7f68a8c875603c2e2ee5c82801db5feb868e5cc35e9babe2d972d322afc50f6de6cce6431b9b2ff
+  languageName: node
+  linkType: hard
+
+"iterate-iterator@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "iterate-iterator@npm:1.0.2"
+  checksum: 10/3528a3668eb9c146bcda4f616166cfa8e49e01e8302ffcfc7b4c923f9862a20d9dc4e3336c8517695bea22036686fde98a43718718ce188d1fead4dc1603a94f
+  languageName: node
+  linkType: hard
+
+"iterate-value@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "iterate-value@npm:1.0.2"
+  dependencies:
+    es-get-iterator: "npm:^1.0.2"
+    iterate-iterator: "npm:^1.0.1"
+  checksum: 10/fc426ba672e8ef9bec471fb1990a0914c9c3640d64bfc365068ea17ec537388058942b896adc29c9151d8c99e745dcfe2c5e3161475c040d5228dd2c6856a24d
   languageName: node
   linkType: hard
 
@@ -35948,7 +36056,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.entries@npm:^1.1.9":
+"object.entries@npm:^1.1.8, object.entries@npm:^1.1.9":
   version: 1.1.9
   resolution: "object.entries@npm:1.1.9"
   dependencies:
@@ -40917,6 +41025,114 @@ __metadata:
   languageName: node
   linkType: hard
 
+"set.prototype.difference@npm:^1.1.7":
+  version: 1.1.7
+  resolution: "set.prototype.difference@npm:1.1.7"
+  dependencies:
+    call-bind: "npm:^1.0.8"
+    call-bound: "npm:^1.0.4"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.9"
+    es-errors: "npm:^1.3.0"
+    es-set: "npm:^1.1.2"
+    is-set: "npm:^2.0.3"
+    stop-iteration-iterator: "npm:^1.1.0"
+  checksum: 10/5e5c95c56cab2bcd11ea09eb34332720d7d88ecb8a992cefa3f339db70ca1a7bf60c0f927da63d6973f0c8a4de97ef9bd5b284cee814014900f1ef7e6204a4df
+  languageName: node
+  linkType: hard
+
+"set.prototype.intersection@npm:^1.1.7":
+  version: 1.1.7
+  resolution: "set.prototype.intersection@npm:1.1.7"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.3"
+    es-errors: "npm:^1.3.0"
+    es-set: "npm:^1.1.1"
+    is-set: "npm:^2.0.3"
+    stop-iteration-iterator: "npm:^1.0.0"
+  checksum: 10/5f60022ed31d68770e3431db881b29ebb69c609b9dc7cf8b3561099e2d61a4b18e623819ca86f6c6962b755e8a25f78fccca0a4b9a1f521c337ccd812af73081
+  languageName: node
+  linkType: hard
+
+"set.prototype.isdisjointfrom@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "set.prototype.isdisjointfrom@npm:1.1.5"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.3"
+    es-errors: "npm:^1.3.0"
+    es-set: "npm:^1.1.1"
+    is-set: "npm:^2.0.3"
+    stop-iteration-iterator: "npm:^1.0.0"
+  checksum: 10/33e35ab2e6c9d1015b0f42d95bd3edc3561016152c7e44614f304b078edc6a14049bfc25f29ff6d0b6f065ca30efd8120bb95b0f230d3cbc1c625160158ed612
+  languageName: node
+  linkType: hard
+
+"set.prototype.issubsetof@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "set.prototype.issubsetof@npm:1.1.4"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.3"
+    es-errors: "npm:^1.3.0"
+    es-set: "npm:^1.1.1"
+    is-set: "npm:^2.0.3"
+    stop-iteration-iterator: "npm:^1.0.0"
+  checksum: 10/c9ca470b9e5a4af69821efaf3a06412f3f05fea85d09ba4d8e6b2c883d8fab011aac37ce0e82c6459ce2382ca9d594da57824b7df77a018fe49b5eac018d7295
+  languageName: node
+  linkType: hard
+
+"set.prototype.issupersetof@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "set.prototype.issupersetof@npm:1.1.3"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.3"
+    es-errors: "npm:^1.3.0"
+    es-set: "npm:^1.1.1"
+    is-set: "npm:^2.0.3"
+    stop-iteration-iterator: "npm:^1.0.0"
+  checksum: 10/d92d90f86c369ab0803bf91457b5e9deb772f5e187f8f410330487a17fab54ce912de6b32dc7fb631de5ad1dc349c805d62f40f082cf04a7f6f9d2c8425943fa
+  languageName: node
+  linkType: hard
+
+"set.prototype.symmetricdifference@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "set.prototype.symmetricdifference@npm:1.1.3"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.3"
+    es-errors: "npm:^1.3.0"
+    es-set: "npm:^1.1.1"
+    is-set: "npm:^2.0.3"
+    stop-iteration-iterator: "npm:^1.0.0"
+  checksum: 10/26d2b79b4967433b55debe88b4c686494d67605af97b8d3327104688e90e0ef1a67a3debe167af6faca5318e5e4abf24a31f20efaa8e49fdc4996e489fae34d6
+  languageName: node
+  linkType: hard
+
+"set.prototype.union@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "set.prototype.union@npm:1.1.3"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.3"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.0.0"
+    es-set: "npm:^1.1.1"
+    get-intrinsic: "npm:^1.2.4"
+    is-set: "npm:^2.0.3"
+    stop-iteration-iterator: "npm:^1.0.0"
+  checksum: 10/943e6a1046fae202324c751eba3918c31fd2616c73fc303151196bdb71eeff7a954e41ee6452d362fda5928970fe492c7ceb4f3fea2e1c80f1b0ab3f64ad446c
+  languageName: node
+  linkType: hard
+
 "setimmediate@npm:^1.0.4, setimmediate@npm:^1.0.5":
   version: 1.0.5
   resolution: "setimmediate@npm:1.0.5"
@@ -41886,7 +42102,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stop-iteration-iterator@npm:^1.1.0":
+"stop-iteration-iterator@npm:^1.0.0, stop-iteration-iterator@npm:^1.1.0":
   version: 1.1.0
   resolution: "stop-iteration-iterator@npm:1.1.0"
   dependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

see https://github.com/evoluhq/evolu/commit/c11bb3973c7d0faea283c56b997a738d0e5cca61

Those polyfills should ideally be inlined in evolu in the future. 

## Notes for QA

Suite Sync should be working again

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23599



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/add-set-polyfills&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/add-set-polyfills&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/add-set-polyfills&lookback=7)