### PR TITLE
fix(suite): Enable account details when discovery fails

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
@@ -6,7 +6,7 @@ import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavi
 import { HeaderActionButton } from 'src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActionButton';
 import { TradeActions } from 'src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions';
 import { useDevice, useSelector } from 'src/hooks/suite';
-import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { selectFullSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { WalletParams } from 'src/types/wallet';
 
 import { HeaderDropdown } from './HeaderDropdown';
@@ -14,12 +14,11 @@ import { useGoToWithAnalytics } from './useGoToWithAnalytics';
 
 export const HeaderActions = () => {
     const goToWithAnalytics = useGoToWithAnalytics();
-    const account = useSelector(selectSelectedAccount);
+    const selectedAccount = useSelector(selectFullSelectedAccount);
     const routerParams = useSelector(state => state.router.params) as WalletParams;
-    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const { device } = useDevice();
 
-    const accountType = account?.accountType || routerParams?.accountType || '';
+    const accountType = selectedAccount.account?.accountType || routerParams?.accountType || '';
     const isTradingAvailable = !['coinjoin'].includes(accountType);
     const isAccountLoading = selectedAccount.status === 'loading';
     const isDeviceConnected = device?.connected && device?.available;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
@@ -34,6 +34,20 @@ const Container = styled.div`
     z-index: ${zIndices.pageHeader};
 `;
 
+const PageHeaderIndex = () => {
+    const hasAccounts = useSelector(state => selectAccounts(state).length > 0);
+
+    if (!hasAccounts) return null;
+
+    return (
+        <Row gap={12}>
+            <HeaderDropdown />
+            <TradeActions />
+            <GlobalSendReceive />
+        </Row>
+    );
+};
+
 interface PageHeaderProps {
     children?: ReactNode;
 }
@@ -41,26 +55,21 @@ interface PageHeaderProps {
 export const PageHeader = ({ children }: PageHeaderProps) => {
     // Select minimal state to avoid unnecessary re-renders
     const selectedAccountKey = useSelector(selectSelectedAccountKey);
-    const hasAccounts = useSelector(state => selectAccounts(state).length > 0);
-    const isAccountTabPage = useSelector(selectIsAccountTabPage);
     const routeName = useSelector(selectRouteName);
+    const isAccountTabPage = useSelector(selectIsAccountTabPage);
 
     // handle moment when children are not rendered yet in the Trade section
-    const isTradeSection = routeName?.includes('wallet-trading');
+    const isTradeSection = !!routeName?.includes('wallet-trading');
 
-    return isTradeSection || children ? (
-        <Container>{children ?? null}</Container>
-    ) : (
+    if (isTradeSection || children != null) {
+        return <Container>{children}</Container>;
+    }
+
+    return (
         <Container>
             <PageName />
 
-            {routeName === 'suite-index' && hasAccounts && (
-                <Row gap={12}>
-                    <HeaderDropdown />
-                    <TradeActions />
-                    <GlobalSendReceive />
-                </Row>
-            )}
+            {routeName === 'suite-index' && <PageHeaderIndex />}
             {!!selectedAccountKey && isAccountTabPage && <HeaderActions />}
         </Container>
     );

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountName.tsx
@@ -34,7 +34,8 @@ export const AccountName = ({ selectedAccount }: AccountNameProps) => {
         observer.observe(target);
 
         return () => observer.disconnect();
-    }, [balanceSectionRef]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [balanceSectionRef?.current]);
 
     return <AccountDetails selectedAccount={selectedAccount} isBalanceShown={isScrolled} />;
 };

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
@@ -1,4 +1,5 @@
 import { Translation } from '@suite/intl';
+import { selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex } from '@suite-common/wallet-core';
 
 import { useSelector } from 'src/hooks/suite';
 import { selectIsAccountTabPage } from 'src/reducers/suite/routerReducer';
@@ -13,6 +14,16 @@ export const PageName = () => {
     const currentRoute = useSelector(state => state.router.route?.name);
     const selectedAccount = useSelector(selectSelectedAccount);
     const isAccountTabPage = useSelector(selectIsAccountTabPage);
+    const { params } = useSelector(state => state.wallet.selectedAccount);
+
+    const fallbackAccount = useSelector(state =>
+        selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex(
+            state,
+            params?.symbol,
+            params?.accountType,
+            params?.accountIndex,
+        ),
+    );
 
     // TODO: does not work properly with foreground apps, e.g. FW update,
     // as the `route` does not indicate the current page
@@ -32,8 +43,13 @@ export const PageName = () => {
     if (selectedAccount && isAccountTabPage) {
         return <AccountName selectedAccount={selectedAccount} />;
     }
+
     if (selectedAccount) {
         return <AccountSubpageName selectedAccount={selectedAccount} />;
+    }
+
+    if (fallbackAccount) {
+        return <AccountName selectedAccount={fallbackAccount} />;
     }
 
     return (

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Context } from '@suite-common/message-system';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectBaseCurrency, useDisplayBaseCurrency } from '@suite-common/wallet-core';
-import { SkeletonCircle, SkeletonRectangle } from '@trezor/components';
+import { Column, SkeletonCircle, SkeletonRectangle } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 import { spacingsPx, zIndices } from '@trezor/theme';
 
@@ -31,11 +31,6 @@ const AccountCryptoBalance = styled.div`
     color: ${({ theme }) => theme.textSubdued};
 `;
 
-const BalanceSection = styled.div`
-    display: flex;
-    flex-direction: column;
-`;
-
 interface AccountTopPanelSkeletonProps {
     animate?: boolean;
     symbol?: NetworkSymbol;
@@ -58,6 +53,10 @@ export const AccountTopPanel = () => {
     const { balanceSectionRef } = useAccountHeaderContext();
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account?.symbol);
 
+    if (status === 'exception') {
+        return null;
+    }
+
     if (status !== 'loaded' || !account) {
         return (
             <AccountTopPanelSkeleton
@@ -71,7 +70,7 @@ export const AccountTopPanel = () => {
 
     return (
         <Container>
-            <BalanceSection ref={balanceSectionRef}>
+            <Column ref={balanceSectionRef}>
                 <AmountUnitSwitchWrapper symbol={symbol}>
                     {shallDisplayBaseCurrency && (
                         <AccountCryptoBalance>
@@ -90,7 +89,7 @@ export const AccountTopPanel = () => {
                     localCurrency={baseCurrency}
                     data-testid="@wallet/account-top-panel/fiat-amount"
                 />
-            </BalanceSection>
+            </Column>
             <ContextMessage context={Context.getAccount(symbol, accountType)} />
         </Container>
     );

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/AccountItemBottomLine.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/AccountItemBottomLine.tsx
@@ -1,0 +1,39 @@
+import { Account } from '@suite-common/wallet-types';
+import { Text } from '@trezor/components';
+
+import { CoinBalance } from 'src/components/suite';
+
+import { BalancePlaceholder } from './BalancePlaceholder';
+
+type AccountItemBottomLineProps = {
+    account: Account;
+    formattedBalance: string;
+    shouldShowCryptoBalance: boolean;
+    shouldShowBalancePlaceholder: boolean;
+};
+
+export const AccountItemBottomLine = ({
+    account,
+    formattedBalance,
+    shouldShowCryptoBalance,
+    shouldShowBalancePlaceholder,
+}: AccountItemBottomLineProps) => {
+    if (!shouldShowCryptoBalance && !shouldShowBalancePlaceholder) return null;
+
+    return (
+        <>
+            {shouldShowCryptoBalance && (
+                <Text typographyStyle="hint" variant="tertiary">
+                    <CoinBalance
+                        data-testid="@wallet"
+                        value={formattedBalance}
+                        symbol={account.symbol}
+                        showApproximation
+                    />
+                </Text>
+            )}
+
+            {shouldShowBalancePlaceholder && <BalancePlaceholder networkSymbol={account.symbol} />}
+        </>
+    );
+};

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/AccountItemContent.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/AccountItemContent.tsx
@@ -1,18 +1,13 @@
-import { Translation } from '@suite/intl';
-import { selectCardanoPoolsInfo, selectIsDiscreteModeActive } from '@suite-common/wallet-core';
+import { selectIsDiscreteModeActive } from '@suite-common/wallet-core';
 import { Account, BaseCurrencyAmount } from '@suite-common/wallet-types';
-import {
-    isCardanoStakedWithEverstake,
-    isCardanoStakedWithFiveBinaries,
-} from '@suite-common/wallet-utils';
-import { Column, Icon, Row, Text } from '@trezor/components';
+import { Column, Row, Text } from '@trezor/components';
 
-import { AccountLabel, CoinBalance } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { AccountItemType } from 'src/types/wallet';
 
-import { BalancePlaceholder } from './BalancePlaceholder';
-import { BaseCurrency } from './BaseCurrency';
+import { AccountItemBottomLine } from './AccountItemBottomLine';
+import { AccountItemLabel } from './AccountItemLabel';
+import { AccountItemRightSide } from './AccountItemRightSide';
 
 type AccountItemContentProps = {
     customFiatValue?: BaseCurrencyAmount;
@@ -32,15 +27,16 @@ export const AccountItemContent = ({
     isFiatLoading,
 }: AccountItemContentProps) => {
     const discreetMode = useSelector(selectIsDiscreteModeActive);
-    const cardanoStakingPools = useSelector(selectCardanoPoolsInfo);
-    const isCardanoStaking = account.networkType === 'cardano' && type === 'staking';
-    const isBalanceShown = account.backendType !== 'coinjoin' || account.status !== 'initial';
 
-    const cardanoStakingIcon = isCardanoStakedWithEverstake(account, cardanoStakingPools) ? (
-        <Icon name="check" variant="primary" size={16} />
-    ) : (
-        <Icon name="warning" variant="warning" size={16} />
-    );
+    const isCardanoStakingRow = account.networkType === 'cardano' && type === 'staking';
+    const isFailed = !!account.failed;
+
+    const canShowBalance = account.backendType !== 'coinjoin' || account.status !== 'initial';
+
+    const shouldShowCryptoBalance =
+        !isCardanoStakingRow && !isFailed && canShowBalance && type !== 'tokens';
+
+    const shouldShowBalancePlaceholder = !isCardanoStakingRow && !isFailed && !canShowBalance;
 
     return (
         // Content is constant size in discreet mode, so overflow: hidden is unnecessary.
@@ -52,48 +48,25 @@ export const AccountItemContent = ({
                     ellipsisLineCount={1}
                     data-testid={`${dataTestKey}/label`}
                 >
-                    {type === 'coin' && <AccountLabel account={account} />}
-                    {type === 'staking' && (
-                        <Column alignItems="flex-start">
-                            <Translation id="TR_NAV_STAKING" />
-                            {isCardanoStakedWithFiveBinaries(account) && (
-                                <Text typographyStyle="hint" variant="warning">
-                                    <Translation id="TR_STAKING_REWARDS_REDUCED" />
-                                </Text>
-                            )}
-                        </Column>
-                    )}
-                    {type === 'tokens' && <Translation id="TR_NAV_TOKENS" />}
+                    <AccountItemLabel account={account} type={type} />
                 </Text>
 
-                {!isCardanoStaking ? (
-                    <Text typographyStyle="hint" variant="tertiary">
-                        <BaseCurrency
-                            isLoading={isFiatLoading}
-                            customFiatValue={customFiatValue}
-                            symbol={account.symbol}
-                            formattedBalance={formattedBalance}
-                        />
-                    </Text>
-                ) : (
-                    cardanoStakingIcon
-                )}
+                <AccountItemRightSide
+                    account={account}
+                    isCardanoStakingRow={isCardanoStakingRow}
+                    isFailed={isFailed}
+                    formattedBalance={formattedBalance}
+                    customFiatValue={customFiatValue}
+                    isFiatLoading={isFiatLoading}
+                />
             </Row>
-            {!isCardanoStaking && (
-                <>
-                    {isBalanceShown && type !== 'tokens' && (
-                        <Text typographyStyle="hint" variant="tertiary">
-                            <CoinBalance
-                                data-testid="@wallet"
-                                value={formattedBalance}
-                                symbol={account.symbol}
-                                showApproximation
-                            />
-                        </Text>
-                    )}
-                    {!isBalanceShown && <BalancePlaceholder networkSymbol={account.symbol} />}
-                </>
-            )}
+
+            <AccountItemBottomLine
+                account={account}
+                formattedBalance={formattedBalance}
+                shouldShowCryptoBalance={shouldShowCryptoBalance}
+                shouldShowBalancePlaceholder={shouldShowBalancePlaceholder}
+            />
         </Column>
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/AccountItemLabel.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/AccountItemLabel.tsx
@@ -1,0 +1,37 @@
+import { Translation } from '@suite/intl';
+import { Account } from '@suite-common/wallet-types';
+import { isCardanoStakedWithFiveBinaries } from '@suite-common/wallet-utils';
+import { Column, Text } from '@trezor/components';
+
+import { AccountLabel } from 'src/components/suite';
+import { AccountItemType } from 'src/types/wallet';
+
+type AccountItemLabelProps = {
+    account: Account;
+    type: AccountItemType;
+};
+
+export const AccountItemLabel = ({ account, type }: AccountItemLabelProps) => {
+    switch (type) {
+        case 'coin':
+            return <AccountLabel account={account} />;
+
+        case 'staking':
+            return (
+                <Column alignItems="flex-start">
+                    <Translation id="TR_NAV_STAKING" />
+                    {isCardanoStakedWithFiveBinaries(account) && (
+                        <Text typographyStyle="hint" variant="warning">
+                            <Translation id="TR_STAKING_REWARDS_REDUCED" />
+                        </Text>
+                    )}
+                </Column>
+            );
+
+        case 'tokens':
+            return <Translation id="TR_NAV_TOKENS" />;
+
+        default:
+            return null;
+    }
+};

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/AccountItemRightSide.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/AccountItemRightSide.tsx
@@ -1,0 +1,57 @@
+import { selectCardanoPoolsInfo } from '@suite-common/wallet-core';
+import { Account, BaseCurrencyAmount } from '@suite-common/wallet-types';
+import { isCardanoStakedWithEverstake } from '@suite-common/wallet-utils';
+import { Icon, Text } from '@trezor/components';
+
+import { useSelector } from 'src/hooks/suite';
+
+import { BaseCurrency } from './BaseCurrency';
+
+const ICON_SIZE = 16;
+
+type AccountItemRightSideProps = {
+    account: Account;
+    isCardanoStakingRow: boolean;
+    isFailed: boolean;
+    formattedBalance: string;
+    customFiatValue?: BaseCurrencyAmount;
+    isFiatLoading?: boolean;
+};
+
+export const AccountItemRightSide = ({
+    account,
+    isCardanoStakingRow,
+    isFailed,
+    formattedBalance,
+    customFiatValue,
+    isFiatLoading,
+}: AccountItemRightSideProps) => {
+    const cardanoStakingPools = useSelector(selectCardanoPoolsInfo);
+
+    if (isCardanoStakingRow) {
+        const isEverstake = isCardanoStakedWithEverstake(account, cardanoStakingPools);
+
+        return (
+            <Icon
+                name={isEverstake ? 'check' : 'warning'}
+                variant={isEverstake ? 'primary' : 'warning'}
+                size={ICON_SIZE}
+            />
+        );
+    }
+
+    if (isFailed) {
+        return <Icon name="warning" size={ICON_SIZE} variant="warning" />;
+    }
+
+    return (
+        <Text typographyStyle="hint" variant="tertiary">
+            <BaseCurrency
+                isLoading={isFiatLoading}
+                customFiatValue={customFiatValue}
+                symbol={account.symbol}
+                formattedBalance={formattedBalance}
+            />
+        </Text>
+    );
+};

--- a/packages/suite/src/components/wallet/WalletLayout/WalletLayout.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/WalletLayout.tsx
@@ -2,8 +2,7 @@ import { ReactNode } from 'react';
 
 import { TranslationKey, useTranslation } from '@suite/intl';
 import { Column, SkeletonRectangle } from '@trezor/components';
-import { spacings } from '@trezor/theme';
-import { PrimitiveType } from '@trezor/type-utils';
+import { PrimitiveType, exhaustive } from '@trezor/type-utils';
 
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
 import { useLayout } from 'src/hooks/suite';
@@ -23,10 +22,50 @@ type WalletPageHeaderProps = {
 const WalletPageHeader = ({ isSubpage }: WalletPageHeaderProps) => (
     <AccountHeaderProvider>
         <PageHeader />
-        {!isSubpage && <AccountTopPanel />}
-        {!isSubpage && <AccountNavigation />}
+        {!isSubpage && (
+            <>
+                <AccountTopPanel />
+                <AccountNavigation />
+            </>
+        )}
     </AccountHeaderProvider>
 );
+
+type WalletBodyProps = {
+    account: AppState['wallet']['selectedAccount'];
+    children?: ReactNode;
+};
+
+const WalletBody = ({ account, children }: WalletBodyProps) => {
+    const { status, account: selectedAccount, loader, network } = account;
+
+    switch (status) {
+        case 'loading': {
+            if (selectedAccount?.accountType === 'coinjoin') {
+                return <CoinjoinAccountDiscovery />;
+            }
+
+            return (
+                <SkeletonRectangle
+                    width="100%"
+                    height="300px"
+                    borderRadius="12px"
+                    animate={loader === 'account-loading'}
+                />
+            );
+        }
+
+        case 'exception':
+            return children ?? <AccountException loader={loader} network={network} />;
+
+        case 'loaded':
+        case 'none':
+            return children;
+
+        default:
+            return exhaustive(status);
+    }
+};
 
 type WalletLayoutProps = {
     title: TranslationKey;
@@ -48,42 +87,10 @@ export const WalletLayout = ({
 
     useLayout(l10nTitle, <WalletPageHeader isSubpage={isSubpage} />);
 
-    const { status, account: selectedAccount, loader, network } = account;
-
-    const getPageContent = () => {
-        if (status === 'loading') {
-            if (selectedAccount?.accountType === 'coinjoin') {
-                return (
-                    <>
-                        <AccountBanners account={selectedAccount} />
-                        <CoinjoinAccountDiscovery />
-                    </>
-                );
-            } else {
-                return (
-                    <>
-                        <SkeletonRectangle
-                            width="100%"
-                            height="300px"
-                            borderRadius="12px"
-                            animate={loader === 'account-loading'}
-                        />
-                    </>
-                );
-            }
-        } else {
-            return (
-                <>
-                    <AccountBanners account={selectedAccount} />
-                    {status === 'exception' ? (
-                        <AccountException loader={loader} network={network} />
-                    ) : (
-                        children
-                    )}
-                </>
-            );
-        }
-    };
-
-    return <Column gap={spacings.xxxl}>{getPageContent()}</Column>;
+    return (
+        <Column gap={40}>
+            <AccountBanners account={account.account} />
+            <WalletBody account={account}>{children}</WalletBody>
+        </Column>
+    );
 };

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -4,9 +4,10 @@ import styled from 'styled-components';
 
 import { Translation, TranslationKey } from '@suite/intl';
 import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
+import { selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex } from '@suite-common/wallet-core';
 import { getAccountTypeTech } from '@suite-common/wallet-utils';
 import { Button, Card, Column, InfoItem, Paragraph } from '@trezor/components';
-import { spacings, typography } from '@trezor/theme';
+import { typography } from '@trezor/theme';
 import {
     HELP_CENTER_BIP329_URL,
     HELP_CENTER_BIP32_URL,
@@ -47,25 +48,22 @@ const DetailsRow = ({ title, description, learnMoreUrl, children }: DetailsRowPr
     const isContentBelowBreakpoint = useIsContentBelowBreakpoint();
 
     return (
-        <ContentFlex gap={spacings.xxxl} justifyContent="space-between">
+        <ContentFlex gap={40} justifyContent="space-between">
             <InfoItem
                 label={<Translation id={title} />}
                 typographyStyle="body"
                 variant="default"
-                gap={spacings.xs}
+                gap={8}
                 maxWidth={500}
             >
-                <Column gap={spacings.sm}>
+                <Column gap={12}>
                     <Paragraph typographyStyle="hint" variant="tertiary">
                         {description}
                     </Paragraph>
                     {learnMoreUrl && <LearnMoreButton url={learnMoreUrl} />}
                 </Column>
             </InfoItem>
-            <Column
-                alignItems={isContentBelowBreakpoint ? 'flex-start' : 'flex-end'}
-                gap={spacings.xs}
-            >
+            <Column alignItems={isContentBelowBreakpoint ? 'flex-start' : 'flex-end'} gap={8}>
                 {children}
             </Column>
         </ContentFlex>
@@ -76,6 +74,15 @@ const Details = () => {
     const { device, isLocked } = useDevice();
     const { getDefaultAccountLabel } = useDefaultAccountLabel();
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const { params } = selectedAccount;
+    const fallbackAccount = useSelector(state =>
+        selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex(
+            state,
+            params?.symbol,
+            params?.accountType,
+            params?.accountIndex,
+        ),
+    );
     const isLocalFirstStorageEnabled = useSelector(selectIsSuiteSyncEnabled);
 
     const { isReceiveDisabled, ReceiveDisabledWrapper } = useReceiveDisabled();
@@ -85,13 +92,18 @@ const Details = () => {
 
     const dispatch = useDispatch();
 
-    if (!device || selectedAccount.status !== 'loaded') {
+    if (
+        !device ||
+        (selectedAccount.status !== 'loaded' && selectedAccount.status !== 'exception') ||
+        fallbackAccount == null
+    ) {
         return <WalletLayout title="TR_ACCOUNT_DETAILS_HEADER" account={selectedAccount} />;
     }
 
-    const { account } = selectedAccount;
+    const account = selectedAccount.account ?? fallbackAccount;
+
     const locked = isLocked(true);
-    const disabled = locked || isReceiveDisabled;
+    const disabled = locked || isReceiveDisabled || !selectedAccount.account;
 
     const accountTypeTech = getAccountTypeTech(account.path);
 
@@ -121,7 +133,7 @@ const Details = () => {
             )}
 
             <Card data-testid="@wallet/account-details">
-                <Column gap={spacings.xxxl} hasDivider>
+                <Column gap={40} hasDivider>
                     <DetailsRow
                         title="TR_ACCOUNT_DETAILS_TYPE_HEADER"
                         description={

--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -93,7 +93,7 @@ export const selectDeviceAccountsForNetworkSymbolAndAccountType = createMemoized
     },
 );
 
-export const selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex = createMemoizedSelector(
+export const selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex = createMemoizedSelector(
     [
         selectDeviceAccountsForNetworkSymbolAndAccountType,
         (
@@ -106,8 +106,13 @@ export const selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex = cre
     (accounts, accountIndex) => {
         if (accountIndex === undefined || accountIndex < 0) return undefined;
 
-        return accounts[accountIndex]?.key;
+        return accounts[accountIndex];
     },
+);
+
+export const selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex = createMemoizedSelector(
+    [selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex],
+    account => account?.key,
 );
 
 export const selectDeviceMainnetAccounts = createMemoizedSelector(


### PR DESCRIPTION
## Description

When an account ends in a _discovery error_, it is now still possible to open **Details** and access account-specific information.

Additionally:
- The page header is fixed – instead of showing *Dashboard*, it now correctly displays the **account name**
- In the sidebar, accounts with a discovery error no longer display a balance and are marked with a **warning icon**
- Components related to **WalletLayout** were refactored to improve readability and maintainability

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17353

## Screenshots:

<img width="1430" height="1125" alt="image" src="https://github.com/user-attachments/assets/ec365b6d-3415-4b23-a495-ad34dbf96d9d" />

<img width="1439" height="786" alt="image" src="https://github.com/user-attachments/assets/7dfcdfaa-231e-4780-b1d2-1f8eb004c516" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/account-details-discovery-error&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/account-details-discovery-error&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/account-details-discovery-error&lookback=7)