### PR TITLE
feat(common): send Suite version as header to QM api

### DIFF
--- a/suite-common/suite-sync-quota-manager/package.json
+++ b/suite-common/suite-sync-quota-manager/package.json
@@ -21,6 +21,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "react-redux": "9.2.0"

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerFetch.ts
@@ -1,3 +1,4 @@
+import { getSuiteVersion } from '@trezor/env-utils';
 import { err, ok } from '@trezor/type-utils';
 import { typedObjectEntries } from '@trezor/utils';
 
@@ -35,6 +36,7 @@ export const quotaManagerFetch = async ({
         method,
         headers: {
             'Content-Type': 'application/json',
+            'Suite-Version': getSuiteVersion(),
         },
         body: body ? JSON.stringify(body) : null,
     });

--- a/suite-common/suite-sync-quota-manager/tsconfig.json
+++ b/suite-common/suite-sync-quota-manager/tsconfig.json
@@ -13,6 +13,7 @@
         { "path": "../wallet-types" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" },
+        { "path": "../../packages/env-utils" },
         { "path": "../../packages/type-utils" },
         { "path": "../../packages/utils" }
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -11001,6 +11001,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     react-redux: "npm:9.2.0"


### PR DESCRIPTION
**Changes**:
- to every QM API EP suite sends its own version

## Notes for QA

- to every QM API you should see a header `Suite-version`

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24348

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/qm/suite-version-header&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/qm/suite-version-header&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/qm/suite-version-header&lookback=7)