### PR TITLE
chore(transport-bluetooth): server version 0.4.3

### DIFF
--- a/packages/transport-bluetooth/CHANGELOG.md
+++ b/packages/transport-bluetooth/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 0.4.3
+
+- feat: add linux pairing Agent and handle pairing PIN request
+- fix: linux manual unpair via https://github.com/deviceplug/btleplug/pull/446
+- fix: linux get_info when systemctl is disabled
+- fix: linux abort pairing when system UI is missing
+- fix: linux + macos, wait for missing characteristics
+
 ### 0.4.2
 
 - added open_device/close_device characteristics param

--- a/packages/transport-bluetooth/Cargo.lock
+++ b/packages/transport-bluetooth/Cargo.lock
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "trezor-bluetooth"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bluez-async",
  "btleplug",

--- a/packages/transport-bluetooth/Cargo.toml
+++ b/packages/transport-bluetooth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trezor-bluetooth"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 
 [profile.release]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Last binary update was done 21.10 and there was [few fixes since then](https://github.com/trezor/trezor-suite/commits/develop/packages/transport-bluetooth/src/server)

i've updated the version and changelog (including few already released changes/fixes)

the build will fix: https://github.com/trezor/trezor-suite/issues/17835

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/transport-bluetooth-0.4.3&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/transport-bluetooth-0.4.3&lookback=7)