### PR TITLE
fix(transport-bluetooth): clear readBuffer on openDevice

### DIFF
--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -113,6 +113,7 @@ export class BluetoothApi extends AbstractApi {
     openDevice(path: string, options?: { channel?: OpenDeviceChannel }) {
         const isReadChannel = !options?.channel || options.channel === 'read';
         if (isReadChannel) {
+            this.readBuffer.cancelRead(path);
             if (this.readSubscription[path]) {
                 // already subscribed to TX (read) characteristics
                 return Promise.resolve(this.success(undefined));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fixing BT firmware update on linux

TLDR: when calling transport.openDevice() we need to clear all the data collected before actual opening (data which was read before we need/expect them)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-clear-read-buffer&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-clear-read-buffer&lookback=7)