### PR TITLE
fix(suite): improve address formatting and handling in Address component

### DIFF
--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -97,7 +97,7 @@ const InnerModalBase = ({
     });
 
     return (
-        <Box maxWidth="95%" maxHeight="90vh" width={mapModalSizeToWidth(size)} height={height}>
+        <Box maxWidth="95%" maxHeight="85vh" width={mapModalSizeToWidth(size)} height={height}>
             <Container $elevation={elevation} data-testid={dataTest} id={MODAL_CONTENT_ID}>
                 <Column height="100%">
                     {hasHeader && (

--- a/packages/components/src/components/typography/Text/Text.tsx
+++ b/packages/components/src/components/typography/Text/Text.tsx
@@ -106,8 +106,7 @@ const StyledText = styled.span<StyledTextProps>`
     ${({ $breakAll }) =>
         $breakAll &&
         css`
-            word-break: break-all;
-            overflow-wrap: anywhere;
+            overflow-wrap: break-word;
         `}
 
     ${withTextProps}

--- a/packages/suite/src/components/suite/Address.tsx
+++ b/packages/suite/src/components/suite/Address.tsx
@@ -8,6 +8,8 @@ import { useSelector } from 'src/hooks/suite';
 import { selectAddressDisplayType } from 'src/selectors/suite/suiteSelectors';
 
 const TRUNCATION_PLACEHOLDER = ' ... ';
+const REGEXP_ADDRESS = /^(0x)?((.{8}).*(.{8})$)/;
+const REGEXP_ADDRESS_CHUNKS = /((?:\S+\s){3}\S+)\s/g;
 
 const mapDeviceModelToFontStyle = (deviceModelInternal: DeviceModelInternal): RuleSet<object> => {
     switch (deviceModelInternal) {
@@ -29,14 +31,16 @@ const mapDeviceModelToFontStyle = (deviceModelInternal: DeviceModelInternal): Ru
 };
 
 const AddressWrapper = styled.p<{ $device?: DeviceModelInternal; $isChunked: boolean }>`
-    text-wrap: balance;
     letter-spacing: 0;
     word-break: ${({ $isChunked }) => ($isChunked ? 'normal' : 'break-all')};
+    white-space: ${({ $isChunked }) => ($isChunked ? 'pre-line' : 'break-all')};
 
     ${({ $device }) => $device && mapDeviceModelToFontStyle($device)}
 `;
 
-const addSpacing = (value: string) => value.match(/.{1,4}/g)?.join(' ') || value;
+const addSpacing = (value: string) => value?.match(/.{1,4}/g)?.join(' ') ?? value;
+const addNewlineAfterEveryFourthChunk = (value: string) =>
+    value?.replace(REGEXP_ADDRESS_CHUNKS, '$1\n') ?? value;
 
 export type AddressProps = {
     value: string;
@@ -59,20 +63,21 @@ export const Address = ({
     const isAddressChunked = isChunked ?? isChunkedSettings === 'chunked';
     const placeholder = isAddressChunked ? TRUNCATION_PLACEHOLDER : TRUNCATION_PLACEHOLDER.trim();
 
-    const [full, beginning, middle, end] = (value.match(/^(.{8})(.*)(.{8})$/) || []).map(part =>
+    const [, prefix = '', rest, beginning, end] = (value.match(REGEXP_ADDRESS) || []).map(part =>
         isAddressChunked ? addSpacing(part) : part,
     );
 
-    const formattedValue = isTruncated ? beginning + placeholder + end : full;
+    const formattedValueBase = prefix + (isTruncated ? beginning + placeholder + end : rest);
+    const formattedValue =
+        isAddressChunked && isDeviceRendered && !isTruncated
+            ? addNewlineAfterEveryFourthChunk(formattedValueBase)
+            : formattedValueBase;
 
     const handleCopy = (e: React.ClipboardEvent) => {
         const selection = window.getSelection()?.toString();
 
         e.preventDefault();
-        e.clipboardData?.setData(
-            'text/plain',
-            selection?.replace(placeholder, middle).replace(/\s/g, '') ?? value,
-        );
+        e.clipboardData?.setData('text/plain', selection?.replace(/\s/g, '') ?? value);
     };
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -70,6 +70,7 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
             label={<Translation id="TR_ADDRESS" />}
             validateOnDevice={validateAddress}
             value={value}
+            isAddress={true}
             data-testid="@metadata/copy-address-button"
             {...props}
         />

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -50,6 +50,7 @@ export type ConfirmValueModalProps = Pick<ModalProps, 'onCancel' | 'heading'> & 
     label?: ReactNode;
     validateOnDevice: () => ThunkAction;
     value: string;
+    isAddress?: boolean;
 };
 
 export const ConfirmValueModal = ({
@@ -61,6 +62,7 @@ export const ConfirmValueModal = ({
     isValueChunked,
     onCancel,
     validateOnDevice,
+    isAddress = false,
     value,
 }: ConfirmValueModalProps) => {
     const [isCopied, setIsCopied] = useState(false);
@@ -193,36 +195,39 @@ export const ConfirmValueModal = ({
                                 <QrCode value={value} />
                             </Box>
                             <Column gap={12} alignItems="flex-start">
-                                {account ? (
-                                    <Labeling
-                                        deviceStaticSessionId={account.deviceState}
-                                        isDisabled={isMetadataBlockedByDeviceCall}
-                                        displayValue={
-                                            <Text typographyStyle="highlight">
-                                                <Translation id="TR_LABELING_ADD_ADDRESS_LABEL" />
-                                            </Text>
-                                        }
-                                        placeholder={translationString('TR_LABELING_ADDRESS_LABEL')}
-                                        leftAddon={
-                                            addressLabel ? undefined : (
-                                                <Icon name="tag" size={16} variant="tertiary" />
-                                            )
-                                        }
-                                        payload={{
-                                            type: 'addressLabel',
-                                            entityKey: account.key,
-                                            defaultValue: value,
-                                            networkSymbol: account.symbol,
-                                            accountDescriptor: account.descriptor,
-                                            value: addressLabel,
-                                        }}
-                                        maxWidth={255}
-                                    >
-                                        {addressLabel}
-                                    </Labeling>
-                                ) : (
-                                    label
-                                )}
+                                {isAddress &&
+                                    (account ? (
+                                        <Labeling
+                                            deviceStaticSessionId={account.deviceState}
+                                            isDisabled={isMetadataBlockedByDeviceCall}
+                                            displayValue={
+                                                <Text typographyStyle="highlight">
+                                                    <Translation id="TR_LABELING_ADD_ADDRESS_LABEL" />
+                                                </Text>
+                                            }
+                                            placeholder={translationString(
+                                                'TR_LABELING_ADDRESS_LABEL',
+                                            )}
+                                            leftAddon={
+                                                addressLabel ? undefined : (
+                                                    <Icon name="tag" size={16} variant="tertiary" />
+                                                )
+                                            }
+                                            payload={{
+                                                type: 'addressLabel',
+                                                entityKey: account.key,
+                                                defaultValue: value,
+                                                networkSymbol: account.symbol,
+                                                accountDescriptor: account.descriptor,
+                                                value: addressLabel,
+                                            }}
+                                            maxWidth={255}
+                                        >
+                                            {addressLabel}
+                                        </Labeling>
+                                    ) : (
+                                        label
+                                    ))}
                                 <Address
                                     value={value}
                                     data-testid="@modal/output-value"
@@ -249,54 +254,56 @@ export const ConfirmValueModal = ({
                             </Column>
                         </Row>
                     </Card>
-                    <Card>
-                        <Row gap={spacings.lg}>
-                            <IconCircle
-                                hasBorder={false}
-                                variant="info"
-                                size={32}
-                                name="warningFilled"
-                            />
-                            <H3>
-                                <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_HEADING" />
-                            </H3>
-                        </Row>
-                        <BulletList
-                            isOrdered
-                            margin={{ top: spacings.xxxl }}
-                            gap={spacings.xl}
-                            titleGap={spacings.zero}
-                            bulletGap={spacings.lg}
-                        >
-                            <BulletList.Item
-                                title={
-                                    <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_1_HEADING" />
-                                }
+                    {isAddress && (
+                        <Card>
+                            <Row gap={spacings.lg}>
+                                <IconCircle
+                                    hasBorder={false}
+                                    variant="info"
+                                    size={32}
+                                    name="warningFilled"
+                                />
+                                <H3>
+                                    <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_HEADING" />
+                                </H3>
+                            </Row>
+                            <BulletList
+                                isOrdered
+                                margin={{ top: spacings.xxxl }}
+                                gap={spacings.xl}
+                                titleGap={spacings.zero}
+                                bulletGap={spacings.lg}
                             >
-                                <Paragraph variant="tertiary" textWrap="pretty">
-                                    <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_1_DESCRIPTION" />
-                                </Paragraph>
-                            </BulletList.Item>
-                            <BulletList.Item
-                                title={
-                                    <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_2_HEADING" />
-                                }
-                            >
-                                <Paragraph variant="tertiary" textWrap="pretty">
-                                    <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_2_DESCRIPTION" />
-                                </Paragraph>
-                            </BulletList.Item>
-                            <BulletList.Item
-                                title={
-                                    <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_3_HEADING" />
-                                }
-                            >
-                                <Paragraph variant="tertiary" textWrap="pretty">
-                                    <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_3_DESCRIPTION" />
-                                </Paragraph>
-                            </BulletList.Item>
-                        </BulletList>
-                    </Card>
+                                <BulletList.Item
+                                    title={
+                                        <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_1_HEADING" />
+                                    }
+                                >
+                                    <Paragraph variant="tertiary" textWrap="pretty">
+                                        <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_1_DESCRIPTION" />
+                                    </Paragraph>
+                                </BulletList.Item>
+                                <BulletList.Item
+                                    title={
+                                        <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_2_HEADING" />
+                                    }
+                                >
+                                    <Paragraph variant="tertiary" textWrap="pretty">
+                                        <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_2_DESCRIPTION" />
+                                    </Paragraph>
+                                </BulletList.Item>
+                                <BulletList.Item
+                                    title={
+                                        <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_3_HEADING" />
+                                    }
+                                >
+                                    <Paragraph variant="tertiary" textWrap="pretty">
+                                        <Translation id="TR_RECEIVE_ADDRESS_CONFIRMATION_ITEM_3_DESCRIPTION" />
+                                    </Paragraph>
+                                </BulletList.Item>
+                            </BulletList>
+                        </Card>
+                    )}
                 </Column>
             </Modal.ModalBase>
         </Modal.Backdrop>

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -189,7 +189,6 @@ const Details = () => {
                                 data-testid="@wallets/details/export-label-bip329"
                                 onClick={handleExportBip329}
                                 isLoading={locked}
-                                size="small"
                                 minWidth={140}
                             >
                                 <Translation id="TR_ACCOUNT_DETAILS_EXPORT_LABELS_BUTTON" />

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -98,8 +98,6 @@ export const FreshAddress = ({
 
     if (!account) return null;
 
-    const addressValue = firstFreshAddress?.address?.substring(0, 20);
-
     // On coinjoin account, disallow to reveal more than the first receive address until it is used,
     // because discovery of coinjoin account relies on assumption that user uses his first address first.
     const coinjoinDisallowReveal =
@@ -150,8 +148,8 @@ export const FreshAddress = ({
                     flex="1"
                 >
                     <Text typographyStyle="titleMedium">
-                        {addressValue ? (
-                            <Address value={addressValue} isTruncated />
+                        {firstFreshAddress?.address ? (
+                            <Address value={firstFreshAddress.address} isTruncated />
                         ) : (
                             <Translation id="RECEIVE_ADDRESS_UNAVAILABLE" />
                         )}

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -36,7 +36,6 @@ const Item = ({ account, addr, locked, symbol, onClick, metadataPayload, index }
 
     const amount = formatNetworkAmount(addr.received || '0', symbol);
     const fresh = !addr.transfers;
-    const address = addr.address.substring(0, 20);
     const isDisabled = locked || isReceiveDisabled;
 
     return (
@@ -48,7 +47,7 @@ const Item = ({ account, addr, locked, symbol, onClick, metadataPayload, index }
                             ...metadataPayload,
                         }}
                         deviceStaticSessionId={account.deviceState}
-                        displayValue={<Address value={address} isTruncated />}
+                        displayValue={<Address value={addr.address} isTruncated />}
                         placeholder={translationString('TR_LABELING_ADDRESS_LABEL')}
                         margin={{ vertical: 4 }}
                         minHeight={28}

--- a/suite/e2e/support/common.ts
+++ b/suite/e2e/support/common.ts
@@ -66,6 +66,21 @@ export const isEqualWithOmit = (param: { object1: any; object2: any; mask: strin
 
 export const formatAddress = (address: string) => splitStringEveryNCharacters(address, 4).join(' ');
 
+const REGEXP_ADDRESS_CHUNKS = /((?:\S+\s){3}\S+)\s/g;
+
+const formatEvmAddress = (address: string) => {
+    if (!address.startsWith('0x')) {
+        return formatAddress(address);
+    }
+
+    const spacedBody = splitStringEveryNCharacters(address.slice(2), 4).join(' ');
+
+    return spacedBody ? `0x${spacedBody}` : address;
+};
+
+export const formatAddressWithNewlines = (address: string) =>
+    formatEvmAddress(address).replace(REGEXP_ADDRESS_CHUNKS, '$1\n');
+
 // This function is used to override automatic fixtures that we want to skip in specific tests.
 /* eslint-disable react-hooks/rules-of-hooks */
 export async function skipFixture({}, use: (r: void) => Promise<void>) {

--- a/suite/e2e/support/testExtends/customMatchers.ts
+++ b/suite/e2e/support/testExtends/customMatchers.ts
@@ -11,7 +11,7 @@ import messages from '@trezor/suite/src//support/messages';
 import { formatAddress, isEqualWithOmit, normalizeWhitespace } from '../common';
 import { DevicePrompt } from '../pageObjects/devicePrompt';
 
-type LineFormats = 'fourTetragrams' | 'fullLine';
+type LineFormats = 'fourTetragrams' | 'evmTetragrams' | 'fullLine';
 
 const DISPLAY_CHAR_LIMIT = 18;
 const STRING_UP_TO_DISPLAY_LIMIT = new RegExp(`.{1,${DISPLAY_CHAR_LIMIT}}`, 'g');
@@ -61,6 +61,22 @@ const addNewlinesToAddress = (address: string, regex: RegExp, newLineFormat: str
         .trim()
         .split(' ');
 
+const formatEvmAddress = (address: string) => {
+    if (!address.startsWith('0x')) {
+        return formatAddress(address);
+    }
+
+    const tetragrams = address.slice(2).match(/.{1,4}/g);
+
+    if (!tetragrams) {
+        return address;
+    }
+
+    const [firstTetragram, ...rest] = tetragrams;
+
+    return ['0x' + firstTetragram, ...rest].join(' ');
+};
+
 export const transformAddress = (address: string, lineFormat: LineFormats = 'fourTetragrams') => {
     // Address is split to lines on Display so it can fit. There are different formats:
     // 1. Four tetragrams of address:
@@ -76,6 +92,10 @@ export const transformAddress = (address: string, lineFormat: LineFormats = 'fou
 
     if (lineFormat === 'fourTetragrams') {
         return addNewlinesToAddress(formatAddress(address), fourTetragramsOfAddress, ' \n');
+    }
+
+    if (lineFormat === 'evmTetragrams') {
+        return addNewlinesToAddress(formatEvmAddress(address), fourTetragramsOfAddress, ' \n');
     }
 
     if (lineFormat === 'fullLine') {

--- a/suite/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/sell-bitcoin.test.ts
@@ -8,7 +8,7 @@ import {
     sellTradeBTC,
     sellWatchBTC,
 } from '../../fixtures/invity';
-import { formatAddress } from '../../support/common';
+import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
@@ -20,7 +20,7 @@ const providerPaymentId = sellWatchBTC.destinationPaymentExtraId;
 const formattedCryptoAmount = `${cryptoAmount} BTC`;
 const formattedFiatAmount = `€${fiatAmount}`;
 const { paymentMethodName } = sellTradeBTC.trade;
-const formattedAddress = formatAddress(sellWatchBTC.destinationAddress);
+const formattedAddress = formatAddressWithNewlines(sellWatchBTC.destinationAddress);
 
 test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });

--- a/suite/e2e/tests/trading/sell-ethereum-token.test.ts
+++ b/suite/e2e/tests/trading/sell-ethereum-token.test.ts
@@ -7,7 +7,7 @@ import {
     sellTradeEthereumToken,
     sellWatchEthereum,
 } from '../../fixtures/invity';
-import { formatAddress } from '../../support/common';
+import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
@@ -18,7 +18,7 @@ const providerAddress = sellWatchEthereum.destinationAddress;
 const formattedCryptoAmount = `${cryptoAmount} USDC`;
 const formattedFiatAmount = `€${fiatAmount}`;
 const { paymentMethodName } = sellTradeEthereumToken.trade;
-const formattedAddress = formatAddress(sellWatchEthereum.destinationAddress);
+const formattedAddress = formatAddressWithNewlines(sellWatchEthereum.destinationAddress);
 
 test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({

--- a/suite/e2e/tests/trading/sell-ethereum.test.ts
+++ b/suite/e2e/tests/trading/sell-ethereum.test.ts
@@ -7,7 +7,7 @@ import {
     sellTradeEthereum,
     sellWatchEthereum,
 } from '../../fixtures/invity';
-import { formatAddress } from '../../support/common';
+import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
@@ -18,7 +18,7 @@ const providerAddress = sellWatchEthereum.destinationAddress;
 const formattedCryptoAmount = `${cryptoAmount} ETH`;
 const formattedFiatAmount = `€${fiatAmount}`;
 const { paymentMethodName } = sellTradeEthereum.trade;
-const formattedAddress = formatAddress(sellWatchEthereum.destinationAddress);
+const formattedAddress = formatAddressWithNewlines(sellWatchEthereum.destinationAddress);
 // Fees
 const gasLimit = '26000';
 const maxFeePerGas = '2.67674454';

--- a/suite/e2e/tests/trading/sell-solana.test.ts
+++ b/suite/e2e/tests/trading/sell-solana.test.ts
@@ -8,7 +8,7 @@ import {
     sellTradeSolana,
     sellWatchSolana,
 } from '../../fixtures/invity';
-import { formatAddress } from '../../support/common';
+import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
@@ -22,7 +22,7 @@ const providerAddress = sellWatchSolana.destinationAddress;
 const formattedCryptoAmount = `${cryptoAmount} SOL`;
 const formattedFiatAmount = `€${fiatAmount}`;
 const { paymentMethodName } = sellTradeSolana.trade;
-const formattedAddress = formatAddress(sellWatchSolana.destinationAddress);
+const formattedAddress = formatAddressWithNewlines(sellWatchSolana.destinationAddress);
 
 test.describe('Trading - Sell Solana', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({

--- a/suite/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/suite/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -8,7 +8,7 @@ import {
     swapQuotesSolanaUSDC,
     swapTradeSolanaUSDC,
 } from '../../fixtures/invity';
-import { formatAddress } from '../../support/common';
+import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
@@ -18,7 +18,7 @@ const provider = getCompanyNameFromList(swapQuotesSolanaUSDC[0].exchange, 'swapL
 const formattedSendAmount = `${localizeNumber(sendAmount)} SOL`;
 const formattedReceiveAmount = `${receiveAmount} USDC`;
 const { sendAddress, receive: usdcMint, receiveAddress } = swapTradeSolanaUSDC;
-const formattedSendAddress = formatAddress(sendAddress);
+const formattedSendAddress = formatAddressWithNewlines(sendAddress);
 
 test.describe('Trading - Swap coin to token', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });

--- a/suite/e2e/tests/trading/swap-coins.test.ts
+++ b/suite/e2e/tests/trading/swap-coins.test.ts
@@ -9,7 +9,7 @@ import {
     swapQuotesSolanaBTC,
     swapTradeSolanaBTC,
 } from '../../fixtures/invity';
-import { formatAddress } from '../../support/common';
+import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 import { transformAddress } from '../../support/testExtends/customMatchers';
 
@@ -37,7 +37,7 @@ const provider = getCompanyNameFromList(swapQuotesSolanaBTC[1].exchange, 'swapLi
 const formattedSendAmount = `${localizeNumber(sendAmount)} SOL`;
 const formattedReceiveAmount = `${receiveAmount} BTC`;
 const { sendAddress, receiveAddress } = swapTradeSolanaBTC;
-const formattedSendAddress = formatAddress(sendAddress);
+const formattedSendAddress = formatAddressWithNewlines(sendAddress);
 
 test.describe('Trading - Swap coins', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });

--- a/suite/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/suite/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -8,7 +8,7 @@ import {
     swapQuotesTetherBTC,
     swapTradeTetherBTC,
 } from '../../fixtures/invity';
-import { formatAddress } from '../../support/common';
+import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
@@ -18,7 +18,7 @@ const provider = getCompanyNameFromList(swapQuotesTetherBTC[2].exchange, 'swapLi
 const formattedSendAmount = `${localizeNumber(sendAmount)} USDT`;
 const formattedReceiveAmount = `${receiveAmount} BTC`;
 const { sendAddress, send: tetherMint, receiveAddress } = swapTradeTetherBTC;
-const formattedSendAddress = formatAddress(sendAddress);
+const formattedSendAddress = formatAddressWithNewlines(sendAddress);
 
 test.describe('Trading - Swap token to coin', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });

--- a/suite/e2e/tests/trading/swap-tokens.test.ts
+++ b/suite/e2e/tests/trading/swap-tokens.test.ts
@@ -8,7 +8,7 @@ import {
     swapQuotesSolanaTokens,
     swapTradeSolanaTokens,
 } from '../../fixtures/invity';
-import { formatAddress } from '../../support/common';
+import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
@@ -18,7 +18,7 @@ const provider = getCompanyNameFromList(swapQuotesSolanaTokens[0].exchange, 'swa
 const formattedSendAmount = `${localizeNumber(sendAmount)} USDT`;
 const formattedReceiveAmount = `${receiveAmount} USDC`;
 const { sendAddress, send: tetherMint, receive: usdcMint, receiveAddress } = swapTradeSolanaTokens;
-const formattedSendAddress = formatAddress(sendAddress);
+const formattedSendAddress = formatAddressWithNewlines(sendAddress);
 
 test.describe('Trading - Swap tokens', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });

--- a/suite/e2e/tests/wallet/send-doge.test.ts
+++ b/suite/e2e/tests/wallet/send-doge.test.ts
@@ -1,6 +1,6 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
 
-import { formatAddress } from '../../support/common';
+import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 test.describe('Doge Send', { tag: ['@group=wallet', '@snapshot'] }, () => {
@@ -59,7 +59,7 @@ test.describe('Doge Send', { tag: ['@group=wallet', '@snapshot'] }, () => {
             await expect(devicePrompt.outputValueOf('total')).toContainText(`${totalAmount} DOGE`);
             await expect(devicePrompt.outputValueOf('fee')).toContainText(`${feeAmount} DOGE`);
             await expect(devicePrompt.outputValueOf('address')).toHaveText(
-                formatAddress(recipientAddress),
+                formatAddressWithNewlines(recipientAddress),
             );
             // await expect(devicePrompt.modal).toHaveScreenshot('send-doge.png');
             await trezorUserEnvLink.pressYes();

--- a/suite/e2e/tests/wallet/send-eth.test.ts
+++ b/suite/e2e/tests/wallet/send-eth.test.ts
@@ -2,7 +2,7 @@ import { localizeNumber } from '@suite-common/wallet-utils';
 import messages from '@trezor/suite/src//support/messages';
 import { BigNumber } from '@trezor/utils';
 
-import { formatAddress } from '../../support/common';
+import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 import {
     splitStringByDisplayLimit,
@@ -10,7 +10,7 @@ import {
 } from '../../support/testExtends/customMatchers';
 
 const sendAddress = '0xdcaB74E62b9D08a9f8Fa4A3Ccb5c46AE039C9d7C';
-const formattedSendAddress = formatAddress(sendAddress);
+const formattedSendAddress = formatAddressWithNewlines(sendAddress);
 const sendAmount = '0.008';
 const formattedSendAmount = `${localizeNumber(sendAmount)} ETH`;
 const gasLimit = '26000';
@@ -67,6 +67,7 @@ test.describe('Send Eth', { tag: ['@group=wallet'] }, () => {
             await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedSendAddress);
             await expect(devicePrompt).toDisplayOnEmulator({
                 header: { title: 'Address', subtitle: 'Recipient' },
+                // TODO: Use evmTetragrams when FW supports it
                 body: [transformAddress(sendAddress)],
                 footer: 'Tap to continue',
             });

--- a/suite/e2e/tests/wallet/send-sol.test.ts
+++ b/suite/e2e/tests/wallet/send-sol.test.ts
@@ -1,12 +1,12 @@
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 
-import { formatAddress } from '../../support/common';
+import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 import { transformAddress } from '../../support/testExtends/customMatchers';
 
 const RECIPIENT_ADDRESS = 'ENk2eeP4umP6cjAGRsVG4NEVKEVQmRn6JEpN8hubv2Hf';
-const FORMATTED_ADDRESS = formatAddress(RECIPIENT_ADDRESS);
+const FORMATTED_ADDRESS = formatAddressWithNewlines(RECIPIENT_ADDRESS);
 const TRANSFORMED_ADDRESS = transformAddress(RECIPIENT_ADDRESS, 'fullLine');
 const SOL_DECIMALS = 9;
 


### PR DESCRIPTION
## Notes for QA
Fixed address chunking for EVM addresses

## Screenshots:

### Before
<img width="482" height="183" alt="Screenshot 2025-12-16 at 10 01 39" src="https://github.com/user-attachments/assets/b1047097-b820-4c60-bd61-2d1464f10511" />
<img width="627" height="320" alt="Screenshot 2025-12-16 at 10 01 49" src="https://github.com/user-attachments/assets/ae3fbe01-aae0-4128-9f85-2cef1c21b0ab" />

### After
<img width="486" height="179" alt="Screenshot 2025-12-16 at 9 57 54" src="https://github.com/user-attachments/assets/ca50bc31-b642-42db-8d64-54e3d9199ddb" />
<img width="636" height="326" alt="Screenshot 2025-12-17 at 9 16 00" src="https://github.com/user-attachments/assets/fda02a98-3a47-4a66-a61a-bf015a1bc1f8" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/address-component&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/address-component&lookback=7)