### PR TITLE
fix(suite-native): fix BridgeTransport port after change

### DIFF
--- a/suite-native/app/.detoxrc.js
+++ b/suite-native/app/.detoxrc.js
@@ -27,13 +27,13 @@ module.exports = {
             type: 'android.apk',
             binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
             build: 'cd android && NODE_ENV=test ./gradlew :app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug',
-            reversePorts: [8081, 21325, 19121],
+            reversePorts: [8081, 21328, 19121],
         },
         'android.release': {
             type: 'android.apk',
             binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
             build: 'cd android && NODE_ENV=test ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release',
-            reversePorts: [21325, 19121],
+            reversePorts: [21328, 19121],
         },
     },
     devices: {

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -20,7 +20,7 @@
         "build:e2e": "npx detox build --configuration",
         "test:e2e": "node ./scripts/cleanArtifacts.js && npx detox test --configuration ",
         "start:e2e": "NODE_ENV=test RN_SRC_EXT=e2e.ts,e2e.tsx expo start --dev-client",
-        "reverse-ports": "adb reverse tcp:8081 tcp:8081 && adb reverse tcp:21325 tcp:21325 && adb reverse tcp:19121 tcp:19121",
+        "reverse-ports": "adb reverse tcp:8081 tcp:8081 && adb reverse tcp:21328 tcp:21328 && adb reverse tcp:19121 tcp:19121",
         "github:report:manual": "npx jest --config=./e2e/jest.config.reporter.js"
     },
     "dependencies": {

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -24,7 +24,7 @@ import { mergeDeepObject } from '@trezor/utils';
 
 const deviceType = Device.isDevice ? 'device' : 'emulator';
 
-const bridgeTransport = new BridgeTransport({ messages, port: 21325, id: 'bridge' });
+const bridgeTransport = new BridgeTransport({ messages, port: 21328, id: 'bridge' });
 
 const transportsPerDeviceType = {
     device: Platform.select({


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- iOS simulator was not able to connect to trezor emulator after the [port change](https://github.com/trezor/trezor-suite/pull/20245), this fixes it.



## Notes for QA

This does not affect app running on real device, only simulator.




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/bridge-transport-port&lookback=7)