### PR TITLE
refactor(suite-native): rework PIN protection navigation in device settings

### DIFF
--- a/suite-native/module-device-settings/src/components/DevicePinProtectionCard.tsx
+++ b/suite-native/module-device-settings/src/components/DevicePinProtectionCard.tsx
@@ -56,7 +56,7 @@ export const DevicePinProtectionCard = () => {
     })();
 
     const handleOnPress = () => {
-        navigation.navigate(DeviceSettingsStackRoutes.PinProtection);
+        navigation.navigate(DeviceSettingsStackRoutes.DevicePinProtection);
     };
 
     return (

--- a/suite-native/module-device-settings/src/navigation/DevicePinProtectionStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DevicePinProtectionStackNavigator.tsx
@@ -4,9 +4,11 @@ import { A } from '@mobily/ts-belt';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-import { selectDeviceButtonRequestsCodes } from '@suite-common/wallet-core';
+import {
+    selectDeviceButtonRequestsCodes,
+    selectIsDeviceConnected,
+} from '@suite-common/wallet-core';
 import { usePinAction } from '@suite-native/device';
-import { useDeviceConnectionGuard } from '@suite-native/device-authorization';
 import {
     DevicePinProtectionStackParamList,
     DevicePinProtectionStackRoutes,
@@ -17,6 +19,7 @@ import {
 } from '@suite-native/navigation';
 
 import { ContinueOnTrezorScreen } from '../screens/ContinueOnTrezorScreen';
+import { DeviceConnectionGuardScreen } from '../screens/DeviceConnectionGuardScreen';
 import {
     ConfirmNewPinScreen,
     EnterCurrentPinScreen,
@@ -43,8 +46,8 @@ export const DevicePinProtectionStackNavigator = () => {
 
     const { type } = route.params;
     usePinAction({ type, onSuccess: navigation.goBack });
-    const { isDeviceConnected } = useDeviceConnectionGuard();
 
+    const isDeviceConnected = useSelector(selectIsDeviceConnected);
     const buttonRequestCodes = useSelector(selectDeviceButtonRequestsCodes);
     const lastButtonRequestCode = A.last(buttonRequestCodes);
 
@@ -53,15 +56,16 @@ export const DevicePinProtectionStackNavigator = () => {
     const isConfirmNewPin = lastButtonRequestCode === 'PinMatrixRequestType_NewSecond';
     const isContinueOnTrezor = !isEnterCurrentPin && !isEnterNewPin && !isConfirmNewPin;
 
-    if (!isDeviceConnected) return;
-
     // To indicate progress to the user we need separate screens for individual steps of the flow.
     // At the same time we need just one available so that navigation.goBack() works as expected.
     return (
-        <DevicePinProtectionStack.Navigator
-            initialRouteName={DevicePinProtectionStackRoutes.ContinueOnTrezor}
-            screenOptions={stackNavigationOptionsConfig}
-        >
+        <DevicePinProtectionStack.Navigator screenOptions={stackNavigationOptionsConfig}>
+            {!isDeviceConnected && (
+                <DevicePinProtectionStack.Screen
+                    name={DevicePinProtectionStackRoutes.DeviceConnectionGuard}
+                    component={DeviceConnectionGuardScreen}
+                />
+            )}
             {isContinueOnTrezor && (
                 <DevicePinProtectionStack.Screen
                     name={DevicePinProtectionStackRoutes.ContinueOnTrezor}

--- a/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
@@ -36,16 +36,12 @@ export const DeviceSettingsStackNavigator = () => (
             component={DeviceSettingsModalScreen}
         />
         <DeviceSettingsStack.Screen
-            name={DeviceSettingsStackRoutes.DevicePinProtectionStack}
-            component={DevicePinProtectionStackNavigator}
-        />
-        <DeviceSettingsStack.Screen
-            name={DeviceSettingsStackRoutes.PinProtection}
-            component={PinProtectionScreen}
-        />
-        <DeviceSettingsStack.Screen
             name={DeviceSettingsStackRoutes.DeviceFirmware}
             component={DeviceFirmwareScreen}
+        />
+        <DeviceSettingsStack.Screen
+            name={DeviceSettingsStackRoutes.DevicePinProtection}
+            component={PinProtectionScreen}
         />
         <DeviceSettingsStack.Group screenOptions={{ animation: 'slide_from_bottom' }}>
             <DeviceSettingsStack.Screen
@@ -55,6 +51,10 @@ export const DeviceSettingsStackNavigator = () => (
             <DeviceSettingsStack.Screen
                 name={DeviceSettingsStackRoutes.FirmwareLanguageStack}
                 component={FirmwareLanguageStackNavigator}
+            />
+            <DeviceSettingsStack.Screen
+                name={DeviceSettingsStackRoutes.DevicePinProtectionStack}
+                component={DevicePinProtectionStackNavigator}
             />
         </DeviceSettingsStack.Group>
         <DeviceSettingsStack.Screen

--- a/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
@@ -47,7 +47,6 @@ export const DeviceSettingsModalScreen = () => {
                 <TitledSection
                     title={<Translation id="moduleDeviceSettings.sectionTitles.general" />}
                 >
-                    {isDeviceInitialized && <DevicePinProtectionCard />}
                     <DeviceFirmwareCard />
                     {isThpDevice && <DeviceAutoConnectCard />}
                     {isDeviceConnectedViaBluetooth && <UnpairBluetoothDeviceCard />}
@@ -55,6 +54,7 @@ export const DeviceSettingsModalScreen = () => {
                 <TitledSection
                     title={<Translation id="moduleDeviceSettings.sectionTitles.security" />}
                 >
+                    {isDeviceInitialized && <DevicePinProtectionCard />}
                     {isDeviceInitialized && <BackupAndPassphraseCard />}
                     {SUPPORTS_DEVICE_AUTHENTICITY_CHECK[deviceModel] && <DeviceAuthenticityCard />}
                 </TitledSection>

--- a/suite-native/module-device-settings/src/screens/PinProtectionScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/PinProtectionScreen.tsx
@@ -30,7 +30,7 @@ const DisableOrChangePinCard = () => (
             icon="check"
             title={<Translation id="moduleDeviceSettings.pinProtection.pictograms.change.title" />}
         />
-        <VStack>
+        <VStack spacing="sp12">
             <DevicePinActionButton type="change" colorScheme="primary">
                 <Translation id="moduleDeviceSettings.pinProtection.buttons.changePin" />
             </DevicePinActionButton>
@@ -50,12 +50,12 @@ export const PinProtectionScreen = () => {
                 <DynamicScreenHeader
                     title={<Translation id="moduleDeviceSettings.pinProtection.title" />}
                     subtitle={<Translation id="moduleDeviceSettings.pinProtection.content" />}
-                    closeActionType="close"
+                    closeActionType="back"
                 />
             }
         >
             <Card>
-                <VStack spacing="sp32">
+                <VStack marginTop="sp16" spacing="sp32">
                     {isDeviceProtectedByPin ? <DisableOrChangePinCard /> : <EnablePinCard />}
                 </VStack>
             </Card>

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -227,31 +227,24 @@ export type AddCoinAccountStackParamList = {
 
 export type DeviceSettingsStackParamList = {
     [DeviceSettingsStackRoutes.DeviceSettings]: undefined;
-    [DeviceSettingsStackRoutes.DevicePinProtectionStack]: {
-        type: PinActionType;
-    };
-    [DeviceSettingsStackRoutes.DeviceAuthenticity]: undefined;
-    [DeviceSettingsStackRoutes.DeviceAuthenticityStack]: NavigatorScreenParams<DeviceAuthenticityStackParamList>;
     [DeviceSettingsStackRoutes.DeviceFirmware]: {
         closeActionType: CloseActionType;
     };
     [DeviceSettingsStackRoutes.FirmwareUpdateStack]: undefined;
     [DeviceSettingsStackRoutes.FirmwareLanguageStack]: undefined;
+    [DeviceSettingsStackRoutes.DevicePinProtection]: undefined;
+    [DeviceSettingsStackRoutes.DevicePinProtectionStack]: {
+        type: PinActionType;
+    };
+    [DeviceSettingsStackRoutes.DeviceAuthenticity]: undefined;
+    [DeviceSettingsStackRoutes.DeviceAuthenticityStack]: NavigatorScreenParams<DeviceAuthenticityStackParamList>;
     [DeviceSettingsStackRoutes.ContinueOnTrezor]: undefined;
     [DeviceSettingsStackRoutes.DeviceNameStack]: NavigatorScreenParams<DeviceNameStackParamList>;
     [DeviceSettingsStackRoutes.WipeDeviceStack]: NavigatorScreenParams<WipeDeviceStackParamList>;
-    [DeviceSettingsStackRoutes.PinProtection]: undefined;
     [DeviceSettingsStackRoutes.BackupAndPassphraseStack]: NavigatorScreenParams<BackupAndPassphraseParamList>;
     [DeviceSettingsStackRoutes.AutoConnectSettings]: undefined;
     [DeviceSettingsStackRoutes.DeviceCheckBackupStack]: NavigatorScreenParams<DeviceCheckBackupStackParamList>;
     [DeviceSettingsStackRoutes.UnpairBluetoothDevice]: undefined;
-};
-
-export type DevicePinProtectionStackParamList = {
-    [DevicePinProtectionStackRoutes.ContinueOnTrezor]: undefined;
-    [DevicePinProtectionStackRoutes.EnterCurrentPin]: undefined;
-    [DevicePinProtectionStackRoutes.EnterNewPin]: undefined;
-    [DevicePinProtectionStackRoutes.ConfirmNewPin]: undefined;
 };
 
 export type FirmwareUpdateStackParamList = {
@@ -264,6 +257,14 @@ export type FirmwareUpdateStackParamList = {
 export type FirmwareLanguageStackParamList = {
     [FirmwareLanguageStackRoutes.DeviceConnectionGuard]: undefined;
     [FirmwareLanguageStackRoutes.ConfirmLanguageChange]: undefined;
+};
+
+export type DevicePinProtectionStackParamList = {
+    [DevicePinProtectionStackRoutes.DeviceConnectionGuard]: undefined;
+    [DevicePinProtectionStackRoutes.ContinueOnTrezor]: undefined;
+    [DevicePinProtectionStackRoutes.EnterCurrentPin]: undefined;
+    [DevicePinProtectionStackRoutes.EnterNewPin]: undefined;
+    [DevicePinProtectionStackRoutes.ConfirmNewPin]: undefined;
 };
 
 export type WipeDeviceStackParamList = {

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -77,12 +77,12 @@ export enum AccountsImportStackRoutes {
 
 export enum DeviceSettingsStackRoutes {
     DeviceSettings = 'DeviceSettings',
-    PinProtection = 'PinProtection',
-    BackupAndPassphraseStack = 'BackupAndPassphraseStack',
-    DevicePinProtectionStack = 'DevicePinProtectionStack',
     DeviceFirmware = 'DeviceFirmware',
     FirmwareUpdateStack = 'FirmwareUpdateStack',
     FirmwareLanguageStack = 'FirmwareLanguageStack',
+    DevicePinProtection = 'DevicePinProtection',
+    DevicePinProtectionStack = 'DevicePinProtectionStack',
+    BackupAndPassphraseStack = 'BackupAndPassphraseStack',
     DeviceAuthenticity = 'DeviceAuthenticity',
     DeviceAuthenticityStack = 'DeviceAuthenticityStack',
     ContinueOnTrezor = 'ContinueOnTrezor',
@@ -94,6 +94,7 @@ export enum DeviceSettingsStackRoutes {
 }
 
 export enum DevicePinProtectionStackRoutes {
+    DeviceConnectionGuard = 'DeviceConnectionGuard',
     ContinueOnTrezor = 'ContinueOnTrezor',
     EnterCurrentPin = 'EnterCurrentPin',
     EnterNewPin = 'EnterNewPin',


### PR DESCRIPTION
- Used same navigation pattern as for firmware settings
- Moved the _PIN protection_ card under _Security_
- Fixed couple of UI inconsistencies

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/device-settings-pin-protection&lookback=7)