### PR TITLE
fix(e2e-suite): add missing locator for recovery modal

### DIFF
--- a/packages/suite/src/views/recovery/steps/EnterOnDeviceStep.tsx
+++ b/packages/suite/src/views/recovery/steps/EnterOnDeviceStep.tsx
@@ -15,7 +15,7 @@ export const EnterOnDeviceStep = ({
         icon={mapTrezorModelToIcon[deviceModelInternal]}
         margin={{ top: spacings.xs }}
     >
-        <Paragraph>
+        <Paragraph data-testid="@recovery/paragraph">
             <Translation id="TR_ENTER_SEED_WORDS_ON_DEVICE" />
         </Paragraph>
     </Banner>

--- a/suite/e2e/support/pageObjects/recoveryModal.ts
+++ b/suite/e2e/support/pageObjects/recoveryModal.ts
@@ -19,7 +19,7 @@ export class RecoveryModal {
         this.startButton = page.getByTestId('@recovery/start-button');
         this.successTitle = page.getByTestId('@recovery/success-title');
         this.header = page.getByTestId('@modal/header');
-        this.prompt = page.getByTestId('@modal').locator('div[role="paragraph"]');
+        this.prompt = page.getByTestId('@modal').getByTestId('@recovery/paragraph');
     }
 
     @step()


### PR DESCRIPTION
adds missing locator to dry run recovery test

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-add-missing-locator&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-add-missing-locator&lookback=7)