### PR TITLE
ci: make connect-misc-test run all even when fail

### DIFF
--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -26,10 +26,20 @@ jobs:
         with:
           submodules: true
 
-      - run: ./packages/connect/e2e/test-npm-install.sh beta
-      - run: ./packages/connect/e2e/test-npm-install.sh latest
-      - run: ./packages/connect/e2e/test-yarn-install.sh beta
-      - run: ./packages/connect/e2e/test-yarn-install.sh latest
+      - name: Test npm install (beta)
+        run: ./packages/connect/e2e/test-npm-install.sh beta
+
+      - name: Test npm install (latest)
+        run: ./packages/connect/e2e/test-npm-install.sh latest
+        if: always()
+
+      - name: Test yarn install (beta)
+        run: ./packages/connect/e2e/test-yarn-install.sh beta
+        if: always()
+
+      - name: Test yarn install (latest)
+        run: ./packages/connect/e2e/test-yarn-install.sh latest
+        if: always()
 
   test-protobuf:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With this changes the connect-misc-test running in CI are going to complete running all of them even if the first one fails. Before this if the first test was failing the rest of the test where not running.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/make-test-connect-misc-run-even-one-fail&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/make-test-connect-misc-run-even-one-fail&lookback=7)