### PR TITLE
Improve Suite router

### DIFF
--- a/packages/suite-desktop-ui/package.json
+++ b/packages/suite-desktop-ui/package.json
@@ -13,6 +13,7 @@
     },
     "dependencies": {
         "@sentry/electron": "^7.4.0",
+        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@trezor/components": "workspace:*",

--- a/packages/suite-desktop-ui/src/MainDesktop.tsx
+++ b/packages/suite-desktop-ui/src/MainDesktop.tsx
@@ -1,8 +1,9 @@
 import { Provider as ReduxProvider } from 'react-redux';
 
-import { type History, createMemoryHistory } from 'history';
+import { createMemoryHistory } from 'history';
 import { createRoot } from 'react-dom/client';
 
+import { RouterServices } from '@suite-common/redux-utils';
 import TrezorConnect from '@trezor/connect';
 import { createIpcProxy } from '@trezor/ipc-proxy';
 import { desktopApi } from '@trezor/suite-desktop-api';
@@ -37,13 +38,16 @@ import { TorLoadingScreen } from './support/screens/TorLoadingScreen';
 import { BioAuthGuard } from '../../suite/src/components/suite/BioAuthGuard/BioAuthGuard';
 import { FindBar } from '../../suite/src/components/suite/FindBar/FindBar';
 
-const MainDesktop = ({ history }: { history: History }) => {
+const MainDesktop = ({ routerServices }: { routerServices: RouterServices }) => {
     useTor();
     useDebugLanguageShortcut();
     useConnectPopupDesktop();
 
     return (
-        <Main history={history} trafficLightOffset={<TrafficLightDraggableWindowHeader />}>
+        <Main
+            routerServices={routerServices}
+            trafficLightOffset={<TrafficLightDraggableWindowHeader />}
+        >
             <GlobalStyle />
             <DesktopUpdater />
             <Metadata />
@@ -70,9 +74,10 @@ export const init = async (container: HTMLElement) => {
     const memoryHistory = createMemoryHistory();
     const preloadAction = await preloadStore();
     const { statePatch } = await desktopApi.handshake();
+    const routerServices = createRouterServices(memoryHistory);
     const { store, services } = initStore(preloadAction, {
         statePatch,
-        additionalExtraDeps: { routerServices: createRouterServices(memoryHistory) },
+        additionalExtraDeps: { routerServices },
     });
 
     // Expose Redux store for Playwright/e2e tests
@@ -141,7 +146,7 @@ export const init = async (container: HTMLElement) => {
     root.render(
         <SuiteServicesProvider services={services}>
             <ReduxProvider store={store}>
-                <MainDesktop history={memoryHistory} />
+                <MainDesktop routerServices={routerServices} />
             </ReduxProvider>
         </SuiteServicesProvider>,
     );

--- a/packages/suite-desktop-ui/tsconfig.json
+++ b/packages/suite-desktop-ui/tsconfig.json
@@ -9,6 +9,9 @@
         "../suite/src/components/suite/BioAuthGuard"
     ],
     "references": [
+        {
+            "path": "../../suite-common/redux-utils"
+        },
         { "path": "../../suite-common/sentry" },
         {
             "path": "../../suite-common/suite-types"

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -14,6 +14,7 @@
     },
     "dependencies": {
         "@sentry/browser": "10.27.0",
+        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/packages/suite-web/src/MainWeb.tsx
+++ b/packages/suite-web/src/MainWeb.tsx
@@ -3,8 +3,10 @@ import 'core-js/actual';
 import { Suspense } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
-import { History, createBrowserHistory } from 'history';
+import { createBrowserHistory } from 'history';
 import { createRoot } from 'react-dom/client';
+
+import { RouterServices } from '@suite-common/redux-utils';
 
 import { AppRouter, BundleLoader, Metadata, Preloader, ToastContainer } from 'src/components/suite';
 import { useDebugLanguageShortcut } from 'src/hooks/suite';
@@ -21,14 +23,14 @@ import { initSentry } from './sentry';
 import { usePlaywright } from './support/usePlaywright';
 import { webComponents } from './support/webComponents';
 
-const MainWeb = ({ history }: { history: History }) => {
+const MainWeb = ({ routerServices }: { routerServices: RouterServices }) => {
     usePlaywright();
     useTor();
     useDebugLanguageShortcut();
     useConnectPopupWeb();
 
     return (
-        <Main history={history}>
+        <Main routerServices={routerServices}>
             <Metadata />
             <ToastContainer />
             <Preloader>
@@ -52,16 +54,15 @@ export const init = async (container: HTMLElement) => {
     root.render(<LoadingScreen />);
 
     const preloadAction = await preloadStore();
+    const routerServices = createRouterServices(browserHistory);
     const { store, services } = initStore(preloadAction, {
-        additionalExtraDeps: {
-            routerServices: createRouterServices(browserHistory),
-        },
+        additionalExtraDeps: { routerServices },
     });
 
     root.render(
         <SuiteServicesProvider services={services}>
             <ReduxProvider store={store}>
-                <MainWeb history={browserHistory} />
+                <MainWeb routerServices={routerServices} />
             </ReduxProvider>
         </SuiteServicesProvider>,
     );

--- a/packages/suite-web/tsconfig.json
+++ b/packages/suite-web/tsconfig.json
@@ -6,6 +6,9 @@
     },
     "include": ["."],
     "references": [
+        {
+            "path": "../../suite-common/redux-utils"
+        },
         { "path": "../../suite-common/sentry" },
         {
             "path": "../../suite-common/suite-types"

--- a/packages/suite/src/actions/suite/__fixtures__/routerActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/routerActions.ts
@@ -106,7 +106,7 @@ export const initialRedirection = [
     },
     {
         description: `redirect to modal app`,
-        pathname: '/bridge',
+        pathname: '/bridge' as const,
         app: 'bridge',
     },
     {

--- a/packages/suite/src/actions/suite/__fixtures__/routerActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/routerActions.ts
@@ -1,8 +1,9 @@
-import { findRouteByName } from 'src/utils/suite/router';
+import { getRoute } from 'src/utils/suite/router';
 
 export const init = [
     {
         description: `success`,
+        state: undefined,
         result: {
             app: 'dashboard',
             hash: '',
@@ -12,10 +13,8 @@ export const init = [
             anchor: undefined,
             search: '',
             url: '/',
-            route: findRouteByName('suite-index'),
-            settingsBackRoute: {
-                name: 'suite-index',
-            },
+            route: getRoute('suite-index'),
+            settingsBackRoute: { name: 'suite-index' },
         },
     },
     {
@@ -33,7 +32,7 @@ export const init = [
         },
         result: undefined,
     },
-];
+] as const;
 
 export const onBeforePopState = [
     {

--- a/packages/suite/src/actions/suite/__fixtures__/routerActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/routerActions.ts
@@ -12,7 +12,6 @@ export const init = [
             loaded: true,
             anchor: undefined,
             search: '',
-            url: '/',
             route: getRoute('suite-index'),
             settingsBackRoute: { name: 'suite-index' },
         },

--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -9,6 +9,7 @@ import {
     prepareMessageSystemReducer,
 } from '@suite-common/message-system';
 import { validJws } from '@suite-common/message-system/src/__fixtures__/messageSystemActions';
+import type { PathString } from '@suite-common/redux-utils';
 import { extraDependenciesMock } from '@suite-common/test-utils';
 import {
     initTokenDefinitionsThunk,
@@ -289,7 +290,7 @@ describe('Suite init action', () => {
             const { store, routerServices } = initStore(getInitialState(options.initialRun));
 
             if (options?.initialPath) {
-                routerServices.navigate(options.initialPath);
+                routerServices.navigate({ pathname: options.initialPath as PathString });
             }
 
             if (options?.trezorConnectError) {

--- a/packages/suite/src/actions/suite/__tests__/routerActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/routerActions.test.ts
@@ -19,7 +19,7 @@ const defaultLocation = {
     key: '',
     hash: '',
     search: '',
-};
+} as const;
 
 interface InitialState {
     suite?: Partial<SuiteState>;
@@ -71,7 +71,7 @@ const initStore = (state: State) => {
 describe('Suite Actions', () => {
     fixtures.init.forEach(f => {
         it(`init: ${f.description}`, () => {
-            const state = getInitialState(f.state as InitialState);
+            const state = getInitialState(f.state as InitialState | undefined);
             const { store, routerServices } = initStore(state);
             routerServices.navigate(defaultLocation);
             store.dispatch(routerActions.init());
@@ -110,10 +110,8 @@ describe('Suite Actions', () => {
         it(`goto: ${f.description}`, () => {
             const state = getInitialState(f.state as InitialState);
             const { store, routerServices } = initStore(state);
-            routerServices.navigate({
-                ...defaultLocation,
-                hash: `#${f.hash}`,
-            });
+            routerServices.navigate({ ...defaultLocation, hash: `#${f.hash}` });
+            store.dispatch(routerActions.onLocationChange(routerServices.getLocation()));
 
             store.dispatch(routerActions.goto(f.url as any, { preserveParams: f.preserveHash }));
             if (f.result) {
@@ -130,7 +128,7 @@ describe('Suite Actions', () => {
             router: { loaded: true },
         } as InitialState);
         const { store } = initStore(state);
-        store.dispatch(routerActions.onLocationChange('/'));
+        store.dispatch(routerActions.onLocationChange({ pathname: '/' }));
         expect(store.getActions().length).toEqual(0);
     });
 

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -111,10 +111,9 @@ export const handleProtocolRequest =
                 const decodedPath = decodeURIComponent(redirectPath);
                 const [, hash] = decodedPath.split('/coinmarket-redirect/');
                 if (hash) {
-                    const fullUrl = `/coinmarket-redirect#${hash}`;
-
-                    extra.routerServices.navigate(fullUrl);
-                    dispatch(routerActions.onLocationChange(fullUrl));
+                    const path = { pathname: '/coinmarket-redirect', hash: `#${hash}` } as const;
+                    extra.routerServices.navigate(path);
+                    dispatch(routerActions.onLocationChange(path));
                 }
             }
         }

--- a/packages/suite/src/actions/suite/routerActions.ts
+++ b/packages/suite/src/actions/suite/routerActions.ts
@@ -15,10 +15,9 @@ import { Dispatch, GetState } from 'src/types/suite';
 import {
     RouteParams,
     findRoute,
-    findRouteByName,
     getAppWithParams,
-    getBackgroundRoute,
     getRoute,
+    getRouteHash,
 } from 'src/utils/suite/router';
 
 export type NonLeadingHashString = string & Branded<'NonLeadingHashString'>;
@@ -127,7 +126,11 @@ export const goto =
 
         if (!unlocked) return;
 
-        const urlBase = getRoute(routeName, params);
+        const route = getRoute(routeName);
+        const newHash = getRouteHash(route, params);
+        const pathname = route?.pattern || '/';
+        const hash = preserveParams ? state.router.hash : newHash ? `#${newHash}` : '';
+        const urlBase = `${pathname}${hash}`;
 
         if (urlBase === state.router.url) {
             // if location is same, but anchor is set (e.g. click on tor icon when in app settings), let's propagate it to redux state
@@ -140,8 +143,6 @@ export const goto =
         }
         const location = extra.routerServices.getLocation();
         const newUrl = `${urlBase}${preserveParams ? location.hash : ''}`;
-
-        const route = findRouteByName(routeName);
 
         dispatch(onLocationChange(newUrl, anchor));
         if (route?.isForegroundApp) {
@@ -170,15 +171,14 @@ export const closeModalApp =
     (dispatch: Dispatch, _: GetState, extra: ExtraDependencies) => {
         dispatch(suiteActions.lockRouter(false));
 
-        const route = getBackgroundRoute(extra);
+        const location = extra.routerServices.getLocation();
+        const route = findRoute(location.pathname);
 
         // if user enters route of modal app manually, back would redirect him again to the same route and he would remain stuck
         // so we need a fallback to suite-index
         if (route && route.isForegroundApp) {
             return dispatch(goto('suite-index'));
         }
-
-        const location = extra.routerServices.getLocation();
 
         if (!preserveParams && location.hash.length > 0) {
             extra.routerServices.navigate(location.pathname);
@@ -200,9 +200,7 @@ export const initialRedirection = createThunk(
     '@suite/initial-redirection',
     (_, { dispatch, getState, extra }) => {
         const location = extra.routerServices.getLocation();
-        const route = findRoute(
-            `${location.pathname}${location.search ?? ''}${location.hash ?? ''}`,
-        );
+        const route = findRoute(location.pathname);
 
         const { initialRun } = getState().suite.flags;
         // only do initial redirection of route is valid

--- a/packages/suite/src/actions/suite/routerActions.ts
+++ b/packages/suite/src/actions/suite/routerActions.ts
@@ -4,7 +4,6 @@
 
 import { ExtraDependencies, createThunk } from '@suite-common/redux-utils';
 import { Route } from '@suite-common/suite-types';
-import { Branded } from '@trezor/type-utils';
 
 import { ROUTER } from 'src/actions/suite/constants';
 import * as suiteActions from 'src/actions/suite/suiteActions';
@@ -14,25 +13,20 @@ import { selectIsRouterLocked, selectIsRouterOrUiLocked } from 'src/selectors/su
 import { Dispatch, GetState } from 'src/types/suite';
 import {
     RouteParams,
+    RouterPathOptional,
     findRoute,
     getAppWithParams,
     getRoute,
     getRouteHash,
+    isEqualLocation,
 } from 'src/utils/suite/router';
-
-export type NonLeadingHashString = string & Branded<'NonLeadingHashString'>;
-const sanitizeForNonLeadingHashString = (s: string): NonLeadingHashString =>
-    (s.startsWith('#') ? s.slice(1) : s) as NonLeadingHashString;
 
 export type RouterAction =
     | {
           type: typeof ROUTER.LOCATION_CHANGE;
-          payload: {
-              pathname: string;
-              search?: string;
-              hash?: NonLeadingHashString;
-              settingsBackRoute?: SettingsBackRoute;
+          payload: RouterPathOptional & {
               anchor?: AnchorType;
+              settingsBackRoute?: SettingsBackRoute;
           } & RouterAppWithParams;
       }
     | {
@@ -54,39 +48,30 @@ export const onBeforePopState = () => (_dispatch: Dispatch, getState: GetState) 
 /**
  * Handle changes of history.location and history.location.hash
  * Called from ./support/RouterHandler
- * @param {string} url
  */
 export const onLocationChange =
-    (url: string, anchor?: AnchorType) =>
-    (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
+    (location: RouterPathOptional & { anchor?: AnchorType }) =>
+    (dispatch: Dispatch, getState: GetState) => {
         const unlocked = dispatch(onBeforePopState());
         const { router } = getState();
         if (!unlocked && router.loaded) return;
-        if (router.url === url && router.app !== 'unknown') return null;
+
+        if (isEqualLocation(router, location) && router.app !== 'unknown') {
+            return null;
+        }
+
         // TODO: check if the view is not locked by the device request
-
-        const { pathname, search, hash } = extra.routerServices.getLocation();
-
-        const appWithParams = getAppWithParams(url);
+        const appWithParams = getAppWithParams(location);
 
         return dispatch({
             type: ROUTER.LOCATION_CHANGE,
-            payload: {
-                pathname,
-                search,
-                hash: sanitizeForNonLeadingHashString(hash),
-                anchor,
-                ...appWithParams,
-            },
+            payload: { ...location, ...appWithParams },
         });
     };
 
 // if anchor param is not set, it works as reset
 export const onAnchorChange = (anchor?: AnchorType) => (dispatch: Dispatch, _getState: GetState) =>
-    dispatch({
-        type: ROUTER.ANCHOR_CHANGE,
-        payload: anchor,
-    });
+    dispatch({ type: ROUTER.ANCHOR_CHANGE, payload: anchor });
 
 /**
  * Dispatch initial url
@@ -95,9 +80,8 @@ export const onAnchorChange = (anchor?: AnchorType) => (dispatch: Dispatch, _get
 export const init = () => (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
     // check if location was not already changed by initialRedirection
     if (getState().router.app === 'unknown') {
-        const { pathname, search, hash } = extra.routerServices.getLocation();
-        const url = `${pathname}${search ?? ''}${hash ?? ''}`;
-        dispatch(onLocationChange(url));
+        const location = extra.routerServices.getLocation();
+        dispatch(onLocationChange(location));
     }
 };
 
@@ -127,10 +111,9 @@ export const goto =
         const route = getRoute(routeName);
         const newHash = getRouteHash(route, params);
         const pathname = route?.pattern || '/';
-        const hash = preserveParams ? state.router.hash : newHash ? `#${newHash}` : '';
-        const urlBase = `${pathname}${hash}`;
+        const hash = preserveParams ? state.router.hash : (newHash ?? '');
 
-        if (urlBase === state.router.url) {
+        if (isEqualLocation(state.router, { pathname, hash, search: '' })) {
             // if location is same, but anchor is set (e.g. click on tor icon when in app settings), let's propagate it to redux state
             if (anchor) {
                 // postpone propagation to allow clearing anchor in redux state by click listener
@@ -139,24 +122,22 @@ export const goto =
 
             return;
         }
-        const location = extra.routerServices.getLocation();
-        const newUrl = `${urlBase}${preserveParams ? location.hash : ''}`;
 
-        dispatch(onLocationChange(newUrl, anchor));
+        dispatch(onLocationChange({ pathname, hash, anchor }));
         if (route?.isForegroundApp) {
             dispatch(suiteActions.lockRouter(true));
 
             // NOTE: this is useful eg. on welcome screen / logged out screen
             // where we want to have suite-start router clearing the URL to ensure
             // that there isn't a state stuck
-            if (route?.clearUrl) {
-                extra.routerServices.navigate(urlBase);
+            if (route.clearUrl) {
+                extra.routerServices.navigate({ pathname });
             }
 
             return;
         }
 
-        extra.routerServices.navigate(newUrl);
+        extra.routerServices.navigate({ pathname, hash });
     };
 
 /**
@@ -179,14 +160,10 @@ export const closeModalApp =
         }
 
         if (!preserveParams && location.hash.length > 0) {
-            extra.routerServices.navigate(location.pathname);
+            extra.routerServices.navigate({ pathname: location.pathname });
         } else {
             // + history.location.hash is here to preserve params (e.g. nth account)
-            dispatch(
-                onLocationChange(
-                    `${location.pathname}${location.search ?? ''}${location.hash ?? ''}`,
-                ),
-            );
+            dispatch(onLocationChange(location));
         }
     };
 

--- a/packages/suite/src/actions/suite/routerActions.ts
+++ b/packages/suite/src/actions/suite/routerActions.ts
@@ -18,7 +18,6 @@ import {
     findRouteByName,
     getAppWithParams,
     getBackgroundRoute,
-    getPrefixedURL,
     getRoute,
 } from 'src/utils/suite/router';
 
@@ -128,7 +127,7 @@ export const goto =
 
         if (!unlocked) return;
 
-        const urlBase = getPrefixedURL(getRoute(routeName, params));
+        const urlBase = getRoute(routeName, params);
 
         if (urlBase === state.router.url) {
             // if location is same, but anchor is set (e.g. click on tor icon when in app settings), let's propagate it to redux state
@@ -182,7 +181,7 @@ export const closeModalApp =
         const location = extra.routerServices.getLocation();
 
         if (!preserveParams && location.hash.length > 0) {
-            extra.routerServices.navigate(getPrefixedURL(location.pathname));
+            extra.routerServices.navigate(location.pathname);
         } else {
             // + history.location.hash is here to preserve params (e.g. nth account)
             dispatch(

--- a/packages/suite/src/actions/suite/routerActions.ts
+++ b/packages/suite/src/actions/suite/routerActions.ts
@@ -28,7 +28,6 @@ export type RouterAction =
     | {
           type: typeof ROUTER.LOCATION_CHANGE;
           payload: {
-              url: string;
               pathname: string;
               search?: string;
               hash?: NonLeadingHashString;
@@ -73,7 +72,6 @@ export const onLocationChange =
         return dispatch({
             type: ROUTER.LOCATION_CHANGE,
             payload: {
-                url,
                 pathname,
                 search,
                 hash: sanitizeForNonLeadingHashString(hash),

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -10,6 +10,7 @@ import { HandshakeElectron, desktopApi } from '@trezor/suite-desktop-api';
 import * as modalActions from 'src/actions/suite/modalActions';
 import type { TranslationKey } from 'src/components/suite/Translation';
 import { ExperimentalFeature } from 'src/constants/suite/experimental';
+import { selectRouterUrl } from 'src/reducers/suite/routerReducer';
 import { AutodetectSettings, DebugModeOptions, EvmSettings } from 'src/reducers/suite/suiteReducer';
 import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 import type { AppState, Dispatch, GetState, TorBootstrap } from 'src/types/suite';
@@ -238,7 +239,7 @@ export const toggleTor =
                 type: EventType.SettingsTor,
                 payload: {
                     value: shouldEnable,
-                    location: getState().router.url,
+                    location: selectRouterUrl(getState()),
                     modal,
                 },
             });

--- a/packages/suite/src/actions/wallet/addWalletThunk.ts
+++ b/packages/suite/src/actions/wallet/addWalletThunk.ts
@@ -1,7 +1,7 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { DEVICE_MODULE_PREFIX } from '@suite-common/wallet-core';
 
-import { getBackgroundRoute } from 'src/utils/suite/router';
+import { findRoute } from 'src/utils/suite/router';
 
 import { goto } from '../suite/routerActions';
 
@@ -12,7 +12,8 @@ export const redirectAfterWalletSelectedThunk = createThunk<
 >(
     `${DEVICE_MODULE_PREFIX}/redirectAfterWalletSelectedThunk`,
     async (options, { dispatch, extra }) => {
-        const backgroundRoute = getBackgroundRoute(extra);
+        const location = extra.routerServices.getLocation();
+        const backgroundRoute = findRoute(location.pathname);
 
         // NOTE: the URL is being static when you switch device like /btc/4/norma
         // when you switch to other device (wallet), there might not be /btc/4, but just /btc/1
@@ -41,12 +42,6 @@ export const redirectAfterWalletSelectedThunk = createThunk<
 export const openSwitchDeviceDialog = createThunk<void, void, void>(
     `${DEVICE_MODULE_PREFIX}/openSwitchDeviceDialog`,
     (_, { dispatch }) => {
-        dispatch(
-            goto('suite-switch-device', {
-                params: {
-                    cancelable: true,
-                },
-            }),
-        );
+        dispatch(goto('suite-switch-device', { params: { cancelable: true } }));
     },
 );

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
@@ -12,6 +12,7 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { Deferred } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
+import { selectRouterUrl } from 'src/reducers/suite/routerReducer';
 import { selectAccountIncludingChosenInTrading } from 'src/reducers/wallet/selectedAccountReducer';
 import { redactRouterUrl } from 'src/utils/suite/analytics';
 
@@ -42,7 +43,7 @@ export const TransactionReviewModalBody = ({
     const { precomposedTx } = txInfoState;
     const [hasTxExpired, setHasTxExpired] = useState(false);
 
-    const router = useSelector(state => state.router);
+    const url = useSelector(selectRouterUrl);
 
     const createdTxTimestamp = txInfoState?.precomposedTx?.createdTimestamp ?? 0;
     const shouldCheckTxTimeValidity = account?.networkType === 'solana' && createdTxTimestamp !== 0;
@@ -97,10 +98,10 @@ export const TransactionReviewModalBody = ({
 
             analytics.report({
                 type: EventType.TransactionRetry,
-                payload: { url: redactRouterUrl(router.url) },
+                payload: { url: redactRouterUrl(url) },
             });
         },
-        [tryAgainSignTx, router.url],
+        [tryAgainSignTx, url],
     );
 
     if (!device) return null;

--- a/packages/suite/src/hooks/suite/useResetScrollOnUrl.ts
+++ b/packages/suite/src/hooks/suite/useResetScrollOnUrl.ts
@@ -1,9 +1,11 @@
 import { useLayoutEffect, useRef } from 'react';
 
+import { selectRouterUrl } from 'src/reducers/suite/routerReducer';
+
 import { useSelector } from './useSelector';
 
 export const useResetScrollOnUrl = () => {
-    const url = useSelector(state => state.router.url);
+    const url = useSelector(selectRouterUrl);
 
     const scrollRef = useRef<HTMLDivElement>(null);
 

--- a/packages/suite/src/middlewares/onboarding/__tests__/onboardingMiddleware.test.ts
+++ b/packages/suite/src/middlewares/onboarding/__tests__/onboardingMiddleware.test.ts
@@ -65,7 +65,6 @@ describe('onboardingMiddleware', () => {
             const store = initStore(
                 getInitialState({
                     loaded: false,
-                    url: '/',
                     pathname: '/',
                     hash: undefined,
                     app: 'unknown',

--- a/packages/suite/src/middlewares/onboarding/__tests__/onboardingMiddleware.test.ts
+++ b/packages/suite/src/middlewares/onboarding/__tests__/onboardingMiddleware.test.ts
@@ -66,7 +66,8 @@ describe('onboardingMiddleware', () => {
                 getInitialState({
                     loaded: false,
                     pathname: '/',
-                    hash: undefined,
+                    hash: '',
+                    search: '',
                     app: 'unknown',
                     params: undefined,
                     route: undefined,

--- a/packages/suite/src/middlewares/suite/__tests__/suiteMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/suiteMiddleware.test.ts
@@ -72,7 +72,8 @@ describe('suite middleware', () => {
                 getInitialState({
                     loaded: false,
                     pathname: '/',
-                    hash: undefined,
+                    hash: '',
+                    search: '',
                     app: 'unknown',
                     params: undefined,
                     route: undefined,
@@ -108,7 +109,8 @@ describe('suite middleware', () => {
                 getInitialState({
                     loaded: true,
                     pathname: '/onboarding',
-                    hash: undefined,
+                    hash: '',
+                    search: '',
                     app: 'onboarding',
                     params: undefined,
                     route: {

--- a/packages/suite/src/middlewares/suite/__tests__/suiteMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/suiteMiddleware.test.ts
@@ -71,7 +71,6 @@ describe('suite middleware', () => {
             const store = initStore(
                 getInitialState({
                     loaded: false,
-                    url: '/',
                     pathname: '/',
                     hash: undefined,
                     app: 'unknown',
@@ -83,7 +82,6 @@ describe('suite middleware', () => {
                 }),
             );
             const payload = {
-                url: '/',
                 pathname: '/',
                 app: 'dashboard',
                 route: {
@@ -109,7 +107,6 @@ describe('suite middleware', () => {
             const store = initStore(
                 getInitialState({
                     loaded: true,
-                    url: '/onboarding',
                     pathname: '/onboarding',
                     hash: undefined,
                     app: 'onboarding',
@@ -131,7 +128,6 @@ describe('suite middleware', () => {
                 }),
             );
             const payload = {
-                url: '/onboarding',
                 pathname: '/onboarding',
                 app: 'onboarding',
                 route: {

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -34,6 +34,7 @@ import { ROUTER, SUITE } from 'src/actions/suite/constants';
 import { setFlag } from 'src/actions/suite/suiteActions';
 import { updateLastAnonymityReportTimestamp } from 'src/actions/wallet/coinjoinAccountActions';
 import { COINJOIN } from 'src/actions/wallet/constants';
+import { selectRouterUrl } from 'src/reducers/suite/routerReducer';
 import {
     selectAnonymityGainToReportByAccountKey,
     selectCoinjoinAccountByKey,
@@ -55,7 +56,7 @@ import { hasVisibleTokens } from 'src/utils/wallet/tokenUtils';
 */
 const analyticsMiddleware =
     (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => (action: Action) => {
-        const prevRouterUrl = api.getState().router.url;
+        const prevRouterUrl = selectRouterUrl(api.getState());
 
         // pass action
         next(action);
@@ -250,7 +251,7 @@ const analyticsMiddleware =
                         type: EventType.RouterLocationChange,
                         payload: {
                             prevRouterUrl: redactRouterUrl(prevRouterUrl),
-                            nextRouterUrl: redactRouterUrl(action.payload.url),
+                            nextRouterUrl: redactRouterUrl(selectRouterUrl(state)),
                             anchor: redactTransactionIdFromAnchor(action.payload.anchor),
                         },
                     });

--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -20,6 +20,7 @@ import {
     ROUTER,
     SUITE,
 } from 'src/actions/suite/constants';
+import { selectRouterUrl } from 'src/reducers/suite/routerReducer';
 import { Action, AppState, Dispatch } from 'src/types/suite';
 import { getSuiteReadyPayload } from 'src/utils/suite/analytics';
 import {
@@ -112,7 +113,7 @@ const sentryMiddleware =
                 break;
             }
             case ROUTER.LOCATION_CHANGE:
-                setSentryTag('routerURL', action.payload.url);
+                setSentryTag('routerURL', selectRouterUrl(state));
                 break;
             case SUITE.TOR_STATUS:
                 setSentryTag('torStatus', action.payload);

--- a/packages/suite/src/middlewares/wallet/__fixtures__/tradingMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/__fixtures__/tradingMiddleware.ts
@@ -13,7 +13,6 @@ const TRADING_BUY_ROUTE = {
         app: 'wallet',
     },
     settingsBackRoute: { name: 'wallet-index', params: undefined },
-    url: '/accounts/coinmarket/buy#/btc/0/normal',
 } as RouterState;
 
 const TRADING_SELL_ROUTE = {
@@ -29,7 +28,6 @@ const TRADING_SELL_ROUTE = {
         app: 'wallet',
     },
     settingsBackRoute: { name: 'wallet-index', params: undefined },
-    url: '/accounts/coinmarket/sell#/btc/0/normal',
 } as RouterState;
 
 const TRADING_EXCHANGE_ROUTE = {
@@ -45,12 +43,10 @@ const TRADING_EXCHANGE_ROUTE = {
         app: 'wallet',
     },
     settingsBackRoute: { name: 'wallet-index', params: undefined },
-    url: '/accounts/coinmarket/exchange',
 } as RouterState;
 
 const DEFAULT_ROUTE = {
     loaded: false,
-    url: '/',
     pathname: '/',
     app: 'unknown',
     route: undefined,

--- a/packages/suite/src/middlewares/wallet/__fixtures__/tradingMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/__fixtures__/tradingMiddleware.ts
@@ -1,9 +1,12 @@
 import { RouterState } from 'src/reducers/suite/routerReducer';
 
+type Route = RouterState['route'];
+
 const TRADING_BUY_ROUTE = {
     anchor: undefined,
     app: 'wallet',
-    hash: '/btc/0/normal',
+    hash: '#/btc/0/normal',
+    search: '',
     loaded: true,
     params: { symbol: 'btc', accountIndex: 0, accountType: 'normal' },
     pathname: '/accounts/coinmarket/buy',
@@ -11,14 +14,15 @@ const TRADING_BUY_ROUTE = {
         name: 'wallet-trading-buy',
         pattern: '/accounts/coinmarket/buy',
         app: 'wallet',
-    },
+    } as Route,
     settingsBackRoute: { name: 'wallet-index', params: undefined },
 } as RouterState;
 
 const TRADING_SELL_ROUTE = {
     anchor: undefined,
     app: 'wallet',
-    hash: '/btc/0/normal',
+    hash: '#/btc/0/normal',
+    search: '',
     loaded: true,
     params: { symbol: 'btc', accountIndex: 0, accountType: 'normal' },
     pathname: '/accounts/coinmarket/sell',
@@ -26,14 +30,15 @@ const TRADING_SELL_ROUTE = {
         name: 'wallet-trading-sell',
         pattern: '/accounts/coinmarket/sell',
         app: 'wallet',
-    },
+    } as Route,
     settingsBackRoute: { name: 'wallet-index', params: undefined },
 } as RouterState;
 
 const TRADING_EXCHANGE_ROUTE = {
     anchor: undefined,
     app: 'wallet',
-    hash: '/btc/0/normal',
+    hash: '#/btc/0/normal',
+    search: '',
     loaded: true,
     params: { symbol: 'btc', accountIndex: 0, accountType: 'normal' },
     pathname: '/accounts/coinmarket/exchange',
@@ -41,13 +46,15 @@ const TRADING_EXCHANGE_ROUTE = {
         name: 'wallet-trading-exchange',
         pattern: '/accounts/coinmarket/exchange',
         app: 'wallet',
-    },
+    } as Route,
     settingsBackRoute: { name: 'wallet-index', params: undefined },
 } as RouterState;
 
 const DEFAULT_ROUTE = {
     loaded: false,
     pathname: '/',
+    hash: '',
+    search: '',
     app: 'unknown',
     route: undefined,
     params: undefined,

--- a/packages/suite/src/reducers/suite/routerReducer.ts
+++ b/packages/suite/src/reducers/suite/routerReducer.ts
@@ -19,7 +19,6 @@ const ACCOUNT_TABS = [
 
 export type RouterState = {
     loaded: boolean;
-    url: string;
     pathname: string;
     search?: string;
     hash?: NonLeadingHashString;
@@ -35,7 +34,6 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<RouterRootState>(
 
 const initialState: RouterState = {
     loaded: false,
-    url: '/',
     pathname: '/',
     app: 'unknown',
     route: undefined,
@@ -71,6 +69,8 @@ export const selectRouter = (state: RouterRootState) => state.router;
 export const selectRoute = (state: RouterRootState): RouterState['route'] => state.router.route;
 export const selectRouterParams = (state: RouterRootState) => state.router.params;
 export const selectRouteName = (state: RouterRootState) => state.router.route?.name;
+export const selectRouterUrl = (state: RouterRootState) =>
+    `${state.router.pathname}${state.router.search ?? ''}${state.router.hash ?? ''}`;
 export const selectRouterSearch = (state: RouterRootState) => state.router.search;
 export const selectURLSearchParams = createMemoizedSelector(
     [selectRouterSearch],

--- a/packages/suite/src/reducers/suite/routerReducer.ts
+++ b/packages/suite/src/reducers/suite/routerReducer.ts
@@ -1,10 +1,10 @@
 import { createWeakMapSelector } from '@suite-common/redux-utils';
 
 import { ROUTER } from 'src/actions/suite/constants';
-import { type NonLeadingHashString } from 'src/actions/suite/routerActions';
 import type { AnchorType } from 'src/constants/suite/anchors';
 import { RouterAppWithParams, SettingsBackRoute } from 'src/constants/suite/routes';
 import { Action } from 'src/types/suite';
+import type { RouterPath } from 'src/utils/suite/router';
 
 const ACCOUNT_TABS = [
     'wallet-index',
@@ -17,11 +17,8 @@ const ACCOUNT_TABS = [
     'wallet-staking',
 ];
 
-export type RouterState = {
+export type RouterState = RouterPath & {
     loaded: boolean;
-    pathname: string;
-    search?: string;
-    hash?: NonLeadingHashString;
     settingsBackRoute: SettingsBackRoute; // TODO: Probably not needed with the new router
     anchor?: AnchorType;
 } & RouterAppWithParams;
@@ -35,6 +32,8 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<RouterRootState>(
 const initialState: RouterState = {
     loaded: false,
     pathname: '/',
+    hash: '',
+    search: '',
     app: 'unknown',
     route: undefined,
     params: undefined,
@@ -70,10 +69,9 @@ export const selectRoute = (state: RouterRootState): RouterState['route'] => sta
 export const selectRouterParams = (state: RouterRootState) => state.router.params;
 export const selectRouteName = (state: RouterRootState) => state.router.route?.name;
 export const selectRouterUrl = (state: RouterRootState) =>
-    `${state.router.pathname}${state.router.search ?? ''}${state.router.hash ?? ''}`;
-export const selectRouterSearch = (state: RouterRootState) => state.router.search;
+    `${state.router.pathname}${state.router.search}${state.router.hash}`;
 export const selectURLSearchParams = createMemoizedSelector(
-    [selectRouterSearch],
+    [state => state.router.search],
     (search): URLSearchParams | null => (search ? new URLSearchParams(search) : null),
 );
 

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -33,6 +33,7 @@ import * as modalActions from 'src/actions/suite/modalActions';
 import { StorageLoadAction } from 'src/actions/suite/storageActions';
 import * as cardanoStakingActions from 'src/actions/wallet/cardanoStakingActions';
 import { selectIsWindowVisible } from 'src/reducers/suite/windowReducer';
+import { getPrefixedURL, stripPrefixedURL } from 'src/utils/suite/router';
 import { reportSecurityCheck } from 'src/utils/suite/sentry';
 import { fixLoadedCoinjoinAccount } from 'src/utils/wallet/coinjoinUtils';
 
@@ -61,8 +62,18 @@ const connectInitSettings = {
 };
 
 export const createRouterServices = (history: History): RouterServices => ({
-    getLocation: () => history.location,
-    navigate: (to, state) => history.push(to, state),
+    getLocation: () => {
+        const { location } = history;
+
+        return { ...location, pathname: stripPrefixedURL(location.pathname) };
+    },
+    navigate: (to, state) =>
+        history.push(
+            typeof to === 'string'
+                ? getPrefixedURL(to)
+                : { ...to, pathname: to.pathname && getPrefixedURL(to.pathname) },
+            state,
+        ),
     listen: listener => history.listen(listener),
 });
 

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -7,12 +7,7 @@ import { createWebauthnPlatformEncryption } from '@suite/platform-encryption-web
 import { createSuiteSyncDesktopCompositionRoot } from '@suite/suite-sync';
 import { delegatedIdentityKeyCompositionRoot } from '@suite-common/delegated-identity-key';
 import { FW_HASH_CHECK_DEFAULT_TIMEOUTS } from '@suite-common/firmware-authenticity';
-import {
-    CommonServices,
-    ExtraDependenciesStatic,
-    LocationPushState,
-    To,
-} from '@suite-common/redux-utils';
+import { CommonServices, ExtraDependenciesStatic, RouterServices } from '@suite-common/redux-utils';
 import {
     TokenDefinitionsState,
     buildTokenDefinitionsFromStorage,
@@ -65,9 +60,10 @@ const connectInitSettings = {
     firmwareHashCheckTimeouts: FW_HASH_CHECK_DEFAULT_TIMEOUTS,
 };
 
-export const createRouterServices = (history: History) => ({
+export const createRouterServices = (history: History): RouterServices => ({
     getLocation: () => history.location,
-    navigate: (to: To, state?: LocationPushState) => history.push(to, state),
+    navigate: (to, state) => history.push(to, state),
+    listen: listener => history.listen(listener),
 });
 
 type SuiteAppDeps = {

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -33,7 +33,7 @@ import * as modalActions from 'src/actions/suite/modalActions';
 import { StorageLoadAction } from 'src/actions/suite/storageActions';
 import * as cardanoStakingActions from 'src/actions/wallet/cardanoStakingActions';
 import { selectIsWindowVisible } from 'src/reducers/suite/windowReducer';
-import { getPrefixedURL, stripPrefixedURL } from 'src/utils/suite/router';
+import { ensureRouterPath, getPrefixedURL, stripPrefixedURL } from 'src/utils/suite/router';
 import { reportSecurityCheck } from 'src/utils/suite/sentry';
 import { fixLoadedCoinjoinAccount } from 'src/utils/wallet/coinjoinUtils';
 
@@ -65,16 +65,17 @@ export const createRouterServices = (history: History): RouterServices => ({
     getLocation: () => {
         const { location } = history;
 
-        return { ...location, pathname: stripPrefixedURL(location.pathname) };
+        return ensureRouterPath({ ...location, pathname: stripPrefixedURL(location.pathname) });
     },
     navigate: (to, state) =>
         history.push(
-            typeof to === 'string'
-                ? getPrefixedURL(to)
-                : { ...to, pathname: to.pathname && getPrefixedURL(to.pathname) },
+            { ...to, pathname: to.pathname ? getPrefixedURL(to.pathname) : undefined },
             state,
         ),
-    listen: listener => history.listen(listener),
+    listen: listener =>
+        history.listen(({ location, action }) =>
+            listener({ location: ensureRouterPath(location), action }),
+        ),
 });
 
 type SuiteAppDeps = {

--- a/packages/suite/src/support/suite/Main.tsx
+++ b/packages/suite/src/support/suite/Main.tsx
@@ -1,8 +1,7 @@
 import { HelmetProvider } from 'react-helmet-async';
 
-import { type History } from 'history';
-
 import { FormatterProvider } from '@suite-common/formatters';
+import { RouterServices } from '@suite-common/redux-utils';
 
 import { useFormattersConfig } from 'src/hooks/suite';
 import Autodetect from 'src/support/suite/Autodetect';
@@ -18,11 +17,11 @@ import { RouterHandler } from './RouterHandler';
 import { useConnectPopupModals } from './useConnectPopupModals';
 
 export const Main = ({
-    history,
+    routerServices,
     trafficLightOffset,
     children,
 }: {
-    history: History;
+    routerServices: RouterServices;
     trafficLightOffset?: React.ReactNode;
     children: React.ReactNode;
 }) => {
@@ -41,7 +40,7 @@ export const Main = ({
                         <Resize />
                         <Protocol />
                         <OnlineStatus />
-                        <RouterHandler history={history} />
+                        <RouterHandler routerServices={routerServices} />
                         <ConnectedIntlProvider>
                             <FormatterProvider config={formattersConfig}>
                                 {children}

--- a/packages/suite/src/support/suite/RouterHandler.tsx
+++ b/packages/suite/src/support/suite/RouterHandler.tsx
@@ -1,18 +1,20 @@
 import { useEffect } from 'react';
 
-import { Action, type History, type Update as HistoryUpdate } from 'history';
+import { Action } from 'history';
+
+import type { RouterServices } from '@suite-common/redux-utils';
 
 import { onBeforePopState, onLocationChange } from 'src/actions/suite/routerActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-export const RouterHandler = ({ history }: { history: History }) => {
+export const RouterHandler = ({ routerServices }: { routerServices: RouterServices }) => {
     const dispatch = useDispatch();
     const routerLoaded = useSelector(state => state.router.loaded);
 
     useEffect(() => {
         const emitLocation = () => {
             if (routerLoaded) {
-                const { pathname, hash } = history.location;
+                const { pathname, hash } = routerServices.getLocation();
                 dispatch(onLocationChange(pathname + hash));
             }
         };
@@ -20,7 +22,7 @@ export const RouterHandler = ({ history }: { history: History }) => {
         // initial sync
         emitLocation();
 
-        const unlisten = history.listen((update: HistoryUpdate) => {
+        const unlisten = routerServices.listen(update => {
             // If back navigation is blocked, re-go forward by 1 to cancel it
             if (update.action === Action.Pop) {
                 const canGoBack = dispatch(onBeforePopState());
@@ -34,7 +36,7 @@ export const RouterHandler = ({ history }: { history: History }) => {
         });
 
         return unlisten;
-    }, [dispatch, routerLoaded, history]);
+    }, [dispatch, routerLoaded, routerServices]);
 
     return null;
 };

--- a/packages/suite/src/support/suite/RouterHandler.tsx
+++ b/packages/suite/src/support/suite/RouterHandler.tsx
@@ -14,8 +14,8 @@ export const RouterHandler = ({ routerServices }: { routerServices: RouterServic
     useEffect(() => {
         const emitLocation = () => {
             if (routerLoaded) {
-                const { pathname, hash } = routerServices.getLocation();
-                dispatch(onLocationChange(pathname + hash));
+                const location = routerServices.getLocation();
+                dispatch(onLocationChange(location));
             }
         };
 

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -63,7 +63,9 @@ export const initialAppState: AppState = {
     desktopUpdate: desktopUpdateInitialState,
     router: {
         loaded: true,
-        pathname: '/suite-web/develop/web/',
+        pathname: '/suite-web/develop/web/' as RouterState['pathname'],
+        hash: '',
+        search: '',
         app: 'dashboard',
         route: {
             name: 'suite-index',

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -63,7 +63,6 @@ export const initialAppState: AppState = {
     desktopUpdate: desktopUpdateInitialState,
     router: {
         loaded: true,
-        url: '/suite-web/develop/web/',
         pathname: '/suite-web/develop/web/',
         app: 'dashboard',
         route: {

--- a/packages/suite/src/utils/suite/__tests__/router.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/router.test.ts
@@ -1,11 +1,11 @@
+import { Route } from '@suite-common/suite-types';
+
 import {
-    findRouteByName,
-    getApp,
+    RouteParams,
     getAppWithParams,
     getPrefixedURL,
     getRoute,
-    getTopLevelRoute,
-    stripPrefixedPathname,
+    getRouteHash,
     stripPrefixedURL,
 } from '../router';
 
@@ -14,26 +14,6 @@ const OLD_ENV = { ...process.env };
 describe('router', () => {
     afterEach(() => {
         process.env = OLD_ENV;
-    });
-
-    describe('getApp', () => {
-        it('should return string indicating the current app', () => {
-            expect(getApp('/accounts')).toEqual('wallet');
-            expect(getApp('/accounts/')).toEqual('wallet');
-            expect(getApp('/onboarding')).toEqual('onboarding');
-            expect(getApp('/onboarding/')).toEqual('onboarding');
-            expect(getApp('/unknown-route/')).toEqual('unknown');
-        });
-    });
-
-    describe('getApp with ASSET_PREFIX', () => {
-        it('should return string indicating the current app', () => {
-            process.env.ASSET_PREFIX = '/next';
-            expect(getApp('/next/accounts/')).toEqual('wallet');
-            expect(getApp('/next/accounts/receive/#/btc/0')).toEqual('wallet');
-            expect(getApp('/next/onboarding/')).toEqual('onboarding');
-            expect(getApp('/unknown-route/')).toEqual('unknown');
-        });
     });
 
     describe('getPrefixedURL', () => {
@@ -54,50 +34,50 @@ describe('router', () => {
 
     describe('getRoute', () => {
         it('should return the route for given name', () => {
+            const test = (name: Route['name'], params?: RouteParams) => {
+                const route = getRoute(name);
+                const hash = getRouteHash(route, params);
+
+                return `${route?.pattern ?? '/'}${hash ? `#${hash}` : ''}`;
+            };
+
             // @ts-expect-error: invalid params
-            expect(getRoute('unknown-route')).toEqual('/');
-            expect(getRoute('wallet-index')).toEqual('/accounts');
+            expect(test('unknown-route')).toEqual('/');
+            expect(test('wallet-index')).toEqual('/accounts');
             // tests below with intentionally mixed # params
             expect(
-                getRoute('wallet-index', {
+                test('wallet-index', {
                     symbol: 'btc',
                     accountIndex: 0,
                     accountType: 'legacy',
                 }),
             ).toEqual('/accounts#/btc/0/legacy');
             expect(
-                getRoute('wallet-index', {
+                test('wallet-index', {
                     accountIndex: 0,
                     accountType: 'segwit',
                     symbol: 'btc',
                 }),
             ).toEqual('/accounts#/btc/0/segwit');
             expect(
-                getRoute('wallet-index', {
+                test('wallet-index', {
                     accountType: 'normal',
                     symbol: 'btc',
                     accountIndex: 0,
                 }),
             ).toEqual('/accounts#/btc/0/normal');
             expect(
-                getRoute('wallet-index', {
+                test('wallet-index', {
                     accountIndex: 1,
                     symbol: 'btc',
                 }),
             ).toEqual('/accounts#/btc/1');
             // route shouldn't have params
             expect(
-                getRoute('onboarding-index', {
+                test('onboarding-index', {
                     symbol: 'btc',
                 }),
             ).toEqual('/onboarding');
-        });
-    });
-
-    describe('stripPrefixedPathname', () => {
-        it('should strip params delimited by a hashtag from the URL', () => {
-            expect(stripPrefixedPathname('/accounts/send/#/btc/0')).toEqual('/accounts/send');
-            expect(stripPrefixedPathname('/accounts/send/#/42')).toEqual('/accounts/send');
         });
     });
 
@@ -124,7 +104,7 @@ describe('router', () => {
                     accountIndex: 0,
                     accountType: 'normal',
                 },
-                route: findRouteByName('wallet-index'),
+                route: getRoute('wallet-index'),
             };
             expect(getAppWithParams('/accounts/#/btc/0/normal')).toEqual(resp);
             expect(getAppWithParams('/accounts/#/btc/1/segwit')).toEqual({
@@ -162,7 +142,7 @@ describe('router', () => {
             expect(getAppWithParams('/accounts')).toEqual({
                 ...resp,
                 params: undefined,
-                route: findRouteByName('wallet-index'),
+                route: getRoute('wallet-index'),
             });
         });
 
@@ -170,13 +150,13 @@ describe('router', () => {
             expect(getAppWithParams('/')).toEqual({
                 app: 'dashboard',
                 params: undefined,
-                route: findRouteByName('suite-index'),
+                route: getRoute('suite-index'),
             });
 
             expect(getAppWithParams('/onboarding/')).toEqual({
                 app: 'onboarding',
                 params: undefined,
-                route: findRouteByName('onboarding-index'),
+                route: getRoute('onboarding-index'),
             });
 
             expect(getAppWithParams('/unknown-route/')).toEqual({
@@ -184,26 +164,6 @@ describe('router', () => {
                 params: undefined,
                 route: undefined,
             });
-        });
-    });
-
-    describe('getTopLevelRoute', () => {
-        it('should return value if url is a nested page', () => {
-            process.env.ASSET_PREFIX = undefined;
-            expect(getTopLevelRoute('/')).toEqual(undefined);
-            expect(getTopLevelRoute('/accounts')).toEqual(undefined);
-            expect(getTopLevelRoute('/accounts/receive')).toEqual('/accounts');
-            expect(getTopLevelRoute('dummy-data-without-slash')).toEqual(undefined);
-            // @ts-expect-error: intentional invalid param type
-            expect(getTopLevelRoute(1)).toEqual(undefined);
-        });
-
-        it('should return value if url is a nested page (with prefix)', () => {
-            const prefix = '/test/asset/prefix';
-            process.env.ASSET_PREFIX = prefix;
-            expect(getTopLevelRoute(`${prefix}/`)).toEqual(undefined);
-            expect(getTopLevelRoute(`${prefix}/accounts`)).toEqual(undefined);
-            expect(getTopLevelRoute(`${prefix}/accounts/receive`)).toEqual(`${prefix}/accounts`);
         });
     });
 });

--- a/packages/suite/src/utils/suite/__tests__/router.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/router.test.ts
@@ -38,7 +38,7 @@ describe('router', () => {
                 const route = getRoute(name);
                 const hash = getRouteHash(route, params);
 
-                return `${route?.pattern ?? '/'}${hash ? `#${hash}` : ''}`;
+                return `${route?.pattern ?? '/'}${hash}`;
             };
 
             // @ts-expect-error: invalid params
@@ -106,8 +106,10 @@ describe('router', () => {
                 },
                 route: getRoute('wallet-index'),
             };
-            expect(getAppWithParams('/accounts/#/btc/0/normal')).toEqual(resp);
-            expect(getAppWithParams('/accounts/#/btc/1/segwit')).toEqual({
+            expect(getAppWithParams({ pathname: '/accounts', hash: '#/btc/0/normal' })).toEqual(
+                resp,
+            );
+            expect(getAppWithParams({ pathname: '/accounts', hash: '#/btc/1/segwit' })).toEqual({
                 ...resp,
                 params: {
                     symbol: 'btc',
@@ -115,7 +117,7 @@ describe('router', () => {
                     accountType: 'segwit',
                 },
             });
-            expect(getAppWithParams('/accounts/#/btc/1/legacy')).toEqual({
+            expect(getAppWithParams({ pathname: '/accounts', hash: '#/btc/1/legacy' })).toEqual({
                 ...resp,
                 params: {
                     symbol: 'btc',
@@ -123,23 +125,25 @@ describe('router', () => {
                     accountType: 'legacy',
                 },
             });
-            expect(getAppWithParams('/accounts/#/btc/NaN')).toEqual({
+            expect(getAppWithParams({ pathname: '/accounts', hash: '#/btc/NaN' })).toEqual({
                 ...resp,
                 params: undefined,
             });
-            expect(getAppWithParams('/accounts/#/btc-invalid/0')).toEqual({
+            expect(getAppWithParams({ pathname: '/accounts', hash: '#/btc-invalid/0' })).toEqual({
                 ...resp,
                 params: undefined,
             });
-            expect(getAppWithParams('/accounts/#/btc/0/unknown-type')).toEqual({
+            expect(
+                getAppWithParams({ pathname: '/accounts', hash: '#/btc/0/unknown-type' }),
+            ).toEqual({
                 ...resp,
                 params: undefined,
             });
-            expect(getAppWithParams('/accounts/#/btc')).toEqual({
+            expect(getAppWithParams({ pathname: '/accounts', hash: '#/btc' })).toEqual({
                 ...resp,
                 params: undefined,
             });
-            expect(getAppWithParams('/accounts')).toEqual({
+            expect(getAppWithParams({ pathname: '/accounts', hash: '' })).toEqual({
                 ...resp,
                 params: undefined,
                 route: getRoute('wallet-index'),
@@ -147,19 +151,19 @@ describe('router', () => {
         });
 
         it('other params validation', () => {
-            expect(getAppWithParams('/')).toEqual({
+            expect(getAppWithParams({ pathname: '/' })).toEqual({
                 app: 'dashboard',
                 params: undefined,
                 route: getRoute('suite-index'),
             });
 
-            expect(getAppWithParams('/onboarding/')).toEqual({
+            expect(getAppWithParams({ pathname: '/onboarding/' })).toEqual({
                 app: 'onboarding',
                 params: undefined,
                 route: getRoute('onboarding-index'),
             });
 
-            expect(getAppWithParams('/unknown-route/')).toEqual({
+            expect(getAppWithParams({ pathname: '/unknown-route/' })).toEqual({
                 app: 'unknown',
                 params: undefined,
                 route: undefined,

--- a/packages/suite/src/utils/suite/__tests__/router.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/router.test.ts
@@ -6,6 +6,7 @@ import {
     getRoute,
     getTopLevelRoute,
     stripPrefixedPathname,
+    stripPrefixedURL,
 } from '../router';
 
 const OLD_ENV = { ...process.env };
@@ -97,6 +98,20 @@ describe('router', () => {
         it('should strip params delimited by a hashtag from the URL', () => {
             expect(stripPrefixedPathname('/accounts/send/#/btc/0')).toEqual('/accounts/send');
             expect(stripPrefixedPathname('/accounts/send/#/42')).toEqual('/accounts/send');
+        });
+    });
+
+    describe('stripPrefixedUrl', () => {
+        it('should strip prefix from the URL', () => {
+            const prefix = '/test/asset/prefix';
+            process.env.ASSET_PREFIX = prefix;
+            expect(stripPrefixedURL(`${prefix}/accounts/send/#/btc/0`)).toEqual(
+                `/accounts/send/#/btc/0`,
+            );
+            process.env.ASSET_PREFIX = '';
+            expect(stripPrefixedURL(`${prefix}/accounts/send/#/btc/0`)).toEqual(
+                `${prefix}/accounts/send/#/btc/0`,
+            );
         });
     });
 

--- a/packages/suite/src/utils/suite/router.ts
+++ b/packages/suite/src/utils/suite/router.ts
@@ -1,3 +1,4 @@
+import { HashString, PathString, RouterPath, SearchString } from '@suite-common/redux-utils';
 import { modalAppParams } from '@suite-common/suite-config';
 import { Route } from '@suite-common/suite-types';
 import { yup } from '@suite-common/validators';
@@ -28,6 +29,28 @@ export const stripPrefixedURL = (url: string) => {
 
     return url;
 };
+
+// https://github.com/remix-run/history/blob/main/docs/api-reference.md#locationpathname
+const ensurePathString = (s: string = ''): PathString =>
+    (s.startsWith('/') ? s : `/${s}`) as PathString;
+
+// https://github.com/remix-run/history/blob/main/docs/api-reference.md#locationsearch
+const ensureSearchString = (s: string = ''): SearchString =>
+    (!s || s.startsWith('?') ? s : `?${s}`) as SearchString;
+
+// https://github.com/remix-run/history/blob/main/docs/api-reference.md#locationhash
+const ensureHashString = (s: string = ''): HashString =>
+    (!s || s.startsWith('#') ? s : `#${s}`) as HashString;
+
+export const ensureRouterPath = (path: {
+    pathname?: string;
+    search?: string;
+    hash?: string;
+}): RouterPath => ({
+    pathname: ensurePathString(path.pathname),
+    search: ensureSearchString(path.search),
+    hash: ensureHashString(path.hash),
+});
 
 export const findRoute = (url: string) => {
     const [pathname] = url.split('#');

--- a/packages/suite/src/utils/suite/router.ts
+++ b/packages/suite/src/utils/suite/router.ts
@@ -1,4 +1,3 @@
-import { ExtraDependencies } from '@suite-common/redux-utils';
 import { modalAppParams } from '@suite-common/suite-config';
 import { Route } from '@suite-common/suite-types';
 import { yup } from '@suite-common/validators';
@@ -30,25 +29,11 @@ export const stripPrefixedURL = (url: string) => {
     return url;
 };
 
-// Strips params delimited by a hashtag from the URL
-export const stripPrefixedPathname = (url: string) => {
-    const [pathname] = url.split('#');
-
-    return pathname.length > 1 ? pathname.replace(/\/$/, '') : pathname;
-};
-
 export const findRoute = (url: string) => {
-    const clean = stripPrefixedPathname(url);
+    const [pathname] = url.split('#');
+    const clean = pathname.length > 1 ? pathname.replace(/\/$/, '') : pathname;
 
     return routes.find(r => r.pattern === clean);
-};
-
-export const findRouteByName = (name: Route['name']) => routes.find(r => r.name === name);
-
-export const getApp = (url: string) => {
-    const route = findRoute(url);
-
-    return route ? route.app : 'unknown';
 };
 
 const validateWalletParams = (url: string): CommonWalletParams => {
@@ -194,49 +179,9 @@ export type RouteParams = {
         DashboardParams)[K];
 };
 
-export const getRoute = (name: Route['name'], params?: RouteParams) => {
-    const route = findRouteByName(name);
-    if (!route) return '/';
-    const order = route.params;
-    if (params && order) {
-        const paramsString = Object.entries(params)
-            // sort by order defined in routes
-            .sort((a, b) => {
-                const aIndex = order.findIndex((o: string) => o === a[0]);
-                const bIndex = order.findIndex((o: string) => o === b[0]);
+export const getRoute = (name: Route['name']) => routes.find(r => r.name === name);
 
-                return aIndex - bIndex;
-            })
-            .reduce((val, curr) => {
-                const exists = order.findIndex((o: string) => o === curr[0]);
-                if (exists < 0) return val;
-
-                return `${val}/${curr[1]}`;
-            }, '');
-
-        return paramsString.length > 0 ? `${route.pattern}#${paramsString}` : route.pattern;
-    }
-
-    return route.pattern;
-};
-
-// Used in @suite-native routerActions
-export const getTopLevelRoute = (url: string) => {
-    if (typeof url !== 'string') return;
-    const clean = stripPrefixedPathname(url);
-    const split = clean.split('/');
-    split.splice(0, 1);
-    if (split.length > 1) {
-        return `/${split[0]}`;
-    }
-};
-
-/**
- * Used only in application modal.
- * Returns Route of application beneath the application modal. (real Router value)
- */
-export const getBackgroundRoute = (extra: ExtraDependencies) => {
-    const location = extra.routerServices.getLocation();
-
-    return findRoute(location.pathname + location.hash);
-};
+export const getRouteHash = (route?: Route, params?: RouteParams) =>
+    params &&
+    route?.params &&
+    ['', ...route.params.filter(p => p in params).map(p => params[p])].join('/');

--- a/packages/suite/src/utils/suite/router.ts
+++ b/packages/suite/src/utils/suite/router.ts
@@ -32,7 +32,7 @@ export const stripPrefixedURL = (url: string) => {
 
 // Strips params delimited by a hashtag from the URL
 export const stripPrefixedPathname = (url: string) => {
-    const [pathname] = stripPrefixedURL(url).split('#');
+    const [pathname] = url.split('#');
 
     return pathname.length > 1 ? pathname.replace(/\/$/, '') : pathname;
 };
@@ -52,7 +52,7 @@ export const getApp = (url: string) => {
 };
 
 const validateWalletParams = (url: string): CommonWalletParams => {
-    const [, hash] = stripPrefixedURL(url).split('#');
+    const [, hash] = url.split('#');
     if (!hash) return;
     const [symbol, index, rawAccountType] = hash.split('/').filter(p => p.length > 0);
     if (!index) return;
@@ -90,7 +90,7 @@ const modalAppParamsDefaultValues: ModalAppParams = {
 };
 
 const validateModalAppParams = (url: string, params?: Route['params']): ModalAppParams => {
-    const [, hash] = stripPrefixedURL(url).split('#');
+    const [, hash] = url.split('#');
     const splitted = hash?.split('/').filter(p => p.length > 0);
     if (!splitted || splitted.length === 0) return modalAppParamsDefaultValues;
 
@@ -124,10 +124,9 @@ export function parseDashboardParams(params: unknown): DashboardParams | undefin
 }
 
 const validateDashboardParams = (url: string): DashboardParams | undefined => {
-    const stripped = stripPrefixedURL(url);
-    const hashIndex = stripped.indexOf('#');
+    const hashIndex = url.indexOf('#');
 
-    const hash = hashIndex >= 0 ? stripped.slice(hashIndex + 1) : '';
+    const hash = hashIndex >= 0 ? url.slice(hashIndex + 1) : '';
     const [modal, networkSymbol] = hash.split('/').filter(Boolean);
 
     if (modal === undefined) {
@@ -228,7 +227,7 @@ export const getTopLevelRoute = (url: string) => {
     const split = clean.split('/');
     split.splice(0, 1);
     if (split.length > 1) {
-        return getPrefixedURL(`/${split[0]}`);
+        return `/${split[0]}`;
     }
 };
 

--- a/packages/suite/src/utils/suite/router.ts
+++ b/packages/suite/src/utils/suite/router.ts
@@ -8,7 +8,7 @@ import {
     GlobalSendReceiveType,
 } from '@suite-common/wallet-types';
 
-import routes, { RouterAppWithParams } from 'src/constants/suite/routes';
+import routes, { type RouterAppWithParams } from 'src/constants/suite/routes';
 
 // Prefix a url with ASSET_PREFIX (eg. name of the branch in CI)
 // Useful with next.js Router.push() that accepts `as` prop as second arg
@@ -52,17 +52,29 @@ export const ensureRouterPath = (path: {
     hash: ensureHashString(path.hash),
 });
 
-export const findRoute = (url: string) => {
-    const [pathname] = url.split('#');
+export { type RouterPath };
+
+export type RouterPathOptional = {
+    pathname: RouterPath['pathname'];
+    search?: RouterPath['search'];
+    hash?: RouterPath['hash'];
+};
+
+export const isEqualLocation = (loc1: RouterPathOptional, loc2: RouterPathOptional) =>
+    loc1.pathname === loc2.pathname &&
+    (loc1.search ?? '') === (loc2.search ?? '') &&
+    (loc1.hash ?? '') === (loc2.hash ?? '');
+
+export const findRoute = (pathname: PathString) => {
     const clean = pathname.length > 1 ? pathname.replace(/\/$/, '') : pathname;
 
     return routes.find(r => r.pattern === clean);
 };
 
-const validateWalletParams = (url: string): CommonWalletParams => {
-    const [, hash] = url.split('#');
-    if (!hash) return;
-    const [symbol, index, rawAccountType] = hash.split('/').filter(p => p.length > 0);
+const parseHash = (hash: HashString) => hash.replace(/^#/, '').split('/').filter(Boolean);
+
+const validateWalletParams = (hash: HashString): CommonWalletParams => {
+    const [symbol, index, rawAccountType] = parseHash(hash);
     if (!index) return;
 
     const network = getNetworkOptional(symbol);
@@ -97,9 +109,8 @@ const modalAppParamsDefaultValues: ModalAppParams = {
     variant: undefined,
 };
 
-const validateModalAppParams = (url: string, params?: Route['params']): ModalAppParams => {
-    const [, hash] = url.split('#');
-    const splitted = hash?.split('/').filter(p => p.length > 0);
+const validateModalAppParams = (hash: HashString, params?: Route['params']): ModalAppParams => {
+    const splitted = parseHash(hash);
     if (!splitted || splitted.length === 0) return modalAppParamsDefaultValues;
 
     return {
@@ -131,11 +142,8 @@ export function parseDashboardParams(params: unknown): DashboardParams | undefin
     }
 }
 
-const validateDashboardParams = (url: string): DashboardParams | undefined => {
-    const hashIndex = url.indexOf('#');
-
-    const hash = hashIndex >= 0 ? url.slice(hashIndex + 1) : '';
-    const [modal, networkSymbol] = hash.split('/').filter(Boolean);
+const validateDashboardParams = (hash: HashString): DashboardParams | undefined => {
+    const [modal, networkSymbol] = parseHash(hash);
 
     if (modal === undefined) {
         return undefined;
@@ -152,47 +160,23 @@ const validateDashboardParams = (url: string): DashboardParams | undefined => {
     return params;
 };
 
-// Used in routerReducer
-export const getAppWithParams = (url: string): RouterAppWithParams => {
-    const route = findRoute(url);
-
-    if (!route) {
-        return {
-            app: 'unknown',
-            route: undefined,
-            params: undefined,
-        };
+const getAppParams = (route: Route, hash: HashString = '') => {
+    switch (route.app) {
+        case 'dashboard':
+            return validateDashboardParams(hash);
+        case 'wallet':
+            return validateWalletParams(hash);
+        default:
+            return route.params ? validateModalAppParams(hash, route.params) : undefined;
     }
+};
 
-    if (route.app === 'dashboard') {
-        return {
-            app: route.app,
-            params: validateDashboardParams(url),
-            route,
-        } as RouterAppWithParams;
-    }
+export const getAppWithParams = (path: { pathname: PathString; hash?: HashString }) => {
+    const route = findRoute(path.pathname);
+    const app = route?.app ?? 'unknown';
+    const params = route && getAppParams(route, path.hash);
 
-    if (route.app === 'wallet') {
-        return {
-            app: route.app,
-            params: validateWalletParams(url),
-            route,
-        };
-    }
-
-    if (route.params) {
-        return {
-            app: route.app,
-            params: validateModalAppParams(url, route.params),
-            route,
-        } as RouterAppWithParams;
-    }
-
-    return {
-        app: route.app,
-        route,
-        params: undefined,
-    } as RouterAppWithParams;
+    return { app, params, route } as RouterAppWithParams;
 };
 
 export type WalletParams = CommonWalletParams;
@@ -205,6 +189,13 @@ export type RouteParams = {
 export const getRoute = (name: Route['name']) => routes.find(r => r.name === name);
 
 export const getRouteHash = (route?: Route, params?: RouteParams) =>
-    params &&
-    route?.params &&
-    ['', ...route.params.filter(p => p in params).map(p => params[p])].join('/');
+    ensureHashString(
+        params &&
+            route?.params &&
+            [
+                '',
+                ...route.params
+                    .filter(p => Object.prototype.hasOwnProperty.call(params, p))
+                    .map(p => params[p]),
+            ].join('/'),
+    );

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -33,22 +33,24 @@ type ConnectInitSettings = {
     manifest: Manifest;
 } & Partial<ConnectSettings>;
 
+export type PathString = `/${string}`; // in format `/alpha/beta/gamma`
+export type SearchString = '' | `?${string}`; // in format `?alpha=beta&gamma=delta`
+export type HashString = '' | `#${string}`; // in format `#/alpha/beta/gamma`
+
 // NOTE: this is basically a bit stricter Path from history package (file://./../../../node_modules/history/index.d.ts),
 // but it is satisfied by window.location as well
-type Path = {
-    pathname: string;
-    search: string;
-    hash: string;
+export type RouterPath = {
+    pathname: PathString;
+    search: SearchString;
+    hash: HashString;
 };
 
-export type To = string | Partial<Path>;
-
 // This is a Listener from history package
-type Listener = (_: { location: Path; action: 'PUSH' | 'POP' | 'REPLACE' }) => void;
+type Listener = (_: { location: RouterPath; action: 'PUSH' | 'POP' | 'REPLACE' }) => void;
 
 export type RouterServices = {
-    getLocation: () => Path;
-    navigate: (to: To, state?: LocationPushState) => void;
+    getLocation: () => RouterPath;
+    navigate: (to: Partial<RouterPath>, state?: LocationPushState) => void;
     // calling .listen(listener) returns a cleanup function
     listen: (listener: Listener) => () => void;
 };

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -33,6 +33,8 @@ type ConnectInitSettings = {
     manifest: Manifest;
 } & Partial<ConnectSettings>;
 
+// NOTE: this is basically a bit stricter Path from history package (file://./../../../node_modules/history/index.d.ts),
+// but it is satisfied by window.location as well
 type Path = {
     pathname: string;
     search: string;
@@ -40,6 +42,16 @@ type Path = {
 };
 
 export type To = string | Partial<Path>;
+
+// This is a Listener from history package
+type Listener = (_: { location: Path; action: 'PUSH' | 'POP' | 'REPLACE' }) => void;
+
+export type RouterServices = {
+    getLocation: () => Path;
+    navigate: (to: To, state?: LocationPushState) => void;
+    // calling .listen(listener) returns a cleanup function
+    listen: (listener: Listener) => () => void;
+};
 
 export type LocationPushState = Record<string, unknown>;
 
@@ -123,16 +135,7 @@ export type ExtraDependenciesStatic = {
         connectInitSettings: ConnectInitSettings;
         reportSecurityCheck: (props: ReportSecurityCheckProps) => void;
     };
-    routerServices: {
-        getLocation: () => {
-            // NOTE: this type is satisfied by the history from history package, it is not window.location
-            // but window.location does satisfies it, we can extend it depending of needs of using history object
-            pathname: string;
-            hash: string;
-            search: string;
-        };
-        navigate: (to: To, state?: LocationPushState) => void;
-    };
+    routerServices: RouterServices;
 };
 
 export type ExtraDependencies = ExtraDependenciesStatic & { services: CommonServices };

--- a/suite-common/suite-types/src/route.ts
+++ b/suite-common/suite-types/src/route.ts
@@ -1,14 +1,7 @@
 import { routes } from '@suite-common/suite-config';
-import { ArrayElement, ConstWithOptionalFields } from '@trezor/type-utils';
+import { ArrayElement, ConstWithOptionalFields, Keys } from '@trezor/type-utils';
 
-type RouteKeys =
-    | keyof ArrayElement<typeof routes>
-    | 'params'
-    | 'hasNestedRoutes'
-    | 'isForegroundApp'
-    | 'isNestedRoute'
-    | 'isFullscreenApp'
-    | 'clearUrl';
+type RouteKeys = Keys<ArrayElement<typeof routes>>;
 
 export type Route = ArrayElement<ConstWithOptionalFields<typeof routes, RouteKeys>>;
 

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -6,12 +6,7 @@ import {
     PlatformEncryption,
     asEncryptedHex,
 } from '@suite-common/platform-encryption';
-import {
-    type ExtraDependencies,
-    type LocationPushState,
-    type To,
-    createThunk,
-} from '@suite-common/redux-utils';
+import { type ExtraDependencies, createThunk } from '@suite-common/redux-utils';
 import type { SuiteSync } from '@suite-common/suite-sync-types';
 import { ReportSecurityCheckProps, Route } from '@suite-common/suite-types';
 import { AddressDisplayOptions, SelectedAccountLoaded } from '@suite-common/wallet-types';
@@ -188,7 +183,7 @@ export const extraDependenciesMock: ExtraDependencies = {
             hash: 'mocked_hash',
             search: 'mocked_search',
         }),
-        navigate: (to: To, state?: LocationPushState) =>
-            console.warn(`Mock navigating to ${to} with state`, state),
+        navigate: (to, state) => console.warn(`Mock navigating to ${to} with state`, state),
+        listen: (_: {}) => () => {},
     },
 };

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -179,9 +179,9 @@ export const extraDependenciesMock: ExtraDependencies = {
     },
     routerServices: {
         getLocation: () => ({
-            pathname: 'mocked_path',
-            hash: 'mocked_hash',
-            search: 'mocked_search',
+            pathname: '/mocked_path',
+            hash: '#mocked_hash',
+            search: '?mocked_search',
         }),
         navigate: (to, state) => console.warn(`Mock navigating to ${to} with state`, state),
         listen: (_: {}) => () => {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -15146,6 +15146,7 @@ __metadata:
   resolution: "@trezor/suite-desktop-ui@workspace:packages/suite-desktop-ui"
   dependencies:
     "@sentry/electron": "npm:^7.4.0"
+    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@trezor/components": "workspace:*"
@@ -15243,6 +15244,7 @@ __metadata:
   resolution: "@trezor/suite-web@workspace:packages/suite-web"
   dependencies:
     "@sentry/browser": "npm:10.27.0"
+    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@trezor/connect": "workspace:*"


### PR DESCRIPTION
## Description

**WARNING**: Relatively high-risk PR as it can change formats of some urls, behavior when redirecting etc. etc.

Try to fix a router issue where pathname+search+hash is taken from the current url while app params from the requested one. Gradually, whole app router was remade a bit.

@vojtatranta please check that it doesn't go against your previous goals.

## Commits

- https://github.com/trezor/trezor-suite/pull/23698/commits/a05b93fa6c950fd10ba6a659813d515be7f076ee - add `listen` method from `history` to `routerServices`; for later usage
- https://github.com/trezor/trezor-suite/pull/23698/commits/950d951d12386187bcc894e7378a61bc5e2f81ed - passing `routerServices` object in `Main` components instead of `history` itself, which is now always wrapped inside `routerServices`
- https://github.com/trezor/trezor-suite/pull/23698/commits/3e1d7583ac98aa250cc0a7c42fa0603020dbaf4c - use `getPrefixedUrl` and `stripPrefixedUrl` utils only directly in `routerServices`, so we can presume that every other url occurence is stripped already; this could in theory fix some issues (e.g. `coinmarket-redirect` in `protocolActions` as there wasn't `getPrefixedUrl`?)
- https://github.com/trezor/trezor-suite/pull/23698/commits/63f3bc2a2e894111832bd2f019e5d0a55dbb3707 - remove some unused utils (`getApp`, `getTopLevelRoute`), inline others (`stripPrefixedPathname`, `getBackgroundRoute`) and reformat others (`findRouteByName`, `getRoute`, `getRouteHash`)
- https://github.com/trezor/trezor-suite/pull/23698/commits/e9bf37a981b24d619c4755b67ae53f0e0af3dc5c - remove `url` from `routerReducer` and assemble it dynamically by `selectRouterUrl` from `pathname + search + hash`
- https://github.com/trezor/trezor-suite/pull/23698/commits/e29574df3a2e04ceb995902b74d413a633f87ec8 - use `Keys` type util where it made sense
- https://github.com/trezor/trezor-suite/pull/23698/commits/6f5e1179f69405793116f452af35527242370bf2 - create better typing for path components (pathname/hash/search - consistent with history library) and ensure them directly on `routerServices` level
- https://github.com/trezor/trezor-suite/pull/23698/commits/70119c38794bb69d20f7f0b2c4713660b9e329bc - the real stuff; use `RouterPath` objects directly where possible instead of building urls from them; improve `getAppWithParams`
- https://github.com/trezor/trezor-suite/pull/23698/commits/fb7555e772216c5bcd706518b6388d092d3c8ef1 - unit tests adjustment

## What to test

- that all the navigation is Suite works as intended (including selecting account, anchors, reloads, ...)
- that redirects to some trading/swaping/dunno stuff works as well
- that special url protocols (bitcoin://, deeplinks, ...) works as well
- especially try modals please
- and so on, and so on, ... it may be a bit tedious

## Föllöwüps

- `pathname`, `hash` and `search` can be stored in redux as an array of its components (e.g. `['accounts', 'tokens', 'hidden']` or `['btc', '2', 'segwit']`) which is independent on real format (leading hash, slash separator etc.), can be better type-checked and is generally more flexible
- the final goal could be that `routerReducer` won't be a modified clone of native `history` object but tailored directly to Suite's needs instead.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/router-fixing&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/router-fixing&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/router-fixing&lookback=7)