### PR TITLE
Send X-Suite-Platform header with all backend requests

### DIFF
--- a/suite-common/trading/src/__tests__/invityAPI.test.ts
+++ b/suite-common/trading/src/__tests__/invityAPI.test.ts
@@ -450,4 +450,19 @@ describe('InvityAPI', () => {
 
         expect(url).toEqual('https://exchange.trezor.io');
     });
+
+    describe('headers', () => {
+        it('should provide X-Suite-Platform header', () => {
+            invityAPI.getInfo();
+
+            expect(fetch).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        'X-Suite-Platform': expect.any(String),
+                    }),
+                }),
+            );
+        });
+    });
 });

--- a/suite-common/trading/src/invityAPI.ts
+++ b/suite-common/trading/src/invityAPI.ts
@@ -27,7 +27,7 @@ import type {
     SellVoucherTradeRequest,
 } from 'invity-api';
 
-import { getSuiteVersion, isDesktop, isNative } from '@trezor/env-utils';
+import { getPlatform, getSuiteVersion, isDesktop, isNative } from '@trezor/env-utils';
 
 import {
     InvityServerEnvironment,
@@ -147,6 +147,7 @@ class InvityAPI {
             headers: {
                 [apiHeader]: apiHeaderValue || this.getInvityAPIKey(),
                 'X-Suite-Version': getSuiteVersion(),
+                'X-Suite-Platform': getPlatform(),
                 ...(method === 'POST' && {
                     'Cache-Control': 'no-cache',
                     'Content-Type': 'application/json',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- New header added to all `InvityAPI` fetch calls.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #24071

## Screenshots:

No new UI.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=24071-send-platform-in-headers-to-trade-backend&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=24071-send-platform-in-headers-to-trade-backend&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24071-send-platform-in-headers-to-trade-backend&lookback=7)