### PR TITLE
fix(suite-native): Trade: fix shaking animation in trading inputs

### DIFF
--- a/suite-native/module-trading/src/components/general/Input/AmountInput.tsx
+++ b/suite-native/module-trading/src/components/general/Input/AmountInput.tsx
@@ -45,7 +45,7 @@ const inputStyle = prepareNativeStyle<{ hasError: boolean; fontSize: number }>(
     }),
 );
 
-const useInputLayoutControls = () => {
+const useInputLayoutControls = (value: string | undefined) => {
     const [availableWidth, setAvailableWidth] = useState(
         MIN_INPUT_WIDTH + FONT_SIZE_SHRINK_THRESHOLD,
     );
@@ -60,7 +60,7 @@ const useInputLayoutControls = () => {
         ({ nativeEvent }: LayoutChangeEvent) => {
             const contentWidth = nativeEvent.layout.width;
 
-            if (contentWidth === 0 || availableWidth === 0) {
+            if (contentWidth === 0 || availableWidth === 0 || !value) {
                 setFontSize(MAX_FONT_SIZE);
 
                 return;
@@ -84,7 +84,7 @@ const useInputLayoutControls = () => {
                 setFontSize(newFontSize);
             }
         },
-        [availableWidth, fontSize],
+        [availableWidth, fontSize, value],
     );
 
     return {
@@ -116,7 +116,7 @@ export const AmountInput = forwardRef<TextInput, AmountInputProps>(
         useImperativeHandle(ref, () => innerRef.current!, []);
 
         const { applyStyle, utils } = useNativeStyles();
-        const { fontSize, onBoxLayout, onInputLayout } = useInputLayoutControls();
+        const { fontSize, onBoxLayout, onInputLayout } = useInputLayoutControls(value);
 
         const handleTextChange = useCallback(
             (text: string) => {

--- a/suite-native/module-trading/src/components/general/Input/__tests__/AmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/Input/__tests__/AmountInput.comp.test.tsx
@@ -75,7 +75,7 @@ describe('AmountInput', () => {
         let box: ReturnType<ReturnType<typeof renderAmountInput>['getByTestId']>;
 
         beforeEach(() => {
-            const { getByLabelText, getByTestId } = renderAmountInput({});
+            const { getByLabelText, getByTestId } = renderAmountInput({ value: '1234567890' });
             input = getByLabelText('INPUT');
             box = getByTestId(AMOUNT_INPUT_TEST_ID);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Do not update font size when input has no value

<!--- Describe your changes in detail -->

## Notes for QA

Check whether when you go between trade tabs (buy/sell/swap) the value number (0.0) doesnt change its size on appearing (try swapping between those trade options)

## Related Issue

Resolve #24459


## Screenshots:

https://github.com/user-attachments/assets/d85e1e2c-44ee-4f7c-85c9-c1f90e15b176




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24459-shaking-animation-when-swithing-between-trading-tabs&lookback=7)