### PR TITLE
refactor(suite-native): rework wipe device navigation in device settings

### DIFF
--- a/suite-native/device-bootloader-mode/package.json
+++ b/suite-native/device-bootloader-mode/package.json
@@ -12,7 +12,6 @@
     },
     "dependencies": {
         "@react-navigation/native": "7.1.18",
-        "@react-navigation/native-stack": "7.5.1",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/device": "workspace:*",
         "@suite-native/device-manager": "workspace:*",

--- a/suite-native/device-bootloader-mode/src/screens/BootloaderModeScreen.tsx
+++ b/suite-native/device-bootloader-mode/src/screens/BootloaderModeScreen.tsx
@@ -1,8 +1,7 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
-import { CompositeNavigationProp, useNavigation } from '@react-navigation/native';
-import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useNavigation } from '@react-navigation/native';
 
 import { Button, Card, Pictogram, Text, TextDivider, VStack } from '@suite-native/atoms';
 import { selectShouldFactoryResetBeVisible } from '@suite-native/device';
@@ -11,10 +10,8 @@ import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
     DeviceSettingsStackRoutes,
-    RootStackParamList,
-    RootStackRoutes,
     Screen,
-    WipeDeviceStackParamList,
+    StackNavigationProps,
     WipeDeviceStackRoutes,
     useInterceptNativeNavigation,
     useNavigateToInitialScreen,
@@ -32,12 +29,9 @@ const contentWrapperStyle = prepareNativeStyle(() => ({
     justifyContent: 'center',
 }));
 
-type NavigationProps = CompositeNavigationProp<
-    NativeStackNavigationProp<WipeDeviceStackParamList, WipeDeviceStackRoutes.WipeDevice>,
-    CompositeNavigationProp<
-        NativeStackNavigationProp<DeviceSettingsStackParamList>,
-        NativeStackNavigationProp<RootStackParamList>
-    >
+type NavigationProps = StackNavigationProps<
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes.WipeDeviceStack
 >;
 
 export const BootloaderModeScreen = () => {
@@ -49,11 +43,8 @@ export const BootloaderModeScreen = () => {
     useInterceptNativeNavigation();
 
     const handleRedirectToFactoryReset = () => {
-        navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
-            screen: DeviceSettingsStackRoutes.WipeDeviceStack,
-            params: {
-                screen: WipeDeviceStackRoutes.FactoryReset,
-            },
+        navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack, {
+            screen: WipeDeviceStackRoutes.FactoryReset,
         });
     };
 

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -13,7 +13,6 @@
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@react-navigation/native": "7.1.18",
-        "@react-navigation/native-stack": "7.5.1",
         "@reduxjs/toolkit": "2.11.0",
         "@suite-common/bluetooth": "workspace:*",
         "@suite-common/device-authenticity": "workspace:*",

--- a/suite-native/device/src/hooks/useWipeDevice.tsx
+++ b/suite-native/device/src/hooks/useWipeDevice.tsx
@@ -1,7 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import { CompositeNavigationProp, useNavigation } from '@react-navigation/native';
-import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useNavigation } from '@react-navigation/native';
 import { isFulfilled } from '@reduxjs/toolkit';
 
 import { selectSelectedDevice, wipeDeviceThunk } from '@suite-common/wallet-core';
@@ -11,18 +10,13 @@ import { setWasDeviceOnboardingCancelled } from '@suite-native/device-onboarding
 import {
     DeviceSettingsStackParamList,
     DeviceSettingsStackRoutes,
-    RootStackParamList,
-    RootStackRoutes,
-    WipeDeviceStackParamList,
+    StackNavigationProps,
     WipeDeviceStackRoutes,
 } from '@suite-native/navigation';
 
-type NavigationProps = CompositeNavigationProp<
-    NativeStackNavigationProp<WipeDeviceStackParamList, WipeDeviceStackRoutes.WipeDevice>,
-    CompositeNavigationProp<
-        NativeStackNavigationProp<DeviceSettingsStackParamList>,
-        NativeStackNavigationProp<RootStackParamList>
-    >
+type NavigationProps = StackNavigationProps<
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes.WipeDeviceStack
 >;
 
 export const useWipeDevice = () => {
@@ -38,12 +32,7 @@ export const useWipeDevice = () => {
         // not wanted here. We want to treat it differently since it was wiped so user goes to onboarding through homescreen.
         dispatch(setWasDeviceOnboardingCancelled(true));
 
-        navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
-            screen: DeviceSettingsStackRoutes.WipeDeviceStack,
-            params: {
-                screen: WipeDeviceStackRoutes.ContinueOnTrezor,
-            },
-        });
+        navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack);
 
         const response = await requestPrioritizedDeviceAccess({
             deviceCallback: async () => await dispatch(wipeDeviceThunk()),
@@ -53,11 +42,8 @@ export const useWipeDevice = () => {
             analytics.report({
                 type: EventTypeShared.SettingsDeviceWipe,
             });
-            navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
-                screen: DeviceSettingsStackRoutes.WipeDeviceStack,
-                params: {
-                    screen: WipeDeviceStackRoutes.WipeDeviceLoadingScreen,
-                },
+            navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack, {
+                screen: WipeDeviceStackRoutes.WipeDeviceLoadingScreen,
             });
         } else {
             if (navigation.canGoBack()) {

--- a/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
+++ b/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
@@ -5,7 +5,6 @@ import {
     DeviceSettingsStackParamList,
     DeviceSettingsStackRoutes,
     StackNavigationProps,
-    WipeDeviceStackRoutes,
 } from '@suite-native/navigation';
 
 import { DeviceSettingsItemCard } from './DeviceSettingsItemCard';
@@ -19,9 +18,7 @@ export const WipeDeviceCard = () => {
     const navigation = useNavigation<NavigationProp>();
 
     const handleRedirect = () => {
-        navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack, {
-            screen: WipeDeviceStackRoutes.WipeDevice,
-        });
+        navigation.navigate(DeviceSettingsStackRoutes.WipeDevice);
     };
 
     return (

--- a/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
@@ -29,6 +29,7 @@ import { DeviceFirmwareScreen } from '../screens/DeviceFirmwareScreen';
 import { DeviceSettingsModalScreen } from '../screens/DeviceSettingsModalScreen';
 import { PinProtectionScreen } from '../screens/PinProtectionScreen';
 import { UnpairBluetoothDeviceScreen } from '../screens/UnpairBluetoothDeviceScreen';
+import { WipeDeviceScreen } from '../screens/WipeDeviceScreen';
 
 const DeviceSettingsStack = createNativeStackNavigator<DeviceSettingsStackParamList>();
 
@@ -67,6 +68,10 @@ export const DeviceSettingsStackNavigator = () => {
             <DeviceSettingsStack.Screen
                 name={DeviceSettingsStackRoutes.DeviceAuthenticity}
                 component={DeviceAuthenticityScreen}
+            />
+            <DeviceSettingsStack.Screen
+                name={DeviceSettingsStackRoutes.WipeDevice}
+                component={WipeDeviceScreen}
             />
             <DeviceSettingsStack.Group screenOptions={{ animation: 'slide_from_bottom' }}>
                 <DeviceSettingsStack.Screen
@@ -111,11 +116,11 @@ export const DeviceSettingsStackNavigator = () => {
                     name={DeviceSettingsStackRoutes.DeviceAuthenticityStack}
                     component={DeviceAuthenticityStackNavigator}
                 />
+                <DeviceSettingsStack.Screen
+                    name={DeviceSettingsStackRoutes.WipeDeviceStack}
+                    component={WipeDeviceStackNavigator}
+                />
             </DeviceSettingsStack.Group>
-            <DeviceSettingsStack.Screen
-                name={DeviceSettingsStackRoutes.WipeDeviceStack}
-                component={WipeDeviceStackNavigator}
-            />
         </DeviceSettingsStack.Navigator>
     );
 };

--- a/suite-native/module-device-settings/src/navigation/WipeDeviceStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/WipeDeviceStackNavigator.tsx
@@ -1,6 +1,9 @@
+import { useSelector } from 'react-redux';
+
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-import { useDeviceConnectionGuard } from '@suite-native/device-authorization';
+import { selectIsDeviceConnected } from '@suite-common/wallet-core';
+import { DeviceConnectionGuardScreenWithCancel } from '@suite-native/device-authorization';
 import {
     WipeDeviceStackParamList,
     WipeDeviceStackRoutes,
@@ -10,28 +13,26 @@ import {
 import { FactoryResetScreen } from '../screens/FactoryResetScreen';
 import { WipeDeviceContinueOnTrezorScreen } from '../screens/WipeDeviceContinueOnTrezorScreen';
 import { WipeDeviceLoadingScreen } from '../screens/WipeDeviceLoadingScreen';
-import { WipeDeviceScreen } from '../screens/WipeDeviceScreen';
 
 const WipeDeviceStack = createNativeStackNavigator<WipeDeviceStackParamList>();
 
 export const WipeDeviceStackNavigator = () => {
-    const { isDeviceConnected } = useDeviceConnectionGuard();
-
-    if (!isDeviceConnected) return;
+    const isDeviceConnected = useSelector(selectIsDeviceConnected);
 
     return (
-        <WipeDeviceStack.Navigator
-            initialRouteName={WipeDeviceStackRoutes.WipeDevice}
-            screenOptions={stackNavigationOptionsConfig}
-        >
-            <WipeDeviceStack.Screen
-                name={WipeDeviceStackRoutes.WipeDevice}
-                component={WipeDeviceScreen}
-            />
-            <WipeDeviceStack.Screen
-                name={WipeDeviceStackRoutes.ContinueOnTrezor}
-                component={WipeDeviceContinueOnTrezorScreen}
-            />
+        <WipeDeviceStack.Navigator screenOptions={stackNavigationOptionsConfig}>
+            {!isDeviceConnected && (
+                <WipeDeviceStack.Screen
+                    name={WipeDeviceStackRoutes.DeviceConnectionGuard}
+                    component={DeviceConnectionGuardScreenWithCancel}
+                />
+            )}
+            {isDeviceConnected && (
+                <WipeDeviceStack.Screen
+                    name={WipeDeviceStackRoutes.ContinueOnTrezor}
+                    component={WipeDeviceContinueOnTrezorScreen}
+                />
+            )}
             <WipeDeviceStack.Screen
                 name={WipeDeviceStackRoutes.WipeDeviceLoadingScreen}
                 component={WipeDeviceLoadingScreen}

--- a/suite-native/module-device-settings/src/screens/WipeDeviceContinueOnTrezorScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/WipeDeviceContinueOnTrezorScreen.tsx
@@ -7,14 +7,12 @@ import {
     ContinueOnTrezorScreenContent,
     selectShouldFactoryResetBeVisible,
 } from '@suite-native/device';
-import { useDeviceConnectionGuard } from '@suite-native/device-authorization';
 import { Screen, ScreenHeader, useInterceptNativeNavigation } from '@suite-native/navigation';
 import TrezorConnect from '@trezor/connect';
 
 export const WipeDeviceContinueOnTrezorScreen = () => {
     const shouldFactoryResetBeVisible = useSelector(selectShouldFactoryResetBeVisible);
 
-    useDeviceConnectionGuard();
     useInterceptNativeNavigation({ onPress: TrezorConnect.cancel });
 
     const device = useSelector(selectSelectedDevice);

--- a/suite-native/module-device-settings/src/screens/WipeDeviceScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/WipeDeviceScreen.tsx
@@ -23,7 +23,6 @@ export const WipeDeviceScreen = () => {
                 <DynamicScreenHeader
                     title={<Translation id="moduleDeviceSettings.wipeDevice.title" />}
                     subtitle={<Translation id="moduleDeviceSettings.wipeDevice.subtitle" />}
-                    closeActionType="close"
                 />
             }
         >

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -250,7 +250,10 @@ export type DeviceSettingsStackParamList = {
         | NavigatorScreenParams<DeviceAuthenticityStackParamList>
         | undefined;
     [DeviceSettingsStackRoutes.ContinueOnTrezor]: undefined;
-    [DeviceSettingsStackRoutes.WipeDeviceStack]: NavigatorScreenParams<WipeDeviceStackParamList>;
+    [DeviceSettingsStackRoutes.WipeDevice]: undefined;
+    [DeviceSettingsStackRoutes.WipeDeviceStack]:
+        | NavigatorScreenParams<WipeDeviceStackParamList>
+        | undefined;
 };
 
 export type DeviceNameStackParamList = {
@@ -286,7 +289,7 @@ export type DevicePinProtectionStackParamList = {
 };
 
 export type WipeDeviceStackParamList = {
-    [WipeDeviceStackRoutes.WipeDevice]: undefined;
+    [WipeDeviceStackRoutes.DeviceConnectionGuard]: undefined;
     [WipeDeviceStackRoutes.ContinueOnTrezor]: undefined;
     [WipeDeviceStackRoutes.WipeDeviceLoadingScreen]: undefined;
     [WipeDeviceStackRoutes.FactoryReset]: undefined;

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -94,6 +94,7 @@ export enum DeviceSettingsStackRoutes {
     DevicePassphraseStack = 'DevicePassphraseStack',
     DeviceAuthenticity = 'DeviceAuthenticity',
     DeviceAuthenticityStack = 'DeviceAuthenticityStack',
+    WipeDevice = 'WipeDevice',
     WipeDeviceStack = 'WipeDeviceStack',
 }
 
@@ -152,7 +153,7 @@ export enum DeviceAutoConnectStackRoutes {
 }
 
 export enum WipeDeviceStackRoutes {
-    WipeDevice = 'WipeDevice',
+    DeviceConnectionGuard = 'DeviceConnectionGuard',
     ContinueOnTrezor = 'ContinueOnTrezor',
     WipeDeviceLoadingScreen = 'WipeDeviceLoadingScreen',
     FactoryReset = 'FactoryReset',

--- a/yarn.lock
+++ b/yarn.lock
@@ -12097,7 +12097,6 @@ __metadata:
   resolution: "@suite-native/device-bootloader-mode@workspace:suite-native/device-bootloader-mode"
   dependencies:
     "@react-navigation/native": "npm:7.1.18"
-    "@react-navigation/native-stack": "npm:7.5.1"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/device": "workspace:*"
     "@suite-native/device-manager": "workspace:*"
@@ -12165,7 +12164,6 @@ __metadata:
   dependencies:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@react-navigation/native": "npm:7.1.18"
-    "@react-navigation/native-stack": "npm:7.5.1"
     "@reduxjs/toolkit": "npm:2.11.0"
     "@suite-common/bluetooth": "workspace:*"
     "@suite-common/device-authenticity": "workspace:*"


### PR DESCRIPTION
- Used same navigation pattern as for firmware settings

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/device-settings-wipe-device&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/native/device-settings-wipe-device&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/native/device-settings-wipe-device&lookback=7)