### PR TITLE
Unit tests should not cancel whole matrix on error

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -112,6 +112,7 @@ jobs:
     needs: setup-and-cache
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    continue-on-error: true
     strategy:
         matrix:
             test-task: [suite, native]


### PR DESCRIPTION
Allow other tasks from unit tests matrix to continue when one of them fails.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=tests-ci-continue-on-error&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=tests-ci-continue-on-error&lookback=7)