### PR TITLE
ci(suite-native): fix eas build by omitting suite/e2e package

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -13,6 +13,7 @@ packages/suite-desktop-ui/
 packages/suite-storage/
 packages/suite-web/
 packages/transport-bluetooth/
+suite/e2e/
 
 ### content of all .gitignore files is not applied if .easignore is present
 


### PR DESCRIPTION
## Description
- since the package `@suite/e2e` was added, the eas builds are failing
- it complains about missing package `@trezor/suite-analytics`  ([more here](https://expo.dev/accounts/trezorcompany/projects/trezor-suite-develop/builds/480cab1a-af49-4634-aa3b-92ae62fee29c))
- `@trezor/suite-analytics` is listed in `.easignore` file but included as a dependency in `@suite/e2e` (The eas is trying to install it, but the package is not found due to ignore file) 
  - --> **SOLUTION :  `@suite/e2e` package has to be ignored as well**
- solution inspired by https://github.com/trezor/trezor-suite/pull/15950



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=native/ci/ommit-e2e-in-eas-build&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=native/ci/ommit-e2e-in-eas-build&lookback=7)