### PR TITLE
Fix/connect evoluGetDelegatedIdentityKey params

### DIFF
--- a/packages/connect/src/api/evoluGetDelegatedIdentityKey.ts
+++ b/packages/connect/src/api/evoluGetDelegatedIdentityKey.ts
@@ -1,6 +1,4 @@
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
-import { thp } from '@trezor/protocol';
-import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getFirmwareRange } from './common/paramsValidator';
@@ -12,23 +10,10 @@ export default class EvoluGetDelegatedIdentityKey extends AbstractMethod<
     hasBundle?: boolean;
 
     init() {
+        this.useDevice = true;
+        this.useUi = true;
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
-
-        const { payload } = this;
-
-        Assert(PROTO.EvoluGetDelegatedIdentityKey, payload);
-
-        if (payload.thp !== undefined) {
-            const staticKey = Buffer.from(payload.thp.staticHostKey, 'hex');
-            const hostStaticKeys = thp.getCurve25519KeyPair(staticKey);
-            this.params = {
-                thp_credential: payload.thp.credential,
-                host_static_public_key: hostStaticKeys.publicKey.toString('hex'),
-            };
-        } else {
-            this.params = {};
-        }
     }
 
     get info() {
@@ -36,6 +21,15 @@ export default class EvoluGetDelegatedIdentityKey extends AbstractMethod<
     }
 
     async run() {
+        const thpState = this.device.getThpState();
+        if (thpState) {
+            this.params = {
+                thp_credential: thpState.pairingCredentials[0].credential,
+                host_static_public_key:
+                    thpState.handshakeCredentials?.hostStaticPublicKey.toString('hex'),
+            };
+        }
+
         const cmd = this.device.getCommands();
         const response = await cmd.typedCall(
             'EvoluGetDelegatedIdentityKey',

--- a/packages/connect/src/types/api/evoluGetDelegatedIdentityKey.ts
+++ b/packages/connect/src/types/api/evoluGetDelegatedIdentityKey.ts
@@ -1,11 +1,6 @@
 import { PROTO } from '../../constants';
-import { Params, Response } from '../params';
+import { CommonParams, Params, Response } from '../params';
 
 export declare function evoluGetDelegatedIdentityKey(
-    params: Params<{
-        thp?: {
-            staticHostKey: string;
-            credential: string;
-        };
-    }>,
+    params: Params<CommonParams>,
 ): Response<PROTO.EvoluDelegatedIdentityKey>;

--- a/suite-common/delegated-identity-key/package.json
+++ b/suite-common/delegated-identity-key/package.json
@@ -15,7 +15,6 @@
         "@suite-common/delegated-identity-key-types": "workspace:*",
         "@suite-common/platform-encryption": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
-        "@suite-common/thp": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/suite-common/delegated-identity-key/src/delegatedIdentityKeyCompositionRoot.ts
+++ b/suite-common/delegated-identity-key/src/delegatedIdentityKeyCompositionRoot.ts
@@ -1,7 +1,6 @@
 import { Dispatch } from '@reduxjs/toolkit';
 
 import { PlatformEncryptionDep } from '@suite-common/platform-encryption';
-import { selectThp } from '@suite-common/thp/src/thpSelectors';
 import { selectDeviceDelegatedIdentityKey } from '@suite-common/wallet-core';
 
 import { createEnsureDelegatedIdentityKey } from './ensureDelegatedIdentityKey';
@@ -35,7 +34,6 @@ export const delegatedIdentityKeyCompositionRoot = (
             dispatch: deps.dispatch,
             platformEncryption: deps.platformEncryption,
         }),
-        getThpStaticKey: () => selectThp(deps.getState()).staticKey,
     });
 
     return {

--- a/suite-common/delegated-identity-key/src/ensureDelegatedIdentityKey.ts
+++ b/suite-common/delegated-identity-key/src/ensureDelegatedIdentityKey.ts
@@ -5,9 +5,7 @@ import { LoadDelegatedIdentityKeyFromStateDep } from './loadDelegatedIdentityKey
 import { RetrieveDelegatedIdentityKeyFromDeviceDep } from './retrieveDelegatedIdentityKeyFromDevice';
 import { SaveDelegatedIdentityKeyDep } from './saveDelegatedIdentityKey';
 
-export type EnsureDelegatedIdentityKeyDeps = {
-    getThpStaticKey: () => string | undefined;
-} & SaveDelegatedIdentityKeyDep &
+export type EnsureDelegatedIdentityKeyDeps = SaveDelegatedIdentityKeyDep &
     LoadDelegatedIdentityKeyFromStateDep &
     RetrieveDelegatedIdentityKeyFromDeviceDep;
 
@@ -22,10 +20,8 @@ export const createEnsureDelegatedIdentityKey =
             return ok(currentDelegatedKey);
         }
 
-        const thpStaticHostKey = deps.getThpStaticKey();
         const result = await deps.retrieveDelegatedIdentityKeyFromDevice({
             device,
-            thpStaticHostKey,
         });
 
         if (!result.ok) {

--- a/suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.ts
+++ b/suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.ts
@@ -9,11 +9,7 @@ import TrezorConnect from '@trezor/connect';
 import { Result, err, ok } from '@trezor/type-utils';
 
 export type RetrieveDelegatedIdentityKeyParams = {
-    device: Pick<
-        TrezorDeviceWithState,
-        'path' | 'state' | 'instance' | 'useEmptyPassphrase' | 'thp'
-    >;
-    thpStaticHostKey: string | undefined;
+    device: Pick<TrezorDeviceWithState, 'path' | 'state' | 'instance' | 'useEmptyPassphrase'>;
 };
 
 export type RetrieveDelegatedIdentityKeyFromDeviceDeps = {
@@ -30,9 +26,7 @@ export type RetrieveDelegatedIdentityKeyFromDeviceDep = {
 
 export const createRetrieveDelegatedIdentityKeyFromDevice =
     (deps: RetrieveDelegatedIdentityKeyFromDeviceDeps): RetrieveDelegatedIdentityKeyFromDevice =>
-    async ({ device, thpStaticHostKey }) => {
-        const thpCredential = device.thp?.credentials?.[0].credential;
-
+    async ({ device }) => {
         const result = await deps.trezorConnect.evoluGetDelegatedIdentityKey({
             device: {
                 path: device.path,
@@ -40,14 +34,6 @@ export const createRetrieveDelegatedIdentityKeyFromDevice =
                 instance: device.instance ?? 0,
             },
             useEmptyPassphrase: device.useEmptyPassphrase ?? false,
-            ...(thpStaticHostKey !== undefined && thpCredential !== undefined
-                ? {
-                      thp: {
-                          credential: thpCredential,
-                          staticHostKey: thpStaticHostKey,
-                      },
-                  }
-                : undefined),
         });
 
         if (result.success) {

--- a/suite-common/delegated-identity-key/src/tests/ensureDelegatedIdentityKey.test.ts
+++ b/suite-common/delegated-identity-key/src/tests/ensureDelegatedIdentityKey.test.ts
@@ -14,7 +14,6 @@ const deps: EnsureDelegatedIdentityKeyDeps = {
     saveDelegatedIdentityKey: () => Promise.resolve(),
     retrieveDelegatedIdentityKeyFromDevice: () =>
         Promise.resolve(ok(asDelegatedIdentityKey('trezor-delegated-key-123'))),
-    getThpStaticKey: () => 'thp-static-key',
 };
 
 const device: EnsureDelegatedIdentityKeyParams['device'] = {
@@ -22,12 +21,6 @@ const device: EnsureDelegatedIdentityKeyParams['device'] = {
     path: asDeviceUniquePath('1/2/3'),
     state: {
         staticSessionId: '1@2:3',
-    },
-    thp: {
-        credentials: [
-            { credential: 'thp-credential', trezor_static_public_key: 'trezor_static_public_key' },
-        ],
-        channel: 'thp-channel',
     },
 };
 

--- a/suite-common/delegated-identity-key/src/tests/retrieveDelegatedIdentityKeyFromDevice.test.ts
+++ b/suite-common/delegated-identity-key/src/tests/retrieveDelegatedIdentityKeyFromDevice.test.ts
@@ -28,7 +28,6 @@ describe(createRetrieveDelegatedIdentityKeyFromDevice.name, () => {
 
         const result = await retrieveDelegatedIdentityKeyFromDevice({
             device: device123,
-            thpStaticHostKey: 'thp-static-key',
         });
 
         expect(result.ok).toBe(true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I was changing some fields around ThpCredentials and noticed this:

1. `Assert(PROTO.EvoluGetDelegatedIdentityKey, payload);`
   connect is asserting params using protobuf schema
   ```
   {
       thp_credential: Type.Optional(Type.String()),
       host_static_public_key: Type.Optional(Type.String()),
   }
   ```
   while params are (were) defined as:
   ```
   params: Params<{
        thp?: {
            staticHostKey: string;
            credential: string;
        };
    }>,
   ```
   the only reason why it works is because protobuf field are optional
   
2. `evoluGetDelegatedIdentityKey` doesnt need that params at all as THP static key and credentials are internally known (this.device.getThpState)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-evolu&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-evolu&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-evolu&lookback=7)