### PR TITLE
fix(suite): undefined days to add to pool

### DIFF
--- a/packages/suite/src/components/suite/StakingProcess/StakingInfo.tsx
+++ b/packages/suite/src/components/suite/StakingProcess/StakingInfo.tsx
@@ -125,6 +125,7 @@ export const StakingInfo = ({ isExpanded, flow }: StakingInfoProps) => {
 
     if (!account) return null;
 
+    // TODO: this is only for Ethereum
     const daysToAddToPoolInitial = getDaysToAddToPoolInitial(validatorsQueue);
     const infoRowsData = getInfoRowsData(account, flow, daysToAddToPoolInitial);
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/ConfirmStakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/ConfirmStakeModal.tsx
@@ -44,8 +44,7 @@ export const ConfirmStakeModal = ({
     const account = useSelector(selectSelectedAccount);
     const validatorsQueue = useSelector(state => selectValidatorsQueueData(state, account?.symbol));
 
-    const daysToAddToPoolInitial = getDaysToAddToPoolInitial(validatorsQueue);
-    const daysToAddToPool = daysToAddToPoolInitial === undefined ? 30 : daysToAddToPoolInitial;
+    const daysToAddToPool = getDaysToAddToPoolInitial(validatorsQueue);
 
     const isDisabled = !hasAgreed || isLoading;
 

--- a/suite-common/staking/src/__fixtures__/ethereumStaking.ts
+++ b/suite-common/staking/src/__fixtures__/ethereumStaking.ts
@@ -1,5 +1,7 @@
 import { ETH_NETWORK_ADDRESSES } from '@everstake/wallet-sdk-ethereum';
 
+import { DAYS_TO_ADD_TO_POOL_DEFAULT } from '@suite-common/wallet-constants';
+
 export const transformTxFixtures = [
     {
         description:
@@ -604,7 +606,7 @@ export const getDaysToAddToPoolInitialFixture = [
         args: {
             validatorsQueue: {}, // validatorAddingDelay and validatorActivationTime are undefined
         },
-        result: undefined,
+        result: DAYS_TO_ADD_TO_POOL_DEFAULT,
     },
     {
         description: 'should return the number of days to wait',

--- a/suite-common/staking/src/utils/ethereumStaking.ts
+++ b/suite-common/staking/src/utils/ethereumStaking.ts
@@ -7,6 +7,7 @@ import { fromWei, numberToHex, toWei } from 'web3-utils';
 
 import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
+    DAYS_TO_ADD_TO_POOL_DEFAULT,
     DEFAULT_PAYMENT,
     MIN_ETH_AMOUNT_FOR_STAKING,
     STAKE_GAS_LIMIT_RESERVE,
@@ -592,7 +593,7 @@ export const getDaysToAddToPoolInitial = (validatorsQueue?: ValidatorsQueue) => 
         validatorsQueue?.validatorAddingDelay === undefined ||
         validatorsQueue?.validatorActivationTime === undefined
     ) {
-        return undefined;
+        return DAYS_TO_ADD_TO_POOL_DEFAULT;
     }
 
     const secondsToWait =

--- a/suite-common/wallet-constants/src/ethereumStakingConstants.ts
+++ b/suite-common/wallet-constants/src/ethereumStakingConstants.ts
@@ -20,3 +20,5 @@ export const BACKUP_REWARD_PAYOUT_DAYS = 7;
 
 // Used when Everstake unstaking period is not available from the API.
 export const UNSTAKING_ETH_PERIOD = 3;
+
+export const DAYS_TO_ADD_TO_POOL_DEFAULT = 30;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- I was not able to replicate it, probably it happens when everstake api does not work or when suite is offline
- however, NaN should not happen anymore

## Related Issue

Resolve [#23329](https://github.com/trezor/trezor-suite/issues/23329)

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/days-to-add-to-pool&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/days-to-add-to-pool&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/days-to-add-to-pool&lookback=7)