### PR TITLE
fix(common): expect correct proof after quota sizes change

### DIFF
--- a/suite-common/suite-sync-quota-manager/src/tests/ensureDeviceHasQuotaThunk.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/tests/ensureDeviceHasQuotaThunk.test.ts
@@ -166,7 +166,7 @@ describe(ensureDeviceHasQuotaThunk.name, () => {
             challenge_from_server: 'aa55',
             size_to_acquire: DEFAULT_DEVICE_SIZE_QUOTA,
             proof_of_delegated_identity:
-                'a526cae01826e660a9a2580ccbeb008c768cea6039f3a00f894b8c9a619bbdc21caa7acb1e7648e6af3174dfb4df84e04862f88f9188a215882694fb447ce937',
+                '9d40167d8ec7ce7949f1675d60a4d5c2a6ec5f16152bdc6c7959af99c856d31570c0d262996917cf424a3e638a7ee10b57aa2864c06895b0728d09f040496177',
         });
         expect(registerStorageThunkMock).toHaveBeenCalledWith({
             size: DEFAULT_DEVICE_SIZE_QUOTA,

--- a/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
@@ -142,7 +142,7 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
                 ownerId,
                 publicKey:
                     '0428a3cefc19b41ff56795e371aab72d6d85a3ca2200bd46c54e611a36222295a88b44d6f23ce94025b6010f9eb0f9168ad35d8396dc865fa0a16f2f5471816a45',
-                proof: '3fe8d55f5dfdc54133027c3a94903ab4e038353dc08ec4d324c7fd5eda74def911249c2bf1929313a223ce4fa50140fb6c717b46f123c901a5df39afbe7f2bb7',
+                proof: '106fb51f7945d6bd6fac019eb7953f43400746884f1e4f69c3cbfe13ec6539604039baa2c6b5ada1e395957908fe9777991910d4bee05c124161597cef814e3e',
                 size: DEFAULT_ACCOUNT_SIZE_QUOTA,
                 challenge: 'aa55',
                 sessionId: 'session-123',


### PR DESCRIPTION
expect correct proof after change in https://github.com/trezor/trezor-suite/pull/24386

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/qm-test&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/qm-test&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/qm-test&lookback=7)