### PR TITLE
fix(e2e-suite): stabilize send-base test

### DIFF
--- a/suite/e2e/support/pageObjects/devicePrompt.ts
+++ b/suite/e2e/support/pageObjects/devicePrompt.ts
@@ -262,7 +262,41 @@ export class DevicePrompt {
         );
     };
 
-    wrapText = (text: string, options?: { isAmount?: boolean }) => {
+    private wrapTextByWords = (text: string, lineCharLimit: number) => {
+        const words = text.split(' ');
+        const lines: string[] = [];
+        let currentLine = '';
+
+        const wouldExceedLimit = (line: string, word: string): boolean => {
+            const combinedLength = line ? line.length + 1 + word.length : word.length;
+
+            return combinedLength > lineCharLimit;
+        };
+
+        for (const word of words) {
+            if (!currentLine) {
+                // First word on the line
+                currentLine = word;
+            } else if (wouldExceedLimit(currentLine, word)) {
+                // Word doesn't fit, wrap to new line
+                lines.push(currentLine);
+                lines.push('\n');
+                currentLine = word;
+            } else {
+                // Word fits, add it with a space
+                currentLine += ' ' + word;
+            }
+        }
+
+        // Add the final line without trailing newline
+        if (currentLine) {
+            lines.push(currentLine);
+        }
+
+        return lines;
+    };
+
+    wrapText = (text: string, options?: { isAmount?: boolean; wrapByWords?: boolean }) => {
         const T3W1_EXACT_LINE_LENGTH = 14;
         const T3T1_EXACT_LINE_LENGTH = 18;
         const T3W1_LINE_LENGTH_MINUS_DASH = 13;
@@ -271,12 +305,21 @@ export class DevicePrompt {
             if (text.length === T3W1_EXACT_LINE_LENGTH) {
                 return [text];
             }
+
+            if (options?.wrapByWords) {
+                return this.wrapTextByWords(text, T3W1_EXACT_LINE_LENGTH);
+            }
+
             const lineCharLimit = options?.isAmount
                 ? T3W1_LINE_LENGTH_MINUS_DASH
                 : T3W1_EXACT_LINE_LENGTH;
             const newline = options?.isAmount ? ['-', '\n'] : ['\n'];
 
             return this.wrapTextByLineLimit(text, lineCharLimit, newline);
+        }
+
+        if (options?.wrapByWords) {
+            return this.wrapTextByWords(text, T3T1_EXACT_LINE_LENGTH);
         }
 
         return this.wrapTextByLineLimit(text, T3T1_EXACT_LINE_LENGTH, ['\n']);

--- a/suite/e2e/support/pageObjects/feeSection.ts
+++ b/suite/e2e/support/pageObjects/feeSection.ts
@@ -1,5 +1,6 @@
 import { Locator, Page, Response } from '@playwright/test';
 
+import { localizeNumber } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { step } from '../common';
@@ -171,7 +172,7 @@ export class FeeSection {
         const ratioToEthereum = 1e9;
         const maxFeeInEthereum =
             (parseFloat(gasLimit) * parseFloat(maxFeePerGas)) / ratioToEthereum;
-        const maxFeeRounded = maxFeeInEthereum.toFixed(numberOfDecimals);
+        const maxFeeRounded = localizeNumber(maxFeeInEthereum, 'en-US', 0, numberOfDecimals);
         // This method is also providing detailed error message for troubleshooting expect if it fails
         const errorMessageMaxCalculation = `expected to have max Fee: 
 "(parseFloat(${gasLimit}) * parseFloat(${maxFeePerGas})) / ${ratioToEthereum}"

--- a/suite/e2e/tests/wallet/send-base.test.ts
+++ b/suite/e2e/tests/wallet/send-base.test.ts
@@ -216,27 +216,20 @@ test.describe('Send Base', { tag: ['@group=wallet', '@nightlyOnly'] }, () => {
                         ['Gas limit'],
                         [`${gasLimit} units`],
                         ['Max fee per gas'],
-                        [maxFeePerGas, '\n', 'Gwei'],
+                        devicePrompt.wrapText(`${maxFeePerGas} Gwei`, { wrapByWords: true }),
                         ['Max priority fee'],
-                        [maxPriorityFeePerGas, '\n', 'Gwei'],
+                        devicePrompt.wrapText(`${maxPriorityFeePerGas} Gwei`, {
+                            wrapByWords: true,
+                        }),
                     ],
                 },
-                T3T1: {
-                    header: { title: 'Fee info' },
-                    body: [
-                        ['Gas limit'],
-                        [`${gasLimit} units`],
-                        ['Max fee per gas'],
-                        [`${maxFeePerGas} Gwei`],
-                        ['Max priority fee'],
-                        [`${maxPriorityFeePerGas} Gwei`],
-                    ],
-                    footer: undefined,
-                },
+                T3T1: { footer: undefined },
             });
         });
         await test.step('Confirm transaction', async () => {
             await devicePrompt.waitForPromptAndConfirm();
+            // wait for transaction to be prepared
+            await page.expectReduxObjectToEqual('wallet.send.serializedTx.symbol', 'base');
             await devicePrompt.sendButton.click();
             await page.getByTestId('@toast/tx-sent').click();
             await page.getByRole('button', { name: 'View details' }).hover();


### PR DESCRIPTION
More stabilization
- the wrapping of emu display assert needs to be dynamic. Fees sometimes have many decimals and sometimes only few
- calculation of the final fee must use out localizeNumber. That way we control max number of decimals but if there is less we do not keep trailing zeros. That was failing the test sometimes
- added one more wait for redux object in spot where tests were too fast for the Suite

I might use the new wrapping by word on more places to reduce code duplicity

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-send-base-stability&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-send-base-stability&lookback=7)