### PR TITLE
23614 mobile display trading webview uri

### DIFF
--- a/suite-native/config/src/launch-arguments.ts
+++ b/suite-native/config/src/launch-arguments.ts
@@ -14,6 +14,7 @@ export type LaunchArguments = {
     isFirmwareUpdateEnabled?: boolean;
     areTradingExchangeDexesEnabled?: boolean;
     isTradingResidenceCheckEnabled?: boolean;
+    isTradingDebugEnabled?: boolean;
 };
 
 export const launchArguments = LaunchArguments.value<LaunchArguments>();

--- a/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
@@ -24,6 +24,7 @@ describe('featureFlagsSlice', () => {
                 isTradingExchangeEnabled: false,
                 isTradingResidenceCheckEnabled: true,
                 isTradingSellEnabled: false,
+                isTradingDebugEnabled: false,
             });
         });
 
@@ -43,6 +44,7 @@ describe('featureFlagsSlice', () => {
                 isTradingSellEnabled: false,
                 areTradingExchangeDexesEnabled: false,
                 isTradingResidenceCheckEnabled: false,
+                isTradingDebugEnabled: false,
             });
         });
     });

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -12,6 +12,7 @@ export const FeatureFlag = {
     IsTradingSellEnabled: 'isTradingSellEnabled',
     AreTradingExchangeDexesEnabled: 'areTradingExchangeDexesEnabled',
     IsTradingResidenceCheckEnabled: 'isTradingResidenceCheckEnabled',
+    IsTradingDebugEnabled: 'isTradingDebugEnabled',
 } as const;
 
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
@@ -40,6 +41,8 @@ export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsTradingResidenceCheckEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_TRADING_RESIDENCE_CHECK_ENABLED === 'true' ||
         (isIOs() && process.env.EXPO_PUBLIC_FF_IS_TRADING_RESIDENCE_CHECK_ENABLED !== 'false'),
+    [FeatureFlag.IsTradingDebugEnabled]:
+        process.env.EXPO_PUBLIC_FF_IS_TRADING_DEBUG_ENABLED === 'true',
 };
 
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
@@ -51,6 +54,7 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsTradingSellEnabled,
     FeatureFlag.AreTradingExchangeDexesEnabled,
     FeatureFlag.IsTradingResidenceCheckEnabled,
+    FeatureFlag.IsTradingDebugEnabled,
 ];
 
 export const featureFlagsSlice = createSlice({

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -16,6 +16,7 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsTradingSellEnabled]: '💰 Trading Sell',
     [FeatureFlagEnum.AreTradingExchangeDexesEnabled]: '💰 Trading Exchange Dexes',
     [FeatureFlagEnum.IsTradingResidenceCheckEnabled]: '💰 Trading Residence Check',
+    [FeatureFlagEnum.IsTradingDebugEnabled]: '💰 Trading Debug Mode',
 } as const satisfies Record<FeatureFlagEnum, string>;
 
 const FeatureFlag = ({ featureFlag }: { featureFlag: FeatureFlagEnum }) => {

--- a/suite-native/module-trading/README.md
+++ b/suite-native/module-trading/README.md
@@ -90,6 +90,9 @@ graph TD
     trading-state --> trading-consts
     trading-state -.-> trading-types
     trading-atoms -.-> trading-types
+    trading-debug -.-> trading-types
+    trading-debug -.-> trading-consts
+    trading-debug --> trading-state
     trading-atoms -.-> trading-fixtures
     trading-fixtures -.-> trading-types
     trading-fixtures --> trading-consts

--- a/suite-native/module-trading/README.md
+++ b/suite-native/module-trading/README.md
@@ -32,6 +32,7 @@ Provides logic shared between trading and send flow.
 ### Internal trading modules
 
 - **@suite-native/trading-atoms:** Reusable components.
+- **@suite-native/trading-debug:** Debug UI components for displaying information while `IsTradingDebugEnabled` FF is set.
 - **@suite-native/trading-types:** Types used across trading modules.
 - **@suite-native/trading-consts:** Constants used across trading modules.
 - **@suite-native/trading-fixtures:** Fixtures for testing trading features.
@@ -50,6 +51,7 @@ graph TD
     trading-state["@suite-native/trading-state"]
     subgraph trading-internal["Trading internal modules"]
         trading-atoms["@suite-native/trading-atoms"]
+        trading-debug["@suite-native/trading-debug"]
         trading-fixtures["@suite-native/trading-fixtures"]
         trading-types["@suite-native/trading-types"]
         trading-consts["@suite-native/trading-consts"]
@@ -75,6 +77,7 @@ graph TD
     module-trading -.-> trading-types
     module-trading --> trading-consts
     module-trading -.-> trading-fixtures
+    module-trading --> trading-debug
     module-trading --> trading-atoms
     module-trading --> trading-state
     module-trading --> transaction-management

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -56,6 +56,7 @@
         "@suite-native/tokens": "workspace:*",
         "@suite-native/trading-atoms": "workspace:*",
         "@suite-native/trading-consts": "workspace:*",
+        "@suite-native/trading-debug": "workspace:*",
         "@suite-native/trading-residence": "workspace:*",
         "@suite-native/trading-state": "workspace:*",
         "@suite-native/transaction-management": "workspace:*",

--- a/suite-native/module-trading/src/screens/TradingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.tsx
@@ -7,6 +7,7 @@ import { EventType, analytics } from '@suite-native/analytics';
 import { VStack } from '@suite-native/atoms';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { Screen, TradingStackRoutes } from '@suite-native/navigation';
+import { TradingEnvironmentWarning } from '@suite-native/trading-debug';
 import {
     selectActiveTradingType,
     selectIsTradingEnabled,
@@ -45,6 +46,7 @@ const TradingScreenContent = () => {
 
     return (
         <VStack spacing="sp16">
+            <TradingEnvironmentWarning />
             <Header isFormMountedRecently={isScreenMountedRecently} />
             <TradingTabContent />
             <HistoryButton isFormMountedRecently={isScreenMountedRecently} />

--- a/suite-native/module-trading/src/screens/TradingWebViewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingWebViewScreen.tsx
@@ -18,6 +18,7 @@ import {
     ScreenHeader,
     StackProps,
 } from '@suite-native/navigation';
+import { DebugModeCopyableText } from '@suite-native/trading-debug';
 import { tradingActions } from '@suite-native/trading-state';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
@@ -105,6 +106,7 @@ export const TradingWebViewScreen = () => {
             noHorizontalPadding
             noBottomPadding
         >
+            <DebugModeCopyableText text={source.uri || 'no URI'} title="URI:" />
             <WebView
                 style={applyStyle(webViewStyle)}
                 source={{ ...sourceData }}

--- a/suite-native/module-trading/tsconfig.json
+++ b/suite-native/module-trading/tsconfig.json
@@ -65,6 +65,7 @@
         { "path": "../tokens" },
         { "path": "../trading-atoms" },
         { "path": "../trading-consts" },
+        { "path": "../trading-debug" },
         { "path": "../trading-residence" },
         { "path": "../trading-state" },
         { "path": "../transaction-management" },

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -100,7 +100,7 @@ export const prepareRootReducers = async () => {
 
     const tradingPersistedReducer = await preparePersistReducer({
         reducer: tradingReducer,
-        persistedKeys: ['favouriteAssets', 'trades', 'settings', 'residence'],
+        persistedKeys: ['favouriteAssets', 'trades', 'settings', 'residence', 'tradingEnvironment'],
         key: 'trading',
         version: 2,
         migrations: {

--- a/suite-native/trading-debug/jest.config.js
+++ b/suite-native/trading-debug/jest.config.js
@@ -1,0 +1,11 @@
+/**
+ * Jest configuration for native packages.
+ * Keeping this file next to the package.json file instead of providing configuration
+ * with `-c ../../jest.config.native` option in package.json scripts
+ * allows us to run jest tests directly from IDEs.
+ */
+const baseConfig = require('../../jest.config.native');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-native/trading-debug/package.json
+++ b/suite-native/trading-debug/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "@suite-native/trading-debug",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "yarn g:jest",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@reduxjs/toolkit": "2.10.1",
+        "@suite-native/atoms": "workspace:*",
+        "@suite-native/clipboard": "workspace:*",
+        "@suite-native/feature-flags": "workspace:*",
+        "@trezor/styles": "workspace:*",
+        "react": "19.1.0"
+    },
+    "devDependencies": {
+        "@suite-native/test-utils": "workspace:*"
+    }
+}

--- a/suite-native/trading-debug/package.json
+++ b/suite-native/trading-debug/package.json
@@ -16,10 +16,14 @@
         "@suite-native/atoms": "workspace:*",
         "@suite-native/clipboard": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",
+        "@suite-native/trading-state": "workspace:*",
         "@trezor/styles": "workspace:*",
-        "react": "19.1.0"
+        "react": "19.1.0",
+        "react-redux": "9.2.0"
     },
     "devDependencies": {
-        "@suite-native/test-utils": "workspace:*"
+        "@suite-native/test-utils": "workspace:*",
+        "@suite-native/trading-consts": "workspace:*",
+        "@suite-native/trading-types": "workspace:*"
     }
 }

--- a/suite-native/trading-debug/redux.d.ts
+++ b/suite-native/trading-debug/redux.d.ts
@@ -1,0 +1,7 @@
+import { AsyncThunkAction } from '@reduxjs/toolkit';
+
+declare module 'redux' {
+    export interface Dispatch {
+        <TThunk extends AsyncThunkAction<any, any, any>>(thunk: TThunk): ReturnType<TThunk>;
+    }
+}

--- a/suite-native/trading-debug/src/components/CopyableText.tsx
+++ b/suite-native/trading-debug/src/components/CopyableText.tsx
@@ -1,0 +1,39 @@
+import { HStack, IconButton, Text } from '@suite-native/atoms';
+import { useCopyToClipboard } from '@suite-native/clipboard';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+export type CopyableTextProps = {
+    text: string;
+    title?: string;
+};
+
+const textToCopyStyle = prepareNativeStyle(() => ({
+    flexShrink: 1,
+}));
+
+export const CopyableText = ({ text, title }: CopyableTextProps) => {
+    const copyToClipboard = useCopyToClipboard();
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <HStack justifyContent="space-between" alignItems="center">
+            <Text variant="hint">{title}</Text>
+            <Text
+                variant="hint"
+                color="textSubdued"
+                numberOfLines={1}
+                ellipsizeMode="middle"
+                style={applyStyle(textToCopyStyle)}
+            >
+                {text}
+            </Text>
+            <IconButton
+                iconName="copy"
+                size="extraSmall"
+                colorScheme="tertiaryElevation0"
+                accessibilityLabel="Copy to clipboard"
+                onPress={() => copyToClipboard(text)}
+            />
+        </HStack>
+    );
+};

--- a/suite-native/trading-debug/src/components/DebugModeCopyableText.tsx
+++ b/suite-native/trading-debug/src/components/DebugModeCopyableText.tsx
@@ -1,0 +1,10 @@
+import { CopyableText, type CopyableTextProps } from './CopyableText';
+import { DebugModeView } from './DebugModeView';
+
+export type DebugModeCopyableTextProps = CopyableTextProps;
+
+export const DebugModeCopyableText = (props: DebugModeCopyableTextProps) => (
+    <DebugModeView>
+        <CopyableText {...props} />
+    </DebugModeView>
+);

--- a/suite-native/trading-debug/src/components/DebugModeView.tsx
+++ b/suite-native/trading-debug/src/components/DebugModeView.tsx
@@ -1,0 +1,27 @@
+import { Box, type BoxProps } from '@suite-native/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+import { useTradingDebugModeFlag } from '../hooks/useTradingDebugModeFlag';
+
+export type DebugModeViewProps = BoxProps;
+
+const DebugModeViewStyle = prepareNativeStyle(({ colors, spacings }) => ({
+    marginHorizontal: spacings.sp4,
+    marginVertical: spacings.sp2,
+    paddingHorizontal: spacings.sp4,
+    paddingVertical: spacings.sp2,
+    borderWidth: 1,
+    borderColor: colors.borderInputDefault,
+    backgroundColor: colors.backgroundNeutralDisabled,
+}));
+
+export const DebugModeView = ({ style, ...otherProps }: DebugModeViewProps) => {
+    const isDebugModeEnabled = useTradingDebugModeFlag();
+    const { applyStyle } = useNativeStyles();
+
+    if (!isDebugModeEnabled) {
+        return null;
+    }
+
+    return <Box style={[applyStyle(DebugModeViewStyle), style]} {...otherProps} />;
+};

--- a/suite-native/trading-debug/src/components/TradingEnvironmentWarning.tsx
+++ b/suite-native/trading-debug/src/components/TradingEnvironmentWarning.tsx
@@ -1,0 +1,16 @@
+import { useSelector } from 'react-redux';
+
+import { InlineAlertBox } from '@suite-native/atoms';
+import { selectTradingEnvironment } from '@suite-native/trading-state';
+
+export const TradingEnvironmentWarning = () => {
+    const tradingEnvironment = useSelector(selectTradingEnvironment);
+
+    if (tradingEnvironment === 'production') {
+        return null;
+    }
+
+    return (
+        <InlineAlertBox title={`Trading environment: ${tradingEnvironment}`} variant="warning" />
+    );
+};

--- a/suite-native/trading-debug/src/components/__tests__/CopyableText.comp.test.tsx
+++ b/suite-native/trading-debug/src/components/__tests__/CopyableText.comp.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+
+import { CopyableText, CopyableTextProps } from '../CopyableText';
+
+const mockCopyToClipboard = jest.fn();
+
+jest.mock('@suite-native/clipboard', () => ({
+    useCopyToClipboard: () => mockCopyToClipboard,
+}));
+
+describe('CopyableText', () => {
+    const renderCopyableText = (props: Partial<CopyableTextProps>) =>
+        renderWithBasicProvider(<CopyableText text="TEST TEXT" {...props} />);
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('should render title, text and copy button', () => {
+        const { getByText, getByLabelText } = renderCopyableText({
+            title: 'Title',
+        });
+
+        expect(getByText('TEST TEXT')).toBeOnTheScreen();
+        expect(getByText('Title')).toBeOnTheScreen();
+        expect(getByLabelText('Copy to clipboard')).toBeOnTheScreen();
+    });
+
+    it('should handle copy to clipboard press', () => {
+        const { getByLabelText } = renderCopyableText({});
+
+        fireEvent.press(getByLabelText('Copy to clipboard'));
+
+        expect(mockCopyToClipboard).toHaveBeenCalledWith('TEST TEXT');
+    });
+});

--- a/suite-native/trading-debug/src/components/__tests__/DebugModeCopyableText.comp.test.tsx
+++ b/suite-native/trading-debug/src/components/__tests__/DebugModeCopyableText.comp.test.tsx
@@ -1,0 +1,36 @@
+import { renderWithBasicProvider } from '@suite-native/test-utils';
+
+import { DebugModeCopyableText, DebugModeCopyableTextProps } from '../DebugModeCopyableText';
+
+let mockDebugMode: boolean;
+
+jest.mock('../../hooks/useTradingDebugModeFlag', () => ({
+    useTradingDebugModeFlag: () => mockDebugMode,
+}));
+
+describe('DebugModeCopyableText', () => {
+    const renderDebugModeCopyableText = (props: Partial<DebugModeCopyableTextProps>) =>
+        renderWithBasicProvider(<DebugModeCopyableText text="TEST TEXT" {...props} />);
+
+    beforeEach(() => {
+        mockDebugMode = true;
+    });
+
+    it('should render nothing when debug mode is disabled', () => {
+        mockDebugMode = false;
+
+        const { toJSON } = renderDebugModeCopyableText({});
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render title, text and copy button', () => {
+        const { getByText, getByLabelText } = renderDebugModeCopyableText({
+            title: 'Title',
+        });
+
+        expect(getByText('TEST TEXT')).toBeOnTheScreen();
+        expect(getByText('Title')).toBeOnTheScreen();
+        expect(getByLabelText('Copy to clipboard')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/trading-debug/src/components/__tests__/DebugModeView.comp.test.tsx
+++ b/suite-native/trading-debug/src/components/__tests__/DebugModeView.comp.test.tsx
@@ -1,0 +1,36 @@
+import { Text } from '@suite-native/atoms';
+import { renderWithBasicProvider } from '@suite-native/test-utils';
+
+import { DebugModeView } from '../DebugModeView';
+
+let mockDebugMode: boolean;
+
+jest.mock('../../hooks/useTradingDebugModeFlag', () => ({
+    useTradingDebugModeFlag: () => mockDebugMode,
+}));
+
+describe('DebugModeView', () => {
+    const renderDebugModeView = () =>
+        renderWithBasicProvider(
+            <DebugModeView>
+                <Text>TEST TEXT</Text>
+            </DebugModeView>,
+        );
+
+    beforeEach(() => {
+        mockDebugMode = false;
+    });
+
+    it('should render nothing when debug mode is disabled', () => {
+        const { toJSON } = renderDebugModeView();
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render children when debug mode is enabled', () => {
+        mockDebugMode = true;
+        const { getByText } = renderDebugModeView();
+
+        expect(getByText('TEST TEXT')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/trading-debug/src/components/__tests__/TradingEnvironmentWarning.comp.test.tsx
+++ b/suite-native/trading-debug/src/components/__tests__/TradingEnvironmentWarning.comp.test.tsx
@@ -1,0 +1,36 @@
+import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { tradingInitialState } from '@suite-native/trading-consts';
+import type { TradingState } from '@suite-native/trading-types';
+
+import { TradingEnvironmentWarning } from '../TradingEnvironmentWarning';
+
+describe('TradingEnvironmentWarning', () => {
+    const renderTradingEnvironmentWarning = (
+        tradingEnvironment: TradingState['tradingEnvironment'],
+    ) =>
+        renderWithStoreProviderAsync(<TradingEnvironmentWarning />, {
+            preloadedState: {
+                wallet: {
+                    trading: {
+                        ...tradingInitialState,
+                        tradingEnvironment,
+                    },
+                },
+            },
+        });
+
+    it('should render nothing when tradingEnvironment is [production]', async () => {
+        const { toJSON } = await renderTradingEnvironmentWarning('production');
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it.each<TradingState['tradingEnvironment']>(['staging', 'dev', 'localhost'])(
+        'should render warning for tradingEnvironment [%s]',
+        async tradingEnvironment => {
+            const { getByText } = await renderTradingEnvironmentWarning(tradingEnvironment);
+
+            expect(getByText(`Trading environment: ${tradingEnvironment}`)).toBeOnTheScreen();
+        },
+    );
+});

--- a/suite-native/trading-debug/src/hooks/__tests__/useTradingDebugModeFlag.hook.test.ts
+++ b/suite-native/trading-debug/src/hooks/__tests__/useTradingDebugModeFlag.hook.test.ts
@@ -1,0 +1,20 @@
+import { featureFlagsInitialState } from '@suite-native/feature-flags';
+import { PreloadedState, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { useTradingDebugModeFlag } from '../useTradingDebugModeFlag';
+
+describe('useTradingDebugModeFlag', () => {
+    const renderUseDebugModeFlag = (preloadedState: PreloadedState = {}) =>
+        renderHookWithStoreProviderAsync(() => useTradingDebugModeFlag(), { preloadedState });
+
+    it.each([true, false])('should respect FF [%s]', async ffValue => {
+        const { result } = await renderUseDebugModeFlag({
+            featureFlags: {
+                ...featureFlagsInitialState,
+                isTradingDebugEnabled: ffValue,
+            },
+        });
+
+        expect(result.current).toEqual(ffValue);
+    });
+});

--- a/suite-native/trading-debug/src/hooks/useTradingDebugModeFlag.ts
+++ b/suite-native/trading-debug/src/hooks/useTradingDebugModeFlag.ts
@@ -1,0 +1,3 @@
+import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
+
+export const useTradingDebugModeFlag = () => useFeatureFlag(FeatureFlag.IsTradingDebugEnabled);

--- a/suite-native/trading-debug/src/index.ts
+++ b/suite-native/trading-debug/src/index.ts
@@ -1,4 +1,5 @@
 export * from './components/DebugModeView';
 export * from './components/DebugModeCopyableText';
+export * from './components/TradingEnvironmentWarning';
 
 export * from './hooks/useTradingDebugModeFlag';

--- a/suite-native/trading-debug/src/index.ts
+++ b/suite-native/trading-debug/src/index.ts
@@ -1,0 +1,4 @@
+export * from './components/DebugModeView';
+export * from './components/DebugModeCopyableText';
+
+export * from './hooks/useTradingDebugModeFlag';

--- a/suite-native/trading-debug/tsconfig.json
+++ b/suite-native/trading-debug/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../atoms" },
+        { "path": "../clipboard" },
+        { "path": "../feature-flags" },
+        { "path": "../../packages/styles" },
+        { "path": "../test-utils" }
+    ]
+}

--- a/suite-native/trading-debug/tsconfig.json
+++ b/suite-native/trading-debug/tsconfig.json
@@ -5,7 +5,10 @@
         { "path": "../atoms" },
         { "path": "../clipboard" },
         { "path": "../feature-flags" },
+        { "path": "../trading-state" },
         { "path": "../../packages/styles" },
-        { "path": "../test-utils" }
+        { "path": "../test-utils" },
+        { "path": "../trading-consts" },
+        { "path": "../trading-types" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13243,6 +13243,7 @@ __metadata:
     "@suite-native/tokens": "workspace:*"
     "@suite-native/trading-atoms": "workspace:*"
     "@suite-native/trading-consts": "workspace:*"
+    "@suite-native/trading-debug": "workspace:*"
     "@suite-native/trading-fixtures": "workspace:*"
     "@suite-native/trading-residence": "workspace:*"
     "@suite-native/trading-state": "workspace:*"
@@ -13708,6 +13709,20 @@ __metadata:
   dependencies:
     "@suite-common/trading": "workspace:*"
     "@suite-native/trading-types": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@suite-native/trading-debug@workspace:*, @suite-native/trading-debug@workspace:suite-native/trading-debug":
+  version: 0.0.0-use.local
+  resolution: "@suite-native/trading-debug@workspace:suite-native/trading-debug"
+  dependencies:
+    "@reduxjs/toolkit": "npm:2.10.1"
+    "@suite-native/atoms": "workspace:*"
+    "@suite-native/clipboard": "workspace:*"
+    "@suite-native/feature-flags": "workspace:*"
+    "@suite-native/test-utils": "workspace:*"
+    "@trezor/styles": "workspace:*"
+    react: "npm:19.1.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13721,8 +13721,12 @@ __metadata:
     "@suite-native/clipboard": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/test-utils": "workspace:*"
+    "@suite-native/trading-consts": "workspace:*"
+    "@suite-native/trading-state": "workspace:*"
+    "@suite-native/trading-types": "workspace:*"
     "@trezor/styles": "workspace:*"
     react: "npm:19.1.0"
+    react-redux: "npm:9.2.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Introduce new FF - Trading Debug Mode
- When trading debug mode is enabled - display WebView URI
- Persist Trading environment selection
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #23614


## Screenshots:

<img width="300" alt="Simulator Screenshot - iPhone 16e - 2025-12-05 at 13 15 13" src="https://github.com/user-attachments/assets/c19d458f-db89-4846-a924-36f9ac732203" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2025-12-05 at 13 15 32" src="https://github.com/user-attachments/assets/5322ac64-fda8-43d9-8451-65bb362d283f" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2025-12-05 at 17 34 13" src="https://github.com/user-attachments/assets/20dd2132-98d1-40e7-81ed-1cf989faed25" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=23614-mobile-display-trading-webview-uri&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=23614-mobile-display-trading-webview-uri&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=23614-mobile-display-trading-webview-uri&lookback=7)