### PR TITLE
Refactor e2e staking improvement

### DIFF
--- a/suite/e2e/support/pageObjects/staking/stakingSection.ts
+++ b/suite/e2e/support/pageObjects/staking/stakingSection.ts
@@ -4,6 +4,7 @@ import { paletteV1 } from '@trezor/theme';
 import { hexToRgba } from '@trezor/utils';
 
 import { RewardsList } from './rewardList';
+import { step } from '../../common';
 
 export class StakingSection {
     readonly rewardList: RewardsList;
@@ -127,6 +128,7 @@ export class StakingSection {
         this.modalHeader = this.page.getByTestId('@modal/header');
     }
 
+    @step()
     async expectProgressIndicatorsToMatchPhase(
         phase: 'pendingTransaction' | 'addingToPool' | 'receivingRewards',
     ) {
@@ -163,25 +165,28 @@ export class StakingSection {
         );
     }
 
-    async expectStakingAmounts(options: {
+    @step()
+    async expectStakingAmounts(expected: {
         pending: string | 'hidden';
         staked: string | 'hidden';
         rewards: string | 'hidden';
         unstaking: string | 'hidden';
     }) {
-        const amounts = [
-            { locator: this.pendingAmount, value: options.pending },
-            { locator: this.stakedAmount, value: options.staked },
-            { locator: this.rewardsAmount, value: options.rewards },
-            { locator: this.unstakingAmount, value: options.unstaking },
-        ];
+        await expect(async () => {
+            const getStatus = async (locator: Locator) =>
+                (await locator.isVisible()) ? locator.innerText() : 'hidden';
 
-        for (const { locator, value } of amounts) {
-            if (value === 'hidden') {
-                await expect(locator).toBeHidden();
-            } else {
-                await expect(locator).toHaveText(value);
-            }
-        }
+            const [pending, staked, rewards, unstaking] = await Promise.all([
+                getStatus(this.pendingAmount),
+                getStatus(this.stakedAmount),
+                getStatus(this.rewardsAmount),
+                getStatus(this.unstakingAmount),
+            ]);
+
+            expect(
+                { pending, staked, rewards, unstaking },
+                'expected Staking dashboard to show correct values',
+            ).toEqual(expected);
+        }).toPass();
     }
 }


### PR DESCRIPTION
minor improvement of our staking assert. This one is important assert that checks account state. ATM it did sequentially. Checking 4 number. There could have been situation where first two numbers were checked. 3rd retried. Page would load number and test would continue with 3rd and 4th while first two could be changed now to wrong values.

So I change it to poll assert expect.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-e2e-staking-improvement&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-e2e-staking-improvement&lookback=7)