### PR TITLE
fix: use AccountDescriptor as branded type

### DIFF
--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -233,6 +233,10 @@ export interface TokenInfo {
     // transfers: number, // total transactions?
 }
 
+/**
+ * This is Backend data for the account. Data can change over time as transactions happen.
+ * Suite is subscribed to this and updates Account regularly.
+ */
 export interface AccountInfo {
     descriptor: string;
     balance: string;

--- a/packages/connect/src/types/account.ts
+++ b/packages/connect/src/types/account.ts
@@ -19,6 +19,7 @@ export interface AccountInfo extends AccountInfoBase {
     utxo?: AccountUtxo[]; // bitcoin utxo
     descriptorChecksum?: string;
 }
+
 export interface DiscoveryAccount {
     type: DiscoveryAccountType;
     label: string;

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -10,6 +10,7 @@ import {
     transactionsActions,
 } from '@suite-common/wallet-core';
 import * as discoveryActions from '@suite-common/wallet-core';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { getAccountIdentifier, getAccountTransactions } from '@suite-common/wallet-utils';
 
 import { deviceSlice } from 'src/actions/device/deviceSlice';
@@ -61,14 +62,14 @@ const dev2Instance1 = getSuiteDevice({
 const acc1 = getWalletAccount({
     deviceState: dev1.state?.staticSessionId,
     symbol: 'btc',
-    descriptor: 'desc1',
+    descriptor: asAccountDescriptor('desc1'),
     key: `desc1-btc-${dev1.state?.staticSessionId}`,
     networkType: 'bitcoin',
 });
 const acc2 = getWalletAccount({
     deviceState: dev2.state?.staticSessionId,
     symbol: 'btc',
-    descriptor: 'desc2',
+    descriptor: asAccountDescriptor('desc2'),
     key: `desc2-btc-${dev2.state?.staticSessionId}`,
     networkType: 'bitcoin',
 });
@@ -76,13 +77,13 @@ const acc2 = getWalletAccount({
 const tx1 = getWalletTransaction({
     deviceState: dev1.state?.staticSessionId,
     txid: 'txid1',
-    descriptor: 'desc1',
+    descriptor: asAccountDescriptor('desc1'),
     symbol: 'btc',
 });
 const tx2 = getWalletTransaction({
     deviceState: dev2.state?.staticSessionId,
     txid: 'txid2',
-    descriptor: 'desc2',
+    descriptor: asAccountDescriptor('desc2'),
     symbol: 'btc',
 });
 
@@ -408,7 +409,7 @@ describe('Storage actions', () => {
         const accLtc = getWalletAccount({
             deviceState: dev1.state!.staticSessionId!,
             symbol: 'ltc',
-            descriptor: 'desc2',
+            descriptor: asAccountDescriptor('desc2'),
             key: `desc2-ltc-${dev1.state}`,
             networkType: 'bitcoin',
         });

--- a/packages/suite/src/actions/wallet/__tests__/cardanoStakingActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/cardanoStakingActions.test.ts
@@ -1,6 +1,7 @@
 import { getUnixTime } from 'date-fns';
 
 import { testMocks } from '@suite-common/test-utils';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { BlockchainBlock } from '@trezor/connect';
 
 import * as cardanoStakingActions from 'src/actions/wallet/cardanoStakingActions';
@@ -15,7 +16,7 @@ const { getSuiteDevice } = testMocks;
 const cardanoAccount = testMocks.getWalletAccount({
     networkType: 'cardano',
     symbol: 'ada',
-    descriptor: 'addr123',
+    descriptor: asAccountDescriptor('addr123'),
 });
 const defaultAccount = testMocks.getWalletAccount();
 type CardanoStakingState = ReturnType<typeof cardanoStakingReducer>;

--- a/packages/suite/src/actions/wallet/__tests__/transactionActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/transactionActions.test.ts
@@ -7,6 +7,7 @@ import {
     transactionsActions,
     transactionsInitialState,
 } from '@suite-common/wallet-core';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { getAccountTransactions } from '@suite-common/wallet-utils';
 
 import { transactionsReducer } from 'src/reducers/wallet';
@@ -42,8 +43,8 @@ describe('Transaction Actions', () => {
     });
 
     it('Remove txs for a given account', () => {
-        const account1 = testMocks.getWalletAccount({ descriptor: 'xpub1' });
-        const account2 = testMocks.getWalletAccount({ descriptor: 'xpub2' });
+        const account1 = testMocks.getWalletAccount({ descriptor: asAccountDescriptor('xpub1') });
+        const account2 = testMocks.getWalletAccount({ descriptor: asAccountDescriptor('xpub2') });
         const store = initStore({
             transactions: {
                 [account1.key]: [getWalletTransaction()],

--- a/packages/suite/src/actions/wallet/moveLabelsForRbf/__fixtures__/moveLabelsForRbfAccounts.fixture.ts
+++ b/packages/suite/src/actions/wallet/moveLabelsForRbf/__fixtures__/moveLabelsForRbfAccounts.fixture.ts
@@ -1,5 +1,5 @@
 import { AccountsRootState } from '@suite-common/wallet-core';
-import { Account } from '@suite-common/wallet-types';
+import { Account, asAccountDescriptor } from '@suite-common/wallet-types';
 
 export const accountSpendingCoins: Account = {
     deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@AC94BB9C1B08FE73BE1E3322:0',
@@ -9,8 +9,9 @@ export const accountSpendingCoins: Account = {
     marker: undefined,
     stellarCursor: undefined,
     path: "m/84'/1'/0'",
-    descriptor:
+    descriptor: asAccountDescriptor(
         '(accountSpendingCoins:descriptor)vpub5YX1yJFY8E236pH3iNvCpThsXLxoQoC4nwraaS5h4TZwaSp1Gg9SQoxCsrumxjh7nZRQQkNfH29TEDeMvAZVmD3rpmsDnFc5Sj4JgJG6m4b',
+    ),
     key: '(accountSpendingCoins:key)vpub5YX1yJFY8E236pH3iNvCpThsXLxoQoC4nwraaS5h4TZwaSp1Gg9SQoxCsrumxjh7nZRQQkNfH29TEDeMvAZVmD3rpmsDnFc5Sj4JgJG6m4b-regtest-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@AC94BB9C1B08FE73BE1E3322:0',
     accountType: 'normal',
     symbol: 'regtest',
@@ -404,8 +405,9 @@ export const accountReceivingCoins: Account = {
     marker: undefined,
     stellarCursor: undefined,
     path: "m/84'/1'/1'",
-    descriptor:
+    descriptor: asAccountDescriptor(
         '(accountReceivingCoins:descriptor)vpub5YX1yJFY8E238aESifzcpXQHLzNDYJC22yLWqCwJ5pN85E27ku5wUXdhnh3HSMs3HibDQzeWmVeH52bAAa9LvkK4L1V9XfZbmHxGDuZSJks',
+    ),
     key: '(accountReceivingCoins:key)vpub5YX1yJFY8E238aESifzcpXQHLzNDYJC22yLWqCwJ5pN85E27ku5wUXdhnh3HSMs3HibDQzeWmVeH52bAAa9LvkK4L1V9XfZbmHxGDuZSJks-regtest-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@AC94BB9C1B08FE73BE1E3322:0',
     accountType: 'normal',
     symbol: 'regtest',

--- a/packages/suite/src/actions/wallet/processLegacyMetadataIntoSuiteSyncThunk.ts
+++ b/packages/suite/src/actions/wallet/processLegacyMetadataIntoSuiteSyncThunk.ts
@@ -2,7 +2,11 @@ import { MetadataAddPayload } from '@suite-common/metadata-types';
 import { createThunk } from '@suite-common/redux-utils';
 import { RefreshSuiteKeysUnavailableType } from '@suite-common/suite-sync-types/libDev/src';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { DeviceCancelledErrType, DeviceErrorType } from '@suite-common/wallet-types';
+import {
+    DeviceCancelledErrType,
+    DeviceErrorType,
+    asAccountDescriptor,
+} from '@suite-common/wallet-types';
 import type { StaticSessionId } from '@trezor/connect';
 import { Result, exhaustive } from '@trezor/type-utils';
 
@@ -47,7 +51,7 @@ export const processLegacyMetadataIntoSuiteSyncThunk = createThunk<
                     address: payload.defaultValue, // `payload.defaultValue` is the Address. For example: `"bc1q9mnl3ae6dra54uu2n9hp3d4jwkt0c2ux5l79ja"`
                     // The `payload.entityKey` is something else. For example `zpub6rY6av7j6m7Lnd6rgqw5jffjX2rgeirDWWivEmFDMCKxt7FkWD5XQSrXCSW2Vsh3vnqUo1r9XjoGZiW41jqfEBkrxxdPnS15QhwJFjwfZ1U-btc-momP8m1p6w1nteR3hNREZjNc48buvpPv8K@BCCD2503E021276E78A8EBB2:2`
                     label: value ?? null,
-                    accountDescriptor: payload.accountDescriptor,
+                    accountDescriptor: asAccountDescriptor(payload.accountDescriptor),
                     networkSymbol: payload.networkSymbol as NetworkSymbol,
                 });
 

--- a/packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/accounts.ts
+++ b/packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/accounts.ts
@@ -1,9 +1,11 @@
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+
 import { Account } from 'src/types/wallet';
 
 export const BTC_ACCOUNT: Account = {
     networkType: 'bitcoin',
     symbol: 'btc',
-    descriptor: 'btc-descriptor',
+    descriptor: asAccountDescriptor('btc-descriptor'),
     deviceState: '1stTestnetAddress@device_id:0',
     index: 0,
     path: "m/84'/0'/0'",
@@ -51,7 +53,7 @@ export const BTC_ACCOUNT: Account = {
 export const ETH_ACCOUNT: Account = {
     symbol: 'eth',
     networkType: 'ethereum',
-    descriptor: '0xdB09b793984B862C430b64B9ed53AcF867cC041F',
+    descriptor: asAccountDescriptor('0xdB09b793984B862C430b64B9ed53AcF867cC041F'),
     deviceState: '1stTestnetAddress@device_id:0',
     key: '0xdB09b793984B862C430b64B9ed53AcF867cC041F-eth-deviceState',
     accountType: 'normal',
@@ -90,7 +92,7 @@ export const ETH_ACCOUNT: Account = {
 export const XRP_ACCOUNT: Account = {
     symbol: 'xrp',
     networkType: 'ripple',
-    descriptor: 'rAPERVgXZavGgiGv6xBgtiZurirW2yAmY',
+    descriptor: asAccountDescriptor('rAPERVgXZavGgiGv6xBgtiZurirW2yAmY'),
     deviceState: '1stTestnetAddress@device_id:0',
     key: 'rAPERVgXZavGgiGv6xBgtiZurirW2yAmY-xrp-deviceState',
     availableBalance: '100000000000',

--- a/packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/store.ts
+++ b/packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/store.ts
@@ -1,9 +1,11 @@
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+
 import { Account } from 'src/types/wallet';
 
 export const ACCOUNT: Account = {
     networkType: 'bitcoin',
     symbol: 'btc' as Account['symbol'],
-    descriptor: 'btc-descriptor',
+    descriptor: asAccountDescriptor('btc-descriptor'),
     deviceState: '1stTestnetAddress@device_id:0',
     index: 0,
     path: "m/84'/0'/0'",

--- a/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
@@ -4,6 +4,7 @@ import {
     SelectedAccountLoaded,
     WalletAccountTransaction,
     WalletAccountTransactionWithRequiredRbfParams,
+    asAccountDescriptor,
 } from '@suite-common/wallet-types';
 import { AccountUtxo } from '@trezor/connect';
 import { DeepPartial } from '@trezor/type-utils';
@@ -84,7 +85,7 @@ const BTC_CJ_ACCOUNT: DeepPartial<SelectedAccountLoaded> = {
 
 const txDummyData = {
     deviceState: 'A@B:1',
-    descriptor: '',
+    descriptor: asAccountDescriptor(''),
     type: 'sent',
     txid: '',
     amount: '',

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -6,7 +6,7 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { Network, getNetwork } from '@suite-common/wallet-config';
 import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
 import { SendState, accountsActions, prepareSendFormReducer } from '@suite-common/wallet-core';
-import { FeesState, SelectedAccountStatus } from '@suite-common/wallet-types';
+import { FeesState, SelectedAccountStatus, asAccountDescriptor } from '@suite-common/wallet-types';
 import { PROTO } from '@trezor/connect';
 import { DeepPartial } from '@trezor/type-utils';
 
@@ -61,7 +61,7 @@ export const BTC_ACCOUNT: Omit<SelectedAccountStatus, 'network'> & { network: Pa
     account: testMocks.getWalletAccount({
         symbol: 'btc',
         networkType: 'bitcoin',
-        descriptor: 'xpub',
+        descriptor: asAccountDescriptor('xpub'),
         deviceState: '1stTestnetAddress@device_id:0',
         key: 'xpub-btc-1stTestnetAddress@device_id:0',
         addresses: {
@@ -133,7 +133,7 @@ export const ETH_ACCOUNT: DeepPartial<SelectedAccountStatus> = {
     account: testMocks.getWalletAccount({
         symbol: 'eth',
         networkType: 'ethereum',
-        descriptor: '0xdB09b793984B862C430b64B9ed53AcF867cC041F',
+        descriptor: asAccountDescriptor('0xdB09b793984B862C430b64B9ed53AcF867cC041F'),
         deviceState: '1stTestnetAddress@device_id:0',
         key: '0xdB09b793984B862C430b64B9ed53AcF867cC041F-eth-1stTestnetAddress@device_id:0',
         balance: '10000000000000000000', // 10 ETH
@@ -157,7 +157,7 @@ export const XRP_ACCOUNT: DeepPartial<SelectedAccountStatus> = {
     account: testMocks.getWalletAccount({
         symbol: 'xrp',
         networkType: 'ripple',
-        descriptor: 'rAPERVgXZavGgiGv6xBgtiZurirW2yAmY',
+        descriptor: asAccountDescriptor('rAPERVgXZavGgiGv6xBgtiZurirW2yAmY'),
         deviceState: '1stTestnetAddress@device_id:0',
         key: 'rAPERVgXZavGgiGv6xBgtiZurirW2yAmY-xrp-1stTestnetAddress@device_id:0',
         balance: '100000000', // 100 XRP
@@ -172,7 +172,7 @@ export const SOL_ACCOUNT: DeepPartial<SelectedAccountStatus> = {
     account: {
         symbol: 'sol',
         networkType: 'solana',
-        descriptor: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+        descriptor: asAccountDescriptor('ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF'),
         deviceState: '1stTestnetAddress@device_id:0',
         key: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF-sol-1stTestnetAddress@device_id:0',
         balance: '10000000000', // 10 SOL

--- a/packages/suite/src/reducers/wallet/__fixtures__/transactionConstants.ts
+++ b/packages/suite/src/reducers/wallet/__fixtures__/transactionConstants.ts
@@ -1,12 +1,17 @@
-import { Account as CommonAccount, WalletAccountTransaction } from '@suite-common/wallet-types';
+import {
+    Account as CommonAccount,
+    WalletAccountTransaction,
+    asAccountDescriptor,
+} from '@suite-common/wallet-types';
 
 export const accounts: CommonAccount[] = [
     {
         deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
         index: 0,
         path: "m/84'/0'/0'",
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+        ),
         key: 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
         accountType: 'normal',
         symbol: 'btc',
@@ -99,8 +104,9 @@ export const accounts: CommonAccount[] = [
         deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
         index: 0,
         path: "m/86'/0'/0'",
-        descriptor:
+        descriptor: asAccountDescriptor(
             "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)",
+        ),
         key: "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0",
         accountType: 'taproot',
         symbol: 'btc',
@@ -187,8 +193,9 @@ export const transactions: { [key: string]: WalletAccountTransaction[] } = {
     'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0':
         [
             {
-                descriptor:
+                descriptor: asAccountDescriptor(
                     'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+                ),
                 deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
                 symbol: 'btc',
                 type: 'sent',
@@ -237,8 +244,9 @@ export const transactions: { [key: string]: WalletAccountTransaction[] } = {
                 },
             },
             {
-                descriptor:
+                descriptor: asAccountDescriptor(
                     'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+                ),
                 deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
                 symbol: 'btc',
                 type: 'recv',
@@ -296,8 +304,9 @@ export const transactions: { [key: string]: WalletAccountTransaction[] } = {
     "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0":
         [
             {
-                descriptor:
+                descriptor: asAccountDescriptor(
                     "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)",
+                ),
                 deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
                 symbol: 'btc',
                 type: 'sent',
@@ -367,8 +376,9 @@ export const transactions: { [key: string]: WalletAccountTransaction[] } = {
                 },
             },
             {
-                descriptor:
+                descriptor: asAccountDescriptor(
                     "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)",
+                ),
                 deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
                 symbol: 'btc',
                 type: 'recv',

--- a/packages/suite/src/types/wallet/graph.ts
+++ b/packages/suite/src/types/wallet/graph.ts
@@ -1,5 +1,5 @@
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { BaseCurrencyAmount } from '@suite-common/wallet-types';
+import { AccountDescriptor, BaseCurrencyAmount } from '@suite-common/wallet-types';
 import { BlockchainAccountBalanceHistory, StaticSessionId } from '@trezor/connect';
 
 export interface AccountHistoryWithBalance extends BlockchainAccountBalanceHistory {
@@ -7,7 +7,7 @@ export interface AccountHistoryWithBalance extends BlockchainAccountBalanceHisto
 }
 
 export interface AccountIdentifier {
-    descriptor: string;
+    descriptor: AccountDescriptor;
     deviceState: StaticSessionId;
     symbol: NetworkSymbol;
 }

--- a/packages/suite/src/utils/suite/__tests__/logsUtils.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/logsUtils.test.ts
@@ -1,12 +1,14 @@
 import { testMocks } from '@suite-common/test-utils';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
 
 import { REDACTED_REPLACEMENT, redactAccount, redactDevice } from 'src/utils/suite/logsUtils';
 
 describe('logsUtils', () => {
     const account = testMocks.getWalletAccount({
         deviceState: '1stTestnetAddress@device_id:0',
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+        ),
         symbol: 'btc',
     });
     const device = testMocks.getSuiteDevice();

--- a/packages/suite/src/utils/wallet/__tests__/accountUtils.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/accountUtils.test.ts
@@ -1,4 +1,5 @@
 import { testMocks } from '@suite-common/test-utils';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
 
 import * as accountUtils from '../accountUtils';
 
@@ -16,14 +17,15 @@ describe('account utils', () => {
                 '1stTestnetAddress@device_id:0',
                 [
                     getWalletAccount({
-                        descriptor:
+                        descriptor: asAccountDescriptor(
                             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+                        ),
                         symbol: 'btc',
                         index: 0,
                     }),
                     getWalletAccount({
                         symbol: 'btc',
-                        descriptor: '123',
+                        descriptor: asAccountDescriptor('123'),
                         accountType: 'normal',
                         index: 1,
                     }),
@@ -37,7 +39,7 @@ describe('account utils', () => {
         ).toEqual(
             getWalletAccount({
                 symbol: 'btc',
-                descriptor: '123',
+                descriptor: asAccountDescriptor('123'),
                 accountType: 'normal',
                 index: 1,
             }),
@@ -48,14 +50,15 @@ describe('account utils', () => {
                 '1stTestnetAddress@device_id:0',
                 [
                     getWalletAccount({
-                        descriptor:
+                        descriptor: asAccountDescriptor(
                             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+                        ),
                         symbol: 'btc',
                         index: 0,
                     }),
                     getWalletAccount({
                         symbol: 'btc',
-                        descriptor: '123',
+                        descriptor: asAccountDescriptor('123'),
                         accountType: 'normal',
                         index: 1,
                     }),
@@ -69,14 +72,15 @@ describe('account utils', () => {
                 undefined,
                 [
                     getWalletAccount({
-                        descriptor:
+                        descriptor: asAccountDescriptor(
                             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+                        ),
                         symbol: 'btc',
                         index: 0,
                     }),
                     getWalletAccount({
                         symbol: 'btc',
-                        descriptor: '123',
+                        descriptor: asAccountDescriptor('123'),
                         accountType: 'normal',
                         index: 1,
                     }),
@@ -94,14 +98,15 @@ describe('account utils', () => {
                 '1stTestnetAddress@device_id:0',
                 [
                     getWalletAccount({
-                        descriptor:
+                        descriptor: asAccountDescriptor(
                             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+                        ),
                         symbol: 'btc',
                         index: 0,
                     }),
                     getWalletAccount({
                         symbol: 'btc',
-                        descriptor: '123',
+                        descriptor: asAccountDescriptor('123'),
                         accountType: 'normal',
                         index: 1,
                     }),

--- a/packages/suite/src/utils/wallet/trading/__fixtures__/tradingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/__fixtures__/tradingUtils.ts
@@ -1,7 +1,7 @@
 import { CryptoId } from 'invity-api';
 
 import { DefinitionType, TokenDefinitions } from '@suite-common/token-definitions';
-import { Account } from '@suite-common/wallet-types';
+import { Account, asAccountDescriptor } from '@suite-common/wallet-types';
 
 import { TradingAccountOptionsGroupOptionProps } from 'src/types/trading/trading';
 
@@ -21,7 +21,7 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
         deviceState: '1stTestnetAddress@device_id:0',
         formattedBalance: '0',
         tokens: [],
-        descriptor: 'descriptor1',
+        descriptor: asAccountDescriptor('descriptor1'),
         symbol: 'btc',
         visible: true,
         accountType: 'normal',
@@ -30,7 +30,7 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
         deviceState: '1stTestnetAddress@device_id:0',
         formattedBalance: '0.101213',
         tokens: [],
-        descriptor: 'descriptor2',
+        descriptor: asAccountDescriptor('descriptor2'),
         symbol: 'ltc',
         visible: true,
         accountType: 'normal',
@@ -38,7 +38,7 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
     {
         deviceState: '1stTestnetAddress@device_id:0',
         formattedBalance: '0',
-        descriptor: 'descriptor3',
+        descriptor: asAccountDescriptor('descriptor3'),
         symbol: 'eth',
         visible: true,
         accountType: 'normal',
@@ -76,7 +76,7 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
         deviceState: '1stTestnet@device_id:0',
         formattedBalance: '0.101213',
         tokens: [],
-        descriptor: 'descriptor4',
+        descriptor: asAccountDescriptor('descriptor4'),
         symbol: 'btc',
         visible: true,
         accountType: 'normal',
@@ -96,7 +96,7 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
                 standard: 'ERC20',
             },
         ],
-        descriptor: 'descriptor5',
+        descriptor: asAccountDescriptor('descriptor5'),
         accountType: 'normal',
     },
     {
@@ -115,7 +115,7 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
                 standard: 'ERC20',
             },
         ],
-        descriptor: 'descriptor6',
+        descriptor: asAccountDescriptor('descriptor6'),
         accountType: 'normal',
     },
     {
@@ -134,14 +134,14 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
                 standard: 'ERC20',
             },
         ],
-        descriptor: 'descriptor6',
+        descriptor: asAccountDescriptor('descriptor6'),
         accountType: 'normal',
     },
     {
         deviceState: '1stTestnetAddress@device_id:0',
         formattedBalance: '1',
         tokens: [],
-        descriptor: 'descriptor7',
+        descriptor: asAccountDescriptor('descriptor7'),
         symbol: 'btc',
         visible: true,
         accountType: 'coinjoin',

--- a/suite-common/graph/src/tests/__fixtures__/btc.ts
+++ b/suite-common/graph/src/tests/__fixtures__/btc.ts
@@ -1,12 +1,13 @@
-import { WalletAccountTransaction } from '@suite-common/wallet-types';
+import { WalletAccountTransaction, asAccountDescriptor } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
 import { AccountHistoryMovementItem } from '../../types';
 
 export const btcAccountTransactions: WalletAccountTransaction[] = [
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'sent',
@@ -61,8 +62,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'recv',
@@ -116,8 +118,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'recv',
@@ -183,8 +186,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'sent',
@@ -260,8 +264,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'recv',
@@ -337,8 +342,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'recv',
@@ -465,8 +471,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'sent',
@@ -541,8 +548,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'sent',
@@ -610,8 +618,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'joint',
@@ -701,8 +710,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'sent',
@@ -779,8 +789,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'sent',
@@ -849,8 +860,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'sent',
@@ -918,8 +930,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'recv',
@@ -985,8 +998,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'sent',
@@ -1072,8 +1086,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'sent',
@@ -1142,8 +1157,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'recv',
@@ -1200,8 +1216,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'sent',
@@ -1268,8 +1285,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'recv',
@@ -1325,8 +1343,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'sent',
@@ -1393,8 +1412,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'sent',
@@ -1457,8 +1477,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'recv',
@@ -1514,8 +1535,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'recv',
@@ -1597,8 +1619,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'self',
@@ -1698,8 +1721,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'recv',
@@ -1766,8 +1790,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'recv',
@@ -1842,8 +1867,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'recv',
@@ -1899,8 +1925,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'sent',
@@ -1968,8 +1995,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'sent',
@@ -2036,8 +2064,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'self',
@@ -2107,8 +2136,9 @@ export const btcAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+        ),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'btc',
         type: 'recv',

--- a/suite-common/graph/src/tests/__fixtures__/eth.ts
+++ b/suite-common/graph/src/tests/__fixtures__/eth.ts
@@ -1,11 +1,11 @@
-import { WalletAccountTransaction } from '@suite-common/wallet-types';
+import { WalletAccountTransaction, asAccountDescriptor } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
 import { AccountHistoryMovementItem } from '../../types';
 
 export const ethAccountTransactions: WalletAccountTransaction[] = [
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'recv',
@@ -66,7 +66,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'failed',
@@ -128,7 +128,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -181,7 +181,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -253,7 +253,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -315,7 +315,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -381,7 +381,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'recv',
@@ -435,7 +435,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -511,7 +511,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'recv',
@@ -565,7 +565,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -627,7 +627,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -691,7 +691,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'bsc',
         type: 'sent',
@@ -758,7 +758,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -832,7 +832,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'recv',
@@ -888,7 +888,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -955,7 +955,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -1013,7 +1013,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -1110,7 +1110,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -1175,7 +1175,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -1239,7 +1239,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'recv',
@@ -1293,7 +1293,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -1346,7 +1346,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -1399,7 +1399,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'recv',
@@ -1463,7 +1463,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'recv',
@@ -1527,7 +1527,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -1580,7 +1580,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'recv',
@@ -1644,7 +1644,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -1697,7 +1697,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'sent',
@@ -1750,7 +1750,7 @@ export const ethAccountTransactions: WalletAccountTransaction[] = [
         },
     },
     {
-        descriptor: '0x62270860B9a5337e46bE8563c512c9137AFa0384',
+        descriptor: asAccountDescriptor('0x62270860B9a5337e46bE8563c512c9137AFa0384'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'eth',
         type: 'recv',

--- a/suite-common/graph/src/tests/__fixtures__/xrp.ts
+++ b/suite-common/graph/src/tests/__fixtures__/xrp.ts
@@ -1,11 +1,11 @@
-import { WalletAccountTransaction } from '@suite-common/wallet-types';
+import { WalletAccountTransaction, asAccountDescriptor } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { AccountHistoryMovementItem } from '../../types';
 
 export const xrpAccountTransactions: WalletAccountTransaction[] = [
     {
-        descriptor: 'r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3',
+        descriptor: asAccountDescriptor('r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'xrp',
         type: 'recv',
@@ -28,7 +28,7 @@ export const xrpAccountTransactions: WalletAccountTransaction[] = [
         details: { vin: [], vout: [], size: 0, totalInput: '0', totalOutput: '0' },
     },
     {
-        descriptor: 'r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3',
+        descriptor: asAccountDescriptor('r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'xrp',
         type: 'sent',
@@ -51,7 +51,7 @@ export const xrpAccountTransactions: WalletAccountTransaction[] = [
         details: { vin: [], vout: [], size: 0, totalInput: '0', totalOutput: '0' },
     },
     {
-        descriptor: 'r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3',
+        descriptor: asAccountDescriptor('r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'xrp',
         type: 'sent',
@@ -74,7 +74,7 @@ export const xrpAccountTransactions: WalletAccountTransaction[] = [
         details: { vin: [], vout: [], size: 0, totalInput: '0', totalOutput: '0' },
     },
     {
-        descriptor: 'r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3',
+        descriptor: asAccountDescriptor('r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'xrp',
         type: 'recv',
@@ -97,7 +97,7 @@ export const xrpAccountTransactions: WalletAccountTransaction[] = [
         details: { vin: [], vout: [], size: 0, totalInput: '0', totalOutput: '0' },
     },
     {
-        descriptor: 'r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3',
+        descriptor: asAccountDescriptor('r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'xrp',
         type: 'sent',
@@ -120,7 +120,7 @@ export const xrpAccountTransactions: WalletAccountTransaction[] = [
         details: { vin: [], vout: [], size: 0, totalInput: '0', totalOutput: '0' },
     },
     {
-        descriptor: 'r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3',
+        descriptor: asAccountDescriptor('r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'xrp',
         type: 'recv',
@@ -143,7 +143,7 @@ export const xrpAccountTransactions: WalletAccountTransaction[] = [
         details: { vin: [], vout: [], size: 0, totalInput: '0', totalOutput: '0' },
     },
     {
-        descriptor: 'r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3',
+        descriptor: asAccountDescriptor('r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'xrp',
         type: 'sent',
@@ -166,7 +166,7 @@ export const xrpAccountTransactions: WalletAccountTransaction[] = [
         details: { vin: [], vout: [], size: 0, totalInput: '0', totalOutput: '0' },
     },
     {
-        descriptor: 'r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3',
+        descriptor: asAccountDescriptor('r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'xrp',
         type: 'recv',
@@ -189,7 +189,7 @@ export const xrpAccountTransactions: WalletAccountTransaction[] = [
         details: { vin: [], vout: [], size: 0, totalInput: '0', totalOutput: '0' },
     },
     {
-        descriptor: 'r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3',
+        descriptor: asAccountDescriptor('r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'xrp',
         type: 'sent',
@@ -212,7 +212,7 @@ export const xrpAccountTransactions: WalletAccountTransaction[] = [
         details: { vin: [], vout: [], size: 0, totalInput: '0', totalOutput: '0' },
     },
     {
-        descriptor: 'r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3',
+        descriptor: asAccountDescriptor('r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'xrp',
         type: 'sent',
@@ -235,7 +235,7 @@ export const xrpAccountTransactions: WalletAccountTransaction[] = [
         details: { vin: [], vout: [], size: 0, totalInput: '0', totalOutput: '0' },
     },
     {
-        descriptor: 'r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3',
+        descriptor: asAccountDescriptor('r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'xrp',
         type: 'recv',
@@ -258,7 +258,7 @@ export const xrpAccountTransactions: WalletAccountTransaction[] = [
         details: { vin: [], vout: [], size: 0, totalInput: '0', totalOutput: '0' },
     },
     {
-        descriptor: 'r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3',
+        descriptor: asAccountDescriptor('r9TCDt3HmszcsnPrUrnvpynvLgaGQom9x3'),
         deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
         symbol: 'xrp',
         type: 'recv',

--- a/suite-common/suite-sync-types/src/labeling/updateAddressLabel.ts
+++ b/suite-common/suite-sync-types/src/labeling/updateAddressLabel.ts
@@ -1,5 +1,9 @@
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { Account, DeviceCancelledErrType, DeviceErrorType } from '@suite-common/wallet-types';
+import {
+    AccountDescriptor,
+    DeviceCancelledErrType,
+    DeviceErrorType,
+} from '@suite-common/wallet-types';
 import type { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
@@ -9,7 +13,7 @@ export type UpdateAddressLabelParams = {
     deviceStaticSessionId: StaticSessionId;
     address: string;
     label: string | null;
-    accountDescriptor: Account['descriptor'];
+    accountDescriptor: AccountDescriptor;
     networkSymbol: NetworkSymbol;
 };
 

--- a/suite-common/suite-sync-types/src/refreshSuiteSyncKeys.ts
+++ b/suite-common/suite-sync-types/src/refreshSuiteSyncKeys.ts
@@ -6,6 +6,12 @@ type RefreshSuiteSyncKeysParams = {
     device: TrezorDevice;
 };
 
+/**
+ * This error is used in cases where we need to get keys, but it is not possible
+ * to get them. For example: Device is not connected, Device does not support Suite Sync.
+ *
+ * This error can be split if we need more granular error.
+ */
 export type RefreshSuiteKeysUnavailableType = {
     type: 'RefreshSuiteKeysUnavailable';
 };

--- a/suite-common/suite-sync/src/labeling/tests/labelingReducer.test.ts
+++ b/suite-common/suite-sync/src/labeling/tests/labelingReducer.test.ts
@@ -110,7 +110,7 @@ describe('labelingReducer', () => {
             }),
         );
 
-        const accountKey = getAccountKey('accdesc1', 'btc', 'ignored');
+        const accountKey = getAccountKey(asAccountDescriptor('accdesc1'), 'btc', 'ignored@1:2');
         expect(
             selectAccountLabel({
                 state: store.getState(),

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -14,6 +14,7 @@ import {
     BlockchainNetworks,
     FeeInfo,
     WalletAccountTransaction,
+    asAccountDescriptor,
 } from '@suite-common/wallet-types';
 import {
     AccountUtxo,
@@ -36,7 +37,7 @@ const getWalletAccount = (account?: Partial<Account>): Account => ({
     deviceState: '1stTestnetAddress@device_id:0',
     index: 0,
     path: "m/44'/60'/0'/0/1",
-    descriptor: '0xFA01a39f8Abaeb660c3137f14A310d0b414b2A15',
+    descriptor: asAccountDescriptor('0xFA01a39f8Abaeb660c3137f14A310d0b414b2A15'),
     key: `${account?.descriptor ?? '0xFA01a39f8Abaeb660c3137f14A310d0b414b2A15'}-${
         account?.symbol ?? 'eth'
     }-${account?.deviceState ?? '1stTestnetAddress@device_id:0'}`,
@@ -258,8 +259,9 @@ export const getSuiteDevice = (
 };
 
 const getWalletTransaction = (t?: Partial<WalletAccountTransaction>): WalletAccountTransaction => ({
-    descriptor:
+    descriptor: asAccountDescriptor(
         'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+    ),
     deviceState: '1stTestnetAddress@device_id:0',
     symbol: 'btc',
     type: 'sent',

--- a/suite-common/trading/src/reducers/__fixtures__/account.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/account.ts
@@ -1,12 +1,13 @@
-import { Account, WalletAccountTransaction } from '@suite-common/wallet-types';
+import { Account, WalletAccountTransaction, asAccountDescriptor } from '@suite-common/wallet-types';
 
 export const accounts: Account[] = [
     {
         deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
         index: 0,
         path: "m/84'/0'/0'",
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+        ),
         key: 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
         accountType: 'normal',
         symbol: 'btc',
@@ -99,8 +100,9 @@ export const accounts: Account[] = [
         deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
         index: 0,
         path: "m/86'/0'/0'",
-        descriptor:
+        descriptor: asAccountDescriptor(
             "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)",
+        ),
         key: "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0",
         accountType: 'taproot',
         symbol: 'btc',
@@ -187,8 +189,9 @@ export const transactions: { [key: string]: WalletAccountTransaction[] } = {
     'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0':
         [
             {
-                descriptor:
+                descriptor: asAccountDescriptor(
                     'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+                ),
                 deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
                 symbol: 'btc',
                 type: 'sent',
@@ -237,8 +240,9 @@ export const transactions: { [key: string]: WalletAccountTransaction[] } = {
                 },
             },
             {
-                descriptor:
+                descriptor: asAccountDescriptor(
                     'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+                ),
                 deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
                 symbol: 'btc',
                 type: 'recv',
@@ -296,8 +300,9 @@ export const transactions: { [key: string]: WalletAccountTransaction[] } = {
     "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0":
         [
             {
-                descriptor:
+                descriptor: asAccountDescriptor(
                     "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)",
+                ),
                 deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
                 symbol: 'btc',
                 type: 'sent',
@@ -367,8 +372,9 @@ export const transactions: { [key: string]: WalletAccountTransaction[] } = {
                 },
             },
             {
-                descriptor:
+                descriptor: asAccountDescriptor(
                     "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)",
+                ),
                 deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
                 symbol: 'btc',
                 type: 'recv',

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -6,6 +6,7 @@ import {
     AccountBackendSpecific,
     AccountFailureSpecific,
     SelectedAccountStatus,
+    asAccountDescriptor,
 } from '@suite-common/wallet-types';
 import {
     enhanceAddresses,
@@ -67,13 +68,13 @@ const createAccount = createAction(
 
             const payload: Account = {
                 ...account,
-                descriptor,
+                descriptor: asAccountDescriptor(descriptor),
                 descriptorChecksum,
                 empty,
                 balance,
                 availableBalance,
                 history,
-                key: getAccountKey(descriptor, symbol, deviceState),
+                key: getAccountKey(asAccountDescriptor(descriptor), symbol, deviceState),
                 formattedBalance: formatNetworkAmount(
                     // Ripple and Stellar `availableBalance` is reduced by reserve, use regular balance
                     isArrayMember(networkType, ['ripple', 'stellar']) ? balance : availableBalance,
@@ -121,6 +122,7 @@ const updateAccount = createAction(
                 payload: {
                     ...account,
                     ...accountInfo,
+                    descriptor: asAccountDescriptor(accountInfo.descriptor),
                     path: account.path,
                     empty: accountInfo.empty,
                     visible: account.visible || !accountInfo.empty,

--- a/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
@@ -1,6 +1,7 @@
 import { TrezorDevice } from '@suite-common/suite-types';
 import { testMocks } from '@suite-common/test-utils';
 import { networks } from '@suite-common/wallet-config';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
 
 import { DeviceRootState } from '../../device/deviceReducer';
 import { AccountsRootState } from '../accountsReducer';
@@ -36,7 +37,7 @@ const mockState: AccountsRootState & DeviceRootState = {
                 tokens: [],
                 symbol: 'btc',
                 path: "m/84'/0'/0'",
-                descriptor: '1BitcoinAddress',
+                descriptor: asAccountDescriptor('1BitcoinAddress'),
                 addresses: {
                     unused: [
                         {
@@ -81,7 +82,7 @@ const mockState: AccountsRootState & DeviceRootState = {
             {
                 symbol: 'eth',
                 networkType: 'ethereum',
-                descriptor: '0xEthereumAddress',
+                descriptor: asAccountDescriptor('0xEthereumAddress'),
                 deviceState: ETH_DEVICE_SSID,
                 key: '0xEthereumAddress-eth-deviceState',
                 accountType: 'normal',

--- a/suite-common/wallet-core/src/transactions/__tests__/transactionsReducer.test.ts
+++ b/suite-common/wallet-core/src/transactions/__tests__/transactionsReducer.test.ts
@@ -6,7 +6,7 @@ import { prepareTransactionsReducer, transactionsInitialState } from '../transac
 
 const transactionsReducer = prepareTransactionsReducer(extraDependenciesMock);
 
-describe('transactionsReducer', () => {
+describe(transactionsReducer.name, () => {
     describe('addTransaction', () => {
         fixtures.addTransaction.forEach(f => {
             it(f.description, () => {

--- a/suite-common/wallet-core/tests/send/composeCancelTransaction/chainedTransactions.fixture.ts
+++ b/suite-common/wallet-core/tests/send/composeCancelTransaction/chainedTransactions.fixture.ts
@@ -1,10 +1,11 @@
-import { ChainedTransactions } from '@suite-common/wallet-types';
+import { ChainedTransactions, asAccountDescriptor } from '@suite-common/wallet-types';
 
 export const chainedTxsFixture: ChainedTransactions = {
     own: [
         {
-            descriptor:
+            descriptor: asAccountDescriptor(
                 'vpub5Z9LPnVj4bx9zqAjLJvRgnaUrcwXaW1H48VYtizkQeP2vLDxqWTNKqeYujfqquxuUEXdAfwtdVuCKYscvz4EXH9cADxKFHyvdapGXQnhvWf',
+            ),
             deviceState: 'mk9cuzrhHk5qy4K4u5tu3aiwD6DXo13zuy@8806280C47785970FA58D555:1',
             symbol: 'regtest',
             type: 'sent',

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -127,7 +127,7 @@ export type Account = {
     index: number;
     path: Bip43Path;
     unlockPath?: PROTO.UnlockPath; // parameter used to unlock SLIP-25/coinjoin keychain
-    descriptor: string;
+    descriptor: AccountDescriptor;
     descriptorChecksum?: string;
     accountType: AccountType;
     symbol: NetworkSymbol;

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -19,7 +19,7 @@ import {
 } from '@trezor/connect';
 import { RequiredKey } from '@trezor/type-utils';
 
-import { Account } from './account';
+import { Account, AccountDescriptor } from './account';
 import { FormStateTradingCryptoCurrency, FormStateTradingFiatCurrency } from './sendForm';
 
 export type { PrecomposedTransactionFinalCardano } from '@trezor/connect';
@@ -231,7 +231,7 @@ export type RbfTransactionParams = RbfTransactionParamsBitcoin | RbfTransactionP
 
 export interface WalletAccountTransaction extends AccountTransaction {
     deviceState: StaticSessionId;
-    descriptor: string;
+    descriptor: AccountDescriptor;
     symbol: NetworkSymbol;
     rbfParams?: RbfTransactionParams;
     /**

--- a/suite-common/wallet-utils/src/__fixtures__/accounts.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/accounts.ts
@@ -1,4 +1,5 @@
 import { testMocks } from '@suite-common/test-utils';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
 
 export const ACCOUNTS = {
     test: {
@@ -269,7 +270,7 @@ export const ACCOUNTS = {
     txrp: {
         ...testMocks.getWalletAccount({
             deviceState: '1stTestnetAddress@device_id:0',
-            descriptor: 'rNaqKtKrMSwpwZSzRckPf7S96DkimjkF4H',
+            descriptor: asAccountDescriptor('rNaqKtKrMSwpwZSzRckPf7S96DkimjkF4H'),
             symbol: 'txrp',
         }),
     },

--- a/suite-common/wallet-utils/src/__fixtures__/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/transactionUtils.ts
@@ -1,5 +1,5 @@
 import { testMocks } from '@suite-common/test-utils';
-import { WalletAccountTransaction } from '@suite-common/wallet-types';
+import { WalletAccountTransaction, asAccountDescriptor } from '@suite-common/wallet-types';
 import { TokenTransfer, TransferType } from '@trezor/blockchain-link-types';
 import { AccountTransaction } from '@trezor/connect';
 
@@ -467,8 +467,9 @@ export const enhanceTransaction = [
         },
         account: getWalletAccount({
             deviceState: '1stTestnetAddress@device_id:0',
-            descriptor:
+            descriptor: asAccountDescriptor(
                 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+            ),
             symbol: 'btc',
             networkType: 'bitcoin',
         }),
@@ -559,8 +560,9 @@ export const enhanceTransaction = [
         },
         account: getWalletAccount({
             deviceState: '1stTestnetAddress@device_id:0',
-            descriptor:
+            descriptor: asAccountDescriptor(
                 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+            ),
             symbol: 'btc',
             networkType: 'bitcoin',
         }),
@@ -622,8 +624,9 @@ export const enhanceTransaction = [
         },
         account: getWalletAccount({
             deviceState: '1stTestnetAddress@device_id:0',
-            descriptor:
+            descriptor: asAccountDescriptor(
                 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+            ),
             symbol: 'btc',
             networkType: 'bitcoin',
         }),
@@ -1278,8 +1281,9 @@ export const getAccountTransactions = [
         transactions: TXS,
         account: getWalletAccount({
             deviceState: '1stTestnetAddress@device_id:0',
-            descriptor:
+            descriptor: asAccountDescriptor(
                 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+            ),
             symbol: 'btc',
         }),
         result: [
@@ -1326,7 +1330,7 @@ export const getAccountTransactions = [
         transactions: TXS,
         account: getWalletAccount({
             deviceState: '1stTestnetAddress@device_id:0',
-            descriptor: 'rNaqKtKrMSwpwZSzRckPf7S96DkimjkF4H',
+            descriptor: asAccountDescriptor('rNaqKtKrMSwpwZSzRckPf7S96DkimjkF4H'),
             symbol: 'txrp',
         }),
         result: [
@@ -1377,7 +1381,7 @@ export const getAccountTransactions = [
         transactions: TXS,
         account: getWalletAccount({
             deviceState: '1stTestnetAddress@device_id:0',
-            descriptor: '0xFA01a39f8Abaeb660c3137f14A310d0b414b2A15',
+            descriptor: asAccountDescriptor('0xFA01a39f8Abaeb660c3137f14A310d0b414b2A15'),
             symbol: 'eth',
         }),
         result: [
@@ -1525,7 +1529,7 @@ export const getAccountTransactions = [
         transactions: TXS,
         account: getWalletAccount({
             deviceState: '1stTestnetAddress@device_id:0',
-            descriptor: '0xf69619a3dCAA63757A6BA0AF3628f5F6C42c50d2',
+            descriptor: asAccountDescriptor('0xf69619a3dCAA63757A6BA0AF3628f5F6C42c50d2'),
             symbol: 'eth',
         }),
         result: [],
@@ -1538,8 +1542,9 @@ export const isPending: Record<string, WalletAccountTransaction | AccountTransac
         blockHash: '00000000000000000017277948d61a631dae6cce1d7fb501301b825599189f51',
         blockHeight: 590093,
         blockTime: 1565797979,
-        descriptor:
+        descriptor: asAccountDescriptor(
             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+        ),
         deviceState: '1stTestnetAddress@device_id:0',
         fee: '0.00002929',
         symbol: 'btc',
@@ -1592,8 +1597,9 @@ export const isPending: Record<string, WalletAccountTransaction | AccountTransac
         },
     },
     'Received and pending transaction': {
-        descriptor:
+        descriptor: asAccountDescriptor(
             'vpub5YoEd2jJofNDXriAXpt4fyX23uRhrViFG3721C1wRRKUvDS4P6St7tqFfDP4JZsRARVhaVcGvW5jerdWBVc1c3fgqZeAYt29QSTiafKdwck',
+        ),
         deviceState: 'mvAmt1x3QTsSmJrR4tbPtMpYnLbi3gDEBu@912734FCB107274D3CC465EC:1',
         symbol: 'test',
         type: 'recv',

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -1,6 +1,6 @@
 import { testMocks } from '@suite-common/test-utils';
 import { NetworkFeature } from '@suite-common/wallet-config';
-import { Account } from '@suite-common/wallet-types';
+import { Account, asAccountDescriptor } from '@suite-common/wallet-types';
 
 import * as fixtures from '../__fixtures__/accountUtils';
 import {
@@ -124,8 +124,9 @@ describe('account utils', () => {
             findAccountDevice(
                 getWalletAccount({
                     deviceState: '1stTestnet@device_id:0',
-                    descriptor:
+                    descriptor: asAccountDescriptor(
                         'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+                    ),
                     symbol: 'btc',
                 }),
                 [
@@ -145,9 +146,13 @@ describe('account utils', () => {
     });
 
     it('getAccountKey', () => {
-        expect(getAccountKey('descriptor', 'symbol', '1stTestnetAddress@device_id:0')).toEqual(
-            'descriptor-symbol-1stTestnetAddress@device_id:0',
-        );
+        expect(
+            getAccountKey(
+                asAccountDescriptor('descriptor'),
+                'btc',
+                '1stTestnetAddress@device_id:0',
+            ),
+        ).toEqual('descriptor-btc-1stTestnetAddress@device_id:0');
     });
 
     it('isTestnet', () => {
@@ -166,8 +171,9 @@ describe('account utils', () => {
             getAccountIdentifier(
                 getWalletAccount({
                     deviceState: '1stTestnet@device_id:0',
-                    descriptor:
+                    descriptor: asAccountDescriptor(
                         'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+                    ),
                     symbol: 'btc',
                 }),
             ),
@@ -182,8 +188,9 @@ describe('account utils', () => {
     it('accountSearchFn', () => {
         const btcAcc = getWalletAccount({
             deviceState: '1stTestnet@device_id:0',
-            descriptor:
+            descriptor: asAccountDescriptor(
                 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+            ),
             symbol: 'btc',
             accountType: 'legacy',
             metadata: {

--- a/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
@@ -376,7 +376,7 @@ describe('transaction utils', () => {
     });
 
     describe('advancedSearchTransactions', () => {
-        const transactions = stMock.transactions as WalletAccountTransaction[];
+        const transactions = stMock.transactions as unknown as WalletAccountTransaction[];
         const metadata = stMock.labels;
         fixtures.searchTransactions.forEach(f => {
             it(f.description, () => {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -373,14 +373,12 @@ export const getAllAccounts = (
 
 /**
  * Returns a string used as an index to separate txs for given account inside a transactions reducer
- *
- * @param {string} descriptor
- * @param {string} symbol
- * @param {string} deviceState
- * @returns {string}
  */
-export const getAccountKey = (descriptor: string, symbol: string, deviceState: string) =>
-    `${descriptor}-${symbol}-${deviceState}`;
+export const getAccountKey = (
+    descriptor: AccountDescriptor,
+    symbol: NetworkSymbol,
+    deviceStaticSessionId: StaticSessionId,
+): AccountKey => `${descriptor}-${symbol}-${deviceStaticSessionId}`;
 
 /**
  * Clear invalid tokens and formats amounts

--- a/suite-native/accounts/src/tests/selectors.test.ts
+++ b/suite-native/accounts/src/tests/selectors.test.ts
@@ -1,4 +1,4 @@
-import { Account, TokenInfoBranded } from '@suite-common/wallet-types';
+import { Account, TokenInfoBranded, asAccountDescriptor } from '@suite-common/wallet-types';
 
 import { getAccountListSections, selectFreshAccountAddress } from '../selectors';
 import {
@@ -167,7 +167,7 @@ describe('selectFreshAccountAddress', () => {
         deviceState: 'device@state:1',
         index: 0,
         path: "m/44'/0'/0'",
-        descriptor: 'descriptor',
+        descriptor: asAccountDescriptor('descriptor'),
         accountType: 'normal',
         empty: false,
         visible: true,

--- a/suite-native/labeling/src/components/AddressLabelEditable.tsx
+++ b/suite-native/labeling/src/components/AddressLabelEditable.tsx
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { WithLabelingState, selectAddressLabel } from '@suite-common/suite-sync';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountDescriptor } from '@suite-common/wallet-types';
 import { useNativeServices } from '@suite-native/services';
 import type { StaticSessionId } from '@trezor/connect';
 
@@ -12,7 +13,7 @@ import { selectIsLabelingEnabled } from '../selectors';
 type AddressLabelEditableProps = {
     address: string;
     deviceStaticSessionId: StaticSessionId;
-    accountDescriptor: string;
+    accountDescriptor: AccountDescriptor;
     networkSymbol: NetworkSymbol;
 };
 

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx
@@ -1,4 +1,4 @@
-import { Account } from '@suite-common/wallet-types';
+import { Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 import { ReceiveAccount } from '@suite-native/trading-types';
 
@@ -19,7 +19,7 @@ const createAccount = (
     deviceState: 'a@b:1',
     index: 0,
     path: `m/0'/0'/0'`,
-    descriptor: '',
+    descriptor: asAccountDescriptor(''),
     accountType: 'normal',
     empty: false,
     visible: false,

--- a/suite-native/qr-code/package.json
+++ b/suite-native/qr-code/package.json
@@ -11,6 +11,7 @@
     },
     "dependencies": {
         "@suite-common/wallet-config": "workspace:*",
+        "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/clipboard": "workspace:*",

--- a/suite-native/qr-code/src/components/AddressQRCode.tsx
+++ b/suite-native/qr-code/src/components/AddressQRCode.tsx
@@ -1,6 +1,7 @@
 import { Alert, Pressable, Share } from 'react-native';
 
 import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountDescriptor } from '@suite-common/wallet-types';
 import { Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { useCopyToClipboard } from '@suite-native/clipboard';
 import { Translation, useTranslate } from '@suite-native/intl';
@@ -13,7 +14,7 @@ import { QRCode } from './QRCode';
 type AddressQRCodeProps = {
     address: string;
     deviceStaticSessionId: StaticSessionId;
-    accountDescriptor: string;
+    accountDescriptor: AccountDescriptor;
     networkSymbol: NetworkSymbol;
 };
 

--- a/suite-native/qr-code/tsconfig.json
+++ b/suite-native/qr-code/tsconfig.json
@@ -6,6 +6,9 @@
             "path": "../../suite-common/wallet-config"
         },
         {
+            "path": "../../suite-common/wallet-types"
+        },
+        {
             "path": "../../suite-common/wallet-utils"
         },
         { "path": "../atoms" },

--- a/suite-native/receive/src/components/ReceiveAddressCard.tsx
+++ b/suite-native/receive/src/components/ReceiveAddressCard.tsx
@@ -6,6 +6,7 @@ import {
     selectIsDeviceInViewOnlyMode,
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
+import { AccountDescriptor } from '@suite-common/wallet-types';
 import { Box, Card, InlineAlertBoxProps } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { AddressQRCode } from '@suite-native/qr-code';
@@ -17,7 +18,7 @@ type ReceiveAddressCardProps = {
     address: string;
     deviceStaticSessionId: StaticSessionId;
     isReceiveApproved: boolean;
-    accountDescriptor: string;
+    accountDescriptor: AccountDescriptor;
     isUnverifiedAddressRevealed: boolean;
     symbol: NetworkSymbol;
     onShowAddress: () => void;

--- a/suite-native/transactions/src/tests/fixtures/transactions.ts
+++ b/suite-native/transactions/src/tests/fixtures/transactions.ts
@@ -1,8 +1,9 @@
-import { WalletAccountTransaction } from '@suite-common/wallet-types';
+import { WalletAccountTransaction, asAccountDescriptor } from '@suite-common/wallet-types';
 
 export const transactionWithTargetInOutputs: WalletAccountTransaction = {
-    descriptor:
+    descriptor: asAccountDescriptor(
         'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+    ),
     deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
     symbol: 'btc',
     type: 'recv',
@@ -61,8 +62,9 @@ export const transactionWithTargetInOutputs: WalletAccountTransaction = {
 };
 
 export const transactionWithChangeAddress: WalletAccountTransaction = {
-    descriptor:
+    descriptor: asAccountDescriptor(
         'zpub6rjNNddoAVvuYaD6WPdxiqFEToQHgrERjWMg7kM9gGGk6rhPMWNEmL5X745FGqBq8Wp136LfA3A7UjRGEYdJrf8dUfshzNrb5rvaryNfVJf',
+    ),
     deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
     symbol: 'btc',
     type: 'sent',

--- a/yarn.lock
+++ b/yarn.lock
@@ -13310,6 +13310,7 @@ __metadata:
   resolution: "@suite-native/qr-code@workspace:suite-native/qr-code"
   dependencies:
     "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/clipboard": "workspace:*"


### PR DESCRIPTION
use AccountDescriptor as branded type

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=account-descriptor2&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=account-descriptor2&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=account-descriptor2&lookback=7)