### PR TITLE
feat(common): make quotaManager persistent

### DIFF
--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -13,6 +13,7 @@ import * as discoveryActions from '@suite-common/wallet-core';
 import { getAccountIdentifier, getAccountTransactions } from '@suite-common/wallet-utils';
 
 import { deviceSlice } from 'src/actions/device/deviceSlice';
+import { suiteSyncQuotaManagerSlice } from 'src/actions/suiteSyncQuotaManager/suiteSyncQuotaManagerSlice';
 import { SETTINGS } from 'src/config/suite';
 import storageMiddleware from 'src/middlewares/wallet/storageMiddleware';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
@@ -33,6 +34,7 @@ const discoveryReducer = prepareDiscoveryReducer(extraDependencies);
 const deviceReducer = deviceSlice.prepareReducer(extraDependencies);
 const sendFormReducer = prepareSendFormReducer(extraDependencies);
 const walletSettingsReducer = discoveryActions.prepareWalletSettingsReducer(extraDependencies);
+const quotaManagerSliceReducer = suiteSyncQuotaManagerSlice.prepareReducer(extraDependencies);
 
 // TODO: add method in suite-storage for deleting all stored data (done as a static method on SuiteDB), call it after each test
 // TODO: test deleting device instances on parent device forget
@@ -84,7 +86,7 @@ const tx2 = getWalletTransaction({
     symbol: 'btc',
 });
 
-type PartialState = Pick<AppState, 'suite' | 'device'> & {
+type PartialState = Pick<AppState, 'suite' | 'device' | 'suiteSyncQuotaManager'> & {
     wallet: Partial<
         Pick<
             AppState['wallet'],
@@ -103,6 +105,10 @@ type PartialState = Pick<AppState, 'suite' | 'device'> & {
 const getInitialState = (prevState?: Partial<PartialState>, action?: any) => ({
     suite: suiteReducer(
         prevState ? prevState.suite : undefined,
+        action || ({ type: 'foo' } as any),
+    ),
+    suiteSyncQuotaManager: quotaManagerSliceReducer(
+        prevState ? prevState.suiteSyncQuotaManager : undefined,
         action || ({ type: 'foo' } as any),
     ),
     device: deviceReducer(

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -477,6 +477,24 @@ export const saveSuiteSyncSettings = () => (_dispatch: Dispatch, getState: GetSt
     );
 };
 
+export const saveSuiteSyncQuotaManager = () => (_dispatch: Dispatch, getState: GetState) => {
+    if (!db.isAccessible()) return;
+
+    const { suiteSyncQuotaManager } = getState();
+
+    return db.addItem(
+        'suiteSyncQuotaManager',
+        {
+            baseUrl: suiteSyncQuotaManager.baseUrl,
+            enabled: suiteSyncQuotaManager.enabled,
+            registeredDevices: suiteSyncQuotaManager.registeredDevices,
+            ownersAllowance: suiteSyncQuotaManager.ownersAllowance,
+        },
+        'suiteSyncQuotaManager',
+        true,
+    );
+};
+
 export const saveDeviceMetadataError =
     (device: TrezorDevice) => async (_dispatch: Dispatch, getState: GetState) => {
         if (!db.isAccessible()) return;

--- a/packages/suite/src/actions/suiteSyncQuotaManager/suiteSyncQuotaManagerSlice.ts
+++ b/packages/suite/src/actions/suiteSyncQuotaManager/suiteSyncQuotaManagerSlice.ts
@@ -1,0 +1,32 @@
+import { AnyAction, createSliceWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    quotaManagerInitialState,
+    suiteSyncQuotaManagerReducer,
+} from '@suite-common/suite-sync-quota-manager';
+
+import { STORAGE } from '../suite/constants';
+
+export const suiteSyncQuotaManagerSlice = createSliceWithExtraDeps({
+    name: 'suiteSyncQuotaManager',
+    initialState: quotaManagerInitialState,
+    reducers: {},
+    extraReducers: builder => {
+        builder
+            .addCase(STORAGE.LOAD, (state, action) => {
+                const actionWithPayload = action as AnyAction;
+
+                if (
+                    actionWithPayload.type === STORAGE.LOAD &&
+                    actionWithPayload.payload.suiteSyncQuotaManager
+                ) {
+                    return {
+                        ...state,
+                        ...actionWithPayload.payload.suiteSyncQuotaManager,
+                    };
+                }
+            })
+            .addDefaultCase((state, action) => {
+                suiteSyncQuotaManagerReducer(state, action as AnyAction);
+            });
+    },
+});

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -7,6 +7,7 @@ import { connectPopupActions } from '@suite-common/connect-popup';
 import { firmwareActions } from '@suite-common/firmware';
 import { messageSystemActions } from '@suite-common/message-system';
 import { suiteSyncActions } from '@suite-common/suite-sync';
+import { suiteSyncQuotaManagerActions } from '@suite-common/suite-sync-quota-manager';
 import { isDeviceRemembered } from '@suite-common/suite-utils';
 import { thpActions } from '@suite-common/thp';
 import { TokenManagementAction } from '@suite-common/token-definitions';
@@ -185,6 +186,16 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 )(action)
             ) {
                 api.dispatch(storageActions.saveSuiteSyncSettings());
+            }
+
+            if (
+                isAnyOf(
+                    suiteSyncQuotaManagerActions.quotaManagerDeviceFetched,
+                    suiteSyncQuotaManagerActions.quotaManagerEnabledUpdated,
+                    suiteSyncQuotaManagerActions.updateQuotaManagerBaseUrl,
+                )
+            ) {
+                api.dispatch(storageActions.saveSuiteSyncQuotaManager());
             }
 
             if (deviceActions.setRememberDevice.match(action)) {

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -46,14 +46,14 @@ import { bluetoothSlice } from '../actions/bluetooth/desktopBluetoothReducer';
 import { createSuiteCompositionRoot, extraDependencies } from '../support/extraDependencies';
 import { prepareBioAuthReducer } from './bioAuth';
 import { desktopReducer } from './desktop';
-import { prepareSuiteSyncQuotaManagerReducer } from '@suite-common/suite-sync-quota-manager';
+import { suiteSyncQuotaManagerSlice } from 'src/actions/suiteSyncQuotaManager/suiteSyncQuotaManagerSlice';
 
 const firmwareReducer = prepareFirmwareReducer(extraDependencies);
 const tokenDefinitionsReducer = prepareTokenDefinitionsReducer(extraDependencies);
 const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependencies);
 const thpReducer = prepareThpReducer(extraDependencies);
 const suiteSyncReducer = suiteSyncSlice.prepareReducer(extraDependencies);
-const suiteSyncQuotaManagerReducer = prepareSuiteSyncQuotaManagerReducer(extraDependencies);
+const suiteSyncQuotaManagerReducer = suiteSyncQuotaManagerSlice.prepareReducer(extraDependencies);
 
 const rootReducer = combineReducers({
     ...suiteReducers,

--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -6,6 +6,7 @@ import { AnalyticsState } from '@suite-common/analytics';
 import { AppRememberedPermission } from '@suite-common/connect-popup/src/connectPopupTypes';
 import type { MessageState } from '@suite-common/message-system';
 import { SuiteSyncSettings } from '@suite-common/suite-sync';
+import type { SuiteSyncQuotaManagerState } from '@suite-common/suite-sync-quota-manager';
 import type {
     DeviceWithEmptyPath,
     MessageSystem,
@@ -142,6 +143,10 @@ export interface SuiteDBSchema extends DBSchema {
     suiteSyncSettings: {
         key: 'suiteSyncSettings';
         value: SuiteSyncSettings;
+    };
+    suiteSyncQuotaManager: {
+        key: 'suiteSyncQuotaManager';
+        value: SuiteSyncQuotaManagerState;
     };
     messageSystem: {
         key: string;

--- a/packages/suite/src/storage/migrations/versions/26.1.0.ts
+++ b/packages/suite/src/storage/migrations/versions/26.1.0.ts
@@ -4,6 +4,18 @@ import { SuiteDBSchema } from 'src/storage/definitions';
 
 import { removeNetwork } from '../networks/removeNetwork';
 
-export default createMigration<SuiteDBSchema>('26.1.0', async (_, tx) => {
+export default createMigration<SuiteDBSchema>('26.1.0', async (db, tx) => {
     await removeNetwork(tx, 'tada');
+
+    db.createObjectStore('suiteSyncQuotaManager');
+
+    tx.objectStore('suiteSyncQuotaManager').put(
+        {
+            enabled: false,
+            baseUrl: null,
+            registeredDevices: [],
+            ownersAllowance: [],
+        },
+        'suiteSyncQuotaManager',
+    );
 });

--- a/packages/suite/src/support/suite/preloadStore.ts
+++ b/packages/suite/src/support/suite/preloadStore.ts
@@ -52,6 +52,7 @@ export const preloadStore = async () => {
             bioAuth,
             firmware,
             suiteSyncSettings,
+            suiteSyncQuotaManager,
         ] = await Promise.all([
             db.getItemByPK('suiteSettings', 'suite'),
             db.getItemsExtended('devices'),
@@ -78,6 +79,7 @@ export const preloadStore = async () => {
             db.getItemByPK('bioAuth', 'bioAuth'),
             db.getItemByPK('firmware', 'firmware'),
             db.getItemByPK('suiteSyncSettings', 'suiteSyncSettings'),
+            db.getItemByPK('suiteSyncQuotaManager', 'suiteSyncQuotaManager'),
         ]);
 
         return {
@@ -108,6 +110,7 @@ export const preloadStore = async () => {
                 explorer,
                 firmware,
                 suiteSyncSettings,
+                suiteSyncQuotaManager,
             },
         } as const;
     } catch (error) {

--- a/suite-common/suite-sync-quota-manager/package.json
+++ b/suite-common/suite-sync-quota-manager/package.json
@@ -14,7 +14,6 @@
     "dependencies": {
         "@reduxjs/toolkit": "2.10.1",
         "@suite-common/delegated-identity-key": "workspace:*",
-        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",

--- a/suite-common/suite-sync-quota-manager/src/challenge/prepareChallengeSession.ts
+++ b/suite-common/suite-sync-quota-manager/src/challenge/prepareChallengeSession.ts
@@ -4,7 +4,7 @@ import { quotaManagerFetch } from '../quotaManagerFetch';
 import { generateSessionId } from '../util/generateSessionId';
 
 type PrepareChallengeSessionParams = {
-    baseUrl: string;
+    baseUrl: string | null;
 };
 
 type ChallengeResponse = {

--- a/suite-common/suite-sync-quota-manager/src/constants.ts
+++ b/suite-common/suite-sync-quota-manager/src/constants.ts
@@ -1,1 +1,7 @@
+import { isDevEnv } from '@suite-common/suite-utils';
+
 export const DEFAULT_WALLET_SIZE_QUOTA = 1024 * 1024 * 50; // 50 MB
+
+export const DEFAULT_QUOTA_MANAGER_URL = isDevEnv
+    ? 'https://suite-sync.suite.sldev.cz/gate/'
+    : 'https://suite-sync.trezor.io/gate/';

--- a/suite-common/suite-sync-quota-manager/src/index.ts
+++ b/suite-common/suite-sync-quota-manager/src/index.ts
@@ -4,7 +4,6 @@
 export { checkStorageByOwnerId, checkStorageByPublicKey } from './storage/checkStorage';
 export { registerStorageThunk } from './storage/registerStorageThunk';
 export { transferStorageThunk } from './storage/transferStorageThunk';
-export { prepareChallengeSession as prepareChallengeThunk } from './challenge/prepareChallengeSession';
 export { prepareChallengeSession } from './challenge/prepareChallengeSession';
 export { ensureDeviceHasQuotaThunk } from './ensureDeviceHasQuotaThunk';
 
@@ -32,7 +31,11 @@ export {
 /**
  * Reducers.
  */
-export { prepareSuiteSyncQuotaManagerReducer } from './quotaManagerReducer';
+export {
+    suiteSyncQuotaManagerReducer,
+    quotaManagerInitialState,
+    type SuiteSyncQuotaManagerState,
+} from './quotaManagerReducer';
 
 /**
  * Constants.

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerFetch.ts
@@ -1,13 +1,15 @@
 import { err, ok } from '@trezor/type-utils';
 import { typedObjectEntries } from '@trezor/utils';
 
+import { DEFAULT_QUOTA_MANAGER_URL } from './constants';
+
 type SupportedMethod = 'GET' | 'POST' | 'DELETE';
 
 // explicit list of supported endpoints and their methods
 type SupportedPath = '/challenge' | '/storage/ask' | '/storage/register' | '/storage/add' | '/sync';
 
 type QuotaManagerFetchParams = {
-    baseUrl: string;
+    baseUrl: string | null;
     path: SupportedPath;
     method: SupportedMethod;
     body?: unknown;
@@ -21,7 +23,7 @@ export const quotaManagerFetch = async ({
     body,
     queryParams,
 }: QuotaManagerFetchParams) => {
-    const url = new URL(path, baseUrl);
+    const url = new URL(path, baseUrl ?? DEFAULT_QUOTA_MANAGER_URL);
 
     if (queryParams !== undefined) {
         typedObjectEntries(queryParams).forEach(([key, value]) => {

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerReducer.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerReducer.ts
@@ -1,5 +1,4 @@
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
-import { isDevEnv } from '@suite-common/suite-utils';
+import { createReducer } from '@reduxjs/toolkit';
 
 import {
     quotaManagerDeviceFetched,
@@ -10,23 +9,22 @@ import type { AssignedOwnerId, RegisteredDevice } from './types';
 
 export type SuiteSyncQuotaManagerState = {
     enabled: boolean; // user can enable/disable Quota Manager in settings and quota manager is disabled automatically when relay URL is not Trezor ones
-    baseUrl: string;
+    baseUrl: string | null;
 
     registeredDevices: RegisteredDevice[];
-    assignedOwnerIds: AssignedOwnerId[];
+    ownersAllowance: AssignedOwnerId[];
 };
 
 export const quotaManagerInitialState: SuiteSyncQuotaManagerState = {
     enabled: false,
-    baseUrl: isDevEnv
-        ? 'https://suite-sync.suite.sldev.cz/gate/'
-        : 'https://suite-sync.trezor.io/gate/',
+    baseUrl: null,
     registeredDevices: [],
-    assignedOwnerIds: [],
+    ownersAllowance: [],
 };
 
-export const prepareSuiteSyncQuotaManagerReducer =
-    createReducerWithExtraDeps<SuiteSyncQuotaManagerState>(quotaManagerInitialState, builder =>
+export const suiteSyncQuotaManagerReducer = createReducer<SuiteSyncQuotaManagerState>(
+    quotaManagerInitialState,
+    builder =>
         builder
             .addCase(updateQuotaManagerBaseUrl, (state, { payload }) => {
                 state.baseUrl = payload.baseUrl;
@@ -51,4 +49,4 @@ export const prepareSuiteSyncQuotaManagerReducer =
                     });
                 }
             }),
-    );
+);

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerSelectors.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerSelectors.ts
@@ -15,7 +15,7 @@ export const selectRegisteredDevices = (state: WithSuiteSyncQuotaManagerState) =
     state.suiteSyncQuotaManager.registeredDevices;
 
 export const selectAssignedOwnerIds = (state: WithSuiteSyncQuotaManagerState) =>
-    state.suiteSyncQuotaManager.assignedOwnerIds;
+    state.suiteSyncQuotaManager.ownersAllowance;
 
 export const selectIsQuotaManagerEnabled = (state: WithSuiteSyncQuotaManagerState) =>
     state.suiteSyncQuotaManager.enabled;

--- a/suite-common/suite-sync-quota-manager/src/storage/checkStorage.ts
+++ b/suite-common/suite-sync-quota-manager/src/storage/checkStorage.ts
@@ -11,12 +11,12 @@ type AskForStoragePublicKeyResponse = AskForStorageResponse & {
 };
 
 export type CheckStorageByPublicKeyParams = {
-    baseUrl: string;
+    baseUrl: string | null;
     publicKey: string;
 };
 
 export type CheckStorageByOwnerIdParams = {
-    baseUrl: string;
+    baseUrl: string | null;
     ownerId: string;
 };
 

--- a/suite-common/suite-sync-quota-manager/tsconfig.json
+++ b/suite-common/suite-sync-quota-manager/tsconfig.json
@@ -6,7 +6,6 @@
     },
     "references": [
         { "path": "../delegated-identity-key" },
-        { "path": "../redux-utils" },
         { "path": "../suite-types" },
         { "path": "../suite-utils" },
         { "path": "../wallet-core" },

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -21,6 +21,7 @@
         "@suite-common/platform-encryption-native": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-sync": "workspace:*",
+        "@suite-common/suite-sync-quota-manager": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/thp": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -10,6 +10,7 @@ import {
     prepareMessageSystemReducer,
 } from '@suite-common/message-system';
 import { labelingReducer, suiteSyncReducer } from '@suite-common/suite-sync';
+import { suiteSyncQuotaManagerReducer } from '@suite-common/suite-sync-quota-manager';
 import { prepareThpReducer } from '@suite-common/thp';
 import { notificationsReducer } from '@suite-common/toast-notifications';
 import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions';
@@ -280,6 +281,13 @@ export const prepareRootReducers = async () => {
         version: 1,
     });
 
+    const quotaManagerPersistedReducer = await preparePersistReducer({
+        reducer: suiteSyncQuotaManagerReducer,
+        persistedKeys: ['baseUrl', 'enabled', 'registeredDevices', 'ownersAllowance'],
+        key: 'suiteSyncQuotaManager',
+        version: 1,
+    });
+
     const rootReducer = await preparePersistReducer({
         reducer: combineReducers({
             analytics: analyticsPersistedReducer,
@@ -306,6 +314,7 @@ export const prepareRootReducers = async () => {
             tokenDefinitions: tokenDefinitionsReducer,
             wallet: walletPersistedReducer,
             walletConnect: walletConnectReducer,
+            suiteSyncQuotaManager: quotaManagerPersistedReducer,
         } as const),
         // 'wallet' and 'graph' need to be persisted at the top level to ensure device state
         // is accessible for transformation.

--- a/suite-native/state/tsconfig.json
+++ b/suite-native/state/tsconfig.json
@@ -29,6 +29,9 @@
             "path": "../../suite-common/suite-sync"
         },
         {
+            "path": "../../suite-common/suite-sync-quota-manager"
+        },
+        {
             "path": "../../suite-common/test-utils"
         },
         { "path": "../../suite-common/thp" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11273,7 +11273,6 @@ __metadata:
   dependencies:
     "@reduxjs/toolkit": "npm:2.10.1"
     "@suite-common/delegated-identity-key": "workspace:*"
-    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
@@ -13474,6 +13473,7 @@ __metadata:
     "@suite-common/platform-encryption-native": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-sync": "workspace:*"
+    "@suite-common/suite-sync-quota-manager": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/thp": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"


### PR DESCRIPTION
Make quotaManager persist data on desktop & mobile.

## Notes for QA

Currently you can test only if the settings of QuotaManager persists in debug settings.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/quota-manager-persistency&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/quota-manager-persistency&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/quota-manager-persistency&lookback=7)