### PR TITLE
enhance tradingFeedbackForm experiment with TradingDetailSurvey

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/AfterTradeExperiment.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/AfterTradeExperiment.tsx
@@ -1,0 +1,57 @@
+import {
+    BuyTradeStatus,
+    ExchangeProviderInfo,
+    ExchangeTradeStatus,
+    SellTradeStatus,
+} from 'invity-api';
+
+import { ExperimentId } from '@suite-common/message-system';
+import { TradingType } from '@suite-common/trading';
+
+import { ExperimentWrapper } from 'src/components/suite/Experiment/ExperimentWrapper';
+import { TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
+
+import { TradingDetailFeedback } from './TradingDetailFeedback';
+import { TradingDetailSurvey } from './TradingDetailSurvey';
+
+interface AfterTradeExperimentProps {
+    status: ExchangeTradeStatus | SellTradeStatus | BuyTradeStatus | undefined;
+    type: TradingType;
+    provider?: ExchangeProviderInfo['name'];
+    id?: string;
+    quoteAmounts: TradingGetCryptoQuoteAmountProps;
+    country?: string;
+}
+
+export const AfterTradeExperiment = ({
+    status,
+    type,
+    provider,
+    id,
+    quoteAmounts,
+    country,
+}: AfterTradeExperimentProps) => (
+    <ExperimentWrapper
+        id={ExperimentId.tradingFeedbackForm}
+        components={[
+            { variant: 'A', element: <></> },
+            {
+                variant: 'B',
+                element: (
+                    <TradingDetailFeedback
+                        status={status}
+                        type={type}
+                        provider={provider}
+                        id={id}
+                        quoteAmounts={quoteAmounts}
+                        country={country}
+                    />
+                ),
+            },
+            {
+                variant: 'C',
+                element: <TradingDetailSurvey />,
+            },
+        ]}
+    />
+);

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
@@ -14,11 +14,11 @@ import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { useTradingDetailContext } from 'src/hooks/wallet/trading/useTradingDetail';
 import { TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
+import { AfterTradeExperiment } from 'src/views/wallet/trading/common/TradingDetail/AfterTradeExperiment';
 import { TradingDetailBuyPaymentFailed } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentFailed';
 import { TradingDetailBuyPaymentProcessingStep } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentProcessingStep';
 import { TradingDetailBuyPaymentPaymentSuccessful } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentSuccessful';
 import { TradingDetailBuyPaymentWaitingForUserStep } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentWaitingForUserStep';
-import { TradingDetailFeedback } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback';
 import { TradingSelectedOfferInfo } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo';
 import { TradingWrapper } from 'src/views/wallet/trading/common/TradingWrapper';
 
@@ -163,7 +163,7 @@ export const TradingDetailBuy = () => {
                 <Card paddingType="large" data-testid="@trading/transaction/detail/status-card">
                     {getContent()}
                 </Card>
-                <TradingDetailFeedback
+                <AfterTradeExperiment
                     status={tradeStatus}
                     type={trade.tradeType}
                     provider={provider?.name}

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -4,7 +4,6 @@ import { usePrevious } from 'react-use';
 import { ExchangeTradeStatus } from 'invity-api';
 import styled from 'styled-components';
 
-import { Feature, selectFeatureConfig } from '@suite-common/message-system';
 import {
     type TradingExchangeType,
     selectTradingComposedTransactionInfo,
@@ -19,17 +18,16 @@ import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { useTradingDetailContext } from 'src/hooks/wallet/trading/useTradingDetail';
 import { tradeFinalStatuses } from 'src/hooks/wallet/trading/useTradingWatchTrade';
 import { TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
+import { AfterTradeExperiment } from 'src/views/wallet/trading/common/TradingDetail/AfterTradeExperiment';
 import { TradingDetailExchangePaymentConverting } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentConverting';
 import { TradingDetailExchangePaymentFailed } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentFailed';
 import { TradingDetailExchangePaymentKYC } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentKYC';
 import { TradingDetailExchangePaymentSending } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentSending';
 import { TradingDetailExchangePaymentSuccessful } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentSuccessful';
-import { TradingDetailFeedback } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback';
 import { TradingSelectedOfferInfo } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo';
 import { TradingWrapper } from 'src/views/wallet/trading/common/TradingWrapper';
 
 import { TradingDetailStepList } from '../TradingDetailStepList';
-import { TradingDetailSurvey } from '../TradingDetailSurvey';
 
 const Wrapper = styled.div`
     ${TradingWrapper}
@@ -58,9 +56,6 @@ const getTradeStatusStep = (tradeStatus: ExchangeTradeStatus) => {
 export const TradingDetailExchange = () => {
     const accounts = useSelector(selectAccounts);
     const { trade, info } = useTradingDetailContext<TradingExchangeType>();
-    const tradingSurveyFeature = useSelector(state =>
-        selectFeatureConfig(state, Feature.trading.survey),
-    );
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
 
@@ -179,17 +174,13 @@ export const TradingDetailExchange = () => {
                 <Card paddingType="large" data-testid="@trading/transaction/detail/status-card">
                     {getContent()}
                 </Card>
-                {tradingSurveyFeature ? (
-                    <TradingDetailSurvey />
-                ) : (
-                    <TradingDetailFeedback
-                        status={tradeStatus}
-                        type={trade.tradeType}
-                        provider={provider?.name}
-                        id={trade.data.id}
-                        quoteAmounts={quoteAmounts}
-                    />
-                )}
+                <AfterTradeExperiment
+                    status={tradeStatus}
+                    type={trade.tradeType}
+                    provider={provider?.name}
+                    id={trade.data.id}
+                    quoteAmounts={quoteAmounts}
+                />
             </Column>
             <Card>
                 <TradingSelectedOfferInfo

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback.tsx
@@ -9,12 +9,11 @@ import {
 
 import { Rating, buildUserFeedbackData, sendFeedbackAction } from '@suite-common/feedback';
 import { selectCountryCode } from '@suite-common/geolocation';
-import { ExperimentId, selectActiveExperimentsWithVariants } from '@suite-common/message-system';
+import { selectActiveExperimentsWithVariants } from '@suite-common/message-system';
 import { TradingType } from '@suite-common/trading';
 import { Button, Card, Column, H3, IconCircle, Paragraph, Row, Textarea } from '@trezor/components';
 
 import { EmojiRatingSelector } from 'src/components/suite/EmojiRatingSelector';
-import { ExperimentWrapper } from 'src/components/suite/Experiment/ExperimentWrapper';
 import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
@@ -121,21 +120,10 @@ export const TradingDetailFeedback = ({
     );
 
     return (
-        <ExperimentWrapper
-            id={ExperimentId.tradingFeedbackForm}
-            components={[
-                { variant: 'A', element: <></> },
-                {
-                    variant: 'B',
-                    element: (
-                        <Card>
-                            <Column gap={16} alignItems="start" margin={{ vertical: 8 }}>
-                                {view === 'form' ? Form : Success}
-                            </Column>
-                        </Card>
-                    ),
-                },
-            ]}
-        />
+        <Card>
+            <Column gap={16} alignItems="start" margin={{ vertical: 8 }}>
+                {view === 'form' ? Form : Success}
+            </Column>
+        </Card>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
@@ -15,7 +15,7 @@ import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { useTradingDetailContext } from 'src/hooks/wallet/trading/useTradingDetail';
 import { tradeFinalStatuses } from 'src/hooks/wallet/trading/useTradingWatchTrade';
 import { TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
-import { TradingDetailFeedback } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback';
+import { AfterTradeExperiment } from 'src/views/wallet/trading/common/TradingDetail/AfterTradeExperiment';
 import { TradingDetailSellPaymentFailed } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentFailed';
 import { TradingDetailSellPaymentSending } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentSending';
 import { TradingDetailSellPaymentSuccessful } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentSuccessful';
@@ -146,7 +146,7 @@ export const TradingDetailSell = () => {
                 <Card paddingType="large" data-testid="@trading/transaction/detail/status-card">
                     {getContent()}
                 </Card>
-                <TradingDetailFeedback
+                <AfterTradeExperiment
                     status={tradeStatus}
                     type={trade.tradeType}
                     provider={provider?.name}


### PR DESCRIPTION
Followup to #22136

Previously only TradingDetailFeedback was part of the experiment, but we also want to have TradingDetailSurvey as another variant of such experiment.

<!--- Provide a general summary of your changes in the Title above -->

This PR  puts TradingDetailSurvey into the same experiment

<!--- Describe your changes in detail -->

## Notes for QA

Prepare experiment with variants: A, B and C. A should be empty, B with feedback and C with Survey
## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-improve-survey-experiment-setup&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-improve-survey-experiment-setup&lookback=7)