### PR TITLE
Mobile Sell: Allow to set provider success even when WebView was not closed yet

### DIFF
--- a/suite-native/trading-state/README.md
+++ b/suite-native/trading-state/README.md
@@ -1,0 +1,40 @@
+## Trading state
+
+### Trading slice
+
+#### providerConfirmationStatus state machine
+
+<!-- prettier-ignore-start -->
+
+```mermaid
+graph TD
+    inactive -- on webview open --> window_opened
+
+    window_opened -- on trade close --> inactive
+    window_opened -- on X press --> window_closed_incomplete
+    window_opened -- on automatic redirect --> window_closed_with_success
+    window_opened -- on backend confirmation received --> confirmation_success
+
+    window_closed_incomplete -- on trade close --> inactive
+    window_closed_incomplete -- on automatic redirect -->  window_closed_with_success
+    window_closed_incomplete -- on backend confirmation received --> confirmation_success
+    window_closed_incomplete -- after 30s --> confirmation_failed
+
+    window_closed_with_success -- on backend confirmation received --> confirmation_success
+    window_closed_with_success -- after 30s --> confirmation_failed
+    window_closed_with_success -- on trade close --> inactive
+
+    confirmation_failed -- on backend confirmation received --> confirmation_success
+    confirmation_failed -- on trade close --> inactive
+
+    confirmation_success -- on trade close --> inactive
+
+    classDef initial-state fill: #c61, stroke: #333, stroke-width: 2px
+    classDef fail-state fill: #c22, stroke: #333, stroke-width: 2px
+    classDef success-state fill: #595, stroke: #333, stroke-width: 2px
+    class inactive initial-state
+    class confirmation_failed fail-state
+    class confirmation_success success-state
+```
+
+<!-- prettier-ignore-end -->

--- a/suite-native/trading-state/src/reducers/__tests__/tradingSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/tradingSlice.test.ts
@@ -469,6 +469,7 @@ describe('tradingSlice', () => {
             it.each<ProviderConfirmationStatus>([
                 'window_closed_incomplete',
                 'window_closed_with_success',
+                'confirmation_success',
                 'inactive',
             ])('should set status to [%s]', newStatus => {
                 actions.push(tradingActions.setProviderConfirmationStatus(newStatus));
@@ -478,7 +479,7 @@ describe('tradingSlice', () => {
                 expect(state.providerConfirmationStatus).toBe(newStatus);
             });
 
-            it.each<ProviderConfirmationStatus>(['confirmation_success', 'confirmation_failed'])(
+            it.each<ProviderConfirmationStatus>(['confirmation_failed'])(
                 'should not allow to set status to [%s]',
                 invalidStatus => {
                     actions.push(tradingActions.setProviderConfirmationStatus(invalidStatus));
@@ -500,6 +501,7 @@ describe('tradingSlice', () => {
 
             it.each<ProviderConfirmationStatus>([
                 'window_closed_with_success',
+                'confirmation_success',
                 'confirmation_failed',
                 'inactive',
             ])('should set status to [%s]', newStatus => {
@@ -510,7 +512,7 @@ describe('tradingSlice', () => {
                 expect(state.providerConfirmationStatus).toBe(newStatus);
             });
 
-            it.each<ProviderConfirmationStatus>(['confirmation_success', 'window_opened'])(
+            it.each<ProviderConfirmationStatus>(['window_opened'])(
                 'should not allow to set status to [%s]',
                 invalidStatus => {
                     actions.push(tradingActions.setProviderConfirmationStatus(invalidStatus));

--- a/suite-native/trading-state/src/reducers/tradingSlice.ts
+++ b/suite-native/trading-state/src/reducers/tradingSlice.ts
@@ -19,9 +19,19 @@ const providerConfirmationStatusTransitions: Record<
     // inactive is the initial state, providerConfirmationStatus becomes inactive when transaction prview is closed
     inactive: ['window_opened'],
     // window_opened is set when the webview is opened
-    window_opened: ['window_closed_incomplete', 'window_closed_with_success', 'inactive'],
+    window_opened: [
+        'window_closed_incomplete',
+        'window_closed_with_success',
+        'confirmation_success',
+        'inactive',
+    ],
     // window_closed_incomplete is set when the webview is closed manually by the user before completing the confirmation
-    window_closed_incomplete: ['window_closed_with_success', 'confirmation_failed', 'inactive'],
+    window_closed_incomplete: [
+        'window_closed_with_success',
+        'confirmation_success',
+        'confirmation_failed',
+        'inactive',
+    ],
     // window_closed_with_success is set when the webview is closed after successful confirmation
     window_closed_with_success: ['confirmation_success', 'confirmation_failed', 'inactive'],
     // confirmation_failed is set if we do not know transaction status after 30 seconds after webview is close


### PR DESCRIPTION
Allows two more edges in providerConfirmationStatus state machine.

## Description

- Allow to set success state even before webview was closed.
- Allow to set success state even when webview was closed by X.
- Adds graph of providerConfirmationStatus state machine to README.md.

```mermaid
graph TD
    inactive -- on webview open --> window_opened

    window_opened -- on trade close --> inactive
    window_opened -- on X press --> window_closed_incomplete
    window_opened -- on automatic redirect --> window_closed_with_success
    window_opened -- on backend confirmation received (NEW) --> confirmation_success

    window_closed_incomplete -- on trade close --> inactive
    window_closed_incomplete -- on automatic redirect -->  window_closed_with_success
    window_closed_incomplete -- on backend confirmation received (NEW) --> confirmation_success
    window_closed_incomplete -- after 30s --> confirmation_failed

    window_closed_with_success -- on backend confirmation received --> confirmation_success
    window_closed_with_success -- after 30s --> confirmation_failed
    window_closed_with_success -- on trade close --> inactive

    confirmation_failed -- on backend confirmation received --> confirmation_success
    confirmation_failed -- on trade close --> inactive

    confirmation_success -- on trade close --> inactive
```

<!--- Describe your changes in detail -->

## Notes for QA

User should not be able to get to conflicting state anymore. 

## Related Issue

Resolve #24171

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24171-mobile-sell-occasional-delayed-address-conflicting-errorcontinue-state&lookback=7)