### PR TITLE
fix(suite): format experiments variants for analytics

### DIFF
--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -1,4 +1,7 @@
-import { selectActiveExperimentsWithVariants } from '@suite-common/message-system';
+import {
+    formatExperimentVariantsForAnalytics,
+    selectActiveExperimentsWithVariants,
+} from '@suite-common/message-system';
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';
 import {
     selectRememberedHiddenWalletsCount,
@@ -88,7 +91,7 @@ export const getSuiteReadyPayload = async (
 
         isAutomaticUpdateEnabled: state.desktopUpdate.isAutomaticUpdateEnabled,
 
-        experimentVariants: experimentVariants.map(({ name, variant }) => `${name}:${variant}`),
+        experimentVariants: formatExperimentVariantsForAnalytics(experimentVariants),
 
         mevProtection: state.wallet.settings.mevProtection,
         networkReserve: state.wallet.settings.networkReserve,

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback.tsx
@@ -9,7 +9,10 @@ import {
 
 import { Rating, buildUserFeedbackData, sendFeedbackAction } from '@suite-common/feedback';
 import { selectCountryCode } from '@suite-common/geolocation';
-import { selectActiveExperimentsWithVariants } from '@suite-common/message-system';
+import {
+    formatExperimentVariantsForAnalytics,
+    selectActiveExperimentsWithVariants,
+} from '@suite-common/message-system';
 import { TradingType } from '@suite-common/trading';
 import { Button, Card, Column, H3, IconCircle, Paragraph, Row, Textarea } from '@trezor/components';
 
@@ -65,7 +68,9 @@ export const TradingDetailFeedback = ({
                     receiveCurrency,
                     geolocation: geolocation || undefined,
                     countryOfResidence: country || undefined,
-                    activeExperimentsWithVariants,
+                    activeExperimentsWithVariants: formatExperimentVariantsForAnalytics(
+                        activeExperimentsWithVariants,
+                    ),
                     ...userData,
                 },
             }),

--- a/suite-common/message-system/src/experimentUtils.ts
+++ b/suite-common/message-system/src/experimentUtils.ts
@@ -65,3 +65,7 @@ export const getActiveExperimentGroup = ({
 
     return experimentRange;
 };
+
+export const formatExperimentVariantsForAnalytics = (
+    experimentVariants: Array<{ name: keyof typeof ExperimentId; variant: string }>,
+): string[] => experimentVariants.map(({ name, variant }) => `${name}:${variant}`);


### PR DESCRIPTION
## Description

Replace inline formatting with `formatExperimentVariantsForAnalytics` utility to ensure experiment variants are properly serialized as strings instead of `[object Object]` in analytics payloads.

Applies to `getSuiteReadyPayload` and `TradingDetailFeedback`.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23035#issuecomment-3718315149

## Screenshots:

<img width="758" height="664" alt="image" src="https://github.com/user-attachments/assets/d69ead49-5f90-4fdf-b9cf-43275eb98d82" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/format-experiment-variants-for-analytics&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/format-experiment-variants-for-analytics&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/format-experiment-variants-for-analytics&lookback=7)