### PR TITLE
fix(suite): Hide scanning trezors for web

### DIFF
--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -64,29 +64,39 @@ type ConnectModalContentProps = {
     isBluetoothMode: boolean;
 };
 
-const ConnectModalContent = ({ children, isBluetoothMode }: ConnectModalContentProps) => (
-    <Column alignItems="center" gap={32} overflow="hidden">
-        <H3 typographyStyle="titleMedium" align="center" textWrap="balance">
-            <Translation
-                id={
-                    isBluetoothMode
-                        ? 'TR_CONNECT_UNLOCK_BLUETOOTH_DEVICE'
-                        : 'TR_CONNECT_UNLOCK_YOUR_DEVICE'
-                }
-            />
-        </H3>
-        <Row gap={8} alignItems="center" justifyContent="center" height={36}>
-            <Spinner size={16} isGrey={false} />
-            <Text variant="primary">
+const ConnectModalContent = ({ children, isBluetoothMode }: ConnectModalContentProps) => {
+    const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
+
+    return (
+        <Column alignItems="center" gap={32} overflow="hidden">
+            <H3 typographyStyle="titleMedium" align="center" textWrap="balance">
                 <Translation
-                    id={isBluetoothMode ? 'TR_SCAN_TREZORS_NEARBY' : 'TR_CHECK_CONNECTED_TREZORS'}
+                    id={
+                        isBluetoothMode
+                            ? 'TR_CONNECT_UNLOCK_BLUETOOTH_DEVICE'
+                            : 'TR_CONNECT_UNLOCK_YOUR_DEVICE'
+                    }
                 />
-            </Text>
-        </Row>
-        {children}
-        <CableConnectionAnimation isBluetoothMode={isBluetoothMode} />
-    </Column>
-);
+            </H3>
+            {!isWebUsbTransport && (
+                <Row gap={8} alignItems="center" justifyContent="center" height={36}>
+                    <Spinner size={16} isGrey={false} />
+                    <Text variant="primary">
+                        <Translation
+                            id={
+                                isBluetoothMode
+                                    ? 'TR_SCAN_TREZORS_NEARBY'
+                                    : 'TR_CHECK_CONNECTED_TREZORS'
+                            }
+                        />
+                    </Text>
+                </Row>
+            )}
+            {children}
+            <CableConnectionAnimation isBluetoothMode={isBluetoothMode} />
+        </Column>
+    );
+};
 
 type ConnectionModeCardProps = {
     onClick: () => void;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

"scanning trezors" shouldn't be visible when there is "find trezor" button

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23709

## Screenshots:

before
<img width="1032" height="1870" alt="image" src="https://github.com/user-attachments/assets/3a19b4da-a042-44c8-8ab8-f8d5ac60bde5" />


after
<img width="546" height="926" alt="image" src="https://github.com/user-attachments/assets/2be3cc66-2c5b-45e7-acb6-55a32bd8ac37" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=hide-scanning-trezors-for-web&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=hide-scanning-trezors-for-web&lookback=7)