### PR TITLE
Move Avalanche C-Chain out of Experimental Features

### DIFF
--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -69,6 +69,7 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
                 count: experimentalNetworks.length,
             },
         },
+        isDisabled: () => experimentalNetworks.length === 0,
     },
     // temporarily disabled, moved to debug
     /*     'suite-sync': {

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -287,7 +287,6 @@ export const networks = {
                 isDebugOnlyAccountType: true,
             },
         },
-        isExperimentalOnlyNetwork: true,
         coingeckoId: 'avalanche',
         tradeCryptoId: 'avalanche-2',
         caipId: 'eip155:43114',


### PR DESCRIPTION
## Description

This PR moves the Avalanche C-Chain network out of experimental features.
This PR keeps the `Experimental networks` logic, but hides it when no experimental networks are available

## Related Issue

Resolve #23511 

## Screenshots:

<img width="100%" alt="Screenshot 2025-12-08 at 13 48 38" src="https://github.com/user-attachments/assets/6850061f-7d21-4e9d-9e09-681e7002d729" />

<img width="100%" alt="Screenshot 2025-12-08 at 13 48 44" src="https://github.com/user-attachments/assets/f6e22939-cbbb-4912-8bc9-72beed18da2f" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/avax-out-of-experimental&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/avax-out-of-experimental&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/avax-out-of-experimental&lookback=7)