### PR TITLE
chore(suite): show solana transactions banner only when required

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
@@ -17,7 +17,6 @@ import { ContextMessage } from './ContextMessage';
 import { DeviceUnavailable } from './DeviceUnavailable';
 import { EvmExplanationBanner } from './EvmExplanationBanner';
 import { ReserveBanner } from './ReserveBanner';
-import { SolanaLimitedHistoryBanner } from './SolanaLimitedHistoryBanner';
 import { StakingBanner } from './StakingBanner';
 import { StellarLimitedHistoryBanner } from './StellarLimitedHistoryBanner';
 import { TaprootBanner } from './TaprootBanner';
@@ -52,7 +51,6 @@ export const AccountBanners = ({ account }: AccountBannersProps) => {
             <TaprootBanner account={account} />
             <CardanoLegacyBanner account={account} />
             {account?.networkType === 'stellar' && <StellarLimitedHistoryBanner />}
-            {account?.networkType === 'solana' && <SolanaLimitedHistoryBanner />}
             {account?.symbol && <StakingBanner account={account} />}
         </Column>
     );

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/SolanaLimitedHistoryBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/SolanaLimitedHistoryBanner.tsx
@@ -1,3 +1,5 @@
+import { Account } from '@suite-common/wallet-types';
+
 import { setFlag } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
@@ -7,11 +9,20 @@ import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 import { BannerPoints } from './BannerPoints';
 import { CloseableBanner } from './CloseableBanner';
 
-export const SolanaLimitedHistoryBanner = () => {
+interface SolanaLimitedHistoryBannerProps {
+    account: Account;
+}
+
+const SOLANA_TX_HISTORY_LIMIT = 100;
+
+export const SolanaLimitedHistoryBanner = ({ account }: SolanaLimitedHistoryBannerProps) => {
     const dispatch = useDispatch();
     const { solanaLimitedHistoryBannerClosed } = useSelector(selectSuiteFlags);
 
-    if (solanaLimitedHistoryBannerClosed) {
+    const isSolanaAccount = account.networkType === 'solana';
+    const hasTxCountAboveLimit = account.history.total > SOLANA_TX_HISTORY_LIMIT;
+
+    if (solanaLimitedHistoryBannerClosed || !isSolanaAccount || !hasTxCountAboveLimit) {
         return null;
     }
 

--- a/packages/suite/src/views/wallet/transactions/Transactions.tsx
+++ b/packages/suite/src/views/wallet/transactions/Transactions.tsx
@@ -6,6 +6,7 @@ import {
 } from '@suite-common/wallet-core';
 
 import { CoinjoinAccountDiscoveryProgress, WalletLayout } from 'src/components/wallet';
+import { SolanaLimitedHistoryBanner } from 'src/components/wallet/WalletLayout/AccountBanners/SolanaLimitedHistoryBanner';
 import { useSelector } from 'src/hooks/suite';
 import { AppState } from 'src/types/suite';
 
@@ -73,6 +74,7 @@ export const Transactions = () => {
                 <CardanoNewProviderCard account={account} />
                 <TransactionSummary account={account} />
                 <TradeBox account={account} />
+                <SolanaLimitedHistoryBanner account={account} />
                 <WalletTransactionList account={account} symbol={account.symbol} />
             </Layout>
         );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Moved `SolanaLimitedHistoryBanner` directly above **'Transactions'**
- Banner is now visible only on **'Overview'** tab
- Banner is visible only when account has more than 100 transactions

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #24035

## Screenshots:

### > 100
<img width="1210" height="927" alt="image" src="https://github.com/user-attachments/assets/6ffa7a08-e545-4179-a797-707e5cd7ee32" />

### <= 100
<img width="1206" height="857" alt="image" src="https://github.com/user-attachments/assets/0e88e209-9c51-4106-a914-33b0664cabda" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/solana-tx-history-banner-visibility-update&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/solana-tx-history-banner-visibility-update&lookback=7)