### PR TITLE
fix(ci): temporarily disable Nx cache for typecheck only

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -55,7 +55,8 @@ jobs:
       - name: "Minimal yarn install"
         uses: ./.github/actions/minimal-yarn-install
       - name: Type Check
-        run: yarn nx:type-check --output-style=stream
+        # Temporarily disabling the cache (false positives because of cache mismatch after NX update)
+        run: yarn nx:type-check --output-style=stream --skip-nx-cache
 
   lint:
     name: Linting and formatting


### PR DESCRIPTION
## Description

After #24271, there are problem with Nx cache poisoning.

Attemp to fix it by temporarily skipping cache for type check, because even doing #24332 & #24339 did not help

EDIT: maybe we won't need it.
We found the Nuke cache button in Nx cloud dasbhoard :smile: 
Let's see some other currently open PRs if they pass.

EDIT2: yes we do. The button did not work.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/cache-type-check-only&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/cache-type-check-only&lookback=7)