### PR TITLE
Prevent "act" warnings in trading screens tests

### DIFF
--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.comp.test.tsx
@@ -46,12 +46,18 @@ const testQuote = exchangeQuotes[0];
 
 describe('TradingExchangeApprovalScreen', () => {
     let store: TestStore;
+    let unmount: (() => void) | undefined;
 
-    const renderScreen = () =>
-        renderWithStoreProviderAsync(
+    const renderScreen = async () => {
+        const result = await renderWithStoreProviderAsync(
             <TradingExchangeApprovalScreen route={{ params: {} } as any} navigation={{} as any} />,
             { store },
         );
+
+        ({ unmount } = result);
+
+        return result;
+    };
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -65,6 +71,13 @@ describe('TradingExchangeApprovalScreen', () => {
         store = initStore(preloadedState).store;
         store.dispatch(tradingExchangeActions.savePreselectedQuote(testQuote));
         store.dispatch(tradingExchangeActions.setTradingAccountKey('eth-account-1'));
+    });
+
+    afterEach(() => {
+        if (unmount) {
+            unmount();
+            unmount = undefined;
+        }
     });
 
     it('should render the approval screen with quote details', async () => {
@@ -111,9 +124,10 @@ describe('TradingExchangeApprovalScreen', () => {
     });
 
     it('should clear preselected quote on unmount', async () => {
-        const { unmount } = await renderScreen();
+        const { unmount: localUnmount } = await renderScreen();
 
-        unmount();
+        localUnmount();
+        unmount = undefined;
 
         const preselectedQuote = selectTradingExchangePreselectedQuote(store.getState());
         expect(preselectedQuote).toBeUndefined();

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
@@ -93,20 +93,25 @@ describe('TradingExchangePreviewScreen', () => {
     let store: TestStore;
     const analyticsSpy = jest.spyOn(analytics, 'report');
     let consoleErrorSpy: jest.SpyInstance;
+    let unmount: (() => void) | undefined;
 
-    const renderTradingExchangePreviewScreen = (
+    const renderTradingExchangePreviewScreen = async (
         isApproved: boolean = false,
         customStore?: TestStore,
     ) => {
         const testStore = customStore ?? store;
 
-        return renderWithStoreProviderAsync(
+        const result = await renderWithStoreProviderAsync(
             <TradingExchangePreviewScreen
                 navigation={createNavigationProps()}
                 route={createRouteProps(isApproved)}
             />,
             { store: testStore },
         );
+
+        ({ unmount } = result);
+
+        return result;
     };
 
     beforeEach(() => {
@@ -120,6 +125,10 @@ describe('TradingExchangePreviewScreen', () => {
 
     afterEach(() => {
         consoleErrorSpy.mockRestore();
+        if (unmount) {
+            unmount();
+            unmount = undefined;
+        }
     });
 
     it('should render continue button', async () => {

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeRevokeScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeRevokeScreen.comp.test.tsx
@@ -34,23 +34,37 @@ const preloadedState = {
     },
 };
 
-const renderScreen = () =>
-    renderWithStoreProviderAsync(
-        <TradingExchangeRevokeScreen
-            route={
-                { params: { quote: testQuote } } as RouteProp<
-                    TradingStackParamList,
-                    TradingStackRoutes.TradingExchangeRevoke
-                >
-            }
-            navigation={{} as any}
-        />,
-        {
-            preloadedState,
-        },
-    );
-
 describe('TradingExchangeRevokeScreen', () => {
+    let unmount: (() => void) | undefined;
+
+    const renderScreen = async () => {
+        const result = await renderWithStoreProviderAsync(
+            <TradingExchangeRevokeScreen
+                route={
+                    { params: { quote: testQuote } } as RouteProp<
+                        TradingStackParamList,
+                        TradingStackRoutes.TradingExchangeRevoke
+                    >
+                }
+                navigation={{} as any}
+            />,
+            {
+                preloadedState,
+            },
+        );
+
+        ({ unmount } = result);
+
+        return result;
+    };
+
+    afterEach(() => {
+        if (unmount) {
+            unmount();
+            unmount = undefined;
+        }
+    });
+
     it('should render the revoke screen with quote details', async () => {
         const { getByText } = await renderScreen();
 

--- a/suite-native/module-trading/src/screens/__tests__/TradingFeesScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingFeesScreen.comp.test.tsx
@@ -34,12 +34,19 @@ const preloadedState = {
     },
 };
 
-const renderScreen = () =>
-    renderWithStoreProviderAsync(<TradingFeesScreen />, {
-        preloadedState,
-    });
-
 describe('TradingFeesScreen', () => {
+    let unmount: (() => void) | undefined;
+
+    const renderScreen = async () => {
+        const result = await renderWithStoreProviderAsync(<TradingFeesScreen />, {
+            preloadedState,
+        });
+
+        ({ unmount } = result);
+
+        return result;
+    };
+
     beforeEach(() => {
         jest.clearAllMocks();
         // Default mock return value
@@ -47,6 +54,13 @@ describe('TradingFeesScreen', () => {
             name: 'TradingFeesScreen',
             params: { accountKey: 'btc1' },
         });
+    });
+
+    afterEach(() => {
+        if (unmount) {
+            unmount();
+            unmount = undefined;
+        }
     });
 
     it('should render the screen without crashing', async () => {

--- a/suite-native/module-trading/src/screens/__tests__/TradingHistoryScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingHistoryScreen.comp.test.tsx
@@ -53,14 +53,27 @@ const getPreloadedState = (): PreloadedState => ({
     },
 });
 
-const renderScreen = (preloadedState: PreloadedState) =>
-    renderWithStoreProviderAsync(<TradingHistoryScreen />, {
-        preloadedState,
-    });
-
 describe('TradingHistoryScreen', () => {
+    let unmount: (() => void) | undefined;
+
+    const renderScreen = async (preloadedState: PreloadedState) => {
+        const result = await renderWithStoreProviderAsync(<TradingHistoryScreen />, {
+            preloadedState,
+        });
+
+        ({ unmount } = result);
+
+        return result;
+    };
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        if (unmount) {
+            unmount();
+            unmount = undefined;
+        }
     });
 
     it('should render list of trades', async () => {

--- a/suite-native/module-trading/src/screens/__tests__/TradingOutputsReviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingOutputsReviewScreen.comp.test.tsx
@@ -1,7 +1,11 @@
 import { RouteProp } from '@react-navigation/native';
 
 import { TokenAddress } from '@suite-common/wallet-types';
-import { TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
+import type {
+    StackProps,
+    TradingStackParamList,
+    TradingStackRoutes,
+} from '@suite-native/navigation';
 import { TestStore, initStore, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
@@ -119,66 +123,100 @@ const createExchangeRoute = (params: ReturnType<typeof createExchangeRouteParams
         params,
     }) as RouteProp<TradingStackParamList, TradingStackRoutes.TradingExchangeOutputsReview>;
 
-describe('TradingSellOutputsReviewScreen', () => {
+describe('', () => {
     let store: TestStore;
+    let unmount: (() => void) | undefined;
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-        store = initStore({ wallet: getWalletState({ tradeType: 'sell' }) }).store;
-        mockNavigation.navigate.mockClear();
-        mockNavigation.goBack.mockClear();
-        mockNavigation.popToTop.mockClear();
+    afterEach(() => {
+        if (unmount) {
+            unmount();
+            unmount = undefined;
+        }
     });
 
-    it('should render TradingSellOutputsReviewScreen', async () => {
-        const params = createSellRouteParams();
-        const route = createSellRoute(params);
+    describe('TradingSellOutputsReviewScreen', () => {
+        const renderScreen = async (
+            route: StackProps<
+                TradingStackParamList,
+                TradingStackRoutes.TradingSellOutputsReview
+            >['route'],
+        ) => {
+            const result = await renderWithStoreProviderAsync(
+                <TradingSellOutputsReviewScreen route={route} navigation={mockNavigation} />,
+                { store },
+            );
 
-        const { toJSON } = await renderWithStoreProviderAsync(
-            <TradingSellOutputsReviewScreen route={route} navigation={mockNavigation} />,
-            { store },
-        );
+            ({ unmount } = result);
 
-        expect(toJSON()).not.toBeNull();
-        expect(mockUseSellFlowFn).toHaveBeenCalled();
-        expect(mockUseTradingOutputsReviewScreenControls).toHaveBeenCalledWith(
-            expect.objectContaining({
-                orderId: TEST_ORDER_ID,
-                accountKey: TEST_ACCOUNT_KEY,
-                reportToAnalytics: mockReportToAnalyticsSell,
-            }),
-        );
+            return result;
+        };
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+            store = initStore({ wallet: getWalletState({ tradeType: 'sell' }) }).store;
+            mockNavigation.navigate.mockClear();
+            mockNavigation.goBack.mockClear();
+            mockNavigation.popToTop.mockClear();
+        });
+
+        it('should render TradingSellOutputsReviewScreen', async () => {
+            const params = createSellRouteParams();
+            const route = createSellRoute(params);
+
+            const { toJSON } = await renderScreen(route);
+
+            expect(toJSON()).not.toBeNull();
+            expect(mockUseSellFlowFn).toHaveBeenCalled();
+            expect(mockUseTradingOutputsReviewScreenControls).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    orderId: TEST_ORDER_ID,
+                    accountKey: TEST_ACCOUNT_KEY,
+                    reportToAnalytics: mockReportToAnalyticsSell,
+                }),
+            );
+        });
     });
-});
 
-describe('TradingExchangeOutputsReviewScreen', () => {
-    let store: TestStore;
+    describe('TradingExchangeOutputsReviewScreen', () => {
+        const renderScreen = async (
+            route: StackProps<
+                TradingStackParamList,
+                TradingStackRoutes.TradingExchangeOutputsReview
+            >['route'],
+        ) => {
+            const result = await renderWithStoreProviderAsync(
+                <TradingExchangeOutputsReviewScreen route={route} navigation={mockNavigation} />,
+                { store },
+            );
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-        store = initStore({ wallet: getWalletState({ tradeType: 'exchange' }) }).store;
-        mockNavigation.navigate.mockClear();
-        mockNavigation.goBack.mockClear();
-        mockNavigation.popToTop.mockClear();
-    });
+            ({ unmount } = result);
 
-    it('should render TradingExchangeOutputsReviewScreen', async () => {
-        const params = createExchangeRouteParams();
-        const route = createExchangeRoute(params);
+            return result;
+        };
 
-        const { toJSON } = await renderWithStoreProviderAsync(
-            <TradingExchangeOutputsReviewScreen route={route} navigation={mockNavigation} />,
-            { store },
-        );
+        beforeEach(() => {
+            jest.clearAllMocks();
+            store = initStore({ wallet: getWalletState({ tradeType: 'exchange' }) }).store;
+            mockNavigation.navigate.mockClear();
+            mockNavigation.goBack.mockClear();
+            mockNavigation.popToTop.mockClear();
+        });
 
-        expect(toJSON()).not.toBeNull();
-        expect(mockUseExchangeFlowFn).toHaveBeenCalled();
-        expect(mockUseTradingOutputsReviewScreenControls).toHaveBeenCalledWith(
-            expect.objectContaining({
-                orderId: TEST_ORDER_ID,
-                accountKey: TEST_ACCOUNT_KEY,
-                reportToAnalytics: mockReportToAnalyticsExchange,
-            }),
-        );
+        it('should render TradingExchangeOutputsReviewScreen', async () => {
+            const params = createExchangeRouteParams();
+            const route = createExchangeRoute(params);
+
+            const { toJSON } = await renderScreen(route);
+
+            expect(toJSON()).not.toBeNull();
+            expect(mockUseExchangeFlowFn).toHaveBeenCalled();
+            expect(mockUseTradingOutputsReviewScreenControls).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    orderId: TEST_ORDER_ID,
+                    accountKey: TEST_ACCOUNT_KEY,
+                    reportToAnalytics: mockReportToAnalyticsExchange,
+                }),
+            );
+        });
     });
 });

--- a/suite-native/module-trading/src/screens/__tests__/TradingReceiveAccountsPickerScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingReceiveAccountsPickerScreen.comp.test.tsx
@@ -41,12 +41,26 @@ const getPreloadedState = (preloadedAccounts: Account[]): PreloadedState => ({
     },
 });
 
-const renderScreen = (preloadedState: PreloadedState) =>
-    renderWithStoreProviderAsync(<TradingReceiveAccountsPickerScreen />, {
-        preloadedState,
+describe('TradingReceiveAccountsPickerScreen', () => {
+    let unmount: (() => void) | undefined;
+
+    const renderScreen = async (preloadedState: PreloadedState) => {
+        const result = await renderWithStoreProviderAsync(<TradingReceiveAccountsPickerScreen />, {
+            preloadedState,
+        });
+
+        ({ unmount } = result);
+
+        return result;
+    };
+
+    afterEach(() => {
+        if (unmount) {
+            unmount();
+            unmount = undefined;
+        }
     });
 
-describe('TradingReceiveAccountsPickerScreen', () => {
     it('should render account list with correct title', async () => {
         mockRouteParams = { symbol: 'btc', tradingType: 'buy' };
 

--- a/suite-native/module-trading/src/screens/__tests__/TradingScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingScreen.comp.test.tsx
@@ -89,8 +89,22 @@ const stateWithDisabledTrading = {
 } as unknown as PreloadedState;
 
 describe('TradingScreen', () => {
-    const renderTradingScreen = (preloadedState?: PreloadedState) =>
-        renderWithStoreProviderAsync(<TradingScreen />, { preloadedState });
+    let unmount: (() => void) | undefined;
+
+    const renderTradingScreen = async (preloadedState?: PreloadedState) => {
+        const result = await renderWithStoreProviderAsync(<TradingScreen />, { preloadedState });
+
+        ({ unmount } = result);
+
+        return result;
+    };
+
+    afterEach(() => {
+        if (unmount) {
+            unmount();
+            unmount = undefined;
+        }
+    });
 
     const expectBuyForm = () => {
         expect(screen.getByText('You pay')).toBeOnTheScreen();

--- a/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.comp.test.tsx
@@ -42,10 +42,14 @@ jest.mock('../../hooks/general/useWatchTrade', () => ({
 }));
 
 describe('TradingSellPreviewScreen', () => {
+    let unmount: (() => void) | undefined;
+
     const renderTradingSellPreviewScreen = async (preloadedState?: PreloadedState) => {
         const result = await renderWithStoreProviderAsync(<TradingSellPreviewScreen />, {
             preloadedState,
         });
+
+        unmount = result.unmount;
         // wait for async useEffects callbacks to (hopefully) finish
         await act(() => Promise.resolve());
 
@@ -55,6 +59,13 @@ describe('TradingSellPreviewScreen', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockUseTradingDetailData.trade = undefined;
+    });
+
+    afterEach(() => {
+        if (unmount) {
+            unmount();
+            unmount = undefined;
+        }
     });
 
     it('should render screen with header and preview view', async () => {

--- a/suite-native/module-trading/src/screens/__tests__/TradingWebViewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingWebViewScreen.comp.test.tsx
@@ -1,6 +1,6 @@
 import { TradingTransaction, TradingType } from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';
-import { initStore, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { TestStore, initStore, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
 import { selectTradingProviderConfirmationStatus } from '@suite-native/trading-state';
 
@@ -34,13 +34,29 @@ jest.mock('@suite-common/trading', () => {
 });
 
 describe('TradingWebViewScreen', () => {
+    let unmount: (() => void) | undefined;
+
+    const renderScreen = async (store?: TestStore) => {
+        const result = await renderWithStoreProviderAsync(<TradingWebViewScreen />, { store });
+
+        ({ unmount } = result);
+
+        return result;
+    };
+    afterEach(() => {
+        if (unmount) {
+            unmount();
+            unmount = undefined;
+        }
+    });
+
     it('should render header', async () => {
         mockRouteParams = {
             closeCallbackUrl: 'CALLBACK_URL',
             source: { uri: 'SOURCE_URI', html: undefined },
             tradingType: 'buy',
         };
-        const { getByTestId } = await renderWithStoreProviderAsync(<TradingWebViewScreen />);
+        const { getByTestId } = await renderScreen();
 
         expect(getByTestId('@screen/sub-header/icon-left')).toBeTruthy();
     });
@@ -50,7 +66,7 @@ describe('TradingWebViewScreen', () => {
             closeCallbackUrl: 'CALLBACK_URL',
             tradingType: 'buy',
         };
-        const { getByText } = await renderWithStoreProviderAsync(<TradingWebViewScreen />);
+        const { getByText } = await renderScreen();
 
         expect(getByText('Something went wrong')).toBeTruthy();
     });
@@ -61,7 +77,7 @@ describe('TradingWebViewScreen', () => {
             source: { uri: undefined, html: undefined },
             tradingType: 'buy',
         };
-        const { getByText } = await renderWithStoreProviderAsync(<TradingWebViewScreen />);
+        const { getByText } = await renderScreen();
 
         expect(getByText('Something went wrong')).toBeTruthy();
     });
@@ -91,9 +107,7 @@ describe('TradingWebViewScreen', () => {
                 } as unknown as TradingTransaction,
             ];
 
-            await renderWithStoreProviderAsync(<TradingWebViewScreen />, {
-                preloadedState,
-            });
+            await renderScreen();
 
             expect(analyticsSpy).not.toHaveBeenCalledWith({
                 type: EventType.TradingExchange,
@@ -122,10 +136,9 @@ describe('TradingWebViewScreen', () => {
                     },
                 } as unknown as TradingTransaction,
             ];
+            const { store } = initStore(preloadedState);
 
-            await renderWithStoreProviderAsync(<TradingWebViewScreen />, {
-                preloadedState,
-            });
+            await renderScreen(store);
 
             expect(analyticsSpy).toHaveBeenCalledWith({
                 type: EventType.TradingExchange,
@@ -147,10 +160,9 @@ describe('TradingWebViewScreen', () => {
                     },
                 } as unknown as TradingTransaction,
             ];
+            const { store } = initStore(preloadedState);
 
-            await renderWithStoreProviderAsync(<TradingWebViewScreen />, {
-                preloadedState,
-            });
+            await renderScreen(store);
 
             expect(analyticsSpy).toHaveBeenCalledWith({
                 type: EventType.TradingSell,
@@ -174,9 +186,9 @@ describe('TradingWebViewScreen', () => {
                         },
                     } as unknown as TradingTransaction,
                 ];
-                const { store } = await initStore(preloadedState);
+                const { store } = initStore(preloadedState);
 
-                await renderWithStoreProviderAsync(<TradingWebViewScreen />, { store });
+                await renderScreen(store);
 
                 expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('inactive');
             },
@@ -193,9 +205,9 @@ describe('TradingWebViewScreen', () => {
                     },
                 } as unknown as TradingTransaction,
             ];
-            const { store } = await initStore(preloadedState);
+            const { store } = initStore(preloadedState);
 
-            await renderWithStoreProviderAsync(<TradingWebViewScreen />, { store });
+            await renderScreen(store);
 
             expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('window_opened');
         });

--- a/suite-native/trading-residence/src/screens/__tests__/SettingsTradingLocationScreen.comp.test.tsx
+++ b/suite-native/trading-residence/src/screens/__tests__/SettingsTradingLocationScreen.comp.test.tsx
@@ -2,7 +2,7 @@ import { RouteProp } from '@react-navigation/native';
 
 import { EventType, analytics } from '@suite-native/analytics';
 import { SettingsStackParamList, SettingsStackRoutes } from '@suite-native/navigation';
-import { renderWithStoreProviderAsync, userEvent } from '@suite-native/test-utils';
+import { renderWithStoreProviderAsync, screen, userEvent } from '@suite-native/test-utils';
 
 import { SettingsTradingLocationScreen } from '../SettingsTradingLocationScreen';
 
@@ -26,6 +26,10 @@ describe('TradingLocationSettingsScreen', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        screen.unmount();
     });
 
     it('should render all components', async () => {

--- a/suite-native/trading-residence/src/screens/__tests__/TradingLocationModalScreen.comp.test.tsx
+++ b/suite-native/trading-residence/src/screens/__tests__/TradingLocationModalScreen.comp.test.tsx
@@ -6,7 +6,7 @@ import {
     TradingStackParamList,
     TradingStackRoutes,
 } from '@suite-native/navigation';
-import { renderWithStoreProviderAsync, userEvent } from '@suite-native/test-utils';
+import { renderWithStoreProviderAsync, screen, userEvent } from '@suite-native/test-utils';
 
 import {
     TradingLocationModalScreen,
@@ -43,6 +43,10 @@ describe('TradingLocationModalScreen', () => {
                 route={mockRoute}
             />,
         );
+
+    afterEach(() => {
+        screen.unmount();
+    });
 
     it('should render all components', async () => {
         const { getByText, queryByLabelText } = await renderTradingLocationModalScreen();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Prevent unwanted update to screen components by unmounting them right after test. (According to docs, this should happen automatically, but obviously it does not happen in tests updated in this PR.)

<!--- Describe your changes in detail -->

## Notes for QA

No production changes.



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=no-act-warning-in-trading-screens&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=no-act-warning-in-trading-screens&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=no-act-warning-in-trading-screens&lookback=7)