### PR TITLE
feat(suite-native): show icon and Beta badge for firmware languages

### DIFF
--- a/suite-common/suite-types/src/languages.ts
+++ b/suite-common/suite-types/src/languages.ts
@@ -1,4 +1,5 @@
 export type LocaleInfo = {
+    icon: string;
     name: string;
     en: string;
     type: 'official' | 'community';
@@ -7,25 +8,27 @@ export type LocaleInfo = {
 
 // If you are adding language, add it to suite/package.json translations:download script too
 export const LANGUAGES = {
-    'en-US': { name: 'English', en: 'English', type: 'official' },
-    'es-ES': { name: 'Español', en: 'Spanish', type: 'official' },
-    'cs-CZ': { name: 'Čeština', en: 'Czech', type: 'official' },
-    'de-DE': { name: 'Deutsch', en: 'German', type: 'official' },
-    'fr-FR': { name: 'Français', en: 'French', type: 'official' },
-    'hu-HU': { name: 'Magyar', en: 'Hungarian', type: 'community' },
-    'it-IT': { name: 'Italiano', en: 'Italian', type: 'community' },
-    'ja-JP': { name: '日本語', en: 'Japanese', type: 'official' },
-    'pt-BR': { name: 'Português (BR)', en: 'Portuguese (BR)', type: 'official' },
-    'ru-RU': { name: 'Русский', en: 'Russian', type: 'community' },
-    'tr-TR': { name: 'Türkçe', en: 'Turkish', type: 'community' },
-    'uk-UA': { name: 'Українська', en: 'Ukrainian', type: 'community' },
+    'en-US': { icon: '🇬🇧', name: 'English', en: 'English', type: 'official' },
+    'es-ES': { icon: '🇪🇸', name: 'Español', en: 'Spanish', type: 'official' },
+    'cs-CZ': { icon: '🇨🇿', name: 'Čeština', en: 'Czech', type: 'official' },
+    'de-DE': { icon: '🇩🇪', name: 'Deutsch', en: 'German', type: 'official' },
+    'fr-FR': { icon: '🇫🇷', name: 'Français', en: 'French', type: 'official' },
+    'hu-HU': { icon: '🇭🇺', name: 'Magyar', en: 'Hungarian', type: 'community' },
+    'it-IT': { icon: '🇮🇹', name: 'Italiano', en: 'Italian', type: 'community' },
+    'ja-JP': { icon: '🇯🇵', name: '日本語', en: 'Japanese', type: 'official' },
+    'pt-BR': { icon: '🇧🇷', name: 'Português (BR)', en: 'Portuguese (BR)', type: 'official' },
+    'ru-RU': { icon: '🇷🇺', name: 'Русский', en: 'Russian', type: 'community' },
+    'tr-TR': { icon: '🇹🇷', name: 'Türkçe', en: 'Turkish', type: 'community' },
+    'uk-UA': { icon: '🇺🇦', name: 'Українська', en: 'Ukrainian', type: 'community' },
     'zh-CN': {
+        icon: '简',
         name: '中文(简体)',
         en: 'Chinese Simplified',
         type: 'community',
         nameInOsStartsWith: 'zh-Hans',
     },
     'zh-TW': {
+        icon: '繁',
         name: '中文(繁體)',
         en: 'Chinese Traditional',
         type: 'community',

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -159,9 +159,21 @@ export const selectSupportedDeviceLanguages = createMemoizedSelector(
     availableDeviceTranslations => {
         const supportedDeviceLanguages = Object.entries(LANGUAGES)
             .filter(([code]) => availableDeviceTranslations[code])
-            .map(([code, { name }]) => ({ value: code as Locale, label: `${name} (beta)` }))
+            .map(([code, { icon, name }]) => ({
+                value: code as Locale,
+                icon,
+                label: name,
+                isBeta: true, // TODO: This will need tweaking in the future.
+            }))
             .sort((a, b) => a.label.localeCompare(b.label));
-        supportedDeviceLanguages.unshift({ value: 'en-US', label: LANGUAGES['en-US'].name });
+
+        const { icon, name } = LANGUAGES['en-US'];
+        supportedDeviceLanguages.unshift({
+            value: 'en-US',
+            icon,
+            label: name,
+            isBeta: false,
+        });
 
         return supportedDeviceLanguages;
     },

--- a/suite-native/atoms/src/Select/Select.tsx
+++ b/suite-native/atoms/src/Select/Select.tsx
@@ -14,6 +14,8 @@ import { SelectTrigger } from './SelectTrigger';
 export type SelectItemType<TItemValue extends SelectItemValue> = {
     value: TItemValue;
     label: string;
+    icon?: ReactNode;
+    badge?: ReactNode;
 };
 
 type SelectProps<TItemValue extends SelectItemValue> = {
@@ -35,8 +37,8 @@ export const Select = <TItemValue extends SelectItemValue>({
 }: SelectProps<TItemValue>) => {
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
 
-    const selectTriggerValue = useMemo(
-        () => items.find(item => item.value === value)?.label ?? null,
+    const selectTriggerItem = useMemo(
+        () => items.find(item => item.value === value),
         [items, value],
     );
 
@@ -83,19 +85,22 @@ export const Select = <TItemValue extends SelectItemValue>({
                 isCloseDisplayed
             >
                 <VStack spacing="sp12">
-                    {items.map(({ value: itemValue, label }) => (
+                    {items.map(({ value: itemValue, label, icon, badge }) => (
                         <SelectItem
                             key={itemValue}
                             label={label}
                             value={itemValue}
                             isSelected={itemValue === selectedItemValue}
                             onSelect={() => handleSelectItem(itemValue)}
+                            icon={icon}
+                            badge={badge}
                         />
                     ))}
                 </VStack>
             </BottomSheetModal>
             <SelectTrigger
-                value={selectTriggerValue}
+                value={selectTriggerItem?.label ?? null}
+                icon={selectTriggerItem?.icon}
                 handlePress={openBottomSheet}
                 testID={testID}
             />

--- a/suite-native/atoms/src/Select/SelectItem.tsx
+++ b/suite-native/atoms/src/Select/SelectItem.tsx
@@ -7,6 +7,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { Box } from '../Box';
 import { Radio } from '../Radio';
+import { HStack } from '../Stack';
 import { Text } from '../Text';
 
 export type SelectItemValue = string | number;
@@ -16,6 +17,7 @@ export type SelectItemProps = {
     onSelect: () => void;
     isSelected: boolean;
     icon?: ReactNode;
+    badge?: ReactNode;
 };
 
 type SelectItemStyleProps = {
@@ -23,8 +25,6 @@ type SelectItemStyleProps = {
 };
 
 const selectItemStyle = prepareNativeStyle(utils => ({
-    flexDirection: 'row',
-    alignItems: 'center',
     ...utils.boxShadows.small,
 }));
 
@@ -51,7 +51,14 @@ const selectItemContentStyle = prepareNativeStyle<SelectItemStyleProps>(
     }),
 );
 
-export const SelectItem = ({ label, value, onSelect, isSelected, icon }: SelectItemProps) => {
+export const SelectItem = ({
+    label,
+    value,
+    onSelect,
+    isSelected,
+    icon,
+    badge,
+}: SelectItemProps) => {
     const { applyStyle } = useNativeStyles();
 
     if (G.isNullable(value)) return null;
@@ -65,13 +72,18 @@ export const SelectItem = ({ label, value, onSelect, isSelected, icon }: SelectI
             accessibilityLabel={label}
             testID={`@select/item/${value}`}
         >
-            {icon}
             <Box
                 style={applyStyle(selectItemContentStyle, { isSelected })}
                 testID={`@select/item/${value}/content`}
             >
-                <Text numberOfLines={1}>{label}</Text>
-                <Radio value={value} onPress={onSelect} isChecked={isSelected} />
+                <HStack>
+                    {icon}
+                    <Text numberOfLines={1}>{label}</Text>
+                </HStack>
+                <HStack spacing="sp12">
+                    {badge}
+                    <Radio value={value} onPress={onSelect} isChecked={isSelected} />
+                </HStack>
             </Box>
         </TouchableOpacity>
     );

--- a/suite-native/atoms/src/Select/SelectTrigger.tsx
+++ b/suite-native/atoms/src/Select/SelectTrigger.tsx
@@ -4,7 +4,7 @@ import { TouchableOpacity } from 'react-native';
 import { Icon } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
-import { Box } from '../Box';
+import { HStack } from '../Stack';
 import { ACCESSIBILITY_FONTSIZE_MULTIPLIER, Text } from '../Text';
 
 type SelectTriggerProps = {
@@ -30,21 +30,17 @@ const selectStyle = prepareNativeStyle(utils => ({
     height: SELECT_HEIGHT,
 }));
 
-const iconWrapperStyle = prepareNativeStyle(() => ({ marginRight: 1 }));
-
 export const SelectTrigger = ({ value, icon, handlePress, testID }: SelectTriggerProps) => {
     const { applyStyle } = useNativeStyles();
 
     return (
         <TouchableOpacity onPress={handlePress} style={applyStyle(selectStyle)} testID={testID}>
-            <Box flexDirection="row" alignItems="center">
-                <Text numberOfLines={1}>
-                    {icon && <Box style={applyStyle(iconWrapperStyle)}>{icon}</Box>}
-                    <Text numberOfLines={1} ellipsizeMode="tail">
-                        {value}
-                    </Text>
+            <HStack alignItems="center">
+                {icon}
+                <Text numberOfLines={1} ellipsizeMode="tail">
+                    {value}
                 </Text>
-            </Box>
+            </HStack>
             <Icon size="large" color="iconSubdued" name="caretDown" />
         </TouchableOpacity>
     );

--- a/suite-native/firmware/src/components/FirmwareLanguageCard.tsx
+++ b/suite-native/firmware/src/components/FirmwareLanguageCard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { Locale } from '@suite-common/suite-types';
@@ -6,11 +7,15 @@ import {
     selectIsDeviceLanguageConfigurable,
     selectSupportedDeviceLanguages,
 } from '@suite-common/wallet-core';
-import { Card, HStack, Select, Text, VStack } from '@suite-native/atoms';
+import { Badge, Card, HStack, Select, Text, VStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 
 import { useFirmwareLanguage } from '../hooks/useFirmwareLanguage';
+
+const BetaBadge = () => (
+    <Badge label={<Translation id="firmware.languageCard.betaBadge" />} variant="blue" />
+);
 
 export const FirmwareLanguageCard = () => {
     const { changeFirmwareLanguage } = useFirmwareLanguage();
@@ -18,6 +23,17 @@ export const FirmwareLanguageCard = () => {
     const isDeviceLanguageConfigurable = useSelector(selectIsDeviceLanguageConfigurable);
     const supportedDeviceLanguages = useSelector(selectSupportedDeviceLanguages);
     const deviceLanguage = useSelector(selectDeviceLanguage);
+
+    const deviceLanguageItems = useMemo(
+        () =>
+            supportedDeviceLanguages.map(({ value, icon, label, isBeta }) => ({
+                value,
+                label,
+                icon: <Text>{icon}</Text>,
+                badge: isBeta && <BetaBadge />,
+            })),
+        [supportedDeviceLanguages],
+    );
 
     const changeFirmwareLanguageIfDifferent = (language: Locale) => {
         if (language !== deviceLanguage) {
@@ -38,10 +54,10 @@ export const FirmwareLanguageCard = () => {
                         <Translation id="firmware.languageCard.title" />
                     </Text>
                 </HStack>
-                <Select
-                    items={supportedDeviceLanguages}
-                    value={deviceLanguage}
+                <Select<Locale>
                     title={<Translation id="firmware.languageCard.title" />}
+                    items={deviceLanguageItems}
+                    value={deviceLanguage}
                     onSelectItem={changeFirmwareLanguageIfDifferent}
                     isConfirmable
                 />

--- a/suite-native/intl/src/languages.ts
+++ b/suite-native/intl/src/languages.ts
@@ -4,9 +4,9 @@ export const DEFAULT_LOCALE = 'en-US';
 export type LocaleCode = `${string}-${string}`;
 
 export const LANGUAGES = {
-    'en-US': { name: 'English', en: 'English', type: 'official' },
-    'cs-CZ': { name: 'Čeština', en: 'Czech', type: 'official' },
-    'de-DE': { name: 'Deutsch', en: 'German', type: 'official' },
-    'pt-BR': { name: 'Português (BR)', en: 'Portuguese (BR)', type: 'official' },
-    'ja-JP': { name: '日本語', en: 'Japanese', type: 'official' },
+    'en-US': { icon: '🇬🇧', name: 'English', en: 'English', type: 'official' },
+    'cs-CZ': { icon: '🇨🇿', name: 'Čeština', en: 'Czech', type: 'official' },
+    'de-DE': { icon: '🇩🇪', name: 'Deutsch', en: 'German', type: 'official' },
+    'pt-BR': { icon: '🇧🇷', name: 'Português (BR)', en: 'Portuguese (BR)', type: 'official' },
+    'ja-JP': { icon: '🇯🇵', name: '日本語', en: 'Japanese', type: 'official' },
 } as const satisfies Record<LocaleCode, LocaleInfo>;

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2633,6 +2633,7 @@ export const messages = {
         },
         languageCard: {
             title: 'Language',
+            betaBadge: 'Beta',
         },
         changeLanguage: {
             success: `Language changed to {languageName}`,


### PR DESCRIPTION
- Added `icon` property to Suite supported languages
- Updated `selectSupportedDeviceLanguages` to return new common properties
- Flag and Beta badge shown for firmware languages

## Screenshots:
| Closed | Opened | New selection |
| --- | --- | --- |
| <img width="1080" height="2340" alt="Screenshot_20251211_113026" src="https://github.com/user-attachments/assets/179b04da-d5c5-4898-8aef-100ac48da241" /> | <img width="1080" height="2340" alt="Screenshot_20251211_113047" src="https://github.com/user-attachments/assets/9745aaaa-af49-42d7-a8aa-c15371f3c775" /> | <img width="1080" height="2340" alt="Screenshot_20251211_113054" src="https://github.com/user-attachments/assets/beeea795-722c-4944-b794-14f552dcf130" /> |


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/firmware-language-flag&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/firmware-language-flag&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/firmware-language-flag&lookback=7)