### PR TITLE
fix(e2e-suite): Corrects wrong model looping, removes unnecessary wait

### DIFF
--- a/suite/e2e/tests/backup/t3t1-t2t1-create-additional-share.test.ts
+++ b/suite/e2e/tests/backup/t3t1-t2t1-create-additional-share.test.ts
@@ -6,15 +6,15 @@ import { createTestAnnotation } from '../../support/reporters/annotations';
 
 const testCases: Model[] = ['T2T1', 'T3T1'];
 
-test.describe(
-    'Create additional share',
-    { tag: ['@group=device-management', '@specificModel'] },
-    () => {
-        test.beforeEach(async ({ onboardingPage }) => {
-            await onboardingPage.completeOnboarding();
-        });
+for (const model of testCases) {
+    test.describe(
+        'Create additional share',
+        { tag: ['@group=device-management', '@specificModel'] },
+        () => {
+            test.beforeEach(async ({ onboardingPage }) => {
+                await onboardingPage.completeOnboarding();
+            });
 
-        for (const model of testCases) {
             test.use({
                 emulatorStartConf: { model, wipe: true },
                 emulatorSetupConf: { mnemonic: 'mnemonic_academic' },
@@ -38,19 +38,12 @@ test.describe(
 
                     // [device screen] check your backup?
                     await trezorUserEnvLink.pressYes();
-                    // Firmware 2.9.4 brought instability in firmware/emu interaction, this will be discussed with firmware team
-                    await page.waitForTimeout(500);
 
                     // [device screen] select the number of words in your backup
                     await trezorUserEnvLink.inputEmu('20');
-                    // Firmware 2.9.4 brought instability in firmware/emu interaction, this will be discussed with firmware team
-                    await page.waitForTimeout(500);
 
                     // [device screen] backup instructions
                     await trezorUserEnvLink.pressYes();
-                    // Firmware 2.9.4 brought instability in firmware/emu interaction, this will be discussed with firmware team
-                    await page.waitForTimeout(500);
-
                     for (const word of MNEMONICS.mnemonic_academic.split(' ')) {
                         // [device screen] enter next word
                         await trezorUserEnvLink.inputEmu(word);
@@ -59,8 +52,6 @@ test.describe(
                     // [device screen] create additional backup?
                     await page.waitForTimeout(1000); // without this timeout, backup on device simply disappears, it stinks TODO: https://github.com/trezor/trezor-suite/issues/17128
                     await trezorUserEnvLink.pressYes();
-                    // Firmware 2.9.4 brought instability in firmware/emu interaction, this will be discussed with firmware team
-                    await page.waitForTimeout(500);
                     await trezorUserEnvLink.readAndConfirmShamirMnemonicEmu({
                         shares: 3,
                         threshold: 2,
@@ -69,6 +60,6 @@ test.describe(
                     await settingsPage.device.multiShareBackupGotItButton.click();
                 },
             );
-        }
-    },
-);
+        },
+    );
+}

--- a/suite/e2e/tests/onboarding/firmware-check.test.ts
+++ b/suite/e2e/tests/onboarding/firmware-check.test.ts
@@ -6,11 +6,11 @@ import { createTestAnnotation } from '../../support/reporters/annotations';
 
 const models: Model[] = ['T1B1', 'T2T1', 'T3B1', 'T3T1'];
 
-test.describe(
-    'Firmware - check readiness',
-    { tag: ['@group=device-management', '@firmware-ready'] },
-    () => {
-        for (const model of models) {
+for (const model of models) {
+    test.describe(
+        'Firmware - check readiness',
+        { tag: ['@group=device-management', '@firmware-ready'] },
+        () => {
             test.use({
                 emulatorStartConf: { model, wipe: true },
                 setupEmulator: false,
@@ -31,6 +31,6 @@ test.describe(
                     await onboardingPage.firmware.expectFirmwareToBeReady();
                 },
             );
-        }
-    },
-);
+        },
+    );
+}


### PR DESCRIPTION
I was testing `suite/e2e/tests/backup/t3t1-t2t1-create-additional-share.test.ts` stability without wait for our firmware meeting. And it seems the problem is gone.  So there won't be a meeting.

As sideefect of testing, I undercover a bug we had in our tests. looping of models was wrong. It used same model in each iteration. I guess that is because test.use is not awaited but in some queue or something :/ So if we had `const models: Model[] = ['T1B1', 'T2T1', 'T3B1', 'T3T1'];` then `T3T1` would be run 4 times. 
Fix is that `for loop` needs to be above describe in which we set model using test.use.

fixes typo in test file name 

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-model-looping&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-model-looping&lookback=7)