### PR TITLE
ci(connect): expand npm install check to cover both ESM & CJS

### DIFF
--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
       - name: Test npm install (beta)
         run: ./packages/connect/e2e/test-npm-install.sh beta
 

--- a/packages/connect/e2e/test-npm-install.sh
+++ b/packages/connect/e2e/test-npm-install.sh
@@ -18,5 +18,8 @@ npm install @trezor/connect-web@"$1" --save
 
 cat package.json
 
-echo "const TrezorConnect = require('@trezor/connect')" >./index.js
-node index.js
+printf "const TrezorConnect = require('@trezor/connect');\nconst { cloneObject } = require('@trezor/utils');" >./index.cjs
+printf "import TrezorConnect from '@trezor/connect';\nimport { cloneObject } from '@trezor/utils';" >./index.mjs
+printf "\nconsole.log('typeof TrezorConnect: '+typeof TrezorConnect);\nconsole.log('typeof cloneObject: '+typeof cloneObject);" | tee -a index.cjs index.mjs >/dev/null
+node index.cjs
+node index.mjs


### PR DESCRIPTION
## Description

Tweak and expand the `test-npm-install.sh` CI check:
- use nodeJS as per our `.nvmrc`
- cover both ESM and CJS

It's still failing because of missing paths in `@trezor/utils/package.json`, which are fixed already in `latest`, but `beta` is behind. Need to set beta=latest to fix this, before this can be merged. 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/test-npm-install-ESM-CJS&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/test-npm-install-ESM-CJS&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci/test-npm-install-ESM-CJS&lookback=7)