### PR TITLE
chore(suite): remove internal barrel file imports

### DIFF
--- a/packages/suite/src/components/suite/BaseCurrencyValue.tsx
+++ b/packages/suite/src/components/suite/BaseCurrencyValue.tsx
@@ -14,7 +14,7 @@ import {
 import { SkeletonRectangle } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
-import { HiddenPlaceholder } from 'src/components/suite';
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
 import { useLoadingSkeleton, useSelector } from 'src/hooks/suite';
 import type { UseFiatFromCryptoValueParams } from 'src/hooks/suite/useFiatFromCryptoValue';
 import { useFiatFromCryptoValue } from 'src/hooks/suite/useFiatFromCryptoValue';

--- a/packages/suite/src/components/suite/CoinBalance.tsx
+++ b/packages/suite/src/components/suite/CoinBalance.tsx
@@ -1,7 +1,7 @@
 import type { NetworkSymbolExtended } from '@suite-common/wallet-config';
 import { AmountUnit } from '@suite-common/wallet-utils';
 
-import { FormattedCryptoAmount } from 'src/components/suite';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
 interface CoinBalanceProps {
     value: string | AmountUnit; // Todo: `string` only for back compatibility

--- a/packages/suite/src/components/suite/CoinGroup/CoinGroup.tsx
+++ b/packages/suite/src/components/suite/CoinGroup/CoinGroup.tsx
@@ -6,7 +6,7 @@ import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
-import { CoinList } from 'src/components/suite';
+import { CoinList } from 'src/components/suite/CoinList/CoinList';
 import { useDispatch } from 'src/hooks/suite';
 
 import { CoinGroupHeader } from './CoinGroupHeader';

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -20,7 +20,8 @@ import { Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
-import { HiddenPlaceholder, Sign } from 'src/components/suite';
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
+import { Sign } from 'src/components/suite/Sign';
 import { useSelector } from 'src/hooks/suite';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { selectLanguage } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/components/suite/FormattedNftAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedNftAmount.tsx
@@ -8,9 +8,9 @@ import { Box, Column, Row, Text } from '@trezor/components';
 import { TokenTransfer } from '@trezor/connect';
 import { TypographyStyle, spacings } from '@trezor/theme';
 
-import { HiddenPlaceholder, Sign } from 'src/components/suite';
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
+import { Sign } from 'src/components/suite/Sign';
 import { Translation } from 'src/components/suite/Translation';
-// importing directly, otherwise unit tests fail, seems to be a styled-components issue
 import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { useTranslation } from 'src/hooks/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';

--- a/packages/suite/src/components/suite/Preloader/InitialLoading.tsx
+++ b/packages/suite/src/components/suite/Preloader/InitialLoading.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { Loading } from 'src/components/suite';
+import { Loading } from 'src/components/suite/Loading';
 
 const StyledLoading = styled(Loading)`
     height: 100%;

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
@@ -3,8 +3,8 @@ import { MouseEventHandler } from 'react';
 import { acquireDevice } from '@suite-common/wallet-core';
 import { Banner } from '@trezor/components';
 
-import { TroubleshootingTips } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import {
     TROUBLESHOOTING_TIP_CLOSE_ALL_TABS,
     TROUBLESHOOTING_TIP_RECONNECT,

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceBootloader.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceBootloader.tsx
@@ -1,5 +1,5 @@
-import { TroubleshootingTips } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import { useDevice } from 'src/hooks/suite/useDevice';
 import { getHowToGetFromBootloaderInstructionsMap } from 'src/utils/device/bootloader';
 

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceDisconnectRequired.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceDisconnectRequired.tsx
@@ -1,5 +1,5 @@
-import { TroubleshootingTips } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 
 export const DeviceDisconnectRequired = () => (
     <TroubleshootingTips

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceFirmwareCorrupted.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceFirmwareCorrupted.tsx
@@ -3,8 +3,8 @@ import { MouseEventHandler } from 'react';
 import { Banner } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { TroubleshootingTips } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import { useDispatch } from 'src/hooks/suite';
 
 export const DeviceFirmwareCorrupted = () => {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
@@ -8,8 +8,8 @@ import {
     updateAnalytics,
 } from 'src/actions/onboarding/onboardingActions';
 import { goto } from 'src/actions/suite/routerActions';
-import { TroubleshootingTips } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import { useDispatch } from 'src/hooks/suite';
 
 export const DeviceInitialize = () => {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx
@@ -3,8 +3,8 @@ import { MouseEventHandler } from 'react';
 import { Banner } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { TroubleshootingTips } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import { useDispatch } from 'src/hooks/suite';
 
 export const DeviceNoFirmware = () => {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceRecoveryMode.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceRecoveryMode.tsx
@@ -3,8 +3,8 @@ import { MouseEventHandler } from 'react';
 import { Banner } from '@trezor/components';
 
 import { rerun } from 'src/actions/recovery/recoveryActions';
-import { TroubleshootingTips } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 
 export const DeviceRecoveryMode = () => {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceSeedless.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceSeedless.tsx
@@ -1,5 +1,5 @@
-import { TroubleshootingTips } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 
 // Seedless devices are not supported by Trezor Suite
 export const DeviceSeedless = () => (

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceTrezorHostProtocolPair.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceTrezorHostProtocolPair.tsx
@@ -3,8 +3,8 @@ import { MouseEventHandler } from 'react';
 import { acquireDevice } from '@suite-common/wallet-core';
 import { Banner } from '@trezor/components';
 
-import { TroubleshootingTips } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 
 export const DeviceTrezorHostProtocolPair = () => {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnknown.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnknown.tsx
@@ -1,5 +1,5 @@
-import { TroubleshootingTips } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 
 export const DeviceUnknown = () => (
     <TroubleshootingTips

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
@@ -1,7 +1,7 @@
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { isLinux } from '@trezor/env-utils';
 
-import { TroubleshootingTips } from 'src/components/suite';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import {
     TROUBLESHOOTING_TIP_CLOSE_ALL_TABS,
     TROUBLESHOOTING_TIP_RECONNECT,

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUpdateRequired.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUpdateRequired.tsx
@@ -3,8 +3,8 @@ import { MouseEventHandler } from 'react';
 import { Banner } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { TroubleshootingTips } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import { useDispatch } from 'src/hooks/suite';
 
 export const DeviceUpdateRequired = () => {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUsedElsewhere.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUsedElsewhere.tsx
@@ -2,8 +2,8 @@ import { MouseEventHandler } from 'react';
 
 import { isDesktop } from '@trezor/env-utils';
 
-import { TroubleshootingTips } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import {
     TROUBLESHOOTING_TIP_CLOSE_ALL_TABS,
     TROUBLESHOOTING_TIP_RECONNECT,

--- a/packages/suite/src/components/suite/PrerequisitesGuide/MultiShareBackupInProgress.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/MultiShareBackupInProgress.tsx
@@ -1,5 +1,5 @@
-import { TroubleshootingTips } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 
 export const MultiShareBackupInProgress = () => (
     <TroubleshootingTips

--- a/packages/suite/src/components/suite/PrerequisitesGuide/NoTransport.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/NoTransport.tsx
@@ -1,6 +1,6 @@
 import { isDesktop } from '@trezor/env-utils';
 
-import { TroubleshootingTips } from 'src/components/suite';
+import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import {
     TROUBLESHOOTING_ENABLE_IN_DEBUG,
     TROUBLESHOOTING_TIP_RESTART_COMPUTER,

--- a/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
@@ -12,7 +12,7 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Box, Column, Paragraph, Text, motionEasing } from '@trezor/components';
 import { DeviceWithScene } from '@trezor/product-components';
 
-import { getMessageId } from 'src/components/suite';
+import { getMessageId } from 'src/components/suite/getMessageId';
 import { useSelector } from 'src/hooks/suite';
 import { selectPrerequisite } from 'src/selectors/suite/suiteSelectors';
 

--- a/packages/suite/src/components/suite/ReadMoreLink.tsx
+++ b/packages/suite/src/components/suite/ReadMoreLink.tsx
@@ -1,8 +1,8 @@
 import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import * as URLS from '@trezor/urls';
 
-import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TrezorLink } from 'src/components/suite/TrezorLink';
 
 interface ReadMoreLinkProps {
     url: keyof Omit<typeof URLS, 'TOR_URLS' | 'SUITE_TRADING_REDIRECT_DEEPLINKS'>;

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx
@@ -1,12 +1,12 @@
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Box, Column, Grid, Image } from '@trezor/components';
 import { DeviceModelInternal, getDeviceColorVariant } from '@trezor/device-utils';
+import type { ModelFor } from '@trezor/product-components';
 import {
     DeviceAnimation,
     DeviceWithScene,
     getLargeModelImagePath,
 } from '@trezor/product-components';
-import type { ModelFor } from '@trezor/product-components';
 import { borders, breakpoints, spacings } from '@trezor/theme';
 
 import { useSelector } from 'src/hooks/suite';

--- a/packages/suite/src/components/suite/Ticker/PriceTicker.tsx
+++ b/packages/suite/src/components/suite/Ticker/PriceTicker.tsx
@@ -4,7 +4,8 @@ import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { TokenAddress } from '@suite-common/wallet-types';
 import { typography } from '@trezor/theme';
 
-import { BaseCurrencyValue, HiddenPlaceholder } from 'src/components/suite';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
 
 import { LastUpdateTooltip } from './LastUpdateTooltip';
 import { NoRatesTooltip } from './NoRatesTooltip';

--- a/packages/suite/src/components/suite/Ticker/TrendTicker.tsx
+++ b/packages/suite/src/components/suite/Ticker/TrendTicker.tsx
@@ -7,7 +7,7 @@ import { getFiatRateKey, localizePercentage } from '@suite-common/wallet-utils';
 import { Icon } from '@trezor/components';
 import { spacingsPx, typography } from '@trezor/theme';
 
-import { BaseCurrencyValue } from 'src/components/suite';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
 import { useSelector } from 'src/hooks/suite';
 import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetAmount.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetAmount.tsx
@@ -3,7 +3,7 @@ import { selectBaseCurrency } from '@suite-common/wallet-core';
 import { BaseCurrencyAmount } from '@suite-common/wallet-types';
 import { Column, Text } from '@trezor/components';
 
-import { FormattedCryptoAmount } from 'src/components/suite';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { useSelector } from 'src/hooks/suite';
 
 export type AssetAmountProps = {

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
@@ -9,8 +9,8 @@ import { FirmwareHashCheckError, FirmwareRevisionCheckError } from '@trezor/conn
 import { spacings } from '@trezor/theme';
 import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL } from '@trezor/urls';
 
-import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { useSelector } from 'src/hooks/suite';
 import {
     selectFirmwareHashCheckErrorIfEnabled,

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipBase.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipBase.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { Row, Text } from '@trezor/components';
 import { paletteV1, paletteV2, spacings } from '@trezor/theme';
 
-import { FormattedDate } from 'src/components/suite';
+import { FormattedDate } from 'src/components/suite/FormattedDate';
 import { Translation } from 'src/components/suite/Translation';
 import { CommonAggregatedHistory, GraphRange } from 'src/types/wallet/graph';
 

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphYAxisTick.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphYAxisTick.tsx
@@ -5,7 +5,7 @@ import { useTheme } from 'styled-components';
 import { useFormatters } from '@suite-common/formatters';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
-import { FormattedCryptoAmount } from 'src/components/suite';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
 interface CommonProps {
     setWidth: (n: number) => void;

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx
@@ -9,7 +9,8 @@ import { isPending } from '@suite-common/wallet-utils';
 import { Icon } from '@trezor/components';
 import { typography, zIndices } from '@trezor/theme';
 
-import { GraphRangeSelector, GraphSkeleton } from 'src/components/suite';
+import { GraphRangeSelector } from 'src/components/suite/graph/GraphRangeSelector';
+import { GraphSkeleton } from 'src/components/suite/graph/GraphSkeleton';
 import { useGraph, useSelector } from 'src/hooks/suite';
 import { Account, WalletAccountTransaction } from 'src/types/wallet';
 import {

--- a/packages/suite/src/components/suite/index.tsx
+++ b/packages/suite/src/components/suite/index.tsx
@@ -1,3 +1,7 @@
+/*
+WARNING - do NOT import from this file in the suite/src/components/suite/ subdirectories!
+*/
+
 /* eslint-disable import/order */
 import { AccountLabel } from './AccountLabel';
 import { Address } from './Address';

--- a/packages/suite/src/components/suite/labeling/AccountLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/AccountLabeling.tsx
@@ -3,7 +3,7 @@ import { selectDevices, selectSelectedDevice } from '@suite-common/wallet-core';
 import { findAccountDevice } from '@suite-common/wallet-utils';
 import { BadgeProps } from '@trezor/components';
 
-import { AccountLabel } from 'src/components/suite';
+import { AccountLabel } from 'src/components/suite/AccountLabel';
 import { useSelector } from 'src/hooks/suite';
 import { Account as WalletAccount } from 'src/types/wallet';
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
@@ -11,8 +11,9 @@ import { ProgressPie } from '@trezor/components';
 import { typography } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { CountdownTimer, WalletLabeling } from 'src/components/suite';
+import { CountdownTimer } from 'src/components/suite/CountdownTimer';
 import { Translation } from 'src/components/suite/Translation';
+import { WalletLabeling } from 'src/components/suite/labeling';
 import { ROUND_PHASE_MESSAGES } from 'src/constants/suite/coinjoin';
 import { useDispatch } from 'src/hooks/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
@@ -10,13 +10,11 @@ import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { Column, H2, Row, Text, motionEasing } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 
-import {
-    AmountUnitSwitchWrapper,
-    BaseCurrencyValue,
-    FormattedCryptoAmount,
-    Labeling,
-} from 'src/components/suite';
 import { AccountTypeBadge } from 'src/components/suite/AccountTypeBadge';
+import { AmountUnitSwitchWrapper } from 'src/components/suite/AmountUnitSwitchWrapper';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import { Labeling } from 'src/components/suite/labeling';
 import { useDefaultAccountLabel, useSelector } from 'src/hooks/suite';
 import { useTranslation } from 'src/hooks/suite/useTranslation';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NotificationDropdown.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NotificationDropdown.tsx
@@ -6,7 +6,7 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { Box, Menu, Popover, PopoverRef } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
-import { Notifications } from 'src/components/suite/notifications';
+import { Notifications } from 'src/components/suite/notifications/Notifications/Notifications';
 import { useDispatch, useLayoutSize } from 'src/hooks/suite';
 
 import { NavigationItem, NavigationItemProps } from './NavigationItem';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
@@ -5,7 +5,7 @@ import styled, { useTheme } from 'styled-components';
 import { ElevationContext, ElevationDown, ElevationUp, Modal, variables } from '@trezor/components';
 
 import { GuideButton, GuideRouter } from 'src/components/guide';
-import { Metadata } from 'src/components/suite';
+import { Metadata } from 'src/components/suite/Metadata';
 import { SuiteBanners } from 'src/components/suite/banners';
 import { DiscoveryProgress } from 'src/components/wallet';
 import { useLayoutSize } from 'src/hooks/suite';

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -30,9 +30,11 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { MODAL } from 'src/actions/suite/constants';
-import { AccountLabel, Address, Labeling } from 'src/components/suite';
+import { AccountLabel } from 'src/components/suite/AccountLabel';
+import { Address } from 'src/components/suite/Address';
 import { QrCode } from 'src/components/suite/QrCode';
 import { Translation } from 'src/components/suite/Translation';
+import { Labeling } from 'src/components/suite/labeling';
 import { useGuideOpenNode } from 'src/hooks/guide';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { useLabelingCombined } from 'src/hooks/suite/useLabelingCombined';

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
@@ -8,8 +8,8 @@ import { getDeviceColorVariant } from '@trezor/device-utils';
 import { ConfirmOnDevicePill } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { DeviceConfirmImage } from 'src/components/suite';
 import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
+import { DeviceConfirmImage } from 'src/components/suite/DeviceConfirmImage';
 import { Translation } from 'src/components/suite/Translation';
 import messages from 'src/support/messages';
 import { TrezorDevice } from 'src/types/suite';

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinModal.tsx
@@ -2,7 +2,7 @@ import { usePin } from '@suite-common/wallet-core';
 import { Modal } from '@trezor/components';
 import { ConfirmOnDevicePill } from '@trezor/product-components';
 
-import { PinMatrix } from 'src/components/suite';
+import { PinMatrix } from 'src/components/suite/PinMatrix/PinMatrix';
 import { Translation } from 'src/components/suite/Translation';
 import { TrezorDevice } from 'src/types/suite';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -22,7 +22,9 @@ import { TokenInfo } from '@trezor/connect';
 import { Elevation, mapElevationToBackground, spacings } from '@trezor/theme';
 import { exhaustive } from '@trezor/type-utils';
 
-import { Address, BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
+import { Address } from 'src/components/suite/Address';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { Translation } from 'src/components/suite/Translation';
 import { TransactionReviewOutputStatus } from 'src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputStatus';
 import { Account } from 'src/types/wallet';

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -15,7 +15,7 @@ import { CoinLogo, FeeRate } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
-import { AccountLabel } from 'src/components/suite';
+import { AccountLabel } from 'src/components/suite/AccountLabel';
 import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
 import { DebugOnlyBadge } from 'src/components/suite/DebugOnlyBadge';
 import { Translation } from 'src/components/suite/Translation';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -22,7 +22,7 @@ import { spacings, spacingsPx } from '@trezor/theme';
 import { arrayPartition } from '@trezor/utils';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { CoinList } from 'src/components/suite';
+import { CoinList } from 'src/components/suite/CoinList/CoinList';
 import { Translation } from 'src/components/suite/Translation';
 import { useAvailableNetworkSymbols } from 'src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
@@ -1,7 +1,7 @@
 import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { Paragraph } from '@trezor/components';
 
-import { CoinList } from 'src/components/suite';
+import { CoinList } from 'src/components/suite/CoinList/CoinList';
 
 type SelectNetworkProps = {
     heading: React.ReactNode;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/BackgroundGalleryModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/BackgroundGalleryModal.tsx
@@ -1,6 +1,6 @@
 import { Card, Modal } from '@trezor/components';
 
-import { HomescreenGallery } from 'src/components/suite';
+import { HomescreenGallery } from 'src/components/suite/HomescreenGallery';
 import { Translation } from 'src/components/suite/Translation';
 
 type BackgroundGalleryModalProps = {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -11,7 +11,8 @@ import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
 import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
-import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { Translation } from 'src/components/suite/Translation';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DeviceAuthenticityOptOutModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DeviceAuthenticityOptOutModal.tsx
@@ -4,7 +4,7 @@ import { Banner, Card, Column, H3, Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { toggleDeviceAuthenticityCheck } from 'src/actions/suite/suiteActions';
-import { CheckItem } from 'src/components/suite';
+import { CheckItem } from 'src/components/suite/CheckItem';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/FirmwareRevisionOptOutModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/FirmwareRevisionOptOutModal.tsx
@@ -4,7 +4,7 @@ import { Banner, Card, Column, H3, Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { toggleFirmwareAuthenticityChecks } from 'src/actions/suite/suiteActions';
-import { CheckItem } from 'src/components/suite';
+import { CheckItem } from 'src/components/suite/CheckItem';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep2to4.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep2to4.tsx
@@ -17,8 +17,8 @@ import {
 import { spacings } from '@trezor/theme';
 import { ESHOP_KEEP_METAL_MULTI_SHARE_URL, HELP_CENTER_SEED_CARD_URL } from '@trezor/urls';
 
-import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TrezorLink } from 'src/components/suite/TrezorLink';
 
 import type { Steps } from './MultiShareBackupModal';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeAvailableBalance.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeAvailableBalance.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { InfoItem, Row, Text } from '@trezor/components';
 
-import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { Translation } from 'src/components/suite/Translation';
 
 interface StakeAvailableBalanceProps {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeInputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeInputs.tsx
@@ -8,7 +8,7 @@ import { InputWithOptions } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
-import { BaseCurrencyValue } from 'src/components/suite';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
 import { Translation } from 'src/components/suite/Translation';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { useStakeFormContext } from 'src/hooks/wallet/useStakeForm';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeInfoCards/EstimatedGains.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeInfoCards/EstimatedGains.tsx
@@ -10,8 +10,10 @@ import {
     HELP_CENTER_SOL_STAKING,
 } from '@trezor/urls';
 
-import { BaseCurrencyValue, FormattedCryptoAmount, TrezorLink } from 'src/components/suite';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { Translation } from 'src/components/suite/Translation';
+import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { useSelector } from 'src/hooks/suite';
 import { useStakeFormContext } from 'src/hooks/wallet/useStakeForm';
 import { CRYPTO_INPUT } from 'src/types/wallet/stakeForms';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TorLoadingModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TorLoadingModal.tsx
@@ -1,6 +1,6 @@
 import { UserContextPayload } from '@suite-common/suite-types';
 
-import { TorLoader } from 'src/components/suite';
+import { TorLoader } from 'src/components/suite/TorLoader/TorLoader';
 
 type TorLoadingModalProps = Omit<Extract<UserContextPayload, { type: 'tor-loading' }>, 'type'> & {
     onCancel: () => void;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TradingDCAModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TradingDCAModal.tsx
@@ -27,8 +27,8 @@ import { spacings } from '@trezor/theme';
 
 import { onCancel as closeModal, openModal } from 'src/actions/suite/modalActions';
 import { showAddress } from 'src/actions/wallet/receiveActions';
-import { AccountLabeling } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { AccountLabeling } from 'src/components/suite/labeling';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import useTradingVerifyAccount from 'src/hooks/wallet/trading/form/useTradingVerifyAccount';
 import { selectLabelingDataForAccount } from 'src/reducers/suite/metadataReducer';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/AffectedTransactionItem.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/AffectedTransactionItem.tsx
@@ -3,7 +3,9 @@ import { Transaction } from '@trezor/blockchain-link-types';
 import { Icon, InfoSegments, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Address, FormattedDate, HiddenPlaceholder } from 'src/components/suite';
+import { Address } from 'src/components/suite/Address';
+import { FormattedDate } from 'src/components/suite/FormattedDate';
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
 
 type RowIcon = {
     txType: Transaction['type'];

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/DecreasedOutputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/DecreasedOutputs.tsx
@@ -15,7 +15,9 @@ import {
 import { spacings } from '@trezor/theme';
 import { HELP_CENTER_REPLACE_BY_FEE_BITCOIN } from '@trezor/urls';
 
-import { Address, FormattedCryptoAmount, HiddenPlaceholder } from 'src/components/suite';
+import { Address } from 'src/components/suite/Address';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
 import { Translation, TranslationKey } from 'src/components/suite/Translation';
 import { RbfContextValues, useRbfContext } from 'src/hooks/wallet/useRbfForm';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -21,7 +21,7 @@ import { CoinLogo, FeeRate } from '@trezor/product-components';
 import { Elevation, borders, mapElevationToBorder, spacings, spacingsPx } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
-import { FormattedDateWithBullet } from 'src/components/suite';
+import { FormattedDateWithBullet } from 'src/components/suite/FormattedDateWithBullet';
 import { Translation } from 'src/components/suite/Translation';
 import { TxAddress } from 'src/components/suite/copy/TxAddress';
 import { TransactionHeader } from 'src/components/wallet/TransactionItem/TransactionHeader';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChainedTxs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChainedTxs.tsx
@@ -4,8 +4,8 @@ import { AccountType, Network } from '@suite-common/wallet-config';
 import { ChainedTransactions } from '@suite-common/wallet-types';
 import { typography } from '@trezor/theme';
 
-import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { TransactionItem } from 'src/components/wallet/TransactionItem/TransactionItem';
 
 import { AffectedTransactionItem } from './AffectedTransactions/AffectedTransactionItem';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
@@ -8,7 +8,8 @@ import { Card, Divider, InfoItem, Row, Text } from '@trezor/components';
 import { FeeRate } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { UseRbfProps, useRbfContext } from 'src/hooks/wallet/useRbfForm';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -18,7 +18,9 @@ import {
 import { Table, Text } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
-import { BaseCurrencyValue, FormattedCryptoAmount, FormattedDate } from 'src/components/suite';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import { FormattedDate } from 'src/components/suite/FormattedDate';
 import { Translation } from 'src/components/suite/Translation';
 import { AmountComponent } from 'src/components/wallet/AmountComponent';
 import { useSelector } from 'src/hooks/suite';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModalBase.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModalBase.tsx
@@ -13,8 +13,8 @@ import { Banner, Column, Modal } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { HELP_CENTER_ZERO_VALUE_ATTACKS } from '@trezor/urls';
 
-import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { useSelector } from 'src/hooks/suite';
 import { Account, WalletAccountTransaction } from 'src/types/wallet';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnecoCoinjoinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnecoCoinjoinModal.tsx
@@ -4,7 +4,7 @@ import { spacings } from '@trezor/theme';
 
 import { onCancel } from 'src/actions/suite/modalActions';
 import { goto } from 'src/actions/suite/routerActions';
-import { FormattedCryptoAmount } from 'src/components/suite';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useSelector } from 'src/hooks/suite/useSelector';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
@@ -7,7 +7,8 @@ import { Column, FractionButtonProps, Text } from '@trezor/components';
 import { InputWithOptions } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { Translation } from 'src/components/suite/Translation';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { useUnstakeFormContext } from 'src/hooks/wallet/useUnstakeForm';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -30,7 +30,7 @@ import { spacings, spacingsPx } from '@trezor/theme';
 
 import { onCancel } from 'src/actions/suite/modalActions';
 import { goto } from 'src/actions/suite/routerActions';
-import { AccountLabel } from 'src/components/suite';
+import { AccountLabel } from 'src/components/suite/AccountLabel';
 import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
@@ -14,7 +14,7 @@ import { CoinLogo } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
 import * as modalActions from 'src/actions/suite/modalActions';
-import { AccountLabel } from 'src/components/suite';
+import { AccountLabel } from 'src/components/suite/AccountLabel';
 import { AccountTypeBadge } from 'src/components/suite/AccountTypeBadge';
 import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/ActionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/ActionRenderer.tsx
@@ -1,7 +1,8 @@
 import { acquireDevice, selectDeviceThunk } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 
-import { NotificationRendererProps, NotificationViewProps } from 'src/components/suite';
+import type { NotificationRendererProps } from 'src/components/suite/notifications/NotificationRenderer/NotificationRenderer';
+import type { NotificationViewProps } from 'src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView';
 import { useDispatch } from 'src/hooks/suite';
 
 type ActionRendererProps = NotificationViewProps & NotificationRendererProps;

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/ExchangeInfoRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/ExchangeInfoRenderer.tsx
@@ -1,11 +1,9 @@
 import { selectTradingCoinSymbolByCryptoId } from '@suite-common/trading';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 
-import {
-    HiddenPlaceholder,
-    NotificationRendererProps,
-    NotificationViewProps,
-} from 'src/components/suite';
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
+import type { NotificationRendererProps } from 'src/components/suite/notifications/NotificationRenderer/NotificationRenderer';
+import type { NotificationViewProps } from 'src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView';
 import { useDefaultAccountLabel } from 'src/hooks/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';
 

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -8,7 +8,7 @@ import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
-import { NotificationViewProps } from 'src/components/suite';
+import type { NotificationViewProps } from 'src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView';
 
 import { ActionRenderer } from './ActionRenderer';
 import { AutoEjectRenderer } from './AutoEjectRenderer';

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -18,12 +18,10 @@ import {
 
 import { openModal } from 'src/actions/suite/modalActions';
 import { goto } from 'src/actions/suite/routerActions';
-import {
-    AccountLabeling,
-    HiddenPlaceholder,
-    NotificationRendererProps,
-    NotificationViewProps,
-} from 'src/components/suite';
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
+import { AccountLabeling } from 'src/components/suite/labeling';
+import type { NotificationRendererProps } from 'src/components/suite/notifications/NotificationRenderer/NotificationRenderer';
+import type { NotificationViewProps } from 'src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectRouteName } from 'src/reducers/suite/routerReducer';
 import { getTxAnchor } from 'src/utils/suite/anchor';

--- a/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationList.tsx
+++ b/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationList.tsx
@@ -1,7 +1,7 @@
 import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { NotificationRenderer } from 'src/components/suite';
+import { NotificationRenderer } from 'src/components/suite/notifications/NotificationRenderer/NotificationRenderer';
 import type { AppState } from 'src/types/suite';
 
 import { NotificationView } from './NotificationView';

--- a/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView.tsx
+++ b/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView.tsx
@@ -6,7 +6,7 @@ import { Button, ButtonProps, Column, Icon, IconName, Paragraph, Row } from '@tr
 import { ButtonPriority } from '@trezor/components/src/components/buttons/types';
 import { spacings } from '@trezor/theme';
 
-import { FormattedDateWithBullet } from 'src/components/suite';
+import { FormattedDateWithBullet } from 'src/components/suite/FormattedDateWithBullet';
 import { Translation } from 'src/components/suite/Translation';
 import { useLayoutSize } from 'src/hooks/suite';
 import type { ToastNotificationVariant } from 'src/types/suite';

--- a/packages/suite/src/components/suite/notifications/ToastNotification.tsx
+++ b/packages/suite/src/components/suite/notifications/ToastNotification.tsx
@@ -6,12 +6,10 @@ import { NotificationEntry, notificationsActions } from '@suite-common/toast-not
 import { Button, Column, Icon, Row } from '@trezor/components';
 import { spacings, typography } from '@trezor/theme';
 
-import {
-    NotificationRenderer,
-    NotificationViewProps,
-    mapActionVariantToIntent,
-} from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { NotificationRenderer } from 'src/components/suite/notifications/NotificationRenderer/NotificationRenderer';
+import type { NotificationViewProps } from 'src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView';
+import { mapActionVariantToIntent } from 'src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView';
 import { useDispatch } from 'src/hooks/suite';
 import { getNotificationIcon, getVariantColor } from 'src/utils/suite/notification';
 

--- a/packages/suite/src/components/suite/troubleshooting/tips/BridgeTip.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/BridgeTip.tsx
@@ -1,5 +1,5 @@
-import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { useOpenSuiteDesktop } from 'src/hooks/suite/useOpenSuiteDesktop';
 
 export const SuiteDesktopTip = () => {

--- a/packages/suite/src/components/suite/troubleshooting/tips/UdevDescription.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/UdevDescription.tsx
@@ -1,6 +1,6 @@
 import { goto } from 'src/actions/suite/routerActions';
-import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { useDispatch } from 'src/hooks/suite';
 
 export const UdevDescription = () => {

--- a/packages/suite/src/components/suite/troubleshooting/tips/UpdateGoToSettingsDescription.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/UpdateGoToSettingsDescription.tsx
@@ -1,6 +1,6 @@
 import { goto } from 'src/actions/suite/routerActions';
-import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { useDispatch } from 'src/hooks/suite';
 
 export const UpdateGoToSettingsDescription = () => {

--- a/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
@@ -1,8 +1,8 @@
 import { isDesktop, isLinux, isWeb } from '@trezor/env-utils';
 import { TREZOR_SUPPORT_DEVICE_URL } from '@trezor/urls';
 
-import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
+import { TrezorLink } from 'src/components/suite/TrezorLink';
 
 import { SuiteDesktopTip } from './BridgeTip';
 import { UdevDescription } from './UdevDescription';


### PR DESCRIPTION
## Description

Unsuccessful attempt to fix circular dependencies in `src/components/suite`.
But madge-snapshot remains exactly the same.
Barrel files are therefore not the culprit.

Still, removing the internal imports is an improvement..

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-internal-barrel-file-imports&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-internal-barrel-file-imports&lookback=7)