### PR TITLE
fix(suite-native): fix coin stroke contrast in dark mode

### DIFF
--- a/suite-native/icons/src/CryptoIconWithPercentage.tsx
+++ b/suite-native/icons/src/CryptoIconWithPercentage.tsx
@@ -15,6 +15,7 @@ import {
 
 import { CryptoIconName, cryptoIcons } from '@suite-common/icons';
 import { useNativeStyles } from '@trezor/styles';
+import { paletteV1 } from '@trezor/theme';
 
 import { PizzaIcon, usePizzaAnimation } from './PizzaIcon';
 
@@ -94,6 +95,16 @@ export const CryptoIconWithPercentage = ({
                                 style="stroke"
                                 strokeWidth={6}
                                 color={utils.colors.backgroundSurfaceElevation2}
+                            />
+                            {/* Helps to brighten up the stroke color in dark mode */}
+                            <Path
+                                path={path}
+                                start={0}
+                                end={percentageFill}
+                                style="stroke"
+                                strokeWidth={6}
+                                color={paletteV1.lightGray100}
+                                opacity={0.15}
                             />
                             <Path
                                 path={path}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17945

## Screenshots:
### Before
<img width="1206" height="2622" alt="IMG_3205" src="https://github.com/user-attachments/assets/72b973b1-8163-42d4-8a7b-f83f1cc575c0" />

### After
<img width="1206" height="2622" alt="IMG_3204" src="https://github.com/user-attachments/assets/0cb406a2-ffbb-44ae-9503-3049f0b6e5a7" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/asset-stroke-fill-fix&lookback=7)