### PR TITLE
fix(e2e-native): fixes transformIgnorePatterns in reporter config

### DIFF
--- a/suite-native/app/e2e/jest.config.reporter.js
+++ b/suite-native/app/e2e/jest.config.reporter.js
@@ -10,7 +10,7 @@ module.exports = {
     preset: 'jest-expo',
     testEnvironment: 'node',
     transformIgnorePatterns: [
-        'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|@shopify/react-native-skia)',
+        'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|@shopify/react-native-skia|uuid)',
     ],
     transform: {
         ...nativeJestConfig.transform,


### PR DESCRIPTION
Issue
The github:report:manual command was failing to report manual tests to GitHub, throwing the error:

The reporter was processing test results for "undefined" because [testResult.testResults](vscode-file://vscode-app/snap/code/218/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was an empty array, even though the test file existed and was being discovered by Jest.

Root Cause
The test file failed to execute due to a Jest transformation error. The @trezor/e2e-utils package imports the uuid module, which is distributed as an ES module. Jest's [transformIgnorePatterns](vscode-file://vscode-app/snap/code/218/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was not configured to transform the uuid package, causing a syntax error:

This prevented the test from running, resulting in an empty [testResults](vscode-file://vscode-app/snap/code/218/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) array that the reporter couldn't process.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-e2e-native-reporter&lookback=7)