### PR TITLE
fix(suite-native): device switcher pressable

### DIFF
--- a/suite-native/device-manager/src/components/DeviceSwitch.tsx
+++ b/suite-native/device-manager/src/components/DeviceSwitch.tsx
@@ -32,6 +32,7 @@ const switchStyle = prepareNativeStyle<SwitchStyleProps>((utils, { isDeviceManag
 
 const switchWrapperStyle = prepareNativeStyle(_ => ({
     flex: 1,
+    zIndex: 10,
 }));
 
 export const DeviceSwitch = () => {


### PR DESCRIPTION
## Description
- fixes a bug where the device switcher does not respond to press events.
## Notes for QA
Wallet switcher can be opened and closed on any screen where present.



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-switcher-pressable&lookback=7)