### PR TITLE
fix(suite-native): add missing border to SelectItem atom

### DIFF
--- a/suite-native/atoms/src/Select/SelectItem.tsx
+++ b/suite-native/atoms/src/Select/SelectItem.tsx
@@ -33,16 +33,19 @@ const selectItemContentStyle = prepareNativeStyle<SelectItemStyleProps>(
         flex: 1,
         flexDirection: 'row',
         justifyContent: 'space-between',
+        margin: utils.spacings.sp1, // prevents layout shift after selection
         padding: utils.spacings.sp16,
-        borderWidth: utils.borders.widths.large,
+        borderWidth: utils.borders.widths.small,
         borderRadius: utils.borders.radii.r12,
-        borderColor: utils.colors.backgroundSurfaceElevation1,
+        borderColor: utils.colors.borderOnElevation1,
         backgroundColor: utils.colors.backgroundSurfaceElevation1,
         color: utils.colors.textDefault,
         extend: [
             {
                 condition: isSelected,
                 style: {
+                    margin: 0,
+                    borderWidth: utils.borders.widths.large,
                     borderColor: utils.colors.backgroundPrimaryDefault,
                     color: utils.colors.textDefault,
                 },


### PR DESCRIPTION
| Android | iOS |
| --- | --- |
| <img width="1080" height="2340" alt="Screenshot_20251212_124148" src="https://github.com/user-attachments/assets/d1349807-83c2-4420-8a53-946d0434aeaf" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/803f379f-4409-415c-ba84-ba1e30ec6d4b" /> |


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/select-item-border&lookback=7)