### PR TITLE
chore(suite): improve staking apy loading

### DIFF
--- a/packages/suite/src/components/suite/StakingProcess/StakingInfo.tsx
+++ b/packages/suite/src/components/suite/StakingProcess/StakingInfo.tsx
@@ -18,6 +18,7 @@ import { exhaustive } from '@trezor/type-utils';
 import { useSelector } from 'src/hooks/suite';
 import { CoinjoinRootState } from 'src/reducers/wallet/coinjoinReducer';
 import { Account } from 'src/types/wallet';
+import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
 
 import { InfoRow } from './InfoRow';
 
@@ -145,7 +146,12 @@ export const StakingInfo = ({ isExpanded, flow }: StakingInfoProps) => {
             heading: infoRowsData?.rewardsEarningHeading,
             subheading: <Translation id="TR_STAKING_REWARDS_ARE_RESTAKED" />,
             content: {
-                text: <Translation id="TR_STAKE_APY_APPROX" values={{ apyPercent: apy }} />,
+                text: (
+                    <Translation
+                        id="TR_STAKE_APY_APPROX"
+                        values={{ apyPercent: formatApyValue(apy) }}
+                    />
+                ),
             },
         },
     ];

--- a/packages/suite/src/components/suite/banners/SuiteBanners/CardanoOutdatedStakingBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/CardanoOutdatedStakingBanner.tsx
@@ -6,6 +6,7 @@ import { Banner } from '@trezor/components';
 import { goto } from 'src/actions/suite/routerActions';
 import { DashboardAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
 
 export const CardanoOutdatedStakingBanner = () => {
     const dispatch = useDispatch();
@@ -33,7 +34,9 @@ export const CardanoOutdatedStakingBanner = () => {
                     <Translation id="TR_STAKING_MODAL_OUTDATED_BUTTON" />
                 </Banner.Button>
             }
-            description={<Translation id="TR_STAKING_MODAL_OUTDATED" values={{ apy }} />}
+            description={
+                <Translation id="TR_STAKING_MODAL_OUTDATED" values={{ apy: formatApyValue(apy) }} />
+            }
         />
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeInANutshellModal/StakeInANutshellModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeInANutshellModal/StakeInANutshellModal.tsx
@@ -26,6 +26,7 @@ import { stakingFlowToEventTypeMap } from 'src/constants/suite/staking';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { useAnalytics } from 'src/support/useAnalytics';
+import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
 
 interface StakingDetails {
     id: number;
@@ -201,7 +202,7 @@ export const StakeInANutshellModal = ({ onCancel, flow }: StakeInANutshellModalP
                                 values={{
                                     networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
                                     count: unstakingPeriod,
-                                    apy,
+                                    apy: formatApyValue(apy),
                                     days: CARDANO_ACTIVATION_PERIOD_DAYS,
                                 }}
                             />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeInfoCards/StakeInfoCards.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeInfoCards/StakeInfoCards.tsx
@@ -1,42 +1,52 @@
 import { Translation } from '@suite/intl';
 import { StakingFlow } from '@suite-common/suite-types/src/staking';
+import { selectPoolStatsApyData } from '@suite-common/wallet-core';
+import { Account } from '@suite-common/wallet-types';
 import { CollapsibleBox, Column, H3 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { StakingInfo } from 'src/components/suite/StakingProcess/StakingInfo';
+import { useSelector } from 'src/hooks/suite';
 
 import { EstimatedGains } from './EstimatedGains';
 
 interface StakeInfoCardsProps {
+    account: Account;
     flow: StakingFlow;
 }
 
-export const StakeInfoCards = ({ flow }: StakeInfoCardsProps) => {
+export const StakeInfoCards = ({ account, flow }: StakeInfoCardsProps) => {
+    const apy = useSelector(state => selectPoolStatsApyData(state, account));
+
     const cards = [
         {
             heading: <Translation id="TR_STAKING_ONCE_YOU_CONFIRM" />,
             content: <StakingInfo isExpanded flow={flow} />,
             defaultIsOpen: true,
+            isVisible: true,
         },
         {
             heading: <Translation id="TR_STAKING_ESTIMATED_GAINS" />,
             content: <EstimatedGains />,
             defaultIsOpen: false,
+            isVisible: apy !== null,
         },
     ];
 
     return (
         <Column gap={spacings.lg} margin={{ bottom: spacings.lg }}>
-            {cards.map((card, index) => (
-                <CollapsibleBox
-                    heading={<H3 typographyStyle="highlight">{card.heading}</H3>}
-                    key={index}
-                    hasDivider={false}
-                    defaultIsOpen={card.defaultIsOpen}
-                >
-                    {card.content}
-                </CollapsibleBox>
-            ))}
+            {cards
+                .filter(card => card.isVisible)
+                .map((card, index) => (
+                    <CollapsibleBox
+                        heading={<H3 typographyStyle="highlight">{card.heading}</H3>}
+                        key={index}
+                        hasDivider={false}
+                        defaultIsOpen={card.defaultIsOpen}
+                    >
+                        {card.content}
+                    </CollapsibleBox>
+                ))}
         </Column>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
@@ -66,7 +66,7 @@ export const StakeModalLoaded = ({ onCancel, selectedAccount, flow }: StakeModal
             >
                 <Grid columns={isBelowTablet ? 1 : 2} gap={spacings.xxl}>
                     <StakeForm flow={flow} />
-                    <StakeInfoCards flow={flow} />
+                    <StakeInfoCards account={account} flow={flow} />
                 </Grid>
             </Modal>
         </StakeFormContext.Provider>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -22,6 +22,7 @@ import { setFlag } from 'src/actions/suite/suiteActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 import { useAnalytics } from 'src/support/useAnalytics';
+import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
 
 type StakingBannerProps = {
     account: Account;
@@ -144,7 +145,10 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
             icon="piggyBank"
             intent="brand"
             title={
-                <Translation id="TR_STAKING_BANNER_DETAIL_TITLE" values={{ apy, displaySymbol }} />
+                <Translation
+                    id="TR_STAKING_BANNER_DETAIL_TITLE"
+                    values={{ apy: formatApyValue(apy), displaySymbol }}
+                />
             }
             description={
                 !hasEnoughBalanceForStaking || !hasPotentialRewards ? (

--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardAccountRow.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardAccountRow.tsx
@@ -18,15 +18,18 @@ import {
     getStakingLimitsByNetworkSymbol,
     isCardanoStakedOutsideEverstake,
 } from '@suite-common/wallet-utils';
-import { Button, Column, H4, Icon, Paragraph, Row, Table } from '@trezor/components';
+import { Button, Column, Icon, Paragraph, Row, Table } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useAnalytics, useLegacyAnalytics } from 'src/support/useAnalytics';
+import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
+import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
 
 import { StakingDashboardAccountCell } from './StakingDashboardAccountCell';
+import { StakingDashboardRewardsAmount } from './StakingDashboardRewardsAmount';
 
 export const StakingDashboardAccountRow = ({ account }: { account: Account }) => {
     const dispatch = useDispatch();
@@ -155,7 +158,11 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
             <Table.Cell>
                 <Row width="100%" alignItems="center" justifyContent="space-between">
                     <Column alignItems="flex-start">
-                        <H4>{formatCryptoAmount(isStakingActive ? currentRewards : '0', true)}</H4>
+                        <StakingDashboardRewardsAmount
+                            accountSymbol={account.symbol}
+                            rewards={isStakingActive ? currentRewards : '0'}
+                            apy={apy}
+                        />
 
                         {isStakingActive && (
                             <Paragraph typographyStyle="hint" variant="tertiary">
@@ -170,7 +177,7 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
                         )}
                     </Column>
 
-                    <Icon name="arrowRight" variant="tertiary" size="mediumLarge" />
+                    {apy && <Icon name="arrowRight" variant="tertiary" size="mediumLarge" />}
                 </Row>
             </Table.Cell>
         );
@@ -186,9 +193,16 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
         return (
             <Table.Cell>
                 <Column>
-                    <H4 variant="primary">{formatCryptoAmount(potentialRewards, true)}</H4>
+                    {apy && (
+                        <StakingDashboardRewardsAmount
+                            accountSymbol={account.symbol}
+                            rewards={potentialRewards}
+                            apy={apy}
+                            variant="primary"
+                        />
+                    )}
 
-                    {!isCardanoNetworkType && (
+                    {!isCardanoNetworkType && apy && (
                         <Paragraph typographyStyle="hint" variant="tertiary">
                             <Translation
                                 id="TR_STAKING_DASHBOARD_IF_YOU_ADD"
@@ -212,9 +226,9 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
 
             <Table.Cell>
                 {state === 'staking-outdated-provider' ? (
-                    <Translation id="TR_STAKE_UNKNOWN_APY" />
+                    <Translation id="TR_STAKE_NOT_AVAILABLE" />
                 ) : (
-                    <>~{apy}%</>
+                    <ApyValue apy={apy} />
                 )}
             </Table.Cell>
 
@@ -324,7 +338,7 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
                             <Paragraph typographyStyle="body" variant="warning">
                                 <Translation
                                     id="TR_STAKING_DASHBOARD_OUTDATED_PROVIDER"
-                                    values={{ apy }}
+                                    values={{ apy: formatApyValue(apy) }}
                                 />
                             </Paragraph>
                         </Row>

--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardActivateRow.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardActivateRow.tsx
@@ -6,6 +6,7 @@ import { Button, Paragraph, Table } from '@trezor/components';
 
 import { openModal } from 'src/actions/suite/modalActions';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
 
 import { StakingDashboardAccountCell } from './StakingDashboardAccountCell';
 
@@ -40,7 +41,9 @@ export const StakingDashboardActivateRow = ({ symbol }: { symbol: NetworkSymbol 
                 <StakingDashboardAccountCell symbol={symbol} />
             </Table.Cell>
 
-            <Table.Cell>~{apy}%</Table.Cell>
+            <Table.Cell>
+                <ApyValue apy={apy} />
+            </Table.Cell>
 
             <Table.Cell colSpan={2}>
                 <Paragraph typographyStyle="body" variant="tertiary">

--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardRewardsAmount.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardRewardsAmount.tsx
@@ -1,0 +1,39 @@
+import { Translation } from '@suite/intl';
+import { useFormatters } from '@suite-common/formatters';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { H4, TextVariant } from '@trezor/components';
+
+interface StakingDashboardRewardsAmountProps {
+    accountSymbol: NetworkSymbol;
+    rewards: string;
+    apy: number | null;
+    variant?: TextVariant;
+}
+
+export const StakingDashboardRewardsAmount = ({
+    accountSymbol,
+    rewards,
+    apy,
+    variant,
+}: StakingDashboardRewardsAmountProps) => {
+    const { CryptoAmountFormatter } = useFormatters();
+
+    if (!apy)
+        return (
+            <H4 variant={variant}>
+                <Translation id="TR_STAKE_APY_REQUIRED" />
+            </H4>
+        );
+
+    return (
+        <H4 variant={variant}>
+            {CryptoAmountFormatter.format(rewards, {
+                symbol: accountSymbol,
+                isBalance: true,
+                withSymbol: true,
+                isEllipsisAppended: false,
+                maxDisplayedDecimals: 8,
+            })}
+        </H4>
+    );
+};

--- a/packages/suite/src/views/wallet/staking/components/ApyValue.tsx
+++ b/packages/suite/src/views/wallet/staking/components/ApyValue.tsx
@@ -1,0 +1,13 @@
+import { Translation } from '@suite/intl';
+
+interface ApyValueProps {
+    apy?: number | null;
+}
+
+export const ApyValue = ({ apy }: ApyValueProps) => {
+    if (!apy) {
+        return <Translation id="TR_STAKE_NOT_AVAILABLE" />;
+    }
+
+    return <>~{apy}%</>;
+};

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ApyCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ApyCard.tsx
@@ -2,8 +2,9 @@ import { Translation } from '@suite/intl';
 import { Card, Column, Icon, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
+import { ApyValue } from '../../ApyValue';
 interface ApyCardProps {
-    apy?: number;
+    apy?: number | null;
 }
 
 export const ApyCard = ({ apy }: ApyCardProps) => (
@@ -13,7 +14,7 @@ export const ApyCard = ({ apy }: ApyCardProps) => (
 
             <Column margin={{ top: 'auto' }}>
                 <Paragraph typographyStyle="titleMedium">
-                    {apy ? `${apy}%` : <Translation id="TR_STAKE_UNKNOWN_APY" />}
+                    <ApyValue apy={apy} />
                 </Paragraph>
                 <Paragraph typographyStyle="hint" variant="tertiary">
                     <Translation id="TR_STAKE_APY" />

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
@@ -35,6 +35,7 @@ import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { useAnalytics } from 'src/support/useAnalytics';
+import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
 
 import { DiscoveryWarning } from './DiscoveryWarning';
 
@@ -162,7 +163,7 @@ export const EmptyStakingCard = () => {
                             <H3>
                                 <Translation
                                     id="TR_STAKING_CARD_TITLE"
-                                    values={{ apy, displaySymbol }}
+                                    values={{ apy: formatApyValue(apy), displaySymbol }}
                                 />
                             </H3>
                             <Paragraph variant="tertiary" maxWidth={700}>

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx
@@ -12,6 +12,7 @@ import { openModal } from 'src/actions/suite/modalActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import { useAnalytics } from 'src/support/useAnalytics';
+import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
 
 interface NewProviderCardProps {
     account: Account;
@@ -63,7 +64,7 @@ export const NewProviderCard = ({ account }: NewProviderCardProps) => {
                                         ? 'TR_STAKING_NEW_PROVIDER_OUTDATED_TITLE'
                                         : 'TR_STAKING_NEW_PROVIDER_TITLE'
                                 }
-                                values={{ apy }}
+                                values={{ apy: formatApyValue(apy) }}
                             />
                         </H3>
                         <Paragraph variant="tertiary" maxWidth={700}>
@@ -73,7 +74,7 @@ export const NewProviderCard = ({ account }: NewProviderCardProps) => {
                                         ? 'TR_STAKING_NEW_PROVIDER_OUTDATED_TEXT'
                                         : 'TR_STAKING_NEW_PROVIDER_TEXT'
                                 }
-                                values={{ apy, displaySymbol }}
+                                values={{ apy: formatApyValue(apy), displaySymbol }}
                             />
                         </Paragraph>
                     </Column>

--- a/packages/suite/src/views/wallet/staking/utils/formatStakeValues.tsx
+++ b/packages/suite/src/views/wallet/staking/utils/formatStakeValues.tsx
@@ -1,0 +1,9 @@
+import { Translation } from '@suite/intl';
+
+export const formatApyValue = (apy?: number | null) => {
+    if (apy == null) {
+        return <Translation id="TR_STAKE_N_A" />;
+    }
+
+    return `${apy}`;
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -62,3 +62,4 @@ export * from './union';
 export * from './isInt';
 export * from './number';
 export * from './sanitizeFilename';
+export * from './isSafeObjectKey';

--- a/packages/utils/src/isSafeObjectKey.ts
+++ b/packages/utils/src/isSafeObjectKey.ts
@@ -1,0 +1,2 @@
+export const isSafeObjectKey = (key: string) =>
+    !['__proto__', 'constructor', 'prototype'].includes(key);

--- a/suite-common/staking/src/utils/staking.ts
+++ b/suite-common/staking/src/utils/staking.ts
@@ -10,7 +10,7 @@ import { BigNumber } from '@trezor/utils';
 import { getEthereumStakingAddressByType } from './ethereumStaking';
 import { StakingTotalRewards } from '../types';
 
-export const calculateGains = (amount: string, apy: number, days: number) => {
+export const calculateGains = (amount: string, apy: number | null, days: number) => {
     const rewards = calculateRewards(amount, apy, days);
 
     return new BigNumber(rewards).toFixed(5, 1);

--- a/suite-common/wallet-constants/src/cardanoConstants.ts
+++ b/suite-common/wallet-constants/src/cardanoConstants.ts
@@ -1,6 +1,5 @@
 import { BigNumber } from '@trezor/utils';
 
-export const BACKUP_CARDANO_APY = 2.4;
 export const CARDANO_APY_MIN_THRESHOLD = 1.8;
 export const ESTIMATED_YEARLY_REWARD_RATE = 2.22;
 export const CARDANO_EPOCH_DAYS = 5;

--- a/suite-common/wallet-constants/src/ethereumStakingConstants.ts
+++ b/suite-common/wallet-constants/src/ethereumStakingConstants.ts
@@ -1,8 +1,5 @@
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-// Used when Everstake pool stats are not available from the API.
-export const BACKUP_ETH_APY = 4.13;
-
 // Slack discussion https://satoshilabs.slack.com/archives/C0543DJBK0C/p1719409880504649?thread_ts=1719403259.875369&cid=C0543DJBK0C
 // increasing gas limit as tx can consume more than it was estimated due to edge cases
 // stake/unstake method usually consumes 97k-425k but can take up to 1M

--- a/suite-common/wallet-constants/src/solanaStakingConstants.ts
+++ b/suite-common/wallet-constants/src/solanaStakingConstants.ts
@@ -1,6 +1,5 @@
 import { BigNumber } from '@trezor/utils';
 
-export const BACKUP_SOL_APY = 6.87;
 export const MIN_SOL_AMOUNT_FOR_STAKING = new BigNumber(0.01);
 export const MAX_SOL_AMOUNT_FOR_STAKING = new BigNumber(10_000_000);
 export const MIN_SOL_FOR_WITHDRAWALS = new BigNumber(0.02);

--- a/suite-common/wallet-constants/src/stakingConstants.ts
+++ b/suite-common/wallet-constants/src/stakingConstants.ts
@@ -3,5 +3,3 @@
 // It is a constant which allows the SDK to define which app calls its functions.
 // Each app which integrates the SDK has its own source, e.g. source for Trezor Suite is '1'.
 export const WALLET_SDK_SOURCE = '1';
-
-export const BACKUP_APY = 4.13;

--- a/suite-common/wallet-core/src/stake/__fixtures__/stakeReducer.ts
+++ b/suite-common/wallet-core/src/stake/__fixtures__/stakeReducer.ts
@@ -1,0 +1,322 @@
+import { Timestamp } from '@suite-common/wallet-types';
+
+import type { StakeState } from '../stakeReducer';
+
+export const fetchEverstakeDataPending: {
+    description: string;
+    initialState: Partial<StakeState>;
+    actionPayload: { symbol: 'eth'; endpointType: string };
+    result: StakeState['data'];
+}[] = [
+    {
+        description: 'initial eth poolStats + validatorsQueue created',
+        initialState: {
+            data: {},
+        },
+        actionPayload: { symbol: 'eth', endpointType: 'poolStats' },
+        result: {
+            eth: {
+                poolStats: {
+                    error: false,
+                    isLoading: true,
+                    lastSuccessfulFetchTimestamp: 0 as Timestamp,
+                    data: {},
+                },
+            },
+        },
+    },
+];
+
+export const fetchEverstakeDataFulfilled = [
+    {
+        description: 'poolStats updated on fulfilled',
+        initialState: {
+            data: {
+                eth: {
+                    poolStats: {
+                        error: false,
+                        isLoading: true,
+                        lastSuccessfulFetchTimestamp: 0 as Timestamp,
+                        data: {},
+                    },
+                },
+            },
+        },
+        actionPayload: { symbol: 'eth', endpointType: 'poolStats' },
+        payload: { ethApy: 5, nextRewardPayout: 3 },
+        result: {
+            eth: {
+                poolStats: {
+                    error: false,
+                    isLoading: false,
+                    lastSuccessfulFetchTimestamp: expect.any(Number) as Timestamp,
+                    data: { ethApy: 5, nextRewardPayout: 3 },
+                },
+            },
+        },
+    },
+];
+
+export const fetchEverstakeDataRejected = [
+    {
+        description: 'sets error state for eth.poolStats when request fails',
+        initialState: {
+            data: {
+                eth: {
+                    poolStats: {
+                        error: false,
+                        isLoading: true,
+                        lastSuccessfulFetchTimestamp: 123456 as Timestamp,
+                        data: { ethApy: 1 },
+                    },
+                },
+            },
+        },
+        actionPayload: {
+            symbol: 'eth',
+            endpointType: 'poolStats',
+            error: 'Network error',
+        },
+        result: {
+            eth: {
+                poolStats: {
+                    error: true,
+                    isLoading: false,
+                    lastSuccessfulFetchTimestamp: 0 as Timestamp,
+                    data: {},
+                },
+            },
+        },
+    },
+];
+
+export const fetchEverstakeStakingInfoPending: {
+    description: string;
+    initialState: Partial<StakeState>;
+    actionPayload: { symbol: 'ada' | 'sol'; endpointType: 'stakingInfo' };
+    result: StakeState['data'];
+}[] = [
+    {
+        description: 'initial stakingInfo created for ADA',
+        initialState: { data: {} },
+        actionPayload: { symbol: 'ada', endpointType: 'stakingInfo' },
+        result: {
+            ada: {
+                stakingInfo: {
+                    error: false,
+                    isLoading: true,
+                    lastSuccessfulFetchTimestamp: 0 as Timestamp,
+                    data: {},
+                },
+            },
+        },
+    },
+];
+
+export const fetchEverstakeStakingInfoFulfilled = [
+    {
+        description: 'stakingInfo updated on fulfilled (SOL)',
+        initialState: {
+            data: {
+                sol: {
+                    stakingInfo: {
+                        error: false,
+                        isLoading: true,
+                        lastSuccessfulFetchTimestamp: 0 as Timestamp,
+                        data: {},
+                    },
+                },
+            },
+        },
+        actionPayload: { symbol: 'sol', endpointType: 'stakingInfo' },
+        payload: { apy: 7.5 },
+        result: {
+            sol: {
+                stakingInfo: {
+                    error: false,
+                    isLoading: false,
+                    lastSuccessfulFetchTimestamp: expect.any(Number) as Timestamp,
+                    data: { apy: 7.5 },
+                },
+            },
+        },
+    },
+    {
+        description: 'stakingInfo updated on fulfilled (ADA)',
+        initialState: {
+            data: {
+                ada: {
+                    stakingInfo: {
+                        error: false,
+                        isLoading: true,
+                        lastSuccessfulFetchTimestamp: 0 as Timestamp,
+                        data: {},
+                    },
+                },
+            },
+        },
+        actionPayload: { symbol: 'ada', endpointType: 'stakingInfo' },
+        payload: {
+            pools: [
+                {
+                    apy: 4.2,
+                    saturation: 76.53,
+                    id: 'poolid1',
+                },
+                {
+                    apy: 4.3,
+                    saturation: 16.53,
+                    id: 'poolid2',
+                },
+            ],
+        },
+        result: {
+            ada: {
+                stakingInfo: {
+                    error: false,
+                    isLoading: false,
+                    lastSuccessfulFetchTimestamp: expect.any(Number) as Timestamp,
+                    data: {
+                        pools: [
+                            {
+                                apy: 4.2,
+                                saturation: 76.53,
+                                id: 'poolid1',
+                            },
+                            {
+                                apy: 4.3,
+                                saturation: 16.53,
+                                id: 'poolid2',
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    },
+];
+
+export const fetchEverstakeStakingInfoRejected = [
+    {
+        description: 'sets error state for SOL stakingInfo when request fails',
+        initialState: {
+            data: {
+                sol: {
+                    stakingInfo: {
+                        error: false,
+                        isLoading: true,
+                        lastSuccessfulFetchTimestamp: 1111 as Timestamp,
+                        data: { apy: 3 },
+                    },
+                },
+            },
+        },
+        actionPayload: {
+            symbol: 'sol',
+            endpointType: 'stakingInfo',
+        },
+        result: {
+            sol: {
+                stakingInfo: {
+                    error: true,
+                    isLoading: false,
+                    lastSuccessfulFetchTimestamp: 0 as Timestamp,
+                    data: {},
+                },
+            },
+        },
+    },
+];
+
+export const fetchEverstakeRewardsPending = [
+    {
+        description: 'initial stakingRewards created for SOL',
+        initialState: { data: {} },
+        actionPayload: {
+            symbol: 'sol',
+            endpointType: 'stakingRewards',
+            address: 'Addr111',
+        },
+        result: {
+            sol: {
+                stakingRewards: {
+                    error: false,
+                    isLoading: true,
+                    lastSuccessfulFetchTimestamp: 0 as Timestamp,
+                    data: {},
+                },
+            },
+        },
+    },
+];
+
+export const fetchEverstakeRewardsFulfilled = [
+    {
+        description: 'stakingRewards updated on fulfilled',
+        initialState: {
+            data: {
+                sol: {
+                    stakingRewards: {
+                        error: false,
+                        isLoading: true,
+                        lastSuccessfulFetchTimestamp: 0 as Timestamp,
+                        data: {},
+                    },
+                },
+            },
+        },
+        actionPayload: {
+            symbol: 'sol',
+            endpointType: 'stakingRewards',
+        },
+        payload: {
+            rewardsHistory: { Addr111: [{ epoch: 1, reward: 10 }] },
+            totalRewards: { Addr111: '10' },
+        },
+        result: {
+            sol: {
+                stakingRewards: {
+                    error: false,
+                    isLoading: false,
+                    lastSuccessfulFetchTimestamp: expect.any(Number) as Timestamp,
+                    data: {
+                        rewardsHistory: { Addr111: [{ epoch: 1, reward: 10 }] },
+                        totalRewards: { Addr111: '10' },
+                    },
+                },
+            },
+        },
+    },
+];
+
+export const fetchEverstakeRewardsRejected = [
+    {
+        description: 'error state for stakingRewards when request fails',
+        initialState: {
+            data: {
+                sol: {
+                    stakingRewards: {
+                        error: false,
+                        isLoading: true,
+                        lastSuccessfulFetchTimestamp: 123 as Timestamp,
+                        data: { rewardsHistory: {}, totalRewards: {} },
+                    },
+                },
+            },
+        },
+        actionPayload: {
+            symbol: 'sol',
+            endpointType: 'stakingRewards',
+        },
+        result: {
+            sol: {
+                stakingRewards: {
+                    error: true,
+                    isLoading: false,
+                    lastSuccessfulFetchTimestamp: 0 as Timestamp,
+                    data: {},
+                },
+            },
+        },
+    },
+];

--- a/suite-common/wallet-core/src/stake/__tests__/stakeReducer.test.ts
+++ b/suite-common/wallet-core/src/stake/__tests__/stakeReducer.test.ts
@@ -1,0 +1,172 @@
+import { extraDependenciesMock } from '@suite-common/test-utils';
+
+import * as fixtures from '../__fixtures__/stakeReducer';
+import { prepareStakeReducer, stakeInitialState } from '../stakeReducer';
+import {
+    fetchEverstakeData,
+    fetchEverstakeRewards,
+    fetchEverstakeStakingInfo,
+} from '../stakeThunks';
+
+const stakeReducer = prepareStakeReducer(extraDependenciesMock);
+
+describe('stakeReducer', () => {
+    describe('fetchEverstakeData.pending', () => {
+        fixtures.fetchEverstakeDataPending.forEach(f => {
+            it(f.description, () => {
+                const result = stakeReducer(
+                    {
+                        ...stakeInitialState,
+                        ...f.initialState,
+                    },
+                    {
+                        type: fetchEverstakeData.pending.type,
+                        meta: { arg: f.actionPayload },
+                    },
+                );
+
+                expect(result.data).toStrictEqual(f.result);
+            });
+        });
+    });
+
+    describe('fetchEverstakeData.fulfilled', () => {
+        fixtures.fetchEverstakeDataFulfilled.forEach(f => {
+            it(f.description, () => {
+                const result = stakeReducer(
+                    {
+                        ...stakeInitialState,
+                        ...f.initialState,
+                    },
+                    {
+                        type: fetchEverstakeData.fulfilled.type,
+                        payload: f.payload,
+                        meta: { arg: f.actionPayload },
+                    },
+                );
+
+                expect(result.data).toStrictEqual(f.result);
+            });
+        });
+    });
+
+    describe('fetchEverstakeData.rejected', () => {
+        fixtures.fetchEverstakeDataRejected.forEach(f => {
+            it(f.description, () => {
+                const result = stakeReducer(
+                    {
+                        ...stakeInitialState,
+                        ...f.initialState,
+                    },
+                    {
+                        type: fetchEverstakeData.rejected.type,
+                        meta: { arg: f.actionPayload },
+                        error: { message: 'err' },
+                    },
+                );
+
+                expect(result.data).toStrictEqual(f.result);
+            });
+        });
+    });
+
+    describe('fetchEverstakeStakingInfo.pending', () => {
+        fixtures.fetchEverstakeStakingInfoPending.forEach(f => {
+            it(f.description, () => {
+                const result = stakeReducer(
+                    { ...stakeInitialState, ...f.initialState },
+                    {
+                        type: fetchEverstakeStakingInfo.pending.type,
+                        meta: { arg: f.actionPayload },
+                    },
+                );
+
+                expect(result.data).toStrictEqual(f.result);
+            });
+        });
+    });
+
+    describe('fetchEverstakeStakingInfo.fulfilled', () => {
+        fixtures.fetchEverstakeStakingInfoFulfilled.forEach(f => {
+            it(f.description, () => {
+                const result = stakeReducer(
+                    { ...stakeInitialState, ...f.initialState },
+                    {
+                        type: fetchEverstakeStakingInfo.fulfilled.type,
+                        payload: f.payload,
+                        meta: { arg: f.actionPayload },
+                    },
+                );
+
+                expect(result.data).toStrictEqual(f.result);
+            });
+        });
+    });
+
+    describe('fetchEverstakeStakingInfo.rejected', () => {
+        fixtures.fetchEverstakeStakingInfoRejected.forEach(f => {
+            it(f.description, () => {
+                const result = stakeReducer(
+                    { ...stakeInitialState, ...f.initialState },
+                    {
+                        type: fetchEverstakeStakingInfo.rejected.type,
+                        meta: { arg: f.actionPayload },
+                        error: { message: 'err' },
+                    },
+                );
+
+                expect(result.data).toStrictEqual(f.result);
+            });
+        });
+    });
+
+    describe('fetchEverstakeRewards.pending', () => {
+        fixtures.fetchEverstakeRewardsPending.forEach(f => {
+            it(f.description, () => {
+                const result = stakeReducer(
+                    { ...stakeInitialState, ...f.initialState },
+                    {
+                        type: fetchEverstakeRewards.pending.type,
+                        meta: { arg: f.actionPayload },
+                    },
+                );
+
+                expect(result.data).toStrictEqual(f.result);
+            });
+        });
+    });
+
+    describe('fetchEverstakeRewards.fulfilled', () => {
+        fixtures.fetchEverstakeRewardsFulfilled.forEach(f => {
+            it(f.description, () => {
+                const result = stakeReducer(
+                    { ...stakeInitialState, ...f.initialState },
+                    {
+                        type: fetchEverstakeRewards.fulfilled.type,
+                        payload: f.payload,
+                        meta: { arg: f.actionPayload },
+                    },
+                );
+
+                expect(result.data).toStrictEqual(f.result);
+            });
+        });
+    });
+
+    describe('fetchEverstakeRewards.rejected', () => {
+        fixtures.fetchEverstakeRewardsRejected.forEach(f => {
+            it(f.description, () => {
+                const result = stakeReducer(
+                    { ...stakeInitialState, ...f.initialState },
+                    {
+                        type: fetchEverstakeRewards.rejected.type,
+                        meta: { arg: f.actionPayload },
+                        error: { message: 'err' },
+                    },
+                );
+
+                expect(result.data).toStrictEqual(f.result);
+            });
+        });
+    });
+});

--- a/suite-common/wallet-core/src/stake/stakeReducer.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducer.ts
@@ -1,7 +1,7 @@
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { PrecomposedTransactionFinal, StakeFormState, Timestamp } from '@suite-common/wallet-types';
-import { cloneObject } from '@trezor/utils';
+import { cloneObject, isSafeObjectKey } from '@trezor/utils';
 
 import { VotingDelegationOption, stakeActions } from './stakeActions';
 import {
@@ -102,27 +102,34 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
             delete state.serializedTx;
         })
         .addCase(fetchEverstakeData.pending, (state, action) => {
-            const { symbol } = action.meta.arg;
+            const { symbol, endpointType } = action.meta.arg;
+
+            if (!isSafeObjectKey(endpointType)) {
+                return;
+            }
 
             if (!state.data[symbol]) {
-                state.data[symbol] = {
-                    poolStats: {
-                        error: false,
-                        isLoading: true,
-                        lastSuccessfulFetchTimestamp: 0 as Timestamp,
-                        data: {},
-                    },
-                    validatorsQueue: {
-                        error: false,
-                        isLoading: true,
-                        lastSuccessfulFetchTimestamp: 0 as Timestamp,
-                        data: {},
-                    },
+                state.data[symbol] = {};
+            }
+
+            if (!state.data[symbol][endpointType]) {
+                state.data[symbol][endpointType] = {
+                    error: false,
+                    isLoading: true,
+                    lastSuccessfulFetchTimestamp: 0 as Timestamp,
+                    data: {},
                 };
+            } else {
+                state.data[symbol][endpointType].isLoading = true;
+                state.data[symbol][endpointType].error = false;
             }
         })
         .addCase(fetchEverstakeData.fulfilled, (state, action) => {
             const { symbol, endpointType } = action.meta.arg;
+
+            if (!isSafeObjectKey(endpointType)) {
+                return;
+            }
 
             const data = state.data[symbol];
 
@@ -138,6 +145,10 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
         .addCase(fetchEverstakeData.rejected, (state, action) => {
             const { symbol, endpointType } = action.meta.arg;
 
+            if (!isSafeObjectKey(endpointType)) {
+                return;
+            }
+
             const data = state.data[symbol];
 
             if (data?.[endpointType]) {
@@ -152,7 +163,15 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
         .addCase(fetchEverstakeStakingInfo.pending, (state, action) => {
             const { symbol, endpointType } = action.meta.arg;
 
-            if (!state.data[symbol]?.[endpointType]) {
+            if (!isSafeObjectKey(endpointType)) {
+                return;
+            }
+
+            if (!state.data[symbol]) {
+                state.data[symbol] = {};
+            }
+
+            if (!state.data[symbol][endpointType]) {
                 state.data[symbol] = {
                     ...state.data[symbol],
                     stakingInfo: {
@@ -162,10 +181,17 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
                         data: {},
                     },
                 };
+            } else {
+                state.data[symbol][endpointType].isLoading = true;
+                state.data[symbol][endpointType].error = false;
             }
         })
         .addCase(fetchEverstakeStakingInfo.fulfilled, (state, action) => {
             const { symbol, endpointType } = action.meta.arg;
+
+            if (!isSafeObjectKey(endpointType)) {
+                return;
+            }
 
             const data = state.data[symbol];
 
@@ -181,6 +207,10 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
         .addCase(fetchEverstakeStakingInfo.rejected, (state, action) => {
             const { symbol, endpointType } = action.meta.arg;
 
+            if (!isSafeObjectKey(endpointType)) {
+                return;
+            }
+
             const data = state.data[symbol];
 
             if (data?.[endpointType]) {
@@ -194,6 +224,10 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
         })
         .addCase(fetchEverstakeRewards.pending, (state, action) => {
             const { symbol, endpointType, address } = action.meta.arg;
+
+            if (!isSafeObjectKey(endpointType)) {
+                return;
+            }
 
             const data = state.data[symbol]?.[endpointType]?.data;
 
@@ -212,6 +246,10 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
         .addCase(fetchEverstakeRewards.fulfilled, (state, action) => {
             const { symbol, endpointType } = action.meta.arg;
 
+            if (!isSafeObjectKey(endpointType)) {
+                return;
+            }
+
             const data = state.data[symbol];
 
             if (data?.[endpointType]) {
@@ -226,6 +264,10 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
 
         .addCase(fetchEverstakeRewards.rejected, (state, action) => {
             const { symbol, endpointType } = action.meta.arg;
+
+            if (!isSafeObjectKey(endpointType)) {
+                return;
+            }
 
             const data = state.data[symbol];
 

--- a/suite-common/wallet-core/src/stake/stakeSelectors.ts
+++ b/suite-common/wallet-core/src/stake/stakeSelectors.ts
@@ -1,11 +1,5 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import {
-    BACKUP_APY,
-    BACKUP_CARDANO_APY,
-    BACKUP_ETH_APY,
-    BACKUP_SOL_APY,
-    CARDANO_APY_MIN_THRESHOLD,
-} from '@suite-common/wallet-constants';
+import { CARDANO_APY_MIN_THRESHOLD } from '@suite-common/wallet-constants';
 import { Account } from '@suite-common/wallet-types';
 import {
     isSupportedAdaStakingNetworkSymbol,
@@ -33,18 +27,18 @@ export const selectPoolStatsApyData = (
     const symbol = symbolFromAccount ?? networkSymbol;
 
     if (!symbol || !data) {
-        return BACKUP_APY;
+        return null;
     }
 
     if (isSupportedSolStakingNetworkSymbol(symbol)) {
-        return data?.[symbol]?.stakingInfo?.data?.apy || BACKUP_SOL_APY;
+        return data?.[symbol]?.stakingInfo?.data?.apy || null;
     }
 
     if (isSupportedAdaStakingNetworkSymbol(symbol)) {
         const stakingInfo = data?.[symbol]?.stakingInfo?.data;
 
         if (!stakingInfo?.pools || stakingInfo.pools.length === 0) {
-            return BACKUP_CARDANO_APY;
+            return null;
         }
 
         const stakingPoolId = misc && 'staking' in misc ? misc.staking.poolId : undefined;
@@ -62,19 +56,19 @@ export const selectPoolStatsApyData = (
         const selectedPool = poolFromAccount ?? poolFromBest;
 
         if (!selectedPool) {
-            return BACKUP_CARDANO_APY;
+            return null;
         }
 
         const { apy } = selectedPool;
 
         if (!apy || apy < CARDANO_APY_MIN_THRESHOLD) {
-            return BACKUP_CARDANO_APY;
+            return null;
         }
 
         return apy;
     }
 
-    return data?.[symbol]?.poolStats?.data.ethApy || BACKUP_ETH_APY;
+    return data?.[symbol]?.poolStats?.data.ethApy || null;
 };
 
 export const selectCardanoPoolsInfo = (state: StakeRootState) =>

--- a/suite-common/wallet-core/src/stake/stakeThunks.ts
+++ b/suite-common/wallet-core/src/stake/stakeThunks.ts
@@ -1,15 +1,6 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { NetworkSymbol, networksCollection } from '@suite-common/wallet-config';
-import {
-    SupportedCardanoNetworkSymbols,
-    SupportedEthereumNetworkSymbol,
-    SupportedSolanaNetworkSymbols,
-} from '@suite-common/wallet-types';
-import {
-    isSupportedAdaStakingNetworkSymbol,
-    isSupportedSolStakingNetworkSymbol,
-    isTestnet,
-} from '@suite-common/wallet-utils';
+import { isTestnet } from '@suite-common/wallet-utils';
 import { TimerId } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
@@ -39,7 +30,7 @@ const STAKE_MODULE = '@common/wallet-core/stake';
 export const fetchEverstakeData = createThunk<
     ValidatorsQueue | { ethApy: number; nextRewardPayout: number },
     {
-        symbol: SupportedEthereumNetworkSymbol;
+        symbol: 'eth';
         endpointType: EverstakeEndpointType;
     },
     { rejectValue: string }
@@ -84,20 +75,22 @@ export const fetchEverstakeData = createThunk<
 });
 
 const getStakingInfoEndpointParams = (symbol: NetworkSymbol) => {
-    if (isSupportedSolStakingNetworkSymbol(symbol)) {
-        return `name=solana`;
-    }
-    if (isSupportedAdaStakingNetworkSymbol(symbol)) {
-        return `limit=1000&offset=0&partner=Trezor`;
-    }
+    switch (symbol) {
+        case 'sol':
+            return 'name=solana';
 
-    return '';
+        case 'ada':
+            return 'limit=1000&offset=0&partner=Trezor';
+
+        default:
+            return '';
+    }
 };
 
 export const fetchEverstakeStakingInfo = createThunk<
     EverstakeStakingInfo,
     {
-        symbol: SupportedSolanaNetworkSymbols | SupportedCardanoNetworkSymbols;
+        symbol: 'sol' | 'ada';
         endpointType: EverstakeAssetEndpointType;
     },
     { rejectValue: string }
@@ -114,9 +107,7 @@ export const fetchEverstakeStakingInfo = createThunk<
             const assetResponse = await fetch(
                 `${endpointPrefix}/${endpointSuffix}?${endpointParams}`,
                 {
-                    headers: isSupportedAdaStakingNetworkSymbol(symbol)
-                        ? { 'x-api-key': EVERSTAKE_API_KEY }
-                        : undefined,
+                    headers: symbol === 'ada' ? { 'x-api-key': EVERSTAKE_API_KEY } : undefined,
                 },
             );
             if (!assetResponse.ok) {
@@ -124,7 +115,7 @@ export const fetchEverstakeStakingInfo = createThunk<
             }
             const assetData = await assetResponse.json();
 
-            if (isSupportedAdaStakingNetworkSymbol(symbol)) {
+            if (symbol === 'ada') {
                 return fulfillWithValue({
                     pools: assetData?.data?.map((pool: CardanoValidatorStats) => ({
                         apy: Number(pool.apy.value),
@@ -146,7 +137,7 @@ export const fetchEverstakeStakingInfo = createThunk<
 export const fetchEverstakeRewards = createThunk<
     { rewardsHistory: StakeRewardsByAccount; totalRewards: TotalStakeRewardsByAccount },
     {
-        symbol: SupportedSolanaNetworkSymbols;
+        symbol: 'sol';
         endpointType: EverstakeRewardsEndpointType;
         address: string;
         signal?: AbortSignal;
@@ -218,13 +209,8 @@ export const initStakeDataThunk = createThunk(
             return;
         }
 
-        // TODO: change to accept only mainnet
         const createPromises = (
-            networks: (
-                | SupportedSolanaNetworkSymbols
-                | SupportedEthereumNetworkSymbol
-                | SupportedCardanoNetworkSymbols
-            )[],
+            networks: ['eth' | 'sol' | 'ada'],
             endpointTypes: typeof EverstakeEndpointType | typeof EverstakeAssetEndpointType,
         ) =>
             networks
@@ -239,10 +225,9 @@ export const initStakeDataThunk = createThunk(
                             data?.lastSuccessfulFetchTimestamp <= fiveMinutesAgo;
 
                         if (shouldRefetch) {
-                            if (
-                                isSupportedSolStakingNetworkSymbol(symbol) ||
-                                isSupportedAdaStakingNetworkSymbol(symbol)
-                            ) {
+                            if (isTestnet(symbol)) return null;
+
+                            if (symbol === 'sol' || symbol === 'ada') {
                                 return dispatch(
                                     fetchEverstakeStakingInfo({
                                         symbol,

--- a/suite-common/wallet-utils/src/stakingUtils.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.ts
@@ -230,7 +230,9 @@ export const getOutputTxAmount = (composedLevels?: PrecomposedLevels) => {
     return precomposedTx.outputs[0].amount;
 };
 
-export const calculateRewards = (amount: string, apyPercent: number, days = 365) => {
+export const calculateRewards = (amount: string, apyPercent: number | null, days = 365) => {
+    if (apyPercent === null) return '0';
+
     const apy = apyPercent / 100;
     const factor = Math.pow(1 + apy, days / 365) - 1;
     const currentRewards = new BigNumber(amount).multipliedBy(factor).toString();

--- a/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
+++ b/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
@@ -327,6 +327,7 @@ describe('selectors', () => {
         it('should return correct expected rewards', () => {
             const testState = getTestState({
                 accounts: [solAccountWithStaking],
+                withSolStakeData: true,
             });
 
             expect(
@@ -336,12 +337,13 @@ describe('selectors', () => {
                     },
                     'sol1',
                 ),
-            ).toEqual('0.000376438');
+            ).toEqual('0.000340274');
         });
 
         it('should return "0" for account without activated or deactivating stake', () => {
             const testState = getTestState({
                 accounts: [solAccountWithActivatingStaking],
+                withSolStakeData: true,
             });
 
             expect(

--- a/suite-native/staking/src/solanaStakingSelectors.ts
+++ b/suite-native/staking/src/solanaStakingSelectors.ts
@@ -82,9 +82,9 @@ export const selectExpectedRewardsForEpoch = (
     accountKey: string,
 ) => {
     const stakingInfo = selectSolStakingAccountsInfoByAccountKey(state, accountKey);
-    const apy = selectSolanaAPYByAccountKey(state, accountKey).toString();
+    const apy = selectSolanaAPYByAccountKey(state, accountKey)?.toString();
 
-    if (!stakingInfo) {
+    if (!stakingInfo || !apy) {
         return '0';
     }
 

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9355,6 +9355,18 @@ export const messages = defineMessages({
         id: 'TR_STAKE_UNKNOWN_APY',
         defaultMessage: 'Unknown',
     },
+    TR_STAKE_NOT_AVAILABLE: {
+        id: 'TR_STAKE_NOT_AVAILABLE',
+        defaultMessage: 'Not available',
+    },
+    TR_STAKE_N_A: {
+        id: 'TR_STAKE_N_A',
+        defaultMessage: 'N/A',
+    },
+    TR_STAKE_APY_REQUIRED: {
+        id: 'TR_STAKE_APY_REQUIRED',
+        defaultMessage: 'APY required to calculate rewards',
+    },
     TR_STAKE_APY_DESC: {
         id: 'TR_STAKE_APY_DESC',
         defaultMessage: '*Annual Percentage Yield',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Replace backup APY with N/A
- Update “Unknown” to “Not available” 
- Refine staking APY loading.

## Notes for QA

For APY testing, block next requests in DevTools 
https://stats.everstake.one/blockchain/summary?limit=1000&offset=0&partner=Trezor
https://dashboard-api.everstake.one/chain?name=solana
https://eth-api-b2c.everstake.one/api/v1/stats

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23151

## Screenshots:
<img width="1916" height="720" alt="image" src="https://github.com/user-attachments/assets/2b57d9bc-e03c-4075-a12c-2def7b20af9d" />
<img width="1934" height="166" alt="image" src="https://github.com/user-attachments/assets/53ccfec5-7d1d-49b1-aea9-e322ba080101" />
<img width="1926" height="218" alt="image" src="https://github.com/user-attachments/assets/e87a3e48-f32e-4685-91f0-179356de00ef" />
<img width="1932" height="736" alt="image" src="https://github.com/user-attachments/assets/04853e77-b9da-43a2-a69d-c32d2be04de0" />
<img width="794" height="602" alt="image" src="https://github.com/user-attachments/assets/1545847b-914b-405a-a330-fa5d5aad2998" />
<img width="1936" height="454" alt="image" src="https://github.com/user-attachments/assets/72858562-1d6b-4f0b-ac7a-6c997aa0a348" />
<img width="2220" height="1394" alt="image" src="https://github.com/user-attachments/assets/82631849-2e39-452b-8cce-baf948a58652" />

