### PR TITLE
ci(gihtub): release workflows for connect v10

### DIFF
--- a/.github/workflows/release-connect-v10-production.yml
+++ b/.github/workflows/release-connect-v10-production.yml
@@ -1,0 +1,111 @@
+name: "[Release] connect v10 production"
+
+permissions:
+  id-token: write # for fetching the OIDC token
+  contents: read # for actions/checkout
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploymentType:
+        description: "Select the deployment type. (example: canary, stable)"
+        required: true
+        type: choice
+        options:
+          - canary
+          - stable
+
+jobs:
+  extract-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set-version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          fetch-depth: 0
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Extract connect version
+        id: set-version
+        run: echo "version=$(node ./scripts/ci/get-connect-version.js)" >> $GITHUB_OUTPUT
+
+  check-version-match:
+    runs-on: ubuntu-latest
+    needs: [extract-version]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check connect version match
+        uses: ./.github/actions/check-connect-version-match
+        with:
+          branch_ref: "${{ github.ref }}"
+          extracted_version: "${{ needs.extract-version.outputs.version }}"
+
+  # set the rollback
+  sync-rollback-connect-v10:
+    needs: [extract-version, check-version-match]
+    if: startsWith(github.ref, 'refs/heads/release/connect/')
+    environment: production-connect
+    name: "Backing up current production version ${{ needs.extract-version.outputs.version }} to rollback bucket"
+    runs-on: ubuntu-latest
+    env:
+      LATEST_VERSION: 10
+    steps:
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_connect_prod_deploy
+          aws-region: eu-central-1
+
+      - name: Synching rollback bucket with current production
+        run: |
+          aws s3 sync "s3://connect.trezor.io/${{ env.LATEST_VERSION }}/" "s3://rollback-connect.trezor.io/${{ env.LATEST_VERSION }}/"
+
+  deploy-production-semantic-version:
+    needs: [extract-version, check-version-match]
+    if: startsWith(github.ref, 'refs/heads/release/connect/')
+    environment: production-connect
+    name: "Deploying to connect.trezor.io/10.x.x"
+    runs-on: ubuntu-latest
+    env:
+      CURRENT_VERSION: ${{ needs.extract-version.outputs.version }}
+    steps:
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_connect_prod_deploy
+          aws-region: eu-central-1
+
+      - name: Synching production bucket with current staging
+        run: |
+          aws s3 sync --delete --cache-control 'public, max-age=3600' "s3://staging-connect.trezor.io/${{ env.CURRENT_VERSION }}/" "s3://connect.trezor.io/${{ env.CURRENT_VERSION }}/"
+          aws cloudfront create-invalidation --distribution-id E3LVNAOGT94E37 --paths '/*'
+
+  # From staging move it to production
+  deploy-production-v10:
+    # We deploy to production only if rollback sync was successful.
+    needs: [extract-version, check-version-match, sync-rollback-connect-v10]
+    if: startsWith(github.ref, 'refs/heads/release/connect/') && github.event.inputs.deploymentType == 'stable'
+    environment: production-connect
+    name: "Deploying to connect.trezor.io/10/"
+    runs-on: ubuntu-latest
+    env:
+      LATEST_VERSION: 10
+    steps:
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_connect_prod_deploy
+          aws-region: eu-central-1
+
+      - name: Synching production bucket with current staging
+        run: |
+          aws s3 sync --delete --cache-control 'public, max-age=3600' "s3://staging-connect.trezor.io/${{ env.LATEST_VERSION }}/" "s3://connect.trezor.io/${{ env.LATEST_VERSION }}/"
+          aws cloudfront create-invalidation --distribution-id E3LVNAOGT94E37 --paths '/*'

--- a/.github/workflows/release-connect-v10-rollback.yml
+++ b/.github/workflows/release-connect-v10-rollback.yml
@@ -1,0 +1,27 @@
+name: "[Release] connect v10 rollback"
+
+permissions:
+  id-token: write # for fetching the OIDC token
+  contents: read # for actions/checkout
+
+on:
+  workflow_dispatch:
+
+jobs:
+  rollback-connect-production:
+    if: startsWith(github.ref, 'refs/heads/release/connect/')
+    environment: production-connect
+    name: "Create rollback copy of connect.trezor.io"
+    runs-on: ubuntu-latest
+    env:
+      LATEST_VERSION: 10
+    steps:
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_connect_prod_deploy
+          aws-region: eu-central-1
+
+      - name: Synching production bucket with rollback
+        run: |
+          aws s3 sync --delete s3://rollback-connect.trezor.io/${{ env.LATEST_VERSION }}/ s3://connect.trezor.io/${{ env.LATEST_VERSION }}/

--- a/.github/workflows/release-connect-v10-staging.yml
+++ b/.github/workflows/release-connect-v10-staging.yml
@@ -1,0 +1,101 @@
+name: "[Release] connect v10 staging"
+
+permissions:
+  id-token: write # for fetching the OIDC token
+  contents: read # for actions/checkout
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # Version should have been bumped by now thanks to ./scripts/ci/connect-release-init-npm.js
+  extract-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set-version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          fetch-depth: 0
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Extract connect version
+        id: set-version
+        run: echo "version=$(node ./scripts/ci/get-connect-version.js)" >> $GITHUB_OUTPUT
+
+  check-version-match:
+    runs-on: ubuntu-latest
+    needs: [extract-version]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check connect version match
+        uses: ./.github/actions/check-connect-version-match
+        with:
+          branch_ref: "${{ github.ref }}"
+          extracted_version: "${{ needs.extract-version.outputs.version }}"
+
+  # This job deploys to staging-connect.trezor.io/10.x.x
+  deploy-staging-semantic-version:
+    needs: [extract-version, check-version-match]
+    environment: staging-connect
+    name: "Deploying to staging-connect.trezor.io/${{ needs.extract-version.outputs.version }}"
+    runs-on: ubuntu-latest
+    # Branch should have been created by workflow .github/workflows/release-connect-v10-init.yml
+    if: startsWith(github.ref, 'refs/heads/release/connect/')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: release/connect/${{  needs.extract-version.outputs.version }}
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Build and deploy to staging-connect.trezor.io/10.x.x
+        uses: ./.github/actions/release-connect
+        with:
+          awsRoleToAssume: "arn:aws:iam::538326561891:role/gh_actions_connect_staging_deploy"
+          awsRegion: "eu-central-1"
+          serverHostname: "staging-connect.trezor.io"
+          serverPath: ${{ needs.extract-version.outputs.version }}
+          buildArtifacts: "true"
+          uploadArtifacts: "true"
+          nodeEnv: "production"
+
+  # This job deploys to staging-connect.trezor.io/9
+  deploy-staging-v10:
+    needs: [extract-version, check-version-match]
+    environment: staging-connect
+    name: "Deploying to staging-connect.trezor.io/10"
+    runs-on: ubuntu-latest
+    # Branch should have been created by workflow .github/workflows/release-connect-v10-init.yml
+    if: startsWith(github.ref, 'refs/heads/release/connect/')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: release/connect/${{  needs.extract-version.outputs.version }}
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Build and deploy to staging-connect.trezor.io/10
+        uses: ./.github/actions/release-connect
+        with:
+          awsRoleToAssume: "arn:aws:iam::538326561891:role/gh_actions_connect_staging_deploy"
+          awsRegion: "eu-central-1"
+          serverHostname: "staging-connect.trezor.io"
+          serverPath: "10"
+          nodeEnv: "production"
+          # don't upload artifacts in both jobs, this causes a conflict
+          buildArtifacts: "false"
+          uploadArtifacts: "false"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

New workflows for Connect 10, we keep for now old workflows for Connect 9 in case we still have to release some fix.

## Notes for QA

Nothing to test

## Related Issue
Related https://github.com/trezor/trezor-suite/issues/23816