### PR TITLE
fix(suite-desktop): open bt settings on linux

### DIFF
--- a/packages/suite-desktop-core/src/modules/system-settings.ts
+++ b/packages/suite-desktop-core/src/modules/system-settings.ts
@@ -33,8 +33,6 @@ const openBluetoothSettings = async () => {
         // Electron modifies the value of XDG_CURRENT_DESKTOP
         const xdg =
             process.env.ORIGINAL_XDG_CURRENT_DESKTOP || process.env.XDG_CURRENT_DESKTOP || '';
-        const flatpak = process.env.FLATPAK_ID ?? process.env.FLATPAK_APP_ID;
-        const flatpakPrefix = flatpak ? 'flatpak-spawn --host ' : '';
         const commands = {
             GNOME: 'gnome-control-center bluetooth',
             KDE: 'systemsettings kcm_bluetooth',
@@ -48,14 +46,14 @@ const openBluetoothSettings = async () => {
         const cmd = xdgMatch?.[1];
         const env = { XDG_CURRENT_DESKTOP: xdg };
         if (cmd) {
-            const result = await openSettings(`${flatpakPrefix}${cmd}`, env);
+            const result = await openSettings(cmd, env);
             if (result.success) {
                 return result;
             }
         }
 
         // fallback to blueman
-        return openSettings(`${flatpakPrefix}${commands.BLUEMAN}`, env);
+        return openSettings(commands.BLUEMAN, env);
     }
 
     if (isMacOs()) {

--- a/packages/suite-desktop-core/src/modules/system-settings.ts
+++ b/packages/suite-desktop-core/src/modules/system-settings.ts
@@ -37,8 +37,8 @@ const openBluetoothSettings = async () => {
         const flatpakPrefix = flatpak ? 'flatpak-spawn --host ' : '';
         const commands = {
             GNOME: 'gnome-control-center bluetooth',
-            KDE: 'systemsettings5 bluetooth',
-            PANTHEON: 'switchboard bluetooth',
+            KDE: 'systemsettings kcm_bluetooth',
+            PANTHEON: 'open settings://',
             BLUEMAN: 'blueman-manager',
         };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Should resolve https://github.com/trezor/trezor-suite/issues/22272#issuecomment-3656339102

Also removing `flatpack-spawn` as it will [not work anyway](https://github.com/flathub-infra/flatpak-builder-lint/pull/744#event-21588022806)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-linux-open-settings&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-linux-open-settings&lookback=7)