### PR TITLE
fix: React dev tools working again

### DIFF
--- a/packages/suite-desktop-core/src/config.ts
+++ b/packages/suite-desktop-core/src/config.ts
@@ -13,6 +13,7 @@ export const allowedProtocols = ['http:', 'https:'];
 const allowedDomainsDev = [
     // google store for chrome extensions (devtools) loaded in electron-react-devtools.ts, see https://github.com/MarshallOfSound/electron-devtools-installer/blob/f8ec609/src/downloadChromeExtension.ts#L30
     'google.com',
+    'googleusercontent.com',
 ];
 
 export const allowedDomains = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

For devs: enables react dev tools in dev only. Doesnt matter for production.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-react-components-dev-tools-desktop&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-react-components-dev-tools-desktop&lookback=7)