### PR TITLE
chore(suite): remove unused translation argument

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/BluetoothEraseBonds.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/BluetoothEraseBonds.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react';
 
-import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
-
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -15,7 +13,6 @@ type BluetoothEraseBondsProps = {
 export const BluetoothEraseBonds = ({ isDeviceLocked }: BluetoothEraseBondsProps) => {
     const dispatch = useDispatch();
     const device = useSelector(state => state.device.selectedDevice);
-    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
 
     const [inProgress, setInProgress] = useState(false);
 
@@ -33,12 +30,7 @@ export const BluetoothEraseBonds = ({ isDeviceLocked }: BluetoothEraseBondsProps
         <SectionItem data-test="@settings/debug/bluetooth-erase">
             <TextColumn
                 title={<Translation id="TR_BLUETOOTH_ERASE_BONDS_SETTINGS" />}
-                description={
-                    <Translation
-                        id="TR_BLUETOOTH_ERASE_BONDS_SETTINGS_DESCRIPTION"
-                        values={{ deviceName: deviceLabel }}
-                    />
-                }
+                description={<Translation id="TR_BLUETOOTH_ERASE_BONDS_SETTINGS_DESCRIPTION" />}
             />
             <ActionColumn>
                 <ActionButton


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The translation doesn't use device name anymore, removing the argument.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-arg&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-arg&lookback=7)