### PR TITLE
Fix showing DeviceUnavailable

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/DeviceUnavailable.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/DeviceUnavailable.tsx
@@ -7,8 +7,11 @@ import { useDevice, useDispatch } from 'src/hooks/suite';
 export const DeviceUnavailable = () => {
     const dispatch = useDispatch();
     const { device, isLocked } = useDevice();
+    const passphraseProtection = !!device?.features?.passphrase_protection;
 
-    if (!device?.connected || device.available || !device.features) return null;
+    if (!device?.connected || device.available || !device.features || passphraseProtection) {
+        return null;
+    }
 
     const handleButtonClick = () => dispatch(applySettings({ use_passphrase: true }));
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description & Notes for QA

If the passphrase has been already enabled, don't show DeviceUnavailable banner offering enabling the passphrase protection.


## Related Issue

Resolve #23691


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/23691-passphrase-banner&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/23691-passphrase-banner&lookback=7)