### PR TITLE
Fix `refreshSuiteSyncKeys` for remembered passphrase wallets

### DIFF
--- a/suite-common/suite-sync/src/createRefreshSuiteSyncKeys.ts
+++ b/suite-common/suite-sync/src/createRefreshSuiteSyncKeys.ts
@@ -61,7 +61,8 @@ export const createRefreshSuiteSync =
             // Device's sessionId may have changed, so let's get the current one
             const refreshedDevice = deps.getDeviceForStaticSessionId(deviceStaticId);
             if (!refreshedDevice || !isTrezorDeviceWithState(refreshedDevice)) {
-                return err(RefreshSuiteKeysUnavailable());
+                // This shall not happen, if it does, it's probably a Suite/Connect bug.
+                return err({ type: 'RefreshDeviceFailed' as const });
             }
 
             await deps.dispatch(
@@ -96,7 +97,7 @@ export const createRefreshSuiteSync =
                 // Those errors are most likely due to Bug in the code or data corruption
                 case 'CreateSuiteSyncOwnerError':
                 case 'ProofOfDelegatedSignFailed':
-                case 'RefreshSuiteKeysUnavailable':
+                case 'RefreshDeviceFailed':
                     console.error(result.error);
                     // Todo: dispatch better notification
                     deps.dispatch(notificationsActions.addToast({ type: 'suite-sync-keys-error' }));

--- a/suite-common/suite-sync/src/createRefreshSuiteSyncKeys.ts
+++ b/suite-common/suite-sync/src/createRefreshSuiteSyncKeys.ts
@@ -11,6 +11,7 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
 import { err, exhaustive, ok } from '@trezor/type-utils';
 
+import { GetDeviceForStaticSessionIdDep } from './getDeviceForStaticSessionId';
 import { LoadSuiteSyncOwnerFromStateDep } from './owner/createLoadSuiteSyncOwnerFromState';
 
 /**
@@ -25,7 +26,8 @@ export type RefreshSuiteSyncKeysDeps = {
     dispatch: Dispatch;
 } & EnsureSuiteSyncOwnerDep &
     LoadSuiteSyncOwnerFromStateDep &
-    EnsureDelegatedIdentityKeyDep;
+    EnsureDelegatedIdentityKeyDep &
+    GetDeviceForStaticSessionIdDep;
 
 export const createRefreshSuiteSync =
     (deps: RefreshSuiteSyncKeysDeps): RefreshSuiteSyncKeys =>
@@ -34,9 +36,9 @@ export const createRefreshSuiteSync =
             return err(RefreshSuiteKeysUnavailable());
         }
 
-        const owner = await deps.loadSuiteSyncOwnerFromState({
-            deviceStaticId: device.state.staticSessionId,
-        });
+        const deviceStaticId = device.state.staticSessionId;
+
+        const owner = await deps.loadSuiteSyncOwnerFromState({ deviceStaticId });
 
         if (owner !== null) {
             return ok(owner);
@@ -56,15 +58,21 @@ export const createRefreshSuiteSync =
                 return delegatedKeyResult;
             }
 
+            // Device's sessionId may have changed, so let's get the current one
+            const refreshedDevice = deps.getDeviceForStaticSessionId(deviceStaticId);
+            if (!refreshedDevice || !isTrezorDeviceWithState(refreshedDevice)) {
+                return err(RefreshSuiteKeysUnavailable());
+            }
+
             await deps.dispatch(
                 ensureDeviceHasQuotaThunk({
-                    device,
+                    device: refreshedDevice,
                     delegatedKey: delegatedKeyResult.value,
                 }),
             );
 
             const ownerResult = await deps.ensureSuiteSyncOwner({
-                device,
+                device: refreshedDevice,
                 delegatedKey: delegatedKeyResult.value,
             });
 
@@ -88,6 +96,7 @@ export const createRefreshSuiteSync =
                 // Those errors are most likely due to Bug in the code or data corruption
                 case 'CreateSuiteSyncOwnerError':
                 case 'ProofOfDelegatedSignFailed':
+                case 'RefreshSuiteKeysUnavailable':
                     console.error(result.error);
                     // Todo: dispatch better notification
                     deps.dispatch(notificationsActions.addToast({ type: 'suite-sync-keys-error' }));

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -74,15 +74,16 @@ export const createSuiteSyncCompositionRoot = (
         loadSuiteSyncOwnerFromState,
     });
 
+    const getDeviceForStaticSessionId: GetDeviceForStaticSessionId = deviceStaticId =>
+        selectDeviceByStaticSessionId(deps.getState(), deviceStaticId) ?? null;
+
     const refreshSuiteSyncKeys = createRefreshSuiteSync({
         dispatch: deps.dispatch,
         ensureDelegatedIdentityKey: deps.ensureDelegatedIdentityKey,
         ensureSuiteSyncOwner,
         loadSuiteSyncOwnerFromState,
+        getDeviceForStaticSessionId,
     });
-
-    const getDeviceForStaticSessionId: GetDeviceForStaticSessionId = deviceStaticId =>
-        selectDeviceByStaticSessionId(deps.getState(), deviceStaticId) ?? null;
 
     const ensureStorage = createEnsureStorage({
         refreshSuiteSyncKeys,

--- a/suite-common/suite-sync/src/tests/createRefreshSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/tests/createRefreshSuiteSync.test.ts
@@ -12,6 +12,7 @@ import { ok } from '@trezor/type-utils';
 
 import { mockNotExpected } from '../../tests/utils';
 import { RefreshSuiteSyncKeysDeps, createRefreshSuiteSync } from '../createRefreshSuiteSyncKeys';
+import { GetDeviceForStaticSessionId } from '../getDeviceForStaticSessionId';
 import { LoadSuiteSyncOwnerFromState } from '../owner/createLoadSuiteSyncOwnerFromState';
 
 const createMockDeps = () =>
@@ -23,6 +24,9 @@ const createMockDeps = () =>
         ),
         ensureDelegatedIdentityKey: mockNotExpected<EnsureDelegatedIdentityKey>(
             'ensureDelegatedIdentityKey',
+        ),
+        getDeviceForStaticSessionId: mockNotExpected<GetDeviceForStaticSessionId>(
+            'getDeviceForStaticSessionId',
         ),
     }) satisfies RefreshSuiteSyncKeysDeps;
 
@@ -102,6 +106,8 @@ describe(createRefreshSuiteSync.name, () => {
         );
 
         const mockDevice = createDevice();
+        deps.getDeviceForStaticSessionId.mockImplementation(() => mockDevice);
+
         const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
         await refreshSuiteSyncKeys({
             device: mockDevice,
@@ -122,6 +128,8 @@ describe(createRefreshSuiteSync.name, () => {
         );
 
         const mockDevice = createDevice();
+        deps.getDeviceForStaticSessionId.mockImplementation(() => mockDevice);
+
         const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
         await refreshSuiteSyncKeys({
             device: mockDevice,
@@ -147,9 +155,12 @@ describe(createRefreshSuiteSync.name, () => {
             }),
         );
 
+        const mockDevice = createDevice();
+        deps.getDeviceForStaticSessionId.mockImplementation(() => mockDevice);
+
         const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
         const result = await refreshSuiteSyncKeys({
-            device: createDevice(),
+            device: mockDevice,
         });
 
         expect(result.ok).toBe(true);


### PR DESCRIPTION
## Description

If toggling Suite Sync on is the first thing you do with remembered passphrase wallet, it asks twice for a passphrase, because `device.sessionId` param is not updated between `evoluGetDelegatedIdentityKey` and `evoluGetNode` calls. In this PR device object is reselected from redux state which resolves the issue.

## Notes for QA

Please check that when you:

1) have Suite Sync turned off and no remembered device,
2) add remembered passphrase wallet (so you probably have to forget the standard one)
3) disconnect and connect device, and
4) turn Suite Sync on,

it asks for passphrase only once, while previously it asked twice.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-sync-passphrase-fix&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-sync-passphrase-fix&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-sync-passphrase-fix&lookback=7)