### PR TITLE
chore(eslint): add build-webextension to ignore rules

### DIFF
--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -28,6 +28,7 @@ export const eslint = [
             '**/coverage/*',
             '**/build/*',
             '**/build-electron/*',
+            '**/build-webextension/*',
             '**/node_modules/*',
             '**/public/*',
             '**/ci/',


### PR DESCRIPTION
eslint is otherwise trying to lint packages/connect-explorer/build-webextension 

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=eslint-nitpick&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=eslint-nitpick&lookback=7)