### PR TITLE
fix(suite): prevent URL overflow in backends modal

### DIFF
--- a/packages/components/src/components/typography/Text/Text.tsx
+++ b/packages/components/src/components/typography/Text/Text.tsx
@@ -106,7 +106,7 @@ const StyledText = styled.span<StyledTextProps>`
     ${({ $breakAll }) =>
         $breakAll &&
         css`
-            overflow-wrap: break-word;
+            overflow-wrap: anywhere;
         `}
 
     ${withTextProps}


### PR DESCRIPTION
## Description

break-word does not wrap URLs whereas anywhere does, which is what we want to use in this case.

## Notes for QA

The breakAll prop is used in just one component, meaning testing just the one, the reported, place should be enough.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24046

## Screenshots:
<img width="1463" height="1539" alt="image" src="https://github.com/user-attachments/assets/e8b64c0f-4bca-4201-b50e-d031084d17f9" />

