### PR TITLE
chore(suite-native): enable rozenite in metro

### DIFF
--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -160,6 +160,7 @@ if (
     // enable Rozenite plugins only in debug build
     module.exports = withRozenite(configWithStorybook, {
         enhanceMetroConfig: originalConfig => withRozeniteReduxDevTools(originalConfig),
+        enabled: true,
     });
 } else {
     module.exports = configWithStorybook;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
From next version, Rozenite will no longer be enabled by default. We need to configure it manually and since it's already a supported flag whose default value is going to change, I updated it so we have it ready for upgrade. 

More info here: https://www.rozenite.dev/docs/getting-started

<img width="745" height="299" alt="image" src="https://github.com/user-attachments/assets/91d09dd2-1048-4439-bced-0a6a7c6463b4" />

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/rozenite-enabled-config&lookback=7)