### PR TITLE
refactor(e2e-suite): passphrase tests

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseMismatchModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseMismatchModal.tsx
@@ -38,10 +38,10 @@ export const PassphraseMismatchModal = ({
         <SwitchDeviceModal data-testid="@passphrase-mismatch">
             <CardWithDevice device={device}>
                 <Column gap={spacings.xs} margin={{ bottom: spacings.lg }}>
-                    <H3>
+                    <H3 data-testid="@passphrase-mismatch-header">
                         <Translation id="TR_PASSPHRASE_MISMATCH" />
                     </H3>
-                    <Text variant="tertiary">
+                    <Text data-testid="@passphrase-mismatch-description" variant="tertiary">
                         <Translation id="TR_PASSPHRASE_MISMATCH_DESCRIPTION" />
                     </Text>
                 </Column>

--- a/suite/e2e/support/pageObjects/dashboardPage.ts
+++ b/suite/e2e/support/pageObjects/dashboardPage.ts
@@ -29,18 +29,24 @@ export class DashboardPage {
     readonly addStandardWalletButton: Locator;
     readonly addHiddenWalletButton: Locator;
     readonly addNewHiddenWalletButton: Locator;
+    readonly addExistingHiddenWalletButton: Locator;
     readonly hideBalanceButton: Locator;
     readonly portfolioFiatAmount: Locator;
     readonly deviceStatus: Locator;
     readonly deviceStatusOnSwitchDevice: Locator;
     readonly solveIssuesButton: Locator;
+    readonly passphraseDuplicateHeader: Locator;
+    readonly passphraseDuplicateDesc: Locator;
+    readonly passphraseMismatchHeader: Locator;
+    readonly passphraseMismatchDesc: Locator;
     readonly passphraseInput: Locator;
     readonly passphraseSubmitButton: Locator;
     readonly passphraseShowButton: Locator;
-    readonly loading: Locator;
-    readonly notificationNoBackupButton: Locator;
+    readonly passphraseMismatchStartOverButton: Locator;
     readonly openUnusedWalletButton1: Locator;
     readonly openUnusedWalletButton2: Locator;
+    readonly loading: Locator;
+    readonly notificationNoBackupButton: Locator;
     readonly buyButton = (networkSymbol: NetworkSymbol): Locator =>
         this.page.getByTestId(`@dashboard/asset/${networkSymbol}/buy-button`);
     readonly walletReady: Locator;
@@ -68,24 +74,34 @@ export class DashboardPage {
         this.addNewHiddenWalletButton = this.page.getByTestId(
             '@switch-device/add-new-hidden-wallet-button',
         );
+        this.addExistingHiddenWalletButton = this.page.getByTestId(
+            '@switch-device/add-existing-hidden-wallet-button',
+        );
         this.hideBalanceButton = this.page.getByTestId('@quickActions/hideBalances');
         this.portfolioFiatAmount = this.page.getByTestId('@dashboard/portfolio/fiat-amount');
         this.deviceStatus = this.page.locator("[data-testid-alt='@deviceStatus']");
         this.deviceStatusOnSwitchDevice = this.page
             .getByTestId('@menu/switch-device')
             .locator("[data-testid-alt='@deviceStatus']");
+        this.passphraseDuplicateHeader = this.page.getByTestId('@passphrase-duplicate-header');
+        this.passphraseDuplicateDesc = this.page.getByTestId('@passphrase-duplicate-description');
+        this.passphraseMismatchHeader = this.page.getByTestId('@passphrase-mismatch-header');
+        this.passphraseMismatchDesc = this.page.getByTestId('@passphrase-mismatch-description');
         this.solveIssuesButton = this.page.getByTestId('@switch-device/solve-issue-button');
         this.passphraseInput = this.page.getByTestId('@passphrase/input');
         this.passphraseSubmitButton = this.page.getByTestId('@passphrase/hidden/submit-button');
         this.passphraseShowButton = this.page.getByTestId('@passphrase/show-toggle');
-        this.loading = this.page.getByTestId('@dashboard/loading');
-        this.notificationNoBackupButton = this.page.getByTestId('@notification/no-backup/button');
+        this.passphraseMismatchStartOverButton = this.page.getByTestId(
+            '@passphrase-mismatch/start-over',
+        );
         this.openUnusedWalletButton1 = this.page.getByTestId(
             '@passphrase-confirmation/step1-open-unused-wallet-button',
         );
         this.openUnusedWalletButton2 = this.page.getByTestId(
             '@passphrase-confirmation/step2-button',
         );
+        this.loading = this.page.getByTestId('@dashboard/loading');
+        this.notificationNoBackupButton = this.page.getByTestId('@notification/no-backup/button');
         this.walletReady = this.page.getByTestId('@dashboard/wallet-ready');
         this.discoveryEmptyHeader = this.page.getByTestId('@exception/discovery-empty/header');
         this.discoveryEmptyDesc = this.page.getByTestId('@exception/discovery-empty/description');
@@ -125,7 +141,7 @@ export class DashboardPage {
     @step()
     async addHiddenWallet(passphrase: string, options?: { skipDiscovery?: boolean }) {
         await this.addHiddenWalletButton.click();
-        await this.page.getByTestId('@switch-device/add-existing-hidden-wallet-button').click();
+        await this.addExistingHiddenWalletButton.click();
 
         await this.passphraseInput.fill(passphrase);
         await this.passphraseSubmitButton.click();
@@ -152,7 +168,7 @@ export class DashboardPage {
     async addUnusedHiddenWallet(passphrase: string) {
         await this.addHiddenWalletButton.click();
         await this.addNewHiddenWalletButton.click();
-        await this.page.getByTestId('@passphrase-confirmation/step2-button').click();
+        await this.openUnusedWalletButton2.click();
         await this.passphraseInput.fill(passphrase);
         await this.passphraseSubmitButton.click();
         await expect(this.passphraseInput).toBeHidden();

--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -11,6 +11,7 @@ import { SettingsPage } from '../settings/settingsPage';
 
 export class MetadataPage {
     readonly metadataModal: Locator;
+    readonly copyAddressButton: Locator;
     readonly account: AccountMetadata;
     readonly output: OutputMetadata;
     readonly wallet: WalletMetadata;
@@ -25,6 +26,7 @@ export class MetadataPage {
         private readonly devicePrompt: DevicePrompt,
     ) {
         this.metadataModal = page.getByTestId('@modal/metadata-provider');
+        this.copyAddressButton = page.getByTestId('@metadata/copy-address-button');
 
         this.account = new AccountMetadata(page);
         this.output = new OutputMetadata(page);

--- a/suite/e2e/support/pageObjects/walletPage.ts
+++ b/suite/e2e/support/pageObjects/walletPage.ts
@@ -54,14 +54,18 @@ export class WalletPage {
     readonly segwitGroupButton: Locator;
     readonly addAccountButton: Locator;
     readonly copyToCliboardToast: Locator;
+    readonly verifyAddressErrorToast: Locator;
     readonly accountNotLoaded: Locator;
     readonly emptyAccount: Locator;
     readonly buyButton: Locator;
     readonly sellButton: Locator;
     readonly swapButton: Locator;
     readonly overviewTabButton: Locator;
+    readonly deviceConnectedStatus: Locator;
     readonly deviceDisconnectedStatus: Locator;
     readonly discoveryWarning: Locator;
+    readonly usedAddress = (index: number) =>
+        this.page.getByTestId(`@wallet/receive/used-address/${index}`);
 
     constructor(private readonly page: Page) {
         this.transactionSearch = this.page.getByTestId('@wallet/accounts/search-icon');
@@ -100,6 +104,7 @@ export class WalletPage {
             '@wallet/account-top-panel/crypto-balance-with-symbol',
         );
         this.copyToCliboardToast = this.page.getByTestId('@toast/copy-to-clipboard');
+        this.verifyAddressErrorToast = this.page.getByTestId('@toast/verify-address-error');
         this.segwitGroupButton = this.page.getByTestId('@account-menu/segwit');
         this.addAccountButton = this.page.getByTestId('@account-menu/add-account');
         this.accountNotLoaded = this.page.getByTestId('@accounts/account-not-loaded');
@@ -108,6 +113,9 @@ export class WalletPage {
         this.sellButton = this.page.getByTestId('@trading/menu/wallet-trading-sell');
         this.swapButton = this.page.getByTestId('@trading/menu/wallet-trading-exchange');
         this.overviewTabButton = this.page.getByTestId('@wallet/menu/wallet-overview');
+        this.deviceConnectedStatus = this.page
+            .getByTestId('@menu/switch-device')
+            .getByTestId('@deviceStatus-connected');
         this.deviceDisconnectedStatus = page
             .getByTestId('@menu/switch-device')
             .getByTestId('@deviceStatus-disconnected');

--- a/suite/e2e/tests/passphrase/passphrase-cancel.test.ts
+++ b/suite/e2e/tests/passphrase/passphrase-cancel.test.ts
@@ -4,7 +4,6 @@ test.describe('Passphrase cancel', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all', passphrase_protection: true } });
 
     test('possible to cancel passphrase', async ({
-        page,
         devicePrompt,
         onboardingPage,
         dashboardPage,
@@ -13,11 +12,11 @@ test.describe('Passphrase cancel', { tag: ['@T3W1', '@T3T1'] }, () => {
 
         await dashboardPage.deviceSwitchingOpenButton.click();
         await dashboardPage.addHiddenWalletButton.click();
-        await page.getByTestId('@switch-device/add-existing-hidden-wallet-button').click();
+        await dashboardPage.addExistingHiddenWalletButton.click();
         await dashboardPage.passphraseInput.fill('abc');
         await dashboardPage.passphraseSubmitButton.click();
         await devicePrompt.confirmOnDevicePromptIsShown();
 
-        await page.getByTestId('@confirm-on-device/close-button').click();
+        await devicePrompt.closeButton.click();
     });
 });

--- a/suite/e2e/tests/passphrase/passphrase-cardano.test.ts
+++ b/suite/e2e/tests/passphrase/passphrase-cardano.test.ts
@@ -12,10 +12,10 @@ test.describe('Passphrase with cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
     });
 
     test('verify cardano address behind passphrase', async ({
-        page,
         settingsPage,
         dashboardPage,
         walletPage,
+        metadataPage,
         devicePrompt,
         trezorUserEnvLink,
         emulatorStartConf,
@@ -23,9 +23,9 @@ test.describe('Passphrase with cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
         async function restartEmulator() {
             await test.step('Restart emulator', async () => {
                 await trezorUserEnvLink.stopEmu();
-                await expect(page.getByTestId('@deviceStatus-disconnected')).toBeVisible();
+                await expect(walletPage.deviceDisconnectedStatus).toBeVisible();
                 await trezorUserEnvLink.startEmu({ model: emulatorStartConf.model, wipe: false });
-                await expect(page.getByTestId('@deviceStatus-connected')).toBeVisible({
+                await expect(walletPage.deviceConnectedStatus).toBeVisible({
                     timeout: 15_000,
                 });
             });
@@ -51,9 +51,7 @@ test.describe('Passphrase with cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
             await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
             await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
 
-            await expect(page.getByTestId('@modal/output-value')).toHaveText(
-                formatAddress(correctPassphraseAddr),
-            );
+            await expect(devicePrompt.outputValue).toHaveText(formatAddress(correctPassphraseAddr));
 
             await devicePrompt.confirmOnDevicePromptIsShown();
             await expect(devicePrompt).toDisplayReceiveAddress(correctPassphraseAddr, {
@@ -61,7 +59,7 @@ test.describe('Passphrase with cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
             });
             await trezorUserEnvLink.pressYes(); // Confirm receive address
 
-            await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
+            await expect(metadataPage.copyAddressButton).toBeVisible();
             await devicePrompt.closeModal();
             await expect(walletPage.revealAddressButton).toBeVisible();
         });
@@ -75,7 +73,7 @@ test.describe('Passphrase with cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
             await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
             await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
 
-            await expect(page.getByTestId('@toast/verify-address-error')).toBeVisible();
+            await expect(walletPage.verifyAddressErrorToast).toBeVisible();
         });
     });
 });

--- a/suite/e2e/tests/passphrase/passphrase-duplicate.test.ts
+++ b/suite/e2e/tests/passphrase/passphrase-duplicate.test.ts
@@ -13,7 +13,6 @@ test.describe('Passphrase duplicate', { tag: ['@T3W1', '@T3T1'] }, () => {
     });
 
     test('attempt to add the same hidden wallet twice results in warning', async ({
-        page,
         dashboardPage,
     }) => {
         const passphraseToType = 'taxation is theft';
@@ -26,11 +25,11 @@ test.describe('Passphrase duplicate', { tag: ['@T3W1', '@T3T1'] }, () => {
         await test.step('Attempt to add another wallet with the same passphrase', async () => {
             await dashboardPage.openDeviceSwitcher();
             await dashboardPage.addHiddenWallet(passphraseToType, { skipDiscovery: true });
-            await expect(page.getByTestId('@passphrase-duplicate-header')).toBeVisible();
-            await expect(page.getByTestId('@passphrase-duplicate-header')).toHaveTranslation(
+            await expect(dashboardPage.passphraseDuplicateHeader).toBeVisible();
+            await expect(dashboardPage.passphraseDuplicateHeader).toHaveTranslation(
                 'TR_WALLET_DUPLICATE_TITLE',
             );
-            await expect(page.getByTestId('@passphrase-duplicate-description')).toHaveTranslation(
+            await expect(dashboardPage.passphraseDuplicateDesc).toHaveTranslation(
                 'TR_WALLET_DUPLICATE_DESC',
             );
         });

--- a/suite/e2e/tests/passphrase/passphrase-reconnection.test.ts
+++ b/suite/e2e/tests/passphrase/passphrase-reconnection.test.ts
@@ -13,6 +13,7 @@ test.describe('Passphrase reconnection', { tag: ['@T3W1', '@T3T1'] }, () => {
         page,
         dashboardPage,
         walletPage,
+        metadataPage,
         devicePrompt,
         trezorUserEnvLink,
         emulatorStartConf,
@@ -30,15 +31,13 @@ test.describe('Passphrase reconnection', { tag: ['@T3W1', '@T3T1'] }, () => {
             });
             await walletPage.receiveButton.click();
             await walletPage.revealAddressButton.click();
-            await expect(page.getByTestId('@modal/output-value')).toHaveText(
-                formatAddress(abcAddr),
-            );
+            await expect(devicePrompt.outputValue).toHaveText(formatAddress(abcAddr));
             await devicePrompt.confirmOnDevicePromptIsShown();
             await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
             await trezorUserEnvLink.pressYes(); // confirm address
 
-            await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
-            await expect(page.getByTestId('@metadata/copy-address-button')).toBeEnabled();
+            await expect(metadataPage.copyAddressButton).toBeVisible();
+            await expect(metadataPage.copyAddressButton).toBeEnabled();
 
             await devicePrompt.closeModal();
         });
@@ -76,8 +75,7 @@ test.describe('Passphrase reconnection', { tag: ['@T3W1', '@T3T1'] }, () => {
         await test.step('Displaying receive address should prompt for passphrase', async () => {
             await dashboardPage.walletAtIndex(1).click();
             await walletPage.receiveButton.click();
-            await expect(page.getByTestId('@wallet/receive/used-address/0')).toBeHidden();
-            await expect(walletPage.revealAddressButton).toBeEnabled();
+            await expect(walletPage.usedAddress(0)).toBeHidden();
             await walletPage.revealAddressButton.click();
             await expect(page.getByText('Confirm passphrase')).toBeVisible();
             await dashboardPage.passphraseInput.fill('abc');
@@ -87,27 +85,25 @@ test.describe('Passphrase reconnection', { tag: ['@T3W1', '@T3T1'] }, () => {
         });
 
         await test.step('Verify displayed receive address', async () => {
-            await expect(page.getByTestId('@modal/output-value')).toHaveText(
-                formatAddress(abcAddr),
-            );
+            await expect(devicePrompt.outputValue).toHaveText(formatAddress(abcAddr));
 
             await devicePrompt.confirmOnDevicePromptIsShown();
             await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
             await trezorUserEnvLink.pressYes(); // confirm address
 
-            await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
-            await expect(page.getByTestId('@metadata/copy-address-button')).toBeEnabled();
+            await expect(metadataPage.copyAddressButton).toBeVisible();
+            await expect(metadataPage.copyAddressButton).toBeEnabled();
             await devicePrompt.closeModal();
         });
 
         await test.step('Second displaying receive address after reconnect should NOT prompt for passphrase', async () => {
             await walletPage.revealAddressButton.click();
-            await expect(page.getByTestId('@modal/output-value')).toBeVisible();
+            await expect(devicePrompt.outputValue).toBeVisible();
 
             await trezorUserEnvLink.pressYes(); // confirm address
 
-            await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
-            await expect(page.getByTestId('@metadata/copy-address-button')).toBeEnabled();
+            await expect(metadataPage.copyAddressButton).toBeVisible();
+            await expect(metadataPage.copyAddressButton).toBeEnabled();
         });
     });
 });

--- a/suite/e2e/tests/passphrase/passphrase.test.ts
+++ b/suite/e2e/tests/passphrase/passphrase.test.ts
@@ -25,7 +25,15 @@ test.describe('Passphrase', { tag: ['@T3W1', '@T3T1'] }, () => {
                 priority: TestPriority.High,
             }),
         },
-        async ({ page, analytics, devicePrompt, dashboardPage, walletPage, trezorUserEnvLink }) => {
+        async ({
+            page,
+            analytics,
+            devicePrompt,
+            dashboardPage,
+            walletPage,
+            metadataPage,
+            trezorUserEnvLink,
+        }) => {
             await test.step('Add passphrase wallet #1', async () => {
                 await dashboardPage.openDeviceSwitcher();
                 await dashboardPage.addUnusedHiddenWallet('abc');
@@ -41,15 +49,13 @@ test.describe('Passphrase', { tag: ['@T3W1', '@T3T1'] }, () => {
                 });
                 await walletPage.receiveButton.click();
                 await walletPage.revealAddressButton.click();
-                await expect(page.getByTestId('@modal/output-value')).toHaveText(
-                    formatAddress(abcAddr),
-                );
+                await expect(devicePrompt.outputValue).toHaveText(formatAddress(abcAddr));
                 await devicePrompt.confirmOnDevicePromptIsShown();
                 await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
                 await trezorUserEnvLink.pressYes(); // confirm address
 
-                await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
-                await expect(page.getByTestId('@metadata/copy-address-button')).toBeEnabled();
+                await expect(metadataPage.copyAddressButton).toBeVisible();
+                await expect(metadataPage.copyAddressButton).toBeEnabled();
 
                 await devicePrompt.closeModal();
             });
@@ -69,20 +75,18 @@ test.describe('Passphrase', { tag: ['@T3W1', '@T3T1'] }, () => {
             await test.step('Open receive address of wallet #2', async () => {
                 await walletPage.receiveButton.click();
                 await test.step('Verify no address is yet in table', async () => {
-                    await expect(page.getByTestId('@wallet/receive/used-address/0')).toBeHidden();
+                    await expect(walletPage.usedAddress(0)).toBeHidden();
                 });
 
                 await expect(walletPage.revealAddressButton).toBeEnabled();
                 await walletPage.revealAddressButton.click();
-                await expect(page.getByTestId('@modal/output-value')).toHaveText(
-                    formatAddress(defAddr),
-                );
+                await expect(devicePrompt.outputValue).toHaveText(formatAddress(defAddr));
                 await devicePrompt.confirmOnDevicePromptIsShown();
                 await expect(devicePrompt).toDisplayReceiveAddress(defAddr);
                 await trezorUserEnvLink.pressYes(); // confirm address
 
-                await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
-                await expect(page.getByTestId('@metadata/copy-address-button')).toBeEnabled();
+                await expect(metadataPage.copyAddressButton).toBeVisible();
+                await expect(metadataPage.copyAddressButton).toBeEnabled();
 
                 await devicePrompt.closeModal();
             });
@@ -94,38 +98,30 @@ test.describe('Passphrase', { tag: ['@T3W1', '@T3T1'] }, () => {
             });
 
             await test.step('No address is yet in table of wallet #1', async () => {
-                await expect(page.getByTestId('@wallet/receive/used-address/0')).toBeHidden();
+                await expect(walletPage.usedAddress(0)).toBeHidden();
                 await expect(walletPage.revealAddressButton).toBeEnabled();
 
                 await walletPage.revealAddressButton.click();
-                await expect(page.getByTestId('@modal/output-value')).toHaveText(
-                    formatAddress(abcAddr),
-                );
+                await expect(devicePrompt.outputValue).toHaveText(formatAddress(abcAddr));
                 await devicePrompt.confirmOnDevicePromptIsShown();
                 await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
                 await trezorUserEnvLink.pressYes(); // confirm address
 
-                await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
-                await expect(page.getByTestId('@metadata/copy-address-button')).toBeEnabled();
+                await expect(metadataPage.copyAddressButton).toBeVisible();
+                await expect(metadataPage.copyAddressButton).toBeEnabled();
 
                 await devicePrompt.closeModal();
             });
         },
     );
 
-    test('Errors to confirm passphrase and retry', async ({
-        page,
-        dashboardPage,
-        devicePrompt,
-    }) => {
+    test('Errors to confirm passphrase and retry', async ({ dashboardPage, devicePrompt }) => {
         await test.step('Initiate adding passphrase wallet', async () => {
             await dashboardPage.openDeviceSwitcher();
             await dashboardPage.addHiddenWallet('abc', { skipDiscovery: true });
 
-            await page
-                .getByTestId('@passphrase-confirmation/step1-open-unused-wallet-button')
-                .click();
-            await page.getByTestId('@passphrase-confirmation/step2-button').click();
+            await dashboardPage.openUnusedWalletButton1.click();
+            await dashboardPage.openUnusedWalletButton2.click();
         });
 
         await test.step('Confirm wrong passphrase', async () => {
@@ -151,18 +147,22 @@ test.describe('Passphrase', { tag: ['@T3W1', '@T3T1'] }, () => {
             await dashboardPage.passphraseSubmitButton.click();
             await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
             await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
+            await expect(dashboardPage.passphraseMismatchHeader).toContainTranslation(
+                'TR_PASSPHRASE_MISMATCH',
+            );
+            await expect(dashboardPage.passphraseMismatchDesc).toContainTranslation(
+                'TR_PASSPHRASE_MISMATCH_DESCRIPTION',
+            );
         });
 
         await test.step('Retry passphrase confirmation', async () => {
-            await page.getByTestId('@passphrase-mismatch/start-over').click();
+            await dashboardPage.passphraseMismatchStartOverButton.click();
             await dashboardPage.passphraseInput.fill('abc');
             await dashboardPage.passphraseSubmitButton.click();
             await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
             await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
-            await page
-                .getByTestId('@passphrase-confirmation/step1-open-unused-wallet-button')
-                .click();
-            await page.getByTestId('@passphrase-confirmation/step2-button').click();
+            await dashboardPage.openUnusedWalletButton1.click();
+            await dashboardPage.openUnusedWalletButton2.click();
         });
 
         await test.step('Confirm correct passphrase', async () => {


### PR DESCRIPTION
## Description

Move the locators for the passphrase tests into their corresponding page object classes

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/refactor-passphrase&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/refactor-passphrase&lookback=7)