### PR TITLE
Swap - exclude value of To field from From field

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingBuildAccountGroups.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingBuildAccountGroups.ts
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 
+import { CryptoId } from 'invity-api';
+
 import { type TradingType, selectTradingSupportedSymbols } from '@suite-common/trading';
 import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
 
@@ -10,6 +12,7 @@ import { tradingBuildAccountOptions } from 'src/utils/wallet/trading/tradingUtil
 
 export const useTradingBuildAccountGroups = (
     type: TradingType,
+    excludeCryptoId?: CryptoId,
 ): TradingAccountsOptionsGroupProps[] => {
     const accounts = useSelector(selectAccounts);
     const accountLabels = useSelector(selectAccountLabels);
@@ -27,6 +30,7 @@ export const useTradingBuildAccountGroups = (
                 tokenDefinitions,
                 supportedCryptoIds: new Set(supportedSymbols),
                 getDefaultAccountLabel,
+                excludeCryptoId,
             }),
 
         [
@@ -36,6 +40,7 @@ export const useTradingBuildAccountGroups = (
             tokenDefinitions,
             supportedSymbols,
             getDefaultAccountLabel,
+            excludeCryptoId,
         ],
     );
 

--- a/packages/suite/src/types/trading/trading.ts
+++ b/packages/suite/src/types/trading/trading.ts
@@ -116,6 +116,7 @@ export interface TradingBuildAccountOptionsProps extends TradingGetSortedAccount
     }: GetDefaultAccountLabelParams) => string;
     supportedCryptoIds: Set<CryptoId> | undefined;
     tokenDefinitions: Partial<TokenDefinitionsState>;
+    excludeCryptoId?: CryptoId;
 }
 
 export interface TradingAccountOptionsGroupOptionProps {

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -320,6 +320,7 @@ export interface TradingFormInputAccountProps {
     label?: TranslationKey;
     accountSelectName: typeof TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT;
     'data-testid'?: string;
+    excludeCryptoId?: CryptoId;
 }
 
 export interface TradingFormInputCurrencyProps {

--- a/packages/suite/src/utils/wallet/trading/tradingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingUtils.ts
@@ -2,7 +2,12 @@ import { BuyTrade, CryptoId, ExchangeTrade, FiatCurrencyCode, SellFiatTrade } fr
 
 import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
 import { DefinitionType, isTokenDefinitionKnown } from '@suite-common/token-definitions';
-import { type TradingType, cryptoIdToSymbol, toTokenCryptoId } from '@suite-common/trading';
+import {
+    type TradingType,
+    cryptoIdToNetworkAndContractAddress,
+    cryptoIdToSymbol,
+    toTokenCryptoId,
+} from '@suite-common/trading';
 import {
     Network,
     NetworkSymbol,
@@ -174,6 +179,7 @@ export const tradingBuildAccountOptions = ({
     tokenDefinitions,
     supportedCryptoIds,
     getDefaultAccountLabel,
+    excludeCryptoId,
 }: TradingBuildAccountOptionsProps): TradingAccountsOptionsGroupProps[] => {
     const accountsSorted = tradingGetSortedAccounts({
         accounts,
@@ -181,6 +187,8 @@ export const tradingBuildAccountOptions = ({
     });
 
     const groups: TradingAccountsOptionsGroupProps[] = [];
+
+    const excludeNetworkAndContractAddress = cryptoIdToNetworkAndContractAddress(excludeCryptoId);
 
     accountsSorted.forEach(account => {
         const {
@@ -195,6 +203,13 @@ export const tradingBuildAccountOptions = ({
         const network = getNetwork(accountSymbol);
 
         if (!network.tradeCryptoId) {
+            return;
+        }
+
+        if (
+            !excludeNetworkAndContractAddress.contractAddress &&
+            excludeNetworkAndContractAddress.network?.symbol === accountSymbol
+        ) {
             return;
         }
 
@@ -237,6 +252,18 @@ export const tradingBuildAccountOptions = ({
 
                 const tokenCryptoId = toTokenCryptoId(accountSymbol, contractAddress);
                 if (supportedCryptoIds && !supportedCryptoIds.has(tokenCryptoId)) {
+                    return;
+                }
+
+                if (
+                    excludeCryptoId &&
+                    excludeNetworkAndContractAddress.network &&
+                    tokenCryptoId ===
+                        getContractAddressForNetworkSymbol(
+                            excludeNetworkAndContractAddress.network?.symbol,
+                            excludeCryptoId,
+                        )
+                ) {
                     return;
                 }
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -98,6 +98,7 @@ export const TradingExchangeFormInputs = () => {
                 /> */}
                 <TradingFormInputAccount
                     accountSelectName={TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT}
+                    excludeCryptoId={receiveCryptoSelect?.id}
                     label="TR_FROM"
                     data-testid="@trading/form/trade-from/select-crypto"
                 />

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAccount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAccount.tsx
@@ -29,6 +29,7 @@ import { TradingFormInputAccountOption } from 'src/views/wallet/trading/common/T
 export const TradingFormInputAccount = ({
     label,
     accountSelectName,
+    excludeCryptoId,
     'data-testid': dataTestId,
 }: TradingFormInputAccountProps) => {
     const context = useTradingFormContext<TradingTradeSellExchangeType>();
@@ -41,8 +42,7 @@ export const TradingFormInputAccount = ({
         },
         methods,
     } = context;
-    const optionGroups = useTradingBuildAccountGroups(type);
-
+    const optionGroups = useTradingBuildAccountGroups(type, excludeCryptoId);
     const { isLoading } = useSelector(selectTradingLoadingAndTimestamp);
 
     const { getValues, control } = methods as UseFormReturn<TradingSellExchangeFormProps>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix swap: exclude value of To field from From field. __It's only a hotfix. The whole `From` field gonna be replaced in this [PR](https://github.com/trezor/trezor-suite/pull/24232)__. 🙏   

## Related Issue

Resolve #24266

## Screenshots:

<img width="811" height="661" alt="Snímek obrazovky 2026-01-09 v 13 30 21" src="https://github.com/user-attachments/assets/c8d78bc7-38ca-4c0f-aa1d-cfb4454d330b" />
<img width="802" height="412" alt="Snímek obrazovky 2026-01-09 v 13 35 46" src="https://github.com/user-attachments/assets/d788d4ee-af3a-469c-ad62-6e5a85fa0e74" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/24266-old-from-picker-field&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/24266-old-from-picker-field&lookback=7)