### PR TITLE
Fix macos safe storage not working

### DIFF
--- a/packages/suite-desktop-core/src/modules/safeStorage.ts
+++ b/packages/suite-desktop-core/src/modules/safeStorage.ts
@@ -1,6 +1,7 @@
 import { safeStorage } from 'electron';
 
 import { DecryptionFailed, EncryptionUnavailable } from '@suite-common/secure-storage';
+import { isLinux } from '@trezor/env-utils';
 import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { err, ok } from '@trezor/type-utils';
 
@@ -12,6 +13,19 @@ export const SERVICE_NAME = 'SAFE_STORAGE';
 const isEncryptionAvailable = () => {
     if (!safeStorage.isEncryptionAvailable()) {
         return err(EncryptionUnavailable('SafeStorage encryption is not available'));
+    }
+
+    // NOTE: this method is NOT available on mac / windows, it is linux only
+    if (!('getSelectedStorageBackend' in safeStorage)) {
+        if (isLinux()) {
+            return err(
+                EncryptionUnavailable(
+                    'SafeStorage#getSelectedStorageBackend is not available on Linux',
+                ),
+            );
+        }
+
+        return ok();
     }
 
     // This is probably covered by `isEncryptionAvailable()`, but just to be sure!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes that the Safe Storage / Trezor Sync doesnt work on Mac / Win when retrieving new keys

## Notes for QA

Trezor Sync sould work again with this on a device that hasn't yet retrieved the keys (after appalication wipe)

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-macos-safe-storage-not-working&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-macos-safe-storage-not-working&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-macos-safe-storage-not-working&lookback=7)