### PR TITLE
chore(npm): start publishing source maps

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -9,7 +9,7 @@
     },
     "files": [
         "lib/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "scripts": {
         "test:unit": "yarn g:jest -c ../../jest.config.base.js",

--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -9,7 +9,7 @@
     },
     "files": [
         "lib/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "scripts": {
         "depcheck": "yarn g:depcheck",

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -9,7 +9,7 @@
     },
     "files": [
         "lib/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "scripts": {
         "test:unit": "yarn g:jest -c ../../jest.config.base.js",

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -22,7 +22,7 @@
     "files": [
         "lib/",
         "!lib/ui",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "main": "src/index.ts",
     "browser": {

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -22,8 +22,7 @@
         "lib/",
         "files/**/*.json",
         "files/**/*.txt",
-        "CHANGELOG.md",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "publishConfig": {
         "main": "lib/index.js",

--- a/packages/connect-plugin-ethereum/package.json
+++ b/packages/connect-plugin-ethereum/package.json
@@ -32,7 +32,7 @@
     "files": [
         "lib/",
         "libESM/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "peerDependencies": {
         "@metamask/eth-sig-util": "^8.2.0",

--- a/packages/connect-plugin-stellar/package.json
+++ b/packages/connect-plugin-stellar/package.json
@@ -32,7 +32,7 @@
     "files": [
         "lib/",
         "libESM/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "peerDependencies": {
         "@stellar/stellar-sdk": "^13.3.0",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -25,7 +25,7 @@
     },
     "files": [
         "lib/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "scripts": {
         "predev": "node webpack/generate_dev_cert.js",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -49,7 +49,7 @@
     },
     "files": [
         "lib/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "scripts": {
         "test:unit": "jest --version && jest",

--- a/packages/crypto-utils/package.json
+++ b/packages/crypto-utils/package.json
@@ -21,8 +21,7 @@
     "main": "src/index",
     "files": [
         "lib/",
-        "CHANGELOG.md",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "publishConfig": {
         "main": "lib/index.js"

--- a/packages/device-authenticity/package.json
+++ b/packages/device-authenticity/package.json
@@ -28,7 +28,7 @@
     "files": [
         "lib/",
         "libESM/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "scripts": {
         "build:lib": "yarn build:lib:cjs && yarn build:lib:esm",

--- a/packages/device-utils/package.json
+++ b/packages/device-utils/package.json
@@ -9,7 +9,7 @@
     },
     "files": [
         "lib/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "scripts": {
         "build:lib": "yarn g:rimraf -rf lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",

--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -18,7 +18,7 @@
     },
     "files": [
         "lib/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "scripts": {
         "depcheck": "yarn g:depcheck",

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -17,11 +17,11 @@
     "npmPublishAccess": "public",
     "files": [
         "lib/",
-        "!**/*.map",
         "scripts/protobuf-build.sh",
         "scripts/protobuf-patches",
         "scripts/protobuf-types.js",
-        "messages.json"
+        "messages.json",
+        "CHANGELOG.md"
     ],
     "scripts": {
         "test:unit": "yarn g:jest -c ../../jest.config.base.js",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -17,7 +17,7 @@
     "npmPublishAccess": "public",
     "files": [
         "lib/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "scripts": {
         "test:unit": "yarn g:jest -c ../../jest.config.base.js",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -41,7 +41,7 @@
     },
     "files": [
         "lib/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "scripts": {
         "depcheck": "yarn g:depcheck",

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -18,7 +18,7 @@
     },
     "files": [
         "lib/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "scripts": {
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -59,7 +59,7 @@
     "files": [
         "lib/",
         "libESM/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "scripts": {
         "test:unit": "yarn g:jest --verbose -c ./jest.config.js",

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -23,7 +23,7 @@
     "main": "./src/index.ts",
     "files": [
         "lib/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "publishConfig": {
         "main": "./lib/index.js",

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -36,7 +36,7 @@
     },
     "files": [
         "lib/",
-        "!**/*.map"
+        "CHANGELOG.md"
     ],
     "scripts": {
         "depcheck": "yarn g:depcheck",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Until now we were explicitly not including source map files in the NPM releases. Now we will include souce maps in all the packages that are released to NPM.

This PR is also adding explicitly `CHANGELOG.md` to the files that are published. It was already included because it is the default for `yarn npm pack` but it was only explicitly declared in few packages. Now adding it to all is more consistent.

## Notes for QA
Nothing to test.
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue
Resolves #20298

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/start-publishing-maps&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/start-publishing-maps&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/start-publishing-maps&lookback=7)