### PR TITLE
fix(suite-native): custom fee form refactor

### DIFF
--- a/suite-native/atoms/src/Sheet/BottomSheetModal.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetModal.tsx
@@ -28,8 +28,11 @@ export type BottomSheetModalProps = {
     title?: ReactNode;
     subtitle?: ReactNode;
     isCloseDisplayed?: boolean;
-    onDismiss?: () => void;
     bottomSheetCustomProps?: Partial<BottomSheetModalBaseProps>;
+    // triggered when the close button is pressed
+    onClose?: () => void;
+    // triggered Always when the modal is dismissed
+    onDismiss?: () => void;
 } & BoxProps;
 
 const backgroundStyle = prepareNativeStyle(({ colors }) => ({
@@ -54,6 +57,7 @@ export const BottomSheetModal = forwardRef<BottomSheetModalMethods, BottomSheetM
             subtitle,
             onDismiss,
             bottomSheetCustomProps = {},
+            onClose,
             ...rest
         },
         ref,
@@ -76,13 +80,11 @@ export const BottomSheetModal = forwardRef<BottomSheetModalMethods, BottomSheetM
         );
 
         const onCloseModal = useCallback(() => {
-            if (onDismiss) {
-                onDismiss();
-            }
+            onClose?.();
             if (ref && 'current' in ref && ref.current) {
                 ref.current.dismiss();
             }
-        }, [ref, onDismiss]);
+        }, [ref, onClose]);
 
         return (
             <BottomSheetModalBase

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFee.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFee.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import Animated, { FadeInLeft, FadeOutLeft } from 'react-native-reanimated';
 
 import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
-import { AccountKey, FeeLevelLabel, FormState } from '@suite-common/wallet-types';
+import { AccountKey, FormState } from '@suite-common/wallet-types';
 import { Box, Button, useBottomSheetModal } from '@suite-native/atoms';
 import { useFormContext } from '@suite-native/forms';
 import { Icon } from '@suite-native/icons';
@@ -44,11 +44,20 @@ export const CustomFeeButton = ({ onPress }: CustomFeeButtonProps) => (
 const CustomFeeContentWrapper = ({ accountKey, formDraft, onCustomFeeSet }: CustomFeeProps) => {
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
 
-    const [previousSelectedFeeLevelLabel, setPreviousSelectedFeeLevelLabel] =
-        useState<FeeLevelLabel>('normal');
-    const { watch, setValue, getValues } = useFormContext<FeesFormValues>();
+    const {
+        watch,
+        getValues,
+        reset,
+        formState: { defaultValues },
+    } = useFormContext<FeesFormValues>();
 
     const isCustomFeeSelected = watch('feeLevel') === 'custom';
+    const lastSavedValuesRef = useRef<FeesFormValues>(undefined);
+    const initialFormValuesRef = useRef<FeesFormValues>(undefined);
+
+    useEffect(() => {
+        initialFormValuesRef.current = getValues();
+    }, [getValues]);
 
     // Use the hook to get fee-related values
     const { feeValue, isFeeLoading, isSubmittable, isErrorBoxVisible } = useCustomFee({
@@ -58,14 +67,20 @@ const CustomFeeContentWrapper = ({ accountKey, formDraft, onCustomFeeSet }: Cust
 
     const openCustomFeeBottomSheet = () => {
         openModal();
+        lastSavedValuesRef.current = defaultValues as FeesFormValues;
 
+        // Store the initial form values when opening the modal in case of cancellation
         const currentSelectedFeeLevelLabel = getValues('feeLevel');
-        if (currentSelectedFeeLevelLabel !== 'custom')
-            setPreviousSelectedFeeLevelLabel(currentSelectedFeeLevelLabel);
+        if (currentSelectedFeeLevelLabel !== 'custom' && initialFormValuesRef.current !== undefined)
+            // This allows the "Cancel" button to return to the last known standard fee
+            initialFormValuesRef.current = {
+                ...initialFormValuesRef.current,
+                feeLevel: currentSelectedFeeLevelLabel,
+            };
     };
 
     const cancelCustomFee = () => {
-        setValue('feeLevel', previousSelectedFeeLevelLabel);
+        reset(initialFormValuesRef.current);
         closeModal();
     };
 
@@ -82,6 +97,7 @@ const CustomFeeContentWrapper = ({ accountKey, formDraft, onCustomFeeSet }: Cust
             )}
 
             <CustomFeeBottomSheet
+                lastSavedValuesRef={lastSavedValuesRef}
                 ref={bottomSheetRef}
                 accountKey={accountKey}
                 onClose={closeModal}

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeBottomSheet.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeBottomSheet.tsx
@@ -1,3 +1,4 @@
+import { RefObject, useCallback, useMemo } from 'react';
 import Animated, { FadeInDown, FadeOutDown } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
@@ -19,12 +20,7 @@ import { Translation } from '@suite-native/intl';
 import { CustomFeeInputs } from './CustomFeeInputs';
 import { FeesFormValues } from '../../../feesFormSchema';
 import { CustomFeeParams } from '../../../hooks';
-import {
-    FEE_LIMIT_FIELD_NAME,
-    FEE_PER_UNIT_FIELD_NAME,
-    MAX_FEE_PER_GAS_FIELD_NAME,
-    MAX_PRIORITY_FEE_PER_GAS_FIELD_NAME,
-} from '../../../presets';
+
 type CustomFeeBottomSheetProps = {
     onClose: () => void;
     accountKey: AccountKey;
@@ -34,6 +30,7 @@ type CustomFeeBottomSheetProps = {
     isErrorBoxVisible: boolean;
     onCustomFeeSet: (customFeeParams: CustomFeeParams) => void;
     ref: BottomSheetModalRef;
+    lastSavedValuesRef: RefObject<FeesFormValues | undefined>;
 };
 
 export const CustomFeeBottomSheet = ({
@@ -44,34 +41,59 @@ export const CustomFeeBottomSheet = ({
     isSubmittable,
     isErrorBoxVisible,
     ref,
+    lastSavedValuesRef,
     onCustomFeeSet,
 }: CustomFeeBottomSheetProps) => {
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
 
-    const { setValue, handleSubmit, getValues } = useFormContext<FeesFormValues>();
+    const {
+        setValue,
+        handleSubmit,
+        reset,
+        formState: { isDirty },
+        watch,
+        getValues,
+    } = useFormContext<FeesFormValues>();
 
-    const handleSetCustomFee = handleSubmit(() => {
-        setValue('feeLevel', 'custom');
-        const customFeePerUnit = getValues(FEE_PER_UNIT_FIELD_NAME);
-        const customFeeLimit = getValues(FEE_LIMIT_FIELD_NAME);
-        const customMaxFeePerGas = getValues(MAX_FEE_PER_GAS_FIELD_NAME);
-        const customMaxPriorityFeePerGas = getValues(MAX_PRIORITY_FEE_PER_GAS_FIELD_NAME);
-        onCustomFeeSet({
-            customFeePerUnit,
-            customFeeLimit,
-            customMaxFeePerGas,
-            customMaxPriorityFeePerGas,
-        });
+    const feeLevelValue = watch('feeLevel');
+
+    const isButtonVisible = useMemo(
+        () => (isDirty || feeLevelValue !== 'custom') && isSubmittable,
+        [feeLevelValue, isDirty, isSubmittable],
+    );
+
+    const handleSetCustomFee = handleSubmit(data => {
+        const { feeLevel, ...formData } = data;
+
+        if (feeLevel !== 'custom') {
+            setValue('feeLevel', 'custom');
+        }
+
+        const updatedData = { ...formData, feeLevel: 'custom' } satisfies FeesFormValues;
+        lastSavedValuesRef.current = updatedData;
+
+        // clear the dirty state
+        reset(updatedData);
+
+        onCustomFeeSet(formData);
         onClose();
     });
+
+    const handleDismiss = useCallback(() => {
+        reset({
+            ...lastSavedValuesRef.current,
+            feeLevel: getValues('feeLevel'),
+        });
+    }, [reset, lastSavedValuesRef, getValues]);
 
     if (!symbol) return null;
 
     return (
         <BottomSheetModal
             ref={ref}
+            onClose={handleDismiss}
             title={<Translation id="transactionManagement.fees.custom.bottomSheet.title" />}
             testID="@transactionManagement/custom-fee-bottom-sheet"
             isCloseDisplayed
@@ -118,7 +140,7 @@ export const CustomFeeBottomSheet = ({
             <Box marginTop="sp16">
                 <FormSubmitButton
                     onPress={handleSetCustomFee}
-                    isVisible={isSubmittable}
+                    isVisible={isButtonVisible}
                     testID="@transactionManagement/custom-fee-submit-button"
                 >
                     <Translation id="transactionManagement.fees.custom.bottomSheet.confirmButton" />

--- a/suite-native/transaction-management/src/components/fees/CustomFee/EIP1559CustomInputs.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/EIP1559CustomInputs.tsx
@@ -43,7 +43,6 @@ export const EIP1559CustomInputs = ({
                 keyboardType="decimal-pad"
                 rightIcon={<Text color="textSubdued">{feeUnits}</Text>}
                 onChangeText={handleFieldChangeValue(MAX_FEE_PER_GAS_FIELD_NAME, 'crypto')}
-                asBottomSheetInput
             />
             <HStack paddingLeft="sp12" alignItems="center" spacing="sp4" paddingBottom="sp8">
                 <Icon name="gasPump" size="medium" color="textSubdued" />
@@ -66,7 +65,6 @@ export const EIP1559CustomInputs = ({
                 rightIcon={<Text color="textSubdued">{feeUnits}</Text>}
                 keyboardType="decimal-pad"
                 onChangeText={handleFieldChangeValue(MAX_PRIORITY_FEE_PER_GAS_FIELD_NAME, 'crypto')}
-                asBottomSheetInput
             />
         </>
     );

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFee.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFee.comp.test.tsx
@@ -221,8 +221,7 @@ describe('CustomFee', () => {
 
         await userEvent.press(getByText('Edit'));
 
-        // Verify the confirm button is present
-        expect(getByText('Confirm custom fee')).toBeTruthy();
+        expect(getByText('Gas limit')).toBeTruthy();
     });
 
     it('should handle different account keys', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The current implementation of the custom fee form allowed user input to be saved even when the modal was canceled. This could lead to undesired behavior and incorrect fee settings in some cases.

- The close button now returns all values to their previous state.
- Canceling a custom fee and returning to the standard fee selection screen resets all values, except for the previously selected feeLevel.
- The confirm button is now visible only when the form is "dirty" or has not been submitted yet.


## Notes for QA

Scenario A

1. Go through either the Trade or Sell flow to reach the standard fee selection.
2. Open the custom fee modal using the `Custom fee` button.
3. Change an input and close the modal via the `close` button.
4. Reopen the modal. The values should be **the same as they were in the previous state**.

Scenario B

1. Go through either the Trade or Sell flow to reach the standard fee selection.
2. Open the custom fee modal and confirm the custom fee form via `Confirm` button.
3. Press the `Edit` button on the custom fee card.
4. Change an input and close the modal via the close button.
5. Reopen the modal. The values should still match the previously confirmed state.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

### Before

https://github.com/user-attachments/assets/fd2982bc-a032-4f71-ac22-c983c9bc4b28

### After

https://github.com/user-attachments/assets/5ad7104e-5802-46d1-a443-847a9af0215a



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/custom-fee-form-refactor&lookback=7)