### PR TITLE
fix(connect): module dynamic import issue

### DIFF
--- a/scripts/publish/babel-plugin-sanitize-internal-imports.js
+++ b/scripts/publish/babel-plugin-sanitize-internal-imports.js
@@ -5,6 +5,9 @@ const sanitizeInternalImports = (src, moduleType) => {
     return src.replace(searchValue, replaceValue);
 };
 
+const sanitizeDynamicImport = src =>
+    // Manually replace .ts extensions with .js (for dynamic imports)
+    src.replace(/\.ts(['"`]|$)/g, '.js$1');
 /**
  * Babel plugin to sanitize non-index internal imports, from src to the built lib or libESM folder.
  * e.g. @trezor/utils/src/bufferUtils → @trezor/utils/lib/bufferUtils
@@ -22,6 +25,18 @@ const sanitizeInternalImportsPlugin = ({ types }) => {
         const first = args[0];
         if (!types.isStringLiteral(first)) return;
         first.value = sanitizeInternalImports(first.value, 'cjs');
+    };
+
+    const modifyTemplateLiteral = path => {
+        const { quasis } = path.node;
+        if (!quasis || quasis.length === 0) return;
+
+        quasis.forEach(quasi => {
+            if (quasi.value && quasi.value.raw) {
+                quasi.value.raw = sanitizeDynamicImport(quasi.value.raw);
+                quasi.value.cooked = sanitizeDynamicImport(quasi.value.cooked || quasi.value.raw);
+            }
+        });
     };
 
     return {
@@ -51,6 +66,10 @@ const sanitizeInternalImportsPlugin = ({ types }) => {
                 ) {
                     modifyCJSRequireArg(path);
                 }
+            },
+            // handle template literals (for dynamic imports with template strings)
+            TemplateLiteral(path) {
+                modifyTemplateLiteral(path);
             },
         },
     };

--- a/scripts/publish/replace-imports.sh
+++ b/scripts/publish/replace-imports.sh
@@ -28,5 +28,4 @@ else
     BABEL_CONFIG="$SCRIPT_DIR/babel.config.cjs.json"
 fi
 
-
-babel "$1" --out-dir "$1" --extensions ".js" --config-file "$BABEL_CONFIG"
+yarn run -T babel "$1" --out-dir "$1" --extensions ".js" --config-file "$BABEL_CONFIG"


### PR DESCRIPTION
## Description

Changes in #17152 added `index.ts` to the runtime import path for Connect modules, which is not available in the published package. It should be `index.js`
However for Webpack and Vite we want to keep `index.ts`.

This is fixed by updating the replace-imports babel script to handle this case, resulting in the following change in the build:
```
lib/core/method.js newlib/core/method.js
20c20
<   const methods = methodModule ? await Promise.resolve(`${`../api/${methodModule}/api/index.ts`}`).then(s => tslib_1.__importStar(require(s))) : Methods;
---
>   const methods = methodModule ? await Promise.resolve(`${`../api/${methodModule}/api/index.js`}`).then(s => tslib_1.__importStar(require(s))) : Methods;
```

## Related Issue

Resolve #23593


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-module-import&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-module-import&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-module-import&lookback=7)