### PR TITLE
feat(suite-native): disable sell

### DIFF
--- a/suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts
@@ -203,8 +203,8 @@ describe('commonSelectors', () => {
             expect(selectIsTradingSellEnabled(getPreloadedState({ sell: true }))).toBe(true);
         });
 
-        it('should correctly select that sell is enabled if remote feature is not set', () => {
-            expect(selectIsTradingSellEnabled(getPreloadedState({}))).toBe(true);
+        it('should correctly select that sell is not enabled if remote feature is not enabled', () => {
+            expect(selectIsTradingSellEnabled(getPreloadedState({}))).toBe(false);
         });
     });
 
@@ -218,11 +218,9 @@ describe('commonSelectors', () => {
                 expect(selectIsTradingEnabled(getPreloadedState({}))).toBe(true);
             });
 
-            it('should correctly select that trading is not enabled when buy, exchange and sell are disabled', () => {
+            it('should correctly select that trading is not enabled when buy and exchange are disabled (and sell is not set)', () => {
                 expect(
-                    selectIsTradingEnabled(
-                        getPreloadedState({ buy: false, exchange: false, sell: false }),
-                    ),
+                    selectIsTradingEnabled(getPreloadedState({ buy: false, exchange: false })),
                 ).toBe(false);
             });
         });

--- a/suite-native/trading-state/src/selectors/commonSelectors.ts
+++ b/suite-native/trading-state/src/selectors/commonSelectors.ts
@@ -93,7 +93,7 @@ export const selectIsTradingExchangeEnabled = (
 
 export const selectIsTradingSellEnabled = (state: MessageSystemRootState & FeatureFlagsRootState) =>
     selectIsFeatureFlagEnabled(state, FeatureFlag.IsTradingSellEnabled) ||
-    selectIsFeatureEnabled(state, Feature.trading.sell, true);
+    selectIsFeatureEnabled(state, Feature.trading.sell, false);
 
 export const selectIsTradingEnabled = (
     state: MessageSystemRootState & FeatureFlagsRootState & TradingRootState,


### PR DESCRIPTION
We decided to hide sell for this release


Test: @trezor/qa @Ondra-Zik-SL 

 Sell should be hidden on fresh install or update

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/trade/disable-sell&lookback=7)