### PR TITLE
23653 mobile trade wrong ordering of quotes

### DIFF
--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -18,11 +18,9 @@ import { BuyInfo, TradingBuyState } from '../../reducers/buyReducer';
 import { ExchangeInfo, exchangeInitialState } from '../../reducers/exchangeReducer';
 import { SellInfo, sellInitialState } from '../../reducers/sellReducer';
 import { type TradingRootState, initialState } from '../../reducers/tradingCommonReducer';
-import type { TradingPaymentMethodListProps, TradingPaymentMethodProps } from '../../types';
+import type { TradingPaymentMethodListProps } from '../../types';
 import {
     TradingRootStateWithDeviceAndAccounts,
-    selectBestBuyQuoteByPaymentMethod,
-    selectBuyQuotesByPaymentMethod,
     selectDeviceHasTradingTrades,
     selectDeviceTradingTradesOrderedByDate,
     selectTrading,
@@ -901,50 +899,6 @@ describe('tradingSelectors', () => {
     describe(selectTradingBuyQuotes.name, () => {
         it('should return quotes', () => {
             expect(selectTradingBuyQuotes(state)).toBe(state.wallet.trading.buy.quotes);
-        });
-    });
-
-    describe(selectBestBuyQuoteByPaymentMethod.name, () => {
-        it('should return best quote', () => {
-            expect(selectBestBuyQuoteByPaymentMethod(state, 'eps')).toEqual(
-                expect.objectContaining({
-                    paymentMethod: 'eps',
-                    quoteId: 'quoteId2',
-                }),
-            );
-        });
-
-        it('should be undefined when payment method is not specified', () => {
-            expect(selectBestBuyQuoteByPaymentMethod(state, undefined)).toBeUndefined();
-        });
-
-        it('should be undefined when no quotes are loaded', () => {
-            state.wallet.trading.buy.quotes = [];
-
-            expect(selectBestBuyQuoteByPaymentMethod(state, 'eps')).toBeUndefined();
-        });
-    });
-
-    describe(selectBuyQuotesByPaymentMethod.name, () => {
-        it('should return undefined when payment method is not provided', () => {
-            const result = selectBuyQuotesByPaymentMethod(state, undefined);
-            expect(result).toBeUndefined();
-        });
-
-        it('should filter quotes by payment method and sort by rate', () => {
-            const paymentMethod: TradingPaymentMethodProps = 'eps';
-            const result = selectBuyQuotesByPaymentMethod(state, paymentMethod);
-
-            expect(result).toHaveLength(2);
-            expect(result?.[0].orderId).toBe('orderId2');
-            expect(result?.[1].orderId).toBe('orderId1');
-        });
-
-        it('should return empty array when no quotes match payment method', () => {
-            const paymentMethod: TradingPaymentMethodProps = 'bankTransfer';
-            const result = selectBuyQuotesByPaymentMethod(state, paymentMethod);
-
-            expect(result).toHaveLength(0);
         });
     });
 

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -25,7 +25,6 @@ import {
 } from '../types';
 import {
     cryptoIdToNetwork,
-    getBestRatedQuote,
     getTradingQuotesByPaymentMethod,
     isBuyTrade,
     isExchangeProvider,
@@ -511,6 +510,7 @@ export const selectTradingBuyQuoteByOrderId = (
     orderId: string | undefined,
 ) => (orderId ? state.wallet.trading.buy.quotes.find(q => q.orderId === orderId) : undefined);
 
+// TODO 23653 - not used from anywhere?
 export const selectBuyQuotesByPaymentMethod = createMemoizedSelector(
     [
         selectTradingBuyQuotes,
@@ -518,16 +518,13 @@ export const selectBuyQuotesByPaymentMethod = createMemoizedSelector(
             paymentMethod,
     ],
     (quotes, paymentMethod) =>
-        paymentMethod
-            ? getTradingQuotesByPaymentMethod<'buy'>(quotes, paymentMethod)?.sort(
-                  (a, b) => (a.rate ?? 0) - (b.rate ?? 0),
-              )
-            : undefined,
+        paymentMethod ? getTradingQuotesByPaymentMethod<'buy'>(quotes, paymentMethod) : undefined,
 );
 
+// TODO 23653 - not used from anywhere?
 export const selectBestBuyQuoteByPaymentMethod = createMemoizedSelector(
     [selectBuyQuotesByPaymentMethod],
-    quotes => getBestRatedQuote(quotes, 'buy'),
+    quotes => (quotes && quotes.length > 0 ? quotes[0] : undefined),
 );
 
 export const selectTradingExchangeIsLoading = (state: TradingRootState) =>

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -17,19 +17,8 @@ import { BuyInfo, TradingBuyState } from '../reducers/buyReducer';
 import { ExchangeInfo, TradingExchangeState } from '../reducers/exchangeReducer';
 import { SellInfo, TradingSellState } from '../reducers/sellReducer';
 import type { TradingRootState, TradingState } from '../reducers/tradingCommonReducer';
-import {
-    TradingFiatCurrenciesProps,
-    TradingPaymentMethodProps,
-    TradingTransaction,
-    TradingType,
-} from '../types';
-import {
-    cryptoIdToNetwork,
-    getTradingQuotesByPaymentMethod,
-    isBuyTrade,
-    isExchangeProvider,
-    testnetToProdCryptoId,
-} from '../utils';
+import { TradingFiatCurrenciesProps, TradingTransaction, TradingType } from '../types';
+import { cryptoIdToNetwork, isBuyTrade, isExchangeProvider, testnetToProdCryptoId } from '../utils';
 import {
     getTradingCoinInfoByCryptoId,
     getTradingCoinSymbolByCryptoId,
@@ -509,23 +498,6 @@ export const selectTradingBuyQuoteByOrderId = (
     state: TradingRootState,
     orderId: string | undefined,
 ) => (orderId ? state.wallet.trading.buy.quotes.find(q => q.orderId === orderId) : undefined);
-
-// TODO 23653 - not used from anywhere?
-export const selectBuyQuotesByPaymentMethod = createMemoizedSelector(
-    [
-        selectTradingBuyQuotes,
-        (_: TradingRootState, paymentMethod: TradingPaymentMethodProps | undefined) =>
-            paymentMethod,
-    ],
-    (quotes, paymentMethod) =>
-        paymentMethod ? getTradingQuotesByPaymentMethod<'buy'>(quotes, paymentMethod) : undefined,
-);
-
-// TODO 23653 - not used from anywhere?
-export const selectBestBuyQuoteByPaymentMethod = createMemoizedSelector(
-    [selectBuyQuotesByPaymentMethod],
-    quotes => (quotes && quotes.length > 0 ? quotes[0] : undefined),
-);
 
 export const selectTradingExchangeIsLoading = (state: TradingRootState) =>
     state.wallet.trading.exchange.isLoading;

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -4,11 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import type { BuyCryptoPaymentMethod, BuyTrade, CryptoId, FiatCurrencyCode } from 'invity-api';
 
-import {
-    TradingAmountLimitProps,
-    getBestRatedQuote,
-    selectTradingBuyQuotesRequest,
-} from '@suite-common/trading';
+import { TradingAmountLimitProps, selectTradingBuyQuotesRequest } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
 import { WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
@@ -152,8 +148,7 @@ const useBuyQuotesChangeEffect = ({ getValues, setValue }: BuyFormType) => {
             quoteCandidates = quotes;
         }
 
-        const selectedQuote = getBestRatedQuote(quoteCandidates, 'buy');
-        setValue('quote', selectedQuote);
+        setValue('quote', quoteCandidates[0]);
     }, [quotes, getValues, setValue]);
 };
 

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -48,7 +48,7 @@ describe('useExchangeForm', () => {
     });
 
     describe('on quotes change', () => {
-        it('should select fixed quote with best rate', async () => {
+        it('should select first fixed quote', async () => {
             const { result } = await renderUseExchangeForm();
             act(() => {
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
@@ -56,7 +56,7 @@ describe('useExchangeForm', () => {
 
             expect(result.current.getValues('quote')).toEqual(
                 expect.objectContaining({
-                    quoteId: 'mercuryo-fixed-best',
+                    quoteId: 'mercuryo-fixed-worst',
                 }),
             );
         });
@@ -107,7 +107,7 @@ describe('useExchangeForm', () => {
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
             });
 
-            expect(result.current.getValues('receiveCryptoAmount')).toBe('0.00089537');
+            expect(result.current.getValues('receiveCryptoAmount')).toBe('0.00083554');
         });
 
         it('should set receiveCryptoAmount in sats when using BTC and amount in sats', async () => {
@@ -118,7 +118,7 @@ describe('useExchangeForm', () => {
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
             });
 
-            expect(result.current.getValues('receiveCryptoAmount')).toBe('89537');
+            expect(result.current.getValues('receiveCryptoAmount')).toBe('83554');
         });
 
         describe('when quote is selected and new quotes are fetched', () => {

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
@@ -509,7 +509,7 @@ describe('useSellForm', () => {
             expect(result.current.getValues('quote')).toEqual(sellQuotes[1]);
         });
 
-        it('if no quote is selected and no bankTransferQuote is available should select best rated quote', async () => {
+        it('if no quote is selected and no bankTransferQuote is available should select first quote', async () => {
             const { result } = await renderUseSellForm();
             initFormAndQuoteRequest(result.current);
 
@@ -517,7 +517,7 @@ describe('useSellForm', () => {
                 store.dispatch(tradingSellActions.saveQuotes([sellQuotes[0], sellQuotes[2]]));
             });
 
-            expect(result.current.getValues('quote')).toEqual(sellQuotes[2]);
+            expect(result.current.getValues('quote')).toEqual(sellQuotes[0]);
         });
 
         describe('when quote is selected and new quotes are fetched', () => {

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.ts
@@ -5,7 +5,6 @@ import type { CryptoId, FiatCurrencyCode, SellFiatTrade } from 'invity-api';
 
 import {
     TradingAmountLimitProps,
-    getBestRatedQuote,
     selectTradingSellQuotesRequest,
     selectValidTradingSellQuotes,
 } from '@suite-common/trading';
@@ -137,8 +136,7 @@ const useSellQuotesChangeEffect = ({ getValues, setValue }: SellFormType) => {
             quoteCandidates = quotes;
         }
 
-        const selectedQuote = getBestRatedQuote(quoteCandidates, 'sell');
-        setValue('quote', selectedQuote);
+        setValue('quote', quoteCandidates[0]);
     }, [quotes, getValues, setValue]);
 };
 

--- a/suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts
@@ -280,7 +280,7 @@ describe('buySelectors', () => {
             state.wallet.trading.buy.quotes = buyQuotes;
         });
 
-        it('should return only best quote for each payment method', () => {
+        it('should return only first quote for each payment method', () => {
             expect(selectBuyBestQuotesForAvailablePaymentMethods(state)).toEqual([
                 expect.objectContaining({
                     paymentMethod: 'applePay',

--- a/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
@@ -146,10 +146,10 @@ describe('exchangeSelectors', () => {
             expect(groupedQuotes).toEqual({
                 fixed: [
                     expect.objectContaining({
-                        quoteId: 'mercuryo-fixed-best',
+                        quoteId: 'mercuryo-fixed-worst',
                     }),
                     expect.objectContaining({
-                        quoteId: 'mercuryo-fixed-worst',
+                        quoteId: 'mercuryo-fixed-best',
                     }),
                 ],
                 float: [
@@ -178,20 +178,6 @@ describe('exchangeSelectors', () => {
             const groupedQuotes = selectGroupedExchangeQuotes(state);
 
             expect(groupedQuotes.dex).toEqual([]);
-        });
-
-        it('should sort quotes by rate within each group (highest rate first)', () => {
-            state.wallet.trading.exchange.quotes = exchangeQuotes;
-
-            const groupedQuotes = selectGroupedExchangeQuotes(state);
-
-            // Fixed quotes should be sorted by rate (highest first)
-            expect(groupedQuotes.fixed[0].rate ?? 0).toBeGreaterThan(
-                groupedQuotes.fixed[1].rate ?? 0,
-            );
-
-            // DEX quotes should be sorted by rate (highest first)
-            expect(groupedQuotes.dex[0].rate ?? 0).toBeGreaterThan(groupedQuotes.dex[1].rate ?? 0);
         });
 
         it('should be stable', () => {

--- a/suite-native/trading-state/src/selectors/__tests__/sellSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/sellSelectors.test.ts
@@ -275,11 +275,11 @@ describe('sellSelectors', () => {
             state.wallet.trading.sell.quotes = sellQuotes;
         });
 
-        it('should return only best quote for each payment method', () => {
+        it('should return only first quote for each payment method', () => {
             expect(selectSellBestQuotesForAvailablePaymentMethods(state)).toEqual([
                 expect.objectContaining({
                     paymentMethod: 'creditCard',
-                    rate: 3940,
+                    rate: 3869.9570815450643,
                 }),
                 expect.objectContaining({
                     paymentMethod: 'bankTransfer',
@@ -325,8 +325,8 @@ describe('sellSelectors', () => {
         it('should select valid quotes', () => {
             expect(selectSellQuotesByPaymentMethod(state, 'creditCard')).toEqual({
                 fixed: [
-                    expect.objectContaining({ orderId: 'order_id_2' }),
                     expect.objectContaining({ orderId: 'order_id_0' }),
+                    expect.objectContaining({ orderId: 'order_id_2' }),
                 ],
             });
         });

--- a/suite-native/trading-state/src/selectors/buySelectors.ts
+++ b/suite-native/trading-state/src/selectors/buySelectors.ts
@@ -7,7 +7,6 @@ import { invariant } from '@suite-common/suite-utils';
 import {
     TradingCountryCode,
     TradingPaymentMethodProps,
-    getBestRatedQuote,
     getTradingQuotesByPaymentMethod,
     nonSanctionedRegional,
     selectTradingBuyInfo,
@@ -127,25 +126,19 @@ export const selectValidTradingBuyQuotesNative = createMemoizedSelector(
 export const selectBuyBestQuotesForAvailablePaymentMethods = createMemoizedSelector(
     [selectValidTradingBuyQuotesNative],
     quotes => {
-        const allQuotesByPaymentMethodMap = quotes.reduce((quotesByPaymentMethodMap, quote) => {
+        const bestQuoteByPaymentMethodMap = quotes.reduce((quotesByPaymentMethodMap, quote) => {
             const { paymentMethod, paymentMethodName } = quote;
-            if (!paymentMethod || !paymentMethodName) {
-                return quotesByPaymentMethodMap;
-            }
+            const isValidPaymentMethod = paymentMethod && paymentMethodName;
 
-            const existingQuotes = quotesByPaymentMethodMap.get(paymentMethod);
-            if (!existingQuotes) {
-                quotesByPaymentMethodMap.set(paymentMethod, [quote]);
-            } else {
-                existingQuotes.push(quote);
+            // we only want one quote per payment method (and the 1st is considered the best)
+            if (isValidPaymentMethod && !quotesByPaymentMethodMap.has(paymentMethod)) {
+                quotesByPaymentMethodMap.set(paymentMethod, quote);
             }
 
             return quotesByPaymentMethodMap;
-        }, new Map<BuyCryptoPaymentMethod, BuyTrade[]>());
+        }, new Map<BuyCryptoPaymentMethod, BuyTrade>());
 
-        return [...allQuotesByPaymentMethodMap.values()].map(quotesForPaymentMethod =>
-            getBestRatedQuote(quotesForPaymentMethod, 'buy'),
-        ) as BuyTrade[];
+        return [...bestQuoteByPaymentMethodMap.values()];
     },
 );
 
@@ -156,10 +149,6 @@ export const selectBuyQuotesByPaymentMethodNative = createMemoizedSelector(
             paymentMethod,
     ],
     (quotes, paymentMethod) => ({
-        fixed: paymentMethod
-            ? getTradingQuotesByPaymentMethod<'buy'>(quotes, paymentMethod)?.sort(
-                  (a, b) => (a.rate ?? 0) - (b.rate ?? 0),
-              )
-            : [],
+        fixed: paymentMethod ? getTradingQuotesByPaymentMethod<'buy'>(quotes, paymentMethod) : [],
     }),
 );

--- a/suite-native/trading-state/src/selectors/exchangeSelectors.ts
+++ b/suite-native/trading-state/src/selectors/exchangeSelectors.ts
@@ -75,11 +75,6 @@ export const selectExchangeBuyTradeableAssets = createMemoizedSelector(
 export const selectExchangeQuotes = (state: TradingRootState) =>
     state.wallet.trading.exchange.quotes;
 
-const ratingSortingComparator = (
-    a: { rate?: number | undefined },
-    b: { rate?: number | undefined },
-) => (b.rate ?? 0) - (a.rate ?? 0);
-
 export const selectGroupedExchangeQuotes = createTradingWithFeatureFlagsMemoizedSelector(
     [
         selectExchangeQuotes,
@@ -110,10 +105,6 @@ export const selectGroupedExchangeQuotes = createTradingWithFeatureFlagsMemoized
             } else {
                 groups.float.push(quote);
             }
-        });
-
-        Object.values(groups).forEach(group => {
-            group.sort(ratingSortingComparator);
         });
 
         return groups;

--- a/suite-native/trading-state/src/selectors/sellSelectors.ts
+++ b/suite-native/trading-state/src/selectors/sellSelectors.ts
@@ -4,7 +4,6 @@ import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import {
     TradingCountryCode,
     TradingPaymentMethodProps,
-    getBestRatedQuote,
     getTradingQuotesByPaymentMethod,
     nonSanctionedRegional,
     selectTradingSellInfo,
@@ -77,25 +76,19 @@ export const selectSellSelectedSendAccount = createMemoizedSelectorWithAccounts(
 export const selectSellBestQuotesForAvailablePaymentMethods = createMemoizedSelector(
     [selectValidTradingSellQuotes],
     quotes => {
-        const allQuotesByPaymentMethodMap = quotes.reduce((quotesByPaymentMethodMap, quote) => {
+        const bestQuoteByPaymentMethodMap = quotes.reduce((quotesByPaymentMethodMap, quote) => {
             const { paymentMethod, paymentMethodName } = quote;
-            if (!paymentMethod || !paymentMethodName) {
-                return quotesByPaymentMethodMap;
-            }
+            const isValidPaymentMethod = paymentMethod && paymentMethodName;
 
-            const existingQuotes = quotesByPaymentMethodMap.get(paymentMethod);
-            if (!existingQuotes) {
-                quotesByPaymentMethodMap.set(paymentMethod, [quote]);
-            } else {
-                existingQuotes.push(quote);
+            // we only want one quote per payment method (and the 1st is considered the best)
+            if (isValidPaymentMethod && !quotesByPaymentMethodMap.has(paymentMethod)) {
+                quotesByPaymentMethodMap.set(paymentMethod, quote);
             }
 
             return quotesByPaymentMethodMap;
-        }, new Map<SellCryptoPaymentMethod, SellFiatTrade[]>());
+        }, new Map<SellCryptoPaymentMethod, SellFiatTrade>());
 
-        return [...allQuotesByPaymentMethodMap.values()].map(quotesForPaymentMethod =>
-            getBestRatedQuote(quotesForPaymentMethod, 'sell'),
-        ) as SellFiatTrade[];
+        return [...bestQuoteByPaymentMethodMap.values()];
     },
 );
 
@@ -106,10 +99,6 @@ export const selectSellQuotesByPaymentMethod = createMemoizedSelector(
             paymentMethod,
     ],
     (quotes, paymentMethod) => ({
-        fixed: paymentMethod
-            ? getTradingQuotesByPaymentMethod<'sell'>(quotes, paymentMethod)?.sort(
-                  (a, b) => (b.rate ?? 0) - (a.rate ?? 0),
-              )
-            : [],
+        fixed: paymentMethod ? getTradingQuotesByPaymentMethod<'sell'>(quotes, paymentMethod) : [],
     }),
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Never reorder quotes on frontend.
- Removed unused trading selectors.
- 
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #23653

## Screenshots:

<img width="300" alt="Simulator Screenshot - iPhone 16e - 2025-12-11 at 09 13 11" src="https://github.com/user-attachments/assets/7c8a12e7-d298-415e-bb5c-592d3c34ea7e" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=23653-mobile-trade-wrong-ordering-of-quotes&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=23653-mobile-trade-wrong-ordering-of-quotes&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=23653-mobile-trade-wrong-ordering-of-quotes&lookback=7)