### PR TITLE
Mobile Sell: Validate cryptoStringAmount when quote is loaded

### DIFF
--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
@@ -300,6 +300,34 @@ describe('useSellForm', () => {
                     expect(invalid).toBe(expectedInvalid);
                 },
             );
+
+            it("should be validated once the quote is selected and it changes it's value", async () => {
+                const { result } = await renderUseSellForm();
+                act(() => {
+                    store.dispatch(tradingSellActions.setTradingAccountKey('eth-account-1'));
+                    result.current.setValue('amountInCrypto', false);
+                    result.current.setValue('sendAsset', usdcAsset);
+                    result.current.setValue('fiatStringAmount', '100');
+                });
+
+                await act(async () => {
+                    result.current.setValue('quote', {
+                        ...sellQuotes[0],
+                        cryptoStringAmount: '2',
+                    });
+                    // settle validations
+                    await Promise.resolve();
+                });
+
+                const { invalid, error } = result.current.getFieldState('cryptoStringAmount');
+                expect(invalid).toBe(true);
+                expect(error).toEqual(
+                    expect.objectContaining({
+                        message: 'Insufficient balance',
+                        type: 'insufficient-balance',
+                    }),
+                );
+            });
         });
 
         describe('fiatStringAmount', () => {

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellQuotes.test.ts
@@ -264,6 +264,40 @@ describe('useSellQuotes', () => {
         expect(store.getState().wallet.trading.sell.quotes).toEqual([]);
     });
 
+    it('should not clear quotes when error is from quote', async () => {
+        const sellQuoteWithTooHighCryptoAmount = {
+            ...sellQuotes[0],
+            cryptoStringAmount: '2',
+        };
+        const store = await getInitializedStore();
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const { result } = await renderUseSellQuotes(store);
+
+        act(() => {
+            store.dispatch(tradingSellActions.setTradingAccountKey('eth-account-1'));
+            result.current.setValue('sendAsset', usdcAsset);
+            result.current.setValue('fiatCurrency', 'usd');
+            result.current.setValue('amountInCrypto', false);
+            result.current.setValue('fiatStringAmount', '100');
+        });
+        // handleRequestThunk is mocked, add quotes manually
+        await act(async () => {
+            store.dispatch(tradingSellActions.saveQuotes([sellQuoteWithTooHighCryptoAmount]));
+            // allow validations to run
+            await Promise.resolve();
+        });
+
+        dispatchSpy.mockClear();
+        expect(store.getState().wallet.trading.sell.quotes).toEqual([
+            sellQuoteWithTooHighCryptoAmount,
+        ]);
+        expect(result.current.getValues('quote')).toEqual(sellQuoteWithTooHighCryptoAmount);
+
+        // make sure form has an error
+        const { invalid } = result.current.getFieldState('cryptoStringAmount');
+        expect(invalid).toBe(true);
+    });
+
     it('should not query quotes when form contains error', async () => {
         const store = await getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellSelectQuote.test.ts
@@ -52,6 +52,21 @@ describe('useSellSelectQuote', () => {
             expect(result.current.canProceed).toEqual(false);
         });
 
+        it('should be false when form contains error', async () => {
+            act(() => {
+                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                sellForm.setValue('quote', sellQuotes[0]);
+                sellForm.setError('cryptoStringAmount', {
+                    type: 'manual',
+                    message: 'VALIDATION_ERROR',
+                });
+            });
+
+            const { result } = await renderUseSellSelectQuote();
+
+            expect(result.current.canProceed).toEqual(false);
+        });
+
         it('should be true when quote is selected', async () => {
             act(() => {
                 sellForm.setValue('quote', sellQuotes[0]);

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.ts
@@ -175,7 +175,7 @@ const useSellQuoteChangeEffect = ({ getValues, setValue, watch }: SellFormType) 
                           getNetwork(symbol).decimals,
                       )
                     : truncatedCryptoAmount;
-            setValue('cryptoStringAmount', value);
+            setValue('cryptoStringAmount', value, { shouldValidate: true });
         }
     }, [quote, isAmountInSats, symbol, getValues, setValue]);
 };

--- a/suite-native/module-trading/src/hooks/sell/useSellQuotes.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellQuotes.ts
@@ -48,33 +48,34 @@ const noop = () => {};
 const useShouldFetchSellQuotes = ({ watch, control }: SellFormType): ShouldFetchSellQuotes => {
     const prevState = useRef<ShouldFetchSellQuotesRef>(defaultState);
 
-    const { isValid } = useFormState({ control });
-    if (!isValid) {
-        prevState.current = defaultState;
+    const amountInCrypto = watch('amountInCrypto');
 
-        return {
-            isFetchAllowed: false,
-            shouldFetchQuotes: false,
-        };
+    const { isValid, errors } = useFormState({ control });
+
+    if (!isValid) {
+        const errorCausedByQuote =
+            !amountInCrypto &&
+            Object.values(errors).every(({ type }) => type === 'insufficient-balance');
+
+        if (!errorCausedByQuote) {
+            prevState.current = defaultState;
+
+            return {
+                isFetchAllowed: false,
+                shouldFetchQuotes: false,
+            };
+        }
     }
 
-    const [
-        sendAsset,
-        sendAccount,
-        cryptoStringAmount,
-        fiatStringAmount,
-        amountInCrypto,
-        fiatCurrency,
-        country,
-    ] = watch([
-        'sendAsset',
-        'sendAccount',
-        'cryptoStringAmount',
-        'fiatStringAmount',
-        'amountInCrypto',
-        'fiatCurrency',
-        'country',
-    ]);
+    const [sendAsset, sendAccount, cryptoStringAmount, fiatStringAmount, fiatCurrency, country] =
+        watch([
+            'sendAsset',
+            'sendAccount',
+            'cryptoStringAmount',
+            'fiatStringAmount',
+            'fiatCurrency',
+            'country',
+        ]);
 
     const amount = amountInCrypto ? cryptoStringAmount : fiatStringAmount;
     const isFetchAllowed = !!(sendAsset && fiatCurrency && amount && parseFloat(amount) > 0);

--- a/suite-native/module-trading/src/hooks/sell/useSellSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellSelectQuote.ts
@@ -9,6 +9,7 @@ import {
     sellThunks,
     tradingSellActions,
 } from '@suite-common/trading';
+import { useFormState } from '@suite-native/forms';
 import {
     RootStackParamList,
     StackToStackCompositeNavigationProps,
@@ -36,14 +37,15 @@ export const useSellSelectQuote = (form: SellFormType): SellSelectQuoteReturn =>
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
     const timer = useNullTimer();
-    const { watch } = form;
+    const { watch, control } = form;
+    const { isValid } = useFormState({ control });
     const candidateQuote = watch('quote');
     const isLoading = useSelector(selectTradingSellIsLoading);
     const sellInfo = useSelector(selectTradingSellInfo);
 
     const sendAccount = useSelector(selectSellSelectedSendAccount);
 
-    const canProceed = !!candidateQuote && !!sendAccount && !isLoading;
+    const canProceed = isValid && !!candidateQuote && !!sendAccount && !isLoading;
 
     const selectQuote = useCallback(async () => {
         if (!candidateQuote || isLoading) {

--- a/suite-native/module-trading/src/utils/general/validationSchemes.ts
+++ b/suite-native/module-trading/src/utils/general/validationSchemes.ts
@@ -137,6 +137,7 @@ export const sendCryptoAmountValidationSchema = yup
         }
 
         return testContext.createError({
+            type: 'insufficient-balance',
             message: translate('moduleTrading.validators.insufficientBalance'),
         });
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Validate crypto amount value when it is filled from quote.
- Do not display continue button when form is not valid.

<!--- Describe your changes in detail -->

## Notes for QA

Please test I did not break other form interactions and validations.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #23597

## Screenshots:

<img width="300" alt="Screen Shot 2025-12-04 at 20 00 58 PM" src="https://github.com/user-attachments/assets/bf3e3f35-5506-429d-b064-7269932b3d90" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=23597-mobile-sell-flow-allows-selling-more-crypto-than-available-balance&lookback=7)