### PR TITLE
chore: implement test for SubscriptionLabeling [4]

### DIFF
--- a/packages/suite/src/actions/wallet/processLegacyMetadataIntoSuiteSyncThunk.ts
+++ b/packages/suite/src/actions/wallet/processLegacyMetadataIntoSuiteSyncThunk.ts
@@ -1,6 +1,6 @@
 import { MetadataAddPayload } from '@suite-common/metadata-types';
 import { createThunk } from '@suite-common/redux-utils';
-import { RefreshSuiteKeysUnavailable } from '@suite-common/suite-sync-types';
+import { RefreshSuiteKeysUnavailableType } from '@suite-common/suite-sync-types/libDev/src';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { DeviceCancelledErrType, DeviceErrorType } from '@suite-common/wallet-types';
 import type { StaticSessionId } from '@trezor/connect';
@@ -18,7 +18,7 @@ type ProcessMetadataMessageThunkParams = {
  * @deprecated This shall be removed, once we phase out the old Metadata code.
  */
 export const processLegacyMetadataIntoSuiteSyncThunk = createThunk<
-    Result<void, RefreshSuiteKeysUnavailable | DeviceErrorType | DeviceCancelledErrType>,
+    Result<void, RefreshSuiteKeysUnavailableType | DeviceErrorType | DeviceCancelledErrType>,
     ProcessMetadataMessageThunkParams,
     void
 >(

--- a/suite-common/suite-sync-types/src/index.ts
+++ b/suite-common/suite-sync-types/src/index.ts
@@ -8,7 +8,7 @@ export type {
 export type { RefreshSuiteSyncKeys, RefreshSuiteSyncKeysDep } from './refreshSuiteSyncKeys';
 export type { TurnOffSuiteSyncDep, TurnOffSuiteSync } from './turnOffSuiteSync';
 export type { TurnOnSuiteSyncDep, TurnOnSuiteSync } from './turnOnSuiteSync';
-export { RefreshSuiteKeysUnavailable } from './refreshSuiteSyncKeys';
+export type { RefreshSuiteKeysUnavailableType } from './refreshSuiteSyncKeys';
 export type { ChangeRelayUrl, ChangeRelayUrlDep } from './relay/changeRelayUrl';
 export type {
     SubscriptionName,

--- a/suite-common/suite-sync-types/src/labeling/subscribeLabeling.ts
+++ b/suite-common/suite-sync-types/src/labeling/subscribeLabeling.ts
@@ -2,7 +2,7 @@ import { DeviceCancelledErrType, DeviceErrorType } from '@suite-common/wallet-ty
 import { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
-import { RefreshSuiteKeysUnavailable } from '../refreshSuiteSyncKeys';
+import { RefreshSuiteKeysUnavailableType } from '../refreshSuiteSyncKeys';
 
 type SubscribeLabelingParams = {
     deviceStaticSessionId: StaticSessionId;
@@ -10,4 +10,6 @@ type SubscribeLabelingParams = {
 
 export type SubscribeLabeling = (
     params: SubscribeLabelingParams,
-) => Promise<Result<void, RefreshSuiteKeysUnavailable | DeviceErrorType | DeviceCancelledErrType>>;
+) => Promise<
+    Result<void, RefreshSuiteKeysUnavailableType | DeviceErrorType | DeviceCancelledErrType>
+>;

--- a/suite-common/suite-sync-types/src/labeling/updateAccountLabel.ts
+++ b/suite-common/suite-sync-types/src/labeling/updateAccountLabel.ts
@@ -2,7 +2,7 @@ import { type DeviceCancelledErrType, DeviceErrorType } from '@suite-common/wall
 import type { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
-import { RefreshSuiteKeysUnavailable } from '../refreshSuiteSyncKeys';
+import { RefreshSuiteKeysUnavailableType } from '../refreshSuiteSyncKeys';
 
 export type UpdateAccountLabelParams = {
     deviceStaticSessionId: StaticSessionId;
@@ -12,6 +12,8 @@ export type UpdateAccountLabelParams = {
 
 export type UpdateAccountLabel = (
     params: UpdateAccountLabelParams,
-) => Promise<Result<void, RefreshSuiteKeysUnavailable | DeviceErrorType | DeviceCancelledErrType>>;
+) => Promise<
+    Result<void, RefreshSuiteKeysUnavailableType | DeviceErrorType | DeviceCancelledErrType>
+>;
 
 export type UpdateAccountLabelDep = { updateAccountLabel: UpdateAccountLabel };

--- a/suite-common/suite-sync-types/src/labeling/updateAddressLabel.ts
+++ b/suite-common/suite-sync-types/src/labeling/updateAddressLabel.ts
@@ -3,7 +3,7 @@ import { Account, DeviceCancelledErrType, DeviceErrorType } from '@suite-common/
 import type { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
-import { RefreshSuiteKeysUnavailable } from '../refreshSuiteSyncKeys';
+import { RefreshSuiteKeysUnavailableType } from '../refreshSuiteSyncKeys';
 
 export type UpdateAddressLabelParams = {
     deviceStaticSessionId: StaticSessionId;
@@ -15,6 +15,8 @@ export type UpdateAddressLabelParams = {
 
 export type UpdateAddressLabel = (
     params: UpdateAddressLabelParams,
-) => Promise<Result<void, RefreshSuiteKeysUnavailable | DeviceErrorType | DeviceCancelledErrType>>;
+) => Promise<
+    Result<void, RefreshSuiteKeysUnavailableType | DeviceErrorType | DeviceCancelledErrType>
+>;
 
 export type UpdateAddressLabelDep = { updateAddressLabel: UpdateAddressLabel };

--- a/suite-common/suite-sync-types/src/labeling/updateOutputLabel.ts
+++ b/suite-common/suite-sync-types/src/labeling/updateOutputLabel.ts
@@ -3,7 +3,7 @@ import { DeviceCancelledErrType, DeviceErrorType } from '@suite-common/wallet-ty
 import type { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
-import { RefreshSuiteKeysUnavailable } from '../refreshSuiteSyncKeys';
+import { RefreshSuiteKeysUnavailableType } from '../refreshSuiteSyncKeys';
 
 type UpdateOutputLabelParams = {
     deviceStaticSessionId: StaticSessionId;
@@ -16,6 +16,8 @@ type UpdateOutputLabelParams = {
 
 export type UpdateOutputLabel = (
     params: UpdateOutputLabelParams,
-) => Promise<Result<void, RefreshSuiteKeysUnavailable | DeviceErrorType | DeviceCancelledErrType>>;
+) => Promise<
+    Result<void, RefreshSuiteKeysUnavailableType | DeviceErrorType | DeviceCancelledErrType>
+>;
 
 export type UpdateOutputLabelDep = { updateOutputLabel: UpdateOutputLabel };

--- a/suite-common/suite-sync-types/src/labeling/updateWalletLabel.ts
+++ b/suite-common/suite-sync-types/src/labeling/updateWalletLabel.ts
@@ -2,7 +2,7 @@ import { DeviceCancelledErrType, DeviceErrorType } from '@suite-common/wallet-ty
 import type { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
-import { RefreshSuiteKeysUnavailable } from '../refreshSuiteSyncKeys';
+import { RefreshSuiteKeysUnavailableType } from '../refreshSuiteSyncKeys';
 
 export type UpdateWalletLabelParams = {
     deviceStaticSessionId: StaticSessionId;
@@ -11,6 +11,8 @@ export type UpdateWalletLabelParams = {
 
 export type UpdateWalletLabel = (
     params: UpdateWalletLabelParams,
-) => Promise<Result<void, RefreshSuiteKeysUnavailable | DeviceErrorType | DeviceCancelledErrType>>;
+) => Promise<
+    Result<void, RefreshSuiteKeysUnavailableType | DeviceErrorType | DeviceCancelledErrType>
+>;
 
 export type UpdateWalletLabelDep = { updateWalletLabel: UpdateWalletLabel };

--- a/suite-common/suite-sync-types/src/refreshSuiteSyncKeys.ts
+++ b/suite-common/suite-sync-types/src/refreshSuiteSyncKeys.ts
@@ -6,22 +6,17 @@ type RefreshSuiteSyncKeysParams = {
     device: TrezorDevice;
 };
 
-export type RefreshSuiteKeysUnavailable = {
+export type RefreshSuiteKeysUnavailableType = {
     type: 'RefreshSuiteKeysUnavailable';
 };
-
-/**
- * Device is not connected or device is in a state/configuration, that does not
- * support Suite Sync.
- */
-export const RefreshSuiteKeysUnavailable = (): RefreshSuiteKeysUnavailable => ({
-    type: 'RefreshSuiteKeysUnavailable',
-});
 
 export type RefreshSuiteSyncKeys = (
     params: RefreshSuiteSyncKeysParams,
 ) => Promise<
-    Result<SuiteSyncOwner, RefreshSuiteKeysUnavailable | DeviceErrorType | DeviceCancelledErrType>
+    Result<
+        SuiteSyncOwner,
+        RefreshSuiteKeysUnavailableType | DeviceErrorType | DeviceCancelledErrType
+    >
 >;
 
 export type RefreshSuiteSyncKeysDep = {

--- a/suite-common/suite-sync-types/src/storage/turnOnSuiteSyncForWallet.ts
+++ b/suite-common/suite-sync-types/src/storage/turnOnSuiteSyncForWallet.ts
@@ -2,13 +2,15 @@ import { DeviceCancelledErrType, DeviceErrorType } from '@suite-common/wallet-ty
 import { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
-import { RefreshSuiteKeysUnavailable } from '../refreshSuiteSyncKeys';
+import { RefreshSuiteKeysUnavailableType } from '../refreshSuiteSyncKeys';
 
 export type TurnOnSuiteSyncForWalletParams = { deviceStaticSessionId: StaticSessionId };
 
 export type TurnOnSuiteSyncForWallet = (
     params: TurnOnSuiteSyncForWalletParams,
-) => Promise<Result<void, RefreshSuiteKeysUnavailable | DeviceErrorType | DeviceCancelledErrType>>;
+) => Promise<
+    Result<void, RefreshSuiteKeysUnavailableType | DeviceErrorType | DeviceCancelledErrType>
+>;
 
 export type TurnOnSuiteSyncForWalletDep = {
     turnOnSuiteSyncForWallet: TurnOnSuiteSyncForWallet;

--- a/suite-common/suite-sync/src/labeling/tests/subscribeLabeling.test.ts
+++ b/suite-common/suite-sync/src/labeling/tests/subscribeLabeling.test.ts
@@ -1,0 +1,190 @@
+import {
+    AccountLabel,
+    AddressLabel,
+    OutputLabel,
+    SuiteSyncStorage,
+    WalletLabel,
+} from '@suite-common/suite-sync-storage';
+import { asAccountDescriptor, asWalletDescriptor } from '@suite-common/wallet-types';
+import { StaticSessionId } from '@trezor/connect';
+import { err, ok } from '@trezor/type-utils';
+
+import { mockNotExpected } from '../../../tests/utils';
+import { RefreshSuiteKeysUnavailable } from '../../refreshSuiteSyncKeys';
+import { createSubscriptionStorage } from '../../storage/subscriptionStorage';
+import { createSubscribeLabeling } from '../subscribeLabeling';
+
+const deviceStaticSessionId: StaticSessionId = '1@2:3';
+
+type StorageSubscriptions = {
+    accountLabels: ((payload: AccountLabel) => void)[];
+    addressLabels: ((payload: AddressLabel) => void)[];
+    outputLabels: ((payload: OutputLabel) => void)[];
+    walletLabels: ((payload: WalletLabel) => void)[];
+};
+
+const createSuiteSyncStorageMock = (subscriptions?: StorageSubscriptions): SuiteSyncStorage => ({
+    accountLabels: {
+        subscribe: jest.fn(onChange => {
+            subscriptions?.accountLabels.push(onChange);
+
+            return () => {};
+        }),
+        update: mockNotExpected('update'),
+    },
+    addressLabels: {
+        subscribe: jest.fn(onChange => {
+            subscriptions?.addressLabels.push(onChange);
+
+            return () => {};
+        }),
+        update: mockNotExpected('update'),
+    },
+    outputLabels: {
+        subscribe: jest.fn(onChange => {
+            subscriptions?.outputLabels.push(onChange);
+
+            return () => {};
+        }),
+        update: mockNotExpected('update'),
+    },
+    walletLabels: {
+        subscribe: jest.fn(onChange => {
+            subscriptions?.walletLabels.push(onChange);
+
+            return () => {};
+        }),
+        update: mockNotExpected('update'),
+    },
+    dispose: mockNotExpected('dispose'),
+    updateRelayUrl: mockNotExpected('updateRelayUrl'),
+});
+
+describe(createSubscribeLabeling.name, () => {
+    it('fails when storage is not available', async () => {
+        const subscribeLabeling = createSubscribeLabeling({
+            dispatch: () => {},
+            ensureStorage: () => Promise.resolve(err(RefreshSuiteKeysUnavailable())),
+            subscriptionStorage: createSubscriptionStorage(),
+        });
+
+        const result = await subscribeLabeling({ deviceStaticSessionId });
+
+        expect(!result.ok && result.error.type).toBe('RefreshSuiteKeysUnavailable');
+    });
+
+    it('subscribes labeling', async () => {
+        const storage = createSuiteSyncStorageMock();
+        const subscribeLabeling = createSubscribeLabeling({
+            dispatch: () => {},
+            ensureStorage: () => Promise.resolve(ok(storage)),
+            subscriptionStorage: createSubscriptionStorage(),
+        });
+
+        const result = await subscribeLabeling({ deviceStaticSessionId });
+
+        expect(result.ok).toBe(true);
+
+        expect(storage.walletLabels.subscribe).toHaveBeenCalledTimes(1);
+        expect(storage.accountLabels.subscribe).toHaveBeenCalledTimes(1);
+        expect(storage.addressLabels.subscribe).toHaveBeenCalledTimes(1);
+        expect(storage.outputLabels.subscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('subscription emit actions', async () => {
+        const subscriptions: StorageSubscriptions = {
+            walletLabels: [],
+            accountLabels: [],
+            addressLabels: [],
+            outputLabels: [],
+        };
+
+        const actions: any[] = [];
+        const storage = createSuiteSyncStorageMock(subscriptions);
+        const subscribeLabeling = createSubscribeLabeling({
+            dispatch: (action: any) => actions.push(action),
+            ensureStorage: () => Promise.resolve(ok(storage)),
+            subscriptionStorage: createSubscriptionStorage(),
+        });
+
+        const result = await subscribeLabeling({ deviceStaticSessionId });
+
+        expect(result.ok).toBe(true);
+
+        subscriptions.walletLabels.forEach(it =>
+            it({ walletDescriptor: asWalletDescriptor('1'), label: 'Wallet Label' }),
+        );
+        expect(actions).toStrictEqual([
+            {
+                payload: { label: 'Wallet Label', walletDescriptor: '1' },
+                type: '@suite/labeling/set-device-label',
+            },
+        ]);
+
+        actions.pop();
+        subscriptions.accountLabels.forEach(it =>
+            it({
+                accountDescriptor: asAccountDescriptor('account-1'),
+                label: 'Account for Drugs',
+                networkSymbol: 'btc',
+            }),
+        );
+        expect(actions).toStrictEqual([
+            {
+                payload: {
+                    accountDescriptor: 'account-1',
+                    label: 'Account for Drugs',
+                    networkSymbol: 'btc',
+                    walletDescriptor: '1',
+                },
+                type: '@suite/labeling/set-account-label',
+            },
+        ]);
+
+        actions.pop();
+        subscriptions.addressLabels.forEach(it =>
+            it({
+                networkSymbol: 'btc',
+                accountDescriptor: asAccountDescriptor('account-1'),
+                address: 'address',
+                label: 'Address for drugs',
+            }),
+        );
+        expect(actions).toStrictEqual([
+            {
+                payload: {
+                    accountDescriptor: 'account-1',
+                    address: 'address',
+                    label: 'Address for drugs',
+                    networkSymbol: 'btc',
+                    walletDescriptor: '1',
+                },
+                type: '@suite/labeling/set-address-label',
+            },
+        ]);
+
+        actions.pop();
+        subscriptions.outputLabels.forEach(it =>
+            it({
+                networkSymbol: 'btc',
+                accountDescriptor: asAccountDescriptor('account-1'),
+                txId: 'transaction-id',
+                outputIndex: 0,
+                label: 'Output spend for buying drugs',
+            }),
+        );
+        expect(actions).toStrictEqual([
+            {
+                payload: {
+                    accountDescriptor: 'account-1',
+                    label: 'Output spend for buying drugs',
+                    networkSymbol: 'btc',
+                    walletDescriptor: '1',
+                    outputIndex: 0,
+                    txId: 'transaction-id',
+                },
+                type: '@suite/labeling/set-output-label',
+            },
+        ]);
+    });
+});

--- a/suite-common/suite-sync/src/refreshSuiteSyncKeys.ts
+++ b/suite-common/suite-sync/src/refreshSuiteSyncKeys.ts
@@ -4,12 +4,20 @@ import { EnsureDelegatedIdentityKeyDep } from '@suite-common/delegated-identity-
 import { ensureDeviceHasQuotaThunk } from '@suite-common/suite-sync-quota-manager';
 import {
     EnsureSuiteSyncOwnerDep,
-    RefreshSuiteKeysUnavailable,
+    RefreshSuiteKeysUnavailableType,
     RefreshSuiteSyncKeys,
 } from '@suite-common/suite-sync-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
 import { err, exhaustive, ok } from '@trezor/type-utils';
+
+/**
+ * Device is not connected or device is in a state/configuration, that does not
+ * support Suite Sync.
+ */
+export const RefreshSuiteKeysUnavailable = (): RefreshSuiteKeysUnavailableType => ({
+    type: 'RefreshSuiteKeysUnavailable',
+});
 
 export type RefreshSuiteSyncKeysDeps = {
     dispatch: Dispatch;

--- a/suite-common/suite-sync/src/storage/ensureStorage.ts
+++ b/suite-common/suite-sync/src/storage/ensureStorage.ts
@@ -1,6 +1,6 @@
 import { CreateSuiteStorageDep, SuiteSyncStorage } from '@suite-common/suite-sync-storage';
 import {
-    RefreshSuiteKeysUnavailable,
+    RefreshSuiteKeysUnavailableType,
     RefreshSuiteSyncKeysDep,
     SuiteSyncStorageRepositoryDep,
 } from '@suite-common/suite-sync-types';
@@ -10,6 +10,7 @@ import { Result, err, ok } from '@trezor/type-utils';
 
 import { createStorageIdFromDeviceStaticSessionId } from './createStorageIdFromDeviceStaticSessionId';
 import { GetDeviceForStaticSessionIdDep } from '../getDeviceForStaticSessionId';
+import { RefreshSuiteKeysUnavailable } from '../refreshSuiteSyncKeys';
 
 export type EnsureStorageDeps = {
     defaultRelayUrl: string;
@@ -26,7 +27,10 @@ export type EnsureStorageParams = {
 export type EnsureStorage = (
     params: EnsureStorageParams,
 ) => Promise<
-    Result<SuiteSyncStorage, RefreshSuiteKeysUnavailable | DeviceErrorType | DeviceCancelledErrType>
+    Result<
+        SuiteSyncStorage,
+        RefreshSuiteKeysUnavailableType | DeviceErrorType | DeviceCancelledErrType
+    >
 >;
 
 export type EnsureStorageDep = {


### PR DESCRIPTION
Only adds test, no QA needed

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test-subscription-labeling&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-subscription-labeling&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-subscription-labeling&lookback=7)