### PR TITLE
refactor(components): update Banner component to use description and …

### DIFF
--- a/.github/workflows/test-suite-web-e2e-nightly.yml
+++ b/.github/workflows/test-suite-web-e2e-nightly.yml
@@ -68,7 +68,6 @@ jobs:
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
           enable-coverage: "true"
 
-
   run-e2e-suite-web-tests-fw-canary:
     if: ${{ github.repository == 'trezor/trezor-suite' && always() && !cancelled() }} # make sure this job runs even if others fail
     runs-on: ubuntu-latest

--- a/packages/components/src/components/Banner/Banner.stories.tsx
+++ b/packages/components/src/components/Banner/Banner.stories.tsx
@@ -13,7 +13,8 @@ export default meta;
 
 export const Banner: StoryObj<typeof meta> = {
     args: {
-        children:
+        title: 'Lorem ipsum',
+        description:
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
         isLoading: false,
         intent: undefined,
@@ -22,6 +23,12 @@ export const Banner: StoryObj<typeof meta> = {
         ...getFramePropsStory(allowedBannerFrameProps).args,
     },
     argTypes: {
+        title: {
+            control: 'text',
+        },
+        description: {
+            control: 'text',
+        },
         icon: {
             options: [undefined, true, ...variables.ICONS],
             control: {

--- a/packages/components/src/components/Banner/Banner.tsx
+++ b/packages/components/src/components/Banner/Banner.tsx
@@ -18,7 +18,8 @@ import { Box } from '../Box/Box';
 import { Column, Row } from '../Flex/Flex';
 import { Icon, IconName } from '../Icon/Icon';
 import { Spinner } from '../loaders/Spinner/Spinner';
-import { Text } from '../typography/Text/Text';
+import { H4 } from '../typography/Heading/Heading';
+import { Paragraph } from '../typography/Paragraph/Paragraph';
 
 export const allowedBannerFrameProps = [
     'margin',
@@ -29,16 +30,16 @@ export const allowedBannerFrameProps = [
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedBannerFrameProps)[number]>;
 
 export type BannerProps = AllowedFrameProps & {
-    children: ReactNode;
     intent?: BannerIntent;
     rightContent?: ReactNode;
     icon?: IconName | true;
     'data-testid'?: string;
     isLoading?: boolean;
-};
+} & ({ title: ReactNode; description?: ReactNode } | { title?: ReactNode; description: ReactNode });
 
 export const Banner = ({
-    children,
+    title,
+    description,
     intent = DEFAULT_INTENT,
     icon,
     rightContent,
@@ -72,14 +73,20 @@ export const Banner = ({
                 )}
 
                 <Row flex="1" flexWrap="wrap" gap={12}>
-                    <Column flex="1 1 300px" maxWidth="100%">
-                        <Text
-                            as="div"
-                            typographyStyle="hint"
-                            color={mapIntentToTextColor(intent, theme)}
-                        >
-                            {children}
-                        </Text>
+                    <Column flex="1 1 360px" maxWidth="100%">
+                        {title && (
+                            <H4 typographyStyle="body" color={mapIntentToTextColor(intent, theme)}>
+                                {title}
+                            </H4>
+                        )}
+                        {description && (
+                            <Paragraph
+                                typographyStyle="hint"
+                                color={mapIntentToTextColor(intent, theme)}
+                            >
+                                {description}
+                            </Paragraph>
+                        )}
                     </Column>
                     {rightContent && (
                         <BannerContext.Provider value={{ intent }}>

--- a/packages/suite/src/components/connection/BluetoothAdapterStatusModal.tsx
+++ b/packages/suite/src/components/connection/BluetoothAdapterStatusModal.tsx
@@ -82,9 +82,11 @@ export const BluetoothAdapterStatusModal = ({ onCancel }: BluetoothAdapterStatus
             }
         >
             {hasDeeplinkFailed && status.deeplinkFailed ? (
-                <Banner intent="warning" icon>
-                    <Translation id={status.deeplinkFailed} />
-                </Banner>
+                <Banner
+                    intent="warning"
+                    icon
+                    description={<Translation id={status.deeplinkFailed} />}
+                />
             ) : (
                 <Paragraph>
                     <Translation id={status.description}></Translation>

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -62,29 +62,33 @@ export const FirmwareInitial = () => {
 
     return (
         <Column gap={16}>
-            <Banner intent="info" icon="info">
-                <Translation
-                    id={getDescription({
-                        /**
-                         * `device.firmware` is status of the firmware currently installed on the device.
-                         *  available values: 'valid' | 'outdated' | 'required' | 'unknown' | 'none'
-                         *
-                         *  `device.firmwareReleaseConfigInfo` on the other hand contains latest available firmware to update to
-                         *   (it is whatever returns getInfo() method from connect)
-                         *   so it should not be used here.
-                         */
-                        required: device.firmware === 'required',
-                        reinstall: device.firmware === 'valid' || hasLatestAvailableFw,
-                        targetType: targetFirmwareType,
-                        switchFirmwareType,
-                        isBitcoinOnlyAvailable,
-                    })}
-                    values={{
-                        bitcoinOnly: <Translation id="TR_FIRMWARE_TYPE_BITCOIN_ONLY" />,
-                        regular: <Translation id="TR_FIRMWARE_TYPE_REGULAR" />,
-                    }}
-                />
-            </Banner>
+            <Banner
+                intent="info"
+                icon="info"
+                description={
+                    <Translation
+                        id={getDescription({
+                            /**
+                             * `device.firmware` is status of the firmware currently installed on the device.
+                             *  available values: 'valid' | 'outdated' | 'required' | 'unknown' | 'none'
+                             *
+                             *  `device.firmwareReleaseConfigInfo` on the other hand contains latest available firmware to update to
+                             *   (it is whatever returns getInfo() method from connect)
+                             *   so it should not be used here.
+                             */
+                            required: device.firmware === 'required',
+                            reinstall: device.firmware === 'valid' || hasLatestAvailableFw,
+                            targetType: targetFirmwareType,
+                            switchFirmwareType,
+                            isBitcoinOnlyAvailable,
+                        })}
+                        values={{
+                            bitcoinOnly: <Translation id="TR_FIRMWARE_TYPE_BITCOIN_ONLY" />,
+                            regular: <Translation id="TR_FIRMWARE_TYPE_REGULAR" />,
+                        }}
+                    />
+                }
+            />
             {deviceWillBeWiped && <FirmwareWipeWarning />}
             <Card>
                 <FirmwareOffer targetFirmwareType={targetFirmwareType} />

--- a/packages/suite/src/components/firmware/FirmwareInstallation.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallation.tsx
@@ -65,14 +65,15 @@ export const FirmwareInstallation = ({
                                 <Translation id="TR_SELECT_TREZOR" />
                             </Banner.Button>
                         }
-                    >
-                        <Translation id="TR_SELECT_TREZOR_TO_CONTINUE" />
-                    </Banner>
+                        description={<Translation id="TR_SELECT_TREZOR_TO_CONTINUE" />}
+                    />
                 )}
                 {displayIsSlow && (
-                    <Banner intent="info" icon="bluetooth">
-                        <Translation id="TR_INSTALLATION_FW_SLOW_TIP_BANNER" />
-                    </Banner>
+                    <Banner
+                        intent="info"
+                        icon="bluetooth"
+                        description={<Translation id="TR_INSTALLATION_FW_SLOW_TIP_BANNER" />}
+                    />
                 )}
                 <Card>
                     <Column gap={8}>

--- a/packages/suite/src/components/firmware/FirmwareWipeWarning.tsx
+++ b/packages/suite/src/components/firmware/FirmwareWipeWarning.tsx
@@ -9,11 +9,21 @@ export const FirmwareWipeWarning = () => {
     };
 
     return (
-        <Banner intent="critical" icon="warning">
-            <Paragraph>
-                <Translation id="TR_FIRMWARE_SWITCH_WARNING_1" values={warningTranslationValues} />{' '}
-                <Translation id="TR_FIRMWARE_SWITCH_WARNING_2" values={warningTranslationValues} />
-            </Paragraph>
-        </Banner>
+        <Banner
+            intent="critical"
+            icon="warning"
+            description={
+                <Paragraph>
+                    <Translation
+                        id="TR_FIRMWARE_SWITCH_WARNING_1"
+                        values={warningTranslationValues}
+                    />{' '}
+                    <Translation
+                        id="TR_FIRMWARE_SWITCH_WARNING_2"
+                        values={warningTranslationValues}
+                    />
+                </Paragraph>
+            }
+        />
     );
 };

--- a/packages/suite/src/components/guide/GuideHint.tsx
+++ b/packages/suite/src/components/guide/GuideHint.tsx
@@ -6,32 +6,7 @@ import {
     isValidElement,
 } from 'react';
 
-import styled from 'styled-components';
-
 import { Banner } from '@trezor/components';
-import { typography } from '@trezor/theme';
-
-// eslint-disable-next-line local-rules/no-override-ds-component
-const StyledBanner = styled(Banner)`
-    background: ${({ theme }) => theme.backgroundSurfaceElevation1};
-    color: ${({ theme }) => theme.textDefault};
-    gap: 10px;
-    padding: 10px;
-
-    &:not(:last-child) {
-        margin-bottom: 16px;
-    }
-
-    a {
-        display: inline; /* Allow linebreaks inside links as the space is quite narrow. */
-        ${typography.hint}
-    }
-
-    /* Provide a more specific selector to override paragraph style on parent. */
-    p:last-child {
-        margin: 0;
-    }
-`;
 
 const BULB_EMOJI = '💡';
 const WARNING_EMOJI = '⚠️';
@@ -76,9 +51,5 @@ export const GuideHint = ({ children }: BlockquoteHTMLAttributes<HTMLQuoteElemen
         return child;
     });
 
-    return (
-        <StyledBanner icon intent={intent}>
-            {clonedChildren}
-        </StyledBanner>
-    );
+    return <Banner icon intent={intent} description={clonedChildren} />;
 };

--- a/packages/suite/src/components/settings/DeviceBanner.tsx
+++ b/packages/suite/src/components/settings/DeviceBanner.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 
 import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
-import { Banner, Column, H4, Paragraph } from '@trezor/components';
+import { Banner } from '@trezor/components';
 import { mapTrezorModelToIcon } from '@trezor/product-components';
 
 import { WebUsbButton } from 'src/components/suite/WebUsbButton';
@@ -27,6 +27,8 @@ export const DeviceBanner = ({ title, description }: DeviceBannerProps) => {
             data-testid="@settings/device/disconnected-device-banner"
             intent="warning"
             icon={mapTrezorModelToIcon[selectedDeviceModelInternal]}
+            title={title}
+            description={description}
             rightContent={
                 <>
                     {deviceConnectedButNotAcquired && <AcquireDeviceButton />}
@@ -35,11 +37,6 @@ export const DeviceBanner = ({ title, description }: DeviceBannerProps) => {
                     )}
                 </>
             }
-        >
-            <Column>
-                <H4>{title}</H4>
-                {description && <Paragraph>{description}</Paragraph>}
-            </Column>
-        </Banner>
+        />
     );
 };

--- a/packages/suite/src/components/suite/Address.tsx
+++ b/packages/suite/src/components/suite/Address.tsx
@@ -32,7 +32,7 @@ const mapDeviceModelToFontStyle = (deviceModelInternal: DeviceModelInternal): Ru
     }
 };
 
-const AddressWrapper = styled.span<{ $device?: DeviceModelInternal; $isChunked: boolean }>`
+const AddressWrapper = styled.p<{ $device?: DeviceModelInternal; $isChunked: boolean }>`
     letter-spacing: 0;
     word-break: ${({ $isChunked }) => ($isChunked ? 'normal' : 'break-all')};
     white-space: ${({ $isChunked }) => ($isChunked ? 'pre-line' : 'break-all')};

--- a/packages/suite/src/components/suite/PinMatrix/PinMatrix.tsx
+++ b/packages/suite/src/components/suite/PinMatrix/PinMatrix.tsx
@@ -121,11 +121,12 @@ export const PinMatrix = ({
                             <Translation id="TR_LEARN_MORE" />
                         </Banner.Button>
                     }
-                >
-                    <Paragraph typographyStyle="hint">
-                        <Translation id="TR_MAXIMUM_PIN_LENGTH" />
-                    </Paragraph>
-                </Banner>
+                    description={
+                        <Paragraph typographyStyle="hint">
+                            <Translation id="TR_MAXIMUM_PIN_LENGTH" />
+                        </Paragraph>
+                    }
+                />
             )}
             <Card label={showLabel ? <Translation id="TR_ENTER_PIN" /> : undefined}>
                 <Column gap={40} padding={16} data-testid="@pin" alignItems="center">

--- a/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
+++ b/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
@@ -148,9 +148,13 @@ export const TorLoader = ({ callback }: TorLoadingScreenProps) => {
                     </Row>
                 </Card>
                 {!!torBootstrap?.isSlow && (
-                    <Banner intent="info" icon="clockClockwise">
-                        <Translation id="TR_TOR_IS_SLOW_MESSAGE" values={{ br: () => ' ' }} />
-                    </Banner>
+                    <Banner
+                        intent="info"
+                        icon="clockClockwise"
+                        description={
+                            <Translation id="TR_TOR_IS_SLOW_MESSAGE" values={{ br: () => ' ' }} />
+                        }
+                    />
                 )}
             </Column>
         </Modal>

--- a/packages/suite/src/components/suite/WordInputAdvanced.tsx
+++ b/packages/suite/src/components/suite/WordInputAdvanced.tsx
@@ -104,11 +104,12 @@ export const WordInputAdvanced = ({ count }: WordInputAdvancedProps) => {
                         <Translation id="TR_LEARN_MORE" />
                     </Banner.Button>
                 }
-            >
-                <Paragraph typographyStyle="label">
-                    <Translation id="TR_ADVANCED_RECOVERY_NOT_SURE" />
-                </Paragraph>
-            </Banner>
+                description={
+                    <Paragraph typographyStyle="label">
+                        <Translation id="TR_ADVANCED_RECOVERY_NOT_SURE" />
+                    </Paragraph>
+                }
+            />
             <Card paddingType="none">
                 <Column gap={40} padding={16} alignItems="center">
                     <Grid columns={count === 9 ? 3 : 2} gap={20}>

--- a/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
+++ b/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
@@ -51,8 +51,7 @@ export const MessageSystemBanner = ({ message, margin, width }: MessageSystemBan
             }
             margin={margin}
             width={width}
-        >
-            {resolveMessageContent(content, language) || content.en}
-        </Banner>
+            description={resolveMessageContent(content, language) || content.en}
+        />
     );
 };

--- a/packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.tsx
@@ -19,8 +19,7 @@ export const BridgeDeprecated = () => {
                     <Translation id="TR_LEARN_MORE" />
                 </Banner.Button>
             }
-        >
-            <Translation id="TR_STANDALONE_BRIDGE_DEPRECATED" />
-        </Banner>
+            description={<Translation id="TR_STANDALONE_BRIDGE_DEPRECATED" />}
+        />
     );
 };

--- a/packages/suite/src/components/suite/banners/SuiteBanners/CardanoOutdatedStakingBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/CardanoOutdatedStakingBanner.tsx
@@ -33,8 +33,7 @@ export const CardanoOutdatedStakingBanner = () => {
                     <Translation id="TR_STAKING_MODAL_OUTDATED_BUTTON" />
                 </Banner.Button>
             }
-        >
-            <Translation id="TR_STAKING_MODAL_OUTDATED" values={{ apy }} />
-        </Banner>
+            description={<Translation id="TR_STAKING_MODAL_OUTDATED" values={{ apy }} />}
+        />
     );
 };

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FailedBackupBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FailedBackupBanner.tsx
@@ -31,9 +31,8 @@ export const FailedBackup = () => {
                         <Translation id={buttonTranslation} />
                     </Banner.Button>
                 }
-            >
-                <Translation id="TR_FAILED_BACKUP" />
-            </Banner>
+                description={<Translation id="TR_FAILED_BACKUP" />}
+            />
         </>
     );
 };

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
@@ -80,8 +80,7 @@ export const FirmwareAuthenticityCheckBanner = () => {
                     </Banner.Button>
                 )
             }
-        >
-            <Translation id={message} />
-        </Banner>
+            description={<Translation id={message} />}
+        />
     );
 };

--- a/packages/suite/src/components/suite/banners/SuiteBanners/LocalNetworkAccessPermission.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/LocalNetworkAccessPermission.tsx
@@ -10,7 +10,9 @@ import { Translation } from '../../Translation';
  * 3] have webusb disabled in debug settings or be using Firefox browser.
  */
 export const LocalNetworkAccessPermission = () => (
-    <Banner icon intent="info">
-        <Translation id="TR_LOCAL_NETWORK_ACCESS_PERMISSION_WARNING" />
-    </Banner>
+    <Banner
+        icon
+        intent="info"
+        description={<Translation id="TR_LOCAL_NETWORK_ACCESS_PERMISSION_WARNING" />}
+    />
 );

--- a/packages/suite/src/components/suite/banners/SuiteBanners/NoBackupBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/NoBackupBanner.tsx
@@ -24,8 +24,7 @@ export const NoBackup = () => {
                     <Translation id="TR_CREATE_BACKUP" />
                 </Banner.Button>
             }
-        >
-            {translation}
-        </Banner>
+            description={translation}
+        />
     );
 };

--- a/packages/suite/src/components/suite/banners/SuiteBanners/NoConnectionBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/NoConnectionBanner.tsx
@@ -3,7 +3,9 @@ import { Banner } from '@trezor/components';
 import { Translation } from 'src/components/suite/Translation';
 
 export const NoConnectionBanner = () => (
-    <Banner icon intent="critical">
-        <Translation id="TR_YOU_WERE_DISCONNECTED_DOT" />
-    </Banner>
+    <Banner
+        icon
+        intent="critical"
+        description={<Translation id="TR_YOU_WERE_DISCONNECTED_DOT" />}
+    />
 );

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx
@@ -41,8 +41,7 @@ export const SafetyChecksBanner = ({ onDismiss }: SafetyChecksBannerProps) => {
                     )}
                 </>
             }
-        >
-            <Translation id="TR_SAFETY_CHECKS_DISABLED_WARNING" />
-        </Banner>
+            description={<Translation id="TR_SAFETY_CHECKS_DISABLED_WARNING" />}
+        />
     );
 };

--- a/packages/suite/src/components/suite/bluetooth/BluetoothSelectedDevice.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothSelectedDevice.tsx
@@ -5,9 +5,9 @@ import { Banner, Card, Row } from '@trezor/components';
 
 import { BluetoothDeviceComponent } from './BluetoothDeviceComponent';
 import { BluetoothTips } from './BluetoothTips';
+import { PairingState } from './PairingState';
 import { DesktopBluetoothDevice } from '../../../actions/bluetooth/DesktopBluetoothDevice';
 import { Translation } from '../Translation';
-import { PairingState } from './PairingState';
 
 export type OkComponentProps = {
     device: DesktopBluetoothDevice;
@@ -71,9 +71,12 @@ export const BluetoothSelectedDevice = ({
         <Card>
             <OkComponent device={device} />
             {showHint && (
-                <Banner intent="info" icon="info" margin={{ top: 16 }}>
-                    <Translation id="TR_CONFIRM_BLUETOOTH_PAIRING" />
-                </Banner>
+                <Banner
+                    intent="info"
+                    icon="info"
+                    margin={{ top: 16 }}
+                    description={<Translation id="TR_CONFIRM_BLUETOOTH_PAIRING" />}
+                />
             )}
         </Card>
     );

--- a/packages/suite/src/components/suite/bluetooth/UnpairBluetoothDeviceFromOsModal.tsx
+++ b/packages/suite/src/components/suite/bluetooth/UnpairBluetoothDeviceFromOsModal.tsx
@@ -75,9 +75,10 @@ export const UnpairBluetoothDeviceFromOsModal = ({
                 <Translation id="TR_BLUETOOTH_REMOVE_FROM_BLUETOOTH_SETTINGS_DESCRIPTION" />
             </Paragraph>
             {hasDeeplinkFailed && (
-                <Banner intent="warning">
-                    <Translation id="TR_BLUETOOTH_CANNOT_OPEN_BLUETOOTH_SETTINGS" />
-                </Banner>
+                <Banner
+                    intent="warning"
+                    description={<Translation id="TR_BLUETOOTH_CANNOT_OPEN_BLUETOOTH_SETTINGS" />}
+                />
             )}
         </Modal>
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -151,28 +151,40 @@ export const ConfirmValueModal = ({
             >
                 <Column gap={spacings.md}>
                     {!device?.connected && (
-                        <Banner icon="warning" intent="warning">
-                            <Paragraph typographyStyle="hint">
-                                <Translation
-                                    id="TR_DEVICE_LABEL_IS_NOT_CONNECTED"
-                                    values={{ deviceLabel }}
-                                />
-                            </Paragraph>
-                            <Paragraph typographyStyle="label">
-                                <Translation id="TR_PLEASE_CONNECT_YOUR_DEVICE" />
-                            </Paragraph>
-                        </Banner>
+                        <Banner
+                            icon="warning"
+                            intent="warning"
+                            description={
+                                <>
+                                    <Paragraph typographyStyle="hint">
+                                        <Translation
+                                            id="TR_DEVICE_LABEL_IS_NOT_CONNECTED"
+                                            values={{ deviceLabel }}
+                                        />
+                                    </Paragraph>
+                                    <Paragraph typographyStyle="label">
+                                        <Translation id="TR_PLEASE_CONNECT_YOUR_DEVICE" />
+                                    </Paragraph>
+                                </>
+                            }
+                        />
                     )}
                     {(account?.networkType === 'ripple' || account?.networkType === 'stellar') && (
-                        <Banner intent="info" icon="info">
-                            <Translation
-                                id="DESTINATION_TAG_BANNER_RECEIVE"
-                                values={{
-                                    a: chunks => <Link onClick={handleOpenGuide}>{chunks}</Link>,
-                                    displaySymbol: getDisplaySymbol(account.symbol),
-                                }}
-                            />
-                        </Banner>
+                        <Banner
+                            intent="info"
+                            icon="info"
+                            description={
+                                <Translation
+                                    id="DESTINATION_TAG_BANNER_RECEIVE"
+                                    values={{
+                                        a: chunks => (
+                                            <Link onClick={handleOpenGuide}>{chunks}</Link>
+                                        ),
+                                        displaySymbol: getDisplaySymbol(account.symbol),
+                                    }}
+                                />
+                            }
+                        />
                     )}
                     <Card fillType="flat" paddingType="large">
                         <Row gap={32} alignItems="stretch" data-testid="@modal/output-address">

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletBestPractices.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletBestPractices.tsx
@@ -43,11 +43,14 @@ const PassphraseWalletBestPracticesContent = ({
                 </List.Item>
             </List>
         </Column>
-        <Banner margin={{ top: spacings.sm }}>
-            <Text variant="warning" typographyStyle="callout">
-                <Translation id="TR_PASSPHRASE_WALLET_CONFIRMATION_STEP2_WARNING" />
-            </Text>
-        </Banner>
+        <Banner
+            margin={{ top: spacings.sm }}
+            description={
+                <Text variant="warning" typographyStyle="callout">
+                    <Translation id="TR_PASSPHRASE_WALLET_CONFIRMATION_STEP2_WARNING" />
+                </Text>
+            }
+        />
         <Button width="100%" onClick={onNext} data-testid="@passphrase-confirmation/step2-button">
             <Translation id="TR_PASSPHRASE_WALLET_CONFIRMATION_STEP2_BUTTON" />
         </Button>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmation.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmation.tsx
@@ -36,9 +36,12 @@ export const PassphraseWalletConfirmation = ({
                     <H3>
                         <Translation id="TR_PASSPHRASE_WALLET_CONFIRMATION_STEP3_TITLE" />
                     </H3>
-                    <Banner icon="info">
-                        <Translation id="TR_PASSPHRASE_WALLET_CONFIRMATION_STEP3_WARNING" />
-                    </Banner>
+                    <Banner
+                        icon="info"
+                        description={
+                            <Translation id="TR_PASSPHRASE_WALLET_CONFIRMATION_STEP3_WARNING" />
+                        }
+                    />
                     <PassphraseInputCard
                         deviceModel={deviceModel ?? undefined}
                         onSubmit={onSubmit}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputTimer.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputTimer.tsx
@@ -67,18 +67,19 @@ export const TransactionReviewOutputTimer = ({
                     <Translation id="TR_RETRY" />
                 </Banner.Button>
             }
-        >
-            <TimerBox>
-                <Text typographyStyle="callout" as="div">
-                    <CountdownTimer
-                        deadline={deadline}
-                        unitDisplay="long"
-                        message="TR_TX_CONFIRMATION_TIMER"
-                        pastDeadlineMessage="TR_TX_SEND_FAILED_TITLE"
-                    />
-                </Text>
-                <Translation id="TR_SOLANA_TX_CONFIRMATION_TIMER_DESCRIPTION" />
-            </TimerBox>
-        </Banner>
+            description={
+                <TimerBox>
+                    <Text typographyStyle="callout" as="div">
+                        <CountdownTimer
+                            deadline={deadline}
+                            unitDisplay="long"
+                            message="TR_TX_CONFIRMATION_TIMER"
+                            pastDeadlineMessage="TR_TX_SEND_FAILED_TITLE"
+                        />
+                    </Text>
+                    <Translation id="TR_SOLANA_TX_CONFIRMATION_TIMER_DESCRIPTION" />
+                </TimerBox>
+            }
+        />
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
@@ -130,9 +130,10 @@ export const AdvancedCoinSettingsModal = ({ symbol, onCancel }: AdvancedCoinSett
                 </Card>
 
                 {backendsForm.validationError && (
-                    <Banner intent="critical">
-                        <Text>{backendsForm.validationError}</Text>
-                    </Banner>
+                    <Banner
+                        intent="critical"
+                        description={<Text>{backendsForm.validationError}</Text>}
+                    />
                 )}
 
                 <CollapsibleBox

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -185,9 +185,10 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
                                         data-testid="@modal/claim/fee-warning-banner"
                                         intent="warning"
                                         icon="warning"
-                                    >
-                                        <Translation id="TR_STAKING_REWARDS_NETWORK_FEE_WARNING" />
-                                    </Banner>
+                                        description={
+                                            <Translation id="TR_STAKING_REWARDS_NETWORK_FEE_WARNING" />
+                                        }
+                                    />
                                 )}
 
                                 <Card>
@@ -284,7 +285,7 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
                         )}
 
                         {errors[CRYPTO_INPUT] && (
-                            <Banner intent="critical">{errors[CRYPTO_INPUT]?.message}</Banner>
+                            <Banner intent="critical" description={errors[CRYPTO_INPUT]?.message} />
                         )}
                     </Column>
                 </form>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/CriticalCoinjoinPhaseModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/CriticalCoinjoinPhaseModal.tsx
@@ -40,9 +40,11 @@ export const CriticalCoinjoinPhaseModal = ({
             }
         >
             <Column gap={spacings.md} margin={{ top: spacings.xs }}>
-                <Banner intent="warning" icon="warning">
-                    <Translation id="TR_DO_NOT_DISCONNECT_DEVICE" />
-                </Banner>
+                <Banner
+                    intent="warning"
+                    icon="warning"
+                    description={<Translation id="TR_DO_NOT_DISCONNECT_DEVICE" />}
+                />
                 <Card>
                     <CoinjoinPhaseProgress
                         roundPhase={roundPhase}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DeviceAuthenticityOptOutModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DeviceAuthenticityOptOutModal.tsx
@@ -49,12 +49,18 @@ export const DeviceAuthenticityOptOutModal = ({ onCancel }: DeviceAuthenticityOp
                 <Translation id="TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_DESCRIPTION_3" />
             </Paragraph>
             <Column gap={spacings.sm} margin={{ top: spacings.xl }} alignItems="center">
-                <Banner icon="questionFilled">
-                    <Translation id="TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_DESCRIPTION_1" />
-                </Banner>
-                <Banner icon="warningFilled">
-                    <Translation id="TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_DESCRIPTION_2" />
-                </Banner>
+                <Banner
+                    icon="questionFilled"
+                    description={
+                        <Translation id="TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_DESCRIPTION_1" />
+                    }
+                />
+                <Banner
+                    icon="warningFilled"
+                    description={
+                        <Translation id="TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_DESCRIPTION_2" />
+                    }
+                />
             </Column>
             <Card margin={{ top: spacings.lg }}>
                 <CheckItem

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
@@ -67,10 +67,16 @@ export const DisableTorModal = ({ onCancel, decision }: DisableTorModalProps) =>
         >
             {onionBackends.length ? (
                 <Column gap={spacings.md}>
-                    <Banner intent="warning" icon="torBrowser">
-                        <Translation id="TR_TOR_DISABLE_ONIONS_ONLY_TITLE" />{' '}
-                        <Translation id="TR_TOR_DISABLE_ONIONS_ONLY_DESCRIPTION" />
-                    </Banner>
+                    <Banner
+                        intent="warning"
+                        icon="torBrowser"
+                        description={
+                            <>
+                                <Translation id="TR_TOR_DISABLE_ONIONS_ONLY_TITLE" />{' '}
+                                <Translation id="TR_TOR_DISABLE_ONIONS_ONLY_DESCRIPTION" />
+                            </>
+                        }
+                    />
                     <Card>
                         <Column gap={spacings.xxl} hasDivider>
                             {onionBackends.map(({ symbol, urls }) => (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorStopCoinjoinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorStopCoinjoinModal.tsx
@@ -41,16 +41,20 @@ export const DisableTorStopCoinjoinModal = ({
             }
         >
             <Column gap={spacings.xl}>
-                <Banner intent="warning" icon="torBrowser">
-                    <Paragraph typographyStyle="body">
-                        <Translation
-                            id="TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_TITLE"
-                            values={{
-                                b: chunks => <strong>{chunks}</strong>,
-                            }}
-                        />
-                    </Paragraph>
-                </Banner>
+                <Banner
+                    intent="warning"
+                    icon="torBrowser"
+                    description={
+                        <Paragraph typographyStyle="body">
+                            <Translation
+                                id="TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_TITLE"
+                                values={{
+                                    b: chunks => <strong>{chunks}</strong>,
+                                }}
+                            />
+                        </Paragraph>
+                    }
+                />
                 <Paragraph variant="tertiary" typographyStyle="hint">
                     <Translation id="TR_TOR_KEEP_RUNNING_FOR_COIN_JOIN_SUBTITLE" />
                 </Paragraph>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/EverstakeModal/EverstakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/EverstakeModal/EverstakeModal.tsx
@@ -148,9 +148,7 @@ export const EverstakeModal = ({ onCancel, flow }: EverstakeModalProps) => {
         >
             <Column gap={spacings.sm} margin={{ top: spacings.xs, bottom: spacings.lg }}>
                 {banners.map(({ icon, message }, index) => (
-                    <Banner icon={icon} intent="info" key={index}>
-                        {message}
-                    </Banner>
+                    <Banner icon={icon} intent="info" key={index} description={message} />
                 ))}
             </Column>
             <Column gap={spacings.sm}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/FirmwareRevisionOptOutModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/FirmwareRevisionOptOutModal.tsx
@@ -49,12 +49,18 @@ export const FirmwareRevisionOptOutModal = ({ onCancel }: DeviceAuthenticityOptO
                 <Translation id="TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_DESCRIPTION_3" />
             </Paragraph>
             <Column gap={spacings.sm} margin={{ top: spacings.xl }} alignItems="center">
-                <Banner icon="questionFilled">
-                    <Translation id="TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_DESCRIPTION_1" />
-                </Banner>
-                <Banner icon="warningFilled">
-                    <Translation id="TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_DESCRIPTION_2" />
-                </Banner>
+                <Banner
+                    icon="questionFilled"
+                    description={
+                        <Translation id="TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_DESCRIPTION_1" />
+                    }
+                />
+                <Banner
+                    icon="warningFilled"
+                    description={
+                        <Translation id="TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_DESCRIPTION_2" />
+                    }
+                />
             </Column>
             <Card margin={{ top: spacings.lg }}>
                 <CheckItem

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MetadataProviderModal/MetadataProviderModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MetadataProviderModal/MetadataProviderModal.tsx
@@ -102,11 +102,7 @@ export const MetadataProviderModal = ({ onCancel, decision }: MetadataProviderMo
                 <Paragraph typographyStyle="hint" variant="tertiary">
                     <Translation id="METADATA_MODAL_DESCRIPTION" />
                 </Paragraph>
-                {error && (
-                    <Banner intent="critical" icon>
-                        {error}
-                    </Banner>
-                )}
+                {error && <Banner intent="critical" icon description={error} />}
             </Column>
         </Modal>
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep5.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep5.tsx
@@ -70,26 +70,22 @@ export const MultiShareBackupStep5 = () => (
             </H4>
 
             <Grid columns={2} gap={spacings.md}>
-                <Banner intent="brand" icon="trezorDevicesFilled">
-                    <Column>
-                        <H4>
-                            <Translation id="TR_MULTI_SHARE_BACKUP_LOST_YOUR_TREZOR" />
-                        </H4>
-                        <Paragraph>
-                            <Translation id="TR_MULTI_SHARE_BACKUP_LOST_YOUR_TREZOR_INFO_TEXT" />
-                        </Paragraph>
-                    </Column>
-                </Banner>
-                <Banner intent="warning" icon="recoverySeed">
-                    <Column>
-                        <H4>
-                            <Translation id="TR_MULTI_SHARE_BACKUP_LOST_YOUR_BACKUP" />
-                        </H4>
-                        <Paragraph>
-                            <Translation id="TR_MULTI_SHARE_BACKUP_LOST_YOUR_BACKUP_INFO_TEXT" />
-                        </Paragraph>
-                    </Column>
-                </Banner>
+                <Banner
+                    intent="brand"
+                    icon="trezorDevicesFilled"
+                    title={<Translation id="TR_MULTI_SHARE_BACKUP_LOST_YOUR_TREZOR" />}
+                    description={
+                        <Translation id="TR_MULTI_SHARE_BACKUP_LOST_YOUR_TREZOR_INFO_TEXT" />
+                    }
+                />
+                <Banner
+                    intent="warning"
+                    icon="recoverySeed"
+                    title={<Translation id="TR_MULTI_SHARE_BACKUP_LOST_YOUR_BACKUP" />}
+                    description={
+                        <Translation id="TR_MULTI_SHARE_BACKUP_LOST_YOUR_BACKUP_INFO_TEXT" />
+                    }
+                />
             </Grid>
         </Column>
     </Column>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RequestEnableTorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RequestEnableTorModal.tsx
@@ -59,14 +59,19 @@ export const RequestEnableTorModal = ({ onCancel, decision }: RequestEnableTorMo
                 </>
             }
         >
-            <Banner icon="torBrowser" intent="brand" margin={{ top: spacings.md }}>
-                <Translation
-                    id="TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_TITLE"
-                    values={{
-                        b: chunks => <strong>{chunks}</strong>,
-                    }}
-                />
-            </Banner>
+            <Banner
+                icon="torBrowser"
+                intent="brand"
+                margin={{ top: spacings.md }}
+                description={
+                    <Translation
+                        id="TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_TITLE"
+                        values={{
+                            b: chunks => <strong>{chunks}</strong>,
+                        }}
+                    />
+                }
+            />
         </Modal>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
@@ -202,12 +202,16 @@ export const RevokeModal = ({ setIsWaitingForDevice, onCancel }: RevokeModalProp
         >
             <Column gap={spacings.sm}>
                 {!isIncreasingAllowanceSupported && (
-                    <Banner intent="info" icon="info">
-                        <Translation
-                            id="TR_EXCHANGE_APPROVAL_MODAL_REVOKE_BANNER"
-                            values={{ displaySymbol }}
-                        />
-                    </Banner>
+                    <Banner
+                        intent="info"
+                        icon="info"
+                        description={
+                            <Translation
+                                id="TR_EXCHANGE_APPROVAL_MODAL_REVOKE_BANNER"
+                                values={{ displaySymbol }}
+                            />
+                        }
+                    />
                 )}
 
                 <Box

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SafetyChecksModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SafetyChecksModal.tsx
@@ -51,9 +51,7 @@ export const SafetyChecksModal = ({ onCancel }: ModalProps) => {
                 </>
             }
         >
-            <Banner icon>
-                <Translation id="TR_SAFETY_CHECKS_PROMPT_LEVEL_WARNING" />
-            </Banner>
+            <Banner icon description={<Translation id="TR_SAFETY_CHECKS_PROMPT_LEVEL_WARNING" />} />
             <Card margin={{ top: spacings.md }}>
                 <Column gap={spacings.xl} alignItems="flex-start">
                     <Radio

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SolanaStakingLimitBanner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SolanaStakingLimitBanner.tsx
@@ -91,19 +91,22 @@ export const SolanaStakingLimitBanner = ({
     if (!isAccountLimitExeeded) return null;
 
     return (
-        <Banner intent="info">
-            <Translation
-                id={
-                    type === 'claim'
-                        ? 'TR_STAKE_CAN_CLAIM_FROM_ACCOUNTS'
-                        : 'TR_STAKE_CAN_UNSTAKE_FROM_ACCOUNTS'
-                }
-                values={{
-                    limit: MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT,
-                    amount: formatNetworkAmount(estimatedAmount, account.symbol),
-                    symbol: getDisplaySymbol(account.symbol),
-                }}
-            />
-        </Banner>
+        <Banner
+            intent="info"
+            description={
+                <Translation
+                    id={
+                        type === 'claim'
+                            ? 'TR_STAKE_CAN_CLAIM_FROM_ACCOUNTS'
+                            : 'TR_STAKE_CAN_UNSTAKE_FROM_ACCOUNTS'
+                    }
+                    values={{
+                        limit: MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT,
+                        amount: formatNetworkAmount(estimatedAmount, account.symbol),
+                        symbol: getDisplaySymbol(account.symbol),
+                    }}
+                />
+            }
+        />
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/CardanoStakeWarningBanner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/CardanoStakeWarningBanner.tsx
@@ -18,13 +18,17 @@ export const CardanoStakeWarningBanner = ({
     if (!isCardanoStakingDisabled) return;
 
     return (
-        <Banner intent="critical" icon="warning">
-            <Translation
-                id="TR_STAKE_NOT_ENOUGH_FUNDS_WARNING"
-                values={{
-                    networkDisplaySymbol: getNetworkDisplaySymbol(symbol),
-                }}
-            />
-        </Banner>
+        <Banner
+            intent="critical"
+            icon="warning"
+            description={
+                <Translation
+                    id="TR_STAKE_NOT_ENOUGH_FUNDS_WARNING"
+                    values={{
+                        networkDisplaySymbol: getNetworkDisplaySymbol(symbol),
+                    }}
+                />
+            }
+        />
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/ConfirmStakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/ConfirmStakeModal.tsx
@@ -112,18 +112,21 @@ export const ConfirmStakeModal = ({
             }
         >
             <Column gap={spacings.sm} margin={{ top: spacings.xxs, bottom: spacings.lg }}>
-                <Banner icon="clock">
-                    <Translation
-                        id={getStakeEnteringMessage(account?.networkType)}
-                        values={{
-                            networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
-                            count:
-                                account?.networkType === 'ethereum'
-                                    ? daysToAddToPool
-                                    : SOLANA_EPOCH_DAYS,
-                        }}
-                    />
-                </Banner>
+                <Banner
+                    icon="clock"
+                    description={
+                        <Translation
+                            id={getStakeEnteringMessage(account?.networkType)}
+                            values={{
+                                networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
+                                count:
+                                    account?.networkType === 'ethereum'
+                                        ? daysToAddToPool
+                                        : SOLANA_EPOCH_DAYS,
+                            }}
+                        />
+                    }
+                />
                 <Banner
                     icon="hand"
                     rightContent={
@@ -131,14 +134,15 @@ export const ConfirmStakeModal = ({
                             <Translation id="TR_LEARN_MORE" />
                         </Banner.Button>
                     }
-                >
-                    <Translation
-                        id="TR_STAKE_ETH_WILL_BE_BLOCKED"
-                        values={{
-                            networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
-                        }}
-                    />
-                </Banner>
+                    description={
+                        <Translation
+                            id="TR_STAKE_ETH_WILL_BE_BLOCKED"
+                            values={{
+                                networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
+                            }}
+                        />
+                    }
+                />
             </Column>
 
             <Card>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeInputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeInputs.tsx
@@ -237,30 +237,40 @@ export const StakeInputs = () => {
                 ]}
             />
             {shouldShowAmountForWithdrawalWarning && (
-                <Banner data-testid="@staking/form/withdrawal-warning" intent="info" width="100%">
-                    <Translation
-                        id={
-                            isLessAmountForWithdrawalWarningShown
-                                ? 'TR_STAKE_LEFT_SMALL_AMOUNT_FOR_WITHDRAWAL'
-                                : 'TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL'
-                        }
-                        values={{
-                            amount: stakingLimits.MIN_FOR_WITHDRAWALS.toString(),
-                            networkDisplaySymbol,
-                        }}
-                    />
-                </Banner>
+                <Banner
+                    data-testid="@staking/form/withdrawal-warning"
+                    intent="info"
+                    width="100%"
+                    description={
+                        <Translation
+                            id={
+                                isLessAmountForWithdrawalWarningShown
+                                    ? 'TR_STAKE_LEFT_SMALL_AMOUNT_FOR_WITHDRAWAL'
+                                    : 'TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL'
+                            }
+                            values={{
+                                amount: stakingLimits.MIN_FOR_WITHDRAWALS.toString(),
+                                networkDisplaySymbol,
+                            }}
+                        />
+                    }
+                />
             )}
             {showAdviceBanner && !isAmountForWithdrawalWarningShown && (
-                <Banner data-testid="@staking/form/withdrawal-warning" intent="info" width="100%">
-                    <Translation
-                        id="TR_STAKE_RECOMMENDED_AMOUNT_FOR_WITHDRAWALS"
-                        values={{
-                            amount: stakingLimits.MIN_FOR_WITHDRAWALS.toString(),
-                            networkDisplaySymbol,
-                        }}
-                    />
-                </Banner>
+                <Banner
+                    data-testid="@staking/form/withdrawal-warning"
+                    intent="info"
+                    width="100%"
+                    description={
+                        <Translation
+                            id="TR_STAKE_RECOMMENDED_AMOUNT_FOR_WITHDRAWALS"
+                            values={{
+                                amount: stakingLimits.MIN_FOR_WITHDRAWALS.toString(),
+                                networkDisplaySymbol,
+                            }}
+                        />
+                    }
+                />
             )}
         </Column>
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx
@@ -83,18 +83,23 @@ export const StakeRegistrationDepositCard = ({ account }: StakeRegistrationDepos
                     </Row>
                 </>
             )}
-            <Banner intent="info" icon="info" margin={{ top: spacings.md }}>
-                <Translation
-                    id={
-                        isUpdateProviderFlow
-                            ? 'TR_STAKING_REWARDS_REMAIN_INTACT'
-                            : 'TR_STAKE_FUNDS_WARNING'
-                    }
-                    values={{
-                        networkDisplaySymbol: getNetworkDisplaySymbol(symbol),
-                    }}
-                />
-            </Banner>
+            <Banner
+                intent="info"
+                icon="info"
+                margin={{ top: spacings.md }}
+                description={
+                    <Translation
+                        id={
+                            isUpdateProviderFlow
+                                ? 'TR_STAKING_REWARDS_REMAIN_INTACT'
+                                : 'TR_STAKE_FUNDS_WARNING'
+                        }
+                        values={{
+                            networkDisplaySymbol: getNetworkDisplaySymbol(symbol),
+                        }}
+                    />
+                }
+            />
         </Card>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
@@ -295,15 +295,19 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
                     />
 
                     {insufficientBalanceInfo && (
-                        <Banner intent="warning" icon="warning">
-                            <Translation
-                                id="TR_TOKEN_ACTIVATION_INSUFFICIENT_FUNDS"
-                                values={{
-                                    required: insufficientBalanceInfo.required,
-                                    available: insufficientBalanceInfo.available,
-                                }}
-                            />
-                        </Banner>
+                        <Banner
+                            intent="warning"
+                            icon="warning"
+                            description={
+                                <Translation
+                                    id="TR_TOKEN_ACTIVATION_INSUFFICIENT_FUNDS"
+                                    values={{
+                                        required: insufficientBalanceInfo.required,
+                                        available: insufficientBalanceInfo.available,
+                                    }}
+                                />
+                            }
+                        />
                     )}
                 </Column>
             </FormProvider>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/AffectedTransactions.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/AffectedTransactions.tsx
@@ -32,9 +32,7 @@ export const AffectedTransactions = ({ chainedTxs, showChained }: AffectedTransa
             }
         >
             <Column gap={spacings.md}>
-                <Banner intent="warning">
-                    <Translation id="TR_AFFECTED_TXS" />
-                </Banner>
+                <Banner intent="warning" description={<Translation id="TR_AFFECTED_TXS" />} />
                 <Table>
                     <Table.Body>
                         {chainedTxs.own.map(tx => (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/DecreasedOutputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/DecreasedOutputs.tsx
@@ -117,9 +117,12 @@ export const DecreasedOutputs = () => {
 
             <Divider margin={spacings.zero} />
             <Column margin={spacings.md} gap={spacings.md}>
-                <Banner intent="warning" data-testid="@send/decreased-outputs" icon="warning">
-                    <Translation id={getDecreaseWarring()} />
-                </Banner>
+                <Banner
+                    intent="warning"
+                    data-testid="@send/decreased-outputs"
+                    icon="warning"
+                    description={<Translation id={getDecreaseWarring()} />}
+                />
                 {useRadio && (
                     <Text>
                         <Translation id="TR_DECREASED_AMOUNT_SELECTION_EXPLANATION" />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx
@@ -93,9 +93,12 @@ export const CancelTransactionModal = ({
                             {error !== null ? (
                                 // This shall never happen, error like this always signal big in the code,
                                 // this is here just to make easier to detect and fix
-                                <Banner intent="critical">
-                                    Error: transaction cannot be canceled ({error})
-                                </Banner>
+                                <Banner
+                                    intent="critical"
+                                    description={
+                                        <>Error: transaction cannot be canceled ({error})</>
+                                    }
+                                />
                             ) : null}
                         </>
                     )

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/AnalyzeInExplorerBanner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/AnalyzeInExplorerBanner.tsx
@@ -1,7 +1,7 @@
 import { Explorer, NetworkSymbol } from '@suite-common/wallet-config';
 import { getExplorerUrl } from '@suite-common/wallet-config/src/getExplorerUrls';
 import { selectExplorer } from '@suite-common/wallet-core';
-import { Banner, Column, H4, Paragraph } from '@trezor/components';
+import { Banner } from '@trezor/components';
 
 import { Translation } from 'src/components/suite/Translation';
 import { useExternalLink, useSelector } from 'src/hooks/suite';
@@ -21,20 +21,13 @@ export const AnalyzeInExplorerBanner = ({ txid, symbol }: AnalyzeInExplorerBanne
         <Banner
             intent="info"
             icon="cube"
+            title={<Translation id="TR_ANALYZE_IN_EXPLORER" />}
+            description={<Translation id="TR_ANALYZE_IN_EXPLORER_DESC" />}
             rightContent={
                 <Banner.Button size="small" href={href}>
                     <Translation id="TR_ANALYZE_IN_EXPLORER_OPEN" />
                 </Banner.Button>
             }
-        >
-            <Column>
-                <H4>
-                    <Translation id="TR_ANALYZE_IN_EXPLORER" />
-                </H4>
-                <Paragraph>
-                    <Translation id="TR_ANALYZE_IN_EXPLORER_DESC" />
-                </Paragraph>
-            </Column>
-        </Banner>
+        />
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModalBase.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModalBase.tsx
@@ -69,18 +69,21 @@ export const TxDetailModalBase = ({
                 />
 
                 {isPhishingTransaction && (
-                    <Banner icon>
-                        <Translation
-                            id="TR_ZERO_PHISHING_BANNER"
-                            values={{
-                                a: chunks => (
-                                    <TrezorLink href={HELP_CENTER_ZERO_VALUE_ATTACKS}>
-                                        {chunks}
-                                    </TrezorLink>
-                                ),
-                            }}
-                        />
-                    </Banner>
+                    <Banner
+                        icon
+                        description={
+                            <Translation
+                                id="TR_ZERO_PHISHING_BANNER"
+                                values={{
+                                    a: chunks => (
+                                        <TrezorLink href={HELP_CENTER_ZERO_VALUE_ATTACKS}>
+                                            {chunks}
+                                        </TrezorLink>
+                                    ),
+                                }}
+                            />
+                        }
+                    />
                 )}
 
                 {children}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
@@ -179,25 +179,26 @@ export const TxSimulationBanner = ({
     <Banner
         intent={type === 'warning' ? 'warning' : 'critical'}
         data-testid="@tx-simulation-modal/error-banner"
-    >
-        <Column width="100%" padding={{ vertical: spacings.xxs }}>
-            <Text typographyStyle="callout">{title}</Text>
-            <Text>{description}</Text>
+        description={
+            <Column width="100%" padding={{ vertical: spacings.xxs }}>
+                <Text typographyStyle="callout">{title}</Text>
+                <Text>{description}</Text>
 
-            <Card margin={{ top: spacings.sm }} paddingType="small">
-                <Checkbox
-                    data-testid="@tx-simulation-modal/disclaimer-checkbox"
-                    isChecked={disclaimerAccepted}
-                    onClick={() => setDisclaimerAccepted(!disclaimerAccepted)}
-                    verticalAlignment="center"
-                >
-                    <Text variant="default" typographyStyle="hint">
-                        <Translation id="TR_SIMULATION_DISCLAIMER_OVERRIDE" />
-                    </Text>
-                </Checkbox>
-            </Card>
-        </Column>
-    </Banner>
+                <Card margin={{ top: spacings.sm }} paddingType="small">
+                    <Checkbox
+                        data-testid="@tx-simulation-modal/disclaimer-checkbox"
+                        isChecked={disclaimerAccepted}
+                        onClick={() => setDisclaimerAccepted(!disclaimerAccepted)}
+                        verticalAlignment="center"
+                    >
+                        <Text variant="default" typographyStyle="hint">
+                            <Translation id="TR_SIMULATION_DISCLAIMER_OVERRIDE" />
+                        </Text>
+                    </Checkbox>
+                </Card>
+            </Column>
+        }
+    />
 );
 
 export const TxSimulationModal = () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeForm.tsx
@@ -54,16 +54,19 @@ export const UnstakeForm = () => {
                 <Column gap={spacings.xxl} margin={{ bottom: spacings.lg }}>
                     <Column gap={spacings.md}>
                         {canClaim && (
-                            <Banner intent="info">
-                                <Translation
-                                    id="TR_STAKE_CAN_CLAIM_WARNING"
-                                    values={{
-                                        amount: claimableAmount,
-                                        symbol: getDisplaySymbol(account.symbol),
-                                        br: <br />,
-                                    }}
-                                />
-                            </Banner>
+                            <Banner
+                                intent="info"
+                                description={
+                                    <Translation
+                                        id="TR_STAKE_CAN_CLAIM_WARNING"
+                                        values={{
+                                            amount: claimableAmount,
+                                            symbol: getDisplaySymbol(account.symbol),
+                                            br: <br />,
+                                        }}
+                                    />
+                                }
+                            />
                         )}
                         <SolanaStakingLimitBanner
                             account={account}
@@ -81,7 +84,7 @@ export const UnstakeForm = () => {
                             <Column gap={spacings.lg}>
                                 <UnstakeInputs />
                                 {showError && (
-                                    <Banner intent="critical">{inputError?.message}</Banner>
+                                    <Banner intent="critical" description={inputError?.message} />
                                 )}
                             </Column>
                         </>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -263,15 +263,16 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                                 <Translation id="TR_COIN_SETTINGS" />
                             </Banner.Button>
                         }
-                    >
-                        <Translation
-                            id={
-                                requiredNetworksNotActivated
-                                    ? 'TR_WALLETCONNECT_REQUIRED_NETWORKS_NOT_ACTIVATED'
-                                    : 'TR_WALLETCONNECT_NO_NETWORKS_ACTIVATED'
-                            }
-                        />
-                    </Banner>
+                        description={
+                            <Translation
+                                id={
+                                    requiredNetworksNotActivated
+                                        ? 'TR_WALLETCONNECT_REQUIRED_NETWORKS_NOT_ACTIVATED'
+                                        : 'TR_WALLETCONNECT_NO_NETWORKS_ACTIVATED'
+                                }
+                            />
+                        }
+                    />
                 )}
 
                 {(isMalicious || pendingProposal.isScam) && (
@@ -284,15 +285,17 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                     />
                 )}
                 {pendingProposal.validation === 'INVALID' && (
-                    <Banner intent="critical">
-                        <Translation id="TR_WALLETCONNECT_UNABLE_TO_VERIFY" />
-                    </Banner>
+                    <Banner
+                        intent="critical"
+                        description={<Translation id="TR_WALLETCONNECT_UNABLE_TO_VERIFY" />}
+                    />
                 )}
 
                 {pendingProposal.expired && (
-                    <Banner intent="warning">
-                        <Translation id="TR_WALLETCONNECT_REQUEST_EXPIRED" />
-                    </Banner>
+                    <Banner
+                        intent="warning"
+                        description={<Translation id="TR_WALLETCONNECT_REQUEST_EXPIRED" />}
+                    />
                 )}
             </Column>
         </Modal>

--- a/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
@@ -80,9 +80,12 @@ export const TroubleshootingTips = ({
 
     return cta ? (
         <Column gap={80} alignItems="center">
-            <Banner rightContent={cta} intent={intent} maxWidth={600}>
-                {ctaLabel ?? label}
-            </Banner>
+            <Banner
+                rightContent={cta}
+                intent={intent}
+                maxWidth={600}
+                description={ctaLabel ?? label}
+            />
             {visibleTips.length > 0 && <TroubleshootingButton />}
         </Column>
     ) : (

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeTooLowBanner.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeTooLowBanner.tsx
@@ -28,9 +28,8 @@ export const CustomFeeTooLowBanner = memo(function CustomFeeTooLowBannerInner() 
                     rightContent={
                         <LearnMoreButton url={HELP_CENTER_TRANSACTION_FEES_URL} intent="warning" />
                     }
-                >
-                    <Translation id="TR_CUSTOM_FEE_WARNING" />
-                </Banner>
+                    description={<Translation id="TR_CUSTOM_FEE_WARNING" />}
+                />
             </Collapsible.Content>
         </Collapsible>
     );

--- a/packages/suite/src/components/wallet/Fees/FieldErrorBanner.tsx
+++ b/packages/suite/src/components/wallet/Fees/FieldErrorBanner.tsx
@@ -15,9 +15,5 @@ export function FieldErrorBanner({ fieldName }: FieldErrorBannerProps) {
         return null;
     }
 
-    return (
-        <Banner icon intent="critical">
-            {error.message}
-        </Banner>
-    );
+    return <Banner icon intent="critical" description={error.message} />;
 }

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountImported.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountImported.tsx
@@ -9,7 +9,5 @@ type AccountImportedProps = {
 
 export const AccountImported = ({ account }: AccountImportedProps) =>
     account?.imported ? (
-        <Banner intent="info">
-            <Translation id="TR_ACCOUNT_IMPORTED_ANNOUNCEMENT" />
-        </Banner>
+        <Banner intent="info" description={<Translation id="TR_ACCOUNT_IMPORTED_ANNOUNCEMENT" />} />
     ) : null;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountOutOfSync.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountOutOfSync.tsx
@@ -9,7 +9,5 @@ type AccountOutOfSyncProps = {
 
 export const AccountOutOfSync = ({ account }: AccountOutOfSyncProps) =>
     account?.backendType === 'coinjoin' && account.status === 'out-of-sync' ? (
-        <Banner intent="warning">
-            <Translation id="TR_ACCOUNT_OUT_OF_SYNC" />
-        </Banner>
+        <Banner intent="warning" description={<Translation id="TR_ACCOUNT_OUT_OF_SYNC" />} />
     ) : null;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/BackendDisconnected.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/BackendDisconnected.tsx
@@ -29,12 +29,18 @@ const DisconnectedNotification = ({
                     <Translation id="TR_CONNECT" />
                 </Banner.Button>
             }
-        >
-            <Translation id="TR_BACKEND_DISCONNECTED" />
-            {countdownSeconds ? (
-                <Translation id="TR_BACKEND_RECONNECTING" values={{ time: countdownSeconds }} />
-            ) : null}
-        </Banner>
+            description={
+                <>
+                    <Translation id="TR_BACKEND_DISCONNECTED" />
+                    {countdownSeconds ? (
+                        <Translation
+                            id="TR_BACKEND_RECONNECTING"
+                            values={{ time: countdownSeconds }}
+                        />
+                    ) : null}
+                </>
+            }
+        />
     );
 };
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/CardanoLegacyBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/CardanoLegacyBanner.tsx
@@ -15,8 +15,10 @@ export const CardanoLegacyBanner = ({ account }: CardanoLegacyBannerProps) => {
     }
 
     return (
-        <Banner intent="critical" icon="warning">
-            <Translation id="TR_ACCOUNT_TYPE_CARDANO_LEGACY_BANNER" />
-        </Banner>
+        <Banner
+            intent="critical"
+            icon="warning"
+            description={<Translation id="TR_ACCOUNT_TYPE_CARDANO_LEGACY_BANNER" />}
+        />
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/CloseableBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/CloseableBanner.tsx
@@ -31,13 +31,14 @@ export const CloseableBanner = ({
         }
         icon={hasIcon ? 'shareNetwork' : undefined}
         margin={margin}
-    >
-        <Column gap={spacings.xxs} flex="1" alignItems="flex-start" justifyContent="stretch">
-            <Text typographyStyle="highlight" variant="info">
-                {title}
-            </Text>
+        description={
+            <Column gap={spacings.xxs} flex="1" alignItems="flex-start" justifyContent="stretch">
+                <Text typographyStyle="highlight" variant="info">
+                    {title}
+                </Text>
 
-            {children}
-        </Column>
-    </Banner>
+                {children}
+            </Column>
+        }
+    />
 );

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx
@@ -86,8 +86,7 @@ export const ContextMessage = ({ context }: ContextMessageProps) => {
                     )}
                 </>
             }
-        >
-            {message.content}
-        </Banner>
+            description={message.content}
+        />
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/DeviceUnavailable.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/DeviceUnavailable.tsx
@@ -23,8 +23,7 @@ export const DeviceUnavailable = () => {
                     <Translation id="TR_ACCOUNT_ENABLE_PASSPHRASE" />
                 </Banner.Button>
             }
-        >
-            <Translation id="TR_ACCOUNT_PASSPHRASE_DISABLED" />
-        </Banner>
+            description={<Translation id="TR_ACCOUNT_PASSPHRASE_DISABLED" />}
+        />
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ReserveBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ReserveBanner.tsx
@@ -36,15 +36,16 @@ export const ReserveBanner = ({ account }: ReserveBannerProps) => {
                     <Translation id="TR_LEARN_MORE" />
                 </Banner.Button>
             }
-        >
-            <Translation
-                id="TR_RESERVE_INFO"
-                values={{
-                    minBalance: formatNetworkAmount(account.misc.reserve, account.symbol),
-                    networkName: getNetwork(account.symbol).name,
-                    displaySymbol: getDisplaySymbol(account.symbol),
-                }}
-            />
-        </Banner>
+            description={
+                <Translation
+                    id="TR_RESERVE_INFO"
+                    values={{
+                        minBalance: formatNetworkAmount(account.misc.reserve, account.symbol),
+                        networkName: getNetwork(account.symbol).name,
+                        displaySymbol: getDisplaySymbol(account.symbol),
+                    }}
+                />
+            }
+        />
     ) : null;
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -11,7 +11,7 @@ import {
     getStakingLimitsByNetworkSymbol,
     isSupportedStakingNetworkSymbol,
 } from '@suite-common/wallet-utils';
-import { Banner, Column, H4, Paragraph } from '@trezor/components';
+import { Banner } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
@@ -141,6 +141,22 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
         <Banner
             icon="piggyBank"
             intent="brand"
+            title={
+                <Translation id="TR_STAKING_BANNER_DETAIL_TITLE" values={{ apy, displaySymbol }} />
+            }
+            description={
+                !hasEnoughBalanceForStaking || !hasPotentialRewards ? (
+                    <Translation
+                        id="TR_STAKING_BANNER_DETAIL_TEXT_EMPTY"
+                        values={{ displaySymbol }}
+                    />
+                ) : (
+                    <Translation
+                        id="TR_STAKING_BANNER_DETAIL_TEXT"
+                        values={{ potentialRewards, displaySymbol }}
+                    />
+                )
+            }
             rightContent={
                 <>
                     <Banner.Button onClick={goToStakingTab}>
@@ -154,28 +170,6 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
                     />
                 </>
             }
-        >
-            <Column>
-                <H4>
-                    <Translation
-                        id="TR_STAKING_BANNER_DETAIL_TITLE"
-                        values={{ apy, displaySymbol }}
-                    />
-                </H4>
-                <Paragraph typographyStyle="hint">
-                    {!hasEnoughBalanceForStaking || !hasPotentialRewards ? (
-                        <Translation
-                            id="TR_STAKING_BANNER_DETAIL_TEXT_EMPTY"
-                            values={{ displaySymbol }}
-                        />
-                    ) : (
-                        <Translation
-                            id="TR_STAKING_BANNER_DETAIL_TEXT"
-                            values={{ potentialRewards, displaySymbol }}
-                        />
-                    )}
-                </Paragraph>
-            </Column>
-        </Banner>
+        />
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TorDisconnected.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TorDisconnected.tsx
@@ -29,13 +29,14 @@ export const TorDisconnected = () => {
                     )}
                 </Banner.Button>
             }
-        >
-            <Translation
-                id="TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_TITLE"
-                values={{
-                    b: chunks => <b>{chunks}</b>,
-                }}
-            />
-        </Banner>
+            description={
+                <Translation
+                    id="TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_TITLE"
+                    values={{
+                        b: chunks => <b>{chunks}</b>,
+                    }}
+                />
+            }
+        />
     );
 };

--- a/packages/suite/src/views/firmware/Steps/StepCheckSeed.tsx
+++ b/packages/suite/src/views/firmware/Steps/StepCheckSeed.tsx
@@ -138,9 +138,11 @@ export const StepCheckSeed = ({
                     {description}
                 </Column>
                 {deviceWillBeWiped && (
-                    <Banner intent="critical" icon="warning">
-                        <Translation id="TR_FIRMWARE_SWITCH_WARNING_3" />
-                    </Banner>
+                    <Banner
+                        intent="critical"
+                        icon="warning"
+                        description={<Translation id="TR_FIRMWARE_SWITCH_WARNING_3" />}
+                    />
                 )}
                 <Card>
                     <Checkbox

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/FloatingSelections.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/FloatingSelections.tsx
@@ -82,26 +82,30 @@ const DividerWrapper = styled.div`
 `;
 
 const LegacyWarning = () => (
-    <Banner intent="info" icon>
-        <Column alignItems="start">
-            <Text typographyStyle="highlight" variant="info">
-                <Translation id="TR_THESE_WONT_ALLOW_YOU_UPGRADE_HEADER" />
-            </Text>
-            <Translation
-                id="TR_THESE_WONT_ALLOW_YOU_UPGRADE"
-                values={{
-                    a: chunks => (
-                        <TrezorLink
-                            typographyStyle="callout"
-                            href={HELP_CENTER_MULTI_SHARE_BACKUP_URL}
-                        >
-                            {chunks}
-                        </TrezorLink>
-                    ),
-                }}
-            />
-        </Column>
-    </Banner>
+    <Banner
+        intent="info"
+        icon
+        description={
+            <Column alignItems="start">
+                <Text typographyStyle="highlight" variant="info">
+                    <Translation id="TR_THESE_WONT_ALLOW_YOU_UPGRADE_HEADER" />
+                </Text>
+                <Translation
+                    id="TR_THESE_WONT_ALLOW_YOU_UPGRADE"
+                    values={{
+                        a: chunks => (
+                            <TrezorLink
+                                typographyStyle="callout"
+                                href={HELP_CENTER_MULTI_SHARE_BACKUP_URL}
+                            >
+                                {chunks}
+                            </TrezorLink>
+                        ),
+                    }}
+                />
+            </Column>
+        }
+    />
 );
 
 export const FloatingSelections = forwardRef<HTMLDivElement, FloatingSelectionsProps>(

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx
@@ -53,9 +53,13 @@ const SelectWrapper = styled.div<{ $elevation: Elevation }>`
 `;
 
 const BackupWarning = ({ id }: { id: TranslationKey }) => (
-    <Banner intent="info" icon>
-        <Translation id={id} values={{ strong: chunks => <strong>{chunks}</strong> }} />
-    </Banner>
+    <Banner
+        intent="info"
+        icon
+        description={
+            <Translation id={id} values={{ strong: chunks => <strong>{chunks}</strong> }} />
+        }
+    />
 );
 
 type SelectBackupTypeProps = {

--- a/packages/suite/src/views/recovery/steps/EnterOnDeviceStep.tsx
+++ b/packages/suite/src/views/recovery/steps/EnterOnDeviceStep.tsx
@@ -1,4 +1,4 @@
-import { Banner, Paragraph } from '@trezor/components';
+import { Banner } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { mapTrezorModelToIcon } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
@@ -14,9 +14,10 @@ export const EnterOnDeviceStep = ({
         intent="info"
         icon={mapTrezorModelToIcon[deviceModelInternal]}
         margin={{ top: spacings.xs }}
-    >
-        <Paragraph data-testid="@recovery/paragraph">
-            <Translation id="TR_ENTER_SEED_WORDS_ON_DEVICE" />
-        </Paragraph>
-    </Banner>
+        description={
+            <span data-testid="@recovery/paragraph">
+                <Translation id="TR_ENTER_SEED_WORDS_ON_DEVICE" />
+            </span>
+        }
+    />
 );

--- a/packages/suite/src/views/recovery/steps/WordInputStep.tsx
+++ b/packages/suite/src/views/recovery/steps/WordInputStep.tsx
@@ -10,9 +10,11 @@ export const WordInputStep = () => (
             <Paragraph>
                 <Translation id="TR_ENTER_SEED_WORDS_INSTRUCTION" />
             </Paragraph>
-            <Banner intent="info" icon="question">
-                <Translation id="TR_RANDOM_SEED_WORDS_DISCLAIMER" />
-            </Banner>
+            <Banner
+                intent="info"
+                icon="question"
+                description={<Translation id="TR_RANDOM_SEED_WORDS_DISCLAIMER" />}
+            />
             <WordInput />
         </Column>
     </Card>

--- a/packages/suite/src/views/settings/SettingsCoins/FirmwareTypeSuggestion.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/FirmwareTypeSuggestion.tsx
@@ -29,26 +29,27 @@ export const FirmwareTypeSuggestion = () => {
                     <Translation id="TR_GOT_IT" />
                 </Banner.Button>
             }
-        >
-            <Paragraph>
-                <Translation
-                    id={translationId}
-                    values={{
-                        button: chunks => (
-                            <Banner.Button
-                                margin={{ horizontal: 2 }}
-                                intent="info"
-                                size="small"
-                                onClick={goToFirmwareType}
-                            >
-                                {chunks}
-                            </Banner.Button>
-                        ),
-                        bitcoinOnly: <Translation id="TR_FIRMWARE_TYPE_BITCOIN_ONLY" />,
-                        regular: <Translation id="TR_FIRMWARE_TYPE_REGULAR" />,
-                    }}
-                />
-            </Paragraph>
-        </Banner>
+            description={
+                <Paragraph>
+                    <Translation
+                        id={translationId}
+                        values={{
+                            button: chunks => (
+                                <Banner.Button
+                                    margin={{ horizontal: 2 }}
+                                    intent="info"
+                                    size="small"
+                                    onClick={goToFirmwareType}
+                                >
+                                    {chunks}
+                                </Banner.Button>
+                            ),
+                            bitcoinOnly: <Translation id="TR_FIRMWARE_TYPE_BITCOIN_ONLY" />,
+                            regular: <Translation id="TR_FIRMWARE_TYPE_REGULAR" />,
+                        }}
+                    />
+                </Paragraph>
+            }
+        />
     );
 };

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemExperiment/MessageSystemExperiments.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemExperiment/MessageSystemExperiments.tsx
@@ -20,9 +20,9 @@ import { borders, spacings, spacingsPx } from '@trezor/theme';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { MessageSystemExperimentDetail } from './MessageSystemExperimentDetail';
+import { MessageSystemExperimentFilters } from './MessageSystemExperimentFilters';
 import { MessageSystemExperimentInfo } from './MessageSystemExperimentInfo';
 import { MessageSystemConditionGroup } from '../MessageSystemConditionGroup';
-import { MessageSystemExperimentFilters } from './MessageSystemExperimentFilters';
 import { MessageSystemFormExperiment } from '../MessageSystemForm/MessageSystemFormExperiment';
 
 const MessageContainer = styled.div<{ $active: boolean }>`
@@ -81,7 +81,7 @@ export const MessageSystemExperiments = ({
                     onToggleActive={() => setShowActive(prev => !prev)}
                 />
                 {filteredExperiments.length === 0 && (
-                    <Banner intent="warning">No experiments.</Banner>
+                    <Banner intent="warning" description="No experiments." />
                 )}
 
                 {filteredExperiments.map(({ experiment: rawExperiment, conditions }, index) => {

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemManager/MessageSystemManager.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemManager/MessageSystemManager.tsx
@@ -73,55 +73,61 @@ export const MessageSystemManager = ({ actions, onCloseModal }: MessageSystemMan
                     selectedCategory={selectedCategory}
                     onCategoryChange={setSelectedCategory}
                 />
-                {filteredActions.length === 0 && <Banner intent="warning">No messages.</Banner>}
+                {filteredActions.length === 0 && (
+                    <Banner intent="warning" description="No messages." />
+                )}
 
                 {filteredActions.map(({ message, conditions }, index) => (
-                    <Banner key={`${message.id}-${index}`} intent={message.variant}>
-                        <Text as="div" variant="default">
-                            <Row gap={24} alignItems="flex-start">
-                                <Column flex="1" gap={spacings.md}>
-                                    <MessageSystemManagerDetail message={message} />
-                                    <Divider color="backgroundNeutralBold" />
-                                    <MessageSystemConditionGroup conditions={conditions} />
-                                </Column>
-                                <Column gap={spacings.xs}>
-                                    <MessageSystemManagerInfo
-                                        message={message}
-                                        allValidMessages={allValidMessages}
-                                        isInApp={!!allManuallyAddedMessageIds?.[message.id]}
-                                    />
-                                    <Column alignItems="flex-end" gap={spacings.xs}>
-                                        <Button
-                                            size="small"
-                                            iconLeft="copy"
-                                            intent="neutral"
-                                            onClick={() =>
-                                                copyToClipboard(
-                                                    JSON.stringify(
-                                                        { conditions, message },
-                                                        null,
-                                                        2,
-                                                    ),
-                                                )
-                                            }
-                                        >
-                                            Copy to clipboard
-                                        </Button>
-                                        {!!allManuallyAddedMessageIds?.[message.id] && (
+                    <Banner
+                        key={`${message.id}-${index}`}
+                        intent={message.variant}
+                        description={
+                            <Text as="div" variant="default">
+                                <Row gap={24} alignItems="flex-start">
+                                    <Column flex="1" gap={spacings.md}>
+                                        <MessageSystemManagerDetail message={message} />
+                                        <Divider color="backgroundNeutralBold" />
+                                        <MessageSystemConditionGroup conditions={conditions} />
+                                    </Column>
+                                    <Column gap={spacings.xs}>
+                                        <MessageSystemManagerInfo
+                                            message={message}
+                                            allValidMessages={allValidMessages}
+                                            isInApp={!!allManuallyAddedMessageIds?.[message.id]}
+                                        />
+                                        <Column alignItems="flex-end" gap={spacings.xs}>
                                             <Button
                                                 size="small"
-                                                iconLeft="trash"
-                                                intent="critical"
-                                                onClick={() => removeMessage(message.id)}
+                                                iconLeft="copy"
+                                                intent="neutral"
+                                                onClick={() =>
+                                                    copyToClipboard(
+                                                        JSON.stringify(
+                                                            { conditions, message },
+                                                            null,
+                                                            2,
+                                                        ),
+                                                    )
+                                                }
                                             >
-                                                Remove
+                                                Copy to clipboard
                                             </Button>
-                                        )}
+                                            {!!allManuallyAddedMessageIds?.[message.id] && (
+                                                <Button
+                                                    size="small"
+                                                    iconLeft="trash"
+                                                    intent="critical"
+                                                    onClick={() => removeMessage(message.id)}
+                                                >
+                                                    Remove
+                                                </Button>
+                                            )}
+                                        </Column>
                                     </Column>
-                                </Column>
-                            </Row>
-                        </Text>
-                    </Banner>
+                                </Row>
+                            </Text>
+                        }
+                    />
                 ))}
             </Column>
         </Modal>

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -128,9 +128,11 @@ export const Experimental = () => {
                 <TextColumn
                     title={<Translation id="TR_EXPERIMENTAL_FEATURES_ALLOW" />}
                     description={
-                        <Banner icon="warning" intent="warning">
-                            <Translation id="TR_EXPERIMENTAL_FEATURES_WARNING" />
-                        </Banner>
+                        <Banner
+                            icon="warning"
+                            intent="warning"
+                            description={<Translation id="TR_EXPERIMENTAL_FEATURES_WARNING" />}
+                        />
                     }
                     buttonLink={EXPERIMENTAL_FEATURES_KB_URL}
                 />

--- a/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
@@ -162,8 +162,7 @@ export const NeedsAttentionBanner = ({
                     </Banner.Button>
                 )
             }
-        >
-            {deviceStatusMessage && <Translation id={deviceStatusMessage} />}
-        </Banner>
+            description={deviceStatusMessage ? <Translation id={deviceStatusMessage} /> : undefined}
+        />
     );
 };

--- a/packages/suite/src/views/wallet/details/CoinjoinSetup/AnonymityLevelSetup.tsx
+++ b/packages/suite/src/views/wallet/details/CoinjoinSetup/AnonymityLevelSetup.tsx
@@ -154,14 +154,18 @@ export const AnonymityLevelSetup = ({ accountKey, targetAnonymity }: AnonymityLe
             <AnimatePresence initial={!isErrorDisplayed}>
                 {isErrorDisplayed && (
                     <motion.div {...expandAnimation}>
-                        <Banner icon intent="critical">
-                            <Translation
-                                values={{
-                                    red: chunks => <RedText>{chunks}</RedText>,
-                                }}
-                                id="TR_LOW_ANONYMITY_WARNING"
-                            />
-                        </Banner>
+                        <Banner
+                            icon
+                            intent="critical"
+                            description={
+                                <Translation
+                                    values={{
+                                        red: chunks => <RedText>{chunks}</RedText>,
+                                    }}
+                                    id="TR_LOW_ANONYMITY_WARNING"
+                                />
+                            }
+                        />
                     </motion.div>
                 )}
             </AnimatePresence>

--- a/packages/suite/src/views/wallet/details/CoinjoinSetup/CoinjoinSetup.tsx
+++ b/packages/suite/src/views/wallet/details/CoinjoinSetup/CoinjoinSetup.tsx
@@ -68,9 +68,10 @@ export const CoinjoinSetup = ({ accountKey }: CoinjoinSetupProps) => {
     return (
         <Card>
             {hasSession && (
-                <Banner intent="info">
-                    <Translation id="TR_DISABLED_ANONYMITY_CHANGE_MESSAGE" />
-                </Banner>
+                <Banner
+                    intent="info"
+                    description={<Translation id="TR_DISABLED_ANONYMITY_CHANGE_MESSAGE" />}
+                />
             )}
             <SetupContainer>
                 <SetupOptions>

--- a/packages/suite/src/views/wallet/nfts/NftsTablesSection.tsx
+++ b/packages/suite/src/views/wallet/nfts/NftsTablesSection.tsx
@@ -51,9 +51,11 @@ export const NftsTablesSection = ({
             <H3>
                 <Translation id="TR_COLLECTIONS_UNRECOGNIZED_BY_TREZOR" />
             </H3>
-            <Banner intent="warning" icon>
-                <Translation id="TR_NFT_UNRECOGNIZED_BY_TREZOR_TOOLTIP" />
-            </Banner>
+            <Banner
+                intent="warning"
+                icon
+                description={<Translation id="TR_NFT_UNRECOGNIZED_BY_TREZOR_TOOLTIP" />}
+            />
             <NftsTable
                 selectedAccount={selectedAccount}
                 isShown={false}

--- a/packages/suite/src/views/wallet/receive/components/CoinjoinReceiveWarning.tsx
+++ b/packages/suite/src/views/wallet/receive/components/CoinjoinReceiveWarning.tsx
@@ -21,14 +21,17 @@ export const CoinjoinReceiveWarning = () => {
                     <Translation id="TR_GOT_IT" />
                 </Banner.Button>
             }
-        >
-            <H4>
-                <Translation id="TR_COINJOIN_RECEIVE_WARNING_TITLE" />
-            </H4>
-            <Column>
-                <Translation id="TR_COINJOIN_CEX_WARNING" />
-                <Translation id="TR_UNECO_COINJOIN_RECEIVE_WARNING" />
-            </Column>
-        </Banner>
+            description={
+                <>
+                    <H4>
+                        <Translation id="TR_COINJOIN_RECEIVE_WARNING_TITLE" />
+                    </H4>
+                    <Column>
+                        <Translation id="TR_COINJOIN_CEX_WARNING" />
+                        <Translation id="TR_UNECO_COINJOIN_RECEIVE_WARNING" />
+                    </Column>
+                </>
+            }
+        />
     );
 };

--- a/packages/suite/src/views/wallet/receive/components/ConnectDevicePromo.tsx
+++ b/packages/suite/src/views/wallet/receive/components/ConnectDevicePromo.tsx
@@ -2,7 +2,7 @@ import { JSX } from 'react';
 
 import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
-import { Banner, H4, Paragraph } from '@trezor/components';
+import { Banner } from '@trezor/components';
 import { mapTrezorModelToIcon } from '@trezor/product-components';
 
 import { Translation } from 'src/components/suite/Translation';
@@ -24,10 +24,9 @@ const ConnectDevicePromo = ({ title, description }: ConnectDevicePromoProps) => 
             intent="warning"
             data-testid="@warning/trezorNotConnected"
             icon={mapTrezorModelToIcon[selectedDeviceModelInternal]}
-        >
-            <H4>{title}</H4>
-            <Paragraph>{description}</Paragraph>
-        </Banner>
+            title={title}
+            description={description}
+        />
     );
 };
 

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -10,7 +10,6 @@ import {
     Card,
     H4,
     InfoItem,
-    Paragraph,
     Row,
     Text,
     Tooltip,
@@ -168,24 +167,27 @@ export const FreshAddress = ({
                 </Tooltip>
             </Row>
             {account.networkType === 'ethereum' && account.symbol !== 'eth' && (
-                <Banner icon intent="info" margin={{ top: spacings.xxl }}>
-                    <H4>
+                <Banner
+                    icon
+                    intent="info"
+                    margin={{ top: spacings.xxl }}
+                    title={
                         <Translation
                             id="TR_EVM_EXPLANATION_TITLE"
                             values={{
                                 network: getNetwork(account.symbol).name,
                             }}
                         />
-                    </H4>
-                    <Paragraph>
+                    }
+                    description={
                         <Translation
                             id="TR_EVM_EXPLANATION_RECEIVE_DESCRIPTION"
                             values={{
                                 network: getNetwork(account.symbol).name,
                             }}
                         />
-                    </Paragraph>
-                </Banner>
+                    }
+                />
             )}
         </Card>
     );

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
@@ -195,11 +195,14 @@ export const CoinControl = ({ close }: CoinControlProps) => {
                 </Row>
 
                 {isMissingVisible && (
-                    <Banner icon>
-                        <Paragraph>
-                            <Translation id={missingToInputId} values={missingToInputValues} />
-                        </Paragraph>
-                    </Banner>
+                    <Banner
+                        icon
+                        description={
+                            <Paragraph>
+                                <Translation id={missingToInputId} values={missingToInputValues} />
+                            </Paragraph>
+                        }
+                    />
                 )}
 
                 <Divider margin={0} />

--- a/packages/suite/src/views/wallet/send/Options/MiscNetworkOptions/DestinationTag.tsx
+++ b/packages/suite/src/views/wallet/send/Options/MiscNetworkOptions/DestinationTag.tsx
@@ -112,9 +112,16 @@ export const DestinationTag = ({ networkSymbol }: DestinationTagProps) => {
                     </Note>
                 </>
             ) : (
-                <Banner intent="warning" icon="warning">
-                    <Translation id="DESTINATION_TAG_BANNER_SEND" values={{ networkName: name }} />
-                </Banner>
+                <Banner
+                    intent="warning"
+                    icon="warning"
+                    description={
+                        <Translation
+                            id="DESTINATION_TAG_BANNER_SEND"
+                            values={{ networkName: name }}
+                        />
+                    }
+                />
             )}
         </Column>
     );

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -264,9 +264,11 @@ export const Amount = ({ output, outputId }: AmountProps) => {
             )}
 
             {isLowAnonymity && (
-                <Banner icon margin={{ top: spacings.sm }}>
-                    <Translation id="TR_NOT_ENOUGH_ANONYMIZED_FUNDS_WARNING" />
-                </Banner>
+                <Banner
+                    icon
+                    margin={{ top: spacings.sm }}
+                    description={<Translation id="TR_NOT_ENOUGH_ANONYMIZED_FUNDS_WARNING" />}
+                />
             )}
         </>
     );

--- a/packages/suite/src/views/wallet/send/Outputs/CardanoMinAmountInfo.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/CardanoMinAmountInfo.tsx
@@ -81,9 +81,16 @@ export const CardanoMinAmountInfo = () => {
                 </Text>
             </InfoItem>
             {!hasEnoughADA && (
-                <Banner intent="critical" icon>
-                    <Translation id="TR_SEND_MIN_ADA_AMOUNT" values={{ networkDisplaySymbol }} />
-                </Banner>
+                <Banner
+                    intent="critical"
+                    icon
+                    description={
+                        <Translation
+                            id="TR_SEND_MIN_ADA_AMOUNT"
+                            values={{ networkDisplaySymbol }}
+                        />
+                    }
+                />
             )}
         </>
     );

--- a/packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx
@@ -154,15 +154,18 @@ export const ReviewButton = () => {
     return (
         <Container>
             {showCoinControlWarning && (
-                <Banner intent="critical">
-                    <Checkbox
-                        variant="destructive"
-                        isChecked={anonymityWarningChecked}
-                        onClick={toggleAnonymityWarning}
-                    >
-                        <Translation id="TR_BREAKING_ANONYMITY_CHECKBOX" />
-                    </Checkbox>
-                </Banner>
+                <Banner
+                    intent="critical"
+                    description={
+                        <Checkbox
+                            variant="destructive"
+                            isChecked={anonymityWarningChecked}
+                            onClick={toggleAnonymityWarning}
+                        >
+                            <Translation id="TR_BREAKING_ANONYMITY_CHECKBOX" />
+                        </Checkbox>
+                    }
+                />
             )}
 
             <Tooltip content={tooltipContent}>

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -97,9 +97,12 @@ const SendLoaded = ({ children, selectedAccount }: SendLoadedProps) => {
                             <SendFees />
 
                             {symbol === 'dsol' && (
-                                <Banner icon>
-                                    <Translation id="TR_SOLANA_DEVNET_SHORTCUT_WARNING" />
-                                </Banner>
+                                <Banner
+                                    icon
+                                    description={
+                                        <Translation id="TR_SOLANA_DEVNET_SHORTCUT_WARNING" />
+                                    }
+                                />
                             )}
 
                             <TotalSent />

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/InstantStakeBanner.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/InstantStakeBanner.tsx
@@ -5,9 +5,8 @@ import { fromWei } from 'web3-utils';
 import { getChangedInternalTx, getInstantStakeType } from '@suite-common/staking';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { StakeType, WalletAccountTransaction } from '@suite-common/wallet-types';
-import { Banner, Column, H3, Paragraph } from '@trezor/components';
+import { Banner } from '@trezor/components';
 import { InternalTransfer } from '@trezor/connect';
-import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
@@ -83,9 +82,8 @@ export const InstantStakeBanner = ({
                     <Translation id="TR_GOT_IT" />
                 </Banner.Button>
             }
-        >
-            <Column gap={spacings.xxs} alignItems="flex-start">
-                <H3 data-testid="@staking/instant-stake-banner/header" typographyStyle="highlight">
+            title={
+                <span data-testid="@staking/instant-stake-banner/header">
                     <Translation
                         id={getHeadingTranslationId(stakeType)}
                         values={{
@@ -93,8 +91,10 @@ export const InstantStakeBanner = ({
                             symbol: displaySymbol,
                         }}
                     />
-                </H3>
-                <Paragraph data-testid="@staking/instant-stake-banner/paragraph">
+                </span>
+            }
+            description={
+                <span data-testid="@staking/instant-stake-banner/paragraph">
                     <Translation
                         id={getSubheadingTranslationId(stakeType)}
                         values={{
@@ -103,8 +103,8 @@ export const InstantStakeBanner = ({
                             days: remainingDays ?? 0,
                         }}
                     />
-                </Paragraph>
-            </Column>
-        </Banner>
+                </span>
+            }
+        />
     );
 };

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/StakingRewardsWarning.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/StakingRewardsWarning.tsx
@@ -3,7 +3,9 @@ import { Banner } from '@trezor/components';
 import { Translation } from 'src/components/suite/Translation';
 
 export const StakingRewardsWarning = () => (
-    <Banner intent="warning" icon="warning">
-        <Translation id="TR_SOL_STAKING_REWARD_WARNING" />
-    </Banner>
+    <Banner
+        intent="warning"
+        icon="warning"
+        description={<Translation id="TR_SOL_STAKING_REWARD_WARNING" />}
+    />
 );

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/DiscoveryWarning.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/DiscoveryWarning.tsx
@@ -3,12 +3,19 @@ import { Banner, H4, Paragraph } from '@trezor/components';
 import { Translation } from 'src/components/suite/Translation';
 
 export const DiscoveryWarning = () => (
-    <Banner intent="warning" data-testid="@warning/trezorDiscovery" icon="spinnerGap">
-        <H4>
-            <Translation id="TR_DISCOVERY_WARNING_TITLE" />
-        </H4>
-        <Paragraph>
-            <Translation id="TR_DISCOVERY_WARNING_DESCRIPTION" />
-        </Paragraph>
-    </Banner>
+    <Banner
+        intent="warning"
+        data-testid="@warning/trezorDiscovery"
+        icon="spinnerGap"
+        description={
+            <>
+                <H4>
+                    <Translation id="TR_DISCOVERY_WARNING_TITLE" />
+                </H4>
+                <Paragraph>
+                    <Translation id="TR_DISCOVERY_WARNING_DESCRIPTION" />
+                </Paragraph>
+            </>
+        }
+    />
 );

--- a/packages/suite/src/views/wallet/tokens/hidden-tokens/HiddenTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/hidden-tokens/HiddenTokensTable.tsx
@@ -70,9 +70,11 @@ export const HiddenTokensTable = ({ selectedAccount, searchQuery }: HiddenTokens
                     <H3>
                         <Translation id="TR_TOKEN_UNRECOGNIZED_BY_TREZOR" />
                     </H3>
-                    <Banner intent="warning" icon>
-                        <Translation id="TR_TOKEN_UNRECOGNIZED_BY_TREZOR_TOOLTIP" />
-                    </Banner>
+                    <Banner
+                        intent="warning"
+                        icon
+                        description={<Translation id="TR_TOKEN_UNRECOGNIZED_BY_TREZOR_TOOLTIP" />}
+                    />
                     <TokensTable
                         account={account}
                         hideRates

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSupportBanner.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSupportBanner.tsx
@@ -35,16 +35,20 @@ export const TradingDetailSupportBanner = ({
     }
 
     return (
-        <Banner intent="neutral" icon="question">
-            <Paragraph typographyStyle="hint">
-                <Translation
-                    id="TR_TRADING_PROCESSING_SUPPORT"
-                    values={{
-                        providerName,
-                        link: chunks => <Link href={supportUrl}>{chunks}</Link>,
-                    }}
-                />
-            </Paragraph>
-        </Banner>
+        <Banner
+            intent="neutral"
+            icon="question"
+            description={
+                <Paragraph typographyStyle="hint">
+                    <Translation
+                        id="TR_TRADING_PROCESSING_SUPPORT"
+                        values={{
+                            providerName,
+                            link: chunks => <Link href={supportUrl}>{chunks}</Link>,
+                        }}
+                    />
+                </Paragraph>
+            }
+        />
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingDisabled.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDisabled.tsx
@@ -22,13 +22,17 @@ export const TradingDisabled = ({ type, content }: TradingDisabledProps) => {
     const { translationString } = useTranslation();
 
     return (
-        <Banner icon="warning" intent="warning">
-            {content ?? (
-                <Translation
-                    id="TR_TRADING_DISABLED_DEFAULT"
-                    values={{ type: translationString(typeLabels[type]) }}
-                />
-            )}
-        </Banner>
+        <Banner
+            icon="warning"
+            intent="warning"
+            description={
+                content ?? (
+                    <Translation
+                        id="TR_TRADING_DISABLED_DEFAULT"
+                        values={{ type: translationString(typeLabels[type]) }}
+                    />
+                )
+            }
+        />
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -332,9 +332,13 @@ export const TradingFormApproval = ({
                                         <Translation id="TR_EXCHANGE_APPROVAL_FORM_REVOKE_BUTTON" />
                                     </Button>
 
-                                    <Banner intent="warning" icon="warning">
-                                        <Translation id="TR_EXCHANGE_APPROVAL_FORM_REVOKE_BANNER" />
-                                    </Banner>
+                                    <Banner
+                                        intent="warning"
+                                        icon="warning"
+                                        description={
+                                            <Translation id="TR_EXCHANGE_APPROVAL_FORM_REVOKE_BANNER" />
+                                        }
+                                    />
                                 </>
                             ) : (
                                 <>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferOTC.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferOTC.tsx
@@ -111,39 +111,42 @@ export const TradingFormOfferOTC = () => {
     }
 
     return (
-        <Banner intent="info">
-            <Text margin={{ bottom: spacings.xxs }}>
-                <Translation
-                    id={
-                        context.type === 'buy'
-                            ? 'TR_TRADING_OTC_INFO_BUY'
-                            : 'TR_TRADING_OTC_INFO_SELL'
-                    }
-                    values={{
-                        minimumFiat: localizeNumber(displayedFiatLimit, locale),
-                        fiatSymbol: displayedFiatCurrency.toUpperCase(),
-                    }}
-                />{' '}
-                <FormattedList
-                    type="disjunction"
-                    value={links.map((link, index) => (
-                        <Fragment key={index}>
-                            <TrezorLink href={link.url} target="_blank" typographyStyle="hint">
-                                <Translation
-                                    id={
-                                        context.type === 'buy'
-                                            ? 'TR_TRADING_OTC_LINK_BUY'
-                                            : 'TR_TRADING_OTC_LINK_SELL'
-                                    }
-                                    values={{
-                                        providerName: link.name,
-                                    }}
-                                />
-                            </TrezorLink>
-                        </Fragment>
-                    ))}
-                />
-            </Text>
-        </Banner>
+        <Banner
+            intent="info"
+            description={
+                <Text margin={{ bottom: spacings.xxs }}>
+                    <Translation
+                        id={
+                            context.type === 'buy'
+                                ? 'TR_TRADING_OTC_INFO_BUY'
+                                : 'TR_TRADING_OTC_INFO_SELL'
+                        }
+                        values={{
+                            minimumFiat: localizeNumber(displayedFiatLimit, locale),
+                            fiatSymbol: displayedFiatCurrency.toUpperCase(),
+                        }}
+                    />{' '}
+                    <FormattedList
+                        type="disjunction"
+                        value={links.map((link, index) => (
+                            <Fragment key={index}>
+                                <TrezorLink href={link.url} target="_blank" typographyStyle="hint">
+                                    <Translation
+                                        id={
+                                            context.type === 'buy'
+                                                ? 'TR_TRADING_OTC_LINK_BUY'
+                                                : 'TR_TRADING_OTC_LINK_SELL'
+                                        }
+                                        values={{
+                                            providerName: link.name,
+                                        }}
+                                    />
+                                </TrezorLink>
+                            </Fragment>
+                        ))}
+                    />
+                </Text>
+            }
+        />
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingNetworkReserveBanner.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingNetworkReserveBanner.tsx
@@ -49,14 +49,15 @@ export const TradingNetworkReserveBanner = ({
                     <Translation id="TR_NETWORK_RESERVE_MANAGE" />
                 </Banner.Button>
             }
-        >
-            <Translation
-                id="TR_NETWORK_RESERVE_BANNER"
-                values={{
-                    amount: networkReserve,
-                    displaySymbol: network.displaySymbol,
-                }}
-            />
-        </Banner>
+            description={
+                <Translation
+                    id="TR_NETWORK_RESERVE_BANNER"
+                    values={{
+                        amount: networkReserve,
+                        displaySymbol: network.displaySymbol,
+                    }}
+                />
+            }
+        />
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc.tsx
@@ -68,5 +68,5 @@ export const TradingUtilsKyc = ({
         );
     }
 
-    return <Banner icon>{kycPolicyTranslation}</Banner>;
+    return <Banner icon description={kycPolicyTranslation} />;
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsTorWarning.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsTorWarning.tsx
@@ -56,10 +56,11 @@ export const TradingUtilsTorWarning = ({
                     </Banner.Button>
                 )
             }
-        >
-            <Column gap={spacings.sm}>
-                <Translation id={translationId} />
-            </Column>
-        </Banner>
+            description={
+                <Column gap={spacings.sm}>
+                    <Translation id={translationId} />
+                </Column>
+            }
+        />
     );
 };


### PR DESCRIPTION
## Notes for QA

Updated Banner component to use explicit title and description props instead of children

<img width="615" height="120" alt="image" src="https://github.com/user-attachments/assets/d7562ddc-bb8f-410f-b5b8-362f310698f6" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/banner-children&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/banner-children&lookback=7)