### PR TITLE
Mobile Trade: Allow user to reinitialize sell flow from preview

### DIFF
--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
@@ -74,6 +74,8 @@ describe('useSellFlow', () => {
         capturedHandleTradeArgs = null;
         mockNavigation.navigate.mockClear();
         jest.clearAllMocks();
+
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
     });
 
     describe('doSellTrade', () => {
@@ -324,6 +326,51 @@ describe('useSellFlow', () => {
             });
 
             expect(dispatchSpy).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'handleTradeThunkMock',
+                }),
+            );
+        });
+    });
+
+    describe('retryDoSellTrade', () => {
+        it('should do nothing when no quote is selected', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+            act(() => {
+                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.saveSelectedQuote(undefined));
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            await act(async () => {
+                await result.current.retryDoSellTrade();
+            });
+
+            expect(dispatchSpy).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'handleTradeThunkMock',
+                }),
+            );
+        });
+
+        it('should call doSellTrade', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const trade = { ...sellQuotes[0], quoteId: 'test-quote-id' };
+
+            act(() => {
+                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.saveSelectedQuote(trade));
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            await act(async () => {
+                await result.current.retryDoSellTrade();
+            });
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
                     type: 'handleTradeThunkMock',
                 }),

--- a/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
@@ -173,6 +173,12 @@ export const useSellFlow = () => {
         }
     }, [selectedQuote, sellInfo, doSellTrade]);
 
+    const retryDoSellTrade = useCallback(async () => {
+        if (selectedQuote) {
+            await doSellTrade(selectedQuote);
+        }
+    }, [selectedQuote, doSellTrade]);
+
     return {
         txnErrorString,
         composeRequest,
@@ -184,5 +190,6 @@ export const useSellFlow = () => {
         doSellTrade,
         confirmTrade,
         doBankAccountVerificationCheck,
+        retryDoSellTrade,
     };
 };

--- a/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
@@ -7,6 +7,8 @@ import {
     selectTradingSellSelectedQuote,
     useTradingDetailData,
 } from '@suite-common/trading';
+import { AsyncButton } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
 import { Screen } from '@suite-native/navigation';
 
 import { Footer } from '../components/general/Footer';
@@ -21,13 +23,19 @@ import { clearTradingStateThunk } from '../thunks';
 
 export const TradingSellPreviewScreen = () => {
     const dispatch = useDispatch();
-    const { txnErrorString, doBankAccountVerificationCheck, fetchFeesAndCompose } = useSellFlow();
+    const {
+        txnErrorString,
+        doBankAccountVerificationCheck,
+        fetchFeesAndCompose,
+        retryDoSellTrade,
+    } = useSellFlow();
     const { trade } = useTradingDetailData<TradingSellType>('sell');
     const selectedQuote = useSelector(selectTradingSellSelectedQuote);
     const [shouldFetchFees, setShouldFetchFees] = useState(false);
 
     const currentQuote = trade?.data ? trade.data : selectedQuote;
     const isFinalized = isFinalStatus('sell', currentQuote?.status);
+    const isSubmitted = currentQuote?.status === 'SUBMITTED';
 
     useWatchTrade({
         accountKey: trade?.sendAccountKey,
@@ -78,6 +86,11 @@ export const TradingSellPreviewScreen = () => {
                     isDisabled={!!errorString}
                     onSignTransactionNavigation={onSignTransactionNavigation}
                 />
+            )}
+            {isSubmitted && (
+                <AsyncButton onPress={retryDoSellTrade}>
+                    <Translation id="generic.buttons.continue" />
+                </AsyncButton>
             )}
             <Footer type="sell" />
         </Screen>

--- a/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.comp.test.tsx
@@ -1,5 +1,5 @@
 import type { TradingTransactionSell } from '@suite-common/trading';
-import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { PreloadedState, renderWithStoreProviderAsync, userEvent } from '@suite-native/test-utils';
 import { getSellTrade, getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 
 import { TradingSellPreviewScreen } from '../TradingSellPreviewScreen';
@@ -12,12 +12,14 @@ jest.mock('@react-navigation/native', () => ({
 const mockDoBankAccountVerificationCheck = jest.fn();
 const mockFetchFeesAndCompose = jest.fn();
 const mockTxnErrorString = null;
+const mockRetryDoSellTrade = jest.fn();
 
 jest.mock('../../hooks/sell/useSellFlow', () => ({
     useSellFlow: () => ({
         txnErrorString: mockTxnErrorString,
         doBankAccountVerificationCheck: mockDoBankAccountVerificationCheck,
         fetchFeesAndCompose: mockFetchFeesAndCompose,
+        retryDoSellTrade: mockRetryDoSellTrade,
     }),
 }));
 
@@ -180,5 +182,22 @@ describe('TradingSellPreviewScreen', () => {
 
         // Should be called exactly once for this orderId
         expect(mockFetchFeesAndCompose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should render continue button for submitted quote', async () => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'sell' }),
+        };
+        const submittedStateQuote = {
+            ...sellQuotes[0],
+            status: 'SUBMITTED' as const,
+            orderId: 'test_order_id_1',
+        };
+        preloadedState.wallet!.trading!.sell!.selectedQuote = submittedStateQuote;
+
+        const { getByText } = await renderTradingSellPreviewScreen(preloadedState);
+        await userEvent.press(getByText('Continue'));
+
+        expect(mockRetryDoSellTrade).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Display continue button for quote in state `submitted`.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #23600

## Screenshots:

<img width="300" alt="Simulator Screenshot - iPhone 16e - 2025-12-08 at 16 58 32" src="https://github.com/user-attachments/assets/b5f02335-5fb0-4361-b3bd-0aa4acf77139" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=23600-mobile-sell-user-is-stuck-after-exiting-early-from-partner-site&lookback=7)