### PR TITLE
chore(suite-sync): get slip21 after discovery success

### DIFF
--- a/suite-common/suite-sync/src/suiteSyncMiddleware.ts
+++ b/suite-common/suite-sync/src/suiteSyncMiddleware.ts
@@ -1,21 +1,27 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
-import { applyDeviceStatesThunk, selectDeviceThunk } from '@suite-common/wallet-core';
+import { deviceActions, selectDeviceThunk } from '@suite-common/wallet-core';
 import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
 
 import { selectIsSuiteSyncEnabled } from './suiteSyncSelectors';
 
 // Thunk triggers for which we want to turn on Suite Sync for the currently selected wallet
 const suiteSyncTurnOnTriggers = [
-    // New wallet created
-    applyDeviceStatesThunk.fulfilled,
     // Wallet selected
     selectDeviceThunk.fulfilled,
 ] as const;
 
 export const prepareSuiteSyncMiddleware = createMiddlewareWithExtraDeps(
     (action, { next, getState, extra }) => {
+        if (selectIsSuiteSyncEnabled(getState()) && deviceActions.setDiscovered.match(action)) {
+            if (action.payload.success) {
+                extra.services.suiteSync.turnOnSuiteSyncForWallet({
+                    deviceStaticSessionId: action.payload.staticSessionId,
+                });
+            }
+        }
+
         if (selectIsSuiteSyncEnabled(getState()) && isAnyOf(...suiteSyncTurnOnTriggers)(action)) {
             const { payload } = action as ReturnType<(typeof suiteSyncTurnOnTriggers)[number]>;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After discovery, we call turnOnSuiteSync so we can get owner ID and interact with suite-sync. 

Currently, suite sync is broken in mobile and is blocked by this PR: https://github.com/trezor/trezor-suite/pull/23757/files#diff-b616068fe526596075dbc62b61811d8cc5aec2cc05cdc96380533f906db5fa40

Until that PR is merged, you can test that suite asks for the keys and device gives them back, but labels won't load because there is hanging promise in quota manager code which will be resolved by adding missing quota manager reducer to mobile. 

Resolves https://github.com/trezor/trezor-suite/issues/23887


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/common/get-slip21-after-discovery&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/common/get-slip21-after-discovery&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/common/get-slip21-after-discovery&lookback=7)