### PR TITLE
fix(suite): showing update QuickActions & banner correctly

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/QuickActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/QuickActions.tsx
@@ -24,21 +24,13 @@ const ActionsContainer = styled.div<{ $isSidebarCollapsed: boolean }>`
 `;
 
 type QuickActionsProps = {
-    hideDeviceUpdateStatusBar?: boolean;
     isSidebarCollapsed: boolean;
-    showUpdateBannerNotification?: boolean;
+    hideUpdateQuickAction: boolean;
 };
 
-export const QuickActions = ({
-    hideDeviceUpdateStatusBar,
-    isSidebarCollapsed,
-    showUpdateBannerNotification,
-}: QuickActionsProps) => (
+export const QuickActions = ({ isSidebarCollapsed, hideUpdateQuickAction }: QuickActionsProps) => (
     <ActionsContainer $isSidebarCollapsed={isSidebarCollapsed}>
-        <UpdateStatusActionBarIcon
-            hideDeviceUpdateStatusBar={Boolean(hideDeviceUpdateStatusBar)}
-            showUpdateBannerNotification={Boolean(showUpdateBannerNotification)}
-        />
+        <UpdateStatusActionBarIcon hideUpdateQuickAction={hideUpdateQuickAction} />
         <DebugAndExperimental />
         <CustomBackend />
         <Tor />

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/UpdateNotificationBanner.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/UpdateNotificationBanner.tsx
@@ -3,11 +3,12 @@ import { MouseEvent } from 'react';
 import { type Variants, motion } from 'framer-motion';
 import styled from 'styled-components';
 
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Column, ElevationContext, Icon, Row, Text } from '@trezor/components';
 import { Elevation, borders, mapElevationToBackground, spacingsPx } from '@trezor/theme';
 
+import { Translation, TranslationKey } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
 
 import {
     UpdateStatus,
@@ -16,7 +17,6 @@ import {
     mapDeviceUpdateToClick,
     mapSuiteUpdateToClick,
 } from './updateQuickActionTypes';
-import { Translation, TranslationKey } from '../../../../../Translation';
 
 type ContainerProps = { $elevation: Elevation };
 
@@ -80,8 +80,7 @@ export const UpdateNotificationBanner = ({
     onClose,
 }: UpdateNotificationBannerProps) => {
     const dispatch = useDispatch();
-    const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
-    const discoveryInProgress = discoveryStatus && discoveryStatus.status === 'loading';
+    const discoveryInProgress = useSelector(selectHasRunningDiscovery);
 
     const translationHeader =
         updateStatusSuite !== 'up-to-date' // Update suite first, because it will contain the newest firmware

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/UpdateStatusActionBarIcon.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/UpdateStatusActionBarIcon.tsx
@@ -2,22 +2,14 @@ import { useDispatch } from 'react-redux';
 
 import styled, { DefaultTheme, css, useTheme } from 'styled-components';
 
-import {
-    ComponentWithSubIcon,
-    Icon,
-    IconSize,
-    ManagedTooltipProps,
-    Tooltip,
-    getIconSize,
-    iconSizes,
-} from '@trezor/components';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { ComponentWithSubIcon, Icon, IconSize, getIconSize, iconSizes } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
 import { mapTrezorModelToIcon } from '@trezor/product-components';
 import { CSSColor, Color, borders } from '@trezor/theme';
 
-import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
+import { useDevice, useSelector } from 'src/hooks/suite';
 
-import { useDevice, useSelector } from '../../../../../../../hooks/suite';
 import { QuickActionButton } from '../QuickActionButton';
 import { UpdateIconGroup } from './UpdateIconGroup';
 import { UpdateTooltip } from './UpdateTooltip';
@@ -157,19 +149,17 @@ const SuiteUpdateIcon = ({ iconSize, updateStatus, variant }: SuiteUpdateIconPro
 };
 
 type UpdateStatusActionBarIconProps = {
-    showUpdateBannerNotification: boolean;
-    hideDeviceUpdateStatusBar?: boolean;
+    hideUpdateQuickAction: boolean;
 };
 
 export const UpdateStatusActionBarIcon = ({
-    showUpdateBannerNotification,
-    hideDeviceUpdateStatusBar,
+    hideUpdateQuickAction,
 }: UpdateStatusActionBarIconProps) => {
     const theme = useTheme();
 
     const { updateStatus, updateStatusDevice, updateStatusSuite } = useUpdateStatus();
-    const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
-    const discoveryInProgress = discoveryStatus && discoveryStatus.status === 'loading';
+    const discoveryInProgress = useSelector(selectHasRunningDiscovery);
+    const displayDeviceUpdateStatusBar = !discoveryInProgress;
 
     const { device } = useDevice();
     const dispatch = useDispatch();
@@ -181,7 +171,9 @@ export const UpdateStatusActionBarIcon = ({
     const isDesktopSuite = isDesktop();
 
     const suiteOnClick = mapSuiteUpdateToClick[updateStatusSuite];
-    const deviceOnClick = mapDeviceUpdateToClick[updateStatusDevice];
+    const deviceOnClick = displayDeviceUpdateStatusBar
+        ? mapDeviceUpdateToClick[updateStatusDevice]
+        : null;
 
     const suiteOnClickHandler = suiteOnClick ? () => suiteOnClick({ dispatch }) : undefined;
     const deviceOnClickHandler = deviceOnClick ? () => deviceOnClick({ dispatch }) : undefined;
@@ -194,62 +186,54 @@ export const UpdateStatusActionBarIcon = ({
         }
     };
 
-    const displayDeviceUpdateStatusBar = !hideDeviceUpdateStatusBar && !discoveryInProgress;
-
     const anyUpdateInfoAvailable = isDesktopSuite || displayDeviceUpdateStatusBar;
 
-    const getTooltip = (): Partial<ManagedTooltipProps> => ({
-        isActive: !showUpdateBannerNotification,
-        content: (
-            <UpdateTooltip
-                displayDeviceUpdateStatus={displayDeviceUpdateStatusBar}
-                updateStatusDevice={updateStatusDevice}
-                onClickSuite={suiteOnClickHandler}
-                updateStatusSuite={updateStatusSuite}
-                onClickDevice={deviceOnClickHandler}
-            />
-        ),
-    });
-
-    const tooltip = getTooltip();
+    const tooltipContent = (
+        <UpdateTooltip
+            displayDeviceUpdateStatus={displayDeviceUpdateStatusBar}
+            updateStatusDevice={updateStatusDevice}
+            onClickSuite={suiteOnClickHandler}
+            updateStatusSuite={updateStatusSuite}
+            onClickDevice={deviceOnClickHandler}
+        />
+    );
 
     if (!anyUpdateInfoAvailable) {
         return null;
     }
 
     return (
-        <div>
-            <QuickActionButton onClick={handleClick}>
-                <ComponentWithSubIcon
-                    variant={variant}
-                    icon={
-                        <Icon
-                            name={updateSubIcon}
-                            color={theme.iconDefaultInverted}
-                            size={iconSizes.extraSmall}
+        <QuickActionButton
+            onClick={handleClick}
+            tooltip={{ content: tooltipContent, isActive: !hideUpdateQuickAction }}
+        >
+            <ComponentWithSubIcon
+                variant={variant}
+                icon={
+                    <Icon
+                        name={updateSubIcon}
+                        color={theme.iconDefaultInverted}
+                        size={iconSizes.extraSmall}
+                    />
+                }
+            >
+                <UpdateIconGroup $variant={variant}>
+                    {device?.features !== undefined && (
+                        <DeviceUpdateIcon
+                            iconSize={iconSize}
+                            updateStatus={updateStatusDevice}
+                            variant={variant}
                         />
-                    }
-                >
-                    <Tooltip content={tooltip?.content} cursor="pointer" {...tooltip}>
-                        <UpdateIconGroup $variant={variant}>
-                            {device?.features !== undefined && (
-                                <DeviceUpdateIcon
-                                    iconSize={iconSize}
-                                    updateStatus={updateStatusDevice}
-                                    variant={variant}
-                                />
-                            )}
-                            {isDesktopSuite && (
-                                <SuiteUpdateIcon
-                                    iconSize={iconSize}
-                                    updateStatus={updateStatusSuite}
-                                    variant={variant}
-                                />
-                            )}
-                        </UpdateIconGroup>
-                    </Tooltip>
-                </ComponentWithSubIcon>
-            </QuickActionButton>
-        </div>
+                    )}
+                    {isDesktopSuite && (
+                        <SuiteUpdateIcon
+                            iconSize={iconSize}
+                            updateStatus={updateStatusSuite}
+                            variant={variant}
+                        />
+                    )}
+                </UpdateIconGroup>
+            </ComponentWithSubIcon>
+        </QuickActionButton>
     );
 };

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
@@ -148,9 +148,10 @@ export const Sidebar = ({ showAccounts = true }: SidebarProps) => {
         }
     };
 
-    const showUpdateBannerNotification =
+    const isUpdateAvailable =
         (updateStatusSuite !== 'up-to-date' && !closedNotificationSuite) ||
         (!['up-to-date', 'disconnected'].includes(updateStatusDevice) && !closedNotificationDevice);
+    const showUpdateBannerNotification = !isSidebarCollapsed && isBannerVisible;
 
     const showAccountsAndIsDeviceReady =
         !shouldDisplayDeviceCompromised &&
@@ -227,19 +228,17 @@ export const Sidebar = ({ showAccounts = true }: SidebarProps) => {
                                 {showAccountsAndIsDeviceReady && <AccountsMenu />}
                             </HorizontalSpacer>
                             <AnimatePresence onExitComplete={onNotificationBannerClosed}>
-                                {showUpdateBannerNotification &&
-                                    !isSidebarCollapsed &&
-                                    isBannerVisible && (
-                                        <UpdateNotificationBanner
-                                            updateStatusDevice={updateStatusDevice}
-                                            updateStatusSuite={updateStatusSuite}
-                                            onClose={() => setIsBannerVisible(false)}
-                                        />
-                                    )}
+                                {isUpdateAvailable && showUpdateBannerNotification && (
+                                    <UpdateNotificationBanner
+                                        updateStatusDevice={updateStatusDevice}
+                                        updateStatusSuite={updateStatusSuite}
+                                        onClose={() => setIsBannerVisible(false)}
+                                    />
+                                )}
                             </AnimatePresence>
                             <QuickActions
                                 isSidebarCollapsed={isSidebarCollapsed}
-                                showUpdateBannerNotification={showUpdateBannerNotification}
+                                hideUpdateQuickAction={showUpdateBannerNotification}
                             />
                         </Content>
                     </TrafficLightOffset>


### PR DESCRIPTION
## Description

Fix several bugs with Desktop & FW update UI:
- Severe:
  - tooltip & banner was completely missing for some cases, or even overlapping (they should be mutually exclusive)
  - updates were hidden when there is no device, because Suite thought discovery is running :facepalm:
- Nits:
  - tooltip did not trigger correctly (onmouseover obscured by the badge icon)
  - device FW update was still clickable during discovery – even when UI was intentionally hidden

## Notes for QA

- Please test various scenarios of desktop update flow, that the quick action & banner is correctly displayed.
- same with outdated FW
- test that FW update is not notified when discovery is running
- Try also collapsed sidebar (when small window width)

## Screenshots:

### before

Some bugs are not screenshotable because the tooltips and banners were simply missing in some situations.

FYI I tested with version _mocked_ to 25.9.0, not the actual old release, to test how it is gonna look like when latest version becomes outdated in future (that's what needs to be tested)

Here is the tiny bug where the tooltip onmouseover is obscured by the SubIcon

[onmouseover obscured](https://github.com/user-attachments/assets/04cf5a24-2774-4fc9-917d-4769978bbf73)

### after

Desktop update available banner & notification:

[update available](https://github.com/user-attachments/assets/7a3c2125-fdc9-48b7-8708-2411af826f92)

After update banner & notification:

[after update](https://github.com/user-attachments/assets/a65302fe-9b49-414f-ad9f-090eb862a428)

Device FW update & interaction with running discovery

[device & discovery](https://github.com/user-attachments/assets/d649e9ce-dfd9-4d87-aa50-02cebde6946d)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/showing-update-QuickActions&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/showing-update-QuickActions&lookback=7)