### PR TITLE
Tests: expand display asserts of display to support t3w1

### DIFF
--- a/suite/e2e/support/helpers/displayContentNormalizedParser.ts
+++ b/suite/e2e/support/helpers/displayContentNormalizedParser.ts
@@ -6,7 +6,8 @@ export interface NormalizedDisplayContent {
         subtitle?: string;
     };
     body: Paragraph[];
-    footer?: string;
+    actions?: Record<string, string> | null;
+    footer?: string | null;
 }
 
 function getFirstPresent<T = any>(obj: any, keys: string[]): T | undefined {
@@ -22,17 +23,18 @@ function getFirstPresent<T = any>(obj: any, keys: string[]): T | undefined {
 
 function getValueAtPaths(obj: any, paths: string[][]): any {
     for (const path of paths) {
-        let cur = obj;
-        let ok = true;
-        for (const seg of path) {
-            if (cur && typeof cur === 'object' && seg in cur) {
-                cur = cur[seg];
+        let current = obj;
+
+        for (const segment of path) {
+            if (current && typeof current === 'object' && segment in current) {
+                current = current[segment];
             } else {
-                ok = false;
+                current = undefined;
                 break;
             }
         }
-        if (ok) return cur;
+
+        if (current !== undefined) return current;
     }
 
     return undefined;
@@ -45,6 +47,21 @@ function extractTextish(value: any): string | undefined {
     if (typeof value.instruction === 'string') return value.instruction;
 
     return undefined;
+}
+
+function extractActionsFromActionBar(json: any): Record<string, string> {
+    const actionBar = json?.ActionBar;
+    if (!actionBar || typeof actionBar !== 'object') return {};
+
+    const actions: Record<string, string> = {};
+    for (const [key, value] of Object.entries(actionBar)) {
+        if (!/button/i.test(key)) continue;
+        if (!value || typeof value !== 'object') continue;
+        if (typeof (value as any).text !== 'string') continue;
+        actions[key] = (value as any).text;
+    }
+
+    return actions;
 }
 
 // Vibecode Warning
@@ -85,6 +102,11 @@ export function parseDisplayContent(json: any): NormalizedDisplayContent {
         );
     }
 
+    const paragraphsWithoutEmptyTokens = paragraphs.filter(
+        (paragraph: any) =>
+            !Array.isArray(paragraph) || paragraph.length !== 1 || paragraph[0] !== ' ',
+    );
+
     // footer: could be footer.instruction or simple footer string/object
     const footerCandidate = getValueAtPaths(json, [
         ['footer', 'instruction'],
@@ -94,9 +116,20 @@ export function parseDisplayContent(json: any): NormalizedDisplayContent {
     ]);
     const footer = extractTextish(footerCandidate);
 
+    // T3W1 has ActionBar with buttons instead of the footer
+    const actions = extractActionsFromActionBar(json);
+    const areActionsPresent = Object.keys(actions).length > 0;
+
+    if (areActionsPresent && footer) {
+        throw new Error(
+            `Unexpected Display content: both actions and footer present: ${JSON.stringify(json)}`,
+        );
+    }
+
     const result: NormalizedDisplayContent = {
         header: subtitle ? { title, subtitle } : { title },
-        body: paragraphs,
+        body: paragraphsWithoutEmptyTokens,
+        ...(areActionsPresent ? { actions } : {}),
         ...(footer ? { footer } : {}),
     };
 

--- a/suite/e2e/support/modelFixture.ts
+++ b/suite/e2e/support/modelFixture.ts
@@ -3,6 +3,7 @@ import { Model } from '@trezor/trezor-user-env-link/src/types';
 export class ModelFixture {
     isModelWithSecureElement = () => ['T3B1', 'T3T1', 'T3W1'].includes(this.model);
     isModelWithTHP = () => ['T3W1'].includes(this.model);
+    isT3W1 = () => this.model === 'T3W1';
 
     constructor(readonly model: Model) {}
 }

--- a/suite/e2e/support/pageObjects/devicePrompt.ts
+++ b/suite/e2e/support/pageObjects/devicePrompt.ts
@@ -1,7 +1,5 @@
 import { Locator, Page, expect } from '@playwright/test';
 
-import { Model } from '@trezor/trezor-user-env-link';
-
 import { TrezorUserEnvLinkProxy, analyzeObject, step } from '../common';
 import {
     NormalizedDisplayContent,
@@ -42,7 +40,7 @@ export class DevicePrompt {
 
     constructor(
         private page: Page,
-        private readonly model: ModelFixture,
+        readonly model: ModelFixture,
     ) {
         this.confirmOnDevicePrompt = page.getByTestId('@prompts/confirm-on-device');
         this.connectDevicePrompt = page.getByTestId('@connect-device-prompt');
@@ -105,15 +103,14 @@ export class DevicePrompt {
     }
 
     @step()
-    async waitForPromptAndClick(model?: Model): Promise<void> {
+    async waitForPromptAndClick(): Promise<void> {
         const EMULATOR_CENTER_COORDINATES: Record<string, { x: number; y: number }> = {
             T3T1: { x: 125, y: 150 },
             T3W1: { x: 200, y: 480 },
         };
 
         await this.confirmOnDevicePromptIsShown();
-
-        await TrezorUserEnvLinkProxy.clickEmu(EMULATOR_CENTER_COORDINATES[model ?? 'T3T1']);
+        await TrezorUserEnvLinkProxy.clickEmu(EMULATOR_CENTER_COORDINATES[this.model.model]);
     }
 
     @step()
@@ -153,6 +150,7 @@ export class DevicePrompt {
         return analyzeObject({
             header: debugState.header,
             body: debugState.body,
+            actions: debugState.actions,
             footer: debugState.footer,
         });
     }
@@ -205,6 +203,26 @@ export class DevicePrompt {
     }
 
     @step()
+    async openFeeInfoOnEmulator({
+        buttonIndexT3W1 = 1,
+        buttonIndexT3T1 = 1,
+    }: {
+        buttonIndexT3W1?: number;
+        buttonIndexT3T1?: number;
+    } = {}) {
+        const EMULATOR_BURGER_MENU_COORDINATES: Record<string, { x: number; y: number }> = {
+            T3T1: { x: 200, y: 20 },
+            T3W1: { x: 300, y: 20 },
+        };
+        await TrezorUserEnvLinkProxy.clickEmu(EMULATOR_BURGER_MENU_COORDINATES[this.model.model]);
+        const EMULATOR_FEE_INFO_COORDINATES: Record<string, { x: number; y: number }> = {
+            T3T1: { x: 125, y: buttonIndexT3T1 * 100 },
+            T3W1: { x: 125, y: buttonIndexT3W1 * 100 },
+        };
+        await TrezorUserEnvLinkProxy.clickEmu(EMULATOR_FEE_INFO_COORDINATES[this.model.model]);
+    }
+
+    @step()
     async closeModal() {
         await this.modalCloseButton.click();
         await expect(this.modal).toBeHidden();
@@ -225,4 +243,42 @@ export class DevicePrompt {
     getDeviceModel() {
         return this.model.model;
     }
+
+    private wrapTextByLineLimit = (
+        text: string,
+        lineCharLimit: number,
+        newline: string | string[],
+    ) => {
+        const regex = new RegExp(`.{1,${lineCharLimit}}`, 'g');
+        const splitLines = text.match(regex);
+        if (!splitLines) {
+            throw new Error(`Failed to split text into lines: "${text}"`);
+        }
+
+        const newlineArray = Array.isArray(newline) ? newline : [newline];
+
+        return splitLines.flatMap((line, index) =>
+            index < splitLines.length - 1 ? [line.trim(), ...newlineArray] : [line.trim()],
+        );
+    };
+
+    wrapText = (text: string, options?: { isAmount?: boolean }) => {
+        const T3W1_EXACT_LINE_LENGTH = 14;
+        const T3T1_EXACT_LINE_LENGTH = 18;
+        const T3W1_LINE_LENGTH_MINUS_DASH = 13;
+
+        if (this.model.isT3W1()) {
+            if (text.length === T3W1_EXACT_LINE_LENGTH) {
+                return [text];
+            }
+            const lineCharLimit = options?.isAmount
+                ? T3W1_LINE_LENGTH_MINUS_DASH
+                : T3W1_EXACT_LINE_LENGTH;
+            const newline = options?.isAmount ? ['-', '\n'] : ['\n'];
+
+            return this.wrapTextByLineLimit(text, lineCharLimit, newline);
+        }
+
+        return this.wrapTextByLineLimit(text, T3T1_EXACT_LINE_LENGTH, ['\n']);
+    };
 }

--- a/suite/e2e/support/pageObjects/feeSection.ts
+++ b/suite/e2e/support/pageObjects/feeSection.ts
@@ -2,7 +2,7 @@ import { Locator, Page, Response } from '@playwright/test';
 
 import { BigNumber } from '@trezor/utils';
 
-import { TrezorUserEnvLinkProxy, step } from '../common';
+import { step } from '../common';
 import { solanaUrlPattern } from '../mocks/tradingMock';
 import { expect } from '../testExtends/customMatchers';
 
@@ -200,14 +200,6 @@ before rounding: ${maxFeeInEthereum} ETH, after rounding: ${maxFeeRounded} ETH`;
         }
 
         return match.groups.value;
-    }
-
-    @step()
-    async openFeeInfoOnEmulator() {
-        const burgerMenuCoordinates = { x: 200, y: 20 };
-        await TrezorUserEnvLinkProxy.clickEmu(burgerMenuCoordinates);
-        const feeInfoCoordinates = { x: 125, y: 100 };
-        await TrezorUserEnvLinkProxy.clickEmu(feeInfoCoordinates);
     }
 
     @step()

--- a/suite/e2e/support/testExtends/customMatchers.ts
+++ b/suite/e2e/support/testExtends/customMatchers.ts
@@ -8,12 +8,13 @@ import { TranslationKey } from '@trezor/suite/src//components/suite/Translation'
 import messages from '@trezor/suite/src//support/messages';
 
 import { formatAddress, isEqualWithOmit, normalizeWhitespace } from '../common';
+import type { NormalizedDisplayContent } from '../helpers/displayContentNormalizedParser';
 import { DevicePrompt } from '../pageObjects/devicePrompt';
 
 type LineFormats = 'fourTetragrams' | 'evmTetragrams' | 'fullLine';
 
-const DISPLAY_CHAR_LIMIT = 18;
-const STRING_UP_TO_DISPLAY_LIMIT = new RegExp(`.{1,${DISPLAY_CHAR_LIMIT}}`, 'g');
+const DISPLAY_CHAR_LIMIT_T3T1 = 18;
+const STRING_UP_TO_T3T1_DISPLAY_LIMIT = new RegExp(`.{1,${DISPLAY_CHAR_LIMIT_T3T1}}`, 'g');
 const intlEn = createIntl({ locale: 'en', messages: {} }, createIntlCache());
 
 const compareTextAndNumber = async (
@@ -39,7 +40,7 @@ const compareTextAndNumber = async (
 
 const compareDisplayContent = async (
     devicePrompt: DevicePrompt,
-    expectedContent: any,
+    expectedContent: NormalizedDisplayContent,
     errorMessage: string,
 ) => {
     await test.step(`expected object: ${JSON.stringify(expectedContent)}`, () => {});
@@ -111,20 +112,8 @@ export const transformAddress = (address: string, lineFormat: LineFormats = 'fou
     }
 
     if (lineFormat === 'fullLine') {
-        return addNewlinesToAddress(address, STRING_UP_TO_DISPLAY_LIMIT, ' \n ');
+        return addNewlinesToAddress(address, STRING_UP_TO_T3T1_DISPLAY_LIMIT, ' \n ');
     }
-};
-
-export const splitStringByDisplayLimit = (text: string) => {
-    const splitLines = text.match(STRING_UP_TO_DISPLAY_LIMIT);
-    if (!splitLines) {
-        throw new Error(`Failed to split text into lines: "${text}"`);
-    }
-
-    // Add a newline item into array after each item except the last one
-    return splitLines.flatMap((line, index) =>
-        index < splitLines.length - 1 ? [line.trim(), '\n'] : [line.trim()],
-    );
 };
 
 export const expect = baseExpect.extend({
@@ -185,29 +174,24 @@ export const expect = baseExpect.extend({
     async toDisplayReceiveAddress(
         devicePrompt: DevicePrompt,
         expectedAddress: string,
-        options: { lineFormat: LineFormats; specialAccountType?: string } = {
+        options: { lineFormat: LineFormats } = {
             lineFormat: 'fourTetragrams',
         },
     ) {
-        if (devicePrompt.getDeviceModel() !== 'T3T1') {
-            return { pass: true, message: () => 'Test is skipped on non-T3T1 models' };
-        }
         const transformedExpectedAddress = transformAddress(expectedAddress, options.lineFormat);
-
-        let expectedContent;
-        if (options.specialAccountType) {
-            expectedContent = {
-                header: { title: 'Receive address' },
-                body: [[options.specialAccountType], transformedExpectedAddress],
-                footer: 'Tap to continue',
-            };
-        } else {
-            expectedContent = {
-                header: { title: 'Receive address' },
-                body: [transformedExpectedAddress],
-                footer: 'Tap to continue',
-            };
-        }
+        const expectedContent = devicePrompt.model.isT3W1()
+            ? {
+                  header: { title: 'Receive' },
+                  body: [transformedExpectedAddress],
+                  actions: {
+                      right_button: 'Confirm',
+                  },
+              }
+            : {
+                  header: { title: 'Receive address' },
+                  body: [transformedExpectedAddress],
+                  footer: 'Tap to continue',
+              };
 
         return await compareDisplayContent(
             devicePrompt,
@@ -216,9 +200,30 @@ export const expect = baseExpect.extend({
         );
     },
 
-    async toDisplayOnEmulator(devicePrompt: DevicePrompt, expectedContent: object) {
-        if (devicePrompt.getDeviceModel() !== 'T3T1') {
-            return { pass: true, message: () => 'Test is skipped on non-T3T1 models' };
+    async toDisplayOnEmulator(
+        devicePrompt: DevicePrompt,
+        expected: { T3W1: NormalizedDisplayContent; T3T1?: Partial<NormalizedDisplayContent> },
+    ) {
+        // default T3W1 model
+        let expectedContent = expected.T3W1;
+
+        // expected.T3T1 is used as overrides for the default T3W1 model
+        if (!devicePrompt.model.isT3W1()) {
+            const DEFAULT_T3T1_FOOTER = { footer: 'Tap to continue' };
+            expectedContent = {
+                ...expected.T3W1,
+                ...DEFAULT_T3T1_FOOTER,
+                ...expected.T3T1,
+            };
+
+            // Remove footer if T3T1 override explicitly says it is undefined
+            const noFooterExpected = !expectedContent.footer;
+            if (noFooterExpected) {
+                delete expectedContent.footer;
+            }
+
+            // nonT3W1 does not have actions, remove them
+            delete expectedContent.actions;
         }
 
         return await compareDisplayContent(

--- a/suite/e2e/tests/staking/ada/claim.test.ts
+++ b/suite/e2e/tests/staking/ada/claim.test.ts
@@ -2,7 +2,6 @@ import { TestCategory, TestPriority, TestStream, createTestAnnotation } from '@t
 
 import { toADA } from '../../../support/common';
 import { expect, test } from '../../../support/fixtures';
-import { splitStringByDisplayLimit } from '../../../support/testExtends/customMatchers';
 
 // mocked and expected values
 const startingBalance = 88858306;
@@ -163,39 +162,53 @@ test.describe('Staking - Cardano', { tag: ['@group=staking', '@specificModel'] }
 
             await test.step('Confirm claim on device', async () => {
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Confirm transaction' },
-                    body: [
-                        ['Confirm withdrawal for', '\n', 'reward address:'],
-                        splitStringByDisplayLimit(
-                            'stake1uytalm0k75njyj7v8z580ajs09v5v4lz6yp9akh8cgty43qunjqys',
-                        ),
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Confirm transaction' },
+                        body: [
+                            ['Confirm withdrawal for reward', '\n', 'address:'],
+                            devicePrompt.wrapText(
+                                'stake1uytalm0k75njyj7v8z580ajs09v5v4lz6yp9akh8cgty43qunjqys',
+                            ),
+                        ],
+                        actions: { right_button: 'Confirm' },
+                    },
+                    T3T1: {
+                        body: [
+                            ['Confirm withdrawal for', '\n', 'reward address:'],
+                            devicePrompt.wrapText(
+                                'stake1uytalm0k75njyj7v8z580ajs09v5v4lz6yp9akh8cgty43qunjqys',
+                            ),
+                        ],
+                    },
                 });
 
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Confirm transaction' },
-                    body: [
-                        ['for account #1:'],
-                        ["m/1852'/1815'/0'/2", '\n', '/0'],
-                        ['Amount:'],
-                        [bigRewardAmountFormatted],
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Confirm transaction' },
+                        body: [
+                            ['for account #1:'],
+                            devicePrompt.wrapText("m/1852'/1815'/0'/2/0"),
+                            ['Amount:'],
+                            [bigRewardAmountFormatted],
+                        ],
+                        actions: { right_button: 'Confirm' },
+                    },
                 });
 
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Confirm transaction' },
-                    body: [
-                        ['Transaction fee:'],
-                        [toADA(bigRewardFee)],
-                        ['Network: Mainnet'],
-                        ['Valid since: n/a'],
-                        [/^TTL: \d{9}$/],
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Confirm transaction' },
+                        body: [
+                            ['Transaction fee:'],
+                            [toADA(bigRewardFee)],
+                            ['Network: Mainnet'],
+                            ['Valid since: n/a'],
+                            [/^TTL: \d{9}$/],
+                        ],
+                        actions: { right_button: 'Hold to confirm' },
+                    },
                 });
 
                 // staked account without rewards after claiming

--- a/suite/e2e/tests/staking/ada/stake.test.ts
+++ b/suite/e2e/tests/staking/ada/stake.test.ts
@@ -4,7 +4,6 @@ import { TestCategory, TestPriority, TestStream, createTestAnnotation } from '@t
 import { toADA } from '../../../support/common';
 import { expect, test } from '../../../support/fixtures';
 import { ADA_MOCKED_ACCOUNT } from '../../../support/mocks/ada-endpoints';
-import { splitStringByDisplayLimit } from '../../../support/testExtends/customMatchers';
 
 // mocked and expected values
 const startingBalance = Number(ADA_MOCKED_ACCOUNT.balance);
@@ -94,75 +93,103 @@ test.describe('Staking - Cardano', { tag: ['@group=staking', '@specificModel'] }
             await test.step('Confirm staking on device', async () => {
                 await stakingSection.continueButton.click();
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Confirm transaction' },
-                    body: [
-                        ['Confirm:'],
-                        ['Stake key', '\n', 'registration'],
-                        ['for account #1:'],
-                        ["m/1852'/1815'/0'/2", '\n', '/0'],
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Confirm transaction' },
+                        body: [
+                            ['Confirm:'],
+                            ['Stake key', '\n', 'registration'],
+                            ['for account #1:'],
+                            devicePrompt.wrapText("m/1852'/1815'/0'/2/0"),
+                        ],
+                        actions: { right_button: 'Confirm' },
+                    },
                 });
 
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Confirm transaction' },
-                    body: [
-                        ['Confirm:'],
-                        ['Stake delegation'],
-                        ['for account #1:'],
-                        ["m/1852'/1815'/0'/2", '\n', '/0'],
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Confirm transaction' },
+                        body: [
+                            ['Confirm:'],
+                            ['Stake', '\n', 'delegation'],
+                            ['for account #1:'],
+                            ["m/1852'/1815'/", '\n', "0'/2/0"],
+                        ],
+                        actions: { right_button: 'Confirm' },
+                    },
+                    T3T1: {
+                        body: [
+                            ['Confirm:'],
+                            ['Stake delegation'],
+                            ['for account #1:'],
+                            ["m/1852'/1815'/0'/2", '\n', '/0'],
+                        ],
+                    },
                 });
 
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Confirm transaction' },
-                    body: [
-                        ['to pool:'],
-                        splitStringByDisplayLimit(
-                            'pool1n0uxgs5qfk5n9xl7qvq9jt8zuu02cntrsjnjayjlqtejyffnemj',
-                        ),
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Confirm transaction' },
+                        body: [
+                            ['to pool:'],
+                            devicePrompt.wrapText(
+                                'pool1n0uxgs5qfk5n9xl7qvq9jt8zuu02cntrsjnjayjlqtejyffnemj',
+                            ),
+                        ],
+                        actions: { right_button: 'Confirm' },
+                    },
                 });
 
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Confirm transaction' },
-                    body: [
-                        ['Confirm:'],
-                        ['Vote delegation'],
-                        ['for account #1:'],
-                        ["m/1852'/1815'/0'/2", '\n', '/0'],
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Confirm transaction' },
+                        body: [
+                            ['Confirm:'],
+                            ['Vote', '\n', 'delegation'],
+                            ['for account #1:'],
+                            ["m/1852'/1815'/", '\n', "0'/2/0"],
+                        ],
+                        actions: { right_button: 'Confirm' },
+                    },
+                    T3T1: {
+                        body: [
+                            ['Confirm:'],
+                            ['Vote delegation'],
+                            ['for account #1:'],
+                            ["m/1852'/1815'/0'/2", '\n', '/0'],
+                        ],
+                    },
                 });
 
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Confirm transaction' },
-                    body: [
-                        ['Delegating to key hash:'],
-                        splitStringByDisplayLimit(
-                            'drep1ectemlv45xsnvenfgkhwsxncfvxev4qllj7x5w6vlfc7kmd9zcs',
-                        ),
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Confirm transaction' },
+                        body: [
+                            ['Delegating to key hash:'],
+                            devicePrompt.wrapText(
+                                'drep1ectemlv45xsnvenfgkhwsxncfvxev4qllj7x5w6vlfc7kmd9zcs',
+                            ),
+                        ],
+                        actions: { right_button: 'Confirm' },
+                    },
                 });
 
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Confirm transaction' },
-                    body: [
-                        ['Transaction fee:'],
-                        [toADA(feeAmount)],
-                        ['Network: Mainnet'],
-                        ['Valid since: n/a'],
-                        [/^TTL: \d{9}$/],
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Confirm transaction' },
+                        body: [
+                            ['Transaction fee:'],
+                            [toADA(feeAmount)],
+                            ['Network: Mainnet'],
+                            ['Valid since: n/a'],
+                            [/^TTL: \d{9}$/],
+                        ],
+                        actions: { right_button: 'Hold to confirm' },
+                    },
                 });
 
                 // staked account

--- a/suite/e2e/tests/staking/ada/unstake.test.ts
+++ b/suite/e2e/tests/staking/ada/unstake.test.ts
@@ -106,27 +106,31 @@ test.describe('Staking - Cardano', { tag: ['@group=staking', '@specificModel'] }
 
             await test.step('Confirm claim on device', async () => {
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Confirm transaction' },
-                    body: [
-                        ['Confirm:'],
-                        ['Stake key', '\n', 'deregistration'],
-                        ['for account #1:'],
-                        ["m/1852'/1815'/0'/2", '\n', '/0'],
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Confirm transaction' },
+                        body: [
+                            ['Confirm:'],
+                            ['Stake key', '\n', 'deregistration'],
+                            ['for account #1:'],
+                            devicePrompt.wrapText("m/1852'/1815'/0'/2/0"),
+                        ],
+                        actions: { right_button: 'Confirm' },
+                    },
                 });
 
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Confirm transaction' },
-                    body: [
-                        ['Transaction fee:'],
-                        [toADA(feeAmount)],
-                        ['Network: Mainnet'],
-                        ['Valid since: n/a'],
-                        [/^TTL: \d{9}$/],
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Confirm transaction' },
+                        body: [
+                            ['Transaction fee:'],
+                            [toADA(feeAmount)],
+                            ['Network: Mainnet'],
+                            ['Valid since: n/a'],
+                            [/^TTL: \d{9}$/],
+                        ],
+                        actions: { right_button: 'Hold to confirm' },
+                    },
                 });
 
                 // unstaked account

--- a/suite/e2e/tests/staking/eth/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/eth/initial-stake.test.ts
@@ -5,7 +5,6 @@ import ETH_STAKE_CONFIRMED_TX from '../../../fixtures/staking/eth-stake-confirme
 import ETH_STAKE_PENDING_TX from '../../../fixtures/staking/eth-stake-pending-tx.json';
 import { expect, test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
-import { splitStringByDisplayLimit } from '../../../support/testExtends/customMatchers';
 
 test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
     test.use({
@@ -93,9 +92,11 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                     { values: { symbol: 'ETH' } },
                 );
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Stake' },
-                    body: [['Stake ETH on', '\n', 'Everstake?']],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Stake' },
+                        body: [['Stake ETH on', '\n', 'Everstake?']],
+                        actions: { right_button: 'Continue' },
+                    },
                 });
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
@@ -105,16 +106,18 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                     '0.000290278609719 ETH',
                 );
 
+                const amountWrapped = devicePrompt.wrapText('0.100204158497493752 ETH', {
+                    isAmount: true,
+                });
+                const feeMaxWrapped = devicePrompt.wrapText('0.000290278609719 ETH', {
+                    isAmount: true,
+                });
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Stake' },
-                    body: [
-                        ['Amount'],
-                        splitStringByDisplayLimit('0.100204158497493752 ETH'),
-                        [' '],
-                        ['Maximum fee'],
-                        splitStringByDisplayLimit('0.000290278609719 ETH'),
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Stake' },
+                        body: [['Amount'], amountWrapped, ['Maximum fee'], feeMaxWrapped],
+                        actions: { right_button: 'Hold to sign' },
+                    },
                 });
                 await devicePrompt.waitForFinalPromptAndConfirm();
             });

--- a/suite/e2e/tests/staking/eth/stake-more.test.ts
+++ b/suite/e2e/tests/staking/eth/stake-more.test.ts
@@ -5,7 +5,6 @@ import ETH_STAKE_CONFIRMED_TX from '../../../fixtures/staking/eth-stake-confirme
 import ETH_STAKE_PENDING_TX from '../../../fixtures/staking/eth-stake-pending-tx.json';
 import { expect, test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
-import { splitStringByDisplayLimit } from '../../../support/testExtends/customMatchers';
 
 test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
     test.use({
@@ -86,9 +85,11 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                     { values: { symbol: 'ETH' } },
                 );
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Stake' },
-                    body: [['Stake ETH on', '\n', 'Everstake?']],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Stake' },
+                        body: [['Stake ETH on', '\n', 'Everstake?']],
+                        actions: { right_button: 'Continue' },
+                    },
                 });
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
@@ -99,15 +100,16 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                 );
 
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Stake' },
-                    body: [
-                        ['Amount'],
-                        splitStringByDisplayLimit('0.100204158497493752 ETH'),
-                        [' '],
-                        ['Maximum fee'],
-                        splitStringByDisplayLimit('0.000290278609719 ETH'),
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Stake' },
+                        body: [
+                            ['Amount'],
+                            devicePrompt.wrapText('0.100204158497493752 ETH', { isAmount: true }),
+                            ['Maximum fee'],
+                            devicePrompt.wrapText('0.000290278609719 ETH', { isAmount: true }),
+                        ],
+                        actions: { right_button: 'Hold to sign' },
+                    },
                 });
                 await devicePrompt.waitForFinalPromptAndConfirm();
             });

--- a/suite/e2e/tests/staking/eth/unstake.test.ts
+++ b/suite/e2e/tests/staking/eth/unstake.test.ts
@@ -6,7 +6,6 @@ import ETH_UNSTAKE_PENDING_TX from '../../../fixtures/staking/eth-unstake-pendin
 import { skipFixture } from '../../../support/common';
 import { expect, test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
-import { splitStringByDisplayLimit } from '../../../support/testExtends/customMatchers';
 
 test.describe('ETH unstaking and claim', { tag: ['@group=staking'] }, () => {
     test.use({
@@ -68,9 +67,11 @@ test.describe('ETH unstaking and claim', { tag: ['@group=staking'] }, () => {
                     { values: { symbol: 'ETH' } },
                 );
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Unstake' },
-                    body: [['Unstake ETH from', '\n', 'Everstake?']],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Unstake' },
+                        body: [['Unstake ETH from', '\n', 'Everstake?']],
+                        actions: { right_button: 'Continue' },
+                    },
                 });
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
@@ -79,16 +80,15 @@ test.describe('ETH unstaking and claim', { tag: ['@group=staking'] }, () => {
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(
                     '0.000290278609719 ETH',
                 );
+                const feeMaxWrapped = devicePrompt.wrapText('0.000290278609719 ETH', {
+                    isAmount: true,
+                });
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Unstake' },
-                    body: [
-                        ['Amount'],
-                        [`3,234 ETH`],
-                        [' '],
-                        ['Maximum fee'],
-                        splitStringByDisplayLimit('0.000290278609719 ETH'),
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Unstake' },
+                        body: [['Amount'], ['3,234 ETH'], ['Maximum fee'], feeMaxWrapped],
+                        actions: { right_button: 'Hold to sign' },
+                    },
                 });
                 await devicePrompt.waitForFinalPromptAndConfirm();
             });
@@ -186,9 +186,11 @@ test.describe('ETH unstaking and claim', { tag: ['@group=staking'] }, () => {
                     { values: { symbol: 'ETH' } },
                 );
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Claim' },
-                    body: [['Claim ETH from', '\n', 'Everstake?']],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Claim' },
+                        body: [['Claim ETH from', '\n', 'Everstake?']],
+                        actions: { right_button: 'Continue' },
+                    },
                 });
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
@@ -198,9 +200,14 @@ test.describe('ETH unstaking and claim', { tag: ['@group=staking'] }, () => {
                     '0.000290278609719 ETH',
                 );
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Claim' },
-                    body: [['Maximum fee'], splitStringByDisplayLimit('0.000290278609719 ETH')],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Claim' },
+                        body: [
+                            ['Maximum fee'],
+                            devicePrompt.wrapText('0.000290278609719 ETH', { isAmount: true }),
+                        ],
+                        actions: { right_button: 'Hold to sign' },
+                    },
                 });
                 await devicePrompt.waitForFinalPromptAndConfirm();
                 blockbookMock.updateAccountState({

--- a/suite/e2e/tests/staking/sol/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/sol/initial-stake.test.ts
@@ -3,7 +3,6 @@ import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 import { solStakingAccountFirst } from '../../../fixtures/staking/sol-staking-accounts';
 import { expect, test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
-import { splitStringByDisplayLimit } from '../../../support/testExtends/customMatchers';
 
 // Expected values based on our mocked responses
 const stakedAmount = solStakingAccountFirst.stakeInSol;
@@ -72,9 +71,11 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
                     { values: { symbol: 'SOL' } },
                 );
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Stake' },
-                    body: [['Stake SOL on', '\n', 'Everstake?']],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Stake' },
+                        body: [['Stake SOL on', '\n', 'Everstake?']],
+                        actions: { right_button: 'Continue' },
+                    },
                 });
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
@@ -84,16 +85,32 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
                     solanaStakingMock.feeFormatted,
                 );
 
+                const feeWrapped = devicePrompt.wrapText(solanaStakingMock.feeFormatted, {
+                    isAmount: true,
+                });
+                const amountAndFeeWrapped = devicePrompt.wrapText(
+                    solanaStakingMock.addFeeTo(stakedAmount),
+                    { isAmount: true },
+                );
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Stake' },
-                    body: [
-                        ['Amount:'],
-                        splitStringByDisplayLimit(solanaStakingMock.addFeeTo(stakedAmount)),
-                        [' '],
-                        ['Max fees and rent:'],
-                        splitStringByDisplayLimit(solanaStakingMock.feeFormatted),
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Stake' },
+                        body: [
+                            ['Max fees and rent:'],
+                            feeWrapped,
+                            ['Amount:'],
+                            amountAndFeeWrapped,
+                        ],
+                        actions: { right_button: 'Hold to sign' },
+                    },
+                    T3T1: {
+                        body: [
+                            ['Amount:'],
+                            amountAndFeeWrapped,
+                            ['Max fees and rent:'],
+                            feeWrapped,
+                        ],
+                    },
                 });
                 await devicePrompt.waitForFinalPromptAndConfirm();
             });

--- a/suite/e2e/tests/staking/sol/stake-more.test.ts
+++ b/suite/e2e/tests/staking/sol/stake-more.test.ts
@@ -6,7 +6,6 @@ import {
 } from '../../../fixtures/staking/sol-staking-accounts';
 import { expect, test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
-import { splitStringByDisplayLimit } from '../../../support/testExtends/customMatchers';
 
 // Expected values based on our mocked responses
 const stakedAmount = solStakingAccountFirst.stakeInSol;
@@ -78,9 +77,11 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
                     { values: { symbol: 'SOL' } },
                 );
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Stake' },
-                    body: [['Stake SOL on', '\n', 'Everstake?']],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Stake' },
+                        body: [['Stake SOL on', '\n', 'Everstake?']],
+                        actions: { right_button: 'Continue' },
+                    },
                 });
                 await devicePrompt.waitForPromptAndClick();
                 // labeled as total but excludes fees
@@ -91,16 +92,32 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
                     solanaStakingMock.feeFormatted,
                 );
 
+                const feeWrapped = devicePrompt.wrapText(solanaStakingMock.feeFormatted, {
+                    isAmount: true,
+                });
+                const amountAndFeeWrapped = devicePrompt.wrapText(
+                    solanaStakingMock.addFeeTo(stakeMoreAmount),
+                    { isAmount: true },
+                );
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Stake' },
-                    body: [
-                        ['Amount:'],
-                        splitStringByDisplayLimit(solanaStakingMock.addFeeTo(stakeMoreAmount)),
-                        [' '],
-                        ['Max fees and rent:'],
-                        splitStringByDisplayLimit(solanaStakingMock.feeFormatted),
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Stake' },
+                        body: [
+                            ['Max fees and rent:'],
+                            feeWrapped,
+                            ['Amount:'],
+                            amountAndFeeWrapped,
+                        ],
+                        actions: { right_button: 'Hold to sign' },
+                    },
+                    T3T1: {
+                        body: [
+                            ['Amount:'],
+                            amountAndFeeWrapped,
+                            ['Max fees and rent:'],
+                            feeWrapped,
+                        ],
+                    },
                 });
                 await devicePrompt.waitForFinalPromptAndConfirm();
             });

--- a/suite/e2e/tests/staking/sol/unstake.test.ts
+++ b/suite/e2e/tests/staking/sol/unstake.test.ts
@@ -74,9 +74,14 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
                     { values: { symbol: 'SOL' } },
                 );
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Unstake' },
-                    body: [['Unstake SOL from stake', '\n', 'account?']],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Unstake' },
+                        body: [['Unstake SOL from', '\n', 'stake account?']],
+                        actions: { right_button: 'Continue' },
+                    },
+                    T3T1: {
+                        body: [['Unstake SOL from stake', '\n', 'account?']],
+                    },
                 });
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
@@ -86,9 +91,11 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
                     solanaStakingMock.feeFormatted,
                 );
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Unstake' },
-                    body: [['Transaction fee:'], [`${solanaStakingMock.rentFee} SOL`]],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Unstake' },
+                        body: [['Transaction fee:'], [`${solanaStakingMock.rentFee} SOL`]],
+                        actions: { right_button: 'Hold to sign' },
+                    },
                 });
                 await devicePrompt.waitForFinalPromptAndConfirm();
             });
@@ -144,9 +151,14 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
                     { values: { symbol: 'SOL' } },
                 );
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Claim' },
-                    body: [['Claim SOL from stake', '\n', 'account?']],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Claim' },
+                        body: [['Claim SOL from', '\n', 'stake account?']],
+                        actions: { right_button: 'Continue' },
+                    },
+                    T3T1: {
+                        body: [['Claim SOL from stake', '\n', 'account?']],
+                    },
                 });
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
@@ -156,16 +168,22 @@ test.describe('sol staking', { tag: ['@group=staking', '@webOnly'] }, () => {
                     solanaStakingMock.feeFormatted,
                 );
 
+                const feeWrapped = devicePrompt.wrapText(`${solanaStakingMock.rentFee} SOL`, {
+                    isAmount: true,
+                });
+                const amountAndFeeWrapped = devicePrompt.wrapText(
+                    solanaStakingMock.addFeeTo(unstakingAmount),
+                    { isAmount: true },
+                );
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Claim' },
-                    body: [
-                        ['Amount:'],
-                        [solanaStakingMock.addFeeTo(unstakingAmount)],
-                        [' '],
-                        ['Transaction fee:'],
-                        [`${solanaStakingMock.rentFee} SOL`],
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Claim' },
+                        body: [['Transaction fee:'], feeWrapped, ['Amount:'], amountAndFeeWrapped],
+                        actions: { right_button: 'Hold to sign' },
+                    },
+                    T3T1: {
+                        body: [['Amount:'], amountAndFeeWrapped, ['Transaction fee:'], feeWrapped],
+                    },
                 });
                 await devicePrompt.waitForFinalPromptAndConfirm();
                 await solanaStakingMock.setProgramAccounts([]);

--- a/suite/e2e/tests/trading/sell-ethereum.test.ts
+++ b/suite/e2e/tests/trading/sell-ethereum.test.ts
@@ -122,15 +122,17 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
                 `${maxPriorityFeePerGasRounded} Gwei`,
             );
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Summary' },
-                body: [
-                    ['Amount'],
-                    [formattedCryptoAmount],
-                    [' '],
-                    ['Maximum fee'],
-                    splitStringByDisplayLimit(`${ethereumMaximumFee} ETH`),
-                ],
-                footer: 'Tap to continue',
+                T3W1: {
+                    header: { title: 'Summary' },
+                    body: [
+                        ['Amount'],
+                        [formattedCryptoAmount],
+                        ['Maximum fee'],
+                        devicePrompt.wrapText(`${ethereumMaximumFee} ETH`, { isAmount: true }),
+                    ],
+
+                    actions: { right_button: 'Confirm' }, 
+                },
             });
            
             await expect(
@@ -140,19 +142,20 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
         });
 
         await test.step('Verify Fee Info on emulator', async () => {
-            await tradingPage.fees.openFeeInfoOnEmulator();
+            await devicePrompt.openFeeInfoOnEmulator();
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Fee info' },
-                body: [
-                    ['Gas limit'],
-                    [`${gasLimit} units`],
-                    [' '],
-                    ['Max fee per gas'],
-                    [`${maxFeePerGas} Gwei`],
-                    [' '],
-                    ['Max priority fee'],
-                    [`${maxPriorityFeePerGas} Gwei`],
-                ],
+                T3W1: {
+                    header: { title: 'Fee info' },
+                    body: [
+                        ['Gas limit'],
+                        [`${gasLimit} units`],
+                        ['Max fee per gas'],
+                        [`${maxFeePerGas} Gwei`],
+                        ['Max priority fee'],
+                        [`${maxPriorityFeePerGas} Gwei`],
+                    ],
+                    actions: { right_button: 'Confirm' },
+                },
             });
         });
         */

--- a/suite/e2e/tests/trading/swap-coins.test.ts
+++ b/suite/e2e/tests/trading/swap-coins.test.ts
@@ -94,9 +94,11 @@ test.describe('Trading - Swap coins', { tag: ['@group=trading', '@webOnly'] }, (
             await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedSendAddress);
             const transformedExpectedAddress = transformAddress(sendAddress, 'fullLine');
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Recipient' },
-                body: [transformedExpectedAddress],
-                footer: 'Tap to continue',
+                T3W1: {
+                    header: { title: 'Recipient' },
+                    body: [transformedExpectedAddress],
+                    actions: { right_button: 'Continue' },
+                },
             });
 
             await devicePrompt.waitForPromptAndConfirm();
@@ -119,15 +121,19 @@ test.describe('Trading - Swap coins', { tag: ['@group=trading', '@webOnly'] }, (
                 solanaFee,
             );
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Summary' },
-                body: [
-                    ['Amount:'],
-                    [formattedSendAmount],
-                    [' '],
-                    ['Transaction fee:'],
-                    [`${solanaFee} SOL`],
-                ],
-                footer: 'Tap to continue',
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [
+                        ['Amount:'],
+                        [formattedSendAmount],
+                        ['Transaction fee:'],
+                        devicePrompt.wrapText(`${solanaFee} SOL`, { isAmount: true }),
+                    ],
+                    actions: { right_button: 'Hold to sign' },
+                },
+                T3T1: {
+                    header: { title: 'Summary' },
+                },
             });
 
             await devicePrompt.waitForFinalPromptAndConfirm();

--- a/suite/e2e/tests/trading/swap-fees-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/swap-fees-bitcoin.test.ts
@@ -68,24 +68,31 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@group=trading', '@webOnly
             );
             await expect(devicePrompt.headerFeeRate).toContainText(feeRate);
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Summary' },
-                body: [
-                    ['Total amount'],
-                    [`${totalAmount} BTC`],
-                    [' '],
-                    ['incl. Transaction fee'],
-                    [`${feeFromDeviceModal} BTC`],
-                ],
-                footer: 'Tap to continue',
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [
+                        ['Total amount'],
+                        [`${totalAmount} BTC`],
+                        ['incl. Transaction fee'],
+                        [`${feeFromDeviceModal} BTC`],
+                    ],
+                    actions: { right_button: 'Hold to sign' },
+                },
+                T3T1: {
+                    header: { title: 'Summary' },
+                },
             });
         });
 
         await test.step('Verify Fee Info on emulator', async () => {
-            await tradingPage.fees.openFeeInfoOnEmulator();
+            await devicePrompt.openFeeInfoOnEmulator({ buttonIndexT3W1: 2 });
             const feeRateWithoutDecimals = feeRate.replace('.00\u00A0', ' ');
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Fee info' },
-                body: [['Fee rate'], [feeRateWithoutDecimals]],
+                T3W1: {
+                    header: { title: 'Fee info' },
+                    body: [['Fee rate'], [feeRateWithoutDecimals]],
+                },
+                T3T1: { footer: undefined },
             });
         });
     });

--- a/suite/e2e/tests/trading/swap-fees-ethereum.test.ts
+++ b/suite/e2e/tests/trading/swap-fees-ethereum.test.ts
@@ -5,7 +5,6 @@ import { BigNumber } from '@trezor/utils';
 
 import { invityEndpoint, swapQuotesEthereumBTC, swapTradeEthereumBTC } from '../../fixtures/invity';
 import { expect, test } from '../../support/fixtures';
-import { splitStringByDisplayLimit } from '../../support/testExtends/customMatchers';
 
 const sendAmount = '0.008';
 const formattedSendAmount = `${localizeNumber(sendAmount)} ETH`;
@@ -87,32 +86,47 @@ test.describe('Trading - Swap fees', { tag: ['@group=trading', '@webOnly'] }, ()
                 errorMessageMaxCalculation,
             ).toHaveText(`${ethereumMaximumFee} ETH`);
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Summary' },
-                body: [
-                    ['Amount'],
-                    [formattedSendAmount],
-                    [' '],
-                    ['Maximum fee'],
-                    splitStringByDisplayLimit(`${ethereumMaximumFee} ETH`),
-                ],
-                footer: 'Tap to continue',
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [
+                        ['Amount'],
+                        [formattedSendAmount],
+                        ['Maximum fee'],
+                        devicePrompt.wrapText(`${ethereumMaximumFee} ETH`, { isAmount: true }),
+                    ],
+                    actions: { right_button: 'Hold to sign' },
+                },
+                T3T1: {
+                    header: { title: 'Summary' },
+                },
             });
         });
 
         await test.step('Verify Fee Info on emulator', async () => {
-            await tradingPage.fees.openFeeInfoOnEmulator();
+            await devicePrompt.openFeeInfoOnEmulator();
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Fee info' },
-                body: [
-                    ['Gas limit'],
-                    [`${gasLimit} units`],
-                    [' '],
-                    ['Max fee per gas'],
-                    [`${maxFeePerGas} Gwei`],
-                    [' '],
-                    ['Max priority fee'],
-                    [`${maxPriorityFeePerGas} Gwei`],
-                ],
+                T3W1: {
+                    header: { title: 'Fee info' },
+                    body: [
+                        ['Gas limit'],
+                        [`${gasLimit} units`],
+                        ['Max fee per gas'],
+                        [maxFeePerGas, '\n', 'Gwei'],
+                        ['Max priority fee'],
+                        [maxPriorityFeePerGas, '\n', 'Gwei'],
+                    ],
+                },
+                T3T1: {
+                    body: [
+                        ['Gas limit'],
+                        [`${gasLimit} units`],
+                        ['Max fee per gas'],
+                        [`${maxFeePerGas} Gwei`],
+                        ['Max priority fee'],
+                        [`${maxPriorityFeePerGas} Gwei`],
+                    ],
+                    footer: undefined,
+                },
             });
         });
     });

--- a/suite/e2e/tests/wallet/send-base.test.ts
+++ b/suite/e2e/tests/wallet/send-base.test.ts
@@ -4,10 +4,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
-import {
-    splitStringByDisplayLimit,
-    transformAddress,
-} from '../../support/testExtends/customMatchers';
+import { transformAddress } from '../../support/testExtends/customMatchers';
 
 const networkName = 'Base #1';
 const sendAddress = '0xdcaB74E62b9D08a9f8Fa4A3Ccb5c46AE039C9d7C';
@@ -67,9 +64,15 @@ test.describe('Send Base', { tag: ['@group=wallet', '@nightlyOnly'] }, () => {
             await expect(devicePrompt.headerParagraph).toContainText(networkName);
             await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedSendAddress);
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Address', subtitle: 'Recipient' },
-                body: [transformAddress(sendAddress)],
-                footer: 'Tap to continue',
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [transformAddress(sendAddress)],
+                    actions: { right_button: 'Continue' },
+                },
+                T3T1: {
+                    header: { title: 'Address', subtitle: 'Recipient' },
+                    body: [transformAddress(sendAddress)],
+                },
             });
         });
 
@@ -86,32 +89,48 @@ test.describe('Send Base', { tag: ['@group=wallet', '@nightlyOnly'] }, () => {
                 ethereumMaximumFee,
             );
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Summary' },
-                body: [
-                    ['Amount'],
-                    [formattedSendAmount],
-                    [' '],
-                    ['Maximum fee'],
-                    splitStringByDisplayLimit(`${ethereumMaximumFee} ETH`),
-                ],
-                footer: 'Tap to continue',
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [
+                        ['Amount'],
+                        [formattedSendAmount],
+                        ['Maximum fee'],
+                        devicePrompt.wrapText(`${ethereumMaximumFee} ETH`, { isAmount: true }),
+                    ],
+                    actions: { right_button: 'Hold to sign' },
+                },
+                T3T1: {
+                    header: { title: 'Summary' },
+                },
             });
         });
 
         await test.step('Verify Fee Info on emulator', async () => {
-            await tradingPage.fees.openFeeInfoOnEmulator();
+            await devicePrompt.openFeeInfoOnEmulator();
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Fee info' },
-                body: [
-                    ['Gas limit'],
-                    [`${gasLimit} units`],
-                    [' '],
-                    ['Max fee per gas'],
-                    [`${maxFeePerGas} Gwei`],
-                    [' '],
-                    ['Max priority fee'],
-                    [`${maxPriorityFeePerGas} Gwei`],
-                ],
+                T3W1: {
+                    header: { title: 'Fee info' },
+                    body: [
+                        ['Gas limit'],
+                        [`${gasLimit} units`],
+                        ['Max fee per gas'],
+                        [maxFeePerGas, '\n', 'Gwei'],
+                        ['Max priority fee'],
+                        [maxPriorityFeePerGas, '\n', 'Gwei'],
+                    ],
+                },
+                T3T1: {
+                    header: { title: 'Fee info' },
+                    body: [
+                        ['Gas limit'],
+                        [`${gasLimit} units`],
+                        ['Max fee per gas'],
+                        [`${maxFeePerGas} Gwei`],
+                        ['Max priority fee'],
+                        [`${maxPriorityFeePerGas} Gwei`],
+                    ],
+                    footer: undefined,
+                },
             });
         });
     });
@@ -149,9 +168,15 @@ test.describe('Send Base', { tag: ['@group=wallet', '@nightlyOnly'] }, () => {
             await expect(devicePrompt.headerParagraph).toContainText(networkName);
             await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedSendAddress);
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Address', subtitle: 'Recipient' },
-                body: [transformAddress(sendAddress)],
-                footer: 'Tap to continue',
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [transformAddress(sendAddress)],
+                    actions: { right_button: 'Continue' },
+                },
+                T3T1: {
+                    header: { title: 'Address', subtitle: 'Recipient' },
+                    body: [transformAddress(sendAddress)],
+                },
             });
         });
 
@@ -167,33 +192,47 @@ test.describe('Send Base', { tag: ['@group=wallet', '@nightlyOnly'] }, () => {
             await expect(devicePrompt.cryptoAmountOf('fee'), errorMessageMaxCalculation).toHaveText(
                 ethereumMaximumFee,
             );
+            const maxFeeWrapped = devicePrompt.wrapText(`${ethereumMaximumFee} ETH`, {
+                isAmount: true,
+            });
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Summary' },
-                body: [
-                    ['Amount'],
-                    [formattedSendAmount],
-                    [' '],
-                    ['Maximum fee'],
-                    splitStringByDisplayLimit(`${ethereumMaximumFee} ETH`),
-                ],
-                footer: 'Tap to continue',
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [['Amount'], [formattedSendAmount], ['Maximum fee'], maxFeeWrapped],
+                    actions: { right_button: 'Hold to sign' },
+                },
+                T3T1: {
+                    header: { title: 'Summary' },
+                },
             });
         });
 
         await test.step('Verify Fee Info on emulator', async () => {
-            await tradingPage.fees.openFeeInfoOnEmulator();
+            await devicePrompt.openFeeInfoOnEmulator();
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Fee info' },
-                body: [
-                    ['Gas limit'],
-                    [`${gasLimit} units`],
-                    [' '],
-                    ['Max fee per gas'],
-                    [`${maxFeePerGas} Gwei`],
-                    [' '],
-                    ['Max priority fee'],
-                    [`${maxPriorityFeePerGas} Gwei`],
-                ],
+                T3W1: {
+                    header: { title: 'Fee info' },
+                    body: [
+                        ['Gas limit'],
+                        [`${gasLimit} units`],
+                        ['Max fee per gas'],
+                        [maxFeePerGas, '\n', 'Gwei'],
+                        ['Max priority fee'],
+                        [maxPriorityFeePerGas, '\n', 'Gwei'],
+                    ],
+                },
+                T3T1: {
+                    header: { title: 'Fee info' },
+                    body: [
+                        ['Gas limit'],
+                        [`${gasLimit} units`],
+                        ['Max fee per gas'],
+                        [`${maxFeePerGas} Gwei`],
+                        ['Max priority fee'],
+                        [`${maxPriorityFeePerGas} Gwei`],
+                    ],
+                    footer: undefined,
+                },
             });
         });
         await test.step('Confirm transaction', async () => {

--- a/suite/e2e/tests/wallet/send-eth.test.ts
+++ b/suite/e2e/tests/wallet/send-eth.test.ts
@@ -4,10 +4,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
-import {
-    splitStringByDisplayLimit,
-    transformAddress,
-} from '../../support/testExtends/customMatchers';
+import { transformAddress } from '../../support/testExtends/customMatchers';
 
 const sendAddress = '0xdcaB74E62b9D08a9f8Fa4A3Ccb5c46AE039C9d7C';
 const formattedSendAddress = formatAddressWithNewlines(sendAddress);
@@ -66,10 +63,15 @@ test.describe('Send Eth', { tag: ['@group=wallet'] }, () => {
             await expect(devicePrompt.headerParagraph).toContainText('Ethereum #1');
             await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedSendAddress);
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Address', subtitle: 'Recipient' },
-                // TODO: Use evmTetragrams when FW supports it
-                body: [transformAddress(sendAddress)],
-                footer: 'Tap to continue',
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [transformAddress(sendAddress)],
+                    actions: { right_button: 'Continue' },
+                },
+                T3T1: {
+                    header: { title: 'Address', subtitle: 'Recipient' },
+                    body: [transformAddress(sendAddress)],
+                },
             });
         });
 
@@ -85,33 +87,48 @@ test.describe('Send Eth', { tag: ['@group=wallet'] }, () => {
             await expect(devicePrompt.cryptoAmountOf('fee'), errorMessageMaxCalculation).toHaveText(
                 ethereumMaximumFee,
             );
+            const maxFeeWrapped = devicePrompt.wrapText(`${ethereumMaximumFee} ETH`, {
+                isAmount: true,
+            });
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Summary' },
-                body: [
-                    ['Amount'],
-                    [formattedSendAmount],
-                    [' '],
-                    ['Maximum fee'],
-                    splitStringByDisplayLimit(`${ethereumMaximumFee} ETH`),
-                ],
-                footer: 'Tap to continue',
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [['Amount'], [formattedSendAmount], ['Maximum fee'], maxFeeWrapped],
+                    actions: { right_button: 'Hold to sign' },
+                },
+                T3T1: {
+                    header: { title: 'Summary' },
+                    body: [['Amount'], [formattedSendAmount], ['Maximum fee'], maxFeeWrapped],
+                },
             });
         });
 
         await test.step('Verify Fee Info on emulator', async () => {
-            await tradingPage.fees.openFeeInfoOnEmulator();
+            await devicePrompt.openFeeInfoOnEmulator();
             await expect(devicePrompt).toDisplayOnEmulator({
-                header: { title: 'Fee info' },
-                body: [
-                    ['Gas limit'],
-                    [`${gasLimit} units`],
-                    [' '],
-                    ['Max fee per gas'],
-                    [`${maxFeePerGas} Gwei`],
-                    [' '],
-                    ['Max priority fee'],
-                    [`${maxPriorityFeePerGas} Gwei`],
-                ],
+                T3W1: {
+                    header: { title: 'Fee info' },
+                    body: [
+                        ['Gas limit'],
+                        [`${gasLimit} units`],
+                        ['Max fee per gas'],
+                        [maxFeePerGas, '\n', 'Gwei'],
+                        ['Max priority fee'],
+                        [maxPriorityFeePerGas, '\n', 'Gwei'],
+                    ],
+                },
+                T3T1: {
+                    header: { title: 'Fee info' },
+                    body: [
+                        ['Gas limit'],
+                        [`${gasLimit} units`],
+                        ['Max fee per gas'],
+                        [`${maxFeePerGas} Gwei`],
+                        ['Max priority fee'],
+                        [`${maxPriorityFeePerGas} Gwei`],
+                    ],
+                    footer: undefined,
+                },
             });
         });
     });

--- a/suite/e2e/tests/wallet/send-sol.test.ts
+++ b/suite/e2e/tests/wallet/send-sol.test.ts
@@ -82,13 +82,17 @@ test.describe('Send - Solana', { tag: ['@group=wallet'] }, () => {
 
                 // verify recipient address on device
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Recipient' },
-                    body: [model.model !== 'T3W1' ? TRANSFORMED_ADDRESS : RECIPIENT_ADDRESS],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Recipient' },
+                        body: [TRANSFORMED_ADDRESS],
+                        actions: {
+                            right_button: 'Continue',
+                        },
+                    },
                 });
 
                 // confirm address
-                await devicePrompt.waitForPromptAndClick(model.model);
+                await devicePrompt.waitForPromptAndClick();
             });
             await test.step('Verify Amount & Transaction Fee', async () => {
                 await expect(devicePrompt.cryptoAmountOf('total')).toHaveText(
@@ -97,25 +101,32 @@ test.describe('Send - Solana', { tag: ['@group=wallet'] }, () => {
                 await expect(devicePrompt.cryptoAmountOf('fee')).toHaveText(`${maxFee}`);
 
                 // verify amount & fee
+                const amountWrapped = devicePrompt.wrapText(`${sendMaxAmountWithReserve} SOL`, {
+                    isAmount: true,
+                });
                 await expect(devicePrompt).toDisplayOnEmulator({
-                    header: { title: 'Summary' },
-                    body: [
-                        ['Amount:'],
-                        [`${sendMaxAmountWithReserve} SOL`],
-                        [' '],
-                        ['Transaction fee:'],
-                        [`${maxFee} SOL`],
-                    ],
-                    footer: 'Tap to continue',
+                    T3W1: {
+                        header: { title: 'Send' },
+                        body: [
+                            ['Amount:'],
+                            amountWrapped,
+                            ['Transaction fee:'],
+                            devicePrompt.wrapText(`${maxFee} SOL`, { isAmount: true }),
+                        ],
+                        actions: { right_button: 'Hold to sign' },
+                    },
+                    T3T1: {
+                        header: { title: 'Summary' },
+                    },
                 });
 
                 // confirm amount & fee
-                await devicePrompt.waitForPromptAndClick(model.model);
+                await devicePrompt.waitForPromptAndClick();
             });
             await test.step('Approve and Verify Send readiness', async () => {
                 // hold & sign
                 if (model.model !== 'T3W1') {
-                    await devicePrompt.waitForPromptAndClick(model.model);
+                    await devicePrompt.waitForPromptAndClick();
                 }
 
                 await expect(devicePrompt.sendButton).toBeEnabled();


### PR DESCRIPTION
Our goal is to make our test universal and compatible for our main two models t3t1, t3w1.

Display asserts worked only with t3t1 model. This PR expands the functionality even to t3w1.
Main problem is that every model has slightly different line wrapping and sometimes even wording on same screen. Out of all options we decided to have both screen models definitions in tests. Where t3w1 is the main default one and t3t1 works as overrides.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-e2e-t7-emu-display-asserts&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-e2e-t7-emu-display-asserts&lookback=7)