### PR TITLE
feat(suite-native): connect popup better error state

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -635,6 +635,7 @@ export const messages = {
             discoveryRunning: 'Discovery running, please wait...',
         },
         errors: {
+            requestFailed: 'Request failed',
             deviceNotConnected: 'Device not connected.',
             invalidCallback: 'Invalid callback URL',
             invalidParams: 'Invalid parameters from calling app',
@@ -649,6 +650,7 @@ export const messages = {
         trezorConnect: {
             title: 'Trezor Connect',
             forget: 'Forget',
+            retry: 'Retry',
         },
         walletConnect: {
             title: 'WalletConnect',

--- a/suite-native/module-connect-popup/src/components/ConnectErrorMessage.tsx
+++ b/suite-native/module-connect-popup/src/components/ConnectErrorMessage.tsx
@@ -1,0 +1,93 @@
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { connectPopupCallThunkInner, selectConnectPopupCall } from '@suite-common/connect-popup';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { Box, Button, Card, PictogramTitleHeader, VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+export const ConnectErrorMessage = () => {
+    const dispatch = useDispatch();
+    const navigation = useNavigation();
+    const popupCall = useSelector(selectConnectPopupCall);
+    const selectedDevice = useSelector(selectSelectedDevice);
+
+    if (popupCall?.state !== 'call-error' && popupCall?.state !== 'error') return null;
+
+    const getErrorMessage = () => {
+        switch (popupCall.error.code) {
+            case 'Deeplink_VersionMismatch':
+                return <Translation id="moduleConnectPopup.errors.versionUnsupported" />;
+            case 'Method_NotAllowed':
+                return <Translation id="moduleConnectPopup.errors.methodNotAllowed" />;
+            case 'Device_Disconnected':
+            case 'Device_NotFound':
+                return <Translation id="moduleConnectPopup.errors.deviceNotConnected" />;
+            case 'Method_Interrupted':
+            case 'Method_Cancel':
+            case 'Failure_ActionCancelled':
+                return <Translation id="moduleConnectPopup.errors.methodCanceled" />;
+            case 'Method_InvalidParameter':
+                return <Translation id="moduleConnectPopup.errors.invalidParams" />;
+            default:
+                return (
+                    <Translation
+                        id="moduleConnectPopup.errors.unknownError"
+                        values={{ code: popupCall.error.code }}
+                    />
+                );
+        }
+    };
+    const canRetry =
+        popupCall?.state === 'call-error' &&
+        ['Device_Disconnected', 'Device_NotFound'].includes(popupCall.error.code);
+
+    const onResume = () => {
+        if (popupCall?.state === 'call-error')
+            dispatch(
+                connectPopupCallThunkInner({
+                    ...popupCall,
+                    payload: {
+                        ...popupCall.payload,
+                        // override previously selected device
+                        device: selectedDevice,
+                    },
+                }),
+            );
+    };
+    const onClose = () => {
+        if (navigation.canGoBack()) {
+            navigation.goBack();
+        }
+    };
+
+    return (
+        <VStack testID="@popup/connect-error" flex={1}>
+            <Card>
+                <VStack spacing="sp16">
+                    <Box padding="sp16">
+                        <PictogramTitleHeader
+                            variant="critical"
+                            title={<Translation id="moduleConnectPopup.errors.requestFailed" />}
+                            titleVariant="titleSmall"
+                            subtitle={getErrorMessage()}
+                        />
+                    </Box>
+
+                    <VStack spacing="sp12">
+                        {canRetry && (
+                            <Button testID="@popup/retry" onPress={onResume} colorScheme="redBold">
+                                <Translation id="moduleConnectPopup.trezorConnect.retry" />
+                            </Button>
+                        )}
+
+                        <Button testID="@popup/close" onPress={onClose} colorScheme="redElevation0">
+                            <Translation id="generic.buttons.close" />
+                        </Button>
+                    </VStack>
+                </VStack>
+            </Card>
+        </VStack>
+    );
+};

--- a/suite-native/module-connect-popup/src/components/PermissionConfirmation.tsx
+++ b/suite-native/module-connect-popup/src/components/PermissionConfirmation.tsx
@@ -113,14 +113,16 @@ export const PermissionConfirmation = () => {
                 </PressableOpacity>
             </Card>
 
-            <Button testID="@popup/call-device" onPress={onConfirm}>
-                {popupCall.methodInfo.confirmLabel || (
-                    <Translation id="moduleConnectPopup.confirm" />
-                )}
-            </Button>
-            <Button colorScheme="tertiaryElevation0" onPress={onClose}>
-                <Translation id="generic.buttons.close" />
-            </Button>
+            <VStack spacing="sp12">
+                <Button testID="@popup/call-device" onPress={onConfirm}>
+                    {popupCall.methodInfo.confirmLabel || (
+                        <Translation id="moduleConnectPopup.confirm" />
+                    )}
+                </Button>
+                <Button colorScheme="tertiaryElevation0" onPress={onClose}>
+                    <Translation id="generic.buttons.close" />
+                </Button>
+            </VStack>
         </VStack>
     );
 };

--- a/suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx
@@ -10,13 +10,14 @@ import {
     selectIsDeviceConnectedAndAuthorized,
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
-import { Box, Button, ErrorMessage, Loader } from '@suite-native/atoms';
+import { Box, Loader } from '@suite-native/atoms';
 import { DeviceManager } from '@suite-native/device-manager';
 import { Translation } from '@suite-native/intl';
 import { Screen } from '@suite-native/navigation';
 
 import { AddressConfirmation } from '../components/AddressConfirmation';
 import { ButtonRequestsOverlay } from '../components/ButtonRequestsOverlay';
+import { ConnectErrorMessage } from '../components/ConnectErrorMessage';
 import { PermissionConfirmation } from '../components/PermissionConfirmation';
 import { TxSimulation } from '../components/TxSimulation';
 
@@ -85,49 +86,8 @@ export const ConnectPopupScreen = () => {
             return <TxSimulation />;
         }
 
-        if (popupCall?.state === 'call-error') {
-            const getErrorMessage = () => {
-                switch (popupCall.error.code) {
-                    case 'Deeplink_VersionMismatch':
-                        return <Translation id="moduleConnectPopup.errors.versionUnsupported" />;
-                    case 'Method_NotAllowed':
-                        return <Translation id="moduleConnectPopup.errors.methodNotAllowed" />;
-                    case 'Device_Disconnected':
-                    case 'Device_NotFound':
-                        return <Translation id="moduleConnectPopup.errors.deviceNotConnected" />;
-                    case 'Method_Interrupted':
-                    case 'Method_Cancel':
-                    case 'Failure_ActionCancelled':
-                        return <Translation id="moduleConnectPopup.errors.methodCanceled" />;
-                    case 'Method_InvalidParameter':
-                        return <Translation id="moduleConnectPopup.errors.invalidParams" />;
-                    default:
-                        return (
-                            <Translation
-                                id="moduleConnectPopup.errors.unknownError"
-                                values={{ code: popupCall.error.code }}
-                            />
-                        );
-                }
-            };
-            const onClose = () => {
-                if (navigation.canGoBack()) {
-                    navigation.goBack();
-                }
-            };
-
-            return (
-                <>
-                    <ErrorMessage errorMessage={getErrorMessage()} />
-                    <Button
-                        testID="@popup/close"
-                        onPress={onClose}
-                        colorScheme="tertiaryElevation0"
-                    >
-                        <Translation id="generic.buttons.close" />
-                    </Button>
-                </>
-            );
+        if (popupCall?.state === 'call-error' || popupCall?.state === 'error') {
+            return <ConnectErrorMessage />;
         }
 
         return (
@@ -136,7 +96,7 @@ export const ConnectPopupScreen = () => {
                 title={<Translation id="moduleConnectPopup.connectionStatus.loading" />}
             />
         );
-    }, [validDevice, popupCall, discoveryActive, navigation]);
+    }, [validDevice, popupCall, discoveryActive]);
 
     return (
         <Screen>
@@ -145,7 +105,6 @@ export const ConnectPopupScreen = () => {
             </Box>
 
             <Box
-                padding="sp8"
                 paddingTop="sp16"
                 flex={1}
                 justifyContent={isLoading ? 'center' : 'flex-start'}


### PR DESCRIPTION
## Description

Improved design and functionality of the error screen on mobile for Connect Popup. 
The layout is more polished using design system standards and it now includes a retry button for device reconnection. 

## Notes for QA

Try a connect popup call with device disconnected, see new screen, connect device and click retry. 

## Screenshots:

|Before|After|
|-|-|
|<img width="603" height="1311" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-09 at 13 42 36" src="https://github.com/user-attachments/assets/0c7ad962-3e2c-47d5-9ca6-202845259f40" />|<img width="540" height="1200" alt="Screenshot_1768233770" src="https://github.com/user-attachments/assets/655e5736-bc35-435f-bf91-ba7aa6db881e" />|


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-error-mobile-better-error-screen&lookback=7)