### PR TITLE
fix(suite): rescan BT when entering CantSeeTrezorModal

### DIFF
--- a/packages/suite/src/components/connection/CantSeeTrezorModal.tsx
+++ b/packages/suite/src/components/connection/CantSeeTrezorModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { Column, H3, Modal, Paragraph } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
@@ -38,9 +38,15 @@ export const CantSeeTrezorModal = ({ onClose }: DontSeeYourTrezorModalProps) => 
         isBluetoothMode,
         toggleShouldPairAgain,
         toggleShowHints,
+        onReScanClick,
         notConnectedKnownDevices,
         notConnectedNearbyDevices,
     } = useConnectionGlobalModalContext();
+
+    // when this modal is displayed, scanning should start again in case it stopped due to timeout, so that user can act on the additional instructions
+    useEffect(() => {
+        onReScanClick();
+    }, [onReScanClick]);
 
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
 


### PR DESCRIPTION
## Notes for QA

Open Suite Desktop, keep TS7 **off**,  scan for trezors, and when it timeouts and you enter the screen (see issue screenshot), then turn it on in pairing mode.
It should connect. 

## Related Issue

Resolve #23849 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/BT-scanning&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/BT-scanning&lookback=7)