### PR TITLE
fix(scripts): replace imports cjs parameter

### DIFF
--- a/scripts/publish/prepublish.js
+++ b/scripts/publish/prepublish.js
@@ -16,7 +16,7 @@ if (!isValidPackageName) {
 
 // Run babel with custom plugins to fix non-index internal imports and add .js extensions.
 const scriptPath = path.join(__dirname, 'replace-imports.sh');
-const args = [path.join(__dirname, '..', 'packages', packageName, 'lib')];
+const args = [path.join(__dirname, '..', '..', 'packages', packageName, 'lib'), 'cjs'];
 execFileSync(scriptPath, args, {
     encoding: 'utf-8',
     cwd: __dirname,


### PR DESCRIPTION
## Description

Follow-up to https://github.com/trezor/trezor-suite/commit/9661179627c2d4f3f2f4893e98012c1c3e8211b2
Needed to be updated in prepublish scripts

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/prepublish-replace-imports&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/prepublish-replace-imports&lookback=7)