### PR TITLE
chore(suite-common): import connect in suite-constants via exports

### DIFF
--- a/suite-common/suite-constants/src/units.ts
+++ b/suite-common/suite-constants/src/units.ts
@@ -1,4 +1,4 @@
-import { PROTO } from '@trezor/connect';
+import { PROTO } from '@trezor/connect/src/exports';
 
 export const UNIT_ABBREVIATIONS = {
     [PROTO.AmountUnit.BITCOIN]: 'BTC',


### PR DESCRIPTION
onel ittle step to avoid pulling entire connect everywhere through components... https://github.com/trezor/trezor-suite/actions/runs/20965792809/job/60255724400?pr=23829#step:3:400

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-import-via-exports&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-import-via-exports&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-import-via-exports&lookback=7)