### PR TITLE
fix(ci): free disk space after transport-bluetooth build

### DIFF
--- a/.github/workflows/build-transport-bluetooth-binary.yml
+++ b/.github/workflows/build-transport-bluetooth-binary.yml
@@ -31,6 +31,14 @@ jobs:
           docker create --name trezor-bluetooth-container trezor-bluetooth-image
           docker cp trezor-bluetooth-container:/output/. ../suite-data/files/bin/bluetooth
 
+      - name: free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
+
       - name: Upload binaries as artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
transport-bluetooth build[ is failing](https://github.com/trezor/trezor-suite/actions/runs/20235384849) with `System.IO.IOException: No space left on device` error.

it should help according to [this  and following comment](https://github.com/orgs/community/discussions/26351#discussioncomment-3251595)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ci-transport-bluetooth&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ci-transport-bluetooth&lookback=7)