### PR TITLE
Refactoring inline scripts

### DIFF
--- a/packages/suite-build/configs/web.webpack.config.ts
+++ b/packages/suite-build/configs/web.webpack.config.ts
@@ -79,7 +79,6 @@ const config: webpack.Configuration = {
                     templateParameters: {
                         assetPrefix,
                         isOnionLocation: FLAGS.ONION_LOCATION_META,
-                        isCrowdinEnabled: FLAGS.CROWDIN_IN_ENABLED,
                     },
                     inject: 'body' as const,
                     scriptLoading: 'blocking' as const,

--- a/packages/suite-build/configs/web.webpack.config.ts
+++ b/packages/suite-build/configs/web.webpack.config.ts
@@ -15,6 +15,10 @@ const config: webpack.Configuration = {
     target: 'browserslist',
     entry: {
         main: path.join(baseDir, 'src', 'index.ts'),
+        favicon: {
+            filename: 'static/favicon.js',
+            import: path.join(baseDir, 'src', 'favicon.ts'),
+        },
         ['sessions-background-sharedworker']: {
             filename: 'workers/[name].js',
             import: path.resolve(

--- a/packages/suite-data/files/oauth/oauthReceiver.js
+++ b/packages/suite-data/files/oauth/oauthReceiver.js
@@ -1,0 +1,19 @@
+/**
+ * - Entry for `/static/oauth/oauth_receiver.html` file.
+ * - Used to handle OAuth responses from external providers:
+ *   - Google implicit flow - hash
+ *   - Dropbox authorization code flow - search
+ */
+
+if (window.opener) {
+    window.opener.postMessage(
+        {
+            key: 'trezor-oauth',
+            hash: window.location.hash,
+            search: window.location.search,
+        },
+        window.location.origin,
+    );
+}
+
+window.close();

--- a/packages/suite-data/files/oauth/oauth_receiver.html
+++ b/packages/suite-data/files/oauth/oauth_receiver.html
@@ -1,20 +1,6 @@
 <html>
     <head></head>
     <body>
-        <script>
-            // google implicit flow - hash
-            // dropbox authorization code flow - search
-            const message = {
-                // key used to exclude unexpected messages
-                key: 'trezor-oauth',
-                hash: window.location.hash,
-                search: window.location.search,
-            };
-
-            if (window.opener) {
-                window.opener.postMessage(message, window.location.origin);
-            }
-            window.close();
-        </script>
+        <script src="./oauthReceiver.js"></script>
     </body>
 </html>

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -7,8 +7,8 @@
         "type-check": "yarn g:tsc --build tsconfig.json",
         "type-check:watch": "yarn type-check -- --watch",
         "lint:styles": "npx stylelint './src/**/*{.ts,.tsx}' --cache --config ../../.stylelintrc",
-        "dev": "CROWDIN_IN_ENABLED=true yarn rimraf ./build && yarn workspace @trezor/suite-build run dev:web",
-        "dev:vite": "CROWDIN_IN_ENABLED=true PROJECT=web yarn rimraf ./build && yarn workspace @trezor/suite-build run dev:web:vite",
+        "dev": "yarn rimraf ./build && yarn workspace @trezor/suite-build run dev:web",
+        "dev:vite": "PROJECT=web yarn rimraf ./build && yarn workspace @trezor/suite-build run dev:web:vite",
         "analyze": "ANALYZE=true yarn build",
         "build": "yarn rimraf ./build && yarn workspace @trezor/suite-build run build:web"
     },

--- a/packages/suite-web/src/favicon.ts
+++ b/packages/suite-web/src/favicon.ts
@@ -3,7 +3,7 @@ const faviconLight = `${assetPrefix}/static/images/favicons/favicon.png`;
 const faviconDark = `${assetPrefix}/static/images/favicons/favicon_dm.png`;
 
 /**
- * Set favicon according to current system theme 
+ * Set favicon according to current system theme
  */
 function updateFaviconHandler(event: MediaQueryListEvent | MediaQueryList) {
     const isDarkMode = event.matches;

--- a/packages/suite-web/src/favicon.ts
+++ b/packages/suite-web/src/favicon.ts
@@ -1,0 +1,28 @@
+const assetPrefix = process.env.ASSET_PREFIX ?? '';
+const faviconLight = `${assetPrefix}/static/images/favicons/favicon.png`;
+const faviconDark = `${assetPrefix}/static/images/favicons/favicon_dm.png`;
+
+/**
+ * Set favicon according to current system theme 
+ */
+function updateFaviconHandler(event: MediaQueryListEvent | MediaQueryList) {
+    const isDarkMode = event.matches;
+    const icon = document.querySelector('link[rel=icon]');
+    const appleIcon = document.querySelector('link[rel=apple-touch-icon]');
+
+    if (isDarkMode) {
+        icon?.setAttribute('href', faviconDark);
+        appleIcon?.setAttribute('href', faviconDark);
+    } else {
+        icon?.setAttribute('href', faviconLight);
+        appleIcon?.setAttribute('href', faviconLight);
+    }
+}
+
+if (window.matchMedia) {
+    const matchedMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+    matchedMediaQuery.addEventListener('change', updateFaviconHandler);
+
+    updateFaviconHandler(matchedMediaQuery);
+}

--- a/packages/suite-web/src/static/index.html
+++ b/packages/suite-web/src/static/index.html
@@ -37,45 +37,8 @@
             }
         </script>
         <% } %>
-        <script type="text/javascript">
-            // set favicon according to current system theme
-            function si(event) {
-                var isDM = event.matches; // isDarkMode
-                var i = document.querySelector('link[rel=icon]');
-                var ai = document.querySelector('link[rel=apple-touch-icon]');
-
-                if (isDM) {
-                    i.setAttribute(
-                        'href',
-                        '<%= assetPrefix %>/static/images/favicons/favicon_dm.png',
-                    );
-                    ai.setAttribute(
-                        'href',
-                        '<%= assetPrefix %>/static/images/favicons/favicon_dm.png',
-                    );
-                } else {
-                    i.setAttribute('href', '<%= assetPrefix %>/static/images/favicons/favicon.png');
-                    ai.setAttribute(
-                        'href',
-                        '<%= assetPrefix %>/static/images/favicons/favicon.png',
-                    );
-                }
-            }
-
-            if (window.matchMedia) {
-                var _mm = window.matchMedia('(prefers-color-scheme: dark)');
-
-                // not supported in IE
-                if (_mm.addEventListener) {
-                    _mm.addEventListener('change', function (e) {
-                        return si(e);
-                    });
-                }
-
-                si(_mm);
-            }
-        </script>
-        <script src="<%= assetPrefix %>/static/browser-detection/index.js"></script>
+        <script src="<%= assetPrefix %>/static/browser-detection/index.js" async fetchpriority="high"></script>
+        <script src="<%= assetPrefix %>/static/favicon.js" async fetchpriority="low"></script>
     </head>
     <body></body>
 </html>

--- a/packages/suite-web/src/static/index.html
+++ b/packages/suite-web/src/static/index.html
@@ -19,7 +19,11 @@
                 color-scheme: light dark;
             }
         </style>
-        <script src="<%= assetPrefix %>/static/browser-detection/index.js" async fetchpriority="high"></script>
+        <script
+            src="<%= assetPrefix %>/static/browser-detection/index.js"
+            async
+            fetchpriority="high"
+        ></script>
         <script src="<%= assetPrefix %>/static/favicon.js" async fetchpriority="low"></script>
     </head>
     <body></body>

--- a/packages/suite-web/src/static/index.html
+++ b/packages/suite-web/src/static/index.html
@@ -13,30 +13,12 @@
             http-equiv="onion-location"
             content="http://suite.trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion/web"
         />
+        <% } %>
         <style>
             :root {
                 color-scheme: light dark;
             }
         </style>
-        <% } %> <% if(isCrowdinEnabled) { %>
-        <script type="text/javascript">
-            if (localStorage.getItem('translation_mode') === 'true') {
-                console.warn('INJECTING CROWDIN IN-CONTEXT');
-                var _jipt = [];
-                _jipt.push(['project', 'trezor-suite']);
-                _jipt.push([
-                    'escape',
-                    function () {
-                        localStorage.removeItem('translation_mode');
-                        window.location.reload();
-                    },
-                ]);
-                var script = document.createElement('script');
-                script.setAttribute('src', '//cdn.crowdin.com/jipt/jipt.js');
-                document.head.prepend(script);
-            }
-        </script>
-        <% } %>
         <script src="<%= assetPrefix %>/static/browser-detection/index.js" async fetchpriority="high"></script>
         <script src="<%= assetPrefix %>/static/favicon.js" async fetchpriority="low"></script>
     </head>

--- a/suite-common/suite-config/src/features.ts
+++ b/suite-common/suite-config/src/features.ts
@@ -8,7 +8,6 @@ export const FLAGS = {
     FILE_SYSTEM_SYNC: false, // File system sync (used for labeling)
     ONION_LOCATION_META: true, // Show TOR onion-location meta tag in page head
     DESKTOP_AUTO_UPDATER: true, // Runs auto updater code on desktop
-    CROWDIN_IN_ENABLED: false, // Inject Crowdin in-context script for translation ui
 } as const;
 
 // Web specific flags


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Changes

1. Move OAuth redirect handler and for updating favicon inline scripts to their own files to avoid being required to use hashes (of these inline scripts) in CSP configuration. 
   - I.e. now we can remove `'sha256-CMsgtXIUgF58yz1R2jwFGG5Hnd9ZlhuaLq7llOPYQvY=' 'sha256-Bp/L1f6d9VGA5muDbibfLamHGKKdAXkcEC50i8+Bsk0='`:
   
   CSP before:
   ```
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'sha256-CMsgtXIUgF58yz1R2jwFGG5Hnd9ZlhuaLq7llOPYQvY=' 'sha256-Bp/L1f6d9VGA5muDbibfLamHGKKdAXkcEC50i8+Bsk0='; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; img-src 'self' blob: data: https://*.trezor.io; connect-src data: *; upgrade-insecure-requests; report-uri https://o117836.ingest.us.sentry.io/api/5193825/security/?sentry_key=6d91ca6e6a5d4de7b47989455858b5f6; report-to csp-endpoint
   ```
   CSP after:
   ```
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; img-src 'self' blob: data: https://*.trezor.io; connect-src data: *; upgrade-insecure-requests; report-uri https://o117836.ingest.us.sentry.io/api/5193825/security/?sentry_key=6d91ca6e6a5d4de7b47989455858b5f6; report-to csp-endpoint
   ```
   
2. Remove unused crowdin inline script.

## Notes for QA

- Favicon is being updated based on system theme (light/dark).
- Labelling: Google Drive or Dropbox are still possible to enable as remote storage. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/180

## Screenshots:

Switching color theme:

https://github.com/user-attachments/assets/e8237430-57c3-4f58-887f-c22ee4d376df





🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactoring-inline-scripts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactoring-inline-scripts&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactoring-inline-scripts&lookback=7)