### PR TITLE
chore: update react-toastify

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -129,7 +129,7 @@
         "react-intl": "^7.1.11",
         "react-redux": "9.2.0",
         "react-select": "^5.10.2",
-        "react-toastify": "^10.0.4",
+        "react-toastify": "^10.0.5",
         "react-use": "^17.6.0",
         "react-zxing": "^2.1.0",
         "recharts": "^2.15.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14879,7 +14879,7 @@ __metadata:
     react-intl: "npm:^7.1.14"
     react-redux: "npm:9.2.0"
     react-select: "npm:^5.10.2"
-    react-toastify: "npm:^10.0.4"
+    react-toastify: "npm:^10.0.5"
     react-use: "npm:^17.6.0"
     react-zxing: "npm:^2.1.0"
     recharts: "npm:^2.15.3"
@@ -39310,7 +39310,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-toastify@npm:^10.0.4":
+"react-toastify@npm:^10.0.5":
   version: 10.0.6
   resolution: "react-toastify@npm:10.0.6"
   dependencies:


### PR DESCRIPTION
## Description

The react-toastify library has been updated to version 10.0.5.

## Notes for QA

This is a minor update, there is no risk that the notification will stop working.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23126

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/update-react-toastify&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/update-react-toastify&lookback=7)