### PR TITLE
Text inputs in Custom Fee sheet should avoid keyboard

### DIFF
--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeInputs.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeInputs.tsx
@@ -62,6 +62,7 @@ export const CustomFeeInputs = ({ symbol }: CustomFeeInputsProps) => {
                     accessibilityLabel="address input"
                     keyboardType="number-pad"
                     onChangeText={handleFieldChangeValue(FEE_LIMIT_FIELD_NAME, 'integer')}
+                    asBottomSheetInput
                 />
             )}
             {isEip1559Fee ? (
@@ -87,6 +88,7 @@ export const CustomFeeInputs = ({ symbol }: CustomFeeInputsProps) => {
                     keyboardType={networkType === 'bitcoin' ? 'decimal-pad' : 'number-pad'}
                     rightIcon={<Text color="textSubdued">{feeUnits}</Text>}
                     onChangeText={handleFieldChangeValue(FEE_PER_UNIT_FIELD_NAME, 'crypto')}
+                    asBottomSheetInput
                 />
             )}
             {networkType !== 'ethereum' && !hasFeePerByteError && (

--- a/suite-native/transaction-management/src/components/fees/CustomFee/EIP1559CustomInputs.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/EIP1559CustomInputs.tsx
@@ -43,6 +43,7 @@ export const EIP1559CustomInputs = ({
                 keyboardType="decimal-pad"
                 rightIcon={<Text color="textSubdued">{feeUnits}</Text>}
                 onChangeText={handleFieldChangeValue(MAX_FEE_PER_GAS_FIELD_NAME, 'crypto')}
+                asBottomSheetInput
             />
             <HStack paddingLeft="sp12" alignItems="center" spacing="sp4" paddingBottom="sp8">
                 <Icon name="gasPump" size="medium" color="textSubdued" />
@@ -65,6 +66,7 @@ export const EIP1559CustomInputs = ({
                 rightIcon={<Text color="textSubdued">{feeUnits}</Text>}
                 keyboardType="decimal-pad"
                 onChangeText={handleFieldChangeValue(MAX_PRIORITY_FEE_PER_GAS_FIELD_NAME, 'crypto')}
+                asBottomSheetInput
             />
         </>
     );


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Inputs in CustomFeeSheet now use `BottomSheetTextInput` as underlying component.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #24176 

## Screenshots:
