### PR TITLE
feat(suite): display native token first in assets modal

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/hooks/useBuildOptionsForTabs.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/hooks/useBuildOptionsForTabs.tsx
@@ -62,11 +62,7 @@ const buildTokenOptions = (
         tokens: [],
     };
 
-    tokens.shownWithBalance.forEach(token =>
-        result.tokens.push(createTokenOption(token, symbol, true)),
-    );
-
-    // this represents native currency
+    // this represents the native token
     result.tokens.push({
         ticker: symbol,
         symbol,
@@ -75,6 +71,10 @@ const buildTokenOptions = (
         contractAddress: null,
         height: ITEM_HEIGHT,
     });
+
+    tokens.shownWithBalance.forEach(token =>
+        result.tokens.push(createTokenOption(token, symbol, true)),
+    );
 
     tokens.hiddenWithBalance.forEach(token =>
         result.hidden.push(createTokenOption(token, symbol, true)),


### PR DESCRIPTION
## Description

In send form, display the native token first in the list in assets modal.

## Related Issue

Resolve #23893 

## Screenshots:

<img width="100%" alt="Screenshot 2025-12-16 at 10 31 15" src="https://github.com/user-attachments/assets/8ad899b9-8c74-492c-b8c2-528c735c281c" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/assets-modal-native-token-first&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/assets-modal-native-token-first&lookback=7)