### PR TITLE
fix(staking): correct staking max amount formatting

### DIFF
--- a/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
@@ -320,7 +320,7 @@ describe('sendForm utils', () => {
             ),
         ).toEqual({
             decimals: 18,
-            output: { type: 'send-max', address: 'A', amount: '1' },
+            output: { type: 'send-max', address: 'A', amount: '1000000000000000000' },
             tokenInfo: undefined,
         });
 

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -466,7 +466,7 @@ export const getExternalComposeOutput = (
             output = {
                 type: 'send-max',
                 address,
-                amount,
+                amount: formattedAmount,
             };
         } else {
             output = {


### PR DESCRIPTION
## Description

Fix Solana/Ethereum staking amount formatting.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24318

## Screenshots:


https://github.com/user-attachments/assets/ccb024cd-05cb-4604-bae4-e1fc378bd17c



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/correct-staking-max-amount-formatting&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/correct-staking-max-amount-formatting&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/correct-staking-max-amount-formatting&lookback=7)