### PR TITLE
Fix/23928 to field asset picker

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -155,6 +155,7 @@ export const TradingExchangeFormInputs = () => {
                     inputLabel="TR_TO"
                     inputName={TRADING_FORM_RECEIVE_CRYPTO_CURRENCY_SELECT}
                     enabledCryptoIds={exchangeInfo?.buyCryptoIds}
+                    disabledCryptoId={sendCryptoSelect?.value}
                     onAssetSelect={handleReceiveAssetSelect}
                     dataTestId="@trading/form/select-crypto"
                 />

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetOptionsContext.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetOptionsContext.tsx
@@ -8,9 +8,11 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 const AssetOptionsContext = createContext<{
     networks: NetworkSymbol[];
     assetsByTradingVolume: TradingAssetOption[];
+    disabledCryptoIds: Set<CryptoId> | undefined;
 }>({
     networks: [],
     assetsByTradingVolume: [],
+    disabledCryptoIds: undefined,
 });
 
 export interface AssetOptionsContextProps {
@@ -34,8 +36,9 @@ export function AssetOptionsProvider({
         () => ({
             networks,
             assetsByTradingVolume,
+            disabledCryptoIds,
         }),
-        [networks, assetsByTradingVolume],
+        [networks, assetsByTradingVolume, disabledCryptoIds],
     );
 
     return (

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetOptionsContext.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetOptionsContext.tsx
@@ -7,11 +7,11 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 
 const AssetOptionsContext = createContext<{
     networks: NetworkSymbol[];
-    assetsByTradingVolume: TradingAssetOption[];
+    assets: TradingAssetOption[];
     disabledCryptoIds: Set<CryptoId> | undefined;
 }>({
     networks: [],
-    assetsByTradingVolume: [],
+    assets: [],
     disabledCryptoIds: undefined,
 });
 
@@ -27,7 +27,7 @@ export function AssetOptionsProvider({
     children,
 }: AssetOptionsContextProps) {
     const { buildAssetOptions } = useTradingAssets();
-    const { assets: assetsByTradingVolume, networks } = useMemo(
+    const { assets, networks } = useMemo(
         () => buildAssetOptions({ enabledCryptoIds, disabledCryptoIds }),
         [buildAssetOptions, enabledCryptoIds, disabledCryptoIds],
     );
@@ -35,10 +35,10 @@ export function AssetOptionsProvider({
     const contextValue = useMemo(
         () => ({
             networks,
-            assetsByTradingVolume,
+            assets,
             disabledCryptoIds,
         }),
-        [networks, assetsByTradingVolume, disabledCryptoIds],
+        [networks, assets, disabledCryptoIds],
     );
 
     return (

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 
+import { CryptoId } from 'invity-api';
+
 import { TranslationKey } from '@suite-common/intl-types';
-import { TradingAssetOption } from '@suite-common/trading';
+import { TradingAssetOption, getCryptoId } from '@suite-common/trading';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import { accountSearchFn, isTokenMatchesSearch } from '@suite-common/wallet-utils';
@@ -14,7 +16,10 @@ import {
 import { TokensWithRates } from 'src/utils/wallet/tokenUtils';
 
 import { useAssetsContext } from '../../AssetOptionsContext';
-import { useAgregatedAccountsWithTokens } from '../../hooks/useAgregatedAccountsWithTokens';
+import {
+    AggregatedAccountWithTokens,
+    useAgregatedAccountsWithTokens,
+} from '../../hooks/useAgregatedAccountsWithTokens';
 
 function createSearchFilter(search: string) {
     return function searchFor(property?: string | null) {
@@ -34,6 +39,21 @@ function assetSearchFilter(asset: TradingAssetOption, search: string) {
         searchFor(asset.contractAddress) ||
         searchFor(asset.symbol)
     );
+}
+
+function excludeDisabledCryptoIds(disabledCryptoIds: Set<CryptoId> = new Set()) {
+    return function disabledCryptoIdsFilter(accountOrToken: AggregatedAccountWithTokens) {
+        switch (accountOrToken.type) {
+            case 'account':
+                return !disabledCryptoIds.has(getCryptoId(accountOrToken.account));
+            case 'token':
+                return !disabledCryptoIds.has(
+                    getCryptoId(accountOrToken.account, accountOrToken.token),
+                );
+            default:
+                return false;
+        }
+    };
 }
 
 export type TradingAssetListItem =
@@ -77,7 +97,7 @@ export function useBuildTradingAssetOptions({
     search,
     networkSymbol,
 }: UseBuildTradingAssetOptionsProps) {
-    const { assetsByTradingVolume } = useAssetsContext();
+    const { assetsByTradingVolume, disabledCryptoIds } = useAssetsContext();
     const accountsWithTokens = useAgregatedAccountsWithTokens();
 
     return useMemo(() => {
@@ -101,6 +121,7 @@ export function useBuildTradingAssetOptions({
         }
 
         const filteredAccounts = accountsWithTokens
+            .filter(excludeDisabledCryptoIds(disabledCryptoIds))
             .filter(accountOrToken => {
                 switch (accountOrToken.type) {
                     case 'account':
@@ -179,5 +200,5 @@ export function useBuildTradingAssetOptions({
         }
 
         return { listItems };
-    }, [accountsWithTokens, assetsByTradingVolume, networkSymbol, search]);
+    }, [accountsWithTokens, assetsByTradingVolume, disabledCryptoIds, networkSymbol, search]);
 }

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
@@ -162,9 +162,7 @@ export function useBuildTradingAssetOptions({
                 type: 'group-space',
                 height: ASSET_ROW_HEIGHTS_BY_SIZE['lg'],
             });
-        }
 
-        if (filteredAssets.length > 0) {
             listItems.push({
                 type: 'group-label',
                 label: 'TR_ASSET_PICKER_ALL_ASSETS',

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { CryptoId } from 'invity-api';
 
 import { TranslationKey } from '@suite-common/intl-types';
-import { TradingAssetOption, getCryptoId } from '@suite-common/trading';
+import { TradingAssetOption, createDefaultAssetOption, getCryptoId } from '@suite-common/trading';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import { accountSearchFn, isTokenMatchesSearch } from '@suite-common/wallet-utils';
@@ -56,6 +56,39 @@ function excludeDisabledCryptoIds(disabledCryptoIds: Set<CryptoId> = new Set()) 
     };
 }
 
+/**
+ * Note this is going to be replaced soon with more sophisticated top assets logic.
+ */
+function createTopFiveAssets() {
+    return [
+        createDefaultAssetOption('btc'),
+        createDefaultAssetOption('eth'),
+        {
+            isNativeToken: false,
+            id: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId,
+            name: 'Tether',
+            symbol: 'usdt',
+            coingeckoId: 'ethereum',
+            displaySymbol: 'USDT',
+            contractAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+            networkName: 'Ethereum',
+            networkSymbol: 'eth',
+        },
+        {
+            isNativeToken: false,
+            id: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CryptoId,
+            name: 'USDC',
+            symbol: 'usdc',
+            coingeckoId: 'ethereum',
+            displaySymbol: 'USDC',
+            contractAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            networkName: 'Ethereum',
+            networkSymbol: 'eth',
+        },
+        createDefaultAssetOption('sol'),
+    ] satisfies TradingAssetOption[];
+}
+
 export type TradingAssetListItem =
     | {
           type: 'top-five-assets';
@@ -97,14 +130,14 @@ export function useBuildTradingAssetOptions({
     search,
     networkSymbol,
 }: UseBuildTradingAssetOptionsProps) {
-    const { assetsByTradingVolume, disabledCryptoIds } = useAssetsContext();
+    const { assets, disabledCryptoIds } = useAssetsContext();
     const accountsWithTokens = useAgregatedAccountsWithTokens();
 
     return useMemo(() => {
         const listItems: TradingAssetListItem[] = [];
 
-        const topFiveAssets =
-            search.length === 0 && !networkSymbol ? assetsByTradingVolume.slice(0, 5) : [];
+        const topFiveAssets = search.length === 0 && !networkSymbol ? createTopFiveAssets() : [];
+        const topFiveAssetIds = new Set(topFiveAssets.map(asset => asset.id));
 
         if (topFiveAssets.length > 0) {
             listItems.push(
@@ -173,8 +206,8 @@ export function useBuildTradingAssetOptions({
             }
         }
 
-        const filteredAssets = assetsByTradingVolume
-            .slice(topFiveAssets.length)
+        const filteredAssets = assets
+            .filter(asset => !topFiveAssetIds.has(asset.id))
             .filter(asset => (networkSymbol ? asset.networkSymbol === networkSymbol : true))
             .filter(asset => assetSearchFilter(asset, search));
 
@@ -200,5 +233,5 @@ export function useBuildTradingAssetOptions({
         }
 
         return { listItems };
-    }, [accountsWithTokens, assetsByTradingVolume, disabledCryptoIds, networkSymbol, search]);
+    }, [accountsWithTokens, assets, disabledCryptoIds, networkSymbol, search]);
 }

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerModal/hooks/useUpdateFormInput.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerModal/hooks/useUpdateFormInput.ts
@@ -1,14 +1,11 @@
 import { useCallback } from 'react';
 
-import { CryptoId } from 'invity-api';
-
-import { TradingAssetOption, composeCryptoId } from '@suite-common/trading';
+import { TradingAssetOption, getCryptoId } from '@suite-common/trading';
 import {
     NetworkConfigWithoutTestnets,
     getDisplaySymbol,
     networks,
 } from '@suite-common/wallet-config';
-import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 
 import { TradingAssetListItem } from './useBuildTradingAssetOptions';
 
@@ -25,7 +22,7 @@ export function useUpdateFormInput({ closeModal, onAssetSelect }: UseUpdateFormI
                     const network = networks[asset.account.symbol] as NetworkConfigWithoutTestnets;
 
                     onAssetSelect({
-                        id: network.tradeCryptoId as CryptoId,
+                        id: getCryptoId(asset.account),
                         coingeckoId: network.coingeckoId!,
 
                         isNativeToken: true,
@@ -45,13 +42,7 @@ export function useUpdateFormInput({ closeModal, onAssetSelect }: UseUpdateFormI
                     const network = networks[asset.account.symbol];
 
                     onAssetSelect({
-                        id: composeCryptoId(
-                            network.coingeckoId!,
-                            getContractAddressForNetworkSymbol(
-                                asset.account.symbol,
-                                asset.token.contract,
-                            ),
-                        ),
+                        id: getCryptoId(asset.account, asset.token),
                         coingeckoId: network.coingeckoId!,
 
                         isNativeToken: false,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/TradingFormInputAssetPicker.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/TradingFormInputAssetPicker.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 
 import { CryptoId } from 'invity-api';
 
@@ -20,7 +20,7 @@ export interface TradingFormInputAssetPickerProps {
     onAssetSelect: AssetPickerModalProps['onAssetSelect'];
 
     enabledCryptoIds?: Set<CryptoId> | undefined;
-    disabledCryptoIds?: Set<CryptoId> | undefined;
+    disabledCryptoId?: CryptoId | undefined;
     dataTestId?: string;
 }
 
@@ -31,10 +31,14 @@ export const TradingFormInputAssetPicker = memo(function TradingFormInputAssetPi
     inputDisabled,
     dataTestId,
     enabledCryptoIds,
-    disabledCryptoIds,
+    disabledCryptoId,
     onAssetSelect,
 }: TradingFormInputAssetPickerProps) {
     const modal = useModal();
+    const disabledCryptoIds = useMemo(
+        () => (disabledCryptoId ? new Set([disabledCryptoId]) : undefined),
+        [disabledCryptoId],
+    );
 
     return (
         <AssetOptionsProvider

--- a/suite-common/trading/src/hooks/useTradingAssets.ts
+++ b/suite-common/trading/src/hooks/useTradingAssets.ts
@@ -173,7 +173,7 @@ export function createDefaultAssetOption(
 }
 
 /**
- * Get flat array of all enabled, supported crypto currencies and their tokens sorted by trading volume in descending order.
+ * Get flat array of all enabled, supported crypto currencies and their tokens sorted by market cap in descending order.
  */
 export function useTradingAssets() {
     const getCoinsAndPlatforms = useCoinsAndPlatforms();
@@ -210,7 +210,7 @@ export function useTradingAssets() {
 
             return {
                 /**
-                 * Flat array of all enabled, supported crypto currencies and their tokens sorted by trading volume in descending order.
+                 * Flat array of all enabled, supported crypto currencies and their tokens sorted by market cap in descending order.
                  */
                 assets,
 

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -18,7 +18,6 @@ import {
     getNetwork,
     getNetworkByCoingeckoId,
     getNetworkByTradeCryptoId,
-    networks,
     networksCollection,
 } from '@suite-common/wallet-config';
 import type { Account, FormStateTrading } from '@suite-common/wallet-types';
@@ -70,10 +69,10 @@ export function composeCryptoId(coingeckoId: string, contractAddress?: string | 
 }
 
 /**
- * Get the crypto id for an account or token
+ * Get the crypto id for an account or token of non-testnet network
  */
 export function getCryptoId(account: Account, token?: TokenInfo): CryptoId {
-    const network = networks[account.symbol];
+    const network = getNetwork(account.symbol);
 
     if (token) {
         return composeCryptoId(

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -18,9 +18,12 @@ import {
     getNetwork,
     getNetworkByCoingeckoId,
     getNetworkByTradeCryptoId,
+    networks,
     networksCollection,
 } from '@suite-common/wallet-config';
 import type { Account, FormStateTrading } from '@suite-common/wallet-types';
+import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
+import { TokenInfo } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
 
@@ -64,6 +67,22 @@ export function composeCryptoId(coingeckoId: string, contractAddress?: string | 
             ? `${coingeckoId}${CRYPTO_PLATFORM_SEPARATOR}${contractAddress}`
             : coingeckoId
     ) as CryptoId;
+}
+
+/**
+ * Get the crypto id for an account or token
+ */
+export function getCryptoId(account: Account, token?: TokenInfo): CryptoId {
+    const network = networks[account.symbol];
+
+    if (token) {
+        return composeCryptoId(
+            network.coingeckoId!,
+            getContractAddressForNetworkSymbol(account.symbol, token.contract),
+        );
+    }
+
+    return network.tradeCryptoId as CryptoId;
 }
 
 export const isCryptoIdForNativeToken = (cryptoId: CryptoId) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Make top five assets static again (it's going to be soon removed and replaced with more sophisticated logic -  [slack thread](https://satoshilabs.slack.com/archives/C08PA8C0370/p1767607026274459?thread_ts=1765879742.531959&cid=C08PA8C0370)).
* Exclude cryptoId of `From` field in `To` field asset picker. (Yes, it's not excluded from the static top five assets. This is expected. It's only being excluded from `Your assets` and `All assets`)
* Hide `All assets` if `Your assets` is empty.

## Related Issue

- Resolve #23928
- Resolve #24142

## Screenshots:

<img width="560" height="722" alt="Snímek obrazovky 2026-01-05 v 14 38 21" src="https://github.com/user-attachments/assets/0eeddbe4-5ec7-446a-80c7-9d156f4896a7" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/23928-to-field-asset-picker&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/23928-to-field-asset-picker&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/23928-to-field-asset-picker&lookback=7)