### PR TITLE
fix(suite): ConfirmValueModal unsafe non null assertion

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -77,7 +77,7 @@ export const ConfirmValueModal = ({
     const { translationString } = useTranslation();
 
     const { isSuiteSyncEnabled, legacyMetadataState } = useLabelingCombined({
-        deviceStaticSessionId: account!.deviceState,
+        deviceStaticSessionId: account?.deviceState,
     });
     // block labeling if metadata needs to be enabled on device until receive address is confirmed (device locked)
     const isMetadataBlockedByDeviceCall =


### PR DESCRIPTION
## Description

Problem snuck in #22929

## Notes for QA

Nothing to test

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/confirmvaluemodal-labeling-account-undefined&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/confirmvaluemodal-labeling-account-undefined&lookback=7)