### PR TITLE
chore(ci): organize patches desktop|native to fix yarn focus in CI

### DIFF
--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
+          rm ./patches/app-builder-lib+26.4.0.patch # Hotfix for desktop-only package, which is not installed and crashes patch-package
           npx patch-package # Apply global patches.
       - name: Trigger adhoc build Android
         if: ${{ github.event.inputs.PLATFORM == 'android' || github.event.inputs.PLATFORM == 'all' }}

--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
+          rm ./patches/app-builder-lib+26.4.0.patch # Hotfix for desktop-only package, which is not installed and crashes patch-package
           npx patch-package # Apply global patches.
 
       - name: Check runtimeVersion builds

--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
+          rm ./patches/app-builder-lib+26.4.0.patch # Hotfix for desktop-only package, which is not installed and crashes patch-package
           npx patch-package # Apply global patches.
       - name: Build on EAS Android
         run: eas build

--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
+          rm ./patches/app-builder-lib+26.4.0.patch # Hotfix for desktop-only package, which is not installed and crashes patch-package
           npx patch-package # Apply global patches.
       - name: Build on EAS iOS
         run: eas build

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,11 +1,26 @@
 # Patches
 
+👉 **README, I'M IMPORTANT:**
+
+- Whenever you create or remove a patch, make sure to create/remove a brief explanation why.
+- Remove the patch as soon as we can update to a version that no longer requires the patch.
+- Known problem: `patch-packages` does not work well with `yarn workspaces focus`.
+    - Check cases in github action `yml`s where both are used.
+    - Check for problematic packages, e.g. `electron-builder` patched when `suite-native/app` is focused
+    - A quick hotfix can be as simple as `rm patches/some.patch` in the `yml` (patches are temporary anyway)
+
+---
+
 ## app-builder-lib
+
+Desktop-only, is hotfixed in: `build-suite-native-adhoc.yml, build-suite-native-preview.yml, release-suite-native-develop.yml, release-suite-native-production.yml`
 
 Fixes problem with generating `Info.plist` when building for macOS.
 Remove this patch after when this is fixed upstream in [electron-builder PR](https://github.com/electron-userland/electron-builder/pull/9481).
 
 ## expo-modules-core
+
+Native-only, but does not break any CI.
 
 Gets rid of `The global process.env.EXPO_OS is not defined. This should be inlined by babel-preset-expo during transformation.`
 warning while running unit tests. Probably caused by an issue reported [here](https://github.com/expo/expo/issues/26513) or [here](https://github.com/expo/expo/issues/25452).


### PR DESCRIPTION
## Description

Fix native builds in CI

Build running here https://github.com/trezor/trezor-suite/actions/runs/20921238630 :heavy_check_mark: 

## Notes 

This is bad. I wanted to something cleaner, more organized, but found no better solution :disappointed: 

`npx patch-package` is just not ready for `yarn workspaces focus`.
[As per the docs](https://www.npmjs.com/package/patch-package) there are flags for `--include` and `--exclude` but those are only for **creating** patches, sadly not for applying. That could be used for at least some degree of automation (organize patches into folders).

We could do `npx patch-package PACKAGE_NAME` and maintain lists in some plaintext file.

But idk, I think that patches are something that should not be considered permanent.
A :pig: hotfix which I did for `app-builder-lib` is IMO fine, provided it is documented which I did, and removed later, which I take responsibility for. In any case, when removing the `app-builder-lib` entry from the md, the diff will show that hotfix is in place and should be removed.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/patch-package-with-focus&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/patch-package-with-focus&lookback=7)