### PR TITLE
chore(suite-native): bump suite-native version to 26.1.2

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@suite-native/app",
     "version": "1.0.0",
-    "suiteNativeVersion": "26.1.1",
+    "suiteNativeVersion": "26.1.2",
     "main": "index.js",
     "scripts": {
         "depcheck": "yarn g:depcheck",


### PR DESCRIPTION
## Description

Bumping beta version after freeze

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/bump-app-version-to-26.1.2&lookback=7)