### PR TITLE
fix(suite): adding any Trezor translation

### DIFF
--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -188,7 +188,7 @@ const ViaCableCard = ({ onClick }: ConnectionModeCardProps) => (
                         <Translation
                             id="TR_CONNECT_DEVICE_NAME"
                             values={{
-                                deviceName: 'any Trezor',
+                                deviceName: <Translation id="TR_ANY_TREZOR" />,
                                 b: chunks => (
                                     <Text textWrap="nowrap">
                                         <strong>{chunks}</strong>

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -79,6 +79,11 @@ export default defineMessages({
             'A watch-only account is a public address you’ve imported into your wallet, allowing the wallet to watch for outputs but not spend them.',
         id: 'TR_ACCOUNT_IMPORTED_ANNOUNCEMENT',
     },
+    TR_ANY_TREZOR: {
+        defaultMessage: 'any Trezor',
+        description: 'Used as a variable for device name',
+        id: 'TR_ANY_TREZOR',
+    },
     TR_HIDE_SCAM_TRANSACTIONS_TOOLTIP: {
         defaultMessage: 'Hide suspicious transactions for a cleaner view.',
         id: 'TR_HIDE_SCAM_TRANSACTIONS_TOOLTIP',


### PR DESCRIPTION
## Description

"Any Trezor" as a variable (Device name) was not getting translated to other languages. So we added that in the messages.ts

## Notes for QA

Please check if "any Trezor" is translated to other official languages once translated (double check with @pavelmario ) - after this freeze.

## Screenshots:
<img width="1464" height="863" alt="Screenshot 2026-01-07 at 2 21 10 PM" src="https://github.com/user-attachments/assets/a341a8a8-917e-47ff-a0af-12d9f15c943e" />
<img width="1470" height="956" alt="Screenshot 2026-01-07 at 2 21 28 PM" src="https://github.com/user-attachments/assets/161bf726-cd4b-419e-aa19-0b61d292ac5a" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/translation-any-trezor&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/translation-any-trezor&lookback=7)