### PR TITLE
chore(suite): bump react-intl

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -36,7 +36,7 @@ module.exports = {
         '\\.(js|jsx|ts|tsx)$': ['babel-jest', babelConfig],
     },
 
-    transformIgnorePatterns: ['node_modules/?!(uuid)/'],
+    transformIgnorePatterns: ['node_modules/?!(uuid|react-intl|@formatjs/*|intl-messageformat)/'],
 
     // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
     watchPathIgnorePatterns: ['libDev', 'lib'],

--- a/jest.config.native.js
+++ b/jest.config.native.js
@@ -29,7 +29,7 @@ module.exports = {
         '\\.(js|jsx|ts|tsx)$': ['babel-jest', babelConfig],
     },
     transformIgnorePatterns: [
-        'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|@shopify/react-native-skia|@shopify/flash-list|@noble|@scure|@evolu|nanoid|msgpackr|@gorhom|uuid)',
+        'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|@shopify/react-native-skia|@shopify/flash-list|@noble|@scure|@evolu|nanoid|msgpackr|@gorhom|uuid|react-intl|@formatjs/*|intl-messageformat)',
     ],
     setupFiles: [
         '<rootDir>/../../suite-native/test-utils/src/mocks/expoAndRNMock.jsx',

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -35,7 +35,7 @@
         "react-date-range": "^2.0.1",
         "react-dom": "19.1.0",
         "react-focus-lock": "^2.13.6",
-        "react-intl": "^7.1.11",
+        "react-intl": "^8.0.6",
         "react-markdown": "^10.1.0",
         "react-select": "^5.10.2",
         "react-svg": "16.3.0",

--- a/packages/connect-ui/package.json
+++ b/packages/connect-ui/package.json
@@ -22,7 +22,7 @@
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",
         "framer-motion": "^12.23.3",
-        "react-intl": "^7.1.11"
+        "react-intl": "^8.0.6"
     },
     "devDependencies": {
         "@types/react": "^19.0.0"

--- a/packages/product-components/package.json
+++ b/packages/product-components/package.json
@@ -33,7 +33,7 @@
         "framer-motion": "^12.23.3",
         "react": "19.1.0",
         "react-hook-form": "^7.66.1",
-        "react-intl": "^7.1.11",
+        "react-intl": "^8.0.6",
         "react-svg": "16.3.0",
         "styled-components": "^6.1.19",
         "zxcvbn": "^4.4.2"

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -121,7 +121,7 @@
         "react-focus-lock": "^2.13.6",
         "react-helmet-async": "^2.0.5",
         "react-hook-form": "^7.66.1",
-        "react-intl": "^7.1.11",
+        "react-intl": "^8.0.6",
         "react-redux": "9.2.0",
         "react-select": "^5.10.2",
         "react-toastify": "^10.0.5",

--- a/packages/transport-bridge/package.json
+++ b/packages/transport-bridge/package.json
@@ -35,7 +35,7 @@
         "json-stable-stringify": "^1.2.1",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "react-intl": "^7.1.11",
+        "react-intl": "^8.0.6",
         "styled-components": "^6.1.19",
         "usb": "^2.15.0"
     }

--- a/suite-common/formatters/package.json
+++ b/suite-common/formatters/package.json
@@ -23,6 +23,6 @@
         "@trezor/utils": "workspace:*",
         "date-fns": "^4.1.0",
         "react": "19.1.0",
-        "react-intl": "^7.1.11"
+        "react-intl": "^8.0.6"
     }
 }

--- a/suite-common/intl-types/package.json
+++ b/suite-common/intl-types/package.json
@@ -11,6 +11,6 @@
     },
     "dependencies": {
         "react": "19.1.0",
-        "react-intl": "^7.1.11"
+        "react-intl": "^8.0.6"
     }
 }

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -127,7 +127,7 @@
         "node-libs-browser": "^2.2.1",
         "react": "19.1.0",
         "react-freeze": "^1.0.4",
-        "react-intl": "^7.1.11",
+        "react-intl": "^8.0.6",
         "react-native": "0.81.4",
         "react-native-ble-plx": "patch:react-native-ble-plx@npm%3A3.5.0#~/.yarn/patches/react-native-ble-plx-npm-3.5.0-c98fd0ae25.patch",
         "react-native-edge-to-edge": "1.7.0",

--- a/suite-native/intl/package.json
+++ b/suite-native/intl/package.json
@@ -27,7 +27,7 @@
         "expo-localization": "~17.0.7",
         "intl-pluralrules": "^2.0.1",
         "react": "19.1.0",
-        "react-intl": "^7.1.11",
+        "react-intl": "^8.0.6",
         "react-native": "0.81.4",
         "react-redux": "9.2.0"
     },

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -73,7 +73,7 @@
         "expo-linear-gradient": "~15.0.7",
         "expo-linking": "~8.0.8",
         "react": "19.1.0",
-        "react-intl": "^7.1.11",
+        "react-intl": "^8.0.6",
         "react-native": "0.81.4",
         "react-native-gesture-handler": "2.29.0",
         "react-native-reanimated": "~4.1.5",

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -54,7 +54,7 @@
         "fs-extra": "^11.3.1",
         "jest-diff": "^29.7.0",
         "lodash": "^4.17.21",
-        "react-intl": "^7.1.14",
+        "react-intl": "^8.0.6",
         "tsx": "^4.20.3",
         "xvfb-maybe": "^0.2.1"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4481,15 +4481,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@formatjs/ecma402-abstract@npm:2.3.6":
-  version: 2.3.6
-  resolution: "@formatjs/ecma402-abstract@npm:2.3.6"
+"@formatjs/ecma402-abstract@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@formatjs/ecma402-abstract@npm:3.0.3"
   dependencies:
-    "@formatjs/fast-memoize": "npm:2.2.7"
-    "@formatjs/intl-localematcher": "npm:0.6.2"
+    "@formatjs/fast-memoize": "npm:3.0.1"
+    "@formatjs/intl-localematcher": "npm:0.7.2"
     decimal.js: "npm:^10.4.3"
     tslib: "npm:^2.8.0"
-  checksum: 10/30b1b5cd6b62ba46245f934429936592df5500bc1b089dc92dd49c826757b873dd92c305dcfe370701e4df6b057bf007782113abb9b65db550d73be4961718bc
+  checksum: 10/134192d5ee45e215b3b61d06849f4f311948629417cd57aa4eb26bd8ca8c13d39660b2d3d46797a83f811c877a86d691ca58969fe889be59241782a59b638db1
   languageName: node
   linkType: hard
 
@@ -4499,6 +4499,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.8.0"
   checksum: 10/e7e6efc677d63a13d99a854305db471b69f64cbfebdcb6dbe507dab9aa7eaae482ca5de86f343c856ca0a2c8f251672bd1f37c572ce14af602c0287378097d43
+  languageName: node
+  linkType: hard
+
+"@formatjs/fast-memoize@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@formatjs/fast-memoize@npm:3.0.1"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10/9c152fbb3725a0ba759f75658107504b33cd7d232380cdce5afeea320be3c71762de0af9b1dc3b8f03c652c6db9b7453ad57ab1e82762dd9a1713990988f84b8
   languageName: node
   linkType: hard
 
@@ -4513,14 +4522,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@formatjs/icu-messageformat-parser@npm:2.11.4":
-  version: 2.11.4
-  resolution: "@formatjs/icu-messageformat-parser@npm:2.11.4"
+"@formatjs/icu-messageformat-parser@npm:3.0.4":
+  version: 3.0.4
+  resolution: "@formatjs/icu-messageformat-parser@npm:3.0.4"
   dependencies:
-    "@formatjs/ecma402-abstract": "npm:2.3.6"
-    "@formatjs/icu-skeleton-parser": "npm:1.8.16"
+    "@formatjs/ecma402-abstract": "npm:3.0.3"
+    "@formatjs/icu-skeleton-parser": "npm:2.0.3"
     tslib: "npm:^2.8.0"
-  checksum: 10/2acb100c06c2ade666d72787fb9f9795b1ace41e8e73bfadc2b1a7b8562e81f655e484f0f33d8c39473aa17bf0ad96fb2228871806a9b3dc4f5f876754a0de3a
+  checksum: 10/87bc0504a07b536a17f2ef7fe61529352b67b42f7e9253441120bcf105958747315031a15939791487358198d8790a85cb112c956216bbe07d6e2f284a78279e
   languageName: node
   linkType: hard
 
@@ -4534,13 +4543,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@formatjs/icu-skeleton-parser@npm:1.8.16":
-  version: 1.8.16
-  resolution: "@formatjs/icu-skeleton-parser@npm:1.8.16"
+"@formatjs/icu-skeleton-parser@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@formatjs/icu-skeleton-parser@npm:2.0.3"
   dependencies:
-    "@formatjs/ecma402-abstract": "npm:2.3.6"
+    "@formatjs/ecma402-abstract": "npm:3.0.3"
     tslib: "npm:^2.8.0"
-  checksum: 10/428001e5bed81889b276a2356a1393157af91dc59220b765a1a132f6407ac5832b7ac6ae9737674ac38e44035295c0c1c310b2630f383f2b5779ea90bf2849e6
+  checksum: 10/a402b4cc6765a718ad2b83bb97becc0e17b5cf400d6216e629f1804bd224dbf3a8c04f4a0e3fc5ab4dcf1b449af975d750e003e7958a0eaae8db87b47ac2f971
   languageName: node
   linkType: hard
 
@@ -4553,12 +4562,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@formatjs/intl-localematcher@npm:0.6.2":
-  version: 0.6.2
-  resolution: "@formatjs/intl-localematcher@npm:0.6.2"
+"@formatjs/intl-localematcher@npm:0.7.2":
+  version: 0.7.2
+  resolution: "@formatjs/intl-localematcher@npm:0.7.2"
   dependencies:
     tslib: "npm:^2.8.0"
-  checksum: 10/eb12a7f5367bbecdfafc20d7f005559ce840f420e970f425c5213d35e94e86dfe75bde03464971a26494bf8427d4961269db22ecad2834f2a19d888b5d9cc064
+  checksum: 10/cdf12070f9dbddb35808382baf220c0de67d480626aa115ce3c16b92f608a23235c7e4ac953518c1cf04acb2808230fdf63bd214cb1ea575b2c494e3c69ef88f
   languageName: node
   linkType: hard
 
@@ -4580,21 +4589,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@formatjs/intl@npm:3.1.8":
-  version: 3.1.8
-  resolution: "@formatjs/intl@npm:3.1.8"
+"@formatjs/intl@npm:4.0.4":
+  version: 4.0.4
+  resolution: "@formatjs/intl@npm:4.0.4"
   dependencies:
-    "@formatjs/ecma402-abstract": "npm:2.3.6"
-    "@formatjs/fast-memoize": "npm:2.2.7"
-    "@formatjs/icu-messageformat-parser": "npm:2.11.4"
-    intl-messageformat: "npm:10.7.18"
+    "@formatjs/ecma402-abstract": "npm:3.0.3"
+    "@formatjs/fast-memoize": "npm:3.0.1"
+    "@formatjs/icu-messageformat-parser": "npm:3.0.4"
+    intl-messageformat: "npm:11.0.4"
     tslib: "npm:^2.8.0"
   peerDependencies:
     typescript: ^5.6.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/2e8b992606b8377dc4496fcc06ea0370b4f2b3fb27f4f086172cf618c9d981176831baff6a2b5bffb4a06e7aa580e28a8bda2d71ad2cb51d19f3d4bc4609e90e
+  checksum: 10/b19a7786d6f01b5eac94191de2f18a4f268f9ff580a329208519ef6ca4260c4b31afb122cd625af70cd3d297e2ef36f41c450e0291d6e00f5387c7398a5a9446
   languageName: node
   linkType: hard
 
@@ -10484,7 +10493,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     date-fns: "npm:^4.1.0"
     react: "npm:19.1.0"
-    react-intl: "npm:^7.1.11"
+    react-intl: "npm:^8.0.6"
   languageName: unknown
   linkType: soft
 
@@ -10536,7 +10545,7 @@ __metadata:
   resolution: "@suite-common/intl-types@workspace:suite-common/intl-types"
   dependencies:
     react: "npm:19.1.0"
-    react-intl: "npm:^7.1.11"
+    react-intl: "npm:^8.0.6"
   languageName: unknown
   linkType: soft
 
@@ -11288,7 +11297,7 @@ __metadata:
     node-libs-browser: "npm:^2.2.1"
     react: "npm:19.1.0"
     react-freeze: "npm:^1.0.4"
-    react-intl: "npm:^7.1.11"
+    react-intl: "npm:^8.0.6"
     react-native: "npm:0.81.4"
     react-native-ble-plx: "patch:react-native-ble-plx@npm%3A3.5.0#~/.yarn/patches/react-native-ble-plx-npm-3.5.0-c98fd0ae25.patch"
     react-native-edge-to-edge: "npm:1.7.0"
@@ -11921,7 +11930,7 @@ __metadata:
     expo-localization: "npm:~17.0.7"
     intl-pluralrules: "npm:^2.0.1"
     react: "npm:19.1.0"
-    react-intl: "npm:^7.1.11"
+    react-intl: "npm:^8.0.6"
     react-native: "npm:0.81.4"
     react-redux: "npm:9.2.0"
   languageName: unknown
@@ -12677,7 +12686,7 @@ __metadata:
     expo-linear-gradient: "npm:~15.0.7"
     expo-linking: "npm:~8.0.8"
     react: "npm:19.1.0"
-    react-intl: "npm:^7.1.11"
+    react-intl: "npm:^8.0.6"
     react-native: "npm:0.81.4"
     react-native-gesture-handler: "npm:2.29.0"
     react-native-reanimated: "npm:~4.1.5"
@@ -13753,7 +13762,7 @@ __metadata:
     react-date-range: "npm:^2.0.1"
     react-dom: "npm:19.1.0"
     react-focus-lock: "npm:^2.13.6"
-    react-intl: "npm:^7.1.11"
+    react-intl: "npm:^8.0.6"
     react-markdown: "npm:^10.1.0"
     react-select: "npm:^5.10.2"
     react-svg: "npm:16.3.0"
@@ -14023,7 +14032,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     "@types/react": "npm:^19.0.0"
     framer-motion: "npm:^12.23.3"
-    react-intl: "npm:^7.1.11"
+    react-intl: "npm:^8.0.6"
   peerDependencies:
     postcss-styled-syntax: ^0.7.1
     react: 19.1.0
@@ -14299,7 +14308,7 @@ __metadata:
     postcss-styled-syntax: "npm:^0.7.1"
     react: "npm:19.1.0"
     react-hook-form: "npm:^7.66.1"
-    react-intl: "npm:^7.1.11"
+    react-intl: "npm:^8.0.6"
     react-svg: "npm:16.3.0"
     storybook: "npm:^9.0.16"
     styled-components: "npm:^6.1.19"
@@ -14643,7 +14652,7 @@ __metadata:
     fs-extra: "npm:^11.3.1"
     jest-diff: "npm:^29.7.0"
     lodash: "npm:^4.17.21"
-    react-intl: "npm:^7.1.14"
+    react-intl: "npm:^8.0.6"
     tsx: "npm:^4.20.3"
     xvfb-maybe: "npm:^0.2.1"
   languageName: unknown
@@ -14807,7 +14816,7 @@ __metadata:
     react-focus-lock: "npm:^2.13.6"
     react-helmet-async: "npm:^2.0.5"
     react-hook-form: "npm:^7.66.1"
-    react-intl: "npm:^7.1.11"
+    react-intl: "npm:^8.0.6"
     react-redux: "npm:9.2.0"
     react-select: "npm:^5.10.2"
     react-toastify: "npm:^10.0.5"
@@ -14870,7 +14879,7 @@ __metadata:
     json-stable-stringify: "npm:^1.2.1"
     react: "npm:19.1.0"
     react-dom: "npm:19.1.0"
-    react-intl: "npm:^7.1.11"
+    react-intl: "npm:^8.0.6"
     styled-components: "npm:^6.1.19"
     usb: "npm:^2.15.0"
     webpack: "npm:5.102.1"
@@ -16285,7 +16294,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:16 || 17 || 18 || 19, @types/react@npm:>=16, @types/react@npm:^19.0.0":
+"@types/react@npm:*, @types/react@npm:>=16, @types/react@npm:^19.0.0":
   version: 19.1.6
   resolution: "@types/react@npm:19.1.6"
   dependencies:
@@ -28778,15 +28787,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"intl-messageformat@npm:10.7.18":
-  version: 10.7.18
-  resolution: "intl-messageformat@npm:10.7.18"
+"intl-messageformat@npm:11.0.4":
+  version: 11.0.4
+  resolution: "intl-messageformat@npm:11.0.4"
   dependencies:
-    "@formatjs/ecma402-abstract": "npm:2.3.6"
-    "@formatjs/fast-memoize": "npm:2.2.7"
-    "@formatjs/icu-messageformat-parser": "npm:2.11.4"
+    "@formatjs/ecma402-abstract": "npm:3.0.3"
+    "@formatjs/fast-memoize": "npm:3.0.1"
+    "@formatjs/icu-messageformat-parser": "npm:3.0.4"
     tslib: "npm:^2.8.0"
-  checksum: 10/96650d673912763d21bbfa14b50749b992d45f1901092a020e3155961e3c70f4644dd1731c3ecb1207a1eb94d84bedf4c34b1ac8127c29ad6b015b6a2a4045cb
+  checksum: 10/b7ed6afd7dbb6cc755b12b20d0cf9d506d8530947fa0e631e44fac40a45ee59bdcddea4c1c241de133c51c343b2cae941654f3fbd6cb3f9fbd1aedb59a82a9ce
   languageName: node
   linkType: hard
 
@@ -38778,25 +38787,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-intl@npm:^7.1.11, react-intl@npm:^7.1.14":
-  version: 7.1.14
-  resolution: "react-intl@npm:7.1.14"
+"react-intl@npm:^8.0.6":
+  version: 8.0.6
+  resolution: "react-intl@npm:8.0.6"
   dependencies:
-    "@formatjs/ecma402-abstract": "npm:2.3.6"
-    "@formatjs/icu-messageformat-parser": "npm:2.11.4"
-    "@formatjs/intl": "npm:3.1.8"
+    "@formatjs/ecma402-abstract": "npm:3.0.3"
+    "@formatjs/icu-messageformat-parser": "npm:3.0.4"
+    "@formatjs/intl": "npm:4.0.4"
     "@types/hoist-non-react-statics": "npm:^3.3.1"
-    "@types/react": "npm:16 || 17 || 18 || 19"
     hoist-non-react-statics: "npm:^3.3.2"
-    intl-messageformat: "npm:10.7.18"
+    intl-messageformat: "npm:11.0.4"
     tslib: "npm:^2.8.0"
   peerDependencies:
+    "@types/react": 19
     react: 16 || 17 || 18 || 19
     typescript: ^5.6.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/74b1d9a2f6e6fa964503a08a56e0d27d52344ad5495dca875e08a146d16418d29bd12769273a479f3adf9ab445fc28a322421a8afaed4a4d040a0e9e3bedb79c
+  checksum: 10/8a78dc9ba08a589198be120e2b4e4c86c86c250dd954356bbb86776b1478195486134a6d8320762e4c5825363270089096dec39312654f479c6ed24731e10fab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Bump react-intl to prevent an annoying react error, which is fixed in latest
https://github.com/formatjs/formatjs/issues/5135

## Notes for QA

Test that locale-specific settings still work:
- mainly translation strings
- decimal numbers
- dates
- and if anything else comes up... 

## Screenshots:

### Before

Error on local dev:

<img width="607" height="79" alt="image" src="https://github.com/user-attachments/assets/b43106bc-cca9-48da-92df-9afa56fac103" />

### After

No error


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bump-react-intl&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bump-react-intl&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/bump-react-intl&lookback=7)