### PR TITLE
chore(suite): add network reserve learn more link to settings

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/NetworkReserve.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/NetworkReserve.tsx
@@ -4,6 +4,7 @@ import { networksCollection } from '@suite-common/wallet-config';
 import { selectIsNetworkReserveEnabled, setNetworkReserve } from '@suite-common/wallet-core';
 import { Switch } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
+import { NETWORK_RESERVE_URL } from '@trezor/urls';
 
 import { SettingsSectionItem } from 'src/components/settings/SettingsSectionItem';
 import { ActionColumn, TextColumn } from 'src/components/suite';
@@ -44,6 +45,7 @@ export const NetworkReserve = () => {
                         }}
                     />
                 }
+                buttonLink={NETWORK_RESERVE_URL}
             />
             <ActionColumn>
                 <Switch isChecked={isNetworkReserveEnabled} onChange={handleSwitchChange} />

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -293,6 +293,10 @@ export const EXPERIMENTAL_FEATURES_KB_URL: Url = withPlatformUtm(
     'https://trezor.io/guides/trezor-suite/experimental-features-in-trezor-suite',
 );
 
+export const NETWORK_RESERVE_URL: Url = withPlatformUtm(
+    'https://trezor.io/learn/supported-assets/ethereum-layer-2-EVM/network-reserve-for-base-optimism-and-solana',
+);
+
 export const HELP_CENTER_T3W1_INTRODUCTION_URL: Url = withPlatformUtm(
     'https://trezor.io/guides/trezor-devices/trezor-safe-7/introduction-to-the-trezor-safe-7',
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

**Network reserve** section in Settings now has a "Learn more" link that points to [this](https://trezor.io/learn/supported-assets/ethereum-layer-2-EVM/network-reserve-for-base-optimism-and-solana) article

## Notes for QA

## Related Issue

Resolve #24165

## Screenshots:
<img width="922" height="197" alt="image" src="https://github.com/user-attachments/assets/2f89fc9e-72ff-411c-9ed2-1a804b9bba8f" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/network-reserve-learn-more&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/network-reserve-learn-more&lookback=7)