### PR TITLE
chore(wallet-core): extract mev package to solve circular deps

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -45,6 +45,7 @@
         "@suite-common/logger": "workspace:*",
         "@suite-common/message-system": "workspace:*",
         "@suite-common/metadata-types": "workspace:*",
+        "@suite-common/mev": "workspace:*",
         "@suite-common/platform-encryption": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/sentry": "workspace:*",

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -2,6 +2,7 @@ import { G } from '@mobily/ts-belt';
 import { isRejected } from '@reduxjs/toolkit';
 
 import { MetadataAddPayload } from '@suite-common/metadata-types';
+import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
 import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
 import {
@@ -9,6 +10,7 @@ import {
     enhancePrecomposedTransactionThunk,
     pushSendFormTransactionThunk,
     replaceTransactionThunk,
+    selectIsMevProtectionEnabled,
     selectPrecomposedSendForm,
     selectSelectedDevice,
     selectSendFormDrafts,
@@ -281,11 +283,13 @@ export const signAndPushSendFormTransactionThunk = createThunk(
               )
             : null;
 
+        const isMevProtectionEnabled =
+            selectIsMevProtectionEnabled(getState()) &&
+            selectIsMevProtectionFeatureEnabled(getState());
+
         // push tx to the network
         const pushResponse = await dispatch(
-            pushSendFormTransactionThunk({
-                selectedAccount,
-            }),
+            pushSendFormTransactionThunk({ selectedAccount, isMevProtectionEnabled }),
         );
 
         if (isRejected(pushResponse)) {

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -1,3 +1,4 @@
+import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { StakingFlow } from '@suite-common/suite-types/src/staking';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
@@ -5,7 +6,6 @@ import {
     addFakePendingCardanoTxThunk,
     replaceTransactionThunk,
     selectIsMevProtectionEnabled,
-    selectIsMevProtectionFeatureEnabled,
     selectSelectedDevice,
     stakeActions,
     syncAccountsWithBlockchainThunk,
@@ -97,8 +97,7 @@ const pushTransaction =
         const txData = getMevProtectedTxData(
             serializedTx.symbol,
             serializedTx.tx,
-            isMevProtectionEnabled,
-            isMevProtectionFeatureEnabled,
+            isMevProtectionEnabled && isMevProtectionFeatureEnabled,
         );
 
         const sentTx = await TrezorConnect.pushTransaction({

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -1,8 +1,8 @@
 import { Context } from '@suite-common/message-system';
+import { selectIsMevProtectionSettingsVisible } from '@suite-common/mev';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
     selectEnabledNetworks,
-    selectIsMevProtectionSettingsVisible,
     selectIsNetworkReserveSettingsVisible,
 } from '@suite-common/wallet-core';
 import { isDesktop, isLinux, isWeb } from '@trezor/env-utils';

--- a/packages/suite/src/views/wallet/send/SendRaw.tsx
+++ b/packages/suite/src/views/wallet/send/SendRaw.tsx
@@ -1,6 +1,11 @@
 import { useForm } from 'react-hook-form';
 
-import { pushSendFormRawTransactionThunk, sendFormActions } from '@suite-common/wallet-core';
+import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
+import {
+    pushSendFormRawTransactionThunk,
+    selectIsMevProtectionEnabled,
+    sendFormActions,
+} from '@suite-common/wallet-core';
 import { getInputState, isHexValid, tryGetAccountIdentity } from '@suite-common/wallet-utils';
 import { Button, Card, H3, IconButton, Row, Textarea, Tooltip } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
@@ -8,7 +13,7 @@ import { spacings } from '@trezor/theme';
 
 import { OpenGuideFromTooltip } from 'src/components/guide';
 import { Translation } from 'src/components/suite/Translation';
-import { useDispatch, useTranslation } from 'src/hooks/suite';
+import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
 
 const INPUT_NAME = 'rawTx';
@@ -46,12 +51,15 @@ export const SendRaw = ({ account }: SendRawProps) => {
 
     const cancel = () => dispatch(sendFormActions.sendRaw(false));
 
+    const isMevProtectionEnabled = useSelector(selectIsMevProtectionEnabled);
+    const isMevProtectionFeatureEnabled = useSelector(selectIsMevProtectionFeatureEnabled);
     const send = async () => {
         const result = await dispatch(
             pushSendFormRawTransactionThunk({
                 tx: inputValue,
                 symbol: account.symbol,
                 identity: tryGetAccountIdentity(account),
+                isMevProtectionEnabled: isMevProtectionEnabled && isMevProtectionFeatureEnabled,
             }),
         ).unwrap();
 

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeDetails.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeDetails.tsx
@@ -3,6 +3,7 @@ import { FormattedList } from 'react-intl';
 
 import { CryptoId, ExchangeTrade } from 'invity-api';
 
+import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import {
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
     TradingExchangeType,
@@ -13,10 +14,7 @@ import {
     useTradingUtils,
 } from '@suite-common/trading';
 import { networksCollection } from '@suite-common/wallet-config';
-import {
-    selectIsMevProtectionEnabled,
-    selectIsMevProtectionFeatureEnabled,
-} from '@suite-common/wallet-core';
+import { selectIsMevProtectionEnabled } from '@suite-common/wallet-core';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { Card, Column, Icon, InfoItem, Row, Text, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -55,6 +55,7 @@
         {
             "path": "../../suite-common/metadata-types"
         },
+        { "path": "../../suite-common/mev" },
         {
             "path": "../../suite-common/platform-encryption"
         },

--- a/suite-common/mev/package.json
+++ b/suite-common/mev/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@suite-common/mev",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@suite-common/message-system": "workspace:*",
+        "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/wallet-config": "workspace:*",
+        "@suite-common/wallet-core": "workspace:*"
+    }
+}

--- a/suite-common/mev/src/index.ts
+++ b/suite-common/mev/src/index.ts
@@ -1,0 +1,4 @@
+export {
+    selectIsMevProtectionFeatureEnabled,
+    selectIsMevProtectionSettingsVisible,
+} from './mevProtectionSettings';

--- a/suite-common/mev/src/mevProtectionSettings.ts
+++ b/suite-common/mev/src/mevProtectionSettings.ts
@@ -1,0 +1,28 @@
+import {
+    Feature,
+    MessageSystemRootState,
+    selectIsFeatureEnabled,
+} from '@suite-common/message-system';
+import { createWeakMapSelector } from '@suite-common/redux-utils';
+import { networksCollection } from '@suite-common/wallet-config';
+import { WalletSettingsRootState, selectEnabledNetworks } from '@suite-common/wallet-core';
+
+const createMemoizedSelector = createWeakMapSelector.withTypes<
+    WalletSettingsRootState & MessageSystemRootState
+>();
+
+export const selectIsMevProtectionFeatureEnabled = (state: MessageSystemRootState) =>
+    selectIsFeatureEnabled(state, Feature.mevProtection, true);
+
+const MEV_PROTECTION_SUPPORTED_NETWORK_SYMBOLS = networksCollection
+    .filter(network => network.features.includes('mev-protection'))
+    .map(network => network.symbol);
+
+export const selectIsMevProtectionSettingsVisible = createMemoizedSelector(
+    [selectIsMevProtectionFeatureEnabled, selectEnabledNetworks],
+    (isFeatureEnabled, enabledNetworks) =>
+        isFeatureEnabled &&
+        enabledNetworks.some(enabledNetwork =>
+            MEV_PROTECTION_SUPPORTED_NETWORK_SYMBOLS.includes(enabledNetwork),
+        ),
+);

--- a/suite-common/mev/tsconfig.json
+++ b/suite-common/mev/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../message-system" },
+        { "path": "../redux-utils" },
+        { "path": "../wallet-config" },
+        { "path": "../wallet-core" }
+    ]
+}

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -15,7 +15,6 @@
         "@reduxjs/toolkit": "2.11.0",
         "@suite-common/bluetooth": "workspace:*",
         "@suite-common/fiat-services": "workspace:*",
-        "@suite-common/message-system": "workspace:*",
         "@suite-common/platform-encryption": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-constants": "workspace:*",

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -82,8 +82,6 @@ import { selectSelectedDevice } from '../device/deviceSelectors';
 import {
     selectAreSatsAmountUnit,
     selectBitcoinAmountUnit,
-    selectIsMevProtectionEnabled,
-    selectIsMevProtectionFeatureEnabled,
     selectIsNetworkReserveEnabled,
 } from '../settings/walletSettingsReducer';
 import {
@@ -307,12 +305,12 @@ const synchronizeSentTransactionThunk = createThunk(
 
 export const pushSendFormTransactionThunk = createThunk<
     Success<{ txid: string }>,
-    { selectedAccount: Account },
+    { selectedAccount: Account; isMevProtectionEnabled: boolean },
     { rejectValue: PushTransactionError }
 >(
     `${SEND_MODULE_PREFIX}/pushSendFormTransactionThunk`,
     async (
-        { selectedAccount },
+        { selectedAccount, isMevProtectionEnabled },
         { dispatch, getState, extra, rejectWithValue, fulfillWithValue },
     ) => {
         const {
@@ -323,8 +321,6 @@ export const pushSendFormTransactionThunk = createThunk<
         const serializedTx = selectSendSerializedTx(getState());
         const device = selectSelectedDevice(getState());
         const bitcoinAmountUnit = selectBitcoinAmountUnit(getState());
-        const isMevProtectionEnabled = selectIsMevProtectionEnabled(getState());
-        const isMevProtectionFeatureEnabled = selectIsMevProtectionFeatureEnabled(getState());
 
         if (!serializedTx || !precomposedTransaction)
             return rejectWithValue({
@@ -336,7 +332,6 @@ export const pushSendFormTransactionThunk = createThunk<
             serializedTx.symbol,
             serializedTx.tx,
             isMevProtectionEnabled,
-            isMevProtectionFeatureEnabled,
         );
 
         const pushTxResponse = await TrezorConnect.pushTransaction({
@@ -452,17 +447,18 @@ export const pushSendFormTransactionThunk = createThunk<
 export const pushSendFormRawTransactionThunk = createThunk(
     `${SEND_MODULE_PREFIX}/pushSendFormRawTransactionThunk`,
     async (
-        payload: { tx: string; symbol: NetworkSymbol; identity?: string },
-        { dispatch, getState, fulfillWithValue, rejectWithValue },
+        payload: {
+            tx: string;
+            symbol: NetworkSymbol;
+            identity?: string;
+            isMevProtectionEnabled: boolean;
+        },
+        { dispatch, fulfillWithValue, rejectWithValue },
     ) => {
-        const isMevProtectionEnabled = selectIsMevProtectionEnabled(getState());
-        const isMevProtectionFeatureEnabled = selectIsMevProtectionFeatureEnabled(getState());
-
         const txData = getMevProtectedTxData(
             payload.symbol,
             payload.tx,
-            isMevProtectionEnabled,
-            isMevProtectionFeatureEnabled,
+            payload.isMevProtectionEnabled,
         );
 
         const sentTx = await TrezorConnect.pushTransaction({

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -1,24 +1,11 @@
 import { A } from '@mobily/ts-belt';
 
-// TODO: currently, message-system index mustn't be imported directly, else @suite-common/suite-sync:type-check will fail
-// That's because tsconfig.json in local-first-storage "infects" its upstream packages with exactOptionalPropertyTypes (it shouldn't).
-// Probably caused by circular deps?
-import { selectIsFeatureEnabled } from '@suite-common/message-system/src/messageSystemSelectors';
-import {
-    Feature,
-    MessageSystemRootState,
-} from '@suite-common/message-system/src/messageSystemTypes';
 import {
     createReducerWithExtraDeps,
     createWeakMapSelector,
     returnStableArrayIfEmpty,
 } from '@suite-common/redux-utils';
-import {
-    NetworkSymbol,
-    getNetwork,
-    networkSymbolCollection,
-    networksCollection,
-} from '@suite-common/wallet-config';
+import { NetworkSymbol, getNetwork, networkSymbolCollection } from '@suite-common/wallet-config';
 import type { WalletSettings } from '@suite-common/wallet-types';
 import { isBaseCurrencyWithSats } from '@suite-common/wallet-utils';
 import { PROTO } from '@trezor/connect';
@@ -35,9 +22,7 @@ export type WalletSettingsRootState = {
     };
 };
 
-export const createMemoizedSelector = createWeakMapSelector.withTypes<
-    WalletSettingsRootState & MessageSystemRootState
->();
+export const createMemoizedSelector = createWeakMapSelector.withTypes<WalletSettingsRootState>();
 
 const initialState: WalletSettingsState = {
     localCurrency: 'usd',
@@ -180,24 +165,9 @@ export const selectIsBaseCurrencyInSats = (state: WalletSettingsRootState) => {
 export const selectIsNetworkReserveEnabled = (state: WalletSettingsRootState) =>
     state.wallet.settings.networkReserve;
 
+// Selects the primitive value in walletSettings, see @suite-common/mev for the derived selectors
 export const selectIsMevProtectionEnabled = (state: WalletSettingsRootState) =>
     state.wallet.settings.mevProtection;
-
-export const selectIsMevProtectionFeatureEnabled = (state: MessageSystemRootState) =>
-    selectIsFeatureEnabled(state, Feature.mevProtection, true);
-
-const MEV_PROTECTION_SUPPORTED_NETWORK_SYMBOLS = networksCollection
-    .filter(network => network.features.includes('mev-protection'))
-    .map(network => network.symbol);
-
-export const selectIsMevProtectionSettingsVisible = createMemoizedSelector(
-    [selectIsMevProtectionFeatureEnabled, selectEnabledNetworks],
-    (isFeatureEnabled, enabledNetworks) =>
-        isFeatureEnabled &&
-        enabledNetworks.some(enabledNetwork =>
-            MEV_PROTECTION_SUPPORTED_NETWORK_SYMBOLS.includes(enabledNetwork),
-        ),
-);
 
 export const selectIsNetworkReserveSettingsVisible = createMemoizedSelector(
     [selectEnabledNetworks],

--- a/suite-common/wallet-core/tsconfig.json
+++ b/suite-common/wallet-core/tsconfig.json
@@ -4,7 +4,6 @@
     "references": [
         { "path": "../bluetooth" },
         { "path": "../fiat-services" },
-        { "path": "../message-system" },
         { "path": "../platform-encryption" },
         { "path": "../redux-utils" },
         { "path": "../suite-constants" },

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -701,19 +701,12 @@ export const getMevProtectedTxData = (
     symbol: NetworkSymbol,
     hex: string,
     isMevProtectionEnabled: boolean,
-    isMevProtectionFeatureEnabled: boolean,
 ) => {
-    if (!isMevProtectionFeatureEnabled) {
-        return hex;
-    }
-
+    if (!isMevProtectionEnabled) return hex;
     const isMevSupported = getNetwork(symbol).features.includes('mev-protection');
+    if (!isMevSupported) return hex;
 
-    if (!isMevSupported) {
-        return hex;
-    }
-
-    return isMevProtectionEnabled ? hex : { hex, disableAlternativeRPC: true };
+    return { hex, disableAlternativeRPC: true };
 };
 
 export const isExchangeTradingForm = (

--- a/suite-common/walletconnect/package.json
+++ b/suite-common/walletconnect/package.json
@@ -14,6 +14,7 @@
         "@reown/walletkit": "^1.2.8",
         "@suite-common/analytics": "workspace:*",
         "@suite-common/connect-popup": "workspace:*",
+        "@suite-common/mev": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -2,13 +2,13 @@ import { WalletKitTypes } from '@reown/walletkit';
 import type { ProposalTypes } from '@walletconnect/types';
 
 import * as trezorConnectPopupActions from '@suite-common/connect-popup';
+import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
 import { Network, getNetwork, networksCollection } from '@suite-common/wallet-config';
 import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
     selectAccounts,
     selectIsMevProtectionEnabled,
-    selectIsMevProtectionFeatureEnabled,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { ethereumGetCurrentNonceThunk } from '@suite-common/wallet-core/src/send/sendFormEthereumThunks';
@@ -222,8 +222,7 @@ const ethereumRequestThunk = createThunk<
             const txData = getMevProtectedTxData(
                 account.symbol,
                 typedSignPayload.serializedTx,
-                isMevProtectionEnabled,
-                isMevProtectionFeatureEnabled,
+                isMevProtectionEnabled && isMevProtectionFeatureEnabled,
             );
 
             const pushResponse = await TrezorConnect.pushTransaction({

--- a/suite-common/walletconnect/tsconfig.json
+++ b/suite-common/walletconnect/tsconfig.json
@@ -5,6 +5,7 @@
     "references": [
         { "path": "../analytics" },
         { "path": "../connect-popup" },
+        { "path": "../mev" },
         { "path": "../redux-utils" },
         { "path": "../toast-notifications" },
         { "path": "../wallet-config" },

--- a/suite-native/module-settings/package.json
+++ b/suite-native/module-settings/package.json
@@ -17,6 +17,7 @@
         "@react-navigation/native-stack": "7.5.1",
         "@reduxjs/toolkit": "2.11.0",
         "@suite-common/analytics": "workspace:*",
+        "@suite-common/mev": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-constants": "workspace:*",
         "@suite-common/suite-sync": "workspace:*",

--- a/suite-native/module-settings/src/screens/SettingsDeviceChecksScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsDeviceChecksScreen.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { selectIsMevProtectionSettingsVisible } from '@suite-common/wallet-core';
+import { selectIsMevProtectionSettingsVisible } from '@suite-common/mev';
 import { Text, VStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';

--- a/suite-native/module-settings/tsconfig.json
+++ b/suite-native/module-settings/tsconfig.json
@@ -5,6 +5,7 @@
         {
             "path": "../../suite-common/analytics"
         },
+        { "path": "../../suite-common/mev" },
         {
             "path": "../../suite-common/redux-utils"
         },

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -23,6 +23,7 @@
         "@suite-common/formatters": "workspace:*",
         "@suite-common/geolocation": "workspace:*",
         "@suite-common/message-system": "workspace:*",
+        "@suite-common/mev": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-constants": "workspace:*",
         "@suite-common/suite-sync": "workspace:*",

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -1,5 +1,6 @@
 import { isFulfilled, isRejected } from '@reduxjs/toolkit';
 
+import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
 import {
     TradingExchangeType,
@@ -21,6 +22,7 @@ import {
     formDraftActions,
     pushSendFormTransactionThunk,
     selectDeepCopyOfFormDraft,
+    selectIsMevProtectionEnabled,
     sendFormActions,
     signTransactionThunk,
 } from '@suite-common/wallet-core';
@@ -289,7 +291,7 @@ export const signAndPushSendFormTransactionThunk = createThunk(
         }: TradingSignAndPushSendFormTransactionProps & {
             waitForPushApprovalPromise: () => Promise<boolean>;
         },
-        { dispatch, rejectWithValue, fulfillWithValue },
+        { dispatch, getState, rejectWithValue, fulfillWithValue },
     ) => {
         const signResult = await dispatch(
             signTradingTransactionThunk({
@@ -311,10 +313,11 @@ export const signAndPushSendFormTransactionThunk = createThunk(
             return rejectWithValue('Push approval not received');
         }
 
+        const isMevProtectionEnabled =
+            selectIsMevProtectionEnabled(getState()) &&
+            selectIsMevProtectionFeatureEnabled(getState());
         const pushResult = await dispatch(
-            pushSendFormTransactionThunk({
-                selectedAccount,
-            }),
+            pushSendFormTransactionThunk({ selectedAccount, isMevProtectionEnabled }),
         );
 
         if (isRejected(pushResult)) {

--- a/suite-native/module-trading/tsconfig.json
+++ b/suite-native/module-trading/tsconfig.json
@@ -11,6 +11,7 @@
         {
             "path": "../../suite-common/message-system"
         },
+        { "path": "../../suite-common/mev" },
         {
             "path": "../../suite-common/redux-utils"
         },

--- a/suite-native/send/package.json
+++ b/suite-native/send/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "2.11.0",
+        "@suite-common/mev": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",

--- a/suite-native/send/src/sendFormThunks.ts
+++ b/suite-native/send/src/sendFormThunks.ts
@@ -1,6 +1,7 @@
 import { G } from '@mobily/ts-belt';
 import { isRejected } from '@reduxjs/toolkit';
 
+import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
 import {
     PushTransactionError,
@@ -10,6 +11,7 @@ import {
     enhancePrecomposedTransactionThunk,
     pushSendFormTransactionThunk,
     selectAccountByKey,
+    selectIsMevProtectionEnabled,
     selectSelectedDevice,
     selectSendFormDraftByKey,
     selectSendFormDrafts,
@@ -182,7 +184,12 @@ export const sendTransactionThunk = createThunk<
         { selectedAccount, wasAppLeftDuringReview, tokenContract },
         { dispatch, getState, rejectWithValue, fulfillWithValue },
     ) => {
-        const sendResponse = await dispatch(pushSendFormTransactionThunk({ selectedAccount }));
+        const isMevProtectionEnabled =
+            selectIsMevProtectionEnabled(getState()) &&
+            selectIsMevProtectionFeatureEnabled(getState());
+        const sendResponse = await dispatch(
+            pushSendFormTransactionThunk({ selectedAccount, isMevProtectionEnabled }),
+        );
 
         if (sendResponse.payload === undefined) {
             return rejectWithValue({

--- a/suite-native/send/tsconfig.json
+++ b/suite-native/send/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../../suite-common/mev" },
         {
             "path": "../../suite-common/redux-utils"
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10589,6 +10589,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite-common/mev@workspace:*, @suite-common/mev@workspace:suite-common/mev":
+  version: 0.0.0-use.local
+  resolution: "@suite-common/mev@workspace:suite-common/mev"
+  dependencies:
+    "@suite-common/message-system": "workspace:*"
+    "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-core": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
 "@suite-common/platform-encryption-native@workspace:*, @suite-common/platform-encryption-native@workspace:suite-native/platform-encryption-native":
   version: 0.0.0-use.local
   resolution: "@suite-common/platform-encryption-native@workspace:suite-native/platform-encryption-native"
@@ -10971,7 +10982,6 @@ __metadata:
     "@reduxjs/toolkit": "npm:2.11.0"
     "@suite-common/bluetooth": "workspace:*"
     "@suite-common/fiat-services": "workspace:*"
-    "@suite-common/message-system": "workspace:*"
     "@suite-common/platform-encryption": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"
@@ -11059,6 +11069,7 @@ __metadata:
     "@reown/walletkit": "npm:^1.2.8"
     "@suite-common/analytics": "workspace:*"
     "@suite-common/connect-popup": "workspace:*"
+    "@suite-common/mev": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
@@ -12530,6 +12541,7 @@ __metadata:
     "@react-navigation/native-stack": "npm:7.5.1"
     "@reduxjs/toolkit": "npm:2.11.0"
     "@suite-common/analytics": "workspace:*"
+    "@suite-common/mev": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"
     "@suite-common/suite-sync": "workspace:*"
@@ -12610,6 +12622,7 @@ __metadata:
     "@suite-common/formatters": "workspace:*"
     "@suite-common/geolocation": "workspace:*"
     "@suite-common/message-system": "workspace:*"
+    "@suite-common/mev": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"
     "@suite-common/suite-sync": "workspace:*"
@@ -12846,6 +12859,7 @@ __metadata:
   dependencies:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@reduxjs/toolkit": "npm:2.11.0"
+    "@suite-common/mev": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
@@ -14700,6 +14714,7 @@ __metadata:
     "@suite-common/logger": "workspace:*"
     "@suite-common/message-system": "workspace:*"
     "@suite-common/metadata-types": "workspace:*"
+    "@suite-common/mev": "workspace:*"
     "@suite-common/platform-encryption": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/sentry": "workspace:*"


### PR DESCRIPTION
## Description

Remove circular dependency caused by importing `message-system` in `wallet-core`. We should not do that, [wallet-core should be farely minimal](https://satoshilabs.slack.com/archives/C0A4B5TB2GH/p1765901490955819), pure business logic, free of app-environment concerns such as message system.

Currently wallet-core is a huge leviathan of everything, but at least we can extract the MEV code away.

## Notes for QA

Test transaction with MEV turned on/off both on Suite Desktop & Mobile and  also check that networks without MEV work



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/mev-circular-dep&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/mev-circular-dep&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/mev-circular-dep&lookback=7)