### PR TITLE
chore(device-authenticity): extract prepareDeviceAuthenticityData

### DIFF
--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -3,6 +3,7 @@ import {
     deviceAuthenticityBlacklistConfig,
     deviceAuthenticityConfig,
     getRandomChallenge,
+    prepareDeviceAuthenticityData,
     verifyAuthenticityProof,
 } from '@trezor/device-authenticity';
 import { Assert } from '@trezor/schema-utils';
@@ -47,7 +48,7 @@ export default class AuthenticateDevice extends AbstractMethod<
         const config = this.params.config || deviceAuthenticityConfig;
         const blacklistConfig = this.params.blacklistConfig || deviceAuthenticityBlacklistConfig;
         const commonParams = {
-            challenge,
+            data: prepareDeviceAuthenticityData({ payload: challenge }),
             deviceModel: this.device.features.internal_model,
             allowDebugKeys: this.params.allowDebugKeys,
             config,

--- a/packages/device-authenticity/src/index.ts
+++ b/packages/device-authenticity/src/index.ts
@@ -1,9 +1,6 @@
-export {
-    verifyAuthenticityProof,
-    prepareDeviceAuthenticityData,
-    verifySignatureP256,
-    verifySignatureEd25519,
-} from './verifyAuthenticityProof';
+export { verifyAuthenticityProof, prepareDeviceAuthenticityData } from './verifyAuthenticityProof';
+export { validateCaCertExtensions } from './validateCaCertExtensions';
+export { verifySignatureEd25519, verifySignatureP256 } from './verifySignatures';
 export { type AlgorithmName, parseName, parseCertificate } from './x509certificate';
 export { getRandomChallenge } from './utils';
 export type {

--- a/packages/device-authenticity/src/index.ts
+++ b/packages/device-authenticity/src/index.ts
@@ -1,4 +1,9 @@
-export { verifyAuthenticityProof, verifySignatureP256 } from './verifyAuthenticityProof';
+export {
+    verifyAuthenticityProof,
+    prepareDeviceAuthenticityData,
+    verifySignatureP256,
+    verifySignatureEd25519,
+} from './verifyAuthenticityProof';
 export { type AlgorithmName, parseName, parseCertificate } from './x509certificate';
 export { getRandomChallenge } from './utils';
 export type {

--- a/packages/device-authenticity/src/tests/verifyAuthenticityProof.test.ts
+++ b/packages/device-authenticity/src/tests/verifyAuthenticityProof.test.ts
@@ -1,7 +1,9 @@
+import { bufferUtils } from '@trezor/utils';
+
 import type { DeviceAuthenticityBlacklistConfig } from '../config/deviceAuthenticityBlacklistConfigTypes';
 import type { DeviceAuthenticityConfig } from '../config/deviceAuthenticityConfigTypes';
 import { VerifyAuthenticityProofParams } from '../types';
-import { verifyAuthenticityProof } from '../verifyAuthenticityProof';
+import { prepareDeviceAuthenticityData, verifyAuthenticityProof } from '../verifyAuthenticityProof';
 
 const CA_CERT_OPTIGA =
     '308201df30820184a00302010202040a001ab3300a06082a8648ce3d0403023054310b300906035504061302435a311e301c060355040a0c155472657a6f7220436f6d70616e7920732e722e6f2e3125302306035504030c1c5472657a6f72204d616e75666163747572696e6720526f6f742043413020170d3233303130313030303030305a180f32303533303130313030303030305a304f310b300906035504061302435a311e301c060355040a0c155472657a6f7220436f6d70616e7920732e722e6f2e3120301e06035504030c175472657a6f72204d616e75666163747572696e672043413059301306072a8648ce3d020106082a8648ce3d030107034200041b36cc98d5e3d1a20677aaf26254ef3756f27c9d63080c93ad3e7d39d3ad23bf00497b924789bc8e3f87834994e16780ad4eae7e75db1f03835ca64363e980b4a3473045300e0603551d0f0101ff04040302020430120603551d130101ff040830060101ff020100301f0603551d2304183016801428b202f8f9c78a74e8c152bbfb433d99d0ca03ef300a06082a8648ce3d0403020349003046022100dfe2f837f3644c1f0250d37cd0f7d1e4e9b8cfc4820d7f5a623a8cb69df99f6c02210089148848c5fc597df4b8545d9b19d1cc15abe0e1252fa2938a4cf01ae835c563';
@@ -67,7 +69,7 @@ const BLACKLIST_CONFIG: DeviceAuthenticityBlacklistConfig = {
 const defaultOptigaProps: VerifyAuthenticityProofParams = {
     certificates: [DEVICE_CERT_OPTIGA, CA_CERT_OPTIGA],
     signature: SIGNATURE_OPTIGA,
-    challenge: Buffer.from(CHALLENGE, 'hex'),
+    data: prepareDeviceAuthenticityData({ payload: Buffer.from(CHALLENGE, 'hex') }),
     deviceModel: 'T2B1',
     config: CONFIG,
     blacklistConfig: BLACKLIST_CONFIG,
@@ -274,15 +276,42 @@ describe(`firmware/${verifyAuthenticityProof.name}`, () => {
             Buffer.from(challenge, 'hex'),
             sizeBuffer,
         ];
+        const data = prepareDeviceAuthenticityData({ payload: bufferChunks, prefix: header });
 
         const verify = await verifyAuthenticityProof({
             ...defaultOptigaProps,
-            challenge: Buffer.from(challenge, 'hex'),
+            data,
             signature: SIGNATURE_OPTIGA_EVOLU,
-            challengePrefix: header,
-            bufferChunks,
         });
 
         expect(verify.valid).toBe(true);
+    });
+});
+
+describe(`firmware/${prepareDeviceAuthenticityData.name}`, () => {
+    it('prepare data with single buffer with default prefix', () => {
+        const payload = Buffer.from('deadbeef', 'hex');
+        const data = prepareDeviceAuthenticityData({ payload });
+        const expectedResult = Buffer.concat([
+            bufferUtils.getChunkSize(19),
+            Buffer.from('AuthenticateDevice:'),
+            bufferUtils.getChunkSize(4),
+            payload,
+        ]);
+        expect(data).toEqual(expectedResult);
+    });
+
+    it('prepare data with multiple buffers with custom prefix', () => {
+        const payload = [Buffer.from('dead', 'hex'), Buffer.from('beef', 'hex')];
+        const data = prepareDeviceAuthenticityData({ payload, prefix: 'Something:' });
+        const expectedResult = Buffer.concat([
+            bufferUtils.getChunkSize(10),
+            Buffer.from('Something:'),
+            bufferUtils.getChunkSize(2),
+            Buffer.from('dead', 'hex'),
+            bufferUtils.getChunkSize(2),
+            Buffer.from('beef', 'hex'),
+        ]);
+        expect(data).toEqual(expectedResult);
     });
 });

--- a/packages/device-authenticity/src/types.ts
+++ b/packages/device-authenticity/src/types.ts
@@ -9,16 +9,19 @@ export type VerifySignature = (
     signature: Uint8Array,
 ) => boolean | Promise<boolean>;
 
+export type PrepareDeviceAuthenticityDataParams = {
+    payload: Buffer | Buffer[];
+    prefix?: string;
+};
+
 export type VerifyAuthenticityProofParams = {
-    challenge: Buffer;
     certificates: string[];
     signature: string;
+    data: Uint8Array;
     deviceModel: keyof typeof PROTO.DeviceModelInternal; // Device.features.internal_model
     config: DeviceAuthenticityConfig;
     blacklistConfig: DeviceAuthenticityBlacklistConfig;
     allowDebugKeys?: boolean;
-    challengePrefix?: string;
-    bufferChunks?: Buffer[];
 };
 
 export type VerifyAuthenticityProofResult =

--- a/packages/device-authenticity/src/utils.ts
+++ b/packages/device-authenticity/src/utils.ts
@@ -7,14 +7,14 @@ import type { DeviceAuthenticityConfig } from './config/deviceAuthenticityConfig
 
 export const getRandomChallenge = () => crypto.randomBytes(32);
 
-type GetRootPubKeyBlacklistParams = {
+type GetCaPubKeyBlacklistParams = {
     blacklistConfig: DeviceAuthenticityBlacklistConfig;
     allowDebugKeys?: boolean;
 };
-export const getRootPubKeyBlacklist = ({
+export const getCaPubKeyBlacklist = ({
     blacklistConfig,
     allowDebugKeys,
-}: GetRootPubKeyBlacklistParams): string[] => {
+}: GetCaPubKeyBlacklistParams): string[] => {
     const normalBlacklist = blacklistConfig.blacklistedCaPubKeys ?? [];
     const debugBlacklist = blacklistConfig.debug?.blacklistedCaPubKeys ?? [];
 

--- a/packages/device-authenticity/src/validateCaCertExtensions.ts
+++ b/packages/device-authenticity/src/validateCaCertExtensions.ts
@@ -1,0 +1,40 @@
+import { parseCertificate } from './x509certificate';
+
+// Check that this certificate is a valid Trezor CA.
+// KeyUsage must be present and allow certificate signing.
+// BasicConstraints must be present, have the cA flag and a pathLenConstraint.
+// Any unrecognized non-critical extension is allowed. Any unrecognized critical extension is disallowed.
+export const validateCaCertExtensions = (
+    cert: ReturnType<typeof parseCertificate>,
+    pathLen: number,
+) => {
+    let hasKeyUsage,
+        hasBasicConstraints = false;
+    cert.tbsCertificate.extensions.forEach(ext => {
+        if (ext.key === 'keyUsage') {
+            if (ext.keyCertSign !== '1') {
+                throw new Error(`CA keyCertSign not set`);
+            }
+            hasKeyUsage = true;
+        } else if (ext.key === 'basicConstraints') {
+            if (!ext.cA) {
+                throw new Error(`CA basicConstraints.cA not set`);
+            }
+            if (typeof ext.pathLenConstraint != 'number') {
+                throw new Error('CA basicConstraints.pathLenConstraint not set');
+            }
+            if (ext.pathLenConstraint < pathLen) {
+                throw new Error('Issuer was not permitted to issue certificate');
+            }
+            hasBasicConstraints = true;
+        } else if (ext.critical) {
+            throw new Error(`Unknown critical extension ${ext.key} in CA certificate`);
+        }
+    });
+
+    if (!hasKeyUsage || !hasBasicConstraints) {
+        throw new Error(
+            `CA missing extensions keyUsage: ${hasKeyUsage}, basicConstraints: ${hasBasicConstraints}`,
+        );
+    }
+};

--- a/packages/device-authenticity/src/verifyAuthenticityProof.ts
+++ b/packages/device-authenticity/src/verifyAuthenticityProof.ts
@@ -1,108 +1,14 @@
-import { ed25519 } from '@noble/curves/ed25519.js';
-import * as crypto from 'crypto';
-
-import { getSubtleCrypto } from '@trezor/crypto-utils';
 import { bufferUtils } from '@trezor/utils';
 
 import {
     PrepareDeviceAuthenticityDataParams,
     VerifyAuthenticityProofParams,
     VerifyAuthenticityProofResult,
-    VerifySignature,
 } from './types';
 import { getCaPubKeyBlacklist, getRootPubKeys } from './utils';
-import { AlgorithmName, parseCertificate } from './x509certificate';
-
-// There is incomparability in results between nodejs and window SubtleCrypto api.
-// window.crypto.subtle.importKey (CryptoKey) cannot be used by `crypto-browserify`.Verify
-// The only common format of publicKey is PEM.
-export const verifySignatureP256: VerifySignature = async (rawKey, data, signature) => {
-    const signer = crypto.createVerify('sha256');
-    signer.update(Buffer.from(data));
-
-    const SubtleCrypto = getSubtleCrypto();
-
-    try {
-        // get ECDSA P-256 (secp256r1) key from RAW key
-        const ecPubKey = await SubtleCrypto.importKey(
-            'raw',
-            rawKey,
-            { name: 'ECDSA', namedCurve: 'P-256' },
-            true,
-            ['verify'],
-        );
-
-        // export ECDSA key as spki
-        const spkiPubKey = await SubtleCrypto.exportKey('spki', ecPubKey);
-
-        // create PEM from spki
-        const key = `-----BEGIN PUBLIC KEY-----\n${Buffer.from(spkiPubKey).toString(
-            'base64',
-        )}\n-----END PUBLIC KEY-----`;
-
-        // verify using PEM key
-        return signer.verify({ key }, Buffer.from(signature));
-    } catch {
-        // invalid inputs shall be considered unsuccessful verification, rather than runtime error
-        // (e.g. calling this with a P-256 signature and an Ed25519 key)
-        return false;
-    }
-};
-
-// Verifies Ed25519 signature using @noble/curves, because SubtleCrypto Ed25519 is still not broadly supported.
-// We can revert to SubtleCrypto when we stop supporting Chromium < 137 https://caniuse.com/mdn-api_subtlecrypto_sign_ed25519
-// Also must be verified react-native javascript runtime (unknown support matrix).
-export const verifySignatureEd25519: VerifySignature = (rawKey, data, signature) => {
-    try {
-        return ed25519.verify(signature, data, rawKey);
-    } catch {
-        // invalid inputs shall be considered unsuccessful verification, rather than runtime error
-        // @noble/hashes correctly returns false when calling this with an Ed25519 signature and a P-256 key, but malformed signature sometimes throws
-        return false;
-    }
-};
-
-const getVerifyFn = (algorithmName: AlgorithmName): VerifySignature => {
-    if (algorithmName === 'P-256') return verifySignatureP256;
-    if (algorithmName === 'Ed25519') return verifySignatureEd25519;
-    throw new Error(`Unsupported signature algorithm.`);
-};
-
-// Check that this certificate is a valid Trezor CA.
-// KeyUsage must be present and allow certificate signing.
-// BasicConstraints must be present, have the cA flag and a pathLenConstraint.
-// Any unrecognized non-critical extension is allowed. Any unrecognized critical extension is disallowed.
-const validateCaCertExtensions = (cert: ReturnType<typeof parseCertificate>, pathLen: number) => {
-    let hasKeyUsage,
-        hasBasicConstraints = false;
-    cert.tbsCertificate.extensions.forEach(ext => {
-        if (ext.key === 'keyUsage') {
-            if (ext.keyCertSign !== '1') {
-                throw new Error(`CA keyCertSign not set`);
-            }
-            hasKeyUsage = true;
-        } else if (ext.key === 'basicConstraints') {
-            if (!ext.cA) {
-                throw new Error(`CA basicConstraints.cA not set`);
-            }
-            if (typeof ext.pathLenConstraint != 'number') {
-                throw new Error('CA basicConstraints.pathLenConstraint not set');
-            }
-            if (ext.pathLenConstraint < pathLen) {
-                throw new Error('Issuer was not permitted to issue certificate');
-            }
-            hasBasicConstraints = true;
-        } else if (ext.critical) {
-            throw new Error(`Unknown critical extension ${ext.key} in CA certificate`);
-        }
-    });
-
-    if (!hasKeyUsage || !hasBasicConstraints) {
-        throw new Error(
-            `CA missing extensions keyUsage: ${hasKeyUsage}, basicConstraints: ${hasBasicConstraints}`,
-        );
-    }
-};
+import { validateCaCertExtensions } from './validateCaCertExtensions';
+import { getVerifyFn } from './verifySignatures';
+import { parseCertificate } from './x509certificate';
 
 // Compose the data against which the signatures will be verified.
 export const prepareDeviceAuthenticityData = ({

--- a/packages/device-authenticity/src/verifyAuthenticityProof.ts
+++ b/packages/device-authenticity/src/verifyAuthenticityProof.ts
@@ -5,11 +5,12 @@ import { getSubtleCrypto } from '@trezor/crypto-utils';
 import { bufferUtils } from '@trezor/utils';
 
 import {
+    PrepareDeviceAuthenticityDataParams,
     VerifyAuthenticityProofParams,
     VerifyAuthenticityProofResult,
     VerifySignature,
 } from './types';
-import { getRootPubKeyBlacklist, getRootPubKeys } from './utils';
+import { getCaPubKeyBlacklist, getRootPubKeys } from './utils';
 import { AlgorithmName, parseCertificate } from './x509certificate';
 
 // There is incomparability in results between nodejs and window SubtleCrypto api.
@@ -51,7 +52,7 @@ export const verifySignatureP256: VerifySignature = async (rawKey, data, signatu
 // Verifies Ed25519 signature using @noble/curves, because SubtleCrypto Ed25519 is still not broadly supported.
 // We can revert to SubtleCrypto when we stop supporting Chromium < 137 https://caniuse.com/mdn-api_subtlecrypto_sign_ed25519
 // Also must be verified react-native javascript runtime (unknown support matrix).
-const verifySignatureEd25519: VerifySignature = (rawKey, data, signature) => {
+export const verifySignatureEd25519: VerifySignature = (rawKey, data, signature) => {
     try {
         return ed25519.verify(signature, data, rawKey);
     } catch {
@@ -103,16 +104,32 @@ const validateCaCertExtensions = (cert: ReturnType<typeof parseCertificate>, pat
     }
 };
 
+// Compose the data against which the signatures will be verified.
+export const prepareDeviceAuthenticityData = ({
+    payload,
+    prefix = 'AuthenticateDevice:',
+}: PrepareDeviceAuthenticityDataParams): Uint8Array => {
+    const prefixBuffer = Buffer.from(prefix);
+    const payloadArray = Array.isArray(payload) ? payload : [payload];
+    const chunks = [prefixBuffer, ...payloadArray];
+
+    return Buffer.concat(
+        chunks.flatMap(chunk => [bufferUtils.getChunkSize(chunk.byteLength), chunk]),
+    );
+};
+
+/**
+ * Parses certificate, matches them against known root public keys, and verifies the signature over the prepared data.
+ * P-256 and Ed25519 algorithms are supported and automatically detected from the certificate.
+ */
 export const verifyAuthenticityProof = async ({
-    challenge,
     certificates,
     signature,
+    data,
     deviceModel,
     allowDebugKeys,
     config,
     blacklistConfig,
-    challengePrefix = 'AuthenticateDevice:',
-    bufferChunks = [],
 }: VerifyAuthenticityProofParams): Promise<VerifyAuthenticityProofResult> => {
     // Parse config with given device model, type of secure element and debug mode.
     const allRootPubKeys = getRootPubKeys({
@@ -120,7 +137,7 @@ export const verifyAuthenticityProof = async ({
         deviceModel,
         allowDebugKeys,
     });
-    const rootPubKeyBlacklist = getRootPubKeyBlacklist({
+    const caPubKeyBlacklist = getCaPubKeyBlacklist({
         blacklistConfig,
         allowDebugKeys,
     });
@@ -199,26 +216,16 @@ export const verifyAuthenticityProof = async ({
         deviceCert.signatureValue.bits.bytes,
     );
 
-    // 5. validate that the signature from AuthenticityProof was created using prefixed challenge **and** if DEVICES pubKey is not on blacklist
-    const challengePrefixBuffer = Buffer.from(challengePrefix);
-
-    const chunks =
-        bufferChunks && bufferChunks.length > 0
-            ? [challengePrefixBuffer, ...bufferChunks]
-            : [challengePrefixBuffer, challenge];
-
-    const prefixedBuffer = Buffer.concat(
-        chunks.flatMap(chunk => [bufferUtils.getChunkSize(chunk.byteLength), chunk]),
-    );
-
+    // 5. validate that the signature from AuthenticityProof was created using prefixed challenge
     const isSignatureValid = await verifySignatureFn(
         Buffer.from(deviceCert.tbsCertificate.subjectPublicKeyInfo.bits.bytes),
-        prefixedBuffer,
+        data,
         Buffer.from(signature, 'hex'),
     );
 
+    // 6. checks if DEVICES pubKey is not on blacklist
     if (isDeviceCertValid && isSignatureValid) {
-        if (rootPubKeyBlacklist.includes(caPubKey)) {
+        if (caPubKeyBlacklist.includes(caPubKey)) {
             return {
                 valid: false,
                 caPubKey,

--- a/packages/device-authenticity/src/verifySignatures.ts
+++ b/packages/device-authenticity/src/verifySignatures.ts
@@ -1,0 +1,62 @@
+import { ed25519 } from '@noble/curves/ed25519.js';
+import crypto from 'crypto';
+
+import { getSubtleCrypto } from '@trezor/crypto-utils';
+
+import { VerifySignature } from './types';
+import { AlgorithmName } from './x509certificate';
+
+// There is incomparability in results between Node.js and window SubtleCrypto api.
+// window.crypto.subtle.importKey (CryptoKey) cannot be used by `crypto-browserify`.Verify
+// The only common format of publicKey is PEM.
+export const verifySignatureP256: VerifySignature = async (rawKey, data, signature) => {
+    const signer = crypto.createVerify('sha256');
+    signer.update(Buffer.from(data));
+
+    const SubtleCrypto = getSubtleCrypto();
+
+    try {
+        // get ECDSA P-256 (secp256r1) key from RAW key
+        const ecPubKey = await SubtleCrypto.importKey(
+            'raw',
+            rawKey,
+            { name: 'ECDSA', namedCurve: 'P-256' },
+            true,
+            ['verify'],
+        );
+
+        // export ECDSA key as spki
+        const spkiPubKey = await SubtleCrypto.exportKey('spki', ecPubKey);
+
+        // create PEM from spki
+        const key = `-----BEGIN PUBLIC KEY-----\n${Buffer.from(spkiPubKey).toString(
+            'base64',
+        )}\n-----END PUBLIC KEY-----`;
+
+        // verify using PEM key
+        return signer.verify({ key }, Buffer.from(signature));
+    } catch {
+        // invalid inputs shall be considered unsuccessful verification, rather than runtime error
+        // (e.g. calling this with a P-256 signature and an Ed25519 key)
+        return false;
+    }
+};
+
+// Verifies Ed25519 signature using @noble/curves, because SubtleCrypto Ed25519 is still not broadly supported.
+// We can revert to SubtleCrypto when we stop supporting Chromium < 137 https://caniuse.com/mdn-api_subtlecrypto_sign_ed25519
+// Also must be verified react-native JavaScript runtime (unknown support matrix).
+export const verifySignatureEd25519: VerifySignature = (rawKey, data, signature) => {
+    try {
+        return ed25519.verify(signature, data, rawKey);
+    } catch {
+        // invalid inputs shall be considered unsuccessful verification, rather than runtime error
+        // @noble/hashes correctly returns false when calling this with an Ed25519 signature and a P-256 key, but malformed signature sometimes throws
+        return false;
+    }
+};
+
+export const getVerifyFn = (algorithmName: AlgorithmName): VerifySignature => {
+    if (algorithmName === 'P-256') return verifySignatureP256;
+    if (algorithmName === 'Ed25519') return verifySignatureEd25519;
+    throw new Error(`Unsupported signature algorithm.`);
+};


### PR DESCRIPTION
## Description

Proper refactoring after a quickly needed patch in ddd3bb9798906c41dfa8f24ee2eab527601c025a .
This simplifies the interface of `verifyAuthenticityProof`, which has bloated a bit, by extracting the `prepareDeviceAuthenticityData`. I considered the interface to make it suitable for both suite & [evolu-relay](https://github.com/trezor/trezor-suite-sync/pull/69)

## Notes for QA

Smoke test device authenticity on TS7 (but this is well covered by tests).



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/verifyAuthenticity-cleanup&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/verifyAuthenticity-cleanup&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/verifyAuthenticity-cleanup&lookback=7)