### PR TITLE
fix(suite): correct amounts and token selection

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx
@@ -52,6 +52,7 @@ export function SelectTokenAssetModal({
     const dataEnabled = getDefaultValue('options', []).includes('transactionData');
 
     const amountInputName = `outputs.${outputId}.amount` as const;
+    const fiatInputName = `outputs.${outputId}.fiat` as const;
     const currencyInputName = `outputs.${outputId}.currency` as const;
 
     const currencyValue = watch(currencyInputName);
@@ -77,10 +78,13 @@ export function SelectTokenAssetModal({
 
         resetDraft();
 
-        setValue(tokenInputName, newlySelectedToken?.contract || account.symbol, {
+        setValue(tokenInputName, newlySelectedToken?.contract || null, {
             shouldDirty: true,
         });
         setValue(amountInputName, '', {
+            shouldDirty: true,
+        });
+        setValue(fiatInputName, '', {
             shouldDirty: true,
         });
 


### PR DESCRIPTION
## Description

Correctly handle changing token, amount (crypto/fiat) and send max to prevent mismatched amounts bugs.

## Related Issue

Resolve #23877 

## Screenshots:

https://github.com/user-attachments/assets/67fe29ec-eb0b-4c1c-bafc-17ed0eaf1cd7


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/send-form-amounts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/send-form-amounts&lookback=7)