### PR TITLE
fix(suite): prefer floating CEX quotes, fallback to fixed

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeQuotesFilter.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeQuotesFilter.ts
@@ -9,29 +9,26 @@ import {
     TRADING_EXCHANGE_FORM_DEX,
     TradingExchangeFormProps,
     TradingExchangeFormType,
-    TradingExchangeRateType,
     exchangeUtils,
 } from '@suite-common/trading';
 
 interface TradingExchangeQuotesFilterProps {
     quotes: ExchangeTrade[];
     exchangeType: TradingExchangeFormType;
-    rateType: TradingExchangeRateType;
     exchangeInfo: any;
     setValue: UseFormSetValue<TradingExchangeFormProps>;
 }
 
 export const useTradingExchangeQuotesFilter = ({
     exchangeType,
-    rateType,
     quotes,
     exchangeInfo,
     setValue,
 }: TradingExchangeQuotesFilterProps) => {
     const dexQuotes = useMemo(() => quotes.filter(quote => quote.isDex), [quotes]);
     const cexQuotes = useMemo(
-        () => exchangeUtils.getCexQuotesByRateType(rateType, quotes, exchangeInfo),
-        [rateType, quotes, exchangeInfo],
+        () => exchangeUtils.getPreferredCexQuotes(quotes, exchangeInfo),
+        [quotes, exchangeInfo],
     );
 
     // handle edge case when there are no longer quotes of selected exchange type

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -211,7 +211,6 @@ export const useTradingExchangeForm = ({
 
     const { cexQuotes, dexQuotes } = useTradingExchangeQuotesFilter({
         exchangeType,
-        rateType,
         quotes,
         exchangeInfo,
         setValue,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -58,13 +58,15 @@ export const getSelectedQuote = (
     context: TradingFormContextValues<TradingType>,
     bestScoredQuote: TradingTradeType | undefined,
 ) => {
-    if (isTradingExchangeContext(context)) {
-        return context.getValues(TRADING_EXCHANGE_FORM) === TRADING_EXCHANGE_FORM_DEX
-            ? context.dexQuotes?.[0]
-            : context.cexQuotes?.[0];
-    } else {
+    if (!isTradingExchangeContext(context)) {
         return bestScoredQuote;
     }
+
+    const isDex = context.getValues(TRADING_EXCHANGE_FORM) === TRADING_EXCHANGE_FORM_DEX;
+
+    const selectedQuote = isDex ? context.dexQuotes?.[0] : context.cexQuotes?.[0];
+
+    return selectedQuote ?? bestScoredQuote;
 };
 
 export const TradingFormOffer = () => {

--- a/suite-common/trading/src/utils/exchange/exchangeUtils.ts
+++ b/suite-common/trading/src/utils/exchange/exchangeUtils.ts
@@ -1,8 +1,8 @@
 import { CryptoId, ExchangeTrade, ExchangeTradeStatus } from 'invity-api';
 
-import { CONTRACT_ADDRESS_FOR_NATIVE_TOKEN, TRADING_EXCHANGE_RATE_FIXED } from '../../constants';
+import { CONTRACT_ADDRESS_FOR_NATIVE_TOKEN } from '../../constants';
 import { ExchangeInfo } from '../../reducers/exchangeReducer';
-import { TradingExchangeAmountLimitProps, TradingExchangeRateType } from '../../types';
+import { TradingExchangeAmountLimitProps } from '../../types';
 import { cryptoIdToNetwork, parseCryptoId } from '../../utils';
 
 type GetAmountLimitsProps = {
@@ -88,14 +88,11 @@ const floatRateCexQuotes = (quotes: ExchangeTrade[], exchangeInfo: ExchangeInfo 
         return provider && !provider.isFixedRate && !q.isDex && !isQuoteError(q);
     });
 
-const getCexQuotesByRateType = (
-    rateType: TradingExchangeRateType,
-    quotes: ExchangeTrade[],
-    exchangeInfo: ExchangeInfo | undefined,
-) => {
-    if (rateType === TRADING_EXCHANGE_RATE_FIXED) return fixedRateCexQuotes(quotes, exchangeInfo);
+// Prefer floating-rate quotes, fallback to fixed-rate if none available
+const getPreferredCexQuotes = (quotes: ExchangeTrade[], exchangeInfo: ExchangeInfo | undefined) => {
+    const floatQuotes = floatRateCexQuotes(quotes, exchangeInfo);
 
-    return floatRateCexQuotes(quotes, exchangeInfo);
+    return floatQuotes.length > 0 ? floatQuotes : fixedRateCexQuotes(quotes, exchangeInfo);
 };
 
 const getSuccessQuotesOrdered = (quotes: ExchangeTrade[]): ExchangeTrade[] =>
@@ -131,7 +128,7 @@ export const exchangeUtils = {
     isQuoteError,
     fixedRateCexQuotes,
     floatRateCexQuotes,
-    getCexQuotesByRateType,
+    getPreferredCexQuotes,
     getSuccessQuotesOrdered,
     getStatusMessage,
     tokenSupportsIncreasingAllowance,


### PR DESCRIPTION
## Description

The trading form now prefers floating-rate CEX quotes and falls back to fixed-rate quotes when no floating option is available.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23974

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-best-available-offer&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-best-available-offer&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-best-available-offer&lookback=7)