### PR TITLE
Stabilize useAddressValidationAlerts unit tests

### DIFF
--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/__tests__/useAddressValidationAlerts.test.tsx
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/__tests__/useAddressValidationAlerts.test.tsx
@@ -2,7 +2,12 @@ import { useRoute } from '@react-navigation/native';
 
 import { useAlert } from '@suite-native/alerts';
 import { Form } from '@suite-native/forms';
-import { PreloadedState, act, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import {
+    PreloadedState,
+    act,
+    renderHookWithStoreProviderAsync,
+    waitFor,
+} from '@suite-native/test-utils';
 import TrezorConnect from '@trezor/connect';
 
 import { useAddressValidationAlerts } from '../useAddressValidationAlerts';
@@ -182,7 +187,7 @@ describe('useAddressValidationAlerts', () => {
                 contractAddressChecksum,
                 { shouldValidate: true },
             );
-            expect(result.current.wasAddressChecksummed).toBe(true);
+            await waitFor(() => expect(result.current.wasAddressChecksummed).toBe(true));
             expect(mockShowAlert).not.toHaveBeenCalled();
         });
 
@@ -203,7 +208,7 @@ describe('useAddressValidationAlerts', () => {
                 contractAddressChecksum,
                 { shouldValidate: true },
             );
-            expect(result.current.wasAddressChecksummed).toBe(true);
+            await waitFor(() => expect(result.current.wasAddressChecksummed).toBe(true));
         });
 
         it('should not show checksum alert for valid checksum addresses', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Try to stabilize unstable unit test for useAddressValidationAlerts as mentioned in [table](https://docs.google.com/spreadsheets/d/1XePlzOKdq1RihBsvhDrj_bIMosy4L0I17yhkRFI3KCg/edit?gid=0#gid=0)

<!--- Describe your changes in detail -->

## Notes for QA

No production changes

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=useAddressValidationAlerts-test-stabilization&lookback=7)