### PR TITLE
feat(suite-sync): get evolu keys after wallet creation

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -194,7 +194,7 @@ const selectDevice = [
         state: {},
         device: undefined,
         result: {
-            payload: undefined,
+            payload: 'no-device',
         },
     },
     {
@@ -206,7 +206,7 @@ const selectDevice = [
         },
         device: SUITE_DEVICE,
         result: {
-            payload: undefined,
+            payload: 'no-device',
         },
     },
     {

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -11,7 +11,6 @@ import {
     selectIsDeviceAutoEjectEnabled,
     startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
-import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
 import { DEVICE } from '@trezor/connect';
 
 import { METADATA, ROUTER, SUITE } from 'src/actions/suite/constants';
@@ -45,7 +44,7 @@ const isActionDeviceRelated = (action: AnyAction): boolean => {
 };
 
 export const prepareSuiteMiddleware = createMiddlewareWithExtraDeps(
-    (action, { dispatch, next, getState, extra }) => {
+    (action, { dispatch, next, getState }) => {
         const prevApp = getState().router.app;
         if (action.type === ROUTER.LOCATION_CHANGE && action.payload.app !== prevApp) {
             dispatch(appChanged(action.payload.app));
@@ -87,17 +86,6 @@ export const prepareSuiteMiddleware = createMiddlewareWithExtraDeps(
 
         // pass action to reducers
         next(action);
-
-        if (deviceActions.forgetDevice.match(action)) {
-            const { device } = action.payload;
-
-            dispatch(handleDeviceDisconnect(device));
-            if (isTrezorDeviceWithState(device)) {
-                extra.services.suiteSync.turnOffSuiteSyncForWallet({
-                    owner: device.suiteSyncOwner,
-                });
-            }
-        }
 
         switch (action.type) {
             case SUITE.DESKTOP_HANDSHAKE:

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -11,6 +11,7 @@ import {
     selectIsDeviceAutoEjectEnabled,
     startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
+import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
 import { DEVICE } from '@trezor/connect';
 
 import { METADATA, ROUTER, SUITE } from 'src/actions/suite/constants';
@@ -44,7 +45,7 @@ const isActionDeviceRelated = (action: AnyAction): boolean => {
 };
 
 export const prepareSuiteMiddleware = createMiddlewareWithExtraDeps(
-    (action, { dispatch, next, getState }) => {
+    (action, { dispatch, next, getState, extra }) => {
         const prevApp = getState().router.app;
         if (action.type === ROUTER.LOCATION_CHANGE && action.payload.app !== prevApp) {
             dispatch(appChanged(action.payload.app));
@@ -86,6 +87,17 @@ export const prepareSuiteMiddleware = createMiddlewareWithExtraDeps(
 
         // pass action to reducers
         next(action);
+
+        if (deviceActions.forgetDevice.match(action)) {
+            const { device } = action.payload;
+
+            dispatch(handleDeviceDisconnect(device));
+            if (isTrezorDeviceWithState(device)) {
+                extra.services.suiteSync.turnOffSuiteSyncForWallet({
+                    owner: device.suiteSyncOwner,
+                });
+            }
+        }
 
         switch (action.type) {
             case SUITE.DESKTOP_HANDSHAKE:

--- a/packages/suite/src/middlewares/wallet/index.ts
+++ b/packages/suite/src/middlewares/wallet/index.ts
@@ -17,6 +17,7 @@ import { tradingMiddleware } from './tradingMiddleware';
 import { coinjoinMiddleware } from './coinjoinMiddleware';
 import { replaceByFeeErrorMiddleware } from './replaceByFeeErrorMiddleware';
 import type { ExtraDependencies } from '@suite-common/redux-utils';
+import { prepareSuiteSyncMiddleware } from '@suite-common/suite-sync';
 
 export const getWalletMiddlewares = (getExtra: () => ExtraDependencies | null) => [
     prepareBlockchainMiddleware(getExtra),
@@ -33,4 +34,5 @@ export const getWalletMiddlewares = (getExtra: () => ExtraDependencies | null) =
     replaceByFeeErrorMiddleware,
     prepareConnectPopupMiddleware(getExtra),
     prepareWalletConnectMiddleware(getExtra),
+    prepareSuiteSyncMiddleware(getExtra),
 ];

--- a/suite-common/suite-sync-types/src/storage/turnOnSuiteSyncForWallet.ts
+++ b/suite-common/suite-sync-types/src/storage/turnOnSuiteSyncForWallet.ts
@@ -1,6 +1,6 @@
 import { Dispatch } from '@reduxjs/toolkit';
 
-import { TrezorDeviceWithState } from '@suite-common/suite-types';
+import { StaticSessionId } from '@trezor/connect';
 
 import { SubscribeLabeling } from '../labeling/subscribeLabeling';
 import { RefreshSuiteSyncKeys } from '../refreshSuiteSyncKeys';
@@ -12,7 +12,7 @@ export type TurnOnSuiteSyncForWalletDeps = {
     refreshSuiteSyncKeys: RefreshSuiteSyncKeys;
 };
 
-export type TurnOnSuiteSyncForWalletParams = { device: TrezorDeviceWithState };
+export type TurnOnSuiteSyncForWalletParams = { staticSessionId: StaticSessionId | undefined };
 
 export type TurnOnSuiteSyncForWallet = (params: TurnOnSuiteSyncForWalletParams) => Promise<void>;
 

--- a/suite-common/suite-sync-types/src/turnOnSuteSync.ts
+++ b/suite-common/suite-sync-types/src/turnOnSuteSync.ts
@@ -1,5 +1,7 @@
 import { Dispatch } from '@reduxjs/toolkit';
 
+import { TurnOnSuiteSyncForWallet } from './storage/turnOnSuiteSyncForWallet';
+
 export type TurnOnSuiteSync = () => void;
 
 export type TurnOnSuiteSyncDep = { turnOnSuiteSync: TurnOnSuiteSync };
@@ -7,4 +9,5 @@ export type TurnOnSuiteSyncDep = { turnOnSuiteSync: TurnOnSuiteSync };
 export type CreateTurnOnSuiteSyncDeps = {
     getState: () => any;
     dispatch: Dispatch;
+    turnOnSuiteSyncForWallet: TurnOnSuiteSyncForWallet;
 };

--- a/suite-common/suite-sync/package.json
+++ b/suite-common/suite-sync/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "@reduxjs/toolkit": "2.10.1",
         "@suite-common/metadata-types": "workspace:*",
+        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/secure-storage": "workspace:*",
         "@suite-common/suite-sync-quota-manager": "workspace:*",
         "@suite-common/suite-sync-storage": "workspace:*",

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -100,6 +100,7 @@ export const createSuiteSyncCompositionRoot = (
         turnOnSuiteSync: createTurnOnSuiteSync({
             getState: deps.getState,
             dispatch: deps.dispatch,
+            turnOnSuiteSyncForWallet,
         }),
         labeling: {
             updateWalletLabel: createUpdateWalletLabel({

--- a/suite-common/suite-sync/src/index.ts
+++ b/suite-common/suite-sync/src/index.ts
@@ -29,4 +29,6 @@ export type { WithLabelingState } from './labeling/labelingSelectors';
 export { labelingReducer, initialLabelingState } from './labeling/labelingReducer';
 export type { LabelingState } from './labeling/labelingReducer';
 export { labelingActions } from './labeling/labelingActions';
+export { prepareSuiteSyncMiddleware } from './suiteSyncMiddleware';
+
 export { suiteSyncToBip329 } from './labeling/suiteSyncToBip329';

--- a/suite-common/suite-sync/src/refreshSuiteSyncKeys.ts
+++ b/suite-common/suite-sync/src/refreshSuiteSyncKeys.ts
@@ -24,6 +24,7 @@ export const createRefreshSuiteSyncKeys =
             return err(RefreshSuiteKeysUnavailable());
         }
 
+        // On connect device (musi mit features)
         const delegatedKeyResult = await deps.ensureDelegatedIdentityKey({ device });
 
         if (!delegatedKeyResult.ok) {

--- a/suite-common/suite-sync/src/refreshSuiteSyncKeys.ts
+++ b/suite-common/suite-sync/src/refreshSuiteSyncKeys.ts
@@ -24,7 +24,6 @@ export const createRefreshSuiteSyncKeys =
             return err(RefreshSuiteKeysUnavailable());
         }
 
-        // On connect device (musi mit features)
         const delegatedKeyResult = await deps.ensureDelegatedIdentityKey({ device });
 
         if (!delegatedKeyResult.ok) {

--- a/suite-common/suite-sync/src/storage/turnOnSuiteSyncForWallet.ts
+++ b/suite-common/suite-sync/src/storage/turnOnSuiteSyncForWallet.ts
@@ -3,22 +3,27 @@ import {
     TurnOnSuiteSyncForWalletDeps,
 } from '@suite-common/suite-sync-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { selectDevices } from '@suite-common/wallet-core';
-import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
+import { selectDeviceByStaticSessionId, selectDevices } from '@suite-common/wallet-core';
+import { isTrezorDeviceWithState, parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { exhaustive } from '@trezor/type-utils';
 
 import { isSuiteSyncSupportedByDevice } from '../suiteSyncUtils';
 
 export const createTurnOnSuiteSyncForWallet =
     (deps: TurnOnSuiteSyncForWalletDeps): TurnOnSuiteSyncForWallet =>
-    async ({ device }) => {
-        if (!isSuiteSyncSupportedByDevice(device)) {
+    async ({ staticSessionId }) => {
+        if (!staticSessionId) return;
+
+        const device = selectDeviceByStaticSessionId(deps.getState(), staticSessionId);
+
+        const canTurnOnSuiteSync =
+            device && isTrezorDeviceWithState(device) && isSuiteSyncSupportedByDevice(device);
+
+        if (!canTurnOnSuiteSync) {
             return;
         }
 
-        const deviceStaticSessionId = device.state.staticSessionId;
-
-        const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
+        const { walletDescriptor } = parseDeviceStaticSessionId(staticSessionId);
 
         if (device.suiteSyncOwner === undefined) {
             const result = await deps.refreshSuiteSyncKeys({ device });
@@ -58,7 +63,7 @@ export const createTurnOnSuiteSyncForWallet =
 
         // Reselect the device to get the correct secret (cipherKey)
         const reselectedDevice = selectDevices(deps.getState())?.find(
-            it => it.state?.staticSessionId === deviceStaticSessionId,
+            it => it.state?.staticSessionId === staticSessionId,
         );
 
         const owner = reselectedDevice?.suiteSyncOwner;

--- a/suite-common/suite-sync/src/suiteSyncMiddleware.ts
+++ b/suite-common/suite-sync/src/suiteSyncMiddleware.ts
@@ -6,11 +6,9 @@ import {
     deviceActions,
     handleDeviceDisconnect,
     selectDeviceThunk,
-    selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
 
-import { suiteSyncActions } from './suiteSyncActions';
 import { selectIsSuiteSyncEnabled } from './suiteSyncSelectors';
 
 // Thunk triggers for which we want to turn on Suite Sync for the currently selected wallet
@@ -27,13 +25,6 @@ export const prepareSuiteSyncMiddleware = createMiddlewareWithExtraDeps(
             const { payload } = action as ReturnType<(typeof suiteSyncTurnOnTriggers)[number]>;
             extra.services.suiteSync.turnOnSuiteSyncForWallet({
                 staticSessionId: payload.device.state?.staticSessionId,
-            });
-        }
-
-        if (suiteSyncActions.updateSuiteSyncEnabled.match(action)) {
-            const device = selectSelectedDevice(getState());
-            extra.services.suiteSync.turnOnSuiteSyncForWallet({
-                staticSessionId: device?.state?.staticSessionId ?? undefined,
             });
         }
 

--- a/suite-common/suite-sync/src/suiteSyncMiddleware.ts
+++ b/suite-common/suite-sync/src/suiteSyncMiddleware.ts
@@ -1,13 +1,7 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
-import {
-    applyDeviceStatesThunk,
-    deviceActions,
-    handleDeviceDisconnect,
-    selectDeviceThunk,
-} from '@suite-common/wallet-core';
-import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
+import { applyDeviceStatesThunk, selectDeviceThunk } from '@suite-common/wallet-core';
 
 import { selectIsSuiteSyncEnabled } from './suiteSyncSelectors';
 
@@ -20,23 +14,12 @@ const suiteSyncTurnOnTriggers = [
 ] as const;
 
 export const prepareSuiteSyncMiddleware = createMiddlewareWithExtraDeps(
-    (action, { next, getState, extra, dispatch }) => {
+    (action, { next, getState, extra }) => {
         if (selectIsSuiteSyncEnabled(getState()) && isAnyOf(...suiteSyncTurnOnTriggers)(action)) {
             const { payload } = action as ReturnType<(typeof suiteSyncTurnOnTriggers)[number]>;
             extra.services.suiteSync.turnOnSuiteSyncForWallet({
                 staticSessionId: payload.device.state?.staticSessionId,
             });
-        }
-
-        if (deviceActions.forgetDevice.match(action)) {
-            const { device } = action.payload;
-
-            dispatch(handleDeviceDisconnect(device));
-            if (isTrezorDeviceWithState(device)) {
-                extra.services.suiteSync.turnOffSuiteSyncForWallet({
-                    owner: device.suiteSyncOwner,
-                });
-            }
         }
 
         return next(action);

--- a/suite-common/suite-sync/src/suiteSyncMiddleware.ts
+++ b/suite-common/suite-sync/src/suiteSyncMiddleware.ts
@@ -1,0 +1,57 @@
+import { UnknownAction } from '@reduxjs/toolkit';
+
+import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    applyDeviceStatesThunk,
+    selectDeviceByStaticSessionId,
+    selectDeviceThunk,
+    selectIsPortfolioTrackerDevice,
+    selectSelectedDevice,
+} from '@suite-common/wallet-core';
+import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
+
+import { suiteSyncActions } from './suiteSyncActions';
+import { selectIsSuiteSyncEnabled } from './suiteSyncSelectors';
+
+const getHasWalletBeenCreated = (action: UnknownAction) =>
+    applyDeviceStatesThunk.fulfilled.match(action) &&
+    action.payload &&
+    typeof action.payload === 'object' &&
+    'staticSessionId' in action.payload;
+
+export const prepareSuiteSyncMiddleware = createMiddlewareWithExtraDeps(
+    (action, { next, getState, extra }) => {
+        // Wallet creation getting evolu keys
+        if (getHasWalletBeenCreated(action) && selectIsSuiteSyncEnabled(getState())) {
+            const { payload } = action as ReturnType<typeof applyDeviceStatesThunk.fulfilled>;
+            const { staticSessionId } = payload;
+
+            const device = selectDeviceByStaticSessionId(getState(), staticSessionId);
+
+            if (isTrezorDeviceWithState(device)) {
+                extra.services.suiteSync.turnOnSuiteSyncForWallet({
+                    device,
+                });
+            }
+        }
+
+        // Selecting device (either by user or auto-selection on connect)
+        if (selectDeviceThunk.fulfilled.match(action) && selectIsSuiteSyncEnabled(getState())) {
+            const { device } = action.payload;
+            if (isTrezorDeviceWithState(device)) {
+                extra.services.suiteSync.turnOnSuiteSyncForWallet({ device });
+            }
+        }
+
+        // Check currently selected device and subscribe if SuiteSync got enabled
+        if (suiteSyncActions.updateSuiteSyncEnabled.match(action)) {
+            const device = selectSelectedDevice(getState());
+            const isPortfolioTrackerDevice = selectIsPortfolioTrackerDevice(getState());
+            if (isTrezorDeviceWithState(device) && !isPortfolioTrackerDevice) {
+                extra.services.suiteSync.turnOnSuiteSyncForWallet({ device });
+            }
+        }
+
+        return next(action);
+    },
+);

--- a/suite-common/suite-sync/src/suiteSyncMiddleware.ts
+++ b/suite-common/suite-sync/src/suiteSyncMiddleware.ts
@@ -3,6 +3,8 @@ import { UnknownAction } from '@reduxjs/toolkit';
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import {
     applyDeviceStatesThunk,
+    deviceActions,
+    handleDeviceDisconnect,
     selectDeviceByStaticSessionId,
     selectDeviceThunk,
     selectIsPortfolioTrackerDevice,
@@ -20,8 +22,7 @@ const getHasWalletBeenCreated = (action: UnknownAction) =>
     'staticSessionId' in action.payload;
 
 export const prepareSuiteSyncMiddleware = createMiddlewareWithExtraDeps(
-    (action, { next, getState, extra }) => {
-        // Wallet creation getting evolu keys
+    (action, { next, getState, extra, dispatch }) => {
         if (getHasWalletBeenCreated(action) && selectIsSuiteSyncEnabled(getState())) {
             const { payload } = action as ReturnType<typeof applyDeviceStatesThunk.fulfilled>;
             const { staticSessionId } = payload;
@@ -35,7 +36,6 @@ export const prepareSuiteSyncMiddleware = createMiddlewareWithExtraDeps(
             }
         }
 
-        // Selecting device (either by user or auto-selection on connect)
         if (selectDeviceThunk.fulfilled.match(action) && selectIsSuiteSyncEnabled(getState())) {
             const { device } = action.payload;
             if (isTrezorDeviceWithState(device)) {
@@ -43,12 +43,22 @@ export const prepareSuiteSyncMiddleware = createMiddlewareWithExtraDeps(
             }
         }
 
-        // Check currently selected device and subscribe if SuiteSync got enabled
         if (suiteSyncActions.updateSuiteSyncEnabled.match(action)) {
             const device = selectSelectedDevice(getState());
             const isPortfolioTrackerDevice = selectIsPortfolioTrackerDevice(getState());
             if (isTrezorDeviceWithState(device) && !isPortfolioTrackerDevice) {
                 extra.services.suiteSync.turnOnSuiteSyncForWallet({ device });
+            }
+        }
+
+        if (deviceActions.forgetDevice.match(action)) {
+            const { device } = action.payload;
+
+            dispatch(handleDeviceDisconnect(device));
+            if (isTrezorDeviceWithState(device)) {
+                extra.services.suiteSync.turnOffSuiteSyncForWallet({
+                    owner: device.suiteSyncOwner,
+                });
             }
         }
 

--- a/suite-common/suite-sync/src/suiteSyncMiddleware.ts
+++ b/suite-common/suite-sync/src/suiteSyncMiddleware.ts
@@ -1,13 +1,11 @@
-import { UnknownAction } from '@reduxjs/toolkit';
+import { isAnyOf } from '@reduxjs/toolkit';
 
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import {
     applyDeviceStatesThunk,
     deviceActions,
     handleDeviceDisconnect,
-    selectDeviceByStaticSessionId,
     selectDeviceThunk,
-    selectIsPortfolioTrackerDevice,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
@@ -15,40 +13,28 @@ import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
 import { suiteSyncActions } from './suiteSyncActions';
 import { selectIsSuiteSyncEnabled } from './suiteSyncSelectors';
 
-const getHasWalletBeenCreated = (action: UnknownAction) =>
-    applyDeviceStatesThunk.fulfilled.match(action) &&
-    action.payload &&
-    typeof action.payload === 'object' &&
-    'staticSessionId' in action.payload;
+// Thunk triggers for which we want to turn on Suite Sync for the currently selected wallet
+const suiteSyncTurnOnTriggers = [
+    // New wallet created
+    applyDeviceStatesThunk.fulfilled,
+    // Wallet selected
+    selectDeviceThunk.fulfilled,
+] as const;
 
 export const prepareSuiteSyncMiddleware = createMiddlewareWithExtraDeps(
     (action, { next, getState, extra, dispatch }) => {
-        if (getHasWalletBeenCreated(action) && selectIsSuiteSyncEnabled(getState())) {
-            const { payload } = action as ReturnType<typeof applyDeviceStatesThunk.fulfilled>;
-            const { staticSessionId } = payload;
-
-            const device = selectDeviceByStaticSessionId(getState(), staticSessionId);
-
-            if (isTrezorDeviceWithState(device)) {
-                extra.services.suiteSync.turnOnSuiteSyncForWallet({
-                    device,
-                });
-            }
-        }
-
-        if (selectDeviceThunk.fulfilled.match(action) && selectIsSuiteSyncEnabled(getState())) {
-            const { device } = action.payload;
-            if (isTrezorDeviceWithState(device)) {
-                extra.services.suiteSync.turnOnSuiteSyncForWallet({ device });
-            }
+        if (selectIsSuiteSyncEnabled(getState()) && isAnyOf(...suiteSyncTurnOnTriggers)(action)) {
+            const { payload } = action as ReturnType<(typeof suiteSyncTurnOnTriggers)[number]>;
+            extra.services.suiteSync.turnOnSuiteSyncForWallet({
+                staticSessionId: payload.device.state?.staticSessionId,
+            });
         }
 
         if (suiteSyncActions.updateSuiteSyncEnabled.match(action)) {
             const device = selectSelectedDevice(getState());
-            const isPortfolioTrackerDevice = selectIsPortfolioTrackerDevice(getState());
-            if (isTrezorDeviceWithState(device) && !isPortfolioTrackerDevice) {
-                extra.services.suiteSync.turnOnSuiteSyncForWallet({ device });
-            }
+            extra.services.suiteSync.turnOnSuiteSyncForWallet({
+                staticSessionId: device?.state?.staticSessionId ?? undefined,
+            });
         }
 
         if (deviceActions.forgetDevice.match(action)) {

--- a/suite-common/suite-sync/src/turnOnSuteSync.ts
+++ b/suite-common/suite-sync/src/turnOnSuteSync.ts
@@ -2,6 +2,7 @@ import {
     CreateTurnOnSuiteSyncDeps,
     TurnOnSuiteSync,
 } from '@suite-common/suite-sync-types/src/turnOnSuteSync';
+import { selectDevices } from '@suite-common/wallet-core';
 
 import { suiteSyncActions } from './suiteSyncActions';
 import { selectIsSuiteSyncEnabled } from './suiteSyncSelectors';
@@ -17,5 +18,9 @@ export const createTurnOnSuiteSync =
 
         deps.dispatch(suiteSyncActions.updateSuiteSyncEnabled({ isEnabled: true }));
 
-        // Todo: iterate over all device and turn them ON
+        // Turn on and subscribe labeling for all wallets.
+        const devices = selectDevices(deps.getState());
+        devices?.forEach(device => {
+            deps.turnOnSuiteSyncForWallet({ staticSessionId: device?.state?.staticSessionId });
+        });
     };

--- a/suite-common/suite-sync/tsconfig.json
+++ b/suite-common/suite-sync/tsconfig.json
@@ -6,6 +6,7 @@
     },
     "references": [
         { "path": "../metadata-types" },
+        { "path": "../redux-utils" },
         { "path": "../secure-storage" },
         { "path": "../suite-sync-quota-manager" },
         { "path": "../suite-sync-storage" },

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -3,7 +3,6 @@ import { AcquiredDevice, AuthorizedDevice, TrezorDevice } from '@suite-common/su
 import { getNewInstanceNumber } from '@suite-common/suite-utils';
 import { Bip43Path, TrezorConnectBackendType } from '@suite-common/wallet-config';
 import { DiscoveryStatus } from '@suite-common/wallet-types';
-import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
 import TrezorConnect, {
     AccountInfo,
     BundleProgress,
@@ -73,37 +72,22 @@ const initNewDeviceStateMetadataThunk = createThunk(
         if (isMetadataEnabled && !metadataPresentOnDevice) {
             await dispatch(extra.thunks.initMetadata(false));
         }
-
-        const isSuiteSyncEnabled = extra.selectors.selectIsSuiteSyncEnabled(getState());
-
-        if (isSuiteSyncEnabled && device !== undefined) {
-            const reselectDeviceForSecret = selectDeviceByStaticSessionId(
-                getState(),
-                staticSessionId,
-            );
-
-            if (isTrezorDeviceWithState(reselectDeviceForSecret)) {
-                extra.services.suiteSync.turnOnSuiteSyncForWallet({
-                    device: reselectDeviceForSecret,
-                });
-            }
-        }
     },
 );
 
-const applyDeviceStatesThunk = createThunk(
+export const applyDeviceStatesThunk = createThunk<
+    { staticSessionId: StaticSessionId },
+    {
+        isAddingHiddenWallet?: boolean;
+        newDeviceState: DeviceState;
+        devicePath: DeviceUniquePath;
+    },
+    { rejectValue: string }
+>(
     `${DISCOVERY_MODULE_PREFIX}/applyDeviceStates`,
     async (
-        {
-            isAddingHiddenWallet,
-            newDeviceState,
-            devicePath,
-        }: {
-            isAddingHiddenWallet?: boolean;
-            newDeviceState: DeviceState;
-            devicePath: DeviceUniquePath;
-        },
-        { dispatch, getState },
+        { isAddingHiddenWallet, newDeviceState, devicePath },
+        { dispatch, getState, fulfillWithValue, rejectWithValue },
     ) => {
         try {
             const currentDeviceByStaticSessionId = newDeviceState.staticSessionId
@@ -111,11 +95,9 @@ const applyDeviceStatesThunk = createThunk(
                 : null;
 
             if (currentDeviceByStaticSessionId && isAddingHiddenWallet) {
-                console.warn(
+                return rejectWithValue(
                     'applyDeviceStatesThunk: applying state to a device with static session id',
                 );
-
-                return;
             }
 
             const devices = selectDevices(getState());
@@ -125,9 +107,9 @@ const applyDeviceStatesThunk = createThunk(
             // is when you would create a copy of device and store it in redux before authorizing it (this is actually the old way of doing things)
             // todo: this sanity check could be moved somewhere higher.
             if (devicesByPathWithoutState.length > 1) {
-                console.error('there must be either one or zero physical devices without state');
-
-                return;
+                return rejectWithValue(
+                    'there must be either one or zero physical devices without state',
+                );
             }
             const device = devicesByPath[0];
 
@@ -162,14 +144,19 @@ const applyDeviceStatesThunk = createThunk(
                 // select the device after deviceReducer updates it (it's a new object reference)
                 const newlyAddedDevice = selectDeviceByStaticSessionId(getState(), staticSessionId);
                 if (newlyAddedDevice === undefined) {
-                    return;
+                    return rejectWithValue('applyDeviceStatesThunk: newly added device not found');
                 }
                 dispatch(selectDeviceThunk({ device: newlyAddedDevice }));
             }
 
             await dispatch(initNewDeviceStateMetadataThunk(staticSessionId));
+
+            // TODO isDone is just MVP, tweak this to something better.
+            return fulfillWithValue({ staticSessionId });
         } catch (error) {
             console.error('applyDeviceStatesThunk error', error);
+
+            return rejectWithValue(error);
         }
     },
 );

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -76,7 +76,7 @@ const initNewDeviceStateMetadataThunk = createThunk(
 );
 
 export const applyDeviceStatesThunk = createThunk<
-    { staticSessionId: StaticSessionId },
+    { device: TrezorDevice },
     {
         isAddingHiddenWallet?: boolean;
         newDeviceState: DeviceState;
@@ -151,8 +151,7 @@ export const applyDeviceStatesThunk = createThunk<
 
             await dispatch(initNewDeviceStateMetadataThunk(staticSessionId));
 
-            // TODO isDone is just MVP, tweak this to something better.
-            return fulfillWithValue({ staticSessionId });
+            return fulfillWithValue({ device });
         } catch (error) {
             console.error('applyDeviceStatesThunk error', error);
 

--- a/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
+++ b/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
@@ -1,7 +1,6 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { getSelectedDevice, sortByTimestamp } from '@suite-common/suite-utils';
-import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
 import { Device } from '@trezor/connect';
 import { isNative } from '@trezor/env-utils';
 
@@ -17,9 +16,13 @@ type SelectDeviceThunkParams = {
  * - `@trezor/connect` events handler `handleDeviceConnect`, `handleDeviceDisconnect`
  * - from user action in `@suite-components/DeviceMenu`
  */
-export const selectDeviceThunk = createThunk<void, SelectDeviceThunkParams, void>(
+export const selectDeviceThunk = createThunk<
+    { device: TrezorDevice },
+    SelectDeviceThunkParams,
+    { rejectValue: 'no-device' }
+>(
     `${DEVICE_MODULE_PREFIX}/selectDevice`,
-    ({ device }, { dispatch, getState, extra }) => {
+    ({ device }, { dispatch, getState, fulfillWithValue, rejectWithValue }) => {
         let trezorDevice: TrezorDevice | typeof undefined;
         const devices = selectDevices(getState());
         if (device) {
@@ -37,13 +40,11 @@ export const selectDeviceThunk = createThunk<void, SelectDeviceThunkParams, void
             }
         }
 
+        if (!trezorDevice) return rejectWithValue('no-device');
+
         dispatch(deviceActions.selectDevice(trezorDevice));
 
-        const isSuiteSyncEnabled = extra.selectors.selectIsSuiteSyncEnabled(getState());
-
-        if (isTrezorDeviceWithState(trezorDevice) && isSuiteSyncEnabled) {
-            extra.services.suiteSync.turnOnSuiteSyncForWallet({ device: trezorDevice });
-        }
+        return fulfillWithValue({ device: trezorDevice });
     },
 );
 

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -37,7 +37,7 @@ const isActionDeviceRelated = (action: AnyAction): boolean => {
 };
 
 export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
-    (action, { dispatch, next, getState, extra }) => {
+    (action, { dispatch, next, getState }) => {
         if (isDeviceEventAction(action, DEVICE.DISCONNECT)) {
             dispatch(forgetDisconnectedDevices({ device: action.payload }));
 
@@ -53,14 +53,9 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
 
         if (deviceActions.forgetDevice.match(action)) {
             const { device } = action.payload;
-            dispatch(handleDeviceDisconnect(action.payload.device));
-
             if (isTrezorDeviceWithState(device)) {
                 const accountsToRemove = selectAccountsByDeviceState(getState(), device.state);
                 dispatch(accountsActions.removeAccount(accountsToRemove));
-                extra.services.suiteSync.turnOffSuiteSyncForWallet({
-                    owner: device.suiteSyncOwner,
-                });
             }
         }
 

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -37,7 +37,7 @@ const isActionDeviceRelated = (action: AnyAction): boolean => {
 };
 
 export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
-    (action, { dispatch, next, getState }) => {
+    (action, { dispatch, next, getState, extra }) => {
         if (isDeviceEventAction(action, DEVICE.DISCONNECT)) {
             dispatch(forgetDisconnectedDevices({ device: action.payload }));
 
@@ -53,9 +53,15 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
 
         if (deviceActions.forgetDevice.match(action)) {
             const { device } = action.payload;
+
+            dispatch(handleDeviceDisconnect(device));
+
             if (isTrezorDeviceWithState(device)) {
                 const accountsToRemove = selectAccountsByDeviceState(getState(), device.state);
                 dispatch(accountsActions.removeAccount(accountsToRemove));
+                extra.services.suiteSync.turnOffSuiteSyncForWallet({
+                    owner: device.suiteSyncOwner,
+                });
             }
         }
 

--- a/suite-native/module-dev-utils/src/components/SuiteSyncRelaySettings.tsx
+++ b/suite-native/module-dev-utils/src/components/SuiteSyncRelaySettings.tsx
@@ -1,11 +1,10 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { useServices } from '@suite-common/redux-utils';
 import {
     DEFAULT_SUITE_SYNC_RELAY_URL,
     selectIsFeatureSuiteSyncAvailable,
     selectSuiteSyncRelayUrl,
-    suiteSyncActions,
 } from '@suite-common/suite-sync';
 import { yup } from '@suite-common/validators';
 import { Button, Card, CheckBox, HStack, Text, VStack } from '@suite-native/atoms';
@@ -17,7 +16,6 @@ const DEFAULT_CUSTOM_RELAY_URL = '';
 export const SuiteSyncRelaySettings = () => {
     const suiteSyncRelayUrl = useSelector(selectSuiteSyncRelayUrl);
     const isFeatureSuiteSyncEnabled = useSelector(selectIsFeatureSuiteSyncAvailable);
-    const dispatch = useDispatch();
     const { suiteSync } = useServices();
     const { showToast } = useToast();
 
@@ -39,22 +37,10 @@ export const SuiteSyncRelaySettings = () => {
     });
 
     const handleSuiteSyncEnableToggle = () => {
-        const originalIsSuiteSyncEnabled = isFeatureSuiteSyncEnabled;
-        // This is probably irrelevant for native
-        dispatch(
-            suiteSyncActions.updateIsFeatureSuiteSyncAvailable({
-                isShownInSettings: !isFeatureSuiteSyncEnabled,
-            }),
-        );
-        // Here, we need this as well,as we don't have experimental feature in Native
-        dispatch(
-            suiteSyncActions.updateSuiteSyncEnabled({
-                isEnabled: !isFeatureSuiteSyncEnabled,
-            }),
-        );
-
-        if (originalIsSuiteSyncEnabled) {
+        if (isFeatureSuiteSyncEnabled) {
             suiteSync.turnOffSuiteSync();
+        } else {
+            suiteSync.turnOnSuiteSync();
         }
     };
 

--- a/suite-native/state/src/store.ts
+++ b/suite-native/state/src/store.ts
@@ -7,6 +7,7 @@ import {
     castExtraStore,
     createStoreWithExtraStoreMiddleware,
 } from '@suite-common/redux-utils';
+import { prepareSuiteSyncMiddleware } from '@suite-common/suite-sync';
 import {
     prepareFiatRatesMiddleware,
     preparePushNotificationMiddleware,
@@ -41,6 +42,7 @@ const getMiddlewares = (getExtra: () => ExtraDependencies | null) => {
         thpMiddleware,
         prepareTradingMiddleware(getExtra),
         preparePushNotificationMiddleware(getExtra),
+        prepareSuiteSyncMiddleware(getExtra),
     ];
 
     if (__DEV__) {

--- a/suite/e2e/support/enums/accountLabelId.ts
+++ b/suite/e2e/support/enums/accountLabelId.ts
@@ -1,7 +1,7 @@
 export enum AccountLabelId {
     BitcoinDefault1 = "m/84'/0'/0'",
     BitcoinDefault2 = "m/84'/0'/1'",
-    BitcoinDefault3 = "m/84'/0'/2'",
+    BitcoinDefault3 = "m/84'/0'/3'",
     BitcoinSegwit1 = "m/49'/0'/0'",
     BitcoinSegwit2 = "m/49'/0'/1'",
 }

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -91,8 +91,8 @@ const test = suiteBaseTest.extend<Fixtures>({
     assetsSection: async ({ page }, use) => {
         await use(new AssetsSection(page));
     },
-    metadataPage: async ({ page, settingsPage, dashboardPage, devicePrompt }, use) => {
-        await use(new MetadataPage(page, settingsPage, dashboardPage, devicePrompt));
+    metadataPage: async ({ page, settingsPage, devicePrompt }, use) => {
+        await use(new MetadataPage(page, settingsPage, devicePrompt));
     },
     trezorInput: async ({ page }, use) => {
         await use(new TrezorInput(page));

--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -7,7 +7,6 @@ import { AccountMetadata } from './accountMetadata';
 import { AddressMetadata } from './addressMetadata';
 import { OutputMetadata } from './outputMetadata';
 import { WalletMetadata } from './walletMetadata';
-import { DashboardPage } from '../dashboardPage';
 import { SettingsPage } from '../settings/settingsPage';
 
 export class MetadataPage {
@@ -23,7 +22,6 @@ export class MetadataPage {
     constructor(
         private readonly page: Page,
         private readonly settingsPage: SettingsPage,
-        private readonly dashboardPage: DashboardPage,
         private readonly devicePrompt: DevicePrompt,
     ) {
         this.metadataModal = page.getByTestId('@modal/metadata-provider');
@@ -67,13 +65,8 @@ export class MetadataPage {
             this.settingsPage.metadataSelectInputOption('secure-sync'),
         );
 
-        await this.dashboardPage.openDeviceSwitcher();
-        await this.dashboardPage.addHiddenWalletButton.click();
-
-        await this.dashboardPage.addNewHiddenWalletButton.click(); // this triggers SLIP 21 evolu prompt for some reason
         await this.devicePrompt.confirmOnDevicePromptIsShown();
         await TrezorUserEnvLinkProxy.pressYes();
         await this.page.waitForTimeout(2000); // wait before closing the modal to prevent "Trezor Sync key retrieval failed" error
-        await this.page.getByTestId('@switch-device/close-button').click();
     }
 }

--- a/suite/e2e/tests/metadata/account-metadata.test.ts
+++ b/suite/e2e/tests/metadata/account-metadata.test.ts
@@ -43,13 +43,6 @@ test.describe('Account metadata', { tag: ['@group=metadata', '@webOnly'] }, () =
             await expect(
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
             ).toHaveText('even cooler');
-
-            await expect(
-                metadataPage.account.successLabel(AccountLabelId.BitcoinDefault1),
-            ).toBeVisible();
-            await expect(
-                metadataPage.account.successLabel(AccountLabelId.BitcoinDefault1),
-            ).toBeHidden();
         });
 
         await test.step('Discard label changes via Escape', async () => {
@@ -86,27 +79,6 @@ test.describe('Account metadata', { tag: ['@group=metadata', '@webOnly'] }, () =
             ).toHaveText('Bitcoin #1');
         });
 
-        await test.step('Switch between segwit accounts and check success indicators', async () => {
-            await walletPage.segwitGroupButton.click();
-            await walletPage.openAccount({ symbol: 'btc', type: 'segwit', atIndex: 0 });
-
-            await metadataPage.account.addLabel(
-                AccountLabelId.BitcoinSegwit1,
-                'typing into one input',
-            );
-            await expect(
-                metadataPage.account.successLabel(AccountLabelId.BitcoinSegwit1),
-            ).toBeVisible();
-
-            await walletPage.openAccount({ symbol: 'btc', type: 'segwit', atIndex: 1 });
-            await expect(
-                metadataPage.account.successLabel(AccountLabelId.BitcoinSegwit2),
-            ).toBeHidden();
-            await expect(
-                metadataPage.account.successLabel(AccountLabelId.BitcoinSegwit1),
-            ).toBeHidden();
-        });
-
         await test.step('Navigate to dashboard', async () => {
             await dashboardPage.dashboardMenuButton.click();
             await expect(dashboardPage.graph).toBeVisible();
@@ -122,7 +94,7 @@ test.describe('Account metadata', { tag: ['@group=metadata', '@webOnly'] }, () =
                 'adding label to a newly added account. does it work?',
             );
             await expect(
-                walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 2 }),
+                walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 3 }),
             ).toHaveText('adding label to a newly added account. does it work?');
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11266,6 +11266,7 @@ __metadata:
   dependencies:
     "@reduxjs/toolkit": "npm:2.10.1"
     "@suite-common/metadata-types": "workspace:*"
+    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/secure-storage": "workspace:*"
     "@suite-common/suite-sync-quota-manager": "workspace:*"
     "@suite-common/suite-sync-storage": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- move logic for turning on suite sync into its package rather than having it in wallet-core

## Notes for QA
- This should make it easier to get device keys when turning on labeling in mobile app in settings

## Related Issue
Related to [#23400](https://github.com/trezor/trezor-suite/issues/23400)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/suite-sync/getting-evolu-keys&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/suite-sync/getting-evolu-keys&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/suite-sync/getting-evolu-keys&lookback=7)