### PR TITLE
feat(connect): validation for sign message size for T1B1

### DIFF
--- a/packages/connect/e2e/__fixtures__/signMessage.ts
+++ b/packages/connect/e2e/__fixtures__/signMessage.ts
@@ -244,5 +244,21 @@ export default {
             },
             legacyResults,
         },
+        {
+            description: 'Message over maximum limit allowed by T1B1',
+            skip: ['2'],
+            params: {
+                coin: 'Bitcoin',
+                path: "m/84'/0'/0'/0/0",
+                message: 'a'.repeat(1024 + 1),
+            },
+
+            legacyResults: [
+                {
+                    rules: ['1'],
+                    success: false,
+                },
+            ],
+        },
     ],
 } satisfies TestCase;

--- a/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
@@ -5,6 +5,7 @@ import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork } from '../../../data/coinInfo';
+import { validateModelOneMessageSize } from '../../../device/validateMessageSize';
 import {
     EthereumNetworkInfo,
     EthereumSignMessage as EthereumSignMessageSchema,
@@ -69,6 +70,8 @@ export default class EthereumSignMessage extends AbstractMethod<'ethereumSignMes
     }
 
     async run() {
+        validateModelOneMessageSize(this.device, this.params.message);
+
         const cmd = this.device.getCommands();
         const { address_n, message } = this.params;
 

--- a/packages/connect/src/api/ethereum/api/ethereumVerifyMessage.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumVerifyMessage.ts
@@ -4,6 +4,7 @@ import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../../../core/AbstractMethod';
+import { validateModelOneMessageSize } from '../../../device/validateMessageSize';
 import { EthereumVerifyMessage as EthereumVerifyMessageSchema } from '../../../types';
 import { messageToHex, stripHexPrefix } from '../../../utils/formatUtils';
 import { getFirmwareRange } from '../../common/paramsValidator';
@@ -37,6 +38,8 @@ export default class EthereumVerifyMessage extends AbstractMethod<
     }
 
     async run() {
+        validateModelOneMessageSize(this.device, this.params.message);
+
         const cmd = this.device.getCommands();
         const response = await cmd.typedCall('EthereumVerifyMessage', 'Success', this.params);
 

--- a/packages/connect/src/api/signMessage.ts
+++ b/packages/connect/src/api/signMessage.ts
@@ -8,6 +8,7 @@ import type { BitcoinNetworkInfo } from '../types';
 import { SignMessage as SignMessageSchema } from '../types';
 import { getFirmwareRange, validateCoinPath } from './common/paramsValidator';
 import { getBitcoinNetwork } from '../data/coinInfo';
+import { validateModelOneMessageSize } from '../device/validateMessageSize';
 import { hexToText, messageToHex } from '../utils/formatUtils';
 import { getLabel, getScriptType, getSerializedPath, validatePath } from '../utils/pathUtils';
 
@@ -69,6 +70,8 @@ export default class SignMessage extends AbstractMethod<'signMessage', PROTO.Sig
     }
 
     async run() {
+        validateModelOneMessageSize(this.device, this.params.message);
+
         const cmd = this.device.getCommands();
         const { message } = await cmd.typedCall('SignMessage', 'MessageSignature', this.params);
         // convert signature to base64

--- a/packages/connect/src/api/verifyMessage.ts
+++ b/packages/connect/src/api/verifyMessage.ts
@@ -6,6 +6,7 @@ import { ERRORS, PROTO } from '../constants';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getFirmwareRange } from './common/paramsValidator';
 import { getBitcoinNetwork } from '../data/coinInfo';
+import { validateModelOneMessageSize } from '../device/validateMessageSize';
 import { VerifyMessage as VerifyMessageSchema } from '../types';
 import { messageToHex } from '../utils/formatUtils';
 import { getLabel } from '../utils/pathUtils';
@@ -49,6 +50,8 @@ export default class VerifyMessage extends AbstractMethod<'verifyMessage', PROTO
     }
 
     async run() {
+        validateModelOneMessageSize(this.device, this.params.message);
+
         const cmd = this.device.getCommands();
         const response = await cmd.typedCall('VerifyMessage', 'Success', this.params);
 

--- a/packages/connect/src/constants/errors.ts
+++ b/packages/connect/src/constants/errors.ts
@@ -27,6 +27,7 @@ export const ERROR_CODES = {
     Method_Override: 'override', // inner "error", it's more like a interruption
     Method_NoResponse: 'Call resolved without response', // thrown by npm index(es), call to Core resolved without response, should not happen
     Method_Unsupported: 'Unsupported method', // 3rd party called a method unknown by current version
+    Method_DataOverflowModelOne: 'Model One does not support data over 1024 bytes', // happens in SignMessage, EthereumSignMessage and respective VerifyMessage methods
 
     Backend_NotSupported: 'BlockchainLink settings not found in coins.json', // thrown by methods which using backends, blockchainLink not defined for this coin
     Backend_WorkerMissing: '', // thrown by BlockchainLink class, worker not specified

--- a/packages/connect/src/device/validateMessageSize.ts
+++ b/packages/connect/src/device/validateMessageSize.ts
@@ -1,0 +1,14 @@
+import { Device } from './Device';
+import { TypedError } from '../constants/errors';
+
+/**
+ * for T1B1 maximum message size is 1024 bytes
+ */
+export const validateModelOneMessageSize = (device: Device, messageHex: string) => {
+    if (device.features?.major_version === 1) {
+        const byteSize = messageHex.length / 2;
+        if (byteSize > 1024) {
+            throw TypedError('Method_DataOverflowModelOne');
+        }
+    }
+};


### PR DESCRIPTION
## Description

Taking over forgotten PR #17908 and simplifying it a bit

## Notes for QA

Call signMessage with text over 1024 bytes, it should show a nicer error message than before.

## Related Issue

Resolve #17893

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-sign-message-too-long-t1&lookback=7)