### PR TITLE
fix(suite-native): entropy check transport error false positives

### DIFF
--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -28,6 +28,7 @@ import TrezorConnect, {
     Response as ConnectResponse,
     DEVICE,
     Device,
+    Unsuccessful,
 } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { getEnvironment } from '@trezor/env-utils';
@@ -43,6 +44,7 @@ import {
     selectPhysicalDeviceWallets,
     selectSelectedDevice,
 } from './deviceSelectors';
+import { getIsIgnoredEntropyCheckError } from './deviceUtils';
 import { sortDevices } from './sortDevices';
 import { selectAccountByKey } from '../accounts/accountsSelectors';
 import { startDiscoveryThunk } from '../discovery/discoveryThunks';
@@ -549,7 +551,7 @@ export const wipeDeviceThunk = createThunk(
 
 type FailEntropyCheckParams = {
     device: AcquiredDevice;
-    error: { code?: string; error: string };
+    error: Unsuccessful['payload'];
 };
 
 const failEntropyCheckThunk = createThunk(
@@ -568,15 +570,7 @@ const failEntropyCheckThunk = createThunk(
             payload: error,
         });
 
-        const temporarilySkippedErrorsToBeInvestigated = [
-            // These errors show up in Sentry and they probably lead to false positives.
-            // We should improve the logs to include stack traces so that we can investigate and fix this problem, then remove this condition.
-            'unexpected error',
-            'A transfer error has occurred',
-            // This one was not in Sentry but can be triggered by manually disconnecting the device. Investigate. https://github.com/trezor/trezor-suite-private/issues/135
-            'device disconnected during action',
-        ];
-        if (!temporarilySkippedErrorsToBeInvestigated.includes(error.error)) {
+        if (!getIsIgnoredEntropyCheckError(error.error)) {
             dispatch(deviceActions.setEntropyCheckResult({ deviceId: device.id, success: false }));
         }
     },

--- a/suite-common/wallet-core/src/device/deviceUtils.ts
+++ b/suite-common/wallet-core/src/device/deviceUtils.ts
@@ -17,3 +17,17 @@ export const DeviceError = (message: string): DeviceError => ({
     type: 'DeviceError' as const,
     message,
 });
+
+// Check if error is an entropy check failure, but not one of the temporarily skipped errors (to be investigated)
+export const getIsIgnoredEntropyCheckError = (error: string) => {
+    const ignoredErrors = [
+        // These errors show up in Sentry and they probably lead to false positives.
+        // We should improve the logs to include stack traces so that we can investigate and fix this problem, then remove this condition.
+        'unexpected error',
+        'A transfer error has occurred',
+        // This one was not in Sentry but can be triggered by manually disconnecting the device. Investigate. https://github.com/trezor/trezor-suite-private/issues/135
+        'device disconnected during action',
+    ];
+
+    return ignoredErrors.includes(error);
+};

--- a/suite-native/module-device-onboarding/package.json
+++ b/suite-native/module-device-onboarding/package.json
@@ -40,6 +40,7 @@
         "@suite-native/settings": "workspace:*",
         "@suite-native/swipeable-walkthrough": "workspace:*",
         "@suite-native/thp": "workspace:*",
+        "@suite-native/toasts": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",

--- a/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
@@ -9,6 +9,7 @@ import {
     MessageSystemRootState,
     selectIsFeatureEnabled,
 } from '@suite-common/message-system';
+import { getIsIgnoredEntropyCheckError } from '@suite-common/wallet-core';
 import { ContinueOnTrezorScreenContent, createAndBackupWalletThunk } from '@suite-native/device';
 import {
     DeviceOnboardingStackParamList,
@@ -17,6 +18,7 @@ import {
     RootStackRoutes,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
+import { useToast } from '@suite-native/toasts';
 import { ERRORS } from '@trezor/connect';
 
 import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
@@ -44,6 +46,7 @@ export const WalletCreationScreen = () => {
     const { walletBackupType } = route.params;
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProp>();
+    const { showToast } = useToast();
 
     const isEntropyCheckEnabled = useSelector((state: MessageSystemRootState) =>
         selectIsFeatureEnabled(state, Feature.entropyCheckMobile, true),
@@ -60,20 +63,24 @@ export const WalletCreationScreen = () => {
                     flowType: 'create',
                 });
             }
-            const { code } = responsePayload.payload;
-            if (code && DEFINITIVE_ERRORS.includes(code)) {
-                if (isEntropyCheckEnabled && code === 'Failure_EntropyCheck') {
-                    navigation.navigate(RootStackRoutes.DeviceCompromisedModal);
-                }
+            const { code, error } = responsePayload.payload;
+            const isDefinitiveError = code && DEFINITIVE_ERRORS.includes(code);
+            // inconclusive, so repeat the attempt
+            if (!isDefinitiveError || getIsIgnoredEntropyCheckError(error)) {
+                showToast({ variant: 'error', message: error });
+                // This code is OK, but the eslint plugin crashes on recursive calls
+                // eslint-disable-next-line react-hooks/immutability
+                handleCreateAndBackupWallet();
 
                 return;
             }
+
+            // handle entropy check failure, otherwise continue with the flow
+            if (isEntropyCheckEnabled && code === 'Failure_EntropyCheck') {
+                navigation.navigate(RootStackRoutes.DeviceCompromisedModal);
+            }
         }
-        // repeat the attempt if error was not one of the DEFINITIVE_ERRORS
-        // This code is OK, but the eslint plugin crashes on recursive calls
-        // eslint-disable-next-line react-hooks/immutability
-        handleCreateAndBackupWallet();
-    }, [dispatch, walletBackupType, navigation, isEntropyCheckEnabled]);
+    }, [dispatch, walletBackupType, navigation, isEntropyCheckEnabled, showToast]);
 
     useEffect(() => {
         handleCreateAndBackupWallet();

--- a/suite-native/module-device-onboarding/tsconfig.json
+++ b/suite-native/module-device-onboarding/tsconfig.json
@@ -32,6 +32,7 @@
         { "path": "../settings" },
         { "path": "../swipeable-walkthrough" },
         { "path": "../thp" },
+        { "path": "../toasts" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12933,6 +12933,7 @@ __metadata:
     "@suite-native/settings": "workspace:*"
     "@suite-native/swipeable-walkthrough": "workspace:*"
     "@suite-native/thp": "workspace:*"
+    "@suite-native/toasts": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"


### PR DESCRIPTION
## Description

When the entropy check results in a transport error, display a toast and **retry** the process.

## Notes for QA

Test the happy path – that creating wallet is successful.

## Related Issue

Resolve #23661

## Screenshots:

With `device disconnected` error mocked locally: 

<img width="415" height="930" alt="native device-disconnected" src="https://github.com/user-attachments/assets/ab7babe6-63ae-4865-b6d3-7eafce7acc82" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/entropy-check-mobile-false-positive&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/entropy-check-mobile-false-positive&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/entropy-check-mobile-false-positive&lookback=7)