### PR TITLE
Don't redirect when connected device is already selected

### DIFF
--- a/packages/suite/src/middlewares/suite/redirectMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/redirectMiddleware.ts
@@ -37,8 +37,15 @@ const handleDeviceRedirect = (dispatch: Dispatch, state: AppState, device?: Trez
         dispatch(routerActions.goto('firmware-index'));
     }
 
+    const selected = selectSelectedDevice(state);
+
     // reset wallet params if switching from one device to another
-    if (selectSelectedDevice(state) && state.router.app === 'wallet' && state.router.params) {
+    if (
+        selected &&
+        selected.id !== device.id &&
+        state.router.app === 'wallet' &&
+        state.router.params
+    ) {
         dispatch(routerActions.goto(state.router.route.name));
     }
 };


### PR DESCRIPTION
## Description

Should resolve an issue when already selected remembered device is connected, which resets page params (e.g. selected account).

## Notes for QA

Please check that when remembered account is selected and you connect its device, it remains selected.

Resolves #23670

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/device-connect-redirect&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/device-connect-redirect&lookback=7)