### PR TITLE
test: build packages and test they run properly locally

### DIFF
--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -46,6 +46,30 @@ jobs:
         run: ./packages/connect/e2e/test-yarn-install.sh latest
         if: always()
 
+  install-connect-local:
+    runs-on: ubuntu-latest
+    if: github.repository == 'trezor/trezor-suite'
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Pack packages
+        run: yarn tsx ./scripts/ci/pack-packages.ts
+
+      - name: Test local install
+        run: ./packages/connect/e2e/test-connect-local.sh
+
   test-protobuf:
     runs-on: ubuntu-latest
     if: github.repository == 'trezor/trezor-suite'

--- a/packages/connect/e2e/test-connect-local.sh
+++ b/packages/connect/e2e/test-connect-local.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Validate that installing local connect packages are working.
+
+set -e
+
+PACKED_PACKAGES_DIR="${1:-tmp/packed-packages}"
+
+if [ ! -d "$PACKED_PACKAGES_DIR" ]; then
+    echo "Error: Packed packages directory not found: $PACKED_PACKAGES_DIR"
+    echo "Usage: $0 [path-to-packed-packages]"
+    exit 1
+fi
+
+PACKED_PACKAGES_DIR="$(cd "$PACKED_PACKAGES_DIR" && pwd)"
+echo "Using packed packages from: $PACKED_PACKAGES_DIR"
+
+OVERRIDES_FILE="$PACKED_PACKAGES_DIR/overrides.json"
+if [ ! -f "$OVERRIDES_FILE" ]; then
+    echo "Error: overrides.json not found: $OVERRIDES_FILE"
+    exit 1
+fi
+
+OVERRIDES_CONTENT=$(cat "$OVERRIDES_FILE")
+CONNECT_PATH=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$OVERRIDES_FILE'))['@trezor/connect'])")
+
+trap "cd .. && rm -rf connect-implementation-local" EXIT
+
+npm --version
+node --version
+
+mkdir connect-implementation-local
+cd connect-implementation-local
+
+cat > package.json << EOF
+{
+  "name": "connect-implementation-local",
+  "version": "1.0.0",
+  "description": "Test local @trezor/connect packages",
+  "main": "index.js",
+  "dependencies": {
+    "@trezor/connect": "${CONNECT_PATH}",
+    "tsx": "^4.21.0"
+  },
+  "overrides": ${OVERRIDES_CONTENT}
+}
+EOF
+
+echo "Installing dependencies..."
+npm install
+
+cat package.json
+
+cat > index.cjs << 'EOF'
+const TrezorConnect = require('@trezor/connect').default;
+
+console.log('typeof TrezorConnect: ' + typeof TrezorConnect);
+console.log('TrezorConnect.init exists: ' + (typeof TrezorConnect.init === 'function'));
+EOF
+
+cat > index.mjs << 'EOF'
+import TrezorConnectModule from '@trezor/connect';
+
+// Handle CJS/ESM interop - the default export may be nested
+const TrezorConnect = TrezorConnectModule.default || TrezorConnectModule;
+
+console.log('typeof TrezorConnect: ' + typeof TrezorConnect);
+console.log('TrezorConnect.init exists: ' + (typeof TrezorConnect.init === 'function'));
+EOF
+
+echo ""
+echo "=== Testing CJS (node index.cjs) ==="
+node index.cjs
+
+echo ""
+echo "=== Testing ESM with tsx (npx tsx index.mjs) ==="
+# ESM has issues with pure node, using tsx to run it.
+npx tsx index.mjs
+
+echo ""
+echo "All tests passed!"

--- a/scripts/ci/helpers.ts
+++ b/scripts/ci/helpers.ts
@@ -217,3 +217,13 @@ export const getLocalVersion = (packageName: string) => {
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
     return packageJson.version;
 };
+
+export const getConnectDependencies = async (rootDir: string) => {
+    const connectPackageJsonPath = path.join(rootDir, 'packages', 'connect', 'package.json');
+    const packageJsonContent = await fs.promises.readFile(connectPackageJsonPath, 'utf-8');
+    const packageJson = JSON.parse(packageJsonContent);
+    const dependencies = packageJson.dependencies ? Object.keys(packageJson.dependencies) : [];
+    return dependencies
+        .filter(dep => dep.startsWith('@trezor/'))
+        .map(dep => dep.replace('@trezor/', ''));
+};

--- a/scripts/ci/pack-packages.ts
+++ b/scripts/ci/pack-packages.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import util from 'node:util';
+
+import { exec, getConnectDependencies } from './helpers';
+
+const mkdir = util.promisify(fs.mkdir);
+const existsDirectory = util.promisify(fs.exists);
+const removeDir = util.promisify(fs.rm);
+const writeFile = util.promisify(fs.writeFile);
+
+const __dirname = import.meta.dirname;
+const ROOT_DIR = path.resolve(__dirname, '..', '..');
+const OUTPUT_DIR = path.join(ROOT_DIR, 'tmp/packed-packages');
+
+const PACKAGES = await getConnectDependencies(ROOT_DIR);
+
+// Connect is not a dependency of itself, so we need to add it manually.
+PACKAGES.push('connect');
+
+const buildAllPackages = async () => {
+    if (await existsDirectory(OUTPUT_DIR)) {
+        await removeDir(OUTPUT_DIR, { recursive: true });
+    }
+    await mkdir(OUTPUT_DIR, { recursive: true });
+
+    console.log(`Packing ${PACKAGES.length} packages into ${OUTPUT_DIR}\n`);
+
+    const results: {
+        success: string[];
+        failed: { pkg: string; error: string }[];
+    } = { success: [], failed: [] };
+
+    for (const pkg of PACKAGES) {
+        const pkgDir = path.join(ROOT_DIR, 'packages', pkg);
+
+        if (!(await existsDirectory(pkgDir))) {
+            console.error(`Package not found: ${pkg}`);
+            results.failed.push({ pkg, error: 'Package directory not found' });
+            continue;
+        }
+
+        try {
+            console.log(`Building ${pkg}...`);
+
+            await exec('yarn', ['workspace', `@trezor/${pkg}`, 'build:lib']);
+
+            console.log(`Packing ${pkg}...`);
+            const outputFile = path.join(OUTPUT_DIR, `trezor-${pkg}.tgz`);
+            await exec('yarn', ['workspace', `@trezor/${pkg}`, 'pack', '-o', outputFile]);
+
+            console.log(`${pkg} → trezor-${pkg}.tgz\n`);
+            results.success.push(pkg);
+        } catch (error) {
+            console.error(`Failed to pack ${pkg}: ${error.message}\n`);
+            results.failed.push({ pkg, error: error.message });
+        }
+    }
+
+    console.log('\n---------------');
+    console.log(`Success: ${results.success.length}/${PACKAGES.length}`);
+    if (results.failed.length > 0) {
+        console.log(`Failed: ${results.failed.length}`);
+        results.failed.forEach(({ pkg, error }) => {
+            console.log(`   - ${pkg}: ${error}`);
+        });
+    }
+    console.log(`\nOutput directory: ${OUTPUT_DIR}`);
+
+    // Generate overrides.json so it can be used to build a project using the packed packages.
+    const overrides: Record<string, string> = {};
+    for (const pkg of results.success) {
+        overrides[`@trezor/${pkg}`] = `file:${path.join(OUTPUT_DIR, `trezor-${pkg}.tgz`)}`;
+    }
+
+    const overridesPath = path.join(OUTPUT_DIR, 'overrides.json');
+    await writeFile(overridesPath, JSON.stringify(overrides, null, 2));
+    console.log(`\nGenerated overrides.json with ${results.success.length} packages`);
+};
+
+buildAllPackages();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is creating a script that will package all the packages that are dependency of connect and running a local test using them with a simple node js project. That makes sure that all the packages are building properly and nothing is missing. 

We already have a similar test but it is using the released to npm packages, this new test allow us to catch issues before publishing.

## Notes for QA

This adds new test to CI connect-misc that tests that Connect and Trezor packages that are dependencies of Connect are building and working properly https://github.com/trezor/trezor-suite/actions/runs/21063817695/job/60576248859?pr=24449

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/23779


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/build-packages-and-test-locally&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/build-packages-and-test-locally&lookback=7)