### PR TITLE
fix(protobuf): add back eslint to fix scripts

### DIFF
--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -28,6 +28,7 @@
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",
+        "lint:js": "eslint .",
         "update:schema": "yarn workspace @trezor/schema-utils codegen $(pwd)/src/messages.ts > src/messages-schema.ts && yarn g:eslint --fix src/messages-schema.ts && yarn g:prettier --write src/messages-schema.ts",
         "update:protobuf": "./scripts/protobuf-build.sh",
         "prepublishOnly": "yarn tsx ../../scripts/publish/prepublishNPM.js",
@@ -40,6 +41,7 @@
     },
     "devDependencies": {
         "protobufjs-cli": "^1.1.3",
+        "eslint": "^9.38.0",
         "tsx": "^4.20.3"
     },
     "peerDependencies": {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Scripts using protobuf package for updating were broken and breaking in connect-misc tests because g:eslint expects lint:js script to be define in the package. The way we use it in packages/protobuf/scripts/protobuf-build.sh would create an infinite loop if we use g:eslint in the package script, so for now we use eslint directly in this package.

Failing test https://github.com/trezor/trezor-suite/actions/runs/20648181166/job/59288700402

## Notes for QA

Nothing to test.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/eslint-in-protobuf-to-fix-connect-misc-tests&lookback=7)