### PR TITLE
chore(firmware-authenticity): replace wallet-core import with parameter

### DIFF
--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -7,7 +7,7 @@ import { Card } from '@trezor/components';
 import * as analyticsActions from 'src/actions/suite/analyticsActions';
 import { init } from 'src/actions/suite/initAction';
 import { useGuideKeyboard } from 'src/hooks/guide';
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { useWindowVisibility } from 'src/hooks/suite/useWindowVisibility';
 import {
     selectIsTransportInitialized,
@@ -52,7 +52,8 @@ export const Preloader = ({ children }: PropsWithChildren) => {
     );
     const isAnalyticsConsentConfirmed = useSelector(selectIsAnalyticsConfirmed);
 
-    useReportDeviceCompromised();
+    const { device } = useDevice();
+    useReportDeviceCompromised({ device });
     useDeviceCompromisedNotification();
 
     const dispatch = useDispatch();

--- a/suite-common/firmware-authenticity/package.json
+++ b/suite-common/firmware-authenticity/package.json
@@ -14,7 +14,6 @@
         "@suite-common/firmware": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
-        "@suite-common/wallet-core": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
+++ b/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
@@ -2,8 +2,8 @@ import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { selectFirmwareUpdateSource } from '@suite-common/firmware';
+import { TrezorDevice } from '@suite-common/suite-types';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
-import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { FIRMWARE } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { isArrayMember } from '@trezor/utils';
@@ -11,8 +11,10 @@ import { isArrayMember } from '@trezor/utils';
 import { reportSecurityCheckThunk } from './reportSecurityCheckThunk';
 import { hashCheckErrorScenarios, revisionCheckErrorScenarios } from './scenariosConfig';
 
-const useCommonData = () => {
-    const device = useSelector(selectSelectedDevice);
+// to avoid unnecessary wallet-core import
+type CommonProps = { device: TrezorDevice | undefined };
+
+const useCommonData = ({ device }: CommonProps) => {
     const model = device?.features?.internal_model;
     const revision = device?.features?.revision;
     const version = getFirmwareVersion(device);
@@ -24,10 +26,9 @@ const useCommonData = () => {
     );
 };
 
-const useReportRevisionCheck = () => {
+const useReportRevisionCheck = ({ device }: CommonProps) => {
     const dispatch = useDispatch();
-    const device = useSelector(selectSelectedDevice);
-    const commonData = useCommonData();
+    const commonData = useCommonData({ device });
     const firmwareSource = useSelector(selectFirmwareUpdateSource);
 
     const revisionCheck = isDeviceAcquired(device)
@@ -57,10 +58,9 @@ const useReportRevisionCheck = () => {
     }, [dispatch, commonData, errorType, errorPayload, shouldReport]);
 };
 
-const useReportHashCheck = () => {
+const useReportHashCheck = ({ device }: CommonProps) => {
     const dispatch = useDispatch();
-    const device = useSelector(selectSelectedDevice);
-    const commonData = useCommonData();
+    const commonData = useCommonData({ device });
     const firmwareSource = useSelector(selectFirmwareUpdateSource);
 
     const hashCheck = isDeviceAcquired(device) ? device.authenticityChecks.firmwareHash : null;
@@ -114,7 +114,7 @@ const useReportHashCheck = () => {
  * Optionally report both FW authenticity checks (revision and hash) to Sentry and/or show toast notifications,
  * based on behavior scenarios definitions. This may happen even when no UI is displayed for the checks.
  */
-export const useReportDeviceCompromised = () => {
-    useReportRevisionCheck();
-    useReportHashCheck();
+export const useReportDeviceCompromised = ({ device }: CommonProps) => {
+    useReportRevisionCheck({ device });
+    useReportHashCheck({ device });
 };

--- a/suite-common/firmware-authenticity/tsconfig.json
+++ b/suite-common/firmware-authenticity/tsconfig.json
@@ -5,7 +5,6 @@
         { "path": "../firmware" },
         { "path": "../redux-utils" },
         { "path": "../suite-utils" },
-        { "path": "../wallet-core" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/utils" },

--- a/suite-native/app/src/hooks/useGlobalHooks.tsx
+++ b/suite-native/app/src/hooks/useGlobalHooks.tsx
@@ -1,4 +1,7 @@
+import { useSelector } from 'react-redux';
+
 import { useReportDeviceCompromised } from '@suite-common/firmware-authenticity';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { useBluetoothAdapter } from '@suite-native/bluetooth';
 import {
     useDetectDeviceError,
@@ -14,13 +17,15 @@ import { useConnectPopupNavigation } from '@suite-native/module-connect-popup';
  * that are supposed to be active globally once the app is ready.
  */
 export const useGlobalHooks = () => {
+    const device = useSelector(selectSelectedDevice);
+
     useConnectPopupNavigation();
 
     useBluetoothAdapter();
 
     useDetectDeviceError();
     useHandleDeviceAuthorization();
-    useReportDeviceCompromised();
+    useReportDeviceCompromised({ device });
     useRenderDeviceDangerBanner();
     useDeviceCompromisedNotification();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10942,7 +10942,6 @@ __metadata:
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
-    "@suite-common/wallet-core": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"


### PR DESCRIPTION
## Description

Unlink `firmware-authenticity` package from `wallet-core` by simply passing a parameter.

## Notes for QA

I verified locally at [reportSecurityCheckThunk](https://github.com/trezor/trezor-suite/blob/00edb4eaeb98bd6c54dddf2a2dc1081f5d73a209/suite-common/firmware-authenticity/src/reportSecurityCheckThunk.ts) that all props are correctly passed as they should.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-wallet-core-dependency&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-wallet-core-dependency&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/remove-wallet-core-dependency&lookback=7)