### PR TITLE
Mobile manual sanity tests

### DIFF
--- a/packages/e2e-utils/src/enums/testAnnotations.ts
+++ b/packages/e2e-utils/src/enums/testAnnotations.ts
@@ -58,9 +58,12 @@ export const TestPriorityColors: Record<TestPriority, string> = {
 };
 
 export enum TestStream {
-    Trends = 'Trends',
+    Trends = 'Trends', // do not use for new tests
+    Wallet = 'Wallet',
+    Trade = 'Trade',
     Foundation = 'Foundation',
-    Engagement = 'Engagement',
+    Engagement = 'Engagement', // do not use for new tests
+    Growth = 'Growth',
     Firmware = 'Firmware',
     NotDefined = 'Not Defined',
 }

--- a/suite-native/app/e2e/tests/manual/addNewAccount.test.ts
+++ b/suite-native/app/e2e/tests/manual/addNewAccount.test.ts
@@ -1,0 +1,29 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Add new account',
+        {
+            testCase: 'Add new account',
+            prerequisites: [
+                'Connected device with transaction history',
+                'Already on-boarded Lite application',
+            ],
+            steps: [
+                'Device connected and discovery finished.',
+                'Navigate to My assets section and press +',
+                'Select Bitcoin',
+                'Select Change account type',
+                'Select SegWit or Taproot account type',
+                'Press Continue button',
+                'Account is added',
+            ],
+            category: TestCategory.Accounts,
+            priority: TestPriority.High,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/addNewAccountWithFreshDevice.test.ts
+++ b/suite-native/app/e2e/tests/manual/addNewAccountWithFreshDevice.test.ts
@@ -1,0 +1,30 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Add new account with fresh device',
+        {
+            testCase: 'Add new account with fresh device',
+            prerequisites: [
+                'Connected device without transaction history',
+                'Already on-boarded Lite application',
+            ],
+            steps: [
+                'Device connected and discovery finished.',
+                'Device reports no transaction history',
+                'Navigate to My assets section and press +',
+                'Select Bitcoin',
+                'Select Change account type',
+                'Select SegWit or Taproot account type',
+                'Press Continue button',
+                'Account is added',
+            ],
+            category: TestCategory.Accounts,
+            priority: TestPriority.High,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/arbitrumOptimismBaseSendForm.test.ts
+++ b/suite-native/app/e2e/tests/manual/arbitrumOptimismBaseSendForm.test.ts
@@ -1,0 +1,18 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Arbitrum, Optimism and Base send form',
+        {
+            testCase: 'Arbitrum, Optimisim and Base send form',
+            prerequisites: [],
+            steps: ['No steps defined in source document'],
+            category: TestCategory.Settings,
+            priority: TestPriority.High,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/basicDashboardCheck.test.ts
+++ b/suite-native/app/e2e/tests/manual/basicDashboardCheck.test.ts
@@ -1,0 +1,25 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Basic dashboard check',
+        {
+            testCase: 'Basic dashboard check',
+            prerequisites: ['an app with an account already imported'],
+            steps: [
+                'Click on various graph views (1D / 1W / 1M / 6M / 1Y / ALL) and verify graph re-adjusts',
+                'Verify default time frame is one month',
+                'Verify graph time frame is remembered',
+                'Hold a finger on a point on the graph and verify displayed amount changes',
+                'Verify imported assets are displayed under the graph',
+                'Verify coin icons contain halo indicating % of portfolio of coin',
+            ],
+            category: TestCategory.Dashboard,
+            priority: TestPriority.High,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/biometricsEnable.test.ts
+++ b/suite-native/app/e2e/tests/manual/biometricsEnable.test.ts
@@ -1,0 +1,28 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Biometrics enable',
+        {
+            testCase: 'Biometrics enable',
+            prerequisites: ['an app version with already imported btc XPUB'],
+            steps: [
+                'Navigate to Settings',
+                'Select Privacy & Security',
+                'Enable Biometrics',
+                'Enter PIN, face or fingerprint that’s already registered in system',
+                'Kill the app',
+                'Start app',
+                'Cancel biometric dialogue',
+                'Enter correct biometrics',
+                'Verify navigation to Lite app',
+            ],
+            category: TestCategory.Settings,
+            priority: TestPriority.High,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/cancelAssetImporting.test.ts
+++ b/suite-native/app/e2e/tests/manual/cancelAssetImporting.test.ts
@@ -1,0 +1,25 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Cancel asset importing by X icons',
+        {
+            testCase: 'Cancel asset importing by < and X icons',
+            prerequisites: ['none'],
+            steps: [
+                'Empty app: start the app and verify Sync & Track button appears',
+                'Select Bitcoin',
+                'Type the XPUB in the enter XPUB input field and click Confirm',
+                'Click < button and verify user is transferred back to Home page',
+                'App with at least one account: start the app, go to My assets, click + and select Bitcoin',
+                'Type XPUB, click Confirm, click x button and verify user is transferred back to Home page',
+            ],
+            category: TestCategory.Application,
+            priority: TestPriority.Medium,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/checkAnAccount.test.ts
+++ b/suite-native/app/e2e/tests/manual/checkAnAccount.test.ts
@@ -1,0 +1,23 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Check an account',
+        {
+            testCase: 'Check an account',
+            prerequisites: ['an app with an account BTC already imported'],
+            steps: [
+                'Navigate to My assets and click on any Bitcoin account to open Account detail page',
+                'Verify graph and Transactions history cards are displayed',
+                'Click on any transaction to open tx detail page',
+                'Verify tx detail info is displayed and check buttons: Parameters, Compare values, Inputs & Outputs',
+            ],
+            category: TestCategory.Accounts,
+            priority: TestPriority.High,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/checkBackup.test.ts
+++ b/suite-native/app/e2e/tests/manual/checkBackup.test.ts
@@ -1,0 +1,24 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Check backup',
+        {
+            testCase: 'Check backup',
+            prerequisites: ['already setup device'],
+            steps: [
+                'Navigate to Device settings',
+                'Click on Check wallet backup option',
+                'Verify backup check flow starts and appears on device',
+                'After successful device check, verify Your backup is valid screen appears',
+                'Verify app returns to device settings',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.Medium,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/checkFeatureFlags.test.ts
+++ b/suite-native/app/e2e/tests/manual/checkFeatureFlags.test.ts
@@ -1,0 +1,22 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Check if all feature flags are correctly set up and working',
+        {
+            testCase: 'Check if all feature flags are correctly set up and working',
+            prerequisites: [],
+            steps: [
+                'Enable Dev utils by tapping multiple times on FW revision',
+                'Go to Settings / Dev utils',
+                'Verify all feature flags are correctly disabled and that they work as intended when toggled',
+            ],
+            category: TestCategory.Settings,
+            priority: TestPriority.Critical,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/coinEnablingOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/manual/coinEnablingOnboarding.test.ts
@@ -1,0 +1,24 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Coin enabling - onboarding',
+        {
+            testCase: 'Coin enabling - onboarding',
+            prerequisites: ['fresh app', 'connected device'],
+            steps: [
+                'Coin enabling should appear after initial screens and after connecting a device',
+                'Select any number of coins available for the connected device (only device-supported coins should appear)',
+                'Ensure at least one coin is selected to continue to dashboard',
+                'After confirming selection, verify dashboard appears and discovery starts',
+                'Verify discovery finishes only for enabled coins and empty account shown if no history',
+            ],
+            category: TestCategory.Settings,
+            priority: TestPriority.Critical,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/coinEnablingReceive.test.ts
+++ b/suite-native/app/e2e/tests/manual/coinEnablingReceive.test.ts
@@ -1,0 +1,30 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Coin enabling - receive',
+        {
+            testCase: 'Coin enabling - receive',
+            prerequisites: [
+                'connected device',
+                'one view only device',
+                'two accounts (two different coins) in Portfolio tracker',
+                'one coin enabled that is present in the connected device, view only device and portfolio',
+            ],
+            steps: [
+                'Connect a device (different than the remembered)',
+                'Wait for the initial discovery',
+                'Navigate to Receive and click + to add new',
+                'Click on a new coin that wasn’t enabled before',
+                'Verify dashboard starts discovery for that coin',
+                'Navigate to the view-only device and verify its coins are unchanged',
+            ],
+            category: TestCategory.Settings,
+            priority: TestPriority.Critical,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/coinEnablingSettings.test.ts
+++ b/suite-native/app/e2e/tests/manual/coinEnablingSettings.test.ts
@@ -1,0 +1,29 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Coin enabling - settings',
+        {
+            testCase: 'Coin enabling - settings',
+            prerequisites: [
+                'connected device',
+                'one view only device',
+                'two accounts (two different coins) in Portfolio tracker',
+                'one coin enabled that is present in the connected device, view only device and portfolio',
+            ],
+            steps: [
+                'Connect a device (different than the remembered) and wait for initial discovery',
+                'Navigate to Settings → Enabled coins and enable a new coin that wasn’t enabled before',
+                'Verify dashboard starts discovery for that coin and view-only device unchanged',
+                'Switch back to connected device, go to Settings → Enabled coins and disable a coin present in connected device, Portfolio and view-only device',
+                'Verify the disabled coin is disabled only for devices and remains in Portfolio tracker',
+            ],
+            category: TestCategory.Settings,
+            priority: TestPriority.Critical,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/colorScheme.test.ts
+++ b/suite-native/app/e2e/tests/manual/colorScheme.test.ts
@@ -1,0 +1,22 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Color scheme',
+        {
+            testCase: 'Color scheme',
+            prerequisites: [],
+            steps: [
+                'On bottom bar click on Settings gear icon',
+                'Click on Customization',
+                'Change Color scheme and verify app colors update accordingly',
+            ],
+            category: TestCategory.Settings,
+            priority: TestPriority.Medium,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/currencyChange.test.ts
+++ b/suite-native/app/e2e/tests/manual/currencyChange.test.ts
@@ -1,23 +1,23 @@
-import { TestCategory, TestPriority } from '@trezor/e2e-utils';
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 
 import { it } from '../../support/wrappedIt';
 
-// FIXME https://github.com/trezor/trezor-suite/issues/23438
+// Template-based test (unchanged); original had describe.skip
 describe.skip('Settings', () => {
     it(
         'Change currency',
         {
-            testCase: 'Change currency in settings',
-            prerequisites: ['Suite app with an Bitcoin account already imported'],
+            testCase: 'Currency change',
+            prerequisites: ['an app with an Bitcoin account already imported'],
             steps: [
-                'On bottom bar, click on "Settings gear" icon',
-                'Click on "Localization"',
-                'Change fiat "currency"',
-                'Navigate to "Home" section',
-                'Price of imported accounts changed accordingly',
+                'On bottom bar click on Settings gear icon',
+                'Click on Localization',
+                'Change fiat currency',
+                'Navigate to Home section and verify prices of imported accounts changed accordingly',
             ],
             category: TestCategory.Settings,
             priority: TestPriority.Medium,
+            stream: TestStream.Growth,
         },
         async () => {},
     );

--- a/suite-native/app/e2e/tests/manual/deviceAuthenticityCheck.test.ts
+++ b/suite-native/app/e2e/tests/manual/deviceAuthenticityCheck.test.ts
@@ -1,0 +1,18 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Device authenticity check',
+        {
+            testCase: 'Device authenticity check',
+            prerequisites: [],
+            steps: ['Automatic device authenticity check (no manual steps defined)'],
+            category: TestCategory.Settings,
+            priority: TestPriority.Critical,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/deviceBootloaderMode.test.ts
+++ b/suite-native/app/e2e/tests/manual/deviceBootloaderMode.test.ts
@@ -1,0 +1,21 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Device in bootloader mode',
+        {
+            testCase: 'Device in bootloader mode',
+            prerequisites: ['Already on-boarded application', 'Device in bootloader mode'],
+            steps: [
+                'Connect device in bootloader mode',
+                'Verify application detects device and asks to eject and reconnect it not in bootloader mode',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.High,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/deviceConnectedAndDetected.test.ts
+++ b/suite-native/app/e2e/tests/manual/deviceConnectedAndDetected.test.ts
@@ -1,0 +1,27 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Device connected and detected',
+        {
+            testCase: 'Device connected and detected',
+            prerequisites: [
+                'Device with transaction history connected',
+                'Already on-boarded Lite application',
+            ],
+            steps: [
+                'Connect device and unlock via PIN if enabled',
+                'Verify application recognizes device and informs user it is connecting',
+                'Verify discovery starts and loading account info is displayed',
+                'Verify device name is displayed at upper section of app',
+                'Verify discovery finishes and accounts list is rendered',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.Critical,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/deviceConnectedSuiteOpenedAndroid.test.ts
+++ b/suite-native/app/e2e/tests/manual/deviceConnectedSuiteOpenedAndroid.test.ts
@@ -1,0 +1,28 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Device connected and Suite opened from Android mode',
+        {
+            testCase: 'Device connected and Suite opened from Android modal',
+            prerequisites: [
+                'Device model T or S3 with transaction history connected',
+                'Already on-boarded Lite application',
+                'View-only wallet is enabled (Trezor was connected to this device once in the past)',
+            ],
+            steps: [
+                'Connect device and unlock via PIN if enabled',
+                'Launch the app from Android modal (not app launcher)',
+                'Verify application recognizes device and informs user it is connecting',
+                'Verify discovery starts and loading account info is displayed',
+                'Verify device name is displayed at upper section and discovery finishes with accounts list rendered',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.Critical,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/deviceConnectedUnlockedDetected.test.ts
+++ b/suite-native/app/e2e/tests/manual/deviceConnectedUnlockedDetected.test.ts
@@ -1,0 +1,26 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Device connected, unlocked and detected',
+        {
+            testCase: 'Device connected, unlocked and detected',
+            prerequisites: [
+                'Device model One with PIN enabled and with transaction history',
+                'Already on-boarded Lite application',
+            ],
+            steps: [
+                'Connect device and verify system recognizes it',
+                'Verify device displays PIN matrix and application renders PIN matrix',
+                'After entering incorrect PIN verify prompt to reenter PIN or open help',
+                'Enter correct PIN and verify device unlocks and discovery starts',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.Critical,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/deviceNoFirmware.test.ts
+++ b/suite-native/app/e2e/tests/manual/deviceNoFirmware.test.ts
@@ -1,0 +1,21 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Device with no firmware T1B1',
+        {
+            testCase: 'T1B1 with no firmware',
+            prerequisites: ['Wiped app', 'T1B1 with no firmware installed'],
+            steps: [
+                'Connect device',
+                'Verify application detects device and asks to eject device and use desktop version',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.High,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/deviceOnboardingFreshDevice.test.ts
+++ b/suite-native/app/e2e/tests/manual/deviceOnboardingFreshDevice.test.ts
@@ -1,0 +1,27 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Device - Onboarding - fresh device',
+        {
+            testCase: 'Device - Onboarding - fresh device',
+            prerequisites: ['device without fw'],
+            steps: [
+                'Connect device to phone and verify Let’s get started screen appears',
+                'Continue through security check (3 steps)',
+                'Verify firmware installation warning appears and install firmware',
+                'Verify Firmware installed message and device authentication (Your Trezor is genuine)',
+                'Go through tutorial and choose Create new wallet',
+                'Verify 4 wallet backup info screens and wallet backup type selection',
+                'Complete wallet creation on device and best-practices screens',
+                'Set up PIN, enable at least one coin and verify discovery starts',
+            ],
+            category: TestCategory.Onboarding,
+            priority: TestPriority.Medium,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/deviceOnboardingRecovery.test.ts
+++ b/suite-native/app/e2e/tests/manual/deviceOnboardingRecovery.test.ts
@@ -1,0 +1,26 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Device - Onboarding - recovery',
+        {
+            testCase: 'Device - Onboarding - recovery',
+            prerequisites: ['device without fw'],
+            steps: [
+                'Connect device to phone and verify Let’s get started screen appears',
+                'Continue through security check (3 steps)',
+                'Verify firmware installation warning appears and install firmware',
+                'Verify Firmware installed message and device authentication (Your Trezor is genuine)',
+                'On wallet creation/recovery screen choose Recover and follow Get your wallet backup flow',
+                'Complete wallet recovery on device and best-practices screens',
+                'Set up PIN, enable at least one coin and verify discovery starts',
+            ],
+            category: TestCategory.Onboarding,
+            priority: TestPriority.Medium,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/deviceOutdatedFirmware.test.ts
+++ b/suite-native/app/e2e/tests/manual/deviceOutdatedFirmware.test.ts
@@ -1,0 +1,24 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Device with outdated firmware',
+        {
+            testCase: 'Device with outdated firmware',
+            prerequisites: [
+                'Already on-boarded application',
+                'Device with firmware older than latest production',
+            ],
+            steps: [
+                'Connect device and verify it is detected',
+                'Verify message with outdated firmware info is rendered',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.High,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/deviceSettings.test.ts
+++ b/suite-native/app/e2e/tests/manual/deviceSettings.test.ts
@@ -1,0 +1,26 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Device settings',
+        {
+            testCase: 'Device settings',
+            prerequisites: [
+                'Connected device with transaction history',
+                'Already on-boarded Lite application',
+            ],
+            steps: [
+                'Connect device and wait for detection and discovery start',
+                'In tracker/device switcher ensure Device info button is active and click it',
+                'Verify information about update, model, and label is rendered',
+                'Verify bottom link to trezor.io/store is present and clickable',
+            ],
+            category: TestCategory.Settings,
+            priority: TestPriority.Medium,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/deviceWithFreshSeed.test.ts
+++ b/suite-native/app/e2e/tests/manual/deviceWithFreshSeed.test.ts
@@ -1,0 +1,22 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Device with fresh seed',
+        {
+            testCase: 'Device with fresh seed',
+            prerequisites: ['Already on-boarded application', 'Device with fresh seed loaded'],
+            steps: [
+                'Connect device and verify detection and discovery start',
+                'Wait for discovery to finish and verify no accounts are found',
+                'Verify Your wallet is empty info is rendered',
+            ],
+            category: TestCategory.Dashboard,
+            priority: TestPriority.High,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/disconnectDevice.test.ts
+++ b/suite-native/app/e2e/tests/manual/disconnectDevice.test.ts
@@ -1,0 +1,26 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Disconnect device',
+        {
+            testCase: 'Disconnect device',
+            prerequisites: [
+                'Connected device with transaction history',
+                'Already on-boarded Lite application',
+            ],
+            steps: [
+                'Connect device and verify detection and discovery start',
+                'Disconnect device after or during discovery',
+                'Verify application recognizes the disconnection',
+                'Verify navigation to welcome/landing page or tracker if accounts are imported',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.Medium,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/erc20ContractNameFiatPrice.test.ts
+++ b/suite-native/app/e2e/tests/manual/erc20ContractNameFiatPrice.test.ts
@@ -1,0 +1,23 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'ERC20 contract name and fiat price',
+        {
+            testCase: 'ERC20 contract name and fiat price',
+            prerequisites: ['Imported Ethereum account with token transaction history'],
+            steps: [
+                'Navigate to an Ethereum account in My Assets that includes token transfers',
+                'Toggle Ethereum / Include tokens switch',
+                'Click on an ERC20 transaction with fiat value and open external blockbook link',
+                'Verify same transaction opens in web browser and contract name and fiat value match Coingecko',
+            ],
+            category: TestCategory.Wallets,
+            priority: TestPriority.Low,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/erc20TransactionDetail.test.ts
+++ b/suite-native/app/e2e/tests/manual/erc20TransactionDetail.test.ts
@@ -1,0 +1,24 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'ERC20 Transaction detail',
+        {
+            testCase: 'ERC20 Transaction detail',
+            prerequisites: ['Imported Ethereum account with token transaction history'],
+            steps: [
+                'Navigate to an Ethereum account in My Assets that includes token transfers',
+                'Toggle Ethereum / Include tokens switch',
+                'Click on a received or sent transaction and open detailed sections',
+                'Verify detailed sections contain valid blockbook data: Parameters, Compare values, Inputs and Outputs, Token name and value',
+                'Open external blockbook link and verify the same transaction opens in web browser',
+            ],
+            category: TestCategory.Wallets,
+            priority: TestPriority.Low,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/firmwareUpdate.test.ts
+++ b/suite-native/app/e2e/tests/manual/firmwareUpdate.test.ts
@@ -1,0 +1,18 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Firmware update',
+        {
+            testCase: 'Firmware update',
+            prerequisites: ['including language change'],
+            steps: ['No manual steps defined in source; firmware update flow is not automatable'],
+            category: TestCategory.Firmware,
+            priority: TestPriority.Critical,
+            stream: TestStream.Firmware,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/generateANewBtcAddressAndCopyIt.test.ts
+++ b/suite-native/app/e2e/tests/manual/generateANewBtcAddressAndCopyIt.test.ts
@@ -1,0 +1,23 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Generate a new BTC address and copy it',
+        {
+            testCase: 'Generate a new BTC address and copy it',
+            prerequisites: ['an app with an account already imported'],
+            steps: [
+                'On bottom bar click Receive and select a random imported account',
+                'Verify address verification warning screen shows up and click Show address',
+                'Verify QR code and address appear; click Copy and verify Address copied notification',
+                'Navigate out of account receive address and paste clipboard into a messaging app to verify address matches',
+            ],
+            category: TestCategory.Wallets,
+            priority: TestPriority.Critical,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/generateAndVerifyReceiveAddressOnDevice.test.ts
+++ b/suite-native/app/e2e/tests/manual/generateAndVerifyReceiveAddressOnDevice.test.ts
@@ -1,0 +1,26 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Generate and verify receive address on device',
+        {
+            testCase: 'Generate and verify receive address on device',
+            prerequisites: [
+                'Connected device with transaction history',
+                'Already on-boarded Lite application',
+            ],
+            steps: [
+                'Ensure device connected and discovery finished',
+                'Navigate to a random Bitcoin account and generate receive address',
+                'Compare and confirm the address on device',
+                'Repeat for all devices as needed',
+            ],
+            category: TestCategory.Accounts,
+            priority: TestPriority.High,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/homeSection.test.ts
+++ b/suite-native/app/e2e/tests/manual/homeSection.test.ts
@@ -1,0 +1,27 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Home section',
+        {
+            testCase: 'Home section',
+            prerequisites: [
+                'Already on-boarded application',
+                'Device with transaction history is connected and discovery is finished',
+            ],
+            steps: [
+                'Verify device name is present',
+                'Verify My portfolio balance graph is loaded and rendered',
+                'Click on timeline settings and verify graph changes accordingly',
+                'Verify list of accounts in portfolio is present including accounts count',
+                'Verify Home button in navigation is rendered as active',
+            ],
+            category: TestCategory.Dashboard,
+            priority: TestPriority.Critical,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/importAlreadyImportedXpub.test.ts
+++ b/suite-native/app/e2e/tests/manual/importAlreadyImportedXpub.test.ts
@@ -1,0 +1,26 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Import an already imported XPUB',
+        {
+            testCase: 'Import an already imported XPUB',
+            prerequisites: [
+                'An app version with already imported btc XPUB',
+                'The same btc XPUB key',
+            ],
+            steps: [
+                'Start app, navigate to the already imported btc account, display xpub and copy it',
+                'Navigate back to account section and select import',
+                'Type the XPUB in enter XPUB manually and confirm; verify user is transferred to Coin already synced page',
+                'Press Continue to app',
+            ],
+            category: TestCategory.Application,
+            priority: TestPriority.High,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/importBitcoinAddress.test.ts
+++ b/suite-native/app/e2e/tests/manual/importBitcoinAddress.test.ts
@@ -1,0 +1,22 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Import Bitcoin address',
+        {
+            testCase: 'Import Bitcoin address',
+            prerequisites: ['Bitcoin receive address'],
+            steps: [
+                'Navigate to My Assets and press + to import account',
+                'Select Bitcoin and choose Scan QR',
+                'Try to import Bitcoin receive address and verify address is not imported and user is informed it is a receive address',
+            ],
+            category: TestCategory.Application,
+            priority: TestPriority.High,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/importUnsupportedXpub.test.ts
+++ b/suite-native/app/e2e/tests/manual/importUnsupportedXpub.test.ts
@@ -1,0 +1,23 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Import an unsupported XPUB',
+        {
+            testCase: 'Import an unsupported XPUB',
+            prerequisites: ['An XPUB key of a currently unsupported coin (e.g., DASH)'],
+            steps: [
+                'Navigate to My Assets and press + to import account',
+                'Select Bitcoin and choose Scan public key',
+                'Scan DASH XPUB and verify Account info failed message is displayed',
+                'Press Go back and verify navigation back to XPUB Import page',
+            ],
+            category: TestCategory.Application,
+            priority: TestPriority.High,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/importXpubViaQrCode.test.ts
+++ b/suite-native/app/e2e/tests/manual/importXpubViaQrCode.test.ts
@@ -1,0 +1,24 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Import XPUB via QR code',
+        {
+            testCase: 'Import XPUB via QR code',
+            prerequisites: ['A Suite version without camera privileges', 'A QR code of an XPUB'],
+            steps: [
+                'Start the app and verify Connect and Track page is rendered',
+                'Click Sync & Track and select Bitcoin',
+                'System dialog for camera usage should appear; click Allow and verify camera opens',
+                'Scan the QR code and verify user is transferred to Coin synced screen',
+                'Press Confirm',
+            ],
+            category: TestCategory.Application,
+            priority: TestPriority.Critical,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/incognitoMode.test.ts
+++ b/suite-native/app/e2e/tests/manual/incognitoMode.test.ts
@@ -1,0 +1,22 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Incognito mode',
+        {
+            testCase: 'Incognito mode',
+            prerequisites: ['An app version with already imported btc XPUB'],
+            steps: [
+                'On bottom bar click Settings gear icon and select Privacy & Security',
+                'Enable Discreet mode via toggle',
+                'Navigate through accounts and transactions and verify numeric values are blurred',
+            ],
+            category: TestCategory.Settings,
+            priority: TestPriority.Medium,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/needsBackupDevice.test.ts
+++ b/suite-native/app/e2e/tests/manual/needsBackupDevice.test.ts
@@ -1,0 +1,22 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Needs backup device',
+        {
+            testCase: 'Needs backup device',
+            prerequisites: ['Device that went through onboarding with skipped backup'],
+            steps: [
+                'Connect device to mobile and verify You need wallet backup warning appears with Create wallet backup button',
+                'Click Create wallet backup and verify backup from onboarding starts',
+                'Backup failed variant: fail wallet creation and verify backup failed warning appears with Wipe device & create backup button and Your wallet backup failed screen is available',
+            ],
+            category: TestCategory.Security,
+            priority: TestPriority.Medium,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/passphraseMismatch.test.ts
+++ b/suite-native/app/e2e/tests/manual/passphraseMismatch.test.ts
@@ -1,0 +1,24 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Passphrase mismatch',
+        {
+            testCase: 'Passphrase mismatch',
+            prerequisites: ['connected device'],
+            steps: [
+                'Connect device and perform initial wallet discovery',
+                'Open wallet drop-down and select Open passphrase',
+                'Enter a random passphrase and confirm on device; verify This passphrase wallet is empty modal',
+                'Click Yes, open and then enter a completely different passphrase',
+                'Verify Passphrase mismatch warning is shown',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.Critical,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/renameAccount.test.ts
+++ b/suite-native/app/e2e/tests/manual/renameAccount.test.ts
@@ -1,0 +1,22 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Rename account',
+        {
+            testCase: 'Rename account',
+            prerequisites: ['An app with an account already imported'],
+            steps: [
+                'Navigate to a random bitcoin account in My Assets with transaction history',
+                'Press settings (⚙️) in top-right and select edit (✏️)',
+                'Rename account and verify name changed after navigating back',
+            ],
+            category: TestCategory.Accounts,
+            priority: TestPriority.Low,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/satsBtcSwitching.test.ts
+++ b/suite-native/app/e2e/tests/manual/satsBtcSwitching.test.ts
@@ -1,0 +1,23 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Sats/BTC switching',
+        {
+            testCase: 'Sats/BTC switching',
+            prerequisites: ['An app version with already imported btc XPUB'],
+            steps: [
+                'On bottom bar click Settings gear icon and navigate to Localisation',
+                'Click Bitcoin Amount Units and change from Bitcoin to Satoshis',
+                'Navigate to My assets and open a random bitcoin account',
+                'Verify Bitcoin values are rendered in Satoshis',
+            ],
+            category: TestCategory.Settings,
+            priority: TestPriority.High,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/searchAssets.test.ts
+++ b/suite-native/app/e2e/tests/manual/searchAssets.test.ts
@@ -1,0 +1,22 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Search assets',
+        {
+            testCase: 'Search assets',
+            prerequisites: ['An app with an account BTC already imported'],
+            steps: [
+                'Navigate to My assets and click the search (🔍) icon',
+                'Verify Search assets title and search field are rendered and cancel search via Cancel button',
+                'Open search again, enter text included in at least one account name and verify accounts are filtered',
+            ],
+            category: TestCategory.Accounts,
+            priority: TestPriority.High,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/sendFormBnb.test.ts
+++ b/suite-native/app/e2e/tests/manual/sendFormBnb.test.ts
@@ -1,0 +1,27 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Send form BNB',
+        {
+            testCase: 'Send form BNB',
+            prerequisites: ['connected device', 'seed with funds on it'],
+            steps: [
+                'Navigate to BNB assets and select another account than the one with most funds',
+                'Click Receive, copy address and confirm on device',
+                'Select account with most funds and click Send',
+                'Enter address and amount, verify fiat/BNB values and switching between fields',
+                'Continue to fee selection (one fee shown) and verify recipient and totals',
+                'Continue to Review and sign, approve on device and verify recipient ticked',
+                'Approve and send transaction; verify transaction detail shows Pending',
+                'Repeat procedure for tokens',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.Critical,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/sendFormBtc.test.ts
+++ b/suite-native/app/e2e/tests/manual/sendFormBtc.test.ts
@@ -1,0 +1,27 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Send form BTC',
+        {
+            testCase: 'Send form BTC',
+            prerequisites: ['connected device', 'seed with funds on it'],
+            steps: [
+                'Navigate to BTC assets and select a different account than the one with most funds',
+                'From that account click Receive, copy the address and confirm on device',
+                'Select an account with most funds and click Send to open send form',
+                'Enter the copied address and a reasonable amount; verify crypto/fiat values and switching between fields',
+                'Continue to fee selection and verify low/medium/high options, values, recipient and totals shown',
+                'Continue to Review and sign; approve steps and verify prompt to continue on device',
+                'Approve address on device (optionally switch apps while address shown) and verify recipient ticked',
+                'Approve amount and total including fee, click Send transaction and verify transaction detail shows Pending',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.Critical,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/sendFormEth.test.ts
+++ b/suite-native/app/e2e/tests/manual/sendFormEth.test.ts
@@ -1,0 +1,27 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Send form ETH',
+        {
+            testCase: 'Send form ETH',
+            prerequisites: ['connected device', 'seed with funds on it'],
+            steps: [
+                'Navigate to ETH assets and select another account than the one with most funds',
+                'Click Receive, copy address and confirm on device',
+                'Select account with most funds and click Send',
+                'Enter address and amount, verify fiat/ETH values and switching between fields',
+                'Continue to fee selection (one fee shown) and verify recipient and totals',
+                'Continue to Review and sign, approve on device and verify recipient ticked',
+                'Approve and send transaction; verify transaction detail shows Pending',
+                'Repeat procedure for tokens',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.Critical,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/sendFormPol.test.ts
+++ b/suite-native/app/e2e/tests/manual/sendFormPol.test.ts
@@ -1,0 +1,27 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Send form POL',
+        {
+            testCase: 'Send form POL',
+            prerequisites: ['connected device', 'seed with funds on it'],
+            steps: [
+                'Navigate to POL assets and select another account than the one with most funds',
+                'Click Receive, copy address and confirm on device',
+                'Select account with most funds and click Send',
+                'Enter address and amount, verify fiat/POL values and switching between fields',
+                'Continue to fee selection (one fee shown) and verify recipient and totals',
+                'Continue to Review and sign, approve on device and verify recipient ticked',
+                'Approve and send transaction; verify transaction detail shows Pending',
+                'Repeat procedure for tokens',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.Critical,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/sendFormSol.test.ts
+++ b/suite-native/app/e2e/tests/manual/sendFormSol.test.ts
@@ -1,0 +1,27 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Send form SOL',
+        {
+            testCase: 'Send form SOL',
+            prerequisites: ['connected device', 'seed with funds on it'],
+            steps: [
+                'Navigate to SOL assets and select another account than the one with most funds',
+                'Click Receive, copy address and confirm on device',
+                'Select account with most funds and click Send',
+                'Enter address and amount, verify fiat/SOL values and switching between fields',
+                'Continue to fee selection (one fee shown) and verify recipient and totals',
+                'Continue to Review and sign, approve on device and verify recipient ticked',
+                'Approve and send transaction; verify transaction detail shows Pending',
+                'Repeat procedure for tokens',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.Critical,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/settingsSupportSection.test.ts
+++ b/suite-native/app/e2e/tests/manual/settingsSupportSection.test.ts
@@ -1,0 +1,23 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Settings/Support section',
+        {
+            testCase: 'Settings/Support section',
+            prerequisites: [],
+            steps: [
+                'On bottom bar click Settings gear icon and navigate to About Trezor section',
+                'Check overall page design and text, click links in Follow us and Legal sections',
+                'Navigate back to Settings and open Get help section, expand info via + button',
+                'Click Contract support and verify Support page opens',
+            ],
+            category: TestCategory.Settings,
+            priority: TestPriority.Low,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/shareAccountReceiveAddress.test.ts
+++ b/suite-native/app/e2e/tests/manual/shareAccountReceiveAddress.test.ts
@@ -1,0 +1,22 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        "Share account's receive address",
+        {
+            testCase: "Share account's receive address",
+            prerequisites: ['An app with an account already imported'],
+            steps: [
+                'On bottom bar click Receive and select first account',
+                'Click Show address and verify Receive address screen with QR and address appears',
+                'Click Share and verify device system share dialog appears',
+            ],
+            category: TestCategory.Accounts,
+            priority: TestPriority.Medium,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/splashScreenLoads.test.ts
+++ b/suite-native/app/e2e/tests/manual/splashScreenLoads.test.ts
@@ -1,0 +1,20 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Splash screen loads',
+        {
+            testCase: 'Splash screen loads',
+            prerequisites: [],
+            steps: [
+                'Start the app and verify splash screen appears and transfers promptly to next screen',
+            ],
+            category: TestCategory.NotCategorized,
+            priority: TestPriority.Medium,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/storageUpgradeFromPreviousVersion.test.ts
+++ b/suite-native/app/e2e/tests/manual/storageUpgradeFromPreviousVersion.test.ts
@@ -1,0 +1,22 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Storage upgrade from previous version',
+        {
+            testCase: 'Storage upgrade from previous version',
+            prerequisites: ['An app with an account already imported'],
+            steps: [
+                'Install previous public version and import at least two accounts',
+                'Change at least two default settings and kill app',
+                'Install new version and verify accounts and settings are intact',
+            ],
+            category: TestCategory.Accounts,
+            priority: TestPriority.High,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/switchBetweenTrackerAndConnectedDevice.test.ts
+++ b/suite-native/app/e2e/tests/manual/switchBetweenTrackerAndConnectedDevice.test.ts
@@ -1,0 +1,25 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Switch between tracker and connected device',
+        {
+            testCase: 'Switch between tracker and connected device',
+            prerequisites: [
+                'Connected device with transaction history',
+                'Already on-boarded Lite application',
+                'Imported at least one account in tracker',
+            ],
+            steps: [
+                'Connect device and verify detection and discovery start',
+                'Switch between device and portfolio tracker and verify UI updates accordingly',
+            ],
+            category: TestCategory.Dashboard,
+            priority: TestPriority.Medium,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/viewOnlyRememberDeviceEnable.test.ts
+++ b/suite-native/app/e2e/tests/manual/viewOnlyRememberDeviceEnable.test.ts
@@ -1,0 +1,24 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'View only (remember device) enable',
+        {
+            testCase: 'View only (remember device) enable',
+            prerequisites: ['connected device', 'updated Suite Lite'],
+            steps: [
+                'Connect device and go through initial onboarding',
+                'Wait for discovery of standard wallet and enable view-only when modal appears',
+                'Verify notification about enabling appears',
+                'Open Settings → View only and verify view-only for standard wallet is enabled',
+                'Disconnect device and verify balances remain visible and Disconnected text appears in device switcher',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.High,
+            stream: TestStream.Growth,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/warningMessageRemoveAccount.test.ts
+++ b/suite-native/app/e2e/tests/manual/warningMessageRemoveAccount.test.ts
@@ -1,0 +1,23 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Warning message remove account',
+        {
+            testCase: 'Warning message remove account',
+            prerequisites: ['An app with an account already imported'],
+            steps: [
+                'Navigate to a random bitcoin account in My Assets with transaction history',
+                'Press settings (⚙️) and select Remove coin',
+                'Verify warning is rendered; select Cancel to return to previous section',
+                'Select Remove coin and verify navigation to Home or Import/Sync dialogue if it was the only imported account',
+            ],
+            category: TestCategory.Accounts,
+            priority: TestPriority.Low,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/welcomeOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/manual/welcomeOnboarding.test.ts
@@ -1,0 +1,22 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Welcome onboarding',
+        {
+            testCase: 'Welcome onboarding',
+            prerequisites: ['Freshly installed app or wiped app storage'],
+            steps: [
+                'Start app and verify Welcome screen appears after splash',
+                'Follow info screens and allow anonymous data collection for public builds',
+                'Continue to Import XPUB or Coin enable section',
+            ],
+            category: TestCategory.Onboarding,
+            priority: TestPriority.High,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wipeDevice.test.ts
+++ b/suite-native/app/e2e/tests/manual/wipeDevice.test.ts
@@ -1,0 +1,23 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Wipe device',
+        {
+            testCase: 'Wipe device',
+            prerequisites: ['already setup device'],
+            steps: [
+                'Connect device and go to Device settings',
+                'Choose Wipe device and verify two warnings are shown',
+                'Confirm both warnings and verify wipe starts on device and Continue on your Trezor appears on mobile',
+                'Complete wipe and verify Start setup screen appears',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.Medium,
+            stream: TestStream.Foundation,
+        },
+        async () => {},
+    );
+});


### PR DESCRIPTION
Adds 56 manual E2E tests for the native app under manual (onboarding, device flows, send/receive forms, account and import flows, UI checks, storage/upgrade, etc.) and updates the testAnnotations enum in testAnnotations.ts to support the new test metadata. 

These tests were migrated from our previous Notion specs:  https://www.notion.so/satoshilabs/a2fc2119b5344f1eb3c798de91456de6?v=19ef97b354f7484ea5368a48978cb6e1


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mobile-sanity&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mobile-sanity&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mobile-sanity&lookback=7)