### PR TITLE
fix(e2e-suite): revert tests to expect original init metadata flow

### DIFF
--- a/suite/e2e/support/pageObjects/metadata/accountMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/accountMetadata.ts
@@ -17,7 +17,7 @@ export class AccountMetadata extends MetadataBase {
 
     @step()
     async changeLabel(accountId: string, newLabel: string) {
-        await this.resetMousePosition();
+        await this.page.resetMousePosition();
         // ensure account label is loaded - test can be too fast
         await expect(this.accountLabel(accountId)).toHaveText(/[A-Za-z]+/);
         await this.accountLabel(accountId).hover();
@@ -27,7 +27,7 @@ export class AccountMetadata extends MetadataBase {
 
     @step()
     async clickEditLabelButton(accountId: string) {
-        await this.resetMousePosition();
+        await this.page.resetMousePosition();
         await this.accountLabel(accountId).hover();
         await this.editLabelButton(accountId).click();
     }

--- a/suite/e2e/support/pageObjects/metadata/metadataBase.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataBase.ts
@@ -22,10 +22,6 @@ export class MetadataBase {
             .and(page.locator('[contenteditable="true"]'));
     }
 
-    async resetMousePosition() {
-        await this.page.mouse.move(0, 0); // reset mouse position to avoid hover issues
-    }
-
     @step()
     async fillLabelInput(label: string, options?: MetadataSubmitOptions) {
         await this.metadataInput.fill(label);

--- a/suite/e2e/support/pageObjects/metadata/walletMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/walletMetadata.ts
@@ -11,7 +11,7 @@ export class WalletMetadata extends MetadataBase {
         this.walletOnIndex(index).getByTestId(this.successId);
     @step()
     async clickEditLabel(index: number) {
-        await this.resetMousePosition();
+        await this.page.resetMousePosition();
         // ensure wallet label is loaded - test can be too fast
         await expect(this.walletLabel(index)).toHaveText(/[A-Za-z]+/);
         await this.walletOnIndex(index).getByTestId(this.inputId).hover();

--- a/suite/e2e/support/testExtends/enhancePage.ts
+++ b/suite/e2e/support/testExtends/enhancePage.ts
@@ -9,8 +9,6 @@ declare module '@playwright/test' {
 
         // Methods
         discoveryShouldFinish(): Promise<void>;
-        selectDropdownOptionWithRetry(dropdown: Locator, option: Locator): Promise<void>;
-        getReduxObject(objectPath: string): Promise<any>;
         expectReduxObjectNotToBeEmpty(
             objectPath: string,
             options?: { timeout?: number },
@@ -26,10 +24,13 @@ declare module '@playwright/test' {
             expectedValue: unknown,
             options?: { timeout?: number },
         ): Promise<void>;
+        getReduxObject(objectPath: string): Promise<any>;
+        resetMousePosition(): Promise<void>;
         runWithReduxDump<T>(
             action: () => Promise<T>,
             options?: { slice?: string; filePrefix?: string },
         ): Promise<void>;
+        selectDropdownOptionWithRetry(dropdown: Locator, option: Locator): Promise<void>;
     }
 }
 
@@ -145,6 +146,10 @@ export const enhancePage = (page: Page): Page => {
 - ${afterPath}
 You can use a diff tool to compare the state before and after the action.
         `);
+    };
+
+    page.resetMousePosition = async function () {
+        await page.mouse.move(0, 0); // reset mouse position to avoid hover issues
     };
 
     return page;

--- a/suite/e2e/tests/metadata/account-metadata.test.ts
+++ b/suite/e2e/tests/metadata/account-metadata.test.ts
@@ -31,7 +31,6 @@ test.describe('Account metadata', { tag: ['@group=metadata', '@webOnly'] }, () =
         });
 
         await test.step('Edit label with Enter submit', async () => {
-            await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
             await metadataPage.account.metadataInput.fill('cool new label');
             await page.keyboard.press('Enter');
             await expect(

--- a/suite/e2e/tests/metadata/remembered-device.test.ts
+++ b/suite/e2e/tests/metadata/remembered-device.test.ts
@@ -124,7 +124,6 @@ test.describe(
                 await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
                 await metadataPage.metadataProviderButton(MetadataProvider.GOOGLE).click();
                 await expect(metadataPage.metadataModal).toBeHidden();
-                await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
                 await metadataPage.account.fillLabelInput('mnau');
                 await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toContainText(
                     'mnau',

--- a/suite/e2e/tests/metadata/switching-providers.test.ts
+++ b/suite/e2e/tests/metadata/switching-providers.test.ts
@@ -40,7 +40,6 @@ test.describe(
                     await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
                     await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
 
-                    await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
                     await metadataPage.account.metadataInput.fill(dropboxLabel);
                     await page.keyboard.press('Enter');
                     await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
@@ -79,7 +78,6 @@ test.describe(
                     await page.getByTestId('@modal/metadata-provider/google-button').click();
                     await expect(page.getByTestId('@modal/metadata-provider')).toBeHidden();
 
-                    await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
                     await metadataPage.account.metadataInput.fill(googleLabel);
                     await page.keyboard.press('Enter');
                     await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(


### PR DESCRIPTION
This pull request refactors how the mouse position is reset in Playwright-based end-to-end tests for metadata features. The main improvement is moving the `resetMousePosition` utility from individual page object classes to a shared method on the Playwright `Page` object, reducing code duplication and centralizing its logic. Related test code is also updated to use this new approach.

Refactoring and code deduplication:

* Removed the `resetMousePosition` method from the `MetadataBase` class and its subclasses, and instead implemented it as a shared method (`resetMousePosition`) directly on the Playwright `Page` object via module augmentation in `enhancePage.ts`. This centralizes the logic and reduces duplication. [[1]](diffhunk://#diff-76d40e8d8b90a2d2eba5a86589bb1f750419615c58546bf6f845723cc451fbbdL25-L28) [[2]](diffhunk://#diff-63c8728b5ec7ad179d15ff21c7f62c34b8493a3e11d7e65d9ece22bca2302e20R151-R154)
* Updated all usages of `resetMousePosition` in `AccountMetadata` and `WalletMetadata` classes to use `this.page.resetMousePosition()` instead of the removed local method. [[1]](diffhunk://#diff-9819d7a2510beffe59976b71187b83a8582260ddff3f82570c53dcead044c930L20-R20) [[2]](diffhunk://#diff-9819d7a2510beffe59976b71187b83a8582260ddff3f82570c53dcead044c930L30-R30) [[3]](diffhunk://#diff-df2bf692f5de5b1ca4116118bc638196bab219a057fcf7d4446ae636c1ed2ee6L14-R14)

Playwright type augmentation:

* Updated the Playwright `Page` type definition in `enhancePage.ts` to include the new `resetMousePosition` method, ensuring type safety and discoverability for future test authors. Also reordered some method declarations for clarity. [[1]](diffhunk://#diff-63c8728b5ec7ad179d15ff21c7f62c34b8493a3e11d7e65d9ece22bca2302e20L12-L13) [[2]](diffhunk://#diff-63c8728b5ec7ad179d15ff21c7f62c34b8493a3e11d7e65d9ece22bca2302e20R27-R33)

Test cleanup:

* Removed redundant or duplicate label editing steps in several metadata-related tests, as the new approach and test flows no longer require them. [[1]](diffhunk://#diff-ebf9e4b80d3a3d2aa0c3b92086568b2eddb328a6776a20ff82a3da6eb1f0b6c7L34) [[2]](diffhunk://#diff-bf73ea73b3eb03ac6adafa0738aba6317c427f8d43f2d566fb094a3dfa5316faL127) [[3]](diffhunk://#diff-ac1decc4ca8e306bbd94df6fa5ce1d022d78deee0efd68ce31dff8dbbf182ed7L43) [[4]](diffhunk://#diff-ac1decc4ca8e306bbd94df6fa5ce1d022d78deee0efd68ce31dff8dbbf182ed7L82)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-suite-metadata&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-suite-metadata&lookback=7)