### PR TITLE
Move Testnets into Experimental Features

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -21,7 +21,10 @@ import { Translation } from 'src/components/suite/Translation';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsPublic } from 'src/reducers/wallet/coinjoinReducer';
-import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
+import {
+    selectHasExperimentalFeature,
+    selectIsDebugModeActive,
+} from 'src/selectors/suite/suiteSelectors';
 import { TrezorDevice } from 'src/types/suite';
 import { Account } from 'src/types/wallet';
 
@@ -61,6 +64,7 @@ export const AddAccountModal = ({
     const isDebug = useSelector(selectIsDebugModeActive);
     const isCoinjoinPublic = useSelector(selectIsPublic);
     const enabledNetworkSymbols = useSelector(selectEnabledNetworks);
+    const useTestnetNetworks = useSelector(selectHasExperimentalFeature('testnet-networks'));
     const dispatch = useDispatch();
 
     const { showUnsupportedCoins, supportedMainnets, unsupportedMainnets, supportedTestnets } =
@@ -323,7 +327,7 @@ export const AddAccountModal = ({
                                   handleNetworkSelection={selectNetwork}
                               />
                           </NetworksWrapper>
-                          {!symbol && !!disabledTestnetNetworks.length && (
+                          {!symbol && !!disabledTestnetNetworks.length && useTestnetNetworks && (
                               <CollapsibleBox
                                   heading={
                                       <Tooltip

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -3,7 +3,13 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { Network, NetworkAccount, NetworkSymbol, networks } from '@suite-common/wallet-config';
+import {
+    Network,
+    NetworkAccount,
+    NetworkSymbol,
+    getNetwork,
+    networks,
+} from '@suite-common/wallet-config';
 import {
     accountsActions,
     changeCoinVisibility,
@@ -18,6 +24,7 @@ import { arrayPartition } from '@trezor/utils';
 import { goto } from 'src/actions/suite/routerActions';
 import { CoinList } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { useAvailableNetworkSymbols } from 'src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsPublic } from 'src/reducers/wallet/coinjoinReducer';
@@ -92,9 +99,14 @@ export const AddAccountModal = ({
 
     const isSelectedNetworkEnabled =
         !!selectedNetwork && enabledNetworkSymbols.includes(selectedNetwork.symbol);
-    const [enabledNetworks, disabledNetworks] = arrayPartition(supportedNetworks, network =>
-        enabledNetworkSymbols.includes(network.symbol),
+
+    const availableNetworksSymbols = useAvailableNetworkSymbols();
+
+    const enabledNetworks = availableNetworksSymbols.map(symbol => getNetwork(symbol));
+    const disabledNetworks = supportedNetworks.filter(
+        network => !availableNetworksSymbols.includes(network.symbol),
     );
+
     const [disabledMainnetNetworks, disabledTestnetNetworks] = arrayPartition(
         disabledNetworks,
         network => !network?.testnet,

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols.ts
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols.ts
@@ -1,3 +1,4 @@
+import { getNetwork } from '@suite-common/wallet-config';
 import { selectEnabledNetworks } from '@suite-common/wallet-core';
 
 import { useNetworkSupport } from '../../../../hooks/settings/useNetworkSupport';
@@ -11,9 +12,12 @@ export const useAvailableNetworkSymbols = () => {
         network => network.symbol,
     );
 
-    const availableNetworksSymbols = enabledNetworks.filter(networkSymbol =>
-        supportedNetworkSymbols.includes(networkSymbol),
-    );
+    const availableNetworksSymbols = enabledNetworks.filter(networkSymbol => {
+        // if the testnet is enabled, show it even though testnets are disabled in experimental features
+        const isTestnet = getNetwork(networkSymbol).testnet;
+
+        return isTestnet || supportedNetworkSymbols.includes(networkSymbol);
+    });
 
     return availableNetworksSymbols;
 };

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -15,6 +15,7 @@ const experimentalNetworkNames = experimentalNetworks.map(network => network.nam
 export type ExperimentalFeature =
     | 'password-manager'
     | 'tor-external'
+    | 'testnet-networks'
     | 'nft-section'
     | 'experimental-networks';
 // | 'suite-sync';
@@ -49,6 +50,10 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
                 });
             }
         },
+    },
+    'testnet-networks': {
+        title: { id: 'TR_EXPERIMENTAL_TESTNET_NETWORKS' },
+        description: { id: 'TR_EXPERIMENTAL_TESTNET_NETWORKS_DESCRIPTION' },
     },
     'nft-section': {
         title: { id: 'TR_EXPERIMENTAL_NFT_SECTION' },

--- a/packages/suite/src/hooks/settings/useNetworkSupport.ts
+++ b/packages/suite/src/hooks/settings/useNetworkSupport.ts
@@ -15,10 +15,11 @@ export const useNetworkSupport = () => {
     const useExperimentalNetworks = useSelector(
         selectHasExperimentalFeature('experimental-networks'),
     );
+    const useTestnetNetworks = useSelector(selectHasExperimentalFeature('testnet-networks'));
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
 
-    const mainnets = getMainnets(isDebug, useExperimentalNetworks);
-    const testnets = getTestnets(isDebug, useExperimentalNetworks);
+    const mainnets = getMainnets({ debug: isDebug, useExperimentalNetworks });
+    const testnets = getTestnets({ debug: isDebug, useExperimentalNetworks, useTestnetNetworks });
 
     const isNetworkSupported = (network: Network) =>
         deviceSupportedNetworkSymbols.includes(network.symbol);

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5336,6 +5336,14 @@ export default defineMessages({
         defaultMessage:
             'Send and receive transactions on the {networkNames} {count, plural, one {network} other {networks}}.',
     },
+    TR_EXPERIMENTAL_TESTNET_NETWORKS: {
+        id: 'TR_EXPERIMENTAL_TESTNET_NETWORKS',
+        defaultMessage: 'Testnet networks',
+    },
+    TR_EXPERIMENTAL_TESTNET_NETWORKS_DESCRIPTION: {
+        id: 'TR_EXPERIMENTAL_TESTNET_NETWORKS_DESCRIPTION',
+        defaultMessage: 'Send and receive transactions on the testnet networks.',
+    },
     TR_EXPERIMENTAL_SUITE_SYNC_TITLE: {
         id: 'TR_EXPERIMENTAL_SUITE_SYNC_TITLE',
         defaultMessage: 'Suite Sync',

--- a/packages/suite/src/views/onboarding/steps/CoinsStep/CoinsStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/CoinsStep/CoinsStepBox.tsx
@@ -12,6 +12,7 @@ import { CoinGroup } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectHasExperimentalFeature } from 'src/selectors/suite/suiteSelectors';
 import { getIsTorEnabled } from 'src/utils/suite/tor';
 
 import { TorSection } from './TorSection';
@@ -23,6 +24,7 @@ export const CoinsStepBox = (props: OnboardingCardProps) => {
     const torStatus = useSelector(state => state.suite.torStatus);
     const dispatch = useDispatch();
     const isTorEnabled = getIsTorEnabled(torStatus);
+    const useTestnetNetworks = useSelector(selectHasExperimentalFeature('testnet-networks'));
 
     // BTC should be enabled by default
     useEffect(() => {
@@ -33,18 +35,20 @@ export const CoinsStepBox = (props: OnboardingCardProps) => {
         <OnboardingCard iconName="coins" {...props}>
             <Column gap={32}>
                 <CoinGroup networks={supportedMainnets} enabledNetworks={enabledNetworks} />
-                <CollapsibleBox
-                    heading={
-                        <Tooltip
-                            content={<Translation id="TR_TESTNET_COINS_DESCRIPTION" />}
-                            hasIcon
-                        >
-                            <Translation id="TR_TESTNET_COINS" />
-                        </Tooltip>
-                    }
-                >
-                    <CoinGroup networks={supportedTestnets} enabledNetworks={enabledNetworks} />
-                </CollapsibleBox>
+                {useTestnetNetworks && (
+                    <CollapsibleBox
+                        heading={
+                            <Tooltip
+                                content={<Translation id="TR_TESTNET_COINS_DESCRIPTION" />}
+                                hasIcon
+                            >
+                                <Translation id="TR_TESTNET_COINS" />
+                            </Tooltip>
+                        }
+                    >
+                        <CoinGroup networks={supportedTestnets} enabledNetworks={enabledNetworks} />
+                    </CollapsibleBox>
+                )}
                 {showUnsupportedCoins && (
                     <CollapsibleBox
                         heading={

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -22,7 +22,7 @@ import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanner
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDevice, useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
-import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
+import { selectHasExperimentalFeature, selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 import { isCoinjoinSupportedSymbol } from 'src/utils/wallet/coinjoinUtils';
 
 import { FirmwareTypeSuggestion } from './FirmwareTypeSuggestion';
@@ -85,6 +85,7 @@ export const SettingsCoins = () => {
     const isDiscoveryButtonVisible = useSelector(state =>
         selectShowRediscoverButton(state, device),
     );
+    const useTestnetNetworks = useSelector(selectHasExperimentalFeature('testnet-networks'));
 
     const supportedEnabledNetworks = enabledNetworks.filter(enabledNetwork =>
         deviceSupportedNetworkSymbols.includes(enabledNetwork),
@@ -132,15 +133,17 @@ export const SettingsCoins = () => {
                 </SettingsSectionItem>
             </SettingsSection>
 
-            <SettingsSection
-                tooltipText={<Translation id="TR_TESTNET_COINS_DESCRIPTION" />}
-                title={<Translation id="TR_TESTNET_COINS" />}
-                icon="coin"
-            >
-                <SettingsSectionItem anchorId={SettingsAnchor.TestnetCrypto}>
-                    <CoinGroup networks={supportedTestnets} enabledNetworks={enabledNetworks} />
-                </SettingsSectionItem>
-            </SettingsSection>
+            {useTestnetNetworks && (
+                <SettingsSection
+                    tooltipText={<Translation id="TR_TESTNET_COINS_DESCRIPTION" />}
+                    title={<Translation id="TR_TESTNET_COINS" />}
+                    icon="coin"
+                >
+                    <SettingsSectionItem anchorId={SettingsAnchor.TestnetCrypto}>
+                        <CoinGroup networks={supportedTestnets} enabledNetworks={enabledNetworks} />
+                    </SettingsSectionItem>
+                </SettingsSection>
+            )}
 
             {showUnsupportedCoins && (
                 <SettingsSection

--- a/suite-common/wallet-config/src/__tests__/utils.test.ts
+++ b/suite-common/wallet-config/src/__tests__/utils.test.ts
@@ -7,20 +7,36 @@ const mockNetworks = [bitcoin, ethereum, testnet, regtest];
 
 describe(getMainnets.name, () => {
     it('returns non-testnet, non-debug-only networks when debug is false', () => {
-        const result = getMainnets(false, false, mockNetworks);
+        const result = getMainnets({
+            allNetworks: mockNetworks,
+        });
         expect(result).toEqual([bitcoin, ethereum]);
     });
 });
 
 describe(getTestnets.name, () => {
     it('returns testnet, non-debug-only networks when debug is false', () => {
-        const result = getTestnets(false, false, mockNetworks);
+        const result = getTestnets({
+            useTestnetNetworks: true,
+            allNetworks: mockNetworks,
+        });
         expect(result).toEqual([testnet]);
     });
 
     it('includes all testnets when debug is true', () => {
-        const result = getTestnets(true, false, mockNetworks);
+        const result = getTestnets({
+            debug: true,
+            useTestnetNetworks: true,
+            allNetworks: mockNetworks,
+        });
         expect(result).toEqual([testnet, regtest]);
+    });
+
+    it('returns no testnets when testnet networks feature flag is disabled', () => {
+        const result = getTestnets({
+            allNetworks: mockNetworks,
+        });
+        expect(result).toEqual([]);
     });
 });
 

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -19,11 +19,17 @@ export const networksCollection: Network[] = Object.values(networks);
  */
 export const networkSymbolCollection = networksCollection.map(n => n.symbol);
 
-export const getMainnets = (
+interface GetMainnetsProps {
+    debug?: boolean;
+    useExperimentalNetworks?: boolean;
+    allNetworks?: Network[];
+}
+
+export const getMainnets = ({
     debug = false,
     useExperimentalNetworks = false,
     allNetworks = networksCollection,
-) =>
+}: GetMainnetsProps) =>
     allNetworks.filter(
         n =>
             !n.testnet &&
@@ -31,19 +37,28 @@ export const getMainnets = (
             (!n.isExperimentalOnlyNetwork || useExperimentalNetworks),
     );
 
-export const getTestnets = (
+interface GetTestnetsProps {
+    debug?: boolean;
+    useExperimentalNetworks?: boolean;
+    useTestnetNetworks?: boolean;
+    allNetworks?: Network[];
+}
+
+export const getTestnets = ({
     debug = false,
     useExperimentalNetworks = false,
+    useTestnetNetworks = false,
     allNetworks = networksCollection,
-) =>
+}: GetTestnetsProps) =>
     allNetworks.filter(
         n =>
             n.testnet === true &&
+            useTestnetNetworks &&
             (!n.isDebugOnlyNetwork || debug) &&
             (!n.isExperimentalOnlyNetwork || useExperimentalNetworks),
     );
 
-export const getTestnetSymbols = () => getTestnets().map(n => n.symbol);
+export const getTestnetSymbols = () => getTestnets({ useTestnetNetworks: true }).map(n => n.symbol);
 
 export const isBlockbookBasedNetwork = (symbol: NetworkSymbol) =>
     networks[symbol]?.backendTypes.some(backend => backend === 'blockbook');

--- a/suite/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/suite/e2e/support/pageObjects/settings/settingsPage.ts
@@ -249,6 +249,15 @@ export class SettingsPage {
     }
 
     @step()
+    async toggleTestnetNetworks() {
+        await this.navigateTo('application');
+        await this.page.getByTestId('@settings/experimental-features/toggle-switch').click();
+        await this.page
+            .getByTestId('@settings/experimental-features/testnet-networks-checkbox')
+            .click();
+    }
+
+    @step()
     async changeNetworks(options: {
         enableNetworks: NetworkSymbol[];
         disableNetworks?: NetworkSymbol[];

--- a/suite/e2e/tests/analytics/events.test.ts
+++ b/suite/e2e/tests/analytics/events.test.ts
@@ -146,6 +146,7 @@ test.describe('Analytics Events', { tag: ['@group=suite', '@webOnly'] }, () => {
             await settingsPage.changeFiatCurrency('czk');
             await settingsPage.changeBTCUnits('Satoshis');
             await settingsPage.changeTheme(Theme.Dark);
+            await settingsPage.toggleTestnetNetworks();
             await settingsPage.navigateTo('coins');
             await settingsPage.coins.enableNetwork('eth');
             await settingsPage.coins.enableNetwork('thod');
@@ -198,7 +199,7 @@ test.describe('Analytics Events', { tag: ['@group=suite', '@webOnly'] }, () => {
                 rememberedHiddenWallets: '0',
                 theme: 'dark',
                 earlyAccessProgram: 'false',
-                experimentalFeatures: '',
+                experimentalFeatures: 'testnet-networks',
                 autodetectLanguage: 'false',
                 autodetectTheme: 'false',
                 isAutomaticUpdateEnabled: 'false',

--- a/suite/e2e/tests/settings/coins.test.ts
+++ b/suite/e2e/tests/settings/coins.test.ts
@@ -42,6 +42,9 @@ test.describe('Coin Settings', { tag: ['@group=settings'] }, () => {
             ];
 
             await test.step('No assets are active', async () => {
+                await settingsPage.toggleTestnetNetworks();
+                await settingsPage.navigateTo('coins');
+
                 await expect(settingsPage.coins.networkButton('btc')).toBeEnabledCoin();
                 for (const network of defaultUnchecked) {
                     await expect(settingsPage.coins.networkButton(network)).toBeDisabledCoin();
@@ -62,6 +65,7 @@ test.describe('Coin Settings', { tag: ['@group=settings'] }, () => {
 
             await test.step('Activate assets', async () => {
                 await dashboardPage.discoveryEmptyPrimaryButton.click();
+                await settingsPage.navigateTo('coins');
                 for (const network of ['btc', ...defaultUnchecked] as NetworkSymbol[]) {
                     await settingsPage.coins.enableNetwork(network);
                 }

--- a/suite/e2e/tests/settings/electrum.test.ts
+++ b/suite/e2e/tests/settings/electrum.test.ts
@@ -29,6 +29,7 @@ test.describe(
                 });
                 const electrumUrl = '127.0.0.1:50001:t';
 
+                await settingsPage.toggleTestnetNetworks();
                 await settingsPage.navigateTo('coins');
                 await settingsPage.coins.openNetworkAdvanceSettings('regtest');
                 await settingsPage.coins.changeBackend('electrum', electrumUrl);

--- a/suite/e2e/tests/settings/without-device.test.ts
+++ b/suite/e2e/tests/settings/without-device.test.ts
@@ -30,6 +30,7 @@ test.describe(
                 await settingsPage.navigateTo('application');
                 await settingsPage.toggleDebugModeInSettings();
 
+                await settingsPage.toggleTestnetNetworks();
                 await settingsPage.navigateTo('coins');
                 await settingsPage.coins.enableNetwork('regtest');
 

--- a/suite/e2e/tests/wallet/cardano.test.ts
+++ b/suite/e2e/tests/wallet/cardano.test.ts
@@ -35,6 +35,8 @@ test.describe('Cardano', { tag: ['@group=wallet', '@snapshot'] }, () => {
             walletPage,
             trezorUserEnvLink,
         }) => {
+            await settingsPage.toggleTestnetNetworks();
+            await settingsPage.navigateTo('coins');
             await settingsPage.coins.enableNetwork('tada');
             // await settingsPage.coins.openNetworkAdvanceSettings('tada');
             // await expect(settingsPage.modal).toHaveScreenshot('cardano-advanced-settings.png', {

--- a/suite/e2e/tests/wallet/coin-balance.test.ts
+++ b/suite/e2e/tests/wallet/coin-balance.test.ts
@@ -25,6 +25,7 @@ test.describe('Coin balance', { tag: ['@group=wallet'] }, () => {
             });
             await trezorUserEnvLink.sendToAddressAndMineBlock({ address, btc_amount: 1 });
             await test.step('Regtest discovered with non zero value', async () => {
+                await settingsPage.toggleTestnetNetworks();
                 await settingsPage.changeNetworks({ enableNetworks: ['regtest'] });
                 await dashboardPage.navigateTo();
                 await expect(walletPage.accountLabel({ symbol: 'regtest' })).toHaveText(

--- a/suite/e2e/tests/wallet/pending-transactions.test.ts
+++ b/suite/e2e/tests/wallet/pending-transactions.test.ts
@@ -39,6 +39,7 @@ test.describe(
             });
 
             await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+            await settingsPage.toggleTestnetNetworks();
             await settingsPage.changeNetworks({
                 enableNetworks: ['regtest'],
                 disableNetworks: ['btc'],

--- a/suite/e2e/tests/wallet/send-form-regtest.test.ts
+++ b/suite/e2e/tests/wallet/send-form-regtest.test.ts
@@ -13,6 +13,7 @@ test.describe('Send form for bitcoin', { tag: ['@group=wallet'] }, () => {
         async ({ onboardingPage, dashboardPage, settingsPage, walletPage, trezorUserEnvLink }) => {
             await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
 
+            await settingsPage.toggleTestnetNetworks();
             await settingsPage.navigateTo('coins');
             await settingsPage.coins.enableNetwork('regtest');
 


### PR DESCRIPTION
## Description

Move Testnet networks into experimental features.

## Related Issue

Resolve #11155 

## Screenshots:

<img width="100%" alt="Screenshot 2025-12-04 at 12 40 20" src="https://github.com/user-attachments/assets/8ad213a9-ef5c-4a51-9a16-9047ad155b04" />

<img width="100%" alt="Screenshot 2025-12-04 at 12 40 28" src="https://github.com/user-attachments/assets/1257b118-201b-404d-8efe-5eb3f74e1840" />

Show enabled testnets in filters even though testnets are disabled in experimental features.

<img width="100%" alt="Screenshot 2025-12-10 at 11 38 53" src="https://github.com/user-attachments/assets/2e59f4ec-96a7-4c6e-aba3-b449159bdca8" />

<img width="100%" alt="Screenshot 2025-12-10 at 11 38 58" src="https://github.com/user-attachments/assets/74215807-adb9-47fe-a80f-1361ec2df3ff" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/testnets-experimental&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/testnets-experimental&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/testnets-experimental&lookback=7)