### PR TITLE
feat(suite-desktop): add anonymous mode to Debug

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -116,6 +116,7 @@ export interface InvokeChannels {
     'bridge/get-settings': () => InvokeResult<BridgeSettings>;
     'user-data/clear': () => InvokeResult;
     'user-data/open': (directory?: string) => InvokeResult;
+    'user-data/set-anonymous-mode': (enabled: boolean) => InvokeResult;
     'udev/install': () => InvokeResult;
     'app/auto-start/is-enabled': () => InvokeResult<boolean>;
     'app/auto-start/popup-ack': () => void;
@@ -197,6 +198,7 @@ export type DesktopApi = {
     clearStore: DesktopApiSend<'store/clear'>;
     clearUserData: DesktopApiInvoke<'user-data/clear'>;
     openUserDataDirectory: DesktopApiInvoke<'user-data/open'>;
+    setAnonymousMode: DesktopApiInvoke<'user-data/set-anonymous-mode'>;
     // Logger
     configLogger: DesktopApiSend<'logger/config'>;
     // Bridge

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -151,6 +151,13 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
 
             return Promise.resolve({ success: false, error: 'invalid params' });
         },
+        setAnonymousMode: (enabled: boolean) => {
+            if (validation.isPrimitive('boolean', enabled)) {
+                return ipcRenderer.invoke('user-data/set-anonymous-mode', enabled);
+            }
+
+            return Promise.resolve({ success: false, error: 'invalid params' });
+        },
 
         // Logger
         configLogger: config => {

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -49,6 +49,7 @@ export type HandshakeClient = {
 
 export type HandshakeInit = {
     statePatch?: Record<string, any>;
+    isAnonymousMode?: boolean;
 };
 
 export type HandshakeTorModule = {

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -10,7 +10,7 @@ import type { HandshakeClient } from '@trezor/suite-desktop-api';
 import { colorVariants } from '@trezor/theme';
 import { createDeferred, resolveAfter } from '@trezor/utils';
 
-import { hangDetect } from './hang-detect';
+import { handshakeAndHangDetect } from './handshake-and-hang-detect';
 import { processStatePatch, removeElectronAppData, restartApp } from './libs/app-utils';
 import { APP_NAME } from './libs/constants';
 import { getBuildInfo, getComputerInfo } from './libs/info';
@@ -399,7 +399,12 @@ const init = async () => {
             loadIndex(mainWindow);
         });
 
-        const { handshake, cleanup } = hangDetect(mainWindow, statePatch);
+        const isAnonymousMode = store.getAnonymousMode();
+        const { handshake, cleanup } = handshakeAndHangDetect({
+            mainWindow,
+            statePatch,
+            isAnonymousMode,
+        });
         mainWindowProxy.once('destroy', cleanup);
         const handshakeResult = await handshake;
 

--- a/packages/suite-desktop-core/src/handshake-and-hang-detect.ts
+++ b/packages/suite-desktop-core/src/handshake-and-hang-detect.ts
@@ -21,7 +21,20 @@ const showDialog = async (mainWindow: BrowserWindow) => {
     return (['wait', 'quit', 'reload'] as const)[resp.response];
 };
 
-export const hangDetect = (mainWindow: BrowserWindow, statePatch?: Record<string, any>) => {
+type HandshakeAndHangDetectParams = {
+    mainWindow: BrowserWindow;
+    statePatch?: Record<string, any>;
+    isAnonymousMode?: boolean;
+};
+
+/**
+ * Sets up one-time listener for handshake from renderer process, and handles timeout if nothing is received.
+ */
+export const handshakeAndHangDetect = ({
+    mainWindow,
+    statePatch,
+    isAnonymousMode,
+}: HandshakeAndHangDetectParams) => {
     const { logger } = global;
     const handshakeHandler = (ipcEvent: ElectronIpcMainInvokeEvent) => {
         validateIpcMessage({ ipcEvent });
@@ -55,7 +68,7 @@ export const hangDetect = (mainWindow: BrowserWindow, statePatch?: Record<string
             }
             resolve('success');
 
-            return Promise.resolve({ statePatch });
+            return Promise.resolve({ statePatch, isAnonymousMode });
         });
         loadIndex(mainWindow);
     });

--- a/packages/suite-desktop-core/src/libs/store.ts
+++ b/packages/suite-desktop-core/src/libs/store.ts
@@ -15,6 +15,7 @@ export type WinBoundsCoords = WinBounds & {
 export class Store {
     private static instance: Store;
     private readonly store: ElectronStore<{
+        isAnonymousMode: boolean;
         winBounds: WinBoundsCoords;
         updateSettings: UpdateSettings;
         themeSettings: SuiteThemeVariant;
@@ -37,11 +38,25 @@ export class Store {
         return Store.instance;
     }
 
+    /** Persists the anonymous mode setting. If true, persisting anything else will be disabled. */
+    public setAnonymousMode(isAnonymousMode: boolean) {
+        this.store.set('isAnonymousMode', isAnonymousMode);
+    }
+
+    public getAnonymousMode() {
+        return this.store.get('isAnonymousMode', false);
+    }
+
+    private isEnabled() {
+        return this.getAnonymousMode() === false;
+    }
+
     public getWinBounds() {
         return this.store.get('winBounds', getInitialWindowSize());
     }
 
     public setWinBounds(winBounds: WinBoundsCoords) {
+        if (!this.isEnabled()) return;
         // save only non zero dimensions
         if (winBounds.width > 0 && winBounds.height > 0) {
             this.store.set('winBounds', winBounds);
@@ -56,6 +71,7 @@ export class Store {
     }
 
     public setUpdateSettings(updateSettings: UpdateSettings) {
+        if (!this.isEnabled()) return;
         this.store.set('updateSettings', updateSettings);
     }
 
@@ -64,6 +80,7 @@ export class Store {
     }
 
     public setThemeSettings(themeSettings: SuiteThemeVariant) {
+        if (!this.isEnabled()) return;
         this.store.set('themeSettings', themeSettings);
     }
 
@@ -80,6 +97,7 @@ export class Store {
     }
 
     public setTorSettings(torSettings: TorSettings) {
+        if (!this.isEnabled()) return;
         this.store.set('torSettings', torSettings);
     }
 
@@ -95,6 +113,7 @@ export class Store {
     }
 
     public setBridgeSettings(bridgeSettings: BridgeSettings) {
+        if (!this.isEnabled()) return;
         this.store.set('bridgeSettings', bridgeSettings);
     }
 
@@ -105,6 +124,7 @@ export class Store {
     }
 
     public setTraySettings(traySettings: TraySettings) {
+        if (!this.isEnabled()) return;
         this.store.set('traySettings', traySettings);
     }
 
@@ -117,6 +137,7 @@ export class Store {
     }
 
     public setConnectSettings(connectSettings: Partial<ConnectSettings>) {
+        if (!this.isEnabled()) return;
         this.store.set('connectSettings', {
             ...this.store.get('connectSettings'),
             ...connectSettings,
@@ -130,6 +151,7 @@ export class Store {
     }
 
     public setBioAuthSettings(bioAuthSettings: Partial<BioAuthSettings>) {
+        if (!this.isEnabled()) return;
         this.store.set('bioAuthSettings', {
             ...this.store.get('bioAuthSettings'),
             ...bioAuthSettings,

--- a/packages/suite-desktop-core/src/libs/user-data.ts
+++ b/packages/suite-desktop-core/src/libs/user-data.ts
@@ -5,6 +5,8 @@ import path from 'path';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { InvokeResult } from '@trezor/suite-desktop-api';
 
+import { Store } from './store';
+
 export const clearAppCache = () =>
     new Promise<void>((resolve, reject) => {
         const cachePath = path.join(app.getPath('userData'), 'Cache');
@@ -161,4 +163,22 @@ export const open = async (directory: string): Promise<InvokeResult> => {
 
         return { success: false, error: error.message, code: error.code };
     }
+};
+
+type SetAnonymousModeParams = {
+    enabled: boolean;
+    store: Store;
+};
+export const setAnonymousMode = async ({
+    enabled,
+    store,
+}: SetAnonymousModeParams): Promise<InvokeResult> => {
+    if (enabled) {
+        const clearResult = await clear();
+        if (!clearResult.success) return clearResult;
+    }
+    // at this point, we are creating a new store in the empty user data directory
+    store.setAnonymousMode(enabled);
+
+    return { success: true };
 };

--- a/packages/suite-desktop-core/src/modules/user-data.ts
+++ b/packages/suite-desktop-core/src/modules/user-data.ts
@@ -6,7 +6,7 @@ import type { ModuleInit } from './module';
 
 export const SERVICE_NAME = 'user-data';
 
-export const init: ModuleInit = () => {
+export const init: ModuleInit = ({ store }) => {
     const { logger } = global;
 
     ipcMain.handle('user-data/clear', ipcEvent => {
@@ -23,6 +23,14 @@ export const init: ModuleInit = () => {
         logger.info(SERVICE_NAME, `Opening user-data${directory} folder.`);
 
         return userData.open(directory);
+    });
+
+    ipcMain.handle('user-data/set-anonymous-mode', (ipcEvent, enabled) => {
+        validateIpcMessage({ ipcEvent });
+
+        logger.info(SERVICE_NAME, `Setting anonymous mode to ${enabled}.`);
+
+        return userData.setAnonymousMode({ enabled, store });
     });
 
     const onLoad = () => userData.getInfo();

--- a/packages/suite-desktop-ui/package.json
+++ b/packages/suite-desktop-ui/package.json
@@ -13,6 +13,7 @@
     },
     "dependencies": {
         "@sentry/electron": "^7.4.0",
+        "@suite-common/analytics": "workspace:*",
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@trezor/components": "workspace:*",

--- a/packages/suite-desktop-ui/src/MainDesktop.tsx
+++ b/packages/suite-desktop-ui/src/MainDesktop.tsx
@@ -3,6 +3,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { type History, createMemoryHistory } from 'history';
 import { createRoot } from 'react-dom/client';
 
+import { analyticsActions } from '@suite-common/analytics';
 import TrezorConnect from '@trezor/connect';
 import { createIpcProxy } from '@trezor/ipc-proxy';
 import { desktopApi } from '@trezor/suite-desktop-api';
@@ -16,9 +17,12 @@ import {
     ToastContainer,
     TrafficLightDraggableWindowHeader,
 } from 'src/components/suite';
+import { BioAuthGuard } from 'src/components/suite/BioAuthGuard/BioAuthGuard';
+import { FindBar } from 'src/components/suite/FindBar/FindBar';
 import { Metadata } from 'src/components/suite/Metadata';
 import { useDebugLanguageShortcut } from 'src/hooks/suite';
 import { initStore } from 'src/reducers/store';
+import { db } from 'src/storage';
 import { SuiteServicesProvider } from 'src/support/SuiteServicesProvider';
 import { createRouterServices } from 'src/support/extraDependencies';
 import { ConnectedIntlProvider } from 'src/support/suite/ConnectedIntlProvider';
@@ -34,8 +38,6 @@ import { initSentry } from './sentry';
 import { DesktopUpdater } from './support/DesktopUpdater';
 import { desktopComponents } from './support/desktopComponents';
 import { TorLoadingScreen } from './support/screens/TorLoadingScreen';
-import { BioAuthGuard } from '../../suite/src/components/suite/BioAuthGuard/BioAuthGuard';
-import { FindBar } from '../../suite/src/components/suite/FindBar/FindBar';
 
 const MainDesktop = ({ history }: { history: History }) => {
     useTor();
@@ -68,12 +70,21 @@ export const init = async (container: HTMLElement) => {
     root.render(<LoadingScreen />);
 
     const memoryHistory = createMemoryHistory();
+    const { statePatch, isAnonymousMode } = await desktopApi.handshake();
+    if (isAnonymousMode === true) {
+        // eslint-disable-next-line no-console
+        console.info('🕶️ Suite Desktop starts in Anonymous Mode, nothing will be persisted!');
+        db.setAnonymousMode(true);
+    }
     const preloadAction = await preloadStore();
-    const { statePatch } = await desktopApi.handshake();
     const { store, services } = initStore(preloadAction, {
         statePatch,
         additionalExtraDeps: { routerServices: createRouterServices(memoryHistory) },
     });
+    // QoL tweak to automatically reject analytics, assuming that's what you want in anonymous mode (so you don't see confirmation everytime)
+    if (isAnonymousMode === true) {
+        store.dispatch(analyticsActions.disableAnalytics());
+    }
 
     // Expose Redux store for Playwright/e2e tests
     if (typeof window !== 'undefined' && window.desktopFlags?.exposeStore) {

--- a/packages/suite-desktop-ui/tsconfig.json
+++ b/packages/suite-desktop-ui/tsconfig.json
@@ -9,6 +9,9 @@
         "../suite/src/components/suite/BioAuthGuard"
     ],
     "references": [
+        {
+            "path": "../../suite-common/analytics"
+        },
         { "path": "../../suite-common/sentry" },
         {
             "path": "../../suite-common/suite-types"

--- a/packages/suite-storage/src/index.ts
+++ b/packages/suite-storage/src/index.ts
@@ -26,6 +26,7 @@ class CommonDB<TDBStructure> {
     supported: boolean | undefined;
     blocking = false;
     blocked = false;
+    isAnonymousMode = false;
     onUpgrade!: OnUpgradeFunc<TDBStructure>;
     onDowngrade!: () => any;
     onBlocked?: () => void;
@@ -67,6 +68,7 @@ class CommonDB<TDBStructure> {
     static isDBAvailable = () => !!indexedDB || !!window.indexedDB || !!global.indexedDB;
 
     isSupported = () => {
+        if (this.isAnonymousMode) return false;
         if (this.supported === undefined) {
             const isAvailable = CommonDB.isDBAvailable();
             this.supported = isAvailable;
@@ -82,7 +84,11 @@ class CommonDB<TDBStructure> {
         const isSupported = this.isSupported();
 
         // if the instance is blocking db upgrade, db connection will be closed
-        return isSupported && !this.blocking && !this.blocked;
+        return isSupported && !this.isAnonymousMode && !this.blocking && !this.blocked;
+    };
+
+    setAnonymousMode = (isAnonymousMode: boolean) => {
+        this.isAnonymousMode = isAnonymousMode;
     };
 
     closeAfterTimeout = (timeout = 1000) => {

--- a/packages/suite/src/views/settings/SettingsDebug/WipeData.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/WipeData.tsx
@@ -1,10 +1,52 @@
+import { useState } from 'react';
+
 import styled from 'styled-components';
 
 import { notificationsActions } from '@suite-common/toast-notifications';
+import { Modal, ModalProps, Paragraph, Switch } from '@trezor/components';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { db } from 'src/storage';
+
+export const AnonymousModeConfirmModal = ({ onCancel }: ModalProps) => {
+    // Abusing db instance as a storage for global variable..
+    // But since the app restarts after every change, there is no need for state management and reactivity.
+    const { isAnonymousMode } = db;
+    const willBeEnabled = !isAnonymousMode;
+    const dispatch = useDispatch();
+
+    const toggleAnonymousMode = async () => {
+        const result = await desktopApi.setAnonymousMode(!isAnonymousMode);
+        if (!result.success) {
+            return dispatch(notificationsActions.addToast({ type: 'error', error: result.error }));
+        }
+        desktopApi.appRestart();
+    };
+
+    const heading = `${willBeEnabled ? 'Enable' : 'Disable'} Anonymous Mode?`;
+
+    return (
+        <Modal
+            onCancel={onCancel}
+            heading={heading}
+            variant={willBeEnabled ? 'destructive' : 'warning'}
+            width={600}
+            bottomContent={
+                <>
+                    <Modal.Button onClick={toggleAnonymousMode}>Confirm</Modal.Button>
+                    <Modal.Button intent="neutral" priority="secondary" onClick={onCancel}>
+                        Cancel
+                    </Modal.Button>
+                </>
+            }
+        >
+            {willBeEnabled && <Paragraph>All your data will be erased!</Paragraph>}
+            <Paragraph>Trezor Suite will restart so that this setting can take effect.</Paragraph>
+        </Modal>
+    );
+};
 
 const UserDataLink = styled.span`
     cursor: pointer;
@@ -17,45 +59,63 @@ const UserDataLink = styled.span`
 export const WipeData = () => {
     const userDataDir = useSelector(state => state.desktop?.paths.userDir);
     const dispatch = useDispatch();
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const handleAnonymousModalClick = () => setIsModalOpen(true);
+    const handleModalCancel = () => setIsModalOpen(false);
+    const { isAnonymousMode } = db;
+
+    const openUserDataDir = async () => {
+        const result = await desktopApi.openUserDataDirectory();
+        if (!result.success) {
+            dispatch(notificationsActions.addToast({ type: 'error', error: result.error }));
+        }
+    };
+
+    const clearUserData = async () => {
+        const result = await desktopApi.clearUserData();
+        if (!result.success) {
+            dispatch(notificationsActions.addToast({ type: 'error', error: result.error }));
+
+            return;
+        }
+        desktopApi.appRestart();
+    };
 
     return (
-        <SectionItem>
-            <TextColumn
-                title="Wipe app data"
-                description={
-                    <span>
-                        Clicking this button restarts your application and wipes all your data
-                        including locally saved labels. Your local folder is:{' '}
-                        <UserDataLink
-                            onClick={async () => {
-                                const result = await desktopApi.openUserDataDirectory();
-
-                                if (!result.success) {
-                                    dispatch(
-                                        notificationsActions.addToast({
-                                            type: 'error',
-                                            error: result.error,
-                                        }),
-                                    );
-                                }
-                            }}
-                        >
-                            {userDataDir}
-                        </UserDataLink>
-                    </span>
-                }
-            />
-            <ActionColumn>
-                <ActionButton
-                    intent="critical"
-                    onClick={async () => {
-                        await desktopApi.clearUserData();
-                        desktopApi.appRestart();
-                    }}
-                >
-                    Wipe data
-                </ActionButton>
-            </ActionColumn>
-        </SectionItem>
+        <>
+            <SectionItem>
+                <TextColumn
+                    title="Wipe app data"
+                    description={
+                        <span>
+                            Clicking this button restarts your application and wipes all your data
+                            including locally saved labels. Your local folder is:{' '}
+                            <UserDataLink onClick={openUserDataDir}>{userDataDir}</UserDataLink>.
+                            Note that this will reset Anonymous mode as well.
+                        </span>
+                    }
+                />
+                <ActionColumn>
+                    <ActionButton intent="critical" onClick={clearUserData}>
+                        Wipe data
+                    </ActionButton>
+                </ActionColumn>
+            </SectionItem>
+            <SectionItem>
+                <TextColumn
+                    title="Anonymous mode"
+                    description={
+                        <span>
+                            In Anonymous Mode, Suite Desktop will not persist any user data – will
+                            behave like Suite Web in an incognito window.
+                        </span>
+                    }
+                />
+                <ActionColumn>
+                    <Switch onChange={handleAnonymousModalClick} isChecked={isAnonymousMode} />
+                </ActionColumn>
+            </SectionItem>
+            {isModalOpen && <AnonymousModeConfirmModal onCancel={handleModalCancel} />}
+        </>
     );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -15153,6 +15153,7 @@ __metadata:
   resolution: "@trezor/suite-desktop-ui@workspace:packages/suite-desktop-ui"
   dependencies:
     "@sentry/electron": "npm:^7.4.0"
+    "@suite-common/analytics": "workspace:*"
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@trezor/components": "workspace:*"


### PR DESCRIPTION
## Description

After #24052, Suite Desktop now always remember some fingerprinting data about devices, even with Eject Wallets on.
You can reset your app everytime you leave your computer but that's not very practical :confused: 

At least on Suite Web you can use anonymous window, whereas on Suite Desktop ~there is no such thing~ yes there is :sunglasses: 

:arrow_right: add an "Anonymous mode" debug option to Suite Desktop. Toggling it on erases all your data, and persists the anonymous mode value in electron store. While it is on, nothing else can be persisted in IDB or electron store.

## Notes for QA

**Must have:** please test that persistence still works on Web & Desktop with anonymous mode **off**

**Optional:** enable anonymous mode on window. Then neither IDB nor electron-store changes should persist. Then disable it again, and persistence should work normally (as in the video).
 
:information_source: FYI, example of values that are stored in the two places, so you know what to test:
- IDB (Web & Desktop): language, fiat unit, coin settings
- electron-store (Desktop only): light/dark theme, tor, biometrics, window position

## Screenshots:

### Current state unchanged:

Persistence works normally

[part 1 persistence works.webm](https://github.com/user-attachments/assets/6ff26807-0fc7-415d-a594-49f855c7d1c0)

### Anon mode

1. Turning on anon mode → resets app, so all data are cleared
2. Make new changes, restart app → changes are not persisted
3. Turn off anon mode
4. Make new changes, restart app → changes are persisted again

[part 2 anon mode on and off.webm](https://github.com/user-attachments/assets/074a4c9f-a497-4ae5-b7c4-545ebd299666)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/desktop-anon-mode&lookback=7)