### PR TITLE
fix(suite): remove device disconnected banner from staking

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
@@ -31,10 +31,9 @@ import { openModal } from 'src/actions/suite/modalActions';
 import { DashboardSection } from 'src/components/dashboard';
 import { Translation } from 'src/components/suite/Translation';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
-import { useDevice, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
+import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
-import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 
 import { DiscoveryWarning } from './DiscoveryWarning';
 
@@ -43,10 +42,8 @@ export const EmptyStakingCard = () => {
     const dispatch = useDispatch();
     const { CryptoAmountFormatter } = useFormatters();
     const account = useSelector(selectSelectedAccount);
-    const { device } = useDevice();
 
     const { isStakingDisabled, stakingMessageContent } = useMessageSystemStaking(account?.symbol);
-    const isDeviceConnected = device?.connected && device?.available;
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const isCardano = account?.networkType === 'cardano';
@@ -155,7 +152,6 @@ export const EmptyStakingCard = () => {
     return (
         <DashboardSection data-testid="@wallet/staking/empty-card">
             <Column gap={16}>
-                {!isDeviceConnected && <ConnectDeviceGenericPromo />}
                 {isDiscoveryRunning && <DiscoveryWarning />}
 
                 <Card>


### PR DESCRIPTION
## Description

Follow-up PR for https://github.com/trezor/trezor-suite/pull/23688.

Removes `Trezor disconnected` banner from staking section.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23411

## Screenshots:

### Before

<img width="100%" alt="image" src="https://github.com/user-attachments/assets/54f48b4e-c58a-4996-817c-060fb9955d2d" />

### After

<img width="100%" alt="Screenshot 2025-12-15 at 09 32 43" src="https://github.com/user-attachments/assets/c260a8fb-d139-413d-b1b3-a18f2db3dc16" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/staking-device-disconnected&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/staking-device-disconnected&lookback=7)