### PR TITLE
fix(suite): get fresh device before connect popup call

### DIFF
--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -119,6 +119,10 @@ export const connectPopupCallThunkInner = createThunk<
                 source,
             });
 
+            // refresh device state before call (could have changed during preCallHooks)
+            device = selectSelectedDevice(getState());
+            if (!device) throw TypedError('Device_Disconnected');
+
             const response = await TrezorConnect.call({
                 device: {
                     path: device.path,


### PR DESCRIPTION
## Description

Get fresh device before call in Suite Connect Popup flow. 
The reason is that during `preCallHooks` it may be changed, for example if the session expired and it asks for passphrase. 
Without updating it would previously ask for passphrase twice.  

## Notes for QA

1. Open a passphrase wallet
2. Connect to something via WalletConnect
3. Disconnect and connect Trezor to invalidate sesssion
4. Go to sign a transaction. It should ask for passphrase once in the beginning. Before it would ask twice. 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-connect-popup-passphrase&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-connect-popup-passphrase&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-connect-popup-passphrase&lookback=7)