### PR TITLE
Staking - Trezor Not Connected Modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -10,10 +10,11 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
+import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
 import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { Fees } from 'src/components/wallet/Fees/Fees';
-import { useDevice, useSelector } from 'src/hooks/suite';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import { useCardanoStaking } from 'src/hooks/wallet/useCardanoStaking';
 import { useClaimForm } from 'src/hooks/wallet/useClaimForm';
@@ -27,6 +28,7 @@ interface ClaimModalModalProps {
 }
 
 const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) => {
+    const dispatch = useDispatch();
     const { device, isLocked } = useDevice();
     const { isClaimingDisabled, claimingMessageContent } = useMessageSystemStaking(
         selectedAccount.network.symbol,
@@ -61,7 +63,9 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
         ? formIsValid && hasValues
         : !isCardanoClaimingDisabled;
 
-    const isDisabled = !isFormInputsValid || isSubmitting || isLocked() || !device?.available;
+    const isDeviceConnected = device?.connected && device?.available;
+
+    const isDisabled = !isFormInputsValid || isSubmitting || (isDeviceConnected && isLocked());
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     // cardano specific logic
@@ -89,6 +93,15 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
     }, [onClaimChange, claimableAmount]);
 
     const onClaimClick = () => {
+        if (!isDeviceConnected) {
+            if (device?.descriptor?.apiType === 'bluetooth') {
+                dispatch(setConnectionMode('bluetooth'));
+            }
+            dispatch(setConnectionModal(true));
+
+            return;
+        }
+
         handleSubmit(signTx)();
 
         analytics.report({

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeButton.tsx
@@ -4,9 +4,10 @@ import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Modal, Tooltip } from '@trezor/components';
 import { analytics } from '@trezor/suite-analytics';
 
+import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
 import { Translation } from 'src/components/suite/Translation';
 import { stakingFlowToEventTypeMap } from 'src/constants/suite/staking';
-import { useDevice, useSelector } from 'src/hooks/suite';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import { useStakeFormContext } from 'src/hooks/wallet/useStakeForm';
 import { CRYPTO_INPUT, FIAT_INPUT } from 'src/types/wallet/stakeForms';
@@ -16,6 +17,7 @@ interface StakeButtonProps {
 }
 
 export const StakeButton = ({ flow }: StakeButtonProps) => {
+    const dispatch = useDispatch();
     const { device, isLocked } = useDevice();
     const selectedAccount = useSelector(
         state => state.wallet.selectedAccount,
@@ -38,6 +40,8 @@ export const StakeButton = ({ flow }: StakeButtonProps) => {
         selectAreFeesLoading(state, selectedAccount.network.symbol),
     );
 
+    const isDeviceConnected = device?.connected && device?.available;
+
     const isCardano = selectedAccount.account.networkType === 'cardano';
 
     const hasValues = Boolean(watch(FIAT_INPUT) || watch(CRYPTO_INPUT));
@@ -45,9 +49,18 @@ export const StakeButton = ({ flow }: StakeButtonProps) => {
     const formIsValid = Object.keys(errors).length === 0;
     // there is no input for cardano. Form validation should always pass
     const isFormInputsValid = !isCardano ? formIsValid && hasValues : !isCardanoStakingDisabled;
-    const isDisabled = !isFormInputsValid || isSubmitting || isLocked() || !device?.available;
+    const isDisabled = !isFormInputsValid || isSubmitting || (isDeviceConnected && isLocked());
 
     const onStakeClick = () => {
+        if (!isDeviceConnected) {
+            if (device?.descriptor?.apiType === 'bluetooth') {
+                dispatch(setConnectionMode('bluetooth'));
+            }
+            dispatch(setConnectionModal(true));
+
+            return;
+        }
+
         if (isCardano) {
             // direct call for cardano as there is no need to validate inputs
             onSubmit();

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeButton.tsx
@@ -3,13 +3,15 @@ import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Modal, Tooltip } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
+import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
 import { Translation } from 'src/components/suite/Translation';
-import { useDevice, useSelector } from 'src/hooks/suite';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import { useUnstakeFormContext } from 'src/hooks/wallet/useUnstakeForm';
 import { CRYPTO_INPUT, FIAT_INPUT } from 'src/types/wallet/stakeForms';
 
 export const UnstakeButton = () => {
+    const dispatch = useDispatch();
     const { device, isLocked } = useDevice();
     const selectedAccount = useSelector(
         state => state.wallet.selectedAccount,
@@ -31,14 +33,25 @@ export const UnstakeButton = () => {
     // used instead of formState.isValid, which is sometimes returning false even if there are no errors
     const formIsValid = Object.keys(errors).length === 0;
 
+    const isDeviceConnected = device?.connected && device?.available;
+
     const isDisabled =
-        !(formIsValid && hasValues) || isSubmitting || isLocked() || !device?.available;
+        !(formIsValid && hasValues) || isSubmitting || (isDeviceConnected && isLocked());
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
     const areFeesLoading = useSelector(state =>
         selectAreFeesLoading(state, selectedAccount.network.symbol),
     );
 
     const onUnstakeClick = () => {
+        if (!isDeviceConnected) {
+            if (device?.descriptor?.apiType === 'bluetooth') {
+                dispatch(setConnectionMode('bluetooth'));
+            }
+            dispatch(setConnectionModal(true));
+
+            return;
+        }
+
         handleSubmit(signTx)();
 
         analytics.report({

--- a/packages/suite/src/views/wallet/staking/components/CardanoStakingDashboard/NewCardanoStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/CardanoStakingDashboard/NewCardanoStakingDashboard.tsx
@@ -15,8 +15,7 @@ import { Column, Flex, Grid } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { DashboardSection } from 'src/components/dashboard';
-import { useDevice, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
-import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
+import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 
 import { CardanoNewProviderCard } from '../CardanoNewProviderCard';
 import { StakingDashboard } from '../StakingDashboard/StakingDashboard';
@@ -36,11 +35,9 @@ export const NewCardanoStakingDashboard = ({
     selectedAccount,
 }: NewCardanoStakingDashboardProps) => {
     const { account } = selectedAccount;
-    const { device } = useDevice();
     const accountKey = account?.key ?? '';
 
     const { isBelowLaptop } = useLayoutSize();
-    const isDeviceConnected = device?.connected && device?.available;
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const dispatch = useDispatch();
@@ -76,7 +73,6 @@ export const NewCardanoStakingDashboard = ({
                     {shouldShowStakingDashboard ? (
                         <DashboardSection>
                             <Column alignItems="normal" gap={spacings.sm}>
-                                {!isDeviceConnected && <ConnectDeviceGenericPromo />}
                                 {isDiscoveryRunning && <DiscoveryWarning />}
 
                                 <CardanoNewProviderCard account={account} />

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EthStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EthStakingDashboard.tsx
@@ -17,8 +17,7 @@ import { Column, Flex, Grid } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { DashboardSection } from 'src/components/dashboard';
-import { useDevice, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
-import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
+import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 
 import { InstantStakeBanner } from './InstantStakeBanner';
 import { StakingDashboard } from '../../StakingDashboard/StakingDashboard';
@@ -36,11 +35,9 @@ interface EthStakingDashboardProps {
 
 export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProps) => {
     const { account } = selectedAccount;
-    const { device } = useDevice();
 
     const accountKey = account?.key ?? '';
     const { isBelowLaptop } = useLayoutSize();
-    const isDeviceConnected = device?.connected && device?.available;
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const { data, isLoading } =
@@ -84,7 +81,6 @@ export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProp
                     {isStakingActive ? (
                         <DashboardSection>
                             <Column gap={spacings.sm}>
-                                {!isDeviceConnected && <ConnectDeviceGenericPromo />}
                                 {isDiscoveryRunning && <DiscoveryWarning />}
 
                                 <InstantStakeBanner

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
@@ -10,9 +10,8 @@ import { Column, Flex, Grid } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { DashboardSection } from 'src/components/dashboard';
-import { useDevice, useLayoutSize, useSelector } from 'src/hooks/suite';
+import { useLayoutSize, useSelector } from 'src/hooks/suite';
 import { useSolanaRewards } from 'src/hooks/wallet/useSolanaRewards';
-import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 
 import { StakingDashboard } from '../StakingDashboard/StakingDashboard';
 import { RewardsList } from './Rewards/RewardsList';
@@ -31,10 +30,8 @@ interface SolStakingDashboardProps {
 
 export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProps) => {
     const { account } = selectedAccount;
-    const { device } = useDevice();
 
     const { isBelowLaptop } = useLayoutSize();
-    const isDeviceConnected = device?.connected && device?.available;
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
@@ -58,7 +55,6 @@ export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProp
                         <>
                             <DashboardSection>
                                 <Column alignItems="normal" gap={spacings.sm}>
-                                    {!isDeviceConnected && <ConnectDeviceGenericPromo />}
                                     {isDiscoveryRunning && <DiscoveryWarning />}
                                     {rewardsNotAvailableYet && <StakingRewardsWarning />}
 


### PR DESCRIPTION
## Description

This PR introduces the `Trezor not connected` modal to stake/unstake/claim/update provider flows.

## Related Issue

Resolve #23411 

## Screenshots:

Stake modal:

<img width="100%" alt="Screenshot 2025-12-08 at 14 51 31" src="https://github.com/user-attachments/assets/dd0ff339-bdf4-47fc-91a8-e4aa010bc95b" />

Unstake modal:

<img width="100%" alt="Screenshot 2025-12-08 at 14 51 39" src="https://github.com/user-attachments/assets/15b8fd02-a043-43dd-95d3-37f1fe01e74a" />

Claim modal:

<img width="100%" alt="Screenshot 2025-12-08 at 14 51 48" src="https://github.com/user-attachments/assets/a1141542-a9bf-4d69-8901-a0322236b7d3" />

Update provider modal:

<img width="100%" alt="Screenshot 2025-12-08 at 14 52 02" src="https://github.com/user-attachments/assets/a31744ac-a957-49f5-8cc2-2b48144ebe96" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/staking-not-connected-modal&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/staking-not-connected-modal&lookback=7)