### PR TITLE
Move TPN subscription to DeviceList

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -66,7 +66,6 @@ import {
     parseRevision,
 } from '../utils/deviceFeaturesUtils';
 import { getFirmwareMode, getFirmwareType } from '../utils/firmwareUtils';
-import { trezorPushNotificationHandler } from './workflow/trezorPushNotification';
 
 // custom log
 const _log = initLog('Device');
@@ -341,35 +340,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this.busy = value;
     }
 
-    private subscribe() {
-        if (this.descriptor.id && this.descriptor.apiType === 'bluetooth') {
-            this.transport
-                .subscribe({
-                    path: this.descriptor.id,
-                    channels: ['battery-level', 'trezor-push-notification'],
-                })
-                .then(result => {
-                    if (!result.success) return;
-
-                    this.lifecycle.emit(DEVICE.CHANGED);
-
-                    if (result.payload['battery-level']) {
-                        this.transport.on('battery-level', event => {
-                            this._updateFeature('soc', event.data[0]);
-                            this.lifecycle.emit(DEVICE.CHANGED);
-                        });
-                    }
-                    if (result.payload['trezor-push-notification']) {
-                        this.transport.on('trezor-push-notification', ({ id, data }) => {
-                            if (id === this.descriptor.id) {
-                                trezorPushNotificationHandler({ device: this, message: data });
-                            }
-                        });
-                    }
-                });
-        }
-    }
-
     release() {
         if (!this.sessionAcquired || this.keepTransportSession || this.releasePromise) {
             return;
@@ -447,9 +417,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 this.unreadableError = error.message;
             }
         }
-
-        // We subscribe now that we have completed handshake with device.
-        this.subscribe();
 
         return true;
     }
@@ -970,12 +937,14 @@ export class Device extends TypedEmitter<DeviceEvents> {
         }
     }
 
-    private _updateFeature<K extends keyof Features>(key: K, value: Features[K]) {
+    // For now only battery level is allowed to be updated from outside
+    updateFeature<K extends keyof Pick<Features, 'soc'>>(key: K, value: Features[K]) {
         if (this._features) {
             this._features = {
                 ...this._features,
                 [key]: value,
             };
+            this.lifecycle.emit(DEVICE.CHANGED);
         }
     }
 

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -20,6 +20,7 @@ import { ConnectSettings, DeviceUniquePath, StaticSessionId, asDeviceUniquePath 
 import { createTransportList } from './TransportList';
 import { TransportManager } from './TransportManager';
 import { initLog } from '../utils/debug';
+import { trezorPushNotificationHandler } from './workflow/trezorPushNotification';
 
 const createAuthPenaltyManager = (priority: number) => {
     const penalizedDevices: { [deviceID: string]: number } = {};
@@ -155,6 +156,13 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
             return;
         }
 
+        if (descriptor.id && descriptor.apiType === 'bluetooth') {
+            transport.subscribe({
+                path: device.descriptor.id,
+                channels: ['battery-level', 'trezor-push-notification'],
+            });
+        }
+
         this.devices.push(device);
 
         device.lifecycle.on(DEVICE.CONNECT, () => this.emit(DEVICE.CONNECT, device));
@@ -177,6 +185,18 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         });
 
         this.emit(device.isUnacquired() ? DEVICE.CONNECT_UNACQUIRED : DEVICE.CONNECT, device);
+    }
+
+    private onPushNotification(event: { id: string; data: number[] }) {
+        const device = this.devices.find(d => d.descriptor.id === event.id);
+        if (device) {
+            trezorPushNotificationHandler({ device, message: event.data });
+        }
+    }
+
+    private onBatteryLevel(event: { id: string; data: number[] }) {
+        const device = this.devices.find(d => d.descriptor.id === event.id);
+        device?.updateFeature('soc', event.data[0]);
     }
 
     private getOrCreateTransportManager(apiType: TransportApiType) {
@@ -225,6 +245,8 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
          * where transport.acquire, transport.release is called
          */
         transport.on(TRANSPORT.DEVICE_CONNECTED, d => this.onDeviceConnected(d, transport));
+        transport.on(TRANSPORT.TREZOR_PUSH_NOTIFICATION, this.onPushNotification.bind(this));
+        transport.on(TRANSPORT.BATTERY_LEVEL, this.onBatteryLevel.bind(this));
 
         // enumerating for the first time. we intentionally postpone emitting TRANSPORT_START
         // event until we read descriptors for the first time


### PR DESCRIPTION
## Description

Subscription to THP push notifications was moved from `Device` to `DeviceList`, so that:

a) it's much easier to dedupe them (previously it was possible to subscribe two duplicate listeners when device was reconnected),
b) a bug was fixed where all the device's battery levels were updated on every incoming battery event

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tnp-duplicity&lookback=7)