### PR TITLE
fix: suppress expected errors when the windows hello is not available…

### DIFF
--- a/packages/suite-desktop-core/src/modules/bioAuthModule.ts
+++ b/packages/suite-desktop-core/src/modules/bioAuthModule.ts
@@ -144,13 +144,15 @@ class BioAuthWindows extends BioAuth {
         });
     }
 
-    isAvailable() {
+    async isAvailable() {
         if (!this.winHello) throw new Error('WinHelloManager is not initialized');
 
         try {
-            return this.winHello.isHelloAvailable();
-        } catch {
-            return Promise.resolve(false);
+            return await this.winHello.isHelloAvailable();
+        } catch (err) {
+            logger.warn('bioAuth', `Error checking Windows Hello availability: ${err}`);
+
+            return false;
         }
     }
 


### PR DESCRIPTION
… on the HW

<!--- Provide a general summary of your changes in the Title above -->

## Description

NOTE: waiting for the tests in the office
Testes

## Notes for QA

Won't be visible for the USER, dev thing

## Related Issue

Resolve: @pavelmario request to silence these errors comming to the Sentry. I think these are no longer needed as we were interested just in which cases it crashes.

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=do-not-send-error-to-sentry&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=do-not-send-error-to-sentry&lookback=7)