### PR TITLE
ci: remove deprecated npmAuthToken

### DIFF
--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -63,18 +63,9 @@ runs:
       shell: bash
       run: node ./scripts/ci/check-version.js ${{ inputs.packageName }} ${{ inputs.deploymentType }}
 
-    - name: Set NPM token
-      shell: bash
-      run: yarn config set npmAuthToken ${{ env.NPM_TOKEN }}
-
     - name: Publish to NPM
       shell: bash
       run: |
         cd ./packages/${{ inputs.packageName }}
         yarn build:lib
         yarn npm publish --tag ${{ inputs.deploymentType }} --access public
-
-    - name: Cleanup
-      shell: bash
-      if: always()
-      run: yarn config unset npmAuthToken


### PR DESCRIPTION
## Description

Follow-up to #23701, we need to remove the NPM token config commands

Failing [here](https://github.com/trezor/trezor-suite/actions/runs/20060986499/job/57538018266)


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci-npm-auth-token&lookback=7)