### PR TITLE
Improve sell flow UX

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2443,6 +2443,12 @@ export const messages = {
                 upTo30Seconds: 'This may take up to 30 seconds.',
                 startOver:
                     'If you didn’t finish all steps on the provider’s site, go back and start a new sell. Your funds are safe.',
+                cannotBeCompletedAlert: {
+                    title: 'Your sell couldn’t be completed',
+                    description:
+                        'We didn’t receive confirmation from the provider. Your funds are safe in your account.',
+                    button: 'Start a new sell',
+                },
             },
         },
         tradingExchangeApprovalScreen: {

--- a/suite-native/module-trading/src/components/sell/ProviderConfirmation/ConfirmationFailed.tsx
+++ b/suite-native/module-trading/src/components/sell/ProviderConfirmation/ConfirmationFailed.tsx
@@ -1,0 +1,30 @@
+import { FadeIn, FadeOut } from 'react-native-reanimated';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { AnimatedBox, FullAlertBox } from '@suite-native/atoms';
+import { Translation, useTranslate } from '@suite-native/intl';
+
+export const ConfirmationFailed = () => {
+    const { translate } = useTranslate();
+    const { goBack } = useNavigation();
+
+    return (
+        <AnimatedBox entering={FadeIn} exiting={FadeOut} paddingTop="sp16">
+            <FullAlertBox
+                title={
+                    <Translation id="moduleTrading.tradingSellPreviewScreen.providerStatus.cannotBeCompletedAlert.title" />
+                }
+                description={
+                    <Translation id="moduleTrading.tradingSellPreviewScreen.providerStatus.cannotBeCompletedAlert.description" />
+                }
+                primaryButtonLabel={translate(
+                    'moduleTrading.tradingSellPreviewScreen.providerStatus.cannotBeCompletedAlert.button',
+                )}
+                onPressPrimaryButton={goBack}
+                iconName="info"
+                variant="neutral"
+            />
+        </AnimatedBox>
+    );
+};

--- a/suite-native/module-trading/src/components/sell/ProviderConfirmation/ConfirmationInProgress.tsx
+++ b/suite-native/module-trading/src/components/sell/ProviderConfirmation/ConfirmationInProgress.tsx
@@ -1,0 +1,47 @@
+import { FadeIn, FadeOut } from 'react-native-reanimated';
+
+import { AnimatedBox, InlineAlertBox } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { WaitingCard, type WaitingCardProps } from '@suite-native/trading-atoms';
+import { ProviderConfirmationStatus } from '@suite-native/trading-types';
+
+export type ConfirmationInProgressProps = {
+    status: ProviderConfirmationStatus;
+    loadingState: WaitingCardProps['loadingState'];
+};
+export const ConfirmationInProgress = ({ status, loadingState }: ConfirmationInProgressProps) => {
+    const isClosedIncomplete = status === 'window_closed_incomplete';
+
+    const title = isClosedIncomplete ? (
+        <Translation id="moduleTrading.tradingSellPreviewScreen.providerStatus.confirming" />
+    ) : (
+        <Translation id="moduleTrading.tradingSellPreviewScreen.providerStatus.waitingForAddress" />
+    );
+
+    return (
+        <WaitingCard
+            title={title}
+            subtitle={
+                <Translation id="moduleTrading.tradingSellPreviewScreen.providerStatus.upTo30Seconds" />
+            }
+            loadingState={loadingState}
+        >
+            {isClosedIncomplete && (
+                <AnimatedBox
+                    entering={FadeIn}
+                    exiting={FadeOut}
+                    alignSelf="stretch"
+                    paddingTop="sp16"
+                >
+                    <InlineAlertBox
+                        title={
+                            <Translation id="moduleTrading.tradingSellPreviewScreen.providerStatus.startOver" />
+                        }
+                        iconName="info"
+                        variant="info"
+                    />
+                </AnimatedBox>
+            )}
+        </WaitingCard>
+    );
+};

--- a/suite-native/module-trading/src/components/sell/ProviderConfirmation/ProviderConfirmationStatusInfo.tsx
+++ b/suite-native/module-trading/src/components/sell/ProviderConfirmation/ProviderConfirmationStatusInfo.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+
+import { type WaitingCardProps } from '@suite-native/trading-atoms';
+import { ProviderConfirmationStatus } from '@suite-native/trading-types';
+
+import { ConfirmationFailed } from './ConfirmationFailed';
+import { ConfirmationInProgress } from './ConfirmationInProgress';
+import { useProviderConfirmationStatus } from '../../../hooks/general/providerConfirmation/useProviderConfirmationStatus';
+
+const NOT_VISIBLE_STATUSES: ProviderConfirmationStatus[] = [
+    'confirmation_success',
+    'window_opened',
+    'inactive',
+] as const;
+
+const PENDING_ANIMATION_STATUSES: ProviderConfirmationStatus[] = [
+    'window_closed_with_success',
+    'window_closed_incomplete',
+] as const;
+
+const FINAL_ANIMATION_STATUSES: ProviderConfirmationStatus[] = [
+    'confirmation_success',
+    'confirmation_failed',
+] as const;
+
+const RESOLVE_ANIMATION_DURATION_MS = 2_000;
+
+export const ProviderConfirmationStatusInfo = () => {
+    const status = useProviderConfirmationStatus();
+
+    const [displayStatus, setDisplayStatus] = useState(status);
+    const [loadingState, setLoadingState] = useState<WaitingCardProps['loadingState']>('idle');
+
+    useEffect(() => {
+        if (
+            PENDING_ANIMATION_STATUSES.includes(displayStatus) &&
+            FINAL_ANIMATION_STATUSES.includes(status)
+        ) {
+            setLoadingState(status === 'confirmation_success' ? 'success' : 'error');
+            const timeout = setTimeout(() => {
+                setDisplayStatus(status);
+            }, RESOLVE_ANIMATION_DURATION_MS);
+
+            return () => clearTimeout(timeout);
+        } else {
+            setLoadingState('idle');
+            setDisplayStatus(status);
+
+            return () => {};
+        }
+    }, [displayStatus, status]);
+
+    if (NOT_VISIBLE_STATUSES.includes(displayStatus)) {
+        return null;
+    }
+
+    if (displayStatus === 'confirmation_failed') {
+        return <ConfirmationFailed />;
+    }
+
+    return <ConfirmationInProgress status={displayStatus} loadingState={loadingState} />;
+};

--- a/suite-native/module-trading/src/components/sell/ProviderConfirmation/ProviderStatusDevButtons.tsx
+++ b/suite-native/module-trading/src/components/sell/ProviderConfirmation/ProviderStatusDevButtons.tsx
@@ -1,0 +1,68 @@
+import { Button, HStack, VStack } from '@suite-native/atoms';
+import { DebugModeView } from '@suite-native/trading-debug';
+
+import { useDispatchProviderConfirmationStatus } from '../../../hooks/general/providerConfirmation/useDispatchProviderConfirmationStatus';
+
+const ProviderStatusDevButtonsContent = () => {
+    const dispatchHelper = useDispatchProviderConfirmationStatus();
+
+    return (
+        <VStack spacing="sp4" alignItems="center">
+            <HStack>
+                <Button
+                    colorScheme="redElevation0"
+                    size="tiny"
+                    onPress={() => {
+                        dispatchHelper('window_closed_incomplete');
+                    }}
+                >
+                    incomplete
+                </Button>
+                <Button
+                    colorScheme="blueElevation0"
+                    size="tiny"
+                    onPress={() => {
+                        dispatchHelper('window_closed_with_success');
+                    }}
+                >
+                    with_success
+                </Button>
+                <Button
+                    colorScheme="redBold"
+                    size="tiny"
+                    onPress={() => {
+                        dispatchHelper('confirmation_failed');
+                    }}
+                >
+                    failed
+                </Button>
+                <Button
+                    size="tiny"
+                    onPress={() => {
+                        dispatchHelper('confirmation_success');
+                    }}
+                >
+                    success
+                </Button>
+            </HStack>
+            <HStack>
+                <Button
+                    colorScheme="yellowElevation0"
+                    size="tiny"
+                    onPress={() => {
+                        dispatchHelper('inactive');
+                        dispatchHelper('window_opened');
+                    }}
+                >
+                    restart flow
+                </Button>
+            </HStack>
+        </VStack>
+    );
+};
+
+export const ProviderStatusDevButtons = () => (
+    <DebugModeView>
+        <ProviderStatusDevButtonsContent />
+    </DebugModeView>
+);

--- a/suite-native/module-trading/src/components/sell/ProviderConfirmation/__tests__/ConfirmationFailed.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/ProviderConfirmation/__tests__/ConfirmationFailed.comp.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+
+import { ConfirmationFailed } from '../ConfirmationFailed';
+
+const mockNavigateBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => ({
+        goBack: mockNavigateBack,
+    }),
+}));
+
+describe('ConfirmationFailed', () => {
+    const renderConfirmationFailed = () => renderWithBasicProvider(<ConfirmationFailed />);
+
+    it('should navigate back on button press', () => {
+        const { getByText } = renderConfirmationFailed();
+
+        fireEvent.press(getByText('Start a new sell'));
+
+        expect(mockNavigateBack).toHaveBeenCalledTimes(1);
+    });
+});

--- a/suite-native/module-trading/src/components/sell/ProviderConfirmation/__tests__/ProviderConfirmationStatusInfo.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/ProviderConfirmation/__tests__/ProviderConfirmationStatusInfo.comp.test.tsx
@@ -1,0 +1,45 @@
+import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { ProviderConfirmationStatus } from '@suite-native/trading-types';
+
+import { ProviderConfirmationStatusInfo } from '../ProviderConfirmationStatusInfo';
+
+let mockUseProviderConfirmationStatus: ProviderConfirmationStatus;
+
+jest.mock('../../../../hooks/general/providerConfirmation/useProviderConfirmationStatus', () => ({
+    useProviderConfirmationStatus: () => mockUseProviderConfirmationStatus,
+}));
+
+describe('ProviderConfirmationStatusInfo', () => {
+    const renderProviderConfirmationStatusInfo = () =>
+        renderWithBasicProvider(<ProviderConfirmationStatusInfo />);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it.each<ProviderConfirmationStatus>(['inactive', 'confirmation_success', 'window_opened'])(
+        'should render nothing when providerConfirmationStatus is [%s]',
+        providerConfirmationStatus => {
+            mockUseProviderConfirmationStatus = providerConfirmationStatus;
+
+            const { toJSON } = renderProviderConfirmationStatusInfo();
+
+            expect(toJSON()).toBeNull();
+        },
+    );
+
+    it.each<[string, ProviderConfirmationStatus]>([
+        ['Provider is confirming your sell', 'window_closed_incomplete'],
+        ['Waiting for the provider’s receive address', 'window_closed_with_success'],
+        ['Your sell couldn’t be completed', 'confirmation_failed'],
+    ])(
+        'should render "%s" when providerConfirmationStatus is [%s]',
+        (expectedTitle, providerConfirmationStatus) => {
+            mockUseProviderConfirmationStatus = providerConfirmationStatus;
+
+            const { getByText } = renderProviderConfirmationStatusInfo();
+
+            expect(getByText(expectedTitle)).toBeTruthy();
+        },
+    );
+});

--- a/suite-native/module-trading/src/components/sell/ProviderConfirmation/__tests__/ProviderStatusDevButtons.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/ProviderConfirmation/__tests__/ProviderStatusDevButtons.comp.test.tsx
@@ -1,0 +1,58 @@
+import { FeatureFlag, toggleFeatureFlag } from '@suite-native/feature-flags';
+import {
+    TestStore,
+    initStore,
+    renderWithStoreProviderAsync,
+    userEvent,
+} from '@suite-native/test-utils';
+import { selectTradingProviderConfirmationStatus } from '@suite-native/trading-state';
+
+import { ProviderStatusDevButtons } from '../ProviderStatusDevButtons';
+
+describe('ProviderStatusDevButtons', () => {
+    let store: TestStore;
+
+    const renderProviderStatusDevButtons = () =>
+        renderWithStoreProviderAsync(<ProviderStatusDevButtons />, { store });
+
+    beforeEach(async () => {
+        ({ store } = await initStore());
+    });
+
+    it('should display nothing without debug mode', async () => {
+        const { toJSON } = await renderProviderStatusDevButtons();
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should change state on buttons press', async () => {
+        store.dispatch(toggleFeatureFlag({ featureFlag: FeatureFlag.IsTradingDebugEnabled }));
+        const { getByText } = await renderProviderStatusDevButtons();
+
+        await userEvent.press(getByText('restart flow'));
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('window_opened');
+
+        await userEvent.press(getByText('incomplete'));
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe(
+            'window_closed_incomplete',
+        );
+
+        await userEvent.press(getByText('with_success'));
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe(
+            'window_closed_with_success',
+        );
+
+        await userEvent.press(getByText('failed'));
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe(
+            'confirmation_failed',
+        );
+
+        await userEvent.press(getByText('success'));
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe(
+            'confirmation_success',
+        );
+
+        await userEvent.press(getByText('restart flow'));
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('window_opened');
+    });
+});

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.tsx
@@ -1,11 +1,11 @@
 import { type ReactNode, memo, useState } from 'react';
-import Animated from 'react-native-reanimated';
+import Animated, { LinearTransition } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import type { BankAccount, SellFiatTrade } from 'invity-api';
 
 import { selectTradingSellFormStep } from '@suite-common/trading';
-import { InlineAlertBox, VStack } from '@suite-native/atoms';
+import { AnimatedVStack, InlineAlertBox } from '@suite-native/atoms';
 
 import { SellBankAccountPicker } from './BankAccount/SellBankAccountPicker';
 import { SellFeePickerCard } from './SellFeePickerCard';
@@ -36,7 +36,7 @@ export const SellPreviewView = memo(({ quote, txnErrorString }: SellPreviewViewP
     };
 
     return (
-        <VStack spacing="sp20" paddingVertical="sp20">
+        <AnimatedVStack spacing="sp20" paddingVertical="sp20" layout={LinearTransition}>
             {isTxnError && (
                 <Animated.View>
                     <InlineAlertBox variant="critical" title={txnErrorString} />
@@ -55,6 +55,6 @@ export const SellPreviewView = memo(({ quote, txnErrorString }: SellPreviewViewP
                     onBankAccountSelect={handleBankAccountSelect}
                 />
             )}
-        </VStack>
+        </AnimatedVStack>
     );
 });

--- a/suite-native/module-trading/src/hooks/general/providerConfirmation/__tests__/useDispatchProviderConfirmationStatus.hook.test.ts
+++ b/suite-native/module-trading/src/hooks/general/providerConfirmation/__tests__/useDispatchProviderConfirmationStatus.hook.test.ts
@@ -1,0 +1,30 @@
+import {
+    TestStore,
+    act,
+    initStore,
+    renderHookWithStoreProviderAsync,
+} from '@suite-native/test-utils';
+import { selectTradingProviderConfirmationStatus } from '@suite-native/trading-state';
+
+import { useDispatchProviderConfirmationStatus } from '../useDispatchProviderConfirmationStatus';
+
+describe('useDispatchProviderConfirmationStatus', () => {
+    let store: TestStore;
+
+    const renderUseDispatchProviderConfirmationStatus = () =>
+        renderHookWithStoreProviderAsync(() => useDispatchProviderConfirmationStatus(), { store });
+
+    beforeEach(async () => {
+        ({ store } = await initStore());
+    });
+
+    it('should provide callback for dispatching setProviderConfirmationStatus trading action', async () => {
+        const { result } = await renderUseDispatchProviderConfirmationStatus();
+
+        act(() => {
+            result.current('window_opened');
+        });
+
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('window_opened');
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/providerConfirmation/__tests__/useProviderConfirmationStatus.hook.test.ts
+++ b/suite-native/module-trading/src/hooks/general/providerConfirmation/__tests__/useProviderConfirmationStatus.hook.test.ts
@@ -1,0 +1,134 @@
+import { sendFormActions } from '@suite-common/wallet-core';
+import {
+    TestStore,
+    act,
+    initStore,
+    renderHookWithStoreProviderAsync,
+} from '@suite-native/test-utils';
+import {
+    selectTradingProviderConfirmationStatus,
+    tradingActions,
+} from '@suite-native/trading-state';
+
+import { useProviderConfirmationStatus } from '../useProviderConfirmationStatus';
+
+describe('useProviderConfirmationStatus', () => {
+    let store: TestStore;
+
+    const renderUseProviderConfirmationStatus = () =>
+        renderHookWithStoreProviderAsync(() => useProviderConfirmationStatus(), {
+            store,
+        });
+
+    beforeEach(async () => {
+        ({ store } = await initStore());
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('should return current status', async () => {
+        store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
+        const { result } = await renderUseProviderConfirmationStatus();
+
+        expect(result.current).toEqual('window_opened');
+    });
+
+    it('should clear tradingProviderConfirmationStatus on unmount', async () => {
+        store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
+        const { unmount } = await renderUseProviderConfirmationStatus();
+
+        unmount();
+
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('inactive');
+    });
+
+    it('should set tradingProviderConfirmationStatus to "confirmation_failed" after 30 "window_closed_incomplete" is set', async () => {
+        await renderUseProviderConfirmationStatus();
+        jest.useFakeTimers();
+
+        act(() => {
+            store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
+            store.dispatch(
+                tradingActions.setProviderConfirmationStatus('window_closed_incomplete'),
+            );
+        });
+
+        act(() => {
+            jest.advanceTimersByTime(30_000);
+        });
+
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe(
+            'confirmation_failed',
+        );
+    });
+
+    it('should set tradingProviderConfirmationStatus to "confirmation_failed" after 30 "window_closed_with_success" is set', async () => {
+        await renderUseProviderConfirmationStatus();
+        jest.useFakeTimers();
+
+        act(() => {
+            store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
+            store.dispatch(
+                tradingActions.setProviderConfirmationStatus('window_closed_with_success'),
+            );
+        });
+
+        act(() => {
+            jest.advanceTimersByTime(30_000);
+        });
+
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe(
+            'confirmation_failed',
+        );
+    });
+
+    it('should not set tradingProviderConfirmationStatus to "confirmation_failed" when status changes', async () => {
+        await renderUseProviderConfirmationStatus();
+        jest.useFakeTimers();
+
+        act(() => {
+            store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
+            store.dispatch(
+                tradingActions.setProviderConfirmationStatus('window_closed_with_success'),
+            );
+        });
+
+        act(() => {
+            jest.advanceTimersByTime(15_000);
+        });
+
+        act(() => {
+            store.dispatch(tradingActions.setProviderConfirmationStatus('confirmation_success'));
+        });
+
+        act(() => {
+            jest.advanceTimersByTime(30_000);
+        });
+
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe(
+            'confirmation_success',
+        );
+    });
+
+    it('should set tradingProviderConfirmationStatus to "confirmation_success" when isTradeFinalized becomes truthy', async () => {
+        await renderUseProviderConfirmationStatus();
+
+        act(() => {
+            store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
+            store.dispatch(
+                tradingActions.setProviderConfirmationStatus('window_closed_with_success'),
+            );
+            store.dispatch(
+                sendFormActions.storePrecomposedTransaction({
+                    precomposedTransaction: { type: 'final' },
+                } as any),
+            );
+        });
+
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe(
+            'confirmation_success',
+        );
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/providerConfirmation/__tests__/useProviderWebViewLifecycle.hook.test.ts
+++ b/suite-native/module-trading/src/hooks/general/providerConfirmation/__tests__/useProviderWebViewLifecycle.hook.test.ts
@@ -1,0 +1,63 @@
+import { TradingType } from '@suite-common/trading/';
+import {
+    TestStore,
+    act,
+    initStore,
+    renderHookWithStoreProviderAsync,
+} from '@suite-native/test-utils';
+import { selectTradingProviderConfirmationStatus } from '@suite-native/trading-state';
+
+import { useProviderWebViewLifecycle } from '../useProviderWebViewLifecycle';
+
+describe('useProviderWebViewLifecycle', () => {
+    let store: TestStore;
+
+    const renderUseProviderWebViewLifecycle = (tradingType: TradingType = 'sell') =>
+        renderHookWithStoreProviderAsync(() => useProviderWebViewLifecycle(tradingType), { store });
+
+    beforeEach(async () => {
+        ({ store } = await initStore());
+    });
+
+    it('should set providerConfirmationStatus to "window_opened" on mount', async () => {
+        await renderUseProviderWebViewLifecycle();
+
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('window_opened');
+    });
+
+    it('should set providerConfirmationStatus to "window_closed_incomplete" on unmount', async () => {
+        const { unmount } = await renderUseProviderWebViewLifecycle();
+
+        unmount();
+
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe(
+            'window_closed_incomplete',
+        );
+    });
+
+    it('should provide callback for setting providerConfirmationStatus to "window_closed_with_success"', async () => {
+        const { result, unmount } = await renderUseProviderWebViewLifecycle();
+
+        act(() => {
+            result.current.handleWebViewSuccess();
+        });
+        unmount();
+
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe(
+            'window_closed_with_success',
+        );
+    });
+
+    it('should do nothing when tradingType is not [sell]', async () => {
+        const { result, unmount } = await renderUseProviderWebViewLifecycle('buy');
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('inactive');
+
+        act(() => {
+            result.current.handleWebViewSuccess();
+        });
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('inactive');
+
+        unmount();
+        expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('inactive');
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/providerConfirmation/useDispatchProviderConfirmationStatus.ts
+++ b/suite-native/module-trading/src/hooks/general/providerConfirmation/useDispatchProviderConfirmationStatus.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { tradingActions } from '@suite-native/trading-state';
+import { ProviderConfirmationStatus } from '@suite-native/trading-types';
+
+export const useDispatchProviderConfirmationStatus = () => {
+    const dispatch = useDispatch();
+
+    return useCallback(
+        (status: ProviderConfirmationStatus) => {
+            dispatch(tradingActions.setProviderConfirmationStatus(status));
+        },
+        [dispatch],
+    );
+};

--- a/suite-native/module-trading/src/hooks/general/providerConfirmation/useProviderConfirmationStatus.ts
+++ b/suite-native/module-trading/src/hooks/general/providerConfirmation/useProviderConfirmationStatus.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+
+import { selectSendPrecomposedTx } from '@suite-common/wallet-core';
+import { selectTradingProviderConfirmationStatus } from '@suite-native/trading-state';
+import { ProviderConfirmationStatus } from '@suite-native/trading-types';
+
+import { useDispatchProviderConfirmationStatus } from './useDispatchProviderConfirmationStatus';
+
+const FAIL_CONFIRMATION_TIMEOUT_MS = 30_000;
+
+const STATUSES_TRIGGERING_TIMEOUT: ProviderConfirmationStatus[] = [
+    'window_closed_with_success',
+    'window_closed_incomplete',
+];
+
+export const useProviderConfirmationStatus = () => {
+    const currentStatus = useSelector(selectTradingProviderConfirmationStatus);
+    const precomposedTransaction = useSelector(selectSendPrecomposedTx);
+    const isTradeConfirmed = precomposedTransaction?.type === 'final';
+
+    const dispatchProviderConfirmationStatus = useDispatchProviderConfirmationStatus();
+
+    useEffect(
+        () => () => dispatchProviderConfirmationStatus('inactive'),
+        [dispatchProviderConfirmationStatus],
+    );
+
+    useEffect(() => {
+        if (isTradeConfirmed) {
+            dispatchProviderConfirmationStatus('confirmation_success');
+        }
+    }, [isTradeConfirmed, dispatchProviderConfirmationStatus]);
+
+    useEffect(() => {
+        if (STATUSES_TRIGGERING_TIMEOUT.includes(currentStatus)) {
+            const timeoutId = setTimeout(() => {
+                dispatchProviderConfirmationStatus('confirmation_failed');
+            }, FAIL_CONFIRMATION_TIMEOUT_MS);
+
+            return () => {
+                clearTimeout(timeoutId);
+            };
+        }
+
+        return () => {};
+    }, [currentStatus, dispatchProviderConfirmationStatus]);
+
+    return currentStatus;
+};

--- a/suite-native/module-trading/src/hooks/general/providerConfirmation/useProviderWebViewLifecycle.ts
+++ b/suite-native/module-trading/src/hooks/general/providerConfirmation/useProviderWebViewLifecycle.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect } from 'react';
+
+import { TradingType } from '@suite-common/trading';
+
+import { useDispatchProviderConfirmationStatus } from './useDispatchProviderConfirmationStatus';
+
+export const useProviderWebViewLifecycle = (tradingType: TradingType) => {
+    const dispatchProviderConfirmationStatus = useDispatchProviderConfirmationStatus();
+
+    useEffect(() => {
+        if (tradingType === 'sell') {
+            dispatchProviderConfirmationStatus('window_opened');
+
+            return () => {
+                dispatchProviderConfirmationStatus('window_closed_incomplete');
+            };
+        }
+
+        return () => {};
+    }, [dispatchProviderConfirmationStatus, tradingType]);
+
+    const handleWebViewSuccess = useCallback(() => {
+        if (tradingType === 'sell') {
+            dispatchProviderConfirmationStatus('window_closed_with_success');
+        }
+    }, [dispatchProviderConfirmationStatus, tradingType]);
+
+    return {
+        handleWebViewSuccess,
+    };
+};

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
@@ -333,51 +333,6 @@ describe('useSellFlow', () => {
         });
     });
 
-    describe('retryDoSellTrade', () => {
-        it('should do nothing when no quote is selected', async () => {
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-            act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
-                store.dispatch(tradingSellActions.saveSelectedQuote(undefined));
-            });
-
-            const { result } = await renderUseSellFlow();
-
-            await act(async () => {
-                await result.current.retryDoSellTrade();
-            });
-
-            expect(dispatchSpy).not.toHaveBeenCalledWith(
-                expect.objectContaining({
-                    type: 'handleTradeThunkMock',
-                }),
-            );
-        });
-
-        it('should call doSellTrade', async () => {
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const trade = { ...sellQuotes[0], quoteId: 'test-quote-id' };
-
-            act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
-                store.dispatch(tradingSellActions.saveSelectedQuote(trade));
-            });
-
-            const { result } = await renderUseSellFlow();
-
-            await act(async () => {
-                await result.current.retryDoSellTrade();
-            });
-
-            expect(dispatchSpy).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    type: 'handleTradeThunkMock',
-                }),
-            );
-        });
-    });
-
     describe('handleWebview', () => {
         it('should navigate to webview when processResponseData is called with form data', async () => {
             const trade = sellQuotes[0];

--- a/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
@@ -173,12 +173,6 @@ export const useSellFlow = () => {
         }
     }, [selectedQuote, sellInfo, doSellTrade]);
 
-    const retryDoSellTrade = useCallback(async () => {
-        if (selectedQuote) {
-            await doSellTrade(selectedQuote);
-        }
-    }, [selectedQuote, doSellTrade]);
-
     return {
         txnErrorString,
         composeRequest,
@@ -190,6 +184,5 @@ export const useSellFlow = () => {
         doSellTrade,
         confirmTrade,
         doBankAccountVerificationCheck,
-        retryDoSellTrade,
     };
 };

--- a/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
@@ -7,12 +7,11 @@ import {
     selectTradingSellSelectedQuote,
     useTradingDetailData,
 } from '@suite-common/trading';
-import { AsyncButton, InlineAlertBox, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
 import { Screen } from '@suite-native/navigation';
-import { WaitingCard } from '@suite-native/trading-atoms';
 
 import { Footer } from '../components/general/Footer';
+import { ProviderConfirmationStatusInfo } from '../components/sell/ProviderConfirmation/ProviderConfirmationStatusInfo';
+import { ProviderStatusDevButtons } from '../components/sell/ProviderConfirmation/ProviderStatusDevButtons';
 import {
     SellPreviewContinueButton,
     SellPreviewScreenHeader,
@@ -80,23 +79,8 @@ export const TradingSellPreviewScreen = () => {
 
     return (
         <Screen header={<SellPreviewScreenHeader />}>
-            <VStack spacing="sp16">
-                <WaitingCard
-                    title={
-                        <Translation id="moduleTrading.tradingSellPreviewScreen.providerStatus.confirming" />
-                    }
-                    subtitle={
-                        <Translation id="moduleTrading.tradingSellPreviewScreen.providerStatus.upTo30Seconds" />
-                    }
-                />
-                <InlineAlertBox
-                    title={
-                        <Translation id="moduleTrading.tradingSellPreviewScreen.providerStatus.startOver" />
-                    }
-                    iconName="info"
-                    variant="info"
-                />
-            </VStack>
+            <ProviderStatusDevButtons />
+            <ProviderConfirmationStatusInfo />
             <SellPreviewView quote={currentQuote} txnErrorString={errorString} />
             {!isFinalized && (
                 <SellPreviewContinueButton

--- a/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
@@ -25,19 +25,13 @@ import { clearTradingStateThunk } from '../thunks';
 
 export const TradingSellPreviewScreen = () => {
     const dispatch = useDispatch();
-    const {
-        txnErrorString,
-        doBankAccountVerificationCheck,
-        fetchFeesAndCompose,
-        retryDoSellTrade,
-    } = useSellFlow();
+    const { txnErrorString, doBankAccountVerificationCheck, fetchFeesAndCompose } = useSellFlow();
     const { trade } = useTradingDetailData<TradingSellType>('sell');
     const selectedQuote = useSelector(selectTradingSellSelectedQuote);
     const [shouldFetchFees, setShouldFetchFees] = useState(false);
 
     const currentQuote = trade?.data ? trade.data : selectedQuote;
     const isFinalized = isFinalStatus('sell', currentQuote?.status);
-    const isSubmitted = currentQuote?.status === 'SUBMITTED';
 
     const reportToAnalytics = useSellAnalyticReportCallback();
     useEffect(() => {
@@ -110,11 +104,6 @@ export const TradingSellPreviewScreen = () => {
                     isDisabled={!!errorString}
                     onSignTransactionNavigation={onSignTransactionNavigation}
                 />
-            )}
-            {isSubmitted && (
-                <AsyncButton onPress={retryDoSellTrade}>
-                    <Translation id="generic.buttons.continue" />
-                </AsyncButton>
             )}
             <Footer type="sell" />
         </Screen>

--- a/suite-native/module-trading/src/screens/TradingWebViewScreen.e2e.tsx
+++ b/suite-native/module-trading/src/screens/TradingWebViewScreen.e2e.tsx
@@ -1,11 +1,25 @@
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 
 import { Button, Text, VStack } from '@suite-native/atoms';
-import { Screen, ScreenHeader } from '@suite-native/navigation';
+import {
+    RootStackParamList,
+    RootStackRoutes,
+    Screen,
+    ScreenHeader,
+    StackProps,
+} from '@suite-native/navigation';
+
+import { useProviderWebViewLifecycle } from '../hooks/general/providerConfirmation/useProviderWebViewLifecycle';
+
+type RouteProps = StackProps<RootStackParamList, RootStackRoutes.TradingWebView>['route'];
 
 const CLOSE_WEBVIEW_TEST_ID = '@trading/webview/close';
 
 export const TradingWebViewScreen = () => {
+    const {
+        params: { tradingType },
+    } = useRoute<RouteProps>();
+    useProviderWebViewLifecycle(tradingType);
     const navigation = useNavigation();
 
     return (

--- a/suite-native/module-trading/src/screens/TradingWebViewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingWebViewScreen.tsx
@@ -22,6 +22,7 @@ import { DebugModeCopyableText } from '@suite-native/trading-debug';
 import { tradingActions } from '@suite-native/trading-state';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
+import { useProviderWebViewLifecycle } from '../hooks/general/providerConfirmation/useProviderWebViewLifecycle';
 import { useTradingAnalyticReportCallback } from '../hooks/general/useTradingAnalyticReportCallback';
 import { useWatchTrade } from '../hooks/general/useWatchTrade';
 import { doesUrlContainCloseCallbackUrl } from '../utils/general/utils';
@@ -38,6 +39,8 @@ export const TradingWebViewScreen = () => {
     const { applyStyle } = useNativeStyles();
     const dispatch = useDispatch();
     const receivedDeeplinkUrl = useLinkingURL();
+    const { handleWebViewSuccess } = useProviderWebViewLifecycle(tradingType);
+
     const trade = useSelector((state: TradingRootState) =>
         selectTradingTradeByOrderId(state, orderId ?? ''),
     );
@@ -69,6 +72,9 @@ export const TradingWebViewScreen = () => {
                 if (orderId && tradingType === 'buy') {
                     dispatch(tradingActions.setTradeOrderIdToBeOpened(orderId));
                 }
+                if (tradingType === 'sell') {
+                    handleWebViewSuccess();
+                }
                 navigation.goBack();
 
                 return false;
@@ -76,7 +82,7 @@ export const TradingWebViewScreen = () => {
 
             return true;
         },
-        [closeCallbackUrl, dispatch, navigation, orderId, tradingType],
+        [closeCallbackUrl, dispatch, navigation, orderId, tradingType, handleWebViewSuccess],
     );
 
     useEffect(() => {

--- a/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.comp.test.tsx
@@ -3,7 +3,6 @@ import {
     PreloadedState,
     act,
     renderWithStoreProviderAsync,
-    userEvent,
     waitFor,
 } from '@suite-native/test-utils';
 import { getSellTrade, getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
@@ -199,23 +198,5 @@ describe('TradingSellPreviewScreen', () => {
         await waitFor(() => expect(mockFetchFeesAndCompose).toHaveBeenCalled());
         // Should be called exactly once for this orderId
         expect(mockFetchFeesAndCompose).toHaveBeenCalledTimes(1);
-    });
-
-    it('should render continue button for submitted quote', async () => {
-        const preloadedState: PreloadedState = {
-            wallet: getWalletState({ tradeType: 'sell' }),
-        };
-        const submittedStateQuote = {
-            ...sellQuotes[0],
-            status: 'SUBMITTED' as const,
-            orderId: 'test_order_id_1',
-        };
-        preloadedState.wallet!.trading!.sell!.selectedQuote = submittedStateQuote;
-
-        const { getByText } = await renderTradingSellPreviewScreen(preloadedState);
-        await userEvent.press(getByText('Continue'));
-
-        await waitFor(() => expect(mockRetryDoSellTrade).toHaveBeenCalled());
-        expect(mockRetryDoSellTrade).toHaveBeenCalledTimes(1);
     });
 });

--- a/suite-native/module-trading/src/screens/__tests__/TradingWebViewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingWebViewScreen.comp.test.tsx
@@ -1,7 +1,8 @@
-import { TradingTransaction } from '@suite-common/trading';
+import { TradingTransaction, TradingType } from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { initStore, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
+import { selectTradingProviderConfirmationStatus } from '@suite-native/trading-state';
 
 import { TradingWebViewScreen } from '../TradingWebViewScreen';
 
@@ -9,11 +10,15 @@ let mockRouteParams: {
     closeCallbackUrl: string;
     source?: { uri?: string; html?: string };
     orderId?: string;
-} = { closeCallbackUrl: '' };
+    tradingType: TradingType;
+} = { closeCallbackUrl: '', tradingType: 'buy' };
 
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),
     useRoute: () => ({ name: 'TradingWebViewScreen', params: { ...mockRouteParams } }),
+    useNavigation: () => ({
+        goBack: jest.fn(),
+    }),
 }));
 
 jest.mock('@suite-common/trading', () => {
@@ -33,6 +38,7 @@ describe('TradingWebViewScreen', () => {
         mockRouteParams = {
             closeCallbackUrl: 'CALLBACK_URL',
             source: { uri: 'SOURCE_URI', html: undefined },
+            tradingType: 'buy',
         };
         const { getByTestId } = await renderWithStoreProviderAsync(<TradingWebViewScreen />);
 
@@ -42,6 +48,7 @@ describe('TradingWebViewScreen', () => {
     it('should render error when no source is set', async () => {
         mockRouteParams = {
             closeCallbackUrl: 'CALLBACK_URL',
+            tradingType: 'buy',
         };
         const { getByText } = await renderWithStoreProviderAsync(<TradingWebViewScreen />);
 
@@ -52,6 +59,7 @@ describe('TradingWebViewScreen', () => {
         mockRouteParams = {
             closeCallbackUrl: 'CALLBACK_URL',
             source: { uri: undefined, html: undefined },
+            tradingType: 'buy',
         };
         const { getByText } = await renderWithStoreProviderAsync(<TradingWebViewScreen />);
 
@@ -68,6 +76,7 @@ describe('TradingWebViewScreen', () => {
             mockRouteParams = {
                 closeCallbackUrl: 'CALLBACK_URL',
                 orderId: 'orderId',
+                tradingType: 'buy',
             };
         });
 
@@ -103,6 +112,7 @@ describe('TradingWebViewScreen', () => {
         });
 
         it('should report on mount for exchange', async () => {
+            mockRouteParams.tradingType = 'exchange';
             const preloadedState = { wallet: getWalletState({ tradeType: 'exchange' }) };
             preloadedState.wallet.trading.trades = [
                 {
@@ -127,6 +137,7 @@ describe('TradingWebViewScreen', () => {
         });
 
         it('should report on mount for sell', async () => {
+            mockRouteParams.tradingType = 'sell';
             const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
             preloadedState.wallet.trading.trades = [
                 {
@@ -148,6 +159,45 @@ describe('TradingWebViewScreen', () => {
                     action: 'visit',
                 }),
             });
+        });
+
+        it.each<TradingType>(['exchange', 'buy'])(
+            'should not change providerConfirmationStatus for [%s]',
+            async tradeType => {
+                mockRouteParams.tradingType = tradeType;
+                const preloadedState = { wallet: getWalletState({ tradeType }) };
+                preloadedState.wallet.trading.trades = [
+                    {
+                        tradeType,
+                        data: {
+                            orderId: 'orderId',
+                        },
+                    } as unknown as TradingTransaction,
+                ];
+                const { store } = await initStore(preloadedState);
+
+                await renderWithStoreProviderAsync(<TradingWebViewScreen />, { store });
+
+                expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('inactive');
+            },
+        );
+
+        it('should not change providerConfirmationStatus for [sell]', async () => {
+            mockRouteParams.tradingType = 'sell';
+            const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
+            preloadedState.wallet.trading.trades = [
+                {
+                    tradeType: 'sell',
+                    data: {
+                        orderId: 'orderId',
+                    },
+                } as unknown as TradingTransaction,
+            ];
+            const { store } = await initStore(preloadedState);
+
+            await renderWithStoreProviderAsync(<TradingWebViewScreen />, { store });
+
+            expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('window_opened');
         });
     });
 });

--- a/suite-native/trading-atoms/src/components/WaitingCard.tsx
+++ b/suite-native/trading-atoms/src/components/WaitingCard.tsx
@@ -1,7 +1,13 @@
 import { ReactNode } from 'react';
-import { FadeIn, FadeOut } from 'react-native-reanimated';
+import { FadeIn, FadeOut, FadingTransition } from 'react-native-reanimated';
 
-import { AnimatedVStack, Spinner, SpinnerLoadingState, Text, VStack } from '@suite-native/atoms';
+import {
+    AnimatedText,
+    AnimatedVStack,
+    Spinner,
+    SpinnerLoadingState,
+    VStack,
+} from '@suite-native/atoms';
 
 export type WaitingCardProps = {
     title: ReactNode;
@@ -20,17 +26,22 @@ export const WaitingCard = ({
         entering={FadeIn}
         exiting={FadeOut}
         alignItems="center"
-        paddingVertical="sp16"
+        paddingTop="sp16"
         spacing="sp16"
     >
         <Spinner loadingState={loadingState} />
         <VStack alignItems="center" spacing="sp4">
-            <Text variant="titleSmall" color="textDefault" textAlign="center">
+            <AnimatedText
+                variant="titleSmall"
+                color="textDefault"
+                textAlign="center"
+                layout={FadingTransition}
+            >
                 {title}
-            </Text>
-            <Text variant="hint" color="textDefault" textAlign="center">
+            </AnimatedText>
+            <AnimatedText variant="hint" color="textDefault" textAlign="center">
                 {subtitle}
-            </Text>
+            </AnimatedText>
         </VStack>
         {children}
     </AnimatedVStack>

--- a/suite-native/trading-consts/src/state.ts
+++ b/suite-native/trading-consts/src/state.ts
@@ -14,4 +14,5 @@ export const tradingInitialState: TradingState = {
     tradeOrderIdToBeOpened: undefined,
     isAmountInputActive: false,
     activeTradingType: undefined,
+    providerConfirmationStatus: 'inactive',
 };

--- a/suite-native/trading-state/src/reducers/__tests__/tradingSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/tradingSlice.test.ts
@@ -1,3 +1,4 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
 import type { CryptoId } from 'invity-api';
 
 import { TrezorDevice } from '@suite-common/suite-types';
@@ -17,7 +18,7 @@ import {
     sellQuotes,
     usdcAsset,
 } from '@suite-native/trading-fixtures';
-import { TradingState } from '@suite-native/trading-types';
+import { ProviderConfirmationStatus, TradingState } from '@suite-native/trading-types';
 
 import { buyActions } from '../buySlice';
 import { exchangeActions } from '../exchangeSlice';
@@ -48,6 +49,7 @@ describe('tradingSlice', () => {
                     tradingEnvironment: 'production',
                     isAmountInputActive: false,
                     activeTradingType: undefined,
+                    providerConfirmationStatus: 'inactive',
                 }),
             );
         });
@@ -430,6 +432,216 @@ describe('tradingSlice', () => {
                     },
                 }),
             );
+        });
+    });
+
+    describe('providerConfirmationStatus', () => {
+        let actions: PayloadAction<ProviderConfirmationStatus>[];
+
+        describe('and status inactive', () => {
+            it('should set status to [window_opened]', () => {
+                actions = [tradingActions.setProviderConfirmationStatus('window_opened')];
+
+                const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+                expect(state.providerConfirmationStatus).toBe('window_opened');
+            });
+
+            it.each<ProviderConfirmationStatus>([
+                'window_closed_incomplete',
+                'window_closed_with_success',
+                'confirmation_success',
+                'confirmation_failed',
+            ])('should not allow to set status to [%s]', invalidStatus => {
+                actions = [tradingActions.setProviderConfirmationStatus(invalidStatus)];
+
+                const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+                expect(state.providerConfirmationStatus).toBe('inactive');
+            });
+        });
+
+        describe('and status is "window_opened"', () => {
+            beforeEach(() => {
+                actions = [tradingActions.setProviderConfirmationStatus('window_opened')];
+            });
+
+            it.each<ProviderConfirmationStatus>([
+                'window_closed_incomplete',
+                'window_closed_with_success',
+                'inactive',
+            ])('should set status to [%s]', newStatus => {
+                actions.push(tradingActions.setProviderConfirmationStatus(newStatus));
+
+                const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+                expect(state.providerConfirmationStatus).toBe(newStatus);
+            });
+
+            it.each<ProviderConfirmationStatus>(['confirmation_success', 'confirmation_failed'])(
+                'should not allow to set status to [%s]',
+                invalidStatus => {
+                    actions.push(tradingActions.setProviderConfirmationStatus(invalidStatus));
+
+                    const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+                    expect(state.providerConfirmationStatus).toBe('window_opened');
+                },
+            );
+        });
+
+        describe('and status is "window_closed_incomplete"', () => {
+            beforeEach(() => {
+                actions = [
+                    tradingActions.setProviderConfirmationStatus('window_opened'),
+                    tradingActions.setProviderConfirmationStatus('window_closed_incomplete'),
+                ];
+            });
+
+            it.each<ProviderConfirmationStatus>([
+                'window_closed_with_success',
+                'confirmation_failed',
+                'inactive',
+            ])('should set status to [%s]', newStatus => {
+                actions.push(tradingActions.setProviderConfirmationStatus(newStatus));
+
+                const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+                expect(state.providerConfirmationStatus).toBe(newStatus);
+            });
+
+            it.each<ProviderConfirmationStatus>(['confirmation_success', 'window_opened'])(
+                'should not allow to set status to [%s]',
+                invalidStatus => {
+                    actions.push(tradingActions.setProviderConfirmationStatus(invalidStatus));
+
+                    const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+                    expect(state.providerConfirmationStatus).toBe('window_closed_incomplete');
+                },
+            );
+        });
+
+        describe('and status is "window_closed_with_success"', () => {
+            beforeEach(() => {
+                actions = [
+                    tradingActions.setProviderConfirmationStatus('window_opened'),
+                    tradingActions.setProviderConfirmationStatus('window_closed_with_success'),
+                ];
+            });
+
+            it.each<ProviderConfirmationStatus>([
+                'confirmation_success',
+                'confirmation_failed',
+                'inactive',
+            ])('should set status to [%s]', newStatus => {
+                actions.push(tradingActions.setProviderConfirmationStatus(newStatus));
+
+                const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+                expect(state.providerConfirmationStatus).toBe(newStatus);
+            });
+
+            it.each<ProviderConfirmationStatus>(['window_opened', 'window_closed_incomplete'])(
+                'should not allow to set status to [%s]',
+                invalidStatus => {
+                    actions.push(tradingActions.setProviderConfirmationStatus(invalidStatus));
+
+                    const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+                    expect(state.providerConfirmationStatus).toBe('window_closed_with_success');
+                },
+            );
+        });
+
+        describe('and status is "confirmation_failed"', () => {
+            beforeEach(() => {
+                actions = [
+                    tradingActions.setProviderConfirmationStatus('window_opened'),
+                    tradingActions.setProviderConfirmationStatus('window_closed_with_success'),
+                    tradingActions.setProviderConfirmationStatus('confirmation_failed'),
+                ];
+            });
+
+            it.each<ProviderConfirmationStatus>(['confirmation_success', 'inactive'])(
+                'should set status to [%s]',
+                newStatus => {
+                    actions.push(tradingActions.setProviderConfirmationStatus(newStatus));
+
+                    const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+                    expect(state.providerConfirmationStatus).toBe(newStatus);
+                },
+            );
+
+            it.each<ProviderConfirmationStatus>([
+                'window_opened',
+                'window_closed_incomplete',
+                'window_closed_with_success',
+            ])('should not allow to set status to [%s]', invalidStatus => {
+                actions.push(tradingActions.setProviderConfirmationStatus(invalidStatus));
+
+                const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+                expect(state.providerConfirmationStatus).toBe('confirmation_failed');
+            });
+        });
+
+        describe('and status is "confirmation_success"', () => {
+            beforeEach(() => {
+                actions = [
+                    tradingActions.setProviderConfirmationStatus('window_opened'),
+                    tradingActions.setProviderConfirmationStatus('window_closed_with_success'),
+                    tradingActions.setProviderConfirmationStatus('confirmation_success'),
+                ];
+            });
+
+            it.each<ProviderConfirmationStatus>(['inactive'])(
+                'should set status to [%s]',
+                newStatus => {
+                    actions.push(tradingActions.setProviderConfirmationStatus(newStatus));
+
+                    const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+                    expect(state.providerConfirmationStatus).toBe(newStatus);
+                },
+            );
+
+            it.each<ProviderConfirmationStatus>([
+                'window_opened',
+                'window_closed_incomplete',
+                'window_closed_with_success',
+                'confirmation_failed',
+            ])('should not allow to set status to [%s]', invalidStatus => {
+                actions.push(tradingActions.setProviderConfirmationStatus(invalidStatus));
+
+                const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+                expect(state.providerConfirmationStatus).toBe('confirmation_success');
+            });
+        });
+
+        describe('and with invalid status', () => {
+            it.each<ProviderConfirmationStatus>([
+                'window_opened',
+                'window_closed_incomplete',
+                'window_closed_with_success',
+                'confirmation_failed',
+                'confirmation_success',
+                'inactive',
+            ])('should not allow to set status to [%s]', newStatus => {
+                const prevState: TradingState = {
+                    ...tradingInitialState,
+                    providerConfirmationStatus: 'INVALID_STATUS' as ProviderConfirmationStatus,
+                };
+
+                const state = tradingReducer(
+                    prevState,
+                    tradingActions.setProviderConfirmationStatus(newStatus),
+                );
+
+                expect(state.providerConfirmationStatus).toBe(newStatus);
+            });
         });
     });
 });

--- a/suite-native/trading-state/src/reducers/tradingSlice.ts
+++ b/suite-native/trading-state/src/reducers/tradingSlice.ts
@@ -1,15 +1,34 @@
-import { PayloadAction, isAnyOf } from '@reduxjs/toolkit';
+import { type PayloadAction, isAnyOf } from '@reduxjs/toolkit';
 import type { CryptoId } from 'invity-api';
 
 import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import { InvityServerEnvironment, TradingType, prepareTradingReducer } from '@suite-common/trading';
 import { deviceActions } from '@suite-common/wallet-core';
 import { tradingInitialState } from '@suite-native/trading-consts';
+import type { ProviderConfirmationStatus } from '@suite-native/trading-types';
 
 import { TRADING_BUY, buyActions, buyReducer } from './buySlice';
 import { TRADING_EXCHANGE, exchangeActions, exchangeReducer } from './exchangeSlice';
 import { TRADING_RESIDENCE, residenceReducer } from './residenceSlice';
 import { TRADING_SELL, sellActions, sellReducer } from './sellSlice';
+
+const providerConfirmationStatusTransitions: Record<
+    ProviderConfirmationStatus,
+    ProviderConfirmationStatus[]
+> = {
+    // inactive is the initial state, providerConfirmationStatus becomes inactive when transaction prview is closed
+    inactive: ['window_opened'],
+    // window_opened is set when the webview is opened
+    window_opened: ['window_closed_incomplete', 'window_closed_with_success', 'inactive'],
+    // window_closed_incomplete is set when the webview is closed manually by the user before completing the confirmation
+    window_closed_incomplete: ['window_closed_with_success', 'confirmation_failed', 'inactive'],
+    // window_closed_with_success is set when the webview is closed after successful confirmation
+    window_closed_with_success: ['confirmation_success', 'confirmation_failed', 'inactive'],
+    // confirmation_failed is set if we do not know transaction status after 30 seconds after webview is close
+    confirmation_failed: ['confirmation_success', 'inactive'],
+    // confirmation_success is set when provider confirms transaction
+    confirmation_success: ['inactive'],
+};
 
 export const tradingSlice = createSliceWithExtraDeps({
     name: 'trading',
@@ -42,6 +61,21 @@ export const tradingSlice = createSliceWithExtraDeps({
         },
         clearActiveTradingType: state => {
             state.activeTradingType = undefined;
+        },
+        setProviderConfirmationStatus: (
+            state,
+            { payload: newStatus }: PayloadAction<ProviderConfirmationStatus>,
+        ) => {
+            const currentStatus = state.providerConfirmationStatus;
+
+            if (
+                // this case should never happen, but allows to recover from an invalid state
+                !Object.hasOwn(providerConfirmationStatusTransitions, currentStatus) ||
+                // allow only valid transitions, ignore rest
+                providerConfirmationStatusTransitions[currentStatus].includes(newStatus)
+            ) {
+                state.providerConfirmationStatus = newStatus;
+            }
         },
     },
     extraReducers: (builder, extra) => {

--- a/suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts
@@ -43,6 +43,7 @@ import {
     selectTradeToBeOpened,
     selectTradesToWatchByAccount,
     selectTradingEnvironment,
+    selectTradingProviderConfirmationStatus,
     selectVisibleDeviceAccountsByNetworkSymbolSorted,
 } from '../commonSelectors';
 
@@ -1271,6 +1272,22 @@ describe('commonSelectors', () => {
                     undefined,
                 ),
             ).toBeUndefined();
+        });
+    });
+
+    describe('selectTradingProviderConfirmationStatus', () => {
+        it('should return correct confirmation status for provider', () => {
+            const state = {
+                wallet: {
+                    trading: {
+                        providerConfirmationStatus: 'window_closed_with_success',
+                    },
+                },
+            } as TradingRootState;
+
+            const result = selectTradingProviderConfirmationStatus(state);
+
+            expect(result).toBe('window_closed_with_success');
         });
     });
 });

--- a/suite-native/trading-state/src/selectors/commonSelectors.ts
+++ b/suite-native/trading-state/src/selectors/commonSelectors.ts
@@ -386,3 +386,6 @@ export const selectAccountLabelWithNetworkFallback = (
 
     return undefined;
 };
+
+export const selectTradingProviderConfirmationStatus = (state: TradingRootState) =>
+    state.wallet.trading.providerConfirmationStatus;

--- a/suite-native/trading-types/src/general.ts
+++ b/suite-native/trading-types/src/general.ts
@@ -91,3 +91,11 @@ export type TradingFormContext = Partial<TradingAmountLimitProps> & {
     sendSymbol: string | undefined;
     balance: string | undefined;
 };
+
+export type ProviderConfirmationStatus =
+    | 'inactive'
+    | 'window_opened'
+    | 'window_closed_incomplete'
+    | 'window_closed_with_success'
+    | 'confirmation_success'
+    | 'confirmation_failed';

--- a/suite-native/trading-types/src/state.ts
+++ b/suite-native/trading-types/src/state.ts
@@ -10,6 +10,8 @@ import {
     TradingType,
 } from '@suite-common/trading';
 
+import { ProviderConfirmationStatus } from './general';
+
 export interface TradingBuyState extends CommonTradingBuyState {}
 
 export interface TradingExchangeState extends CommonTradingExchangeState {}
@@ -39,6 +41,7 @@ export interface TradingState extends CommonTradingState {
     tradeOrderIdToBeOpened: string | undefined;
     isAmountInputActive: boolean;
     activeTradingType: TradingType | undefined;
+    providerConfirmationStatus: ProviderConfirmationStatus;
 }
 
 export type TradingRootState = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- New trading state property `providerConfirmationStatus`
- Based on that property sac info is displayed to user on sell preview screen
- Component with buttons to simulate flow and debug animations in available in trading debug mode.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #23652


## Screenshots:
<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-19 at 10 23 01" src="https://github.com/user-attachments/assets/e706878a-47b8-4798-acb6-c515d6e80af1" />
<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-19 at 10 24 15" src="https://github.com/user-attachments/assets/e86c4965-a488-4a52-acfa-7b50e7b5ba52" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=23652-mobile-sell--no-loading-indicator-during-sell-operation&lookback=7)