### PR TITLE
refactor(suite-native): rework device authenticity navigation in device settings

### DIFF
--- a/suite-native/module-device-settings/src/navigation/DeviceAuthenticityStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DeviceAuthenticityStackNavigator.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
+import { selectIsDeviceConnected } from '@suite-common/wallet-core';
 import { useDeviceAuthenticityCheck } from '@suite-native/device';
-import { useDeviceConnectionGuard } from '@suite-native/device-authorization';
+import { DeviceConnectionGuardScreen } from '@suite-native/device-authorization';
 import {
     DeviceAuthenticityStackParamList,
     DeviceAuthenticityStackRoutes,
@@ -28,23 +30,22 @@ type NavigationProp = StackToStackCompositeNavigationProps<
 >;
 
 export const DeviceAuthenticityStackNavigator = () => {
-    const [isAuthenticityCheckStarted, setIsAuthenticityCheckStarted] = useState(false);
     const navigation = useNavigation<NavigationProp>();
+
+    const { checkDeviceAuthenticity } = useDeviceAuthenticityCheck();
+    const [isAuthenticityCheckStarted, setIsAuthenticityCheckStarted] = useState(false);
+
+    const isDeviceConnected = useSelector(selectIsDeviceConnected);
+
     const handleSuccess = useCallback(() => {
-        navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
-            screen: DeviceSettingsStackRoutes.DeviceAuthenticityStack,
-            params: {
-                screen: DeviceAuthenticityStackRoutes.AuthenticitySuccess,
-            },
+        navigation.navigate(DeviceSettingsStackRoutes.DeviceAuthenticityStack, {
+            screen: DeviceAuthenticityStackRoutes.AuthenticitySuccess,
         });
     }, [navigation]);
 
     const handleFailure = useCallback(() => {
         navigation.navigate(RootStackRoutes.DeviceCompromisedModal);
     }, [navigation]);
-
-    const { checkDeviceAuthenticity } = useDeviceAuthenticityCheck();
-    const { isDeviceConnected } = useDeviceConnectionGuard();
 
     useEffect(() => {
         if (isDeviceConnected && !isAuthenticityCheckStarted) {
@@ -59,17 +60,20 @@ export const DeviceAuthenticityStackNavigator = () => {
         isDeviceConnected,
     ]);
 
-    if (!isDeviceConnected) return;
-
     return (
-        <DeviceAuthenticityStack.Navigator
-            initialRouteName={DeviceAuthenticityStackRoutes.AuthenticityCheck}
-            screenOptions={stackNavigationOptionsConfig}
-        >
-            <DeviceAuthenticityStack.Screen
-                name={DeviceAuthenticityStackRoutes.AuthenticityCheck}
-                component={ContinueOnTrezorScreen}
-            />
+        <DeviceAuthenticityStack.Navigator screenOptions={stackNavigationOptionsConfig}>
+            {!isDeviceConnected && (
+                <DeviceAuthenticityStack.Screen
+                    name={DeviceAuthenticityStackRoutes.DeviceConnectionGuard}
+                    component={DeviceConnectionGuardScreen}
+                />
+            )}
+            {isDeviceConnected && (
+                <DeviceAuthenticityStack.Screen
+                    name={DeviceAuthenticityStackRoutes.AuthenticityCheck}
+                    component={ContinueOnTrezorScreen}
+                />
+            )}
             <DeviceAuthenticityStack.Screen
                 name={DeviceAuthenticityStackRoutes.AuthenticitySuccess}
                 component={DeviceAuthenticitySuccessScreen}

--- a/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
@@ -64,6 +64,10 @@ export const DeviceSettingsStackNavigator = () => {
                 name={DeviceSettingsStackRoutes.DeviceBackupAndPassphrase}
                 component={BackupAndPassphraseScreen}
             />
+            <DeviceSettingsStack.Screen
+                name={DeviceSettingsStackRoutes.DeviceAuthenticity}
+                component={DeviceAuthenticityScreen}
+            />
             <DeviceSettingsStack.Group screenOptions={{ animation: 'slide_from_bottom' }}>
                 <DeviceSettingsStack.Screen
                     name={DeviceSettingsStackRoutes.DeviceNameStack}
@@ -103,15 +107,11 @@ export const DeviceSettingsStackNavigator = () => {
                     name={DeviceSettingsStackRoutes.DevicePassphraseStack}
                     component={DevicePassphraseStackNavigator}
                 />
+                <DeviceSettingsStack.Screen
+                    name={DeviceSettingsStackRoutes.DeviceAuthenticityStack}
+                    component={DeviceAuthenticityStackNavigator}
+                />
             </DeviceSettingsStack.Group>
-            <DeviceSettingsStack.Screen
-                name={DeviceSettingsStackRoutes.DeviceAuthenticity}
-                component={DeviceAuthenticityScreen}
-            />
-            <DeviceSettingsStack.Screen
-                name={DeviceSettingsStackRoutes.DeviceAuthenticityStack}
-                component={DeviceAuthenticityStackNavigator}
-            />
             <DeviceSettingsStack.Screen
                 name={DeviceSettingsStackRoutes.WipeDeviceStack}
                 component={WipeDeviceStackNavigator}

--- a/suite-native/module-device-settings/src/screens/DeviceAuthenticityScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceAuthenticityScreen.tsx
@@ -24,9 +24,7 @@ export const DeviceAuthenticityScreen = () => {
     const navigation = useNavigation<NavigationProp>();
 
     const navigateToDeviceAuthenticityStack = useCallback(() => {
-        navigation.navigate(DeviceSettingsStackRoutes.DeviceAuthenticityStack, {
-            screen: DeviceAuthenticityStackRoutes.AuthenticityCheck,
-        });
+        navigation.navigate(DeviceSettingsStackRoutes.DeviceAuthenticityStack);
     }, [navigation]);
 
     return (
@@ -35,7 +33,6 @@ export const DeviceAuthenticityScreen = () => {
                 <DynamicScreenHeader
                     title={<Translation id="moduleDeviceSettings.authenticity.title" />}
                     subtitle={<Translation id="moduleDeviceSettings.authenticity.subtitle" />}
-                    closeActionType="close"
                 />
             }
         >

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -246,7 +246,9 @@ export type DeviceSettingsStackParamList = {
     [DeviceSettingsStackRoutes.DeviceCheckBackupStack]: undefined;
     [DeviceSettingsStackRoutes.DevicePassphraseStack]: undefined;
     [DeviceSettingsStackRoutes.DeviceAuthenticity]: undefined;
-    [DeviceSettingsStackRoutes.DeviceAuthenticityStack]: NavigatorScreenParams<DeviceAuthenticityStackParamList>;
+    [DeviceSettingsStackRoutes.DeviceAuthenticityStack]:
+        | NavigatorScreenParams<DeviceAuthenticityStackParamList>
+        | undefined;
     [DeviceSettingsStackRoutes.ContinueOnTrezor]: undefined;
     [DeviceSettingsStackRoutes.WipeDeviceStack]: NavigatorScreenParams<WipeDeviceStackParamList>;
 };
@@ -309,6 +311,7 @@ export type DevicePassphraseStackParamList = {
 };
 
 export type DeviceAuthenticityStackParamList = {
+    [DeviceAuthenticityStackRoutes.DeviceConnectionGuard]: undefined;
     [DeviceAuthenticityStackRoutes.AuthenticityCheck]: undefined;
     [DeviceAuthenticityStackRoutes.AuthenticitySuccess]: undefined;
 };

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -128,6 +128,12 @@ export enum DevicePassphraseStackRoutes {
     ContinueOnTrezor = 'ContinueOnTrezor',
 }
 
+export enum DeviceAuthenticityStackRoutes {
+    DeviceConnectionGuard = 'DeviceConnectionGuard',
+    AuthenticityCheck = 'AuthenticityCheck',
+    AuthenticitySuccess = 'AuthenticitySuccess',
+}
+
 export enum FirmwareUpdateStackRoutes {
     DeviceConnectionGuard = 'DeviceConnectionGuard',
     ConfirmFirmwareUpdate = 'ConfirmFirmwareUpdate',
@@ -143,11 +149,6 @@ export enum FirmwareLanguageStackRoutes {
 export enum DeviceAutoConnectStackRoutes {
     DeviceConnectionGuard = 'DeviceConnectionGuard',
     ConfirmAutoConnect = 'ConfirmAutoConnect',
-}
-
-export enum DeviceAuthenticityStackRoutes {
-    AuthenticityCheck = 'AuthenticityCheck',
-    AuthenticitySuccess = 'AuthenticitySuccess',
 }
 
 export enum WipeDeviceStackRoutes {


### PR DESCRIPTION
- Used same navigation pattern as for firmware settings


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/device-settings-device-authenticity&lookback=7)