### PR TITLE
ci(suite-native): web storybook auto deploy

### DIFF
--- a/.github/workflows/build-storybook-native.yml
+++ b/.github/workflows/build-storybook-native.yml
@@ -1,0 +1,63 @@
+name: "[Build] suite native storybook"
+
+permissions:
+  id-token: write # for fetching the OIDC token
+  contents: read # for actions/checkout
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'suite-native/storybook/**'
+      - 'suite-native/**/*.story.*'
+
+jobs:
+  build-storybook:
+    if: github.repository == 'trezor/trezor-suite'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_trezor_suite_dev_deploy
+          aws-region: eu-central-1
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+
+      - name: Install node and yarn
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+  
+      - name: Setup node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node_modules/${{ github.ref }}/${{github.run_id}}
+  
+      - name: Install Yarn dependencies
+        run: |
+            echo -e "\nenableScripts: false" >> .yarnrc.yml
+            echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
+            yarn install
+
+      - name: Build storybook
+        working-directory: ./suite-native/storybook
+        run: |
+          yarn storybook:web:build
+
+      - name: Upload suite native storybook to dev.suite.sldev.cz
+        working-directory: ./suite-native/storybook
+        env:
+          COMPONENTS_DEPLOY_PATH: s3://dev.suite.sldev.cz/suite-mobile/components/develop
+        run: |
+          aws s3 sync --delete .build-storybook ${COMPONENTS_DEPLOY_PATH}

--- a/suite-native/storybook/.storybook/fonts.css
+++ b/suite-native/storybook/.storybook/fonts.css
@@ -1,20 +1,20 @@
 @font-face {
     font-family: 'TTSatoshi-Medium';
-    src: url('/TTSatoshi-Medium.otf') format('opentype');
+    src: url('../TTSatoshi-Medium.otf') format('opentype');
     font-weight: 500;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'TTSatoshi-DemiBold';
-    src: url('/TTSatoshi-DemiBold.otf') format('opentype');
+    src: url('../TTSatoshi-DemiBold.otf') format('opentype');
     font-weight: 600;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'TrezorSuiteIcons';
-    src: url('/TrezorSuiteIcons.ttf') format('opentype');
+    src: url('../TrezorSuiteIcons.ttf') format('opentype');
     font-weight: 500;
     font-style: normal;
 }


### PR DESCRIPTION
## Description
- build suite native storybook project and exposes it to url: https://dev.suite.sldev.cz/suite-mobile/components/develop/ on every change of any relevant file
## Notes for QA
- not related to the mobile app builds at all. Just check if the web link is accesible
## Related Issue

Resolve #23949 

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci/native/storybook-auto-deploy&lookback=7)