### PR TITLE
Prevent derivation of unserializable extended keys

### DIFF
--- a/packages/utxo-lib/src/bip32.ts
+++ b/packages/utxo-lib/src/bip32.ts
@@ -222,6 +222,8 @@ class BIP32 implements BIP32Interface {
     derive(index: number): BIP32Interface {
         typeforce(typeforce.UInt32, index);
 
+        if ( this.depth >= 255 ) throw new TypeError('Cannot derive keys with depth over 255');
+
         const isHardened = index >= HIGHEST_BIT;
         const data = Buffer.allocUnsafe(37);
 

--- a/packages/utxo-lib/tests/bip32.test.ts
+++ b/packages/utxo-lib/tests/bip32.test.ts
@@ -195,6 +195,33 @@ it('works when private key has leading zeros', () => {
     );
 });
 
+it('throws when private -> private would overflow depth', () => {
+    let extKey = BIP32.fromSeed(Buffer.alloc(32, 0));
+
+    for (let i = 0; i < 255; i++) {
+        extKey = extKey.derive(0);
+    }
+
+    expect(() => {
+        extKey.derive(0);
+    }).toThrow(new TypeError('Cannot derive keys with depth over 255'));
+
+});
+
+it('throws when public -> public would overflow depth', () => {
+    let extKey = BIP32.fromSeed(Buffer.alloc(32, 0)).neutered();
+
+    for (let i = 0; i < 255; i++) {
+        extKey = extKey.derive(0);
+    }
+
+    expect(() => {
+        extKey.derive(0);
+    }).toThrow(new TypeError('Cannot derive keys with depth over 255'));
+
+});
+
+
 it('fromSeed', () => {
     // TODO
     //    'throws if IL is not within interval [1, n - 1] | IL === n || IL === 0'


### PR DESCRIPTION
It's possible to derive unserializable, as defined by BIP32, extended keys.

## Description

BIP32 serializes the `depth` of an extended key as a single byte. Thus, extended keys that are of depth greater than 255 are not possible to be serialized (in the BIP32 specified format). This commit introduces backwards-incompatible change that prevents a key of depth 256 and greater to be derived.

## Notes for QA

Two tests (one for private -> private and another for public -> public derivation) were added, even though they are covered by the same fix. If there are other parts of the code base that do extended key derivation, these should be verified for similar overflow as well.

The changes are backwards-incompatible - however, as long as one has the original seed, any keys, even the unserializable, can be still derived.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

- For more information, see https://github.com/bitcoin/bitcoin/issues/32201
- Similar problem in `trezor-firmware` https://github.com/trezor/trezor-firmware/pull/6219