### PR TITLE
Hide autoupdate switch

### DIFF
--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -12,11 +12,11 @@ import { isDevEnv, isFeatureFlagEnabled } from '@suite-common/suite-utils';
 import { HandshakeElectron } from '@trezor/suite-desktop-api';
 import { bytesToHumanReadable, serializeError } from '@trezor/utils';
 
+import { ModuleInit, mainThreadEmitter } from './module';
 import { getSwitchValue, hasSwitch } from '../libs/process-switches';
 import { getSignatureFile, verifySignature } from '../libs/update-checker';
 import { b2t } from '../libs/utils';
 import { app, ipcMain } from '../typed-electron';
-import { ModuleInit, mainThreadEmitter } from './module';
 
 const defaultFeedURL = {
     // This should correspond with the value in electron-builder-config.js file.
@@ -42,6 +42,12 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
 
     if (isFeatureFlagEnabled('DESKTOP_AUTO_UPDATER') && disableUpdater) {
         logger.info(SERVICE_NAME, 'Disabled via command line parameter');
+
+        return;
+    }
+
+    if (process.env.SNAP_NAME || process.env.FLATPAK_ID) {
+        logger.info(SERVICE_NAME, 'Disabled - native store');
 
         return;
     }

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/useUpdateStatus.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/useUpdateStatus.ts
@@ -6,6 +6,7 @@ import { useDevice, useSelector } from '../../../../../../../hooks/suite';
 import {
     DesktopUpdateState,
     UpdateState,
+    selectDesktopUpdate,
 } from '../../../../../../../reducers/suite/desktopUpdateReducer';
 
 type UpdateStatusData = {
@@ -70,7 +71,7 @@ const getDeviceStatus = ({
 
 export const useUpdateStatus = (): UpdateStatusData => {
     const { device } = useDevice();
-    const desktopUpdate = useSelector(state => state.desktopUpdate);
+    const desktopUpdate = useSelector(selectDesktopUpdate);
 
     const isDeviceDisconnected = device?.connected !== true;
 

--- a/packages/suite/src/reducers/suite/desktopUpdateReducer.ts
+++ b/packages/suite/src/reducers/suite/desktopUpdateReducer.ts
@@ -114,4 +114,7 @@ const desktopUpdateReducer = (
 
 export const selectDesktopUpdate = (state: DesktopUpdateRootState) => state.desktopUpdate;
 
+export const selectDesktopUpdateEnabled = (state: DesktopUpdateRootState) =>
+    state.desktopUpdate.enabled;
+
 export default desktopUpdateReducer;

--- a/packages/suite/src/views/settings/SettingsGeneral/AutomaticUpdate.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/AutomaticUpdate.tsx
@@ -1,13 +1,13 @@
 import styled from 'styled-components';
 
 import { Switch } from '@trezor/components';
-import { isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { SettingsSectionItem } from 'src/components/settings/SettingsSectionItem';
 import { ActionColumn, TextColumn } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
+import { selectDesktopUpdateEnabled } from 'src/reducers/suite/desktopUpdateReducer';
 
 import { useSelector } from '../../../hooks/suite';
 
@@ -16,11 +16,12 @@ const PositionedSwitch = styled.div`
 `;
 
 export const AutomaticUpdate = () => {
+    const isUpdateEnabled = useSelector(selectDesktopUpdateEnabled);
     const isAutomaticUpdateEnabled = useSelector(
         state => state.desktopUpdate.isAutomaticUpdateEnabled,
     );
 
-    if (!isDesktop()) {
+    if (!isUpdateEnabled) {
         return null;
     }
 


### PR DESCRIPTION
## Description

Hide auto-update switch when update is not available.

## Notes for QA

Affected mostly by platform & auto-updater settings.

## Related Issue

Resolve #23929

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/disable-autoupdate-switch&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/disable-autoupdate-switch&lookback=7)