### PR TITLE
Chore: protocol-v2 message type

### DIFF
--- a/packages/protocol/src/protocol-bridge/encode.ts
+++ b/packages/protocol/src/protocol-bridge/encode.ts
@@ -9,9 +9,6 @@ export const getHeaders: TransportProtocol['getHeaders'] = () => [Buffer.alloc(0
 // it is because bridge does some parts of the protocol itself (like chunking)
 export const encode: TransportProtocol['encode'] = (data, options) => {
     const { messageType } = options;
-    if (typeof messageType === 'string') {
-        throw new Error(`Unsupported message type ${messageType}`);
-    }
 
     const encodedBuffer = Buffer.alloc(HEADER_SIZE + data.length);
 

--- a/packages/protocol/src/protocol-thp/decode.ts
+++ b/packages/protocol/src/protocol-thp/decode.ts
@@ -7,10 +7,8 @@ import { crc32 } from './crypto/crc32';
 import { getHandshakeHash, getTrezorState } from './crypto/pairing';
 import { getIvFromNonce } from './crypto/tools';
 import { ThpDeviceProperties, ThpError, ThpMessageResponse } from './messages';
-import { readThpHeader } from './utils';
 
 type ThpMessage = ReturnType<TransportProtocolDecode> & {
-    magic: number;
     thpState: ThpState;
 };
 
@@ -179,11 +177,11 @@ const validateCrc = (decodedMessage: ReturnType<TransportProtocolDecode>) => {
 export const decodeSendAck = (decodedMessage: MessageV2) => {
     validateCrc(decodedMessage);
 
-    const { magic } = readThpHeader(decodedMessage.header);
-    if (magic === THP_CONTROL_BYTE.ERROR) {
+    const { messageType } = decodedMessage;
+    if (messageType === THP_CONTROL_BYTE.ERROR) {
         return decodeThpError(decodedMessage.payload);
     }
-    if (magic === THP_CONTROL_BYTE.ACK_MESSAGE) {
+    if (messageType === THP_CONTROL_BYTE.ACK_MESSAGE) {
         return decodeReadAck();
     }
 };
@@ -200,37 +198,35 @@ export const decode = (
 
     validateCrc(decodedMessage);
 
-    const header = readThpHeader(decodedMessage.header);
     const message: ThpMessage = {
         ...decodedMessage,
-        ...header,
         thpState,
     };
 
-    const { magic } = header;
-    if (magic === THP_CONTROL_BYTE.ERROR) {
+    const { messageType } = decodedMessage;
+    if (messageType === THP_CONTROL_BYTE.ERROR) {
         return decodeThpError(message.payload);
     }
 
-    if (magic === THP_CONTROL_BYTE.ACK_MESSAGE) {
+    if (messageType === THP_CONTROL_BYTE.ACK_MESSAGE) {
         return decodeReadAck();
     }
 
-    if (magic === THP_CONTROL_BYTE.CHANNEL_ALLOCATION_RES) {
+    if (messageType === THP_CONTROL_BYTE.CHANNEL_ALLOCATION_RES) {
         return createChannelResponse(message, protobufDecoder);
     }
 
-    if (magic === THP_CONTROL_BYTE.HANDSHAKE_INIT_RES) {
+    if (messageType === THP_CONTROL_BYTE.HANDSHAKE_INIT_RES) {
         return readHandshakeInitResponse(message);
     }
 
-    if (magic === THP_CONTROL_BYTE.HANDSHAKE_COMP_RES) {
+    if (messageType === THP_CONTROL_BYTE.HANDSHAKE_COMP_RES) {
         return readHandshakeCompletionResponse(message);
     }
 
-    if (magic === THP_CONTROL_BYTE.ENCRYPTED) {
+    if (messageType === THP_CONTROL_BYTE.ENCRYPTED) {
         return readProtobufMessage(message, protobufDecoder);
     }
 
-    throw new Error('Unknown message type: ' + magic);
+    throw new Error('Unknown message type: ' + messageType);
 };

--- a/packages/protocol/src/protocol-v1/encode.ts
+++ b/packages/protocol/src/protocol-v1/encode.ts
@@ -18,10 +18,6 @@ export const getHeaders: TransportProtocol['getHeaders'] = () => {
 
 export const encode: TransportProtocol['encode'] = (data, options) => {
     const { messageType } = options;
-    if (typeof messageType === 'string') {
-        throw new Error(`Unsupported message type ${messageType}`);
-    }
-
     const fullSize = HEADER_SIZE + data.length;
 
     const encodedBuffer = Buffer.alloc(fullSize);

--- a/packages/protocol/src/protocol-v2/constants.ts
+++ b/packages/protocol/src/protocol-v2/constants.ts
@@ -1,6 +1,5 @@
 export const HEADER_SIZE = 1 + 2; // 1: control_byte + 2: channel
 export const MESSAGE_LEN_SIZE = 2;
-export const MESSAGE_TYPE = 'TrezorHostProtocolMessage';
 
 // https://github.com/trezor/trezor-firmware/blob/dc7dccfa6c6121333f732c39565878fc46e67085/core/src/trezor/wire/thp/__init__.py
 export const THP_CONTROL_BYTE = {

--- a/packages/protocol/src/protocol-v2/decode.ts
+++ b/packages/protocol/src/protocol-v2/decode.ts
@@ -1,5 +1,5 @@
 import * as ERRORS from '../errors';
-import { HEADER_SIZE, MESSAGE_LEN_SIZE, MESSAGE_TYPE, THP_CONTROL_BYTE } from './constants';
+import { HEADER_SIZE, MESSAGE_LEN_SIZE, THP_CONTROL_BYTE } from './constants';
 import { getHeaders } from './encode';
 import { TransportProtocolDecode } from '../types';
 
@@ -56,7 +56,7 @@ export const decode: TransportProtocolDecode = bytes => {
         header,
         chunkHeader,
         length: buffer.readUint16BE(HEADER_SIZE),
-        messageType: MESSAGE_TYPE, // will be decoded by `protocol-thp`, TODO messageType
+        messageType,
         payload: buffer.subarray(HEADER_SIZE + MESSAGE_LEN_SIZE),
     };
 };

--- a/packages/protocol/src/protocol-v2/encode.ts
+++ b/packages/protocol/src/protocol-v2/encode.ts
@@ -1,5 +1,5 @@
 import * as ERRORS from '../errors';
-import { HEADER_SIZE, MESSAGE_LEN_SIZE, MESSAGE_TYPE, THP_CONTROL_BYTE } from './constants';
+import { HEADER_SIZE, MESSAGE_LEN_SIZE, THP_CONTROL_BYTE } from './constants';
 import { TransportProtocol } from '../types';
 
 const getChunkHeader = (data: Buffer) => {
@@ -22,18 +22,12 @@ export const getHeaders: TransportProtocol['getHeaders'] = data => {
 
 // encode `protocol-thp` message
 export const encode: TransportProtocol['encode'] = (data, options) => {
-    if (options.messageType === MESSAGE_TYPE) {
-        if (!options.header || options.header.byteLength !== HEADER_SIZE) {
-            throw new Error(
-                `${options.messageType} unexpected header ${options.header?.toString('hex')}`,
-            );
-        }
-
-        const length = Buffer.alloc(MESSAGE_LEN_SIZE);
-        length.writeUInt16BE(data.length);
-
-        return Buffer.concat([options.header, length, data]);
+    if (!options.header || options.header.byteLength !== HEADER_SIZE) {
+        throw new Error(ERRORS.PROTOCOL_MALFORMED);
     }
 
-    throw new Error(`Use protocol-thp.encode for messageType ${options.messageType}`);
+    const length = Buffer.alloc(MESSAGE_LEN_SIZE);
+    length.writeUInt16BE(data.length);
+
+    return Buffer.concat([options.header, length, data]);
 };

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -8,12 +8,12 @@ export type { ThpState, ThpStateSerialized, ThpChannelState } from './protocol-t
 export type TransportProtocolDecode = (bytes: Buffer) => {
     header: Buffer;
     length: number;
-    messageType: number | string;
+    messageType: number;
     payload: Buffer;
 };
 
 export interface TransportProtocolEncodeOptions {
-    messageType: number | string;
+    messageType: number;
     header?: Buffer;
 }
 

--- a/packages/protocol/tests/protocol-bridge.test.ts
+++ b/packages/protocol/tests/protocol-bridge.test.ts
@@ -12,11 +12,6 @@ describe('protocol-bridge', () => {
         expect(result.subarray(0, 6).toString('hex')).toEqual('003700000173');
         expect(result.readUint32BE(2)).toEqual(371);
         expect(result.length).toEqual(371 + 6);
-
-        // fail to encode unsupported messageType (string)
-        expect(() => bridge.encode(Buffer.alloc(64), { messageType: 'Initialize' })).toThrow(
-            'Unsupported message type Initialize',
-        );
     });
 
     it('decode', () => {

--- a/packages/protocol/tests/protocol-v1.test.ts
+++ b/packages/protocol/tests/protocol-v1.test.ts
@@ -13,11 +13,6 @@ describe('protocol-v1', () => {
         expect(result.length).toEqual(371 + HEADER_SIZE);
         expect(result.subarray(0, HEADER_SIZE).toString('hex')).toEqual('3f2323003700000173');
         expect(result.subarray(HEADER_SIZE).toString('hex')).toEqual('a3'.repeat(371));
-
-        // fail to encode unsupported messageType (string)
-        expect(() => v1.encode(Buffer.alloc(64), { messageType: 'Initialize' })).toThrow(
-            'Unsupported message type Initialize',
-        );
     });
 
     it('decode', () => {

--- a/packages/protocol/tests/protocol-v2.test.ts
+++ b/packages/protocol/tests/protocol-v2.test.ts
@@ -1,7 +1,8 @@
 import { decode, encode, getHeaders } from '../src/protocol-v2';
+import { THP_CONTROL_BYTE } from '../src/protocol-v2/constants';
 
 describe('protocol-v2', () => {
-    it('encode/decode TrezorHostProtocolMessage', () => {
+    it('encode/decode v2 message', () => {
         // ThpCreateNewSession message
         const data = Buffer.from(
             '04123800230003e80a0870617373313233341000a0a1a2a3a4a5a6a7a8a9b0b1b2b3b4b504db712b',
@@ -9,7 +10,7 @@ describe('protocol-v2', () => {
         );
 
         const decoded = decode(data);
-        expect(decoded.messageType).toEqual('TrezorHostProtocolMessage');
+        expect(decoded.messageType).toEqual(THP_CONTROL_BYTE.ENCRYPTED);
         expect(decoded.header).toEqual(data.subarray(0, 3));
         expect(decoded.length).toEqual(35);
         expect(decoded.payload).toEqual(data.subarray(5, 5 + 35));
@@ -20,23 +21,20 @@ describe('protocol-v2', () => {
 
     it('encode with error', () => {
         expect(() => encode(Buffer.alloc(0), { messageType: 1 })).toThrow(
-            'Use protocol-thp.encode',
-        );
-        expect(() => encode(Buffer.alloc(0), { messageType: 'TrezorHostProtocolMessage' })).toThrow(
-            'unexpected header undefined',
+            'Malformed protocol format',
         );
         expect(() =>
             encode(Buffer.alloc(0), {
-                messageType: 'TrezorHostProtocolMessage',
+                messageType: 1,
                 header: Buffer.alloc(1),
             }),
-        ).toThrow('unexpected header 00');
+        ).toThrow('Malformed protocol format');
         expect(() =>
             encode(Buffer.alloc(0), {
-                messageType: 'TrezorHostProtocolMessage',
+                messageType: 1,
                 header: Buffer.alloc(4),
             }),
-        ).toThrow('unexpected header 00000000');
+        ).toThrow('Malformed protocol format');
     });
 
     it('decode with error', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

🧹🧹🧹 follow up for https://github.com/trezor/trezor-suite/pull/23219

- return `messageType` as number from **protocol-v2** decode
- partially revert[ this commit](https://github.com/trezor/trezor-suite/commit/ae3211ab6a9c7021b9e0a4038a9fa7e913a9fa25) protocolDecode.messageType => `number`
- use messageType from decoded v2 message in **protocol-thp** decode

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/v2-message-type&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/v2-message-type&lookback=7)