### PR TITLE
e2e(suite): mock empty message system config on desktop

### DIFF
--- a/.github/actions/build-desktop/action.yml
+++ b/.github/actions/build-desktop/action.yml
@@ -20,6 +20,8 @@ runs:
 
     - name: Build Electron app.js for tests
       shell: bash
+      env:
+        TEST_BUILD: "true"
       run: |
         yarn workspace @trezor/suite-desktop build:app
         yarn workspace @trezor/suite-desktop build:ui

--- a/packages/components/src/components/Banner/Banner.tsx
+++ b/packages/components/src/components/Banner/Banner.tsx
@@ -61,7 +61,7 @@ export const Banner = ({
             {...frameProps}
             width={width}
         >
-            <Row gap={12} padding={{ vertical: 12, horizontal: 20 }}>
+            <Row gap={16} padding={{ vertical: 12, horizontal: 20 }}>
                 {isLoading && <Spinner size={20} />}
                 {!isLoading && withIcon && (
                     <Icon

--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -7,7 +7,7 @@ import { FLAGS } from '@suite-common/suite-config';
 
 import { NixosInterpreterPlugin } from '../plugins/nixos-interpreter-plugin';
 import ShellSpawnPlugin from '../plugins/shell-spawn-plugin';
-import { isCodesignBuild, isDev, launchElectron } from '../utils/env';
+import { isCodesignBuild, isDev, isTestBuild, launchElectron } from '../utils/env';
 import { getPathForProject } from '../utils/path';
 
 const electronArgsIndex = process.argv.indexOf('./webpack.config.ts') + 1;
@@ -15,6 +15,22 @@ const electronArgs = process.argv.slice(electronArgsIndex);
 
 const baseDirUI = getPathForProject('desktop-ui');
 const baseDir = getPathForProject('desktop');
+const messageSystemFile = path.join(
+    __dirname,
+    '../../../',
+    'suite-common',
+    'message-system',
+    'files',
+    'config.v1.ts',
+);
+const messageSystemMockFile = path.join(
+    __dirname,
+    '../../../',
+    'suite-common',
+    'message-system',
+    'mock',
+    'config.v1.ts',
+);
 
 const config: webpack.Configuration = {
     // Electron 39 runs on Chromium 142 https://www.electronjs.org/blog/electron-39-0
@@ -30,6 +46,14 @@ const config: webpack.Configuration = {
         path: path.join(baseDir, 'build'),
         publicPath: './',
     },
+    resolve: {
+        // conditionally mocks message-system config that is being used during build
+        alias: isTestBuild
+            ? {
+                  [messageSystemFile]: messageSystemMockFile,
+              }
+            : {},
+    },
     plugins: [
         new CopyWebpackPlugin({
             patterns: ['bin', 'fonts', 'images', 'videos', 'guide/assets']
@@ -39,14 +63,7 @@ const config: webpack.Configuration = {
                 }))
                 .concat([
                     {
-                        from: path.join(
-                            __dirname,
-                            '../../../',
-                            'suite-common',
-                            'message-system',
-                            'files',
-                            'config.v1.ts',
-                        ),
+                        from: messageSystemFile,
                         to: path.join(baseDir, 'build', 'static', 'message-system'),
                     },
                 ])

--- a/packages/suite-build/utils/env.ts
+++ b/packages/suite-build/utils/env.ts
@@ -8,6 +8,7 @@ const {
     ASSET_PREFIX,
     IS_CODESIGN_BUILD,
     SENTRY_AUTH_TOKEN,
+    TEST_BUILD,
 } = process.env;
 
 const project = PROJECT as Project;
@@ -17,6 +18,7 @@ const isCodesignBuild = IS_CODESIGN_BUILD === 'true';
 const launchElectron = LAUNCH_ELECTRON === 'true';
 const assetPrefix = ASSET_PREFIX || '';
 const sentryAuthToken = SENTRY_AUTH_TOKEN;
+const isTestBuild = TEST_BUILD === 'true';
 
 export {
     isAnalyzing,
@@ -26,4 +28,5 @@ export {
     assetPrefix,
     project,
     sentryAuthToken,
+    isTestBuild,
 };

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx
@@ -14,6 +14,7 @@ export const SafetyChecksBanner = ({ onDismiss }: SafetyChecksBannerProps) => {
 
     return (
         <Banner
+            data-testid="@banner/safety-checks"
             icon
             intent="warning"
             rightContent={

--- a/suite-common/message-system/mock/config.v1.ts
+++ b/suite-common/message-system/mock/config.v1.ts
@@ -1,0 +1,2 @@
+// Prepared for automated tests (loaded instead of the actual config in desktop.webpack.config.ts).
+export { validJws as jws } from '../src/__fixtures__/messageSystemActions';

--- a/suite/e2e/docs/e2e-playwright-suite.md
+++ b/suite/e2e/docs/e2e-playwright-suite.md
@@ -35,9 +35,10 @@ _(in case of Linux with X11 support, skip to step 6.)_
 
 ### Desktop
 
-1. `yarn workspace @trezor/suite-desktop build:ui`
+1. `TEST_BUILD=true yarn workspace @trezor/suite-desktop build:ui`
 
     Produces `suite-desktop/build` directory with javascript bundles & assets in production mode for the electron-renderer process.
+    TEST_BUILD env variable serves to mock bundled message-system config .
 
     _Note: This step needs to be repeated on each change in `suite` or `suite-desktop-ui` package._
 

--- a/suite/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/suite/e2e/support/pageObjects/settings/settingsPage.ts
@@ -29,19 +29,10 @@ export const languageMap = {
     'en-US': 'English',
 };
 
-const backgroundImages = {
-    original_t2t1: {
-        path: 'static/images/homescreens/COLOR_240x240/original_t2t1.jpg',
-        locator: '@modal/gallery/color_240x240/original_t2t1',
-    },
-    circleweb: {
-        path: 'static/images/homescreens/BW_64x128/circleweb.png',
-        locator: '@modal/gallery/bw_64x128/circleweb',
-    },
-    nyancat: {
-        path: 'static/images/homescreens/BW_64x128/nyancat.png',
-        locator: '@modal/gallery/bw_64x128/nyancat',
-    },
+const backgroundImageButton = {
+    original_t2t1: '@modal/gallery/color_240x240/original_t2t1',
+    circleweb: '@modal/gallery/bw_64x128/circleweb',
+    nyancat: '@modal/gallery/bw_64x128/nyancat',
 };
 
 export class SettingsPage {
@@ -224,13 +215,12 @@ export class SettingsPage {
     }
 
     @step()
-    async changeDeviceBackground(image: keyof typeof backgroundImages) {
+    async changeDeviceBackground(image: keyof typeof backgroundImageButton) {
         await test.step('Change display background image', async () => {
-            // To solve the flakiness of the test, we need to wait for the image to load
-            const buttonImageLoad = this.page.waitForResponse(`**/${backgroundImages[image].path}`);
             await this.homescreenGalleryButton.click();
-            await buttonImageLoad;
-            await this.page.getByTestId(backgroundImages[image].locator).click();
+            const imageButton = this.page.getByTestId(backgroundImageButton[image]);
+            await expect(imageButton).toHaveLoadedImage();
+            await imageButton.click();
             await expect(this.confirmOnDevicePrompt).toBeVisible();
             await TrezorUserEnvLinkProxy.pressYes();
             await this.confirmOnDevicePrompt.waitFor({ state: 'detached' });

--- a/suite/e2e/support/testExtends/customMatchers.ts
+++ b/suite/e2e/support/testExtends/customMatchers.ts
@@ -299,4 +299,26 @@ export const expect = baseExpect.extend({
             message: () => 'errors are handled in expects above',
         };
     },
+
+    async toHaveLoadedImage(locator: Locator, options?: { timeout?: number }) {
+        await baseExpect(locator).toBeVisible({ timeout: options?.timeout });
+        await baseExpect
+            .poll(
+                async () =>
+                    await locator.evaluate(
+                        (img: HTMLImageElement) => img.complete && img.naturalWidth > 0,
+                    ),
+                {
+                    timeout: options?.timeout,
+                    message:
+                        'expected locator to have image loaded but naturalWidth is 0 or complete is false',
+                },
+            )
+            .toBe(true);
+
+        return {
+            message: () => 'passed',
+            pass: true,
+        };
+    },
 });

--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -55,6 +55,8 @@ const electronSetup = async (
         .context()
         .tracing.start({ screenshots: true, snapshots: true, sources: true });
 
+    await mockRemoteMessageSystem(suite.window);
+
     return suite;
 };
 

--- a/suite/e2e/tests/suite/safety-checks-warning.test.ts
+++ b/suite/e2e/tests/suite/safety-checks-warning.test.ts
@@ -6,44 +6,31 @@ test.describe('safety_checks Warnings', { tag: ['@group=suite'] }, () => {
         await settingsPage.changeSafetyChecksLevel('prompt');
     });
 
-    test('Dismissible warning appears when safety_checks to prompt', async ({ page }) => {
-        await expect(page.getByTestId('@banner/safety-checks/button')).toBeVisible();
-        await expect(page.getByTestId('@banner/safety-checks/dismiss')).toBeVisible();
-    });
+    test('safety_checks Warnings', async ({ page, settingsPage }) => {
+        await test.step('Dismissible warning appears when safety_checks to prompt', async () => {
+            await expect(page.getByTestId('@banner/safety-checks')).toBeVisible();
+            await expect(page.getByTestId('@banner/safety-checks/button')).toBeVisible();
+            await expect(page.getByTestId('@banner/safety-checks/dismiss')).toBeVisible();
+        });
 
-    test('CTA button opens device settings when safety_checks to prompt', async ({
-        page,
-        settingsPage,
-    }) => {
-        await page.getByTestId('@banner/safety-checks/button').click();
-        await expect(settingsPage.settingsHeader).toBeVisible();
-    });
+        await test.step('CTA button opens device settings when safety_checks to prompt', async () => {
+            await page.getByTestId('@banner/safety-checks/button').click();
+            await expect(settingsPage.settingsHeader).toBeVisible();
+        });
 
-    test('Dismiss button hides the warning when safety_checks to prompt', async ({ page }) => {
-        await page.getByTestId('@banner/safety-checks/dismiss').click();
-        await expect(page.getByTestId('@banner/safety-checks/button')).toBeHidden();
-    });
+        await test.step('Warning re-appears when set to Prompt again', async () => {
+            await settingsPage.changeSafetyChecksLevel('strict');
 
-    test('Warning disappears when safety_checks are set to strict from prompt', async ({
-        page,
-        settingsPage,
-    }) => {
-        await settingsPage.changeSafetyChecksLevel('strict');
+            await expect(page.getByTestId('@banner/safety-checks/button')).toBeHidden();
+            // Set safety_checks back to PromptTemporarily
+            await settingsPage.changeSafetyChecksLevel('prompt');
 
-        await expect(page.getByTestId('@banner/safety-checks/button')).toBeHidden();
-    });
+            await expect(page.getByTestId('@banner/safety-checks/button')).toBeVisible();
+        });
 
-    test('Dismissed warning re-appears when safety_checks are set to strict and then to Prompt again', async ({
-        page,
-        settingsPage,
-    }) => {
-        await settingsPage.changeSafetyChecksLevel('strict');
-
-        await expect(page.getByTestId('@banner/safety-checks/button')).toBeHidden();
-        // Set safety_checks back to PromptTemporarily
-        await settingsPage.changeSafetyChecksLevel('prompt');
-
-        // Assert the warning appears again.
-        await expect(page.getByTestId('@banner/safety-checks/button')).toBeVisible();
+        await test.step('Dismiss button hides the warning when safety_checks to prompt', async () => {
+            await page.getByTestId('@banner/safety-checks/dismiss').click();
+            await expect(page.getByTestId('@banner/safety-checks/button')).toBeHidden();
+        });
     });
 });


### PR DESCRIPTION
Mocking message system config as an empty object in desktop tests, as it was done with web in https://github.com/trezor/trezor-suite/pull/20563. This way, a new message in remote config can't break tests for Suite banners, such as I did [here](https://github.com/trezor/trezor-suite/pull/24007).

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=e2e/mock-empty-message-system-config-for-desktop&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=e2e/mock-empty-message-system-config-for-desktop&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=e2e/mock-empty-message-system-config-for-desktop&lookback=7)