### PR TITLE
fix(scripts): replace-imports to handle .d.ts files

### DIFF
--- a/scripts/publish/replace-imports.sh
+++ b/scripts/publish/replace-imports.sh
@@ -24,8 +24,27 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ "$2" == "esm" ]; then
     BABEL_CONFIG="$SCRIPT_DIR/babel.config.esm.json"
+    LIB_DIR="libESM"
 else
     BABEL_CONFIG="$SCRIPT_DIR/babel.config.cjs.json"
+    LIB_DIR="lib"
 fi
 
+# Transform .js files using Babel
 yarn run -T babel "$1" --out-dir "$1" --extensions ".js" --config-file "$BABEL_CONFIG"
+
+# Determine the operating system
+OS="$(uname)"
+
+# Transform .d.ts files using sed
+# It should be possible to solve this using babel but babel needs @babel/preset-typescript to parse .d.ts files
+# and that preset there is the risk of stripping type declarations, which would break .d.ts files.
+# Using sed is faster and it just works.
+ # Execute the appropriate command based on the OS 
+ if [[ "$OS" == "Darwin" ]]; then
+    # macOS command with -i '' for in-place editing without backup and -E for extended regex 
+    find "$1" -name "*.d.ts" -type f -exec sed -i '' "s|@trezor/\([^/]*\)/src|@trezor/\1/${LIB_DIR}|g" {} +
+else
+    # Linux command with -i and -E for in-place editing without backup (GNU sed syntax) and extended regex 
+    find "$1" -name "*.d.ts" -type f -exec sed -i "s|@trezor/\([^/]*\)/src|@trezor/\1/${LIB_DIR}|g" {} +
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The current implementation of replace-impots.sh that was modified previously to the current stable '9.7.0' connect version was not updating imports in .d.ts files that was causing to have in connect in npm imports like:

    import { Capability } from '@trezor/protobuf/src/messages';

But the released `@trezor/protobuf` package does not publish `src/` but only `lib/` so it has to be handle also when publishing.


## Notes for QA

Nothing to test.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/replace-imports.sh&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/replace-imports.sh&lookback=7)