### PR TITLE
Chore: unify & cleanup connect version utils

### DIFF
--- a/packages/connect/src/api/firmware/modifyFirmware.ts
+++ b/packages/connect/src/api/firmware/modifyFirmware.ts
@@ -1,3 +1,4 @@
+import { getFirmwareOrBootloaderVersionArray } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
 
 import type { Features } from '../../types';
@@ -17,10 +18,7 @@ export const shouldStripFwHeaders = (features: Features) => {
     // -----------------------
 
     // any version installed on bootloader 1.8.0 must be sliced of the first 256 bytes (containing old firmware header)
-    return versionUtils.isNewerOrEqual(
-        [features.major_version, features.minor_version, features.patch_version],
-        [1, 8, 0],
-    );
+    return versionUtils.isNewerOrEqual(getFirmwareOrBootloaderVersionArray(features), [1, 8, 0]);
 };
 
 /**

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -1,3 +1,4 @@
+import { getFirmwareOrBootloaderVersionArray } from '@trezor/device-utils';
 import { resolveAfter } from '@trezor/utils';
 import { isEqual, isNewer } from '@trezor/utils/src/versionUtils';
 
@@ -156,16 +157,8 @@ const waitForReconnectedDevice = async (
             bootloader === !reconnectedDevice.features.bootloader_mode ||
             (intermediary &&
                 !isNewer(
-                    [
-                        reconnectedDevice.features.major_version,
-                        reconnectedDevice.features.minor_version,
-                        reconnectedDevice.features.patch_version,
-                    ],
-                    [
-                        device.features.major_version,
-                        device.features.minor_version,
-                        device.features.patch_version,
-                    ],
+                    getFirmwareOrBootloaderVersionArray(reconnectedDevice.features),
+                    getFirmwareOrBootloaderVersionArray(device.features),
                 )))
     );
 
@@ -224,11 +217,7 @@ const getInstallationParams = (device: Device, params: Params) => {
             : undefined;
         const isUpdatingToNewerVersion = !version
             ? device.firmwareReleaseConfigInfo?.isNewer
-            : isNewer(version, [
-                  device.features.major_version,
-                  device.features.minor_version,
-                  device.features.patch_version,
-              ]);
+            : isNewer(version, getFirmwareOrBootloaderVersionArray(device.features));
         const isUpdatingToEqualFirmwareType =
             (device.firmwareType === FirmwareType.BitcoinOnly) === btcOnly;
 

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -8,7 +8,9 @@ import {
     FirmwareType,
     IntermediaryReleaseConfig,
     VersionArray,
+    getBootloaderVersionArray,
     getFirmwareOrBootloaderVersionArray,
+    getFirmwareVersionArray,
 } from '@trezor/device-utils';
 import { getIntegerInRangeFromString, removeTrailingSlashes, versionUtils } from '@trezor/utils';
 
@@ -357,46 +359,16 @@ export type CurrentVersion = {
     firmwareVersion: VersionArray | null;
 };
 
-export const getCurrentVersion = (features: Features): CurrentVersion => {
+const getCurrentVersion = (features: Features): CurrentVersion => {
     if (!isStrictFeatures(features)) {
         throw new Error('Features of unexpected shape provided.');
     }
-
-    const {
-        bootloader_mode,
-        major_version,
-        minor_version,
-        patch_version,
-        fw_major,
-        fw_minor,
-        fw_patch,
-    } = features;
-
-    // When Trezor device is in Firmware mode the `features`:
-    //  * `major/minor/patch_version` --> it is the firmware version
-    //  * `fw_major/minor/patch` --> null
-    // When Trezor device is in Bootloader mode the `features`:
-    //  * `major/minor/patch_version` --> it is the bootloader version
-    //  * `fw_major/minor/patch` --> it is the firmware version
-
-    // `fw_version` is the firmware version when in bootloader mode, in firmware mode it will be [null, null, null]
-    // when device is factory reset will always be in bootloader mode.
-    const fw_version = [fw_major, fw_minor, fw_patch];
-    // `version` is bootloader version when in bootloader mode, in firmware mode it is firmware version.
-    const version = [major_version, minor_version, patch_version] as VersionArray;
-
-    // In Firmware mode it is for now not possible to know the bootloader version.
-    const bootloaderVersion = bootloader_mode ? version : null;
-
-    // Some old version of T1B1 do not report FW version in bootloader mode,
-    // so it is not 100% true that in bootloader mode we will know the firmware version,
+    const bootloaderVersion = getBootloaderVersionArray({ features });
+    // Old T1B1 versions do not report FW version in bootloader mode, then it cannot be known,
     // but we are handling it `getReleaseInfo` when device is T1B1 we use bootloader version.
-    const fwVersion = bootloader_mode ? fw_version : version;
+    const firmwareVersion = getFirmwareVersionArray({ features });
 
-    return {
-        bootloaderVersion,
-        firmwareVersion: fwVersion.includes(null) ? null : (fwVersion as VersionArray),
-    };
+    return { bootloaderVersion, firmwareVersion };
 };
 
 const getIntermediaryMessageRelease = (features: Features) => {

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -8,6 +8,7 @@ import {
     FirmwareType,
     IntermediaryReleaseConfig,
     VersionArray,
+    getFirmwareOrBootloaderVersionArray,
 } from '@trezor/device-utils';
 import { getIntegerInRangeFromString, removeTrailingSlashes, versionUtils } from '@trezor/utils';
 
@@ -500,11 +501,7 @@ const getChangelog = (releases: FirmwareRelease[], features: StrictFeatures) => 
     // version higher than the previous one, we can filter out the version that is already
     // installed and show only what's new!
     return releases.filter(r =>
-        versionUtils.isNewer(r.version, [
-            features.major_version,
-            features.minor_version,
-            features.patch_version,
-        ]),
+        versionUtils.isNewer(r.version, getFirmwareOrBootloaderVersionArray(features)),
     );
 };
 

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -3,6 +3,7 @@ import {
     DeviceModelInternal,
     FirmwareRelease,
     getFirmwareOrBootloaderVersionArray,
+    getFirmwareVersionArray,
     models,
 } from '@trezor/device-utils';
 import {
@@ -25,7 +26,6 @@ import { abortThpWorkflow, getThpChannel } from './thp';
 import { checkFirmwareHashWithRetries } from './workflow/checkFirmwareHashWithRetries';
 import { getAllNetworks } from '../data/coinInfo';
 import {
-    getCurrentVersion,
     getFirmwareReleaseConfigInfo,
     getFirmwareStatus,
     getLanguage,
@@ -835,7 +835,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     private async _updateCurrentRelease(feat: Features) {
-        const { firmwareVersion } = getCurrentVersion(feat);
+        const firmwareVersion = getFirmwareVersionArray({ features: feat });
         const newFirmwareType = getFirmwareType(feat);
 
         // We need firmwareVersion to lookup the release.

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -1,5 +1,10 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/Device.js
-import { DeviceModelInternal, FirmwareRelease, models } from '@trezor/device-utils';
+import {
+    DeviceModelInternal,
+    FirmwareRelease,
+    getFirmwareOrBootloaderVersionArray,
+    models,
+} from '@trezor/device-utils';
 import {
     type DecodedTrezorPushNotification,
     TransportProtocol,
@@ -875,11 +880,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         }
 
         const version = this.getVersion();
-        const newVersion = [
-            feat.major_version,
-            feat.minor_version,
-            feat.patch_version,
-        ] satisfies VersionArray;
+        const newVersion = getFirmwareOrBootloaderVersionArray(feat);
 
         // check if FW version or capabilities did change
         if (!version || !versionUtils.isEqual(version, newVersion)) {
@@ -1002,13 +1003,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     getVersion(): VersionArray | undefined {
-        if (!this.features) return;
-
-        return [
-            this.features.major_version,
-            this.features.minor_version,
-            this.features.patch_version,
-        ];
+        return this.features ? getFirmwareOrBootloaderVersionArray(this.features) : undefined;
     }
 
     atLeast(versions: string[] | string) {

--- a/packages/connect/src/utils/deviceFeaturesUtils.ts
+++ b/packages/connect/src/utils/deviceFeaturesUtils.ts
@@ -1,4 +1,4 @@
-import { DeviceModelInternal } from '@trezor/device-utils';
+import { DeviceModelInternal, getFirmwareOrBootloaderVersionArray } from '@trezor/device-utils';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { isArrayMember, versionUtils } from '@trezor/utils';
 
@@ -45,7 +45,7 @@ export const getUnavailableCapabilities = (features: Features, coins: CoinInfo[]
     const { capabilities } = features;
     const list: UnavailableCapabilities = {};
     if (!capabilities) return list;
-    const fw = [features.major_version, features.minor_version, features.patch_version].join('.');
+    const fw = getFirmwareOrBootloaderVersionArray(features).join('.');
     const key = features.internal_model;
 
     // 1. check if firmware version is supported by CoinInfo.support

--- a/packages/device-utils/jest.config.js
+++ b/packages/device-utils/jest.config.js
@@ -1,0 +1,8 @@
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+    collectCoverage: true,
+    collectCoverageFrom: ['src/**/*.ts'],
+    testEnvironment: '../../JestCustomEnv.js',
+};

--- a/packages/device-utils/package.json
+++ b/packages/device-utils/package.json
@@ -15,11 +15,12 @@
         "build:lib": "yarn g:rimraf -rf lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
-        "test:unit": "yarn g:jest -c ../../jest.config.base.js --passWithNoTests",
+        "test:unit": "yarn g:jest -c ./jest.config.js",
         "prepublishOnly": "yarn tsx ../../scripts/publish/prepublishNPM.js",
         "prepublish": "yarn tsx ../../scripts/publish/prepublish.js"
     },
     "devDependencies": {
+        "@trezor/protobuf": "workspace:*",
         "tsx": "^4.20.3"
     }
 }

--- a/packages/device-utils/src/__fixtures__/deviceFeatures.ts
+++ b/packages/device-utils/src/__fixtures__/deviceFeatures.ts
@@ -1,0 +1,32 @@
+import type { MessagesSchema as PROTO } from '@trezor/protobuf';
+
+export const T1B1Features = {
+    bootloader_mode: false,
+    major_version: 1,
+    minor_version: 13,
+    patch_version: 1,
+} as PROTO.Features;
+export const T1B1FeaturesBL = {
+    bootloader_mode: true,
+    fw_major: 1,
+    fw_minor: 13,
+    fw_patch: 1,
+    major_version: 1,
+    minor_version: 12,
+    patch_version: 1,
+} as PROTO.Features;
+export const T2T1Features = {
+    bootloader_mode: false,
+    major_version: 2,
+    minor_version: 9,
+    patch_version: 4,
+} as PROTO.Features;
+export const T2T1FeaturesBL = {
+    bootloader_mode: true,
+    fw_major: 2,
+    fw_minor: 9,
+    fw_patch: 4,
+    major_version: 2,
+    minor_version: 1,
+    patch_version: 8,
+} as PROTO.Features;

--- a/packages/device-utils/src/__tests__/bootloaderUtils.test.ts
+++ b/packages/device-utils/src/__tests__/bootloaderUtils.test.ts
@@ -1,0 +1,44 @@
+import {
+    T1B1Features,
+    T1B1FeaturesBL,
+    T2T1Features,
+    T2T1FeaturesBL,
+} from '../__fixtures__/deviceFeatures';
+import { getBootloaderVersion, getBootloaderVersionArray } from '../bootloaderUtils';
+import { PartialDevice } from '../types';
+
+describe('bootloaderUtils', () => {
+    describe(getBootloaderVersionArray.name, () => {
+        it('returns empty on missing data', () => {
+            expect(getBootloaderVersionArray({})).toBeNull();
+            expect(
+                getBootloaderVersionArray({ features: { bootloader_mode: true } } as PartialDevice),
+            ).toBeNull();
+        });
+        it('returns null for normal mode devices', () => {
+            expect(getBootloaderVersionArray({ features: T1B1Features })).toBeNull();
+            expect(getBootloaderVersionArray({ features: T2T1Features })).toBeNull();
+        });
+        it('returns correct version array for bootloader devices', () => {
+            expect(getBootloaderVersionArray({ features: T1B1FeaturesBL })).toEqual([1, 12, 1]);
+            expect(getBootloaderVersionArray({ features: T2T1FeaturesBL })).toEqual([2, 1, 8]);
+        });
+    });
+
+    describe(getBootloaderVersion.name, () => {
+        it('returns empty string on missing data', () => {
+            expect(getBootloaderVersion({})).toBe('');
+            expect(
+                getBootloaderVersion({ features: { bootloader_mode: true } } as PartialDevice),
+            ).toBe('');
+        });
+        it('returns empty string for normal mode devices', () => {
+            expect(getBootloaderVersion({ features: T1B1Features })).toBe('');
+            expect(getBootloaderVersion({ features: T2T1Features })).toBe('');
+        });
+        it('returns correct version for bootloader devices', () => {
+            expect(getBootloaderVersion({ features: T1B1FeaturesBL })).toEqual('1.12.1');
+            expect(getBootloaderVersion({ features: T2T1FeaturesBL })).toEqual('2.1.8');
+        });
+    });
+});

--- a/packages/device-utils/src/__tests__/firmwareUtils.test.ts
+++ b/packages/device-utils/src/__tests__/firmwareUtils.test.ts
@@ -4,8 +4,12 @@ import {
     T2T1Features,
     T2T1FeaturesBL,
 } from '../__fixtures__/deviceFeatures';
-import { getFirmwareOrBootloaderVersionArray } from '../firmwareUtils';
-
+import {
+    getFirmwareOrBootloaderVersionArray,
+    getFirmwareVersion,
+    getFirmwareVersionArray,
+} from '../firmwareUtils';
+import { PartialDevice } from '../types';
 
 describe('firmwareUtils', () => {
     describe(getFirmwareOrBootloaderVersionArray.name, () => {
@@ -16,6 +20,40 @@ describe('firmwareUtils', () => {
         it('returns correct version array for bootloader devices', () => {
             expect(getFirmwareOrBootloaderVersionArray(T1B1FeaturesBL)).toEqual([1, 12, 1]);
             expect(getFirmwareOrBootloaderVersionArray(T2T1FeaturesBL)).toEqual([2, 1, 8]);
+        });
+    });
+
+    describe(getFirmwareVersionArray.name, () => {
+        it('returns null on missing data', () => {
+            expect(getFirmwareVersionArray({})).toBeNull();
+            expect(
+                getFirmwareVersionArray({ features: { bootloader_mode: true } } as PartialDevice),
+            ).toBeNull();
+        });
+        it('returns correct version array for normal mode devices', () => {
+            expect(getFirmwareVersionArray({ features: T1B1Features })).toEqual([1, 13, 1]);
+            expect(getFirmwareVersionArray({ features: T2T1Features })).toEqual([2, 9, 4]);
+        });
+        it('returns correct version array for bootloader devices', () => {
+            expect(getFirmwareVersionArray({ features: T1B1FeaturesBL })).toEqual([1, 13, 1]);
+            expect(getFirmwareVersionArray({ features: T2T1FeaturesBL })).toEqual([2, 9, 4]);
+        });
+    });
+
+    describe(getFirmwareVersion.name, () => {
+        it('returns empty string on missing data', () => {
+            expect(getFirmwareVersion({})).toBe('');
+            expect(
+                getFirmwareVersion({ features: { bootloader_mode: true } } as PartialDevice),
+            ).toBe('');
+        });
+        it('returns correct version for normal mode devices', () => {
+            expect(getFirmwareVersion({ features: T1B1Features })).toEqual('1.13.1');
+            expect(getFirmwareVersion({ features: T2T1Features })).toEqual('2.9.4');
+        });
+        it('returns correct version for bootloader devices', () => {
+            expect(getFirmwareVersion({ features: T1B1FeaturesBL })).toEqual('1.13.1');
+            expect(getFirmwareVersion({ features: T2T1FeaturesBL })).toEqual('2.9.4');
         });
     });
 });

--- a/packages/device-utils/src/__tests__/firmwareUtils.test.ts
+++ b/packages/device-utils/src/__tests__/firmwareUtils.test.ts
@@ -1,0 +1,21 @@
+import {
+    T1B1Features,
+    T1B1FeaturesBL,
+    T2T1Features,
+    T2T1FeaturesBL,
+} from '../__fixtures__/deviceFeatures';
+import { getFirmwareOrBootloaderVersionArray } from '../firmwareUtils';
+
+
+describe('firmwareUtils', () => {
+    describe(getFirmwareOrBootloaderVersionArray.name, () => {
+        it('returns correct version array for normal mode devices', () => {
+            expect(getFirmwareOrBootloaderVersionArray(T1B1Features)).toEqual([1, 13, 1]);
+            expect(getFirmwareOrBootloaderVersionArray(T2T1Features)).toEqual([2, 9, 4]);
+        });
+        it('returns correct version array for bootloader devices', () => {
+            expect(getFirmwareOrBootloaderVersionArray(T1B1FeaturesBL)).toEqual([1, 12, 1]);
+            expect(getFirmwareOrBootloaderVersionArray(T2T1FeaturesBL)).toEqual([2, 1, 8]);
+        });
+    });
+});

--- a/packages/device-utils/src/bootloaderUtils.ts
+++ b/packages/device-utils/src/bootloaderUtils.ts
@@ -1,18 +1,25 @@
+import { getFirmwareOrBootloaderVersionArray } from './firmwareUtils';
 import { isDeviceInBootloaderMode } from './modeUtils';
-import { PartialDevice } from './types';
+import { FirmwareVersionString, PartialDevice, VersionArray } from './types';
 
 export const getBootloaderHash = (device?: PartialDevice) =>
     device?.features?.bootloader_hash || '';
 
-export const getBootloaderVersion = (device?: PartialDevice) => {
+export const getBootloaderVersionArray = (device?: PartialDevice): VersionArray | null => {
     if (!device?.features) {
-        return '';
+        return null;
     }
     const { features } = device;
 
     if (isDeviceInBootloaderMode(device) && features.major_version) {
-        return `${features.major_version}.${features.minor_version}.${features.patch_version}`;
+        return getFirmwareOrBootloaderVersionArray(features);
     }
 
-    return '';
+    return null;
+};
+
+export const getBootloaderVersion = (device?: PartialDevice): '' | FirmwareVersionString => {
+    const versionArray = getBootloaderVersionArray(device);
+
+    return versionArray === null ? '' : (versionArray.join('.') as FirmwareVersionString);
 };

--- a/packages/device-utils/src/bootloaderUtils.ts
+++ b/packages/device-utils/src/bootloaderUtils.ts
@@ -6,12 +6,14 @@ export const getBootloaderHash = (device?: PartialDevice) =>
     device?.features?.bootloader_hash || '';
 
 export const getBootloaderVersionArray = (device?: PartialDevice): VersionArray | null => {
+    // In Firmware mode it is for now not possible to know the bootloader version.
     if (!device?.features) {
         return null;
     }
     const { features } = device;
 
     if (isDeviceInBootloaderMode(device) && features.major_version) {
+        // `version` is bootloader version when in bootloader mode, in firmware mode it is firmware version.
         return getFirmwareOrBootloaderVersionArray(features);
     }
 

--- a/packages/device-utils/src/firmwareUtils.ts
+++ b/packages/device-utils/src/firmwareUtils.ts
@@ -46,21 +46,13 @@ export const getFirmwareVersionArray = (device?: PartialDevice): VersionArray | 
             : null;
     }
 
-    return [features.major_version, features.minor_version, features.patch_version];
+    return getFirmwareOrBootloaderVersionArray(features);
 };
 
 export const getFirmwareVersion = (device?: PartialDevice): '' | FirmwareVersionString => {
-    if (!device?.features) {
-        return '';
-    }
-    const { features } = device;
-    if (isDeviceInBootloaderMode(device)) {
-        return features.fw_major
-            ? `${features.fw_major}.${features.fw_minor!}.${features.fw_patch!}`
-            : '';
-    }
+    const versionArray = getFirmwareVersionArray(device);
 
-    return `${features.major_version}.${features.minor_version}.${features.patch_version}`;
+    return versionArray === null ? '' : (versionArray.join('.') as FirmwareVersionString);
 };
 
 // This can give a false negative in bootloader mode for T1B1 and T2T1.

--- a/packages/device-utils/src/firmwareUtils.ts
+++ b/packages/device-utils/src/firmwareUtils.ts
@@ -1,3 +1,5 @@
+import type { MessagesSchema as PROTO } from '@trezor/protobuf';
+
 import { isDeviceInBootloaderMode } from './modeUtils';
 import {
     FirmwareSource,
@@ -22,6 +24,15 @@ export const getFirmwareSource = (device?: PartialDevice): FirmwareSource => {
 };
 
 export const getFirmwareRevision = (device?: PartialDevice) => device?.features?.revision || '';
+
+/**
+ * Gets the firmware/bootloader version from device features, depending on the mode (it does not distinguish normal | bootloader).
+ */
+export const getFirmwareOrBootloaderVersionArray = (features: PROTO.Features): VersionArray => [
+    features.major_version,
+    features.minor_version,
+    features.patch_version,
+];
 
 export const getFirmwareVersionArray = (device?: PartialDevice): VersionArray | null => {
     if (!device?.features) {

--- a/packages/device-utils/src/firmwareUtils.ts
+++ b/packages/device-utils/src/firmwareUtils.ts
@@ -40,12 +40,14 @@ export const getFirmwareVersionArray = (device?: PartialDevice): VersionArray | 
     }
     const { features } = device;
 
+    // `fw_version` is the firmware version when in bootloader mode, in firmware mode it will be [null, null, null]
     if (isDeviceInBootloaderMode(device)) {
         return features.fw_major
             ? ([features.fw_major, features.fw_minor, features.fw_patch] as VersionArray)
             : null;
     }
 
+    // `version` is bootloader version when in bootloader mode, in firmware mode it is firmware version.
     return getFirmwareOrBootloaderVersionArray(features);
 };
 

--- a/packages/device-utils/src/types.ts
+++ b/packages/device-utils/src/types.ts
@@ -44,6 +44,17 @@ export type FeaturesNarrowing =
           major_version: 1;
           minor_version: number;
           patch_version: number;
+          // Old T1B1 versions do not report FW version in bootloader mode, then it cannot be known
+          fw_major: 1 | null;
+          fw_minor: number | null;
+          fw_patch: number | null;
+          bootloader_mode: true;
+          firmware_present: true;
+      }
+    | {
+          major_version: 1;
+          minor_version: number;
+          patch_version: number;
           fw_major: null;
           fw_minor: null;
           fw_patch: null;
@@ -57,8 +68,8 @@ export type FeaturesNarrowing =
           fw_major: null;
           fw_minor: null;
           fw_patch: null;
-          bootloader_mode: true;
-          firmware_present: true;
+          bootloader_mode: null;
+          firmware_present: null;
       };
 
 // todo: this is copy-pasted from packages/protobuf/src/messages

--- a/packages/device-utils/src/types.ts
+++ b/packages/device-utils/src/types.ts
@@ -1,3 +1,5 @@
+import type { MessagesSchema as PROTO } from '@trezor/protobuf';
+
 import { DeviceModelInternal } from './deviceModelInternal';
 
 export type FirmwareVersionString = `${number}.${number}.${number}`;
@@ -72,7 +74,6 @@ export type FeaturesNarrowing =
           firmware_present: null;
       };
 
-// todo: this is copy-pasted from packages/protobuf/src/messages
 export type PartialDevice = {
     firmwareType?: FirmwareType;
     authenticityChecks?: {
@@ -81,20 +82,7 @@ export type PartialDevice = {
     };
     mode?: 'normal' | 'bootloader' | 'initialize' | 'seedless';
 
-    features?: {
-        major_version: number;
-        minor_version: number;
-        patch_version: number;
-        bootloader_mode: boolean | null;
-        initialized: boolean | null;
-        revision: string | null;
-        bootloader_hash: string | null;
-        fw_major: number | null;
-        fw_minor: number | null;
-        fw_patch: number | null;
-        no_backup: boolean | null;
-        unit_btconly?: boolean;
-    };
+    features?: PROTO.Features;
 };
 
 export type FirmwareSource = 'official' | 'unknown' | 'NA - bootloader';

--- a/packages/device-utils/tsconfig.json
+++ b/packages/device-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": []
+    "references": [{ "path": "../protobuf" }]
 }

--- a/packages/device-utils/tsconfig.lib.json
+++ b/packages/device-utils/tsconfig.lib.json
@@ -4,5 +4,9 @@
         "outDir": "./lib"
     },
     "include": ["./src"],
-    "references": []
+    "references": [
+        {
+            "path": "../protobuf"
+        }
+    ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14506,6 +14506,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/device-utils@workspace:packages/device-utils"
   dependencies:
+    "@trezor/protobuf": "workspace:*"
     tsx: "npm:^4.20.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

Refactoring to cleanup various "get device FW version" utils, which are inconsistent and duplicated.
:eyes: CR commit by commit recommended:
- correct the `FeaturesNarrowing` type, which had missing cases & simplify
  - to be sure, I tested with actual T1B1, T3B1 in all modes: normal, BL with FW, BL without FW
- add `getFirmwareOrBootloaderVersionArray`, a primitive just to DRY some Connect code
- cleanup in device-utils `firmwareUtils` & `bootloaderUtils`
- scrap duplicated logic in the Conncet `getCurrentVersion`, make it just a wrapper for the device-utils

## Notes for QA

All code changes should be just moving code around, but please sanity-test: 

- FW update: that Suite correctly finds the latest FW for various devices, and update works

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/cleanup-connect-getVersion-utils&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/cleanup-connect-getVersion-utils&lookback=7)