### PR TITLE
chore(e2e): hopefully fix Account management and Trade Buy e2e on iOS

### DIFF
--- a/suite-native/app/e2e/pageObjects/accountDetailSettingsActions.ts
+++ b/suite-native/app/e2e/pageObjects/accountDetailSettingsActions.ts
@@ -1,3 +1,4 @@
+import { waitForVisible } from '../support/utils';
 class AccountDetailSettingsActions {
     async renameAccount({ newAccountName }: { newAccountName: string }) {
         await element(by.id('@account-detail/settings/edit-button')).tap();
@@ -6,7 +7,11 @@ class AccountDetailSettingsActions {
         await accountNameInput.clearText();
         await accountNameInput.typeText(newAccountName);
 
-        await element(by.id('@account-detail/settings/account-rename/confirm-button')).tap();
+        const confirmButton = element(
+            by.id('@account-detail/settings/account-rename/confirm-button'),
+        );
+        await waitForVisible(confirmButton);
+        await confirmButton.tap();
     }
 
     async removeAccount() {

--- a/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
@@ -5,6 +5,7 @@ import { onTabBar } from '../pageObjects/tabBarActions';
 import { tradingBuyActions } from '../pageObjects/trading/tradingBuyActions';
 import { tradingHistoryActions } from '../pageObjects/trading/tradingHistoryActions';
 import { openApp, preparePreloadedReduxState } from '../support/setup';
+import { scrollUntilVisible } from '../support/utils';
 
 const preloadedState = preparePreloadedReduxState(
     portfolioTrackerBtcAccountState,
@@ -26,7 +27,11 @@ describe('Trade Buy [@noDevice]', () => {
         await tradingBuyActions.selectCountry('Polan', '🇵🇱 Poland');
         await tradingBuyActions.setFiatAmount('100');
 
-        await onHome.scrollScreenToBottom();
+        // Scroll to bottom of the page.
+        // `scrollScreenToBottom` is not used because it accidentally clicks on links at the bottom on iOS.
+        const learnMoreLink = element(by.text('Learn more'));
+        await scrollUntilVisible(learnMoreLink);
+
         await tradingBuyActions.viewPaymentMethods();
         await tradingBuyActions.viewProviders();
         await tradingBuyActions.expectValidBuyForm();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- hopefully fix Account management e2e on iOS

- fix flaky Trade Buy test on iOS 
`scrollScreenToBottom` accidentally clicks on links at the bottom of the screen on iOS. 
I don't think it's a conceptual solution, it's just workaround fora  workaround. But now I would either skip the test completely for iOS or do this. Feel free to enhance 🙏 



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/ios-e2e-fixing&lookback=7)