### PR TITLE
fix: make sure that the we can use the suite sync when device is not …

### DIFF
--- a/suite-common/suite-sync/src/createRefreshSuiteSync.ts
+++ b/suite-common/suite-sync/src/createRefreshSuiteSync.ts
@@ -11,6 +11,8 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
 import { err, exhaustive, ok } from '@trezor/type-utils';
 
+import { LoadSuiteSyncOwnerFromStateDep } from './owner/loadSuiteSyncOwnerFromState';
+
 /**
  * Device is not connected or device is in a state/configuration, that does not
  * support Suite Sync.
@@ -22,16 +24,27 @@ export const RefreshSuiteKeysUnavailable = (): RefreshSuiteKeysUnavailableType =
 export type RefreshSuiteSyncKeysDeps = {
     dispatch: Dispatch;
 } & EnsureSuiteSyncOwnerDep &
+    LoadSuiteSyncOwnerFromStateDep &
     EnsureDelegatedIdentityKeyDep;
 
 export const createRefreshSuiteSync =
     (deps: RefreshSuiteSyncKeysDeps): RefreshSuiteSyncKeys =>
     async ({ device }): ReturnType<RefreshSuiteSyncKeys> => {
+        if (!device || !isTrezorDeviceWithState(device)) {
+            return err(RefreshSuiteKeysUnavailable());
+        }
+
+        const owner = await deps.loadSuiteSyncOwnerFromState({
+            deviceStaticId: device.state.staticSessionId,
+        });
+
+        if (owner !== null) {
+            return ok(owner);
+        }
+
         if (
-            device === undefined ||
             !device.connected || // disconnected device cannot resolve Evolu-Keys
-            device.mode !== 'normal' || // bootloader,
-            !isTrezorDeviceWithState(device)
+            device.mode !== 'normal' // bootloader
         ) {
             return err(RefreshSuiteKeysUnavailable());
         }

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -11,6 +11,7 @@ import {
 } from '@suite-common/wallet-core';
 import { StaticSessionId } from '@trezor/connect';
 
+import { createRefreshSuiteSync } from './createRefreshSuiteSync';
 import { GetDeviceForStaticSessionId } from './getDeviceForStaticSessionId';
 import { createSubscribeLabeling } from './labeling/subscribeLabeling';
 import { createUpdateAccountLabel } from './labeling/updateAccountLabel';
@@ -24,7 +25,6 @@ import {
     createRetrieveSuiteSyncOwner,
 } from './owner/retrieveSuiteSyncOwner';
 import { createSaveSuiteSyncOwner } from './owner/saveSuiteSyncOwner';
-import { createRefreshSuiteSync } from './refreshSuiteSyncKeys';
 import { createChangeRelayUrl } from './relay/changeRelayUrl';
 import { DEFAULT_SUITE_SYNC_RELAY_URL } from './relay/relayUrl';
 import { createEnsureStorage } from './storage/ensureStorage';
@@ -55,6 +55,12 @@ export const createSuiteSyncCompositionRoot = (
     const findSuiteSyncOwnerForDeviceStaticId = (deviceStaticId: StaticSessionId) =>
         selectSuiteSyncOwnerForDeviceStaticId(deps.getState(), deviceStaticId);
 
+    const loadSuiteSyncOwnerFromState = createLoadSuiteSyncOwnerFromState({
+        dispatch: deps.dispatch,
+        platformEncryption: deps.platformEncryption,
+        getDeviceSuiteSyncOwner: findSuiteSyncOwnerForDeviceStaticId,
+    });
+
     const ensureSuiteSyncOwner = createEnsureSuiteSyncOwner({
         saveSuiteSyncOwner: createSaveSuiteSyncOwner({
             dispatch: deps.dispatch,
@@ -64,17 +70,14 @@ export const createSuiteSyncCompositionRoot = (
             trezorConnect: deps.trezorConnect,
             createSuiteSyncOwner: deps.createSuiteSyncOwner,
         }),
-        loadSuiteSyncOwnerFromState: createLoadSuiteSyncOwnerFromState({
-            dispatch: deps.dispatch,
-            platformEncryption: deps.platformEncryption,
-            getDeviceSuiteSyncOwner: findSuiteSyncOwnerForDeviceStaticId,
-        }),
+        loadSuiteSyncOwnerFromState,
     });
 
     const refreshSuiteSyncKeys = createRefreshSuiteSync({
         dispatch: deps.dispatch,
         ensureDelegatedIdentityKey: deps.ensureDelegatedIdentityKey,
         ensureSuiteSyncOwner,
+        loadSuiteSyncOwnerFromState,
     });
 
     const getDeviceForStaticSessionId: GetDeviceForStaticSessionId = deviceStaticId =>

--- a/suite-common/suite-sync/src/labeling/tests/subscribeLabeling.test.ts
+++ b/suite-common/suite-sync/src/labeling/tests/subscribeLabeling.test.ts
@@ -10,7 +10,7 @@ import { StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
 import { mockNotExpected } from '../../../tests/utils';
-import { RefreshSuiteKeysUnavailable } from '../../refreshSuiteSyncKeys';
+import { RefreshSuiteKeysUnavailable } from '../../createRefreshSuiteSync';
 import { createSubscriptionStorage } from '../../storage/subscriptionStorage';
 import { createSubscribeLabeling } from '../subscribeLabeling';
 

--- a/suite-common/suite-sync/src/storage/ensureStorage.ts
+++ b/suite-common/suite-sync/src/storage/ensureStorage.ts
@@ -9,8 +9,8 @@ import { StaticSessionId } from '@trezor/connect';
 import { Result, err, ok } from '@trezor/type-utils';
 
 import { createStorageIdFromDeviceStaticSessionId } from './createStorageIdFromDeviceStaticSessionId';
+import { RefreshSuiteKeysUnavailable } from '../createRefreshSuiteSync';
 import { GetDeviceForStaticSessionIdDep } from '../getDeviceForStaticSessionId';
-import { RefreshSuiteKeysUnavailable } from '../refreshSuiteSyncKeys';
 
 export type EnsureStorageDeps = {
     defaultRelayUrl: string;

--- a/suite-common/suite-sync/src/tests/createRefreshSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/tests/createRefreshSuiteSync.test.ts
@@ -1,0 +1,159 @@
+import { Dispatch } from '@reduxjs/toolkit';
+
+import { EnsureDelegatedIdentityKey } from '@suite-common/delegated-identity-key-types';
+import { EnsureSuiteSyncOwner } from '@suite-common/suite-sync-types';
+import {
+    TrezorDevice,
+    asDelegatedIdentityKey,
+    asSuiteSyncOwnerId,
+    asSuiteSyncOwnerSecretHex,
+} from '@suite-common/suite-types';
+import { ok } from '@trezor/type-utils';
+
+import { mockNotExpected } from '../../tests/utils';
+import { RefreshSuiteSyncKeysDeps, createRefreshSuiteSync } from '../createRefreshSuiteSync';
+import { LoadSuiteSyncOwnerFromState } from '../owner/loadSuiteSyncOwnerFromState';
+
+const createMockDeps = () =>
+    ({
+        dispatch: mockNotExpected<Dispatch>('dispatch'),
+        ensureSuiteSyncOwner: mockNotExpected<EnsureSuiteSyncOwner>('ensureSuiteSyncOwner'),
+        loadSuiteSyncOwnerFromState: mockNotExpected<LoadSuiteSyncOwnerFromState>(
+            'loadSuiteSyncOwnerFromState',
+        ),
+        ensureDelegatedIdentityKey: mockNotExpected<EnsureDelegatedIdentityKey>(
+            'ensureDelegatedIdentityKey',
+        ),
+    }) satisfies RefreshSuiteSyncKeysDeps;
+
+const OWNER_1 = {
+    ownerId: asSuiteSyncOwnerId('new-owner-id'),
+    ownerSecret: asSuiteSyncOwnerSecretHex('new-owner-secret'),
+};
+
+const createDevice = (
+    overrides: Partial<TrezorDevice> = {},
+    deviceStateOverrides: Partial<TrezorDevice['state']> | null = {},
+): TrezorDevice =>
+    ({
+        id: 'test-device-id',
+        connected: true,
+        mode: 'normal',
+        ...(deviceStateOverrides
+            ? {
+                  state: {
+                      device: {
+                          path: 'test-path',
+                          instance: 1,
+                      },
+                      staticSessionId: 'test-session-id',
+                      ...deviceStateOverrides,
+                  },
+              }
+            : {}),
+        ...overrides,
+    }) as unknown as TrezorDevice;
+
+describe(createRefreshSuiteSync.name, () => {
+    it('fails with "unable to get keys" when device is not initialized', async () => {
+        const deps = createMockDeps();
+        const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
+        const result = await refreshSuiteSyncKeys({
+            device: createDevice({}, null),
+        });
+
+        expect(result.ok).toEqual(false);
+        expect(!result.ok && result.error.type).toBe('RefreshSuiteKeysUnavailable');
+    });
+
+    it('returns an suite sync owner when device has state and is available', async () => {
+        const deps = createMockDeps();
+        deps.loadSuiteSyncOwnerFromState.mockResolvedValue(OWNER_1);
+
+        const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
+        const result = await refreshSuiteSyncKeys({
+            device: createDevice(),
+        });
+
+        expect(result.ok).toEqual(true);
+        expect(result.ok && result.value).toEqual(OWNER_1);
+    });
+
+    it('fails to get keys, when device is disconnected', async () => {
+        const deps = createMockDeps();
+        deps.loadSuiteSyncOwnerFromState.mockResolvedValue(null);
+
+        const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
+        const result = await refreshSuiteSyncKeys({
+            device: createDevice({ connected: false }),
+        });
+
+        expect(result.ok).toEqual(false);
+        expect(!result.ok && result.error.type).toEqual('RefreshSuiteKeysUnavailable');
+    });
+
+    it('ensures that the delegated identity key is available when owner is not in state', async () => {
+        const deps = createMockDeps();
+        deps.dispatch.mockImplementation(() => Promise.resolve(undefined));
+        deps.loadSuiteSyncOwnerFromState.mockResolvedValue(null);
+        deps.ensureSuiteSyncOwner.mockResolvedValue(ok(OWNER_1));
+        deps.ensureDelegatedIdentityKey.mockResolvedValue(
+            ok(asDelegatedIdentityKey('delegated-key-value')),
+        );
+
+        const mockDevice = createDevice();
+        const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
+        await refreshSuiteSyncKeys({
+            device: mockDevice,
+        });
+
+        expect(deps.ensureDelegatedIdentityKey).toHaveBeenCalledWith({
+            device: mockDevice,
+        });
+    });
+
+    it('requests ensureSuiteSyncOwner when owner is not in state', async () => {
+        const deps = createMockDeps();
+        deps.dispatch.mockImplementation(() => Promise.resolve(undefined));
+        deps.loadSuiteSyncOwnerFromState.mockResolvedValue(null);
+        deps.ensureSuiteSyncOwner.mockResolvedValue(ok(OWNER_1));
+        deps.ensureDelegatedIdentityKey.mockResolvedValue(
+            ok(asDelegatedIdentityKey('delegated-key-value')),
+        );
+
+        const mockDevice = createDevice();
+        const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
+        await refreshSuiteSyncKeys({
+            device: mockDevice,
+        });
+
+        expect(deps.ensureSuiteSyncOwner).toHaveBeenCalledWith({
+            device: mockDevice,
+            delegatedKey: 'delegated-key-value',
+        });
+    });
+
+    it('finally returns the new refreshed owner', async () => {
+        const deps = createMockDeps();
+        deps.dispatch.mockImplementation(() => Promise.resolve(undefined));
+        deps.loadSuiteSyncOwnerFromState.mockResolvedValue(null);
+        deps.ensureDelegatedIdentityKey.mockResolvedValue(
+            ok(asDelegatedIdentityKey('delegated-key-value')),
+        );
+        deps.ensureSuiteSyncOwner.mockResolvedValue(
+            ok({
+                ownerId: asSuiteSyncOwnerId('new-owner-id'),
+                ownerSecret: asSuiteSyncOwnerSecretHex('new-secret-public-key'),
+            }),
+        );
+
+        const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
+        const result = await refreshSuiteSyncKeys({
+            device: createDevice(),
+        });
+
+        expect(result.ok).toBe(true);
+        expect(result.ok && result.value.ownerId).toEqual('new-owner-id');
+        expect(result.ok && result.value.ownerSecret).toEqual('new-secret-public-key');
+    });
+});

--- a/suite-common/suite-sync/tests/utils.ts
+++ b/suite-common/suite-sync/tests/utils.ts
@@ -1,3 +1,4 @@
-export const mockNotExpected = (key: string) => () => {
-    throw new Error(`Method ${key} was not expected to be called`);
-};
+export const mockNotExpected = <T extends (...args: any[]) => any>(key: string) =>
+    jest.fn<ReturnType<T>, Parameters<T>>().mockImplementation(() => {
+        throw new Error(`Method ${key} was not expected to be called`);
+    });


### PR DESCRIPTION
…connected but the keys are available

## Description

We have forgotten on if-case here. Because we want to allow the user to use the suite-sync without the need for the device to be connected if the keys are available.

## Notes for QA

You should be able to use the Suite Sync even when the device is not connected (but you have the keys provided already eg. when the app runs some time before)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23677

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=23677-suite-sync-without-keys&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=23677-suite-sync-without-keys&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=23677-suite-sync-without-keys&lookback=7)