### PR TITLE
suite-native: test-utils update

### DIFF
--- a/suite-native/test-utils/src/StoreProviderForTests.tsx
+++ b/suite-native/test-utils/src/StoreProviderForTests.tsx
@@ -1,5 +1,4 @@
-import { type ReactNode, useEffect, useState } from 'react';
-import { View } from 'react-native';
+import { type ReactNode, useMemo } from 'react';
 import { Provider } from 'react-redux';
 
 import { useFormattersConfig } from '@suite-native/formatters-config';
@@ -15,8 +14,6 @@ type ReduxProviderProps = {
     injectedStore?: TestStore;
 };
 
-export const STORE_WARMING_UP_MSG = 'Store is warming up...';
-
 const BasicProviderWithFormattingConfig = ({ children }: { children: ReactNode }) => {
     const formattersConfig = useFormattersConfig();
 
@@ -28,34 +25,24 @@ const BasicProviderWithFormattingConfig = ({ children }: { children: ReactNode }
 };
 
 /*
-This file is a copy of `StoreProvider.tsx` from `suite-native/state` but with ability
-to pass `preloadedState` of `injectedStore` as a prop and without the `Persistor` and  `Sentry` logic.
+Simplified synchronous (= no async warming up) version of `StoreProvider.tsx` from `suite-native/state` but without async logic
+for persisted state or Sentry. Allows to specify `preloadedState` of store or even inject precomposed
+store with `injectedStore`.
  */
 export const StoreProviderForTests = ({
     children,
     injectedStore,
     preloadedState,
 }: ReduxProviderProps) => {
-    const [store, setStore] = useState<TestStore | null>(null);
-
-    useEffect(() => {
+    const store = useMemo(() => {
         if (injectedStore) {
-            setStore(injectedStore);
-
-            return;
+            return injectedStore;
         }
 
-        const initStoreAsync = () => {
-            const { store: freshStore } = initStore(preloadedState);
-            setStore(freshStore);
-        };
+        const { store: freshStore } = initStore(preloadedState);
 
-        initStoreAsync();
+        return freshStore;
     }, [injectedStore, preloadedState]);
-
-    if (store === null) {
-        return <View accessibilityLabel={STORE_WARMING_UP_MSG} />;
-    }
 
     return (
         <Provider store={store}>

--- a/suite-native/test-utils/src/renderWithStore.tsx
+++ b/suite-native/test-utils/src/renderWithStore.tsx
@@ -10,25 +10,23 @@ import {
 
 import type { PreloadedState } from '@suite-native/state';
 
-import {
-    STORE_WARMING_UP_MSG,
-    StoreProviderForTests,
-    type TestStore,
-} from './StoreProviderForTests';
+import { StoreProviderForTests, type TestStore } from './StoreProviderForTests';
 
-export const renderWithStoreProviderAsync = async <Props,>(
+type RenderOptionsExtended = RenderOptions & {
+    preloadedState?: PreloadedState;
+    store?: TestStore;
+};
+
+type RenderHookOptionsExtended<Props> = RenderHookOptions<Props> & {
+    preloadedState?: PreloadedState;
+    store?: TestStore;
+};
+
+export const renderWithStoreProvider = <Props,>(
     element: ReactElement<Props>,
-    {
-        preloadedState,
-        wrapper: Wrapper,
-        store,
-        ...options
-    }: RenderOptions & {
-        preloadedState?: PreloadedState;
-        store?: TestStore;
-    } = {},
-) => {
-    const ret = render(element, {
+    { preloadedState, wrapper: Wrapper, store, ...options }: RenderOptionsExtended = {},
+) =>
+    render(element, {
         wrapper: ({ children }) => (
             <StoreProviderForTests preloadedState={preloadedState} injectedStore={store}>
                 {Wrapper ? <Wrapper>{children}</Wrapper> : children}
@@ -37,24 +35,25 @@ export const renderWithStoreProviderAsync = async <Props,>(
         ...options,
     });
 
-    await waitFor(() => expect(ret.queryByLabelText(STORE_WARMING_UP_MSG)).toBeNull());
+/**
+ * @deprecated Use renderWithStoreProvider instead
+ */
+export const renderWithStoreProviderAsync = async <Props,>(
+    element: ReactElement<Props>,
+    options?: RenderOptionsExtended,
+) => {
+    const ret = renderWithStoreProvider(element, options);
+    // There is no need to wait anymore, but keep the async logic here to maintain async behavior.
+    await waitFor(() => expect(true).toBeTruthy());
 
     return ret;
 };
 
-export const renderHookWithStoreProviderAsync = async <Result, Props>(
+export const renderHookWithStoreProvider = <Result, Props>(
     callback: (props: Props) => Result,
-    {
-        preloadedState,
-        wrapper: Wrapper,
-        store,
-        ...options
-    }: RenderHookOptions<Props> & {
-        preloadedState?: PreloadedState;
-        store?: TestStore;
-    } = {},
-) => {
-    const ret = renderHook(callback, {
+    { preloadedState, wrapper: Wrapper, store, ...options }: RenderHookOptionsExtended<Props> = {},
+) =>
+    renderHook(callback, {
         wrapper: ({ children }) => (
             <StoreProviderForTests preloadedState={preloadedState} injectedStore={store}>
                 {Wrapper ? <Wrapper>{children}</Wrapper> : children}
@@ -63,6 +62,15 @@ export const renderHookWithStoreProviderAsync = async <Result, Props>(
         ...options,
     });
 
+/**
+ * @deprecated Use renderHookWithStoreProvider instead
+ */
+export const renderHookWithStoreProviderAsync = async <Result, Props>(
+    callback: (props: Props) => Result,
+    options?: RenderHookOptionsExtended<Props>,
+) => {
+    const ret = renderHookWithStoreProvider(callback, options);
+    // There is no need to wait anymore, but keep the async logic here to maintain async behavior.
     await waitFor(() => expect(ret.result.current).not.toBeNull());
 
     return ret;

--- a/suite-native/trading-debug/src/components/__tests__/TradingEnvironmentWarning.comp.test.tsx
+++ b/suite-native/trading-debug/src/components/__tests__/TradingEnvironmentWarning.comp.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 import { tradingInitialState } from '@suite-native/trading-consts';
 import type { TradingState } from '@suite-native/trading-types';
 
@@ -8,7 +8,7 @@ describe('TradingEnvironmentWarning', () => {
     const renderTradingEnvironmentWarning = (
         tradingEnvironment: TradingState['tradingEnvironment'],
     ) =>
-        renderWithStoreProviderAsync(<TradingEnvironmentWarning />, {
+        renderWithStoreProvider(<TradingEnvironmentWarning />, {
             preloadedState: {
                 wallet: {
                     trading: {
@@ -19,16 +19,16 @@ describe('TradingEnvironmentWarning', () => {
             },
         });
 
-    it('should render nothing when tradingEnvironment is [production]', async () => {
-        const { toJSON } = await renderTradingEnvironmentWarning('production');
+    it('should render nothing when tradingEnvironment is [production]', () => {
+        const { toJSON } = renderTradingEnvironmentWarning('production');
 
         expect(toJSON()).toBeNull();
     });
 
     it.each<TradingState['tradingEnvironment']>(['staging', 'dev', 'localhost'])(
         'should render warning for tradingEnvironment [%s]',
-        async tradingEnvironment => {
-            const { getByText } = await renderTradingEnvironmentWarning(tradingEnvironment);
+        tradingEnvironment => {
+            const { getByText } = renderTradingEnvironmentWarning(tradingEnvironment);
 
             expect(getByText(`Trading environment: ${tradingEnvironment}`)).toBeOnTheScreen();
         },

--- a/suite-native/trading-debug/src/hooks/__tests__/useTradingDebugModeFlag.hook.test.ts
+++ b/suite-native/trading-debug/src/hooks/__tests__/useTradingDebugModeFlag.hook.test.ts
@@ -1,14 +1,14 @@
 import { featureFlagsInitialState } from '@suite-native/feature-flags';
-import { PreloadedState, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { PreloadedState, renderHookWithStoreProvider } from '@suite-native/test-utils';
 
 import { useTradingDebugModeFlag } from '../useTradingDebugModeFlag';
 
 describe('useTradingDebugModeFlag', () => {
     const renderUseDebugModeFlag = (preloadedState: PreloadedState = {}) =>
-        renderHookWithStoreProviderAsync(() => useTradingDebugModeFlag(), { preloadedState });
+        renderHookWithStoreProvider(() => useTradingDebugModeFlag(), { preloadedState });
 
-    it.each([true, false])('should respect FF [%s]', async ffValue => {
-        const { result } = await renderUseDebugModeFlag({
+    it.each([true, false])('should respect FF [%s]', ffValue => {
+        const { result } = renderUseDebugModeFlag({
             featureFlags: {
                 ...featureFlagsInitialState,
                 isTradingDebugEnabled: ffValue,

--- a/suite-native/trading-residence/src/components/CountrySheet/__tests__/CountryOfResidencePicker.comp.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/__tests__/CountryOfResidencePicker.comp.test.tsx
@@ -2,7 +2,7 @@ import { analytics } from '@suite-native/analytics';
 import { Form, useForm } from '@suite-native/forms';
 import {
     renderHookWithBasicProvider,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
     renderWithBasicProvider,
     screen,
     userEvent,
@@ -35,10 +35,8 @@ describe('CountryOfResidencePicker', () => {
         screen.unmount();
     });
 
-    const renderCountryOfResidencePicker = async (
-        props: Partial<CountryOfResidencePickerProps> = {},
-    ) => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useLocationForm());
+    const renderCountryOfResidencePicker = (props: Partial<CountryOfResidencePickerProps> = {}) => {
+        const { result } = renderHookWithStoreProvider(() => useLocationForm());
 
         return renderWithBasicProvider(
             <CountryOfResidencePicker testID="TEST_ID" context="settings" {...props} />,
@@ -48,14 +46,14 @@ describe('CountryOfResidencePicker', () => {
         );
     };
 
-    it('should display value from expo-localization (Poland) when in default state', async () => {
-        const { getByLabelText } = await renderCountryOfResidencePicker();
+    it('should display value from expo-localization (Poland) when in default state', () => {
+        const { getByLabelText } = renderCountryOfResidencePicker();
 
         expect(getByLabelText('Selected country of residence')).toHaveTextContent('🇵🇱 Poland');
     });
 
     it('should allow to select country', async () => {
-        const { getByText, getByLabelText } = await renderCountryOfResidencePicker();
+        const { getByText, getByLabelText } = renderCountryOfResidencePicker();
 
         // select country
         await userEvent.press(getByText('Country of residence'));
@@ -70,7 +68,7 @@ describe('CountryOfResidencePicker', () => {
             setFilterValue: jest.fn(),
             filterValue: 'test-key',
         });
-        const { getByText } = await renderCountryOfResidencePicker();
+        const { getByText } = renderCountryOfResidencePicker();
         await userEvent.press(getByText('Country of residence'));
 
         expect(getByText('Country not found')).toBeTruthy();
@@ -81,7 +79,7 @@ describe('CountryOfResidencePicker', () => {
 
     it('should report to analytics after country changed', async () => {
         const reportSpy = jest.spyOn(analytics, 'report');
-        const { getByText } = await renderCountryOfResidencePicker();
+        const { getByText } = renderCountryOfResidencePicker();
 
         await userEvent.press(getByText('Country of residence'));
         await userEvent.press(getByText(/Algeria/));
@@ -91,7 +89,7 @@ describe('CountryOfResidencePicker', () => {
 
     it('should not report to analytics when user selects already selected country', async () => {
         const reportSpy = jest.spyOn(analytics, 'report');
-        const { getByText, getAllByText } = await renderCountryOfResidencePicker();
+        const { getByText, getAllByText } = renderCountryOfResidencePicker();
 
         await userEvent.press(getByText('Country of residence'));
         await userEvent.press(getByText(/Algeria/));
@@ -122,8 +120,8 @@ describe('CountryOfResidencePicker', () => {
         );
     });
 
-    it('should render without TestID', async () => {
-        const { getByText, queryByTestId } = await renderCountryOfResidencePicker({
+    it('should render without TestID', () => {
+        const { getByText, queryByTestId } = renderCountryOfResidencePicker({
             testID: undefined,
         });
 

--- a/suite-native/trading-residence/src/components/__tests__/ConfirmLocationButton.comp.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/ConfirmLocationButton.comp.test.tsx
@@ -1,12 +1,7 @@
 import { useEffect } from 'react';
 
 import { useFormContext } from '@suite-native/forms';
-import {
-    TestStore,
-    fireEvent,
-    initStore,
-    renderWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { TestStore, fireEvent, initStore, renderWithStoreProvider } from '@suite-native/test-utils';
 import { selectTradingResidenceCountry } from '@suite-native/trading-state';
 
 import { TradingLocationFormValues } from '../../types/tradingLocationForm';
@@ -33,7 +28,7 @@ describe('ConfirmLocationButton', () => {
     let store: TestStore;
 
     const renderConfirmLocationButton = (props: Partial<ConfirmLocationButtonProps>) =>
-        renderWithStoreProviderAsync(<ConfirmLocationButton afterConfirm={jest.fn} {...props} />, {
+        renderWithStoreProvider(<ConfirmLocationButton afterConfirm={jest.fn} {...props} />, {
             wrapper: LocationForm,
             store,
         });
@@ -43,10 +38,10 @@ describe('ConfirmLocationButton', () => {
         store = initStore().store;
     });
 
-    it('should set location and call afterConfirmMock on press', async () => {
+    it('should set location and call afterConfirmMock on press', () => {
         const afterConfirmMock = jest.fn();
 
-        const { getByText } = await renderConfirmLocationButton({ afterConfirm: afterConfirmMock });
+        const { getByText } = renderConfirmLocationButton({ afterConfirm: afterConfirmMock });
         fireEvent.press(getByText('Confirm location'));
 
         // from expo-localization mock
@@ -54,22 +49,19 @@ describe('ConfirmLocationButton', () => {
         expect(afterConfirmMock).toHaveBeenCalled();
     });
 
-    it('should log submitDefault event on press', async () => {
-        const { getByText } = await renderConfirmLocationButton({});
+    it('should log submitDefault event on press', () => {
+        const { getByText } = renderConfirmLocationButton({});
         fireEvent.press(getByText('Confirm location'));
 
         expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
         expect(mockAnalyticsReport).toHaveBeenCalledWith('submitDefault');
     });
 
-    it('should log submitCustom when selected value does not match the default one', async () => {
-        const { getByText } = await renderWithStoreProviderAsync(
-            <ConfirmLocationButtonWithChangedCountry />,
-            {
-                wrapper: LocationForm,
-                store,
-            },
-        );
+    it('should log submitCustom when selected value does not match the default one', () => {
+        const { getByText } = renderWithStoreProvider(<ConfirmLocationButtonWithChangedCountry />, {
+            wrapper: LocationForm,
+            store,
+        });
 
         fireEvent.press(getByText('Confirm location'));
 

--- a/suite-native/trading-residence/src/components/__tests__/OnboardingButtons.comp.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/OnboardingButtons.comp.test.tsx
@@ -1,9 +1,4 @@
-import {
-    TestStore,
-    fireEvent,
-    initStore,
-    renderWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { TestStore, fireEvent, initStore, renderWithStoreProvider } from '@suite-native/test-utils';
 import {
     selectTradingResidenceCountry,
     selectWasTradingResidenceOnboardingVisited,
@@ -16,7 +11,7 @@ describe('OnboardingButtons', () => {
     let store: TestStore;
 
     const renderOnboardingButtons = (props: OnboardingButtonsProps) =>
-        renderWithStoreProviderAsync(<OnboardingButtons {...props} />, {
+        renderWithStoreProvider(<OnboardingButtons {...props} />, {
             wrapper: LocationForm,
             store,
         });
@@ -25,8 +20,8 @@ describe('OnboardingButtons', () => {
         store = initStore().store;
     });
 
-    it('should render correctly', async () => {
-        const { getByText } = await renderOnboardingButtons({ afterPress: () => {} });
+    it('should render correctly', () => {
+        const { getByText } = renderOnboardingButtons({ afterPress: () => {} });
 
         expect(getByText('Confirm location')).toBeOnTheScreen();
         expect(getByText('Not now')).toBeOnTheScreen();
@@ -36,9 +31,9 @@ describe('OnboardingButtons', () => {
         expect(selectWasTradingResidenceOnboardingVisited(store.getState())).toBe(false);
     });
 
-    it('should dispatch setResidenceCountry and setOnboardingVisited on `Confirm location` press', async () => {
+    it('should dispatch setResidenceCountry and setOnboardingVisited on `Confirm location` press', () => {
         const afterPressMock = jest.fn();
-        const { getByText } = await renderOnboardingButtons({ afterPress: afterPressMock });
+        const { getByText } = renderOnboardingButtons({ afterPress: afterPressMock });
 
         fireEvent.press(getByText('Confirm location'));
 
@@ -48,9 +43,9 @@ describe('OnboardingButtons', () => {
         expect(afterPressMock).toHaveBeenCalledTimes(1);
     });
 
-    it('should dispatch only setOnboardingVisited on `Not now` press', async () => {
+    it('should dispatch only setOnboardingVisited on `Not now` press', () => {
         const afterPressMock = jest.fn();
-        const { getByText } = await renderOnboardingButtons({ afterPress: afterPressMock });
+        const { getByText } = renderOnboardingButtons({ afterPress: afterPressMock });
 
         fireEvent.press(getByText('Not now'));
 

--- a/suite-native/trading-residence/src/components/__tests__/ResidenceCheckAwareAnimatedBox.comp.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/ResidenceCheckAwareAnimatedBox.comp.test.tsx
@@ -1,15 +1,15 @@
-import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { ResidenceCheckAwareAnimatedBox } from '../ResidenceCheckAwareAnimatedBox';
 
 describe('ResidenceCheckAwareAnimatedBox', () => {
     const renderResidenceCheckAwareAnimatedBox = (preloadedState: PreloadedState = {}) =>
-        renderWithStoreProviderAsync(<ResidenceCheckAwareAnimatedBox testID="TEST_ID" />, {
+        renderWithStoreProvider(<ResidenceCheckAwareAnimatedBox testID="TEST_ID" />, {
             preloadedState,
         });
 
-    it('should have no border when residence check is enabled', async () => {
-        const { getByTestId } = await renderResidenceCheckAwareAnimatedBox({
+    it('should have no border when residence check is enabled', () => {
+        const { getByTestId } = renderResidenceCheckAwareAnimatedBox({
             featureFlags: { isTradingResidenceCheckEnabled: true },
         });
 
@@ -18,8 +18,8 @@ describe('ResidenceCheckAwareAnimatedBox', () => {
         });
     });
 
-    it('should have border when residence check is disabled', async () => {
-        const { getByTestId } = await renderResidenceCheckAwareAnimatedBox({
+    it('should have border when residence check is disabled', () => {
+        const { getByTestId } = renderResidenceCheckAwareAnimatedBox({
             featureFlags: { isTradingResidenceCheckEnabled: false },
         });
 

--- a/suite-native/trading-residence/src/components/__tests__/TradingLocationSettings.comp.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/TradingLocationSettings.comp.test.tsx
@@ -1,10 +1,5 @@
 import { Text } from '@suite-native/atoms';
-import {
-    TestStore,
-    initStore,
-    renderWithStoreProviderAsync,
-    screen,
-} from '@suite-native/test-utils';
+import { TestStore, initStore, renderWithStoreProvider, screen } from '@suite-native/test-utils';
 
 import { TradingLocationSettings, TradingLocationSettingsProps } from '../TradingLocationSettings';
 
@@ -12,7 +7,7 @@ describe('TradingLocationSettings', () => {
     let store: TestStore;
 
     const renderTradingLocationSettings = (props: TradingLocationSettingsProps) =>
-        renderWithStoreProviderAsync(<TradingLocationSettings {...props} />, { store });
+        renderWithStoreProvider(<TradingLocationSettings {...props} />, { store });
 
     beforeEach(() => {
         store = initStore().store;
@@ -23,8 +18,8 @@ describe('TradingLocationSettings', () => {
         screen.unmount();
     });
 
-    it('should render all components', async () => {
-        const { getByText } = await renderTradingLocationSettings({
+    it('should render all components', () => {
+        const { getByText } = renderTradingLocationSettings({
             context: 'settings',
             children: <Text>Test Children</Text>,
         });

--- a/suite-native/trading-residence/src/hooks/__tests__/useFormCountryCode.hook.test.tsx
+++ b/suite-native/trading-residence/src/hooks/__tests__/useFormCountryCode.hook.test.tsx
@@ -3,7 +3,7 @@ import { Form } from '@suite-native/forms';
 import {
     act,
     renderHookWithBasicProvider,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 
 import { TradingLocationFormType } from '../../types/tradingLocationForm';
@@ -11,27 +11,24 @@ import { useFormCountryCode } from '../useFormCountryCode';
 import { useLocationForm } from '../useLocationForm';
 
 describe('useFormCountryCode', () => {
-    const renderLocationForm = () => renderHookWithStoreProviderAsync(() => useLocationForm());
+    const renderLocationForm = () => renderHookWithStoreProvider(() => useLocationForm());
 
     const renderUseFormCountryCode = (locationForm: TradingLocationFormType) =>
         renderHookWithBasicProvider(() => useFormCountryCode(), {
             wrapper: ({ children }) => <Form form={locationForm}>{children}</Form>,
         });
 
-    it.each<TradingCountryCode>(['US', 'unknown'])(
-        'should reflect country for %s',
-        async country => {
-            const { result: formResult } = await renderLocationForm();
+    it.each<TradingCountryCode>(['US', 'unknown'])('should reflect country for %s', country => {
+        const { result: formResult } = renderLocationForm();
 
-            act(() => {
-                formResult.current.setValue('country', {
-                    value: country,
-                    label: 'does not matter',
-                });
+        act(() => {
+            formResult.current.setValue('country', {
+                value: country,
+                label: 'does not matter',
             });
-            const { result } = renderUseFormCountryCode(formResult.current);
+        });
+        const { result } = renderUseFormCountryCode(formResult.current);
 
-            expect(result.current).toEqual(country);
-        },
-    );
+        expect(result.current).toEqual(country);
+    });
 });

--- a/suite-native/trading-residence/src/hooks/__tests__/useIsTradingAvailableForForm.hook.test.tsx
+++ b/suite-native/trading-residence/src/hooks/__tests__/useIsTradingAvailableForForm.hook.test.tsx
@@ -1,12 +1,12 @@
 import { TradingCountryCode } from '@suite-common/trading';
-import { PreloadedState, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { PreloadedState, renderHookWithStoreProvider } from '@suite-native/test-utils';
 
 import { LocationForm } from '../../components/LocationForm';
 import { useIsTradingAvailableForForm } from '../useIsTradingAvailableForForm';
 
 describe('useIsTradingAvailableForForm', () => {
     const renderUseIsTradingAvailableForForm = (preloadedState: PreloadedState) =>
-        renderHookWithStoreProviderAsync(() => useIsTradingAvailableForForm(), {
+        renderHookWithStoreProvider(() => useIsTradingAvailableForForm(), {
             wrapper: LocationForm,
             preloadedState,
         });
@@ -22,12 +22,12 @@ describe('useIsTradingAvailableForForm', () => {
         [true, undefined],
         // US is whitelisted
         [true, 'US'],
-    ])('should be [%s] for country [%s]', async (expectedValue, country) => {
+    ])('should be [%s] for country [%s]', (expectedValue, country) => {
         const preloadedState: PreloadedState = {
             wallet: { trading: { residence: { country } } },
         };
 
-        const { result } = await renderUseIsTradingAvailableForForm(preloadedState);
+        const { result } = renderUseIsTradingAvailableForForm(preloadedState);
 
         expect(result.current).toEqual(expectedValue);
     });

--- a/suite-native/trading-residence/src/hooks/__tests__/useLocationForm.hook.test.ts
+++ b/suite-native/trading-residence/src/hooks/__tests__/useLocationForm.hook.test.ts
@@ -1,11 +1,6 @@
 import Localization, { type Locale } from 'expo-localization';
 
-import {
-    TestStore,
-    act,
-    initStore,
-    renderHookWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { TestStore, act, initStore, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { residenceActions } from '@suite-native/trading-state';
 
 import { useLocationForm } from '../useLocationForm';
@@ -14,18 +9,18 @@ describe('useLocationForm', () => {
     let store: TestStore;
 
     const renderUseLocationForm = () =>
-        renderHookWithStoreProviderAsync(() => useLocationForm(), { store });
+        renderHookWithStoreProvider(() => useLocationForm(), { store });
 
     beforeEach(() => {
         store = initStore().store;
     });
 
-    it('should use default value from redux state', async () => {
+    it('should use default value from redux state', () => {
         act(() => {
             store.dispatch(residenceActions.setResidenceCountry('CZ'));
         });
 
-        const { result } = await renderUseLocationForm();
+        const { result } = renderUseLocationForm();
 
         expect(result.current.getValues('country')).toEqual({
             label: '🇨🇿 Czechia',
@@ -33,8 +28,8 @@ describe('useLocationForm', () => {
         });
     });
 
-    it('should use value from expo-localization when country is not set in store', async () => {
-        const { result } = await renderUseLocationForm();
+    it('should use value from expo-localization when country is not set in store', () => {
+        const { result } = renderUseLocationForm();
 
         expect(result.current.getValues('country')).toEqual({
             label: '🇵🇱 Poland',
@@ -42,7 +37,7 @@ describe('useLocationForm', () => {
         });
     });
 
-    it('should fallback to worldwide when country is not set in store and expo-localization country is not supported', async () => {
+    it('should fallback to worldwide when country is not set in store and expo-localization country is not supported', () => {
         jest.spyOn(Localization, 'getLocales').mockReturnValue([
             {
                 languageTag: 'es-CU',
@@ -58,7 +53,7 @@ describe('useLocationForm', () => {
             } as unknown as Locale,
         ]);
 
-        const { result } = await renderUseLocationForm();
+        const { result } = renderUseLocationForm();
 
         expect(result.current.getValues('country')).toEqual({
             label: '🌍 Worldwide',

--- a/suite-native/trading-residence/src/screens/__tests__/SettingsTradingLocationScreen.comp.test.tsx
+++ b/suite-native/trading-residence/src/screens/__tests__/SettingsTradingLocationScreen.comp.test.tsx
@@ -2,7 +2,7 @@ import { RouteProp } from '@react-navigation/native';
 
 import { EventType, analytics } from '@suite-native/analytics';
 import { SettingsStackParamList, SettingsStackRoutes } from '@suite-native/navigation';
-import { renderWithStoreProviderAsync, screen, userEvent } from '@suite-native/test-utils';
+import { renderWithStoreProvider, screen, userEvent } from '@suite-native/test-utils';
 
 import { SettingsTradingLocationScreen } from '../SettingsTradingLocationScreen';
 
@@ -22,7 +22,7 @@ jest.mock('@react-navigation/native', () => ({
 
 describe('TradingLocationSettingsScreen', () => {
     const renderTradingLocationSettingsScreen = () =>
-        renderWithStoreProviderAsync(<SettingsTradingLocationScreen />);
+        renderWithStoreProvider(<SettingsTradingLocationScreen />);
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -32,9 +32,8 @@ describe('TradingLocationSettingsScreen', () => {
         screen.unmount();
     });
 
-    it('should render all components', async () => {
-        const { getByText, queryByText, getByLabelText } =
-            await renderTradingLocationSettingsScreen();
+    it('should render all components', () => {
+        const { getByText, queryByText, getByLabelText } = renderTradingLocationSettingsScreen();
 
         expect(getByText('Trading is now available')).toBeOnTheScreen();
         expect(getByText('Confirm location')).toBeOnTheScreen();
@@ -44,7 +43,7 @@ describe('TradingLocationSettingsScreen', () => {
     });
 
     it('should goBack on `Confirm location` press', async () => {
-        const { getByText } = await renderTradingLocationSettingsScreen();
+        const { getByText } = renderTradingLocationSettingsScreen();
 
         await userEvent.press(getByText('Confirm location'));
 
@@ -53,7 +52,7 @@ describe('TradingLocationSettingsScreen', () => {
 
     it('should log analytics event on country change', async () => {
         const analyticsSpy = jest.spyOn(analytics, 'report');
-        const { getByText } = await renderTradingLocationSettingsScreen();
+        const { getByText } = renderTradingLocationSettingsScreen();
 
         await userEvent.press(getByText('Country of residence'));
         await userEvent.press(getByText('🇦🇷 Argentina'));
@@ -70,7 +69,7 @@ describe('TradingLocationSettingsScreen', () => {
 
     it('should go back and log analytics event on back button press', async () => {
         const analyticsSpy = jest.spyOn(analytics, 'report');
-        const { getByLabelText } = await renderTradingLocationSettingsScreen();
+        const { getByLabelText } = renderTradingLocationSettingsScreen();
 
         await userEvent.press(getByLabelText('Go back'));
 

--- a/suite-native/trading-residence/src/screens/__tests__/TradingLocationModalScreen.comp.test.tsx
+++ b/suite-native/trading-residence/src/screens/__tests__/TradingLocationModalScreen.comp.test.tsx
@@ -6,7 +6,7 @@ import {
     TradingStackParamList,
     TradingStackRoutes,
 } from '@suite-native/navigation';
-import { renderWithStoreProviderAsync, screen, userEvent } from '@suite-native/test-utils';
+import { renderWithStoreProvider, screen, userEvent } from '@suite-native/test-utils';
 
 import {
     TradingLocationModalScreen,
@@ -33,7 +33,7 @@ jest.mock('@react-navigation/native', () => ({
 
 describe('TradingLocationModalScreen', () => {
     const renderTradingLocationModalScreen = () =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <TradingLocationModalScreen
                 navigation={
                     {
@@ -48,8 +48,8 @@ describe('TradingLocationModalScreen', () => {
         screen.unmount();
     });
 
-    it('should render all components', async () => {
-        const { getByText, queryByLabelText } = await renderTradingLocationModalScreen();
+    it('should render all components', () => {
+        const { getByText, queryByLabelText } = renderTradingLocationModalScreen();
 
         expect(getByText('Trading is now available')).toBeOnTheScreen();
         expect(getByText('Confirm location')).toBeOnTheScreen();
@@ -60,7 +60,7 @@ describe('TradingLocationModalScreen', () => {
 
     it('should log analytics event on country change', async () => {
         const analyticsSpy = jest.spyOn(analytics, 'report');
-        const { getByText } = await renderTradingLocationModalScreen();
+        const { getByText } = renderTradingLocationModalScreen();
 
         await userEvent.press(getByText('Country of residence'));
         await userEvent.press(getByText('🇦🇷 Argentina'));
@@ -76,7 +76,7 @@ describe('TradingLocationModalScreen', () => {
     });
 
     it('should reset navigation on button press', async () => {
-        const { getByText } = await renderTradingLocationModalScreen();
+        const { getByText } = renderTradingLocationModalScreen();
 
         await userEvent.press(getByText('Not now'));
 

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemList.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemList.comp.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { getWalletState } from '../../../__fixtures__/walletState';
 import { ReviewSummaryOutput, StatefulReviewOutput } from '../../../types';
@@ -25,7 +25,7 @@ jest.mock('../../../selectors', () => {
 
 describe('ReviewOutputItemList', () => {
     const renderReviewOutputItemList = (props: Partial<ReviewOutputItemListProps> = {}) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <ReviewOutputItemList prefix="send" accountKey="eth-account-1" {...props} />,
             { preloadedState: { wallet: getWalletState() } },
         );
@@ -47,14 +47,14 @@ describe('ReviewOutputItemList', () => {
         mockSelectIsTransactionAlreadySignedValue = false;
     });
 
-    it('should render Error when account is not found', async () => {
-        const { getByText } = await renderReviewOutputItemList({ accountKey: 'btc-account-3' });
+    it('should render Error when account is not found', () => {
+        const { getByText } = renderReviewOutputItemList({ accountKey: 'btc-account-3' });
 
         expect(getByText('Error: Account not found.')).toBeOnTheScreen();
     });
 
-    it('should render outputs list', async () => {
-        const { getByText } = await renderReviewOutputItemList({});
+    it('should render outputs list', () => {
+        const { getByText } = renderReviewOutputItemList({});
 
         expect(getByText('Recipient address')).toBeOnTheScreen();
         expect(getByText('abcd efgh ijkl mnop qrst uvwx')).toBeOnTheScreen();
@@ -64,9 +64,9 @@ describe('ReviewOutputItemList', () => {
         expect(getByText('Maximum fee')).toBeOnTheScreen();
     });
 
-    it('should render empty list when reviewOutputs are undefined', async () => {
+    it('should render empty list when reviewOutputs are undefined', () => {
         mockSelectTransactionReviewOutputsFromDraftReturnValue = null;
-        const { queryByText } = await renderReviewOutputItemList({});
+        const { queryByText } = renderReviewOutputItemList({});
 
         expect(queryByText('Recipient address')).toBeNull();
         expect(queryByText('TimeBounds')).toBeNull();
@@ -75,15 +75,15 @@ describe('ReviewOutputItemList', () => {
     });
 
     describe('SlidingFooterOverlay', () => {
-        it('should render when transaction is not signed', async () => {
-            const { getByTestId } = await renderReviewOutputItemList({});
+        it('should render when transaction is not signed', () => {
+            const { getByTestId } = renderReviewOutputItemList({});
 
             expect(getByTestId('sliding-footer-overlay')).toBeOnTheScreen();
         });
 
-        it('should render when transaction is already signed', async () => {
+        it('should render when transaction is already signed', () => {
             mockSelectIsTransactionAlreadySignedValue = true;
-            const { queryByTestId } = await renderReviewOutputItemList({});
+            const { queryByTestId } = renderReviewOutputItemList({});
 
             expect(queryByTestId('sliding-footer-overlay')).toBeNull();
         });

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemValues.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemValues.comp.test.tsx
@@ -1,5 +1,5 @@
 import { TokenAddress } from '@suite-common/wallet-types';
-import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { getWalletState } from '../../../__fixtures__/walletState';
 import { ReviewOutputItemValues, ReviewOutputItemValuesProps } from '../ReviewOutputItemValues';
@@ -11,7 +11,7 @@ describe('ReviewOutputItemValues', () => {
         props: Partial<ReviewOutputItemValuesProps> = {},
         preloadedState: PreloadedState = {},
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <ReviewOutputItemValues
                 accountKey="eth-account-1"
                 value={oneUsdc}
@@ -23,14 +23,14 @@ describe('ReviewOutputItemValues', () => {
             },
         );
 
-    it('should render translated title', async () => {
-        const { getByText } = await renderReviewOutputItemValues({}, { wallet: getWalletState() });
+    it('should render translated title', () => {
+        const { getByText } = renderReviewOutputItemValues({}, { wallet: getWalletState() });
 
         expect(getByText('Total amount')).toBeOnTheScreen();
     });
 
-    it('should render token balance', async () => {
-        const { getByText } = await renderReviewOutputItemValues(
+    it('should render token balance', () => {
+        const { getByText } = renderReviewOutputItemValues(
             {
                 tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
             },

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFee.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFee.comp.test.tsx
@@ -4,8 +4,8 @@ import { Form } from '@suite-native/forms';
 import {
     PreloadedState,
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     userEvent,
 } from '@suite-native/test-utils';
 
@@ -41,12 +41,12 @@ describe('CustomFee', () => {
         wallet: getWalletState(),
     };
 
-    const renderUseFeesForm = async (
+    const renderUseFeesForm = (
         accountKey: AccountKey = 'eth-account-1',
         preloadedState?: PreloadedState,
         defaultFeePerUnit?: string,
     ) => {
-        const { result } = await renderHookWithStoreProviderAsync(
+        const { result } = renderHookWithStoreProvider(
             () =>
                 useFeesForm({
                     accountKey,
@@ -87,7 +87,7 @@ describe('CustomFee', () => {
             formDraft: mockFormDraft,
         };
 
-        return renderWithStoreProviderAsync(<CustomFee {...finalProps} />, {
+        return renderWithStoreProvider(<CustomFee {...finalProps} />, {
             preloadedState: preloadedState || defaultState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
@@ -107,9 +107,9 @@ describe('CustomFee', () => {
         jest.clearAllMocks();
     });
 
-    it('should render custom fee button when custom fee is not selected', async () => {
-        const form = await renderUseFeesForm();
-        const { getByTestId, getByText } = await renderCustomFee({
+    it('should render custom fee button when custom fee is not selected', () => {
+        const form = renderUseFeesForm();
+        const { getByTestId, getByText } = renderCustomFee({
             form,
         });
 
@@ -117,15 +117,15 @@ describe('CustomFee', () => {
         expect(getByText('Add custom fee')).toBeTruthy();
     });
 
-    it('should render custom fee card when custom fee is selected', async () => {
-        const form = await renderUseFeesForm();
+    it('should render custom fee card when custom fee is selected', () => {
+        const form = renderUseFeesForm();
 
         // Set fee level to custom
         act(() => {
             form.setValue('feeLevel', 'custom');
         });
 
-        const { getByText } = await renderCustomFee({
+        const { getByText } = renderCustomFee({
             form,
         });
 
@@ -134,9 +134,9 @@ describe('CustomFee', () => {
         expect(getByText('Edit')).toBeTruthy();
     });
 
-    it('should not render for solana network', async () => {
-        const form = await renderUseFeesForm();
-        const { toJSON } = await renderCustomFee({
+    it('should not render for solana network', () => {
+        const form = renderUseFeesForm();
+        const { toJSON } = renderCustomFee({
             form,
             props: {
                 symbol: 'sol' as NetworkSymbol,
@@ -146,13 +146,13 @@ describe('CustomFee', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should not call useCustomFee hook for solana network', async () => {
-        const form = await renderUseFeesForm();
+    it('should not call useCustomFee hook for solana network', () => {
+        const form = renderUseFeesForm();
 
         // Clear any previous calls
         mockUseCustomFee.mockClear();
 
-        await renderCustomFee({
+        renderCustomFee({
             form,
             props: {
                 symbol: 'sol' as NetworkSymbol,
@@ -163,13 +163,13 @@ describe('CustomFee', () => {
         expect(mockUseCustomFee).not.toHaveBeenCalled();
     });
 
-    it('should call useCustomFee hook for ethereum network', async () => {
-        const form = await renderUseFeesForm();
+    it('should call useCustomFee hook for ethereum network', () => {
+        const form = renderUseFeesForm();
 
         // Clear any previous calls
         mockUseCustomFee.mockClear();
 
-        await renderCustomFee({
+        renderCustomFee({
             form,
             props: {
                 symbol: 'eth' as NetworkSymbol,
@@ -183,9 +183,9 @@ describe('CustomFee', () => {
         });
     });
 
-    it('should render for bitcoin network', async () => {
-        const form = await renderUseFeesForm();
-        const { getByTestId } = await renderCustomFee({
+    it('should render for bitcoin network', () => {
+        const form = renderUseFeesForm();
+        const { getByTestId } = renderCustomFee({
             form,
             props: {
                 symbol: 'btc' as NetworkSymbol,
@@ -195,9 +195,9 @@ describe('CustomFee', () => {
         expect(getByTestId('@transactionManagement/fees-level-custom')).toBeTruthy();
     });
 
-    it('should render for ethereum network', async () => {
-        const form = await renderUseFeesForm();
-        const { getByTestId } = await renderCustomFee({
+    it('should render for ethereum network', () => {
+        const form = renderUseFeesForm();
+        const { getByTestId } = renderCustomFee({
             form,
             props: {
                 symbol: 'eth' as NetworkSymbol,
@@ -208,14 +208,14 @@ describe('CustomFee', () => {
     });
 
     it('should open bottom sheet when edit button is pressed', async () => {
-        const form = await renderUseFeesForm();
+        const form = renderUseFeesForm();
 
         // Set fee level to custom to show the card
         act(() => {
             form.setValue('feeLevel', 'custom');
         });
 
-        const { getByText } = await renderCustomFee({
+        const { getByText } = renderCustomFee({
             form,
         });
 
@@ -224,9 +224,9 @@ describe('CustomFee', () => {
         expect(getByText('Gas limit')).toBeTruthy();
     });
 
-    it('should handle different account keys', async () => {
-        const form = await renderUseFeesForm('btc-account-1');
-        const { getByTestId } = await renderCustomFee({
+    it('should handle different account keys', () => {
+        const form = renderUseFeesForm('btc-account-1');
+        const { getByTestId } = renderCustomFee({
             form,
             props: {
                 accountKey: 'btc-account-1' as AccountKey,

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeCard.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeCard.comp.test.tsx
@@ -2,8 +2,8 @@ import { AccountKey } from '@suite-common/wallet-types';
 import { Form } from '@suite-native/forms';
 import {
     PreloadedState,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     userEvent,
 } from '@suite-native/test-utils';
 
@@ -23,12 +23,12 @@ describe('CustomFeeCard', () => {
         wallet: getWalletState(),
     };
 
-    const renderUseFeesForm = async (
+    const renderUseFeesForm = (
         accountKey: AccountKey = 'eth-account-1',
         preloadedState?: PreloadedState,
         defaultFeePerUnit?: string,
     ) => {
-        const { result } = await renderHookWithStoreProviderAsync(
+        const { result } = renderHookWithStoreProvider(
             () =>
                 useFeesForm({
                     accountKey,
@@ -53,7 +53,7 @@ describe('CustomFeeCard', () => {
     }) => {
         const finalProps = { ...defaultProps, ...props };
 
-        return renderWithStoreProviderAsync(<CustomFeeCard {...finalProps} />, {
+        return renderWithStoreProvider(<CustomFeeCard {...finalProps} />, {
             preloadedState: preloadedState || defaultState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
@@ -64,9 +64,9 @@ describe('CustomFeeCard', () => {
     });
 
     describe('Rendering', () => {
-        it('should render custom fee card when custom fee transaction is available', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText } = await renderCustomFeeCard({
+        it('should render custom fee card when custom fee transaction is available', () => {
+            const form = renderUseFeesForm();
+            const { getByText } = renderCustomFeeCard({
                 form,
             });
 
@@ -75,28 +75,28 @@ describe('CustomFeeCard', () => {
             expect(getByText('Edit')).toBeTruthy();
         });
 
-        it('should display fee amount correctly', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText } = await renderCustomFeeCard({
+        it('should display fee amount correctly', () => {
+            const form = renderUseFeesForm();
+            const { getByText } = renderCustomFeeCard({
                 form,
             });
 
             expect(getByText('0.000000426691398 ETH')).toBeTruthy();
         });
 
-        it('should display price and limit correctly', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText } = await renderCustomFeeCard({
+        it('should display price and limit correctly', () => {
+            const form = renderUseFeesForm();
+            const { getByText } = renderCustomFeeCard({
                 form,
             });
 
             expect(getByText('1.00 Gwei')).toBeTruthy();
         });
 
-        it('should not render if using wrong accountKey', async () => {
+        it('should not render if using wrong accountKey', () => {
             const accountKey = 'wrong-key' as AccountKey;
-            const form = await renderUseFeesForm(accountKey);
-            const { toJSON } = await renderCustomFeeCard({
+            const form = renderUseFeesForm(accountKey);
+            const { toJSON } = renderCustomFeeCard({
                 form,
                 props: {
                     accountKey,
@@ -109,8 +109,8 @@ describe('CustomFeeCard', () => {
 
     describe('Interaction', () => {
         it('should call onEdit when edit button is pressed', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText } = await renderCustomFeeCard({
+            const form = renderUseFeesForm();
+            const { getByText } = renderCustomFeeCard({
                 form,
             });
 
@@ -120,8 +120,8 @@ describe('CustomFeeCard', () => {
         });
 
         it('should call onCancel when cancel button is pressed', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText } = await renderCustomFeeCard({
+            const form = renderUseFeesForm();
+            const { getByText } = renderCustomFeeCard({
                 form,
             });
 
@@ -131,10 +131,10 @@ describe('CustomFeeCard', () => {
         });
     });
 
-    it('should render for bitcoin network', async () => {
+    it('should render for bitcoin network', () => {
         const accountKey = 'btc-account-1' as AccountKey;
-        const form = await renderUseFeesForm(accountKey);
-        const { getByText } = await renderCustomFeeCard({
+        const form = renderUseFeesForm(accountKey);
+        const { getByText } = renderCustomFeeCard({
             form,
             props: {
                 accountKey,

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeInputs.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeInputs.comp.test.tsx
@@ -5,8 +5,8 @@ import {
     PreloadedState,
     TestStore,
     initStore,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 
 import { FeesFormType } from '../../../..';
@@ -34,12 +34,12 @@ describe('CustomFeeInputs', () => {
         wallet: getWalletState(),
     };
 
-    const renderUseFeesForm = async (
+    const renderUseFeesForm = (
         accountKey: AccountKey = 'eth-account-1',
         preloadedState?: PreloadedState,
         defaultFeePerUnit?: string,
     ) => {
-        const { result } = await renderHookWithStoreProviderAsync(
+        const { result } = renderHookWithStoreProvider(
             () =>
                 useFeesForm({
                     accountKey,
@@ -65,7 +65,7 @@ describe('CustomFeeInputs', () => {
     }) => {
         const finalProps = { ...defaultProps, ...props };
 
-        return renderWithStoreProviderAsync(<CustomFeeInputs {...finalProps} />, {
+        return renderWithStoreProvider(<CustomFeeInputs {...finalProps} />, {
             preloadedState: preloadedState || defaultState,
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
@@ -84,18 +84,18 @@ describe('CustomFeeInputs', () => {
         jest.clearAllMocks();
     });
     describe('Rendering', () => {
-        it('should render fee per unit input for bitcoin', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText, getByTestId } = await renderCustomFeeInputs({
+        it('should render fee per unit input for bitcoin', () => {
+            const form = renderUseFeesForm();
+            const { getByText, getByTestId } = renderCustomFeeInputs({
                 form,
             });
             expect(getByText('Fee rate')).toBeTruthy();
             expect(getByTestId('@transactionManagement/customFeePerUnit-input')).toBeTruthy();
         });
 
-        it('should render fee per unit input for ethereum', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText, getByTestId } = await renderCustomFeeInputs({
+        it('should render fee per unit input for ethereum', () => {
+            const form = renderUseFeesForm();
+            const { getByText, getByTestId } = renderCustomFeeInputs({
                 form,
                 props: { symbol: 'eth' },
             });
@@ -104,9 +104,9 @@ describe('CustomFeeInputs', () => {
             expect(getByTestId('@transactionManagement/customFeePerUnit-input')).toBeTruthy();
         });
 
-        it('should render fee limit input for ethereum', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText, getByTestId } = await renderCustomFeeInputs({
+        it('should render fee limit input for ethereum', () => {
+            const form = renderUseFeesForm();
+            const { getByText, getByTestId } = renderCustomFeeInputs({
                 form,
                 props: { symbol: 'eth' },
             });
@@ -115,9 +115,9 @@ describe('CustomFeeInputs', () => {
             expect(getByTestId('@transactionManagement/customFeeLimit-input')).toBeTruthy();
         });
 
-        it('should not render fee limit input for bitcoin', async () => {
-            const form = await renderUseFeesForm();
-            const { queryByText, queryByTestId } = await renderCustomFeeInputs({
+        it('should not render fee limit input for bitcoin', () => {
+            const form = renderUseFeesForm();
+            const { queryByText, queryByTestId } = renderCustomFeeInputs({
                 form,
                 props: { symbol: 'btc' },
             });
@@ -125,33 +125,33 @@ describe('CustomFeeInputs', () => {
             expect(queryByTestId('@transactionManagement/customFeeLimit-input')).toBeNull();
         });
 
-        it('should display correct units for different networks', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText } = await renderCustomFeeInputs({
+        it('should display correct units for different networks', () => {
+            const form = renderUseFeesForm();
+            const { getByText } = renderCustomFeeInputs({
                 form,
                 props: { symbol: 'btc' },
             });
             expect(getByText('sat/vB')).toBeTruthy();
 
-            const { getByText: getByText2 } = await renderCustomFeeInputs({
+            const { getByText: getByText2 } = renderCustomFeeInputs({
                 form,
                 props: { symbol: 'eth' },
             });
             expect(getByText2('Gwei')).toBeTruthy();
         });
 
-        it('should show minimum fee hint for bitcoin', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText } = await renderCustomFeeInputs({
+        it('should show minimum fee hint for bitcoin', () => {
+            const form = renderUseFeesForm();
+            const { getByText } = renderCustomFeeInputs({
                 form,
                 props: { symbol: 'btc' },
             });
             expect(getByText('The minimum fee rate is 1 sat/vB')).toBeTruthy();
         });
 
-        it('should not show minimum fee hint for ethereum', async () => {
-            const form = await renderUseFeesForm();
-            const { queryByText } = await renderCustomFeeInputs({
+        it('should not show minimum fee hint for ethereum', () => {
+            const form = renderUseFeesForm();
+            const { queryByText } = renderCustomFeeInputs({
                 form,
                 props: { symbol: 'eth' },
             });

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeLabel.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeLabel.comp.test.tsx
@@ -3,8 +3,8 @@ import { Form } from '@suite-native/forms';
 import {
     PreloadedState,
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 
 import { getWalletState } from '../../../../__fixtures__/walletState';
@@ -17,11 +17,8 @@ describe('CustomFeeLabel', () => {
         wallet: getWalletState(),
     };
 
-    const renderUseFeesForm = async (
-        preloadedState?: PreloadedState,
-        defaultFeePerUnit?: string,
-    ) => {
-        const { result } = await renderHookWithStoreProviderAsync(
+    const renderUseFeesForm = (preloadedState?: PreloadedState, defaultFeePerUnit?: string) => {
+        const { result } = renderHookWithStoreProvider(
             () =>
                 useFeesForm({
                     accountKey: 'test-account-key',
@@ -44,15 +41,15 @@ describe('CustomFeeLabel', () => {
         form: FeesFormType;
         preloadedState?: PreloadedState;
     }) =>
-        renderWithStoreProviderAsync(<CustomFeeLabel networkType={networkType} />, {
+        renderWithStoreProvider(<CustomFeeLabel networkType={networkType} />, {
             preloadedState: preloadedState || defaultState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
     describe('Bitcoin Network', () => {
-        it('should render custom fee label for bitcoin', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText } = await renderCustomFeeLabel({
+        it('should render custom fee label for bitcoin', () => {
+            const form = renderUseFeesForm();
+            const { getByText } = renderCustomFeeLabel({
                 networkType: 'bitcoin',
                 form,
             });
@@ -60,21 +57,21 @@ describe('CustomFeeLabel', () => {
             expect(getByText(/Custom/)).toBeTruthy();
         });
 
-        it('should display fee per unit with correct units', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText } = await renderCustomFeeLabel({ networkType: 'bitcoin', form });
+        it('should display fee per unit with correct units', () => {
+            const form = renderUseFeesForm();
+            const { getByText } = renderCustomFeeLabel({ networkType: 'bitcoin', form });
 
             expect(getByText(/sat\/vB/)).toBeTruthy();
         });
 
-        it('should handle different fee per unit values', async () => {
-            const form = await renderUseFeesForm();
+        it('should handle different fee per unit values', () => {
+            const form = renderUseFeesForm();
 
             act(() => {
                 form.setValue('customFeePerUnit', '50');
             });
 
-            const { getByText } = await renderCustomFeeLabel({
+            const { getByText } = renderCustomFeeLabel({
                 networkType: 'bitcoin',
                 form,
             });
@@ -84,9 +81,9 @@ describe('CustomFeeLabel', () => {
     });
 
     describe('Ethereum Network', () => {
-        it('should render custom fee label for ethereum', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText } = await renderCustomFeeLabel({
+        it('should render custom fee label for ethereum', () => {
+            const form = renderUseFeesForm();
+            const { getByText } = renderCustomFeeLabel({
                 networkType: 'ethereum',
                 form,
             });
@@ -94,9 +91,9 @@ describe('CustomFeeLabel', () => {
             expect(getByText(/Custom/)).toBeTruthy();
         });
 
-        it('should display gas price and gas limit for ethereum', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText } = await renderCustomFeeLabel({
+        it('should display gas price and gas limit for ethereum', () => {
+            const form = renderUseFeesForm();
+            const { getByText } = renderCustomFeeLabel({
                 networkType: 'ethereum',
                 form,
             });
@@ -104,9 +101,9 @@ describe('CustomFeeLabel', () => {
             expect(getByText(/Gwei/)).toBeTruthy();
         });
 
-        it('should display fee per unit with Gwei units for ethereum', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText } = await renderCustomFeeLabel({
+        it('should display fee per unit with Gwei units for ethereum', () => {
+            const form = renderUseFeesForm();
+            const { getByText } = renderCustomFeeLabel({
                 networkType: 'ethereum',
                 form,
             });
@@ -114,15 +111,15 @@ describe('CustomFeeLabel', () => {
             expect(getByText(/Gwei/)).toBeTruthy();
         });
 
-        it('should handle different gas price and gas limit values', async () => {
-            const form = await renderUseFeesForm();
+        it('should handle different gas price and gas limit values', () => {
+            const form = renderUseFeesForm();
 
             act(() => {
                 form.setValue('customFeePerUnit', '25');
                 form.setValue('customFeeLimit', '50000');
             });
 
-            const { getByText } = await renderCustomFeeLabel({
+            const { getByText } = renderCustomFeeLabel({
                 networkType: 'ethereum',
                 form,
             });
@@ -132,9 +129,9 @@ describe('CustomFeeLabel', () => {
     });
 
     describe('Other Networks', () => {
-        it('should render custom fee label for other networks', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText } = await renderCustomFeeLabel({
+        it('should render custom fee label for other networks', () => {
+            const form = renderUseFeesForm();
+            const { getByText } = renderCustomFeeLabel({
                 networkType: 'ripple',
                 form,
             });
@@ -142,9 +139,9 @@ describe('CustomFeeLabel', () => {
             expect(getByText(/Custom/)).toBeTruthy();
         });
 
-        it('should display fee per unit with appropriate units for other networks', async () => {
-            const form = await renderUseFeesForm();
-            const { getByText } = await renderCustomFeeLabel({
+        it('should display fee per unit with appropriate units for other networks', () => {
+            const form = renderUseFeesForm();
+            const { getByText } = renderCustomFeeLabel({
                 networkType: 'ripple',
                 form,
             });

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOption.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOption.comp.test.tsx
@@ -1,12 +1,7 @@
 import { yup } from '@suite-common/validators';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Form, useForm } from '@suite-native/forms';
-import {
-    TestStore,
-    initStore,
-    renderWithStoreProviderAsync,
-    userEvent,
-} from '@suite-native/test-utils';
+import { TestStore, initStore, renderWithStoreProvider, userEvent } from '@suite-native/test-utils';
 
 import { getWalletState } from '../../../../__fixtures__/walletState';
 import { NativeSupportedPredefinedFeeLevel } from '../../../../types';
@@ -96,7 +91,7 @@ describe('FeeOption', () => {
         const finalProps = { ...defaultProps, ...props };
         mockOnSelectedFeeLevel = finalProps.onSelectedFeeLevel;
 
-        return renderWithStoreProviderAsync(
+        return renderWithStoreProvider(
             <TestFormWrapper>
                 <FeeOption {...finalProps} />
             </TestFormWrapper>,
@@ -124,35 +119,35 @@ describe('FeeOption', () => {
             ['normal', /Normal/],
             ['economy', /Low/],
             ['high', /High/],
-        ])('should render %s fee level with correct label', async (feeKey, expectedLabel) => {
-            const { getByText } = await renderFeeOption({ feeKey });
+        ])('should render %s fee level with correct label', (feeKey, expectedLabel) => {
+            const { getByText } = renderFeeOption({ feeKey });
 
             expect(getByText(expectedLabel)).toBeTruthy();
         });
 
-        it('should display fee information correctly', async () => {
-            const { getByText } = await renderFeeOption();
+        it('should display fee information correctly', () => {
+            const { getByText } = renderFeeOption();
 
             expect(getByText('4 sat/vB')).toBeTruthy();
             expect(getByText('~ ~10 minutes')).toBeTruthy();
         });
 
-        it('should show radio button when interactive', async () => {
-            const { getByTestId } = await renderFeeOption();
+        it('should show radio button when interactive', () => {
+            const { getByTestId } = renderFeeOption();
 
             expect(getByTestId('@transactionManagement/fees-level-radio-normal')).toBeTruthy();
         });
 
-        it('should not show radio button when not interactive', async () => {
-            const { queryByTestId } = await renderFeeOption({
+        it('should not show radio button when not interactive', () => {
+            const { queryByTestId } = renderFeeOption({
                 isInteractive: false,
             });
 
             expect(queryByTestId('@transactionManagement/fees-level-radio-normal')).toBeNull();
         });
 
-        it('should show loading skeleton when isLoading is true', async () => {
-            const { queryAllByTestId } = await renderFeeOption({
+        it('should show loading skeleton when isLoading is true', () => {
+            const { queryAllByTestId } = renderFeeOption({
                 isLoading: true,
             });
 
@@ -162,7 +157,7 @@ describe('FeeOption', () => {
 
     describe('Interaction', () => {
         it('should call onSelectedFeeLevel when pressed', async () => {
-            const { getByTestId } = await renderFeeOption();
+            const { getByTestId } = renderFeeOption();
 
             await userEvent.press(getByTestId('@transactionManagement/fees-level-radio-normal'));
 
@@ -170,7 +165,7 @@ describe('FeeOption', () => {
         });
 
         it('should not call onSelectedFeeLevel when not interactive', async () => {
-            const { getByTestId } = await renderFeeOption({
+            const { getByTestId } = renderFeeOption({
                 isInteractive: false,
             });
 
@@ -182,7 +177,7 @@ describe('FeeOption', () => {
         });
 
         it('should handle different fee levels correctly', async () => {
-            const { getByTestId } = await renderFeeOption({
+            const { getByTestId } = renderFeeOption({
                 feeKey: 'economy',
             });
 
@@ -193,8 +188,8 @@ describe('FeeOption', () => {
     });
 
     describe('Fee calculation', () => {
-        it('should calculate fee per unit correctly for bitcoin', async () => {
-            const { getByText } = await renderFeeOption({
+        it('should calculate fee per unit correctly for bitcoin', () => {
+            const { getByText } = renderFeeOption({
                 symbol: 'btc',
                 feeLevel: createMockFeeLevel(),
                 transactionBytes: 250,
@@ -204,8 +199,8 @@ describe('FeeOption', () => {
             expect(getByText('4 sat/vB')).toBeTruthy();
         });
 
-        it('should use feePerByte for non-bitcoin networks', async () => {
-            const { getByText } = await renderFeeOption({
+        it('should use feePerByte for non-bitcoin networks', () => {
+            const { getByText } = renderFeeOption({
                 symbol: 'eth',
                 feeLevel: createMockFeeLevel(),
                 transactionBytes: 250,

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOptionsList.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOptionsList.comp.test.tsx
@@ -5,8 +5,8 @@ import {
     PreloadedState,
     TestStore,
     initStore,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     userEvent,
 } from '@suite-native/test-utils';
 
@@ -58,12 +58,12 @@ describe('FeeOptionsList', () => {
         wallet: getWalletState(),
     };
 
-    const renderUseFeesForm = async (
+    const renderUseFeesForm = (
         accountKey: AccountKey = 'eth-account-1',
         preloadedState?: PreloadedState,
         defaultFeePerUnit?: string,
     ) => {
-        const { result } = await renderHookWithStoreProviderAsync(
+        const { result } = renderHookWithStoreProvider(
             () =>
                 useFeesForm({
                     accountKey,
@@ -77,7 +77,7 @@ describe('FeeOptionsList', () => {
         return result.current;
     };
 
-    const renderFeeOptionsList = async ({
+    const renderFeeOptionsList = ({
         preloadedState,
         props,
     }: {
@@ -85,9 +85,9 @@ describe('FeeOptionsList', () => {
         props?: Partial<FeeOptionsListProps>;
     }) => {
         const finalProps = { ...defaultProps, ...props };
-        const form = await renderUseFeesForm();
+        const form = renderUseFeesForm();
 
-        return renderWithStoreProviderAsync(<FeeOptionsList {...finalProps} />, {
+        return renderWithStoreProvider(<FeeOptionsList {...finalProps} />, {
             store,
             preloadedState: preloadedState || defaultState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
@@ -107,16 +107,16 @@ describe('FeeOptionsList', () => {
     });
 
     describe('Rendering', () => {
-        it('should render all fee options', async () => {
-            const { getByText } = await renderFeeOptionsList({});
+        it('should render all fee options', () => {
+            const { getByText } = renderFeeOptionsList({});
 
             expect(getByText(/Low/)).toBeTruthy();
             expect(getByText(/Normal/)).toBeTruthy();
             expect(getByText(/High/)).toBeTruthy();
         });
 
-        it('should show loading state when isLoading is true', async () => {
-            const { queryAllByTestId } = await renderFeeOptionsList({
+        it('should show loading state when isLoading is true', () => {
+            const { queryAllByTestId } = renderFeeOptionsList({
                 props: { isLoading: true },
             });
 
@@ -124,14 +124,14 @@ describe('FeeOptionsList', () => {
             expect(queryAllByTestId('BoxSkeleton').length).toBeGreaterThan(0);
         });
 
-        it('should filter out custom and low fee levels for btc network', async () => {
+        it('should filter out custom and low fee levels for btc network', () => {
             const feeLevels = {
                 ...createMockFeeLevels(),
                 custom: createMockFeeLevel(),
                 low: createMockFeeLevel(),
             };
 
-            const { getByText, queryByText } = await renderFeeOptionsList({
+            const { getByText, queryByText } = renderFeeOptionsList({
                 props: { feeLevels, symbol: 'btc' },
             });
 
@@ -143,13 +143,13 @@ describe('FeeOptionsList', () => {
             expect(queryByText(/Custom/)).toBeNull();
         });
 
-        it('should work with economy if there is no normal', async () => {
+        it('should work with economy if there is no normal', () => {
             const feeLevels = {
                 economy: createMockFeeLevels().economy,
                 high: createMockFeeLevels().high,
             } as GeneralPrecomposedLevels;
 
-            const { getByText, queryByText } = await renderFeeOptionsList({
+            const { getByText, queryByText } = renderFeeOptionsList({
                 props: { feeLevels },
             });
 
@@ -161,7 +161,7 @@ describe('FeeOptionsList', () => {
 
     describe('Interaction', () => {
         it('should call onSelectedFeeLevel when a fee option is selected', async () => {
-            const { getByTestId } = await renderFeeOptionsList({});
+            const { getByTestId } = renderFeeOptionsList({});
 
             await userEvent.press(getByTestId('@transactionManagement/fees-level-radio-normal'));
 
@@ -169,7 +169,7 @@ describe('FeeOptionsList', () => {
         });
 
         it('should handle different fee level selections', async () => {
-            const { getByTestId } = await renderFeeOptionsList({});
+            const { getByTestId } = renderFeeOptionsList({});
 
             await userEvent.press(getByTestId('@transactionManagement/fees-level-radio-economy'));
             expect(defaultProps.onSelectedFeeLevel).toHaveBeenCalledWith('economy');
@@ -178,8 +178,8 @@ describe('FeeOptionsList', () => {
             expect(defaultProps.onSelectedFeeLevel).toHaveBeenCalledWith('high');
         });
 
-        it('should make options interactive when multiple options are available', async () => {
-            const { getByTestId } = await renderFeeOptionsList({});
+        it('should make options interactive when multiple options are available', () => {
+            const { getByTestId } = renderFeeOptionsList({});
 
             // Should have radio buttons when multiple options are available
             expect(getByTestId('@transactionManagement/fees-level-radio-normal')).toBeTruthy();
@@ -187,12 +187,12 @@ describe('FeeOptionsList', () => {
             expect(getByTestId('@transactionManagement/fees-level-radio-high')).toBeTruthy();
         });
 
-        it('should make options non-interactive when only one option is available', async () => {
+        it('should make options non-interactive when only one option is available', () => {
             const singleFeeLevel = {
                 normal: createMockFeeLevel(),
             };
 
-            const { queryByTestId } = await renderFeeOptionsList({
+            const { queryByTestId } = renderFeeOptionsList({
                 props: { feeLevels: singleFeeLevel },
             });
 

--- a/suite-native/transaction-management/src/components/fees/__tests__/FeesContent.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/__tests__/FeesContent.comp.test.tsx
@@ -1,7 +1,7 @@
 import { yup } from '@suite-common/validators';
 import { AccountKey, FormState } from '@suite-common/wallet-types';
 import { Form, useForm } from '@suite-native/forms';
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { getWalletState } from '../../../__fixtures__/walletState';
 import { FeesContent, FeesContentProps } from '../FeesContent';
@@ -66,7 +66,7 @@ describe('FeesContent', () => {
     const renderFeesContent = (props: Partial<FeesContentProps> = {}) => {
         const finalProps = { ...defaultProps, ...props };
 
-        return renderWithStoreProviderAsync(
+        return renderWithStoreProvider(
             <TestFormWrapper>
                 <FeesContent {...finalProps} />
             </TestFormWrapper>,
@@ -80,8 +80,8 @@ describe('FeesContent', () => {
         jest.clearAllMocks();
     });
 
-    it('should render title and description', async () => {
-        const { getByText } = await renderFeesContent();
+    it('should render title and description', () => {
+        const { getByText } = renderFeesContent();
 
         expect(getByText('Transaction fee')).toBeTruthy();
         expect(
@@ -89,59 +89,59 @@ describe('FeesContent', () => {
         ).toBeTruthy();
     });
 
-    it('should render fee options list when selected fee level is not custom', async () => {
-        const { getByTestId } = await renderFeesContent({
+    it('should render fee options list when selected fee level is not custom', () => {
+        const { getByTestId } = renderFeesContent({
             selectedFeeLevel: 'normal',
         });
 
         expect(getByTestId('@transactionManagement/fees-level-container-normal')).toBeTruthy();
     });
 
-    it('should not render fee options list when selected fee level is custom', async () => {
-        const { queryByTestId } = await renderFeesContent({
+    it('should not render fee options list when selected fee level is custom', () => {
+        const { queryByTestId } = renderFeesContent({
             selectedFeeLevel: 'custom',
         });
 
         expect(queryByTestId('@transactionManagement/fees-level-container-normal')).toBeNull();
     });
 
-    it('should always render custom fee component', async () => {
-        const { getByTestId } = await renderFeesContent();
+    it('should always render custom fee component', () => {
+        const { getByTestId } = renderFeesContent();
 
         expect(getByTestId('@transactionManagement/fees-level-custom')).toBeTruthy();
     });
 
-    it('should render all three fee level options', async () => {
-        const { getByTestId } = await renderFeesContent();
+    it('should render all three fee level options', () => {
+        const { getByTestId } = renderFeesContent();
 
         expect(getByTestId('@transactionManagement/fees-level-container-economy')).toBeTruthy();
         expect(getByTestId('@transactionManagement/fees-level-container-normal')).toBeTruthy();
         expect(getByTestId('@transactionManagement/fees-level-container-high')).toBeTruthy();
     });
 
-    it('should handle loading state', async () => {
-        const { getByTestId } = await renderFeesContent({
+    it('should handle loading state', () => {
+        const { getByTestId } = renderFeesContent({
             areFeesLoading: true,
         });
 
         expect(getByTestId('@transactionManagement/fees-level-custom')).toBeTruthy();
     });
 
-    it('should work with different network symbols', async () => {
-        const { getByText } = await renderFeesContent({
+    it('should work with different network symbols', () => {
+        const { getByText } = renderFeesContent({
             symbol: 'eth',
         });
 
         expect(getByText('Transaction fee')).toBeTruthy();
     });
 
-    it('should render with form draft data', async () => {
+    it('should render with form draft data', () => {
         const mockFormDraft = {
             selectedFee: 'high',
             feePerUnit: '10',
         } as FormState;
 
-        const { getByTestId } = await renderFeesContent({
+        const { getByTestId } = renderFeesContent({
             selectedFeeLevel: 'high',
             formDraft: mockFormDraft,
         });

--- a/suite-native/transaction-management/src/components/fees/__tests__/FeesFooter.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/__tests__/FeesFooter.comp.test.tsx
@@ -2,12 +2,7 @@ import { yup } from '@suite-common/validators';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { Form, useForm } from '@suite-native/forms';
-import {
-    TestStore,
-    initStore,
-    renderWithStoreProviderAsync,
-    userEvent,
-} from '@suite-native/test-utils';
+import { TestStore, initStore, renderWithStoreProvider, userEvent } from '@suite-native/test-utils';
 
 import { getWalletState } from '../../../__fixtures__/walletState';
 import { FeesFooter } from '../FeesFooter';
@@ -74,9 +69,9 @@ describe('FeesFooter', () => {
         const finalProps = { ...defaultProps, ...props };
         mockOnSubmit = finalProps.onSubmit;
 
-        return renderWithStoreProviderAsync(
+        return renderWithStoreProvider(
             <TestFormWrapper>
-                {/* 
+                {/*
                   FeesFooterProps expects withSubmitButton: true when present.
                   So we must ensure withSubmitButton is always true when passed.
                   This cast is safe because defaultProps and all usages set withSubmitButton: true.
@@ -103,14 +98,14 @@ describe('FeesFooter', () => {
         jest.clearAllMocks();
     });
 
-    it('should render mainnet summary when no token contract is provided', async () => {
-        const { getByText } = await renderFeesFooter();
+    it('should render mainnet summary when no token contract is provided', () => {
+        const { getByText } = renderFeesFooter();
 
         expect(getByText('Total amount')).toBeTruthy();
     });
 
-    it('should render token summary when token contract is provided', async () => {
-        const { getByText } = await renderFeesFooter({
+    it('should render token summary when token contract is provided', () => {
+        const { getByText } = renderFeesFooter({
             tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
         });
 
@@ -118,24 +113,24 @@ describe('FeesFooter', () => {
         expect(getByText('Fee')).toBeTruthy();
     });
 
-    it('should display total amount correctly', async () => {
-        const { getByText } = await renderFeesFooter({
+    it('should display total amount correctly', () => {
+        const { getByText } = renderFeesFooter({
             totalAmount: '5000000',
         });
 
         expect(getByText('0.05 BTC')).toBeTruthy();
     });
 
-    it('should show submit button when isSubmittable is true', async () => {
-        const { getByTestId } = await renderFeesFooter({
+    it('should show submit button when isSubmittable is true', () => {
+        const { getByTestId } = renderFeesFooter({
             isSubmittable: true,
         });
 
         expect(getByTestId('@transactionManagement/fees-submit-button')).toBeTruthy();
     });
 
-    it('should not show submit button when isSubmittable is false', async () => {
-        const { queryByTestId } = await renderFeesFooter({
+    it('should not show submit button when isSubmittable is false', () => {
+        const { queryByTestId } = renderFeesFooter({
             isSubmittable: false,
         });
 
@@ -143,7 +138,7 @@ describe('FeesFooter', () => {
     });
 
     it('should call onSubmit when submit button is pressed', async () => {
-        const { getByTestId } = await renderFeesFooter({
+        const { getByTestId } = renderFeesFooter({
             isSubmittable: true,
         });
 
@@ -152,20 +147,20 @@ describe('FeesFooter', () => {
         expect(mockOnSubmit).toHaveBeenCalledTimes(1);
     });
 
-    it('should display token symbol correctly', async () => {
+    it('should display token symbol correctly', () => {
         mockSelectAccountTokenSymbol.mockReturnValue('USDC');
 
-        const { getByText } = await renderFeesFooter({
+        const { getByText } = renderFeesFooter({
             tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
         });
 
         expect(getByText(/USDC/)).toBeTruthy();
     });
 
-    it('should display token amount with correct decimals', async () => {
+    it('should display token amount with correct decimals', () => {
         mockSelectAccountTokenDecimals.mockReturnValue(6);
 
-        const { getByText } = await renderFeesFooter({
+        const { getByText } = renderFeesFooter({
             tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
             totalAmount: '1000', // 1 USDC with 6 decimals
         });
@@ -173,18 +168,18 @@ describe('FeesFooter', () => {
         expect(getByText('0.001 USDC')).toBeTruthy();
     });
 
-    it('should handle different token contracts', async () => {
+    it('should handle different token contracts', () => {
         mockSelectAccountTokenSymbol.mockReturnValue('DAI');
 
-        const { getByText } = await renderFeesFooter({
+        const { getByText } = renderFeesFooter({
             tokenContract: '0x6b175474e89094c44da98b954eedeac495271d0f' as TokenAddress,
         });
 
         expect(getByText(/DAI/)).toBeTruthy();
     });
 
-    it('should show submit button when withSubmitButton is true and isSubmittable is true', async () => {
-        const { getByText } = await renderFeesFooter({
+    it('should show submit button when withSubmitButton is true and isSubmittable is true', () => {
+        const { getByText } = renderFeesFooter({
             isSubmittable: true,
             withSubmitButton: true,
         });
@@ -198,15 +193,15 @@ describe('FeesFooter', () => {
         { isSubmittable: false, withSubmitButton: false },
     ])(
         'should not show submit button when withSubmitButton is $withSubmitButton even if isSubmittable is $isSubmittable',
-        async props => {
-            const { queryByText } = await renderFeesFooter(props);
+        props => {
+            const { queryByText } = renderFeesFooter(props);
 
             expect(queryByText('Review and sign')).toBeNull();
         },
     );
 
-    it('should default withSubmitButton to true when not provided', async () => {
-        const { getByText } = await renderFeesFooter({
+    it('should default withSubmitButton to true when not provided', () => {
+        const { getByText } = renderFeesFooter({
             isSubmittable: true,
             // withSubmitButton not provided, should default to true
         });

--- a/suite-native/transaction-management/src/hooks/__tests__/useShowReviewCancellationAlert.test.ts
+++ b/suite-native/transaction-management/src/hooks/__tests__/useShowReviewCancellationAlert.test.ts
@@ -1,4 +1,4 @@
-import { TestStore, initStore, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { TestStore, initStore, renderHookWithStoreProvider } from '@suite-native/test-utils';
 
 import { useShowReviewCancellationAlert } from '../useShowReviewCancellationAlert';
 
@@ -21,15 +21,15 @@ describe('useShowReviewCancellationAlert', () => {
     let store: TestStore;
 
     const renderUseShowReviewCancellationAlert = () =>
-        renderHookWithStoreProviderAsync(() => useShowReviewCancellationAlert(), { store });
+        renderHookWithStoreProvider(() => useShowReviewCancellationAlert(), { store });
 
     beforeEach(() => {
         mockShowAlert.mockClear();
         store = initStore().store;
     });
 
-    it('should return stable callback', async () => {
-        const { result, rerender } = await renderUseShowReviewCancellationAlert();
+    it('should return stable callback', () => {
+        const { result, rerender } = renderUseShowReviewCancellationAlert();
 
         const firstCallback = result.current;
 
@@ -40,8 +40,8 @@ describe('useShowReviewCancellationAlert', () => {
         expect(firstCallback).toBe(secondCallback);
     });
 
-    it('should call showAlert on callback execution', async () => {
-        const { result } = await renderUseShowReviewCancellationAlert();
+    it('should call showAlert on callback execution', () => {
+        const { result } = renderUseShowReviewCancellationAlert();
 
         result.current();
 
@@ -50,7 +50,7 @@ describe('useShowReviewCancellationAlert', () => {
 
     it('should resolve with wasReviewCanceled true when primary button is pressed', async () => {
         const dispatchSpy = jest.spyOn(store, 'dispatch').mockReturnValue({} as any);
-        const { result } = await renderUseShowReviewCancellationAlert();
+        const { result } = renderUseShowReviewCancellationAlert();
         const promise = result.current();
         const alertConfig = mockShowAlert.mock.calls[0][0];
 
@@ -64,7 +64,7 @@ describe('useShowReviewCancellationAlert', () => {
     });
 
     it('should resolve with wasReviewCanceled false when secondary button is pressed', async () => {
-        const { result } = await renderUseShowReviewCancellationAlert();
+        const { result } = renderUseShowReviewCancellationAlert();
         const promise = result.current();
         const alertConfig = mockShowAlert.mock.calls[0][0];
 

--- a/suite-native/transaction-management/src/hooks/__tests__/useWaitForButtonRequest.test.ts
+++ b/suite-native/transaction-management/src/hooks/__tests__/useWaitForButtonRequest.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils';
 
 import { useWaitForButtonRequest } from '../useWaitForButtonRequest';
 
@@ -11,7 +11,7 @@ jest.mock('@suite-common/wallet-core', () => ({
 
 describe('useWaitForButtonRequest.ts', () => {
     const renderUseWaitForButtonRequest = (initialCallback: jest.Mock) =>
-        renderHookWithStoreProviderAsync(
+        renderHookWithStoreProvider(
             ({ onButtonRequest }) => useWaitForButtonRequest(onButtonRequest),
             {
                 initialProps: {
@@ -24,9 +24,9 @@ describe('useWaitForButtonRequest.ts', () => {
         jest.clearAllMocks();
     });
 
-    it('should call callback once there are any button requests', async () => {
+    it('should call callback once there are any button requests', () => {
         const callback = jest.fn();
-        const { result, rerender } = await renderUseWaitForButtonRequest(callback);
+        const { result, rerender } = renderUseWaitForButtonRequest(callback);
 
         act(() => {
             result.current();
@@ -41,9 +41,9 @@ describe('useWaitForButtonRequest.ts', () => {
         expect(callback).toHaveBeenCalledTimes(1);
     });
 
-    it('should not call callback multiple times', async () => {
+    it('should not call callback multiple times', () => {
         const callback = jest.fn();
-        const { result, rerender } = await renderUseWaitForButtonRequest(callback);
+        const { result, rerender } = renderUseWaitForButtonRequest(callback);
 
         act(() => {
             result.current();

--- a/suite-native/transaction-management/src/hooks/fees/__tests__/useFeesFetching.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/__tests__/useFeesFetching.test.ts
@@ -4,7 +4,7 @@ import {
     PreloadedState,
     TestStore,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 
 import { getWalletState } from '../../../__fixtures__/walletState';
@@ -51,10 +51,9 @@ describe('useFeesFetching', () => {
         networkSymbol?: NetworkSymbol;
         isRefetchDisabled?: boolean;
     }) =>
-        renderHookWithStoreProviderAsync(
-            () => useFeesFetching({ networkSymbol, isRefetchDisabled }),
-            { store },
-        );
+        renderHookWithStoreProvider(() => useFeesFetching({ networkSymbol, isRefetchDisabled }), {
+            store,
+        });
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -64,9 +63,9 @@ describe('useFeesFetching', () => {
         mockSelectAreFeesLoading.mockReturnValue(false);
     });
 
-    it('should select account by key from state', async () => {
+    it('should select account by key from state', () => {
         const { store } = initStore(createMockState());
-        const { result } = await renderUseFeesFetching({ store, networkSymbol: 'btc' });
+        const { result } = renderUseFeesFetching({ store, networkSymbol: 'btc' });
 
         expect(result.current.areFeesLoading).toBe(false);
         expect(mockUseFetchFeesOnce).toHaveBeenCalledWith({ networkSymbol: 'btc' });
@@ -76,10 +75,10 @@ describe('useFeesFetching', () => {
         });
     });
 
-    it('should handle loading state correctly', async () => {
+    it('should handle loading state correctly', () => {
         mockSelectAreFeesLoading.mockReturnValue(true);
         const { store } = initStore(createMockState());
-        const { result } = await renderUseFeesFetching({ store, networkSymbol: 'btc' });
+        const { result } = renderUseFeesFetching({ store, networkSymbol: 'btc' });
 
         expect(result.current.areFeesLoading).toBe(true);
         expect(mockUseFetchFeesOnce).toHaveBeenCalledWith({ networkSymbol: 'btc' });
@@ -89,9 +88,9 @@ describe('useFeesFetching', () => {
         });
     });
 
-    it('should handle refetch disabled correctly', async () => {
+    it('should handle refetch disabled correctly', () => {
         const { store } = initStore(createMockState());
-        const { result } = await renderUseFeesFetching({
+        const { result } = renderUseFeesFetching({
             store,
             networkSymbol: 'btc',
             isRefetchDisabled: true,
@@ -105,9 +104,9 @@ describe('useFeesFetching', () => {
         });
     });
 
-    it('should handle undefined networkSymbol gracefully', async () => {
+    it('should handle undefined networkSymbol gracefully', () => {
         const { store } = initStore(createMockState());
-        const { result } = await renderUseFeesFetching({
+        const { result } = renderUseFeesFetching({
             store,
             networkSymbol: undefined,
         });

--- a/suite-native/transaction-management/src/hooks/fees/__tests__/useFeesForm.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/__tests__/useFeesForm.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils';
 
 import { UseFeesFormProps, useFeesForm } from '../useFeesForm';
 
@@ -10,7 +10,7 @@ describe('useFeesForm', () => {
     };
 
     const renderUseFeesForm = (props: UseFeesFormProps = mockProps) =>
-        renderHookWithStoreProviderAsync(() => useFeesForm(props), {
+        renderHookWithStoreProvider(() => useFeesForm(props), {
             preloadedState: {
                 wallet: {
                     send: {
@@ -65,8 +65,8 @@ describe('useFeesForm', () => {
             },
         });
 
-    it('should initialize with default values', async () => {
-        const { result } = await renderUseFeesForm();
+    it('should initialize with default values', () => {
+        const { result } = renderUseFeesForm();
 
         expect(result.current.getValues()).toEqual({
             feeLevel: 'normal',
@@ -75,8 +75,8 @@ describe('useFeesForm', () => {
         });
     });
 
-    it('should update fee level when changed', async () => {
-        const { result } = await renderUseFeesForm();
+    it('should update fee level when changed', () => {
+        const { result } = renderUseFeesForm();
 
         act(() => {
             result.current.setValue('feeLevel', 'high');
@@ -85,8 +85,8 @@ describe('useFeesForm', () => {
         expect(result.current.getValues('feeLevel')).toBe('high');
     });
 
-    it('should update custom fee per unit when changed', async () => {
-        const { result } = await renderUseFeesForm();
+    it('should update custom fee per unit when changed', () => {
+        const { result } = renderUseFeesForm();
 
         act(() => {
             result.current.setValue('customFeePerUnit', '30000000000');
@@ -95,8 +95,8 @@ describe('useFeesForm', () => {
         expect(result.current.getValues('customFeePerUnit')).toBe('30000000000');
     });
 
-    it('should update custom fee limit when changed', async () => {
-        const { result } = await renderUseFeesForm();
+    it('should update custom fee limit when changed', () => {
+        const { result } = renderUseFeesForm();
 
         act(() => {
             result.current.setValue('customFeeLimit', '21000');
@@ -105,14 +105,14 @@ describe('useFeesForm', () => {
         expect(result.current.getValues('customFeeLimit')).toBe('21000');
     });
 
-    it('should initialize with custom default values', async () => {
+    it('should initialize with custom default values', () => {
         const customProps: UseFeesFormProps = {
             accountKey: 'eth-1',
             defaultFeeLevel: 'high',
             defaultFeePerUnit: '15000000000',
         };
 
-        const { result } = await renderUseFeesForm(customProps);
+        const { result } = renderUseFeesForm(customProps);
 
         expect(result.current.getValues()).toEqual({
             feeLevel: 'high',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`initStore` is no longer async, therefore there is no need to have `renderWithStoreProviderAsync` in `async` version.

- Updated and deprecated `renderWithStoreProviderAsync` and `renderHookWithStoreProviderAsync`
- Introduced sync versions `renderWithStoreProvider` and `renderHookWithStoreProvider`
- updated some trading packages (=all except the biggest one - `module-trading`) to use new methods only.
- No production changes. Just tests.
- 
<!--- Describe your changes in detail -->

## Notes for QA

Nothing to test.




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=suite-native-test-utils-update&lookback=7)