### PR TITLE
fix(auth-server): not released package

### DIFF
--- a/packages/auth-server/package.json
+++ b/packages/auth-server/package.json
@@ -9,7 +9,6 @@
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "dev": "yarn g:tsx watch ./src/index.ts",
-        "build": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",
         "start": "node ./lib/index.js"
     },
     "dependencies": {

--- a/packages/auth-server/tsconfig.lib.json
+++ b/packages/auth-server/tsconfig.lib.json
@@ -1,8 +1,0 @@
-{
-    "extends": "../../tsconfig.lib.json",
-    "compilerOptions": {
-        "outDir": "lib"
-    },
-    "include": ["./src"],
-    "references": []
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There is no need to have tsconfig.lib if it is not a package that we want to release to npm.
## Notes for QA
Nothing to test

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/23779

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/auth-server-is-not-released-package&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/auth-server-is-not-released-package&lookback=7)