### PR TITLE
chore(suite-e2e): unify store manipulation in playwright Web vs. Desktop

### DIFF
--- a/suite/e2e/support/electron.ts
+++ b/suite/e2e/support/electron.ts
@@ -2,18 +2,12 @@ import { ElectronApplication, Page, _electron as electron } from '@playwright/te
 import { createWriteStream, ensureDirSync } from 'fs-extra';
 import path from 'path';
 
-import { StartEmu, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { BRIDGE_VERSION } from './bridge';
-import { getModelFromEnv } from './helpers/modelFromEnv';
+
 const appDir = path.join(__dirname, '../../../packages/suite-desktop');
-const disableHashChecksPatch = '--state.suite.settings.enabledSecurityChecks.firmwareHash=false';
-const disableFirmwareRevisionChecksPatch =
-    '--state.suite.settings.enabledSecurityChecks.firmwareRevision=false';
-const disableAuthenticityCheckPatch =
-    '--state.suite.settings.enabledSecurityChecks.deviceAuthenticity=false';
 const showDebugMenuStatePatch = '--state.suite.settings.debug.showDebugMenu=true';
-const disableDisconnectPromptPatch = '--state.suite.flags.hasSeenDisconnectTooltip=true';
 const showConnectLogsArgument = '--state.suite.settings.debug.showConnectLogs=true';
 // #15670 Bug in desktop app that loglevel is ignored
 const logLevelArgument = `--log-level=${process.env.LOGLEVEL ?? 'debug'}`;
@@ -47,7 +41,7 @@ const formatErrorLogMessage = (data: string) => {
     return `${timestamp} - ${bold}${red}ERROR${unbold}: ${data}${reset}`;
 };
 
-const buildArgs = (params: LaunchSuiteParams, emulatorStartConf: StartEmu) => {
+const buildArgs = (params: LaunchSuiteParams) => {
     const args = [
         // This needs to be just path to the app root, so it is same as for production builds,
         // electron will resolve the path to app.js from the package.json => "main": "dist/app.js",
@@ -58,9 +52,7 @@ const buildArgs = (params: LaunchSuiteParams, emulatorStartConf: StartEmu) => {
         `--height=${params.viewport.height}`,
         logLevelArgument,
         disableHWAccelerationArgument,
-        disableHashChecksPatch,
         showDebugMenuStatePatch,
-        disableDisconnectPromptPatch,
         showConnectLogsArgument,
     ];
 
@@ -77,14 +69,6 @@ const buildArgs = (params: LaunchSuiteParams, emulatorStartConf: StartEmu) => {
     const deleteUserData = !params.keepUserData;
     if (deleteUserData) {
         args.push(removeUserDataArgument);
-    }
-
-    if (emulatorStartConf.version?.endsWith('-main')) {
-        args.push(disableFirmwareRevisionChecksPatch);
-    }
-
-    if (getModelFromEnv() === 'T3W1' || params.disableAuthenticityCheck) {
-        args.push(disableAuthenticityCheckPatch);
     }
 
     return args;
@@ -104,17 +88,14 @@ const setupLoggingToFile = (electronApp: ElectronApplication, params: LaunchSuit
     });
 };
 
-export const launchSuiteElectronApp = async (
-    params: LaunchSuiteParams,
-    emulatorStartConf: StartEmu,
-) => {
+export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
     if (!params.bridgeDaemon) {
         await TrezorUserEnvLink.startBridge(BRIDGE_VERSION);
     }
 
     const electronApp = await electron.launch({
         cwd: appDir,
-        args: buildArgs(params, emulatorStartConf),
+        args: buildArgs(params),
         env: {
             ...process.env,
             PLAYWRIGHT_RUN: 'true',
@@ -129,11 +110,8 @@ export const launchSuiteElectronApp = async (
     return electronApp;
 };
 
-export const launchSuite = async (
-    params: LaunchSuiteParams,
-    emulatorStartConf: StartEmu,
-): Promise<Suite> => {
-    const electronApp = await launchSuiteElectronApp(params, emulatorStartConf);
+export const launchSuite = async (params: LaunchSuiteParams): Promise<Suite> => {
+    const electronApp = await launchSuiteElectronApp(params);
     const window = await electronApp.firstWindow();
 
     return { electronApp, window };

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -62,13 +62,11 @@ const test = suiteBaseTest.extend<Fixtures>({
     onboardingPage: async (
         { page, model, devicePrompt, analyticsSection, settingsPage, emulatorStartConf },
         use,
-        testInfo,
     ) => {
         await use(
             new OnboardingPage(
                 page,
                 model,
-                testInfo,
                 devicePrompt,
                 analyticsSection,
                 settingsPage,

--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -1,10 +1,10 @@
-import { Locator, Page, TestInfo, expect } from '@playwright/test';
+import { Locator, Page, expect } from '@playwright/test';
 
 import { BackupType } from '@suite-common/suite-types';
 import { SUITE as SuiteActions } from '@trezor/suite/src/actions/suite/constants';
 import { StartEmu } from '@trezor/trezor-user-env-link';
 
-import { TrezorUserEnvLinkProxy, isWebProject, step } from '../../common';
+import { TrezorUserEnvLinkProxy, step } from '../../common';
 import { AnalyticsSection } from '../analyticsSection';
 import { DevicePrompt } from '../devicePrompt';
 import { BackupSection } from './backupSection';
@@ -45,7 +45,6 @@ export class OnboardingPage {
     constructor(
         public page: Page,
         private readonly model: ModelFixture,
-        private readonly testInfo: TestInfo,
         private readonly devicePrompt: DevicePrompt,
         private readonly analyticsSection: AnalyticsSection,
         private readonly settingsPage: SettingsPage,
@@ -170,88 +169,61 @@ export class OnboardingPage {
 
     @step()
     async disableFirmwareHashCheck(options?: { skipSuiteLoadedCheck?: boolean }) {
-        // Desktop starts with already disabled firmware hash check. Web needs to disable it.
-        if (!isWebProject(this.testInfo)) {
-            return;
-        }
-
         if (!options?.skipSuiteLoadedCheck) {
             await this.verifySuiteIsLoaded();
         }
 
-        /* eslint-disable-next-line @typescript-eslint/no-shadow */
-        await this.page.evaluate(SuiteActions => {
-            // WARNING: If this dispatch is changed as part of refactoring. You need to change also:
-            // suite/e2e/support/electron.ts variable disableHashCheckArgument
-            window.store.dispatch({
-                type: SuiteActions.TOGGLE_FIRMWARE_HASH_CHECK,
-                payload: false,
-            });
-            window.store.dispatch({
-                type: SuiteActions.SET_DEBUG_MODE,
-                payload: { showDebugMenu: true },
-            });
-        }, SuiteActions);
+        await this.page.ensureStoreOnDesktop();
+        await this.page.evaluate(
+            actions => actions.forEach(window.store.dispatch),
+            [
+                {
+                    type: SuiteActions.TOGGLE_FIRMWARE_HASH_CHECK,
+                    payload: false,
+                },
+                {
+                    type: SuiteActions.SET_DEBUG_MODE,
+                    payload: { showDebugMenu: true },
+                },
+            ],
+        );
     }
 
     @step()
     async disableDebugMode() {
-        /* eslint-disable-next-line @typescript-eslint/no-shadow */
-        await this.page.evaluate(SuiteActions => {
-            window.store.dispatch({
-                type: SuiteActions.SET_DEBUG_MODE,
-                payload: { showDebugMenu: false },
-            });
-        }, SuiteActions);
+        await this.page.ensureStoreOnDesktop();
+        await this.page.evaluate(action => window.store.dispatch(action), {
+            type: SuiteActions.SET_DEBUG_MODE,
+            payload: { showDebugMenu: false },
+        });
     }
 
     @step()
     async disableFirmwareRevisionCheck() {
-        // Desktop starts with already disabled firmware revision check. Web needs to disable it.
-        if (!isWebProject(this.testInfo)) {
-            return;
-        }
-
-        /* eslint-disable-next-line @typescript-eslint/no-shadow */
-        await this.page.evaluate(SuiteActions => {
-            window.store.dispatch({
-                type: SuiteActions.TOGGLE_FIRMWARE_REVISION_CHECK,
-                payload: false,
-            });
-        }, SuiteActions);
+        await this.page.ensureStoreOnDesktop();
+        await this.page.evaluate(action => window.store.dispatch(action), {
+            type: SuiteActions.TOGGLE_FIRMWARE_REVISION_CHECK,
+            payload: false,
+        });
     }
 
     @step()
     async disableAuthenticityCheck() {
-        // Desktop starts with already disabled authenticity check. Web needs to disable it.
-        if (!isWebProject(this.testInfo)) {
-            return;
-        }
-
-        /* eslint-disable-next-line @typescript-eslint/no-shadow */
-        await this.page.evaluate(SuiteActions => {
-            window.store.dispatch({
-                type: SuiteActions.TOGGLE_DEVICE_AUTHENTICITY_CHECK,
-                payload: false,
-            });
-        }, SuiteActions);
+        await this.page.ensureStoreOnDesktop();
+        await this.page.evaluate(action => window.store.dispatch(action), {
+            type: SuiteActions.TOGGLE_DEVICE_AUTHENTICITY_CHECK,
+            payload: false,
+        });
     }
 
     @step()
     async disableDisconnectPrompt() {
-        // Desktop starts with already disabled disconnect prompt. Web needs to disable it.
-        if (!isWebProject(this.testInfo)) {
-            return;
-        }
-
-        /* eslint-disable-next-line @typescript-eslint/no-shadow */
-        await this.page.evaluate(SuiteActions => {
-            window.store.dispatch({
-                type: SuiteActions.SET_FLAG,
-                key: 'hasSeenDisconnectTooltip',
-                value: true,
-            });
-        }, SuiteActions);
+        await this.page.ensureStoreOnDesktop();
+        await this.page.evaluate(action => window.store.dispatch(action), {
+            type: SuiteActions.SET_FLAG,
+            key: 'hasSeenDisconnectTooltip',
+            value: true,
+        });
     }
 
     @step()

--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -21,10 +21,7 @@ import { getModelFromEnv } from '../helpers/modelFromEnv';
 
 type StartEmuModelRequired = StartEmu & { model: Model };
 
-type ElectronConf = Pick<
-    LaunchSuiteParams,
-    'keepUserData' | 'bridgeDaemon' | 'exposeConnectWs' | 'disableAuthenticityCheck'
->;
+type ElectronConf = Pick<LaunchSuiteParams, 'keepUserData' | 'bridgeDaemon' | 'exposeConnectWs'>;
 
 type suiteBaseFixture = {
     startEmulator: boolean;
@@ -45,18 +42,14 @@ const electronSetup = async (
     locale: string | undefined,
     colorScheme: any,
     electronConf: ElectronConf,
-    emulatorStartConf: StartEmu,
 ) => {
-    const suite = await launchSuite(
-        {
-            locale,
-            colorScheme,
-            artefactFolder: testInfo.outputDir,
-            viewport: testInfo.project.use.viewport!,
-            ...electronConf,
-        },
-        emulatorStartConf,
-    );
+    const suite = await launchSuite({
+        locale,
+        colorScheme,
+        artefactFolder: testInfo.outputDir,
+        viewport: testInfo.project.use.viewport!,
+        ...electronConf,
+    });
 
     await suite.window
         .context()
@@ -238,13 +231,7 @@ const suiteBaseTest = baseWithCurrents.extend<suiteBaseFixture>({
         });
 
         if (isDesktopProject(testInfo)) {
-            const suite = await electronSetup(
-                testInfo,
-                locale,
-                colorScheme,
-                electronConf,
-                emulatorStartConf,
-            );
+            const suite = await electronSetup(testInfo, locale, colorScheme, electronConf);
             enhancePage(suite.window);
             await use(suite.window);
             await electronTeardown(suite, testInfo, electronConf);

--- a/suite/e2e/tests/analytics/toggle.test.ts
+++ b/suite/e2e/tests/analytics/toggle.test.ts
@@ -3,7 +3,6 @@ import { EventType } from '@trezor/suite-analytics';
 import { expect, test } from '../../support/fixtures';
 
 test.describe('Analytics Toggle - Enabling and Disabling', { tag: ['@group=other'] }, () => {
-    test.use({ electronConf: { disableAuthenticityCheck: true } });
     test.beforeEach(async ({ analytics, onboardingPage }) => {
         await analytics.interceptAnalytics();
         await onboardingPage.disableNecessaryFirmwareChecks();

--- a/suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
+++ b/suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
@@ -17,33 +17,24 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
         await trezorUserEnvLink.stopBridge();
     });
 
-    test('App in daemon mode spawns node-bridge', async ({
-        request,
-        emulatorStartConf,
-    }, testInfo) => {
+    test('App in daemon mode spawns node-bridge', async ({ request }, testInfo) => {
         await expectBridgeToBeStopped(request);
 
-        const daemonApp = await launchSuiteElectronApp(
-            {
-                bridgeDaemon: true,
-                artefactFolder: testInfo.outputDir,
-                viewport: testInfo.project.use.viewport!,
-            },
-            emulatorStartConf,
-        );
+        const daemonApp = await launchSuiteElectronApp({
+            bridgeDaemon: true,
+            artefactFolder: testInfo.outputDir,
+            viewport: testInfo.project.use.viewport!,
+        });
 
         await expect(async () => {
             await expectBridgeToBeRunning(request);
         }).toPass({ timeout: 3_000 });
 
         // launch UI, with node-bridge already running in background
-        const suite = await launchSuite(
-            {
-                artefactFolder: testInfo.outputDir,
-                viewport: testInfo.project.use.viewport!,
-            },
-            emulatorStartConf,
-        );
+        const suite = await launchSuite({
+            artefactFolder: testInfo.outputDir,
+            viewport: testInfo.project.use.viewport!,
+        });
         const title = await suite.window.title();
         expect(title).toContain('Trezor Suite');
 

--- a/suite/e2e/tests/bridge-tor/spawn-bridge.test.ts
+++ b/suite/e2e/tests/bridge-tor/spawn-bridge.test.ts
@@ -26,18 +26,12 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
         await trezorUserEnvLink.stopBridge();
     });
 
-    test('App spawns bundled bridge and stops it after app quit', async ({
-        request,
-        emulatorStartConf,
-    }, testInfo) => {
-        const suite = await launchSuite(
-            {
-                bridgeDaemon: true,
-                artefactFolder: testInfo.outputDir,
-                viewport: testInfo.project.use.viewport!,
-            },
-            emulatorStartConf,
-        );
+    test('App spawns bundled bridge and stops it after app quit', async ({ request }, testInfo) => {
+        const suite = await launchSuite({
+            bridgeDaemon: true,
+            artefactFolder: testInfo.outputDir,
+            viewport: testInfo.project.use.viewport!,
+        });
         const title = await suite.window.title();
         enhancePage(suite.window);
         expect(title).toContain('Trezor Suite');
@@ -72,13 +66,10 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
         await trezorUserEnvLink.setupEmu({});
         await trezorUserEnvLink.startBridge(BRIDGE_VERSION);
 
-        const suite = await launchSuite(
-            {
-                artefactFolder: testInfo.outputDir,
-                viewport: testInfo.project.use.viewport!,
-            },
-            emulatorStartConf,
-        );
+        const suite = await launchSuite({
+            artefactFolder: testInfo.outputDir,
+            viewport: testInfo.project.use.viewport!,
+        });
         enhancePage(suite.window);
         await suite.window.title();
 
@@ -87,7 +78,6 @@ test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
         const onboardingPage = new OnboardingPage(
             suite.window,
             model,
-            testInfo,
             devicePrompt,
             new AnalyticsSection(suite.window),
             new SettingsPage(suite.window),

--- a/suite/e2e/tests/suite/multiple-sessions.test.ts
+++ b/suite/e2e/tests/suite/multiple-sessions.test.ts
@@ -87,7 +87,7 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
                 priority: TestPriority.Medium,
             }),
         },
-        async ({ context, model, onboardingPage, dashboardPage, emulatorStartConf }, testInfo) => {
+        async ({ context, model, onboardingPage, dashboardPage, emulatorStartConf }) => {
             await onboardingPage.completeOnboarding();
 
             const pageTwo = await context.newPage();
@@ -102,7 +102,6 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
             const onboardingPageTwo = new OnboardingPage(
                 pageTwo,
                 model,
-                testInfo,
                 devicePromptTwo,
                 analyticsSectionTwo,
                 settingsPageTwo,


### PR DESCRIPTION
## Description

Cleanup handling of runtime store manipulation in playwright:

- simplify the page.evaluate calls by predefining the redux action and passing that as a constant arg
- use exposed `window.store` both on Desktop & Web instead of state patches on Desktop (unification, less complexity)
  - using `window.store` desktop used to be broken, fixed in [23774](https://github.com/trezor/trezor-suite/pull/23774)
- a cascade of interface simplifications as a nice side effect :slightly_smiling_face: 


**Note:** E2E is run manually until this is rebased on develop:
[Desktop run](https://github.com/trezor/trezor-suite/actions/runs/20262463056)
[Web run](https://github.com/trezor/trezor-suite/actions/runs/20262465775)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/unify-playwright-store-manipulation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/unify-playwright-store-manipulation&lookback=7)