### PR TITLE
Bump versions/connect 9.7.1 beta.2

### DIFF
--- a/packages/connect-mobile/package.json
+++ b/packages/connect-mobile/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-mobile",
-    "version": "9.7.1-beta.1",
+    "version": "9.7.1-beta.2",
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "src/index.ts",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-web",
-    "version": "9.7.1-beta.1",
+    "version": "9.7.1-beta.2",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-web",
     "description": "High-level javascript interface for Trezor hardware wallet in web environment.",

--- a/packages/connect-web/src/webextension/trezor-usb-permissions.js
+++ b/packages/connect-web/src/webextension/trezor-usb-permissions.js
@@ -1,4 +1,4 @@
-const VERSION = '9.7.1-beta.1';
+const VERSION = '9.7.1-beta.2';
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 
 const isBeta = VERSION.includes('beta');

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-webextension",
-    "version": "9.7.1-beta.1",
+    "version": "9.7.1-beta.2",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-webextension",
     "description": "High-level javascript interface for Trezor hardware wallet in webextension serviceworker environment.",

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 Use the persistent link [connect.trezor.io/9](https://connect.trezor.io/9/) to access the latest stable version of Connect Explorer.
 
-# 9.7.1-beta.1
+# 9.7.1-beta.2
 
 We are deprecating `coreMode: 'iframe'` for connect-web, which is now limited due to [Local Network Access](https://developer.chrome.com/blog/local-network-access) permission. If you are using it explicitly, we recommend moving to `coreMode: 'auto'` for a better user experience.
 

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -1,6 +1,6 @@
 # @trezor/connect
 
-API version 9.7.1-beta.1
+API version 9.7.1-beta.2
 
 [![Build Status](https://github.com/trezor/trezor-suite/actions/workflows/test-connect.yml/badge.svg)](https://github.com/trezor/trezor-suite/actions/workflows/test-connect.yml)
 [![NPM](https://img.shields.io/npm/v/@trezor/connect.svg)](https://www.npmjs.org/package/@trezor/connect)

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect",
-    "version": "9.7.1-beta.1",
+    "version": "9.7.1-beta.2",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",

--- a/packages/connect/src/data/version.ts
+++ b/packages/connect/src/data/version.ts
@@ -1,4 +1,4 @@
-export const VERSION = '9.7.1-beta.1';
+export const VERSION = '9.7.1-beta.2';
 
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 

--- a/packages/device-authenticity/package.json
+++ b/packages/device-authenticity/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/device-authenticity",
-    "version": "1.1.0",
+    "version": "1.1.1-beta.1",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/device-authenticity",
     "description": "Utils for authenticity verification of trezor device secure element response.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bumping versions for connect-9.7.1-beta.2.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bump-versions/connect-9.7.1-beta.2&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bump-versions/connect-9.7.1-beta.2&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=bump-versions/connect-9.7.1-beta.2&lookback=7)