### PR TITLE
chore(suite-native): Hotfix trading footer in czech translation

### DIFF
--- a/suite-native/intl/translations/cs-CZ.json
+++ b/suite-native/intl/translations/cs-CZ.json
@@ -1175,7 +1175,7 @@
     "moduleTrading.tradingScreen.quotesLoadingLabel": "Načítání nabídek...",
     "moduleTrading.tradingScreen.rate": "Kurz",
     "moduleTrading.tradingScreen.selectedRate": "Zvolený kurz",
-    "moduleTrading.tradingScreen.footer.learnMore": "Více informací",
+    "moduleTrading.tradingScreen.footer.learnMore": "Více informací",
     "moduleTrading.tradingScreen.balance": "Zůstatek:",
     "moduleTrading.tradingScreen.providerOffer": "Nabídka poskytovatele: {amount}",
     "moduleTrading.tradingScreen.tabs.buy": "Koupit",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes strange behavior of trading footer link.

Translation in CrowdIn fixed as well.

<!--- Describe your changes in detail -->

## Notes for QA
We want to have nice trading footer for all languages. (problem was only in czech translation)

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

### Before

<img width="401"  alt="1000021938" src="https://github.com/user-attachments/assets/3397e770-700f-470e-8d55-a6423ab7b124" />
<img width="401" height="151" alt="Screenshot 2025-12-04 at 11 27 29" src="https://github.com/user-attachments/assets/3c79ffb1-a010-46a1-9eb8-e533032a3f85" />

### After

<img width="403" height="113" alt="Screenshot 2025-12-04 at 11 27 15" src="https://github.com/user-attachments/assets/1d6814b6-2358-4633-a16d-2e1b3e5c56f5" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=trading-footer-hotfix&lookback=7)