### PR TITLE
23592 turn on suite sync with a hotfix

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -144,6 +144,9 @@ export interface InvokeChannels {
     'bio-auth/get-validation-status': () => boolean;
     'safe-storage/decrypt': (params: { value: string }) => Result<string, DecryptionError>;
     'safe-storage/encrypt': (params: { value: string }) => Result<string, EncryptionError>;
+
+    // Browser Window
+    'browser-window/reload': () => void;
 }
 
 type DesktopApiListener = ListenerMethod<RendererChannels>;
@@ -223,4 +226,7 @@ export type DesktopApi = {
     // safeStorage
     safeStoreEncrypt: DesktopApiInvoke<'safe-storage/encrypt'>;
     safeStoreDecrypt: DesktopApiInvoke<'safe-storage/decrypt'>;
+
+    // Browser Window
+    reloadBrowserWindow: DesktopApiInvoke<'browser-window/reload'>;
 };

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -207,5 +207,8 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
         // safeStorage
         safeStoreEncrypt: ({ value }) => ipcRenderer.invoke('safe-storage/encrypt', { value }),
         safeStoreDecrypt: ({ value }) => ipcRenderer.invoke('safe-storage/decrypt', { value }),
+
+        // Browser Window
+        reloadBrowserWindow: () => ipcRenderer.invoke('browser-window/reload'),
     };
 };

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -321,6 +321,12 @@ const init = async () => {
         store,
     });
 
+    ipcMain.handle('browser-window/reload', ipcEvent => {
+        validateIpcMessage({ ipcEvent });
+
+        mainWindowProxy.getInstance()?.webContents.reload();
+    });
+
     loadBioAuthModule();
 
     ipcMain.handle('handshake/load-tor-module', ipcEvent => {

--- a/packages/suite-desktop-ui/src/MainDesktop.tsx
+++ b/packages/suite-desktop-ui/src/MainDesktop.tsx
@@ -1,6 +1,5 @@
 import { Provider as ReduxProvider } from 'react-redux';
 
-import { createMemoryHistory } from 'history';
 import { createRoot } from 'react-dom/client';
 
 import TrezorConnect from '@trezor/connect';
@@ -20,7 +19,6 @@ import { BioAuthGuard } from 'src/components/suite/BioAuthGuard/BioAuthGuard';
 import { FindBar } from 'src/components/suite/FindBar/FindBar';
 import { Metadata } from 'src/components/suite/Metadata';
 import { useDebugLanguageShortcut } from 'src/hooks/suite';
-import { initStore } from 'src/reducers/store';
 import { SuiteServicesProvider } from 'src/support/SuiteServicesProvider';
 import { ConnectedIntlProvider } from 'src/support/suite/ConnectedIntlProvider';
 import { Main } from 'src/support/suite/Main';
@@ -31,6 +29,7 @@ import { useConnectPopupDesktop } from 'src/support/suite/useConnectPopupDesktop
 import { useTor } from 'src/support/suite/useTor';
 
 import { GlobalStyle } from './GlobalStyle';
+import { createSuiteDesktopCompositionRoot } from './createSuiteDesktopCompositionRoot';
 import { initSentry } from './sentry';
 import { DesktopUpdater } from './support/DesktopUpdater';
 import { desktopComponents } from './support/desktopComponents';
@@ -68,18 +67,8 @@ export const init = async (container: HTMLElement) => {
 
     const preloadAction = await preloadStore();
     const { statePatch } = await desktopApi.handshake();
-    const { store, services } = initStore(
-        {
-            history: createMemoryHistory(),
-            flushSuiteSyncStorage: () => {
-                desktopApi.reloadBrowserWindow();
-            },
-        },
-        preloadAction,
-        {
-            statePatch,
-        },
-    );
+
+    const { store, services } = createSuiteDesktopCompositionRoot(preloadAction, statePatch);
 
     // Expose Redux store for Playwright/e2e tests
     if (typeof window !== 'undefined' && window.desktopFlags?.exposeStore) {

--- a/packages/suite-desktop-ui/src/MainDesktop.tsx
+++ b/packages/suite-desktop-ui/src/MainDesktop.tsx
@@ -71,6 +71,9 @@ export const init = async (container: HTMLElement) => {
     const { store, services } = initStore(
         {
             history: createMemoryHistory(),
+            flushSuiteSyncStorage: () => {
+                desktopApi.reloadBrowserWindow();
+            },
         },
         preloadAction,
         {

--- a/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
+++ b/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
@@ -1,0 +1,19 @@
+import { createMemoryHistory } from 'history';
+
+import { StorageFlusher } from '@suite-common/suite-sync-types';
+import { desktopApi } from '@trezor/suite-desktop-api';
+
+import { initStore } from 'src/reducers/store';
+import { PreloadStoreAction } from 'src/support/suite/preloadStore';
+
+export const createSuiteDesktopCompositionRoot = (
+    preloadStoreAction?: PreloadStoreAction,
+    statePatch: Record<string, any> = {},
+) => {
+    const history = createMemoryHistory();
+    const flushSuiteSyncStorage: StorageFlusher = () => {
+        desktopApi.reloadBrowserWindow();
+    };
+
+    return initStore({ history, flushSuiteSyncStorage }, preloadStoreAction, { statePatch });
+};

--- a/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
+++ b/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
@@ -1,6 +1,5 @@
 import { createMemoryHistory } from 'history';
 
-import { SuiteSyncStorageFlusher } from '@suite-common/suite-sync-types';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { initStore } from 'src/reducers/store';
@@ -11,7 +10,7 @@ export const createSuiteDesktopCompositionRoot = (
     statePatch: Record<string, any> = {},
 ) => {
     const history = createMemoryHistory();
-    const flushSuiteSyncStorage: SuiteSyncStorageFlusher = () => {
+    const flushSuiteSyncStorage = () => {
         desktopApi.reloadBrowserWindow();
     };
 

--- a/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
+++ b/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
@@ -1,6 +1,6 @@
 import { createMemoryHistory } from 'history';
 
-import { StorageFlusher } from '@suite-common/suite-sync-types';
+import { SuiteSyncStorageFlusher } from '@suite-common/suite-sync-types';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { initStore } from 'src/reducers/store';
@@ -11,7 +11,7 @@ export const createSuiteDesktopCompositionRoot = (
     statePatch: Record<string, any> = {},
 ) => {
     const history = createMemoryHistory();
-    const flushSuiteSyncStorage: StorageFlusher = () => {
+    const flushSuiteSyncStorage: SuiteSyncStorageFlusher = () => {
         desktopApi.reloadBrowserWindow();
     };
 

--- a/packages/suite-web/src/MainWeb.tsx
+++ b/packages/suite-web/src/MainWeb.tsx
@@ -3,7 +3,6 @@ import 'core-js/actual';
 import { Suspense } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
-import { createBrowserHistory } from 'history';
 import { createRoot } from 'react-dom/client';
 
 import {
@@ -14,7 +13,6 @@ import {
     ToasterProvider,
 } from 'src/components/suite';
 import { useDebugLanguageShortcut } from 'src/hooks/suite';
-import { initStore } from 'src/reducers/store';
 import { SuiteServicesProvider } from 'src/support/SuiteServicesProvider';
 import { Main } from 'src/support/suite/Main';
 import { preloadStore } from 'src/support/suite/preloadStore';
@@ -22,6 +20,7 @@ import { LoadingScreen } from 'src/support/suite/screens/LoadingScreen';
 import { useConnectPopupWeb } from 'src/support/suite/useConnectPopupWeb';
 import { useTor } from 'src/support/suite/useTor';
 
+import { createSuiteWebCompositionRoot } from './createSuiteWebCompositionRoot';
 import { initSentry } from './sentry';
 import { usePlaywright } from './support/usePlaywright';
 import { webComponents } from './support/webComponents';
@@ -55,10 +54,8 @@ export const init = async (container: HTMLElement) => {
     root.render(<LoadingScreen />);
 
     const preloadAction = await preloadStore();
-    const { store, services } = initStore(
-        { history: createBrowserHistory(), flushSuiteSyncStorage: () => window.location.reload() },
-        preloadAction,
-    );
+
+    const { store, services } = createSuiteWebCompositionRoot(preloadAction);
 
     root.render(
         <SuiteServicesProvider services={services}>

--- a/packages/suite-web/src/MainWeb.tsx
+++ b/packages/suite-web/src/MainWeb.tsx
@@ -55,7 +55,10 @@ export const init = async (container: HTMLElement) => {
     root.render(<LoadingScreen />);
 
     const preloadAction = await preloadStore();
-    const { store, services } = initStore({ history: createBrowserHistory() }, preloadAction);
+    const { store, services } = initStore(
+        { history: createBrowserHistory(), flushSuiteSyncStorage: () => window.location.reload() },
+        preloadAction,
+    );
 
     root.render(
         <SuiteServicesProvider services={services}>

--- a/packages/suite-web/src/createSuiteWebCompositionRoot.ts
+++ b/packages/suite-web/src/createSuiteWebCompositionRoot.ts
@@ -1,13 +1,11 @@
 import { createBrowserHistory } from 'history';
 
-import { SuiteSyncStorageFlusher } from '@suite-common/suite-sync-types';
-
 import { initStore } from 'src/reducers/store';
 import { PreloadStoreAction } from 'src/support/suite/preloadStore';
 
 export const createSuiteWebCompositionRoot = (preloadStoreAction?: PreloadStoreAction) => {
     const history = createBrowserHistory();
-    const flushSuiteSyncStorage: SuiteSyncStorageFlusher = () => {
+    const flushSuiteSyncStorage = () => {
         window.location.reload();
     };
 

--- a/packages/suite-web/src/createSuiteWebCompositionRoot.ts
+++ b/packages/suite-web/src/createSuiteWebCompositionRoot.ts
@@ -1,0 +1,15 @@
+import { createBrowserHistory } from 'history';
+
+import { StorageFlusher } from '@suite-common/suite-sync-types';
+
+import { initStore } from 'src/reducers/store';
+import { PreloadStoreAction } from 'src/support/suite/preloadStore';
+
+export const createSuiteWebCompositionRoot = (preloadStoreAction?: PreloadStoreAction) => {
+    const history = createBrowserHistory();
+    const flushSuiteSyncStorage: StorageFlusher = () => {
+        window.location.reload();
+    };
+
+    return initStore({ history, flushSuiteSyncStorage }, preloadStoreAction);
+};

--- a/packages/suite-web/src/createSuiteWebCompositionRoot.ts
+++ b/packages/suite-web/src/createSuiteWebCompositionRoot.ts
@@ -1,13 +1,13 @@
 import { createBrowserHistory } from 'history';
 
-import { StorageFlusher } from '@suite-common/suite-sync-types';
+import { SuiteSyncStorageFlusher } from '@suite-common/suite-sync-types';
 
 import { initStore } from 'src/reducers/store';
 import { PreloadStoreAction } from 'src/support/suite/preloadStore';
 
 export const createSuiteWebCompositionRoot = (preloadStoreAction?: PreloadStoreAction) => {
     const history = createBrowserHistory();
-    const flushSuiteSyncStorage: StorageFlusher = () => {
+    const flushSuiteSyncStorage: SuiteSyncStorageFlusher = () => {
         window.location.reload();
     };
 

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -19,6 +19,7 @@ import {
     createStoreWithExtraStoreMiddleware,
 } from '@suite-common/redux-utils';
 import { suiteSyncDataReducer } from '@suite-common/suite-sync';
+import { StorageFlusherDep } from '@suite-common/suite-sync-types';
 import { prepareThpReducer } from '@suite-common/thp';
 import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions';
 import { accountsActions } from '@suite-common/wallet-core';
@@ -128,7 +129,7 @@ type RootReducerShape = typeof rootReducer;
 type PreloadedState = Partial<AppState>;
 type InferredAction = Parameters<RootReducerShape>[1];
 
-type SuiteStoreDeps = HistoryDep;
+type SuiteStoreDeps = HistoryDep & StorageFlusherDep;
 
 export const initStore = (
     deps: SuiteStoreDeps,

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -19,7 +19,7 @@ import {
     createStoreWithExtraStoreMiddleware,
 } from '@suite-common/redux-utils';
 import { suiteSyncDataReducer } from '@suite-common/suite-sync';
-import { StorageFlusherDep } from '@suite-common/suite-sync-types';
+import { SuiteSyncStorageFlusherDep } from '@suite-common/suite-sync-types';
 import { prepareThpReducer } from '@suite-common/thp';
 import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions';
 import { accountsActions } from '@suite-common/wallet-core';
@@ -129,7 +129,7 @@ type RootReducerShape = typeof rootReducer;
 type PreloadedState = Partial<AppState>;
 type InferredAction = Parameters<RootReducerShape>[1];
 
-type SuiteStoreDeps = HistoryDep & StorageFlusherDep;
+export type SuiteStoreDeps = HistoryDep & SuiteSyncStorageFlusherDep;
 
 export const initStore = (
     deps: SuiteStoreDeps,

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -143,7 +143,7 @@ export const initStore = (
         : undefined;
 
     const patchedState =
-        preloadedState && options.statePatch && patchConfirm(options.statePatch)
+        preloadedState && options?.statePatch && patchConfirm(options.statePatch)
             ? mergeDeepObject.withOptions(
                   { dotNotation: true },
                   preloadedState,
@@ -154,9 +154,10 @@ export const initStore = (
     const extraFactory = (api: MiddlewareAPI) => ({
         ...extraDependencies,
         services: createSuiteServicesCompositionRoot({
-            history: deps.history,
             getState: api.getState,
             dispatch: api.dispatch,
+            flushSuiteSyncStorage: deps.flushSuiteSyncStorage,
+            history: deps.history,
         }),
     });
 

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -16,7 +16,7 @@ import {
 import { delegatedIdentityKeyCompositionRoot } from '@suite-common/delegated-identity-key';
 import { FW_HASH_CHECK_DEFAULT_TIMEOUTS } from '@suite-common/firmware-authenticity';
 import { CommonServices, ExtraDependenciesStatic } from '@suite-common/redux-utils';
-import { StorageFlusherDep } from '@suite-common/suite-sync-types';
+import { SuiteSyncStorageFlusherDep } from '@suite-common/suite-sync-types';
 import {
     TokenDefinitionsState,
     buildTokenDefinitionsFromStorage,
@@ -97,10 +97,10 @@ export const createSuiteRouterHistory = ({
 
 export type StoreAPIDep = {
     getState: () => any;
-    dispatch: (arg1: any) => any;
+    dispatch: (_: any) => any;
 };
 
-export type SuiteAppDeps = StoreAPIDep & HistoryDep & StorageFlusherDep;
+export type SuiteAppDeps = StoreAPIDep & HistoryDep & SuiteSyncStorageFlusherDep;
 
 export type SuiteServices = CommonServices &
     DesktopAnalyticsDep &

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -95,11 +95,12 @@ export const createSuiteRouterHistory = ({
         ),
 });
 
-type SuiteAppDeps = {
+export type StoreAPIDep = {
     getState: () => any;
-    dispatch: any;
-} & HistoryDep &
-    StorageFlusherDep;
+    dispatch: (arg1: any) => any;
+};
+
+export type SuiteAppDeps = StoreAPIDep & HistoryDep & StorageFlusherDep;
 
 export type SuiteServices = CommonServices &
     DesktopAnalyticsDep &

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -16,6 +16,7 @@ import {
 import { delegatedIdentityKeyCompositionRoot } from '@suite-common/delegated-identity-key';
 import { FW_HASH_CHECK_DEFAULT_TIMEOUTS } from '@suite-common/firmware-authenticity';
 import { CommonServices, ExtraDependenciesStatic } from '@suite-common/redux-utils';
+import { StorageFlusherDep } from '@suite-common/suite-sync-types';
 import {
     TokenDefinitionsState,
     buildTokenDefinitionsFromStorage,
@@ -97,7 +98,8 @@ export const createSuiteRouterHistory = ({
 type SuiteAppDeps = {
     getState: () => any;
     dispatch: any;
-} & HistoryDep;
+} & HistoryDep &
+    StorageFlusherDep;
 
 export type SuiteServices = CommonServices &
     DesktopAnalyticsDep &
@@ -129,6 +131,7 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
         suiteSync: createSuiteSyncDesktopCompositionRoot({
             dispatch: deps.dispatch,
             getState: deps.getState,
+            flushSuiteSyncStorage: deps.flushSuiteSyncStorage,
             platformEncryption,
             trezorConnect: TrezorConnect,
             ensureDelegatedIdentityKey,

--- a/packages/suite/src/support/suite/createSuiteDesktopCompositionRoot.ts
+++ b/packages/suite/src/support/suite/createSuiteDesktopCompositionRoot.ts
@@ -1,0 +1,19 @@
+import { createMemoryHistory } from 'history';
+
+import { StorageFlusher } from '@suite-common/suite-sync-types';
+import { desktopApi } from '@trezor/suite-desktop-api';
+
+import type { PreloadStoreAction } from './preloadStore';
+import { initStore } from '../../reducers/store';
+
+export const createSuiteDesktopCompositionRoot = (
+    preloadStoreAction?: PreloadStoreAction,
+    statePatch: Record<string, any> = {},
+) => {
+    const history = createMemoryHistory();
+    const flushSuiteSyncStorage: StorageFlusher = () => {
+        desktopApi.reloadBrowserWindow();
+    };
+
+    return initStore({ history, flushSuiteSyncStorage }, preloadStoreAction, { statePatch });
+};

--- a/packages/suite/src/support/suite/createSuiteDesktopCompositionRoot.ts
+++ b/packages/suite/src/support/suite/createSuiteDesktopCompositionRoot.ts
@@ -1,6 +1,6 @@
 import { createMemoryHistory } from 'history';
 
-import { StorageFlusher } from '@suite-common/suite-sync-types';
+import { SuiteSyncStorageFlusher } from '@suite-common/suite-sync-types';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import type { PreloadStoreAction } from './preloadStore';
@@ -11,7 +11,7 @@ export const createSuiteDesktopCompositionRoot = (
     statePatch: Record<string, any> = {},
 ) => {
     const history = createMemoryHistory();
-    const flushSuiteSyncStorage: StorageFlusher = () => {
+    const flushSuiteSyncStorage: SuiteSyncStorageFlusher = () => {
         desktopApi.reloadBrowserWindow();
     };
 

--- a/suite-common/suite-sync-types/src/index.ts
+++ b/suite-common/suite-sync-types/src/index.ts
@@ -59,3 +59,5 @@ export type {
     UpdateWalletLabelDep,
     UpdateWalletLabelParams,
 } from './data/updateWalletLabel';
+
+export type { StorageFlusherDep, StorageFlusher } from './storageFlusher';

--- a/suite-common/suite-sync-types/src/index.ts
+++ b/suite-common/suite-sync-types/src/index.ts
@@ -60,4 +60,7 @@ export type {
     UpdateWalletLabelParams,
 } from './data/updateWalletLabel';
 
-export type { StorageFlusherDep, StorageFlusher } from './storageFlusher';
+export type {
+    SuiteSyncStorageFlusher,
+    SuiteSyncStorageFlusherDep,
+} from './suiteSyncStorageFlusher';

--- a/suite-common/suite-sync-types/src/storage/subscriptionStorage.ts
+++ b/suite-common/suite-sync-types/src/storage/subscriptionStorage.ts
@@ -7,7 +7,7 @@ export type SubscriptionStorageParams = {
 
 export type SubscriptionStorage = {
     add: (params: SubscriptionStorageParams) => void;
-    disposeAll: (storageId: StorageId) => void;
+    dispose: (storageId: StorageId) => void;
     has: (storageId: StorageId) => boolean;
 };
 

--- a/suite-common/suite-sync-types/src/storageFlusher.ts
+++ b/suite-common/suite-sync-types/src/storageFlusher.ts
@@ -1,5 +1,0 @@
-export type StorageFlusher = () => void;
-
-export type StorageFlusherDep = {
-    flushSuiteSyncStorage: StorageFlusher;
-};

--- a/suite-common/suite-sync-types/src/storageFlusher.ts
+++ b/suite-common/suite-sync-types/src/storageFlusher.ts
@@ -1,0 +1,5 @@
+export type StorageFlusher = () => void;
+
+export type StorageFlusherDep = {
+    flushSuiteSyncStorage: StorageFlusher;
+};

--- a/suite-common/suite-sync-types/src/suiteSyncStorageFlusher.ts
+++ b/suite-common/suite-sync-types/src/suiteSyncStorageFlusher.ts
@@ -1,0 +1,5 @@
+export type SuiteSyncStorageFlusher = () => void;
+
+export type SuiteSyncStorageFlusherDep = {
+    flushSuiteSyncStorage: SuiteSyncStorageFlusher;
+};

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -4,7 +4,7 @@ import { EnsureDelegatedIdentityKeyDep } from '@suite-common/delegated-identity-
 import { PlatformEncryptionDep } from '@suite-common/platform-encryption';
 import { selectHasDeviceAllowance } from '@suite-common/suite-sync-quota-manager';
 import { CreateSuiteStorageDep, CreateSuiteSyncOwnerDep } from '@suite-common/suite-sync-storage';
-import { SuiteSync } from '@suite-common/suite-sync-types';
+import { StorageFlusherDep, SuiteSync } from '@suite-common/suite-sync-types';
 import {
     selectAllDeviceStaticIds,
     selectDeviceByStaticSessionId,
@@ -45,7 +45,8 @@ type CreateSuiteSyncCompositionRootDeps = {
 } & EnsureDelegatedIdentityKeyDep &
     CreateSuiteStorageDep &
     CreateSuiteSyncOwnerDep &
-    PlatformEncryptionDep;
+    PlatformEncryptionDep &
+    StorageFlusherDep;
 
 export const createSuiteSyncCompositionRoot = (
     deps: CreateSuiteSyncCompositionRootDeps,
@@ -135,6 +136,7 @@ export const createSuiteSyncCompositionRoot = (
             dispatch: deps.dispatch,
             getState: deps.getState,
             turnOffSuiteSyncForWallet,
+            flushSuiteSyncStorage: deps.flushSuiteSyncStorage,
         }),
         turnOnSuiteSync: createTurnOnSuiteSync({
             getState: deps.getState,

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -4,7 +4,7 @@ import { EnsureDelegatedIdentityKeyDep } from '@suite-common/delegated-identity-
 import { PlatformEncryptionDep } from '@suite-common/platform-encryption';
 import { selectHasDeviceAllowance } from '@suite-common/suite-sync-quota-manager';
 import { CreateSuiteStorageDep, CreateSuiteSyncOwnerDep } from '@suite-common/suite-sync-storage';
-import { StorageFlusherDep, SuiteSync } from '@suite-common/suite-sync-types';
+import { SuiteSync, SuiteSyncStorageFlusherDep } from '@suite-common/suite-sync-types';
 import {
     selectAllDeviceStaticIds,
     selectDeviceByStaticSessionId,
@@ -46,7 +46,7 @@ type CreateSuiteSyncCompositionRootDeps = {
     CreateSuiteStorageDep &
     CreateSuiteSyncOwnerDep &
     PlatformEncryptionDep &
-    StorageFlusherDep;
+    SuiteSyncStorageFlusherDep;
 
 export const createSuiteSyncCompositionRoot = (
     deps: CreateSuiteSyncCompositionRootDeps,

--- a/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
@@ -1,7 +1,7 @@
 import { Dispatch } from '@reduxjs/toolkit';
 
 import {
-    StorageFlusherDep,
+    SuiteSyncStorageFlusherDep,
     TurnOffSuiteSync,
     TurnOffSuiteSyncForWalletDep,
 } from '@suite-common/suite-sync-types';
@@ -15,7 +15,7 @@ export type CreateTurnOffSuiteSyncDeps = {
     getState: () => any;
     getAllDeviceSessionIds: () => StaticSessionId[];
 } & TurnOffSuiteSyncForWalletDep &
-    StorageFlusherDep;
+    SuiteSyncStorageFlusherDep;
 
 export const createTurnOffSuiteSync =
     (deps: CreateTurnOffSuiteSyncDeps): TurnOffSuiteSync =>

--- a/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
@@ -1,6 +1,10 @@
 import { Dispatch } from '@reduxjs/toolkit';
 
-import { TurnOffSuiteSync, TurnOffSuiteSyncForWalletDep } from '@suite-common/suite-sync-types';
+import {
+    StorageFlusherDep,
+    TurnOffSuiteSync,
+    TurnOffSuiteSyncForWalletDep,
+} from '@suite-common/suite-sync-types';
 import { StaticSessionId } from '@trezor/connect';
 
 import { suiteSyncActions } from './suiteSyncActions';
@@ -10,7 +14,8 @@ export type CreateTurnOffSuiteSyncDeps = {
     dispatch: Dispatch;
     getState: () => any;
     getAllDeviceSessionIds: () => StaticSessionId[];
-} & TurnOffSuiteSyncForWalletDep;
+} & TurnOffSuiteSyncForWalletDep &
+    StorageFlusherDep;
 
 export const createTurnOffSuiteSync =
     (deps: CreateTurnOffSuiteSyncDeps): TurnOffSuiteSync =>
@@ -28,4 +33,7 @@ export const createTurnOffSuiteSync =
         for (const deviceStaticSessionId of deviceStaticSessionIds) {
             await deps.turnOffSuiteSyncForWallet({ deviceStaticSessionId });
         }
+
+        // NOTE: this is TEMPORARY solution until https://github.com/trezor/trezor-suite/issues/23641 is resolved
+        deps.flushSuiteSyncStorage();
     };

--- a/suite-common/suite-sync/src/storage/createSubscriptionStorage.mock.ts
+++ b/suite-common/suite-sync/src/storage/createSubscriptionStorage.mock.ts
@@ -1,0 +1,9 @@
+import { SubscriptionStorage } from '@suite-common/suite-sync-types';
+
+type SubscriptionStorageMock = jest.Mocked<SubscriptionStorage>;
+
+export const createSubscriptionStorageMock = (): SubscriptionStorageMock => ({
+    add: jest.fn(),
+    dispose: jest.fn(),
+    has: jest.fn(),
+});

--- a/suite-common/suite-sync/src/storage/createSubscriptionStorage.ts
+++ b/suite-common/suite-sync/src/storage/createSubscriptionStorage.ts
@@ -14,7 +14,7 @@ export const createSubscriptionStorage = (): SubscriptionStorage => {
 
             storage[storageId] = unsubscribe;
         },
-        disposeAll: storageId => {
+        dispose: storageId => {
             storage[storageId]?.();
             delete storage[storageId];
         },

--- a/suite-common/suite-sync/src/storage/createTurnOffSuiteSyncForWallet.ts
+++ b/suite-common/suite-sync/src/storage/createTurnOffSuiteSyncForWallet.ts
@@ -14,6 +14,6 @@ export const createTurnOffSuiteSyncForWallet =
     async ({ deviceStaticSessionId }) => {
         const storageId = createStorageIdFromDeviceStaticSessionId(deviceStaticSessionId);
 
-        deps.subscriptionStorage.disposeAll(storageId);
+        deps.subscriptionStorage.dispose(storageId);
         await deps.suiteSyncStorageRepository.delete(storageId);
     };

--- a/suite-common/suite-sync/src/storage/tests/createEnsureWalletSuiteSyncOn.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createEnsureWalletSuiteSyncOn.test.ts
@@ -9,6 +9,7 @@ import { createMockDeps } from '../../../tests/utils';
 import { SuiteSyncUnavailableOnDeviceError } from '../../createRefreshSuiteSyncKeys';
 import type { EnsureWalletSuiteSyncOnDeps } from '../createEnsureWalletSuiteSyncOn';
 import { createEnsureWalletSuiteSyncOn } from '../createEnsureWalletSuiteSyncOn';
+import { createSubscriptionStorageMock } from '../createSubscriptionStorage.mock';
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3';
 
@@ -34,11 +35,7 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
         const deps = createMockDeps<EnsureWalletSuiteSyncOnDeps>({
             getState: () => createMockState([]),
             ensureSuiteSyncData: null,
-            subscriptionStorage: {
-                add: null,
-                disposeAll: null,
-                has: null,
-            },
+            subscriptionStorage: createSubscriptionStorageMock(),
             refreshSuiteSyncKeys: null,
             dispatch: null,
         });
@@ -61,11 +58,7 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
             getState: () => createMockState([createDevice({ unavailableCapabilities })]),
             refreshSuiteSyncKeys: null,
             ensureSuiteSyncData: null,
-            subscriptionStorage: {
-                add: null,
-                disposeAll: null,
-                has: null,
-            },
+            subscriptionStorage: createSubscriptionStorageMock(),
         });
 
         const ensureWalletSuiteSyncOn = createEnsureWalletSuiteSyncOn(deps);
@@ -86,11 +79,7 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
             getState: () => createMockState([createDevice()]),
             refreshSuiteSyncKeys: null,
             ensureSuiteSyncData: () => Promise.resolve(ensureResult),
-            subscriptionStorage: {
-                add: null,
-                disposeAll: null,
-                has: null,
-            },
+            subscriptionStorage: createSubscriptionStorageMock(),
         });
 
         const ensureWalletSuiteSyncOn = createEnsureWalletSuiteSyncOn(deps);
@@ -108,11 +97,7 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
             getState: () => createMockState([createDevice()]),
             refreshSuiteSyncKeys: null,
             ensureSuiteSyncData: () => Promise.resolve(ensureResult),
-            subscriptionStorage: {
-                add: null,
-                disposeAll: null,
-                has: null,
-            },
+            subscriptionStorage: createSubscriptionStorageMock(),
         });
 
         const ensureWalletSuiteSyncOn = createEnsureWalletSuiteSyncOn(deps);

--- a/suite-common/suite-sync/src/storage/tests/createSubscriptionStorage.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createSubscriptionStorage.test.ts
@@ -24,7 +24,7 @@ describe(createSubscriptionStorage.name, () => {
             },
         });
 
-        storage.disposeAll(storageId1);
+        storage.dispose(storageId1);
         expect(isOwnerID1Unsubscribed).toBe(true);
         expect(isOwnerID2Unsubscribed).toBe(false);
     });

--- a/suite-common/suite-sync/src/storage/tests/createSuiteSyncStorageRepository.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createSuiteSyncStorageRepository.test.ts
@@ -1,5 +1,6 @@
 import { SuiteSyncStorage } from '@suite-common/suite-sync-storage';
 
+import { createSuiteSyncStorageMock } from '../../../tests/createSuiteSyncStorageMock.mock';
 import { mockNotExpected } from '../../../tests/utils';
 import { asStorageId, createSuiteSyncStorageRepository } from '../createSuiteSyncStorageRepository';
 
@@ -25,5 +26,15 @@ describe(createSuiteSyncStorageRepository.name, () => {
         await repository.delete(storageId1);
         expect(storage.dispose).toHaveBeenCalledTimes(1);
         expect(repository.get(storageId1)).toBeNull();
+    });
+
+    it('sets the suite sync storage', () => {
+        const suiteSyncStorage = createSuiteSyncStorageMock();
+
+        const repository = createSuiteSyncStorageRepository();
+
+        expect(repository.get(storageId1)).toBeNull();
+        repository.set(storageId1, suiteSyncStorage);
+        expect(repository.get(storageId1)).toBe(suiteSyncStorage);
     });
 });

--- a/suite-native/suite-sync/package.json
+++ b/suite-native/suite-sync/package.json
@@ -21,6 +21,7 @@
         "@trezor/connect": "workspace:*",
         "expo": "~54.0.30",
         "expo-sqlite": "^16.0.8",
+        "react-native-restart": "0.0.27",
         "react-redux": "9.2.0"
     }
 }

--- a/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
+++ b/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
@@ -1,3 +1,5 @@
+import RNRestart from 'react-native-restart';
+
 import { evoluReactNativeDeps } from '@evolu/react-native/expo-sqlite';
 import { Dispatch } from '@reduxjs/toolkit';
 
@@ -29,5 +31,8 @@ export const createSuiteSyncNativeCompositionRoot = (
         ...deps,
         createSuiteStorage: createEvoluStorage,
         createSuiteSyncOwner: evoluCreateSuiteSyncOwner,
+        flushSuiteSyncStorage: () => {
+            RNRestart.restart();
+        },
     });
 };

--- a/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
+++ b/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
@@ -10,7 +10,7 @@ import {
     createEvoluStorageFactory,
     evoluCreateSuiteSyncOwner,
 } from '@suite-common/suite-sync-evolu';
-import { SuiteSync } from '@suite-common/suite-sync-types';
+import { StorageFlusherDep, SuiteSync } from '@suite-common/suite-sync-types';
 import { TrezorConnect } from '@trezor/connect';
 
 import {
@@ -25,7 +25,8 @@ type SuiteSyncDesktopCompositionRootDeps = {
 } & PlatformEncryptionDep &
     EnsureDelegatedIdentityKeyDep &
     DesktopLegacyAnalyticsDep &
-    DisableLegacyMetadataIfNeededDep;
+    DisableLegacyMetadataIfNeededDep &
+    StorageFlusherDep;
 
 export const createSuiteSyncDesktopCompositionRoot = (
     deps: SuiteSyncDesktopCompositionRootDeps,

--- a/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
+++ b/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
@@ -10,7 +10,7 @@ import {
     createEvoluStorageFactory,
     evoluCreateSuiteSyncOwner,
 } from '@suite-common/suite-sync-evolu';
-import { StorageFlusherDep, SuiteSync } from '@suite-common/suite-sync-types';
+import { SuiteSync, SuiteSyncStorageFlusherDep } from '@suite-common/suite-sync-types';
 import { TrezorConnect } from '@trezor/connect';
 
 import {
@@ -26,7 +26,7 @@ type SuiteSyncDesktopCompositionRootDeps = {
     EnsureDelegatedIdentityKeyDep &
     DesktopLegacyAnalyticsDep &
     DisableLegacyMetadataIfNeededDep &
-    StorageFlusherDep;
+    SuiteSyncStorageFlusherDep;
 
 export const createSuiteSyncDesktopCompositionRoot = (
     deps: SuiteSyncDesktopCompositionRootDeps,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13478,6 +13478,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     expo: "npm:~54.0.30"
     expo-sqlite: "npm:^16.0.8"
+    react-native-restart: "npm:0.0.27"
     react-redux: "npm:9.2.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

~‼️ BLOCKED BY EVOLU ‼️~ we will do a "refresh" workaround

## Notes for QA

- technically hard to test
- you could test if the suite sync works properly when you turn it off and then turn it on again
- turning of should be done through Debug settings (disabled flag) and from Settings - just select different labeling
- when oyu turn off the labeling on mobil / desktop, the app should refresh / restart to make sure that evolus resources are cleared and no error will be displayed

## Related Issue

Resolve (temporary)  https://github.com/trezor/trezor-suite/issues/23641

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=23592-turn-on-suite-sync&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=23592-turn-on-suite-sync&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=23592-turn-on-suite-sync&lookback=7)