### PR TITLE
feat(suite-native): allow copy instanceID for sentry

### DIFF
--- a/suite-native/module-dev-utils/package.json
+++ b/suite-native/module-dev-utils/package.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "7.1.18",
         "@react-navigation/native-stack": "7.5.1",
         "@reduxjs/toolkit": "2.11.0",
+        "@suite-common/analytics": "workspace:*",
         "@suite-common/firmware": "workspace:*",
         "@suite-common/message-system": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",

--- a/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
@@ -1,7 +1,9 @@
 import { Alert, Pressable } from 'react-native';
+import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
+import { selectAnalyticsInstanceId } from '@suite-common/analytics';
 import { Button, Card, Text, TitleHeader, VStack } from '@suite-native/atoms';
 import { useCopyToClipboard } from '@suite-native/clipboard';
 import { getEnv, isDevelopOrDebugEnv } from '@suite-native/config';
@@ -36,6 +38,7 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 export const DevUtilsScreen = () => {
     const navigation = useNavigation<NavigationProps>();
     const copyToClipboard = useCopyToClipboard();
+    const instanceId = useSelector(selectAnalyticsInstanceId);
     const versionString = `${getEnv()}-${getSuiteVersion()}, commit ${getCommitHash() || 'N/A in debug build'}`;
 
     const handleCopyVersion = () => {
@@ -57,11 +60,9 @@ export const DevUtilsScreen = () => {
                         <Pressable onPress={handleCopyVersion}>
                             <TitleHeader title="Build version" subtitle={versionString} />
                         </Pressable>
-                        {isDevelopOrDebugEnv() && (
-                            <Button onPress={() => navigation.navigate(DevUtilsStackRoutes.Demo)}>
-                                See Component Demo
-                            </Button>
-                        )}
+                        <Pressable onPress={handleCopyVersion}>
+                            <TitleHeader title="Instance ID" subtitle={instanceId} />
+                        </Pressable>
                     </VStack>
                 </Card>
                 <FeatureFlags />
@@ -104,6 +105,11 @@ export const DevUtilsScreen = () => {
                     </VStack>
                 </Card>
                 <SuiteSyncRelaySettings />
+                {isDevelopOrDebugEnv() && (
+                    <Button onPress={() => navigation.navigate(DevUtilsStackRoutes.Demo)}>
+                        See Component Demo
+                    </Button>
+                )}
             </VStack>
         </Screen>
     );

--- a/suite-native/module-dev-utils/tsconfig.json
+++ b/suite-native/module-dev-utils/tsconfig.json
@@ -2,6 +2,9 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        {
+            "path": "../../suite-common/analytics"
+        },
         { "path": "../../suite-common/firmware" },
         {
             "path": "../../suite-common/message-system"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12277,6 +12277,7 @@ __metadata:
     "@react-navigation/native": "npm:7.1.18"
     "@react-navigation/native-stack": "npm:7.5.1"
     "@reduxjs/toolkit": "npm:2.11.0"
+    "@suite-common/analytics": "workspace:*"
     "@suite-common/firmware": "workspace:*"
     "@suite-common/message-system": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add option to copy instance ID so we can track instances of errors in sentry if user encounters specific problem that we want to debug. 

## Notes for QA
Probably nothing to test. But the way to test this would be to force some kind of error, copy the instance ID and verify that there is an error in sentry. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23521

## Screenshots:
<img width="362" height="814" alt="image" src="https://github.com/user-attachments/assets/323c5c96-98f0-4498-b755-66f8e5e1e6f7" />
<img width="738" height="586" alt="Snímek obrazovky 2025-12-17 v 17 38 56" src="https://github.com/user-attachments/assets/8e1e40b7-d31c-41e8-bcb4-0c734903466b" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/allow-copy-instance-id&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/allow-copy-instance-id&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/allow-copy-instance-id&lookback=7)