### PR TITLE
refactor(e2e-suite): remove unnecesary string interpolation

### DIFF
--- a/suite/e2e/support/common.ts
+++ b/suite/e2e/support/common.ts
@@ -203,8 +203,8 @@ export const analyzeObject = (obj: any): any => {
         const paddedCodes = chars.map(char => char.charCodeAt(0).toString().padStart(padding, ' '));
 
         return {
-            chars: `${paddedChars.join(' ')}`,
-            codes: `${paddedCodes.join(' ')}`,
+            chars: paddedChars.join(' '),
+            codes: paddedCodes.join(' '),
         };
     };
 

--- a/suite/e2e/tests/wallet/send-sol.test.ts
+++ b/suite/e2e/tests/wallet/send-sol.test.ts
@@ -107,9 +107,9 @@ test.describe('Send - Solana', { tag: ['@group=wallet'] }, () => {
 
             await test.step('Verify Amount & Transaction Fee', async () => {
                 await expect(devicePrompt.cryptoAmountOf('total')).toHaveText(
-                    `${sendMaxAmountWithReserve}`,
+                    sendMaxAmountWithReserve,
                 );
-                await expect(devicePrompt.cryptoAmountOf('fee')).toHaveText(`${maxFee}`);
+                await expect(devicePrompt.cryptoAmountOf('fee')).toHaveText(maxFee.toString());
 
                 // verify amount & fee
                 const amountWrapped = devicePrompt.wrapText(`${sendMaxAmountWithReserve} SOL`, {


### PR DESCRIPTION
Minot nitpick refactoring.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-e2e-remove-unnecesary-interpolation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-e2e-remove-unnecesary-interpolation&lookback=7)