### PR TITLE
chore: fix spam from baseline-browser-mapping

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18992,11 +18992,11 @@ __metadata:
   linkType: hard
 
 "baseline-browser-mapping@npm:^2.8.9":
-  version: 2.8.17
-  resolution: "baseline-browser-mapping@npm:2.8.17"
+  version: 2.9.5
+  resolution: "baseline-browser-mapping@npm:2.9.5"
   bin:
     baseline-browser-mapping: dist/cli.js
-  checksum: 10/241045decb543c589840e8d442f28c2e47b1111a051b446807ee9500c6dd2b0bb560df0bb3890154cb066d2d92f2a67d15eb2678765e7229af80cbe93c481221
+  checksum: 10/4b07dfdac31f8ca9aa585bdfac86d00400d282f1d22d1ce1d9b31b66b66c530295bdac2527197b50d23d0b58467d971ed5acf1c031d9f780f4687f2ce11a7e43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Resolves this spam that you see all the time when running various scripts locally, sometimes even repeated:
```
[baseline-browser-mapping] The data in this module is over two months old.  To ensure accurate Baseline data, please update: `npm i baseline-browser-mapping@latest -D`
```

FYI [the issue](https://github.com/web-platform-dx/baseline-browser-mapping/issues/105), fixed in 2.9.0.
TL;DR: not just renewing this package (would spam again in 2 months), but they changed the limits to 2 years :ok_hand: 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/fix-browser-mapping-spam&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/fix-browser-mapping-spam&lookback=7)