### PR TITLE
ci(connect): run all tests in PR for T3W1

### DIFF
--- a/.github/workflows/test-connect.yml
+++ b/.github/workflows/test-connect.yml
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 60
     outputs:
       dailyMatrix: ${{ steps.set-matrix-daily.outputs.matrix }}
-      dailyT3W1Matrix: ${{ steps.set-matrix-daily-t3w1.outputs.matrix }}
+      dailyWebMatrix: ${{ steps.set-matrix-daily-web.outputs.matrix }}
       nightlyT3W1Matrix: ${{ steps.set-matrix-nightly-t3w1.outputs.matrix }}
       otherDevicesMatrix: ${{ steps.set-matrix-other-devices.outputs.matrix }}
       allFwsMatrix: ${{ steps.set-matrix-all-firmwares.outputs.matrix }}
@@ -80,11 +80,11 @@ jobs:
 
       - name: Set daily matrix
         id: set-matrix-daily
-        run: echo "matrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=T2T1 --firmware=2-latest --env=all --groups=api,api-flaky --disable_cache_tx=true --transport=node-bridge)" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=T3W1 --firmware=2-latest --env=node --groups=all --disable_cache_tx=false --transport=node-bridge)" >> $GITHUB_OUTPUT
 
-      - name: Set daily T3W1 matrix
-        id: set-matrix-daily-t3w1
-        run: echo "matrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=T3W1 --firmware=2-latest --env=all --groups=thp --disable_cache_tx=true --transport=node-bridge)" >> $GITHUB_OUTPUT
+      - name: Set daily web matrix
+        id: set-matrix-daily-web
+        run: echo "matrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=T3W1 --firmware=2-latest --env=web --groups=api,init --disable_cache_tx=true --transport=node-bridge)" >> $GITHUB_OUTPUT
 
       - name: Set nightly T3W1 matrix
         id: set-matrix-nightly-t3w1
@@ -124,9 +124,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.dailyMatrix) }}
 
-  PR-check-t3w1:
+  PR-check-web:
     needs: [build, set-matrix]
-    name: PR-check-t3w1 ${{ matrix.key }}
+    name: PR-check-web ${{ matrix.key }}
     if: github.repository == 'trezor/trezor-suite'
     uses: ./.github/workflows/template-connect-test-params.yml
     with:
@@ -140,7 +140,7 @@ jobs:
       testFirmwareModel: ${{ matrix.model }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.set-matrix.outputs.dailyT3W1Matrix) }}
+      matrix: ${{ fromJson(needs.set-matrix.outputs.dailyWebMatrix) }}
 
   PR-nightly-t3w1:
     needs: [build, set-matrix]

--- a/packages/connect/e2e/tests/device/methods.test.ts
+++ b/packages/connect/e2e/tests/device/methods.test.ts
@@ -62,6 +62,8 @@ const getFixtures = () => {
     return result || [];
 };
 
+let lastSetupConfig: TestCase['setup'] | null = null;
+
 describe(`TrezorConnect methods`, () => {
     afterAll(() => {
         // reset controller at the end
@@ -113,7 +115,14 @@ describe(`TrezorConnect methods`, () => {
                         }
 
                         // single test may require a different setup
-                        await setup(controller, t.setup || testCase.setup);
+                        const setupConfig = t.setup || testCase.setup;
+                        if (
+                            setupConfig.wiped ||
+                            JSON.stringify(setupConfig) !== JSON.stringify(lastSetupConfig)
+                        ) {
+                            await setup(controller, setupConfig);
+                            lastSetupConfig = setupConfig;
+                        }
 
                         // @ts-expect-error, string + params union
                         const result = await TrezorConnect[testCase.method](t.params);


### PR DESCRIPTION
## Description

We want to test all methods in PRs, previously this was covered by Connect Popup, but that's no longer the case. 
Run all tests in node, and a few select groups (api, init) in web. 
Also use T3W1 by default

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci-connect-run-all-methods-in-pr&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci-connect-run-all-methods-in-pr&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci-connect-run-all-methods-in-pr&lookback=7)