### PR TITLE
Remove deprecated Trading header behavior

### DIFF
--- a/suite-native/app/src/navigation/AppTabNavigator.tsx
+++ b/suite-native/app/src/navigation/AppTabNavigator.tsx
@@ -8,55 +8,22 @@ import { HomeStackNavigator } from '@suite-native/module-home';
 import { SettingsScreen } from '@suite-native/module-settings';
 import { TradingStackNavigator } from '@suite-native/module-trading';
 import { AppTabsParamList, AppTabsRoutes, TabBar } from '@suite-native/navigation';
-import {
-    selectIsTradingBuyEnabled,
-    selectIsTradingEnabled,
-    selectIsTradingExchangeEnabled,
-    selectIsTradingSellEnabled,
-} from '@suite-native/trading-state';
+import { selectIsTradingEnabled } from '@suite-native/trading-state';
 
 import { rootTabsOptions } from './routes';
 
 const Tab = createBottomTabNavigator<AppTabsParamList>();
 
-const getTradingAnalyticsType = (
-    isTradingBuyEnabled: boolean,
-    isTradingExchangeEnabled: boolean,
-    isTradingSellEnabled: boolean,
-) => {
-    if (isTradingBuyEnabled) {
-        return 'buy';
-    }
-    if (isTradingExchangeEnabled) {
-        return 'exchange';
-    }
-    if (isTradingSellEnabled) {
-        return 'sell';
-    }
-
-    return null;
-};
-
 export const AppTabNavigator = () => {
     const isTradingEnabled = useSelector(selectIsTradingEnabled);
-    const isTradingBuyEnabled = useSelector(selectIsTradingBuyEnabled);
-    const isTradingExchangeEnabled = useSelector(selectIsTradingExchangeEnabled);
-    const isTradingSellEnabled = useSelector(selectIsTradingSellEnabled);
 
     const handleTradeTabPress = () => {
-        const tradingType = getTradingAnalyticsType(
-            isTradingBuyEnabled,
-            isTradingExchangeEnabled,
-            isTradingSellEnabled,
-        );
-
-        if (!tradingType) return;
-
+        // Buy is the default tab when navigating to the Trading stack
         analytics.report({
             type: EventType.TradingNavigate,
             payload: {
                 action: 'navigate',
-                type: tradingType,
+                type: 'buy',
                 from: 'trade',
             },
         });

--- a/suite-native/module-trading/src/components/general/Header/Header.tsx
+++ b/suite-native/module-trading/src/components/general/Header/Header.tsx
@@ -1,15 +1,8 @@
 import { FadeInUp, FadeOutUp } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
-import { AnimatedBox, Text } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
-import {
-    selectIsAmountInputActive,
-    selectIsTradingBuyEnabled,
-    selectIsTradingEnabled,
-    selectIsTradingExchangeEnabled,
-    selectIsTradingSellEnabled,
-} from '@suite-native/trading-state';
+import { AnimatedBox } from '@suite-native/atoms';
+import { selectIsAmountInputActive } from '@suite-native/trading-state';
 
 import { HeaderTabs } from './HeaderTabs';
 
@@ -18,33 +11,15 @@ export type HeaderProps = {
 };
 
 export const Header = ({ isFormMountedRecently }: HeaderProps) => {
-    const isTradingEnabled = useSelector(selectIsTradingEnabled);
-    const isBuyEnabled = useSelector(selectIsTradingBuyEnabled);
-    const isExchangeEnabled = useSelector(selectIsTradingExchangeEnabled);
-    const isSellEnabled = useSelector(selectIsTradingSellEnabled);
     const shouldHideHeader = useSelector(selectIsAmountInputActive);
 
-    if (!isTradingEnabled || shouldHideHeader) {
+    if (shouldHideHeader) {
         return null;
     }
 
-    const shouldDisplayDeprecatedBuyHeader = isBuyEnabled && !isExchangeEnabled && !isSellEnabled;
-    const padding = shouldDisplayDeprecatedBuyHeader ? 'sp16' : undefined;
-
     return (
-        <AnimatedBox
-            paddingHorizontal={padding}
-            paddingTop={padding}
-            entering={isFormMountedRecently ? undefined : FadeInUp}
-            exiting={FadeOutUp}
-        >
-            {shouldDisplayDeprecatedBuyHeader ? (
-                <Text variant="titleSmall" color="textDefault">
-                    <Translation id="moduleTrading.tradingScreen.buyTitle" />
-                </Text>
-            ) : (
-                <HeaderTabs />
-            )}
+        <AnimatedBox entering={isFormMountedRecently ? undefined : FadeInUp} exiting={FadeOutUp}>
+            <HeaderTabs />
         </AnimatedBox>
     );
 };

--- a/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
+++ b/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
@@ -11,7 +11,6 @@ import { useTranslate } from '@suite-native/intl';
 import {
     TradingWithFeatureFlagsRootState,
     selectActiveTradingType,
-    selectIsTradingSellEnabled,
     tradingActions,
 } from '@suite-native/trading-state';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -36,8 +35,6 @@ const useSelectedTab = () => {
 const useTabsData = () => {
     const { translate } = useTranslate();
 
-    const isSellEnabled = useSelector(selectIsTradingSellEnabled);
-
     return useMemo(() => {
         const tabs = [
             {
@@ -46,7 +43,7 @@ const useTabsData = () => {
                 icon: 'plus',
                 testID: '@trading/buy/header-tab',
             },
-            isSellEnabled && {
+            {
                 key: 'sell',
                 label: translate('moduleTrading.tradingScreen.tabs.sell'),
                 icon: 'minus',
@@ -61,7 +58,7 @@ const useTabsData = () => {
         ] as { key: TradingType; label: string; icon: IconName; testID: string }[];
 
         return tabs.filter(Boolean);
-    }, [translate, isSellEnabled]);
+    }, [translate]);
 };
 
 const tabsStyle = prepareNativeStyle(({ spacings }) => ({

--- a/suite-native/module-trading/src/components/general/Header/__tests__/Header.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/Header/__tests__/Header.comp.test.tsx
@@ -97,72 +97,38 @@ describe('Header', () => {
         jest.clearAllMocks();
     });
 
-    it('should render nothing when no trade type is enabled', async () => {
-        const { toJSON } = await renderHeader({});
-
-        expect(toJSON()).toBeNull();
-    });
-
-    it('should render Buy header without buttons when only buy is enabled', async () => {
-        const { getByText, queryByText } = await renderHeader({ buyEnabled: true });
+    it.each([
+        {
+            buyEnabled: true,
+            sellEnabled: true,
+            exchangeEnabled: true,
+        },
+        {
+            buyEnabled: true,
+            sellEnabled: false,
+            exchangeEnabled: false,
+        },
+        {
+            buyEnabled: false,
+            sellEnabled: true,
+            exchangeEnabled: false,
+        },
+        {
+            buyEnabled: true,
+            sellEnabled: true,
+            exchangeEnabled: false,
+        },
+        {
+            buyEnabled: false,
+            sellEnabled: false,
+            exchangeEnabled: true,
+        },
+    ])('should display Header tabs with Buy, Swap and Sell tabs, case %#', async config => {
+        const { getByText } = await renderHeader(config);
 
         expect(getByText('Buy')).toBeOnTheScreen();
-        expect(queryByText('Sell')).toBeNull();
-        expect(queryByText('Swap')).toBeNull();
-    });
-
-    it.each([
-        {
-            buyEnabled: true,
-            sellEnabled: true,
-            exchangeEnabled: true,
-        },
-        {
-            buyEnabled: false,
-            sellEnabled: true,
-            exchangeEnabled: true,
-        },
-        {
-            buyEnabled: true,
-            sellEnabled: true,
-            exchangeEnabled: false,
-        },
-        {
-            buyEnabled: false,
-            sellEnabled: true,
-            exchangeEnabled: false,
-        },
-    ])(
-        'should display Header tabs with Buy, Swap and Sell tabs otherwise, case %#',
-        async config => {
-            const { getByText, queryByText } = await renderHeader(config);
-
-            expect(getByText('Buy')).toBeOnTheScreen();
-            expect(getByText('Swap')).toBeOnTheScreen();
-            expect(queryByText('Sell')).toBeOnTheScreen();
-        },
-    );
-
-    it.each([
-        {
-            buyEnabled: true,
-            sellEnabled: false,
-            exchangeEnabled: true,
-        },
-        {
-            buyEnabled: false,
-            sellEnabled: false,
-            exchangeEnabled: true,
-        },
-        {
-            buyEnabled: false,
-            sellEnabled: false,
-            exchangeEnabled: false,
-        },
-    ])('should display Header tabs without Sell tab, case %#', async config => {
-        const { queryByText } = await renderHeader(config);
-
-        expect(queryByText('Sell')).toBeNull();
+        expect(getByText('Swap')).toBeOnTheScreen();
+        expect(getByText('Sell')).toBeOnTheScreen();
     });
 
     it('should display nothing when isAmountInputActive is true', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Removed deprecated trading buy header
- Shows always all 3 trading tabs, even when any 

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #20472

## Screenshots:

<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-01-12 at 10 42 56" src="https://github.com/user-attachments/assets/51697d58-4177-42eb-a6e9-a3cccab2753e" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=20472-mobile-sell-update-logic-to-always-show-buysellswap-tabs&lookback=7)