### PR TITLE
feat(blockchain-link): cache addresses by Electrum worker

### DIFF
--- a/packages/blockchain-link/src/workers/electrum/index.ts
+++ b/packages/blockchain-link/src/workers/electrum/index.ts
@@ -3,6 +3,7 @@ import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/src/constants
 import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
 import { Message } from '@trezor/blockchain-link-types/src/messages';
 import { Without } from '@trezor/type-utils';
+import { AddressCache, createAddressCache } from '@trezor/utxo-lib';
 
 import { BaseWorker, CONTEXT, ContextType } from '../baseWorker';
 import { CachingElectrumClient } from './client/caching';
@@ -15,7 +16,12 @@ type BlockListener = ReturnType<typeof L.blockListener>;
 type TxListener = ReturnType<typeof L.txListener>;
 
 type Request<T> = T extends any
-    ? T & ContextType<ElectrumClient> & { blockListener: BlockListener; txListener: TxListener }
+    ? T &
+          ContextType<ElectrumClient> & {
+              blockListener: BlockListener;
+              txListener: TxListener;
+              addressCache: AddressCache;
+          }
     : never;
 type MessageType = Message['type'];
 type ResponseType<T extends MessageType> = T extends typeof MESSAGES.GET_INFO
@@ -47,6 +53,8 @@ const onRequest = async <T extends Message>(
     request: Request<T>,
 ): Promise<Reply<typeof request.type>> => {
     const client = await request.connect();
+    const { addressCache } = request;
+    const context = { client, addressCache };
     switch (request.type) {
         case MESSAGES.GET_INFO:
             return {
@@ -56,22 +64,22 @@ const onRequest = async <T extends Message>(
         case MESSAGES.GET_BLOCK_HASH:
             return {
                 type: RESPONSES.GET_BLOCK_HASH,
-                payload: await M.getBlockHash(client, request.payload),
+                payload: await M.getBlockHash(context, request.payload),
             };
         case MESSAGES.GET_ACCOUNT_INFO:
             return {
                 type: RESPONSES.GET_ACCOUNT_INFO,
-                payload: await M.getAccountInfo(client, request.payload),
+                payload: await M.getAccountInfo(context, request.payload),
             };
         case MESSAGES.GET_ACCOUNT_UTXO:
             return {
                 type: RESPONSES.GET_ACCOUNT_UTXO,
-                payload: await M.getAccountUtxo(client, request.payload),
+                payload: await M.getAccountUtxo(context, request.payload),
             };
         case MESSAGES.GET_TRANSACTION:
             return {
                 type: RESPONSES.GET_TRANSACTION,
-                payload: await M.getTransaction(client, request.payload),
+                payload: await M.getTransaction(context, request.payload),
             };
         case MESSAGES.GET_TRANSACTION_HEX:
             return {
@@ -81,17 +89,17 @@ const onRequest = async <T extends Message>(
         case MESSAGES.GET_ACCOUNT_BALANCE_HISTORY:
             return {
                 type: RESPONSES.GET_ACCOUNT_BALANCE_HISTORY,
-                payload: await M.getAccountBalanceHistory(client, request.payload),
+                payload: await M.getAccountBalanceHistory(context, request.payload),
             };
         case MESSAGES.ESTIMATE_FEE:
             return {
                 type: RESPONSES.ESTIMATE_FEE,
-                payload: await M.estimateFee(client, request.payload),
+                payload: await M.estimateFee(context, request.payload),
             };
         case MESSAGES.PUSH_TRANSACTION:
             return {
                 type: RESPONSES.PUSH_TRANSACTION,
-                payload: await M.pushTransaction(client, request.payload),
+                payload: await M.pushTransaction(context, request.payload),
             };
         case MESSAGES.SUBSCRIBE:
             switch (request.payload.type) {
@@ -140,8 +148,9 @@ const onRequest = async <T extends Message>(
 };
 
 class ElectrumWorker extends BaseWorker<ElectrumClient> {
-    private blockListener: BlockListener;
-    private txListener: TxListener;
+    private readonly blockListener: BlockListener;
+    private readonly txListener: TxListener;
+    private addressCache: AddressCache | undefined;
 
     constructor() {
         super();
@@ -171,6 +180,8 @@ class ElectrumWorker extends BaseWorker<ElectrumClient> {
                 protocolVersion: '1.4',
             },
         });
+
+        this.addressCache = createAddressCache(api.getInfo()?.network);
 
         this.post({
             id: -1,
@@ -206,6 +217,7 @@ class ElectrumWorker extends BaseWorker<ElectrumClient> {
                 state: this.state,
                 blockListener: this.blockListener,
                 txListener: this.txListener,
+                addressCache: this.addressCache!,
             };
             const response = await onRequest(request);
             this.post({ id: event.data.id, ...response });

--- a/packages/blockchain-link/src/workers/electrum/methods/estimateFee.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/estimateFee.ts
@@ -3,7 +3,7 @@ import type { EstimateFee as Res } from '@trezor/blockchain-link-types/src/respo
 
 import { Api, btcToSat } from '../utils';
 
-const estimateFee: Api<Req, Res> = (client, payload) =>
+const estimateFee: Api<Req, Res> = ({ client }, payload) =>
     Promise.all(
         (payload.blocks || []).map(num =>
             client

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountBalanceHistory.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountBalanceHistory.ts
@@ -69,7 +69,7 @@ const aggregateTransactions = (txs: (Transaction & { blockTime: number })[], gro
 };
 
 const getAccountBalanceHistory: Api<Req, Res> = async (
-    client,
+    { client, addressCache },
     { descriptor, from, to, groupBy },
 ) => {
     let history: HistoryTx[];
@@ -82,8 +82,8 @@ const getAccountBalanceHistory: Api<Req, Res> = async (
         addresses = undefined;
     } else {
         const discover = discoverAddress(client);
-        const receive = await discovery(discover, descriptor, 'receive', network);
-        const change = await discovery(discover, descriptor, 'change', network);
+        const receive = await discovery(discover, addressCache(descriptor, 'receive'));
+        const change = await discovery(discover, addressCache(descriptor, 'change'));
         addresses = {
             change: change.map(transformAddress),
             used: receive.filter(({ history }) => history.length).map(transformAddress),

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
@@ -60,7 +60,7 @@ export const sumAddressValues = <T>(
         )
         .reduce((a, b) => a + b, 0);
 
-const getAccountInfo: Api<Req, Res> = async (client, payload) => {
+const getAccountInfo: Api<Req, Res> = async ({ client, addressCache }, payload) => {
     const { descriptor, details = 'basic', pageSize = PAGE_SIZE_DEFAULT } = payload;
     const network = client.getInfo()?.network;
 
@@ -97,10 +97,10 @@ const getAccountInfo: Api<Req, Res> = async (client, payload) => {
         };
     }
     const discover = discoverAddress(client);
-    const receive = await discovery(discover, descriptor, 'receive', network).then(
+    const receive = await discovery(discover, addressCache(descriptor, 'receive')).then(
         getBalances(client),
     );
-    const change = await discovery(discover, descriptor, 'change', network).then(
+    const change = await discovery(discover, addressCache(descriptor, 'change')).then(
         getBalances(client),
     );
     const batch = receive.concat(change);

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountUtxo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountUtxo.ts
@@ -26,7 +26,7 @@ const transformUtxo =
               }),
     });
 
-const getAccountUtxo: Api<Req, Res> = async (client, descriptor) => {
+const getAccountUtxo: Api<Req, Res> = async ({ client, addressCache }, descriptor) => {
     const {
         block: { height },
         network,
@@ -41,8 +41,8 @@ const getAccountUtxo: Api<Req, Res> = async (client, descriptor) => {
     }
 
     const discover = discoverAddress(client);
-    const receive = await discovery(discover, descriptor, 'receive', network);
-    const change = await discovery(discover, descriptor, 'change', network);
+    const receive = await discovery(discover, addressCache(descriptor, 'receive'));
+    const change = await discovery(discover, addressCache(descriptor, 'change'));
     const result = await Promise.all(
         receive
             .concat(change)

--- a/packages/blockchain-link/src/workers/electrum/methods/getBlockHash.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getBlockHash.ts
@@ -3,7 +3,7 @@ import type { GetBlockHash as Res } from '@trezor/blockchain-link-types/src/resp
 
 import { Api, blockheaderToBlockhash } from '../utils';
 
-const getBlockHash: Api<Req, Res> = async (client, payload) => {
+const getBlockHash: Api<Req, Res> = async ({ client }, payload) => {
     const blockheader = await client.request('blockchain.block.header', payload);
 
     return blockheaderToBlockhash(blockheader);

--- a/packages/blockchain-link/src/workers/electrum/methods/getTransaction.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getTransaction.ts
@@ -4,7 +4,7 @@ import { transformTransaction } from '@trezor/blockchain-link-utils/src/blockboo
 
 import { Api, getTransactions } from '../utils';
 
-const getTransaction: Api<Req, Res> = async (client, payload) => {
+const getTransaction: Api<Req, Res> = async ({ client }, payload) => {
     const [tx] = await getTransactions(client, [{ tx_hash: payload, height: -1 }]);
 
     return transformTransaction(tx);

--- a/packages/blockchain-link/src/workers/electrum/methods/pushTransaction.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/pushTransaction.ts
@@ -3,7 +3,7 @@ import type { PushTransaction as Res } from '@trezor/blockchain-link-types/src/r
 
 import { Api } from '../utils';
 
-const pushTransaction: Api<Req, Res> = async (client, payload) => {
+const pushTransaction: Api<Req, Res> = async ({ client }, payload) => {
     const res = await client.request('blockchain.transaction.broadcast', payload.hex);
 
     return res;

--- a/packages/blockchain-link/src/workers/electrum/utils/index.ts
+++ b/packages/blockchain-link/src/workers/electrum/utils/index.ts
@@ -1,5 +1,6 @@
 import type { Response } from '@trezor/blockchain-link-types/src';
 import type { ElectrumAPI } from '@trezor/blockchain-link-types/src/electrum';
+import type { AddressCache } from '@trezor/utxo-lib';
 
 export * from './addressManager';
 export * from './discovery';
@@ -7,5 +8,8 @@ export * from './transform';
 export * from './transaction';
 
 export type Api<M, R extends Omit<Response, 'id'>> = M extends { payload: any }
-    ? (client: ElectrumAPI, params: M['payload']) => Promise<R['payload']>
+    ? (
+          context: { client: ElectrumAPI; addressCache: AddressCache },
+          params: M['payload'],
+      ) => Promise<R['payload']>
     : (client: ElectrumAPI) => Promise<R['payload']>;

--- a/packages/utxo-lib/src/discovery.ts
+++ b/packages/utxo-lib/src/discovery.ts
@@ -24,11 +24,37 @@ export const countUnusedFromEnd = <T>(
     return array.length;
 };
 
-export const discovery = <T>(
+type AddressType = 'receive' | 'change';
+
+export const createAddressCache = (network: Network | undefined) => {
+    const cache: Record<`${string}/${AddressType}`, AddressInfo[]> = {};
+
+    return (xpub: string, type: AddressType) => {
+        const key = `${xpub}/${type}` as const;
+
+        const getAllDerived = () => cache[key] ?? [];
+
+        const getAddresses = (from: number, count: number) => {
+            const derived = cache[key] ?? [];
+            const needed = from + count - derived.length;
+            if (needed > 0) {
+                const newDerived = deriveAddresses(xpub, type, derived.length, needed, network);
+                cache[key] = derived.concat(newDerived);
+            }
+
+            return cache[key].slice(from, from + count);
+        };
+
+        return { getAllDerived, getAddresses };
+    };
+};
+
+export type AddressCache = ReturnType<typeof createAddressCache>;
+export type AddressProvider = ReturnType<AddressCache>;
+
+export const discovery = async <T>(
     discover: (addr: AddressInfo) => Promise<AddressResult<T>>,
-    xpub: string,
-    type: 'receive' | 'change',
-    network?: Network,
+    addressProvider: AddressProvider,
     lookout: number = DISCOVERY_LOOKOUT,
 ) => {
     const discoverRecursive = async (
@@ -37,12 +63,14 @@ export const discovery = <T>(
     ): Promise<AddressResult<T>[]> => {
         const unused = countUnusedFromEnd(prev, a => a.empty, lookout);
         if (unused >= lookout) return prev;
-        const moreCount = lookout - unused;
-        const addresses = deriveAddresses(xpub, type, from, moreCount, network);
+        const count = lookout - unused;
+        const addresses = addressProvider.getAddresses(from, count);
         const more = await Promise.all(addresses.map(discover));
 
-        return discoverRecursive(from + moreCount, prev.concat(more));
+        return discoverRecursive(from + count, prev.concat(more));
     };
 
-    return discoverRecursive(0, []);
+    const known = await Promise.all(addressProvider.getAllDerived().map(discover));
+
+    return discoverRecursive(known.length, known);
 };

--- a/packages/utxo-lib/src/index.ts
+++ b/packages/utxo-lib/src/index.ts
@@ -4,7 +4,7 @@ import * as bufferutils from './bufferutils';
 import { composeTx } from './compose';
 import * as crypto from './crypto';
 import { deriveAddresses, getXpubOrDescriptorInfo } from './derivation';
-import { discovery } from './discovery';
+import { createAddressCache, discovery } from './discovery';
 import * as networks from './networks';
 import * as payments from './payments';
 import * as script from './script';
@@ -23,9 +23,11 @@ export {
     deriveAddresses,
     getXpubOrDescriptorInfo,
     discovery,
+    createAddressCache,
 };
 
 export type { PaymentType } from './derivation';
+export type { AddressCache, AddressProvider } from './discovery';
 export type {
     ComposeInput,
     ComposeOutput,


### PR DESCRIPTION
When connected to an Electrum backend, deriving addresses over and over takes quite some time.
This improves performance significantly.

Required for #23657, otherwise the mobile app is painful to use.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/blockchain-link/electrum-address-caching&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/blockchain-link/electrum-address-caching&lookback=7)