### PR TITLE
connect src

### DIFF
--- a/packages/connect-examples/mobile-expo/App.tsx
+++ b/packages/connect-examples/mobile-expo/App.tsx
@@ -22,7 +22,6 @@ const styles = StyleSheet.create({
 export const App = () => {
     const [errorData, setErrorData] = useState<any>(null);
     const [successData, setSuccessData] = useState<any>(null);
-    const isEmulator = true;
 
     const initialize = () => {
         TrezorConnect.init({
@@ -32,7 +31,7 @@ export const App = () => {
                 appUrl: 'http://your.application.com',
             },
             // for local development purposes. for production, leave it undefined to use the default value.
-            connectSrc: isEmulator ? 'trezorsuite://connect' : undefined,
+            connectSrc: 'trezorsuite://connect',
             deeplinkOpen: url => {
                 // eslint-disable-next-line no-console
                 console.log('deeplinkOpen', url);

--- a/packages/connect-examples/webextension-mv3-sw-ts/src/service-worker.ts
+++ b/packages/connect-examples/webextension-mv3-sw-ts/src/service-worker.ts
@@ -4,9 +4,6 @@
 // Import using ES6 module TrezorConnect and the DEVICE_EVENT constant from the Trezor Connect WebExtension package
 import TrezorConnect from '@trezor/connect-webextension';
 
-// URL of the Trezor Connect
-const connectSrc = 'https://connect.trezor.io/9/';
-
 chrome.runtime.onInstalled.addListener((details: chrome.runtime.InstalledDetails) => {
     console.log('details', details);
 
@@ -18,7 +15,6 @@ chrome.runtime.onInstalled.addListener((details: chrome.runtime.InstalledDetails
             appUrl: 'https://yourAppUrl.com/',
         },
         transports: ['BridgeTransport', 'WebUsbTransport'], // Transport protocols to be used
-        connectSrc,
         _extendWebextensionLifetime: true, // Makes the service worker in @trezor/connect-webextension stay alive longer.
     });
 

--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -30,27 +30,6 @@ const isRelativePath = (path: string) =>
     // This regex checks if the path starts with a scheme (like http://, https://, file://, etc.)
     // or an absolute path indicator (like //)
     !/^(?:[a-z]+:)?\/\//i.test(path);
-const testLoadingScript = (src: string) =>
-    new Promise((resolve, reject) => {
-        if (process.env.BUILD_TARGET === 'webextension') {
-            // Webextension does not support loading scripts in this way, we skip this check
-            resolve(null);
-
-            return;
-        }
-        const script = document.createElement('script');
-        script.src = src;
-        script.type = 'module';
-        script.onload = data => {
-            document.body.removeChild(script);
-            resolve(data);
-        };
-        script.onerror = error => {
-            document.body.removeChild(script);
-            reject(error);
-        };
-        document.body.appendChild(script);
-    });
 
 export const init =
     (options: ConnectOptions = {}) =>
@@ -103,17 +82,6 @@ export const init =
             // Check if has trailing slash
             if (options.connectSrc.slice(-1) !== '/') {
                 options.connectSrc += '/';
-            }
-            try {
-                // Verify if valid by loading core.js, if this file exists we can assume the connectSrc is valid
-                await testLoadingScript(options.connectSrc + 'js/core.js');
-            } catch {
-                dispatch({
-                    type: ON_INIT_ERROR,
-                    payload: `Invalid connectSrc: ${options.connectSrc}`,
-                });
-
-                return;
             }
 
             window.__TREZOR_CONNECT_SRC = options.connectSrc;

--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -68,7 +68,6 @@ export const init =
                 appName: 'Trezor Connect Explorer',
                 appIcon: 'https://trezor.io/favicon/apple-touch-icon.png',
             },
-            trustedHost: false,
             ...options,
         };
 

--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -26,11 +26,6 @@ export const onConnectOptionChange = (option: Field<any>, value: any) => ({
     },
 });
 
-const isRelativePath = (path: string) =>
-    // This regex checks if the path starts with a scheme (like http://, https://, file://, etc.)
-    // or an absolute path indicator (like //)
-    !/^(?:[a-z]+:)?\/\//i.test(path);
-
 export const init =
     (options: ConnectOptions = {}) =>
     async (dispatch: Dispatch) => {
@@ -57,42 +52,6 @@ export const init =
             // this type of event should not be emitted in "popup mode"
         });
 
-        const { host } = window.location;
-
-        if (process?.env?.__TREZOR_CONNECT_SRC && host !== 'connect.trezor.io') {
-            let src = process?.env?.__TREZOR_CONNECT_SRC;
-            if (isRelativePath(src)) {
-                src = `${window.location.origin}${src}`;
-            }
-            window.__TREZOR_CONNECT_SRC = src;
-        }
-        // yarn workspace @trezor/connect-explorer dev starts @trezor/connect-web on localhost port
-        // so we may use it
-        if (!window.__TREZOR_CONNECT_SRC && host.startsWith('localhost')) {
-            // use local connect for local development
-            window.__TREZOR_CONNECT_SRC = `${window.location.origin}/`;
-        }
-
-        if (window.location.search.includes('trezor-connect-src')) {
-            const search = new URLSearchParams(window.location.search);
-            window.__TREZOR_CONNECT_SRC = search.get('trezor-connect-src')?.toString();
-        }
-
-        if (options.connectSrc) {
-            // Check if has trailing slash
-            if (options.connectSrc.slice(-1) !== '/') {
-                options.connectSrc += '/';
-            }
-
-            window.__TREZOR_CONNECT_SRC = options.connectSrc;
-        }
-
-        if (!window.__TREZOR_CONNECT_SRC) {
-            console.log('using production @trezor/connect');
-        } else {
-            console.log('using @trezor/connect hosted on: ', window.__TREZOR_CONNECT_SRC);
-        }
-
         // Get default coreMode from URL params (?core-mode=auto)
         const urlParams = new URLSearchParams(window.location.search);
         const coreMode = (urlParams.get('core-mode') as ConnectOptions['coreMode']) || 'auto';
@@ -110,7 +69,6 @@ export const init =
                 appIcon: 'https://trezor.io/favicon/apple-touch-icon.png',
             },
             trustedHost: false,
-            connectSrc: window.__TREZOR_CONNECT_SRC,
             ...options,
         };
 

--- a/packages/connect-explorer/src/components/Settings.tsx
+++ b/packages/connect-explorer/src/components/Settings.tsx
@@ -26,7 +26,6 @@ export const ErrorMessage = styled(ConfirmationMessage)`
 export const Settings = () => {
     const connectOptions = useSelector(state => ({
         trustedHost: state.connect?.options?.trustedHost,
-        connectSrc: state.connect?.options?.connectSrc,
         coreMode: state?.connect?.options?.coreMode,
     }));
 
@@ -57,12 +56,6 @@ export const Settings = () => {
                 { value: 'suite-desktop', label: 'Suite desktop' },
                 { value: 'suite-web', label: 'Suite web' },
             ],
-        },
-        {
-            name: 'connectSrc',
-            type: 'input' as const,
-            key: 'connectSrc',
-            value: connectOptions?.connectSrc || '',
         },
     ];
 

--- a/packages/connect-explorer/src/components/Settings.tsx
+++ b/packages/connect-explorer/src/components/Settings.tsx
@@ -25,7 +25,6 @@ export const ErrorMessage = styled(ConfirmationMessage)`
 
 export const Settings = () => {
     const connectOptions = useSelector(state => ({
-        trustedHost: state.connect?.options?.trustedHost,
         coreMode: state?.connect?.options?.coreMode,
     }));
 
@@ -39,12 +38,6 @@ export const Settings = () => {
 
     const submitButton = 'Init Connect';
     const fields = [
-        {
-            name: 'trustedHost',
-            type: 'checkbox' as const,
-            key: 'trustedHost',
-            value: connectOptions?.trustedHost || false,
-        },
         {
             name: 'coreMode',
             type: 'select' as const,

--- a/packages/connect-explorer/src/middlewares/trezorConnectMiddleware.ts
+++ b/packages/connect-explorer/src/middlewares/trezorConnectMiddleware.ts
@@ -3,7 +3,6 @@ import { MiddlewareAPI } from 'redux';
 import { init } from '../actions/trezorConnectActions';
 import { Action, AppState, Dispatch } from '../types';
 import { SET_METHOD, SET_SCHEMA } from '../types/actions';
-import { getQueryVariable } from '../utils/windowUtils';
 
 export const trezorConnectMiddleware =
     (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => (action: Action) => {

--- a/packages/connect-explorer/src/middlewares/trezorConnectMiddleware.ts
+++ b/packages/connect-explorer/src/middlewares/trezorConnectMiddleware.ts
@@ -12,11 +12,7 @@ export const trezorConnectMiddleware =
         next(action);
 
         if ([SET_SCHEMA, SET_METHOD].includes(action.type) && !prevConnectOptions) {
-            const connectSrc = getQueryVariable('src');
             const options = {};
-            if (connectSrc) {
-                Object.assign(options, { connectSrc });
-            }
             api.dispatch(init(options));
         }
     };

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -54,7 +54,6 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
 
         this._settings = {
             ...parseConnectSettings({ ...this._settings, ...settings }),
-            connectSrc,
             deeplinkUrl: `${removeTrailingSlashes(connectSrc)}/deeplink/${DEEPLINK_VERSION}/`,
             deeplinkOpen: settings.deeplinkOpen,
             deeplinkCallbackUrl: settings.deeplinkCallbackUrl,

--- a/packages/connect-web/src/connectSettings.ts
+++ b/packages/connect-web/src/connectSettings.ts
@@ -29,18 +29,6 @@ declare let global: any;
  */
 export const parseConnectSettings = (input: Partial<ConnectSettings> = {}): ConnectSettings => {
     const settings = { popup: true, ...input };
-    // For debugging purposes `connectSrc` could be defined in `global.__TREZOR_CONNECT_SRC` variable
-    let globalSrc: string | undefined;
-    if (typeof window !== 'undefined') {
-        // @ts-expect-error not defined in globals outside of the package
-        globalSrc = window.__TREZOR_CONNECT_SRC;
-    } else if (typeof global !== 'undefined') {
-        globalSrc = global.__TREZOR_CONNECT_SRC;
-    }
-    if (typeof globalSrc === 'string') {
-        settings.connectSrc = globalSrc;
-        settings.debug = true;
-    }
 
     if (typeof input.env !== 'string') {
         settings.env = getEnv();

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -77,10 +77,11 @@ export class CoreInSuiteWeb implements ConnectFactoryDependencies<ConnectSetting
     }
 
     private getSuiteUrl() {
-        if (this._settings.connectSrc?.startsWith('http://localhost')) {
+        // todo: we need to control this in a better way. For example 3rd party probably wants to develop against production suite-web
+        if (window.location.origin === 'http://localhost:8088') {
             return 'http://localhost:8000/connect-popup';
         }
-        if (this._settings.connectSrc?.startsWith('https://dev.suite.sldev.cz/connect/')) {
+        if (window.location.href.startsWith('https://dev.suite.sldev.cz/connect/')) {
             const branch = this._settings.connectSrc?.replace(
                 'https://dev.suite.sldev.cz/connect/',
                 '',

--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -204,7 +204,6 @@ export const initTrezorConnect = async (
         popup: false,
         pendingTransportEvent: true,
         transportReconnect: false,
-        connectSrc: process.env.TREZOR_CONNECT_SRC, // custom source for karma tests
         coreMode: 'core-in-module', // for connect-web
         thp: {
             appName: 'TrezorConnect',

--- a/packages/connect/src/data/__tests__/DataManager.test.ts
+++ b/packages/connect/src/data/__tests__/DataManager.test.ts
@@ -1,7 +1,6 @@
 import { DataManager } from '../DataManager';
 
 const settings = {
-    connectSrc: 'https://connect.trezor.io/9/',
     transportReconnect: true,
     debug: false,
     popup: false,
@@ -37,7 +36,6 @@ describe('data/DataManager', () => {
     });
 
     test('getSettings', () => {
-        expect(DataManager.getSettings('connectSrc')).toEqual(settings.connectSrc);
         expect(DataManager.getSettings()).toEqual(settings);
         // @ts-expect-error
         expect(DataManager.getSettings('foo')).toEqual(undefined);

--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -17,7 +17,6 @@ const initialSettings: ConnectSettings = {
     debug: false,
     priority: DEFAULT_PRIORITY,
     trustedHost: true,
-    connectSrc: DEFAULT_DOMAIN,
     popup: false,
     popupSrc: `${DEFAULT_DOMAIN}popup.html`,
     transports: undefined,
@@ -90,15 +89,6 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
     if (input.trustedHost === false) {
         settings.trustedHost = input.trustedHost;
     }
-
-    if (typeof input.connectSrc === 'string') {
-        settings.connectSrc = corsValidator(input.connectSrc);
-    } else if (settings.trustedHost) {
-        settings.connectSrc = input.connectSrc;
-    }
-
-    const src = settings.connectSrc || DEFAULT_DOMAIN;
-    settings.popupSrc = `${src}popup.html`;
 
     if (typeof input.transportReconnect === 'boolean') {
         settings.transportReconnect = input.transportReconnect;

--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -16,6 +16,7 @@ const initialSettings: ConnectSettings = {
     version: VERSION, // constant
     debug: false,
     priority: DEFAULT_PRIORITY,
+    // todo: trustedHost can be removed now, I just didn't want to touch core at the moment
     trustedHost: true,
     popup: false,
     popupSrc: `${DEFAULT_DOMAIN}popup.html`,
@@ -83,11 +84,6 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
         } else if (typeof input.debug === 'string') {
             settings.debug = input.debug === 'true';
         }
-    }
-
-    // trust level can only be lowered by implementator!
-    if (input.trustedHost === false) {
-        settings.trustedHost = input.trustedHost;
     }
 
     if (typeof input.transportReconnect === 'boolean') {

--- a/packages/connect/src/types/api/__tests__/index.ts
+++ b/packages/connect/src/types/api/__tests__/index.ts
@@ -35,7 +35,6 @@ export const init = async (api: TrezorConnect) => {
     if (settings.success) {
         const { payload } = settings;
         payload.manifest?.appUrl.toLowerCase();
-        payload.connectSrc?.toLowerCase();
         if (payload.debug === true && payload.popup === true) {
             //
         }

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -40,7 +40,6 @@ export type ConnectSettingsTransport =
 
 export interface ConnectSettingsPublic {
     manifest?: Manifest;
-    connectSrc?: string;
     debug?: boolean;
     popup?: boolean;
     transportReconnect?: boolean;
@@ -85,6 +84,7 @@ export interface ConnectSettingsWebextension {
     coreMode?: 'auto' | 'suite-desktop' | 'suite-web';
 }
 export interface ConnectSettingsMobile {
+    connectSrc?: string;
     deeplinkUrl: string;
     deeplinkOpen?: (url: string) => void;
     deeplinkCallbackUrl?: string;

--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -28,6 +28,7 @@ export const eslint = [
             '**/coverage/*',
             '**/build/*',
             '**/build-electron/*',
+            '**/build-webextension/*',
             '**/node_modules/*',
             '**/public/*',
             '**/ci/',

--- a/packages/suite-build/vite.config.mts
+++ b/packages/suite-build/vite.config.mts
@@ -257,24 +257,6 @@ const workerPlugin = (): Plugin => ({
     },
 });
 
-// Plugin to serve core.js in dev mode
-const serveCorePlugin = () => ({
-    name: 'serve-core',
-    configureServer(server: ViteDevServer) {
-        server.middlewares.use((req, res, next) => {
-            if (req.url?.includes('/js/core.js')) {
-                const coreEntryPath = resolve(__dirname, '../connect/src/core/index.ts');
-                const moduleSpecifier = `/@fs/${coreEntryPath}`;
-                res.setHeader('Content-Type', 'application/javascript');
-                res.end(`export { initCoreState } from ${JSON.stringify(moduleSpecifier)};\n`);
-
-                return;
-            }
-            next();
-        });
-    },
-});
-
 const commitId = execSync('git rev-parse HEAD').toString().trim();
 
 // Plugin to provide a no-op replacement for core-js/actual as a virtual module
@@ -456,7 +438,6 @@ export default defineConfig({
         guideMarkdownPlugin(),
         trezorLogosRequirePlugin(),
         staticAliasPlugin(),
-        serveCorePlugin(),
         sessionsSharedWorkerPlugin(),
         viteCommonjs(),
         workerPlugin(),

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -42,12 +42,7 @@ import * as suiteActions from '../actions/suite/suiteActions';
 import type { BioAuthState } from '../reducers/bioAuth';
 import { AppState, TrezorDevice } from '../types/suite';
 
-const connectSrc = '../';
-// 'https://localhost:8088/';
-// 'https://connect.corp.sldev.cz/develop/';
-
 const connectInitSettings = {
-    connectSrc,
     transportReconnect: true,
     debug: false,
     popup: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- TrezorConnect({ connectSrc, trustedHost }) options are gone now. 
- connectSrc is left for @trezor/mobile 

## Notes for QA

- localhost dev explorer with localhost suite should work
- the same for sldev
- the same for production :D  but we are not there yet

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-src&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-src&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-src&lookback=7)