### PR TITLE
fix(urls): unit test for invity link

### DIFF
--- a/packages/urls/tests/urls.test.ts
+++ b/packages/urls/tests/urls.test.ts
@@ -19,6 +19,8 @@ const excluded = [
     URLS.HELP_CENTER_FW_DOWNGRADE_T3W1_URL,
     URLS.HELP_CENTER_SOLANA_HELP_URL,
     URLS.IMAGE_PROXY_API_URL, // returns 'unauthorized'
+    // TODO temporary ignore; fix the link on invity's side
+    URLS.TRADING_DOWNLOAD_INVITY_APP_URL,
 ];
 
 // Sometimes we run test too much, I guess....


### PR DESCRIPTION
Temporarily exclude [https://invity.onelink.me/yIY4/q7ltbnv0](https://invity.onelink.me/yIY4/q7ltbnv0) from unit tests.
It is broken and must be resolved on invity's side.

Currently it goes 301 to a not found page on :apple: appstore https://apps.apple.com/CZ/app/id6446398883?mt=8
Though looking at the usage, this link should be for both apple and android.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=hotfix-urls-unit-test&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=hotfix-urls-unit-test&lookback=7)