### PR TITLE
Trading - Include Experiments in Feedback Form

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback.tsx
@@ -9,7 +9,7 @@ import {
 
 import { Rating, buildUserFeedbackData, sendFeedbackAction } from '@suite-common/feedback';
 import { selectCountryCode } from '@suite-common/geolocation';
-import { ExperimentId } from '@suite-common/message-system';
+import { ExperimentId, selectActiveExperimentsWithVariants } from '@suite-common/message-system';
 import { TradingType } from '@suite-common/trading';
 import { Button, Card, Column, H3, IconCircle, Paragraph, Row, Textarea } from '@trezor/components';
 
@@ -44,6 +44,8 @@ export const TradingDetailFeedback = ({
     const dispatch = useDispatch();
     const geolocation = useSelector(selectCountryCode);
 
+    const activeExperimentsWithVariants = useSelector(selectActiveExperimentsWithVariants);
+
     const submitFeedback = () => {
         if (!rating) return;
 
@@ -64,6 +66,7 @@ export const TradingDetailFeedback = ({
                     receiveCurrency,
                     geolocation: geolocation || undefined,
                     countryOfResidence: country || undefined,
+                    activeExperimentsWithVariants,
                     ...userData,
                 },
             }),

--- a/suite-common/feedback/src/feedback.ts
+++ b/suite-common/feedback/src/feedback.ts
@@ -12,7 +12,7 @@ export type FeedbackCategory =
     | 'trade'
     | 'other';
 
-type FeedbackExtras = Record<string, string | number | boolean | undefined>;
+type FeedbackExtras = Record<string, any>;
 
 interface BasePayload extends UserData, FeedbackExtras {
     description: string;


### PR DESCRIPTION
## Description

Include A/B testing experiments and their active variants in the trading feedback form.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23035


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-feedback-experiments&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-feedback-experiments&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/trading-feedback-experiments&lookback=7)