### PR TITLE
Chore/fix web e2e tests

### DIFF
--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -75,12 +75,17 @@ export const getNftContractExplorerUrl = (explorer: Explorer, nft: TokenInfo) =>
     return `${explorerUrl}${contractAddress}${queryString}`;
 };
 
-export const isTokenMatchesSearch = (token: TokenInfo, search: string) =>
-    token.symbol?.toLowerCase().includes(search) ||
-    token.name?.toLowerCase().includes(search) ||
-    token.contract.toLowerCase().includes(search) ||
-    token.fingerprint?.toLowerCase().includes(search) ||
-    token.policyId?.toLowerCase().includes(search);
+export const isTokenMatchesSearch = (token: TokenInfo, rawSearch: string) => {
+    const search = rawSearch.toLowerCase();
+
+    return (
+        token.symbol?.toLowerCase().includes(search) ||
+        token.name?.toLowerCase().includes(search) ||
+        token.contract.toLowerCase().includes(search) ||
+        token.fingerprint?.toLowerCase().includes(search) ||
+        token.policyId?.toLowerCase().includes(search)
+    );
+};
 
 export const isTokenTransferMatchesSearch = (token: TokenTransfer, search: string) =>
     token.symbol?.toLowerCase().includes(search) ||

--- a/suite/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/suite/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -48,7 +48,7 @@ test.describe('Trading - Swap token to coin', { tag: ['@webOnly', '@T3W1', '@T3T
                 amount: sendAmount,
                 sellAsset: {
                     networkSymbol: 'sol',
-                    tokenSymbol: 'usdt',
+                    tokenSymbol: 'USDT',
                     assetCryptoId: tetherMint as CryptoId,
                 },
                 buyAsset: {

--- a/suite/e2e/tests/trading/swap-tokens.test.ts
+++ b/suite/e2e/tests/trading/swap-tokens.test.ts
@@ -48,7 +48,7 @@ test.describe('Trading - Swap tokens', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
                 sellAsset: {
                     networkFilter: 'sol',
                     networkSymbol: 'sol',
-                    tokenSymbol: 'usdt',
+                    tokenSymbol: 'USDT',
                     assetCryptoId: tetherMint as CryptoId,
                     searchFilter: 'USDT',
                 },


### PR DESCRIPTION
## Description

This PR fixes failing web e2e tests. There were 2 issues:

1. Unable to access `dataTestId` because of the difference in token symbol casing (usdt -> USDT)
2. Asset picker search input didn't lowercase its value therefore if user searched for token with wrong casing it would not work

## Notes for QA


## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/fix-web-e2e-tests&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/fix-web-e2e-tests&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/fix-web-e2e-tests&lookback=7)