### PR TITLE
Fix trading e2e tests

### DIFF
--- a/packages/suite/src/views/wallet/trading/redirect/TradingRedirect.tsx
+++ b/packages/suite/src/views/wallet/trading/redirect/TradingRedirect.tsx
@@ -35,7 +35,7 @@ export const TradingRedirect = () => {
 
     useEffect(() => {
         // get rid of parameters appended by some partners to url which we pass to them
-        const params = router?.hash?.split('?')[0].split('/');
+        const params = router?.hash?.replace(/^#/, '').split('?')[0].split('/');
         if (!params) return;
 
         const redirectCommonParams = {


### PR DESCRIPTION
## Description

Hash string from the router now starts with #, so it's required to strip it in `TradingRedirect`.

Also, the whole local-hash-parsing is an abomination and I'm going to move it to router where it belongs.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/e2e-trading-redirection&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/e2e-trading-redirection&lookback=7)