### PR TITLE
fix(connect): change THP phase after successful ThpEndResponse

### DIFF
--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -227,10 +227,11 @@ export const getThpCredentials = async (device: Device, autoconnect = false) => 
     return { ...credentials.message, autoconnect, host_static_key };
 };
 
-export const thpPairingEnd = (device: Device) => {
+export const thpPairingEnd = async (device: Device) => {
+    const result = await thpCall(device, 'ThpEndRequest', {});
     device.getThpState()?.setPhase('paired');
 
-    return thpCall(device, 'ThpEndRequest', {});
+    return result;
 };
 
 // State HH2/HH3 -> HP0 -> HP1 -> HP2 -> HP3 -> HP4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

issue i've found while working on THP piggybacking.

 ThpState.phase is set to "paired" before `ThpEndRequest` regardless of the result but it should be set after successful response

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thp-phase&lookback=7)