### PR TITLE
Fix warnings in unit tests

### DIFF
--- a/suite-common/suite-sync/src/data/suiteSyncDataSelectors.ts
+++ b/suite-common/suite-sync/src/data/suiteSyncDataSelectors.ts
@@ -1,5 +1,10 @@
-import { createWeakMapSelector } from '@suite-common/redux-utils';
-import { SuiteSyncAccount, createSuiteSyncOutputId } from '@suite-common/suite-sync-storage';
+import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
+import {
+    SuiteSyncAccount,
+    SuiteSyncAddress,
+    SuiteSyncOutput,
+    createSuiteSyncOutputId,
+} from '@suite-common/suite-sync-storage';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { AccountDescriptor, WalletDescriptor } from '@suite-common/wallet-types';
 import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
@@ -19,32 +24,34 @@ const selectAllAccountsForWallet = createMemoizedSelector(
     [(state, walletDescriptor) => selectWalletById(state, walletDescriptor)],
     wallet => {
         if (wallet === null) {
-            return [];
+            return returnStableArrayIfEmpty<SuiteSyncAccount>();
         }
 
         return typedObjectValues(wallet.accounts);
     },
 );
 
-const selectAllAddressesForWallet = (
-    state: SuiteSyncDataRootState,
-    walletDescriptor: WalletDescriptor,
-) => {
-    const wallet = selectWalletById(state, walletDescriptor);
-    if (!wallet) return [];
+const selectAllAddressesForWallet = createMemoizedSelector(
+    [(state, walletDescriptor) => selectWalletById(state, walletDescriptor)],
+    wallet => {
+        if (!wallet) {
+            return returnStableArrayIfEmpty<SuiteSyncAddress>();
+        }
 
-    return typedObjectValues(wallet.addresses);
-};
+        return typedObjectValues(wallet.addresses);
+    },
+);
 
-const selectAllOutputsForWallet = (
-    state: SuiteSyncDataRootState,
-    walletDescriptor: WalletDescriptor,
-) => {
-    const wallet = selectWalletById(state, walletDescriptor);
-    if (!wallet) return [];
+const selectAllOutputsForWallet = createMemoizedSelector(
+    [(state, walletDescriptor) => selectWalletById(state, walletDescriptor)],
+    wallet => {
+        if (!wallet) {
+            return returnStableArrayIfEmpty<SuiteSyncOutput>();
+        }
 
-    return typedObjectValues(wallet.outputs);
-};
+        return typedObjectValues(wallet.outputs);
+    },
+);
 
 export const selectSuiteSyncWalletLabel = (
     state: SuiteSyncDataRootState,

--- a/suite-native/module-onboarding/src/screens/__tests__/TradingLocationScreen.comp.test.tsx
+++ b/suite-native/module-onboarding/src/screens/__tests__/TradingLocationScreen.comp.test.tsx
@@ -2,7 +2,7 @@ import { RouteProp } from '@react-navigation/core';
 
 import { EventType, analytics } from '@suite-native/analytics';
 import { TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
-import { renderWithStoreProviderAsync, userEvent } from '@suite-native/test-utils';
+import { renderWithStoreProviderAsync, screen, userEvent } from '@suite-native/test-utils';
 
 import { TradingLocationScreen } from '../TradingLocationScreen';
 
@@ -24,6 +24,10 @@ jest.mock('../../hooks/useExitOnboardingFlow', () => ({
 describe('TradingLocationOnboardingScreen', () => {
     const renderTradingLocationScreen = () =>
         renderWithStoreProviderAsync(<TradingLocationScreen />);
+
+    afterEach(() => {
+        screen.unmount();
+    });
 
     it('should render all components', async () => {
         const { getByText, getByLabelText } = await renderTradingLocationScreen();

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencyPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencyPicker.comp.test.tsx
@@ -4,6 +4,7 @@ import {
     fireEvent,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
+    screen,
 } from '@suite-native/test-utils';
 import { useListDataFilter } from '@suite-native/trading-atoms';
 import { getInitializedTradingState } from '@suite-native/trading-fixtures';
@@ -39,6 +40,10 @@ describe('BuyFiatCurrencyPicker', () => {
             },
         );
     };
+
+    afterEach(() => {
+        screen.unmount();
+    });
 
     it('should display selected currency', async () => {
         const { getByLabelText } = await renderFiatCurrencyPicker();

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencySheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencySheet.comp.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProviderAsync, screen } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
 import { BuyFiatCurrencySheet } from '../BuyFiatCurrencySheet';
@@ -9,6 +9,10 @@ describe('BuyFiatCurrencySheet', () => {
             <BuyFiatCurrencySheet onFiatSelect={jest.fn()} onClose={jest.fn()} isVisible={true} />,
             { preloadedState: { wallet: getWalletState({ tradeType: 'buy' }) } },
         );
+
+    afterEach(() => {
+        screen.unmount();
+    });
 
     it('should render items based on buy state', async () => {
         const { getByText } = await renderBuyFiatCurrencySheet();

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyForm.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyForm.comp.test.tsx
@@ -4,6 +4,7 @@ import {
     act,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
+    screen,
 } from '@suite-native/test-utils';
 import {
     btcAsset,
@@ -28,6 +29,10 @@ describe('BuyForm', () => {
             preloadedState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
+
+    afterEach(() => {
+        screen.unmount();
+    });
 
     it('should render when buy data are not preloaded', async () => {
         const { result } = await renderFormHook(residenceCheckDisabledState);

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
@@ -10,6 +10,7 @@ import {
     initStore,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
+    screen,
 } from '@suite-native/test-utils';
 import { buyQuotes, getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixtures';
 import { BuyFormType } from '@suite-native/trading-types';
@@ -34,6 +35,10 @@ describe('BuyPaymentMethodPicker', () => {
             { preloadedState, store },
         );
     };
+
+    afterEach(() => {
+        screen.unmount();
+    });
 
     it('should not render when there are no payment methods', async () => {
         const { toJSON } = await renderPaymentMethodPicker();

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.comp.test.tsx
@@ -6,6 +6,7 @@ import {
     fireEvent,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
+    screen,
 } from '@suite-native/test-utils';
 import {
     buyCexdirect,
@@ -38,6 +39,10 @@ describe('BuyProviderPicker', () => {
             </Form>,
             { preloadedState },
         );
+
+    afterEach(() => {
+        screen.unmount();
+    });
 
     it('should display nothing when in default state', async () => {
         await renderUseTradingBuyForm();

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeForm.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeForm.comp.test.tsx
@@ -3,6 +3,7 @@ import {
     act,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
+    screen,
 } from '@suite-native/test-utils';
 import {
     btcAsset,
@@ -34,6 +35,10 @@ describe('ExchangeForm', () => {
     beforeEach(async () => {
         const { result } = await renderForm();
         form = result.current;
+    });
+
+    afterEach(() => {
+        screen.unmount();
     });
 
     it('should render form', async () => {

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRateAndProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRateAndProviderPicker.comp.test.tsx
@@ -5,6 +5,7 @@ import {
     act,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
+    screen,
     userEvent,
 } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
@@ -30,6 +31,10 @@ describe('ExchangeRateAndProviderPicker', () => {
         exchangeForm = result.current;
 
         preloadedState = { wallet: getWalletState({ tradeType: 'exchange' }) };
+    });
+
+    afterEach(() => {
+        screen.unmount();
     });
 
     it('should render nothing when no quote is selected and quotes are not loading', async () => {

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.comp.test.tsx
@@ -2,7 +2,7 @@ import type { CryptoId } from 'invity-api';
 
 import { selectFormattedAccountType } from '@suite-common/wallet-core';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
-import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { fireEvent, renderWithStoreProviderAsync, screen } from '@suite-native/test-utils';
 import {
     getBtcAccount,
     getEthAccount,
@@ -81,6 +81,10 @@ describe('MyAssetSheet', () => {
         jest.clearAllMocks();
         // Default mock implementation - return null for most accounts
         mockedSelectFormattedAccountType.mockReturnValue(null);
+    });
+
+    afterEach(() => {
+        screen.unmount();
     });
 
     it('should render account information correctly', async () => {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.comp.test.tsx
@@ -1,6 +1,6 @@
 import { TradingTradeType, TradingType } from '@suite-common/trading';
 import { FeatureFlag } from '@suite-native/feature-flags';
-import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { PreloadedState, renderWithStoreProviderAsync, screen } from '@suite-native/test-utils';
 import { buyQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import { ProviderSheet, ProviderSheetProps } from '../ProviderSheet';
@@ -21,6 +21,10 @@ describe('ProviderSheet', () => {
             />,
             { preloadedState },
         );
+
+    afterEach(() => {
+        screen.unmount();
+    });
 
     it('should render empty providers placeholder and no section header and for buy', async () => {
         const { queryByText, getByText } = await renderProviderSheet({}, {});

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.comp.test.tsx
@@ -1,6 +1,6 @@
 import { Keyboard } from 'react-native';
 
-import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { fireEvent, renderWithStoreProviderAsync, screen } from '@suite-native/test-utils';
 import { adaAsset, btcAsset, usdcAsset } from '@suite-native/trading-fixtures';
 import { TradeableAsset } from '@suite-native/trading-types';
 
@@ -22,6 +22,10 @@ describe('TradeableAssetSheet', () => {
                 {...props}
             />,
         );
+
+    afterEach(() => {
+        screen.unmount();
+    });
 
     it('should call Keyboard.dismiss, onAssetSelect and onClose when an item is pressed', async () => {
         const closeMock = jest.fn();

--- a/suite-native/module-trading/src/components/general/__tests__/TradingCountryOfResidencePicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingCountryOfResidencePicker.comp.test.tsx
@@ -8,6 +8,7 @@ import {
     act,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
+    screen,
     userEvent,
 } from '@suite-native/test-utils';
 import {
@@ -38,6 +39,10 @@ describe('TradingCountryOfResidencePicker', () => {
     beforeEach(async () => {
         const { result } = await renderForm();
         form = result.current;
+    });
+
+    afterEach(() => {
+        screen.unmount();
     });
 
     it('should use country from form', async () => {

--- a/suite-native/module-trading/src/components/sell/__tests__/SellCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellCard.comp.test.tsx
@@ -3,6 +3,7 @@ import {
     act,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
+    screen,
 } from '@suite-native/test-utils';
 import { getWalletState, sellQuotes, usdcAsset } from '@suite-native/trading-fixtures';
 import { SellFormType } from '@suite-native/trading-types';
@@ -31,6 +32,10 @@ describe('SellCard', () => {
     beforeEach(async () => {
         const { result } = await renderForm();
         form = result.current;
+    });
+
+    afterEach(() => {
+        screen.unmount();
     });
 
     it('should render all components for "you pay" part', async () => {

--- a/suite-native/module-trading/src/components/sell/__tests__/SellForm.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellForm.comp.test.tsx
@@ -5,6 +5,7 @@ import {
     act,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
+    screen,
 } from '@suite-native/test-utils';
 import {
     btcAsset,
@@ -31,6 +32,10 @@ describe('SellForm', () => {
             preloadedState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
+
+    afterEach(() => {
+        screen.unmount();
+    });
 
     it('should render when sell data are not preloaded', async () => {
         const { result } = await renderFormHook({});

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencyPicker.test.tsx
@@ -4,6 +4,7 @@ import {
     fireEvent,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
+    screen,
 } from '@suite-native/test-utils';
 import { useListDataFilter } from '@suite-native/trading-atoms';
 import { getWalletState } from '@suite-native/trading-fixtures';
@@ -22,6 +23,10 @@ jest.mock('@suite-native/trading-atoms', () => ({
 describe('SellFiatCurrencyPicker', () => {
     beforeEach(() => {
         mockUseListDataFilter = jest.requireActual('@suite-native/trading-atoms').useListDataFilter;
+    });
+
+    afterEach(() => {
+        screen.unmount();
     });
 
     const renderFiatCurrencyPicker = async () => {

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencySheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencySheet.comp.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProviderAsync, screen } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
 import { SellFiatCurrencySheet } from '../SellFiatCurrencySheet';
@@ -9,6 +9,10 @@ describe('SellFiatCurrencySheet', () => {
             <SellFiatCurrencySheet onFiatSelect={jest.fn()} onClose={jest.fn()} isVisible={true} />,
             { preloadedState: { wallet: getWalletState({ tradeType: 'sell' }) } },
         );
+
+    afterEach(() => {
+        screen.unmount();
+    });
 
     it('should render items based on Sell state', async () => {
         const { getByText } = await renderSellFiatCurrencySheet();

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.comp.test.tsx
@@ -6,6 +6,7 @@ import {
     fireEvent,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
+    screen,
 } from '@suite-native/test-utils';
 import { getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 import { SellFormType } from '@suite-native/trading-types';
@@ -30,6 +31,10 @@ describe('SellReceiveMethodPicker', () => {
 
         const { result } = await renderSellForm();
         form = result.current;
+    });
+
+    afterEach(() => {
+        screen.unmount();
     });
 
     it('should render nothing when no quotes are loaded', async () => {

--- a/suite-native/module-trading/src/components/sell/payment/__tests__/SellProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/__tests__/SellProviderPicker.comp.test.tsx
@@ -6,6 +6,7 @@ import {
     fireEvent,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
+    screen,
 } from '@suite-native/test-utils';
 import { getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 import { SellFormType } from '@suite-native/trading-types';
@@ -30,6 +31,10 @@ describe('SellProviderPicker', () => {
 
         const { result } = await renderSellForm();
         form = result.current;
+    });
+
+    afterEach(() => {
+        screen.unmount();
     });
 
     it('should render nothing when no quotes are loaded', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- No `An update to XXX inside a test was not wrapped in act(...)` should be logged to suite test unit (native) console.
- Memoize `selectAllAddressesForWallet` unstable selector.

<!--- Describe your changes in detail -->

## Notes for QA

Nothing to test.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-warnings-in-unit-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-warnings-in-unit-tests&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-warnings-in-unit-tests&lookback=7)