### PR TITLE
feat(e2e): Instrumented code for code coverage by E2E tests

### DIFF
--- a/.github/actions/build-web/action.yml
+++ b/.github/actions/build-web/action.yml
@@ -1,6 +1,10 @@
 name: "Build and Upload Suite Web app"
 description: "Builds the Trezor Suite Web app and uploads it to S3 for e2e testing."
-
+inputs:
+  instrument-code:
+    description: "Enables Istanbul plugin for Babel to instrument the code for coverage reporting"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -34,6 +38,7 @@ runs:
       env:
         ASSET_PREFIX: /suite-web/${{ env.branch }}/web
         DESKTOP_APP_NAME: "Trezor-Suite"
+        INSTRUMENT_CODE: ${{ inputs.instrument-code }}
       run: |
         yarn message-system-sign-config
         yarn workspace @trezor/suite-data build:lib

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -55,6 +55,10 @@ inputs:
   run-reporter:
     description: "Flag to run GitHub Reporter, only on Release workflows"
     required: false
+  enable-coverage:
+    description: "Enable code coverage collection with Currents"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -132,10 +136,17 @@ runs:
           REPORTER_OPT=""
         fi
 
+        if [[ "${{ inputs.enable-coverage }}" == "true" ]]; then
+          COVERAGE_OPT="--pwc-coverage ${{ inputs.project }}"
+        else
+          COVERAGE_OPT=""
+        fi
+
         docker compose up -d ${{ inputs.containers }}
         echo "Starting Playwright project ${{ inputs.project }} for test group ${{ inputs.test-group }}"
         yarn workspace @trezor/suite-e2e test:orchestrated:e2e:${{ inputs.project }} \
           --pwc-cancel-after-failures ${{ inputs.fail-fast }} \
+          $COVERAGE_OPT \
           --forbid-only \
           $REPORTER_OPT \
           --grep="${{ inputs.additional-grep }}" \

--- a/.github/workflows/test-suite-web-e2e-nightly.yml
+++ b/.github/workflows/test-suite-web-e2e-nightly.yml
@@ -26,12 +26,15 @@ jobs:
   build-web:
     if: github.repository == 'trezor/trezor-suite'
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Build and Upload Suite Web
         uses: ./.github/actions/build-web
+        with:
+          instrument-code: "true"
 
   run-e2e-suite-web-tests:
     if: github.repository == 'trezor/trezor-suite'
@@ -62,6 +65,7 @@ jobs:
           currents-ci-build-id: "nightly-run-${{ github.run_id }}-${{ github.run_attempt }}"
           currents-tags: "nightly"
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
+          enable-coverage: "true"
 
   run-e2e-suite-web-tests-t3w1:
     if: github.repository == 'trezor/trezor-suite'

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ packages/suite-data/files/translations/master.json
 .direnv/
 .zed/*
 .cursorrules
+
+# currents coverage files
+.nyc_output/

--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -102,7 +102,7 @@ const config: webpack.Configuration = {
                 use: {
                     loader: 'babel-loader',
                     options: {
-                        cacheDirectory: true,
+                        cacheDirectory: !process.env.INSTRUMENT_CODE,
                         presets: [
                             [
                                 '@babel/preset-react',
@@ -130,6 +130,29 @@ const config: webpack.Configuration = {
                                 },
                             ],
                             ...(isDev ? ['react-refresh/babel'] : []),
+                            ...(process.env.INSTRUMENT_CODE
+                                ? [
+                                      [
+                                          'istanbul',
+                                          {
+                                              cwd: resolve(__dirname, '../../../'),
+                                              include: [
+                                                  'packages/*/src/**/*',
+                                                  'suite-common/*/src/**/*',
+                                              ],
+                                              exclude: [
+                                                  '**/*.test.{ts,tsx,js,jsx}',
+                                                  '**/*.spec.{ts,tsx,js,jsx}',
+                                                  '**/__tests__/**',
+                                                  '**/tests/**',
+                                                  '**/test/**',
+                                                  '**/e2e/**',
+                                              ],
+                                              extension: ['.js', '.jsx', '.ts', '.tsx'],
+                                          },
+                                      ],
+                                  ]
+                                : []),
                         ],
                     },
                 },

--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 /* eslint-disable jest/no-commented-out-tests */
-import { BrowserContext, Page, TestInfo, test as base, mergeTests } from '@playwright/test';
+import { BrowserContext, Page, TestInfo, test as base } from '@playwright/test';
 import { execSync } from 'child_process';
 
 import { TestAnnotationType } from '@trezor/e2e-utils';
@@ -109,19 +109,6 @@ const webSetup = async (browserContext: BrowserContext) => {
     return page;
 };
 
-const webTeardown = async (page: Page, browserContext: BrowserContext, testInfo: TestInfo) => {
-    await page.close();
-    await browserContext.close();
-    const videoPath = getVideoPath(testInfo.outputDir);
-    if (videoPath) {
-        testInfo.attachments.push({
-            name: 'video',
-            path: videoPath,
-            contentType: 'video/webm',
-        });
-    }
-};
-
 const getDefaultFirmwareVersion = (model: Model): string => {
     const DefaultFirmwareMajorVersion = model === 'T1B1' ? 1 : 2;
     const defaultFirmwareType = process.env.CANARY_FIRMWARE ? '-main' : '-latest';
@@ -181,12 +168,11 @@ const trezorEnvSetup = async (
     await trezorUserEnvStuckProtection(setupPromise);
 };
 
-// We first add currents fixtures to ensure current initialize first and quarantine works even for fails in beforeEach
-const baseWithCurrents = mergeTests(base, currentsTest);
 // This is the base Suite text fixture containing all the necessary setup and core page object
 // Depending on the project type (desktop or web) it will launch the appropriate environment
 // and provide the necessary page object which is either electron window or web page
-const suiteBaseTest = baseWithCurrents.extend<suiteBaseFixture>({
+// Extending our fixtures from currentsTest ensures Currents fixtures initialize first and quarantine works even for fails in beforeEach section
+const suiteBaseTest = currentsTest.extend<suiteBaseFixture>({
     startEmulator: true,
     setupEmulator: true,
     emulatorStartConf: { model: getModelFromEnv(), wipe: true },
@@ -217,7 +203,7 @@ const suiteBaseTest = baseWithCurrents.extend<suiteBaseFixture>({
         {
             locale,
             colorScheme,
-            browser,
+            context,
             startEmulator,
             setupEmulator,
             emulatorStartConf,
@@ -244,15 +230,9 @@ const suiteBaseTest = baseWithCurrents.extend<suiteBaseFixture>({
             await use(suite.window);
             await electronTeardown(suite, testInfo, electronConf);
         } else {
-            const browserContext = await browser.newContext({
-                recordVideo: {
-                    dir: testInfo.outputPath(),
-                },
-            });
-            const page = await webSetup(browserContext);
+            const page = await webSetup(context);
             enhancePage(page);
             await use(page);
-            await webTeardown(page, browserContext, testInfo);
         }
 
         await TrezorUserEnvLinkProxy.logTestDetails(

--- a/suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
+++ b/suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
@@ -8,9 +8,9 @@ import { launchSuite, launchSuiteElectronApp } from '../../support/electron';
 import { expect, test } from '../../support/fixtures';
 
 test.use({ exceptionLogger: skipFixture });
+test.use({ context: undefined }); // disable default context fixture to be able to use beforeAll
 test.describe('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
     test.describe.configure({ mode: 'serial' });
-
     test.beforeAll(async ({ trezorUserEnvLink, onboardingPage }) => {
         // Ensure bridge is stopped so we properly test the electron app starting node-bridge module.
         await trezorUserEnvLink.connect();

--- a/suite/e2e/tests/suite/multiple-sessions.test.ts
+++ b/suite/e2e/tests/suite/multiple-sessions.test.ts
@@ -3,11 +3,8 @@ import * as messages from '@trezor/protobuf/src/messages';
 import { BridgeTransport } from '@trezor/transport';
 
 import { expect, test } from '../../support/fixtures';
-import { AnalyticsSection } from '../../support/pageObjects/analyticsSection';
 import { DashboardPage } from '../../support/pageObjects/dashboardPage';
 import { DevicePrompt } from '../../support/pageObjects/devicePrompt';
-import { OnboardingPage } from '../../support/pageObjects/onboarding/onboardingPage';
-import { SettingsPage } from '../../support/pageObjects/settings/settingsPage';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 import { enhancePage } from '../../support/testExtends/enhancePage';
 
@@ -88,7 +85,7 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
                 priority: TestPriority.Medium,
             }),
         },
-        async ({ context, model, onboardingPage, dashboardPage, emulatorStartConf }) => {
+        async ({ context, model, onboardingPage, dashboardPage }) => {
             await onboardingPage.completeOnboarding();
 
             const pageTwo = await context.newPage();
@@ -98,20 +95,12 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
                 window.Playwright = true;
             });
             await pageTwo.goto('./');
-            const analyticsSectionTwo = new AnalyticsSection(pageTwo);
             const devicePromptTwo = new DevicePrompt(pageTwo, model);
-            const settingsPageTwo = new SettingsPage(pageTwo);
-            const onboardingPageTwo = new OnboardingPage(
-                pageTwo,
-                model,
-                devicePromptTwo,
-                analyticsSectionTwo,
-                settingsPageTwo,
-                emulatorStartConf,
-            );
-            await onboardingPageTwo.completeOnboarding();
+
             const dashboardPageTwo = new DashboardPage(pageTwo, devicePromptTwo);
-            await expect(dashboardPageTwo.deviceStatus).toHaveTranslation('TR_CONNECTED');
+            await expect(dashboardPageTwo.deviceStatus).toHaveTranslation('TR_CONNECTED', {
+                timeout: 30_000, // Longer timeout needed here to wait for page load and session restore
+            });
             await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE');
 
             await pageTwo.close();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a Istanbul plugin for babel to gather code coverage from E2E tests. The Instrumentation is disabled by default and needs to be enabled via env. var INSTRUMENT_CODE.
The code coverage currently will only work for web Suite and it's enabled only in nightly test runs.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-e2e-instrumentation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-e2e-instrumentation&lookback=7)