### PR TITLE
Better error for turn on suite sync

### DIFF
--- a/packages/suite/src/hooks/suite/useLabelingCombined.ts
+++ b/packages/suite/src/hooks/suite/useLabelingCombined.ts
@@ -4,9 +4,11 @@ import {
     selectIsSuiteSyncEnabled,
     suiteSyncActions,
 } from '@suite-common/suite-sync';
+import { notificationsActions } from '@suite-common/toast-notifications';
 import { selectDeviceByStaticSessionId } from '@suite-common/wallet-core';
 import type { StaticSessionId } from '@trezor/connect';
 import { EventType, analytics } from '@trezor/suite-analytics';
+import { exhaustive } from '@trezor/type-utils';
 
 import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import * as metadataThunks from 'src/actions/suite/metadataThunks';
@@ -67,7 +69,22 @@ export const useLabelingCombined = ({ deviceStaticSessionId }: UseLabelingCombin
                 provider: 'evolu',
             },
         });
-        suiteSync.turnOnSuiteSync();
+
+        suiteSync.turnOnSuiteSync({
+            onError: ({ error }) => {
+                const { type } = error;
+                switch (type) {
+                    case 'SuiteSyncUnavailableOnDeviceError':
+                    case 'DeviceCancelled':
+                    case 'DeviceError':
+                        dispatch(notificationsActions.addToast({ type: 'error', error: type }));
+
+                        return;
+                    default:
+                        return exhaustive(type);
+                }
+            },
+        });
     };
 
     const legacyEnableIfNeeded = () => {

--- a/suite-common/suite-sync-types/src/turnOnSuiteSync.ts
+++ b/suite-common/suite-sync-types/src/turnOnSuiteSync.ts
@@ -1,3 +1,15 @@
-export type TurnOnSuiteSync = () => void;
+import { DeviceCancelledErrType, DeviceErrorType } from '@suite-common/wallet-types';
+import { StaticSessionId } from '@trezor/connect';
+
+import { SuiteSyncUnavailableOnDeviceErrorType } from './refreshSuiteSyncKeys';
+
+type TurnOnSuiteSyncParams = {
+    onError: (params: {
+        deviceStaticSessionId: StaticSessionId;
+        error: SuiteSyncUnavailableOnDeviceErrorType | DeviceErrorType | DeviceCancelledErrType;
+    }) => void;
+};
+
+export type TurnOnSuiteSync = (params: TurnOnSuiteSyncParams) => void;
 
 export type TurnOnSuiteSyncDep = { turnOnSuiteSync: TurnOnSuiteSync };

--- a/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
@@ -3,9 +3,11 @@ import { Dispatch } from '@reduxjs/toolkit';
 import { TurnOnSuiteSync } from '@suite-common/suite-sync-types';
 import { EnsureWalletSuiteSyncOnDep } from '@suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn';
 import { selectDevices } from '@suite-common/wallet-core';
+import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
 
 import { suiteSyncActions } from './suiteSyncActions';
 import { selectIsSuiteSyncEnabled } from './suiteSyncSelectors';
+import { isSuiteSyncSupportedByDevice } from './suiteSyncUtils';
 
 export type CreateTurnOnSuiteSyncDeps = {
     getState: () => any;
@@ -14,7 +16,7 @@ export type CreateTurnOnSuiteSyncDeps = {
 
 export const createTurnOnSuiteSync =
     (deps: CreateTurnOnSuiteSyncDeps): TurnOnSuiteSync =>
-    async () => {
+    async ({ onError }) => {
         const isSuiteSyncEnabled = selectIsSuiteSyncEnabled(deps.getState());
 
         if (isSuiteSyncEnabled) {
@@ -28,13 +30,22 @@ export const createTurnOnSuiteSync =
 
         for (const device of devices) {
             if (device?.state?.staticSessionId) {
+                const canTurnOnSuiteSync =
+                    isTrezorDeviceWithState(device) && isSuiteSyncSupportedByDevice(device);
+
+                if (!canTurnOnSuiteSync) {
+                    continue;
+                }
+
                 const result = await deps.ensureWalletSuiteSyncOn({
                     deviceStaticSessionId: device.state.staticSessionId,
                 });
 
                 if (!result.success) {
-                    // Todo: notification? Here or in the caller?
-                    console.error('[createTurnOnSuiteSync] error', result.error);
+                    onError({
+                        deviceStaticSessionId: device.state.staticSessionId,
+                        error: result.error,
+                    });
                 }
             }
         }

--- a/suite-native/labeling/package.json
+++ b/suite-native/labeling/package.json
@@ -23,7 +23,9 @@
         "@suite-native/forms": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/services": "workspace:*",
+        "@suite-native/toasts": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/type-utils": "workspace:*",
         "react": "19.1.0",
         "react-redux": "9.2.0"
     }

--- a/suite-native/labeling/src/components/EditableLabelLayout.tsx
+++ b/suite-native/labeling/src/components/EditableLabelLayout.tsx
@@ -8,6 +8,8 @@ import { useAlert } from '@suite-native/alerts';
 import { BottomSheetModal, TextButton, useBottomSheetModal } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useNativeServices } from '@suite-native/services';
+import { useToast } from '@suite-native/toasts';
+import { exhaustive } from '@trezor/type-utils';
 
 import { selectIsLabelingEnabled } from '../selectors';
 
@@ -20,6 +22,7 @@ type EditableLabelLayoutParams = {
 export const EditableLabelLayout = ({ children, label, testID }: EditableLabelLayoutParams) => {
     const { showAlert } = useAlert();
     const { suiteSync } = useNativeServices();
+    const { showToast } = useToast();
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
 
     const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
@@ -31,7 +34,21 @@ export const EditableLabelLayout = ({ children, label, testID }: EditableLabelLa
             description: <Translation id="suiteSync.enableAlert.description" />,
             primaryButtonTitle: <Translation id="suiteSync.enableAlert.cta" />,
             onPressPrimaryButton: () => {
-                suiteSync.turnOnSuiteSync();
+                suiteSync.turnOnSuiteSync({
+                    onError: ({ error }) => {
+                        const { type } = error;
+                        switch (type) {
+                            case 'SuiteSyncUnavailableOnDeviceError':
+                            case 'DeviceCancelled':
+                            case 'DeviceError':
+                                showToast({ variant: 'error', icon: 'warning', message: type });
+
+                                return;
+                            default:
+                                return exhaustive(type);
+                        }
+                    },
+                });
                 onSuccess();
             },
             secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,

--- a/suite-native/labeling/tsconfig.json
+++ b/suite-native/labeling/tsconfig.json
@@ -25,6 +25,8 @@
         { "path": "../forms" },
         { "path": "../intl" },
         { "path": "../services" },
-        { "path": "../../packages/connect" }
+        { "path": "../toasts" },
+        { "path": "../../packages/connect" },
+        { "path": "../../packages/type-utils" }
     ]
 }

--- a/suite-native/module-settings/package.json
+++ b/suite-native/module-settings/package.json
@@ -50,6 +50,7 @@
         "@trezor/env-utils": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
+        "@trezor/type-utils": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",
         "jotai": "2.15.0",

--- a/suite-native/module-settings/src/components/ToggleLabelingCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleLabelingCard.tsx
@@ -5,9 +5,12 @@ import { useAlert } from '@suite-native/alerts';
 import { TouchableSwitchRow } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useNativeServices } from '@suite-native/services';
+import { useToast } from '@suite-native/toasts';
+import { exhaustive } from '@trezor/type-utils';
 
 export const ToggleLabelingCard = () => {
     const { showAlert } = useAlert();
+    const { showToast } = useToast();
     const { suiteSync } = useNativeServices();
     const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
 
@@ -25,7 +28,21 @@ export const ToggleLabelingCard = () => {
         if (isSuiteSyncEnabled) {
             showSuiteSyncDisableConfirmationAlert();
         } else {
-            suiteSync.turnOnSuiteSync();
+            suiteSync.turnOnSuiteSync({
+                onError: ({ error }) => {
+                    const { type } = error;
+                    switch (type) {
+                        case 'SuiteSyncUnavailableOnDeviceError':
+                        case 'DeviceCancelled':
+                        case 'DeviceError':
+                            showToast({ variant: 'error', icon: 'warning', message: type });
+
+                            return;
+                        default:
+                            return exhaustive(type);
+                    }
+                },
+            });
         }
     };
 

--- a/suite-native/module-settings/tsconfig.json
+++ b/suite-native/module-settings/tsconfig.json
@@ -52,6 +52,7 @@
         { "path": "../../packages/env-utils" },
         { "path": "../../packages/styles" },
         { "path": "../../packages/theme" },
+        { "path": "../../packages/type-utils" },
         { "path": "../../packages/urls" },
         { "path": "../../packages/utils" },
         { "path": "../test-utils" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12250,7 +12250,9 @@ __metadata:
     "@suite-native/forms": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/services": "workspace:*"
+    "@suite-native/toasts": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/type-utils": "workspace:*"
     react: "npm:19.1.0"
     react-redux: "npm:9.2.0"
   languageName: unknown
@@ -12883,6 +12885,7 @@ __metadata:
     "@trezor/env-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
+    "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     jotai: "npm:2.15.0"


### PR DESCRIPTION
Turning on Suite Sync iterates over wallets. If any wallet fails, user is at least notified. 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=better-error-for-turn-on-suite-sync&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=better-error-for-turn-on-suite-sync&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=better-error-for-turn-on-suite-sync&lookback=7)