### PR TITLE
fix(suite): auto-enable cardano derivation

### DIFF
--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -150,7 +150,10 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
 
                     // cardano patch
                     const enabledNetworks = getEnabledNetworks();
-                    const isCardanoMethod = key.startsWith('cardano');
+                    const isCardanoMethod =
+                        key === 'call'
+                            ? params.method.startsWith('cardano')
+                            : key.startsWith('cardano');
                     const cardanoEnabled =
                         !!enabledNetworks.find(a => a === 'ada') || isCardanoMethod;
 


### PR DESCRIPTION
## Description

Auto-enable Cardano derivation when calling Cardano methods. I believe this broke after changing TrezorConnect.call API

## Notes for QA

Try any Cardano method in Connect Explorer with Suite desktop, while not having Cardano enabled in Coins

Before this fix, it would show "Cardano derivation is enabled for this session"

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-call-cardano-enabled&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-call-cardano-enabled&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-call-cardano-enabled&lookback=7)