### PR TITLE
test(e2e-suite): new cardano staking automation

### DIFF
--- a/packages/e2e-utils/src/mocks/backendServer.ts
+++ b/packages/e2e-utils/src/mocks/backendServer.ts
@@ -58,6 +58,10 @@ export class BackendWebsocketServerMock extends WebSocketServer {
     }
 
     getFixtures() {
+        if (!this.fixtures) {
+            throw new Error('No fixtures set in BackendWebsocketServerMock');
+        }
+
         return this.fixtures;
     }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -181,7 +181,11 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
                         {isCardanoNetworkType ? (
                             <>
                                 {shouldShowCardanoWarning && shouldShowCardanoClaimRewardsCard && (
-                                    <Banner intent="warning" icon="warning">
+                                    <Banner
+                                        data-testid="@modal/claim/fee-warning-banner"
+                                        intent="warning"
+                                        icon="warning"
+                                    >
                                         <Translation id="TR_STAKING_REWARDS_NETWORK_FEE_WARNING" />
                                     </Banner>
                                 )}
@@ -202,6 +206,7 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
                                                     >
                                                         <Paragraph typographyStyle="highlight">
                                                             <FormattedCryptoAmount
+                                                                data-testid="@modal/claim/rewards-amount"
                                                                 value={restakedReward}
                                                                 symbol={account.symbol}
                                                             />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx
@@ -48,7 +48,10 @@ export const StakeRegistrationDepositCard = ({ account }: StakeRegistrationDepos
                         <Paragraph typographyStyle="body">
                             <Translation id="TR_STAKE_REGISTRATION_DEPOSIT" />
                         </Paragraph>
-                        <Paragraph typographyStyle="highlight">
+                        <Paragraph
+                            data-testid="@modal/staking/registration-deposit-amount-with-symbol"
+                            typographyStyle="highlight"
+                        >
                             {CARDANO_STAKING_REGISTRATION_DEPOSIT} {getNetworkDisplaySymbol(symbol)}
                         </Paragraph>
                     </Row>

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
@@ -46,6 +46,7 @@ type ItemProps = {
     description: React.ReactNode;
     isReward?: boolean;
     isLoading?: boolean;
+    'data-testid'?: string;
 };
 
 const Item = ({
@@ -55,6 +56,7 @@ const Item = ({
     isLoading = false,
     title,
     description,
+    'data-testid': dataTestId,
 }: ItemProps) => (
     <InfoItem label={label} iconName={iconName}>
         {isLoading ? (
@@ -64,7 +66,11 @@ const Item = ({
             </>
         ) : (
             <>
-                <Paragraph typographyStyle="titleSmall" variant={isReward ? 'primary' : 'default'}>
+                <Paragraph
+                    data-testid={dataTestId}
+                    typographyStyle="titleSmall"
+                    variant={isReward ? 'primary' : 'default'}
+                >
                     {title}
                 </Paragraph>
                 <Paragraph typographyStyle="hint" variant="tertiary">
@@ -367,6 +373,7 @@ export const StakingCard = ({
                             onClick={openClaimModal}
                             isDisabled={!canClaimRewards}
                             intent="brand"
+                            data-testid="@account/staking/claim-rewards-button"
                         >
                             <Translation id="TR_STAKE_CLAIM_REWARDS" />
                         </Button>

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -335,6 +335,7 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
     }
 
     async getDebugState() {
+        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
         const { response } = await this.client.send({ type: 'emulator-get-debug-state' });
 
         return response;

--- a/suite/e2e/fixtures/staking/ada-address.json
+++ b/suite/e2e/fixtures/staking/ada-address.json
@@ -1,0 +1,287 @@
+{
+    "change": [
+        {
+            "address": "addr1q8u30j2rdmvm499n60p62f6azwp83urw5ruwl3s6u7psw2shmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqtfmggl",
+            "path": "m/1852'/1815'/i'/1/0",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1q9s5fvcrxh3zre0as7r7zxf89x2y3wfnc0hm3psc6dqt69ghmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq2xhleh",
+            "path": "m/1852'/1815'/i'/1/1",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1qxxx5saek73hxwwte3888qrqvx48ztlyyrzmdfkf27gcr0shmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqpw8hkg",
+            "path": "m/1852'/1815'/i'/1/2",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1q9avrsed286xvkpf9s8jejkhjpdh2a5dnvuwjnjgl7223wshmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqgwwphw",
+            "path": "m/1852'/1815'/i'/1/3",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1qyymxzptjpstg4ltl8804zmwkl5ran0ytdu6nq7s5mw0azshmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqjy3ark",
+            "path": "m/1852'/1815'/i'/1/4",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1q80rrrnu3c4ndru48wdg4x4avpxequrrtny480dn2fz3uyqhmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqpl2mhk",
+            "path": "m/1852'/1815'/i'/1/5",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1qx7equuf4r57ty2f3r570qhuhvcrpa38mdrxpcywsjal6qghmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq0qjnyq",
+            "path": "m/1852'/1815'/i'/1/6",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1qye8wr7v66qdx0hn9sc3ua0an64mu6xy82lvd284mtu5drghmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq5ck40m",
+            "path": "m/1852'/1815'/i'/1/7",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1qy6uq228nqzmp6tdqme0vhadqxtqqh65x8dzms4l9numnhghmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqx8uqy0",
+            "path": "m/1852'/1815'/i'/1/8",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1q8c08kj33tqky7ny40v90cep3h5d0rawd32kgjefcvenu8ghmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq86tfwj",
+            "path": "m/1852'/1815'/i'/1/9",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1qxll292xaj2m06hd7my9w6pgzad4hcwpyznc83zyxg6hkgchmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqdv6mgg",
+            "path": "m/1852'/1815'/i'/1/10",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1q93esw4emgxhwz25smpzs4awxx87up02anqnth64s96duxghmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq7a5ejs",
+            "path": "m/1852'/1815'/i'/1/11",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1qxgf02grmhw75lucvthj8ywsxfdahpa62gjretzte9ezewchmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq0xpyzj",
+            "path": "m/1852'/1815'/i'/1/12",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1q83lsqa0vu4cn2x7mnu37tezedmsjvzlmtl4azkgme6535chmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq8lw34r",
+            "path": "m/1852'/1815'/i'/1/13",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1qyt69fnmdkhjynvpv203rnt76vc8d3yx3fgz3xzutt80l8qhmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqkshy7l",
+            "path": "m/1852'/1815'/i'/1/14",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1q9yyw98gyqe6kxkuuz5k5daknfueqt2rqw83kc2t9uxeh6chmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq6q08r7",
+            "path": "m/1852'/1815'/i'/1/15",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1qxkr4j9srn087gvfjlspvjvalyucm79khyps637cd7k6kpqhmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqrc4d2d",
+            "path": "m/1852'/1815'/i'/1/16",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1qx9ez5ejan99nsx2v56dk4mwsx87dxgnu4x9gj8a3rrhqtshmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq3hh8e9",
+            "path": "m/1852'/1815'/i'/1/17",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1q9zfxddu4yyxqwxun3txgq6ya3lquvjptfleexhrg2dcveghmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqcjv4s2",
+            "path": "m/1852'/1815'/i'/1/18",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        },
+        {
+            "address": "addr1q928mtpshwwqyt9ge0hh94kvpj9eulh5j5dgg3z460rhj5ghmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq97hxne",
+            "path": "m/1852'/1815'/i'/1/19",
+            "transfers": 0,
+            "received": "0",
+            "sum": "0"
+        }
+    ],
+    "used": [],
+    "unused": [
+        {
+            "address": "addr1q8drjz9rp0pfvxjc8fea3ghyf9dq4a9knvtcc3kve22fljchmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq0c5a2j",
+            "path": "m/1852'/1815'/i'/0/0",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1q8mk8muwryc9x07q0yyqezdd636yez8yjv5qvnhxcysxd9qhmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqhd9l0g",
+            "path": "m/1852'/1815'/i'/0/1",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1q9vx4kkg5g6e267uwgac9k0g7zr0v7dwhcavm9vtudn6veshmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqef2zg8",
+            "path": "m/1852'/1815'/i'/0/2",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1qxymqah8wjqjwec7zty99vxf352yrvc0422zljmuzcg23nqhmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqgsk0m7",
+            "path": "m/1852'/1815'/i'/0/3",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1qyfmq7q237gfs83mk77nugt3hrrw2y8wm7kcvnvafdx0vpshmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq05tt8w",
+            "path": "m/1852'/1815'/i'/0/4",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1qxsus6lq85n3pyskk42y38wye72x7xwhz4lauex98pt9jlchmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqc8aj78",
+            "path": "m/1852'/1815'/i'/0/5",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1qy4tqneqw26wev5ku36applguuneskag69awyt0xvstu2kqhmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqq2as2t",
+            "path": "m/1852'/1815'/i'/0/6",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1qx8ueev7fx0v0azzh9d8l8xntf86e9ue3s5jqde0lgdy45shmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqr38hqc",
+            "path": "m/1852'/1815'/i'/0/7",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1q8jx3ejwyy4wqq60fytfe7uj8v4qcrhx6r7dlcmtz33e85ghmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqa7zhle",
+            "path": "m/1852'/1815'/i'/0/8",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1qynvk7xr3d47nmwypmyrqz94lzjn055x2mawm27ajrd2sechmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqfm2ld3",
+            "path": "m/1852'/1815'/i'/0/9",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1qywjj9stf88cw8ejg5rusue5tcm6aykgt8a7lphput7qfcqhmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqn4afvy",
+            "path": "m/1852'/1815'/i'/0/10",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1q962tq65wtz4vgwzmh6wrrf6sptdwhk0qsa5qdkuf960f2shmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqx8kl39",
+            "path": "m/1852'/1815'/i'/0/11",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1q8432kjd2ald2d26rw9pdmee0whwaxlmnfcpq0k6yx4c63ghmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzquqzmml",
+            "path": "m/1852'/1815'/i'/0/12",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1qxr4xeduzsy20v5ge50qk4j2yktrs5g58l4wnfv2qxv2p0chmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqn9qmm3",
+            "path": "m/1852'/1815'/i'/0/13",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1qxzeupue94lnd49ye8stcda98l64gkxks34eh9qcwvj4exchmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq653p58",
+            "path": "m/1852'/1815'/i'/0/14",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1q8rr23qjysm534dwn9xmwys2hpenqkpw3hmfvy42q7tzy7qhmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq9as7vr",
+            "path": "m/1852'/1815'/i'/0/15",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1qyux2p0azful35jjedlkx6sq7qjeafjhr6t367hdkj365cghmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqj76k2r",
+            "path": "m/1852'/1815'/i'/0/16",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1qygs5dnzkxfrh8djx3j7gquu3ua36vdc9ngulcrs4h0c5lqhmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzq7x624k",
+            "path": "m/1852'/1815'/i'/0/17",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1qye8tjshwk3u0hmq38mljaxva5mv5qfqn65dhwlyg52zueqhmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqlt7q5a",
+            "path": "m/1852'/1815'/i'/0/18",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        },
+        {
+            "address": "addr1q80vn543w80klefctduxf5mqylwjru8kqjm4jdfa3zupuschmlkldaf8yf9ucw9gwlm9q72eget795gztmdw0sskftzqm093vq",
+            "path": "m/1852'/1815'/i'/0/19",
+            "transfers": 0,
+            "received": "0",
+            "sent": "0"
+        }
+    ]
+}

--- a/suite/e2e/fixtures/staking/ada-utxos.json
+++ b/suite/e2e/fixtures/staking/ada-utxos.json
@@ -1,0 +1,45 @@
+{
+    "type": "message",
+    "data": [
+        {
+            "address": "addr1q9xzs0ptvuu8twtwlgrz3c4lw6cxm0fkym9qt607uvrpe2pj2fnhvv26nr4fcxck2fs03m0rc6x3fymxrr4yealp9vpqe4ndhn",
+            "path": "m/1852'/1815'/0'/0/0",
+            "utxoData": {
+                "address": "addr1q9xzs0ptvuu8twtwlgrz3c4lw6cxm0fkym9qt607uvrpe2pj2fnhvv26nr4fcxck2fs03m0rc6x3fymxrr4yealp9vpqe4ndhn",
+                "tx_hash": "48df2ef4a46c6df38818273d5d63b3b8251c3c3d032954763fdf1fa5f90a17a8",
+                "tx_index": 1,
+                "output_index": 1,
+                "amount": [
+                    {
+                        "unit": "lovelace",
+                        "quantity": "88858306",
+                        "decimals": 6
+                    }
+                ],
+                "block": "c72853c702204bdab20016627b379fcbf4c5bc28564a3d6379be248aa1623754",
+                "data_hash": null,
+                "inline_datum": null,
+                "reference_script_hash": null
+            },
+            "blockInfo": {
+                "time": 1765880722,
+                "height": 12783742,
+                "hash": "c72853c702204bdab20016627b379fcbf4c5bc28564a3d6379be248aa1623754",
+                "slot": 174314431,
+                "epoch": 601,
+                "epoch_slot": 45631,
+                "slot_leader": "pool1w4cetqsly2cz9fq2te95tnk2r56mh6ew6dmpyfctv2ldv8xuj9g",
+                "size": 22453,
+                "tx_count": 13,
+                "output": "2636802238673",
+                "fees": "5104464",
+                "block_vrf": "vrf_vk1fdrhmdp543kp7tweqd42eqt9ynf8n6schtwfdmx7x80wthkl5qcs2ul2we",
+                "op_cert": "795a32ce8421299961c192e413f7231e15faf3aff8a34b51af9b623fa10076d8",
+                "op_cert_counter": "7",
+                "previous_block": "aa5a05c6112bd60d6950d48ccdad5d94c36100af0c1ec2a7ba4061ac4af452f9",
+                "next_block": "b0303724c49efd3ca2d2e7136ab641ac672bcd916426b5585469dedc8701ba1a",
+                "confirmations": 38948
+            }
+        }
+    ]
+}

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -33,6 +33,7 @@
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/trading": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
+        "@suite-common/wallet-constants": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:^",

--- a/suite/e2e/support/common.ts
+++ b/suite/e2e/support/common.ts
@@ -237,3 +237,6 @@ export const sanitizeAndStringifyLogFields = (fields: Record<string, unknown>) =
         null,
         2,
     );
+
+export const toADA = (lovelace: number, options?: { maxDecimals?: number }) =>
+    `${localizeNumber(lovelace / 1000000, 'en-US', 0, options?.maxDecimals ?? 6)} ADA`;

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -11,13 +11,14 @@ import { AssetsSection } from './pageObjects/assetsSection';
 import { ConnectPermissionsModal } from './pageObjects/connectPermissionsModal';
 import { DashboardPage } from './pageObjects/dashboardPage';
 import { DevicePrompt } from './pageObjects/devicePrompt';
+import { FeeSection } from './pageObjects/feeSection';
 import { GuidePanel } from './pageObjects/guidePanel';
 import { MetadataPage } from './pageObjects/metadata/metadataPage';
 import { OnboardingPage } from './pageObjects/onboarding/onboardingPage';
 import { RecoveryModal } from './pageObjects/recoveryModal';
 import { SettingsPage } from './pageObjects/settings/settingsPage';
 import { StakingSection } from './pageObjects/staking/stakingSection';
-import { TradingPage } from './pageObjects/trading/tradingPage';
+import { TradingPage } from './pageObjects/tradingPage';
 import { TrezorInput } from './pageObjects/trezorInput';
 import { WalletPage } from './pageObjects/walletPage';
 import { suiteBaseTest } from './testExtends/suiteBaseFixture';
@@ -32,6 +33,7 @@ type Fixtures = {
     devicePrompt: DevicePrompt;
     recoveryModal: RecoveryModal;
     tradingPage: TradingPage;
+    feeSection: FeeSection;
     assetsSection: AssetsSection;
     metadataPage: MetadataPage;
     trezorInput: TrezorInput;
@@ -85,6 +87,9 @@ const test = suiteBaseTest.extend<Fixtures>({
     },
     tradingPage: async ({ page, devicePrompt }, use) => {
         await use(new TradingPage(page, devicePrompt));
+    },
+    feeSection: async ({ page }, use) => {
+        await use(new FeeSection(page));
     },
     assetsSection: async ({ page }, use) => {
         await use(new AssetsSection(page));

--- a/suite/e2e/support/mocks/ada-endpoints.ts
+++ b/suite/e2e/support/mocks/ada-endpoints.ts
@@ -1,0 +1,132 @@
+import addressJSON from '../../fixtures/staking/ada-address.json';
+import utxosJSON from '../../fixtures/staking/ada-utxos.json';
+
+const FIRST_ACCOUNT_DESCRIPTOR =
+    '124ae1de317623ddc8fc91f3c0e67d01f519710df091bc13713548cf2e69d903e52877fc869c6128a63cedb64449499cc04ec2cd5e17f79f0909d96b7efb9046';
+const isFirstAccount = (descriptor: string) => descriptor === FIRST_ACCOUNT_DESCRIPTOR;
+
+export const ADA_MOCKED_ACCOUNT = {
+    descriptor: FIRST_ACCOUNT_DESCRIPTOR,
+    empty: false,
+    balance: '88858306',
+    availableBalance: '88858306',
+    tokens: [],
+    history: { total: 0, unconfirmed: 0, transactions: [] },
+    page: { index: 1, size: 8, total: 0 },
+    misc: {
+        staking: {
+            address: 'stake1uytalm0k75njyj7v8z580ajs09v5v4lz6yp9akh8cgty43qunjqys',
+            rewards: '0',
+            isActive: false,
+            poolId: null,
+            drep: null,
+        },
+    },
+    addresses: addressJSON,
+};
+
+export const ADA_MOCKED_EMPTY_ACCOUNT = {
+    descriptor: 'some-other-descriptor',
+    empty: true,
+    balance: '0',
+    availableBalance: '0',
+    tokens: [],
+    history: { total: 0, unconfirmed: 0, transactions: [] },
+    page: { index: 1, size: 8, total: 0 },
+    misc: {
+        staking: {
+            address: null,
+            rewards: '0',
+            isActive: false,
+            poolId: null,
+            drep: null,
+        },
+    },
+    addresses: addressJSON,
+};
+
+export const fixtures = [
+    {
+        method: 'GET_SERVER_INFO',
+        default: true,
+        response: {
+            type: 'message',
+            data: {
+                hostname: 'backend13',
+                name: 'Cardano',
+                shortcut: 'ada',
+                testnet: false,
+                version: '4.2.0',
+                decimals: 6,
+                blockHeight: 12822637,
+                blockHash: 'd37a84e3f2a5a57e914b2ca0317b77a6521d308288ef85619e67fd771a60b3c1',
+            },
+        },
+    },
+    {
+        method: 'GET_ACCOUNT_INFO',
+        default: true,
+        response: ({ params }: any) => {
+            if (isFirstAccount(params.descriptor)) {
+                return { data: ADA_MOCKED_ACCOUNT };
+            } else {
+                return { data: ADA_MOCKED_EMPTY_ACCOUNT };
+            }
+        },
+    },
+    {
+        method: 'GET_ACCOUNT_UTXO',
+        default: true,
+        response: ({ params }: any) => {
+            if (isFirstAccount(params.descriptor)) {
+                return utxosJSON;
+            }
+        },
+    },
+    {
+        method: 'ESTIMATE_FEE',
+        default: true,
+        response: { type: 'message', data: { lovelacePerByte: 44 } },
+    },
+    {
+        method: 'SUBSCRIBE_ADDRESS',
+        default: true,
+        response: { type: 'message', data: { subscribed: true } },
+    },
+    {
+        method: 'SUBSCRIBE_BLOCK',
+        default: true,
+        response: { type: 'message', data: { subscribed: true } },
+    },
+    {
+        method: 'GET_BLOCK',
+        default: true,
+        response: {
+            data: {
+                time: 1506203091,
+                height: null,
+                hash: '5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb',
+                slot: null,
+                epoch: null,
+                epoch_slot: null,
+                slot_leader: 'Genesis slot leader',
+                size: 0,
+                tx_count: 14505,
+                output: '31112484745000000',
+                fees: '0',
+                block_vrf: null,
+                previous_block: null,
+                next_block: '89d9b5a5b8ddc8d7e5a6795e9774d97faf1efea59b2caf7eaf9f8c5b32059df4',
+                confirmations: 5833137,
+            },
+        },
+    },
+    {
+        method: 'PUSH_TRANSACTION',
+        default: true,
+        response: {
+            type: 'message',
+            data: 'f67d0ba095ab897c388c07f6911a70fb48ab4927652c7def353184eb3a4fe8a5',
+        },
+    },
+];

--- a/suite/e2e/support/mocks/blockBookMock.ts
+++ b/suite/e2e/support/mocks/blockBookMock.ts
@@ -1,77 +1,110 @@
 import { BackendWebsocketServerMock } from '@trezor/e2e-utils';
+import { BackendType } from '@trezor/e2e-utils/src/mocks/backendServer';
 
 import { step } from '../common';
+import {
+    ADA_MOCKED_ACCOUNT,
+    ADA_MOCKED_EMPTY_ACCOUNT,
+    fixtures as adaFixtures,
+} from './ada-endpoints';
 import { fixtures as dogeFixtures } from './doge-endpoints';
-import { ETH_ACC, fixtures as ethFixtures } from './eth-endpoints';
+import { ETH_MOCKED_ACCOUNT, fixtures as ethFixtures } from './eth-endpoints';
 import { fixtures as ltcFixtures } from './ltc-mw-endpoints';
 
-export class BlockbookMock {
-    private mockServer: BackendWebsocketServerMock | undefined;
-    private accountState: any = null;
+type SupportedSymbols = 'ltc' | 'doge' | 'eth' | 'ada';
 
-    get url() {
-        if (!this.mockServer) {
+export class BlockbookMock {
+    private _mockServer: BackendWebsocketServerMock | undefined;
+    private accountState: any = null;
+    private mockType: SupportedSymbols | null = null;
+
+    get mockServer() {
+        if (!this._mockServer) {
             throw new Error('Blockbook mock not initialized');
         }
 
+        return this._mockServer;
+    }
+
+    get url() {
         return `ws://localhost:${this.mockServer.options.port}`;
     }
 
-    private selectFixture(type: 'ltc' | 'doge' | 'eth') {
+    private selectFixture(type: SupportedSymbols) {
         switch (type) {
             case 'ltc':
                 return ltcFixtures;
             case 'doge':
                 return dogeFixtures;
             case 'eth':
-                this.accountState = ETH_ACC;
+                this.accountState = ETH_MOCKED_ACCOUNT;
 
                 return ethFixtures;
+            case 'ada':
+                this.accountState = ADA_MOCKED_ACCOUNT;
+
+                return adaFixtures;
             default:
                 throw new Error('Unknown blockbook mock type');
         }
     }
 
     @step()
-    async start(type: 'ltc' | 'doge' | 'eth') {
-        this.mockServer = await BackendWebsocketServerMock.create('blockbook');
-        const fixtures = this.selectFixture(type);
+    async start(mockType: SupportedSymbols, serverType: BackendType = 'blockbook') {
+        this._mockServer = await BackendWebsocketServerMock.create(serverType);
+        this.mockType = mockType;
+        const fixtures = this.selectFixture(mockType);
         this.mockServer.setFixtures(fixtures);
     }
 
     @step()
     stop() {
-        if (this.mockServer) {
-            this.mockServer.stop();
+        if (this._mockServer) {
+            this._mockServer.stop();
         }
     }
 
     @step()
     updateAccountState(accountData: any) {
-        if (!this.mockServer) {
-            throw new Error('Blockbook mock not initialized');
+        if (this.mockType !== 'eth' && this.mockType !== 'ada') {
+            throw new Error(
+                `Account state update not supported for this mock type: ${this.mockType}`,
+            );
         }
+
+        const accountParams = {
+            eth: {
+                accountMethod: 'getAccountInfo',
+                accountId: 'address',
+                fallbackResponse: undefined,
+            },
+
+            ada: {
+                accountMethod: 'GET_ACCOUNT_INFO',
+                accountId: 'descriptor',
+                fallbackResponse: ADA_MOCKED_EMPTY_ACCOUNT,
+            },
+        };
+        const { accountMethod, accountId, fallbackResponse } = accountParams[this.mockType];
 
         this.accountState = { ...this.accountState, ...accountData };
         const currentFixture = this.mockServer.getFixtures();
-        if (!currentFixture) {
-            throw new Error('No fixtures found in Blockbook mock');
-        }
-
         const updatedFixtures = currentFixture.map(fixture => {
-            if (fixture.method === 'getAccountInfo') {
-                return {
-                    method: 'getAccountInfo',
-                    default: true,
-                    response: ({ params }: any) => {
-                        if (params.descriptor === this.accountState.address) {
-                            return { data: this.accountState };
-                        }
-                    },
-                };
+            if (fixture.method !== accountMethod) {
+                return fixture;
             }
 
-            return fixture;
+            return {
+                method: accountMethod,
+                default: true,
+                response: ({ params }: any) => {
+                    if (params.descriptor === this.accountState[accountId]) {
+                        return { data: this.accountState };
+                    } else if (fallbackResponse) {
+                        return { data: fallbackResponse };
+                    }
+                },
+            };
         });
 
         this.mockServer.setFixtures(updatedFixtures);

--- a/suite/e2e/support/mocks/eth-endpoints.ts
+++ b/suite/e2e/support/mocks/eth-endpoints.ts
@@ -1,6 +1,6 @@
 import ETH_BASE_TX from '../../fixtures/staking/eth-base-tx.json';
 
-export const ETH_ACC = {
+export const ETH_MOCKED_ACCOUNT = {
     page: 1,
     totalPages: 1,
     itemsOnPage: 25,
@@ -30,7 +30,7 @@ export const ETH_ACC = {
     addressAliases: {},
 };
 
-const isFirstAccount = (descriptor: string) => descriptor === ETH_ACC.address;
+const isFirstAccount = (descriptor: string) => descriptor === ETH_MOCKED_ACCOUNT.address;
 
 export const fixtures = [
     {
@@ -60,7 +60,7 @@ export const fixtures = [
         default: true,
         response: ({ params }: any) => {
             if (isFirstAccount(params.descriptor)) {
-                return { data: ETH_ACC };
+                return { data: ETH_MOCKED_ACCOUNT };
             }
         },
     },

--- a/suite/e2e/support/pageObjects/dashboardPage.ts
+++ b/suite/e2e/support/pageObjects/dashboardPage.ts
@@ -58,7 +58,7 @@ export class DashboardPage {
         this.graph = this.page.getByTestId('@dashboard/graph');
         this.deviceSwitchingOpenButton = this.page.getByTestId('@menu/switch-device');
         this.deviceSwitchingCloseButton = this.page.getByTestId('@modal/backdrop').first();
-        this.modal = this.page.getByTestId('@modal');
+        this.modal = this.page.modal;
         this.deviceSwitcherModal = this.page.getByTestId('@modal/switch-device');
         this.confirmDeviceEjectButton = this.page.getByTestId('@switch-device/eject');
         this.addStandardWalletButton = this.page.getByTestId('@switch-device/add-wallet-button');

--- a/suite/e2e/support/pageObjects/devicePrompt.ts
+++ b/suite/e2e/support/pageObjects/devicePrompt.ts
@@ -47,7 +47,7 @@ export class DevicePrompt {
         this.confirmOnDevicePrompt = page.getByTestId('@prompts/confirm-on-device');
         this.connectDevicePrompt = page.getByTestId('@connect-device-prompt');
         this.modalCloseButton = page.getByTestId('@modal/close-button');
-        this.modal = page.getByTestId('@modal');
+        this.modal = page.modal;
         this.paginatedText = page.locator("[data-testid-alt='@device-display/paginated-text']");
         this.paginatedTextSeparator = page.getByTestId('@device-display/paginated-text/separator');
         this.chunkedText = page.getByTestId('@device-display/chunked-text');
@@ -170,7 +170,14 @@ export class DevicePrompt {
     @step()
     async getDisplayContent(): Promise<NormalizedDisplayContent> {
         const debugState = await TrezorUserEnvLinkProxy.getDebugState();
-        const raw = JSON.parse(debugState.tokens.join(''));
+        let raw: any;
+        try {
+            raw = JSON.parse(debugState.tokens.join(''));
+        } catch (error) {
+            throw new Error(`Failed to parse display content JSON: ${debugState.tokens.join('')}`, {
+                cause: error as Error,
+            });
+        }
 
         return parseDisplayContent(raw);
     }

--- a/suite/e2e/support/pageObjects/feeSection.ts
+++ b/suite/e2e/support/pageObjects/feeSection.ts
@@ -2,13 +2,13 @@ import { Locator, Page, Response } from '@playwright/test';
 
 import { BigNumber } from '@trezor/utils';
 
-import { TrezorUserEnvLinkProxy, step } from '../../common';
-import { solanaUrlPattern } from '../../mocks/tradingMock';
-import { expect } from '../../testExtends/customMatchers';
+import { TrezorUserEnvLinkProxy, step } from '../common';
+import { solanaUrlPattern } from '../mocks/tradingMock';
+import { expect } from '../testExtends/customMatchers';
 
 export type FeeTypes = 'low' | 'economy' | 'normal' | 'high';
 
-export class Fees {
+export class FeeSection {
     readonly switchModeButton = (feeMode: 'standard' | 'custom') =>
         this.page.getByTestId(`@wallet/fees/select-${feeMode}-fee`);
     readonly card = (feeType: FeeTypes) => this.page.getByTestId(`@fee-card/${feeType}-card`);
@@ -19,6 +19,7 @@ export class Fees {
     readonly maxFeeLoading: Locator;
     readonly customInput: Locator;
     readonly maxFee: Locator;
+    readonly maxFeeWithSymbol: Locator;
     readonly maxFeeFiat: Locator;
     readonly swapDetails: Locator;
     readonly dustPreventionNotice: Locator;
@@ -32,6 +33,9 @@ export class Fees {
         this.maxFeeLoading = this.page.getByTestId('@trading/quote/maximum-fee-amount-loading');
         this.customInput = this.page.getByTestId('feePerUnit');
         this.maxFee = this.page.getByTestId('@trading/quote/maximum-fee-amount');
+        this.maxFeeWithSymbol = this.page.getByTestId(
+            '@trading/quote/maximum-fee-amount-with-symbol',
+        );
         this.maxFeeFiat = this.page.getByTestId('@trading/quote/maximum-fee-fiat-amount');
         this.swapDetails = this.page.getByTestId('@wallet/fee-details');
         this.dustPreventionNotice = this.page.getByTestId('@wallet/fees/dust-prevention-notice');

--- a/suite/e2e/support/pageObjects/settings/coinsTab.ts
+++ b/suite/e2e/support/pageObjects/settings/coinsTab.ts
@@ -22,7 +22,7 @@ export class CoinsTab {
         this.coinBackendSelector = this.page.getByTestId('@settings/advance/select-type/input');
         this.coinAddressInput = this.page.getByTestId('@settings/advance/url');
         this.coinAdvanceSettingSaveButton = this.page.getByTestId('@settings/advance/button/save');
-        this.modal = this.page.getByTestId('@modal');
+        this.modal = this.page.modal;
         this.activateCoinsButton = this.page.getByTestId('@settings-coins/discovery-button');
     }
 

--- a/suite/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/suite/e2e/support/pageObjects/settings/settingsPage.ts
@@ -113,7 +113,7 @@ export class SettingsPage {
         );
         this.earlyAccessSkipButton = this.page.getByTestId('@settings/early-access-skip-button');
         this.settingsCloseButton = this.page.getByTestId('@suite/menu/suite-start');
-        this.modal = this.page.getByTestId('@modal');
+        this.modal = this.page.modal;
         this.modalCloseButton = this.page.getByTestId('@modal/close-button');
         this.deviceLabelInput = this.page.getByTestId('@settings/device/label-input');
         this.deviceLabelSubmit = this.page.getByTestId('@settings/device/label-submit');

--- a/suite/e2e/support/pageObjects/staking/stakingSection.ts
+++ b/suite/e2e/support/pageObjects/staking/stakingSection.ts
@@ -58,7 +58,12 @@ export class StakingSection {
     readonly stakedToast: Locator;
     readonly unstakedToast: Locator;
     readonly claimedToast: Locator;
-    readonly modalHeader: Locator;
+    readonly claimRewardsButton: Locator;
+    readonly cardanoRewardAmount: Locator;
+    readonly cardanoDepositAmount: Locator;
+    readonly cardanoModalRewardAmount: Locator;
+    readonly cardanoStakedFullBalanceText: Locator;
+    readonly claimWarningBanner: Locator;
 
     constructor(private readonly page: Page) {
         this.rewardList = new RewardsList(page);
@@ -125,7 +130,16 @@ export class StakingSection {
         this.stakedToast = this.page.getByTestId('@toast/tx-staked');
         this.unstakedToast = this.page.getByTestId('@toast/tx-unstaked');
         this.claimedToast = this.page.getByTestId('@toast/tx-claimed');
-        this.modalHeader = this.page.getByTestId('@modal/header');
+        this.claimRewardsButton = this.page.getByTestId('@account/staking/claim-rewards-button');
+        this.cardanoRewardAmount = this.page.getByTestId('@account/staking/rewards-with-symbol');
+        this.cardanoDepositAmount = this.page.getByTestId(
+            '@modal/staking/registration-deposit-amount-with-symbol',
+        );
+        this.cardanoModalRewardAmount = this.page.getByTestId(
+            '@modal/claim/rewards-amount-with-symbol',
+        );
+        this.cardanoStakedFullBalanceText = this.page.getByTestId('@account/staking/full-balance');
+        this.claimWarningBanner = this.page.getByTestId('@modal/claim/fee-warning-banner');
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/tradingPage.ts
@@ -6,12 +6,12 @@ import { NetworkConfigWithoutTestnets, NetworkSymbol } from '@suite-common/walle
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import messages from '@trezor/suite/src//support/messages';
 
-import { Fees } from './fees';
-import { getCompanyNameFromList, invityEndpoint } from '../../../fixtures/invity';
-import { calculatePercentageOfBalance, getCountryLabel, step } from '../../common';
-import { expect } from '../../testExtends/customMatchers';
-import { PaymentMethods, PercentageOfBalanceParams } from '../../types';
-import { DevicePrompt } from '../devicePrompt';
+import { FeeSection } from './feeSection';
+import { getCompanyNameFromList, invityEndpoint } from '../../fixtures/invity';
+import { calculatePercentageOfBalance, getCountryLabel, step } from '../common';
+import { expect } from '../testExtends/customMatchers';
+import { PaymentMethods, PercentageOfBalanceParams } from '../types';
+import { DevicePrompt } from './devicePrompt';
 
 const quoteProviderLocator = '@trading/offers/quote/provider';
 
@@ -27,7 +27,7 @@ const paymentMethodNameMap: Record<string, PaymentMethods> = {
 type AccountTabFilter = 'all-networks' | NetworkConfigWithoutTestnets['symbol'];
 
 export class TradingPage {
-    readonly fees: Fees;
+    readonly fees: FeeSection;
 
     // Input and general
     readonly offerSpinner: Locator;
@@ -152,7 +152,7 @@ export class TradingPage {
         private page: Page,
         private readonly devicePrompt: DevicePrompt,
     ) {
-        this.fees = new Fees(page);
+        this.fees = new FeeSection(page);
 
         this.offerSpinner = this.page.getByTestId('@trading/offers/loading-spinner');
         this.section = this.page.getByTestId('@trading');
@@ -199,7 +199,7 @@ export class TradingPage {
         this.refreshTime = this.page.getByTestId('@trading/refresh-time-text');
         this.selectThisQuoteButton = this.page.getByTestId('@trading/offers/get-this-deal-button');
         // Confirmation modal
-        this.modal = this.page.getByTestId('@modal');
+        this.modal = this.page.modal;
         this.confirmOnTrezorButton = this.page.getByTestId(
             '@trading/offer/confirm-on-trezor-button',
         );

--- a/suite/e2e/support/pageObjects/walletPage.ts
+++ b/suite/e2e/support/pageObjects/walletPage.ts
@@ -50,6 +50,7 @@ export class WalletPage {
         this.page.getByTestId(`@account-menu/filter/${symbol}`);
     readonly showMoreButton: Locator;
     readonly topPanelBalance: Locator;
+    readonly topPanelBalanceWithSymbol: Locator;
     readonly segwitGroupButton: Locator;
     readonly addAccountButton: Locator;
     readonly copyToCliboardToast: Locator;
@@ -60,6 +61,7 @@ export class WalletPage {
     readonly swapButton: Locator;
     readonly overviewTabButton: Locator;
     readonly deviceDisconnectedStatus: Locator;
+    readonly discoveryWarning: Locator;
 
     constructor(private readonly page: Page) {
         this.transactionSearch = this.page.getByTestId('@wallet/accounts/search-icon');
@@ -94,6 +96,9 @@ export class WalletPage {
         this.fiatAmount = this.page.getByTestId('@wallet/account-top-panel/fiat-amount');
         this.showMoreButton = this.page.getByTestId('@wallet/receive/used-address/show-more');
         this.topPanelBalance = this.page.getByTestId('@wallet/account-top-panel/crypto-balance');
+        this.topPanelBalanceWithSymbol = this.page.getByTestId(
+            '@wallet/account-top-panel/crypto-balance-with-symbol',
+        );
         this.copyToCliboardToast = this.page.getByTestId('@toast/copy-to-clipboard');
         this.segwitGroupButton = this.page.getByTestId('@account-menu/segwit');
         this.addAccountButton = this.page.getByTestId('@account-menu/add-account');
@@ -106,6 +111,7 @@ export class WalletPage {
         this.deviceDisconnectedStatus = page
             .getByTestId('@menu/switch-device')
             .getByTestId('@deviceStatus-disconnected');
+        this.discoveryWarning = this.page.getByTestId('@warning/trezorDiscovery');
     }
 
     accountButton = ({

--- a/suite/e2e/support/testExtends/customMatchers.ts
+++ b/suite/e2e/support/testExtends/customMatchers.ts
@@ -2,7 +2,7 @@ import { createIntl, createIntlCache } from 'react-intl';
 
 import { Locator, Request, expect as baseExpect, test } from '@playwright/test';
 import { diff } from 'jest-diff';
-import { isEqual } from 'lodash';
+import { isEqualWith } from 'lodash';
 
 import { TranslationKey } from '@trezor/suite/src//components/suite/Translation';
 import messages from '@trezor/suite/src//support/messages';
@@ -47,8 +47,17 @@ const compareDisplayContent = async (
     const content = normalizeWhitespace(contentRaw);
     const debugInfo = JSON.stringify(await devicePrompt.getAnalyzedDisplayContent(), null, 2);
 
+    const regexAndStringComparator = (expectedValue: any, actualValue: any) => {
+        if (expectedValue instanceof RegExp && typeof actualValue === 'string') {
+            return expectedValue.test(actualValue);
+        }
+
+        // Let default comparison handle all other cases
+        return undefined;
+    };
+
     return {
-        pass: isEqual(expectedContent, content),
+        pass: isEqualWith(expectedContent, content, regexAndStringComparator),
         message: () =>
             `${errorMessage}. Diff:\n${diff(expectedContent, content)}\n\nAnalysis:\n${debugInfo}`,
     };
@@ -82,7 +91,11 @@ export const transformAddress = (address: string, lineFormat: LineFormats = 'fou
     // bc1q pyfv fvm5 2zx7
     // gek8 6ajj 5pkk ne3h
     // 385a da8r 2y
-    // 1. Full lines (18 chars) of address:
+    // 2. EVM tetragrams of address:
+    // 0x12as 34ab cdef 5678
+    // 9abc def0 1234 5678
+    // 9abc def0
+    // 3. Full lines (18 chars) of address:
     // bc1qpyfvfvm52zx7ge
     // k86ajj5pkkne3h385a
     // da8r2y

--- a/suite/e2e/support/testExtends/enhancePage.ts
+++ b/suite/e2e/support/testExtends/enhancePage.ts
@@ -6,6 +6,9 @@ import { join } from 'path';
 declare module '@playwright/test' {
     interface Page {
         // Locators
+        modal: Locator;
+        modalHeader: Locator;
+        modalCloseButton: Locator;
 
         // Methods
         discoveryShouldFinish(): Promise<void>;
@@ -45,6 +48,9 @@ declare module '@playwright/test' {
 // It is not specific to any particular test or feature.
 export const enhancePage = (page: Page): Page => {
     // Locators
+    page.modal = page.getByTestId('@modal');
+    page.modalHeader = page.getByTestId('@modal/header');
+    page.modalCloseButton = page.getByTestId('@modal/close-button');
 
     // Methods
     page.discoveryShouldFinish = async function () {
@@ -94,6 +100,7 @@ export const enhancePage = (page: Page): Page => {
                 expect(testedObject).toBeDefined();
                 expect(testedObject).not.toBeNull();
                 expect(testedObject).not.toEqual({});
+                expect(testedObject).not.toEqual([]);
             }).toPass({ timeout: options.timeout });
         });
     };

--- a/suite/e2e/tests/staking/ada/claim.test.ts
+++ b/suite/e2e/tests/staking/ada/claim.test.ts
@@ -1,0 +1,247 @@
+import { TestCategory, TestPriority, TestStream, createTestAnnotation } from '@trezor/e2e-utils';
+
+import { toADA } from '../../../support/common';
+import { expect, test } from '../../../support/fixtures';
+import { splitStringByDisplayLimit } from '../../../support/testExtends/customMatchers';
+
+// mocked and expected values
+const startingBalance = 88858306;
+const startingBalanceFormatted = toADA(startingBalance);
+const smallRewardFee = 171700; // mocked 44 lovelace/byte
+const tooSmallRewardAmount = 56398; // lower than fee 171700
+const tooSmallRewardAmountFormatted = toADA(tooSmallRewardAmount);
+const bigRewardFee = 171837; // mocked 44 lovelace/byte
+const bigRewardAmount = 2636772; // bigger than fee 171837
+const bigRewardAmountFormatted = toADA(bigRewardAmount);
+const finalBalance = startingBalance + bigRewardAmount - bigRewardFee;
+const finalBalanceFormatted = toADA(finalBalance);
+
+test.describe('Staking - Cardano', { tag: ['@group=staking', '@specificModel'] }, () => {
+    test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic' } });
+
+    test.beforeEach(
+        async ({ page, onboardingPage, dashboardPage, settingsPage, blockbookMock }) => {
+            await onboardingPage.completeOnboarding();
+
+            await test.step('Enable Cardano and set mocked backend', async () => {
+                await settingsPage.navigateTo('coins');
+                await blockbookMock.start('ada', 'blockfrost');
+                // staked account with too small rewards for claiming
+                blockbookMock.updateAccountState({
+                    availableBalance: startingBalance.toString(),
+                    balance: (startingBalance + tooSmallRewardAmount).toString(),
+                    misc: {
+                        staking: {
+                            address: 'stake1uytalm0k75njyj7v8z580ajs09v5v4lz6yp9akh8cgty43qunjqys',
+                            rewards: tooSmallRewardAmount.toString(),
+                            isActive: true,
+                            poolId: 'pool1n0uxgs5qfk5n9xl7qvq9jt8zuu02cntrsjnjayjlqtejyffnemj',
+                            drep: {
+                                drep_id:
+                                    'drep1yt8p080ajks6zdnxd9z6a6q60p9sm9j5rl7tc63mfna8r6cnp4wr3',
+                                hex: '22ce179dfd95a1a136666945aee81a784b0d96541ffcbc6a3b4cfa71eb',
+                                amount: startingBalance.toString(),
+                                active: true,
+                                active_epoch: 573,
+                                has_script: false,
+                                retired: false,
+                                expired: false,
+                                last_active_epoch: 601,
+                            },
+                        },
+                    },
+                });
+
+                await settingsPage.coins.disableNetwork('btc');
+                await settingsPage.coins.enableNetwork('ada');
+                await settingsPage.coins.openNetworkAdvanceSettings('ada');
+                await settingsPage.coins.changeBackend('blockfrost', blockbookMock.url);
+
+                await dashboardPage.dashboardMenuButton.click();
+                await page.discoveryShouldFinish();
+            });
+        },
+    );
+
+    test(
+        'Claim rewards from Cardano staking',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can claim stake rewards to his Cardano account.',
+                category: TestCategory.Staking,
+                priority: TestPriority.Critical,
+                stream: TestStream.Trends,
+            }),
+        },
+        async ({ page, devicePrompt, walletPage, feeSection, stakingSection, blockbookMock }) => {
+            const stakingAccountItemInLeftSection = walletPage.accountButton({
+                symbol: 'ada',
+                type: 'normal',
+                atIndex: 0,
+                subAccount: 'staking',
+            });
+            await test.step('Verify staked account with rewards', async () => {
+                await page.clock.install();
+                await expect(stakingAccountItemInLeftSection).toBeVisible();
+                await walletPage.openAccount({ symbol: 'ada', type: 'normal', atIndex: 0 });
+                await stakingSection.stakingTabButton.click();
+                await expect(walletPage.discoveryWarning).toBeHidden();
+                await expect(stakingSection.claimRewardsButton).toBeEnabled();
+                await expect(stakingSection.unstakeToClaimButton).toBeEnabled();
+                await expect(stakingSection.startStakingButton).toBeHidden();
+                await expect(walletPage.topPanelBalanceWithSymbol).toHaveText(
+                    startingBalanceFormatted,
+                );
+                await expect(stakingSection.cardanoRewardAmount).toHaveText(
+                    tooSmallRewardAmountFormatted,
+                );
+                await expect(stakingSection.cardanoStakedFullBalanceText).toHaveTranslation(
+                    'TR_STAKE_FULL_BALANCE',
+                );
+            });
+
+            await test.step('Verify warning on too small reward claim', async () => {
+                await stakingSection.claimRewardsButton.click();
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_CLAIM_REWARDS');
+                await expect(stakingSection.claimWarningBanner).toHaveTranslation(
+                    'TR_STAKING_REWARDS_NETWORK_FEE_WARNING',
+                );
+                await expect(stakingSection.cardanoModalRewardAmount).toHaveText(
+                    tooSmallRewardAmountFormatted,
+                );
+                await expect(feeSection.maxFeeWithSymbol).toHaveText(toADA(smallRewardFee));
+                await page.modalCloseButton.click();
+            });
+
+            await test.step('Increase reward amount', async () => {
+                // staked account with big enough rewards for claiming
+                blockbookMock.updateAccountState({
+                    availableBalance: startingBalance.toString(),
+                    balance: (startingBalance + bigRewardAmount).toString(),
+                    misc: {
+                        staking: {
+                            address: 'stake1uytalm0k75njyj7v8z580ajs09v5v4lz6yp9akh8cgty43qunjqys',
+                            rewards: bigRewardAmount.toString(),
+                            isActive: true,
+                            poolId: 'pool1n0uxgs5qfk5n9xl7qvq9jt8zuu02cntrsjnjayjlqtejyffnemj',
+                            drep: {
+                                drep_id:
+                                    'drep1yt8p080ajks6zdnxd9z6a6q60p9sm9j5rl7tc63mfna8r6cnp4wr3',
+                                hex: '22ce179dfd95a1a136666945aee81a784b0d96541ffcbc6a3b4cfa71eb',
+                                amount: startingBalance.toString(),
+                                active: true,
+                                active_epoch: 573,
+                                has_script: false,
+                                retired: false,
+                                expired: false,
+                                last_active_epoch: 601,
+                            },
+                        },
+                    },
+                });
+                await page.clock.fastForward(stakingSection.watchPeriod);
+                // navigate away and back to refresh rewards
+                await walletPage.overviewTabButton.click();
+                await stakingSection.stakingTabButton.click();
+                await expect(stakingSection.cardanoRewardAmount).toHaveText(
+                    bigRewardAmountFormatted,
+                );
+            });
+
+            await test.step('Initiate reward claim with big enough reward', async () => {
+                await stakingSection.claimRewardsButton.click();
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_CLAIM_REWARDS');
+                await expect(stakingSection.claimWarningBanner).toBeHidden();
+                await expect(stakingSection.cardanoModalRewardAmount).toHaveText(
+                    bigRewardAmountFormatted,
+                );
+                await expect(feeSection.maxFeeWithSymbol).toHaveText(
+                    toADA(bigRewardFee, { maxDecimals: 4 }),
+                );
+                await stakingSection.claimModalButton.click();
+            });
+
+            await test.step('Confirm claim on device', async () => {
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    header: { title: 'Confirm transaction' },
+                    body: [
+                        ['Confirm withdrawal for', '\n', 'reward address:'],
+                        splitStringByDisplayLimit(
+                            'stake1uytalm0k75njyj7v8z580ajs09v5v4lz6yp9akh8cgty43qunjqys',
+                        ),
+                    ],
+                    footer: 'Tap to continue',
+                });
+
+                await devicePrompt.waitForPromptAndClick();
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    header: { title: 'Confirm transaction' },
+                    body: [
+                        ['for account #1:'],
+                        ["m/1852'/1815'/0'/2", '\n', '/0'],
+                        ['Amount:'],
+                        [bigRewardAmountFormatted],
+                    ],
+                    footer: 'Tap to continue',
+                });
+
+                await devicePrompt.waitForPromptAndClick();
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    header: { title: 'Confirm transaction' },
+                    body: [
+                        ['Transaction fee:'],
+                        [toADA(bigRewardFee)],
+                        ['Network: Mainnet'],
+                        ['Valid since: n/a'],
+                        [/^TTL: \d{9}$/],
+                    ],
+                    footer: 'Tap to continue',
+                });
+
+                // staked account without rewards after claiming
+                blockbookMock.updateAccountState({
+                    availableBalance: finalBalance.toString(),
+                    balance: finalBalance.toString(),
+                    misc: {
+                        staking: {
+                            address: 'stake1uytalm0k75njyj7v8z580ajs09v5v4lz6yp9akh8cgty43qunjqys',
+                            rewards: '0',
+                            isActive: true,
+                            poolId: 'pool1n0uxgs5qfk5n9xl7qvq9jt8zuu02cntrsjnjayjlqtejyffnemj',
+                            drep: {
+                                drep_id:
+                                    'drep1yt8p080ajks6zdnxd9z6a6q60p9sm9j5rl7tc63mfna8r6cnp4wr3',
+                                hex: '22ce179dfd95a1a136666945aee81a784b0d96541ffcbc6a3b4cfa71eb',
+                                amount: finalBalance.toString(),
+                                active: true,
+                                active_epoch: 573,
+                                has_script: false,
+                                retired: false,
+                                expired: false,
+                                last_active_epoch: 601,
+                            },
+                        },
+                    },
+                });
+                await devicePrompt.waitForPromptAndConfirm();
+            });
+
+            await test.step('Verify claimed and staked account', async () => {
+                await expect(stakingSection.claimedToast).toContainTranslation('TOAST_TX_CLAIMED', {
+                    values: { amount: bigRewardAmountFormatted },
+                });
+                await expect(stakingSection.claimRewardsButton).toBeDisabled();
+                await expect(stakingSection.unstakeToClaimButton).toBeEnabled();
+                await expect(stakingSection.startStakingButton).toBeHidden();
+                await expect(stakingAccountItemInLeftSection).toBeVisible();
+                await expect(walletPage.topPanelBalanceWithSymbol).toHaveText(
+                    finalBalanceFormatted,
+                );
+                await expect(stakingSection.cardanoRewardAmount).toHaveText('0 ADA');
+                await expect(stakingSection.cardanoStakedFullBalanceText).toHaveTranslation(
+                    'TR_STAKE_FULL_BALANCE',
+                );
+            });
+        },
+    );
+});

--- a/suite/e2e/tests/staking/ada/stake.test.ts
+++ b/suite/e2e/tests/staking/ada/stake.test.ts
@@ -1,0 +1,216 @@
+import { CARDANO_STAKING_REGISTRATION_DEPOSIT } from '@suite-common/wallet-constants';
+import { TestCategory, TestPriority, TestStream, createTestAnnotation } from '@trezor/e2e-utils';
+
+import { toADA } from '../../../support/common';
+import { expect, test } from '../../../support/fixtures';
+import { ADA_MOCKED_ACCOUNT } from '../../../support/mocks/ada-endpoints';
+import { splitStringByDisplayLimit } from '../../../support/testExtends/customMatchers';
+
+// mocked and expected values
+const startingBalance = Number(ADA_MOCKED_ACCOUNT.balance);
+const startingBalanceFormatted = toADA(startingBalance);
+const feeAmount = 177601; // mocked 44 lovelace/byte
+const finalBalance =
+    startingBalance - feeAmount - Number(CARDANO_STAKING_REGISTRATION_DEPOSIT) * 1_000_000;
+const finalBalanceFormatted = toADA(finalBalance);
+
+test.describe('Staking - Cardano', { tag: ['@group=staking', '@specificModel'] }, () => {
+    test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic' } });
+
+    test.beforeEach(
+        async ({ page, onboardingPage, dashboardPage, settingsPage, blockbookMock }) => {
+            await onboardingPage.completeOnboarding();
+
+            await test.step('Enable Cardano and set mocked backend', async () => {
+                await settingsPage.navigateTo('coins');
+                await blockbookMock.start('ada', 'blockfrost');
+
+                await settingsPage.coins.disableNetwork('btc');
+                await settingsPage.coins.enableNetwork('ada');
+                await settingsPage.coins.openNetworkAdvanceSettings('ada');
+                await settingsPage.coins.changeBackend('blockfrost', blockbookMock.url);
+
+                await dashboardPage.dashboardMenuButton.click();
+                await page.discoveryShouldFinish();
+            });
+        },
+    );
+
+    test(
+        'Stake Cardano',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can stake from his Cardano account.',
+                category: TestCategory.Staking,
+                priority: TestPriority.Critical,
+                stream: TestStream.Trends,
+            }),
+        },
+        async ({ page, devicePrompt, walletPage, feeSection, stakingSection, blockbookMock }) => {
+            const stakingAccountItemInLeftSection = walletPage.accountButton({
+                symbol: 'ada',
+                type: 'normal',
+                atIndex: 0,
+                subAccount: 'staking',
+            });
+
+            await test.step('Verify inactive staking account', async () => {
+                await page.clock.install();
+                await walletPage.openAccount({ symbol: 'ada', type: 'normal', atIndex: 0 });
+                await stakingSection.stakingTabButton.click();
+                await expect(walletPage.discoveryWarning).toBeHidden();
+                await expect(walletPage.topPanelBalanceWithSymbol).toHaveText(
+                    startingBalanceFormatted,
+                );
+                await expect(stakingSection.claimRewardsButton).toBeHidden();
+                await expect(stakingSection.unstakeToClaimButton).toBeHidden();
+                await expect(stakingAccountItemInLeftSection).toBeHidden();
+            });
+
+            await test.step('Initiate staking flow', async () => {
+                await stakingSection.startStakingButton.click();
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_STAKING_IN_A_NUTSHELL');
+                await expect(page.modal).toContainTranslation(
+                    'TR_STAKE_YOUR_FUNDS_STAY_ACCESSIBLE',
+                    {
+                        values: { networkDisplaySymbol: 'ADA' },
+                    },
+                );
+
+                await stakingSection.continueButton.click();
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
+                    values: { symbol: 'ADA' },
+                });
+                await stakingSection.everstakeAcknowledgeCheckbox.click();
+                await stakingSection.confirmButton.click();
+                await expect(stakingSection.cardanoDepositAmount).toHaveText(
+                    `${CARDANO_STAKING_REGISTRATION_DEPOSIT} ADA`,
+                );
+                await expect(feeSection.maxFeeWithSymbol).toHaveText(
+                    toADA(feeAmount, { maxDecimals: 4 }),
+                );
+            });
+
+            await test.step('Confirm staking on device', async () => {
+                await stakingSection.continueButton.click();
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    header: { title: 'Confirm transaction' },
+                    body: [
+                        ['Confirm:'],
+                        ['Stake key', '\n', 'registration'],
+                        ['for account #1:'],
+                        ["m/1852'/1815'/0'/2", '\n', '/0'],
+                    ],
+                    footer: 'Tap to continue',
+                });
+
+                await devicePrompt.waitForPromptAndClick();
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    header: { title: 'Confirm transaction' },
+                    body: [
+                        ['Confirm:'],
+                        ['Stake delegation'],
+                        ['for account #1:'],
+                        ["m/1852'/1815'/0'/2", '\n', '/0'],
+                    ],
+                    footer: 'Tap to continue',
+                });
+
+                await devicePrompt.waitForPromptAndClick();
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    header: { title: 'Confirm transaction' },
+                    body: [
+                        ['to pool:'],
+                        splitStringByDisplayLimit(
+                            'pool1n0uxgs5qfk5n9xl7qvq9jt8zuu02cntrsjnjayjlqtejyffnemj',
+                        ),
+                    ],
+                    footer: 'Tap to continue',
+                });
+
+                await devicePrompt.waitForPromptAndClick();
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    header: { title: 'Confirm transaction' },
+                    body: [
+                        ['Confirm:'],
+                        ['Vote delegation'],
+                        ['for account #1:'],
+                        ["m/1852'/1815'/0'/2", '\n', '/0'],
+                    ],
+                    footer: 'Tap to continue',
+                });
+
+                await devicePrompt.waitForPromptAndClick();
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    header: { title: 'Confirm transaction' },
+                    body: [
+                        ['Delegating to key hash:'],
+                        splitStringByDisplayLimit(
+                            'drep1ectemlv45xsnvenfgkhwsxncfvxev4qllj7x5w6vlfc7kmd9zcs',
+                        ),
+                    ],
+                    footer: 'Tap to continue',
+                });
+
+                await devicePrompt.waitForPromptAndClick();
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    header: { title: 'Confirm transaction' },
+                    body: [
+                        ['Transaction fee:'],
+                        [toADA(feeAmount)],
+                        ['Network: Mainnet'],
+                        ['Valid since: n/a'],
+                        [/^TTL: \d{9}$/],
+                    ],
+                    footer: 'Tap to continue',
+                });
+
+                // staked account
+                blockbookMock.updateAccountState({
+                    balance: finalBalance.toString(),
+                    availableBalance: finalBalance.toString(),
+                    misc: {
+                        staking: {
+                            address: 'stake1uytalm0k75njyj7v8z580ajs09v5v4lz6yp9akh8cgty43qunjqys',
+                            rewards: '0',
+                            isActive: true,
+                            poolId: 'pool1n0uxgs5qfk5n9xl7qvq9jt8zuu02cntrsjnjayjlqtejyffnemj',
+                            drep: {
+                                drep_id: 'drep1ectemlv45xsnvenfgkhwsxncfvxev4qllj7x5w6vlfc7kmd9zcs',
+                                hex: '22ce179dfd95a1a136666945aee81a784b0d96541ffcbc6a3b4cfa71eb',
+                                amount: finalBalance.toString(),
+                                active: true,
+                                active_epoch: 573,
+                                has_script: false,
+                                retired: false,
+                                expired: false,
+                                last_active_epoch: 601,
+                            },
+                        },
+                    },
+                });
+                await devicePrompt.waitForPromptAndConfirm();
+                await expect(stakingSection.stakedToast).toContainTranslation('TOAST_TX_STAKED', {
+                    values: {
+                        amount: finalBalanceFormatted,
+                        account: 'Cardano #1',
+                    },
+                });
+            });
+
+            await test.step('Verify account is staked', async () => {
+                await page.clock.fastForward(stakingSection.watchPeriod);
+                await expect(walletPage.topPanelBalanceWithSymbol).toHaveText(
+                    finalBalanceFormatted,
+                );
+                await expect(stakingSection.cardanoRewardAmount).toHaveText('0 ADA');
+                await expect(stakingSection.claimRewardsButton).toBeDisabled();
+                await expect(stakingSection.unstakeToClaimButton).toBeEnabled();
+                await expect(stakingAccountItemInLeftSection).toBeVisible();
+                await expect(stakingSection.cardanoStakedFullBalanceText).toHaveTranslation(
+                    'TR_STAKE_FULL_BALANCE',
+                );
+            });
+        },
+    );
+});

--- a/suite/e2e/tests/staking/ada/unstake.test.ts
+++ b/suite/e2e/tests/staking/ada/unstake.test.ts
@@ -1,0 +1,171 @@
+import { CARDANO_STAKING_REGISTRATION_DEPOSIT } from '@suite-common/wallet-constants';
+import { TestCategory, TestPriority, TestStream, createTestAnnotation } from '@trezor/e2e-utils';
+
+import { toADA } from '../../../support/common';
+import { expect, test } from '../../../support/fixtures';
+
+// mocked and expected values
+const startingBalance = 86858306;
+const startingBalanceFormatted = toADA(startingBalance);
+const feeAmount = 171881;
+const unstakedAmountFormatted = toADA(startingBalance - feeAmount);
+const finalBalance =
+    startingBalance - feeAmount + Number(CARDANO_STAKING_REGISTRATION_DEPOSIT) * 1_000_000;
+const finalBalanceFormatted = toADA(finalBalance);
+
+test.describe('Staking - Cardano', { tag: ['@group=staking', '@specificModel'] }, () => {
+    test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic' } });
+
+    test.beforeEach(
+        async ({ page, onboardingPage, dashboardPage, settingsPage, blockbookMock }) => {
+            await onboardingPage.completeOnboarding();
+
+            await test.step('Enable Cardano and set mocked backend', async () => {
+                await settingsPage.navigateTo('coins');
+                await blockbookMock.start('ada', 'blockfrost');
+                // staked account
+                blockbookMock.updateAccountState({
+                    availableBalance: startingBalance.toString(),
+                    balance: startingBalance.toString(),
+                    misc: {
+                        staking: {
+                            address: 'stake1uytalm0k75njyj7v8z580ajs09v5v4lz6yp9akh8cgty43qunjqys',
+                            rewards: '0',
+                            isActive: true,
+                            poolId: 'pool1n0uxgs5qfk5n9xl7qvq9jt8zuu02cntrsjnjayjlqtejyffnemj',
+                            drep: {
+                                drep_id:
+                                    'drep1yt8p080ajks6zdnxd9z6a6q60p9sm9j5rl7tc63mfna8r6cnp4wr3',
+                                hex: '22ce179dfd95a1a136666945aee81a784b0d96541ffcbc6a3b4cfa71eb',
+                                amount: startingBalance.toString(),
+                                active: true,
+                                active_epoch: 573,
+                                has_script: false,
+                                retired: false,
+                                expired: false,
+                                last_active_epoch: 601,
+                            },
+                        },
+                    },
+                });
+
+                await settingsPage.coins.disableNetwork('btc');
+                await settingsPage.coins.enableNetwork('ada');
+                await settingsPage.coins.openNetworkAdvanceSettings('ada');
+                await settingsPage.coins.changeBackend('blockfrost', blockbookMock.url);
+
+                await dashboardPage.dashboardMenuButton.click();
+                await page.discoveryShouldFinish();
+            });
+        },
+    );
+
+    test(
+        'Unstake Cardano',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can unstake his Cardano account.',
+                category: TestCategory.Staking,
+                priority: TestPriority.Critical,
+                stream: TestStream.Trends,
+            }),
+        },
+        async ({ page, devicePrompt, walletPage, feeSection, stakingSection, blockbookMock }) => {
+            const stakingAccountItemInLeftSection = walletPage.accountButton({
+                symbol: 'ada',
+                type: 'normal',
+                atIndex: 0,
+                subAccount: 'staking',
+            });
+            await test.step('Verify staked account', async () => {
+                await walletPage.openAccount({ symbol: 'ada', type: 'normal', atIndex: 0 });
+                await stakingSection.stakingTabButton.click();
+                await expect(walletPage.discoveryWarning).toBeHidden();
+                await expect(stakingSection.claimRewardsButton).toBeDisabled();
+                await expect(stakingSection.unstakeToClaimButton).toBeEnabled();
+                await expect(stakingSection.startStakingButton).toBeHidden();
+                await expect(walletPage.topPanelBalanceWithSymbol).toHaveText(
+                    startingBalanceFormatted,
+                );
+                await expect(stakingSection.cardanoRewardAmount).toHaveText('0 ADA');
+                await expect(stakingSection.cardanoStakedFullBalanceText).toHaveTranslation(
+                    'TR_STAKE_FULL_BALANCE',
+                );
+            });
+
+            await test.step('Initiate unstaking', async () => {
+                await stakingSection.unstakeToClaimButton.click();
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_UNSTAKE_TOKEN', {
+                    values: { symbol: 'ADA' },
+                });
+                await expect(feeSection.maxFeeWithSymbol).toHaveText(
+                    toADA(feeAmount, { maxDecimals: 4 }),
+                );
+                await stakingSection.unstakeButton.click();
+            });
+
+            await test.step('Confirm claim on device', async () => {
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    header: { title: 'Confirm transaction' },
+                    body: [
+                        ['Confirm:'],
+                        ['Stake key', '\n', 'deregistration'],
+                        ['for account #1:'],
+                        ["m/1852'/1815'/0'/2", '\n', '/0'],
+                    ],
+                    footer: 'Tap to continue',
+                });
+
+                await devicePrompt.waitForPromptAndClick();
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    header: { title: 'Confirm transaction' },
+                    body: [
+                        ['Transaction fee:'],
+                        [toADA(feeAmount)],
+                        ['Network: Mainnet'],
+                        ['Valid since: n/a'],
+                        [/^TTL: \d{9}$/],
+                    ],
+                    footer: 'Tap to continue',
+                });
+
+                // unstaked account
+                blockbookMock.updateAccountState({
+                    availableBalance: finalBalance,
+                    balance: finalBalance,
+                    misc: {
+                        staking: {
+                            address: 'stake1uytalm0k75njyj7v8z580ajs09v5v4lz6yp9akh8cgty43qunjqys',
+                            rewards: '0',
+                            isActive: false,
+                            poolId: null,
+                            drep: null,
+                        },
+                    },
+                });
+                await devicePrompt.waitForPromptAndConfirm();
+            });
+
+            await test.step('Verify unstaked account', async () => {
+                await expect(stakingSection.unstakedToast).toContainTranslation(
+                    'TOAST_TX_UNSTAKED',
+                    {
+                        values: {
+                            amount: unstakedAmountFormatted,
+                            account: 'Cardano #1',
+                        },
+                    },
+                );
+                await expect(walletPage.topPanelBalanceWithSymbol).toHaveText(
+                    finalBalanceFormatted,
+                );
+                await expect(stakingSection.startStakingButton).toBeEnabled();
+                await expect(stakingSection.claimRewardsButton).toBeHidden();
+                await expect(stakingSection.unstakeToClaimButton).toBeHidden();
+                await expect(stakingAccountItemInLeftSection).toBeHidden();
+                await expect(stakingSection.cardanoRewardAmount).toBeHidden();
+                await expect(stakingSection.cardanoStakedFullBalanceText).toBeHidden();
+            });
+        },
+    );
+});

--- a/suite/e2e/tests/staking/eth/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/eth/initial-stake.test.ts
@@ -72,11 +72,9 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
 
             await test.step('Open and fill staking form', async () => {
                 await stakingSection.startStakingButton.click();
-                await expect(stakingSection.modalHeader).toHaveTranslation(
-                    'TR_STAKE_STAKING_IN_A_NUTSHELL',
-                );
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_STAKING_IN_A_NUTSHELL');
                 await stakingSection.continueButton.click();
-                await expect(stakingSection.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
                     values: { symbol: 'ETH' },
                 });
                 await stakingSection.everstakeAcknowledgeCheckbox.click();

--- a/suite/e2e/tests/staking/sol/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/sol/initial-stake.test.ts
@@ -48,11 +48,9 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
 
             await test.step('Open and fill staking form', async () => {
                 await stakingSection.startStakingButton.click();
-                await expect(stakingSection.modalHeader).toHaveTranslation(
-                    'TR_STAKE_STAKING_IN_A_NUTSHELL',
-                );
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_STAKING_IN_A_NUTSHELL');
                 await stakingSection.continueButton.click();
-                await expect(stakingSection.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
                     values: { symbol: 'SOL' },
                 });
                 await stakingSection.everstakeAcknowledgeCheckbox.click();
@@ -62,7 +60,7 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
             });
 
             await test.step('Initiate staking and confirm on device', async () => {
-                await expect(stakingSection.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
                     values: { symbol: 'SOL' },
                 });
                 await stakingSection.continueButton.click();

--- a/suite/e2e/tests/staking/sol/stake-more.test.ts
+++ b/suite/e2e/tests/staking/sol/stake-more.test.ts
@@ -58,7 +58,7 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
 
             await test.step('Open and fill staking form', async () => {
                 await stakingSection.stakeMoreButton.click();
-                await expect(stakingSection.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
                     values: { symbol: 'SOL' },
                 });
                 await expect(stakingSection.availableBalanceWithSymbol).toHaveText('1,000 SOL');
@@ -66,7 +66,7 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
             });
 
             await test.step('Initiate staking and confirm on device', async () => {
-                await expect(stakingSection.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_STAKE_TOKEN', {
                     values: { symbol: 'SOL' },
                 });
                 await stakingSection.continueButton.click();

--- a/suite/e2e/tests/staking/sol/unstake.test.ts
+++ b/suite/e2e/tests/staking/sol/unstake.test.ts
@@ -55,10 +55,9 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
 
             await test.step('Open unstaking form', async () => {
                 await stakingSection.unstakeToClaimButton.click();
-                await expect(stakingSection.modalHeader).toHaveTranslation(
-                    'TR_STAKE_UNSTAKE_TOKEN',
-                    { values: { symbol: 'SOL' } },
-                );
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_UNSTAKE_TOKEN', {
+                    values: { symbol: 'SOL' },
+                });
                 await expect(stakingSection.availableBalanceWithSymbol).toHaveText(
                     stakedAmountFormatted,
                 );
@@ -67,10 +66,9 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
 
             await test.step('Initiate unstaking and confirm on device', async () => {
                 await stakingSection.unstakeButton.click();
-                await expect(stakingSection.modalHeader).toHaveTranslation(
-                    'TR_STAKE_UNSTAKE_TOKEN',
-                    { values: { symbol: 'SOL' } },
-                );
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_UNSTAKE_TOKEN', {
+                    values: { symbol: 'SOL' },
+                });
                 await expect(devicePrompt.outputValueOf('data')).toHaveTranslation(
                     'TR_UNSTAKE_FROM_STAKE_ACCOUNT',
                     { values: { symbol: 'SOL' } },
@@ -133,12 +131,12 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
             });
 
             await test.step('Finish claiming', async () => {
-                await expect(stakingSection.modalHeader).toHaveTranslation('TR_STAKE_CLAIM_TOKEN', {
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_CLAIM_TOKEN', {
                     values: { symbol: 'SOL' },
                 });
                 await expect(stakingSection.claimModalAmount).toHaveText(unstakingAmountFormatted);
                 await stakingSection.claimModalButton.click();
-                await expect(stakingSection.modalHeader).toHaveTranslation('TR_STAKE_CLAIM_TOKEN', {
+                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_CLAIM_TOKEN', {
                     values: { symbol: 'SOL' },
                 });
                 await expect(devicePrompt.outputValueOf('data')).toHaveTranslation(

--- a/suite/e2e/tsconfig.json
+++ b/suite/e2e/tsconfig.json
@@ -23,6 +23,9 @@
             "path": "../../suite-common/wallet-config"
         },
         {
+            "path": "../../suite-common/wallet-constants"
+        },
+        {
             "path": "../../suite-common/wallet-core"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14849,6 +14849,7 @@ __metadata:
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/trading": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-constants": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:^"


### PR DESCRIPTION
New cardano staking automation
- new page locators for modal - to be discussed
- blockbook mock modify to support cardano
- cardano fixtures
- matcher for emu display now support regexp
- fee page objects can be now use standalonely from trading
- cardano staking works both on web and desktop yay
- new sleep before all emulator getDebugState

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-e2e-cardano-staking&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-e2e-cardano-staking&lookback=7)