### PR TITLE
feat(suite-native): improve Select and SelectTrigger atoms

### DIFF
--- a/suite-native/atoms/src/Select/Select.tsx
+++ b/suite-native/atoms/src/Select/Select.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useMemo, useState } from 'react';
+import { Keyboard } from 'react-native';
 
 import { Translation } from '@suite-native/intl';
 
@@ -24,6 +25,7 @@ type SelectProps<TItemValue extends SelectItemValue> = {
     value: TItemValue;
     onSelectItem: (value: TItemValue) => void;
     isConfirmable?: boolean;
+    isLabelShown?: boolean;
     testID?: string;
 };
 
@@ -33,6 +35,7 @@ export const Select = <TItemValue extends SelectItemValue>({
     value,
     onSelectItem,
     isConfirmable = false,
+    isLabelShown = false,
     testID,
 }: SelectProps<TItemValue>) => {
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
@@ -46,6 +49,7 @@ export const Select = <TItemValue extends SelectItemValue>({
     const [isConfirmButtonVisible, setIsConfirmButtonVisible] = useState(false);
 
     const openBottomSheet = () => {
+        Keyboard.dismiss();
         setSelectedItemValue(value);
         setIsConfirmButtonVisible(false);
         openModal();
@@ -99,6 +103,7 @@ export const Select = <TItemValue extends SelectItemValue>({
                 </VStack>
             </BottomSheetModal>
             <SelectTrigger
+                label={isLabelShown && title}
                 value={selectTriggerItem?.label ?? null}
                 icon={selectTriggerItem?.icon}
                 handlePress={openBottomSheet}

--- a/suite-native/atoms/src/Select/SelectTrigger.tsx
+++ b/suite-native/atoms/src/Select/SelectTrigger.tsx
@@ -3,11 +3,13 @@ import { ReactNode } from 'react';
 import { Icon } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
+import { Box } from '../Box';
 import { PressableOpacity } from '../Pressable';
 import { HStack } from '../Stack';
 import { ACCESSIBILITY_FONTSIZE_MULTIPLIER, Text } from '../Text';
 
 type SelectTriggerProps = {
+    label?: ReactNode;
     value: string | null;
     icon?: ReactNode;
     handlePress: () => void;
@@ -22,25 +24,32 @@ const selectStyle = prepareNativeStyle(utils => ({
     alignItems: 'center',
     backgroundColor: utils.colors.backgroundNeutralSubtleOnElevation1,
     borderWidth: utils.borders.widths.small,
-    borderRadius: utils.borders.radii.r8,
-    borderColor: utils.colors.backgroundNeutralSubtleOnElevation1,
+    borderRadius: utils.borders.radii.r12,
+    borderColor: utils.colors.borderInputDefault,
     color: utils.colors.textSubdued,
     paddingLeft: utils.spacings.sp12,
     paddingRight: 23.25,
     height: SELECT_HEIGHT,
 }));
 
-export const SelectTrigger = ({ value, icon, handlePress, testID }: SelectTriggerProps) => {
+export const SelectTrigger = ({ label, value, icon, handlePress, testID }: SelectTriggerProps) => {
     const { applyStyle } = useNativeStyles();
 
     return (
         <PressableOpacity onPress={handlePress} style={applyStyle(selectStyle)} testID={testID}>
-            <HStack alignItems="center">
-                {icon}
-                <Text numberOfLines={1} ellipsizeMode="tail">
-                    {value}
-                </Text>
-            </HStack>
+            <Box>
+                {label && (
+                    <Text variant="label" color="textSubdued">
+                        {label}
+                    </Text>
+                )}
+                <HStack alignItems="center">
+                    {icon}
+                    <Text numberOfLines={1} ellipsizeMode="tail">
+                        {value}
+                    </Text>
+                </HStack>
+            </Box>
             <Icon size="large" color="iconSubdued" name="caretDown" />
         </PressableOpacity>
     );


### PR DESCRIPTION
- allow label to be shown on the trigger
- use correct border colour and radius
- dismiss keyboard before displaying options

## Related Issue

Required for #23657

## Screenshots

<img width="1179" height="1000" alt="image" src="https://github.com/user-attachments/assets/8020cb1b-3c41-42a2-9392-66a01207e02a" />

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/select-improvements&lookback=7)