### PR TITLE
feat(suite): add TradingFormInputSellAsset component

### DIFF
--- a/packages/suite/src/components/suite/asset-picker/hooks/index.ts
+++ b/packages/suite/src/components/suite/asset-picker/hooks/index.ts
@@ -2,3 +2,6 @@ export * from './useDataFingerprint';
 export * from './useModal';
 export * from './useListScrollReset';
 export * from './useSearchFilter';
+export * from './useInsertGroupLabelsAndSpaces';
+export * from './useAccountWithTokensOptions';
+export * from './useFilterAccountsWithTokens';

--- a/packages/suite/src/components/suite/asset-picker/hooks/useAccountWithTokensOptions.ts
+++ b/packages/suite/src/components/suite/asset-picker/hooks/useAccountWithTokensOptions.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useThrottle } from 'react-use';
 
 import { selectTokenDefinitions } from '@suite-common/token-definitions';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkSymbol, getMainnets } from '@suite-common/wallet-config';
 import {
     selectAllAccountsToList,
     selectBaseCurrency,
@@ -16,27 +16,13 @@ import {
 import { useCurrentRef } from '@trezor/react-utils';
 
 import { ASSET_ROW_HEIGHT } from 'src/components/suite/asset-picker/constants';
+import { AccountWithTokensOption } from 'src/components/suite/asset-picker/hooks';
 import { useSelector } from 'src/hooks/suite';
-import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
 import {
-    TokensWithRates,
     enhanceTokensWithRates,
     getTokens,
     sortTokensWithRates,
 } from 'src/utils/wallet/tokenUtils';
-
-export type AccountWithTokensOption =
-    | {
-          type: 'account';
-          account: Account;
-          height: number;
-      }
-    | {
-          type: 'token';
-          account: Account;
-          token: TokensWithRates;
-          height: number;
-      };
 
 function filterAccountsByNetworkSymbol(
     accounts: Account[],
@@ -44,9 +30,15 @@ function filterAccountsByNetworkSymbol(
 ): Account[] {
     return networkSymbol ? findAccountsByNetwork(networkSymbol, accounts) : accounts;
 }
+export interface UseAccountWithTokensOptionsProps {
+    networkSymbolFilter: NetworkSymbol | undefined;
+    includeTestnets?: boolean;
+}
 
-export function useAccountWithTokensOptions(): AccountWithTokensOption[] {
-    const networkSymbol = useSelector(globalSendReceiveFilters.selectors.selectNetworkSymbol);
+export function useAccountWithTokensOptions({
+    networkSymbolFilter,
+    includeTestnets = true,
+}: UseAccountWithTokensOptionsProps): AccountWithTokensOption[] {
     const accounts = useSelector(selectAllAccountsToList);
     const fiatRates = useSelector(selectCurrentFiatRates);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
@@ -63,9 +55,15 @@ export function useAccountWithTokensOptions(): AccountWithTokensOption[] {
             return [];
         }
 
-        const networkAccounts = filterAccountsByNetworkSymbol(throttledAccounts, networkSymbol);
+        const networkAccounts = filterAccountsByNetworkSymbol(
+            throttledAccounts,
+            networkSymbolFilter,
+        );
+
+        const mainnets = new Set(getMainnets().map(network => network.symbol));
 
         const accountsAndTokensSortedByFiatBalance = networkAccounts
+            .filter(account => (includeTestnets ? true : mainnets.has(account.symbol)))
             .toSorted(function sortByFiatBalanceInDescOrder(accountA, accountB) {
                 return accountsFiatBalanceInDescOrderComparator({
                     accountA,
@@ -115,5 +113,12 @@ export function useAccountWithTokensOptions(): AccountWithTokensOption[] {
             ]);
 
         return accountsWithTokensOptions;
-    }, [throttledAccounts, baseCurrencyCode, fiatRatesRef, networkSymbol, tokenDefinitions]);
+    }, [
+        fiatRatesRef,
+        throttledAccounts,
+        networkSymbolFilter,
+        includeTestnets,
+        baseCurrencyCode,
+        tokenDefinitions,
+    ]);
 }

--- a/packages/suite/src/components/suite/asset-picker/hooks/useFilterAccountsWithTokens.ts
+++ b/packages/suite/src/components/suite/asset-picker/hooks/useFilterAccountsWithTokens.ts
@@ -2,14 +2,12 @@ import { useMemo } from 'react';
 
 import { accountSearchFn, isTokenMatchesSearch } from '@suite-common/wallet-utils';
 
-import { useSelector } from 'src/hooks/suite';
-import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
+import { AccountWithTokensOption } from './useInsertGroupLabelsAndSpaces';
 
-import { AccountWithTokensOption } from './useAccountWithTokensOptions';
-
-export function useFilterAccountsWithTokens(accountsWithTokens: AccountWithTokensOption[]) {
-    const search = useSelector(globalSendReceiveFilters.selectors.selectSearch);
-
+export function useFilterAccountsWithTokens(
+    accountsWithTokens: AccountWithTokensOption[],
+    search: string,
+) {
     return useMemo(
         () =>
             accountsWithTokens.filter(accountOrToken => {

--- a/packages/suite/src/components/suite/asset-picker/hooks/useInsertGroupLabelsAndSpaces.tsx
+++ b/packages/suite/src/components/suite/asset-picker/hooks/useInsertGroupLabelsAndSpaces.tsx
@@ -2,15 +2,26 @@ import { ReactNode, useMemo } from 'react';
 
 import { Account } from '@suite-common/wallet-types';
 
-import { AccountLabel } from 'src/components/suite/AccountLabel';
-import {
-    ASSET_ROW_GROUP_LABEL_HEIGHT,
-    ASSET_ROW_HEIGHTS_BY_SIZE,
-} from 'src/components/suite/asset-picker/constants';
+import { TokensWithRates } from 'src/utils/wallet/tokenUtils';
 
-import { AccountWithTokensOption } from './useAccountWithTokensOptions';
+import { AccountLabel } from '../../AccountLabel';
+import { ASSET_ROW_GROUP_LABEL_HEIGHT, ASSET_ROW_HEIGHTS_BY_SIZE } from '../constants';
+import { AssetGroupSpaceSize } from '../types';
 
-export type GlobalSendListItem =
+export type AccountWithTokensOption =
+    | {
+          type: 'account';
+          account: Account;
+          height: number;
+      }
+    | {
+          type: 'token';
+          account: Account;
+          token: TokensWithRates;
+          height: number;
+      };
+
+export type AssetPickerListItem =
     | AccountWithTokensOption
     | {
           type: 'group-label';
@@ -20,13 +31,14 @@ export type GlobalSendListItem =
     | {
           type: 'group-space';
           height: number;
+          size: AssetGroupSpaceSize;
       };
 
 export function useInsertGroupLabelsAndSpaces(
     accountsWithTokens: AccountWithTokensOption[],
-): GlobalSendListItem[] {
+): AssetPickerListItem[] {
     return useMemo(() => {
-        const list: GlobalSendListItem[] = [];
+        const list: AssetPickerListItem[] = [];
         let currentAccount: Account | null = null;
 
         for (const item of accountsWithTokens) {
@@ -38,6 +50,7 @@ export function useInsertGroupLabelsAndSpaces(
                             list.push({
                                 type: 'group-space',
                                 height: ASSET_ROW_HEIGHTS_BY_SIZE['md'],
+                                size: 'md',
                             });
                         }
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx
@@ -15,16 +15,16 @@ import {
     AssetsListEmpty,
     AssetsModal,
 } from 'src/components/suite/asset-picker/components';
-import { useDataFingerprint } from 'src/components/suite/asset-picker/hooks';
+import {
+    AssetPickerListItem,
+    useAccountWithTokensOptions,
+    useDataFingerprint,
+    useFilterAccountsWithTokens,
+    useInsertGroupLabelsAndSpaces,
+} from 'src/components/suite/asset-picker/hooks';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
 
-import { useAccountWithTokensOptions } from './hooks/useAccountWithTokensOptions';
-import { useFilterAccountsWithTokens } from './hooks/useFilterAccountsWithTokens';
-import {
-    GlobalSendListItem,
-    useInsertGroupLabelsAndSpaces,
-} from './hooks/useInsertGroupLabelsAndSpaces';
 import { AssetSearchWithNetworkFilter } from '../AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter';
 
 type GlobalSendModalProps = {
@@ -37,8 +37,14 @@ const LIST_HEIGHT = 480;
 export function GlobalSendModal({ onCancel, onSubmit }: GlobalSendModalProps) {
     const dispatch = useDispatch();
 
-    const accountsWithTokens = useAccountWithTokensOptions();
-    const filteredAccountsWithTokens = useFilterAccountsWithTokens(accountsWithTokens);
+    const networkSymbolFilter = useSelector(globalSendReceiveFilters.selectors.selectNetworkSymbol);
+    const searchFilter = useSelector(globalSendReceiveFilters.selectors.selectSearch);
+
+    const accountsWithTokens = useAccountWithTokensOptions({ networkSymbolFilter });
+    const filteredAccountsWithTokens = useFilterAccountsWithTokens(
+        accountsWithTokens,
+        searchFilter,
+    );
     const fingerprintWithTokens = useDataFingerprint(filteredAccountsWithTokens);
     const globalSendListItems = useInsertGroupLabelsAndSpaces(filteredAccountsWithTokens);
 
@@ -61,13 +67,13 @@ export function GlobalSendModal({ onCancel, onSubmit }: GlobalSendModalProps) {
     );
 
     const renderItem = useCallback(
-        (item: GlobalSendListItem) => {
+        (item: AssetPickerListItem) => {
             switch (item.type) {
                 case 'group-label':
                     return <AssetGroupLabel label={item.label} />;
 
                 case 'group-space':
-                    return <AssetGroupSpace size="md" />;
+                    return <AssetGroupSpace size={item.size} />;
 
                 case 'account':
                     return (

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -89,6 +89,13 @@ export const TradingExchangeFormInputs = () => {
     return (
         <Card paddingType="none">
             <Column gap={spacings.lg} padding={spacings.lg}>
+                {/* TODO: finish integration to trading exchange form */}
+                {/* <TradingFormInputSellAsset
+                    inputName={TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT}
+                    inputLabel="TR_FROM"
+                    dataTestId="@trading/form/trade-from/select-crypto"
+                    onAssetSelect={handleSellAssetSelect}
+                /> */}
                 <TradingFormInputAccount
                     accountSelectName={TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT}
                     label="TR_FROM"

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInput.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInput.tsx
@@ -9,6 +9,7 @@ import {
     TRADING_FORM_RECEIVE_CRYPTO_CURRENCY_SELECT,
     TradingBuyFormProps,
     TradingExchangeFormProps,
+    TradingSellFormProps,
     selectTradingLoadingAndTimestamp,
 } from '@suite-common/trading';
 import { Icon, Input, Spinner, Text } from '@trezor/components';
@@ -18,7 +19,7 @@ import { useSelector, useTranslation } from 'src/hooks/suite';
 
 import { AssetPickerInputContent } from './AssetPickerInputContent';
 
-type TradingFormValues = TradingExchangeFormProps | TradingBuyFormProps;
+type TradingFormValues = TradingExchangeFormProps | TradingBuyFormProps | TradingSellFormProps;
 
 const OpenModalButton = styled.button`
     border: unset;
@@ -43,6 +44,8 @@ export interface AssetPickerInputProps {
     name:
         | typeof TRADING_FORM_CRYPTO_CURRENCY_SELECT
         | typeof TRADING_FORM_RECEIVE_CRYPTO_CURRENCY_SELECT;
+    // TODO: finish integration to trading exchange and sell form
+    // | typeof TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT;
     label: TranslationKey;
     placeholder?: TranslationKey;
     isDisabled?: boolean;

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetListWrapper.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetListWrapper.tsx
@@ -1,0 +1,44 @@
+import { ReactNode, memo, useRef } from 'react';
+
+import { AssetsList, AssetsListEmpty } from 'src/components/suite/asset-picker/components';
+import { AssetPickerListItem, useListScrollReset } from 'src/components/suite/asset-picker/hooks';
+
+const LIST_HEIGHT = 530;
+
+export interface AssetListWrapperProps {
+    listItems: AssetPickerListItem[];
+    listItemsFingerprint: string;
+    renderItem: (item: AssetPickerListItem) => ReactNode;
+}
+
+export const AssetListWrapper = memo(
+    function AssetListWrapperInner({
+        listItems,
+        listItemsFingerprint,
+        renderItem,
+    }: AssetListWrapperProps) {
+        const listRef = useRef<HTMLDivElement>(null);
+
+        useListScrollReset(listRef, listItemsFingerprint);
+
+        return (
+            <AssetsListEmpty
+                isEmpty={listItems.length === 0}
+                heading="TR_ASSET_PICKER_SEARCH_NO_RESULTS"
+                description="TR_ASSET_PICKER_SEARCH_NO_RESULTS_DESCRIPTION"
+                height={LIST_HEIGHT}
+            >
+                <AssetsList
+                    items={listItems}
+                    itemsFingerprint={listItemsFingerprint}
+                    renderItem={renderItem}
+                    height={LIST_HEIGHT}
+                    ref={listRef}
+                />
+            </AssetsListEmpty>
+        );
+    },
+    function isEqual(prevProps, nextProps) {
+        return prevProps.listItemsFingerprint === nextProps.listItemsFingerprint;
+    },
+);

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx
@@ -1,0 +1,97 @@
+import { memo, useCallback, useState } from 'react';
+
+import { TranslationKey } from '@suite-common/intl-types';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { Divider } from '@trezor/components';
+
+import {
+    AssetGroupLabel,
+    AssetGroupSpace,
+    AssetRowAccountWithBalance,
+    AssetRowToken,
+    AssetsModal,
+} from 'src/components/suite/asset-picker/components';
+import { AssetPickerListItem, useSearchFilter } from 'src/components/suite/asset-picker/hooks';
+
+import { AssetListWrapper } from './AssetListWrapper';
+import { UseUpdateFormInputProps, useUpdateFormInput } from './hooks/useUpdateFormInput';
+import { AssetSearchWithNetworkFilter } from '../../TradingFormInputAssetPicker';
+import { useBuildTradingAssetOptions } from './hooks/useBuildTradingAssetOptions';
+
+export type AssetPickerModalProps = {
+    closeModal: () => void;
+    heading: TranslationKey;
+    dataTestId?: string;
+    onAssetSelect: UseUpdateFormInputProps['onAssetSelect'];
+};
+
+export const AssetPickerModal = memo(function AssetPickerModalInner({
+    closeModal,
+    heading,
+    onAssetSelect,
+    dataTestId,
+}: AssetPickerModalProps) {
+    const { search, throttledSearch, setSearch } = useSearchFilter();
+
+    const [networkFilter, setNetworkFilter] = useState<NetworkSymbol | undefined>(undefined);
+
+    const { listItems, listItemsFingerprint, networks } = useBuildTradingAssetOptions({
+        search: throttledSearch,
+        networkSymbol: networkFilter,
+    });
+
+    const handleAssetClick = useUpdateFormInput({ closeModal, onAssetSelect });
+
+    const renderItem = useCallback(
+        (item: AssetPickerListItem) => {
+            switch (item.type) {
+                case 'account':
+                    return (
+                        <AssetRowAccountWithBalance
+                            account={item.account}
+                            onClick={() => handleAssetClick(item)}
+                            dataTestId={`${dataTestId}/account`}
+                        />
+                    );
+
+                case 'token':
+                    return (
+                        <AssetRowToken
+                            token={item.token}
+                            account={item.account}
+                            onClick={() => handleAssetClick(item)}
+                            dataTestId={`${dataTestId}/token`}
+                        />
+                    );
+
+                case 'group-label':
+                    return <AssetGroupLabel label={item.label} />;
+
+                case 'group-space':
+                    return <AssetGroupSpace size={item.size} />;
+            }
+        },
+        [dataTestId, handleAssetClick],
+    );
+
+    return (
+        <AssetsModal onClose={closeModal} heading={{ id: heading }}>
+            <AssetSearchWithNetworkFilter
+                placeholder="TR_ASSET_PICKER_SEARCH_PLACEHOLDER"
+                search={search}
+                setSearch={setSearch}
+                networkFilter={networkFilter}
+                setNetworkFilter={setNetworkFilter}
+                networks={networks}
+            />
+
+            <Divider margin={{ top: 16 }} />
+
+            <AssetListWrapper
+                listItems={listItems}
+                listItemsFingerprint={listItemsFingerprint}
+                renderItem={renderItem}
+            />
+        </AssetsModal>
+    );
+});

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { union } from '@trezor/utils';
+
+import {
+    useAccountWithTokensOptions,
+    useDataFingerprint,
+    useFilterAccountsWithTokens,
+    useInsertGroupLabelsAndSpaces,
+} from 'src/components/suite/asset-picker/hooks';
+
+export interface UseBuildTradingAssetOptionsProps {
+    search: string;
+    networkSymbol: NetworkSymbol | undefined;
+}
+
+export function useBuildTradingAssetOptions({
+    search,
+    networkSymbol,
+}: UseBuildTradingAssetOptionsProps) {
+    const accountsWithTokens = useAccountWithTokensOptions({
+        networkSymbolFilter: networkSymbol,
+        includeTestnets: false,
+    });
+    const filteredAccountsWithTokens = useFilterAccountsWithTokens(accountsWithTokens, search);
+    const listItemsFingerprint = useDataFingerprint(filteredAccountsWithTokens);
+    const listItems = useInsertGroupLabelsAndSpaces(filteredAccountsWithTokens);
+    const networks = useMemo(
+        () =>
+            union(
+                accountsWithTokens
+                    .filter(item => item.type === 'account')
+                    .map(item => item.account.symbol),
+            ),
+        [accountsWithTokens],
+    );
+
+    return { listItemsFingerprint, listItems, networks };
+}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useUpdateFormInput.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useUpdateFormInput.ts
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+
+import {
+    TradingAssetOption,
+    createAssetNativeTokenOption,
+    createAssetTokenOption,
+} from '@suite-common/trading';
+import { NetworkConfigWithoutTestnets } from '@suite-common/wallet-config';
+
+import { AssetPickerListItem } from 'src/components/suite/asset-picker/hooks';
+
+export interface UseUpdateFormInputProps {
+    closeModal: () => void;
+    onAssetSelect: (asset: TradingAssetOption) => void;
+}
+
+export function useUpdateFormInput({ closeModal, onAssetSelect }: UseUpdateFormInputProps) {
+    const handleAssetClick = useCallback(
+        (asset: AssetPickerListItem) => {
+            switch (asset.type) {
+                case 'account': {
+                    onAssetSelect(
+                        createAssetNativeTokenOption(
+                            asset.account.symbol as NetworkConfigWithoutTestnets['symbol'],
+                        ),
+                    );
+                    break;
+                }
+
+                case 'token': {
+                    onAssetSelect(createAssetTokenOption(asset.account.symbol, asset.token));
+                    break;
+                }
+            }
+
+            closeModal();
+        },
+        [closeModal, onAssetSelect],
+    );
+
+    return handleAssetClick;
+}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/TradingFormInputSellAsset.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/TradingFormInputSellAsset.tsx
@@ -1,0 +1,52 @@
+import { memo } from 'react';
+
+import { useModal } from 'src/components/suite/asset-picker/hooks';
+
+import { AssetPickerInput, AssetPickerInputProps } from '../TradingFormInputAssetPicker';
+import { AssetPickerModal, AssetPickerModalProps } from './AssetPickerModal/AssetPickerModal';
+
+export interface TradingFormInputSellAssetProps {
+    inputPlaceholder?: AssetPickerInputProps['placeholder'];
+    inputLabel: AssetPickerInputProps['label'];
+    inputName: AssetPickerInputProps['name'];
+    inputDisabled?: AssetPickerInputProps['isDisabled'];
+
+    /**
+     * Make to sure to use `useCallback` to avoid breaking the `memo`
+     */
+    onAssetSelect: AssetPickerModalProps['onAssetSelect'];
+
+    dataTestId?: string;
+}
+
+export const TradingFormInputSellAsset = memo(function TradingFormInputSellAssetInner({
+    inputPlaceholder,
+    inputLabel,
+    inputName,
+    inputDisabled,
+    dataTestId,
+    onAssetSelect,
+}: TradingFormInputSellAssetProps) {
+    const modal = useModal();
+
+    return (
+        <>
+            <AssetPickerInput
+                name={inputName}
+                label={inputLabel}
+                placeholder={inputPlaceholder}
+                isDisabled={inputDisabled}
+                onClick={modal.openModal}
+                dataTestId={dataTestId}
+            />
+            {modal.open && (
+                <AssetPickerModal
+                    heading={inputLabel}
+                    closeModal={modal.closeModal}
+                    dataTestId={dataTestId}
+                    onAssetSelect={onAssetSelect}
+                />
+            )}
+        </>
+    );
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `TradingFormInputSellAsset` component without integration to the exchange and sell form.

## Related Issue

Resolve #22837

## Screenshots:

<img width="543" height="720" alt="Snímek obrazovky 2026-01-06 v 11 13 43" src="https://github.com/user-attachments/assets/f59fe498-cd88-42f5-b2b0-589ccd367fee" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/22837-trading-asset-picker-from-field-2&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/22837-trading-asset-picker-from-field-2&lookback=7)