### PR TITLE
feat(e2e): test adding new passphrase wallet with locked device

### DIFF
--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -70,6 +70,7 @@ interface GenerateBlock {
 
 interface ApplySettings {
     passphrase_always_on_device?: boolean;
+    auto_lock_delay_ms?: number;
 }
 
 interface ReadAndConfirmShamirMnemonicEmu {

--- a/suite-native/app/e2e/support/setup.ts
+++ b/suite-native/app/e2e/support/setup.ts
@@ -12,6 +12,7 @@ import { onDevicePrompt } from '../pageObjects/devicePromptActions';
 
 type PrepareTrezorEmulatorProps = {
     seed?: string;
+    pin?: string;
     passphrase_protection?: boolean;
     model?: Model;
     version?: string;
@@ -130,6 +131,7 @@ const getFwVersion = (model: Model, version: string | undefined) => {
 export const prepareTrezorEmulator = async ({
     version,
     seed = MNEMONICS.mnemonic_immune,
+    pin = '',
     passphrase_protection = false,
     model = getModelFromEnv(),
     args,
@@ -148,6 +150,7 @@ export const prepareTrezorEmulator = async ({
             await TrezorUserEnvLink.setupEmu({
                 label: TREZOR_E2E_DEVICE_LABEL,
                 mnemonic: seed,
+                pin,
                 passphrase_protection,
             });
         }

--- a/suite-native/app/e2e/tests/lockedDevice.test.ts
+++ b/suite-native/app/e2e/tests/lockedDevice.test.ts
@@ -1,0 +1,71 @@
+import { conditionalDescribe } from '@suite-common/test-utils';
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+
+import { deviceChecksDisabledState } from '../fixtures/deviceChecksDisabledState';
+import { deviceChecksEnabledState } from '../fixtures/deviceChecksEnabledState';
+import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
+import { regtestDiscoveryFinishedStateT3T1 } from '../fixtures/regtestDiscoveryFinishedStateT3T1';
+import { regtestDiscoveryFinishedStateT3W1 } from '../fixtures/regtestDiscoveryFinishedStateT3W1';
+import { onDeviceManager } from '../pageObjects/deviceManagerActions';
+import { onPassphrase } from '../pageObjects/passphraseModule';
+import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
+import { getModelFromEnv, wait, waitForVisible } from '../support/utils';
+
+const PIN = '1234';
+const AUTO_LOCK_DELAY_MS = 10_000; // 5 seconds for testing
+const TEST_PASSPHRASE = 'E2E:device actions locked test';
+
+const preloadedState = preparePreloadedReduxState(
+    onboardingCompletedState,
+    getModelFromEnv() === 'T3T1'
+        ? regtestDiscoveryFinishedStateT3T1
+        : regtestDiscoveryFinishedStateT3W1,
+    getModelFromEnv() === 'T3W1' ? deviceChecksDisabledState : deviceChecksEnabledState,
+);
+
+conditionalDescribe(
+    device.getPlatform() === 'android' || getModelFromEnv() === 'T3W1',
+    'Device actions with locked device [@deviceActions]',
+    () => {
+        describe('PIN required scenarios', () => {
+            beforeEach(async () => {
+                await openApp({ args: { preloadedState } });
+                // Setup emulator with PIN protection enabled
+                await prepareTrezorEmulator({ pin: PIN, passphrase_protection: true });
+                await TrezorUserEnvLink.applySettings({ auto_lock_delay_ms: AUTO_LOCK_DELAY_MS });
+                await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
+            });
+
+            it('Add hidden wallet requires PIN after device lock', async () => {
+                // Wait for auto-lock to trigger
+                await wait(AUTO_LOCK_DELAY_MS);
+
+                // Try to add passphrase wallet - should require PIN
+                await onPassphrase.openNewPassphraseFlow();
+
+                await waitForVisible(by.id('@screen/PinMatrix'));
+                // Device should request PIN unlock
+                // Enter PIN on emulator
+                await TrezorUserEnvLink.inputEmu(PIN);
+
+                // After PIN, passphrase form should appear
+                await onPassphrase.expectEnterPassphraseScreen();
+                await onPassphrase.enterPassphrase(TEST_PASSPHRASE);
+
+                await onPassphrase.expectConfirmPassphraseOnDeviceRequest();
+                await onPassphrase.confirmPassphraseOnEmu();
+
+                await onPassphrase.expectEmptyPassphraseWalletScreen();
+                await onPassphrase.openEmptyPassphraseWalletAndConfirmBestPractices();
+
+                await onPassphrase.expectEmptyPassphraseWalletConfirmationScreen();
+                await onPassphrase.enterPassphrase(TEST_PASSPHRASE);
+
+                await onPassphrase.expectConfirmPassphraseOnDeviceRequest();
+                await onPassphrase.confirmPassphraseOnEmu();
+
+                await onPassphrase.expectSwitcherSubheader('Passphrase wallet #1');
+            });
+        });
+    },
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Notes for QA

This is an attempt to cover at least partially the scenarios described here https://www.notion.so/satoshilabs/Testing-scenarios-Suite-Mobile-Device-Action-Guards-2e8dc5260606804ab298f979cd84a9d4?source=copy_link by E2E test. 

The goal is to simplify verifying that the refactor of unlocking the Trezor before performing some action on the device didn’t break anything. Verifying it manually takes a very long time.

Covering it completely with tests is probably not possible either and would take too long, but it would be great to have at least some of the harder-to-reproduce flows covered.

I’m not sure it would make sense to have these tests run normally as part of pull requests. I’d probably rather come up with some kind of toggle that runs them only under some condition.




<details>

<summary>List of all scenarios for reference (It's not an ambition of this PR to cover all of them):</summary>

### 1. Add Hidden Wallet with Locked Device

**Setup**: Device with PIN set, passphrase protection enabled

**Steps**:

1. Open device switcher, tap "Add passphrase wallet"
2. Device requests PIN unlock
3. Enter PIN (T1B1: blind matrix via `enterPinOnBlindMatrix`, T3T1/T3W1: `inputEmu`)
4. Passphrase form appears
5. Enter passphrase, confirm on device

**Checks**:

- PIN matrix/input displayed after action initiated
- Passphrase screen shown after successful PIN entry
- Wallet added after passphrase confirmation

---

### 2. Enable Passphrase with Locked Device

**Setup**:  device with PIN, passphrase_protection=false

**Steps**:

1. Navigate to device settings
2. Toggle passphrase switch
3. Enter PIN (T1B1: blind matrix via `enterPinOnBlindMatrix`, T3T1/T3W1: `inputEmu`)
4. Confirm on device

**Checks**:

- T1B1: Blind PIN matrix displayed (9-button grid) / T3: Pin entry screen
- Setting changed after PIN + device confirmation

---

### 3. Receive Address Confirmation

### 3a. Locked Device

**Steps**: Open receive -> device locked -> PIN entry -> address confirmation

**Checks**: PIN prompt before address reveal

### 3b. Disconnected Device

**Steps**: Open receive -> device disconnected -> reconnect prompt

**Checks**: "Connect device" message shown

### 3c. Passphrase Wallet (Reconnected)

**Steps**:

1. Add passphrase wallet
2. Disconnect device
3. Restart app
4. Reconnect
5. Open receive
6. Passphrase re-entry required

**Checks**: Passphrase prompt on address reveal after reconnection

---

### 4. Send Transaction Confirmation

### 4a. Standard Wallet - Locked

**Steps**: Fill send form -> submit -> PIN entry -> sign transaction

**Checks**: PIN required before transaction signing

### 4b. Standard Wallet - Disconnected

**Steps**: Fill send form -> device disconnected -> reconnect prompt

**Checks**: Cannot proceed without device

### 4c. Passphrase Wallet - Reconnected

**Steps**:

1. Open passphrase wallet
2. Disconnect/reconnect device
3. Fill send form
4. Passphrase re-entry -> PIN (if locked) -> sign

**Checks**: Full re-authorization flow after reconnection

---

### 5. THP pairing (T3W1 only)

**Setup**: T3W1 model with THP enabled

**Steps**:

1. Start app
2. THP confirmation screen appears
3. Confirm on device
4. Enter pairing code from device screen
5. Connection established

**Checks**:

- THP confirmation modal appears
- Pairing code entry screen
- Successful pairing notification

---

### 6. Firmware Update

### 6a. Locked Device

**Setup**: Device with outdated firmware

**Steps**:

1. Navigate to Settings -> Device
2. Tap "Update firmware" button
3. PIN entry
4. Confirm update on device
5. Wait for update completion
6. Device reconnects
**Checks**:
- Update modal with confirmation
- Device enters bootloader mode
- Successful update notification
- Accounts still accessible post-update

### 6b. Disconnected Device

Setup**: Device with outdated firmware

**Steps**:

1. Navigate to Settings -> Device
2. Tap "Update firmware" button
3. Reconnect prompt, connect device
4. Confirm update on device
5. Wait for update completion
6. Device reconnects
**Checks**:
- Update modal with confirmation
- Device enters bootloader mode
- Successful update notification
- Accounts still accessible post-update

---

### 7. Change PIN

### 7a. Locked Device

**Setup**: Device with existing PIN

**Steps**:

1. Navigate to device settings
2. Tap "Change PIN"
3. PIN entry
4. Enter current PIN
5. Enter new PIN twice
6. Confirm on device

**Checks**:

- Current PIN required first
- New PIN confirmation screen
- Success notification

### 7a. Disconnected Device

**Setup**: Device with existing PIN

**Steps**:

1. Navigate to device settings
2. Tap "Change PIN"
3. Reconnect prompt, connect device
4. Enter current PIN
5. Enter new PIN twice
6. Confirm on device

**Checks**:

- Current PIN required first
- New PIN confirmation screen
- Success notification

---

### 8. Enable New Coin

### 8a. Locked Device

**Setup**: Standard wallet connected

**Steps**:

1. Navigate to coin settings
2. Enable a disabled coin (e.g., ETH)
3. Go to dashboard
4. PIN entry
5. Discovery runs for new coin

**Checks**:

- Coin toggle state changes
- New accounts discovered

---

### 9. Suite Sync Confirmation

**Setup**: Passphrase wallet, Suite Sync enabled

**Steps**:

1. Enable Suite Sync in settings
2. Create/modify label
3. Label syncs to backend
4. Wipe app, re-onboard
5. Labels restored after passphrase entry

**Checks**:

- Labels persist across sessions (see suite-sync.test.ts)

---

### 10. Device Auth Check

### 10a. Locked Device

**Setup**: Device with secure element

**Steps**:

1. Navigate to device settings
2. Tap "Check authenticity"
3. PIN entry
4. Confirm check
5. Success/failure modal

**Checks**:

- Device Authenticity Success displayed

### 10b. Disconnected Device

**Setup**: Device with secure element

**Steps**:

1. Navigate to device settings
2. Tap "Check authenticity"
3. Reconnect prompt, connect device
4. Confirm check
5. Success/failure modal

**Checks**:

- Device Authenticity Success displayed

## Cancellation Scenarios

### 12. Cancel on Trezor Device

- 12a. Cancel PIN Entry - User cancels PIN on device
- 12b. Cancel Passphrase Confirmation - Cancel during passphrase confirmation on device
- 12c. Cancel Address Verification - Cancel receive address confirmation
- 12d. Cancel Transaction Signing - Cancel during send flow
- 12e. Cancel THP Pairing (T3W1) - Cancel THP pairing on device
- 12f. Cancel Firmware Update - Abort firmware update

### 13. Cancel in Suite App

- 13a. Cancel Passphrase Entry - Close passphrase modal via app UI
- 13b. Cancel PIN Entry Modal - Dismiss PIN input
- 13c. Cancel Receive Flow - Navigate back before confirmation
- 13d. Cancel Send Flow - Cancel during transaction review
- 13e. Cancel Device Settings Change - Cancel before device confirmation
- 13f. Dismiss THP Code Entry - Close pairing code screen

</details>



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/locked-device-e2e&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/locked-device-e2e&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/locked-device-e2e&lookback=7)