### PR TITLE
fix(suite-native): tap tx detail included coin is not crashing

### DIFF
--- a/suite-native/module-transactions/src/components/TransactionDetailListItem.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailListItem.tsx
@@ -52,7 +52,7 @@ export const TransactionDetailListItem = ({
 
     const handleNavigation = () => {
         onPress();
-        navigation.push(RootStackRoutes.TransactionDetailStack, {
+        navigation.navigate(RootStackRoutes.TransactionDetailStack, {
             screen: TransactionDetailStackRoutes.TransactionDetail,
             params: {
                 txid: transaction.txid,


### PR DESCRIPTION
Tap on transaction detail included coin detail [crashed the app](https://satoshilabs.sentry.io/issues/6847896417/?environment=production&project=4504214699245568&query=is%3Aunresolved&referrer=issue-stream). Discussed in [slack](https://satoshilabs.slack.com/archives/C03FL9TCURZ/p1765470530563489)

## Notes for QA
Find ethereum txn marked with coin badge. On iOS taping on coin included detail should not crash. On android there previously was white screen after tap.


## Screenshots:
https://github.com/user-attachments/assets/cd7143f3-c566-486d-90af-9f8083f8630a



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/txn-detail-coin-tap&lookback=7)