### PR TITLE
feat(suite-native): add analytics for Bitcoin backends settings

### DIFF
--- a/suite-native/analytics/src/constants.ts
+++ b/suite-native/analytics/src/constants.ts
@@ -19,6 +19,7 @@ export enum EventType {
     SettingsChangeBtcUnit = 'settings/change_btc_unit',
     SettingsDiscreetToggle = 'settings/discreet_toggle',
     SettingsChangeCoinEnabled = 'settings/change_coin_enabled',
+    SettingsChangeCoinBackend = 'settings/change_coin_backend',
     BiometricsChange = 'biometrics_change',
     SettingsDataPermission = 'settings/data_permission',
     EmptyDashboardClick = 'empty_dashboard/action',

--- a/suite-native/analytics/src/events/index.ts
+++ b/suite-native/analytics/src/events/index.ts
@@ -1,1 +1,2 @@
 export { assetDetailEvent } from './assetDetailEvent';
+export { settingsChangeCoinBackendEvent } from './settingsChangeCoinBackendEvent';

--- a/suite-native/analytics/src/events/settingsChangeCoinBackendEvent.ts
+++ b/suite-native/analytics/src/events/settingsChangeCoinBackendEvent.ts
@@ -1,0 +1,26 @@
+import type { AttributeDef, EventDef } from '@suite-common/analytics-types';
+import { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
+
+import { EventType } from '../constants';
+
+type Attributes = {
+    symbol: AttributeDef<NetworkSymbol>;
+    type: AttributeDef<BackendType | 'default'>;
+};
+
+export const settingsChangeCoinBackendEvent: EventDef<
+    Attributes,
+    EventType.SettingsChangeCoinBackend
+> = {
+    name: EventType.SettingsChangeCoinBackend,
+    descriptionTrigger: 'A user confirms custom backend settings.',
+    changelog: [{ version: '26.2.0', notes: 'added' }],
+    attributes: {
+        symbol: {
+            changelog: [{ version: '26.2.0', notes: 'added' }],
+        },
+        type: {
+            changelog: [{ version: '26.2.0', notes: 'added' }],
+        },
+    },
+};

--- a/suite-native/module-settings/src/hooks/useBackendServersForm.ts
+++ b/suite-native/module-settings/src/hooks/useBackendServersForm.ts
@@ -12,9 +12,11 @@ import {
     reconnectBlockchainThunk,
     selectNetworkBlockchainInfo,
 } from '@suite-common/wallet-core';
+import { EventType } from '@suite-native/analytics';
 import { SelectItemType } from '@suite-native/atoms';
 import { useForm } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
+import { useAnalytics } from '@suite-native/services';
 import TrezorConnect, { BLOCKCHAIN, BlockchainError } from '@trezor/connect';
 import { parseElectrumUrl } from '@trezor/utils';
 
@@ -30,6 +32,7 @@ type FormValues = {
 export const useBackendServersForm = () => {
     const dispatch = useDispatch();
     const { translate } = useTranslate();
+    const analytics = useAnalytics();
 
     const {
         connected,
@@ -40,7 +43,9 @@ export const useBackendServersForm = () => {
         () => [
             {
                 value: 'default',
-                label: translate('moduleSettings.advanced.bitcoinBackends.servers.serverType'),
+                label: translate(
+                    'moduleSettings.advanced.bitcoinBackends.servers.serverTypeDefault',
+                ),
             },
             { value: 'electrum', label: 'Electrum' },
         ],
@@ -89,6 +94,10 @@ export const useBackendServersForm = () => {
             }),
         );
         dispatch(reconnectBlockchainThunk({ symbol }));
+        analytics.report({
+            type: EventType.SettingsChangeCoinBackend,
+            payload: { symbol, type: serverType },
+        });
     };
 
     const submit = form.handleSubmit(formValues => {


### PR DESCRIPTION
Mimics desktop analytics event; Tor/clearnet attributes removed. 

Follow-up for #23657

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/bitcoin-backends-analytics&lookback=7)