### PR TITLE
CI test

### DIFF
--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -315,6 +315,7 @@ export const LTC_ADDRESS_INFO_URL: Url = withPlatformUtm(
     'https://blog.trezor.io/litecoins-new-p2sh-segwit-addresses-843633e3e707',
 );
 
+// borken
 export const TRADING_DOWNLOAD_INVITY_APP_URL: Url = 'https://invity.onelink.me/yIY4/q7ltbnv0';
 
 // =====================


### PR DESCRIPTION
dont merge this.

Just checking that this unit test is broken on develop: 

```
@trezor/urls:  FAIL  tests/urls.test.ts (42.084 s)
@trezor/urls:   ● Test that all external links are alive › HTTP GET request to https://invity.onelink.me/yIY4/q7ltbnv0 should respond with an acceptable http code
@trezor/urls:     expect(received).toBe(expected) // Object.is equality
@trezor/urls:     Expected: true
@trezor/urls:     Received: false
@trezor/urls: 
@trezor/urls:       65 |             it(`HTTP GET request to ${url} should respond with an acceptable http code`, async () => {
@trezor/urls:       66 |                 const { status } = await fetch(url);
@trezor/urls:     > 67 |                 expect(isAcceptableHttpCode(status)).toBe(true);
@trezor/urls:          |                                                      ^
@trezor/urls:       68 |             });
@trezor/urls:       69 |         });
@trezor/urls:       70 | });
@trezor/urls: 
@trezor/urls:       at Object.toBe (tests/urls.test.ts:67:54)
@trezor/urls: Test Suites: 1 failed, 1 passed, 2 total
@trezor/urls: Tests:       1 failed, 111 passed, 112 total
```