### PR TITLE
chore(suite): remove unused `wallet.blockchain.explorer`

### DIFF
--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -631,7 +631,6 @@ const intlMock = {
 const mockedBlockchainNetworks = networksCollection.reduce((result, network) => {
     result[network.symbol] = {
         connected: false,
-        explorer: network.explorer,
         blockHash: '0',
         blockHeight: 0,
         version: '0',

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -38,7 +38,6 @@ export const blockchainInitialState: BlockchainNetworks = networksCollection.red
     (state, network) => {
         state[network.symbol] = {
             connected: false,
-            explorer: network.explorer,
             blockHash: '0',
             blockHeight: 0,
             version: '0',
@@ -86,48 +85,8 @@ const connect = (draft: BlockchainState, info: BlockchainInfo) => {
         return;
     }
 
-    const isHttp = isHttpProtocol(info.url); // can use dynamic backend url settings
-
-    // solana rpc nodes and stellar horizon nodes do not have explorer, so we cannot use backend as explorer
-    const isBackendAlsoExplorer =
-        network.networkType !== 'solana' && network.networkType !== 'stellar';
-
-    const useBackendAsExplorer = isHttp && isBackendAlsoExplorer;
-
     draft[network.symbol] = {
         url: info.url,
-        explorer: {
-            base: `${
-                useBackendAsExplorer
-                    ? info.url + getBlockExplorerUrlSuffix(network.explorer.base)
-                    : network.explorer.base
-            }`,
-            tx: `${
-                useBackendAsExplorer
-                    ? info.url + getBlockExplorerUrlSuffix(network.explorer.tx)
-                    : network.explorer.tx
-            }`,
-            queryString: network.explorer.queryString,
-            nft: network.explorer.nft
-                ? `${
-                      isHttp
-                          ? info.url + getBlockExplorerUrlSuffix(network.explorer.nft)
-                          : network.explorer.nft
-                  }`
-                : undefined,
-            address: `${
-                isHttp
-                    ? info.url + getBlockExplorerUrlSuffix(network.explorer.address)
-                    : network.explorer.address
-            }`,
-            token: network.explorer.token
-                ? `${
-                      isHttp
-                          ? info.url + getBlockExplorerUrlSuffix(network.explorer.token)
-                          : network.explorer.token
-                  }`
-                : undefined,
-        },
         connected: true,
         blockHash: info.blockHash,
         blockHeight: info.blockHeight,
@@ -152,7 +111,6 @@ const error = (draft: BlockchainState, payload: BlockchainError) => {
         draft[network.symbol] = {
             ...draft[network.symbol],
             connected: false,
-            explorer: network.explorer,
             error,
         };
         delete draft[network.symbol].url;

--- a/suite-common/wallet-types/src/backend.ts
+++ b/suite-common/wallet-types/src/backend.ts
@@ -1,4 +1,4 @@
-import { BackendType, Explorer, NetworkSymbol } from '@suite-common/wallet-config';
+import { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
 import { TimerId } from '@trezor/type-utils';
 
 /**
@@ -31,7 +31,6 @@ export interface ConnectionStatus {
 
 export interface Blockchain extends ConnectionStatus {
     url?: string;
-    explorer: Explorer;
     blockHash: string;
     blockHeight: number;
     version: string;


### PR DESCRIPTION
## Description

Removed unused `wallet.blockchain.explorer` from Redux.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22141


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-explorer-code&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-explorer-code&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/remove-unused-explorer-code&lookback=7)