### PR TITLE
feat(suite-native): enable Cardano Features

### DIFF
--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+          cache: gradle
 
       - name: Prebuild native expo project
         working-directory: ./suite-native/app
@@ -142,6 +143,18 @@ jobs:
         run: $ANDROID_HOME/build-tools/35.0.0/apksigner sign --ks $KEYSTORE_PATH --ks-pass $KEYSTORE_PASSWORD --out app-release.apk app-release.apk
 
       ############# CACHE MISS - COMPILE A FRESH .APK FILE #############
+
+      - name: Rust Cache
+        if: steps.s3_build_cache.outputs.hit == 'false'
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            ./node_modules/@emurgo/csl-mobile-bridge/rust -> target
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: "x86_64-linux-android, armv7-linux-androideabi, aarch64-linux-android, i686-linux-android"
 
       - name: Build a new Detox test .apk
         if: steps.s3_build_cache.outputs.hit == 'false'

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -52,6 +52,20 @@ jobs:
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
           yarn install
 
+      - name: Rust Cache
+        if: steps.s3_build_cache.outputs.hit == 'false'
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            ./node_modules/@emurgo/csl-mobile-bridge/rust -> target
+
+      # Add required Rust targets for @emurgo/csl-mobile-bridge support
+      # https://github.com/Emurgo/csl-mobile-bridge?tab=readme-ov-file#requirements
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: "aarch64-apple-ios, aarch64-apple-ios-sim, x86_64-apple-ios"
+
       - name: Prebuild native expo project
         working-directory: ./suite-native/app
         run: yarn prebuild --platform ios --clean

--- a/patches/@emurgo+csl-mobile-bridge+9.0.1.patch
+++ b/patches/@emurgo+csl-mobile-bridge+9.0.1.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/@emurgo/csl-mobile-bridge/android/CMakeLists.txt b/node_modules/@emurgo/csl-mobile-bridge/android/CMakeLists.txt
+index 7539091..1191142 100644
+--- a/node_modules/@emurgo/csl-mobile-bridge/android/CMakeLists.txt
++++ b/node_modules/@emurgo/csl-mobile-bridge/android/CMakeLists.txt
+@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.13)
+ project(csl_mobile_bridge_jsi)
+
+ set(CMAKE_VERBOSE_MAKEFILE ON)
+-set(CMAKE_CXX_STANDARD 17)
++set(CMAKE_CXX_STANDARD 20)
++set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+ # Paths
+ set(BUILD_DIR ${CMAKE_CURRENT_LIST_DIR}/build)

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -1,3 +1,4 @@
+@emurgo/csl-mobile-bridge
 @ethereumjs/common
 @ethereumjs/tx
 @everstake/wallet-sdk-ethereum

--- a/suite-native/app/.depcheckrc.json
+++ b/suite-native/app/.depcheckrc.json
@@ -37,6 +37,7 @@
         "redux-persist",
         "@config-plugins/detox",
         "@currents/cmd",
+        "@emurgo/csl-mobile-bridge",
         "expo-atlas"
     ]
 }

--- a/suite-native/app/README.md
+++ b/suite-native/app/README.md
@@ -11,6 +11,29 @@ Generally it's recommended to follow official [React Native environment setup](h
 2. [iOS Guide](https://reactnative.dev/docs/set-up-your-environment?os=macos&platform=ios)
     - Make sure you have the latest version of the Xcode command line tools installed: `xcode-select --install`
 
+### Requirements for Cardano Support
+
+Due to the integration of Cardano via `csl-mobile-bridge`, you need to set up Rust and specific cross-compilation targets:
+
+- **Rust** — [Install rustup](https://rustup.rs/)
+- **Python 3** — Required for Android builds
+- **Rust targets** — Cross-compilation targets for iOS/Android
+
+```bash
+# Install Rust
+curl --proto '=https' --tlsv1.2 -sSf [https://sh.rustup.rs](https://sh.rustup.rs) | sh
+source $HOME/.cargo/env
+
+# Install Rust targets
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios \
+    aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+
+# Verify Python 3
+python3 --version
+```
+
+more info: https://github.com/Emurgo/csl-mobile-bridge
+
 ## Before you run the app
 
 1. Run `yarn native:prebuild:clean` to generate `ios/` and `android/` directories.

--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -134,6 +134,7 @@ const getPlugins = (): ExpoPlugins => {
             },
         ],
         '@trezor/react-native-usb/plugins/withUSBDevice.js',
+        './plugins/withFollyFlags',
         [
             './plugins/withAndroidMainActivityAttributes.js',
             {

--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -126,13 +126,13 @@ const getPlugins = (): ExpoPlugins => {
                     minSdkVersion: 28,
                     // this fixes expo-updates build error
                     kotlinVersion: '2.1.20',
-                    ndkVersion: '27.0.12077973',
                 },
                 ios: {
                     deploymentTarget: '15.1',
                 },
             },
         ],
+        ['./plugins/withNdkVersion', { ndkVersion: '27.0.12077973' }],
         '@trezor/react-native-usb/plugins/withUSBDevice.js',
         './plugins/withFollyFlags',
         [

--- a/suite-native/app/cardanoPolyfills.js
+++ b/suite-native/app/cardanoPolyfills.js
@@ -1,2 +1,0 @@
-/* eslint-disable import/no-default-export */
-export default {};

--- a/suite-native/app/eas-pre-install.sh
+++ b/suite-native/app/eas-pre-install.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+
+# Check if rustup is installed
+if ! command -v rustup &> /dev/null; then
+    echo "Rustup not found, installing..."
+    # Install rustup in non-interactive mode (-y)
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+    # Source the environment to make rustup available in the current shell
+    # shellcheck source=/dev/null
+    source "$HOME/.cargo/env"
+else
+    echo "Rustup is already installed."
+fi
+
+sudo ln -sf "$HOME/.cargo/bin/rustup" /usr/local/bin/rustup
+sudo ln -sf "$HOME/.cargo/bin/cargo" /usr/local/bin/cargo
+sudo ln -sf "$HOME/.cargo/bin/rustc" /usr/local/bin/rustc
+
+# Add required Rust targets for @emurgo/csl-mobile-bridge support
+# https://github.com/Emurgo/csl-mobile-bridge?tab=readme-ov-file#requirements
+echo "Adding Rust targets..."
+rustup target add \
+    aarch64-linux-android \
+    armv7-linux-androideabi \
+    i686-linux-android \
+    x86_64-linux-android \
+    aarch64-apple-ios \
+    aarch64-apple-ios-sim \
+    x86_64-apple-ios
+
+echo "Rust environment setup complete."
+
+# Check Python version
+echo "Checking Python 3 version..."
+python3 --version || { echo "Python 3 is missing!"; exit 1; }
+

--- a/suite-native/app/eas.json
+++ b/suite-native/app/eas.json
@@ -7,6 +7,9 @@
     "build": {
         "base": {
             "node": "24.11.1",
+            "android": {
+                "ndk": "27.0.12077973"
+            },
             "env": {
                 "EAS_NO_FROZEN_LOCKFILE": "1"
             }

--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -64,12 +64,9 @@ const config = {
                 };
             }
 
-            if (moduleName.startsWith('@emurgo/cardano')) {
-                // Cardano libs doesn't have main field in package.json which will cause error in metro
-                // Also they use WASM which doesn't work in RN so we polyfill it with empty file to build errors
-                // In future we will need JS implementation of Cardano libs or C++ implementation
+            if (moduleName === '@emurgo/cardano-serialization-lib-nodejs') {
                 return {
-                    filePath: require.resolve('./cardanoPolyfills.js'),
+                    filePath: require.resolve(rootNodeModulesPath + '/@emurgo/csl-mobile-bridge'),
                     type: 'sourceFile',
                 };
             }

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -157,6 +157,7 @@
         "@babel/core": "7.28.5",
         "@config-plugins/detox": "^11.0.0",
         "@currents/cmd": "^1.9.4",
+        "@emurgo/csl-mobile-bridge": "9.0.1",
         "@jest/globals": "^29.7.0",
         "@react-native-community/cli": "^15.1.2",
         "@react-native/babel-preset": "0.81.0",

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -16,6 +16,7 @@
         "build:adhoc": "npx eas-cli build --profile adhoc",
         "eas-build-post-install": "yarn workspace @suite-common/message-system sign-config",
         "eas-build-on-success": "./eas-post-success.sh",
+        "eas-build-pre-install": "./eas-pre-install.sh",
         "prebuild:clean": "expo prebuild --clean",
         "build:e2e": "npx detox build --configuration",
         "test:e2e": "node ./scripts/cleanArtifacts.js && npx detox test --configuration ",

--- a/suite-native/app/plugins/withFollyFlags.js
+++ b/suite-native/app/plugins/withFollyFlags.js
@@ -1,0 +1,36 @@
+const { withDangerousMod } = require('expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function withPodsFollyNoCoroutines(config) {
+    return withDangerousMod(config, [
+        'ios',
+        cfg => {
+            const podfilePath = path.join(cfg.modRequest.platformProjectRoot, 'Podfile');
+            let podfile = fs.readFileSync(podfilePath, 'utf8');
+
+            const marker = '### FOLLY_NO_COROUTINES_FOR_PODS';
+            if (podfile.includes(marker)) return cfg;
+
+            const snippet = `
+  # ${marker}
+# Prevents Folly from including the missing \`folly/coro/Coroutine.h\` header.
+# Required for React Native New Architecture when building C++ Pods
+# (e.g. @emurgo/csl-mobile-bridge) to match Folly flags used by the app target. https://github.com/facebook/folly/issues/2297
+  installer.pods_project.build_configurations.each do |config|
+    flags = config.build_settings['OTHER_CPLUSPLUSFLAGS']
+    flags = ['$(inherited)'] if flags.nil?
+    flags = [flags] if flags.is_a?(String)
+    flags << '-DFOLLY_CFG_NO_COROUTINES=1' unless flags.include?('-DFOLLY_CFG_NO_COROUTINES=1')
+    config.build_settings['OTHER_CPLUSPLUSFLAGS'] = flags
+  end
+`;
+
+            podfile = podfile.replace(/post_install do \|installer\|\n/, m => m + snippet);
+
+            fs.writeFileSync(podfilePath, podfile);
+
+            return cfg;
+        },
+    ]);
+};

--- a/suite-native/app/plugins/withNdkVersion.js
+++ b/suite-native/app/plugins/withNdkVersion.js
@@ -1,0 +1,24 @@
+const { withProjectBuildGradle } = require('expo/config-plugins');
+
+module.exports = function withNdkVersion(config, { ndkVersion }) {
+    return withProjectBuildGradle(config, modConfig => {
+        let { contents } = modConfig.modResults;
+
+        const ndkBlock = `// Custom NDK Version\nallprojects { ext.ndkVersion = "${ndkVersion}" }\n`;
+
+        if (contents.includes('ext.ndkVersion')) {
+            contents = contents.replace(
+                /ext\.ndkVersion\s*=\s*["'].*["']/,
+                `ext.ndkVersion = "${ndkVersion}"`,
+            );
+        } else {
+            contents = ndkBlock + contents;
+        }
+
+        modConfig.modResults.contents = contents;
+
+        console.log(`[withNdkVersion] Applied NDK: ${ndkVersion}`);
+
+        return modConfig;
+    });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,6 +2772,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emurgo/csl-mobile-bridge@npm:9.0.1":
+  version: 9.0.1
+  resolution: "@emurgo/csl-mobile-bridge@npm:9.0.1"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/82c08d7fd2b6a06d2def418556b54f5e6901ba3b75a777abb6ea59853ba444afbc14b68704b96f7b2da27bdf1d4e711680904cb8f6464587c04d8113e9c6e580
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.25.2":
   version: 0.25.2
   resolution: "@esbuild/aix-ppc64@npm:0.25.2"
@@ -11455,6 +11465,7 @@ __metadata:
     "@babel/core": "npm:7.28.5"
     "@config-plugins/detox": "npm:^11.0.0"
     "@currents/cmd": "npm:^1.9.4"
+    "@emurgo/csl-mobile-bridge": "npm:9.0.1"
     "@exodus/patch-broken-hermes-typed-arrays": "npm:^1.0.0-alpha.1"
     "@gorhom/bottom-sheet": "npm:5.2.6"
     "@jest/globals": "npm:^29.7.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Install `@emurgo/csl-mobile-bridge` to enable Cardano serialization on mobile
- Add iOS Pods build flag to prevent Folly coroutine header build errors

### Build requirements

Cardano support uses `@emurgo/csl-mobile-bridge`, which compiles native Rust code
during iOS and Android builds.

Because of this, the following tools are required in dev and CI environments:

- **Rust** — [Install rustup](https://rustup.rs/)
- **Python 3** — Required for Android builds
- **Rust targets** — Cross-compilation targets for iOS/Android

```bash
# Install Rust
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
source ~/.zshrc

# Install Rust targets
rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios \
    aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android

# Verify Python 3
python3 --version
```

More:
https://github.com/Emurgo/csl-mobile-bridge#requirements

TODO: ‼️
- [x] test android
- [x] update README

out of scope: 
 - removing Cardano Send Flag  - https://github.com/trezor/trezor-suite/issues/24034

## Notes for QA

- First go to `Dev utils Menu` and enable `Cardano Send` Feature Flag
- test the cardano features

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23545

## Screenshots:

https://github.com/user-attachments/assets/bcf677dd-d9f8-4c20-a3eb-3483ef14ca51



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/cardano-send&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/cardano-send&lookback=7)