### PR TITLE
docs: hint about nvm on cd

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Welcome to the Trezor Suite repository! This repository contains the source code
 ### Prerequisities
 
 - Install [NVM](https://github.com/nvm-sh/nvm)
+    - _Hint: you can have your shell [automatically switch versions](https://github.com/nvm-sh/nvm/blob/master/README.md#calling-nvm-use-automatically-in-a-directory-with-a-nvmrc-file) in each repo_
 - Enable [Yarn](https://yarnpkg.com/getting-started/install) through npm
 - Install [Git LFS](https://git-lfs.github.com/) (For Linux/Ubuntu, [after adding the repository](https://packagecloud.io/github/git-lfs/install) do `sudo apt-get install git-lfs`, more info [here](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md))
 


### PR DESCRIPTION
## Description

Add hint to enable automatic `nvm use` on each `cd`.

Looks like many people don't know about it, because they were using outdated nodeJS after it was bumped to 24 :slightly_smiling_face: 

It really works (the bash variant):

```
$ node -v
v24.11.1
$ cat ./trezor-evolu-relay/.nvmrc 
22.11.0 
$ cd ./trezor-evolu-relay/
Now using node v22.11.0 (npm v11.6.2)
/trezor-evolu-relay$ node -v
v22.11.0
/trezor-evolu-relay$ cd ..
Now using node v24.11.1 (npm v11.6.2)
$ node -v
v24.11.1
```