### PR TITLE
Add hidden tokens to global send

### DIFF
--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetAmount.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetAmount.tsx
@@ -4,6 +4,7 @@ import { BaseCurrencyAmount } from '@suite-common/wallet-types';
 import { Column, Text } from '@trezor/components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 
 export type AssetAmountProps = {
@@ -11,9 +12,16 @@ export type AssetAmountProps = {
     amount: string;
     contractAddress: string;
     fiatAmount?: BaseCurrencyAmount;
+    fiatFallackText?: boolean;
 };
 
-export function AssetAmount({ amount, symbol, fiatAmount, contractAddress }: AssetAmountProps) {
+export function AssetAmount({
+    amount,
+    symbol,
+    fiatAmount,
+    contractAddress,
+    fiatFallackText = false,
+}: AssetAmountProps) {
     const { BaseCurrencyAmountFormatter } = useFormatters();
     const fiatCurrency = useSelector(selectBaseCurrency);
 
@@ -31,6 +39,11 @@ export function AssetAmount({ amount, symbol, fiatAmount, contractAddress }: Ass
             {fiatAmount && (
                 <Text variant="tertiary" typographyStyle="hint">
                     <BaseCurrencyAmountFormatter value={fiatAmount} currency={fiatCurrency} />
+                </Text>
+            )}
+            {!fiatAmount && fiatFallackText && (
+                <Text variant="tertiary" typographyStyle="hint">
+                    <Translation id="TR_HIDDEN_TOKEN_WITHOUT_FIAT" />
                 </Text>
             )}
         </Column>

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
@@ -14,14 +14,22 @@ export type AssetRowTokenProps = {
     account: Account;
     onClick: (token: TokensWithRates, account: Account) => void;
     dataTestId?: string;
+    hiddenToken?: boolean;
 };
 
-export function AssetRowToken({ token, account, dataTestId, onClick }: AssetRowTokenProps) {
+export function AssetRowToken({
+    token,
+    account,
+    dataTestId,
+    onClick,
+    hiddenToken = false,
+}: AssetRowTokenProps) {
     return (
         <ItemClickableContainer
             onClick={() => {
                 onClick(token, account);
             }}
+            padding={hiddenToken ? { left: 16, vertical: 8, right: 16 } : undefined}
         >
             <Row
                 data-testid={`${dataTestId}/${account.symbol}/${token.symbol}`}
@@ -48,6 +56,7 @@ export function AssetRowToken({ token, account, dataTestId, onClick }: AssetRowT
                     fiatAmount={token.fiatRate ? asBaseCurrencyAmount(token.fiatValue) : undefined}
                     contractAddress={token.contract}
                     amount={token.balance}
+                    fiatFallackText={hiddenToken}
                 />
             )}
         </ItemClickableContainer>

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/ExpandableAssetRowTokens/ExpandableAssetRowTokens.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/ExpandableAssetRowTokens/ExpandableAssetRowTokens.tsx
@@ -1,0 +1,87 @@
+import styled from 'styled-components';
+
+import { Account, AccountKey } from '@suite-common/wallet-types';
+import { TokenInfo } from '@trezor/blockchain-link-types';
+import { Card, Collapsible, Row, Text } from '@trezor/components';
+
+import { Translation } from 'src/components/suite/Translation';
+import { TokensWithRates } from 'src/utils/wallet/tokenUtils';
+
+import { EXPANDABLE_ASSET_ROW_TOKENS_HEADER_HEIGHT } from '../../../constants';
+import { AssetRowToken } from '../AssetRowToken/AssetRowToken';
+
+// Don't use `Collapsible.Content`, it's not optimized for larger content.
+// Use this custom component, thanks to 'will-change' it acts as single layer.
+const CollapsibleContent = styled.div<{ $height: number; $expanded: boolean }>`
+    will-change: opacity;
+    height: ${({ $height, $expanded }) =>
+        $expanded ? $height - EXPANDABLE_ASSET_ROW_TOKENS_HEADER_HEIGHT : 0}px;
+    overflow: hidden;
+    position: relative;
+    transition: opacity 0.4s ease-in-out;
+    opacity: ${({ $expanded }) => ($expanded ? 1 : 0)};
+`;
+
+export interface ExpandableAssetRowTokensProps {
+    account: Account;
+    tokens: TokensWithRates[];
+    expanded: boolean;
+    onExpandToggle: (accountKey: AccountKey, expanded: boolean) => void;
+    onTokenClick: (token: TokenInfo, account: Account) => void;
+    height: number;
+}
+
+export function ExpandableAssetRowTokens({
+    account,
+    tokens,
+    expanded,
+    onExpandToggle,
+    onTokenClick,
+    height,
+}: ExpandableAssetRowTokensProps) {
+    return (
+        <Collapsible isOpen={expanded}>
+            <Card fillType="flat" paddingType="none">
+                <Collapsible.Toggle
+                    onClick={() => {
+                        // The operation will be probably expensive. Ask for fresh frame before switching the state.
+                        requestAnimationFrame(() => {
+                            onExpandToggle(account.key, !expanded);
+                        });
+                    }}
+                >
+                    <Row
+                        alignItems="center"
+                        justifyContent="space-between"
+                        gap={12}
+                        padding={{
+                            vertical: 12,
+                            horizontal: 16,
+                        }}
+                    >
+                        <Text typographyStyle="hint">
+                            <Translation id="TR_HIDDEN_TOKENS" />
+                        </Text>
+
+                        <Collapsible.ToggleIcon
+                            iconName={expanded ? 'caretUpDownReverse' : 'caretUpDown'}
+                        />
+                    </Row>
+                </Collapsible.Toggle>
+
+                <CollapsibleContent $height={height} $expanded={expanded}>
+                    {expanded &&
+                        tokens.map(token => (
+                            <AssetRowToken
+                                key={token.contract}
+                                token={token}
+                                account={account}
+                                onClick={onTokenClick}
+                                hiddenToken={true}
+                            />
+                        ))}
+                </CollapsibleContent>
+            </Card>
+        </Collapsible>
+    );
+}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/ItemClickableContainer.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/ItemClickableContainer.tsx
@@ -1,18 +1,27 @@
-import { GhostContainer, Row } from '@trezor/components';
+import { GhostContainer, Padding, Row } from '@trezor/components';
 
 import { ASSET_ROW_HEIGHT } from '../../constants';
 
 type ItemClickableContainerProps = {
     children: React.ReactNode;
     onClick: () => void;
+    padding?: Padding;
 };
 
-export function ItemClickableContainer({ children, onClick }: ItemClickableContainerProps) {
+export function ItemClickableContainer({
+    children,
+    onClick,
+    padding = {
+        left: 8,
+        vertical: 8,
+        right: 12,
+    },
+}: ItemClickableContainerProps) {
     return (
         <GhostContainer
             width="100%"
             height={ASSET_ROW_HEIGHT - 8}
-            padding={{ left: 8, vertical: 8, right: 12 }}
+            padding={padding}
             onClick={e => {
                 e.stopPropagation();
                 onClick();

--- a/packages/suite/src/components/suite/asset-picker/components/index.ts
+++ b/packages/suite/src/components/suite/asset-picker/components/index.ts
@@ -6,3 +6,4 @@ export * from './AssetRow/AssetGroupLabel';
 export * from './AssetRow/AssetGroupSpace';
 export * from './AssetRow/AssetRowToken/AssetRowToken';
 export * from './AssetRow/AssetRowAsset/AssetRowAsset';
+export * from './AssetRow/ExpandableAssetRowTokens/ExpandableAssetRowTokens';

--- a/packages/suite/src/components/suite/asset-picker/constants/index.ts
+++ b/packages/suite/src/components/suite/asset-picker/constants/index.ts
@@ -6,3 +6,5 @@ export const ASSET_ROW_HEIGHTS_BY_SIZE = {
     md: 24,
     lg: 32,
 } as const satisfies Record<AssetGroupSpaceSize, number>;
+
+export const EXPANDABLE_ASSET_ROW_TOKENS_HEADER_HEIGHT = 46;

--- a/packages/suite/src/components/suite/asset-picker/hooks/index.ts
+++ b/packages/suite/src/components/suite/asset-picker/hooks/index.ts
@@ -2,5 +2,4 @@ export * from './useModal';
 export * from './useListScrollReset';
 export * from './useSearchFilter';
 export * from './useInsertGroupLabelsAndSpaces';
-export * from './useAccountWithTokensOptions';
 export * from './useFilterAccountsWithTokens';

--- a/packages/suite/src/components/suite/asset-picker/hooks/useFilterAccountsWithTokens.ts
+++ b/packages/suite/src/components/suite/asset-picker/hooks/useFilterAccountsWithTokens.ts
@@ -2,7 +2,8 @@ import { useMemo } from 'react';
 
 import { accountSearchFn, isTokenMatchesSearch } from '@suite-common/wallet-utils';
 
-import { AccountWithTokensOption } from './useInsertGroupLabelsAndSpaces';
+import { AccountWithTokensOption } from '../types';
+import { calculateHiddenTokensHeight } from '../utils';
 
 export function useFilterAccountsWithTokens(
     accountsWithTokens: AccountWithTokensOption[],
@@ -10,21 +11,44 @@ export function useFilterAccountsWithTokens(
 ) {
     return useMemo(
         () =>
-            accountsWithTokens.filter(accountOrToken => {
-                if (!search) {
-                    return true;
-                }
+            accountsWithTokens
+                .filter(item => {
+                    if (!search) {
+                        return true;
+                    }
 
-                switch (accountOrToken.type) {
-                    case 'account':
-                        return accountSearchFn(accountOrToken.account, search, {
-                            tokensMatch: false,
-                        });
+                    switch (item.type) {
+                        case 'account':
+                            return accountSearchFn(item.account, search, {
+                                tokensMatch: false,
+                            });
 
-                    case 'token':
-                        return isTokenMatchesSearch(accountOrToken.token, search);
-                }
-            }),
+                        case 'token':
+                            return isTokenMatchesSearch(item.token, search);
+
+                        case 'hidden-tokens':
+                            return item.tokens.some(token => isTokenMatchesSearch(token, search));
+                    }
+                })
+                .map(item => {
+                    if (item.type === 'hidden-tokens') {
+                        const matchedTokens = item.tokens.filter(token =>
+                            isTokenMatchesSearch(token, search),
+                        );
+
+                        return {
+                            ...item,
+                            tokens: matchedTokens,
+                            // Update height based on matched tokens count
+                            height: calculateHiddenTokensHeight(
+                                item.expanded,
+                                matchedTokens.length,
+                            ),
+                        };
+                    }
+
+                    return item;
+                }),
         [accountsWithTokens, search],
     );
 }

--- a/packages/suite/src/components/suite/asset-picker/hooks/useInsertGroupLabelsAndSpaces.tsx
+++ b/packages/suite/src/components/suite/asset-picker/hooks/useInsertGroupLabelsAndSpaces.tsx
@@ -2,24 +2,9 @@ import { ReactNode, useMemo } from 'react';
 
 import { Account } from '@suite-common/wallet-types';
 
-import { TokensWithRates } from 'src/utils/wallet/tokenUtils';
-
 import { AccountLabel } from '../../AccountLabel';
 import { ASSET_ROW_GROUP_LABEL_HEIGHT, ASSET_ROW_HEIGHTS_BY_SIZE } from '../constants';
-import { AssetGroupSpaceSize } from '../types';
-
-export type AccountWithTokensOption =
-    | {
-          type: 'account';
-          account: Account;
-          height: number;
-      }
-    | {
-          type: 'token';
-          account: Account;
-          token: TokensWithRates;
-          height: number;
-      };
+import { AccountWithTokensOption, AssetGroupSpaceSize } from '../types';
 
 export type AssetPickerListItem =
     | AccountWithTokensOption
@@ -42,38 +27,26 @@ export function useInsertGroupLabelsAndSpaces(
         let currentAccount: Account | null = null;
 
         for (const item of accountsWithTokens) {
-            switch (item.type) {
-                case 'account': {
-                    // New account -> insert group label and some group padding
-                    if (currentAccount !== item.account) {
-                        if (currentAccount) {
-                            list.push({
-                                type: 'group-space',
-                                height: ASSET_ROW_HEIGHTS_BY_SIZE['md'],
-                                size: 'md',
-                            });
-                        }
-
-                        list.push({
-                            type: 'group-label',
-                            label: (
-                                <AccountLabel account={item.account} showAccountTypeBadge={true} />
-                            ),
-                            height: ASSET_ROW_GROUP_LABEL_HEIGHT,
-                        });
-
-                        currentAccount = item.account;
-                    }
-
-                    list.push(item);
-
-                    continue;
+            // New account -> insert group label and some group padding
+            if (currentAccount !== item.account) {
+                if (currentAccount) {
+                    list.push({
+                        type: 'group-space',
+                        height: ASSET_ROW_HEIGHTS_BY_SIZE['md'],
+                        size: 'md',
+                    });
                 }
 
-                case 'token':
-                    list.push(item);
-                    continue;
+                list.push({
+                    type: 'group-label',
+                    label: <AccountLabel account={item.account} showAccountTypeBadge={true} />,
+                    height: ASSET_ROW_GROUP_LABEL_HEIGHT,
+                });
+
+                currentAccount = item.account;
             }
+
+            list.push(item);
         }
 
         return list;

--- a/packages/suite/src/components/suite/asset-picker/types/index.ts
+++ b/packages/suite/src/components/suite/asset-picker/types/index.ts
@@ -1,1 +1,25 @@
+import { Account } from '@suite-common/wallet-types';
+
+import { TokensWithRates } from 'src/utils/wallet/tokenUtils';
+
 export type AssetGroupSpaceSize = 'md' | 'lg';
+
+export type AccountWithTokensOption =
+    | {
+          type: 'account';
+          account: Account;
+          height: number;
+      }
+    | {
+          type: 'token';
+          account: Account;
+          token: TokensWithRates;
+          height: number;
+      }
+    | {
+          type: 'hidden-tokens';
+          account: Account;
+          tokens: TokensWithRates[];
+          height: number;
+          expanded: boolean;
+      };

--- a/packages/suite/src/components/suite/asset-picker/utils/index.ts
+++ b/packages/suite/src/components/suite/asset-picker/utils/index.ts
@@ -1,0 +1,49 @@
+import { Account, AccountKey } from '@suite-common/wallet-types';
+
+import { TokensWithRates } from 'src/utils/wallet/tokenUtils';
+
+import { ASSET_ROW_HEIGHT, EXPANDABLE_ASSET_ROW_TOKENS_HEADER_HEIGHT } from '../constants';
+import { AccountWithTokensOption } from '../types';
+
+export function calculateHiddenTokensHeight(expanded: boolean, hiddenTokensLength: number) {
+    const tokensHeight = expanded ? hiddenTokensLength * (ASSET_ROW_HEIGHT - 8) : 0;
+
+    return EXPANDABLE_ASSET_ROW_TOKENS_HEADER_HEIGHT + tokensHeight;
+}
+
+interface CreateHiddenTokensOptionProps {
+    account: Account;
+    hiddenTokens: TokensWithRates[];
+    expandedHiddenTokensGroups: AccountKey[];
+}
+
+export function createHiddenTokensOption({
+    account,
+    hiddenTokens,
+    expandedHiddenTokensGroups,
+}: CreateHiddenTokensOptionProps) {
+    const expanded = expandedHiddenTokensGroups.includes(account.key);
+
+    return {
+        type: 'hidden-tokens',
+        account,
+        tokens: hiddenTokens,
+        height: calculateHiddenTokensHeight(expanded, hiddenTokens.length),
+        expanded,
+    } satisfies Extract<AccountWithTokensOption, { type: 'hidden-tokens' }>;
+}
+
+export const createAccountOption = (account: Account) =>
+    ({
+        type: 'account',
+        account,
+        height: ASSET_ROW_HEIGHT,
+    }) satisfies Extract<AccountWithTokensOption, { type: 'account' }>;
+
+export const createTokenOption = (account: Account, token: TokensWithRates) =>
+    ({
+        type: 'token',
+        account,
+        token,
+        height: ASSET_ROW_HEIGHT,
+    }) satisfies Extract<AccountWithTokensOption, { type: 'token' }>;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
@@ -7,6 +7,7 @@ import { GlobalSendReceiveType } from '@suite-common/wallet-types';
 import { Box } from '@trezor/components';
 import { SearchAsset } from '@trezor/product-components';
 
+import { useListScrollReset } from 'src/components/suite/asset-picker/hooks';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 
 import { useNetworkFilter } from './hooks/useNetworkFilter';
@@ -37,6 +38,8 @@ export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetwork
     const networks = protocolSymbol ? [protocolSymbol] : enabledNetworks;
 
     const { translationString } = useTranslation();
+
+    useListScrollReset(listRef, search);
 
     return (
         <Box padding={{ horizontal: 16 }}>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx
@@ -14,10 +14,10 @@ import {
     AssetsList,
     AssetsListEmpty,
     AssetsModal,
+    ExpandableAssetRowTokens,
 } from 'src/components/suite/asset-picker/components';
 import {
     AssetPickerListItem,
-    useAccountWithTokensOptions,
     useFilterAccountsWithTokens,
     useInsertGroupLabelsAndSpaces,
 } from 'src/components/suite/asset-picker/hooks';
@@ -25,6 +25,8 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
 
 import { AssetSearchWithNetworkFilter } from '../AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter';
+import { useAccountWithTokensOptions } from './hooks/useAccountWithTokensOptions';
+import { useExpandableAccountGroups } from './hooks/useExpandableAccountGroups';
 
 type GlobalSendModalProps = {
     onCancel: (filledSearch: boolean) => void;
@@ -38,8 +40,13 @@ export function GlobalSendModal({ onCancel, onSubmit }: GlobalSendModalProps) {
 
     const networkSymbolFilter = useSelector(globalSendReceiveFilters.selectors.selectNetworkSymbol);
     const searchFilter = useSelector(globalSendReceiveFilters.selectors.selectSearch);
+    const { expandedAccountTokensGroups, updateExpandableAccountGroups } =
+        useExpandableAccountGroups();
 
-    const { accountsWithTokens } = useAccountWithTokensOptions({ networkSymbolFilter });
+    const accountsWithTokens = useAccountWithTokensOptions({
+        networkSymbolFilter,
+        expandedHiddenTokensGroups: expandedAccountTokensGroups,
+    });
     const filteredAccountsWithTokens = useFilterAccountsWithTokens(
         accountsWithTokens,
         searchFilter,
@@ -89,9 +96,21 @@ export function GlobalSendModal({ onCancel, onSubmit }: GlobalSendModalProps) {
                             onClick={handleTokenClick}
                         />
                     );
+
+                case 'hidden-tokens':
+                    return (
+                        <ExpandableAssetRowTokens
+                            account={item.account}
+                            tokens={item.tokens}
+                            expanded={item.expanded}
+                            height={item.height}
+                            onExpandToggle={updateExpandableAccountGroups}
+                            onTokenClick={handleTokenClick}
+                        />
+                    );
             }
         },
-        [handleAccountClick, handleTokenClick],
+        [handleAccountClick, handleTokenClick, updateExpandableAccountGroups],
     );
 
     return (

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts
@@ -1,0 +1,121 @@
+import { useMemo } from 'react';
+import { useThrottle } from 'react-use';
+
+import { selectTokenDefinitions } from '@suite-common/token-definitions';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    selectBaseCurrency,
+    selectCurrentFiatRates,
+    selectVisibleDeviceAccounts,
+} from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
+import {
+    accountsFiatBalanceInDescOrderComparator,
+    filterAccountsByNetworkSymbol,
+} from '@suite-common/wallet-utils';
+import { useCurrentRef } from '@trezor/react-utils';
+
+import { AccountWithTokensOption } from 'src/components/suite/asset-picker/types';
+import {
+    createAccountOption,
+    createHiddenTokensOption,
+    createTokenOption,
+} from 'src/components/suite/asset-picker/utils';
+import { useSelector } from 'src/hooks/suite';
+import {
+    enhanceTokensWithRates,
+    getTokens,
+    sortTokensWithRates,
+} from 'src/utils/wallet/tokenUtils';
+export interface UseAccountWithTokensOptionsProps {
+    networkSymbolFilter: NetworkSymbol | undefined;
+
+    /**
+     * Each account might have expandable hidden token group.
+     */
+    expandedHiddenTokensGroups: AccountKey[];
+}
+
+export function useAccountWithTokensOptions({
+    networkSymbolFilter,
+    expandedHiddenTokensGroups,
+}: UseAccountWithTokensOptionsProps): AccountWithTokensOption[] {
+    const accounts = useSelector(selectVisibleDeviceAccounts);
+    const fiatRates = useSelector(selectCurrentFiatRates);
+    const baseCurrencyCode = useSelector(selectBaseCurrency);
+    const tokenDefinitions = useSelector(selectTokenDefinitions);
+
+    // Accounts are constantly being updated in Redux. So throttle them to significantly reduce re-renders
+    const throttledAccounts = useThrottle(accounts, 1000);
+    const fiatRatesRef = useCurrentRef(fiatRates);
+
+    const accountsAndTokensSortedByFiatBalance = useMemo(() => {
+        const fiatRates = fiatRatesRef.current;
+
+        if (!fiatRates) {
+            return [];
+        }
+
+        const networkAccounts = filterAccountsByNetworkSymbol(
+            throttledAccounts,
+            networkSymbolFilter,
+        );
+
+        return networkAccounts
+            .toSorted(function sortByFiatBalanceInDescOrder(accountA, accountB) {
+                return accountsFiatBalanceInDescOrderComparator({
+                    accountA,
+                    accountB,
+                    baseCurrencyCode,
+                    fiatRates,
+                });
+            })
+            .map(account => {
+                const { shownWithBalance, hiddenWithBalance } = getTokens({
+                    tokens: account.tokens ?? [],
+                    symbol: account.symbol,
+                    tokenDefinitions: tokenDefinitions?.[account.symbol]?.coin,
+                });
+
+                const sortedTokensByFiatBalance = enhanceTokensWithRates(
+                    shownWithBalance,
+                    baseCurrencyCode,
+                    account.symbol,
+                    fiatRates,
+                ).sort(sortTokensWithRates);
+
+                const sortedHiddenTokensByFiatBalance = enhanceTokensWithRates(
+                    hiddenWithBalance,
+                    baseCurrencyCode,
+                    account.symbol,
+                    fiatRates,
+                ).sort(sortTokensWithRates);
+
+                return {
+                    account,
+                    tokens: sortedTokensByFiatBalance,
+                    hiddenTokens: sortedHiddenTokensByFiatBalance,
+                };
+            });
+    }, [fiatRatesRef, throttledAccounts, networkSymbolFilter, baseCurrencyCode, tokenDefinitions]);
+
+    return useMemo(() => {
+        const accountsWithTokens: AccountWithTokensOption[] = [];
+
+        for (const { account, tokens, hiddenTokens } of accountsAndTokensSortedByFiatBalance) {
+            accountsWithTokens.push(createAccountOption(account));
+
+            tokens.forEach(token => {
+                accountsWithTokens.push(createTokenOption(account, token));
+            });
+
+            if (hiddenTokens.length > 0) {
+                accountsWithTokens.push(
+                    createHiddenTokensOption({ account, hiddenTokens, expandedHiddenTokensGroups }),
+                );
+            }
+        }
+
+        return accountsWithTokens;
+    }, [accountsAndTokensSortedByFiatBalance, expandedHiddenTokensGroups]);
+}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useExpandableAccountGroups.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useExpandableAccountGroups.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState } from 'react';
+
+import { AccountKey } from '@suite-common/wallet-types';
+
+export function useExpandableAccountGroups() {
+    const [expandedAccountTokensGroups, setExpandedAccountTokensGroups] = useState<AccountKey[]>(
+        [],
+    );
+
+    const updateExpandableAccountGroups = useCallback(
+        (accountKey: AccountKey, expanded: boolean) => {
+            setExpandedAccountTokensGroups(prev => {
+                if (expanded) {
+                    return prev.concat(accountKey);
+                }
+
+                return prev.filter(key => key !== accountKey);
+            });
+        },
+        [],
+    );
+
+    return {
+        expandedAccountTokensGroups,
+        updateExpandableAccountGroups,
+    } as const;
+}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10799,4 +10799,16 @@ export default defineMessages({
         id: 'TR_ASSET_PICKER_SEARCH_NO_RESULTS_DESCRIPTION',
         defaultMessage: 'Check the spelling or browse the list to select an asset.',
     },
+    TR_HIDDEN_TOKENS: {
+        id: 'TR_HIDDEN_TOKENS',
+        defaultMessage: 'Hidden tokens',
+    },
+    TR_HIDDEN_TOKEN_WITHOUT_FIAT: {
+        id: 'TR_HIDDEN_TOKEN_WITHOUT_FIAT',
+        defaultMessage: 'No pair',
+    },
+    TR_NON_TRADABLE_TOKENS: {
+        id: 'TR_NON_TRADABLE_TOKENS',
+        defaultMessage: 'Non-tradable tokens',
+    },
 } as const);

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts
@@ -1,22 +1,26 @@
 import { useMemo } from 'react';
 import { useThrottle } from 'react-use';
 
+import { CryptoId } from 'invity-api';
+
 import { selectTokenDefinitions } from '@suite-common/token-definitions';
+import { getCryptoId } from '@suite-common/trading';
 import { NetworkSymbol, networkSymbolCollection } from '@suite-common/wallet-config';
 import {
     selectBaseCurrency,
     selectCurrentFiatRates,
     selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
-import { Account } from '@suite-common/wallet-types';
 import {
     accountsFiatBalanceInDescOrderComparator,
-    findAccountsByNetwork,
+    filterAccountsByNetworkSymbol,
+    isTestnet,
 } from '@suite-common/wallet-utils';
 import { useCurrentRef } from '@trezor/react-utils';
+import { BigNumber } from '@trezor/utils';
 
-import { ASSET_ROW_HEIGHT } from 'src/components/suite/asset-picker/constants';
-import { AccountWithTokensOption } from 'src/components/suite/asset-picker/hooks';
+import { AccountWithTokensOption } from 'src/components/suite/asset-picker/types';
+import { createAccountOption, createTokenOption } from 'src/components/suite/asset-picker/utils';
 import { useSelector } from 'src/hooks/suite';
 import {
     enhanceTokensWithRates,
@@ -24,23 +28,14 @@ import {
     sortTokensWithRates,
 } from 'src/utils/wallet/tokenUtils';
 
-function filterAccountsByNetworkSymbol(
-    accounts: Account[],
-    networkSymbol: NetworkSymbol | undefined,
-): Account[] {
-    return networkSymbol ? findAccountsByNetwork(networkSymbol, accounts) : accounts;
-}
 export interface UseAccountWithTokensOptionsProps {
     networkSymbolFilter: NetworkSymbol | undefined;
-    /**
-     * Filter accounts before they are converted to AccountWithTokensOption.
-     */
-    accountFilter?: (account: Account) => boolean;
+    supportedCryptoIds: Set<CryptoId>;
 }
 
 export function useAccountWithTokensOptions({
     networkSymbolFilter,
-    accountFilter = () => true,
+    supportedCryptoIds,
 }: UseAccountWithTokensOptionsProps): {
     accountsWithTokens: AccountWithTokensOption[];
     networks: NetworkSymbol[];
@@ -64,7 +59,23 @@ export function useAccountWithTokensOptions({
             };
         }
 
-        const validAccounts = throttledAccounts.filter(accountFilter);
+        const validAccounts = throttledAccounts.filter(account => {
+            if (isTestnet(account.symbol) || account.accountType === 'coinjoin') {
+                return false;
+            }
+
+            if (account.tokens?.length === 0) {
+                return new BigNumber(account.balance).gt(0);
+            }
+
+            const tokens = getTokens({
+                tokens: account.tokens ?? [],
+                symbol: account.symbol,
+                tokenDefinitions: tokenDefinitions?.[account.symbol]?.coin,
+            });
+
+            return tokens.shownWithBalance.length > 0;
+        });
 
         const networks = new Set(validAccounts.map(account => account.symbol));
         const orderedNetworks = networkSymbolCollection.filter(network => networks.has(network));
@@ -97,39 +108,40 @@ export function useAccountWithTokensOptions({
                 const sortedTokensByFiatBalance = tokensWithRates.sort(sortTokensWithRates);
 
                 return {
-                    ...account,
+                    account,
                     tokens: sortedTokensByFiatBalance,
                 };
             });
 
         const accountsWithTokens: AccountWithTokensOption[] =
-            accountsAndTokensSortedByFiatBalance.flatMap(account => [
-                {
-                    type: 'account',
-                    account,
-                    height: ASSET_ROW_HEIGHT,
-                },
-                ...(account.tokens ?? []).map(
-                    token =>
-                        ({
-                            type: 'token',
-                            account,
-                            token,
-                            height: ASSET_ROW_HEIGHT,
-                        }) satisfies AccountWithTokensOption,
-                ),
+            accountsAndTokensSortedByFiatBalance.flatMap(({ account, tokens }) => [
+                createAccountOption(account),
+                ...tokens.map(token => createTokenOption(account, token)),
             ]);
 
+        const supportedAccountsWithTokens = accountsWithTokens.filter(option => {
+            switch (option.type) {
+                case 'account':
+                    return supportedCryptoIds.has(getCryptoId(option.account.symbol));
+                case 'token':
+                    return supportedCryptoIds.has(
+                        getCryptoId(option.account.symbol, option.token?.contract),
+                    );
+                default:
+                    return false;
+            }
+        });
+
         return {
-            accountsWithTokens,
+            accountsWithTokens: supportedAccountsWithTokens,
             networks: orderedNetworks,
         };
     }, [
         fiatRatesRef,
         throttledAccounts,
         networkSymbolFilter,
-        accountFilter,
-        baseCurrencyCode,
         tokenDefinitions,
+        baseCurrencyCode,
+        supportedCryptoIds,
     ]);
 }

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
@@ -1,20 +1,13 @@
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 
-import { selectTokenDefinitions } from '@suite-common/token-definitions';
-import { getCryptoId } from '@suite-common/trading';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { Account } from '@suite-common/wallet-types';
-import { isTestnet } from '@suite-common/wallet-utils';
-import { BigNumber } from '@trezor/utils';
 
 import {
-    useAccountWithTokensOptions,
     useFilterAccountsWithTokens,
     useInsertGroupLabelsAndSpaces,
 } from 'src/components/suite/asset-picker/hooks';
-import { useSelector } from 'src/hooks/suite';
-import { getTokens } from 'src/utils/wallet/tokenUtils';
 
+import { useAccountWithTokensOptions } from './useAccountWithTokensOptions';
 import { useAssetsContext } from '../../AssetOptionsContext';
 
 export interface UseBuildTradingAssetOptionsProps {
@@ -26,31 +19,6 @@ export function useBuildTradingAssetOptions({
     search,
     networkSymbol,
 }: UseBuildTradingAssetOptionsProps) {
-    const tokenDefinitions = useSelector(selectTokenDefinitions);
-    const accountFilter = useCallback(
-        (account: Account) => {
-            if (isTestnet(account.symbol) || account.accountType === 'coinjoin') {
-                return false;
-            }
-
-            if (account.tokens?.length === 0) {
-                return new BigNumber(account.balance).gt(0);
-            }
-
-            const tokens = getTokens({
-                tokens: account.tokens ?? [],
-                symbol: account.symbol,
-                tokenDefinitions: tokenDefinitions?.[account.symbol]?.coin,
-            });
-
-            return tokens.shownWithBalance.length > 0;
-        },
-        [tokenDefinitions],
-    );
-    const { networks, accountsWithTokens } = useAccountWithTokensOptions({
-        networkSymbolFilter: networkSymbol,
-        accountFilter,
-    });
     const { includedCryptoIds, excludedCryptoIds } = useAssetsContext();
     const supportedCryptoIds = useMemo(() => {
         const supportedCryptoIds = new Set(includedCryptoIds);
@@ -61,23 +29,13 @@ export function useBuildTradingAssetOptions({
 
         return supportedCryptoIds;
     }, [includedCryptoIds, excludedCryptoIds]);
-    const supportedAccountsWithTokens = useMemo(
-        () =>
-            accountsWithTokens.filter(option => {
-                const cryptoId =
-                    option.type === 'account'
-                        ? getCryptoId(option.account.symbol)
-                        : getCryptoId(option.account.symbol, option.token?.contract);
 
-                return supportedCryptoIds.has(cryptoId);
-            }),
-        [accountsWithTokens, supportedCryptoIds],
-    );
+    const { networks, accountsWithTokens } = useAccountWithTokensOptions({
+        networkSymbolFilter: networkSymbol,
+        supportedCryptoIds,
+    });
 
-    const filteredAccountsWithTokens = useFilterAccountsWithTokens(
-        supportedAccountsWithTokens,
-        search,
-    );
+    const filteredAccountsWithTokens = useFilterAccountsWithTokens(accountsWithTokens, search);
     const listItems = useInsertGroupLabelsAndSpaces(filteredAccountsWithTokens);
 
     return { listItems, networks };

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1234,3 +1234,10 @@ export function accountsFiatBalanceInDescOrderComparator({
 
 export const isProgramDerivedAccount = (data: AccountInfo) =>
     !(data?.misc?.owner === SYSTEM_PROGRAM_PUBLIC_KEY || data?.misc?.owner === undefined);
+
+export function filterAccountsByNetworkSymbol(
+    accounts: Account[],
+    networkSymbol: NetworkSymbol | undefined,
+): Account[] {
+    return networkSymbol ? findAccountsByNetwork(networkSymbol, accounts) : accounts;
+}


### PR DESCRIPTION
## Description

- Add "Hidden tokens" (`hiddenWithBalance`) groups to each account (if there are some) to global send:
- Divide useAccountWithTokensOptions hook for global send and for From asset picker in trading.

## Notes for QA

Display "Hidden tokens" in global send if there are some.

## Related Issue

Resolve #23256

## Screenshots:

https://github.com/user-attachments/assets/114a0f1b-f7f6-4504-a9af-082d9073ae48




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/23256-global-send-hidden-tokens&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/23256-global-send-hidden-tokens&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/23256-global-send-hidden-tokens&lookback=7)