### PR TITLE
tiny suite cleanup - remove unused code

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
@@ -3,7 +3,10 @@ import { FC, useMemo } from 'react';
 import styled from 'styled-components';
 
 import { Route } from '@suite-common/suite-types';
-import { selectHasBitcoinOnlyFirmware } from '@suite-common/wallet-core';
+import {
+    selectHasBitcoinOnlyFirmware,
+    selectIsAnyNonBitcoinLikeNetworkEnabled,
+} from '@suite-common/wallet-core';
 import { type SpacingPxValues, spacingsPx } from '@trezor/theme';
 
 import { useSelector } from 'src/hooks/suite';
@@ -44,6 +47,7 @@ export const Navigation = ({ children, margin = spacingsPx.xs }: NavigationProps
 
     const isDebug = useSelector(selectIsDebugModeActive);
     const isBtcOnly = useSelector(selectHasBitcoinOnlyFirmware);
+    const hasNonBitcoinEnabled = useSelector(selectIsAnyNonBitcoinLikeNetworkEnabled);
 
     const navItems: Array<NavigationItemProps & { CustomComponent?: FC<NavigationItemProps> }> =
         useMemo(
@@ -54,7 +58,7 @@ export const Navigation = ({ children, margin = spacingsPx.xs }: NavigationProps
                     goToRoute: startRoute,
                     routes: [startRoute],
                 },
-                ...(isDebug && !isBtcOnly
+                ...(isDebug && !isBtcOnly && hasNonBitcoinEnabled
                     ? [
                           {
                               nameId: 'TR_EARN',
@@ -77,7 +81,7 @@ export const Navigation = ({ children, margin = spacingsPx.xs }: NavigationProps
                     'data-testid': '@suite/menu/settings',
                 },
             ],
-            [startRoute, isDebug, isBtcOnly],
+            [startRoute, isDebug, isBtcOnly, hasNonBitcoinEnabled],
         );
 
     return (

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { SUPPORTS_DEVICE_AUTHENTICITY_CHECK } from '@suite-common/suite-constants';
 import { AcquiredDevice } from '@suite-common/suite-types';
-import { getConnectedDeviceStatus } from '@suite-common/suite-utils';
 import { deviceActions, selectDevices, selectSelectedDevice } from '@suite-common/wallet-core';
 import {
     Button,
@@ -146,8 +145,7 @@ const SecurityCheckContent = ({
     const { goToNextStep, rerun, updateAnalytics } = useOnboarding();
     const dispatch = useDispatch();
 
-    const deviceStatus = getConnectedDeviceStatus(device);
-    const initialized = deviceStatus === 'initialized';
+    const initialized = !!device?.features?.initialized;
     const isRecoveryInProgress = recovery.status === 'in-progress';
     const isFirmwareInstalled = device?.firmware !== 'none';
     const secondaryButtonText = isFirmwareInstalled ? 'TR_I_HAVE_NOT_USED_IT' : 'TR_I_HAVE_DOUBTS';

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -29,10 +29,7 @@ export const getConnectedDeviceStatus = (device: TrezorDevice | undefined) => {
 
     if (isInBlWithFwPresent) return 'bootloader';
     if (device.features?.initialized) return 'initialized';
-    if (device.features?.no_backup) return 'seedless';
-    if (device.type === 'unreadable') return 'unreadable';
-
-    return 'ok';
+    // removed branches that never executed in our codebase
 };
 
 export const deviceStatuses = [
@@ -64,6 +61,7 @@ export const getStatus = (device: TrezorDevice): DeviceStatus => {
     if (device.status === 'busy') {
         return 'device-busy';
     }
+
     if (device.type === 'acquired') {
         if (!device.connected) {
             return 'disconnected';

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -14,24 +14,6 @@ import { exhaustive } from '@trezor/type-utils';
 import * as URLS from '@trezor/urls';
 import { isArrayMember } from '@trezor/utils';
 
-/**
- * Used in the Welcome step in Onboarding
- * Status 'ok' or 'initialized' is what we expect, 'bootloader', 'seedless' and 'unreadable' are no go
- *
- * @param {(TrezorDevice | undefined)} device
- * @returns
- */
-export const getConnectedDeviceStatus = (device: TrezorDevice | undefined) => {
-    if (!device) return null;
-
-    const isInBlWithFwPresent =
-        device.mode === 'bootloader' && device.features?.firmware_present === true;
-
-    if (isInBlWithFwPresent) return 'bootloader';
-    if (device.features?.initialized) return 'initialized';
-    // removed branches that never executed in our codebase
-};
-
 export const deviceStatuses = [
     'acquired',
     'unacquired',
@@ -61,7 +43,6 @@ export const getStatus = (device: TrezorDevice): DeviceStatus => {
     if (device.status === 'busy') {
         return 'device-busy';
     }
-
     if (device.type === 'acquired') {
         if (!device.connected) {
             return 'disconnected';

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -5,7 +5,12 @@ import {
     createWeakMapSelector,
     returnStableArrayIfEmpty,
 } from '@suite-common/redux-utils';
-import { NetworkSymbol, getNetwork, networkSymbolCollection } from '@suite-common/wallet-config';
+import {
+    NetworkSymbol,
+    getNetwork,
+    getNetworkType,
+    networkSymbolCollection,
+} from '@suite-common/wallet-config';
 import type { WalletSettings } from '@suite-common/wallet-types';
 import { isBaseCurrencyWithSats } from '@suite-common/wallet-utils';
 import { PROTO } from '@trezor/connect';
@@ -133,6 +138,11 @@ export const selectIsAnyNetworkEnabled = (state: WalletSettingsRootState) =>
 export const selectIsBitcoinEnabled = createMemoizedSelector(
     [selectEnabledNetworks],
     enabledNetworks => enabledNetworks.includes('btc'),
+);
+
+export const selectIsAnyNonBitcoinLikeNetworkEnabled = createMemoizedSelector(
+    [selectEnabledNetworks],
+    enabledNetworks => enabledNetworks.some(network => getNetworkType(network) !== 'bitcoin'),
 );
 
 export const selectAreSatsAmountUnit = (state: WalletSettingsRootState) => {


### PR DESCRIPTION
I believe that we could simplify like this without any changes to the actual business logic

- 1st commit just removed return values that were never consumed anywhere
- 2nd commit inlines the remaining part of  `getConnectedDeviceStatus` to the only place where it is used.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=suite-nitpics&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=suite-nitpics&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=suite-nitpics&lookback=7)