### PR TITLE
fix(e2e-suite): add 'trezor-firmware/blob' to ignore patters

### DIFF
--- a/suite/e2e/tests/general/check-links.test.ts
+++ b/suite/e2e/tests/general/check-links.test.ts
@@ -14,39 +14,68 @@ async function getAllLinksFromAllPages(
     const allValidHrefs = new Set<string>();
 
     for (const path of paths) {
-        await page.goto(`.${path}`, { waitUntil: 'domcontentloaded' });
+        await test.step(`Get the links from ${path}`, async () => {
+            await page.goto(`.${path}`, { waitUntil: 'domcontentloaded' });
 
-        // Ensure the page is loaded by asserting the element is attached to the DOM.
-        // For unknown reasons, this is the only available method to wait for the page to load.
-        await expect(
-            page
+            // Ensure the page is loaded by asserting the element is attached to the DOM.
+            // For unknown reasons, this is the only available method to wait for the page to load.
+            const pageContent = page
                 .locator('[data-testid^="@welcome"]')
                 .or(page.locator('[data-testid^="@suite-layout"]'))
                 .or(page.locator('[data-testid^="@onboarding"]'))
-                .first(),
-            `The page element for route "${path}" should be attached`,
-        ).toBeAttached();
-        await expect(page.getByTestId('@suite/bundle-loader')).toBeHidden();
+                .first();
 
-        // Extract all hrefs in a single browser operation to reduce network latency in CI.
-        const allHrefs = await page
-            .locator('a')
-            .evaluateAll(anchors => anchors.map(a => a.getAttribute('href')));
-
-        for (const link of allHrefs) {
-            if (link) {
-                // Normalize the links.
-                allValidHrefs.add(new URL(link, page.url()).href);
-            } else {
-                testInfo.annotations.push({
-                    type: 'Not Link',
-                    description: `${link} is not valid href`,
+            try {
+                await pageContent.waitFor({ state: 'attached', timeout: 10_000 });
+            } catch {
+                await test.step(`Page element not found for ${path}, reloading...`, async () => {
+                    await page.reload({ waitUntil: 'domcontentloaded', timeout: 10_000 });
                 });
             }
-        }
+
+            await expect(
+                pageContent,
+                `The page element for route "${path}" should be attached`,
+            ).toBeAttached();
+            await expect(page.getByTestId('@suite/bundle-loader')).toBeHidden();
+
+            // Extract all hrefs in a single browser operation to reduce network latency in CI.
+            const allHrefs = await page
+                .locator('a')
+                .evaluateAll(anchors => anchors.map(a => a.getAttribute('href')));
+
+            for (const link of allHrefs) {
+                if (link) {
+                    // Normalize the links.
+                    allValidHrefs.add(new URL(link, page.url()).href);
+                } else {
+                    testInfo.annotations.push({
+                        type: 'Not Link',
+                        description: `${link} is not a valid href`,
+                    });
+                }
+            }
+        });
     }
 
     return allValidHrefs;
+}
+
+async function fetchWithRetry(page: Page, url: string, maxRetries = 3) {
+    let response = await page.request.get(url);
+
+    let attempts = 0;
+    while (response.status() === 429 && attempts < maxRetries) {
+        attempts++;
+        const waitTime = 2000 * attempts;
+
+        await test.step(`[429] Rate limit on ${url}. Retry ${attempts}/${maxRetries}`, async () => {
+            await page.waitForTimeout(waitTime);
+            response = await page.request.get(url);
+        });
+    }
+
+    return response;
 }
 
 test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@specificModel'] }, () => {
@@ -92,8 +121,7 @@ test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@specificModel
 
             await test.step('Filter known broken links', () => {
                 // Define patterns for known broken links here.
-                const ignoredPatterns = ['github.com/trezor/trezor-suite/releases/tag'];
-
+                const ignoredPatterns: string[] = ['github.com/trezor/trezor-suite/releases/tag'];
                 const knownBrokenLinks: string[] = [];
 
                 for (const url of allUrls) {
@@ -115,15 +143,27 @@ test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@specificModel
             });
 
             await test.step(`Check ${urlsToCheck.length} valid links`, async () => {
-                await Promise.all(
-                    Array.from(urlsToCheck).map(async url => {
-                        await test.step(`Checking link: ${url}`, async () => {
-                            const response = await page.request.get(url);
+                const chunkSize = 20;
 
-                            expect.soft(response.ok(), `${url} should be OK`).toBeTruthy();
-                        });
-                    }),
-                );
+                // Implement batching to prevent network flooding and false failures or timeouts.
+                for (let i = 0; i < urlsToCheck.length; i += chunkSize) {
+                    const chunk = urlsToCheck.slice(i, i + chunkSize);
+
+                    await Promise.all(
+                        chunk.map(async url => {
+                            await test.step(`Checking link: ${url}`, async () => {
+                                const response = await fetchWithRetry(page, url);
+
+                                expect
+                                    .soft(
+                                        response.ok(),
+                                        `${url} failed: HTTP Status ${response.status()} ${response.statusText()}`,
+                                    )
+                                    .toBeTruthy();
+                            });
+                        }),
+                    );
+                }
             });
         },
     );


### PR DESCRIPTION
## Description

The test failed on the link `https://github.com/trezor/trezor-firmware/blob.../CHANGELOG.T3T1.md` which seemingly didn't exist when the test ran. 
The issue may lie in the bulk request, since GitHub prevents requesting multiple links simultaneously.

https://app.currents.dev/projects/Og0NOQ/insights/tests/950ffb6b3a448a40d504c69530019f6f?s=check-links&testId=647112395de41d718228-495fb3299403f7ce4d2f&instanceId=DFMLUVsFavjQ78xq&testExplorerTab=attempts


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/test-check-broken-links&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/test-check-broken-links&lookback=7)