### PR TITLE
fix(connect): turn requestLogin to a normal method

### DIFF
--- a/packages/connect-explorer/src/pages/methods/other/requestLogin.mdx
+++ b/packages/connect-explorer/src/pages/methods/other/requestLogin.mdx
@@ -8,7 +8,6 @@ import login from '../../../data/methods/other/login.ts';
 <ApiPlayground
     options={[
         { title: 'Synchronous', legacyConfig: login[0] },
-        { title: 'Asynchronous', legacyConfig: login[1] },
         { title: 'Advanced schema', method: 'requestLogin', schema: RequestLoginSchema },
     ]}
 />
@@ -37,6 +36,8 @@ To understand the full mechanics, please consult the Challenge-Response chapter
 of
 [SLIP-0013: Authentication using deterministic hierarchy](https://github.com/satoshilabs/slips/blob/master/slip-0013.md).
 
+**Note:** `callback` and `asyncChallenge` parameters are now deprecated. Simply fetch the data first and pass it to the method.
+
 ```javascript
 const result = await TrezorConnect.requestLogin(params);
 ```
@@ -50,20 +51,6 @@ const result = await TrezorConnect.requestLogin(params);
 <ParamsTable schema={RequestLoginSchema} descriptions={paramDescriptions} />
 
 ### Example
-
-###### Login using server-side async challenge
-
-```javascript
-TrezorConnect.requestLogin({
-    callback: function () {
-        // here should be a request to server to fetch "challengeHidden" and "challengeVisual"
-        return {
-            challengeHidden: '0123456789abcdef',
-            challengeVisual: 'Login to',
-        };
-    },
-});
-```
 
 ###### Login without async challenge
 

--- a/packages/connect-explorer/src/pages/methods/other/requestLogin.mdx
+++ b/packages/connect-explorer/src/pages/methods/other/requestLogin.mdx
@@ -13,10 +13,11 @@ import login from '../../../data/methods/other/login.ts';
 />
 
 export const paramDescriptions = {
-    callback:
-        'which will be called from API to fetch `challengeHidden` and `challengeVisual` from server',
     challengeHidden: 'hexadecimal value',
     challengeVisual: 'text displayed on Trezor',
+    origin: 'domain requesting the login, do not fill manually under normal circumstances',
+    asyncChallenge: 'deprecated',
+    callback: 'deprecated',
 };
 
 ## Request login

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -5,14 +5,8 @@ import { corsValidator, parseConnectSettings } from '@trezor/connect/src/data/co
 import { DEEPLINK_VERSION, DEFAULT_DOMAIN_MAJOR_VER } from '@trezor/connect/src/data/version';
 import type { CallMethodPayload } from '@trezor/connect/src/events/call';
 import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
-import type {
-    ConnectSettings,
-    ConnectSettingsMobile,
-    Manifest,
-    Response,
-} from '@trezor/connect/src/types';
+import type { ConnectSettings, ConnectSettingsMobile, Manifest } from '@trezor/connect/src/types';
 import { InitFullSettings } from '@trezor/connect/src/types/api/init';
-import { Login } from '@trezor/connect/src/types/api/requestLogin';
 import { Deferred, createDeferred, removeTrailingSlashes } from '@trezor/utils';
 
 export class TrezorConnectDeeplink implements ConnectFactoryDependencies<ConnectSettingsMobile> {
@@ -89,10 +83,6 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
         this._settings.deeplinkOpen(url);
 
         return this.messagePromises[this.messageID].promise;
-    }
-
-    public requestLogin(): Response<Login> {
-        throw ERRORS.TypedError('Method_InvalidPackage');
     }
 
     public uiResponse() {
@@ -221,7 +211,6 @@ const TrezorConnect = factory<
         call: impl.call.bind(impl),
         setTransports: impl.setTransports.bind(impl),
         manifest: impl.manifest.bind(impl),
-        requestLogin: impl.requestLogin.bind(impl),
         uiResponse: impl.uiResponse.bind(impl),
         cancel: impl.cancel.bind(impl),
         dispose: impl.dispose.bind(impl),

--- a/packages/connect-web/src/impl/core-in-iframe.ts
+++ b/packages/connect-web/src/impl/core-in-iframe.ts
@@ -14,7 +14,6 @@ import {
     RESPONSE_EVENT,
     TRANSPORT,
     TRANSPORT_EVENT,
-    UI,
     UI_EVENT,
     UiResponseEvent,
     createErrorMessage,
@@ -303,45 +302,6 @@ export class CoreInIframe implements ConnectFactoryDependencies<ConnectSettingsW
         webUSBButton(className, this._settings.webusbSrc);
     }
 
-    public async requestLogin(params: any) {
-        if (typeof params.callback === 'function') {
-            const { callback } = params;
-
-            // TODO: set message listener only if iframe is loaded correctly
-            const loginChallengeListener = async (event: MessageEvent<CoreEventMessage>) => {
-                const { data } = event;
-                if (data && data.type === UI.LOGIN_CHALLENGE_REQUEST) {
-                    try {
-                        const payload = await callback();
-                        iframe.postMessage({
-                            type: UI.LOGIN_CHALLENGE_RESPONSE,
-                            payload,
-                        });
-                    } catch (error) {
-                        iframe.postMessage({
-                            type: UI.LOGIN_CHALLENGE_RESPONSE,
-                            payload: error.message,
-                        });
-                    }
-                }
-            };
-
-            window.addEventListener('message', loginChallengeListener, false);
-
-            const response = await this.call({
-                method: 'requestLogin',
-                ...params,
-                asyncChallenge: true,
-                callback: null,
-            });
-            window.removeEventListener('message', loginChallengeListener);
-
-            return response;
-        }
-
-        return this.call({ method: 'requestLogin', ...params });
-    }
-
     public disableWebUSB() {
         if (!iframe.instance) {
             throw ERRORS.TypedError('Init_NotInitialized');
@@ -374,7 +334,6 @@ export const TrezorConnect = factory(
         call: impl.call.bind(impl),
         setTransports: impl.setTransports.bind(impl),
         manifest: impl.manifest.bind(impl),
-        requestLogin: impl.requestLogin.bind(impl),
         uiResponse: impl.uiResponse.bind(impl),
         cancel: impl.cancel.bind(impl),
         dispose: impl.dispose.bind(impl),

--- a/packages/connect-web/src/impl/core-in-popup.ts
+++ b/packages/connect-web/src/impl/core-in-popup.ts
@@ -13,14 +13,8 @@ import {
     createErrorMessage,
 } from '@trezor/connect/src/events';
 import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
-import type {
-    ConnectSettings,
-    ConnectSettingsWeb,
-    Manifest,
-    Response,
-} from '@trezor/connect/src/types';
+import type { ConnectSettings, ConnectSettingsWeb, Manifest } from '@trezor/connect/src/types';
 import { InitFullSettings } from '@trezor/connect/src/types/api/init';
-import { Login } from '@trezor/connect/src/types/api/requestLogin';
 import { Log, LogMessage, LogWriter, initLog, setLogWriter } from '@trezor/connect/src/utils/debug';
 import { createDeferred } from '@trezor/utils';
 
@@ -223,11 +217,6 @@ export class CoreInPopup implements ConnectFactoryDependencies<ConnectSettingsWe
 
     renderWebUSBButton() {}
 
-    requestLogin(): Response<Login> {
-        // todo: not supported yet
-        throw ERRORS.TypedError('Method_InvalidPackage');
-    }
-
     disableWebUSB() {
         // todo: not supported yet, probably not needed
         throw ERRORS.TypedError('Method_InvalidPackage');
@@ -249,7 +238,6 @@ export const TrezorConnect = factory({
     call: impl.call.bind(impl),
     setTransports: impl.setTransports.bind(impl),
     manifest: impl.manifest.bind(impl),
-    requestLogin: impl.requestLogin.bind(impl),
     uiResponse: impl.uiResponse.bind(impl),
     cancel: impl.cancel.bind(impl),
     dispose: impl.dispose.bind(impl),

--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -15,9 +15,7 @@ import type {
     ConnectSettingsPublic,
     ConnectSettingsWeb,
     Manifest,
-    Response,
 } from '@trezor/connect/src/types';
-import { Login } from '@trezor/connect/src/types/api/requestLogin';
 import { WebsocketClient } from '@trezor/websocket-client';
 import { WebsocketError } from '@trezor/websocket-client/src/client';
 
@@ -185,11 +183,6 @@ export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSet
         throw ERRORS.TypedError('Method_InvalidPackage');
     }
 
-    // todo: not supported yet
-    requestLogin(): Response<Login> {
-        throw ERRORS.TypedError('Method_InvalidPackage');
-    }
-
     // not needed, only because of types
     disableWebUSB() {
         throw ERRORS.TypedError('Method_InvalidPackage');
@@ -214,7 +207,6 @@ export const TrezorConnect = factory({
     call: impl.call.bind(impl),
     setTransports: impl.setTransports.bind(impl),
     manifest: impl.manifest.bind(impl),
-    requestLogin: impl.requestLogin.bind(impl),
     uiResponse: impl.uiResponse.bind(impl),
     cancel: impl.cancel.bind(impl),
     dispose: impl.dispose.bind(impl),

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -12,14 +12,8 @@ import {
     createErrorMessage,
 } from '@trezor/connect/src/events';
 import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
-import type {
-    ConnectSettings,
-    ConnectSettingsWeb,
-    Manifest,
-    Response,
-} from '@trezor/connect/src/types';
+import type { ConnectSettings, ConnectSettingsWeb, Manifest } from '@trezor/connect/src/types';
 import { InitFullSettings } from '@trezor/connect/src/types/api/init';
-import { Login } from '@trezor/connect/src/types/api/requestLogin';
 import { Log, initLog } from '@trezor/connect/src/utils/debug';
 
 import { parseConnectSettings } from '../connectSettings';
@@ -157,11 +151,6 @@ export class CoreInSuiteWeb implements ConnectFactoryDependencies<ConnectSetting
         throw ERRORS.TypedError('Method_InvalidPackage');
     }
 
-    // todo: not supported yet
-    requestLogin(): Response<Login> {
-        throw ERRORS.TypedError('Method_InvalidPackage');
-    }
-
     // not needed, only because of types
     disableWebUSB() {
         throw ERRORS.TypedError('Method_InvalidPackage');
@@ -186,7 +175,6 @@ export const TrezorConnect = factory({
     call: impl.call.bind(impl),
     setTransports: impl.setTransports.bind(impl),
     manifest: impl.manifest.bind(impl),
-    requestLogin: impl.requestLogin.bind(impl),
     uiResponse: impl.uiResponse.bind(impl),
     cancel: impl.cancel.bind(impl),
     dispose: impl.dispose.bind(impl),

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -112,7 +112,6 @@ const TrezorConnect = factory<ConnectSettingsWeb, ConnectWebExtraMethods>(
         call: impl.call.bind(impl),
         setTransports: impl.setTransports.bind(impl),
         manifest: impl.manifest.bind(impl),
-        requestLogin: impl.requestLogin.bind(impl),
         uiResponse: impl.uiResponse.bind(impl),
         cancel: impl.cancel.bind(impl),
         dispose: impl.dispose.bind(impl),

--- a/packages/connect-web/src/module/index.ts
+++ b/packages/connect-web/src/module/index.ts
@@ -68,7 +68,6 @@ const TrezorConnect = factory(
         call: impl.call.bind(impl),
         setTransports: impl.setTransports.bind(impl),
         manifest: impl.manifest.bind(impl),
-        requestLogin: impl.requestLogin.bind(impl),
         uiResponse: impl.uiResponse.bind(impl),
         cancel: impl.cancel.bind(impl),
         dispose: impl.dispose.bind(impl),

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -79,7 +79,6 @@ const TrezorConnect = factory({
     call: impl.call.bind(impl),
     setTransports: impl.setTransports.bind(impl),
     manifest: impl.manifest.bind(impl),
-    requestLogin: impl.requestLogin.bind(impl),
     uiResponse: impl.uiResponse.bind(impl),
     cancel: impl.cancel.bind(impl),
     dispose: impl.dispose.bind(impl),

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -108,18 +108,12 @@ const uiResponse = () => {
     throw ERRORS.TypedError('Method_InvalidPackage');
 };
 
-const requestLogin = () => {
-    // Not needed here - Not used here.
-    throw ERRORS.TypedError('Method_InvalidPackage');
-};
-
 const TrezorConnect = factory({
     eventEmitter,
     manifest,
     init,
     call,
     setTransports,
-    requestLogin,
     uiResponse,
     cancel,
     dispose,

--- a/packages/connect/src/api/requestLogin.ts
+++ b/packages/connect/src/api/requestLogin.ts
@@ -17,10 +17,22 @@ export default class RequestLogin extends AbstractMethod<'requestLogin', PROTO.S
 
         const { payload } = this;
 
+        // validate incoming parameters
+        Assert(RequestLoginSchema, payload);
+
         const identity: PROTO.IdentityType = {};
         const settings: ConnectSettings = DataManager.getSettings();
-        if (settings.origin) {
-            const [proto, host, port] = settings.origin.split(':');
+
+        let origin;
+        if (settings.trustedHost && payload.origin) {
+            // passed from Suite
+            origin = payload.origin;
+        } else if (settings.origin) {
+            origin = settings.origin;
+        }
+
+        if (origin) {
+            const [proto, host, port] = origin.split(':');
             identity.proto = proto;
             identity.host = host.substring(2);
             if (port) {
@@ -28,9 +40,6 @@ export default class RequestLogin extends AbstractMethod<'requestLogin', PROTO.S
             }
             identity.index = 0;
         }
-
-        // validate incoming parameters
-        Assert(RequestLoginSchema, payload);
 
         this.params = {
             identity,

--- a/packages/connect/src/api/requestLogin.ts
+++ b/packages/connect/src/api/requestLogin.ts
@@ -1,19 +1,15 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/RequestLogin.js
 
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
-import { Assert, Type } from '@trezor/schema-utils';
+import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS } from '../constants';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { UI, createUiMessage } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';
 import { DataManager } from '../data/DataManager';
 import type { ConnectSettings } from '../types';
 import { RequestLoginSchema } from '../types/api/requestLogin';
 
 export default class RequestLogin extends AbstractMethod<'requestLogin', PROTO.SignIdentity> {
-    asyncChallenge?: boolean;
-
     init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
@@ -41,7 +37,6 @@ export default class RequestLogin extends AbstractMethod<'requestLogin', PROTO.S
             challenge_hidden: payload.challengeHidden || '',
             challenge_visual: payload.challengeVisual || '',
         };
-        this.asyncChallenge = !!payload.asyncChallenge;
     }
 
     get info() {
@@ -49,34 +44,6 @@ export default class RequestLogin extends AbstractMethod<'requestLogin', PROTO.S
     }
 
     async run() {
-        if (this.asyncChallenge) {
-            // create ui promise
-            const uiPromise = this.createUiPromise(UI.LOGIN_CHALLENGE_RESPONSE);
-            // send request to developer
-            this.postMessage(createUiMessage(UI.LOGIN_CHALLENGE_REQUEST));
-            // wait for response from developer
-            const { payload } = await uiPromise.promise;
-
-            // error handler
-            if (typeof payload === 'string') {
-                throw ERRORS.TypedError(
-                    'Runtime',
-                    `TrezorConnect.requestLogin callback error: ${payload}`,
-                );
-            }
-
-            // validate incoming parameters
-            Assert(
-                Type.Object({
-                    challengeHidden: Type.String(),
-                    challengeVisual: Type.String(),
-                }),
-                payload,
-            );
-
-            this.params.challenge_hidden = payload.challengeHidden;
-            this.params.challenge_visual = payload.challengeVisual;
-        }
         const cmd = this.device.getCommands();
         const { message } = await cmd.typedCall('SignIdentity', 'SignedIdentity', this.params);
 

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -11,7 +11,6 @@ export interface ConnectFactoryDependencies<SettingsType extends Record<string, 
     eventEmitter: EventEmitter;
     manifest: TrezorConnect['manifest'];
     setTransports: TrezorConnect['setTransports'];
-    requestLogin: TrezorConnect['requestLogin'];
     uiResponse: TrezorConnect['uiResponse'];
     cancel: TrezorConnect['cancel'];
     dispose: TrezorConnect['dispose'];
@@ -83,6 +82,7 @@ export const connectCallableMethods = [
     'nemSignTransaction',
     'pushTransaction',
     'recoveryDevice',
+    'requestLogin',
     'resetDevice',
     'rippleGetAddress',
     'rippleSignTransaction',
@@ -118,7 +118,6 @@ export const factory = <
         init,
         call,
         setTransports,
-        requestLogin,
         uiResponse,
         cancel,
         dispose,
@@ -170,8 +169,6 @@ export const factory = <
         dispose,
 
         cancel,
-
-        requestLogin,
 
         ...callableMethods,
 

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -6,7 +6,6 @@ import * as ERRORS from '../constants/errors';
 import { parseConnectSettings } from '../data/connectSettings';
 import {
     BLOCKCHAIN_EVENT,
-    CORE_EVENT,
     CallMethodPayload,
     CoreEventMessage,
     CoreRequestMessage,
@@ -231,45 +230,6 @@ export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsP
         }
         this.handleCoreMessage(response);
     }
-
-    public async requestLogin(params: any) {
-        if (typeof params.callback === 'function') {
-            const { callback } = params;
-            const core = this._coreManager.get();
-
-            // TODO: set message listener only if _core is loaded correctly
-            const loginChallengeListener = async (event: MessageEvent<CoreEventMessage>) => {
-                const { data } = event;
-                if (data && data.type === UI.LOGIN_CHALLENGE_REQUEST) {
-                    try {
-                        const payload = await callback();
-                        this.handleCoreMessage({
-                            type: UI.LOGIN_CHALLENGE_RESPONSE,
-                            payload,
-                        });
-                    } catch (error) {
-                        this.handleCoreMessage({
-                            type: UI.LOGIN_CHALLENGE_RESPONSE,
-                            payload: error.message,
-                        });
-                    }
-                }
-            };
-
-            core?.on(CORE_EVENT, loginChallengeListener);
-            const response = await this.call({
-                method: 'requestLogin',
-                ...params,
-                asyncChallenge: true,
-                callback: null,
-            });
-            core?.removeListener(CORE_EVENT, loginChallengeListener);
-
-            return response;
-        }
-
-        return this.call({ method: 'requestLogin', ...params });
-    }
 }
 
 const impl = new CoreInModule();
@@ -281,7 +241,6 @@ export const TrezorConnect = factory({
     init: impl.init.bind(impl),
     call: impl.call.bind(impl),
     setTransports: impl.setTransports.bind(impl),
-    requestLogin: impl.requestLogin.bind(impl),
     uiResponse: impl.uiResponse.bind(impl),
     cancel: impl.cancel.bind(impl),
     dispose: impl.dispose.bind(impl),

--- a/packages/connect/src/impl/dynamic.ts
+++ b/packages/connect/src/impl/dynamic.ts
@@ -166,10 +166,6 @@ export class TrezorConnectDynamic<
         }
     }
 
-    public requestLogin(params: any) {
-        return this.getTarget().requestLogin(params);
-    }
-
     public uiResponse(params: any) {
         return this.getTarget().uiResponse(params);
     }

--- a/packages/connect/src/index-browser.ts
+++ b/packages/connect/src/index-browser.ts
@@ -17,7 +17,6 @@ const TrezorConnect = factory({
     init: fallback,
     setTransports: fallback,
     call: fallback,
-    requestLogin: fallback,
     uiResponse: fallback,
     cancel: fallback,
     dispose: fallback,

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -7,7 +7,6 @@ import { initCoreState } from './core';
 import { parseConnectSettings } from './data/connectSettings';
 import {
     BLOCKCHAIN_EVENT,
-    CORE_EVENT,
     CallMethod,
     CoreEventMessage,
     DEVICE_EVENT,
@@ -166,45 +165,6 @@ const uiResponse = (response: UiResponseEvent) => {
     core.handleMessage(response);
 };
 
-const requestLogin = async (params: any) => {
-    if (typeof params.callback === 'function') {
-        const { callback } = params;
-        const core = coreManager.get();
-
-        // TODO: set message listener only if _core is loaded correctly
-        const loginChallengeListener = async (event: MessageEvent<CoreEventMessage>) => {
-            const { data } = event;
-            if (data && data.type === UI.LOGIN_CHALLENGE_REQUEST) {
-                try {
-                    const payload = await callback();
-                    core?.handleMessage({
-                        type: UI.LOGIN_CHALLENGE_RESPONSE,
-                        payload,
-                    });
-                } catch (error) {
-                    core?.handleMessage({
-                        type: UI.LOGIN_CHALLENGE_RESPONSE,
-                        payload: error.message,
-                    });
-                }
-            }
-        };
-
-        core?.on(CORE_EVENT, loginChallengeListener);
-        const response = await call({
-            method: 'requestLogin',
-            ...params,
-            asyncChallenge: true,
-            callback: null,
-        });
-        core?.removeListener(CORE_EVENT, loginChallengeListener);
-
-        return response;
-    }
-
-    return call({ method: 'requestLogin', ...params });
-};
-
 const cancel = (error?: string) => {
     const core = coreManager.get();
     if (!core) {
@@ -224,7 +184,6 @@ const TrezorConnect = factory(
         init,
         call,
         setTransports,
-        requestLogin,
         uiResponse,
         cancel,
         dispose,

--- a/packages/connect/src/types/api/__tests__/misc.ts
+++ b/packages/connect/src/types/api/__tests__/misc.ts
@@ -29,43 +29,6 @@ export const cipherKeyValue = async (api: TrezorConnect) => {
     }
 };
 
-// Method with mixed params
-export const requestLogin = async (api: TrezorConnect) => {
-    // async call
-    const a = await api.requestLogin({
-        callback: () => ({
-            challengeHidden: 'a',
-            challengeVisual: 'b',
-        }),
-    });
-
-    if (a.success) {
-        a.payload.address.toLowerCase();
-        a.payload.publicKey.toLowerCase();
-        a.payload.signature.toLowerCase();
-        // @ts-expect-error
-        a.payload.error.toLowerCase();
-    } else {
-        a.payload.error.toLowerCase();
-        // @ts-expect-error
-        a.payload.address.toLowerCase();
-    }
-    // sync call
-    api.requestLogin({
-        challengeHidden: 'a',
-        challengeVisual: 'b',
-    });
-
-    // @ts-expect-error
-    api.requestLogin();
-    // @ts-expect-error
-    api.requestLogin({ callback: 'string' });
-    // @ts-expect-error
-    api.requestLogin({ challengeHidden: 'a' });
-    // @ts-expect-error
-    api.requestLogin({ challengeVisual: 1 });
-};
-
 export const setProxy = async (api: TrezorConnect) => {
     const proxy = await api.setProxy({ proxy: 'socks://localhost:9050' });
     if (proxy.success) {

--- a/packages/connect/src/types/api/requestLogin.ts
+++ b/packages/connect/src/types/api/requestLogin.ts
@@ -17,16 +17,8 @@ export const LoginChallenge = Type.Object({
     callback: Type.Optional(Type.Undefined()),
 });
 
-export type RequestLoginAsync = Static<typeof RequestLoginAsync>;
-export const RequestLoginAsync = Type.Object({
-    challengeHidden: Type.Optional(Type.Undefined()),
-    challengeVisual: Type.Optional(Type.Undefined()),
-    asyncChallenge: Type.Optional(Type.Boolean()),
-    callback: Type.Function([], LoginChallenge),
-});
-
 export type RequestLoginSchema = Static<typeof RequestLoginSchema>;
-export const RequestLoginSchema = Type.Union([RequestLoginAsync, LoginChallenge]);
+export const RequestLoginSchema = Type.Union([LoginChallenge]);
 
 export interface Login {
     address: string;

--- a/packages/connect/src/types/api/requestLogin.ts
+++ b/packages/connect/src/types/api/requestLogin.ts
@@ -13,6 +13,7 @@ export type LoginChallenge = Static<typeof LoginChallenge>;
 export const LoginChallenge = Type.Object({
     challengeHidden: Type.String(),
     challengeVisual: Type.String(),
+    origin: Type.Optional(Type.String()),
     asyncChallenge: Type.Optional(Type.Undefined()),
     callback: Type.Optional(Type.Undefined()),
 });

--- a/scripts/circular-dependencies/madge-snapshot.txt
+++ b/scripts/circular-dependencies/madge-snapshot.txt
@@ -73,10 +73,6 @@ packages/suite/src/utils/wallet/graph/utilsShared.ts > packages/suite/src/utils/
 packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTable.tsx > packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
 packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx > packages/suite/src/views/onboarding/steps/SelectBackupType/FloatingSelections.tsx
 packages/transport/src/transports/abstract.ts > packages/transport/src/transports/bridge.ts
-suite-common/connect-popup/src/methodHooks/index.ts > suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
-suite-common/connect-popup/src/methodHooks/index.ts > suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
-suite-common/connect-popup/src/methodHooks/index.ts > suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
-suite-common/connect-popup/src/methodHooks/index.ts > suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
 suite-common/graph/src/graphDataFetching.ts > suite-common/graph/src/graphUtils.ts
 suite-common/intl-types/src/index.ts > suite-common/intl-types/src/types.ts > packages/suite/src/components/suite/Translation.tsx
 suite-common/trading/src/reducers/tradingReducer.ts > suite-common/trading/src/thunks/buy/index.ts > suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts

--- a/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
+++ b/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
@@ -3,8 +3,7 @@ import { HDNodeResponse } from '@trezor/connect/src/types/api/getPublicKey';
 
 import { connectPopupActions } from '../connectPopupActions';
 import { getPermissionDeferred } from '../connectPopupPromiseManager';
-
-import { PostCallHookParams, PreCallHookParams } from './index';
+import { PostCallHookParams, PreCallHookParams } from './types';
 
 const methodsAddress = [
     'getAddress',

--- a/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
@@ -9,9 +9,8 @@ import type { CallMethodKeys, SignTransaction } from '@trezor/connect';
 import { getSerializedPath } from '@trezor/connect/src/utils/pathUtils';
 
 import { connectPopupActions } from '../connectPopupActions';
+import { PostCallHookParams, PreCallHookParams } from './types';
 import { createPlaceholderAccount } from './utils';
-
-import { PostCallHookParams, PreCallHookParams } from './index';
 
 const temporaryAccounts: Account[] = [];
 

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -15,8 +15,7 @@ import { connectPopupActions } from '../connectPopupActions';
 import { createPlaceholderAccount } from './utils';
 import { getPermissionDeferred } from '../connectPopupPromiseManager';
 import { selectConnectPopupCall } from '../connectPopupReducer';
-
-import { PostCallHookParams, PreCallHookParams } from './index';
+import { PostCallHookParams, PreCallHookParams } from './types';
 
 const temporaryAccounts: Account[] = [];
 

--- a/suite-common/connect-popup/src/methodHooks/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/index.ts
@@ -1,33 +1,11 @@
-import { Dispatch } from '@reduxjs/toolkit/react';
-
-import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
-import {
-    CallMethodKeys,
-    CallMethodParams,
-    CallMethodResponse,
-    Success,
-    Unsuccessful,
-} from '@trezor/connect';
+import { CallMethodKeys } from '@trezor/connect';
 
 import { addressConfirmationModalHooks } from './addressConfirmation';
 import { bitcoinSignTransaction } from './bitcoinSignTransaction';
 import { ethereumSignTransaction } from './ethereumSignTransaction';
 import { requestLoginHooks } from './requestLogin';
 import { solanaSignTransaction } from './solanaSignTransaction';
-import { ConnectCallSource } from '../connectPopupTypes';
-
-export type PreCallHookParams<M extends CallMethodKeys> = {
-    method: M;
-    payload: Omit<CallMethodParams<M>, 'method'>;
-    dispatch: Dispatch;
-    getState: () => any;
-    txSigningPrecomposed?: PrecomposedTransactionFinal;
-    source: ConnectCallSource;
-};
-export type PostCallHookParams<M extends CallMethodKeys> = PreCallHookParams<M> & {
-    originalPayload: Omit<CallMethodParams<M>, 'method'>;
-    response: Success<CallMethodResponse<M>> | Unsuccessful;
-};
+import { PostCallHookParams, PreCallHookParams } from './types';
 
 export const preCallHooks = async <M extends CallMethodKeys>(params: PreCallHookParams<M>) => {
     await bitcoinSignTransaction.preCallHook(params);

--- a/suite-common/connect-popup/src/methodHooks/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/index.ts
@@ -12,6 +12,7 @@ import {
 import { addressConfirmationModalHooks } from './addressConfirmation';
 import { bitcoinSignTransaction } from './bitcoinSignTransaction';
 import { ethereumSignTransaction } from './ethereumSignTransaction';
+import { requestLoginHooks } from './requestLogin';
 import { solanaSignTransaction } from './solanaSignTransaction';
 import { ConnectCallSource } from '../connectPopupTypes';
 
@@ -34,6 +35,9 @@ export const preCallHooks = async <M extends CallMethodKeys>(params: PreCallHook
 
     const ethereumPayload = await ethereumSignTransaction.preCallHook(params);
     if (ethereumPayload) return ethereumPayload;
+
+    const requestLoginPayload = requestLoginHooks.preCallHook(params);
+    if (requestLoginPayload) return requestLoginPayload;
 
     const addressConfirmPayload = await addressConfirmationModalHooks.preCallHook(params);
     if (addressConfirmPayload) return addressConfirmPayload;

--- a/suite-common/connect-popup/src/methodHooks/requestLogin.ts
+++ b/suite-common/connect-popup/src/methodHooks/requestLogin.ts
@@ -1,6 +1,6 @@
 import type { CallMethodKeys } from '@trezor/connect';
 
-import { PreCallHookParams } from './index';
+import { PreCallHookParams } from './types';
 
 const preCallHook = <M extends CallMethodKeys>({
     method,

--- a/suite-common/connect-popup/src/methodHooks/requestLogin.ts
+++ b/suite-common/connect-popup/src/methodHooks/requestLogin.ts
@@ -1,0 +1,20 @@
+import type { CallMethodKeys } from '@trezor/connect';
+
+import { PreCallHookParams } from './index';
+
+const preCallHook = <M extends CallMethodKeys>({
+    method,
+    payload,
+    source,
+}: PreCallHookParams<M>) => {
+    if (method === 'requestLogin') {
+        return {
+            ...payload,
+            origin: source.origin,
+        };
+    }
+};
+
+export const requestLoginHooks = {
+    preCallHook,
+};

--- a/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
@@ -9,9 +9,8 @@ import type { CallMethodKeys, SolanaSignTransaction } from '@trezor/connect';
 import { getSerializedPath, validatePath } from '@trezor/connect/src/utils/pathUtils';
 
 import { connectPopupActions } from '../connectPopupActions';
+import { PostCallHookParams, PreCallHookParams } from './types';
 import { createPlaceholderAccount } from './utils';
-
-import { PostCallHookParams, PreCallHookParams } from './index';
 
 const temporaryAccounts: Account[] = [];
 

--- a/suite-common/connect-popup/src/methodHooks/types.ts
+++ b/suite-common/connect-popup/src/methodHooks/types.ts
@@ -1,0 +1,25 @@
+import { Dispatch } from '@reduxjs/toolkit/react';
+
+import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import {
+    CallMethodKeys,
+    CallMethodParams,
+    CallMethodResponse,
+    Success,
+    Unsuccessful,
+} from '@trezor/connect';
+
+import { ConnectCallSource } from '../connectPopupTypes';
+
+export type PreCallHookParams<M extends CallMethodKeys> = {
+    method: M;
+    payload: Omit<CallMethodParams<M>, 'method'>;
+    dispatch: Dispatch;
+    getState: () => any;
+    txSigningPrecomposed?: PrecomposedTransactionFinal;
+    source: ConnectCallSource;
+};
+export type PostCallHookParams<M extends CallMethodKeys> = PreCallHookParams<M> & {
+    originalPayload: Omit<CallMethodParams<M>, 'method'>;
+    response: Success<CallMethodResponse<M>> | Unsuccessful;
+};


### PR DESCRIPTION
## Description

Remove async callback from requestLogin, making it work as any other normal method. 

This makes it possible to use in new environments like Popup in Suite. 

## Notes for QA

requestLogin in Connect Explorer


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/requestlogin-async-deprecation&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/requestlogin-async-deprecation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/requestlogin-async-deprecation&lookback=7)