### PR TITLE
Proposal: @tanstack/react-query use-cases

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -71,6 +71,8 @@
         "@suite/secure-storage-electron": "workspace:*",
         "@suite/secure-storage-webauthn": "workspace:*",
         "@suite/suite-sync": "workspace:*",
+        "@tanstack/react-query": "^5.90.10",
+        "@tanstack/react-query-devtools": "^5.91.0",
         "@testing-library/jest-dom": "6.9.1",
         "@trezor/address-validator": "workspace:*",
         "@trezor/analytics": "workspace:*",

--- a/packages/suite/src/components/suite/ConnectAppIcon.tsx
+++ b/packages/suite/src/components/suite/ConnectAppIcon.tsx
@@ -21,9 +21,9 @@ export const ConnectAppIcon = ({
     type?: 'walletConnect' | 'trezorConnect';
     size?: SpacingValues;
 }) => {
-    const { loading, error, imageBlob } = useProxyImage(src);
+    const proxyImageQuery = useProxyImage(src);
 
-    if (loading || error || !src || !imageBlob) {
+    if (!proxyImageQuery.isSuccess) {
         return (
             <IconCircle
                 name={type === 'walletConnect' ? 'walletConnect' : 'plugs'}
@@ -35,5 +35,5 @@ export const ConnectAppIcon = ({
         );
     }
 
-    return <AppIconImage src={imageBlob} alt="App Icon" size={size} />;
+    return <AppIconImage src={proxyImageQuery.data} alt="App Icon" size={size} />;
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/BackendUrls/BackendUrls.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/BackendUrls/BackendUrls.tsx
@@ -21,7 +21,7 @@ export function BackendUrls({
     removeUrl,
 }: BackendUrlsProps) {
     const blockchain = useSelector(state => state.wallet.blockchain);
-    const { defaultUrls } = useDefaultUrls(symbol);
+    const { data: defaultUrls } = useDefaultUrls(symbol);
 
     const { ref: inputRef, ...inputField } = input.register(input.name, {
         validate: input.validate,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
@@ -209,8 +209,7 @@ export const TxSimulationModal = () => {
         a => popupCall?.state === 'tx-simulation' && a.key === popupCall?.selectedAccountKey,
     );
     const [disclaimerAccepted, setDisclaimerAccepted] = useState(false);
-    const { isLoading, simulationResult, error, needsDisclaimer, network, targetContract } =
-        useTxSimulationConnectPopup(popupCall);
+    const { txSimulationQuery, network, targetContract } = useTxSimulationConnectPopup(popupCall);
     const explorer = useSelector(state => selectExplorer(state, network?.symbol));
     const defaultGasLimit =
         (popupCall?.state === 'tx-simulation' && popupCall.payload?.transaction?.gasLimit) ||
@@ -239,16 +238,22 @@ export const TxSimulationModal = () => {
         popupCall?.state === 'tx-simulation' && popupCall?.method === 'ethereumSignTransaction';
 
     useEffect(() => {
+        if (!txSimulationQuery.isSuccess) {
+            return;
+        }
+
+        const { gas_estimation } = txSimulationQuery.data;
+
         // Use TX simulation gas estimation instead of the default
         if (
-            simulationResult?.gas_estimation?.status === 'Success' &&
+            gas_estimation?.status === 'Success' &&
             defaultGasLimit === ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT
         ) {
-            const newFeeLimit = Number(simulationResult.gas_estimation.estimate).toString();
+            const newFeeLimit = Number(gas_estimation.estimate).toString();
             setValue('feeLimit', newFeeLimit);
             setValue('estimatedFeeLimit', newFeeLimit);
         }
-    }, [simulationResult, defaultGasLimit, setValue]);
+    }, [txSimulationQuery, defaultGasLimit, setValue]);
 
     const onConfirm = () => {
         if (isSigningTransaction) {
@@ -331,7 +336,10 @@ export const TxSimulationModal = () => {
                         <Modal.Button
                             onClick={onConfirm}
                             data-testid="@tx-simulation-modal/confirm-button"
-                            isDisabled={isLoading || (needsDisclaimer && !disclaimerAccepted)}
+                            isDisabled={
+                                txSimulationQuery.isLoading ||
+                                (txSimulationQuery.data?.needsDisclaimer && !disclaimerAccepted)
+                            }
                         >
                             <Translation id="TR_CONFIRM" />
                         </Modal.Button>
@@ -350,11 +358,11 @@ export const TxSimulationModal = () => {
             >
                 <FormProvider {...methods}>
                     <Column gap={spacings.xs}>
-                        {isLoading && <Spinner size={50} />}
+                        {txSimulationQuery.isLoading && <Spinner size={50} />}
 
-                        {simulationResult && (
+                        {txSimulationQuery.isSuccess && (
                             <>
-                                {simulationResult.simulation?.status === 'Success' && (
+                                {txSimulationQuery.data.simulation?.status === 'Success' && (
                                     <>
                                         <Card
                                             header={
@@ -376,7 +384,7 @@ export const TxSimulationModal = () => {
                                                 }}
                                                 hasDivider
                                             >
-                                                {simulationResult.simulation.account_summary.assets_diffs.map(
+                                                {txSimulationQuery.data.simulation.account_summary.assets_diffs.map(
                                                     (assetDiff, index) => (
                                                         <TxSimulationAsset
                                                             key={index}
@@ -385,7 +393,7 @@ export const TxSimulationModal = () => {
                                                         />
                                                     ),
                                                 )}
-                                                {simulationResult.simulation.account_summary.exposures.map(
+                                                {txSimulationQuery.data.simulation.account_summary.exposures.map(
                                                     (assetExposure, index) => (
                                                         <TxSimulationAsset
                                                             key={index}
@@ -394,10 +402,10 @@ export const TxSimulationModal = () => {
                                                         />
                                                     ),
                                                 )}
-                                                {simulationResult.simulation.account_summary
+                                                {txSimulationQuery.data.simulation.account_summary
                                                     .assets_diffs.length === 0 &&
-                                                    simulationResult.simulation.account_summary
-                                                        .exposures.length === 0 && (
+                                                    txSimulationQuery.data.simulation
+                                                        .account_summary.exposures.length === 0 && (
                                                         <Row
                                                             padding={{
                                                                 horizontal: spacings.md,
@@ -441,7 +449,7 @@ export const TxSimulationModal = () => {
                                                         {
                                                             label: <Translation id="TR_PROTOCOL" />,
                                                             value: Object.entries(
-                                                                simulationResult.simulation
+                                                                txSimulationQuery.data.simulation
                                                                     .address_details,
                                                             ).find(
                                                                 ([address]) =>
@@ -476,7 +484,7 @@ export const TxSimulationModal = () => {
                                                             label: (
                                                                 <Translation id="TR_CONTRACT_FUNCTION" />
                                                             ),
-                                                            value: simulationResult.simulation
+                                                            value: txSimulationQuery.data.simulation
                                                                 .params?.calldata
                                                                 ?.function_signature,
                                                         },
@@ -509,33 +517,33 @@ export const TxSimulationModal = () => {
                                     </>
                                 )}
 
-                                {simulationResult.validation?.result_type === 'Malicious' && (
+                                {txSimulationQuery.data.validation?.result_type === 'Malicious' && (
                                     <TxSimulationBanner
                                         type="error"
                                         title={<Translation id="TR_SIMULATION_MALICIOUS" />}
-                                        description={simulationResult.validation?.description}
+                                        description={txSimulationQuery.data.validation?.description}
                                         disclaimerAccepted={disclaimerAccepted}
                                         setDisclaimerAccepted={setDisclaimerAccepted}
                                     />
                                 )}
 
-                                {simulationResult.validation?.result_type === 'Warning' && (
+                                {txSimulationQuery.data.validation?.result_type === 'Warning' && (
                                     <TxSimulationBanner
                                         type="warning"
                                         title={<Translation id="TR_SIMULATION_WARNING" />}
-                                        description={simulationResult.validation?.description}
+                                        description={txSimulationQuery.data.validation?.description}
                                         disclaimerAccepted={disclaimerAccepted}
                                         setDisclaimerAccepted={setDisclaimerAccepted}
                                     />
                                 )}
 
-                                {simulationResult.simulation?.status === 'Error' && (
+                                {txSimulationQuery.data.simulation?.status === 'Error' && (
                                     <TxSimulationBanner
                                         type={getSimulationErrorRiskLevel(
-                                            simulationResult.simulation.error,
+                                            txSimulationQuery.data.simulation.error,
                                         )}
                                         title={<Translation id="TR_SIMULATION_ERROR" />}
-                                        description={simulationResult.simulation.error}
+                                        description={txSimulationQuery.data.simulation.error}
                                         disclaimerAccepted={disclaimerAccepted}
                                         setDisclaimerAccepted={setDisclaimerAccepted}
                                     />
@@ -543,11 +551,11 @@ export const TxSimulationModal = () => {
                             </>
                         )}
 
-                        {error && (
+                        {txSimulationQuery.error && (
                             <TxSimulationBanner
                                 type="error"
                                 title={<Translation id="TR_SIMULATION_ERROR" />}
-                                description={error.message}
+                                description={txSimulationQuery.error.message}
                                 disclaimerAccepted={disclaimerAccepted}
                                 setDisclaimerAccepted={setDisclaimerAccepted}
                             />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -68,7 +68,7 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
         selectableAccounts[0] || null,
     );
     const [ignoreWarning, setIgnoreWarning] = useState(false);
-    const { isLoading, isMalicious } = useDappScan(pendingProposal?.params.proposer.metadata.url);
+    const dappScanQuery = useDappScan(pendingProposal?.params.proposer.metadata.url);
 
     const handleAccept = () => {
         dispatch(
@@ -120,9 +120,10 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                         isDisabled={
                             pendingProposal.expired ||
                             noNetworksActivated ||
-                            ((pendingProposal.isScam || isMalicious) && !ignoreWarning)
+                            ((pendingProposal.isScam || dappScanQuery.data?.isMalicious) &&
+                                !ignoreWarning)
                         }
-                        isLoading={isLoading}
+                        isLoading={dappScanQuery.isLoading}
                     >
                         <Translation id="TR_CONFIRM" />
                     </Modal.Button>
@@ -278,7 +279,7 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                     </Banner>
                 )}
 
-                {(isMalicious || pendingProposal.isScam) && (
+                {(dappScanQuery.data?.isMalicious || pendingProposal.isScam) && (
                     <TxSimulationBanner
                         type="error"
                         title={<Translation id="TR_WALLETCONNECT_IS_SCAM" />}

--- a/packages/suite/src/hooks/settings/backends/useDefaultUrls.ts
+++ b/packages/suite/src/hooks/settings/backends/useDefaultUrls.ts
@@ -1,22 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import TrezorConnect, { BlockchainLink } from '@trezor/connect';
+import TrezorConnect from '@trezor/connect';
 
-export const useDefaultUrls = (
-    symbol: NetworkSymbol,
-): { defaultUrls: string[]; isLoading: boolean } => {
-    const [link, setLink] = useState<BlockchainLink>();
-    const [isLoading, setIsLoading] = useState(false);
-    useEffect(() => {
-        setIsLoading(true);
-        TrezorConnect.getCoinInfo({ coin: symbol }).then(result => {
-            if (result.success) {
-                setLink(result.payload.blockchainLink);
+export const useDefaultUrls = (symbol: NetworkSymbol) =>
+    useQuery({
+        queryKey: ['default-urls', symbol],
+        queryFn: async () => {
+            const result = await TrezorConnect.getCoinInfo({ coin: symbol });
+
+            if (!result.success) {
+                throw new Error('Failed to get coin info');
             }
-            setIsLoading(false);
-        });
-    }, [symbol]);
 
-    return { defaultUrls: link?.url ?? [], isLoading };
-};
+            return result.payload.blockchainLink?.url ?? [];
+        },
+        initialData: [],
+    });

--- a/packages/suite/src/hooks/suite/useProxyImage.ts
+++ b/packages/suite/src/hooks/suite/useProxyImage.ts
@@ -1,5 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
+import { useQuery } from '@tanstack/react-query';
+
+import { useCurrentRef } from '@trezor/react-utils';
 import { IMAGE_PROXY_API_AUTH_BEARER, IMAGE_PROXY_API_URL } from '@trezor/urls';
 
 /**
@@ -8,54 +11,47 @@ import { IMAGE_PROXY_API_AUTH_BEARER, IMAGE_PROXY_API_URL } from '@trezor/urls';
  * Display fallbackComponent if the image fails to load
  */
 export const useProxyImage = (src?: string) => {
-    const [imageBlob, setImageBlob] = useState<string | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(false);
+    const abortControllersRef = useRef(new Map<string, AbortController>());
+    const proxyImageQuery = useQuery({
+        enabled: Boolean(src),
+        queryKey: ['proxy-image', src],
+        queryFn: async () => {
+            const abortController = new AbortController();
 
-    useEffect(() => {
-        let isCancelled = false;
-        setLoading(true);
-        setError(false);
-        setImageBlob(null);
+            abortControllersRef.current.set(src!, abortController);
 
-        if (!src) {
-            setLoading(false);
-            setError(true);
-
-            return;
-        }
-
-        fetch(`${IMAGE_PROXY_API_URL}?url=${encodeURIComponent(src)}`, {
-            headers: {
-                Authorization: `Bearer ${IMAGE_PROXY_API_AUTH_BEARER}`,
-            },
-        })
-            .then(res => {
-                if (!res.ok) throw new Error('Image fetch failed');
-
-                return res.blob();
-            })
-            .then(blob => {
-                if (!isCancelled) {
-                    const objectUrl = URL.createObjectURL(blob);
-                    setImageBlob(objectUrl);
-                }
-            })
-            .catch(() => {
-                if (!isCancelled) setError(true);
-            })
-            .finally(() => {
-                if (!isCancelled) setLoading(false);
+            const res = await fetch(`${IMAGE_PROXY_API_URL}?url=${encodeURIComponent(src!)}`, {
+                headers: {
+                    Authorization: `Bearer ${IMAGE_PROXY_API_AUTH_BEARER}`,
+                },
+                signal: abortController.signal,
             });
 
-        return () => {
-            isCancelled = true;
-        };
-    }, [src]);
+            if (!res.ok) {
+                throw new Error('Image fetch failed');
+            }
 
-    return {
-        imageBlob,
-        loading,
-        error,
-    };
+            const blob = await res.blob();
+
+            abortControllersRef.current.delete(src!);
+
+            return URL.createObjectURL(blob);
+        },
+    });
+    const inProgressRef = useCurrentRef(proxyImageQuery.isLoading);
+
+    useEffect(() => {
+        if (!src) return;
+
+        const inProgress = inProgressRef.current;
+        const abortController = abortControllersRef.current.get(src);
+
+        return () => {
+            if (inProgress && abortController) {
+                abortController.abort('Image fetch aborted on unmount.');
+            }
+        };
+    }, [src, abortControllersRef, inProgressRef]);
+
+    return proxyImageQuery;
 };

--- a/packages/suite/src/support/suite/Main.tsx
+++ b/packages/suite/src/support/suite/Main.tsx
@@ -14,6 +14,7 @@ import Protocol from 'src/support/suite/Protocol';
 import Resize from 'src/support/suite/Resize';
 import { ResponsiveContextProvider } from 'src/support/suite/ResponsiveContext';
 
+import { ReactQueryProvider } from './ReactQueryProvider';
 import { RouterHandler } from './RouterHandler';
 import { useConnectPopupModals } from './useConnectPopupModals';
 
@@ -37,16 +38,18 @@ export const Main = ({
             <ConnectedThemeProvider>
                 <ResponsiveContextProvider>
                     <ErrorBoundary>
-                        <Autodetect />
-                        <Resize />
-                        <Protocol />
-                        <OnlineStatus />
-                        <RouterHandler history={history} />
-                        <ConnectedIntlProvider>
-                            <FormatterProvider config={formattersConfig}>
-                                {children}
-                            </FormatterProvider>
-                        </ConnectedIntlProvider>
+                        <ReactQueryProvider>
+                            <Autodetect />
+                            <Resize />
+                            <Protocol />
+                            <OnlineStatus />
+                            <RouterHandler history={history} />
+                            <ConnectedIntlProvider>
+                                <FormatterProvider config={formattersConfig}>
+                                    {children}
+                                </FormatterProvider>
+                            </ConnectedIntlProvider>
+                        </ReactQueryProvider>
                     </ErrorBoundary>
                 </ResponsiveContextProvider>
             </ConnectedThemeProvider>

--- a/packages/suite/src/support/suite/ReactQueryProvider.tsx
+++ b/packages/suite/src/support/suite/ReactQueryProvider.tsx
@@ -1,0 +1,53 @@
+import { type ReactNode, Suspense, lazy, useMemo } from 'react';
+
+import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const ReactQueryDevtools = lazy(async () => {
+    const { ReactQueryDevtools } = await import('@tanstack/react-query-devtools');
+
+    return { default: ReactQueryDevtools };
+});
+
+export interface ReactQueryProviderProps {
+    children: ReactNode;
+}
+
+const IS_DEV = process.env.NODE_ENV === 'development';
+const MAX_RETRY_COUNT = IS_DEV ? 0 : 3;
+const DEV_TOOLS = IS_DEV;
+
+export const ReactQueryProvider = ({ children }: ReactQueryProviderProps) => {
+    const queryClient = useMemo(
+        () =>
+            new QueryClient({
+                queryCache: new QueryCache({
+                    onError: error => {
+                        console.error(error);
+                    },
+                }),
+                mutationCache: new MutationCache({
+                    onError: error => {
+                        console.error(error);
+                    },
+                }),
+                defaultOptions: {
+                    mutations: {},
+                    queries: {
+                        retry: failureCount => failureCount < MAX_RETRY_COUNT,
+                    },
+                },
+            }),
+        [],
+    );
+
+    return (
+        <QueryClientProvider client={queryClient}>
+            {children}
+            {DEV_TOOLS && (
+                <Suspense fallback={null}>
+                    <ReactQueryDevtools />
+                </Suspense>
+            )}
+        </QueryClientProvider>
+    );
+};

--- a/packages/suite/src/views/wallet/tokens/inactive-tokens/InactiveTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/inactive-tokens/InactiveTokensTable.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
+import { useMutation, useQuery } from '@tanstack/react-query';
 import styled from 'styled-components';
 
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -82,37 +83,30 @@ export const InactiveTokensTable = ({ selectedAccount, searchQuery }: InactiveTo
     const dispatch = useDispatch();
     const { account } = selectedAccount;
     const coingeckoId = getCoingeckoId(account.symbol);
-    const [allInactiveTokens, setAllInactiveTokens] = useState<StellarTokenInfo[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const [hasError, setHasError] = useState(false);
     const [tokenToActivate, setTokenToActivate] = useState<StellarTokenInfo | null>(null);
 
-    useEffect(() => {
-        if (account.symbol === 'xlm') {
-            setIsLoading(true);
-            setHasError(false);
-            getInactiveStellarTokens(account)
-                .then(tokens => {
-                    setAllInactiveTokens(tokens);
-                    setIsLoading(false);
-                })
-                .catch(error => {
-                    console.error('Failed to load inactive tokens:', error);
-                    setAllInactiveTokens([]);
-                    setIsLoading(false);
-                    setHasError(true);
-                    dispatch(
-                        notificationsActions.addToast({
-                            type: 'error',
-                            error: 'Failed to load inactive tokens. Please try again later.',
-                        }),
-                    );
-                });
-        } else {
-            setAllInactiveTokens([]);
-            setIsLoading(false);
-        }
-    }, [account, dispatch]);
+    const getInactiveTokens = useMutation({
+        mutationFn: getInactiveStellarTokens,
+        onError: () => {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: 'Failed to load inactive tokens. Please try again later.',
+                }),
+            );
+        },
+    });
+
+    const {
+        data: allInactiveTokens,
+        isLoading,
+        isError,
+    } = useQuery({
+        enabled: account.symbol === 'xlm',
+        queryKey: ['inactive-tokens', account.symbol],
+        queryFn: () => getInactiveTokens.mutateAsync(account),
+        initialData: [],
+    });
 
     const filteredTokens = useMemo(() => {
         if (!searchQuery) {
@@ -143,7 +137,7 @@ export const InactiveTokensTable = ({ selectedAccount, searchQuery }: InactiveTo
         return <Loading />;
     }
 
-    if (hasError) {
+    if (isError) {
         return <NoTokens title={<Translation id="TR_ERROR_LOADING_TOKENS" />} />;
     }
 

--- a/packages/utils/src/delay.ts
+++ b/packages/utils/src/delay.ts
@@ -1,0 +1,1 @@
+export const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -62,3 +62,4 @@ export * from './union';
 export * from './isInt';
 export * from './number';
 export * from './sanitizeFilename';
+export * from './delay';

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -73,3 +73,5 @@ web3-utils
 worker-loader
 xrpl
 yup
+@tanstack/react-query-devtools
+@tanstack/react-query

--- a/suite-common/tx-simulation/package.json
+++ b/suite-common/tx-simulation/package.json
@@ -13,6 +13,7 @@
         "@blockaid/client": "^0.56.0",
         "@suite-common/connect-popup": "workspace:^",
         "@suite-common/wallet-config": "workspace:^",
+        "@tanstack/react-query": "^5.90.10",
         "@trezor/connect": "workspace:^",
         "react": "18.2.0"
     }

--- a/suite-common/tx-simulation/src/hooks.tsx
+++ b/suite-common/tx-simulation/src/hooks.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 
-import type { SiteScanResponse, TransactionScanResponse } from '@blockaid/client/resources';
 import type { JsonRpcScanParams } from '@blockaid/client/resources/evm';
+import { useQuery } from '@tanstack/react-query';
 
 import { ConnectPopupCall } from '@suite-common/connect-popup';
 import { getNetwork, getNetworkByEvmChainId } from '@suite-common/wallet-config';
@@ -9,52 +9,27 @@ import type { EthereumSignTransaction, EthereumSignTypedData } from '@trezor/con
 
 import { client } from './client';
 
-export const useTxSimulationEVM = (input?: JsonRpcScanParams) => {
-    // Call tx simulation API with the provided input
-    const [isLoading, setIsLoading] = useState(false);
-    const [simulationResult, setSimulationResult] = useState<TransactionScanResponse | null>(null);
-    const [error, setError] = useState<Error | null>(null);
-    const lastInput = useRef<JsonRpcScanParams | undefined>(undefined);
+function useTxSimulationEVM(input?: JsonRpcScanParams) {
+    return useQuery({
+        enabled: Boolean(input),
+        // TODO: use global constant for query keys
+        queryKey: ['tx-simulation-evm', input],
+        queryFn: async () => {
+            const simulationResult = await client.evm.jsonRpc.scan(input!);
+            const needsDisclaimer =
+                simulationResult.validation?.result_type === 'Malicious' ||
+                simulationResult.validation?.result_type === 'Warning' ||
+                simulationResult.simulation?.status === 'Error';
 
-    useEffect(() => {
-        if (!input) {
-            setSimulationResult(null);
-            setError(null);
+            return {
+                ...simulationResult,
+                needsDisclaimer,
+            };
+        },
+    });
+}
 
-            return;
-        }
-        // Avoid unnecessary re-fetching
-        if (lastInput.current && JSON.stringify(lastInput.current) === JSON.stringify(input)) {
-            return;
-        }
-        lastInput.current = input;
-        setIsLoading(true);
-        client.evm.jsonRpc
-            .scan(input)
-            .then(result => {
-                setSimulationResult(result);
-            })
-            .catch(err => {
-                setError(err);
-            })
-            .finally(() => {
-                setIsLoading(false);
-            });
-    }, [input]);
-
-    const needsDisclaimer =
-        error ||
-        simulationResult?.simulation?.status === 'Error' ||
-        simulationResult?.validation?.result_type === 'Malicious' ||
-        simulationResult?.validation?.result_type === 'Warning';
-
-    return {
-        isLoading,
-        simulationResult,
-        error,
-        needsDisclaimer,
-    };
-};
+export type TxSimulationResult = NonNullable<ReturnType<typeof useTxSimulationEVM>['data']>;
 
 export const useTxSimulationConnectPopup = (popupCall?: ConnectPopupCall) => {
     const payload = useMemo(() => {
@@ -134,43 +109,26 @@ export const useTxSimulationConnectPopup = (popupCall?: ConnectPopupCall) => {
         }
     }, [popupCall]);
 
-    const result = useTxSimulationEVM(payload);
+    const txSimulationQuery = useTxSimulationEVM(payload);
 
     return {
-        ...result,
+        txSimulationQuery,
         network,
         targetContract,
     };
 };
 
-export const useDappScan = (url?: string) => {
-    const [isLoading, setIsLoading] = useState(false);
-    const [result, setResult] = useState<SiteScanResponse | null>(null);
-    const [error, setError] = useState<Error | null>(null);
+export const useDappScan = (url?: string) =>
+    useQuery({
+        enabled: Boolean(url),
+        queryKey: ['dapp-scan', url],
+        queryFn: async () => {
+            const scanResult = await client.site.scan({ url: url! });
+            const isMalicious = scanResult?.status === 'hit' && scanResult.is_malicious;
 
-    useEffect(() => {
-        if (!url) {
-            setResult(null);
-            setError(null);
-
-            return;
-        }
-
-        setIsLoading(true);
-        client.site
-            .scan({ url })
-            .then(res => {
-                setResult(res);
-            })
-            .catch(err => {
-                setError(err);
-            })
-            .finally(() => {
-                setIsLoading(false);
-            });
-    }, [url]);
-
-    const isMalicious = result?.status === 'hit' && result.is_malicious;
-
-    return { isLoading, result, error, isMalicious };
-};
+            return {
+                ...scanResult,
+                isMalicious,
+            };
+        },
+    });

--- a/suite-native/module-connect-popup/src/components/TxSimulation.tsx
+++ b/suite-native/module-connect-popup/src/components/TxSimulation.tsx
@@ -41,8 +41,7 @@ export const TxSimulation = () => {
     const { bottomSheetRef: feeInfoBottomSheetRef, openModal: openFeeInfoModal } =
         useBottomSheetModal();
     const [disclaimerAccepted, setDisclaimerAccepted] = useState(false);
-    const { isLoading, simulationResult, error, needsDisclaimer, network, targetContract } =
-        useTxSimulationConnectPopup(popupCall);
+    const { txSimulationQuery, network, targetContract } = useTxSimulationConnectPopup(popupCall);
 
     const isSigningTransaction =
         popupCall?.state === 'tx-simulation' && popupCall?.method === 'ethereumSignTransaction';
@@ -54,15 +53,21 @@ export const TxSimulation = () => {
     const [gasLimit, setGasLimit] = useState(defaultGasLimit);
 
     useEffect(() => {
+        if (!txSimulationQuery.isSuccess) {
+            return;
+        }
+
+        const { gas_estimation } = txSimulationQuery.data;
+
         // Use TX simulation gas estimation instead of the default
         if (
-            simulationResult?.gas_estimation?.status === 'Success' &&
+            gas_estimation?.status === 'Success' &&
             defaultGasLimit === ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT
         ) {
-            const newFeeLimit = Number(simulationResult.gas_estimation.estimate).toString();
+            const newFeeLimit = Number(gas_estimation.estimate).toString();
             setGasLimit(newFeeLimit);
         }
-    }, [simulationResult, defaultGasLimit]);
+    }, [txSimulationQuery, defaultGasLimit]);
 
     const onConfirm = () => {
         if (isSigningTransaction) {
@@ -135,7 +140,7 @@ export const TxSimulation = () => {
                 </VStack>
             )}
 
-            {isLoading && (
+            {txSimulationQuery.isLoading && (
                 <Card>
                     <HStack paddingVertical="sp64" justifyContent="center" alignItems="center">
                         <Loader
@@ -147,14 +152,14 @@ export const TxSimulation = () => {
                 </Card>
             )}
 
-            {simulationResult?.simulation?.status === 'Success' && (
+            {txSimulationQuery.data?.simulation?.status === 'Success' && (
                 <VStack>
                     <Text>
                         <Translation id="moduleConnectPopup.simulation.simulation" />
                     </Text>
                     <Card noPadding>
                         <VStack spacing={0}>
-                            {simulationResult.simulation.account_summary.assets_diffs.map(
+                            {txSimulationQuery.data.simulation.account_summary.assets_diffs.map(
                                 (assetDiff, index) => (
                                     <TxSimulationAsset
                                         key={index}
@@ -163,7 +168,7 @@ export const TxSimulation = () => {
                                     />
                                 ),
                             )}
-                            {simulationResult.simulation.account_summary.exposures.map(
+                            {txSimulationQuery.data.simulation.account_summary.exposures.map(
                                 (assetExposure, index) => (
                                     <TxSimulationAsset
                                         key={index}
@@ -211,45 +216,45 @@ export const TxSimulation = () => {
                 </VStack>
             )}
 
-            {simulationResult?.validation?.result_type === 'Malicious' && (
+            {txSimulationQuery.data?.validation?.result_type === 'Malicious' && (
                 <TxSimulationBanner
                     type="error"
                     title={
                         <Translation id="moduleConnectPopup.simulation.simulationStatusMalicious" />
                     }
-                    description={simulationResult.validation?.description}
+                    description={txSimulationQuery.data.validation?.description}
                     disclaimerAccepted={disclaimerAccepted}
                     setDisclaimerAccepted={setDisclaimerAccepted}
                 />
             )}
 
-            {simulationResult?.validation?.result_type === 'Warning' && (
+            {txSimulationQuery.data?.validation?.result_type === 'Warning' && (
                 <TxSimulationBanner
                     type="warning"
                     title={
                         <Translation id="moduleConnectPopup.simulation.simulationStatusWarning" />
                     }
-                    description={simulationResult.validation?.description}
+                    description={txSimulationQuery.data.validation?.description}
                     disclaimerAccepted={disclaimerAccepted}
                     setDisclaimerAccepted={setDisclaimerAccepted}
                 />
             )}
 
-            {simulationResult?.simulation?.status === 'Error' && (
+            {txSimulationQuery.data?.simulation?.status === 'Error' && (
                 <TxSimulationBanner
                     type="error"
                     title={<Translation id="moduleConnectPopup.simulation.simulationStatusError" />}
-                    description={simulationResult.simulation.error}
+                    description={txSimulationQuery.data.simulation.error}
                     disclaimerAccepted={disclaimerAccepted}
                     setDisclaimerAccepted={setDisclaimerAccepted}
                 />
             )}
 
-            {error && (
+            {txSimulationQuery.error && (
                 <TxSimulationBanner
                     type="error"
                     title={<Translation id="moduleConnectPopup.simulation.simulationStatusError" />}
-                    description={error.message}
+                    description={txSimulationQuery.error.message}
                     disclaimerAccepted={disclaimerAccepted}
                     setDisclaimerAccepted={setDisclaimerAccepted}
                 />
@@ -265,7 +270,10 @@ export const TxSimulation = () => {
             <Button
                 testID="@popup/confirm-simulation"
                 onPress={onConfirm}
-                isDisabled={isLoading || (needsDisclaimer && !disclaimerAccepted)}
+                isDisabled={
+                    txSimulationQuery.isLoading ||
+                    (txSimulationQuery.data?.needsDisclaimer && !disclaimerAccepted)
+                }
             >
                 <Translation id="generic.buttons.continue" />
             </Button>
@@ -281,7 +289,7 @@ export const TxSimulation = () => {
             <ContractInfoBottomSheet
                 ref={contractInfoBottomSheetRef}
                 targetContract={targetContract}
-                simulationResult={simulationResult}
+                simulationResult={txSimulationQuery.data}
             />
             <FeeInfoBottomSheet
                 ref={feeInfoBottomSheetRef}

--- a/suite-native/module-connect-popup/src/components/TxSimulation/ContractInfoBottomSheet.tsx
+++ b/suite-native/module-connect-popup/src/components/TxSimulation/ContractInfoBottomSheet.tsx
@@ -1,6 +1,6 @@
 import { Pressable } from 'react-native';
 
-import { TransactionScanResponse } from '@suite-common/tx-simulation';
+import { TxSimulationResult } from '@suite-common/tx-simulation';
 import { BottomSheetModal, BottomSheetModalRef, Card, Text, VStack } from '@suite-native/atoms';
 import { useCopyToClipboard } from '@suite-native/clipboard';
 import { Translation } from '@suite-native/intl';
@@ -12,7 +12,7 @@ export const ContractInfoBottomSheet = ({
 }: {
     ref: BottomSheetModalRef;
     targetContract: string;
-    simulationResult: TransactionScanResponse | null;
+    simulationResult: TxSimulationResult | undefined;
 }) => {
     const copyToClipboard = useCopyToClipboard();
     const handleCopy = () => copyToClipboard(targetContract);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11534,6 +11534,7 @@ __metadata:
     "@blockaid/client": "npm:^0.56.0"
     "@suite-common/connect-popup": "workspace:^"
     "@suite-common/wallet-config": "workspace:^"
+    "@tanstack/react-query": "npm:^5.90.10"
     "@trezor/connect": "workspace:^"
     react: "npm:18.2.0"
   languageName: unknown
@@ -13988,6 +13989,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/query-core@npm:5.90.10":
+  version: 5.90.10
+  resolution: "@tanstack/query-core@npm:5.90.10"
+  checksum: 10/0aa6118110f28d0d706a1bb939dfe73e4a385078b7b5ef2a603cada9eb73e89ee32cc49bdcf099be0b993e2355b1755785dcb1ba841b35e4456ac996eb4cb341
+  languageName: node
+  linkType: hard
+
+"@tanstack/query-devtools@npm:5.91.0":
+  version: 5.91.0
+  resolution: "@tanstack/query-devtools@npm:5.91.0"
+  checksum: 10/053757751304f8a99a2d2d803cd5b8867c70a35f8b85349a4425ced192068ab7d8978b706c0d081a58e02d01693995d581bc3943a17be5d6b9ecf89e622b6643
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query-devtools@npm:^5.91.0":
+  version: 5.91.0
+  resolution: "@tanstack/react-query-devtools@npm:5.91.0"
+  dependencies:
+    "@tanstack/query-devtools": "npm:5.91.0"
+  peerDependencies:
+    "@tanstack/react-query": ^5.90.10
+    react: ^18 || ^19
+  checksum: 10/4bdfb309a212efd4b5aa0909efd6556b3bf83ed92968803a1b8a1b39507bf85313100cf11bc560cf4ad669880724fc885d341010f00c68fe2140ae81b6b0770f
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query@npm:^5.90.10":
+  version: 5.90.10
+  resolution: "@tanstack/react-query@npm:5.90.10"
+  dependencies:
+    "@tanstack/query-core": "npm:5.90.10"
+  peerDependencies:
+    react: ^18 || ^19
+  checksum: 10/5ff30c09154ab4848440bba567d6a45622ae35d3a87a7e9546535c9400192c1dab160a8d6a5c37891d932717c3cb15ce4d60fba45525184cdeda1a236b24838f
+  languageName: node
+  linkType: hard
+
 "@tanstack/react-virtual@npm:^3.13.9":
   version: 3.13.9
   resolution: "@tanstack/react-virtual@npm:3.13.9"
@@ -15286,6 +15324,8 @@ __metadata:
     "@suite/secure-storage-electron": "workspace:*"
     "@suite/secure-storage-webauthn": "workspace:*"
     "@suite/suite-sync": "workspace:*"
+    "@tanstack/react-query": "npm:^5.90.10"
+    "@tanstack/react-query-devtools": "npm:^5.91.0"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:^16.3.0"
     "@testing-library/user-event": "npm:^14.6.1"


### PR DESCRIPTION
## Description

In the light of the #22782 proposal, I found several use-cases across codebase and applied the `@tanstack/react-query`. 

It's just PoC, so obv. some improvements would be further required:
- Use global constants for queryKeys (maybe mutationKeys) so we can reset / invalidate quires via the queryClient:
- Define queries `staleTime` (`gcTime`). 
- Adjust refetching strategies (e.g. `refetchOnWindowFocus`, `refetchOnMount`, etc.).
- Connect to error reporting (Sentry).

## Related Issue

Resolve #22782


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=proposal/22782-tanstack-react-query&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=proposal/22782-tanstack-react-query&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=proposal/22782-tanstack-react-query&lookback=7)