### PR TITLE
fix(e2e): Speculative Suite sync test stability improvement

### DIFF
--- a/suite/e2e/tests/metadata/suite-sync.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync.test.ts
@@ -33,6 +33,8 @@ test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@specificFirmware']
             await expect(
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
             ).toHaveText(newLabel);
+
+            await page.waitForTimeout(5_000); // wait for sync to complete
         });
 
         await test.step('Wipe Suite to simulate new session', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I couldn't find an obvious way to wait for the sync.  I will try to dig deep, but in the meantime, let's just try the crude approach.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-suite-sync-test&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-suite-sync-test&lookback=7)