### PR TITLE
fix: handle exception error from fetch

### DIFF
--- a/suite-common/suite-sync-quota-manager/src/ensureDeviceHasQuotaThunk.ts
+++ b/suite-common/suite-sync-quota-manager/src/ensureDeviceHasQuotaThunk.ts
@@ -53,12 +53,12 @@ export const ensureDeviceHasQuotaThunk =
 
         // 404 is expected when device is not registered yet, other errors should be shown to the user
         // as quota manager unavailability
-        if (!hasPublicKeyStorage.success && hasPublicKeyStorage.error.code !== 404) {
-            dispatch(
-                quotaManagerFetchError({
-                    error: hasPublicKeyStorage.error.message,
-                }),
-            );
+        const isHttp404 =
+            hasPublicKeyStorage.error.type === 'HttpError' &&
+            hasPublicKeyStorage.error.code === 404;
+
+        if (!isHttp404) {
+            dispatch(quotaManagerFetchError({ error: hasPublicKeyStorage.error.message }));
 
             return;
         }
@@ -68,11 +68,7 @@ export const ensureDeviceHasQuotaThunk =
         });
 
         if (!sessionChallenge.success) {
-            dispatch(
-                quotaManagerFetchError({
-                    error: sessionChallenge.error.message,
-                }),
-            );
+            dispatch(quotaManagerFetchError({ error: sessionChallenge.error.message }));
 
             return;
         }

--- a/suite-common/suite-sync-quota-manager/src/ensureOwnerHasAllocatedQuotaThunk.ts
+++ b/suite-common/suite-sync-quota-manager/src/ensureOwnerHasAllocatedQuotaThunk.ts
@@ -48,12 +48,11 @@ export const ensureOwnerHasAllocatedQuotaThunk =
             return;
         }
 
-        if (!hasOwnerStorage.success && hasOwnerStorage.error.code !== 404) {
-            dispatch(
-                quotaManagerFetchError({
-                    error: hasOwnerStorage.error.message,
-                }),
-            );
+        const isHttp404 =
+            hasOwnerStorage.error.type === 'HttpError' && hasOwnerStorage.error.code === 404;
+
+        if (!isHttp404) {
+            dispatch(quotaManagerFetchError({ error: hasOwnerStorage.error.message }));
 
             return;
         }
@@ -63,11 +62,7 @@ export const ensureOwnerHasAllocatedQuotaThunk =
         });
 
         if (!sessionChallenge.success) {
-            dispatch(
-                quotaManagerFetchError({
-                    error: sessionChallenge.error.message,
-                }),
-            );
+            dispatch(quotaManagerFetchError({ error: sessionChallenge.error.message }));
 
             return;
         }

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerFetch.ts
@@ -1,5 +1,5 @@
 import { getSuiteVersion } from '@trezor/env-utils';
-import { err, ok } from '@trezor/type-utils';
+import { Result, err, ok } from '@trezor/type-utils';
 import { typedObjectEntries } from '@trezor/utils';
 
 import { DEFAULT_QUOTA_MANAGER_URL } from './constants';
@@ -17,13 +17,26 @@ type QuotaManagerFetchParams = {
     queryParams?: Record<string, string | number | boolean>;
 };
 
+type HttpError = {
+    type: 'HttpError';
+    code: number;
+    message: string;
+};
+
+type FetchError = {
+    type: 'FetchError';
+    message: string;
+};
+
+type QuotaManagerFetchResult = Result<unknown, HttpError | FetchError>;
+
 export const quotaManagerFetch = async ({
     baseUrl,
     path,
     method,
     body,
     queryParams,
-}: QuotaManagerFetchParams) => {
+}: QuotaManagerFetchParams): Promise<QuotaManagerFetchResult> => {
     const base = baseUrl ?? DEFAULT_QUOTA_MANAGER_URL;
 
     const normalizedBase = base.endsWith('/') ? base : `${base}/`;
@@ -37,23 +50,31 @@ export const quotaManagerFetch = async ({
         });
     }
 
-    const response = await fetch(url.toString(), {
-        method,
-        headers: {
-            'Content-Type': 'application/json',
-            'Suite-Version': getSuiteVersion(),
-        },
-        body: body ? JSON.stringify(body) : null,
-    });
+    try {
+        const response = await fetch(url.toString(), {
+            method,
+            headers: {
+                'Content-Type': 'application/json',
+                'Suite-Version': getSuiteVersion(),
+            },
+            body: body ? JSON.stringify(body) : null,
+        });
 
-    if (!response.ok) {
+        if (!response.ok) {
+            return err({
+                type: 'HttpError' as const,
+                code: response.status,
+                message: response.statusText,
+            });
+        }
+
+        const data = (await response.json()) as unknown;
+
+        return ok(data);
+    } catch (e) {
         return err({
-            code: response.status,
-            message: response.statusText,
+            type: 'FetchError' as const,
+            message: e.message,
         });
     }
-
-    const data = (await response.json()) as unknown;
-
-    return ok(data);
 };

--- a/suite-common/suite-sync-quota-manager/src/tests/ensureDeviceHasQuotaThunk.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/tests/ensureDeviceHasQuotaThunk.test.ts
@@ -117,7 +117,7 @@ describe(ensureDeviceHasQuotaThunk.name, () => {
         const dispatch = jest.fn();
 
         checkStorageByPublicKeyMock.mockResolvedValue(
-            err({ code: 500, message: 'Internal error' }),
+            err({ type: 'HttpError', code: 500, message: 'Internal error' }),
         );
 
         await ensureDeviceHasQuotaThunk({ delegatedKey, device })(dispatch, getState);
@@ -141,7 +141,9 @@ describe(ensureDeviceHasQuotaThunk.name, () => {
             return action;
         });
 
-        checkStorageByPublicKeyMock.mockResolvedValue(err({ code: 404, message: 'Not Found' }));
+        checkStorageByPublicKeyMock.mockResolvedValue(
+            err({ type: 'HttpError', code: 404, message: 'Not Found' }),
+        );
         prepareChallengeSessionMock.mockResolvedValue(
             ok({ sessionId: 'session-123', challenge: 'aa55' }),
         );

--- a/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
@@ -96,7 +96,9 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
         const getState = createGetState({ enabled: true });
         const dispatch = jest.fn();
 
-        checkStorageByOwnerIdMock.mockResolvedValue(err({ code: 500, message: 'Internal error' }));
+        checkStorageByOwnerIdMock.mockResolvedValue(
+            err({ type: 'HttpError', code: 500, message: 'Internal error' }),
+        );
 
         await ensureOwnerHasAllocatedQuotaThunk({ ownerId, delegatedKey, walletDescriptor })(
             dispatch,
@@ -121,7 +123,9 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
             return action;
         });
 
-        checkStorageByOwnerIdMock.mockResolvedValue(err({ code: 404, message: 'Not Found' }));
+        checkStorageByOwnerIdMock.mockResolvedValue(
+            err({ type: 'HttpError', code: 404, message: 'Not Found' }),
+        );
         prepareChallengeSessionMock.mockResolvedValue(
             ok({ sessionId: 'session-123', challenge: 'aa55' }),
         );

--- a/suite-common/suite-sync-quota-manager/src/tests/quotaManagerFetch.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/tests/quotaManagerFetch.test.ts
@@ -78,6 +78,7 @@ describe(quotaManagerFetch.name, () => {
         expect(!result.success && result.error).toStrictEqual({
             code: 404,
             message: 'Not Found',
+            type: 'HttpError',
         });
     });
 });


### PR DESCRIPTION
This PR fixes a bug when Quota Manager URL is not working (offline, localhost-offline, ...)

Fetch throws error in this case, which was not handled.

## Test
Before: getting keys was o completed, after delegated key, the process topped with error in console

After:
- invalid URL (non-existing / offline)
- Get Evolu keys wont show error in console and will continue to get keys so evolu will start

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-error-fetch-quota-manager&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-error-fetch-quota-manager&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-error-fetch-quota-manager&lookback=7)