### PR TITLE
Fix native buy flow

### DIFF
--- a/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
@@ -22,6 +22,10 @@ export abstract class TradingFormActions extends TradingActions {
         return this.getElementById('fiat-amount-input');
     }
 
+    getReceiveCryptoAmountElement() {
+        return this.getElementById('crypto-amount-input');
+    }
+
     getSendCryptoAmountElement() {
         return this.getElementById('send-amount-input');
     }
@@ -39,6 +43,7 @@ export abstract class TradingFormActions extends TradingActions {
         await this.expectSheetHeaderTitle('Currency');
         await this.getSearchFiatElement().replaceText(fiatCurrency.slice(0, -1));
         await wait(this.BOTTOM_SHEET_ANIMATION_DURATION);
+        await waitForVisible(by.text(fiatCurrency));
         await element(by.text(fiatCurrency)).tap();
 
         await waitFor(this.getElementById('fiat-button/ticker'))
@@ -53,6 +58,7 @@ export abstract class TradingFormActions extends TradingActions {
 
         await this.expectSheetHeaderTitle('Country of residence');
         await this.getSearchCountryElement().replaceText(countrySearch);
+        await waitForVisible(by.text(country));
         await element(by.text(country)).tap();
 
         await waitFor(this.getElementById('country/value'))
@@ -133,7 +139,7 @@ export abstract class TradingFormActions extends TradingActions {
             await networkFilterTab.tap();
         }
 
-        await waitForVisible(by.text(asset), { timeout: this.BOTTOM_SHEET_ANIMATION_DURATION });
+        await waitForVisible(by.text(asset));
         await element(by.text(asset)).tap();
 
         await waitFor(this.getElementById('asset-receive-button/symbol'))

--- a/suite-native/app/e2e/support/utils.ts
+++ b/suite-native/app/e2e/support/utils.ts
@@ -1,8 +1,16 @@
 import path from 'node:path';
 
-const isIndexableNativeElement = (
-    v: Detox.IndexableNativeElement | Detox.NativeMatcher,
-): v is Detox.IndexableNativeElement => {
+import { scheduleAction } from '@trezor/utils';
+
+type ElementAttributes = {
+    text?: string;
+    label?: string;
+    value?: string;
+};
+
+type ElementOrMatcher = Detox.IndexableNativeElement | Detox.NativeMatcher;
+
+const isIndexableNativeElement = (v: ElementOrMatcher): v is Detox.IndexableNativeElement => {
     const anyV = v as any;
 
     return !!anyV && (typeof anyV.tap === 'function' || typeof anyV.atIndex === 'function');
@@ -13,6 +21,11 @@ export const platform = device.getPlatform();
 // There is inconsistency between platforms. Android needs to have 100% of an element visible to be able to interact with it.
 // On the other hand, if we are trying to scroll to 100% visibility on iOS, it causes scrolling more than height of the screen and it makes Detox crash.
 const SCROLL_VISIBILITY_THRESHOLD = platform === 'android' ? 100 : undefined;
+
+export const RETRY_CONF = {
+    attempts: 5,
+    gap: 500,
+};
 
 export const wait = async (ms: number) => {
     await new Promise(resolve => setTimeout(resolve, ms));
@@ -40,13 +53,17 @@ function pruneToAppStack(invocationStack: string): string {
     return kept.length ? ['Error'].concat(kept).join('\n') : invocationStack;
 }
 
-export const waitForVisible = async (
-    elementOrMatcher: Detox.IndexableNativeElement | Detox.NativeMatcher,
-    { timeout = 30_000 }: { timeout?: number } = {},
-) => {
-    const target = isIndexableNativeElement(elementOrMatcher)
+function getTarget(elementOrMatcher: ElementOrMatcher) {
+    return isIndexableNativeElement(elementOrMatcher)
         ? elementOrMatcher
         : element(elementOrMatcher);
+}
+
+export const waitForVisible = async (
+    elementOrMatcher: ElementOrMatcher,
+    { timeout = 30_000 }: { timeout?: number } = {},
+) => {
+    const target = getTarget(elementOrMatcher);
     const invocationStack = new Error().stack || '';
     try {
         await waitFor(target).toBeVisible().withTimeout(timeout);
@@ -56,6 +73,34 @@ export const waitForVisible = async (
         appStackError.stack = `${appStackError.name}: ${appStackError.message}\n${pruneToAppStack(invocationStack)}`;
         throw appStackError;
     }
+};
+
+export const waitToHaveRegex = async (
+    elementOrMatcher: ElementOrMatcher,
+    expectedRegex: RegExp,
+    {
+        timeout = 30_000,
+        attributeType = 'text',
+    }: { timeout?: number; attributeType?: 'text' | 'label' | 'value' } = {},
+) => {
+    const target = getTarget(elementOrMatcher);
+    await waitForVisible(target, { timeout });
+    await scheduleAction(async () => {
+        const attributes = await target.getAttributes();
+        const testedAttribute = (attributes as ElementAttributes)[attributeType];
+
+        if (typeof testedAttribute !== 'string') {
+            throw new Error(
+                `waitForRegex(): could not get "${attributeType}" property from the element`,
+            );
+        }
+
+        if (!expectedRegex.test(testedAttribute)) {
+            throw new Error(
+                `waitForRegex(): target text "${testedAttribute}" not matching ${expectedRegex} after ${timeout}ms`,
+            );
+        }
+    }, RETRY_CONF);
 };
 
 export const appIsFullyLoaded = async () => {
@@ -85,9 +130,7 @@ export const inputTextToElement = async (element: Detox.IndexableNativeElement, 
 };
 
 // Use this method in absolute necessity only! Try-catch in tests is discouraged because it may hide real issues.
-export const isElementVisible = async (
-    elementOrMatcher: Detox.IndexableNativeElement | Detox.NativeMatcher,
-): Promise<boolean> => {
+export const isElementVisible = async (elementOrMatcher: ElementOrMatcher): Promise<boolean> => {
     const target = isIndexableNativeElement(elementOrMatcher)
         ? elementOrMatcher
         : element(elementOrMatcher);

--- a/suite-native/app/e2e/tests/deviceSettingsT3T1.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettingsT3T1.test.ts
@@ -22,7 +22,7 @@ conditionalDescribe(
         beforeEach(async () => {
             await openApp({ args: { preloadedState: preloadedStateT3T1 } });
             await prepareTrezorEmulator({ model: 'T3T1' });
-            await waitForVisible(by.id('@device-manager/connection-status'));
+            await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
             await onDeviceManager.tapDeviceSwitch();
             await onDeviceManager.tapDeviceSettingsButton();
         });


### PR DESCRIPTION
- ~~fixes buyFlow test~~ that was done by [this PR](https://github.com/trezor/trezor-suite/pull/23606) so I just make the test more robust.
- new test wrapper `testWithRepeat` which I used to test stability of my fix. You can replace original `it('<tests name>` with `testWithRepeat(<number of repeats>, <test name>`. Commit, push to CI, see results, revert commit. ATM I was not able to think of more cleaner solution. Unfortunately, Detox does not provide any support for this whatsoever
- new method waitToHaveRegex - waits for visibility and then with retry mechanism test either text, label or value based on you parameters. 



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-native-buy-flow&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-native-buy-flow&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-native-buy-flow&lookback=7)