### PR TITLE
Chore/revide token symbol shortening

### DIFF
--- a/packages/blockchain-link-utils/src/blockfrost.ts
+++ b/packages/blockchain-link-utils/src/blockfrost.ts
@@ -17,13 +17,7 @@ import type {
 } from '@trezor/blockchain-link-types/src/common';
 import { BigNumber, BigNumberValue } from '@trezor/utils/src/bigNumber';
 
-import {
-    enhanceVinVout,
-    filterTargets,
-    formatTokenSymbol,
-    sumVinVout,
-    transformTarget,
-} from './utils';
+import { enhanceVinVout, filterTargets, sumVinVout, transformTarget } from './utils';
 
 export const transformUtxos = (utxos: BlockfrostUtxos[]): Utxo[] => {
     const result: Utxo[] = [];
@@ -95,7 +89,7 @@ export const parseAsset = (hex: string): ParseAssetResult => {
 export const transformToken = (token: AssetBalance) => {
     const { policyId, assetName } = parseAsset(token.unit);
 
-    const symbol = token.ticker || assetName || formatTokenSymbol(token.fingerprint!);
+    const symbol = token.ticker || assetName || token.fingerprint!;
 
     return {
         name: token.name || symbol,

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -21,7 +21,6 @@ import type {
     PartiallyDecodedInstruction,
     SolanaValidParsedTxWithMeta,
 } from './solana-types';
-import { formatTokenSymbol } from './utils';
 
 export type ApiTokenAccount = {
     account: AccountInfo<ParsedAccountData>;
@@ -86,7 +85,7 @@ export const getTokenNameAndSymbol = (mint: string, tokenDetailByMint: TokenDeta
         ? { name: tokenDetail.name, symbol: tokenDetail.symbol }
         : {
               name: mint,
-              symbol: formatTokenSymbol(mint),
+              symbol: mint,
           };
 };
 

--- a/packages/blockchain-link-utils/src/utils.ts
+++ b/packages/blockchain-link-utils/src/utils.ts
@@ -70,13 +70,6 @@ export const sortTxsFromLatest = (transactions: Transaction[]) => {
     return txs;
 };
 
-// should be aligned with "formatTokenSymbol" in suite
-export const formatTokenSymbol = (symbol: string) => {
-    const isTokenSymbolLong = symbol.length > 7;
-
-    return isTokenSymbolLong ? `${symbol.slice(0, 7)}...` : symbol;
-};
-
 const isOutgoing = (lowerCasedDescriptor: string, tx: Transaction) =>
     tx.details?.vin?.[0]?.addresses?.[0]?.toLowerCase() === lowerCasedDescriptor;
 

--- a/packages/suite/src/utils/wallet/tokenUtils.ts
+++ b/packages/suite/src/utils/wallet/tokenUtils.ts
@@ -66,12 +66,6 @@ export const enhanceTokensWithRates = (
 
 export type EnahncedTokenInfoWithFiat = ReturnType<typeof enhanceTokensWithRates>[number];
 
-export const formatTokenSymbol = (symbol: string) => {
-    const isTokenSymbolLong = symbol.length > 7;
-
-    return isTokenSymbolLong ? `${symbol.slice(0, 7)}...` : symbol;
-};
-
 type GetTokens<T extends EnhancedTokenInfo | TokenInfo | EnahncedTokenInfoWithFiat> = {
     tokens: T[];
     symbol: NetworkSymbol;

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/hooks/useBuildOptionsForTabs.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/hooks/useBuildOptionsForTabs.tsx
@@ -16,7 +16,6 @@ import { Account } from 'src/types/wallet';
 import {
     EnahncedTokenInfoWithFiat,
     enhanceTokensWithRates,
-    formatTokenSymbol,
     getTokens,
     sortTokensWithRates,
 } from 'src/utils/wallet/tokenUtils';
@@ -38,7 +37,7 @@ const createTokenOption = (
         token.balance && verified
             ? {
                   baseAmount: token.balance,
-                  baseSymbol: formatTokenSymbol(token.symbol ?? ''),
+                  baseSymbol: token.symbol ?? '',
                   fiatAmount: toFiatCurrency({ amount: token.balance, rate: token.fiatRate?.rate }),
               }
             : undefined,

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -68,7 +68,7 @@ import {
     selectIsUnhideTokenModalShown,
 } from 'src/selectors/suite/suiteSelectors';
 import { useLegacyAnalytics } from 'src/support/useAnalytics';
-import { formatTokenSymbol, getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
+import { getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
 
 import { BlurUrls } from '../BlurUrls';
 
@@ -230,7 +230,7 @@ export const TokenRow = ({
                             {/* TODO(stellar): I think it would be better to display the asset code as a symbol. */}
                             <FormattedCryptoAmount
                                 value={token.balance}
-                                symbol={formatTokenSymbol(token.symbol ?? '')}
+                                symbol={token.symbol}
                                 contractAddress={token.contract}
                             />
                         </Text>

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -133,6 +133,9 @@ export const getNetworkByEvmChainId = (chainId: number) =>
 export const getNetworkDisplaySymbol = (symbol: NetworkSymbol) => getNetwork(symbol).displaySymbol;
 
 export const getDisplaySymbol = (coinSymbol: string, contractAddress?: string | null) => {
+    const MAX_SYMBOL_LENGTH = 8;
+    const isTokenSymbolLong = coinSymbol.length > MAX_SYMBOL_LENGTH;
+
     const symbol = coinSymbol.toLowerCase();
 
     // TODO: L2 networks - Base, Arbitrum, Optimism native tokens
@@ -140,7 +143,7 @@ export const getDisplaySymbol = (coinSymbol: string, contractAddress?: string | 
         return getNetworkDisplaySymbol(symbol);
     }
 
-    return coinSymbol;
+    return isTokenSymbolLong ? `${coinSymbol.slice(0, MAX_SYMBOL_LENGTH)}...` : coinSymbol;
 };
 
 export const getNetworkDisplaySymbolName = (symbol: NetworkSymbol) => {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -28,7 +28,7 @@ import {
     asBaseCurrencyAmount,
 } from '@suite-common/wallet-types';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
-import { formatTokenSymbol, solanaUtils } from '@trezor/blockchain-link-utils';
+import { solanaUtils } from '@trezor/blockchain-link-utils';
 import TrezorConnect, {
     AccountAddress,
     AccountAddresses,
@@ -384,7 +384,7 @@ export const enhanceTokens = (tokens: Account['tokens']) => {
     if (!tokens) return [];
 
     return tokens.map(t => {
-        const symbol = formatTokenSymbol(t.symbol || t.contract);
+        const symbol = t.symbol || t.contract;
 
         return {
             ...t,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Remove `formatTokenSymbol`, shortening logic is now part of `getDisplaySymbol`

Now symbols are shortened only when displaying them, not when they are stored.

## Notes for QA

Long token symbols (> 8 chars) should still be shortened, there should be no visual change.

## Related Issue

Resolve [#15814](https://github.com/trezor/trezor-suite/issues/15814)

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/revide-token-symbol-shortening&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/revide-token-symbol-shortening&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/revide-token-symbol-shortening&lookback=7)