### PR TITLE
fix(ci): Optimized nightly tests to run only on weekdays

### DIFF
--- a/.github/workflows/test-suite-desktop-e2e-nightly.yml
+++ b/.github/workflows/test-suite-desktop-e2e-nightly.yml
@@ -10,7 +10,7 @@ permissions:
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 1-5"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -7,7 +7,7 @@ permissions:
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 1-5"
   pull_request:
     paths:
       - "suite-native/**"

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -2,7 +2,7 @@ name: "[Test] suite-native iOS E2E"
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 1-5"
   push:
     branches:
       - release-native/*

--- a/.github/workflows/test-suite-web-e2e-nightly.yml
+++ b/.github/workflows/test-suite-web-e2e-nightly.yml
@@ -11,7 +11,7 @@ permissions:
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 1-5"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The idea is, that nobody checks there test results on weekends, so let's save a bit by not running them.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-nightly-optimize&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-nightly-optimize&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-nightly-optimize&lookback=7)