### PR TITLE
chore(suite-desktop): remove links to nonexistent bridge files

### DIFF
--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -84,10 +84,6 @@ module.exports = {
         files: ['entitlements.mac.inherit.plist'],
         extraResources: [
             {
-                from: 'build/static/bin/bridge/mac-${arch}',
-                to: 'bin/bridge',
-            },
-            {
                 from: 'build/static/bin/tor/mac-${arch}',
                 to: 'bin/tor',
             },
@@ -121,10 +117,6 @@ module.exports = {
     win: {
         extraResources: [
             {
-                from: 'build/static/bin/bridge/win-${arch}',
-                to: 'bin/bridge',
-            },
-            {
                 from: 'build/static/bin/tor/win-${arch}',
                 to: 'bin/tor',
             },
@@ -152,10 +144,6 @@ module.exports = {
     },
     linux: {
         extraResources: [
-            {
-                from: 'build/static/bin/bridge/linux-${arch}',
-                to: 'bin/bridge',
-            },
             {
                 from: 'build/static/bin/tor/linux-${arch}',
                 to: 'bin/tor',


### PR DESCRIPTION
## Description

Fix after 567dcbf1
`electron-builder` config still tries to include the missing files and spams a lot of warnings like:
```
  • file source doesn't exist  from=/my-path-to-repo/trezor-suite/packages/suite-desktop/build/static/bin/bridge/linux-x64
```


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/electron-builder-remove-bridge-files&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/electron-builder-remove-bridge-files&lookback=7)