### PR TITLE
Connect cleanup

### DIFF
--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -36,30 +36,30 @@ const POPUP_REQUEST_TIMEOUT = 850;
 const POPUP_CLOSE_INTERVAL = 500;
 
 export class PopupManager extends EventEmitter {
-    popupWindow:
+    private popupWindow:
         | { mode: 'tab'; tab: chrome.tabs.Tab }
         | { mode: 'window'; window: Window }
         | undefined;
 
-    settings: ConnectSettings;
+    private settings: ConnectSettings;
 
-    origin: string;
+    private origin: string;
 
-    locked = false;
+    private locked = false;
 
     channel: AbstractMessageChannel<CoreEventMessage>;
 
     handshakePromise: Deferred<void> | undefined;
 
-    popupPromise: Deferred<void> | undefined;
+    private popupPromise: Deferred<void> | undefined;
 
-    requestTimeout: TimerId | undefined;
+    private requestTimeout: TimerId | undefined;
 
-    closeInterval: IntervalId | undefined;
+    private closeInterval: IntervalId | undefined;
 
-    extensionTabId = 0;
+    private extensionTabId = 0;
 
-    logger: Log;
+    private logger: Log;
 
     constructor(settings: ConnectSettings, { logger }: { logger: Log }) {
         super();

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -261,9 +261,7 @@ export class PopupManager extends EventEmitter {
     };
 
     private handleCoreMessage(message: Message<CoreEventMessage>) {
-        if (message.type === POPUP.BOOTSTRAP) {
-            this.channel.init();
-        } else if (message.type === POPUP.LOADED) {
+        if (message.type === POPUP.LOADED) {
             this.handleMessage(message);
             this.channel.postMessage({
                 type: POPUP.INIT,

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -3,7 +3,7 @@
 import EventEmitter from 'events';
 
 import { CONTENT_SCRIPT_VERSION, VERSION } from '@trezor/connect/src/data/version';
-import { CoreEventMessage, DEVICE_EVENT, POPUP, UI } from '@trezor/connect/src/events';
+import { CoreEventMessage, DEVICE_EVENT, POPUP } from '@trezor/connect/src/events';
 import type { ConnectSettings } from '@trezor/connect/src/types';
 import { Log } from '@trezor/connect/src/utils/debug';
 import { getOrigin } from '@trezor/connect/src/utils/urlUtils';
@@ -50,8 +50,6 @@ export class PopupManager extends EventEmitter {
     channel: AbstractMessageChannel<CoreEventMessage>;
 
     handshakePromise: Deferred<void> | undefined;
-
-    private popupPromise: Deferred<void> | undefined;
 
     private requestTimeout: TimerId | undefined;
 
@@ -138,13 +136,8 @@ export class PopupManager extends EventEmitter {
         }, timeout);
     }
 
-    private unlock() {
-        this.locked = false;
-    }
-
     private open() {
         const src = this.settings.popupSrc;
-        this.popupPromise = createDeferred(POPUP.LOADED);
         const url = this.buildPopupUrl(src);
         this.openWrapper(url);
 
@@ -261,16 +254,7 @@ export class PopupManager extends EventEmitter {
     };
 
     private handleCoreMessage(message: Message<CoreEventMessage>) {
-        if (message.type === POPUP.LOADED) {
-            this.handleMessage(message);
-            this.channel.postMessage({
-                type: POPUP.INIT,
-                payload: {
-                    settings: this.settings,
-                    useCore: true,
-                },
-            });
-        } else if (message.type === POPUP.CORE_LOADED) {
+        if (message.type === POPUP.CORE_LOADED) {
             this.channel.postMessage({
                 type: POPUP.HANDSHAKE,
                 // in this case, settings will be validated in popup
@@ -291,27 +275,8 @@ export class PopupManager extends EventEmitter {
         }
     }
 
-    private handleMessage(data: Message<CoreEventMessage>) {
-        if (data.type === POPUP.LOADED) {
-            // in case of webextension where bootstrap message is not sent
-            if (this.popupPromise) {
-                this.popupPromise.resolve();
-                this.popupPromise = undefined;
-            }
-        } else if (data.type === POPUP.CANCEL_POPUP_REQUEST) {
-            clearTimeout(this.requestTimeout);
-            if (this.popupPromise) {
-                this.close();
-            }
-            this.unlock();
-        } else if (data.type === UI.CLOSE_UI_WINDOW) {
-            this.clear(false);
-        }
-    }
-
     private clear(focus = true) {
         this.locked = false;
-        this.popupPromise = undefined;
         this.handshakePromise = createDeferred();
 
         if (this.channel) {

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -292,13 +292,7 @@ export class PopupManager extends EventEmitter {
     }
 
     private handleMessage(data: Message<CoreEventMessage>) {
-        if (data.type === POPUP.ERROR && this.popupWindow) {
-            // handle popup error
-            const errorMessage =
-                data.payload && typeof data.payload.error === 'string' ? data.payload.error : null;
-            this.emit(POPUP.CLOSED, errorMessage ? `Popup error: ${errorMessage}` : null);
-            this.clear();
-        } else if (data.type === POPUP.LOADED) {
+        if (data.type === POPUP.LOADED) {
             // in case of webextension where bootstrap message is not sent
             if (this.popupPromise) {
                 this.popupPromise.resolve();

--- a/packages/connect-webextension/src/contentScript.ts
+++ b/packages/connect-webextension/src/contentScript.ts
@@ -1,4 +1,3 @@
-import { CONTENT_SCRIPT_VERSION } from '@trezor/connect/src/data/version';
 import { POPUP } from '@trezor/connect/src/events/popup';
 import { WindowServiceWorkerChannel } from '@trezor/connect-common/src/messageChannel/window-serviceworker';
 
@@ -40,19 +39,6 @@ function trezorContentScript() {
     window.addEventListener('message', event => {
         if (event.data?.channel?.here === '@trezor/connect-webextension') {
             return;
-        }
-        if (event.data?.type === POPUP.LOADED) {
-            window.postMessage(
-                {
-                    type: POPUP.CONTENT_SCRIPT_LOADED,
-                    payload: {
-                        ...chrome.runtime.getManifest(),
-                        id: chrome.runtime.id,
-                        contentScriptVersion: CONTENT_SCRIPT_VERSION,
-                    },
-                },
-                window.location.origin,
-            );
         }
 
         if (event.source === window && event.data) {

--- a/packages/connect/src/events/core.ts
+++ b/packages/connect/src/events/core.ts
@@ -1,7 +1,7 @@
 import type { BlockchainEventMessage } from './blockchain';
 import type { IFrameCallMessage, MethodResponseMessage } from './call';
 import type { DeviceEventMessage } from './device';
-import type { PopupAnalyticsResponse, PopupClosedMessage, PopupEventMessage } from './popup';
+import type { PopupClosedMessage, PopupEventMessage } from './popup';
 import type {
     TransportDisableWebUSB,
     TransportEventMessage,
@@ -18,7 +18,6 @@ export const CORE_EVENT = 'CORE_EVENT';
 
 export type CoreRequestMessage =
     | PopupClosedMessage
-    | PopupAnalyticsResponse
     | TransportDisableWebUSB
     | TransportSetTransports
     | TransportRequestWebUSBDevice

--- a/packages/connect/src/events/popup.ts
+++ b/packages/connect/src/events/popup.ts
@@ -4,8 +4,6 @@ import type { ConnectSettings, SystemInfo } from '../types/settings';
 import type { MessageFactoryFn } from '../types/utils';
 
 export const POPUP = {
-    // Message from popup.js to window.opener, called after "window.onload" event. This is second message from popup to window.opener.
-    LOADED: 'popup-loaded',
     // Message from popup run in "core" mode. Connect core has been loaded, popup is ready to handle messages
     CORE_LOADED: 'popup-core-loaded',
     // Message from window.opener to popup.js. Send settings to popup. This is first message from window.opener to popup.
@@ -81,7 +79,7 @@ export interface PopupCloseWindow {
 
 export type PopupEvent =
     | {
-          type: typeof POPUP.LOADED | typeof POPUP.CORE_LOADED | typeof POPUP.CANCEL_POPUP_REQUEST;
+          type: typeof POPUP.CORE_LOADED | typeof POPUP.CANCEL_POPUP_REQUEST;
           payload?: typeof undefined;
       }
     | PopupInit

--- a/packages/connect/src/events/popup.ts
+++ b/packages/connect/src/events/popup.ts
@@ -22,7 +22,7 @@ export const POPUP = {
     CANCEL_POPUP_REQUEST: 'ui-cancel-popup-request',
     // Message called from inline element in popup.html (window.closeWindow), this is used only with webextensions to properly handle popup close event
     CLOSE_WINDOW: 'window.close',
-    /** webextension injected content script and content script notified popup */
+    // not used anymore, will removed in https://github.com/trezor/trezor-suite/pull/24471
     CONTENT_SCRIPT_LOADED: 'popup-content-script-loaded',
     /** method.info async getter result passed from core to popup */
     METHOD_INFO: 'popup-method-info',

--- a/packages/connect/src/events/popup.ts
+++ b/packages/connect/src/events/popup.ts
@@ -22,8 +22,6 @@ export const POPUP = {
     CANCEL_POPUP_REQUEST: 'ui-cancel-popup-request',
     // Message called from inline element in popup.html (window.closeWindow), this is used only with webextensions to properly handle popup close event
     CLOSE_WINDOW: 'window.close',
-    // todo: shouldn't it be UI_RESPONSE?
-    ANALYTICS_RESPONSE: 'popup-analytics-response',
     /** webextension injected content script and content script notified popup */
     CONTENT_SCRIPT_LOADED: 'popup-content-script-loaded',
     /** method.info async getter result passed from core to popup */
@@ -51,11 +49,6 @@ export interface PopupHandshake {
 export interface PopupClosedMessage {
     type: typeof POPUP.CLOSED;
     payload: { error: any } | null;
-}
-
-export interface PopupAnalyticsResponse {
-    type: typeof POPUP.ANALYTICS_RESPONSE;
-    payload: { enabled: boolean };
 }
 
 export interface PopupMethodInfo {

--- a/packages/connect/src/events/popup.ts
+++ b/packages/connect/src/events/popup.ts
@@ -10,8 +10,6 @@ export const POPUP = {
     CORE_LOADED: 'popup-core-loaded',
     // Message from window.opener to popup.js. Send settings to popup. This is first message from window.opener to popup.
     INIT: 'popup-init',
-    // Error message from popup to window.opener. Could be thrown during popup initialization process (POPUP.INIT)
-    ERROR: 'popup-error',
     // Message to webextensions, opens "trezor-usb-permission.html" within webextension
     EXTENSION_USB_PERMISSIONS: 'open-usb-permissions',
     // Message called from both [popup > iframe] then [iframe > popup] in this exact order.
@@ -52,13 +50,6 @@ export interface PopupHandshake {
     };
 }
 
-export interface PopupError {
-    type: typeof POPUP.ERROR;
-    payload: {
-        error: string;
-    };
-}
-
 export interface PopupClosedMessage {
     type: typeof POPUP.CLOSED;
     payload: { error: any } | null;
@@ -95,7 +86,6 @@ export type PopupEvent =
       }
     | PopupInit
     | PopupHandshake
-    | PopupError
     | PopupContentScriptLoaded
     | PopupMethodInfo
     | PopupExtensionUsbPermissions

--- a/packages/connect/src/events/popup.ts
+++ b/packages/connect/src/events/popup.ts
@@ -24,8 +24,6 @@ export const POPUP = {
     CLOSE_WINDOW: 'window.close',
     // not used anymore, will removed in https://github.com/trezor/trezor-suite/pull/24471
     CONTENT_SCRIPT_LOADED: 'popup-content-script-loaded',
-    /** method.info async getter result passed from core to popup */
-    METHOD_INFO: 'popup-method-info',
 } as const;
 
 export interface PopupInit {
@@ -51,11 +49,6 @@ export interface PopupClosedMessage {
     payload: { error: any } | null;
 }
 
-export interface PopupMethodInfo {
-    type: typeof POPUP.METHOD_INFO;
-    payload: { info: string; method: string };
-}
-
 export interface PopupContentScriptLoaded {
     type: typeof POPUP.CONTENT_SCRIPT_LOADED;
     payload: { id: string; contentScriptVersion: number };
@@ -78,7 +71,6 @@ export type PopupEvent =
     | PopupInit
     | PopupHandshake
     | PopupContentScriptLoaded
-    | PopupMethodInfo
     | PopupExtensionUsbPermissions
     | PopupCloseWindow
     | PopupClosedMessage;

--- a/packages/connect/src/events/popup.ts
+++ b/packages/connect/src/events/popup.ts
@@ -4,8 +4,6 @@ import type { ConnectSettings, SystemInfo } from '../types/settings';
 import type { MessageFactoryFn } from '../types/utils';
 
 export const POPUP = {
-    // Message called from popup.html inline script before "window.onload" event. This is first message from popup to window.opener.
-    BOOTSTRAP: 'popup-bootstrap',
     // Message from popup.js to window.opener, called after "window.onload" event. This is second message from popup to window.opener.
     LOADED: 'popup-loaded',
     // Message from popup run in "core" mode. Connect core has been loaded, popup is ready to handle messages
@@ -85,12 +83,6 @@ export interface PopupExtensionUsbPermissions {
     type: typeof POPUP.EXTENSION_USB_PERMISSIONS;
     payload: typeof undefined;
 }
-
-export interface PopupBootstrap {
-    type: typeof POPUP.BOOTSTRAP;
-    payload: typeof undefined;
-}
-
 export interface PopupCloseWindow {
     type: typeof POPUP.CLOSE_WINDOW;
     payload: typeof undefined;
@@ -107,7 +99,6 @@ export type PopupEvent =
     | PopupContentScriptLoaded
     | PopupMethodInfo
     | PopupExtensionUsbPermissions
-    | PopupBootstrap
     | PopupCloseWindow
     | PopupClosedMessage;
 


### PR DESCRIPTION
Another connect cleanup. This time focused on unused code in popup constants and popupManager.

After I remove self-evidently unused code I intend to proceed with removal of content-script and usb permissions in https://github.com/trezor/trezor-suite/pull/24471 and replacing it with https://developer.chrome.com/docs/extensions/reference/manifest/externally-connectable

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-cleanup&lookback=7)