### PR TITLE
fix(suite-native): fix account list bottom sheet behavior

### DIFF
--- a/suite-native/accounts/src/components/AccountSelectBottomSheet.tsx
+++ b/suite-native/accounts/src/components/AccountSelectBottomSheet.tsx
@@ -15,6 +15,7 @@ type AccountSelectBottomSheetProps = {
     onSelectAccount: OnSelectAccount;
     isStakingPressable?: boolean;
     onClose: () => void;
+    isVisible: boolean;
 };
 
 const ESTIMATED_ITEM_SIZE = 76;
@@ -23,8 +24,9 @@ export const AccountSelectBottomSheet = React.memo(
     ({
         data,
         onSelectAccount,
-        isStakingPressable = false,
         onClose,
+        isStakingPressable = false,
+        isVisible,
     }: AccountSelectBottomSheetProps) => {
         const { showToast } = useToast();
 
@@ -93,7 +95,7 @@ export const AccountSelectBottomSheet = React.memo(
 
         return (
             <BottomSheetFlashList<AccountSelectBottomSheetSection>
-                isVisible
+                isVisible={isVisible}
                 onClose={onClose}
                 data={data}
                 renderItem={renderItem}

--- a/suite-native/accounts/src/components/TokenSelectBottomSheet.tsx
+++ b/suite-native/accounts/src/components/TokenSelectBottomSheet.tsx
@@ -22,6 +22,11 @@ export const TokenSelectBottomSheet = ({
 }: TokenSelectBottomSheetProps) => {
     const [selectedAccount, setSelectedAccount] = useAtom(bottomSheetAccountAtom);
 
+    const data = useSelector((state: NativeAccountsRootState) =>
+        selectAccountListSections(state, selectedAccount?.key),
+    );
+
+    const isBottomSheetVisible = Boolean(selectedAccount && data.length);
     const handleSelectAccount: OnSelectAccount = useCallback(
         params => {
             setSelectedAccount(null);
@@ -34,17 +39,11 @@ export const TokenSelectBottomSheet = ({
         setSelectedAccount(null);
     }, [setSelectedAccount]);
 
-    const data = useSelector((state: NativeAccountsRootState) =>
-        selectAccountListSections(state, selectedAccount?.key),
-    );
-    if (!selectedAccount) {
-        return null;
-    }
-
     return (
         <AccountSelectBottomSheet
             onSelectAccount={handleSelectAccount}
             data={data}
+            isVisible={isBottomSheetVisible}
             onClose={handleClose}
             isStakingPressable={isStakingPressable}
         />

--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -83,10 +83,12 @@ export const selectBottomSheetDeviceNetworkItems = createMemoizedSelector(
     [
         selectVisibleDeviceAccountsByNetworkSymbol,
         selectTokenDefinitions,
-        (_state, symbol: NetworkSymbol) => symbol,
+        (_state, symbol: NetworkSymbol | null) => symbol,
     ],
-    (accounts, tokenDefinitions, symbol) =>
-        pipe(
+    (accounts, tokenDefinitions, symbol) => {
+        if (G.isNull(symbol)) return [];
+
+        return pipe(
             accounts,
             sortAccountsByNetworksAndAccountTypes,
             A.map(account =>
@@ -97,7 +99,8 @@ export const selectBottomSheetDeviceNetworkItems = createMemoizedSelector(
             ),
             A.flat,
             F.toMutable,
-        ),
+        );
+    },
 );
 
 const selectDeviceAssetsWithBalances = createMemoizedSelector(

--- a/suite-native/assets/src/components/Assets.tsx
+++ b/suite-native/assets/src/components/Assets.tsx
@@ -79,13 +79,11 @@ export const Assets = () => {
                 ))}
                 {isLoading && <DiscoveryAssetsLoader isListEmpty={deviceNetworks.length < 1} />}
             </AnimatedCard>
-            {selectedAssetSymbol && (
-                <NetworkAssetsBottomSheet
-                    symbol={selectedAssetSymbol}
-                    onSelectAccount={handleSelectAssetsAccount}
-                    onClose={handleCloseBottomSheet}
-                />
-            )}
+            <NetworkAssetsBottomSheet
+                symbol={selectedAssetSymbol}
+                onSelectAccount={handleSelectAssetsAccount}
+                onClose={handleCloseBottomSheet}
+            />
         </>
     );
 };

--- a/suite-native/assets/src/components/NetworkAssetsBottomSheet.tsx
+++ b/suite-native/assets/src/components/NetworkAssetsBottomSheet.tsx
@@ -8,7 +8,7 @@ import { AccountSelectBottomSheet } from '@suite-native/accounts/src/components/
 import { AssetsRootState, selectBottomSheetDeviceNetworkItems } from '../assetsSelectors';
 
 type NetworkAssetsBottomSheetProps = {
-    symbol: NetworkSymbol;
+    symbol: NetworkSymbol | null;
     onSelectAccount: OnSelectAccount;
     onClose: () => void;
 };
@@ -25,6 +25,7 @@ export const NetworkAssetsBottomSheet = React.memo(
                 onClose={onClose}
                 onSelectAccount={onSelectAccount}
                 isStakingPressable
+                isVisible={Boolean(symbol && items.length)}
             />
         );
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- bottom sheet should close on asset selection

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24366

## Screenshots:

https://github.com/user-attachments/assets/e5397f09-06d4-4f95-88ac-bfa9f3fcb2ab



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/account-bottom-sheet-fix&lookback=7)