### PR TITLE
feat(common): update quota values

### DIFF
--- a/suite-common/suite-sync-quota-manager/src/constants.ts
+++ b/suite-common/suite-sync-quota-manager/src/constants.ts
@@ -1,7 +1,15 @@
 import { isDevEnv } from '@suite-common/suite-utils';
 
-export const DEFAULT_DEVICE_SIZE_QUOTA = 1024 * 1024 * 50; // 50 MB
-export const DEFAULT_OWNER_SIZE_QUOTA = 1024 * 1024 * 2; // 2 MB
+/**
+ * Device size quota is set to 1 MB, which is approximately enough for 2500 label edits.
+ */
+export const DEFAULT_DEVICE_SIZE_QUOTA = 1024 * 1024;
+
+/**
+ * Default account size quota is set to 1/250th of the device size quota,
+ * which is approximately enough for 10 label edits.
+ */
+export const DEFAULT_ACCOUNT_SIZE_QUOTA = DEFAULT_DEVICE_SIZE_QUOTA / 250;
 
 export const DEFAULT_QUOTA_MANAGER_URL = isDevEnv
     ? 'https://suite-sync.suite.sldev.cz/gate/'

--- a/suite-common/suite-sync-quota-manager/src/ensureOwnerHasAllocatedQuotaThunk.ts
+++ b/suite-common/suite-sync-quota-manager/src/ensureOwnerHasAllocatedQuotaThunk.ts
@@ -8,7 +8,7 @@ import { DelegatedIdentityKey, SuiteSyncOwnerId } from '@suite-common/suite-type
 import { WalletDescriptor } from '@suite-common/wallet-types';
 
 import { prepareChallengeSession } from './challenge/prepareChallengeSession';
-import { DEFAULT_OWNER_SIZE_QUOTA } from './constants';
+import { DEFAULT_ACCOUNT_SIZE_QUOTA } from './constants';
 import { quotaManagerFetchError, quotaManagerOwnerFetched } from './quotaManagerActions';
 import { selectIsQuotaManagerEnabled, selectQuotaManagerBaseUrl } from './quotaManagerSelectors';
 import { checkStorageByOwnerId } from './storage/checkStorage';
@@ -79,7 +79,7 @@ export const ensureOwnerHasAllocatedQuotaThunk =
                 publicKey: getPublicIdentityKeyFromDelegatedKey(delegatedKey),
                 ownerId,
                 challenge: sessionChallenge.payload.challenge,
-                size: DEFAULT_OWNER_SIZE_QUOTA,
+                size: DEFAULT_ACCOUNT_SIZE_QUOTA,
             }),
         });
 
@@ -93,7 +93,7 @@ export const ensureOwnerHasAllocatedQuotaThunk =
                     ownerId,
                     publicKey: getPublicIdentityKeyFromDelegatedKey(delegatedKey),
                     proof: proofOfDelegatedIdentity.payload,
-                    size: DEFAULT_OWNER_SIZE_QUOTA,
+                    size: DEFAULT_ACCOUNT_SIZE_QUOTA,
                     challenge: sessionChallenge.payload.challenge,
                     sessionId: sessionChallenge.payload.sessionId,
                 },

--- a/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
@@ -3,7 +3,7 @@ import { WalletDescriptor, asWalletDescriptor } from '@suite-common/wallet-types
 import { err, ok } from '@trezor/type-utils';
 
 import { prepareChallengeSession } from '../challenge/prepareChallengeSession';
-import { DEFAULT_OWNER_SIZE_QUOTA } from '../constants';
+import { DEFAULT_ACCOUNT_SIZE_QUOTA } from '../constants';
 import { ensureOwnerHasAllocatedQuotaThunk } from '../ensureOwnerHasAllocatedQuotaThunk';
 import { SuiteSyncQuotaManagerState, quotaManagerInitialState } from '../quotaManagerReducer';
 import { checkStorageByOwnerId } from '../storage/checkStorage';
@@ -143,7 +143,7 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
                 publicKey:
                     '0428a3cefc19b41ff56795e371aab72d6d85a3ca2200bd46c54e611a36222295a88b44d6f23ce94025b6010f9eb0f9168ad35d8396dc865fa0a16f2f5471816a45',
                 proof: '3fe8d55f5dfdc54133027c3a94903ab4e038353dc08ec4d324c7fd5eda74def911249c2bf1929313a223ce4fa50140fb6c717b46f123c901a5df39afbe7f2bb7',
-                size: DEFAULT_OWNER_SIZE_QUOTA,
+                size: DEFAULT_ACCOUNT_SIZE_QUOTA,
                 challenge: 'aa55',
                 sessionId: 'session-123',
             },


### PR DESCRIPTION
Changes:
- lowered the device and account quotas

## Notes for QA

- changed the default quota from 50MB to 1MB - you should see that in debug settings as well as the new account quota (1MB / 250 per each account)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24385



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/qm/storage-constants&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/qm/storage-constants&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/qm/storage-constants&lookback=7)