### PR TITLE
chore: document node version 24 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "repository": "https://github.com/trezor/trezor-suite.git",
     "license": "SEE LICENSE IN LICENSE.md",
     "engines": {
-        "node": "22",
+        "node": "24",
         "yarn": ">=4"
     },
     "workspaces": {


### PR DESCRIPTION
## Description

This value is just FYI only; forgotten in 1e187587

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/document-node24-in-package.json&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/document-node24-in-package.json&lookback=7)