### PR TITLE
feat(components): create UI component Toast

### DIFF
--- a/packages/components/src/components/Toast/Toast.stories.tsx
+++ b/packages/components/src/components/Toast/Toast.stories.tsx
@@ -1,0 +1,59 @@
+import { ArgTypes, Meta, StoryObj } from '@storybook/react';
+
+import { Toast as ToastComponent, ToastProps } from './Toast';
+import { variables } from '../../config';
+
+const meta: Meta<typeof ToastComponent> = {
+    title: 'Toast',
+    component: ToastComponent,
+};
+export default meta;
+
+const args: Partial<ToastProps> | undefined = {
+    content: 'This is a toast message.',
+    intent: 'info',
+    icon: undefined,
+    dismissible: true,
+    onDismiss: () => alert('Toast closed'),
+};
+
+const argTypes: Partial<ArgTypes<ToastProps>> | undefined = {
+    content: {
+        type: 'string',
+    },
+    icon: {
+        options: [undefined, ...variables.ICONS],
+        control: {
+            type: 'select',
+        },
+    },
+    dismissible: {
+        control: {
+            type: 'boolean',
+        },
+    },
+};
+
+export const Default: StoryObj<ToastProps> = {
+    args,
+    argTypes,
+};
+
+export const WithActions: StoryObj<ToastProps> = {
+    args: {
+        ...args,
+        actions: [
+            {
+                label: 'Action A',
+                onClick: () => alert('Action A clicked'),
+                position: 'right',
+            },
+            {
+                label: 'Action B',
+                onClick: () => alert('Action B clicked'),
+                position: 'right',
+            },
+        ],
+    },
+    argTypes,
+};

--- a/packages/components/src/components/Toast/Toast.tsx
+++ b/packages/components/src/components/Toast/Toast.tsx
@@ -1,0 +1,132 @@
+import { ReactNode } from 'react';
+
+import styled, { useTheme } from 'styled-components';
+
+import { borders, spacings, spacingsPx } from '@trezor/theme';
+import { hexToRgba } from '@trezor/utils';
+
+import { ToastAction, ToastIntent } from './types';
+import { mapToastIntentToIcon, mapToastVariantToColor, normalizeToastActions } from './utils';
+import { Column, Row } from '../Flex/Flex';
+import { Icon, IconName } from '../Icon/Icon';
+import { Button } from '../buttons/Button/Button';
+import { IconButton } from '../buttons/IconButton/IconButton';
+import { Text } from '../typography/Text/Text';
+
+const Container = styled.div<{ $variant: ToastIntent }>`
+    display: flex;
+    align-items: center;
+    min-height: 3.25rem;
+
+    padding-inline: ${spacingsPx.md};
+    padding-block: ${spacingsPx.xs};
+
+    font-size: 1rem;
+    color: ${({ theme }) => theme.textDefault};
+
+    overflow-wrap: anywhere;
+    word-break: normal;
+
+    border-radius: ${borders.radii.xs};
+    position: relative;
+
+    background: ${({ theme }) => hexToRgba(theme.backgroundNeutralBoldInverted, 0.5)};
+    backdrop-filter: blur(12px);
+
+    &::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        border-radius: inherit;
+        border: 1px solid ${({ theme }) => hexToRgba(theme.backgroundNeutralBold, 0.1)};
+    }
+
+    &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        border-left: ${spacingsPx.xxs} solid
+            ${({ theme, $variant }) => mapToastVariantToColor($variant, theme)};
+        border-radius: inherit;
+    }
+`;
+
+export type ToastProps = {
+    icon?: IconName;
+    content: ReactNode;
+    intent: ToastIntent;
+    actions?: ToastAction | ToastAction[];
+    dismissible?: boolean;
+    onDismiss?: () => void;
+};
+
+export const Toast = ({
+    icon,
+    content,
+    intent,
+    actions,
+    dismissible = true,
+    onDismiss,
+}: ToastProps) => {
+    const theme = useTheme();
+
+    const dataTestBase = `@toast/${intent}`;
+    const showIcon = intent !== 'neutral' || icon != null;
+
+    const { bottomActions, rightActions } = normalizeToastActions(actions, intent);
+
+    const renderActionButton = (action: ToastAction, index: number) => (
+        <Button
+            key={`${action.label}-${action.intent ?? ''}-${index}`}
+            intent={action.intent}
+            priority={action.priority}
+            onClick={action.onClick}
+            size="small"
+        >
+            {action.label}
+        </Button>
+    );
+
+    return (
+        <Container data-testid={dataTestBase} $variant={intent}>
+            <Row gap={spacings.sm} justifyContent="space-between" flex="1">
+                {showIcon && (
+                    <Icon
+                        name={icon ?? mapToastIntentToIcon(intent)}
+                        color={mapToastVariantToColor(intent, theme)}
+                    />
+                )}
+
+                <Column gap={spacings.xs} flex="1">
+                    {typeof content === 'string' || typeof content === 'number' ? (
+                        <Text typographyStyle="highlight">{content}</Text>
+                    ) : (
+                        content
+                    )}
+
+                    <Row gap={spacings.xs}>
+                        {bottomActions.map((action, index) => renderActionButton(action, index))}
+                    </Row>
+                </Column>
+
+                <Row gap={spacings.xs}>
+                    {rightActions.map((action, index) => renderActionButton(action, index))}
+                </Row>
+
+                {dismissible && (
+                    <IconButton
+                        icon="x"
+                        size="small"
+                        intent="neutral"
+                        priority="secondary"
+                        onClick={onDismiss}
+                        data-testid={`${dataTestBase}/close`}
+                        aria-label="Close toast"
+                    />
+                )}
+            </Row>
+        </Container>
+    );
+};

--- a/packages/components/src/components/Toast/types.ts
+++ b/packages/components/src/components/Toast/types.ts
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+import { UIIntent } from '../../config/types';
+import { ButtonIntent, ButtonPriority } from '../buttons/types';
+
+export const toastIntents = ['brand', 'neutral', 'info', 'warning', 'critical'] as const;
+export type ToastIntent = Extract<UIIntent, (typeof toastIntents)[number]>;
+
+export type ToastIconVariant = 'info' | 'warning' | 'check';
+
+export type ToastActionPosition = 'right' | 'bottom';
+
+export type ToastAction = {
+    label: ReactNode;
+    position?: ToastActionPosition;
+    intent?: ButtonIntent;
+    priority?: ButtonPriority;
+    onClick?: () => void;
+};

--- a/packages/components/src/components/Toast/utils.ts
+++ b/packages/components/src/components/Toast/utils.ts
@@ -1,0 +1,63 @@
+import { DefaultTheme } from 'styled-components';
+
+import { CSSColor } from '@trezor/theme';
+
+import { ToastAction, ToastIconVariant, ToastIntent } from './types';
+
+export const mapToastIntentToIcon = (intent: ToastIntent) => {
+    const iconMap: Record<ToastIntent, ToastIconVariant> = {
+        brand: 'check',
+        info: 'info',
+        warning: 'warning',
+        critical: 'warning',
+        neutral: 'info',
+    };
+
+    return iconMap[intent];
+};
+
+export const mapToastVariantToColor = (variant: ToastIntent, theme: DefaultTheme) => {
+    const colorMap: Record<ToastIntent, CSSColor> = {
+        brand: theme.textPrimaryDefault,
+        info: theme.textAlertBlue,
+        warning: theme.textAlertYellow,
+        critical: theme.textAlertRed,
+        neutral: theme.textSubdued,
+    };
+
+    return colorMap[variant];
+};
+
+export const normalizeToastActions = (
+    actions: ToastAction | ToastAction[] | undefined,
+    toastIntent: ToastIntent,
+) => {
+    let list: ToastAction[] = [];
+
+    if (actions) {
+        list = Array.isArray(actions) ? actions : [actions];
+    }
+
+    return list.reduce(
+        (acc, action) => {
+            const normalized = {
+                ...action,
+                intent: action.intent ?? toastIntent,
+                priority: action.priority ?? 'secondary',
+                position: action.position ?? 'right',
+            };
+
+            if (normalized.position === 'bottom') {
+                acc.bottomActions.push(normalized);
+            } else {
+                acc.rightActions.push(normalized);
+            }
+
+            return acc;
+        },
+        {
+            bottomActions: [] as typeof list,
+            rightActions: [] as typeof list,
+        },
+    );
+};

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -80,6 +80,7 @@ export * from './components/skeletons/SkeletonSpread';
 export * from './components/skeletons/SkeletonStack';
 export * from './components/skeletons/types';
 export * from './components/Timerange/Timerange';
+export * from './components/Toast/Toast';
 export * from './components/Tooltip/Tooltip';
 export * from './components/Tooltip/TooltipDelay';
 export * from './components/typography/Heading/Heading';


### PR DESCRIPTION
## Description

Introduces a new Toast UI component in Storybook as part of the `react-toastify` refactor.

This PR is UI-only (no toast logic yet) and focuses on visual variants and layout.

## Related Issue

Related #22595

## Screenshots:

<img width="548" height="86" alt="image" src="https://github.com/user-attachments/assets/d5872f7f-1b0a-4ee2-a0b6-34529e994a6f" />

<img width="549" height="83" alt="image" src="https://github.com/user-attachments/assets/6b871a9d-5aa1-408b-ac73-dd761a3c168e" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/toast-component&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/toast-component&lookback=7)