### PR TITLE
fix(suite-native): fix validation for pre-filled send form

### DIFF
--- a/suite-native/module-send/src/hooks/useSendForm.ts
+++ b/suite-native/module-send/src/hooks/useSendForm.ts
@@ -129,7 +129,7 @@ export const useSendForm = (accountKey: string, tokenContract?: TokenAddress) =>
         }),
     });
 
-    const { handleSubmit, control, getValues, setValue, trigger, setError } = form;
+    const { handleSubmit, control, getValues, trigger, setError } = form;
     const watchedFormValues = useWatch({ control });
     const watchedAddress = useWatch({ name: 'outputs.0.address', control });
 
@@ -215,14 +215,22 @@ export const useSendForm = (accountKey: string, tokenContract?: TokenAddress) =>
     useEffect(() => {
         const prefillValuesFromStoredDraft = async () => {
             if (sendFormDraft?.outputs) {
-                // TODO: use reset() instead of setValue()
-                setValue('outputs', sendFormDraft.outputs, { shouldTouch: true });
-                setValue('destinationTag', sendFormDraft.destinationTag, {
-                    shouldTouch: true,
+                form.reset({
+                    ...getDefaultValues({
+                        tokenContract,
+                        isDestinationTagEnabled:
+                            network?.networkType === 'ripple' || network?.networkType === 'stellar',
+                    }),
+                    ...sendFormDraft,
                 });
+
                 // The max amount is equal to the total token balance for tokens. (fee is paid in mainnet currency)
                 if (!tokenContract) await calculateNormalFeeMaxAmount();
-                trigger();
+
+                // We need to wait for the context to hydrate before validating the form with the draft values.
+                setTimeout(() => {
+                    trigger();
+                }, 0);
             }
         };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fixed a race condition where pre-filled inputs failed validation because the form context was not yet hydrated with asynchronous `feeLevelsMaxAmount` data during the initial lifecycle.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24299

## Screenshots:
### BEFORE


https://github.com/user-attachments/assets/d10a588f-2731-44bd-b540-e9441ae7350a


### AFTER

https://github.com/user-attachments/assets/50fc7515-f9e5-4db0-8f79-b03d51ea8568



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/send-form-validation-fix&lookback=7)