### PR TITLE
fix(ci): reenable Nx cache on unit tests & typecheck

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -55,8 +55,7 @@ jobs:
       - name: "Minimal yarn install"
         uses: ./.github/actions/minimal-yarn-install
       - name: Type Check
-        # Temporarily disabling the cache (false positives because of cache mismatch after NX update)
-        run: yarn nx:type-check --output-style=stream --skip-nx-cache
+        run: yarn nx:type-check --output-style=stream
 
   lint:
     name: Linting and formatting
@@ -127,8 +126,7 @@ jobs:
       - name: "Minimal yarn install"
         uses: ./.github/actions/minimal-yarn-install
       - name: Unit Tests
-        # Temporarily disabling the cache (false positives because of cache mismatch after NX update)
-        run: yarn nx:test-unit:${{ matrix.test-task }} --output-style=stream --skip-nx-cache
+        run: yarn nx:test-unit:${{ matrix.test-task }} --output-style=stream
 
   build-libs-for-publishing:
     name: "Build libs for publishing"

--- a/packages/type-utils/src/index.ts
+++ b/packages/type-utils/src/index.ts
@@ -8,3 +8,4 @@ export * from './timeout';
 export * from './utils';
 
 // no-op change to trigger Nx cache invalidation
+// TODO remove this after 1st February 2026


### PR DESCRIPTION
Partially reverts commit 83d4142f88761ba01868c041676954baafc613b4.

That should be enough to have Nx cache working again, with all stale results invalidated.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ci-reenable-nx-cache&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ci-reenable-nx-cache&lookback=7)