### PR TITLE
fix(nix): update playwright-web-flake adjust overlay for chromium

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763283776,
-        "narHash": "sha256-Y7TDFPK4GlqrKrivOcsHG8xSGqQx3A6c+i7novT85Uk=",
+        "lastModified": 1767379071,
+        "narHash": "sha256-EgE0pxsrW9jp9YFMkHL9JMXxcqi/OoumPJYwf+Okucw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50a96edd8d0db6cc8db57dab6bb6d6ee1f3dc49a",
+        "rev": "fb7944c166a3b630f177938e478f0378e64ce108",
         "type": "github"
       },
       "original": {
@@ -86,16 +86,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1755759088,
-        "narHash": "sha256-lW2EfwKyCTye30g2yqFXFFv/yVr0G+Wna1FLfHdEhlQ=",
+        "lastModified": 1764677445,
+        "narHash": "sha256-TKpMwDUR6dJ3JG0Ypw9y/tIiZbqEVnzGWbsqZRMoqgs=",
         "owner": "pietdevries94",
         "repo": "playwright-web-flake",
-        "rev": "8cfb83f241f326b62e69597cda66ad2ea2dbf340",
+        "rev": "276c607189273ab3b4a3e163fed738bef7f18a7c",
         "type": "github"
       },
       "original": {
         "owner": "pietdevries94",
-        "ref": "1.55.0",
+        "ref": "1.57.0",
         "repo": "playwright-web-flake",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,8 +12,11 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         overlay = final: prev: {
-          # Overlay playwright packages
-          inherit (playwright-web-flake.packages.${system}) playwright-test playwright-driver;
+          # Overlay playwright packages with chromium from nixpkgs unstable
+          playwright-driver = (playwright-web-flake.packages.${system}.playwright-driver.override {
+            chromium = prev.chromium;
+          });
+          playwright-test = playwright-web-flake.packages.${system}.playwright-test;
           
           # Override GCC with older version
           gccPkgs = import old-gcc-nixpkgs { system = prev.system; };


### PR DESCRIPTION
This modifies the Nix flake overlay to use a newer version of Chromium by overriding the playwright-driver package configuration.

Modifying the overlay in `flake.nix` to override playwright-driver with the nixpkgs-unstable Chromium package instead of using the bundled version

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=nix-flake-fix-playwright&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=nix-flake-fix-playwright&lookback=7)