### PR TITLE
test: entropy check E2E Desktop & Web

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -83,6 +83,11 @@ jobs:
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
           yarn install
 
+      # Detox runtime may indirectly import the built config, and that would crash if message-system is not built
+      - name: Sign message system config
+        working-directory: ./suite-common/message-system
+        run: yarn sign-config
+
       - name: Generate GitHub App token
         id: trezor-bot-token
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -56,6 +56,7 @@ jobs:
         working-directory: ./suite-native/app
         run: yarn prebuild --platform ios --clean
 
+      # Detox runtime may indirectly import the built config, and that would crash if message-system is not built
       - name: Sign message system config
         working-directory: ./suite-common/message-system
         run: yarn sign-config

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -2,7 +2,11 @@ import { FIRMWARE_MODULE_PREFIX } from '@suite-common/firmware';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { processEntropyCheckResultThunk, selectSelectedDevice } from '@suite-common/wallet-core';
+import {
+    processEntropyCheckResultThunk,
+    selectSelectedDevice,
+    selectSimulatedEntropyCheckFail,
+} from '@suite-common/wallet-core';
 import TrezorConnect, { ERRORS } from '@trezor/connect';
 
 import * as modalActions from 'src/actions/suite/modalActions';
@@ -149,6 +153,8 @@ export const resetDevice =
 
         const isEntropyCheckEnabled =
             isEntropyCheckEnabledInSettings && !isEntropyCheckDisabledByMessageSystem;
+        // Used only in tests! See deviceReducer for the property definition.
+        const simulatedFailResult = selectSimulatedEntropyCheckFail(getState());
 
         const result = await TrezorConnect.resetDevice({
             ...defaults,
@@ -160,6 +166,11 @@ export const resetDevice =
         });
 
         if (isEntropyCheckEnabled) {
+            if (simulatedFailResult) {
+                dispatch(processEntropyCheckResultThunk({ device, result: simulatedFailResult }));
+
+                return simulatedFailResult;
+            }
             dispatch(processEntropyCheckResultThunk({ device, result }));
         }
 

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -15,6 +15,7 @@ import {
     Device,
     DeviceState,
     StaticSessionId,
+    Unsuccessful,
 } from '@trezor/connect';
 
 export const DEVICE_MODULE_PREFIX = '@suite/device';
@@ -174,6 +175,12 @@ const setDiscovered = createAction(
     }),
 );
 
+// Use in tests only! See deviceReducer for the property definition.
+const setSimulatedEntropyCheckFail = createAction(
+    `${DEVICE_MODULE_PREFIX}/setSimulatedEntropyCheckFail`,
+    (payload: Unsuccessful) => ({ payload }),
+);
+
 export const deviceActions = {
     connectDevice,
     createDeviceInstance,
@@ -199,4 +206,5 @@ export const deviceActions = {
     setSuiteSyncOwner,
     setDiscovered,
     devicePushNotification,
+    setSimulatedEntropyCheckFail,
 };

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -14,7 +14,14 @@ import {
 import * as deviceUtils from '@suite-common/suite-utils';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { shouldDeviceBeRemembered } from '@suite-common/wallet-utils';
-import { Device, DeviceState, Features, KnownDevice, StaticSessionId } from '@trezor/connect';
+import {
+    Device,
+    DeviceState,
+    Features,
+    KnownDevice,
+    StaticSessionId,
+    Unsuccessful,
+} from '@trezor/connect';
 import { getFirmwareVersionArray } from '@trezor/device-utils';
 
 import { DeviceStateActionPayload, deviceActions } from './deviceActions';
@@ -41,6 +48,8 @@ export type DeviceReducerState = {
         firmwareAuthenticity?: string[];
     };
     lastConnectedAuthenticityChecks?: KnownDevice['authenticityChecks'];
+    // Setting with no UI to toggle it on, used in tests to simulate various outcomes of entropy check failure
+    simulatedEntropyCheckFail?: Unsuccessful;
 };
 
 export const deviceInitialState: DeviceReducerState = {
@@ -719,6 +728,9 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
                     d => d.state?.staticSessionId === payload.staticSessionId,
                 );
                 if (device) device.discovered = payload.success;
+            })
+            .addCase(deviceActions.setSimulatedEntropyCheckFail, (state, { payload }) => {
+                state.simulatedEntropyCheckFail = payload;
             })
             .addMatcher(
                 isAnyOf(deviceActions.connectDevice, deviceActions.connectUnacquiredDevice),

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -69,6 +69,10 @@ export const selectSelectedFirstThpDevice = (state: DeviceRootState) => {
 export const selectPersistentDeviceData = (state: DeviceRootState) =>
     state.device.persistentDeviceData;
 
+// Use in tests only! See deviceReducer for the property definition.
+export const selectSimulatedEntropyCheckFail = (state: DeviceRootState) =>
+    state.device.simulatedEntropyCheckFail;
+
 // Derived selectors
 export const selectIsPendingTransportEvent = createMemoizedSelector(
     [selectDevices],

--- a/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
@@ -1,7 +1,8 @@
 import { BackupType } from '@suite-common/suite-types';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { scrollUntilVisible, waitForVisible } from '../support/utils';
+import { getModelFromEnv } from '../support/setup';
+import { isElementVisible, scrollUntilVisible, wait, waitForVisible } from '../support/utils';
 
 class DeviceOnboardingActions {
     async selectCreateWalletOption() {
@@ -108,6 +109,10 @@ class DeviceOnboardingActions {
         await element(by.id(buttonId)).tap();
     }
 
+    async waitForDeviceCompromisedModal() {
+        await waitForVisible(by.id('@screen/DeviceCompromisedModal'));
+    }
+
     async dismissTheUninitializedDeviceLanding() {
         await element(by.id('@deviceOnboarding/UninitializedDeviceLandingScreen/confirmBtn')).tap();
     }
@@ -127,6 +132,57 @@ class DeviceOnboardingActions {
             throw new Error(`Screen content did not contain pairing code\n${screenContentBody}`);
         }
         await element(by.id('@thpSecurityCode/Input')).replaceText(code);
+    }
+
+    async proceedToCreateOrRecoverCrossroads() {
+        await this.waitForUninitializedDeviceLanding();
+        await this.dismissTheUninitializedDeviceLanding();
+        // During our release process, the TrezorUserEnv might not have the latest firmware version.
+        // In such cases, the firmware update screen appears here.
+        // We want to skip the update in e2e tests as it is not supported.
+        const isFirmwareUpdateScreenPresent = await isElementVisible(
+            by.id('@device-firmware/update-button'),
+        );
+        if (isFirmwareUpdateScreenPresent) {
+            await this.skipFirmwareUpdate();
+            console.warn(
+                'SKIPPING FIRMWARE UPDATE: Firmware update was displayed, make sure it was only due to TrezorUserEnv not having latest firmware version.',
+            );
+        }
+
+        await TrezorUserEnvLink.pressYes();
+
+        if (getModelFromEnv() !== 'T3W1') {
+            // skip device authenticity check on T3W1 because we are using 2-main FW
+            await this.waitForDeviceAuthenticitySuccess();
+            await this.dismissDeviceAuthenticitySuccess();
+        }
+
+        await TrezorUserEnvLink.pressYes();
+
+        await this.waitForCreateOrRecoverCrossroadsScreen();
+    }
+
+    async startCreatingWallet() {
+        await this.selectCreateWalletOption();
+        await this.waitForCreateWalletLoadingScreen();
+        await this.waitForWalletBackupTutorialScreen();
+        await this.gotToNextWalletBackupTutorialStep(1);
+        await this.gotToNextWalletBackupTutorialStep(2);
+        await this.gotToNextWalletBackupTutorialStep(3);
+        await this.gotToNextWalletBackupTutorialStep(4);
+        await this.validateSelectedBackupType('shamir-single');
+        await this.gotToNextWalletBackupTutorialStep(5);
+        await wait(5000); // wait for entering animation to finish
+
+        await this.pressHoldToConfirmButton();
+        await this.waitForWalletCreationScreen();
+
+        await TrezorUserEnvLink.swipeEmu('up');
+        await TrezorUserEnvLink.pressYes();
+        await TrezorUserEnvLink.pressYes();
+        await TrezorUserEnvLink.pressNo();
+        // at this point, wallet creation + entropy check on device has begun
     }
 }
 

--- a/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
@@ -1,8 +1,13 @@
 import { BackupType } from '@suite-common/suite-types';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { getModelFromEnv } from '../support/setup';
-import { isElementVisible, scrollUntilVisible, wait, waitForVisible } from '../support/utils';
+import {
+    getModelFromEnv,
+    isElementVisible,
+    scrollUntilVisible,
+    wait,
+    waitForVisible,
+} from '../support/utils';
 
 class DeviceOnboardingActions {
     async selectCreateWalletOption() {

--- a/suite-native/app/e2e/pageObjects/passphraseModule.ts
+++ b/suite-native/app/e2e/pageObjects/passphraseModule.ts
@@ -3,8 +3,7 @@ import { expect as detoxExpect } from 'detox';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { onDeviceManager } from './deviceManagerActions';
-import { getModelFromEnv } from '../support/setup';
-import { waitForVisible } from '../support/utils';
+import { getModelFromEnv, waitForVisible } from '../support/utils';
 
 class PassphraseModule {
     public async openNewPassphraseFlow() {

--- a/suite-native/app/e2e/support/setup.ts
+++ b/suite-native/app/e2e/support/setup.ts
@@ -3,10 +3,10 @@ import { resolveConfig } from 'detox/internals';
 
 import { LaunchArguments } from '@suite-native/config';
 import { PreloadedState } from '@suite-native/state';
-import { MNEMONICS, MODELS, Model, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+import { MNEMONICS, Model, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import { mergeDeepObject } from '@trezor/utils';
 
-import { appIsFullyLoaded, platform } from './utils';
+import { appIsFullyLoaded, getModelFromEnv, platform } from './utils';
 import { onDeviceOnboarding } from '../pageObjects/deviceOnboardingActions';
 import { onDevicePrompt } from '../pageObjects/devicePromptActions';
 
@@ -113,12 +113,6 @@ export const openApp = async ({
         await appIsFullyLoaded();
     }
 };
-
-export function getModelFromEnv(): Model {
-    const envValue = process.env.EMULATOR_MODEL as Model;
-
-    return MODELS.includes(envValue) ? envValue : 'T3T1';
-}
 
 const getFwVersion = (model: Model, version: string | undefined) => {
     if (model === 'T3W1') {

--- a/suite-native/app/e2e/support/utils.ts
+++ b/suite-native/app/e2e/support/utils.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 
+import { MODELS, Model } from '@trezor/trezor-user-env-link';
 import { scheduleAction } from '@trezor/utils';
 
 type ElementAttributes = {
@@ -142,3 +143,9 @@ export const isElementVisible = async (elementOrMatcher: ElementOrMatcher): Prom
         return false;
     }
 };
+
+export function getModelFromEnv(): Model {
+    const envValue = process.env.EMULATOR_MODEL as Model;
+
+    return MODELS.includes(envValue) ? envValue : 'T3T1';
+}

--- a/suite-native/app/e2e/tests/coinEnabling.test.ts
+++ b/suite-native/app/e2e/tests/coinEnabling.test.ts
@@ -10,13 +10,8 @@ import { onDeviceConnecting } from '../pageObjects/deviceConnectingActions';
 import { onHome } from '../pageObjects/homeActions';
 import { onSettings } from '../pageObjects/settingsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
-import {
-    getModelFromEnv,
-    openApp,
-    preparePreloadedReduxState,
-    prepareTrezorEmulator,
-} from '../support/setup';
-import { waitForVisible } from '../support/utils';
+import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
+import { getModelFromEnv, waitForVisible } from '../support/utils';
 
 const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,

--- a/suite-native/app/e2e/tests/deeplinkPopup.test.ts
+++ b/suite-native/app/e2e/tests/deeplinkPopup.test.ts
@@ -12,13 +12,8 @@ import { deviceChecksDisabledState } from '../fixtures/deviceChecksDisabledState
 import { deviceChecksEnabledState } from '../fixtures/deviceChecksEnabledState';
 import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
 import { DeepLinkServer } from '../support/deepLinkServer';
-import {
-    getModelFromEnv,
-    openApp,
-    preparePreloadedReduxState,
-    prepareTrezorEmulator,
-} from '../support/setup';
-import { waitForVisible } from '../support/utils';
+import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
+import { getModelFromEnv, waitForVisible } from '../support/utils';
 
 const deepLinkServer = new DeepLinkServer();
 

--- a/suite-native/app/e2e/tests/deviceOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/deviceOnboarding.test.ts
@@ -7,12 +7,8 @@ import { deviceChecksEnabledState } from '../fixtures/deviceChecksEnabledState';
 import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
 import { onDeviceOnboarding } from '../pageObjects/deviceOnboardingActions';
 import { onHome } from '../pageObjects/homeActions';
-import {
-    getModelFromEnv,
-    openApp,
-    preparePreloadedReduxState,
-    prepareTrezorEmulator,
-} from '../support/setup';
+import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
+import { getModelFromEnv } from '../support/utils';
 
 const finishOnboardingFlow = async () => {
     // Create Pin

--- a/suite-native/app/e2e/tests/deviceOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/deviceOnboarding.test.ts
@@ -13,36 +13,6 @@ import {
     preparePreloadedReduxState,
     prepareTrezorEmulator,
 } from '../support/setup';
-import { isElementVisible, wait } from '../support/utils';
-
-const proceedToCreateOrRecoverCrossroads = async () => {
-    await onDeviceOnboarding.waitForUninitializedDeviceLanding();
-    await onDeviceOnboarding.dismissTheUninitializedDeviceLanding();
-    // During our release process, the TrezorUserEnv might not have the latest firmware version.
-    // In such cases, the firmware update screen appears here.
-    // We want to skip the update in e2e tests as it is not supported.
-    const isFirmwareUpdateScreenPresent = await isElementVisible(
-        by.id('@device-firmware/update-button'),
-    );
-    if (isFirmwareUpdateScreenPresent) {
-        await onDeviceOnboarding.skipFirmwareUpdate();
-        console.warn(
-            'SKIPPING FIRMWARE UPDATE: Firmware update was displayed, make sure it was only due to TrezorUserEnv not having latest firmware version.',
-        );
-    }
-
-    await TrezorUserEnvLink.pressYes();
-
-    if (getModelFromEnv() !== 'T3W1') {
-        // skip device authenticity check on T3W1 because we are using 2-main FW
-        await onDeviceOnboarding.waitForDeviceAuthenticitySuccess();
-        await onDeviceOnboarding.dismissDeviceAuthenticitySuccess();
-    }
-
-    await TrezorUserEnvLink.pressYes();
-
-    await onDeviceOnboarding.waitForCreateOrRecoverCrossroadsScreen();
-};
 
 const finishOnboardingFlow = async () => {
     // Create Pin
@@ -60,48 +30,33 @@ const preloadedState = preparePreloadedReduxState(
     btcCoinEnabled,
 );
 
+const LONG_RUNNING_TEST_TIMEOUT = 5 * 60 * 1000; // [ms]
+
 conditionalDescribe(device.getPlatform() === 'android', 'Device onboarding [@fixT3W1]', () => {
     beforeEach(async () => {
         await openApp({ args: { preloadedState } });
         await prepareTrezorEmulator({ seed: '' });
-        await proceedToCreateOrRecoverCrossroads();
+        await onDeviceOnboarding.proceedToCreateOrRecoverCrossroads();
     });
 
-    it('Create Wallet', async () => {
-        await onDeviceOnboarding.selectCreateWalletOption();
+    it(
+        'Create Wallet',
+        async () => {
+            await onDeviceOnboarding.startCreatingWallet();
 
-        await onDeviceOnboarding.waitForCreateWalletLoadingScreen();
+            // Wallet Backup Recap
+            await onDeviceOnboarding.waitForWalletBackupRecapScreen();
 
-        // Create Wallet Backup
-        await onDeviceOnboarding.waitForWalletBackupTutorialScreen();
+            await onDeviceOnboarding.goToNextWalletBackupRecapStep(1);
+            await onDeviceOnboarding.goToNextWalletBackupRecapStep(2);
+            await onDeviceOnboarding.goToNextWalletBackupRecapStep(3);
 
-        await onDeviceOnboarding.gotToNextWalletBackupTutorialStep(1);
-        await onDeviceOnboarding.gotToNextWalletBackupTutorialStep(2);
-        await onDeviceOnboarding.gotToNextWalletBackupTutorialStep(3);
-        await onDeviceOnboarding.gotToNextWalletBackupTutorialStep(4);
-        await onDeviceOnboarding.validateSelectedBackupType('shamir-single');
-        await onDeviceOnboarding.gotToNextWalletBackupTutorialStep(5);
-        await wait(5000); // wait for entering animation to finish
+            await onDeviceOnboarding.pressHoldToConfirmButton();
 
-        await onDeviceOnboarding.pressHoldToConfirmButton();
-        await onDeviceOnboarding.waitForWalletCreationScreen();
-
-        await TrezorUserEnvLink.swipeEmu('up');
-        await TrezorUserEnvLink.pressYes();
-        await TrezorUserEnvLink.pressYes();
-        await TrezorUserEnvLink.pressNo();
-
-        // Wallet Backup Recap
-        await onDeviceOnboarding.waitForWalletBackupRecapScreen();
-
-        await onDeviceOnboarding.goToNextWalletBackupRecapStep(1);
-        await onDeviceOnboarding.goToNextWalletBackupRecapStep(2);
-        await onDeviceOnboarding.goToNextWalletBackupRecapStep(3);
-
-        await onDeviceOnboarding.pressHoldToConfirmButton();
-
-        await finishOnboardingFlow();
-    });
+            await finishOnboardingFlow();
+        },
+        LONG_RUNNING_TEST_TIMEOUT,
+    );
 
     it('Recover Wallet', async () => {
         await onDeviceOnboarding.selectRecoverWalletOption();

--- a/suite-native/app/e2e/tests/ejectWallets.test.ts
+++ b/suite-native/app/e2e/tests/ejectWallets.test.ts
@@ -10,12 +10,8 @@ import { onAlertSheet } from '../pageObjects/alertSheetActions';
 import { onDeviceManager } from '../pageObjects/deviceManagerActions';
 import { onSettings } from '../pageObjects/settingsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
-import {
-    getModelFromEnv,
-    openApp,
-    preparePreloadedReduxState,
-    prepareTrezorEmulator,
-} from '../support/setup';
+import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
+import { getModelFromEnv } from '../support/utils';
 
 const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,

--- a/suite-native/app/e2e/tests/entropyCheckFailT3T1.test.ts
+++ b/suite-native/app/e2e/tests/entropyCheckFailT3T1.test.ts
@@ -1,0 +1,70 @@
+import { expect as detoxExpect } from 'detox';
+
+import { conditionalDescribe } from '@suite-common/test-utils';
+import { DeviceReducerState, deviceReducerInitialState } from '@suite-common/wallet-core';
+
+import { deviceChecksEnabledState } from '../fixtures/deviceChecksEnabledState';
+import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
+import { onDeviceOnboarding } from '../pageObjects/deviceOnboardingActions';
+import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
+import { wait, waitForVisible } from '../support/utils';
+
+const getPreloadedState = (payload: DeviceReducerState['simulatedEntropyCheckFail']) =>
+    preparePreloadedReduxState(onboardingCompletedState, deviceChecksEnabledState, {
+        device: { ...deviceReducerInitialState, simulatedEntropyCheckFail: payload },
+    });
+
+const LONG_RUNNING_TEST_TIMEOUT = 5 * 60 * 1000; // [ms]
+
+conditionalDescribe(
+    device.getPlatform() === 'android',
+    'Simulated entropy check failure on T3T1 [@specificModel]',
+    () => {
+        beforeEach(async () => {
+            await prepareTrezorEmulator({ model: 'T3T1', seed: '' });
+        });
+
+        it(
+            'Device compromised (entropy-mismatch)',
+            async () => {
+                await openApp({
+                    args: {
+                        preloadedState: getPreloadedState({
+                            success: false,
+                            payload: { code: 'Failure_EntropyCheck', error: 'SIMULATED ERROR' },
+                        }),
+                    },
+                });
+                await onDeviceOnboarding.proceedToCreateOrRecoverCrossroads();
+                await onDeviceOnboarding.startCreatingWallet();
+
+                await onDeviceOnboarding.waitForDeviceCompromisedModal();
+            },
+            LONG_RUNNING_TEST_TIMEOUT,
+        );
+
+        it(
+            'Transport error (device disconnected during entropy check)',
+            async () => {
+                // note that this specific string is one of the ignored errors, see getIsIgnoredEntropyCheckError
+                const mockedError = 'device disconnected during action';
+                await openApp({
+                    args: {
+                        preloadedState: getPreloadedState({
+                            success: false,
+                            payload: { code: 'Failure_EntropyCheck', error: mockedError },
+                        }),
+                    },
+                });
+                await onDeviceOnboarding.proceedToCreateOrRecoverCrossroads();
+                await onDeviceOnboarding.startCreatingWallet();
+
+                await waitForVisible(by.id('@toast'));
+                await detoxExpect(element(by.id('@toast'))).toHaveText(mockedError);
+                await wait(500); // we do not expect any navigation, so ensure no navigation occurs
+                await onDeviceOnboarding.waitForWalletCreationScreen(); // still on the same screen (can be retried)
+            },
+            LONG_RUNNING_TEST_TIMEOUT,
+        );
+    },
+);

--- a/suite-native/app/e2e/tests/onboardAndConnect.test.ts
+++ b/suite-native/app/e2e/tests/onboardAndConnect.test.ts
@@ -5,8 +5,8 @@ import { onDeviceOnboarding } from '../pageObjects/deviceOnboardingActions';
 import { onDevicePrompt } from '../pageObjects/devicePromptActions';
 import { onHome } from '../pageObjects/homeActions';
 import { onOnboarding } from '../pageObjects/onboardingActions';
-import { getModelFromEnv, openApp, prepareTrezorEmulator } from '../support/setup';
-import { waitForVisible } from '../support/utils';
+import { openApp, prepareTrezorEmulator } from '../support/setup';
+import { getModelFromEnv, waitForVisible } from '../support/utils';
 
 conditionalDescribe(
     device.getPlatform() === 'android',

--- a/suite-native/app/e2e/tests/passphraseFlow.test.ts
+++ b/suite-native/app/e2e/tests/passphraseFlow.test.ts
@@ -11,13 +11,8 @@ import { regtestDiscoveryFinishedStateT3T1 } from '../fixtures/regtestDiscoveryF
 import { regtestDiscoveryFinishedStateT3W1 } from '../fixtures/regtestDiscoveryFinishedStateT3W1';
 import { onDeviceManager } from '../pageObjects/deviceManagerActions';
 import { onPassphrase } from '../pageObjects/passphraseModule';
-import {
-    getModelFromEnv,
-    openApp,
-    preparePreloadedReduxState,
-    prepareTrezorEmulator,
-} from '../support/setup';
-import { wait } from '../support/utils';
+import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
+import { getModelFromEnv, wait } from '../support/utils';
 
 const INITIAL_ACCOUNT_BALANCE = 3.14;
 

--- a/suite-native/app/e2e/tests/receive.test.ts
+++ b/suite-native/app/e2e/tests/receive.test.ts
@@ -11,12 +11,8 @@ import { onAccountReceive } from '../pageObjects/accountReceiveActions';
 import { onHome } from '../pageObjects/homeActions';
 import { onMyAssets } from '../pageObjects/myAssetsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
-import {
-    getModelFromEnv,
-    openApp,
-    preparePreloadedReduxState,
-    prepareTrezorEmulator,
-} from '../support/setup';
+import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
+import { getModelFromEnv } from '../support/utils';
 
 const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,

--- a/suite-native/app/e2e/tests/send.test.ts
+++ b/suite-native/app/e2e/tests/send.test.ts
@@ -16,12 +16,8 @@ import { FeeValues, onSendFees } from '../pageObjects/send/sendFeesActions';
 import { onSendOutputsForm } from '../pageObjects/send/sendOutputsFormActions';
 import { onSendOutputsReview } from '../pageObjects/send/sendOutputsReviewActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
-import {
-    getModelFromEnv,
-    openApp,
-    preparePreloadedReduxState,
-    prepareTrezorEmulator,
-} from '../support/setup';
+import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
+import { getModelFromEnv } from '../support/utils';
 
 const SEND_FORM_ERROR_MESSAGES = {
     invalidAddress: 'The address format is incorrect.',

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -7,6 +7,7 @@ import {
     selectDevicePath,
     selectIsDeviceInitialized,
     selectSelectedDevice,
+    selectSimulatedEntropyCheckFail,
 } from '@suite-common/wallet-core';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import TrezorConnect, { PROTO, SuccessWithDevice, Unsuccessful } from '@trezor/connect';
@@ -77,6 +78,8 @@ export const createAndBackupWalletThunk = createThunk<
             Feature.entropyCheckMobile,
             true,
         );
+        // Used only in tests! See deviceReducer for the property definition.
+        const simulatedFailResult = selectSimulatedEntropyCheckFail(getState());
 
         if (!device || !device.features || !devicePath) {
             return rejectWithValue('Device not found');
@@ -124,6 +127,11 @@ export const createAndBackupWalletThunk = createThunk<
         // full response from connect, which is either success or error
         const result = deviceResponse.payload;
         if (isEntropyCheckEnabled) {
+            if (simulatedFailResult) {
+                dispatch(processEntropyCheckResultThunk({ device, result: simulatedFailResult }));
+
+                return fulfillWithValue(simulatedFailResult);
+            }
             dispatch(processEntropyCheckResultThunk({ device, result }));
         }
 

--- a/suite-native/toasts/src/components/Toast.tsx
+++ b/suite-native/toasts/src/components/Toast.tsx
@@ -117,7 +117,7 @@ export const Toast = ({ toast }: ToastProps) => {
                         <Icon name={icon} color={iconColor} size="medium" />
                     </Box>
                 )}
-                <Text color={textColor} variant="hint">
+                <Text color={textColor} variant="hint" testID="@toast">
                     {message}
                 </Text>
             </HStack>

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -33,6 +33,7 @@
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/trading": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
+        "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:^",
         "@trezor/connect-web": "workspace:*",

--- a/suite/e2e/support/enums/seedType.ts
+++ b/suite/e2e/support/enums/seedType.ts
@@ -1,4 +1,0 @@
-export enum SeedType {
-    Default = 'single',
-    Advanced = 'shamir-advanced',
-}

--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -1,10 +1,10 @@
 import { Locator, Page, TestInfo, expect } from '@playwright/test';
 
-import { SUITE as SuiteActions } from '@trezor/suite/src//actions/suite/constants';
+import { BackupType } from '@suite-common/suite-types';
+import { SUITE as SuiteActions } from '@trezor/suite/src/actions/suite/constants';
 import { StartEmu } from '@trezor/trezor-user-env-link';
 
 import { TrezorUserEnvLinkProxy, isWebProject, step } from '../../common';
-import { SeedType } from '../../enums/seedType';
 import { AnalyticsSection } from '../analyticsSection';
 import { DevicePrompt } from '../devicePrompt';
 import { BackupSection } from './backupSection';
@@ -33,11 +33,12 @@ export class OnboardingPage {
     readonly retryRecoveryButton: Locator;
     readonly suiteLoadedIndicator: Locator;
     readonly createWalletButton: Locator;
-    readonly selectSeedTypeCheckbox = (seedType: SeedType): Locator =>
-        this.page.getByTestId(`@onboarding/select-seed-type-${seedType}`);
+    readonly selectSeedTypeCheckbox = (backupType: BackupType): Locator =>
+        this.page.getByTestId(`@onboarding/select-seed-type-${backupType}`);
     readonly selectSeedTypeOpenButton: Locator;
     readonly selectSeedConfirmButton: Locator;
     readonly continueAtYourOwnRiskButton: Locator;
+    readonly deviceCompromisedModal: Locator;
     readonly pairingInputAtIndex = (index: number) =>
         this.page.getByTestId('@modal/thp-paring').locator('input').nth(index);
 
@@ -78,6 +79,7 @@ export class OnboardingPage {
             '@onboarding/select-seed-type-confirm',
         );
         this.continueAtYourOwnRiskButton = this.page.getByTestId('@continue-to-suite');
+        this.deviceCompromisedModal = this.page.getByTestId('@device-compromised');
     }
 
     @step()
@@ -273,9 +275,9 @@ export class OnboardingPage {
     }
 
     @step()
-    async selectSeedType(seedType: SeedType) {
+    async selectSeedType(backupType: BackupType) {
         await this.selectSeedTypeOpenButton.click();
-        await this.selectSeedTypeCheckbox(seedType).click();
+        await this.selectSeedTypeCheckbox(backupType).click();
         await this.selectSeedConfirmButton.click();
     }
 }

--- a/suite/e2e/support/testExtends/enhancePage.ts
+++ b/suite/e2e/support/testExtends/enhancePage.ts
@@ -9,6 +9,12 @@ declare module '@playwright/test' {
 
         // Methods
         discoveryShouldFinish(): Promise<void>;
+        /**
+         * Ensure that the Redux store is exposed, which is not instant in Playwright Electron.
+         * On Desktop this must be called before using the store further.
+         * On Web this is no-op (resolves instantly).
+         */
+        ensureStoreOnDesktop(): Promise<void>;
         expectReduxObjectNotToBeEmpty(
             objectPath: string,
             options?: { timeout?: number },
@@ -63,6 +69,13 @@ export const enhancePage = (page: Page): Page => {
                 await option.click({ timeout: 2000 });
             }).toPass({ timeout: 10_000 });
         });
+    };
+
+    page.ensureStoreOnDesktop = async () => {
+        await expect(async () => {
+            const store = await page.evaluate(() => window.store);
+            expect(store).toBeDefined();
+        }).toPass({ timeout: 5000 });
     };
 
     page.getReduxObject = async (objectPath: string) => {

--- a/suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
@@ -1,4 +1,3 @@
-import { SeedType } from '../../../support/enums/seedType';
 import { expect, test } from '../../../support/fixtures';
 
 test.describe(
@@ -25,7 +24,7 @@ test.describe(
 
             // Will be clicking on Shamir backup button
             await onboardingPage.createWalletButton.click();
-            await onboardingPage.selectSeedType(SeedType.Advanced);
+            await onboardingPage.selectSeedType('shamir-advanced');
             await devicePrompt.confirmOnDevicePromptIsShown();
             await trezorUserEnvLink.pressYes();
 

--- a/suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts
+++ b/suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts
@@ -1,0 +1,93 @@
+import { deviceActions } from '@suite-common/wallet-core';
+import { TestCategory, TestPriority, createTestAnnotation } from '@trezor/e2e-utils';
+
+import { expect, test } from '../../../support/fixtures';
+
+test.describe(
+    'Onboarding - simulated entropy check failure',
+    { tag: ['@group=device-management'] },
+    () => {
+        test.use({
+            emulatorStartConf: { wipe: true, model: 'T2T1' },
+            setupEmulator: false,
+        });
+
+        test.beforeEach(async ({ onboardingPage, analyticsSection }) => {
+            await onboardingPage.disableNecessaryFirmwareChecks();
+            await analyticsSection.passThroughAnalytics();
+        });
+
+        test(
+            'Device compromised (entropy-mismatch)',
+            {
+                annotation: createTestAnnotation({
+                    testCase:
+                        'Verify that the proper modal is shown when entropy check fails during wallet creation.',
+                    category: TestCategory.Onboarding,
+                    priority: TestPriority.High,
+                }),
+            },
+            async ({ page, onboardingPage, devicePrompt, trezorUserEnvLink }) => {
+                await page.ensureStoreOnDesktop();
+
+                await page.evaluate(
+                    action => window.store.dispatch(action),
+                    deviceActions.setSimulatedEntropyCheckFail({
+                        success: false,
+                        payload: { code: 'Failure_EntropyCheck', error: 'SIMULATED ERROR' },
+                    }),
+                );
+
+                await test.step('Start creating wallet', async () => {
+                    await onboardingPage.firmware.continueThroughFirmware();
+                    await onboardingPage.createWalletButton.click();
+                    await onboardingPage.selectSeedType('12-words');
+                    await devicePrompt.confirmOnDevicePromptIsShown();
+                    await trezorUserEnvLink.pressYes();
+                });
+
+                await test.step('Land on entropy check failure', async () => {
+                    await expect(onboardingPage.deviceCompromisedModal).toBeVisible();
+                });
+            },
+        );
+
+        test(
+            'Transport error (device disconnected during entropy check)',
+            {
+                annotation: createTestAnnotation({
+                    testCase:
+                        'Verify that the proper modal is shown when entropy check gets interrupted by transport error during wallet creation.',
+                    category: TestCategory.Onboarding,
+                    priority: TestPriority.High,
+                }),
+            },
+            async ({ page, onboardingPage, devicePrompt, trezorUserEnvLink }) => {
+                // note that this specific string is one of the ignored errors, see getIsIgnoredEntropyCheckError
+                const mockedError = 'device disconnected during action';
+                await page.ensureStoreOnDesktop();
+                await page.evaluate(
+                    action => window.store.dispatch(action),
+                    deviceActions.setSimulatedEntropyCheckFail({
+                        success: false,
+                        payload: { code: 'Failure_EntropyCheck', error: mockedError },
+                    }),
+                );
+
+                await test.step('Start creating wallet', async () => {
+                    await onboardingPage.firmware.continueThroughFirmware();
+                    await onboardingPage.createWalletButton.click();
+                    await onboardingPage.selectSeedType('12-words');
+                    await devicePrompt.confirmOnDevicePromptIsShown();
+                    await trezorUserEnvLink.pressYes();
+                });
+
+                await test.step('Display error toast, but stay on the same screen (no device compromised)', async () => {
+                    await expect(page.getByTestId('@toast/error')).toContainText(mockedError);
+                    await page.waitForTimeout(500); // we do not expect any navigation, so ensure no navigation occurs
+                    await expect(onboardingPage.selectSeedConfirmButton).toBeVisible();
+                });
+            },
+        );
+    },
+);

--- a/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
@@ -1,6 +1,5 @@
 import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 
-import { SeedType } from '../../../support/enums/seedType';
 import { test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
@@ -38,7 +37,7 @@ test.describe(
 
                 // Create wallet with Shamir backup
                 await onboardingPage.createWalletButton.click();
-                await onboardingPage.selectSeedType(SeedType.Advanced);
+                await onboardingPage.selectSeedType('shamir-advanced');
 
                 // Accept ToS
                 await devicePrompt.confirmOnDevicePromptIsShown();

--- a/suite/e2e/tsconfig.json
+++ b/suite/e2e/tsconfig.json
@@ -23,6 +23,9 @@
             "path": "../../suite-common/wallet-config"
         },
         {
+            "path": "../../suite-common/wallet-core"
+        },
+        {
             "path": "../../suite-common/wallet-utils"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15181,6 +15181,7 @@ __metadata:
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/trading": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:^"
     "@trezor/connect-web": "workspace:*"


### PR DESCRIPTION
## Description

- create a hidden setting in deviceReducer to always fail entropy check with a specified result
- use it for a new Playwright test (Web + Desktop)
  - fix `window.store` on Desktop with a utility `ensureStoreOnDesktop`
- use it for a new Detox test (Android)
- small refactoring to prevent circular imports
- fix message system import in Detox runtime

This will ensure correct handling of a entropy check result: hard failures vs. soft failures, which has been notorically a problem in the past.

## Notes for QA

I have added the debug value to redux, but it should not play any role except in E2E tests.
So test that creating wallet is unaffected. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22545

## Screenshots

Just for reference, this is how the tested behaviors **should** look in app:

[web/desktop soft failure](https://github.com/user-attachments/assets/8c0ec5c2-c5f0-48e0-9f05-a7e3e84a76de)
[web/desktop hard failure](https://github.com/user-attachments/assets/84ff6b60-c2b5-4cea-a59d-85aa302a1ea6)
[native soft failure](https://github.com/user-attachments/assets/955a9d23-2780-434a-803c-af7c8470f01a)
[native hard failure](https://github.com/user-attachments/assets/d0f2768c-7ac8-4d4b-9248-b75546488fc4)



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/entropy-check-E2E&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/entropy-check-E2E&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/entropy-check-E2E&lookback=7)