### PR TITLE
chore(blockchain-link-utils): remove dependency to protobuf

### DIFF
--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -23,7 +23,6 @@
         "@mobily/ts-belt": "^3.13.1",
         "@stellar/stellar-sdk": "14.2.0",
         "@trezor/env-utils": "workspace:*",
-        "@trezor/protobuf": "workspace:*",
         "@trezor/utils": "workspace:*",
         "xrpl": "4.4.3"
     },

--- a/packages/blockchain-link-utils/src/stellar.ts
+++ b/packages/blockchain-link-utils/src/stellar.ts
@@ -13,8 +13,14 @@ import {
 
 import type { TokenDetailByMint, Transaction } from '@trezor/blockchain-link-types';
 import { isCodesignBuild } from '@trezor/env-utils';
-import type { StellarAsset } from '@trezor/protobuf/src/messages';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
+
+// copy paste from protobuf to avoid extra dependency
+export type StellarAsset = {
+    type: 0 | 1 | 2 | 'NATIVE' | 'ALPHANUM4' | 'ALPHANUM12';
+    code?: string;
+    issuer?: string;
+};
 
 export const STELLAR_DECIMALS = 7;
 

--- a/packages/blockchain-link-utils/src/tests/stellar.test.ts
+++ b/packages/blockchain-link-utils/src/tests/stellar.test.ts
@@ -1,9 +1,8 @@
 import { Horizon } from '@stellar/stellar-sdk';
 
-import type { StellarAsset } from '@trezor/protobuf/src/messages';
 import { BigNumber } from '@trezor/utils';
 
-import { buildSendTransaction, toStroops, transformTransaction } from '../stellar';
+import { StellarAsset, buildSendTransaction, toStroops, transformTransaction } from '../stellar';
 import { fixtures } from './fixtures/stellar';
 
 describe('stellar/utils', () => {

--- a/packages/blockchain-link-utils/tsconfig.json
+++ b/packages/blockchain-link-utils/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../env-utils" },
-        { "path": "../protobuf" },
         { "path": "../utils" },
         { "path": "../blockchain-link-types" },
         { "path": "../eslint" },

--- a/packages/blockchain-link-utils/tsconfig.lib.json
+++ b/packages/blockchain-link-utils/tsconfig.lib.json
@@ -9,9 +9,6 @@
             "path": "../env-utils"
         },
         {
-            "path": "../protobuf"
-        },
-        {
             "path": "../utils"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14142,7 +14142,6 @@ __metadata:
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/eslint": "workspace:*"
-    "@trezor/protobuf": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     tsx: "npm:^4.20.3"


### PR DESCRIPTION
our npm dependency graph is already crazy enough...
https://npmgraph.js.org/?q=%40trezor%2Fblockchain-link-utils

related [#23782](https://github.com/trezor/trezor-suite/issues/23782)
but maybe this is not important at all after our discussion about modules today 🤔 