### PR TITLE
refactor(protocol): return unmasked magic from readThpHeader

### DIFF
--- a/packages/protocol/src/protocol-thp/decode.ts
+++ b/packages/protocol/src/protocol-thp/decode.ts
@@ -16,7 +16,7 @@ import { crc32 } from './crypto/crc32';
 import { getHandshakeHash, getTrezorState } from './crypto/pairing';
 import { getIvFromNonce } from './crypto/tools';
 import { ThpDeviceProperties, ThpError, ThpMessageResponse } from './messages';
-import { clearControlBit, readThpHeader } from './utils';
+import { readThpHeader } from './utils';
 
 type ThpMessage = ReturnType<TransportProtocolDecode> & {
     magic: number;
@@ -188,8 +188,7 @@ const validateCrc = (decodedMessage: ReturnType<TransportProtocolDecode>) => {
 export const decodeSendAck = (decodedMessage: MessageV2) => {
     validateCrc(decodedMessage);
 
-    const header = readThpHeader(decodedMessage.header);
-    const magic = clearControlBit(header.magic);
+    const { magic } = readThpHeader(decodedMessage.header);
     if (magic === THP_ERROR_HEADER_BYTE) {
         return decodeThpError(decodedMessage.payload);
     }
@@ -217,7 +216,7 @@ export const decode = (
         thpState,
     };
 
-    const magic = clearControlBit(message.magic);
+    const { magic } = header;
     if (magic === THP_ERROR_HEADER_BYTE) {
         return decodeThpError(message.payload);
     }

--- a/packages/protocol/src/protocol-thp/utils.ts
+++ b/packages/protocol/src/protocol-thp/utils.ts
@@ -48,7 +48,7 @@ export const readThpHeader = (bytes: Buffer) => {
     const channel = bytes.subarray(1, 3);
 
     return {
-        magic,
+        magic: clearControlBit(magic),
         ackBit,
         sequenceBit,
         channel,
@@ -71,8 +71,7 @@ export const isAckExpected = (bytesOrMagic: Buffer | number[]) => {
 
 // get expected responses from decoded request data
 export const getExpectedResponses = (bytes: Buffer) => {
-    const header = readThpHeader(bytes);
-    const magic = clearControlBit(header.magic);
+    const { magic } = readThpHeader(bytes);
 
     if (magic === THP_CREATE_CHANNEL_REQUEST) {
         return [THP_CREATE_CHANNEL_RESPONSE];
@@ -121,7 +120,7 @@ export const isExpectedResponse = (bytes: Buffer, state: ThpState) => {
         return false;
     }
 
-    const magic = clearControlBit(header.magic);
+    const { magic } = header;
     if (magic === THP_ERROR_HEADER_BYTE) {
         // ThpError is always expected
         return true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Random cosmetic change,

use `clearControlBit` inside `readThpHeader` and return already unmasked magic (control byte)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/thp-clearbits&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/thp-clearbits&lookback=7)