### PR TITLE
fix(staking): fix inconsistent Solana staking amounts between UI and device

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -7,6 +7,7 @@ import {
     composeStakingTransaction,
 } from '@suite-common/staking/src/actions/stakeFormActions';
 import {
+    SolanaTxMeta,
     prepareClaimSolTx,
     prepareStakeSolTx,
     prepareUnstakeSolTx,
@@ -26,6 +27,7 @@ import {
     BlockchainNetworks,
     EstimatedFee,
     ExternalOutput,
+    PrecomposedLevels,
     PrecomposedTransaction,
     PrecomposedTransactionFinal,
     PrepareStakeSolTxResponse,
@@ -157,6 +159,35 @@ async function estimateFee(
     return { success: false };
 }
 
+const applySolanaTxMeta = (
+    composed: PrecomposedLevels,
+    solanaTxMeta: SolanaTxMeta,
+): PrecomposedLevels =>
+    Object.fromEntries(
+        Object.entries(composed).map(([key, tx]) => {
+            if (tx.type === 'error') return [key, tx];
+
+            const nextTx = { ...tx, solanaTxMeta };
+
+            if (tx.type === 'final') {
+                const totalSpent = new BigNumber(solanaTxMeta.deviceAmountLamports)
+                    .plus(solanaTxMeta.feeIncludingRentLamports)
+                    .toString();
+
+                return [
+                    key,
+                    {
+                        ...nextTx,
+                        fee: solanaTxMeta.feeIncludingRentLamports,
+                        totalSpent,
+                    },
+                ];
+            }
+
+            return [key, nextTx];
+        }),
+    );
+
 export const composeTransaction =
     (formValues: StakeFormState, formState: ComposeActionContext) =>
     async (_: Dispatch, getState: GetState) => {
@@ -179,7 +210,7 @@ export const composeTransaction =
         const { levels } = feeInfo;
         const predefinedLevels = levels.filter(l => l.label !== 'custom');
 
-        return composeStakingTransaction(
+        const composed = composeStakingTransaction(
             formValues,
             formState,
             predefinedLevels,
@@ -187,6 +218,23 @@ export const composeTransaction =
             estimatedFee,
             undefined,
         );
+        if (!composed) return;
+
+        if (estimatedFee.success && estimatedFee.payload) {
+            const txDataWithFee = await getTransactionData(
+                formValues,
+                selectedAccount,
+                blockchain,
+                estimatedFee.payload,
+            );
+            const solanaTxMeta = txDataWithFee?.success ? txDataWithFee.solanaTxMeta : undefined;
+
+            if (solanaTxMeta) {
+                return applySolanaTxMeta(composed, solanaTxMeta);
+            }
+        }
+
+        return composed;
     };
 
 export const signTransaction =

--- a/suite-common/staking-solana/package.json
+++ b/suite-common/staking-solana/package.json
@@ -20,6 +20,7 @@
         "@suite-common/wallet-constants": "workspace:*",
         "@trezor/blockchain-link": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
+        "@trezor/blockchain-link-utils": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",

--- a/suite-common/staking-solana/src/types.ts
+++ b/suite-common/staking-solana/src/types.ts
@@ -28,11 +28,19 @@ export interface SolNetworkConfig {
     network: Network;
 }
 
+export type SolanaTxMeta = {
+    deviceAmountLamports: string;
+    feeLamports: string;
+    rentLamports: string;
+    feeIncludingRentLamports: string;
+};
+
 export type StakeResponse = {
     stakeTx:
         | (CompilableTransactionMessage & TransactionMessageWithBlockhashLifetime)
         | (Transaction & TransactionMessageWithBlockhashLifetime);
     stakeAccount: Address;
+    txMeta: SolanaTxMeta;
 };
 
 export type Delegations = Array<Account<StakeStateAccount, Address>>;
@@ -40,6 +48,7 @@ export type Delegations = Array<Account<StakeStateAccount, Address>>;
 export type UnstakeResponse = {
     unstakeTx: CompilableTransactionMessage & TransactionMessageWithBlockhashLifetime;
     unstakeAmount: bigint;
+    txMeta: SolanaTxMeta;
 };
 
 export type Connection = RpcFromTransport<
@@ -50,6 +59,7 @@ export type Connection = RpcFromTransport<
 export type ClaimResponse = {
     claimTx: CompilableTransactionMessage & TransactionMessageWithBlockhashLifetime;
     totalClaimAmount: bigint;
+    txMeta: SolanaTxMeta;
 };
 
 export type TransactionShim = {

--- a/suite-common/staking-solana/src/utils/stakingUtils.ts
+++ b/suite-common/staking-solana/src/utils/stakingUtils.ts
@@ -61,7 +61,7 @@ const getStakingParams = (estimatedFee?: Fee[number]) => {
     }
 
     return {
-        сomputeUnitPrice: BigInt(estimatedFee.feePerUnit),
+        computeUnitPrice: BigInt(estimatedFee.feePerUnit),
         computeUnitLimit: Number(estimatedFee.feeLimit), // solana package expects number
     };
 };
@@ -97,6 +97,7 @@ export const prepareStakeSolTx = async ({
         return {
             success: true,
             tx: transformedTx,
+            solanaTxMeta: tx.txMeta,
         };
     } catch (e) {
         console.error(e);
@@ -132,6 +133,7 @@ export const prepareUnstakeSolTx = async ({
         return {
             success: true,
             tx: transformedTx,
+            solanaTxMeta: tx.txMeta,
         };
     } catch (e) {
         console.error(e);
@@ -163,6 +165,7 @@ export const prepareClaimSolTx = async ({
         return {
             success: true,
             tx: transformedTx,
+            solanaTxMeta: tx.txMeta,
         };
     } catch (e) {
         console.error(e);

--- a/suite-common/staking-solana/src/utils/transactionUtils.ts
+++ b/suite-common/staking-solana/src/utils/transactionUtils.ts
@@ -9,6 +9,7 @@ import {
     TransactionMessageWithBlockhashLifetime,
     address,
     appendTransactionMessageInstruction,
+    compileTransactionMessage,
     createAddressWithSeed,
     createNoopSigner,
     createTransactionMessage,
@@ -21,8 +22,12 @@ import {
     setTransactionMessageLifetimeUsingBlockhash,
 } from '@solana/kit';
 import {
+    SET_COMPUTE_UNIT_LIMIT_DISCRIMINATOR,
+    SET_COMPUTE_UNIT_PRICE_DISCRIMINATOR,
     getSetComputeUnitLimitInstruction,
+    getSetComputeUnitLimitInstructionDataDecoder,
     getSetComputeUnitPriceInstruction,
+    getSetComputeUnitPriceInstructionDataDecoder,
 } from '@solana-program/compute-budget';
 import {
     STAKE_PROGRAM_ADDRESS,
@@ -40,12 +45,18 @@ import {
 } from '@solana-program/system';
 
 import {
+    SOL_BASE_FEE,
+    SOL_COMPUTE_UNIT_LIMIT,
+    SOL_MICROLAMPORTS_PER_LAMPORT,
+} from '@suite-common/wallet-constants';
+import {
     STAKE_ACCOUNT_V2_SIZE,
     getDelegations,
     isStake,
     stakeAccountState,
 } from '@trezor/blockchain-link/src/workers/solana/utils/stakingAccounts';
 import { StakeState } from '@trezor/blockchain-link-types/src/solana';
+import { COMPUTE_BUDGET_PROGRAM_ID } from '@trezor/blockchain-link-utils/src/solana';
 import { serializeError } from '@trezor/utils';
 
 import { selectSolanaWalletSdkNetwork } from '../connection';
@@ -64,6 +75,7 @@ import {
     Connection,
     Delegations,
     Params,
+    SolanaTxMeta,
     StakeParams,
     StakeResponse,
     UnstakeResponse,
@@ -160,6 +172,59 @@ const baseTx = async (
     return transactionMessage;
 };
 
+export const getFeeSummary = ({
+    transactionMessage,
+}: {
+    transactionMessage: CompilableTransactionMessage & TransactionMessageWithBlockhashLifetime;
+}) => {
+    const compiledMessage = compileTransactionMessage(transactionMessage);
+
+    const baseFeeLamports = SOL_BASE_FEE * BigInt(compiledMessage.header.numSignerAccounts);
+
+    let unitLimit = BigInt(SOL_COMPUTE_UNIT_LIMIT);
+    let unitPriceMicroLamports = 0n;
+    let isUnitLimitSet = false;
+    let isUnitPriceSet = false;
+
+    compiledMessage.instructions.forEach(instruction => {
+        if (
+            compiledMessage.staticAccounts[instruction.programAddressIndex] !==
+            COMPUTE_BUDGET_PROGRAM_ID
+        ) {
+            return;
+        }
+
+        const { data } = instruction;
+        if (!data || data.length === 0) return;
+
+        if (data[0] === SET_COMPUTE_UNIT_LIMIT_DISCRIMINATOR && !isUnitLimitSet) {
+            const decoded = getSetComputeUnitLimitInstructionDataDecoder().decode(data);
+            unitLimit = BigInt(decoded.units);
+            isUnitLimitSet = true;
+
+            return;
+        }
+
+        if (data[0] === SET_COMPUTE_UNIT_PRICE_DISCRIMINATOR && !isUnitPriceSet) {
+            const decoded = getSetComputeUnitPriceInstructionDataDecoder().decode(data);
+            unitPriceMicroLamports = BigInt(decoded.microLamports);
+            isUnitPriceSet = true;
+        }
+    });
+
+    const priorityFeeLamports =
+        (unitPriceMicroLamports * BigInt(unitLimit) + SOL_MICROLAMPORTS_PER_LAMPORT - 1n) /
+        SOL_MICROLAMPORTS_PER_LAMPORT;
+
+    const feeLamports = baseFeeLamports + priorityFeeLamports;
+
+    return {
+        baseFeeLamports: baseFeeLamports.toString(10),
+        priorityFeeLamports: priorityFeeLamports.toString(10),
+        feeLamports: feeLamports.toString(10),
+    };
+};
+
 const timestampInSec = (): number => (Date.now() / 1000) | 0;
 
 const isLockupInForce = (
@@ -248,7 +313,6 @@ export const stake = async ({
             initializeStakeAccountInstruction,
             stakeAccountPublicKey,
         ] = await createAccountWithSeedTx(address(sender), BigInt(lamports) + minimumRent, source);
-
         const delegateInstruction = getDelegateStakeInstruction({
             stake: stakeAccountPublicKey,
             vote: validator,
@@ -276,9 +340,21 @@ export const stake = async ({
                 ? await partiallySignTransactionMessageWithSigners(transactionMessage)
                 : transactionMessage;
 
+        const feeSummary = getFeeSummary({ transactionMessage });
+        const feeLamports = BigInt(feeSummary.feeLamports);
+        const feeIncludingRentLamports = (feeLamports + minimumRent).toString();
+        const deviceAmountLamports = (lamports + minimumRent).toString();
+        const txMeta: SolanaTxMeta = {
+            deviceAmountLamports,
+            feeLamports: feeSummary.feeLamports,
+            rentLamports: minimumRent.toString(),
+            feeIncludingRentLamports,
+        };
+
         return {
             stakeTx: signedTransactionMessage,
             stakeAccount: stakeAccountPublicKey,
+            txMeta,
         };
     } catch (error) {
         throw new Error(
@@ -430,7 +506,17 @@ export const unstake = async ({
             throw new Error('Zero instructions');
         }
 
-        return { unstakeTx: transactionMessage, unstakeAmount };
+        const feeSummary = getFeeSummary({ transactionMessage });
+        const feeLamports = BigInt(feeSummary.feeLamports);
+        const feeIncludingRentLamports = (feeLamports + minimumRent).toString();
+        const txMeta: SolanaTxMeta = {
+            deviceAmountLamports: unstakeAmount.toString(),
+            feeLamports: feeSummary.feeLamports,
+            rentLamports: minimumRent.toString(),
+            feeIncludingRentLamports,
+        };
+
+        return { unstakeTx: transactionMessage, unstakeAmount, txMeta };
     } catch (error) {
         throw new Error(
             `Solana staking: unstaking failed - ${error instanceof Error ? error.message : serializeError(error)}`,
@@ -488,9 +574,18 @@ export const claim = async ({
             }
         }
 
+        const feeSummary = getFeeSummary({ transactionMessage });
+        const txMeta: SolanaTxMeta = {
+            deviceAmountLamports: totalClaimableStake.toString(),
+            feeLamports: feeSummary.feeLamports,
+            rentLamports: '0',
+            feeIncludingRentLamports: feeSummary.feeLamports,
+        };
+
         return {
             claimTx: transactionMessage,
             totalClaimAmount: totalClaimableStake,
+            txMeta,
         };
     } catch (error) {
         throw new Error(

--- a/suite-common/staking-solana/tsconfig.json
+++ b/suite-common/staking-solana/tsconfig.json
@@ -10,6 +10,9 @@
         {
             "path": "../../packages/blockchain-link-types"
         },
+        {
+            "path": "../../packages/blockchain-link-utils"
+        },
         { "path": "../../packages/connect" },
         { "path": "../../packages/env-utils" },
         { "path": "../../packages/type-utils" },

--- a/suite-common/wallet-constants/src/solanaStakingConstants.ts
+++ b/suite-common/wallet-constants/src/solanaStakingConstants.ts
@@ -9,4 +9,7 @@ export const SOL_STAKING_OPERATION_FEE = new BigNumber(70_000); // 0.00007 SOL
 export const SOL_COMPUTE_UNIT_PRICE = 100000;
 export const SOL_COMPUTE_UNIT_LIMIT = 200000;
 
+export const SOL_BASE_FEE = 5000n;
+export const SOL_MICROLAMPORTS_PER_LAMPORT = 1_000_000n;
+
 export const SOLANA_EPOCH_DAYS = 2;

--- a/suite-common/wallet-types/src/solanaStaking.ts
+++ b/suite-common/wallet-types/src/solanaStaking.ts
@@ -1,4 +1,4 @@
-import { SolanaTx } from '@suite-common/staking-solana';
+import { SolanaTx, SolanaTxMeta } from '@suite-common/staking-solana';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Fee } from '@trezor/blockchain-link-types/src/blockbook';
 
@@ -28,6 +28,7 @@ export type PrepareStakeSolTxResponse =
     | {
           success: true;
           tx: SolanaTx;
+          solanaTxMeta: SolanaTxMeta;
       }
     | {
           success: false;

--- a/suite/e2e/fixtures/staking/sol-simulate-claim-transaction.json
+++ b/suite/e2e/fixtures/staking/sol-simulate-claim-transaction.json
@@ -1,0 +1,31 @@
+{
+    "accounts": null,
+    "err": null,
+    "fee": 145000,
+    "innerInstructions": null,
+    "loadedAccountsDataSize": 249647,
+    "loadedAddresses": {
+        "readonly": [],
+        "writable": []
+    },
+    "logs": [
+        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+        "Program ComputeBudget111111111111111111111111111111 success",
+        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+        "Program ComputeBudget111111111111111111111111111111 success",
+        "Program Stake11111111111111111111111111111111111111 invoke [1]",
+        "Program log: Instruction: Withdraw",
+        "Program Stake11111111111111111111111111111111111111 consumed 9711 of 1399700 compute units",
+        "Program Stake11111111111111111111111111111111111111 success"
+    ],
+    "postBalances": [999564667, 0, 1, 1141440, 1169280, 114979200],
+    "postTokenBalances": [],
+    "preBalances": [796473333, 203236667, 1, 1141440, 1169280, 114979200],
+    "preTokenBalances": [],
+    "replacementBlockhash": {
+        "blockhash": "8qhi21UjdfoBeRDTTrCbJecmDLDA9PsK9GfpAbU6mKRU",
+        "lastValidBlockHeight": 373500318
+    },
+    "returnData": null,
+    "unitsConsumed": 10011
+}

--- a/suite/e2e/fixtures/staking/sol-simulate-stake-more-transaction.json
+++ b/suite/e2e/fixtures/staking/sol-simulate-stake-more-transaction.json
@@ -1,0 +1,39 @@
+{
+    "accounts": null,
+    "err": null,
+    "fee": 145000,
+    "innerInstructions": null,
+    "loadedAccountsDataSize": 253449,
+    "loadedAddresses": {
+        "readonly": [],
+        "writable": []
+    },
+    "logs": [
+        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+        "Program ComputeBudget111111111111111111111111111111 success",
+        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+        "Program ComputeBudget111111111111111111111111111111 success",
+        "Program 11111111111111111111111111111111 invoke [1]",
+        "Program 11111111111111111111111111111111 success",
+        "Program Stake11111111111111111111111111111111111111 invoke [1]",
+        "Program log: Instruction: Initialize",
+        "Program Stake11111111111111111111111111111111111111 consumed 8684 of 1399550 compute units",
+        "Program Stake11111111111111111111111111111111111111 success",
+        "Program Stake11111111111111111111111111111111111111 invoke [1]",
+        "Program log: Instruction: DelegateStake",
+        "Program Stake11111111111111111111111111111111111111 consumed 21037 of 1390866 compute units",
+        "Program Stake11111111111111111111111111111111111111 success"
+    ],
+    "postBalances": [
+        649865586, 146752747, 1, 10000000000, 1, 1141440, 960480, 1169280, 1009200, 114979200
+    ],
+    "postTokenBalances": [],
+    "preBalances": [796618333, 0, 1, 10000000000, 1, 1141440, 960480, 1169280, 1009200, 114979200],
+    "preTokenBalances": [],
+    "replacementBlockhash": {
+        "blockhash": "89LBDmshqCkD2tpidabFCRLdzvScinp6pQ1Xc5sXBRni",
+        "lastValidBlockHeight": 376546017
+    },
+    "returnData": null,
+    "unitsConsumed": 30171
+}

--- a/suite/e2e/fixtures/staking/sol-simulate-stake-transaction.json
+++ b/suite/e2e/fixtures/staking/sol-simulate-stake-transaction.json
@@ -1,0 +1,39 @@
+{
+    "accounts": null,
+    "err": null,
+    "fee": 145000,
+    "innerInstructions": null,
+    "loadedAccountsDataSize": 253449,
+    "loadedAddresses": {
+        "readonly": [],
+        "writable": []
+    },
+    "logs": [
+        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+        "Program ComputeBudget111111111111111111111111111111 success",
+        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+        "Program ComputeBudget111111111111111111111111111111 success",
+        "Program 11111111111111111111111111111111 invoke [1]",
+        "Program 11111111111111111111111111111111 success",
+        "Program Stake11111111111111111111111111111111111111 invoke [1]",
+        "Program log: Instruction: Initialize",
+        "Program Stake11111111111111111111111111111111111111 consumed 8684 of 1399550 compute units",
+        "Program Stake11111111111111111111111111111111111111 success",
+        "Program Stake11111111111111111111111111111111111111 invoke [1]",
+        "Program log: Instruction: DelegateStake",
+        "Program Stake11111111111111111111111111111111111111 consumed 21037 of 1390866 compute units",
+        "Program Stake11111111111111111111111111111111111111 success"
+    ],
+    "postBalances": [
+        796618333, 203236667, 1, 10000000000, 1, 1141440, 960480, 1169280, 1009200, 114979200
+    ],
+    "postTokenBalances": [],
+    "preBalances": [1000000000, 0, 1, 10000000000, 1, 1141440, 960480, 1169280, 1009200, 114979200],
+    "preTokenBalances": [],
+    "replacementBlockhash": {
+        "blockhash": "89LBDmshqCkD2tpidabFCRLdzvScinp6pQ1Xc5sXBRni",
+        "lastValidBlockHeight": 376546017
+    },
+    "returnData": null,
+    "unitsConsumed": 30171
+}

--- a/suite/e2e/fixtures/staking/sol-simulate-unstake-transaction.json
+++ b/suite/e2e/fixtures/staking/sol-simulate-unstake-transaction.json
@@ -1,0 +1,39 @@
+{
+    "accounts": null,
+    "err": null,
+    "fee": 145000,
+    "innerInstructions": null,
+    "loadedAccountsDataSize": 253449,
+    "loadedAddresses": {
+        "readonly": [],
+        "writable": []
+    },
+    "logs": [
+        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+        "Program ComputeBudget111111111111111111111111111111 success",
+        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+        "Program ComputeBudget111111111111111111111111111111 success",
+        "Program Stake11111111111111111111111111111111111111 invoke [1]",
+        "Program log: Instruction: Deactivate",
+        "Program Stake11111111111111111111111111111111111111 consumed 12920 of 1399700 compute units",
+        "Program Stake11111111111111111111111111111111111111 success",
+        "Program Stake11111111111111111111111111111111111111 invoke [1]",
+        "Program log: Instruction: Deactivate",
+        "Program Stake11111111111111111111111111111111111111 consumed 12920 of 1386780 compute units",
+        "Program Stake11111111111111111111111111111111111111 success"
+    ],
+    "postBalances": [
+        796473333, 203236667, 1, 10000000000, 1, 1141440, 960480, 1169280, 1009200, 114979200
+    ],
+    "postTokenBalances": [],
+    "preBalances": [
+        796618333, 203236667, 1, 10000000000, 1, 1141440, 960480, 1169280, 1009200, 114979200
+    ],
+    "preTokenBalances": [],
+    "replacementBlockhash": {
+        "blockhash": "6Bo3L9T2LGopQ38tYuhLttAF1MFzJQBQj7gZeygcGXoD",
+        "lastValidBlockHeight": 372905228
+    },
+    "returnData": null,
+    "unitsConsumed": 30171
+}

--- a/suite/e2e/fixtures/staking/sol-staking-accounts.ts
+++ b/suite/e2e/fixtures/staking/sol-staking-accounts.ts
@@ -207,6 +207,14 @@ class SolanaStakingAccountFixture {
         return (Number(this.decoded.state.fields[1].delegation.stake) / 1_000_000_000).toString();
     }
 
+    get stakeAndRentInSol(): string {
+        return (
+            (Number(this.decoded.state.fields[1].delegation.stake) +
+                Number(this.decoded.state.fields[0].rentExemptReserve)) /
+            1_000_000_000
+        ).toString();
+    }
+
     get activationEpoch(): number {
         return Number(this.decoded.state.fields[1].delegation.activationEpoch);
     }

--- a/suite/e2e/support/mocks/solanaStakingMock.ts
+++ b/suite/e2e/support/mocks/solanaStakingMock.ts
@@ -1,6 +1,7 @@
 import type { Page, Route } from '@playwright/test';
 
 import { solanaUrlPattern } from './tradingMock';
+import solSimulateTransactionResponse from '../../fixtures/staking/sol-simulate-stake-transaction.json';
 import transactionResponse from '../../fixtures/staking/sol-stake-transactionResponse.json';
 import {
     SolanaStakingAccount,
@@ -31,7 +32,10 @@ export type SolanaRouteMethod =
     | 'getSignatureStatuses'
     | 'getSignaturesForAddress'
     | 'getTransaction'
-    | 'getProgramAccounts';
+    | 'getProgramAccounts'
+    | 'getRecentPrioritizationFees'
+    | 'getFeeForMessage'
+    | 'getMinimumBalanceForRentExemption';
 
 const BASE_EPOCH = 864; // chosen based of our mocked program accounts activation/deactivation epochs
 
@@ -89,11 +93,7 @@ const createDefaultHandlers = (): SolanaRouteHandlers => ({
         enabled: true,
         respond: async (route, body) => {
             await fulfillWithResult(route, body, {
-                value: {
-                    err: null,
-                    logs: [],
-                    unitsConsumed: 0,
-                },
+                value: solSimulateTransactionResponse,
             });
         },
     },
@@ -148,6 +148,31 @@ const createDefaultHandlers = (): SolanaRouteHandlers => ({
             await fulfillWithResult(route, body, []);
         },
     },
+    getRecentPrioritizationFees: {
+        enabled: true,
+        respond: async (route, body) => {
+            await fulfillWithResult(route, body, [
+                {
+                    prioritizationFee: 0,
+                    slot: 394770899,
+                },
+            ]);
+        },
+    },
+    getFeeForMessage: {
+        enabled: true,
+        respond: async (route, body) => {
+            await fulfillWithResult(route, body, {
+                value: 5000,
+            });
+        },
+    },
+    getMinimumBalanceForRentExemption: {
+        enabled: true,
+        respond: async (route, body) => {
+            await fulfillWithResult(route, body, 2282880);
+        },
+    },
 });
 
 const hasEnabledHandler = (
@@ -160,9 +185,9 @@ const hasEnabledHandler = (
 export class SolanaStakingMock {
     readonly handlers: SolanaRouteHandlers;
     protected currentEpoch: number = BASE_EPOCH;
-    readonly fee: number = 0.00228788;
-    readonly feeFormatted: string = '0.00228788 SOL';
-    readonly rentFee: number = 0.000005;
+    readonly stakeFeeFormatted = '0.002298742 SOL';
+    readonly unstakeFeeFormatted = '0.000015862 SOL';
+    readonly claimFeeFormatted = '0.000008605 SOL';
 
     constructor(
         private readonly page: Page,
@@ -173,12 +198,6 @@ export class SolanaStakingMock {
 
     async routeSolana(routeHandlers: SolanaRouteHandlers = this.handlers) {
         await this.page.route(solanaUrlPattern, route => this.handle(route, routeHandlers));
-    }
-
-    addFeeTo(amountInSol: string): string {
-        const total = Number(amountInSol) + this.fee - this.rentFee;
-
-        return `${total.toFixed(9)} SOL`;
     }
 
     @step()

--- a/suite/e2e/tests/staking/sol/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/sol/initial-stake.test.ts
@@ -6,7 +6,7 @@ import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 // Expected values based on our mocked responses
 const stakedAmount = solStakingAccountFirst.stakeInSol;
-const stakedAmountFormatted = `${stakedAmount} SOL`;
+const stakedAndRentFormatted = `${solStakingAccountFirst.stakeAndRentInSol} SOL`;
 
 test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     test.use({
@@ -79,37 +79,26 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 });
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
-                    stakedAmountFormatted,
+                    stakedAndRentFormatted,
                 );
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(
-                    solanaStakingMock.feeFormatted,
+                    solanaStakingMock.stakeFeeFormatted,
                 );
 
-                const feeWrapped = device.wrapText(solanaStakingMock.feeFormatted, {
+                const feeWrapped = device.wrapText(solanaStakingMock.stakeFeeFormatted, {
                     isAmount: true,
                 });
-                const amountAndFeeWrapped = device.wrapText(
-                    solanaStakingMock.addFeeTo(stakedAmount),
-                    { isAmount: true },
-                );
+                const amountWrapped = device.wrapText(stakedAndRentFormatted, {
+                    isAmount: true,
+                });
                 await expect(device).toShowOnDisplay({
                     T3W1: {
                         header: { title: 'Stake' },
-                        body: [
-                            ['Max fees and rent:'],
-                            feeWrapped,
-                            ['Amount:'],
-                            amountAndFeeWrapped,
-                        ],
+                        body: [['Max fees and rent:'], feeWrapped, ['Amount:'], amountWrapped],
                         actions: { right_button: 'Hold to sign' },
                     },
                     T3T1: {
-                        body: [
-                            ['Amount:'],
-                            amountAndFeeWrapped,
-                            ['Max fees and rent:'],
-                            feeWrapped,
-                        ],
+                        body: [['Amount:'], amountWrapped, ['Max fees and rent:'], feeWrapped],
                     },
                 });
                 await devicePrompt.waitForFinalPromptAndConfirm();
@@ -120,7 +109,9 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 await solanaStakingMock.setProgramAccounts([solStakingAccountFirst.payload]);
                 await devicePrompt.sendButton.click();
                 await expect(stakingSection.stakedToastAccount).toContainText('Solana #1');
-                await expect(stakingSection.stakedToastAmount).toContainText(stakedAmountFormatted);
+                await expect(stakingSection.stakedToastAmount).toContainText(
+                    stakedAndRentFormatted,
+                );
             });
 
             await test.step('Verify pending on dashboard', async () => {

--- a/suite/e2e/tests/staking/sol/stake-more.test.ts
+++ b/suite/e2e/tests/staking/sol/stake-more.test.ts
@@ -1,16 +1,18 @@
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 
+import solSimulateStakeTransactionResponse from '../../../fixtures/staking/sol-simulate-stake-more-transaction.json';
 import {
     solStakingAccountFirst,
     solStakingAccountSecond,
 } from '../../../fixtures/staking/sol-staking-accounts';
 import { expect, test } from '../../../support/fixtures';
+import { fulfillWithResult } from '../../../support/mocks/solanaStakingMock';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 // Expected values based on our mocked responses
 const stakedAmount = solStakingAccountFirst.stakeInSol;
 const stakeMoreAmount = solStakingAccountSecond.stakeInSol;
-const stakeMoreAmountFormatted = `${stakeMoreAmount} SOL`;
+const stakeMoreAndRentFormatted = `${solStakingAccountSecond.stakeAndRentInSol} SOL`;
 const totalStakedAmount = (Number(stakedAmount) + Number(stakeMoreAmount)).toFixed(9);
 
 test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
@@ -23,6 +25,14 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     test.beforeEach(async ({ onboardingPage, settingsPage, solanaStakingMock }) => {
         await solanaStakingMock.setupStakedAccount();
         await solanaStakingMock.setEpoch(solStakingAccountSecond.activationEpoch);
+        // Mock simulate stake-more transaction response
+        await solanaStakingMock.replaceRoute('simulateTransaction', {
+            respond: async (route, body) => {
+                await fulfillWithResult(route, body, {
+                    value: solSimulateStakeTransactionResponse,
+                });
+            },
+        });
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({
             enableNetworks: ['sol'],
@@ -84,39 +94,28 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                     },
                 });
                 await devicePrompt.waitForPromptAndClick();
-                // labeled as total but excludes fees
+
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
-                    stakeMoreAmountFormatted,
+                    stakeMoreAndRentFormatted,
                 );
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(
-                    solanaStakingMock.feeFormatted,
+                    solanaStakingMock.stakeFeeFormatted,
                 );
 
-                const feeWrapped = device.wrapText(solanaStakingMock.feeFormatted, {
+                const feeWrapped = device.wrapText(solanaStakingMock.stakeFeeFormatted, {
                     isAmount: true,
                 });
-                const amountAndFeeWrapped = device.wrapText(
-                    solanaStakingMock.addFeeTo(stakeMoreAmount),
-                    { isAmount: true },
-                );
+                const amountWrapped = device.wrapText(stakeMoreAndRentFormatted, {
+                    isAmount: true,
+                });
                 await expect(device).toShowOnDisplay({
                     T3W1: {
                         header: { title: 'Stake' },
-                        body: [
-                            ['Max fees and rent:'],
-                            feeWrapped,
-                            ['Amount:'],
-                            amountAndFeeWrapped,
-                        ],
+                        body: [['Max fees and rent:'], feeWrapped, ['Amount:'], amountWrapped],
                         actions: { right_button: 'Hold to sign' },
                     },
                     T3T1: {
-                        body: [
-                            ['Amount:'],
-                            amountAndFeeWrapped,
-                            ['Max fees and rent:'],
-                            feeWrapped,
-                        ],
+                        body: [['Amount:'], amountWrapped, ['Max fees and rent:'], feeWrapped],
                     },
                 });
                 await devicePrompt.waitForFinalPromptAndConfirm();
@@ -131,7 +130,7 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 await devicePrompt.sendButton.click();
                 await expect(stakingSection.stakedToastAccount).toContainText('Solana #1');
                 await expect(stakingSection.stakedToastAmount).toContainText(
-                    stakeMoreAmountFormatted,
+                    stakeMoreAndRentFormatted,
                 );
             });
 

--- a/suite/e2e/tests/staking/sol/unstake.test.ts
+++ b/suite/e2e/tests/staking/sol/unstake.test.ts
@@ -1,10 +1,13 @@
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 
+import solSimulateClaimTransactionResponse from '../../../fixtures/staking/sol-simulate-claim-transaction.json';
+import solSimulateUnstakeTransactionResponse from '../../../fixtures/staking/sol-simulate-unstake-transaction.json';
 import {
     solStakingAccountDeactivating,
     solStakingAccountFirst,
 } from '../../../fixtures/staking/sol-staking-accounts';
 import { expect, test } from '../../../support/fixtures';
+import { fulfillWithResult } from '../../../support/mocks/solanaStakingMock';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 // Expected values based on our mocked responses
@@ -12,6 +15,7 @@ const stakedAmount = solStakingAccountFirst.stakeInSol;
 const stakedAmountFormatted = `${stakedAmount} SOL`;
 const unstakingAmount = solStakingAccountDeactivating.stakeInSol;
 const unstakingAmountFormatted = `${unstakingAmount} SOL`;
+const unstakingAndRentFormatted = `${solStakingAccountDeactivating.stakeAndRentInSol} SOL`;
 
 test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     test.use({
@@ -22,6 +26,14 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
 
     test.beforeEach(async ({ onboardingPage, settingsPage, solanaStakingMock }) => {
         await solanaStakingMock.setupStakedAccount();
+        // Mock simulate unstake transaction response
+        await solanaStakingMock.replaceRoute('simulateTransaction', {
+            respond: async (route, body) => {
+                await fulfillWithResult(route, body, {
+                    value: solSimulateUnstakeTransactionResponse,
+                });
+            },
+        });
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({
             enableNetworks: ['sol'],
@@ -88,12 +100,16 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                     stakedAmountFormatted,
                 );
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(
-                    solanaStakingMock.feeFormatted,
+                    solanaStakingMock.unstakeFeeFormatted,
                 );
+
+                const feeWrapped = device.wrapText(solanaStakingMock.unstakeFeeFormatted, {
+                    isAmount: true,
+                });
                 await expect(device).toShowOnDisplay({
                     T3W1: {
                         header: { title: 'Unstake' },
-                        body: [['Transaction fee:'], [`${solanaStakingMock.rentFee} SOL`]],
+                        body: [['Transaction fee:'], feeWrapped],
                         actions: { right_button: 'Hold to sign' },
                     },
                 });
@@ -117,6 +133,15 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 });
                 await expect(stakingSection.unstakeToClaimButton).toBeDisabled();
                 await expect(stakingSection.stakeMoreButton).toBeEnabled();
+            });
+
+            // Mock simulate claim transaction response
+            await solanaStakingMock.replaceRoute('simulateTransaction', {
+                respond: async (route, body) => {
+                    await fulfillWithResult(route, body, {
+                        value: solSimulateClaimTransactionResponse,
+                    });
+                },
             });
 
             await test.step('Wait few epochs for claim to be available', async () => {
@@ -162,27 +187,26 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 });
                 await devicePrompt.waitForPromptAndClick();
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
-                    unstakingAmountFormatted,
+                    unstakingAndRentFormatted,
                 );
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(
-                    solanaStakingMock.feeFormatted,
+                    solanaStakingMock.claimFeeFormatted,
                 );
 
-                const feeWrapped = device.wrapText(`${solanaStakingMock.rentFee} SOL`, {
+                const feeWrapped = device.wrapText(solanaStakingMock.claimFeeFormatted, {
                     isAmount: true,
                 });
-                const amountAndFeeWrapped = device.wrapText(
-                    solanaStakingMock.addFeeTo(unstakingAmount),
-                    { isAmount: true },
-                );
+                const amountWrapped = device.wrapText(unstakingAndRentFormatted, {
+                    isAmount: true,
+                });
                 await expect(device).toShowOnDisplay({
                     T3W1: {
                         header: { title: 'Claim' },
-                        body: [['Transaction fee:'], feeWrapped, ['Amount:'], amountAndFeeWrapped],
+                        body: [['Transaction fee:'], feeWrapped, ['Amount:'], amountWrapped],
                         actions: { right_button: 'Hold to sign' },
                     },
                     T3T1: {
-                        body: [['Amount:'], amountAndFeeWrapped, ['Transaction fee:'], feeWrapped],
+                        body: [['Amount:'], amountWrapped, ['Transaction fee:'], feeWrapped],
                     },
                 });
                 await devicePrompt.waitForFinalPromptAndConfirm();
@@ -190,7 +214,7 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 await devicePrompt.sendButton.click();
                 await expect(stakingSection.claimedToastAccount).toContainText('Solana #1');
                 await expect(stakingSection.claimedToastAmount).toContainText(
-                    unstakingAmountFormatted,
+                    unstakingAndRentFormatted,
                 );
             });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10986,6 +10986,7 @@ __metadata:
     "@suite-common/wallet-constants": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
+    "@trezor/blockchain-link-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"


### PR DESCRIPTION
## Description

Fixes inconsistent Solana staking amount and fee values shown in Suite UI and on the device.

## Notes for QA

- try to stake, unstake and claim

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #17388

## Screenshots:

<img width="866" height="749" alt="image" src="https://github.com/user-attachments/assets/defa741f-4033-4911-acba-134ba33af9af" />

<img width="892" height="748" alt="image" src="https://github.com/user-attachments/assets/93d645fe-0782-4d56-b3d4-035a4928513e" />

<img width="838" height="742" alt="image" src="https://github.com/user-attachments/assets/4d0e1af4-df68-40eb-960b-22441ee1ab74" />

<img width="776" height="740" alt="image" src="https://github.com/user-attachments/assets/ada6b52d-aeda-41b4-a4ed-8b9831f6b621" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/correct-staking-amount-calculation-and-formatting&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/correct-staking-amount-calculation-and-formatting&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/correct-staking-amount-calculation-and-formatting&lookback=7)