### PR TITLE
Fix findProcessFromIncomingPort test on Mac

### DIFF
--- a/packages/node-utils/src/tests/findProcessFromIncomingPort.test.ts
+++ b/packages/node-utils/src/tests/findProcessFromIncomingPort.test.ts
@@ -19,10 +19,15 @@ describe('findProcessFromIncomingPort', () => {
             const processInfo = await findProcessFromIncomingPort(port);
             expect(processInfo).toBeDefined();
 
-            if (process.platform === 'win32') {
-                expect(processInfo?.name).toEqual('Node.js');
-            } else {
-                expect(processInfo?.name).toEqual('MainThread');
+            switch (process.platform) {
+                case 'win32':
+                    expect(processInfo?.name).toEqual('Node.js');
+                    break;
+                case 'darwin':
+                    expect(processInfo?.name).toEqual('node');
+                    break;
+                default:
+                    expect(processInfo?.name).toEqual('MainThread');
             }
         } finally {
             server.close();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Test started failing on mac after last update.
<!--- Describe your changes in detail -->

## Notes for QA

Nothing to test
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-findProcessFromIncomingPort-test-mac&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-findProcessFromIncomingPort-test-mac&lookback=7)