### PR TITLE
fix(suite-native): add loading state on receive screen

### DIFF
--- a/suite-native/receive/src/components/ReceiveAddressCard.tsx
+++ b/suite-native/receive/src/components/ReceiveAddressCard.tsx
@@ -23,6 +23,7 @@ type ReceiveAddressCardProps = {
     symbol: NetworkSymbol;
     onShowAddress: () => void;
     isTokenAddress?: boolean;
+    isLoading?: boolean;
 };
 
 export const ReceiveAddressCard = ({
@@ -33,6 +34,7 @@ export const ReceiveAddressCard = ({
     isReceiveApproved,
     onShowAddress,
     symbol,
+    isLoading,
     isTokenAddress = false,
 }: ReceiveAddressCardProps) => {
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
@@ -86,7 +88,8 @@ export const ReceiveAddressCard = ({
                     ) : (
                         <UnverifiedAddress
                             address={address}
-                            isAddressRevealed={isUnverifiedAddressRevealed}
+                            isLoading={isLoading}
+                            isAddressRevealed={isUnverifiedAddressRevealed && !isLoading}
                             isCardanoAddress={networkType === 'cardano'}
                             onShowAddress={onShowAddress}
                         />

--- a/suite-native/receive/src/components/ShowAddressButtons.tsx
+++ b/suite-native/receive/src/components/ShowAddressButtons.tsx
@@ -14,9 +14,10 @@ import { ShowAddressViewOnlyBottomSheet } from './ShowAddressViewOnlyBottomSheet
 
 type ShowAddressButtonsProps = {
     onShowAddress: () => void;
+    isLoading?: boolean;
 };
 
-export const ShowAddressButtons = ({ onShowAddress }: ShowAddressButtonsProps) => {
+export const ShowAddressButtons = ({ onShowAddress, isLoading }: ShowAddressButtonsProps) => {
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
@@ -42,6 +43,7 @@ export const ShowAddressButtons = ({ onShowAddress }: ShowAddressButtonsProps) =
                 viewLeft="eye"
                 size="large"
                 onPress={handleShowAddress}
+                isLoading={isLoading}
             >
                 <Translation
                     id={

--- a/suite-native/receive/src/components/UnverifiedAddress.tsx
+++ b/suite-native/receive/src/components/UnverifiedAddress.tsx
@@ -15,6 +15,7 @@ type UnverifiedAddressSectionProps = {
     isAddressRevealed: boolean;
     isCardanoAddress: boolean;
     onShowAddress: () => void;
+    isLoading?: boolean;
 };
 
 export const UnverifiedAddress = ({
@@ -22,6 +23,7 @@ export const UnverifiedAddress = ({
     isAddressRevealed,
     isCardanoAddress,
     onShowAddress,
+    isLoading,
 }: UnverifiedAddressSectionProps) => {
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
@@ -37,7 +39,9 @@ export const UnverifiedAddress = ({
                     isCardanoAddress={isCardanoAddress}
                 />
             )}
-            {!isAddressRevealed && <ShowAddressButtons onShowAddress={onShowAddress} />}
+            {!isAddressRevealed && (
+                <ShowAddressButtons onShowAddress={onShowAddress} isLoading={isLoading} />
+            )}
         </VStack>
     );
 };

--- a/suite-native/receive/src/screens/ReceiveAddressScreen.tsx
+++ b/suite-native/receive/src/screens/ReceiveAddressScreen.tsx
@@ -75,6 +75,8 @@ export const ReceiveAddressScreen = ({
         }
     }, [handleShowAddress, openModal, isDeviceBackupRequired]);
 
+    const isLoading =
+        !(isReceiveApproved || hasReceiveButtonRequest) && isUnverifiedAddressRevealed;
     const isConfirmOnTrezorReady =
         isUnverifiedAddressRevealed && !isReceiveApproved && hasReceiveButtonRequest;
 
@@ -160,6 +162,7 @@ export const ReceiveAddressScreen = ({
                     accountDescriptor={account.descriptor}
                     symbol={account.symbol}
                     address={address}
+                    isLoading={isLoading}
                     deviceStaticSessionId={account.deviceState}
                     isTokenAddress={!!tokenContract}
                     isReceiveApproved={isReceiveApproved}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a loading state to fill the time between pressing the “Show full address” button and displaying the address on the device.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/10150

## Screenshots:

https://github.com/user-attachments/assets/6421e678-aec4-478a-b4f1-348f95ff2c2b



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/show-address-loading&lookback=7)