### PR TITLE
feat(authenticity): export verifySignatureP256

### DIFF
--- a/packages/device-authenticity/src/index.ts
+++ b/packages/device-authenticity/src/index.ts
@@ -1,4 +1,4 @@
-export { verifyAuthenticityProof } from './verifyAuthenticityProof';
+export { verifyAuthenticityProof, verifySignatureP256 } from './verifyAuthenticityProof';
 export { type AlgorithmName, parseName, parseCertificate } from './x509certificate';
 export { getRandomChallenge } from './utils';
 export type {

--- a/packages/device-authenticity/src/verifyAuthenticityProof.ts
+++ b/packages/device-authenticity/src/verifyAuthenticityProof.ts
@@ -15,7 +15,7 @@ import { AlgorithmName, parseCertificate } from './x509certificate';
 // There is incomparability in results between nodejs and window SubtleCrypto api.
 // window.crypto.subtle.importKey (CryptoKey) cannot be used by `crypto-browserify`.Verify
 // The only common format of publicKey is PEM.
-const verifySignatureP256: VerifySignature = async (rawKey, data, signature) => {
+export const verifySignatureP256: VerifySignature = async (rawKey, data, signature) => {
     const signer = crypto.createVerify('sha256');
     signer.update(Buffer.from(data));
 


### PR DESCRIPTION
Just export the `verifySignatureP256`.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/export-verify-signature&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/export-verify-signature&lookback=7)