### PR TITLE
fix(e2e-suite): update metadata automation according to new implementation

### DIFF
--- a/packages/product-components/src/components/EditableText/ActionsContainer.tsx
+++ b/packages/product-components/src/components/EditableText/ActionsContainer.tsx
@@ -81,7 +81,6 @@ export const ActionsContainer = ({
     isDeleteButtonVisible,
     isSubmitButtonVisible,
     savingStatus,
-    dataTestIdBase,
 }: ActionContainerProps) => {
     const [isDirty, setIsDirty] = useState(false);
 
@@ -112,7 +111,7 @@ export const ActionsContainer = ({
                     margin={{ right: 4 }}
                     hasFinished={!isLoading}
                     isGrey={isLoading}
-                    data-testid={savingStatus === 'saved' ? `${dataTestIdBase}/success` : undefined}
+                    data-testid={savingStatus === 'saved' ? `@metadata/success` : undefined}
                 />
             );
         }
@@ -170,11 +169,7 @@ export const ActionsContainer = ({
                         delayShow={1000}
                     >
                         <IconButton
-                            data-testid={
-                                isDeleteButtonVisible
-                                    ? `${dataTestIdBase}/edit-label-button`
-                                    : `${dataTestIdBase}/add-label-button`
-                            }
+                            data-testid="@metadata/edit"
                             intent="neutral"
                             icon="pencil"
                             onClick={() => {

--- a/suite/e2e/support/enums/accountLabelId.ts
+++ b/suite/e2e/support/enums/accountLabelId.ts
@@ -1,7 +1,6 @@
 export enum AccountLabelId {
     BitcoinDefault1 = "m/84'/0'/0'",
     BitcoinDefault2 = "m/84'/0'/1'",
-    BitcoinDefault3 = "m/84'/0'/2'",
     BitcoinSegwit1 = "m/49'/0'/0'",
     BitcoinSegwit2 = "m/49'/0'/1'",
 }

--- a/suite/e2e/support/pageObjects/metadata/accountMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/accountMetadata.ts
@@ -1,13 +1,13 @@
+import { expect } from '@playwright/test';
+
 import { MetadataBase } from './metadataBase';
 import { step } from '../../common';
 
 export class AccountMetadata extends MetadataBase {
-    readonly addLabelButton = (accountId: string) =>
-        this.page.getByTestId(`${this.getLabelTestId(accountId)}/add-label-button`);
     readonly editLabelButton = (accountId: string) =>
-        this.page.getByTestId(`${this.getLabelTestId(accountId)}/edit-label-button`);
+        this.accountLabel(accountId).getByTestId(this.editButtonId);
     readonly successLabel = (accountId: string) =>
-        this.page.getByTestId(`${this.getLabelTestId(accountId)}/success`);
+        this.accountLabel(accountId).getByTestId(this.successId);
     readonly accountLabel = (accountId: string) =>
         this.page.getByTestId(`${this.getLabelTestId(accountId)}/hover-container`);
 
@@ -16,21 +16,25 @@ export class AccountMetadata extends MetadataBase {
     }
 
     @step()
-    async editLabel(accountId: string, newLabel: string) {
-        await this.accountLabel(accountId).click();
+    async changeLabel(accountId: string, newLabel: string) {
+        await this.resetMousePosition();
+        // ensure account label is loaded - test can be too fast
+        await expect(this.accountLabel(accountId)).toHaveText(/[A-Za-z]+/);
+        await this.accountLabel(accountId).hover();
         await this.editLabelButton(accountId).click();
         await this.fillLabelInput(newLabel, { useButton: true });
     }
 
     @step()
-    async clickAddLabelButton(accountId: string) {
+    async clickEditLabelButton(accountId: string) {
+        await this.resetMousePosition();
         await this.accountLabel(accountId).hover();
-        await this.addLabelButton(accountId).click();
+        await this.editLabelButton(accountId).click();
     }
 
     @step()
-    async addLabel(accountId: string, label: string) {
-        await this.clickAddLabelButton(accountId);
-        await this.fillLabelInput(label);
+    async successIconIsVisible(accountId: string) {
+        await expect(this.successLabel(accountId)).toBeVisible();
+        await expect(this.successLabel(accountId)).toBeHidden();
     }
 }

--- a/suite/e2e/support/pageObjects/metadata/addressMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/addressMetadata.ts
@@ -1,27 +1,29 @@
+import { expect } from '@playwright/test';
+
 import { MetadataBase } from './metadataBase';
 import { step } from '../../common';
 
 export class AddressMetadata extends MetadataBase {
     private readonly addressMetadataTestId = '@metadata/addressLabel';
 
-    private readonly labelHoverContainer = (address: string) =>
+    private readonly addressHoverContainer = (address: string) =>
         this.page.getByTestId(`${this.addressMetadataTestId}/${address}/hover-container`);
     readonly label = (address: string) =>
-        this.page.getByTestId(`${this.addressMetadataTestId}/${address}`);
-
-    @step()
-    async clickAddLabel(address: string) {
-        await this.labelHoverContainer(address).hover();
-        await this.page
-            .getByTestId(`${this.addressMetadataTestId}/${address}/add-label-button`)
-            .click();
-    }
+        this.addressHoverContainer(address).getByTestId(this.inputId);
+    readonly editLabelButton = (address: string) =>
+        this.addressHoverContainer(address).getByTestId(this.editButtonId);
+    readonly successLabel = (address: string) =>
+        this.addressHoverContainer(address).getByTestId(this.successId);
 
     @step()
     async clickEditLabel(address: string) {
-        await this.labelHoverContainer(address).hover();
-        await this.page
-            .getByTestId(`${this.addressMetadataTestId}/${address}/edit-label-button`)
-            .click();
+        await this.addressHoverContainer(address).hover();
+        await this.editLabelButton(address).click();
+    }
+
+    @step()
+    async successIconIsVisible(accountId: string) {
+        await expect(this.successLabel(accountId)).toBeVisible();
+        await expect(this.successLabel(accountId)).toBeHidden();
     }
 }

--- a/suite/e2e/support/pageObjects/metadata/metadataBase.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataBase.ts
@@ -10,11 +10,20 @@ export class MetadataBase {
     readonly metadataSubmitButton: Locator;
     readonly metadataCancelButton: Locator;
     readonly metadataInput: Locator;
+    readonly editButtonId = '@metadata/edit';
+    readonly inputId = '@metadata/input';
+    readonly successId = '@metadata/success';
 
     constructor(protected readonly page: Page) {
         this.metadataSubmitButton = page.getByTestId('@metadata/submit');
         this.metadataCancelButton = page.getByTestId('@metadata/cancel');
-        this.metadataInput = page.getByTestId('@metadata/input');
+        this.metadataInput = page
+            .getByTestId('@metadata/input')
+            .and(page.locator('[contenteditable="true"]'));
+    }
+
+    async resetMousePosition() {
+        await this.page.mouse.move(0, 0); // reset mouse position to avoid hover issues
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/metadata/outputMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/outputMetadata.ts
@@ -8,6 +8,10 @@ export class OutputMetadata extends MetadataBase {
         this.page.getByTestId(`${this.getLabelTestId(outputId, txNumber)}/dropdown/copy-address`);
     readonly outputDropdownEditLabel = (outputId: string, txNumber: number) =>
         this.page.getByTestId(`${this.getLabelTestId(outputId, txNumber)}/dropdown/edit-label`);
+    readonly outputMetadataInput = (outputId: string, txNumber: number) =>
+        this.page
+            .getByTestId(this.getLabelTestId(outputId, txNumber))
+            .getByTestId('@metadata/input');
 
     private getLabelTestId(outputId: string, txNumber: number): string {
         return `@metadata/outputLabel/${outputId}-${txNumber}`;
@@ -24,13 +28,15 @@ export class OutputMetadata extends MetadataBase {
     @step()
     async addLabel(outputId: string, txNumber: number, label: string) {
         await this.clickAddLabelButton(outputId, txNumber);
-        await this.fillLabelInput(label);
+        await this.outputMetadataInput(outputId, txNumber).fill(label);
+        await this.page.keyboard.press('Enter');
     }
 
     @step()
     async editLabel(outputId: string, txNumber: number, newLabel: string) {
         await this.outputLabel(outputId, txNumber).click();
         await this.outputDropdownEditLabel(outputId, txNumber).click();
-        await this.fillLabelInput(newLabel);
+        await this.outputMetadataInput(outputId, txNumber).fill(newLabel);
+        await this.page.keyboard.press('Enter');
     }
 }

--- a/suite/e2e/support/pageObjects/metadata/walletMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/walletMetadata.ts
@@ -1,38 +1,26 @@
+import { expect } from '@playwright/test';
+
 import { MetadataBase } from './metadataBase';
 import { step } from '../../common';
 
 export class WalletMetadata extends MetadataBase {
-    private readonly walletSelectorBeginPart = '[data-testid^="@metadata/walletLabel/"]';
-    readonly walletLabel = (index: number) =>
-        this.page.locator(`${this.walletSelectorBeginPart}[data-testid$=":${index + 1}"]`);
-
+    readonly walletLabel = (index: number) => this.walletOnIndex(index).getByTestId(this.inputId);
+    readonly walletOnIndex = (index: number) =>
+        this.page.getByTestId(`@switch-device/wallet-on-index/${index}`);
+    readonly labelChangeSuccessIcon = (index: number) =>
+        this.walletOnIndex(index).getByTestId(this.successId);
     @step()
-    async clickAddLabel(index: number) {
-        await this.page.waitForTimeout(2000); // I couldn't figure out any other working solution for flaky hover+click
-        await this.page
-            .locator(
-                `${this.walletSelectorBeginPart}[data-testid$=":${index + 1}/hover-container"]`,
-            )
-            .hover();
-        await this.page
-            .locator(
-                `${this.walletSelectorBeginPart}[data-testid$=":${index + 1}/add-label-button"]`,
-            )
-            .click();
+    async clickEditLabel(index: number) {
+        await this.resetMousePosition();
+        // ensure wallet label is loaded - test can be too fast
+        await expect(this.walletLabel(index)).toHaveText(/[A-Za-z]+/);
+        await this.walletOnIndex(index).getByTestId(this.inputId).hover();
+        await this.walletOnIndex(index).getByTestId(this.editButtonId).click();
     }
 
     @step()
-    async clickEditLabel(index: number) {
-        await this.page.waitForTimeout(2000); // I couldn't figure out any other working solution for flaky hover+click
-        await this.page
-            .locator(
-                `${this.walletSelectorBeginPart}[data-testid$=":${index + 1}/hover-container"]`,
-            )
-            .hover();
-        await this.page
-            .locator(
-                `${this.walletSelectorBeginPart}[data-testid$=":${index + 1}/edit-label-button"]`,
-            )
-            .click();
+    async successIconIsVisible(standardWalletIndex: number) {
+        await expect(this.labelChangeSuccessIcon(standardWalletIndex)).toBeVisible();
+        await expect(this.labelChangeSuccessIcon(standardWalletIndex)).toBeHidden();
     }
 }

--- a/suite/e2e/tests/metadata/account-metadata.test.ts
+++ b/suite/e2e/tests/metadata/account-metadata.test.ts
@@ -26,30 +26,26 @@ test.describe('Account metadata', { tag: ['@group=metadata', '@webOnly'] }, () =
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
             ).toHaveText('Bitcoin #1');
 
-            await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
+            await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
             await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
         });
 
         await test.step('Edit label with Enter submit', async () => {
+            await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
             await metadataPage.account.metadataInput.fill('cool new label');
             await page.keyboard.press('Enter');
             await expect(
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
             ).toHaveText('cool new label');
+            await metadataPage.account.successIconIsVisible(AccountLabelId.BitcoinDefault1);
         });
 
         await test.step('Edit label with button submit', async () => {
-            await metadataPage.account.editLabel(AccountLabelId.BitcoinDefault1, 'even cooler');
+            await metadataPage.account.changeLabel(AccountLabelId.BitcoinDefault1, 'even cooler');
             await expect(
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
             ).toHaveText('even cooler');
-
-            await expect(
-                metadataPage.account.successLabel(AccountLabelId.BitcoinDefault1),
-            ).toBeVisible();
-            await expect(
-                metadataPage.account.successLabel(AccountLabelId.BitcoinDefault1),
-            ).toBeHidden();
+            await metadataPage.account.successIconIsVisible(AccountLabelId.BitcoinDefault1);
         });
 
         await test.step('Discard label changes via Escape', async () => {
@@ -86,43 +82,33 @@ test.describe('Account metadata', { tag: ['@group=metadata', '@webOnly'] }, () =
             ).toHaveText('Bitcoin #1');
         });
 
-        await test.step('Switch between segwit accounts and check success indicators', async () => {
-            await walletPage.segwitGroupButton.click();
-            await walletPage.openAccount({ symbol: 'btc', type: 'segwit', atIndex: 0 });
-
-            await metadataPage.account.addLabel(
-                AccountLabelId.BitcoinSegwit1,
-                'typing into one input',
-            );
-            await expect(
-                metadataPage.account.successLabel(AccountLabelId.BitcoinSegwit1),
-            ).toBeVisible();
-
-            await walletPage.openAccount({ symbol: 'btc', type: 'segwit', atIndex: 1 });
-            await expect(
-                metadataPage.account.successLabel(AccountLabelId.BitcoinSegwit2),
-            ).toBeHidden();
-            await expect(
-                metadataPage.account.successLabel(AccountLabelId.BitcoinSegwit1),
-            ).toBeHidden();
-        });
-
         await test.step('Navigate to dashboard', async () => {
             await dashboardPage.dashboardMenuButton.click();
             await expect(dashboardPage.graph).toBeVisible();
         });
 
         await test.step('Add and label a new account', async () => {
+            // Account number can change so we determine it dynamically
+            const btcAccountCount = await page
+                .locator('[data-testid^="@account-menu/btc/normal/"][data-testid$="/label"]')
+                .count();
+            const newAccountIndex = btcAccountCount;
+            const newAccountLabelId = `m/84'/0'/${newAccountIndex}'` as AccountLabelId;
             await walletPage.openAccount();
             await walletPage.addAccountButton.click();
             await settingsPage.coins.networkButton('btc').click();
             await page.getByTestId('@add-account').click();
-            await metadataPage.account.addLabel(
-                AccountLabelId.BitcoinDefault3,
+            await metadataPage.account.changeLabel(
+                newAccountLabelId,
                 'adding label to a newly added account. does it work?',
             );
+            await metadataPage.account.successIconIsVisible(newAccountLabelId);
             await expect(
-                walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 2 }),
+                walletPage.accountLabel({
+                    symbol: 'btc',
+                    type: 'normal',
+                    atIndex: newAccountIndex,
+                }),
             ).toHaveText('adding label to a newly added account. does it work?');
         });
     });

--- a/suite/e2e/tests/metadata/address-metadata.test.ts
+++ b/suite/e2e/tests/metadata/address-metadata.test.ts
@@ -5,31 +5,34 @@ const metadataAddress = 'bc1q7e6qu5smalrpgqrx9k2gnf0hgjyref5p36ru2m';
 
 test.describe('Metadata - address labeling', { tag: ['@group=metadata', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
-    test.beforeEach(async ({ metadataMock }) => {
+    test.beforeEach(async ({ metadataMock, onboardingPage }) => {
         await metadataMock.start(MetadataProvider.GOOGLE);
+        await onboardingPage.completeOnboarding();
     });
 
-    test('google provider', async ({ page, onboardingPage, metadataPage, walletPage }) => {
-        await onboardingPage.completeOnboarding();
+    test('google provider', async ({ page, metadataPage, walletPage }) => {
+        await test.step('Interact with accounts and metadata', async () => {
+            await walletPage.openAccount();
+            await walletPage.receiveButton.click();
+            await walletPage.showMoreButton.click();
+            await metadataPage.address.clickEditLabel(metadataAddress);
+            await metadataPage.passThroughInitMetadata(MetadataProvider.GOOGLE);
+        });
 
-        // Interact with accounts and metadata
-        await walletPage.openAccount();
-        await walletPage.receiveButton.click();
-        await walletPage.showMoreButton.click();
-        await metadataPage.address.clickAddLabel(metadataAddress);
+        await test.step('Add address label', async () => {
+            await metadataPage.address.clickEditLabel(metadataAddress);
+            await metadataPage.address.fillLabelInput('meow address');
+            await page.keyboard.press('Enter');
+            await metadataPage.address.successIconIsVisible(metadataAddress);
+            await expect(metadataPage.address.label(metadataAddress)).toHaveText('meow address');
+        });
 
-        // Initialize metadata flow
-        // Metadata provider: google
-        metadataPage.passThroughInitMetadata(MetadataProvider.GOOGLE);
-
-        await metadataPage.address.metadataInput.fill('meow address');
-        await page.keyboard.press('Enter');
-        await expect(metadataPage.address.label(metadataAddress)).toHaveText('meow address');
-
-        // Edit metadata label
-        await metadataPage.address.clickEditLabel(metadataAddress);
-        await metadataPage.address.metadataInput.fill('meow meow');
-        await page.keyboard.press('Enter');
-        await expect(metadataPage.address.label(metadataAddress)).toHaveText('meow meow');
+        await test.step('Edit metadata label', async () => {
+            await metadataPage.address.clickEditLabel(metadataAddress);
+            await metadataPage.address.fillLabelInput('meow meow');
+            await page.keyboard.press('Enter');
+            await metadataPage.address.successIconIsVisible(metadataAddress);
+            await expect(metadataPage.address.label(metadataAddress)).toHaveText('meow meow');
+        });
     });
 });

--- a/suite/e2e/tests/metadata/dropbox-api-errors.test.ts
+++ b/suite/e2e/tests/metadata/dropbox-api-errors.test.ts
@@ -122,7 +122,7 @@ test.describe('Dropbox API errors', { tag: ['@group=metadata', '@webOnly'] }, ()
             });
 
             await walletPage.openAccount();
-            await metadataPage.account.editLabel(AccountLabelId.BitcoinDefault1, 'Kvooo');
+            await metadataPage.account.changeLabel(AccountLabelId.BitcoinDefault1, 'Kvooo');
             await expect(
                 metadataPage.account.accountLabel(AccountLabelId.BitcoinDefault1),
             ).toContainText('Kvooo');
@@ -162,7 +162,7 @@ test.describe('Dropbox API errors', { tag: ['@group=metadata', '@webOnly'] }, ()
 
             await walletPage.openAccount();
             // just enter some label, this indicates that app did not crash
-            await metadataPage.account.editLabel(AccountLabelId.BitcoinDefault1, 'Kvooo');
+            await metadataPage.account.changeLabel(AccountLabelId.BitcoinDefault1, 'Kvooo');
         },
     );
 

--- a/suite/e2e/tests/metadata/google-api-errors.test.ts
+++ b/suite/e2e/tests/metadata/google-api-errors.test.ts
@@ -47,7 +47,7 @@ test.describe('Google API errors', { tag: ['@group=metadata', '@webOnly'] }, () 
             await onboardingPage.completeOnboarding();
 
             await walletPage.openAccount();
-            await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
+            await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
 
             await metadataPage.passThroughInitMetadata(MetadataProvider.GOOGLE, {
                 skipVerification: true,

--- a/suite/e2e/tests/metadata/interval-fetching.test.ts
+++ b/suite/e2e/tests/metadata/interval-fetching.test.ts
@@ -39,7 +39,7 @@ test.describe('Account metadata', { tag: ['@group=metadata', '@webOnly'] }, () =
             await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
                 'Bitcoin #1',
             );
-            await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
+            await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
             await metadataPage.passThroughInitMetadata(p.provider);
             await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
                 'already existing label',

--- a/suite/e2e/tests/metadata/metadata-lifecycle.test.ts
+++ b/suite/e2e/tests/metadata/metadata-lifecycle.test.ts
@@ -35,7 +35,7 @@ test.describe(
             // Navigate to account and hover over add label button
             await page.getByTestId('@suite/menu/suite-index').click();
             await walletPage.openAccount();
-            await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
+            await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
             await devicePrompt.confirmOnDevicePromptIsShown();
             await trezorUserEnvLink.pressNo();
 
@@ -71,10 +71,6 @@ test.describe(
             // Enable labeling dialogue appears again
             await devicePrompt.confirmOnDevicePromptIsShown({ timeout: 15_000 });
             await trezorUserEnvLink.pressNo();
-        });
-
-        test.afterEach(async ({ metadataMock }) => {
-            await metadataMock.stop();
         });
     },
 );

--- a/suite/e2e/tests/metadata/output-labeling.test.ts
+++ b/suite/e2e/tests/metadata/output-labeling.test.ts
@@ -24,83 +24,106 @@ test.describe('Metadata - Output labeling', { tag: ['@group=metadata', '@webOnly
         },
         async ({ page, onboardingPage, metadataPage, walletPage }) => {
             await onboardingPage.completeOnboarding();
-
             await walletPage.openAccount();
-
             await metadataPage.output.clickAddLabelButton(OutputLabelId.BitcoinDefault1, 0);
-
             await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
-
-            await metadataPage.output.fillLabelInput('mnau cool label');
-
-            // go to legacy account 6, it has txs with multiple outputs
-            await page.getByTestId('@account-menu/legacy').click();
-            await walletPage.openAccount({ symbol: 'btc', type: 'legacy', atIndex: 5 });
-
-            // Try to open multiple metadata inputs
-            await metadataPage.output.clickAddLabelButton(OutputLabelId.BitcoinLegacy6, 0);
-            await metadataPage.output.clickAddLabelButton(OutputLabelId.BitcoinLegacy6, 1);
-
-            // Only one metadata input should be visible at a time
-            await expect(metadataPage.output.metadataInput).toHaveCount(1);
-
-            await metadataPage.output.addLabel(OutputLabelId.BitcoinLegacy6, 2, 'output 3');
-            await expect(
-                metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy6, 2),
-            ).toContainText('output 3');
-
-            // label "send to myself tx"
-            await walletPage.openAccount({ symbol: 'btc', type: 'legacy', atIndex: 9 });
-            await metadataPage.output.addLabel(
-                OutputLabelId.BitcoinLegacy10,
-                0,
-                'really to myself',
-            );
-            await expect(
-                metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0),
-            ).toContainText('really to myself');
-
-            // Test that label can be edited and submitted by enter
-            await metadataPage.output.editLabel(OutputLabelId.BitcoinLegacy10, 0, 'edited');
-            await expect(
-                metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0),
-            ).toContainText('edited');
-
-            // Check that there is a copy address button
-            await metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0).click();
-            await expect(
-                metadataPage.output.outputDropdownCopyAddress(OutputLabelId.BitcoinLegacy10, 0),
-            ).toBeVisible();
-
-            // Test that label can be edited and submitted by submit button
             await metadataPage.output
-                .outputDropdownEditLabel(OutputLabelId.BitcoinLegacy10, 0)
-                .click();
-            await metadataPage.output.fillLabelInput('submitted by button', { useButton: true });
-            await expect(
-                metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0),
-            ).toContainText('submitted by button');
+                .outputMetadataInput(OutputLabelId.BitcoinDefault1, 0)
+                .fill('mnau cool label');
+            await page.keyboard.press('Enter');
 
-            await metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0).click();
-            await metadataPage.output
-                .outputDropdownEditLabel(OutputLabelId.BitcoinLegacy10, 0)
-                .click();
-            await metadataPage.output.metadataInput.clear();
-            await metadataPage.output.metadataInput.fill('write something that wont be saved');
-            await metadataPage.output.metadataCancelButton.click();
-            await expect(
-                metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0),
-            ).toContainText('submitted by button');
+            await test.step('Go to legacy account 6, it has txs with multiple outputs', async () => {
+                await page.getByTestId('@account-menu/legacy').click();
+                await walletPage.openAccount({ symbol: 'btc', type: 'legacy', atIndex: 5 });
+            });
 
-            await onboardingPage.completeTransactionOnboarding();
-            await walletPage.exportTransactions('csv');
+            await test.step('Try to open multiple metadata inputs', async () => {
+                await metadataPage.output.clickAddLabelButton(OutputLabelId.BitcoinLegacy6, 0);
+                await metadataPage.output.clickAddLabelButton(OutputLabelId.BitcoinLegacy6, 1);
+            });
 
-            const download = await page.waitForEvent('download');
-            const downloadPath = await download.path();
-            const fileContent = fs.readFileSync(downloadPath, 'utf8');
-            const expectedSubstr = '1PmVvr5DNVYJygtDT7J312qmxpa5pceu9E,submitted by button';
-            expect(fileContent).toContain(expectedSubstr);
-            expect(typeof fileContent).toBe('string');
+            await test.step('Only one metadata input should be visible at a time', async () => {
+                await expect(
+                    page
+                        .getByTestId('@wallet/accounts/transaction-list')
+                        .getByTestId('@metadata/input'),
+                ).toHaveCount(1);
+            });
+
+            await test.step('Add label to output 3 and verify', async () => {
+                await metadataPage.output.addLabel(OutputLabelId.BitcoinLegacy6, 2, 'output 3');
+                await expect(
+                    metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy6, 2),
+                ).toContainText('output 3');
+            });
+
+            await test.step('Label "send to myself tx"', async () => {
+                await walletPage.openAccount({ symbol: 'btc', type: 'legacy', atIndex: 9 });
+                await metadataPage.output.addLabel(
+                    OutputLabelId.BitcoinLegacy10,
+                    0,
+                    'really to myself',
+                );
+                await expect(
+                    metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0),
+                ).toContainText('really to myself');
+            });
+
+            await test.step('Test that label can be edited and submitted by enter', async () => {
+                await metadataPage.output.editLabel(OutputLabelId.BitcoinLegacy10, 0, 'edited');
+                await expect(
+                    metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0),
+                ).toContainText('edited');
+            });
+
+            await test.step('Check that there is a copy address button', async () => {
+                await metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0).click();
+                await expect(
+                    metadataPage.output.outputDropdownCopyAddress(OutputLabelId.BitcoinLegacy10, 0),
+                ).toBeVisible();
+            });
+
+            await test.step('Test that label can be edited and submitted by submit button', async () => {
+                await metadataPage.output
+                    .outputDropdownEditLabel(OutputLabelId.BitcoinLegacy10, 0)
+                    .click();
+                await metadataPage.output
+                    .outputMetadataInput(OutputLabelId.BitcoinLegacy10, 0)
+                    .fill('submitted by button');
+                await metadataPage.output.metadataSubmitButton.click();
+                await expect(
+                    metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0),
+                ).toContainText('submitted by button');
+            });
+
+            await test.step('Test canceling label edit does not change label', async () => {
+                await metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0).click();
+                await metadataPage.output
+                    .outputDropdownEditLabel(OutputLabelId.BitcoinLegacy10, 0)
+                    .click();
+                await metadataPage.output
+                    .outputMetadataInput(OutputLabelId.BitcoinLegacy10, 0)
+                    .clear();
+                await metadataPage.output
+                    .outputMetadataInput(OutputLabelId.BitcoinLegacy10, 0)
+                    .fill('write something that wont be saved');
+                await metadataPage.output.metadataCancelButton.click();
+                await expect(
+                    metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0),
+                ).toContainText('submitted by button');
+            });
+
+            await test.step('Export transactions and verify CSV contains label', async () => {
+                await onboardingPage.completeTransactionOnboarding();
+                await walletPage.exportTransactions('csv');
+
+                const download = await page.waitForEvent('download');
+                const downloadPath = await download.path();
+                const fileContent = fs.readFileSync(downloadPath, 'utf8');
+                const expectedSubstr = '1PmVvr5DNVYJygtDT7J312qmxpa5pceu9E,submitted by button';
+                expect(fileContent).toContain(expectedSubstr);
+                expect(typeof fileContent).toBe('string');
+            });
         },
     );
 });

--- a/suite/e2e/tests/metadata/remembered-device.test.ts
+++ b/suite/e2e/tests/metadata/remembered-device.test.ts
@@ -31,111 +31,124 @@ test.describe(
             devicePrompt,
             trezorUserEnvLink,
         }) => {
-            await onboardingPage.completeOnboarding();
+            await test.step('Complete onboarding and open BTC account', async () => {
+                await onboardingPage.completeOnboarding();
+                await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+                await settingsPage.navigateTo('application');
+            });
 
-            await page.getByTestId('@account-menu/btc/normal/0/label').click();
+            await test.step('Enable metadata (legacy) and initialize with Google provider', async () => {
+                await page.selectDropdownOptionWithRetry(
+                    settingsPage.metadataSelectInput,
+                    settingsPage.metadataSelectInputOption('legacy'),
+                );
+                await metadataPage.passThroughInitMetadata(MetadataProvider.GOOGLE);
+            });
 
-            await settingsPage.navigateTo('application');
-
-            await page.selectDropdownOptionWithRetry(
-                settingsPage.metadataSelectInput,
-                settingsPage.metadataSelectInputOption('legacy'),
-            );
-
-            await metadataPage.passThroughInitMetadata(MetadataProvider.GOOGLE);
-
-            // Now metadata is enabled, go to accounts and see what we got loaded from provider
-            await walletPage.openAccount();
-
-            await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toContainText(
-                'already existing label',
-            );
+            await test.step('Verify metadata loaded from provider', async () => {
+                await walletPage.openAccount();
+                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toContainText(
+                    'already existing label',
+                );
+            });
 
             // device not saved, disconnect provider
-            // Now go back to settings, disconnect provider and check that we don't see metadata in app
-            await settingsPage.navigateTo('application');
-            await page.getByTestId('@settings/metadata/disconnect-provider-button').click();
-            await expect(
-                page.getByTestId('@settings/metadata/connect-provider-button'),
-            ).toBeVisible();
-            await walletPage.openAccount();
-            await expect(page.getByTestId('@account-menu/btc/normal/0/label')).not.toContainText(
-                'already existing label',
-            );
+            await test.step('Disconnect provider and verify metadata is not visible', async () => {
+                await settingsPage.navigateTo('application');
+                await page.getByTestId('@settings/metadata/disconnect-provider-button').click();
+                await expect(
+                    page.getByTestId('@settings/metadata/connect-provider-button'),
+                ).toBeVisible();
+                await walletPage.openAccount();
+                await expect(
+                    page.getByTestId('@account-menu/btc/normal/0/label'),
+                ).not.toContainText('already existing label');
+            });
 
             // At this moment, there are no labels. But we still can see "add label" button, which inits metadata flow but without obtaining keys from device (they are saved!)
-            await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
-            await metadataPage.metadataProviderButton(MetadataProvider.GOOGLE).click();
-            await expect(metadataPage.metadataModal).toBeHidden();
-            await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toContainText(
-                'already existing label',
-            );
+            await test.step('Edit label after disconnecting provider (keys are saved)', async () => {
+                await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
+                await metadataPage.metadataProviderButton(MetadataProvider.GOOGLE).click();
+                await expect(metadataPage.metadataModal).toBeHidden();
+                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toContainText(
+                    'already existing label',
+                );
+            });
 
             // device not saved, disable metadata
-            await settingsPage.navigateTo('application');
+            await test.step('Disable metadata and verify all keys and metadata are removed', async () => {
+                await settingsPage.navigateTo('application');
+                await page.selectDropdownOptionWithRetry(
+                    settingsPage.metadataSelectInput,
+                    settingsPage.metadataSelectInputOption('off'),
+                );
+                await walletPage.openAccount();
+                await expect(
+                    page.getByTestId('@account-menu/btc/normal/0/label'),
+                ).not.toContainText('label');
+                await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
 
-            await page.selectDropdownOptionWithRetry(
-                settingsPage.metadataSelectInput,
-                settingsPage.metadataSelectInputOption('off'),
-            );
+                // disabling metadata removed also all keys, so metadata init flow takes all steps now expect for providers, these stay connected
 
-            await walletPage.openAccount();
-            await expect(page.getByTestId('@account-menu/btc/normal/0/label')).not.toContainText(
-                'label',
-            );
-            await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
-
-            // disabling metadata removed also all keys, so metadata init flow takes all steps now expect for providers, these stay connected
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await trezorUserEnvLink.pressYes();
-            await page.waitForTimeout(1000);
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await trezorUserEnvLink.pressYes();
+                await page.waitForTimeout(1000);
+            });
 
             // device saved, disconnect provider
-            await page.getByTestId('@menu/switch-device').click();
-            await page.getByTestId('@switch-device/wallet-on-index/0').click();
+            await test.step('Switch device, stop emulator, and edit label on remembered device', async () => {
+                await page.getByTestId('@menu/switch-device').click();
+                await page.getByTestId('@switch-device/wallet-on-index/0').click();
+                await trezorUserEnvLink.stopEmu();
 
-            await trezorUserEnvLink.stopEmu();
+                // Device is saved, when disconnected, user still can edit labels
+                await metadataPage.account.changeLabel(
+                    AccountLabelId.BitcoinDefault1,
+                    'edited for remembered',
+                );
+                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toContainText(
+                    'edited for remembered',
+                );
+            });
 
-            // Device is saved, when disconnected, user still can edit labels
-            await metadataPage.account.editLabel(
-                AccountLabelId.BitcoinDefault1,
-                'edited for remembered',
-            );
-            await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toContainText(
-                'edited for remembered',
-            );
+            await test.step('Disconnect provider again and verify labels are removed', async () => {
+                await settingsPage.navigateTo('application');
+                await page.getByTestId('@settings/metadata/disconnect-provider-button').click();
+                await walletPage.openAccount();
+                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toContainText(
+                    'Bitcoin',
+                );
+            });
 
-            // Now again, lets try disconnecting provider
-            await settingsPage.navigateTo('application');
-            await page.getByTestId('@settings/metadata/disconnect-provider-button').click();
-            await walletPage.openAccount();
-
-            // Disconnecting removes labels
-            await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toContainText(
-                'Bitcoin',
-            );
-
-            // Still possible to reconnect provider, we have keys still saved
-            await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
-            await metadataPage.metadataProviderButton(MetadataProvider.GOOGLE).click();
-            await expect(metadataPage.metadataModal).toBeHidden();
-            await metadataPage.account.fillLabelInput('mnau');
-            await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toContainText(
-                'mnau',
-            );
+            await test.step('Still possible to reconnect provider, we have keys still saved', async () => {
+                await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
+                await metadataPage.metadataProviderButton(MetadataProvider.GOOGLE).click();
+                await expect(metadataPage.metadataModal).toBeHidden();
+                await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
+                await metadataPage.account.fillLabelInput('mnau');
+                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toContainText(
+                    'mnau',
+                );
+            });
 
             // device saved, disable metadata
-            await settingsPage.navigateTo('application');
-            await page.selectDropdownOptionWithRetry(
-                settingsPage.metadataSelectInput,
-                settingsPage.metadataSelectInputOption('off'),
-            );
-            await walletPage.openAccount();
+            // TODO: Not possible to disabled the metadata in this state, the dropdown is greyed out.
+            await test.step.skip(
+                'Disable metadata and verify editing labels is not possible',
+                async () => {
+                    await settingsPage.navigateTo('application');
+                    await page.selectDropdownOptionWithRetry(
+                        settingsPage.metadataSelectInput,
+                        settingsPage.metadataSelectInputOption('off'),
+                    );
+                    await walletPage.openAccount();
 
-            // Now it is not possible to add labels, keys are gone and device is not connected
-            await expect(
-                metadataPage.account.addLabelButton(AccountLabelId.BitcoinDefault1),
-            ).toBeHidden();
+                    // Now it is not possible to add labels, keys are gone and device is not connected
+                    await expect(
+                        metadataPage.account.editLabelButton(AccountLabelId.BitcoinDefault1),
+                    ).toBeHidden();
+                },
+            );
         });
     },
 );

--- a/suite/e2e/tests/metadata/suite-sync.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync.test.ts
@@ -27,7 +27,7 @@ test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@specificFirmware']
         const newLabel = 'my synced btc account label';
         await test.step('Change BTC account label in first session', async () => {
             await walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }).click();
-            await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
+            await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
             await metadataPage.account.metadataInput.fill(newLabel);
             await page.keyboard.press('Enter');
             await expect(

--- a/suite/e2e/tests/metadata/switching-providers.test.ts
+++ b/suite/e2e/tests/metadata/switching-providers.test.ts
@@ -26,63 +26,67 @@ test.describe(
                 metadataMock,
                 walletPage,
             }) => {
-                await onboardingPage.completeOnboarding();
+                await test.step('Navigate to account and verify initial state', async () => {
+                    await onboardingPage.completeOnboarding();
+                    await walletPage.openAccount();
+                    await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
+                        defaultLabel,
+                    );
+                });
 
-                // Navigate to account and verify initial state
-                await walletPage.openAccount();
-                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
-                    defaultLabel,
-                );
+                await test.step('Start Dropbox provider and add a label', async () => {
+                    await metadataMock.start(MetadataProvider.DROPBOX);
 
-                await metadataMock.start(MetadataProvider.DROPBOX);
+                    await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
+                    await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
 
-                // Add a label using Dropbox
-                await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
-                await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
+                    await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
+                    await metadataPage.account.metadataInput.fill(dropboxLabel);
+                    await page.keyboard.press('Enter');
+                    await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
+                        dropboxLabel,
+                    );
+                });
 
-                await metadataPage.account.metadataInput.fill(dropboxLabel);
-                await page.keyboard.press('Enter');
-                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
-                    dropboxLabel,
-                );
+                await test.step('Disconnect Dropbox', async () => {
+                    await settingsPage.navigateTo('application');
+                    await page.getByTestId('@settings/metadata/disconnect-provider-button').click();
+                    await expect(
+                        page.getByTestId('@settings/metadata/connect-provider-button'),
+                    ).toBeVisible();
 
-                // Disconnect Dropbox
-                await settingsPage.navigateTo('application');
-                await page.getByTestId('@settings/metadata/disconnect-provider-button').click();
-                await expect(
-                    page.getByTestId('@settings/metadata/connect-provider-button'),
-                ).toBeVisible();
+                    await metadataMock.stop();
+                });
 
-                await metadataMock.stop();
+                await test.step('Verify that labels are removed after disconnect', async () => {
+                    await walletPage.openAccount();
+                    await expect(
+                        page.getByTestId('@account-menu/btc/normal/0/label'),
+                    ).toBeVisible();
+                    await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
+                        defaultLabel,
+                    );
+                });
 
-                // Verify that labels are removed after disconnect
-                await walletPage.openAccount();
-                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toBeVisible();
-                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
-                    defaultLabel,
-                );
+                await test.step('Start Google provider and add a label', async () => {
+                    await metadataMock.start(MetadataProvider.GOOGLE);
 
-                await metadataMock.start(MetadataProvider.GOOGLE);
+                    await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
+                    await expect(page.getByTestId('@modal/metadata-provider')).toBeVisible();
+                    await expect(
+                        page.getByTestId('@modal/metadata-provider/file-system-button'),
+                    ).toBeHidden();
+                    await page.getByTestId('@modal/metadata-provider/google-button').click();
+                    await expect(page.getByTestId('@modal/metadata-provider')).toBeHidden();
 
-                // Connect to Google and add a label
-                await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
-                await expect(page.getByTestId('@modal/metadata-provider')).toBeVisible();
-                await expect(
-                    page.getByTestId('@modal/metadata-provider/file-system-button'),
-                ).toBeHidden();
-                await page.getByTestId('@modal/metadata-provider/google-button').click();
-                await expect(page.getByTestId('@modal/metadata-provider')).toBeHidden();
-
-                await metadataPage.account.metadataInput.fill(googleLabel);
-                await page.keyboard.press('Enter');
-                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
-                    googleLabel,
-                );
+                    await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
+                    await metadataPage.account.metadataInput.fill(googleLabel);
+                    await page.keyboard.press('Enter');
+                    await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
+                        googleLabel,
+                    );
+                });
             },
         );
-
-        test.afterEach(async ({ metadataMock }) => {
-            await metadataMock.stop();
-        });
     },
 );

--- a/suite/e2e/tests/metadata/wallet-metadata.test.ts
+++ b/suite/e2e/tests/metadata/wallet-metadata.test.ts
@@ -25,93 +25,107 @@ test.describe('Metadata - wallet labeling', { tag: ['@group=metadata', '@webOnly
         trezorUserEnvLink,
         metadataMock,
     }) => {
-        // Setup standard wallet with label and edit it
-        await page.getByTestId('@account-menu/btc/normal/0/label').click();
-        await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText('Bitcoin #1');
+        await test.step('Setup standard wallet and enable labels', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await metadataPage.wallet.clickEditLabel(standardWalletIndex);
+            await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
+        });
 
-        await dashboardPage.openDeviceSwitcher();
-        await metadataPage.wallet.clickAddLabel(standardWalletIndex);
-        await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
-        await metadataPage.wallet.fillLabelInput('label for standard wallet');
-        await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
-            'label for standard wallet',
-        );
+        await test.step('Add and Edit label of standard wallet', async () => {
+            await metadataPage.wallet.clickEditLabel(standardWalletIndex);
+            await metadataPage.wallet.fillLabelInput('label for standard wallet');
 
-        await metadataPage.wallet.clickEditLabel(standardWalletIndex);
-        await metadataPage.wallet.fillLabelInput('wallet for drugs');
+            await metadataPage.wallet.successIconIsVisible(standardWalletIndex);
+            await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
+                'label for standard wallet',
+            );
 
-        // Add hidden wallet and enable labeling
-        await dashboardPage.addUnusedHiddenWallet('abc');
+            await metadataPage.wallet.clickEditLabel(standardWalletIndex);
+            await metadataPage.wallet.fillLabelInput('wallet for drugs');
+            await metadataPage.wallet.successIconIsVisible(standardWalletIndex);
+        });
 
-        await devicePrompt.confirmOnDevicePromptIsShown();
-        await trezorUserEnvLink.pressYes();
+        await test.step('Add hidden wallet and enable labeling', async () => {
+            await dashboardPage.addUnusedHiddenWallet('abc');
 
-        await dashboardPage.openDeviceSwitcher();
-        await metadataPage.wallet.clickAddLabel(hiddenWalletIndex);
-        await metadataPage.wallet.fillLabelInput('wallet not for drugs');
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await trezorUserEnvLink.pressYes();
 
-        // Verify wallet labels
-        await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
-            'wallet for drugs',
-        );
-        await expect(metadataPage.wallet.walletLabel(hiddenWalletIndex)).toHaveText(
-            'wallet not for drugs',
-        );
+            await dashboardPage.openDeviceSwitcher();
+            await metadataPage.wallet.clickEditLabel(hiddenWalletIndex);
+            await metadataPage.wallet.fillLabelInput('wallet not for drugs');
+            await metadataPage.wallet.successIconIsVisible(hiddenWalletIndex);
+        });
 
-        // Reload app
-        await page.waitForTimeout(1000); // wait for changes to db
-        await page.reload();
-        await metadataMock.setupWindowStubs();
+        await test.step('Verify wallet labels', async () => {
+            await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
+                'wallet for drugs',
+            );
+            await expect(metadataPage.wallet.walletLabel(hiddenWalletIndex)).toHaveText(
+                'wallet not for drugs',
+            );
+        });
 
-        // Verify wallet labels after reload
-        await dashboardPage.openDeviceSwitcher();
+        await test.step('Reload app', async () => {
+            await page.waitForTimeout(1000); // wait for changes to db
+            await page.reload();
+            await metadataMock.setupWindowStubs();
+        });
 
-        await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
-            'wallet for drugs',
-        );
-        await expect(metadataPage.wallet.walletLabel(hiddenWalletIndex)).toHaveText(
-            'wallet not for drugs',
-        );
+        await test.step('Verify wallet labels after reload', async () => {
+            await dashboardPage.openDeviceSwitcher();
+
+            await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
+                'wallet for drugs',
+            );
+            await expect(metadataPage.wallet.walletLabel(hiddenWalletIndex)).toHaveText(
+                'wallet not for drugs',
+            );
+        });
     });
 
     test('labels can be enabled and edited when different wallet is open', async ({
-        page,
         dashboardPage,
         metadataPage,
         devicePrompt,
         trezorUserEnvLink,
     }) => {
-        // Setup standard wallet with label and edit it
-        await page.getByTestId('@account-menu/btc/normal/0/label').click();
-        await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText('Bitcoin #1');
+        await test.step('Setup standard wallet with label and edit it', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await metadataPage.wallet.clickEditLabel(standardWalletIndex);
+            await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
+            await metadataPage.wallet.clickEditLabel(standardWalletIndex);
+            await metadataPage.wallet.fillLabelInput('label for standard wallet');
+            await metadataPage.wallet.successIconIsVisible(standardWalletIndex);
+        });
 
-        await dashboardPage.openDeviceSwitcher();
-        await metadataPage.wallet.clickAddLabel(standardWalletIndex);
-        await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
-        await metadataPage.wallet.fillLabelInput('label for standard wallet');
+        await test.step('Add passphrase wallet C and switch back to first wallet', async () => {
+            await dashboardPage.addUnusedHiddenWallet('C');
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await trezorUserEnvLink.pressNo();
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.walletAtIndex(standardWalletIndex).click();
+        });
 
-        // Add passphrase wallet C and switch back to first wallet
-        await dashboardPage.addUnusedHiddenWallet('C');
-        await devicePrompt.confirmOnDevicePromptIsShown();
-        await trezorUserEnvLink.pressNo();
-        await dashboardPage.openDeviceSwitcher();
-        await dashboardPage.walletAtIndex(standardWalletIndex).click();
+        await test.step('Enable labeling for wallet C', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await metadataPage.wallet.clickEditLabel(hiddenWalletIndex);
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await trezorUserEnvLink.pressYes();
+            await metadataPage.wallet.clickEditLabel(hiddenWalletIndex);
+            await metadataPage.wallet.fillLabelInput(
+                'still works, metadata enabled for currently not selected device',
+            );
+            await metadataPage.wallet.successIconIsVisible(hiddenWalletIndex);
+        });
 
-        // Enable labeling for wallet C
-        await dashboardPage.openDeviceSwitcher();
-        await metadataPage.wallet.clickAddLabel(hiddenWalletIndex);
-        await devicePrompt.confirmOnDevicePromptIsShown();
-        await trezorUserEnvLink.pressYes();
-        await metadataPage.wallet.fillLabelInput(
-            'still works, metadata enabled for currently not selected device',
-        );
-
-        // Verify wallet labels
-        await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
-            'label for standard wallet',
-        );
-        await expect(metadataPage.wallet.walletLabel(hiddenWalletIndex)).toHaveText(
-            'still works, metadata enabled for currently not selected device',
-        );
+        await test.step('Verify wallet labels', async () => {
+            await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
+                'label for standard wallet',
+            );
+            await expect(metadataPage.wallet.walletLabel(hiddenWalletIndex)).toHaveText(
+                'still works, metadata enabled for currently not selected device',
+            );
+        });
     });
 });

--- a/suite/e2e/tests/wallet/import-btc-csv.test.ts
+++ b/suite/e2e/tests/wallet/import-btc-csv.test.ts
@@ -26,7 +26,7 @@ test.describe('Import a BTC csv file', { tag: ['@group=wallet', '@webOnly'] }, (
         },
         async ({ page, dashboardPage, metadataPage, walletPage }) => {
             await walletPage.openAccount();
-            await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
+            await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
             await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
 
             await walletPage.openSendFormButton.click();


### PR DESCRIPTION
Updates tests to be up to date

Reason for so many changes is metadata implementation is now split. Wallet and Account now rely on new one and rest on the old one.
Plus I added test.step wrapping because without it troubleshooting was a bit painful.

[PR WEB tests](https://github.com/trezor/trezor-suite/actions/runs/20110811856)

- [ ] discuss the change of flow:
Original behaviour: starting on green field -> open switcher - hover - click edit - prompt for provider -> choose dropbox -> edit is active and I can change label right away
Now:  After choosing dropbox, I need to hover and click edit again.
