### PR TITLE
fix(suite: e2e): remove emulatorStartConf

### DIFF
--- a/suite/e2e/tests/general/check-links.test.ts
+++ b/suite/e2e/tests/general/check-links.test.ts
@@ -78,9 +78,7 @@ async function fetchWithRetry(page: Page, url: string, maxRetries = 3) {
     return response;
 }
 
-test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@T3W1', '@T3T1'] }, () => {
-    test.use({ emulatorStartConf: { model: 'T3T1', wipe: true } });
-
+test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@T3T1'] }, () => {
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
     });


### PR DESCRIPTION
## Description

Fix failing test general/check-links.test.ts by removing emulatorStartConf, which is no longer necessary. There is no need to define the model in test.use, as models are now defined using tags

https://app.currents.dev/instance/uqptuPwH97H53pil/test/647112395de41d718228-e8c626befdf5a8572e39

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/test-check-links&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/test-check-links&lookback=7)