### PR TITLE
wip: fix(connect): when bootloader always use V1 protocol

### DIFF
--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -495,6 +495,8 @@ export const onCallFirmwareUpdate = async ({
             await device.release();
             // wait for device-change
             await waitForBluetoothReboot({ device, target: 'bootloader', postMessage });
+            // Bootloader always uses V1 protocol.
+            device.reset();
         } else {
             await disconnectedPromise;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/fw-installation-in-ble-linux-reset-device&lookback=7)