### PR TITLE
feat(suite): add insufficient funds warning for Stellar token activation.

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
@@ -12,7 +12,7 @@ import { fetchAndUpdateAccountThunk, selectRawNetworkFeeInfo } from '@suite-comm
 import { FormState, PrecomposedLevels } from '@suite-common/wallet-types';
 import { formatNetworkAmount, getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import { BASE_INFO } from '@trezor/blockchain-link-utils/src/stellar';
-import { Button, Column, Modal, Row, Text } from '@trezor/components';
+import { Banner, Button, Column, Modal, Row, Text } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -101,6 +101,27 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
 
         return levels;
     }, [feeInfo.levels, feePerUnit, selectedFee]);
+
+    const composedTx = composedLevels[selectedFee || 'normal'];
+    const currentFee = composedTx?.type === 'final' ? composedTx.fee : '0';
+
+    // Check if balance is sufficient for activation (need fee + BASE_RESERVE for new trustline)
+    const insufficientBalanceInfo = useMemo(() => {
+        if (mode !== 'activate' || !account) {
+            return null;
+        }
+        const availableBalance = BigNumber(account.availableBalance);
+        const requiredAmount = BigNumber(currentFee).plus(BASE_INFO.BASE_RESERVE);
+
+        if (availableBalance.lt(requiredAmount)) {
+            return {
+                required: formatNetworkAmount(requiredAmount.toString(), symbol, true),
+                available: formatNetworkAmount(availableBalance.toString(), symbol, true),
+            };
+        }
+
+        return null;
+    }, [mode, account, currentFee, symbol]);
 
     if (!account) {
         return null;
@@ -228,7 +249,7 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
                 <Row gap={spacings.xs}>
                     <Button
                         onClick={handleSubmit(handleSubmitTrustline)}
-                        isDisabled={isProcessing}
+                        isDisabled={isProcessing || !!insufficientBalanceInfo}
                         isLoading={isProcessing}
                         intent="brand"
                     >
@@ -272,6 +293,18 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
                         composedLevels={composedLevels}
                         changeFeeLevel={changeFeeLevel}
                     />
+
+                    {insufficientBalanceInfo && (
+                        <Banner intent="warning" icon="warning">
+                            <Translation
+                                id="TR_TOKEN_ACTIVATION_INSUFFICIENT_FUNDS"
+                                values={{
+                                    required: insufficientBalanceInfo.required,
+                                    available: insufficientBalanceInfo.available,
+                                }}
+                            />
+                        </Banner>
+                    )}
                 </Column>
             </FormProvider>
         </Modal>

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4533,6 +4533,11 @@ export default defineMessages({
         id: 'TR_DEACTIVATE_TOKEN_BALANCE_WARNING',
         defaultMessage: 'To deactivate this token, transfer its remaining balance.',
     },
+    TR_TOKEN_ACTIVATION_INSUFFICIENT_FUNDS: {
+        id: 'TR_TOKEN_ACTIVATION_INSUFFICIENT_FUNDS',
+        defaultMessage:
+            'Insufficient funds. You need {required} to cover the reserve and network fee, but only {available} is available.',
+    },
     TR_ASSET_CODE: {
         id: 'TR_ASSET_CODE',
         defaultMessage: 'Asset code',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Give a warning when the XLM held by the user is insufficient to complete the activation token operation.
## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #23591 
## Screenshots:
<img width="2198" height="1728" alt="Screenshot From 2025-12-17 16-42-03" src="https://github.com/user-attachments/assets/acfc4f9e-e792-480a-b4cc-6862c06afd98" />

