### PR TITLE
fix(connect): using @types/node@22.13.10 in check

### DIFF
--- a/packages/connect/e2e/test-yarn-install.sh
+++ b/packages/connect/e2e/test-yarn-install.sh
@@ -23,5 +23,5 @@ yarn add @trezor/connect@"$1"
 echo import TrezorConnect from \"@trezor/connect\" >index.ts
 
 # compile with typescript
-yarn add typescript@5.8.2
-yarn tsc ./index.ts --types node,w3c-web-usb --esModuleInterop --target ES2022 --module commonjs
+yarn add typescript@5.8.3 @types/node@22.13.10
+yarn tsc ./index.ts --types node,w3c-web-usb --esModuleInterop --target ES2024 --module commonjs


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

The definitions for @types/node have changed in latest version and the tests test-yarn-insatll.sh is using the latest one since it it not fixed in the script.

So fixing it to @types/node@22.13.10 makes the test successful.


## Notes for QA
Nothing to test.
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yarn-install-checl&lookback=7)