### PR TITLE
feat(suite-native): cardano staking view only

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -8,7 +8,7 @@ import {
     type NetworkSymbol,
 } from '@suite-common/wallet-config';
 import { Account, AccountKey } from '@suite-common/wallet-types';
-import { isTestnet, isUtxoBased } from '@suite-common/wallet-utils';
+import { isCardanoStakingActive, isTestnet, isUtxoBased } from '@suite-common/wallet-utils';
 import { DeviceState, StaticSessionId } from '@trezor/connect';
 
 import { formattedAccountTypeMap } from './accountsConstants';
@@ -292,6 +292,10 @@ export const selectSolAccountHasStaked = createMemoizedSelector([selectAccountBy
 
     return !!account.misc.solStakingAccounts?.length;
 });
+
+export const selectAdaAccountHasStaked = createMemoizedSelector([selectAccountByKey], account =>
+    isCardanoStakingActive(account),
+);
 
 export const selectAddressByNetworkAndPath = createMemoizedSelector(
     [

--- a/suite-common/wallet-core/src/stake/stakeUtils.ts
+++ b/suite-common/wallet-core/src/stake/stakeUtils.ts
@@ -1,6 +1,7 @@
 import { Account, WalletAccountTransaction } from '@suite-common/wallet-types';
 import {
     getStakingDataForNetwork,
+    isCardanoStakingActive,
     isPending,
     isSupportedStakingNetworkSymbol,
 } from '@suite-common/wallet-utils';
@@ -15,9 +16,7 @@ export const isAccountStakingActive = (
     if (!isSupportedStakingNetworkSymbol(account.symbol)) return false;
 
     if (account.networkType === 'cardano') {
-        const { isActive } = account.misc.staking;
-
-        return isActive;
+        return isCardanoStakingActive(account);
     }
 
     const {

--- a/suite-common/wallet-utils/src/cardanoStakingUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoStakingUtils.ts
@@ -39,6 +39,14 @@ export const getCardanoStakingSymbols = (networkSymbols: NetworkSymbol[]) =>
         return acc;
     }, [] as SupportedCardanoNetworkSymbols[]);
 
+export const isCardanoStakingActive = (account: Account | null) => {
+    if (!account?.misc || account.networkType !== 'cardano') return false;
+
+    const { isActive } = account.misc.staking;
+
+    return isActive;
+};
+
 const getAccountPoolId = (account?: Account) => {
     if (!account) return null;
     if (account.networkType !== 'cardano') return null;

--- a/suite-native/accounts/src/components/AccountsList/AccountsListStakingItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListStakingItem.tsx
@@ -1,10 +1,7 @@
 import { Account } from '@suite-common/wallet-types';
-import { RoundedIcon } from '@suite-native/atoms';
-import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
-import { Translation } from '@suite-native/intl';
-import { useNativeStyles } from '@trezor/styles';
 
-import { AccountsListItemBase } from './AccountsListItemBase';
+import { AdaAccountsListStakingItem } from './AdaAccountsListStakingItem';
+import { DefaultAccountsListStakingItem } from './DefaultAccountsListStakingItem';
 
 type AccountsListStakingItemProps = {
     account: Account;
@@ -16,42 +13,12 @@ type AccountsListStakingItemProps = {
     isLast?: boolean;
 };
 
-export const AccountsListStakingItem = ({
-    account,
-    stakingCryptoBalance,
-    isLast,
-    ...props
-}: AccountsListStakingItemProps) => {
-    const { utils } = useNativeStyles();
+export const AccountsListStakingItem = (props: AccountsListStakingItemProps) => {
+    const { account } = props;
 
-    return (
-        <AccountsListItemBase
-            {...props}
-            isLast={isLast}
-            showDivider={!isLast}
-            icon={
-                <RoundedIcon
-                    name="piggyBankFilled"
-                    color="iconSubdued"
-                    containerSize={utils.spacings.sp32}
-                />
-            }
-            title={<Translation id="accountList.staking" />}
-            mainValue={
-                <CryptoToFiatAmountFormatter
-                    value={stakingCryptoBalance}
-                    symbol={account.symbol}
-                    isBalance
-                />
-            }
-            secondaryValue={
-                <CryptoAmountFormatter
-                    value={stakingCryptoBalance}
-                    symbol={account.symbol}
-                    numberOfLines={1}
-                    adjustsFontSizeToFit
-                />
-            }
-        />
-    );
+    if (account.symbol === 'ada') {
+        return <AdaAccountsListStakingItem {...props} />;
+    }
+
+    return <DefaultAccountsListStakingItem {...props} />;
 };

--- a/suite-native/accounts/src/components/AccountsList/AdaAccountsListStakingItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AdaAccountsListStakingItem.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { Account } from '@suite-common/wallet-types';
+import { RoundedIcon } from '@suite-native/atoms';
+import { Icon } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+import { NativeStakingRootState } from '@suite-native/staking';
+import { selectIsCardanoStakedOutsideEverstake } from '@suite-native/staking/src/cardanoStakingSelectors';
+import { useNativeStyles } from '@trezor/styles';
+
+import { AccountsListItemBase } from './AccountsListItemBase';
+
+type AdaAccountsListStakingItemProps = {
+    account: Account;
+    stakingCryptoBalance: string;
+    onPress: () => void;
+
+    hasBackground?: boolean;
+    isFirst?: boolean;
+    isLast?: boolean;
+};
+
+export const AdaAccountsListStakingItem = ({
+    account,
+    stakingCryptoBalance,
+    isLast,
+    ...props
+}: AdaAccountsListStakingItemProps) => {
+    const { utils } = useNativeStyles();
+
+    const isStakedOutsideEverstake = useSelector((state: NativeStakingRootState) =>
+        selectIsCardanoStakedOutsideEverstake(state, account.key),
+    );
+
+    const icon = useMemo(
+        () =>
+            isStakedOutsideEverstake ? (
+                <Icon name="warning" color="iconAlertYellow" />
+            ) : (
+                <Icon name="check" color="iconPrimaryDefault" />
+            ),
+        [isStakedOutsideEverstake],
+    );
+
+    return (
+        <AccountsListItemBase
+            {...props}
+            isLast={isLast}
+            showDivider={!isLast}
+            icon={
+                <RoundedIcon
+                    name="piggyBankFilled"
+                    color="iconSubdued"
+                    containerSize={utils.spacings.sp32}
+                />
+            }
+            title={<Translation id="accountList.staking" />}
+            mainValue={icon}
+            secondaryValue={undefined}
+        />
+    );
+};

--- a/suite-native/accounts/src/components/AccountsList/DefaultAccountsListStakingItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/DefaultAccountsListStakingItem.tsx
@@ -1,0 +1,57 @@
+import { Account } from '@suite-common/wallet-types';
+import { RoundedIcon } from '@suite-native/atoms';
+import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
+import { Translation } from '@suite-native/intl';
+import { useNativeStyles } from '@trezor/styles';
+
+import { AccountsListItemBase } from './AccountsListItemBase';
+
+type DefaultAccountsListStakingItemProps = {
+    account: Account;
+    stakingCryptoBalance: string;
+    onPress: () => void;
+
+    hasBackground?: boolean;
+    isFirst?: boolean;
+    isLast?: boolean;
+};
+
+export const DefaultAccountsListStakingItem = ({
+    account,
+    stakingCryptoBalance,
+    isLast,
+    ...props
+}: DefaultAccountsListStakingItemProps) => {
+    const { utils } = useNativeStyles();
+
+    return (
+        <AccountsListItemBase
+            {...props}
+            isLast={isLast}
+            showDivider={!isLast}
+            icon={
+                <RoundedIcon
+                    name="piggyBankFilled"
+                    color="iconSubdued"
+                    containerSize={utils.spacings.sp32}
+                />
+            }
+            title={<Translation id="accountList.staking" />}
+            mainValue={
+                <CryptoToFiatAmountFormatter
+                    value={stakingCryptoBalance}
+                    symbol={account.symbol}
+                    isBalance
+                />
+            }
+            secondaryValue={
+                <CryptoAmountFormatter
+                    value={stakingCryptoBalance}
+                    symbol={account.symbol}
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
+                />
+            }
+        />
+    );
+};

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -29,6 +29,7 @@ import {
     getAccountTotalStakingBalance,
     getFiatRateKey,
     getFirstFreshAddress,
+    isCardanoStakingActive,
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
 import { doesCoinSupportStaking } from '@suite-native/staking';
@@ -131,8 +132,11 @@ export const getAccountListSections = (
 
     const tokens = filterKnownTokens(tokenDefinitions, account.symbol, account.tokens ?? []);
     const hasAnyKnownTokens = canHasTokens && !!tokens.length;
+
     const stakingBalance = getAccountTotalStakingBalance(account) ?? '0';
-    const hasStaking = doesCoinSupportStaking(account.symbol) && stakingBalance !== '0';
+
+    const hasStakingBalance = stakingBalance !== '0' || isCardanoStakingActive(account);
+    const hasStaking = doesCoinSupportStaking(account.symbol) && hasStakingBalance;
 
     if (canHasTokens) {
         sections.push({

--- a/suite-native/atoms/src/InlineAlertBox/InlineAlertBox.tsx
+++ b/suite-native/atoms/src/InlineAlertBox/InlineAlertBox.tsx
@@ -4,6 +4,8 @@ import { Icon, IconName } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { BoxProps } from '../Box';
+import { Button, ButtonProps } from '../Button/Button';
+import { HStack } from '../Stack';
 import { Text } from '../Text';
 import {
     InlineAlertBoxStyles,
@@ -11,8 +13,6 @@ import {
     variantToColorMap,
     variantToIconName,
 } from './presets';
-import { Button, ButtonProps } from '../Button/Button';
-import { HStack } from '../Stack';
 
 const alertWrapperStyle = prepareNativeStyle<
     Omit<InlineAlertBoxStyles, 'buttonColorScheme'> & { isButtonVisible: boolean }

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2232,11 +2232,21 @@ export const messages = {
             title: 'Staking',
         },
         staked: 'Staked',
+        stakedAutomatically: 'Staked automatically',
+        fullBalance: 'Full balance',
         rewards: 'Rewards',
         rewardsPerEpoch: 'Next estimated reward',
         apy: 'Annual percentage yield',
         stakingCanBeManaged: 'Staking can be currently managed only in',
         trezorDesktop: 'Trezor Suite for desktop or web.',
+        adaStaysFullyAccessuble: 'Your ADA stays fully accesible while earning rewards.',
+        infoBanner: {
+            providerReducingRewards:
+                'Your current provider is reducing ADA rewards. Update your provider on desktop and earn {apy}% APY.',
+            updateToNewProvider: `Update to our new provider, Everstake, and earn ~{apy}% APY. Your ADA with our previous provider is safe, and your rewards stay intact, though rates aren’t guaranteed.`,
+        },
+        notAvailable: 'Not available',
+        notAvailableShort: 'N/A',
         stakePendingCard: {
             totalStakePending: 'Total stake pending',
             addingToStakingPool: 'Adding to staking pool',

--- a/suite-native/module-staking-management/src/components/AutoStakedBalancesCard.tsx
+++ b/suite-native/module-staking-management/src/components/AutoStakedBalancesCard.tsx
@@ -1,0 +1,139 @@
+import { useSelector } from 'react-redux';
+
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { Box, Card, PressableOpacity, Text } from '@suite-native/atoms';
+import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
+import { Icon } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+import { NativeStakingRootState } from '@suite-native/staking';
+import { selectIsCardanoStakedOutsideEverstake } from '@suite-native/staking/src/cardanoStakingSelectors';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+const stakingItemStyle = prepareNativeStyle(utils => ({
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: utils.spacings.sp4,
+    paddingBottom: utils.spacings.sp8,
+}));
+
+const infoItemStyle = prepareNativeStyle(utils => ({
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: utils.spacings.sp8,
+    paddingTop: utils.spacings.sp16,
+}));
+
+const stakingWrapperStyle = prepareNativeStyle(utils => ({
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+    paddingBottom: utils.spacings.sp16,
+}));
+
+const separatorStyle = prepareNativeStyle(utils => ({
+    borderBottomWidth: utils.borders.widths.small,
+    borderBottomColor: utils.colors.borderElevation1,
+}));
+
+type AutoStakedBalancesCardProps = {
+    accountKey: string;
+    symbol: NetworkSymbol | null;
+    rewardsBalance: string | null;
+    apy: number | null;
+    handleToggleBottomSheet: (value: boolean) => void;
+};
+
+const CRYPTO_BALANCE_DECIMALS = 5;
+
+export const AutoStakedBalancesCard = ({
+    accountKey,
+    symbol,
+    rewardsBalance,
+    apy,
+    handleToggleBottomSheet,
+}: AutoStakedBalancesCardProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    const isAdaStakedOutsideEverstake = useSelector((state: NativeStakingRootState) =>
+        selectIsCardanoStakedOutsideEverstake(state, accountKey),
+    );
+
+    if (!symbol) return null;
+
+    return (
+        <PressableOpacity onPress={() => handleToggleBottomSheet(true)}>
+            <Card>
+                <Box style={applyStyle(stakingWrapperStyle)}>
+                    <Box flex={1}>
+                        <Box style={applyStyle(stakingItemStyle)}>
+                            <Icon name="check" color="textSubdued" size="medium" />
+                            <Text color="textSubdued" variant="label">
+                                <Translation id="staking.stakedAutomatically" />
+                            </Text>
+                        </Box>
+
+                        <Text color="textDefault" variant="titleSmall">
+                            <Translation id="staking.fullBalance" />
+                        </Text>
+                    </Box>
+                    <Box flex={1}>
+                        <Box style={applyStyle(stakingItemStyle)}>
+                            <Icon name="plusCircle" color="textSubdued" size="medium" />
+                            <Text color="textSubdued" variant="label">
+                                <Translation id="staking.rewards" />
+                            </Text>
+                        </Box>
+                        <CryptoAmountFormatter
+                            value={rewardsBalance}
+                            symbol={symbol}
+                            decimals={CRYPTO_BALANCE_DECIMALS}
+                            color="textSecondaryHighlight"
+                            variant="titleSmall"
+                        />
+                        <Box flexDirection="row">
+                            <Text color="textSubdued">≈</Text>
+                            <CryptoToFiatAmountFormatter
+                                value={rewardsBalance}
+                                symbol={symbol}
+                                color="textSubdued"
+                                isBalance
+                            />
+                        </Box>
+                    </Box>
+                </Box>
+                <Box style={applyStyle(separatorStyle)} />
+
+                <Box
+                    flexDirection="row"
+                    alignItems="center"
+                    justifyContent="space-between"
+                    paddingTop="sp16"
+                >
+                    <Text color="textSubdued">
+                        <Translation id="staking.apy" />
+                    </Text>
+                    <Text>
+                        {!isAdaStakedOutsideEverstake && apy ? (
+                            `${apy}%`
+                        ) : (
+                            <Translation id="staking.notAvailable" />
+                        )}
+                    </Text>
+                </Box>
+
+                <Box paddingTop="sp16">
+                    <Box style={applyStyle(separatorStyle)} />
+
+                    <Box style={applyStyle(infoItemStyle)}>
+                        <Icon name="info" color="textSubdued" size="mediumLarge" />
+                        <Box flexShrink={1}>
+                            <Text color="textSubdued" variant="hint" numberOfLines={0}>
+                                <Translation id="staking.adaStaysFullyAccessuble" />
+                            </Text>
+                        </Box>
+                    </Box>
+                </Box>
+            </Card>
+        </PressableOpacity>
+    );
+};

--- a/suite-native/module-staking-management/src/components/CardanoStakingInfoBanner.tsx
+++ b/suite-native/module-staking-management/src/components/CardanoStakingInfoBanner.tsx
@@ -1,0 +1,44 @@
+import { useSelector } from 'react-redux';
+
+import { AccountsRootState } from '@suite-common/wallet-core';
+import { InlineAlertBox } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { NativeStakingRootState, selectAPYByAccountKey } from '@suite-native/staking';
+import {
+    selectIsCardanoStakedOutsideEverstake,
+    selectIsCardanoStakedWithFiveBinaries,
+} from '@suite-native/staking/src/cardanoStakingSelectors';
+
+type CardanoStakingInfoBannerProps = {
+    accountKey: string;
+};
+
+export const CardanoStakingInfoBanner = ({ accountKey }: CardanoStakingInfoBannerProps) => {
+    const apy = useSelector((state: NativeStakingRootState) =>
+        selectAPYByAccountKey(state, accountKey),
+    );
+
+    const isStakedWithFiveBinaries = useSelector((state: AccountsRootState) =>
+        selectIsCardanoStakedWithFiveBinaries(state, accountKey),
+    );
+
+    const isStakedOutsideEverstake = useSelector((state: NativeStakingRootState) =>
+        selectIsCardanoStakedOutsideEverstake(state, accountKey),
+    );
+
+    if (!isStakedWithFiveBinaries && !isStakedOutsideEverstake) {
+        return null;
+    }
+
+    const apyValue = apy ?? <Translation id="staking.notAvailableShort" />;
+    const translationId = isStakedWithFiveBinaries
+        ? 'staking.infoBanner.providerReducingRewards'
+        : 'staking.infoBanner.updateToNewProvider';
+
+    return (
+        <InlineAlertBox
+            variant="warning"
+            title={<Translation id={translationId} values={{ apy: apyValue }} />}
+        />
+    );
+};

--- a/suite-native/module-staking-management/src/components/ManualStakedBalancesCard.tsx
+++ b/suite-native/module-staking-management/src/components/ManualStakedBalancesCard.tsx
@@ -1,0 +1,130 @@
+import { useSelector } from 'react-redux';
+
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { Box, Card, PressableOpacity, Text } from '@suite-native/atoms';
+import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
+import { Icon } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+import { NativeStakingRootState, selectStakedBalanceByAccountKey } from '@suite-native/staking';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+const stakingItemStyle = prepareNativeStyle(utils => ({
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: utils.spacings.sp4,
+    paddingBottom: utils.spacings.sp8,
+}));
+
+const stakingWrapperStyle = prepareNativeStyle(utils => ({
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+    paddingBottom: utils.spacings.sp16,
+}));
+
+const separatorStyle = prepareNativeStyle(utils => ({
+    borderBottomWidth: utils.borders.widths.small,
+    borderBottomColor: utils.colors.borderElevation1,
+}));
+
+type ManualStakedBalancesCardProps = {
+    accountKey: string;
+    symbol: NetworkSymbol | null;
+    rewardsBalance: string | null;
+    apy: number | null;
+    handleToggleBottomSheet: (value: boolean) => void;
+};
+
+const CRYPTO_BALANCE_DECIMALS = 5;
+
+export const ManualStakedBalancesCard = ({
+    accountKey,
+    symbol,
+    rewardsBalance,
+    apy,
+    handleToggleBottomSheet,
+}: ManualStakedBalancesCardProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    const stakedBalance = useSelector((state: NativeStakingRootState) =>
+        selectStakedBalanceByAccountKey(state, accountKey),
+    );
+
+    if (!symbol) return null;
+
+    const rewardsTitle = ['sol', 'dsol'].includes(symbol) ? (
+        <Translation id="staking.rewardsPerEpoch" />
+    ) : (
+        <Translation id="staking.rewards" />
+    );
+
+    return (
+        <PressableOpacity onPress={() => handleToggleBottomSheet(true)}>
+            <Card>
+                <Box style={applyStyle(stakingWrapperStyle)}>
+                    <Box flex={1}>
+                        <Box style={applyStyle(stakingItemStyle)}>
+                            <Icon name="lock" color="textSubdued" size="medium" />
+                            <Text color="textSubdued" variant="label">
+                                <Translation id="staking.staked" />
+                            </Text>
+                        </Box>
+                        <CryptoAmountFormatter
+                            value={stakedBalance}
+                            symbol={symbol}
+                            decimals={CRYPTO_BALANCE_DECIMALS}
+                            color="textDefault"
+                            variant="titleSmall"
+                        />
+                        <Box flexDirection="row">
+                            <Text color="textSubdued">≈</Text>
+                            <CryptoToFiatAmountFormatter
+                                value={stakedBalance}
+                                symbol={symbol}
+                                color="textSubdued"
+                                isBalance
+                            />
+                        </Box>
+                    </Box>
+                    <Box flex={1}>
+                        <Box style={applyStyle(stakingItemStyle)}>
+                            <Icon name="plusCircle" color="textSubdued" size="medium" />
+                            <Text color="textSubdued" variant="label">
+                                {rewardsTitle}
+                            </Text>
+                        </Box>
+                        <CryptoAmountFormatter
+                            value={rewardsBalance}
+                            symbol={symbol}
+                            decimals={CRYPTO_BALANCE_DECIMALS}
+                            color="textSecondaryHighlight"
+                            variant="titleSmall"
+                        />
+                        <Box flexDirection="row">
+                            <Text color="textSubdued">≈</Text>
+                            <CryptoToFiatAmountFormatter
+                                value={rewardsBalance}
+                                symbol={symbol}
+                                color="textSubdued"
+                                isBalance
+                            />
+                        </Box>
+                    </Box>
+                </Box>
+                <Box style={applyStyle(separatorStyle)} />
+
+                <Box
+                    flexDirection="row"
+                    alignItems="center"
+                    justifyContent="space-between"
+                    paddingTop="sp16"
+                >
+                    <Text color="textSubdued">
+                        <Translation id="staking.apy" />
+                    </Text>
+                    <Text>{apy ? `${apy}%` : <Translation id="staking.notAvailable" />}</Text>
+                </Box>
+            </Card>
+        </PressableOpacity>
+    );
+};

--- a/suite-native/module-staking-management/src/components/StakingBalancesOverviewCard.tsx
+++ b/suite-native/module-staking-management/src/components/StakingBalancesOverviewCard.tsx
@@ -1,50 +1,25 @@
 import { useSelector } from 'react-redux';
 
 import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
-import { Box, Card, PressableOpacity, Text } from '@suite-native/atoms';
-import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
-import { Icon } from '@suite-native/icons';
-import { Translation } from '@suite-native/intl';
 import {
+    AUTO_STAKED_SYMBOLS,
     NativeStakingRootState,
     selectAPYByAccountKey,
     selectRewardsBalanceByAccountKey,
-    selectStakedBalanceByAccountKey,
 } from '@suite-native/staking';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
-const stakingItemStyle = prepareNativeStyle(utils => ({
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: utils.spacings.sp4,
-    paddingBottom: utils.spacings.sp8,
-}));
-
-const stakingWrapperStyle = prepareNativeStyle(utils => ({
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'flex-start',
-    paddingBottom: utils.spacings.sp16,
-}));
-
-const separatorStyle = prepareNativeStyle(utils => ({
-    borderBottomWidth: utils.borders.widths.small,
-    borderBottomColor: utils.colors.borderElevation1,
-}));
+import { AutoStakedBalancesCard } from './AutoStakedBalancesCard';
+import { ManualStakedBalancesCard } from './ManualStakedBalancesCard';
 
 type StakingBalancesCardProps = {
     accountKey: string;
     handleToggleBottomSheet: (value: boolean) => void;
 };
 
-const CRYPTO_BALANCE_DECIMALS = 5;
-
 export const StakingBalancesOverviewCard = ({
     accountKey,
     handleToggleBottomSheet,
 }: StakingBalancesCardProps) => {
-    const { applyStyle } = useNativeStyles();
-
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
@@ -53,88 +28,29 @@ export const StakingBalancesOverviewCard = ({
         selectAPYByAccountKey(state, accountKey),
     );
 
-    const stakedBalance = useSelector((state: NativeStakingRootState) =>
-        selectStakedBalanceByAccountKey(state, accountKey),
-    );
     const rewardsBalance = useSelector((state: NativeStakingRootState) =>
         selectRewardsBalanceByAccountKey(state, accountKey),
     );
 
     if (!symbol) return null;
 
-    const rewardsTitle = ['sol', 'dsol'].includes(symbol) ? (
-        <Translation id="staking.rewardsPerEpoch" />
+    const isAutoStaked = AUTO_STAKED_SYMBOLS.includes(symbol);
+
+    return isAutoStaked ? (
+        <AutoStakedBalancesCard
+            accountKey={accountKey}
+            symbol={symbol}
+            rewardsBalance={rewardsBalance}
+            apy={apy}
+            handleToggleBottomSheet={handleToggleBottomSheet}
+        />
     ) : (
-        <Translation id="staking.rewards" />
-    );
-
-    return (
-        <PressableOpacity onPress={() => handleToggleBottomSheet(true)}>
-            <Card>
-                <Box style={applyStyle(stakingWrapperStyle)}>
-                    <Box flex={1}>
-                        <Box style={applyStyle(stakingItemStyle)}>
-                            <Icon name="lock" color="textSubdued" size="medium" />
-                            <Text color="textSubdued" variant="label">
-                                <Translation id="staking.staked" />
-                            </Text>
-                        </Box>
-                        <CryptoAmountFormatter
-                            value={stakedBalance}
-                            symbol={symbol}
-                            decimals={CRYPTO_BALANCE_DECIMALS}
-                            color="textDefault"
-                            variant="titleSmall"
-                        />
-                        <Box flexDirection="row">
-                            <Text color="textSubdued">≈</Text>
-                            <CryptoToFiatAmountFormatter
-                                value={stakedBalance}
-                                symbol={symbol}
-                                color="textSubdued"
-                                isBalance
-                            />
-                        </Box>
-                    </Box>
-                    <Box flex={1}>
-                        <Box style={applyStyle(stakingItemStyle)}>
-                            <Icon name="plusCircle" color="textSubdued" size="medium" />
-                            <Text color="textSubdued" variant="label">
-                                {rewardsTitle}
-                            </Text>
-                        </Box>
-                        <CryptoAmountFormatter
-                            value={rewardsBalance}
-                            symbol={symbol}
-                            decimals={CRYPTO_BALANCE_DECIMALS}
-                            color="textSecondaryHighlight"
-                            variant="titleSmall"
-                        />
-                        <Box flexDirection="row">
-                            <Text color="textSubdued">≈</Text>
-                            <CryptoToFiatAmountFormatter
-                                value={rewardsBalance}
-                                symbol={symbol}
-                                color="textSubdued"
-                                isBalance
-                            />
-                        </Box>
-                    </Box>
-                </Box>
-                <Box style={applyStyle(separatorStyle)} />
-
-                <Box
-                    flexDirection="row"
-                    alignItems="center"
-                    justifyContent="space-between"
-                    paddingTop="sp16"
-                >
-                    <Text color="textSubdued">
-                        <Translation id="staking.apy" />
-                    </Text>
-                    <Text>{apy}%</Text>
-                </Box>
-            </Card>
-        </PressableOpacity>
+        <ManualStakedBalancesCard
+            accountKey={accountKey}
+            symbol={symbol}
+            rewardsBalance={rewardsBalance}
+            apy={apy}
+            handleToggleBottomSheet={handleToggleBottomSheet}
+        />
     );
 };

--- a/suite-native/module-staking-management/src/components/StakingInfo.tsx
+++ b/suite-native/module-staking-management/src/components/StakingInfo.tsx
@@ -4,6 +4,7 @@ import { useOpenLink } from '@suite-native/link';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { SUITE_URL } from '@trezor/urls';
 
+import { CardanoStakingInfoBanner } from './CardanoStakingInfoBanner';
 import { StakeClaimableCard } from './StakeClaimableCard';
 import { StakePendingCard } from './StakePendingCard';
 import { StakingBalancesOverviewCard } from './StakingBalancesOverviewCard';
@@ -38,6 +39,8 @@ export const StakingInfo = ({ accountKey }: StakingInfoProps) => {
             <StakePendingCard accountKey={accountKey} handleToggleBottomSheet={openModal} />
 
             <StakeClaimableCard accountKey={accountKey} handleToggleBottomSheet={openModal} />
+
+            <CardanoStakingInfoBanner accountKey={accountKey} />
 
             <StakingBalancesOverviewCard
                 accountKey={accountKey}

--- a/suite-native/staking/src/cardanoStakingSelectors.ts
+++ b/suite-native/staking/src/cardanoStakingSelectors.ts
@@ -1,0 +1,87 @@
+import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    AccountsRootState,
+    selectAccountByKey,
+    selectCardanoPoolsInfo,
+    selectDeviceAccounts,
+} from '@suite-common/wallet-core';
+import {
+    getStakingDataForNetwork,
+    isCardanoStakedOutsideEverstake,
+    isCardanoStakedWithFiveBinaries,
+    isCardanoStakingActive,
+} from '@suite-common/wallet-utils';
+
+import { NativeStakingRootState } from './types';
+
+export const createMemoizedSelector = createWeakMapSelector.withTypes<NativeStakingRootState>();
+
+export const selectVisibleDeviceCardanoAccountsWithStakingByNetworkSymbol = createMemoizedSelector(
+    [selectDeviceAccounts, (_state, symbol: NetworkSymbol) => symbol],
+    accounts =>
+        returnStableArrayIfEmpty(
+            accounts.filter(
+                account =>
+                    account.visible && account.symbol === 'ada' && isCardanoStakingActive(account),
+            ),
+        ),
+);
+
+export const selectCardanoStakedBalanceByAccountKey = (
+    state: AccountsRootState,
+    accountKey: string,
+) => {
+    const account = selectAccountByKey(state, accountKey);
+    if (!account || account.networkType !== 'cardano') return null;
+
+    const stakingData = getStakingDataForNetwork(account);
+
+    return stakingData?.autocompoundBalance ?? '0';
+};
+
+export const selectCardanoRewardsBalanceByAccountKey = (
+    state: AccountsRootState,
+    accountKey: string,
+) => {
+    const account = selectAccountByKey(state, accountKey);
+    if (!account || account.networkType !== 'cardano') return null;
+
+    const stakingData = getStakingDataForNetwork(account);
+
+    return stakingData?.restakedReward ?? '0';
+};
+
+export const selectCardanoTotalStakePendingByAccountKey = (
+    state: AccountsRootState,
+    accountKey: string,
+) => {
+    const account = selectAccountByKey(state, accountKey);
+    if (!account || account.networkType !== 'cardano') return null;
+
+    const stakingData = getStakingDataForNetwork(account);
+
+    return stakingData?.totalPendingStakeBalance ?? '0';
+};
+
+export const selectIsCardanoStakedWithFiveBinaries = (
+    state: AccountsRootState,
+    accountKey: string,
+) => {
+    const account = selectAccountByKey(state, accountKey);
+    if (!account || account.networkType !== 'cardano') return false;
+
+    return isCardanoStakedWithFiveBinaries(account);
+};
+
+export const selectIsCardanoStakedOutsideEverstake = (
+    state: NativeStakingRootState,
+    accountKey: string,
+) => {
+    const account = selectAccountByKey(state, accountKey);
+    if (!account || account.networkType !== 'cardano') return false;
+
+    const cardanoStakingPool = selectCardanoPoolsInfo(state);
+
+    return isCardanoStakedOutsideEverstake(account, cardanoStakingPool);
+};

--- a/suite-native/staking/src/selectors.ts
+++ b/suite-native/staking/src/selectors.ts
@@ -1,6 +1,7 @@
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import {
     selectAccountByKey,
+    selectAdaAccountHasStaked,
     selectPoolStatsApyData,
     selectSolAccountHasStaked,
 } from '@suite-common/wallet-core';
@@ -11,6 +12,12 @@ import {
 } from '@suite-common/wallet-utils';
 import { exhaustive } from '@trezor/type-utils';
 
+import {
+    selectCardanoRewardsBalanceByAccountKey,
+    selectCardanoStakedBalanceByAccountKey,
+    selectCardanoTotalStakePendingByAccountKey,
+    selectVisibleDeviceCardanoAccountsWithStakingByNetworkSymbol,
+} from './cardanoStakingSelectors';
 import {
     selectEthereumAccountHasStaking,
     selectEthereumCanClaimByAccountKey,
@@ -53,6 +60,8 @@ export const selectDeviceAccountsWithStaking = (
         case 'dsol':
         case 'sol':
             return selectVisibleDeviceSolanaAccountsWithStakingByNetworkSymbol(state, 'sol');
+        case 'ada':
+            return selectVisibleDeviceCardanoAccountsWithStakingByNetworkSymbol(state, 'ada');
         default:
             return exhaustive(symbol);
     }
@@ -78,6 +87,8 @@ export const getAccountCryptoBalanceWithStaking = (account: Account | null) => {
         case 'dsol':
         case 'sol':
             return getSolanaCryptoBalanceWithStaking(account);
+        case 'ada':
+            return account.formattedBalance;
         default:
             return exhaustive(account.symbol);
     }
@@ -108,6 +119,8 @@ export const selectAccountHasStaking = (state: NativeStakingRootState, accountKe
         case 'dsol':
         case 'sol':
             return selectSolAccountHasStaked(state, accountKey);
+        case 'ada':
+            return selectAdaAccountHasStaked(state, accountKey);
         default:
             return exhaustive(symbol);
     }
@@ -131,6 +144,8 @@ export const selectIsStakePendingByAccountKey = (
         case 'dsol':
         case 'sol':
             return selectSolanaIsStakePendingByAccountKey(state, accountKey);
+        case 'ada':
+            return false;
         default:
             return exhaustive(symbol);
     }
@@ -154,6 +169,8 @@ export const selectIsStakeConfirmingByAccountKey = (
         case 'dsol':
         case 'sol':
             return false; // there are no pending txns for solana staking;
+        case 'ada':
+            return false;
         default:
             return exhaustive(symbol);
     }
@@ -187,6 +204,8 @@ export const selectStakedBalanceByAccountKey = (
         case 'dsol':
         case 'sol':
             return selectSolanaStakedBalanceByAccountKey(state, accountKey);
+        case 'ada':
+            return selectCardanoStakedBalanceByAccountKey(state, accountKey);
         default:
             return exhaustive(symbol);
     }
@@ -211,6 +230,8 @@ export const selectRewardsBalanceByAccountKey = (
         case 'sol':
             // on solana we show rewards per one epoch
             return selectExpectedRewardsForEpoch(state, accountKey);
+        case 'ada':
+            return selectCardanoRewardsBalanceByAccountKey(state, accountKey);
         default:
             return exhaustive(symbol);
     }
@@ -234,6 +255,8 @@ export const selectTotalStakePendingByAccountKey = (
         case 'dsol':
         case 'sol':
             return selectSolanaTotalStakePendingByAccountKey(state, accountKey);
+        case 'ada':
+            return selectCardanoTotalStakePendingByAccountKey(state, accountKey);
         default:
             return exhaustive(symbol);
     }
@@ -257,6 +280,8 @@ export const selectClaimableAmountByAccountKey = (
         case 'dsol':
         case 'sol':
             return selectSolanaClaimableAmountByAccountKey(state, accountKey);
+        case 'ada':
+            return '0';
         default:
             return exhaustive(symbol);
     }
@@ -280,6 +305,8 @@ export const selectCanClaimByAccountKey = (
         case 'dsol':
         case 'sol':
             return selectSolanaCanClaimByAccountKey(state, accountKey);
+        case 'ada':
+            return false;
         default:
             return exhaustive(symbol);
     }

--- a/suite-native/staking/src/utils.ts
+++ b/suite-native/staking/src/utils.ts
@@ -1,8 +1,17 @@
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { isArrayMember } from '@trezor/utils';
 
-const stakingCoins = ['eth', 'thod', 'tsep', 'sol', 'dsol'] as const satisfies NetworkSymbol[];
+const stakingCoins = [
+    'eth',
+    'thod',
+    'tsep',
+    'sol',
+    'dsol',
+    'ada',
+] as const satisfies NetworkSymbol[];
 type NetworkSymbolWithStaking = (typeof stakingCoins)[number];
 
 export const doesCoinSupportStaking = (symbol: NetworkSymbol): symbol is NetworkSymbolWithStaking =>
     isArrayMember(symbol, stakingCoins);
+
+export const AUTO_STAKED_SYMBOLS: NetworkSymbol[] = ['ada'] as const;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enabled Cardano view-only staking on mobile and added update provider info to the staking dashboard. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23178

## Screenshots:
<img width="800" height="1658" alt="image" src="https://github.com/user-attachments/assets/c9162630-286e-4228-904b-49c3806c8967" />
<img width="848" height="970" alt="image" src="https://github.com/user-attachments/assets/03ef255e-007c-4c1c-96f4-9a7f15f1495b" />
<img width="832" height="1150" alt="image" src="https://github.com/user-attachments/assets/0eb51d54-75e4-4fc9-ae6e-11785f082806" />


