### PR TITLE
feat(suite): label for low balance accounts in sidebar

### DIFF
--- a/packages/suite/src/components/suite/CoinBalance.tsx
+++ b/packages/suite/src/components/suite/CoinBalance.tsx
@@ -6,18 +6,21 @@ import { FormattedCryptoAmount } from 'src/components/suite';
 interface CoinBalanceProps {
     value: string | AmountUnit; // Todo: `string` only for back compatibility
     symbol: NetworkSymbolExtended;
+    showApproximation?: boolean;
     'data-testid'?: string;
 }
 
 export const CoinBalance = ({
     value,
     symbol,
+    showApproximation,
     'data-testid': dataTestId = '@dashboard',
 }: CoinBalanceProps) => (
     <FormattedCryptoAmount
         value={value}
         symbol={symbol}
         isBalance
+        showApproximation={showApproximation}
         data-testid={`${dataTestId}/coin-balance/value-${symbol}`}
     />
 );

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import styled from 'styled-components';
 
 import { isSignValuePositive } from '@suite-common/formatters';
@@ -7,6 +9,7 @@ import {
     getDisplaySymbol,
     getNetworkOptional,
 } from '@suite-common/wallet-config';
+import { LOW_BALANCE_THRESHOLD } from '@suite-common/wallet-constants';
 import {
     AmountUnit,
     formatCoinBalance,
@@ -15,6 +18,7 @@ import {
 } from '@suite-common/wallet-utils';
 import { Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { BigNumber } from '@trezor/utils';
 
 import { HiddenPlaceholder, Sign } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
@@ -36,6 +40,7 @@ export interface FormattedCryptoAmountProps {
     symbol?: NetworkSymbolExtended;
     contractAddress?: string | null;
     isBalance?: boolean;
+    showApproximation?: boolean;
     signValue?: SignValue;
     disableHiddenPlaceholder?: boolean;
     /**
@@ -52,6 +57,7 @@ export const FormattedCryptoAmount = ({
     symbol,
     contractAddress, // include contractAddress whenever the symbol is an token
     isBalance,
+    showApproximation = false,
     signValue,
     disableHiddenPlaceholder,
     isRawString,
@@ -62,6 +68,13 @@ export const FormattedCryptoAmount = ({
     const locale = useSelector(selectLanguage);
 
     const { areSatsDisplayed } = useBitcoinAmountUnit();
+
+    const isAmountLow = useMemo(() => {
+        if (!value || !showApproximation) return false;
+        const valueBn = new BigNumber(value);
+
+        return !valueBn.isZero() && valueBn.lt(LOW_BALANCE_THRESHOLD);
+    }, [value, showApproximation]);
 
     if (!value) {
         return null;
@@ -89,11 +102,14 @@ export const FormattedCryptoAmount = ({
     }
 
     // format truncation + locale (used for balances) or just locale
-    if (isBalance) {
+    if (isBalance && !isAmountLow) {
         formattedValue = formatCoinBalance(String(formattedValue), locale);
     } else {
         formattedValue = localizeNumber(formattedValue, locale);
     }
+
+    // prefix balance with < if it's below threshold
+    formattedValue = isAmountLow ? `< ${LOW_BALANCE_THRESHOLD}` : formattedValue;
 
     // output as a string, mostly for compatibility with graphs
     if (isRawString) {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/AccountItemContent.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/AccountItemContent.tsx
@@ -95,6 +95,7 @@ export const AccountItemContent = ({
                             data-testid="@wallet"
                             value={formattedBalance}
                             symbol={account.symbol}
+                            showApproximation
                         />
                     )}
                 </Column>
@@ -133,6 +134,7 @@ export const AccountItemContent = ({
                             data-testid="@wallet"
                             value={formattedBalance}
                             symbol={account.symbol}
+                            showApproximation
                         />
                     )}
                     {!isBalanceShown && <BalancePlaceholder networkSymbol={account.symbol} />}

--- a/suite-common/wallet-constants/src/accountConstants.ts
+++ b/suite-common/wallet-constants/src/accountConstants.ts
@@ -1,0 +1,5 @@
+/**
+ * used for showing approximate account balance if below this threshold
+ * less than 1 USD for BTC, even less for other coins/tokens
+ */
+export const LOW_BALANCE_THRESHOLD = '0.00001';

--- a/suite-common/wallet-constants/src/index.ts
+++ b/suite-common/wallet-constants/src/index.ts
@@ -5,3 +5,4 @@ export * from './ethereumStakingConstants';
 export * from './solanaStakingConstants';
 export * from './cardanoConstants';
 export * from './stakingConstants';
+export * from './accountConstants';


### PR DESCRIPTION
## Description

If account balance is below `0.00001` crypto, display it as `< 0.00001` instead of `0.00` (in sidebar only).

The reason behind the `0.00001` threshold is that `0.00001 BTC` is less than `1 USD` (even less for other coins and tokens), discussed with @matous-jemelka and @shenkys .

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13626

## Screenshots:

Non-zero, but low balance (Base):

<img width="100%" alt="Screenshot 2025-12-10 at 16 29 11" src="https://github.com/user-attachments/assets/054f8986-05a2-4f9d-b317-baf80f2e0871" />

Zero balance (ETH):

<img width="100%" alt="Screenshot 2025-12-10 at 16 46 22" src="https://github.com/user-attachments/assets/e49cde09-cf31-4a8f-bec0-2c944bf525eb" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/account-low-balance&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/account-low-balance&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/account-low-balance&lookback=7)