### PR TITLE
fix(suite-desktop): catch windows hello unavailable errors

### DIFF
--- a/packages/suite-desktop-core/src/modules/bioAuthModule.ts
+++ b/packages/suite-desktop-core/src/modules/bioAuthModule.ts
@@ -147,7 +147,11 @@ class BioAuthWindows extends BioAuth {
     isAvailable() {
         if (!this.winHello) throw new Error('WinHelloManager is not initialized');
 
-        return this.winHello.isHelloAvailable();
+        try {
+            return this.winHello.isHelloAvailable();
+        } catch {
+            return Promise.resolve(false);
+        }
     }
 
     validate(message?: string) {


### PR DESCRIPTION
## Description

Catch errors from windows hello native code, [as it was before](https://github.com/trezor/trezor-suite/blob/89fe8f0438ce6b1bee439956ada1adbefd6c8106/packages/suite-desktop-core/src/modules/bioAuthModule.ts#L56-L68) PR [#21549](https://github.com/trezor/trezor-suite/pull/21549)

We do not want to log to sentry that windows hello is unavailable.

Also, I fear that the sentry errors might have been runtime crashes. I don't know how far the crash propagates, probably not that far; with only thunk crashing, but who knows.

## Related Issue

Will resolve [sentry issue](https://satoshilabs.sentry.io/issues/7102091469/events/044691cda726437f877adb5633282d66/events/?project=5193825&referrer=event-or-group-header)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/windows-henlo-errors&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/windows-henlo-errors&lookback=7)