### PR TITLE
Chore: scripts ESM

### DIFF
--- a/packages/eslint/src/importConfig.mjs
+++ b/packages/eslint/src/importConfig.mjs
@@ -16,7 +16,8 @@ export const globalNoExtraneousDependenciesDevDependencies = [
     // ----------------------------------------------------------------
     '**/*fixtures*/**',
     '**/*.test.{tsx,ts,js}',
-    '**/eslint.config.mjs',
+    '**/eslint.config.mjs', // for CJS packages, those files should eventually be renamed to .js and this line deleted
+    '**/eslint.config.js',
 
     '**/*e2e/**', // Todo: This shall be only in packages that has e2e tests
 ];

--- a/scripts/check-workspace-resolutions.ts
+++ b/scripts/check-workspace-resolutions.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { getWorkspacesList } from './utils/getWorkspacesList';
 

--- a/scripts/ci/check-npm-and-local.ts
+++ b/scripts/ci/check-npm-and-local.ts
@@ -1,10 +1,10 @@
-import { execSync } from 'child_process';
-import fs from 'fs';
-import util from 'util';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import util from 'node:util';
 import fetch from 'cross-fetch';
-import path from 'path';
+import path from 'node:path';
 import * as tar from 'tar';
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import semver from 'semver';
 
 import { fileURLToPath } from 'node:url';

--- a/scripts/ci/check-npm-and-local.ts
+++ b/scripts/ci/check-npm-and-local.ts
@@ -7,10 +7,6 @@ import * as tar from 'tar';
 import crypto from 'node:crypto';
 import semver from 'semver';
 
-import { fileURLToPath } from 'node:url';
-
-// duplicated with ./helpers.ts to avoidi circular dep
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const mkdir = util.promisify(fs.mkdir);
 const existsDirectory = util.promisify(fs.exists);
 
@@ -71,7 +67,7 @@ const downloadFile = (url: string, filePath: string) =>
 
 const packModule = (moduleName: string, modulePath: string, outputDirectory: string) => {
     try {
-        const currentPwd = __dirname;
+        const currentPwd = import.meta.dirname;
         // Change the current working directory
         process.chdir(modulePath);
 
@@ -127,11 +123,11 @@ export const getLocalAndRemoteChecksums = async (
       }
     | { success: false; error: string }
 > => {
-    const ROOT = path.join(__dirname, '..', '..');
+    const ROOT = path.join(import.meta.dirname, '..', '..');
 
     const [_prefix, name] = moduleName.split('/');
     const PACKAGE_PATH = path.join(ROOT, 'packages', name);
-    const tmpDir = path.join(__dirname, 'tmp');
+    const tmpDir = path.join(import.meta.dirname, 'tmp');
     const npmRegistryUrl = `https://registry.npmjs.org/${moduleName}`;
 
     try {
@@ -156,12 +152,12 @@ export const getLocalAndRemoteChecksums = async (
 
         const tarballUrl = data.versions[greatestSemver].dist.tarball;
 
-        const tarballDestination = path.join(__dirname, 'tmp', name);
+        const tarballDestination = path.join(import.meta.dirname, 'tmp', name);
         console.info(`downloading tarball from ${tarballUrl} to `);
         const fileName = await downloadFile(tarballUrl, tarballDestination);
         console.info(`File downloaded!: ${fileName}`);
 
-        const extractRemotePath = path.join(__dirname, 'tmp', 'remote', name);
+        const extractRemotePath = path.join(import.meta.dirname, 'tmp', 'remote', name);
         console.info(
             `extracting remote tarball from ${tarballDestination} to ${extractRemotePath}`,
         );
@@ -173,7 +169,7 @@ export const getLocalAndRemoteChecksums = async (
             return { success: false, error: 'Error packing module tarball' };
         }
 
-        const extractLocalPath = path.join(__dirname, 'tmp', 'local', name);
+        const extractLocalPath = path.join(import.meta.dirname, 'tmp', 'local', name);
 
         console.info(`extracting local tarball  from ${tarballPath} to ${extractLocalPath}`);
         await extractTarball(tarballPath, extractLocalPath);

--- a/scripts/ci/check-npm-and-local.ts
+++ b/scripts/ci/check-npm-and-local.ts
@@ -1,5 +1,4 @@
 import { execSync } from 'child_process';
-
 import fs from 'fs';
 import util from 'util';
 import fetch from 'cross-fetch';
@@ -8,6 +7,10 @@ import * as tar from 'tar';
 import crypto from 'crypto';
 import semver from 'semver';
 
+import { fileURLToPath } from 'node:url';
+
+// duplicated with ./helpers.ts to avoidi circular dep
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const mkdir = util.promisify(fs.mkdir);
 const existsDirectory = util.promisify(fs.exists);
 

--- a/scripts/ci/check-npm-dependencies.ts
+++ b/scripts/ci/check-npm-dependencies.ts
@@ -3,7 +3,7 @@
  *
  * This script checks the dependencies for the specified package to ensure they match expected criteria.
  * It is used to verify the output of scripts/ci/connect-bump-versions.ts. */
-import { promisify } from 'util';
+import { promisify } from 'node:util';
 import fs from 'node:fs';
 import path from 'node:path';
 import { checkPackageDependencies, getDirname } from './helpers';

--- a/scripts/ci/check-npm-dependencies.ts
+++ b/scripts/ci/check-npm-dependencies.ts
@@ -3,14 +3,14 @@
  *
  * This script checks the dependencies for the specified package to ensure they match expected criteria.
  * It is used to verify the output of scripts/ci/connect-bump-versions.ts. */
-const { promisify } = require('util');
-const fs = require('fs');
-const path = require('path');
+import { promisify } from 'util';
+import fs from 'node:fs';
+import path from 'node:path';
+import { checkPackageDependencies, getDirname } from './helpers';
 
 const readdir = promisify(fs.readdir);
-const { checkPackageDependencies } = require('./helpers');
 
-const rootPath = path.join(__dirname, '..', '..');
+const rootPath = path.join(getDirname(import.meta.url), '..', '..');
 const packagesPath = path.join(rootPath, 'packages');
 
 const args = process.argv.slice(2);

--- a/scripts/ci/check-npm-dependencies.ts
+++ b/scripts/ci/check-npm-dependencies.ts
@@ -6,11 +6,11 @@
 import { promisify } from 'node:util';
 import fs from 'node:fs';
 import path from 'node:path';
-import { checkPackageDependencies, getDirname } from './helpers';
+import { checkPackageDependencies } from './helpers';
 
 const readdir = promisify(fs.readdir);
 
-const rootPath = path.join(getDirname(import.meta.url), '..', '..');
+const rootPath = path.join(import.meta.dirname, '..', '..');
 const packagesPath = path.join(rootPath, 'packages');
 
 const args = process.argv.slice(2);

--- a/scripts/ci/check-version.js
+++ b/scripts/ci/check-version.js
@@ -4,7 +4,6 @@ import semver from 'semver';
 import child_process from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { getDirname } from './helpers';
 
 const args = process.argv.slice(2);
 
@@ -19,7 +18,7 @@ if (!['latest', 'beta'].includes(distTag)) {
     throw new Error('distTag (3rd parameter) must be either "beta" or "latest"');
 }
 
-const ROOT = path.join(getDirname(import.meta.url), '..', '..');
+const ROOT = path.join(import.meta.dirname, '..', '..');
 const PACKAGE_PATH = path.join(ROOT, 'packages', packageName);
 
 // read package version

--- a/scripts/ci/check-version.js
+++ b/scripts/ci/check-version.js
@@ -1,9 +1,10 @@
 /* eslint-disable camelcase */
 
-const semver = require('semver');
-const child_process = require('child_process');
-const fs = require('fs');
-const path = require('path');
+import semver from 'semver';
+import child_process from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { getDirname } from './helpers';
 
 const args = process.argv.slice(2);
 
@@ -18,7 +19,7 @@ if (!['latest', 'beta'].includes(distTag)) {
     throw new Error('distTag (3rd parameter) must be either "beta" or "latest"');
 }
 
-const ROOT = path.join(__dirname, '..', '..');
+const ROOT = path.join(getDirname(import.meta.url), '..', '..');
 const PACKAGE_PATH = path.join(ROOT, 'packages', packageName);
 
 // read package version

--- a/scripts/ci/connect-bump-versions.ts
+++ b/scripts/ci/connect-bump-versions.ts
@@ -2,13 +2,17 @@ import path from 'path';
 import fs from 'fs';
 
 import { promisify } from 'util';
-import { getPackagesAndDependenciesRequireUpdate, gettingNpmDistributionTags } from './helpers';
+import {
+    getDirname,
+    getPackagesAndDependenciesRequireUpdate,
+    gettingNpmDistributionTags,
+} from './helpers';
 
 const readFile = promisify(fs.readFile);
 const existsDirectory = promisify(fs.exists);
 const writeFile = promisify(fs.writeFile);
 
-const { checkPackageDependencies, exec, commit, comment } = require('./helpers');
+import { checkPackageDependencies, exec, commit, comment } from './helpers';
 
 const args = process.argv.slice(2);
 
@@ -35,7 +39,7 @@ const deploymentType = ['prepatch', 'preminor', 'prerelease'].includes(semver)
     ? 'canary'
     : 'stable';
 
-const ROOT = path.join(__dirname, '..', '..');
+const ROOT = path.join(getDirname(import.meta.url), '..', '..');
 
 const getGitCommitByPackageName = (packageName: string, maxCount = 10) =>
     exec('git', [
@@ -232,7 +236,7 @@ const bumpConnect = async () => {
         const branchName = `bump-versions/connect-${version}`;
 
         // Check if branch exists and if so, delete it.
-        const branchExists = await exec('git', ['branch', '--list', branchName]).stdout;
+        const branchExists = (await exec('git', ['branch', '--list', branchName])).stdout;
         if (branchExists) {
             throw new Error(
                 `Branch ${branchName} already exists, delete it and call script again.`,

--- a/scripts/ci/connect-bump-versions.ts
+++ b/scripts/ci/connect-bump-versions.ts
@@ -2,11 +2,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 
 import { promisify } from 'node:util';
-import {
-    getDirname,
-    getPackagesAndDependenciesRequireUpdate,
-    gettingNpmDistributionTags,
-} from './helpers';
+import { getPackagesAndDependenciesRequireUpdate, gettingNpmDistributionTags } from './helpers';
 
 const readFile = promisify(fs.readFile);
 const existsDirectory = promisify(fs.exists);
@@ -39,7 +35,7 @@ const deploymentType = ['prepatch', 'preminor', 'prerelease'].includes(semver)
     ? 'canary'
     : 'stable';
 
-const ROOT = path.join(getDirname(import.meta.url), '..', '..');
+const ROOT = path.join(import.meta.dirname, '..', '..');
 
 const getGitCommitByPackageName = (packageName: string, maxCount = 10) =>
     exec('git', [

--- a/scripts/ci/connect-bump-versions.ts
+++ b/scripts/ci/connect-bump-versions.ts
@@ -1,7 +1,7 @@
-import path from 'path';
-import fs from 'fs';
+import path from 'node:path';
+import fs from 'node:fs';
 
-import { promisify } from 'util';
+import { promisify } from 'node:util';
 import {
     getDirname,
     getPackagesAndDependenciesRequireUpdate,

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -1,5 +1,3 @@
-const process = require('process');
-
 const DEBUG = false;
 
 const log = (...args) => {

--- a/scripts/ci/determine-deployment-type.ts
+++ b/scripts/ci/determine-deployment-type.ts
@@ -1,4 +1,4 @@
-const semver = require('semver');
+import semver from 'semver';
 
 const version = process.argv[2];
 

--- a/scripts/ci/get-connect-dependencies-to-release.ts
+++ b/scripts/ci/get-connect-dependencies-to-release.ts
@@ -6,11 +6,11 @@ import util from 'util';
 import path from 'path';
 import semver from 'semver';
 
-import { getNpmRemoteGreatestVersion } from './helpers';
+import { getDirname, getNpmRemoteGreatestVersion } from './helpers';
 
 const readFile = util.promisify(fs.readFile);
 
-const ROOT = path.join(__dirname, '..', '..');
+const ROOT = path.join(getDirname(import.meta.url), '..', '..');
 
 const nonReleaseDependencies: string[] = [];
 

--- a/scripts/ci/get-connect-dependencies-to-release.ts
+++ b/scripts/ci/get-connect-dependencies-to-release.ts
@@ -1,9 +1,9 @@
 // This script should check what packages from the repository have a higher version than in NPM
 // and stdout out those to be used by GitHub workflow.
 
-import fs from 'fs';
-import util from 'util';
-import path from 'path';
+import fs from 'node:fs';
+import util from 'node:util';
+import path from 'node:path';
 import semver from 'semver';
 
 import { getDirname, getNpmRemoteGreatestVersion } from './helpers';

--- a/scripts/ci/get-connect-dependencies-to-release.ts
+++ b/scripts/ci/get-connect-dependencies-to-release.ts
@@ -6,11 +6,11 @@ import util from 'node:util';
 import path from 'node:path';
 import semver from 'semver';
 
-import { getDirname, getNpmRemoteGreatestVersion } from './helpers';
+import { getNpmRemoteGreatestVersion } from './helpers';
 
 const readFile = util.promisify(fs.readFile);
 
-const ROOT = path.join(getDirname(import.meta.url), '..', '..');
+const ROOT = path.join(import.meta.dirname, '..', '..');
 
 const nonReleaseDependencies: string[] = [];
 

--- a/scripts/ci/get-connect-version.js
+++ b/scripts/ci/get-connect-version.js
@@ -2,9 +2,8 @@
 
 import path from 'node:path';
 import fs from 'node:fs';
-import { getDirname } from './helpers';
 
-const ROOT = path.join(getDirname(import.meta.url), '..', '..');
+const ROOT = path.join(import.meta.dirname, '..', '..');
 
 const PACKAGE_PATH = path.join(ROOT, 'packages', 'connect');
 const PACKAGE_JSON_PATH = path.join(PACKAGE_PATH, 'package.json');

--- a/scripts/ci/get-connect-version.js
+++ b/scripts/ci/get-connect-version.js
@@ -1,9 +1,10 @@
 /* eslint-disable camelcase */
 
-const path = require('path');
-const fs = require('fs');
+import path from 'node:path';
+import fs from 'node:fs';
+import { getDirname } from './helpers';
 
-const ROOT = path.join(__dirname, '..', '..');
+const ROOT = path.join(getDirname(import.meta.url), '..', '..');
 
 const PACKAGE_PATH = path.join(ROOT, 'packages', 'connect');
 const PACKAGE_JSON_PATH = path.join(PACKAGE_PATH, 'package.json');

--- a/scripts/ci/helpers.ts
+++ b/scripts/ci/helpers.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import semver from 'semver';
 import fetch from 'cross-fetch';
 import { promisify } from 'node:util';
@@ -10,10 +9,7 @@ import { getLocalAndRemoteChecksums } from './check-npm-and-local';
 
 const readFile = promisify(fs.readFile);
 
-// Helper to get __dirname equivalent in ESM scope when called with getDirname(import.meta.url)
-export const getDirname = (fileURL: string) => path.dirname(fileURLToPath(fileURL));
-
-const ROOT = path.join(getDirname(import.meta.url), '..', '..');
+const ROOT = path.join(import.meta.dirname, '..', '..');
 
 const updateNeeded: string[] = [];
 const errors: string[] = [];

--- a/scripts/ci/helpers.ts
+++ b/scripts/ci/helpers.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'node:url';
 import semver from 'semver';
 import fetch from 'cross-fetch';
 import { promisify } from 'util';
@@ -9,7 +10,10 @@ import { getLocalAndRemoteChecksums } from './check-npm-and-local';
 
 const readFile = promisify(fs.readFile);
 
-const ROOT = path.join(__dirname, '..', '..');
+// Helper to get __dirname equivalent in ESM scope when called with getDirname(import.meta.url)
+export const getDirname = (fileURL: string) => path.dirname(fileURLToPath(fileURL));
+
+const ROOT = path.join(getDirname(import.meta.url), '..', '..');
 
 const updateNeeded: string[] = [];
 const errors: string[] = [];

--- a/scripts/ci/helpers.ts
+++ b/scripts/ci/helpers.ts
@@ -1,10 +1,10 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import semver from 'semver';
 import fetch from 'cross-fetch';
-import { promisify } from 'util';
-import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import { promisify } from 'node:util';
+import { ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
 
 import { getLocalAndRemoteChecksums } from './check-npm-and-local';
 

--- a/scripts/convertFigmaPalette.ts
+++ b/scripts/convertFigmaPalette.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import prettier from 'prettier';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';

--- a/scripts/eslint.config.js
+++ b/scripts/eslint.config.js
@@ -7,6 +7,7 @@ export default [
             'no-console': 'off',
             '@typescript-eslint/no-shadow': 'off', // Todo: shall be fixed
             'import/no-default-export': 'off', // in scripts this is OK, some of them are expected to work that way
+            'import/no-extraneous-dependencies': ['error', { devDependencies: ['**'] }],
         },
     },
 ];

--- a/scripts/filterCoins.ts
+++ b/scripts/filterCoins.ts
@@ -1,5 +1,5 @@
 // Exclude coins that are not supported by any device model during yarn update-coins
-import fs from 'fs';
+import fs from 'node:fs';
 
 const coinsJsonPath = './packages/connect-common/files/coins.json';
 const coinsData: Record<string, { support: Record<string, string | boolean> }[]> = JSON.parse(

--- a/scripts/generatePackage.ts
+++ b/scripts/generatePackage.ts
@@ -9,6 +9,7 @@ import templatePackageJsonWeb from './package-template/package.json';
 import templatePackageJsonNative from './package-template-native/package.json';
 import { getPrettierConfig } from './utils/getPrettierConfig';
 import { getWorkspacesList } from './utils/getWorkspacesList';
+import { getDirname } from './ci/helpers';
 
 const scopes = {
     '@suite-common': {
@@ -42,7 +43,7 @@ const isValidScope = (scope: string): scope is keyof typeof scopes =>
     Object.keys(scopes).includes(scope);
 
 // Get the directory of the current file
-const currentDir = path.dirname(__filename);
+const currentDir = getDirname(import.meta.url);
 const rootDir = path.resolve(currentDir, '..');
 
 (async () => {

--- a/scripts/generatePackage.ts
+++ b/scripts/generatePackage.ts
@@ -1,15 +1,15 @@
 import chalk from 'chalk';
-import fs from 'node:fs';
 import fsExtra from 'fs-extra';
+import fs from 'node:fs';
 import path from 'node:path';
 import prettier from 'prettier';
 import sortPackageJson from 'sort-package-json';
 
+import { getDirname } from './ci/helpers';
 import templatePackageJsonWeb from './package-template/package.json';
 import templatePackageJsonNative from './package-template-native/package.json';
 import { getPrettierConfig } from './utils/getPrettierConfig';
 import { getWorkspacesList } from './utils/getWorkspacesList';
-import { getDirname } from './ci/helpers';
 
 const scopes = {
     '@suite-common': {

--- a/scripts/generatePackage.ts
+++ b/scripts/generatePackage.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
-import fs from 'fs';
+import fs from 'node:fs';
 import fsExtra from 'fs-extra';
-import path from 'path';
+import path from 'node:path';
 import prettier from 'prettier';
 import sortPackageJson from 'sort-package-json';
 

--- a/scripts/generatePackage.ts
+++ b/scripts/generatePackage.ts
@@ -5,7 +5,6 @@ import path from 'node:path';
 import prettier from 'prettier';
 import sortPackageJson from 'sort-package-json';
 
-import { getDirname } from './ci/helpers';
 import templatePackageJsonWeb from './package-template/package.json';
 import templatePackageJsonNative from './package-template-native/package.json';
 import { getPrettierConfig } from './utils/getPrettierConfig';
@@ -43,7 +42,7 @@ const isValidScope = (scope: string): scope is keyof typeof scopes =>
     Object.keys(scopes).includes(scope);
 
 // Get the directory of the current file
-const currentDir = getDirname(import.meta.url);
+const currentDir = import.meta.dirname;
 const rootDir = path.resolve(currentDir, '..');
 
 (async () => {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -2,6 +2,7 @@
     "name": "@trezor/scripts",
     "version": "1.0.0",
     "private": true,
+    "type": "module",
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
@@ -15,14 +16,14 @@
         "fs-extra": "^11.3.1",
         "minimatch": "^10.1.1",
         "prettier": "^3.6.2",
+        "semver": "^7.7.1",
         "sort-package-json": "^3.4.0",
+        "tar": "^7.5.1",
         "tsx": "^4.20.3",
         "yargs": "^18.0.0"
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "@types/semver": "^7.7.0",
-        "semver": "^7.7.1",
-        "tar": "^7.5.1"
+        "@types/semver": "^7.7.0"
     }
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,11 +6,14 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "generate-package": "tsx generatePackage.ts"
     },
-    "dependencies": {
+    "devDependencies": {
         "@babel/cli": "7.28.3",
         "@mobily/ts-belt": "^3.13.1",
+        "@trezor/eslint": "workspace:*",
+        "@types/semver": "^7.7.0",
         "chalk": "^5.6.2",
         "cross-fetch": "^4.0.0",
         "fs-extra": "^11.3.1",
@@ -21,9 +24,5 @@
         "tar": "^7.5.1",
         "tsx": "^4.20.3",
         "yargs": "^18.0.0"
-    },
-    "devDependencies": {
-        "@trezor/eslint": "workspace:*",
-        "@types/semver": "^7.7.0"
     }
 }

--- a/scripts/publish/prepublish.js
+++ b/scripts/publish/prepublish.js
@@ -1,9 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 
-import { getDirname } from '../ci/helpers';
-
-const __dirname = getDirname(import.meta.url);
+const currentDir = import.meta.dirname;
 
 console.log('prepublish script running for package: ' + process.env.npm_package_name);
 const packageName = process.env.npm_package_name.split('/')[1];
@@ -15,11 +13,11 @@ if (!isValidPackageName) {
 }
 
 // Run babel with custom plugins to fix non-index internal imports and add .js extensions.
-const scriptPath = path.join(__dirname, 'replace-imports.sh');
-const args = [path.join(__dirname, '..', '..', 'packages', packageName, 'lib'), 'cjs'];
+const scriptPath = path.join(currentDir, 'replace-imports.sh');
+const args = [path.join(currentDir, '..', '..', 'packages', packageName, 'lib'), 'cjs'];
 execFileSync(scriptPath, args, {
     encoding: 'utf-8',
-    cwd: __dirname,
+    cwd: currentDir,
 });
 
 if (!process.env.CI) {

--- a/scripts/publish/prepublish.js
+++ b/scripts/publish/prepublish.js
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
+
 import { getDirname } from '../ci/helpers';
 
 const __dirname = getDirname(import.meta.url);

--- a/scripts/publish/prepublish.js
+++ b/scripts/publish/prepublish.js
@@ -1,5 +1,5 @@
-import { execFileSync } from 'child_process';
-import path from 'path';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
 import { getDirname } from '../ci/helpers';
 
 const __dirname = getDirname(import.meta.url);

--- a/scripts/publish/prepublish.js
+++ b/scripts/publish/prepublish.js
@@ -1,9 +1,8 @@
 import { execFileSync } from 'child_process';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { getDirname } from '../ci/helpers';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = getDirname(import.meta.url);
 
 console.log('prepublish script running for package: ' + process.env.npm_package_name);
 const packageName = process.env.npm_package_name.split('/')[1];

--- a/scripts/publish/replace-imports.sh
+++ b/scripts/publish/replace-imports.sh
@@ -10,7 +10,7 @@ set -euxo pipefail
 #   <module-type>   (Optional) The module system to use: "cjs" | "esm"
 #
 # Example:
-#   To replace imports in the ./lib directory using the CJS module typ:
+#   To replace imports in the ./lib directory using the CJS module type:
 #     bash replace-imports.sh ./lib cjs
 #
 #   To replace imports in the ./libESM directory using the ESM module type:

--- a/scripts/updateProjectReferences.ts
+++ b/scripts/updateProjectReferences.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
-import fs from 'node:fs';
 import { minimatch } from 'minimatch';
+import fs from 'node:fs';
 import path from 'node:path';
 import prettier from 'prettier';
 import yargs from 'yargs';

--- a/scripts/updateProjectReferences.ts
+++ b/scripts/updateProjectReferences.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
-import fs from 'fs';
+import fs from 'node:fs';
 import { minimatch } from 'minimatch';
-import path from 'path';
+import path from 'node:path';
 import prettier from 'prettier';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';

--- a/scripts/utils/getWorkspacesList.ts
+++ b/scripts/utils/getWorkspacesList.ts
@@ -1,5 +1,5 @@
 import { A, D, pipe } from '@mobily/ts-belt';
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 
 type WorkspacePackageName = string;
 type WorkspaceItem = {


### PR DESCRIPTION
## Description

- rewrite `scripts` from CJS to ESM
- turn on eslint, which was defined but not working here

## Notes for QA

Locally I tested:
```
yarn tsx ./scripts/ci/connect-bump-versions.ts minor
yarn generate-package @suite-common/henlo-lizer
yarn refs
yarn check-workspace-resolutions
yarn build:libs
node ./scripts/ci/connect-test-matrix-generator.js --model=T2T1 --firmware=2-latest --env=all --groups=api,api-flaky --disable_cache_tx=true --transport=node-bridge
yarn tsx ./scripts/ci/get-connect-dependencies-to-release.ts
yarn tsx ./scripts/ci/determine-deployment-type.ts 3.2.1
```

(it's not everything, but a representative sample of scripts that we have)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/scripts-ESM&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/scripts-ESM&lookback=7)