### PR TITLE
fix(suite-desktop): possibly unhandled promise rejection in tor

### DIFF
--- a/packages/suite-desktop-core/src/libs/processes/TorProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/TorProcess.ts
@@ -52,6 +52,6 @@ export class TorProcess extends BaseProcess {
 
         await super.start(torConfiguration);
 
-        return this.torController.waitUntilAlive();
+        return await this.torController.waitUntilAlive();
     }
 }


### PR DESCRIPTION
## Description

Hopeful fix for [Sentry error](https://satoshilabs.sentry.io/issues/6226654433/?project=5193825).

This ["Tor not alive" error](https://github.com/trezor/trezor-suite/blob/afc495c9c5210198ecbec7cd349422b25083d5a9/packages/request-manager/src/controller.ts#L167) should be caught, but it is somehow propagated, even in 25.12.1, and it's very spammy. I have inspected the whole code around it and found no reason why it should be unhandled, except this: `waitUntilAlive` returns `Promise<void>`, where `scheduleAction` is running, which may eventually reject. That should be awaited, so that [the reject is caught here](https://github.com/trezor/trezor-suite/blob/82bd29126f571685fb6a3127b3d7150383649ba0/packages/suite-desktop-core/src/modules/tor.ts#L180-L187), so we don't it reject async into the air sometime whenever ???

This is correct in [TorExternalProcess](https://github.com/trezor/trezor-suite/blob/586bc925cc92a7c371030dc374a9a391e9e7971e/packages/suite-desktop-core/src/libs/processes/TorExternalProcess.ts#L39)

I did not reproduce a Sentry capture though, so it's just a theory :confused: 

## Notes for QA

- Test turning on/off Tor
- Test starting suite with Tor=on (setting persisted from last time)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sentry-tor&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sentry-tor&lookback=7)