### PR TITLE
fix(ci): remove docker image after transport-bluetooth build

### DIFF
--- a/.github/workflows/build-transport-bluetooth-binary.yml
+++ b/.github/workflows/build-transport-bluetooth-binary.yml
@@ -30,14 +30,8 @@ jobs:
           docker build . -f ./scripts/Dockerfile -t trezor-bluetooth-image --build-arg BUILD_VERSION_TAG=$BUILD_VERSION_TAG
           docker create --name trezor-bluetooth-container trezor-bluetooth-image
           docker cp trezor-bluetooth-container:/output/. ../suite-data/files/bin/bluetooth
-
-      - name: free disk space
-        run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          sudo apt clean
-          docker rmi $(docker image ls -aq)
-          df -h
+          docker rm trezor-bluetooth-container
+          docker rmi trezor-bluetooth-image
 
       - name: Upload binaries as artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fix for https://github.com/trezor/trezor-suite/pull/23876  as it [throws](https://github.com/trezor/trezor-suite/actions/runs/20300501998/job/58304642030)
```
Error response from daemon: conflict: unable to delete 24571dbe8762 (must be forced) 
image is being used by stopped container cdff211b0b88
```

also im removing whole "free disk space step" since we are not doing any apt installs here. hopefully removing docker image and container will be enough.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ci-bt-build&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ci-bt-build&lookback=7)