### PR TITLE
Revert "fix(urls): unit test for invity link"

### DIFF
--- a/packages/urls/tests/urls.test.ts
+++ b/packages/urls/tests/urls.test.ts
@@ -19,8 +19,6 @@ const excluded = [
     URLS.HELP_CENTER_FW_DOWNGRADE_T3W1_URL,
     URLS.HELP_CENTER_SOLANA_HELP_URL,
     URLS.IMAGE_PROXY_API_URL, // returns 'unauthorized'
-    // TODO temporary ignore; fix the link on invity's side
-    URLS.TRADING_DOWNLOAD_INVITY_APP_URL,
 ];
 
 // Sometimes we run test too much, I guess....


### PR DESCRIPTION
https://github.com/trezor/trezor-suite/pull/23730 no longer needed, the URL should be working again

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=revert/invity-link&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=revert/invity-link&lookback=7)