### PR TITLE
fix(e2e): update address formatting in send-base test

### DIFF
--- a/suite/e2e/tests/wallet/send-base.test.ts
+++ b/suite/e2e/tests/wallet/send-base.test.ts
@@ -2,7 +2,7 @@ import { localizeNumber } from '@suite-common/wallet-utils';
 import messages from '@trezor/suite/src/support/messages';
 import { BigNumber } from '@trezor/utils';
 
-import { formatAddress } from '../../support/common';
+import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 import {
     splitStringByDisplayLimit,
@@ -11,7 +11,7 @@ import {
 
 const networkName = 'Base #1';
 const sendAddress = '0xdcaB74E62b9D08a9f8Fa4A3Ccb5c46AE039C9d7C';
-const formattedSendAddress = formatAddress(sendAddress);
+const formattedSendAddress = formatAddressWithNewlines(sendAddress);
 const sendAmount = '0.000008';
 const formattedSendAmount = `${localizeNumber(sendAmount)} ETH`;
 


### PR DESCRIPTION
Updated `send-base.test.ts` to use `formatAddressWithNewlines` instead of `formatAddress` The test was failing because the expected address string did not match the multi-line formatting used in the UI.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-EVM-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-EVM-tests&lookback=7)