### PR TITLE
Hide sell fee preview until transaction is approved by provider

### DIFF
--- a/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
@@ -96,20 +96,21 @@ export abstract class TradingFormActions extends TradingActions {
         );
     }
 
-    async setFiatAmount(amount: string) {
-        await this.getFiatAmountElement().replaceText(amount);
+    async setAmountValue(amount: string, getElement: () => Detox.IndexableNativeElement) {
+        await getElement().tap();
         await wait(100);
-        await this.getFiatAmountElement().tapReturnKey();
+        await getElement().replaceText(amount);
+        await wait(100);
+        await getElement().tapReturnKey();
         await this.waitForQuotesToLoad();
     }
 
-    async setSendCryptoAmount(amount: string) {
-        await this.getSendCryptoAmountElement().tap();
-        await wait(100);
-        await this.getSendCryptoAmountElement().replaceText(amount);
-        await wait(100);
-        await this.getSendCryptoAmountElement().tapReturnKey();
-        await this.waitForQuotesToLoad();
+    setFiatAmount(amount: string) {
+        return this.setAmountValue(amount, this.getFiatAmountElement.bind(this));
+    }
+
+    setSendCryptoAmount(amount: string) {
+        return this.setAmountValue(amount, this.getSendCryptoAmountElement.bind(this));
     }
 
     async viewProviders() {

--- a/suite-native/module-trading/src/components/general/TradeInfo/TradeFiatSideCard.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/TradeFiatSideCard.tsx
@@ -41,11 +41,10 @@ const getPaymentMethodTranslation = (paymentMethod: ExtendedSellCryptoPaymentMet
 
 export const TradeFiatSideCard = ({ paymentMethod, amount, title }: TradeFiatSideCardProps) => (
     <Card noPadding>
-        <TradeInfoHeader title={title} />
-        <TradeInfoRow>
-            <Text variant="hint">{getPaymentMethodTranslation(paymentMethod)}</Text>
-        </TradeInfoRow>
-
+        <TradeInfoHeader
+            title={title}
+            rightContent={<Text variant="hint">{getPaymentMethodTranslation(paymentMethod)}</Text>}
+        />
         <TradeInfoRow>
             <HStack alignItems="center">
                 <FiatCurrencyIcon size="small" />

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellFeePickerCard.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellFeePickerCard.tsx
@@ -2,7 +2,10 @@ import { useSelector } from 'react-redux';
 
 import type { SellFiatTrade } from 'invity-api';
 
-import { selectSellSelectedSendAccount } from '@suite-native/trading-state';
+import {
+    selectSellSelectedSendAccount,
+    selectTradingProviderConfirmationStatus,
+} from '@suite-native/trading-state';
 
 import { FeePickerCard } from '../../fees/FeePickerCard';
 
@@ -13,8 +16,11 @@ export type SellFeePickerCardProps = {
 
 export const SellFeePickerCard = ({ quote, isTxnError }: SellFeePickerCardProps) => {
     const fromAccount = useSelector(selectSellSelectedSendAccount);
+    const providerConfirmationStatus = useSelector(selectTradingProviderConfirmationStatus);
 
-    if (!fromAccount || !quote?.cryptoCurrency || isTxnError) {
+    const isTradeConfirmedOnProviderSide = providerConfirmationStatus === 'confirmation_success';
+
+    if (!fromAccount || !quote?.cryptoCurrency || isTxnError || !isTradeConfirmedOnProviderSide) {
         return null;
     }
 

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFeePickerCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFeePickerCard.comp.test.tsx
@@ -1,5 +1,6 @@
 import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 import { getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
+import type { ProviderConfirmationStatus } from '@suite-native/trading-types';
 
 import { SellFeePickerCard, SellFeePickerCardProps } from '../SellFeePickerCard';
 
@@ -7,12 +8,14 @@ describe('SellFeePickerCard', () => {
     const renderSellFeePickerCard = (
         props: Partial<SellFeePickerCardProps> = {},
         tradingAccountKey = 'eth-account-1',
+        providerConfirmationStatus: ProviderConfirmationStatus = 'confirmation_success',
     ) => {
         const preloadedState: PreloadedState = {
             wallet: getWalletState({ tradeType: 'sell' }),
         };
         preloadedState.wallet!.trading!.composedTransactionInfo = { composed: { fee: '1000' } };
         preloadedState.wallet!.trading!.sell!.tradingAccountKey = tradingAccountKey;
+        preloadedState.wallet!.trading!.providerConfirmationStatus = providerConfirmationStatus;
 
         return renderWithStoreProviderAsync(<SellFeePickerCard isTxnError={false} {...props} />, {
             preloadedState,
@@ -50,6 +53,16 @@ describe('SellFeePickerCard', () => {
         const { toJSON } = await renderSellFeePickerCard(
             { quote: sellQuotes[0] },
             'unknown-account-key',
+        );
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render nothing when providerConfirmationStatus is not in "confirmation_success" state', async () => {
+        const { toJSON } = await renderSellFeePickerCard(
+            { quote: sellQuotes[0] },
+            'eth-account-1',
+            'window_closed_with_success',
         );
 
         expect(toJSON()).toBeNull();

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewView.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewView.comp.test.tsx
@@ -22,6 +22,7 @@ describe('SellPreviewView', () => {
         preloadedState.wallet!.trading!.sell!.tradingAccountKey = 'eth-account-1';
         preloadedState.wallet!.trading!.sell!.selectedQuote = sellQuotes[1]; // Use quote with bank accounts
         preloadedState.wallet!.trading!.trades = [getSellTradeWithBankAccounts()];
+        preloadedState.wallet!.trading!.providerConfirmationStatus = 'confirmation_success';
 
         Object.assign(preloadedState.wallet!.trading!.sell!, overrides);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Do not display "Transaction details" card until provider confirms sell.
- Make "To" card more compact in sell.
- Updated trading e2e - click to fiat input and wait to allow animations to run.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="300" alt="Simulator Screenshot - iPhone 16 - 2026-01-05 at 16 56 31" src="https://github.com/user-attachments/assets/6de80bed-ec6d-4718-97ea-e55cba425d43" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=hide-sell-fee-row-preview&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=hide-sell-fee-row-preview&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=hide-sell-fee-row-preview&lookback=7)