### PR TITLE
chore(suite): hide evm network info banner on receive screen

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/EvmExplanationBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/EvmExplanationBanner.tsx
@@ -4,6 +4,7 @@ import { SUITE } from 'src/actions/suite/constants';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useSelector } from 'src/hooks/suite/useSelector';
+import { selectRouteName } from 'src/reducers/suite/routerReducer';
 import { Account } from 'src/types/wallet';
 
 import { BannerPoints } from './BannerPoints';
@@ -15,13 +16,17 @@ interface EvmExplanationBannerProps {
 
 export const EvmExplanationBanner = ({ account }: EvmExplanationBannerProps) => {
     const { explanationBannerClosed } = useSelector(state => state.suite.evmSettings);
+    const routeName = useSelector(selectRouteName);
     const dispatch = useDispatch();
+
+    const isReceiveRoute = routeName === 'wallet-receive';
 
     const isVisible =
         account &&
         !explanationBannerClosed[account.symbol] &&
         account.symbol !== 'eth' &&
-        networks[account.symbol].networkType === 'ethereum';
+        networks[account.symbol].networkType === 'ethereum' &&
+        !isReceiveRoute;
 
     if (!isVisible) {
         return null;


### PR DESCRIPTION
## Description

`EvmExplanationBanner` is not longer duplicated on the account receive screen.

## Notes for QA

## Related Issue

Resolve #23983

## Screenshots:
<img width="1202" height="807" alt="image" src="https://github.com/user-attachments/assets/b4b1d706-caee-445a-b910-6ded71dea00d" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-network-info-from-receive&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-network-info-from-receive&lookback=7)