### PR TITLE
Revert "feat(connect-web): enable suite-web instead of old popup"

### DIFF
--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -53,7 +53,7 @@ const impl = new TrezorConnectDynamic<
                 console.warn(`Invalid coreMode: ${settings.coreMode}`);
             }
 
-            return 'core-in-suite-web';
+            return 'iframe';
         }
     },
     handleBeforeCall: async () => {
@@ -77,7 +77,7 @@ const impl = new TrezorConnectDynamic<
             impl.getTargetType() === 'core-in-suite-desktop' &&
             (errorCode === 'Desktop_ConnectionMissing' || errorCode === 'Method_Unsupported')
         ) {
-            await impl.switchTarget('core-in-suite-web');
+            await impl.switchTarget('iframe');
 
             return true;
         }

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -42,10 +42,10 @@ const impl = new TrezorConnectDynamic<
     getInitTarget: (settings: Partial<ConnectSettingsPublic & ConnectSettingsWebextension>) => {
         if (settings.coreMode === 'suite-desktop') {
             return 'core-in-suite-desktop';
-        } else if (settings.coreMode === 'popup') {
-            return 'core-in-popup';
-        } else {
+        } else if (settings.coreMode === 'suite-web') {
             return 'core-in-suite-web';
+        } else {
+            return 'core-in-popup';
         }
     },
     handleBeforeCall: async () => {
@@ -63,7 +63,7 @@ const impl = new TrezorConnectDynamic<
             impl.getTargetType() === 'core-in-suite-desktop' &&
             errorCode === 'Desktop_ConnectionMissing'
         ) {
-            await impl.switchTarget('core-in-suite-web');
+            await impl.switchTarget('core-in-popup');
 
             return true;
         }


### PR DESCRIPTION
## Description

We decided not to enable the Suite web flow by default in Connect v9. It will be enabled in Connect 10

## Notes for QA

Make sure coreMode auto opens old popup in Connect Explorer