### PR TITLE
fix(suite-native): broken discreet mode trigger

### DIFF
--- a/suite-native/atoms/src/DiscreetText/DiscreetCanvas.tsx
+++ b/suite-native/atoms/src/DiscreetText/DiscreetCanvas.tsx
@@ -36,7 +36,7 @@ export const DiscreetCanvas = ({ width, height, fontSize, text, color }: Discree
     const blurValue = height * 0.3;
 
     return (
-        <Canvas style={applyStyle(discreetCanvasStyle, { height, width })}>
+        <Canvas style={applyStyle(discreetCanvasStyle, { height, width })} pointerEvents="none">
             <SkiaText y={fontSize} text={text} font={font} color={colors[color]}>
                 <Blur blur={blurValue} mode="decal" />
             </SkiaText>


### PR DESCRIPTION
## Description
- fixes the balance discreet mode toggle
- the discreet mode onPress event was captured by the Skia canvas and never propagated up to the dedicated Pressable (probably broken since the update to the new RN arch)

## Notes for QA
- try to toggle on and off the discreet mode from the homescreen
## Related Issue

Resolve #24190 

## Screenshots:

https://github.com/user-attachments/assets/b205031c-3d6f-4d1c-9975-9f6325c7ff2f




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/broken-discreet-mode-trigger&lookback=7)