### PR TITLE
fix: add mev-protection to arb

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -168,6 +168,7 @@ export const networks = {
             'nfts',
             'coin-definitions',
             'nft-definitions',
+            'mev-protection',
             'eip1559',
             'graph',
         ],


### PR DESCRIPTION
Adds MEV protection flag to the Arbitrum network configuration.

## Notes for QA

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23978



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=arb-mev-protection&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=arb-mev-protection&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=arb-mev-protection&lookback=7)