### PR TITLE
refactor(e2e-suite): adds few text asserts to staking tests

### DIFF
--- a/suite/e2e/support/mocks/solanaStakingMock.ts
+++ b/suite/e2e/support/mocks/solanaStakingMock.ts
@@ -199,7 +199,7 @@ export class SolanaStakingMock {
     enableRoutesForTransactions() {
         // necessary routes for sending and finalizing transactions
         // cannot be enabled during discovery as they would interfere with it
-        this.enableRoutes(['sendTransaction', 'getSignaturesForAddress']);
+        this.enableRoutes(['getTransaction', 'getSignaturesForAddress']);
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/staking/stakingSection.ts
+++ b/suite/e2e/support/pageObjects/staking/stakingSection.ts
@@ -57,6 +57,7 @@ export class StakingSection {
     readonly stakedToast: Locator;
     readonly unstakedToast: Locator;
     readonly claimedToast: Locator;
+    readonly modalHeader: Locator;
 
     constructor(private readonly page: Page) {
         this.rewardList = new RewardsList(page);
@@ -123,6 +124,7 @@ export class StakingSection {
         this.stakedToast = this.page.getByTestId('@toast/tx-staked');
         this.unstakedToast = this.page.getByTestId('@toast/tx-unstaked');
         this.claimedToast = this.page.getByTestId('@toast/tx-claimed');
+        this.modalHeader = this.page.getByTestId('@modal/header');
     }
 
     async expectProgressIndicatorsToMatchPhase(

--- a/suite/e2e/tests/staking/eth/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/eth/initial-stake.test.ts
@@ -72,14 +72,13 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
 
             await test.step('Open and fill staking form', async () => {
                 await stakingSection.startStakingButton.click();
-                await expect(page.getByTestId('@modal/header')).toHaveTranslation(
+                await expect(stakingSection.modalHeader).toHaveTranslation(
                     'TR_STAKE_STAKING_IN_A_NUTSHELL',
                 );
                 await stakingSection.continueButton.click();
-                await expect(page.getByTestId('@modal/header')).toHaveTranslation(
-                    'TR_STAKE_STAKE_TOKEN',
-                    { values: { symbol: 'ETH' } },
-                );
+                await expect(stakingSection.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
+                    values: { symbol: 'ETH' },
+                });
                 await stakingSection.everstakeAcknowledgeCheckbox.click();
                 await stakingSection.confirmButton.click();
                 await expect(stakingSection.availableBalanceWithSymbol).toHaveText('1,234 ETH');

--- a/suite/e2e/tests/staking/sol/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/sol/initial-stake.test.ts
@@ -48,14 +48,13 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
 
             await test.step('Open and fill staking form', async () => {
                 await stakingSection.startStakingButton.click();
-                await expect(page.getByTestId('@modal/header')).toHaveTranslation(
+                await expect(stakingSection.modalHeader).toHaveTranslation(
                     'TR_STAKE_STAKING_IN_A_NUTSHELL',
                 );
                 await stakingSection.continueButton.click();
-                await expect(page.getByTestId('@modal/header')).toHaveTranslation(
-                    'TR_STAKE_STAKE_TOKEN',
-                    { values: { symbol: 'SOL' } },
-                );
+                await expect(stakingSection.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
+                    values: { symbol: 'SOL' },
+                });
                 await stakingSection.everstakeAcknowledgeCheckbox.click();
                 await stakingSection.confirmButton.click();
                 await expect(stakingSection.availableBalanceWithSymbol).toHaveText('1,000 SOL');
@@ -63,6 +62,9 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
             });
 
             await test.step('Initiate staking and confirm on device', async () => {
+                await expect(stakingSection.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
+                    values: { symbol: 'SOL' },
+                });
                 await stakingSection.continueButton.click();
                 await stakingSection.acknowledgeCheckbox.click();
                 await stakingSection.confirmAndStakeButton.click();

--- a/suite/e2e/tests/staking/sol/stake-more.test.ts
+++ b/suite/e2e/tests/staking/sol/stake-more.test.ts
@@ -58,15 +58,17 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
 
             await test.step('Open and fill staking form', async () => {
                 await stakingSection.stakeMoreButton.click();
-                await expect(page.getByTestId('@modal/header')).toHaveTranslation(
-                    'TR_STAKE_STAKE_TOKEN',
-                    { values: { symbol: 'SOL' } },
-                );
+                await expect(stakingSection.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
+                    values: { symbol: 'SOL' },
+                });
                 await expect(stakingSection.availableBalanceWithSymbol).toHaveText('1,000 SOL');
                 await stakingSection.cryptoInput.fill(stakeMoreAmount);
             });
 
             await test.step('Initiate staking and confirm on device', async () => {
+                await expect(stakingSection.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
+                    values: { symbol: 'SOL' },
+                });
                 await stakingSection.continueButton.click();
                 await stakingSection.acknowledgeCheckbox.click();
                 await stakingSection.confirmAndStakeButton.click();

--- a/suite/e2e/tests/staking/sol/unstake.test.ts
+++ b/suite/e2e/tests/staking/sol/unstake.test.ts
@@ -55,6 +55,10 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
 
             await test.step('Open unstaking form', async () => {
                 await stakingSection.unstakeToClaimButton.click();
+                await expect(stakingSection.modalHeader).toHaveTranslation(
+                    'TR_STAKE_UNSTAKE_TOKEN',
+                    { values: { symbol: 'SOL' } },
+                );
                 await expect(stakingSection.availableBalanceWithSymbol).toHaveText(
                     stakedAmountFormatted,
                 );
@@ -63,6 +67,10 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
 
             await test.step('Initiate unstaking and confirm on device', async () => {
                 await stakingSection.unstakeButton.click();
+                await expect(stakingSection.modalHeader).toHaveTranslation(
+                    'TR_STAKE_UNSTAKE_TOKEN',
+                    { values: { symbol: 'SOL' } },
+                );
                 await expect(devicePrompt.outputValueOf('data')).toHaveTranslation(
                     'TR_UNSTAKE_FROM_STAKE_ACCOUNT',
                     { values: { symbol: 'SOL' } },
@@ -125,8 +133,14 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
             });
 
             await test.step('Finish claiming', async () => {
+                await expect(stakingSection.modalHeader).toHaveTranslation('TR_STAKE_CLAIM_TOKEN', {
+                    values: { symbol: 'SOL' },
+                });
                 await expect(stakingSection.claimModalAmount).toHaveText(unstakingAmountFormatted);
                 await stakingSection.claimModalButton.click();
+                await expect(stakingSection.modalHeader).toHaveTranslation('TR_STAKE_CLAIM_TOKEN', {
+                    values: { symbol: 'SOL' },
+                });
                 await expect(devicePrompt.outputValueOf('data')).toHaveTranslation(
                     'TR_CLAIM_FROM_STAKE_ACCOUNT',
                     { values: { symbol: 'SOL' } },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-e2e-staking-headers&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-e2e-staking-headers&lookback=7)