### PR TITLE
feat(e2e): add send tests for Base transactions

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -101,7 +101,11 @@ export const BasicTxDetails = ({
                 <Row gap={spacings.xxs} margin={{ left: 'auto' }}>
                     {isConfirmed ? (
                         <InfoSegments typographyStyle="hint" variant="tertiary">
-                            <Text typographyStyle="callout" variant="primary">
+                            <Text
+                                typographyStyle="callout"
+                                variant="primary"
+                                data-testid="@modal/tx-details/confirmed"
+                            >
                                 <Translation id="TR_CONFIRMED_TX" />
                             </Text>
                             {confirmations > 0 ? (
@@ -112,7 +116,11 @@ export const BasicTxDetails = ({
                             ) : undefined}
                         </InfoSegments>
                     ) : (
-                        <Text typographyStyle="callout" variant="warning">
+                        <Text
+                            typographyStyle="callout"
+                            variant="warning"
+                            data-testid="@modal/tx-details/unconfirmed"
+                        >
                             <Translation id="TR_UNCONFIRMED_TX" />
                         </Text>
                     )}

--- a/suite/e2e/support/pageObjects/trading/fees.ts
+++ b/suite/e2e/support/pageObjects/trading/fees.ts
@@ -1,5 +1,7 @@
 import { Locator, Page, Response } from '@playwright/test';
 
+import { BigNumber } from '@trezor/utils';
+
 import { TrezorUserEnvLinkProxy, step } from '../../common';
 import { solanaUrlPattern } from '../../mocks/tradingMock';
 import { expect } from '../../testExtends/customMatchers';
@@ -153,17 +155,24 @@ export class Fees {
         return feeRateText;
     }
 
-    calculateEthereumMaxFee(params: { gasLimit: string; maxFeePerGas: string }) {
+    calculateEthereumMaxFee({
+        gasLimit,
+        maxFeePerGas,
+        numberOfDecimals = 14,
+    }: {
+        gasLimit: string;
+        maxFeePerGas: string;
+        numberOfDecimals?: number;
+    }) {
         const ratioToEthereum = 1e9;
         const maxFeeInEthereum =
-            (parseFloat(params.gasLimit) * parseFloat(params.maxFeePerGas)) / ratioToEthereum;
-        const maxFeeRounded = maxFeeInEthereum.toFixed(14);
-
+            (parseFloat(gasLimit) * parseFloat(maxFeePerGas)) / ratioToEthereum;
+        const maxFeeRounded = maxFeeInEthereum.toFixed(numberOfDecimals);
         // This method is also providing detailed error message for troubleshooting expect if it fails
         const errorMessageMaxCalculation = `expected to have max Fee: 
-"(parseFloat(${params.gasLimit}) * parseFloat(${params.maxFeePerGas})) / ${ratioToEthereum}"
+"(parseFloat(${gasLimit}) * parseFloat(${maxFeePerGas})) / ${ratioToEthereum}"
 here are applied parseFloats:
-(${parseFloat(params.gasLimit)} * ${parseFloat(params.maxFeePerGas)}) / ${ratioToEthereum}
+(${parseFloat(gasLimit)} * ${parseFloat(maxFeePerGas)}) / ${ratioToEthereum}
 before rounding: ${maxFeeInEthereum} ETH, after rounding: ${maxFeeRounded} ETH`;
 
         return {
@@ -202,6 +211,11 @@ before rounding: ${maxFeeInEthereum} ETH, after rounding: ${maxFeeRounded} ETH`;
         await this.openCollapsibleFees();
         await this.switchModeButton('custom').click();
     }
+    @step()
+    async switchToStandard() {
+        await this.openCollapsibleFees();
+        await this.switchModeButton('standard').click();
+    }
 
     @step()
     async setEthereumCustomFees(input: {
@@ -230,5 +244,28 @@ before rounding: ${maxFeeInEthereum} ETH, after rounding: ${maxFeeRounded} ETH`;
         }
 
         return Number(match[1]);
+    }
+
+    @step()
+    async getStandardFeeWorkaround() {
+        await this.switchToCustom();
+        const gasLimit = (await this.ethereumFeeLimit.inputValue()).replace(/,/g, '');
+        const maxFeePerGas = await this.ethereumMaxFeePerGas.inputValue();
+        const maxFeePerGasRounded = new BigNumber(maxFeePerGas)
+            .decimalPlaces(4, BigNumber.ROUND_UP)
+            .toFixed(4);
+        const maxPriorityFeePerGas = await this.ethereumMaxPriorityFeePerGas.inputValue();
+        const maxPriorityFeePerGasRounded = new BigNumber(maxPriorityFeePerGas)
+            .decimalPlaces(4, BigNumber.ROUND_UP)
+            .toFixed(4);
+        await this.switchToStandard();
+
+        return {
+            gasLimit,
+            maxFeePerGas,
+            maxPriorityFeePerGas,
+            maxFeePerGasRounded,
+            maxPriorityFeePerGasRounded,
+        };
     }
 }

--- a/suite/e2e/tests/wallet/send-base.test.ts
+++ b/suite/e2e/tests/wallet/send-base.test.ts
@@ -1,0 +1,216 @@
+import { localizeNumber } from '@suite-common/wallet-utils';
+import messages from '@trezor/suite/src/support/messages';
+import { BigNumber } from '@trezor/utils';
+
+import { formatAddress } from '../../support/common';
+import { expect, test } from '../../support/fixtures';
+import {
+    splitStringByDisplayLimit,
+    transformAddress,
+} from '../../support/testExtends/customMatchers';
+
+const networkName = 'Base #1';
+const sendAddress = '0xdcaB74E62b9D08a9f8Fa4A3Ccb5c46AE039C9d7C';
+const formattedSendAddress = formatAddress(sendAddress);
+const sendAmount = '0.000008';
+const formattedSendAmount = `${localizeNumber(sendAmount)} ETH`;
+
+test.describe('Send Base', { tag: ['@group=wallet', '@nightlyOnly'] }, () => {
+    test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
+
+    test.beforeEach(async ({ onboardingPage, dashboardPage, walletPage, settingsPage, page }) => {
+        await page.clock.install();
+        await onboardingPage.completeOnboarding();
+        await settingsPage.changeNetworks({
+            enableNetworks: ['base'], //add more EVMs
+            disableNetworks: ['btc'],
+        });
+        await dashboardPage.deviceSwitchingOpenButton.click();
+        await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+        await walletPage.openAccount({ symbol: 'base', type: 'normal', atIndex: 0 });
+    });
+
+    test('User can set custom fees', async ({ devicePrompt, walletPage, tradingPage }) => {
+        const gasLimit = '26000';
+        const maxFeePerGas = '0.67674454';
+        const maxFeePerGasRounded = new BigNumber(maxFeePerGas).decimalPlaces(
+            4,
+            BigNumber.ROUND_UP,
+        ); // beware of decimal places rounding
+        const maxPriorityFeePerGas = '0.375641927';
+        const maxPriorityFeePerGasRounded = new BigNumber(maxPriorityFeePerGas).decimalPlaces(
+            4, // beware of decimal places rounding
+            BigNumber.ROUND_UP,
+        );
+        await test.step('Fill in a Send form', async () => {
+            await walletPage.openSendFormButton.click();
+            // Race condition 1:5, if input is filled before form completely loads then
+            // input will be cleared and test will fail. As a workaround we wait for fees to be loaded.
+            await tradingPage.fees.expectEthereumFeeCalculated();
+            await tradingPage.sendAddressInput.fill(sendAddress);
+            await tradingPage.sendAmountInput.fill(sendAmount);
+            await tradingPage.fees.setEthereumCustomFees({
+                gasLimit,
+                maxFeePerGas,
+                maxPriorityFeePerGas,
+            });
+        });
+
+        const { ethereumMaximumFee, errorMessageMaxCalculation } =
+            tradingPage.fees.calculateEthereumMaxFee({
+                gasLimit,
+                maxFeePerGas,
+            });
+
+        await test.step('Verify Recipient address', async () => {
+            await tradingPage.sendButton.click();
+            await expect(devicePrompt.headerParagraph).toContainText(networkName);
+            await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedSendAddress);
+            await expect(devicePrompt).toDisplayOnEmulator({
+                header: { title: 'Address', subtitle: 'Recipient' },
+                body: [transformAddress(sendAddress)],
+                footer: 'Tap to continue',
+            });
+        });
+
+        await test.step('Verify Total including fee', async () => {
+            await devicePrompt.waitForPromptAndClick();
+            const gasLimitTranslation = `${messages['TR_GAS_LIMIT'].defaultMessage}: ${gasLimit}`;
+            await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitTranslation);
+            await expect(devicePrompt.ethereumFeeRate).toHaveText(`${maxFeePerGasRounded} Gwei`);
+            await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(
+                `${maxPriorityFeePerGasRounded} Gwei`,
+            );
+            await expect(devicePrompt.cryptoAmountOf('amount')).toHaveText(sendAmount);
+            await expect(devicePrompt.cryptoAmountOf('fee'), errorMessageMaxCalculation).toHaveText(
+                ethereumMaximumFee,
+            );
+            await expect(devicePrompt).toDisplayOnEmulator({
+                header: { title: 'Summary' },
+                body: [
+                    ['Amount'],
+                    [formattedSendAmount],
+                    [' '],
+                    ['Maximum fee'],
+                    splitStringByDisplayLimit(`${ethereumMaximumFee} ETH`),
+                ],
+                footer: 'Tap to continue',
+            });
+        });
+
+        await test.step('Verify Fee Info on emulator', async () => {
+            await tradingPage.fees.openFeeInfoOnEmulator();
+            await expect(devicePrompt).toDisplayOnEmulator({
+                header: { title: 'Fee info' },
+                body: [
+                    ['Gas limit'],
+                    [`${gasLimit} units`],
+                    [' '],
+                    ['Max fee per gas'],
+                    [`${maxFeePerGas} Gwei`],
+                    [' '],
+                    ['Max priority fee'],
+                    [`${maxPriorityFeePerGas} Gwei`],
+                ],
+            });
+        });
+    });
+
+    test('User can perform ethereum sending on base network', async ({
+        devicePrompt,
+        walletPage,
+        tradingPage,
+        page,
+    }) => {
+        await test.step('Fill in a Send form', async () => {
+            await walletPage.openSendFormButton.click();
+            // Race condition 1:5, if input is filled before form completely loads then
+            // input will be cleared and test will fail. As a workaround we wait for fees to be loaded.
+            await tradingPage.fees.expectEthereumFeeCalculated();
+            await tradingPage.sendAddressInput.fill(sendAddress);
+            await tradingPage.sendAmountInput.fill(sendAmount);
+        });
+        const {
+            gasLimit,
+            maxFeePerGas,
+            maxPriorityFeePerGas,
+            maxFeePerGasRounded,
+            maxPriorityFeePerGasRounded,
+        } = await tradingPage.fees.getStandardFeeWorkaround();
+        const { ethereumMaximumFee, errorMessageMaxCalculation } =
+            tradingPage.fees.calculateEthereumMaxFee({
+                gasLimit,
+                maxFeePerGas,
+                numberOfDecimals: 15,
+            });
+
+        await test.step('Verify Recipient address', async () => {
+            await tradingPage.sendButton.click();
+            await expect(devicePrompt.headerParagraph).toContainText(networkName);
+            await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedSendAddress);
+            await expect(devicePrompt).toDisplayOnEmulator({
+                header: { title: 'Address', subtitle: 'Recipient' },
+                body: [transformAddress(sendAddress)],
+                footer: 'Tap to continue',
+            });
+        });
+
+        await test.step('Verify Total including fee', async () => {
+            await devicePrompt.waitForPromptAndClick();
+            const gasLimitTranslation = `${messages['TR_GAS_LIMIT'].defaultMessage}: ${gasLimit}`;
+            await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitTranslation);
+            await expect(devicePrompt.ethereumFeeRate).toHaveText(`${maxFeePerGasRounded} Gwei`);
+            await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(
+                `${maxPriorityFeePerGasRounded} Gwei`,
+            );
+            await expect(devicePrompt.cryptoAmountOf('amount')).toHaveText(sendAmount);
+            await expect(devicePrompt.cryptoAmountOf('fee'), errorMessageMaxCalculation).toHaveText(
+                ethereumMaximumFee,
+            );
+            await expect(devicePrompt).toDisplayOnEmulator({
+                header: { title: 'Summary' },
+                body: [
+                    ['Amount'],
+                    [formattedSendAmount],
+                    [' '],
+                    ['Maximum fee'],
+                    splitStringByDisplayLimit(`${ethereumMaximumFee} ETH`),
+                ],
+                footer: 'Tap to continue',
+            });
+        });
+
+        await test.step('Verify Fee Info on emulator', async () => {
+            await tradingPage.fees.openFeeInfoOnEmulator();
+            await expect(devicePrompt).toDisplayOnEmulator({
+                header: { title: 'Fee info' },
+                body: [
+                    ['Gas limit'],
+                    [`${gasLimit} units`],
+                    [' '],
+                    ['Max fee per gas'],
+                    [`${maxFeePerGas} Gwei`],
+                    [' '],
+                    ['Max priority fee'],
+                    [`${maxPriorityFeePerGas} Gwei`],
+                ],
+            });
+        });
+        await test.step('Confirm transaction', async () => {
+            await devicePrompt.waitForPromptAndConfirm();
+            await devicePrompt.sendButton.click();
+            await page.getByTestId('@toast/tx-sent').click();
+            await page.getByRole('button', { name: 'View details' }).click();
+
+            // Transaction takes ~5s to confirm on the network, but we need to pull
+            // for updated data and check status repeatedly until confirmed
+            await expect(async () => {
+                await page.clock.fastForward(30_000);
+
+                await expect(page.getByTestId('@modal/tx-details/confirmed')).toHaveText(
+                    'Confirmed',
+                );
+            }).toPass({ timeout: 30_000 });
+        });
+    });
+});


### PR DESCRIPTION
## Description

This PR adds end-to-end tests for sending transactions on the Base network (EVM chain).

1. **Custom fee transaction test**: Tests the ability to set custom gas fees (gas limit, max fee per gas, and max priority fee per gas) and verifies all fee-related information displayed on the device emulator.

2. **Standard fee transaction test**: Tests a complete send flow with standard fees, including transaction confirmation on the network and verification of the confirmed status in the transaction details modal.

### Key changes:

- **New test file**: Added `send-base.test.ts` with comprehensive tests for Base network transactions
- **Enhanced page object**: Extended the `Fees` page object with:
  - `getStandardFeeWorkaround()`: Helper method to extract standard fee values by temporarily switching to custom mode
  - `switchToStandard()`: Method to switch back to standard fee mode
  - Improved `calculateEthereumMaxFee()` with configurable decimal precision
- **Added test IDs**: Added `data-testid` attributes to transaction detail modal for better testability of confirmed/unconfirmed states

Test will be only in nightly desktop because on how it has a finite resources.
https://github.com/trezor/trezor-suite/actions/runs/20138399179

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=EVM-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=EVM-tests&lookback=7)