### PR TITLE
Enable nonce in style-src directice

### DIFF
--- a/packages/suite-desktop-core/src/modules/csp.ts
+++ b/packages/suite-desktop-core/src/modules/csp.ts
@@ -12,12 +12,11 @@ type CreateCspRulesParams = {
     nonce: string;
 };
 
-// eslint-disable-next-line no-empty-pattern
-const createCspRules = ({}: CreateCspRulesParams) => [
+const createCspRules = ({ nonce }: CreateCspRulesParams) => [
     // Default to only own resources
     "default-src 'self'",
     "script-src 'self'",
-    `style-src 'self' 'unsafe-inline'`,
+    `style-src 'self' 'nonce-${nonce}'`,
     // Allow all API calls (Can't be restricted bc of custom backends)
     'connect-src data: *',
     // Allow images from trezor.io


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Enable nonce in style-src directice in Suite desktop.
- It had been disabled as a hotfix to #23267. However, it works now just fine without any issue.
- I checked the desktop app and found no related error. 

## Related Issue

Resolve #23267


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/23267-csp-desktop-style-directive&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/23267-csp-desktop-style-directive&lookback=7)