### PR TITLE
fix(suite-native): create logger middleware

### DIFF
--- a/suite-native/state/src/store.ts
+++ b/suite-native/state/src/store.ts
@@ -49,8 +49,8 @@ const getMiddlewares = (getExtra: () => ExtraDependencies | null) => {
         enhancers.push(rozeniteDevToolsEnhancer());
 
         if (ENABLE_REDUX_LOGGER) {
-            const logger = require('redux-logger');
-            middlewares.push(logger);
+            const { createLogger } = require('redux-logger');
+            middlewares.push(createLogger());
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`redux-logger` exports `createLogger`, not the middleware directly. Updated to call `createLogger()` before adding it to the middleware array


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/create-logger-middleware&lookback=7)