### PR TITLE
chore(address-validator): remove cbor-js dep, use already existing cb…

### DIFF
--- a/packages/address-validator/package.json
+++ b/packages/address-validator/package.json
@@ -13,7 +13,7 @@
         "base-x": "^5.0.1",
         "bech32": "^2.0.0",
         "browserify-bignum": "^1.3.0-2",
-        "cbor-js": "^0.1.0",
+        "cbor": "^10.0.10",
         "chai": "^5.2.0",
         "crc": "^3.8.0",
         "groestl-hash-js": "1.0.0",

--- a/packages/address-validator/src/ada_validator.js
+++ b/packages/address-validator/src/ada_validator.js
@@ -1,5 +1,5 @@
 const { addressType } = require('./crypto/utils');
-var cbor = require('cbor-js');
+var cbor = require('cbor');
 var CRC = require('crc');
 var base58 = require('./crypto/base58');
 var { bech32 } = require('bech32');
@@ -18,7 +18,6 @@ function getDecoded(address) {
 
 function isValidLegacyAddress(address) {
     var decoded = getDecoded(address);
-
     if (!decoded || (!Array.isArray(decoded) && decoded.length != 2)) {
         return false;
     }
@@ -28,9 +27,8 @@ function isValidLegacyAddress(address) {
     if (typeof validCrc != 'number') {
         return false;
     }
-
     // get crc of the payload
-    var crc = CRC.crc32(tagged);
+    var crc = CRC.crc32(tagged.value);
 
     return crc == validCrc;
 }

--- a/scripts/list-outdated-dependencies/connect-dependencies.txt
+++ b/scripts/list-outdated-dependencies/connect-dependencies.txt
@@ -32,7 +32,6 @@ base-x
 browserify-bignum
 buffer
 cbor
-cbor-js
 clsx
 codemirror-json-schema
 codemirror-json5

--- a/yarn.lock
+++ b/yarn.lock
@@ -13585,7 +13585,7 @@ __metadata:
     base-x: "npm:^5.0.1"
     bech32: "npm:^2.0.0"
     browserify-bignum: "npm:^1.3.0-2"
-    cbor-js: "npm:^0.1.0"
+    cbor: "npm:^10.0.10"
     chai: "npm:^5.2.0"
     crc: "npm:^3.8.0"
     groestl-hash-js: "npm:1.0.0"
@@ -19963,13 +19963,6 @@ __metadata:
   dependencies:
     lodash: "npm:^4.17.15"
   checksum: 10/a4f54d5982c0bc4342b1b27b89aa7fb359994ecd1d41431d8bd30432171188179fce1d11a0240863adb05edd157d5af1ded4c72b4972b0098f266e28f9c67164
-  languageName: node
-  linkType: hard
-
-"cbor-js@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "cbor-js@npm:0.1.0"
-  checksum: 10/763b1aebba89cb576874d0273976e0e51f2aec5665fd8ae05603eab3efa8bb3af6fec24d19f186ef801dfa79f9ce2486bc4b454b10b4fab0f012fd55516eb611
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
there are tests so maybe we can afford trying fixing somethign whats not broken 

https://github.com/trezor/trezor-suite/blob/develop/packages/address-validator/tests/wallet_address_validator.test.js#L1403

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-cbor-js&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-cbor-js&lookback=7)