### PR TITLE
feat(suite-native): use PressableOpacity for device connect cards

### DIFF
--- a/suite-native/atoms/src/Button/TextButton.tsx
+++ b/suite-native/atoms/src/Button/TextButton.tsx
@@ -9,9 +9,9 @@ import Animated, {
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Color } from '@trezor/theme';
 
-import { ButtonAccessoryView, ButtonProps, ButtonSize, buttonToTextSizeMap } from './Button';
-import { BUTTON_PRESS_ANIMATION_DURATION } from './useButtonPressAnimatedStyle';
 import { HStack } from '../Stack';
+import { pressTimingConfig } from '../constants';
+import { ButtonAccessoryView, ButtonProps, ButtonSize, buttonToTextSizeMap } from './Button';
 
 export type TextButtonVariant = 'primary' | 'tertiary' | 'blue';
 
@@ -105,11 +105,11 @@ export const TextButton = ({
     };
 
     const handlePressIn = () => {
-        textPressedColorValue.value = withTiming(1, { duration: BUTTON_PRESS_ANIMATION_DURATION });
+        textPressedColorValue.value = withTiming(1, pressTimingConfig);
         interpolatePressColor();
     };
     const handlePressOut = () => {
-        textPressedColorValue.value = withTiming(0, { duration: BUTTON_PRESS_ANIMATION_DURATION });
+        textPressedColorValue.value = withTiming(0, pressTimingConfig);
         interpolatePressColor();
     };
 

--- a/suite-native/atoms/src/Button/useButtonPressAnimatedStyle.ts
+++ b/suite-native/atoms/src/Button/useButtonPressAnimatedStyle.ts
@@ -8,9 +8,7 @@ import {
 import { useNativeStyles } from '@trezor/styles';
 import { Color } from '@trezor/theme';
 
-export const BUTTON_PRESS_ANIMATION_DURATION = 70;
-
-const pressTimingConfig = { duration: BUTTON_PRESS_ANIMATION_DURATION };
+import { pressTimingConfig } from '../constants';
 
 export const useButtonPressAnimatedStyle = (
     isPressed: boolean,

--- a/suite-native/atoms/src/PressableOpacity.tsx
+++ b/suite-native/atoms/src/PressableOpacity.tsx
@@ -1,0 +1,28 @@
+import { Pressable, PressableProps } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+
+import { pressTimingConfig } from './constants';
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+export const PressableOpacity = ({ onPress, children, ...rest }: PressableProps) => {
+    const opacity = useSharedValue(1);
+    const fadeOut = () => (opacity.value = withTiming(0.5, pressTimingConfig));
+    const fadeIn = () => (opacity.value = withTiming(1, pressTimingConfig));
+
+    const animatedStyle = useAnimatedStyle(() => ({
+        opacity: opacity.value,
+    }));
+
+    return (
+        <AnimatedPressable
+            onPress={onPress}
+            onPressIn={fadeOut}
+            onPressOut={fadeIn}
+            style={animatedStyle}
+            {...rest}
+        >
+            {children}
+        </AnimatedPressable>
+    );
+};

--- a/suite-native/atoms/src/constants.ts
+++ b/suite-native/atoms/src/constants.ts
@@ -1,1 +1,3 @@
 export const ENDLESS_ANIMATION_VALUE = -1;
+
+export const pressTimingConfig = { duration: 70 };

--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -75,6 +75,7 @@ export * from './Sheet/BottomSheetModal';
 export * from './Sheet/hooks/useBottomSheetModal';
 export * from './AnimatedDoubleView/AnimatedDoubleView';
 export * from './AnimatedDoubleView/AnimatedDoubleInput';
+export * from './PressableOpacity';
 
 export { useDebugView } from './DebugView';
 export { TouchableSwitchRow, TouchableSwitchRowDescription } from './TouchableSwitchRow';

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectDeviceCrossroadsScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectDeviceCrossroadsScreen.tsx
@@ -1,4 +1,3 @@
-import { Pressable } from 'react-native';
 import { useDispatch } from 'react-redux';
 
 import { bluetoothActions } from '@suite-common/bluetooth';
@@ -7,6 +6,7 @@ import {
     Card,
     HStack,
     Image,
+    PressableOpacity,
     RoundedIcon,
     Text,
     TextDivider,
@@ -28,33 +28,40 @@ type ConnectCardProps = {
     title: TxKeyPath;
     subtitle: TxKeyPath;
     icon: IconName;
+    onPress: () => void;
 };
 
-const ConnectCard = ({ image, title, subtitle, icon }: ConnectCardProps) => (
+const ConnectCard = ({ image, title, subtitle, icon, onPress }: ConnectCardProps) => (
     <Card>
-        <VStack marginTop="sp16" spacing="sp24" alignItems="center">
-            <Image source={image} width={228} height={128} contentFit="contain" />
-            <Box alignItems="center">
-                <Text variant="titleSmall">
-                    <Translation
-                        id={title}
-                        values={{
-                            bold: chunks => (
-                                <Text key={1} variant="titleSmall" style={{ fontWeight: 'bold' }}>
-                                    {chunks}
-                                </Text>
-                            ),
-                        }}
-                    />
-                </Text>
-                <HStack alignItems="center">
+        <PressableOpacity onPress={onPress}>
+            <VStack marginTop="sp16" spacing="sp24" alignItems="center">
+                <Image source={image} width={228} height={128} contentFit="contain" />
+                <Box alignItems="center">
                     <Text variant="titleSmall">
-                        <Translation id={subtitle} />
+                        <Translation
+                            id={title}
+                            values={{
+                                bold: chunks => (
+                                    <Text
+                                        key={1}
+                                        variant="titleSmall"
+                                        style={{ fontWeight: 'bold' }}
+                                    >
+                                        {chunks}
+                                    </Text>
+                                ),
+                            }}
+                        />
                     </Text>
-                    <RoundedIcon name={icon} iconSize="mediumLarge" containerSize={28} />
-                </HStack>
-            </Box>
-        </VStack>
+                    <HStack alignItems="center">
+                        <Text variant="titleSmall">
+                            <Translation id={subtitle} />
+                        </Text>
+                        <RoundedIcon name={icon} iconSize="mediumLarge" containerSize={28} />
+                    </HStack>
+                </Box>
+            </VStack>
+        </PressableOpacity>
     </Card>
 );
 
@@ -80,23 +87,21 @@ export const ConnectDeviceCrossroadsScreen = ({
     return (
         <ConnectDeviceScreen>
             <VStack marginTop="sp16" spacing="sp16">
-                <Pressable onPress={navigateToTurnOnAndUnlockDeviceScreen}>
-                    <ConnectCard
-                        image={require('../../assets/devices-bluetooth.webp')}
-                        title="moduleConnectDevice.crossroads.bluetooth.title"
-                        subtitle="moduleConnectDevice.crossroads.bluetooth.subtitle"
-                        icon="bluetooth"
-                    />
-                </Pressable>
+                <ConnectCard
+                    image={require('../../assets/devices-bluetooth.webp')}
+                    title="moduleConnectDevice.crossroads.bluetooth.title"
+                    subtitle="moduleConnectDevice.crossroads.bluetooth.subtitle"
+                    icon="bluetooth"
+                    onPress={navigateToTurnOnAndUnlockDeviceScreen}
+                />
                 <TextDivider />
-                <Pressable onPress={navigateToConnectAndUnlockDeviceScreen}>
-                    <ConnectCard
-                        image={require('../../assets/devices-cable.webp')}
-                        title="moduleConnectDevice.crossroads.cable.title"
-                        subtitle="moduleConnectDevice.crossroads.cable.subtitle"
-                        icon="cableUsbC"
-                    />
-                </Pressable>
+                <ConnectCard
+                    image={require('../../assets/devices-cable.webp')}
+                    title="moduleConnectDevice.crossroads.cable.title"
+                    subtitle="moduleConnectDevice.crossroads.cable.subtitle"
+                    icon="cableUsbC"
+                    onPress={navigateToConnectAndUnlockDeviceScreen}
+                />
             </VStack>
         </ConnectDeviceScreen>
     );


### PR DESCRIPTION
Connect cards now fade out when tapped.

<img width="1080" height="2340" alt="Screenshot_20251210_173046" src="https://github.com/user-attachments/assets/776156fd-a48a-4c8c-aff6-375e27c0f777" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/pressable-opacity&lookback=7)