### PR TITLE
chore: fix eslint import/order

### DIFF
--- a/packages/suite-desktop-ui/src/MainDesktop.tsx
+++ b/packages/suite-desktop-ui/src/MainDesktop.tsx
@@ -1,41 +1,41 @@
-/* eslint-disable import/order */
 import { Provider as ReduxProvider } from 'react-redux';
+
+import { type History, createMemoryHistory } from 'history';
 import { createRoot } from 'react-dom/client';
 
-import { desktopApi } from '@trezor/suite-desktop-api';
-import { createIpcProxy } from '@trezor/ipc-proxy';
+import { ServicesProvider } from '@suite-common/redux-utils';
 import TrezorConnect from '@trezor/connect';
+import { createIpcProxy } from '@trezor/ipc-proxy';
+import { desktopApi } from '@trezor/suite-desktop-api';
 
-import { initStore } from 'src/reducers/store';
-import { preloadStore } from 'src/support/suite/preloadStore';
-import { Metadata } from 'src/components/suite/Metadata';
+import { initBluetoothThunk } from 'src/actions/bluetooth/initBluetoothThunk';
+import * as STORAGE from 'src/actions/suite/constants/storageConstants';
+import { desktopHandshake } from 'src/actions/suite/suiteActions';
 import {
     AppRouter,
     Preloader,
     ToastContainer,
     TrafficLightDraggableWindowHeader,
 } from 'src/components/suite';
-import { ConnectedIntlProvider } from 'src/support/suite/ConnectedIntlProvider';
-import { useTor } from 'src/support/suite/useTor';
-import { useConnectPopupDesktop } from 'src/support/suite/useConnectPopupDesktop';
-import { Main } from 'src/support/suite/Main';
-import { LoadingScreen } from 'src/support/suite/screens/LoadingScreen';
-import { ErrorScreen } from 'src/support/suite/screens/ErrorScreen';
+import { Metadata } from 'src/components/suite/Metadata';
 import { useDebugLanguageShortcut } from 'src/hooks/suite';
-import { desktopHandshake } from 'src/actions/suite/suiteActions';
-import { initBluetoothThunk } from 'src/actions/bluetooth/initBluetoothThunk';
-import * as STORAGE from 'src/actions/suite/constants/storageConstants';
-
-import { DesktopUpdater } from './support/DesktopUpdater';
-import { TorLoadingScreen } from './support/screens/TorLoadingScreen';
-import { BioAuthGuard } from '../../suite/src/components/suite/BioAuthGuard/BioAuthGuard';
-import { desktopComponents } from './support/desktopComponents';
-import { type History, createMemoryHistory } from 'history';
+import { initStore } from 'src/reducers/store';
 import { createRouterServices } from 'src/support/extraDependencies';
-import { FindBar } from '../../suite/src/components/suite/FindBar/FindBar';
+import { ConnectedIntlProvider } from 'src/support/suite/ConnectedIntlProvider';
+import { Main } from 'src/support/suite/Main';
+import { preloadStore } from 'src/support/suite/preloadStore';
+import { ErrorScreen } from 'src/support/suite/screens/ErrorScreen';
+import { LoadingScreen } from 'src/support/suite/screens/LoadingScreen';
+import { useConnectPopupDesktop } from 'src/support/suite/useConnectPopupDesktop';
+import { useTor } from 'src/support/suite/useTor';
+
 import { GlobalStyle } from './GlobalStyle';
 import { initSentry } from './sentry';
-import { ServicesProvider } from '@suite-common/redux-utils';
+import { DesktopUpdater } from './support/DesktopUpdater';
+import { desktopComponents } from './support/desktopComponents';
+import { TorLoadingScreen } from './support/screens/TorLoadingScreen';
+import { BioAuthGuard } from '../../suite/src/components/suite/BioAuthGuard/BioAuthGuard';
+import { FindBar } from '../../suite/src/components/suite/FindBar/FindBar';
 
 const MainDesktop = ({ history }: { history: History }) => {
     useTor();

--- a/packages/suite/src/components/suite/index.tsx
+++ b/packages/suite/src/components/suite/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable import/order */
+// TODO Change this to direct export {} from, instead of importing and re-exporting, but currently cannot be done because of circular dependencies.
 import { AccountLabel } from './AccountLabel';
 import { Address } from './Address';
 import { DeviceConfirmImage } from './DeviceConfirmImage';

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -11,15 +11,14 @@ import { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { ServerInfo } from '@trezor/blockchain-link-types';
 import TrezorConnect from '@trezor/connect';
 
-// eslint-disable-next-line import/order
+import { ChangeFee } from 'src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee';
+import { ReplaceTxButton } from 'src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton';
 import {
     actionSequence,
     findByTestId,
     renderWithProviders,
     waitForLoader,
 } from 'src/support/tests/hooksHelper';
-import { ChangeFee } from 'src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee';
-import { ReplaceTxButton } from 'src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton';
 
 import * as fixtures from '../__fixtures__/useRbfForm';
 import { RbfContext, useRbf, useRbfContext } from '../useRbfForm';

--- a/packages/suite/src/middlewares/wallet/index.ts
+++ b/packages/suite/src/middlewares/wallet/index.ts
@@ -1,23 +1,22 @@
-/* eslint-disable import/order */
+import { prepareConnectPopupMiddleware } from '@suite-common/connect-popup';
+import type { ExtraDependencies } from '@suite-common/redux-utils';
+import { prepareSuiteSyncMiddleware } from '@suite-common/suite-sync';
+import { prepareTokenDefinitionsMiddleware } from '@suite-common/token-definitions';
 import {
     prepareAccountsMiddleware,
     prepareBlockchainMiddleware,
     prepareFiatRatesMiddleware,
     prepareStakeMiddleware,
 } from '@suite-common/wallet-core';
-import { prepareTokenDefinitionsMiddleware } from '@suite-common/token-definitions';
-import { prepareConnectPopupMiddleware } from '@suite-common/connect-popup';
 import { prepareWalletConnectMiddleware } from '@suite-common/walletconnect';
 
-import { prepareDiscoveryMiddleware } from './discoveryMiddleware';
-import storageMiddleware from './storageMiddleware';
-import walletMiddleware from './walletMiddleware';
-import graphMiddleware from './graphMiddleware';
-import { tradingMiddleware } from './tradingMiddleware';
 import { coinjoinMiddleware } from './coinjoinMiddleware';
+import { prepareDiscoveryMiddleware } from './discoveryMiddleware';
+import graphMiddleware from './graphMiddleware';
 import { replaceByFeeErrorMiddleware } from './replaceByFeeErrorMiddleware';
-import type { ExtraDependencies } from '@suite-common/redux-utils';
-import { prepareSuiteSyncMiddleware } from '@suite-common/suite-sync';
+import storageMiddleware from './storageMiddleware';
+import { tradingMiddleware } from './tradingMiddleware';
+import walletMiddleware from './walletMiddleware';
 
 export const getWalletMiddlewares = (getExtra: () => ExtraDependencies | null) => [
     prepareBlockchainMiddleware(getExtra),

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/order */
 // fixes bindActionCreators() https://github.com/reduxjs/redux-thunk/blob/e3d452948d5562b9ce871cc9391403219f83b4ff/extend-redux.d.ts#L11
 import {
     DevToolsEnhancerOptions,
@@ -11,42 +10,41 @@ import {
 import { createLogger } from 'redux-logger';
 
 import { prepareFirmwareReducer } from '@suite-common/firmware';
+import { geolocationReducer } from '@suite-common/geolocation';
 import { addLog } from '@suite-common/logger';
-import { prepareThpReducer } from '@suite-common/thp';
-import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions';
-import { accountsActions } from '@suite-common/wallet-core';
-import { isCodesignBuild } from '@trezor/env-utils';
-import { mergeDeepObject } from '@trezor/utils';
-import { suiteSyncSlice } from 'src/actions/suiteSync/suiteSyncSlice';
 import {
     ExtraDependencies,
     castExtraStore,
     createStoreWithExtraStoreMiddleware,
 } from '@suite-common/redux-utils';
+import { labelingReducer } from '@suite-common/suite-sync';
+import { prepareThpReducer } from '@suite-common/thp';
+import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions';
+import { accountsActions } from '@suite-common/wallet-core';
+import { isCodesignBuild } from '@trezor/env-utils';
+import { mergeDeepObject } from '@trezor/utils';
 
+import { OPEN_USER_CONTEXT } from 'src/actions/suite/constants/modalConstants';
+import { suiteSyncSlice } from 'src/actions/suiteSync/suiteSyncSlice';
+import { suiteSyncQuotaManagerSlice } from 'src/actions/suiteSyncQuotaManager/suiteSyncQuotaManagerSlice';
 import backupMiddlewares from 'src/middlewares/backup';
 import onboardingMiddlewares from 'src/middlewares/onboarding';
 import recoveryMiddlewares from 'src/middlewares/recovery';
 import { getSuiteMiddleware } from 'src/middlewares/suite';
+import toastMiddleware from 'src/middlewares/suite/toastMiddleware';
 import { getWalletMiddlewares } from 'src/middlewares/wallet';
 import backupReducers from 'src/reducers/backup';
 import onboardingReducers from 'src/reducers/onboarding';
 import recoveryReducers from 'src/reducers/recovery';
 import suiteReducers from 'src/reducers/suite';
 import walletReducers from 'src/reducers/wallet';
-// toastMiddleware can be used only in suite-desktop and suite-web
-// it's not included into `@suite-middlewares` index
-import { geolocationReducer } from '@suite-common/geolocation';
-import { labelingReducer } from '@suite-common/suite-sync';
-import { OPEN_USER_CONTEXT } from 'src/actions/suite/constants/modalConstants';
-import toastMiddleware from 'src/middlewares/suite/toastMiddleware';
 import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
 import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
-import { bluetoothSlice } from '../actions/bluetooth/desktopBluetoothReducer';
-import { createSuiteCompositionRoot, extraDependencies } from '../support/extraDependencies';
+
 import { prepareBioAuthReducer } from './bioAuth';
 import { desktopReducer } from './desktop';
-import { suiteSyncQuotaManagerSlice } from 'src/actions/suiteSyncQuotaManager/suiteSyncQuotaManagerSlice';
+import { bluetoothSlice } from '../actions/bluetooth/desktopBluetoothReducer';
+import { createSuiteCompositionRoot, extraDependencies } from '../support/extraDependencies';
 
 const firmwareReducer = prepareFirmwareReducer(extraDependencies);
 const tokenDefinitionsReducer = prepareTokenDefinitionsReducer(extraDependencies);


### PR DESCRIPTION
## Description

Remove some eslint disables, which were likely forgotten there in 70e6c68a (I guess to quickly circumvent merge conclifcts? idk)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-disable-eslint-import-order&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-disable-eslint-import-order&lookback=7)