### PR TITLE
chore(suite-native): Trade: update fiat and asset button colors

### DIFF
--- a/suite-native/module-trading/src/components/general/FiatCurrencyButton.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencyButton.tsx
@@ -22,7 +22,7 @@ const buttonStyle = prepareNativeStyle(({ borders, colors, spacings }) => ({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: colors.backgroundSurfaceElevation1,
+    backgroundColor: colors.backgroundNeutralSubtleOnElevation1,
     borderColor: colors.borderElevation0,
     borderRadius: borders.radii.round,
     borderWidth: borders.widths.small,
@@ -45,10 +45,10 @@ export const FiatCurrencyButton = ({ currency, onPress, testID }: FiatCurrencyBu
             testID={testID}
         >
             <FiatCurrencyIcon size="small" />
-            <Text variant="callout" color="textSubdued" testID={tickerTestID}>
+            <Text variant="callout" color="textDefault" testID={tickerTestID}>
                 {displayCurrency}
             </Text>
-            <Icon name="caretDown" color="textSubdued" size="medium" />
+            <Icon name="caretDown" color="textDefault" size="medium" />
         </Pressable>
     );
 };

--- a/suite-native/module-trading/src/components/general/TradeableAssetButton.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetButton.tsx
@@ -93,9 +93,10 @@ export const TradeableAssetButton = ({
                 <NetworkSymbolExtendedFormatter
                     symbol={symbol}
                     variant="callout"
+                    color="textDefault"
                     testID={symbolTestID}
                 />
-                {caret ? <Icon name="caretDown" color="textSubdued" size="medium" /> : <Box />}
+                {caret ? <Icon name="caretDown" color="textDefault" size="medium" /> : <Box />}
             </Pressable>
         </LinearGradient>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Just colors update.
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #24454

## Screenshots:

### Before

<img width="300" alt="before-dark" src="https://github.com/user-attachments/assets/877c6466-da59-49db-8128-96d5edc4e613" />
<img width="300" alt="before-light" src="https://github.com/user-attachments/assets/3d8edbf6-7058-48be-9018-bc3bc8f7c303" />


### After

<img width="300" alt="after-dark" src="https://github.com/user-attachments/assets/6ddea50d-ccc0-4305-9293-201bb189fdf5" />
<img width="300" alt="after-light" src="https://github.com/user-attachments/assets/d47f56a0-36e6-4800-ae64-4c9d96c984f9" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24454-fix-colors-on-currency-selector&lookback=7)