### PR TITLE
fix(trading): clear preselectedQuote after loading into buy form

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -9,6 +9,8 @@ import {
     TRADING_DEFAULT_CRYPTO_CURRENCY,
     TRADING_FORM_CRYPTO_INPUT,
     TRADING_FORM_FIAT_INPUT,
+    TRADING_FORM_PAYMENT_METHOD_SELECT,
+    TRADING_FORM_PROVIDER_SELECT,
     TradingAmountLimitProps,
     TradingBuyFormProps,
     type TradingBuyType,
@@ -121,6 +123,7 @@ export const useTradingBuyForm = ({
     });
     const { formState, reset, setValue, handleSubmit, control } = methods;
     const values = useWatch({ control }) as TradingBuyFormProps;
+    const { paymentMethod, provider } = values;
     const previousValues = useRef<TradingBuyFormProps | null>(
         !isFromRedirect && isNotFormPage ? draftUpdated : null,
     );
@@ -306,6 +309,38 @@ export const useTradingBuyForm = ({
         setValue('receiveAddress', receiveAddress);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [receiveAddress]);
+
+    useEffect(() => {
+        if (!preselectedQuote) {
+            return;
+        }
+
+        const preselectedProvider = preselectedQuote.exchange;
+        const preselectedPaymentMethod = preselectedQuote.paymentMethod;
+        const shouldUpdateProvider = !!preselectedProvider && preselectedProvider !== provider;
+        const shouldUpdatePaymentMethod =
+            !!preselectedPaymentMethod && paymentMethod?.value !== preselectedPaymentMethod;
+
+        dispatch(tradingBuyActions.savePreselectedQuote(undefined));
+
+        if (shouldUpdateProvider) {
+            setValue(TRADING_FORM_PROVIDER_SELECT, preselectedProvider);
+        }
+
+        if (shouldUpdatePaymentMethod) {
+            const matchingOption = paymentMethods.find(
+                method => method.value === preselectedPaymentMethod,
+            );
+
+            setValue(
+                TRADING_FORM_PAYMENT_METHOD_SELECT,
+                matchingOption ?? {
+                    value: preselectedPaymentMethod,
+                    label: preselectedQuote.paymentMethodName ?? preselectedPaymentMethod,
+                },
+            );
+        }
+    }, [paymentMethod, paymentMethods, preselectedQuote, provider, setValue, dispatch]);
 
     useEffect(() => {
         dispatch(tradingThunks.loadInitialDataThunk({ activeSection: type }));

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts
@@ -68,6 +68,7 @@ export const useTradingBuyFormDefaultValues = (
             cryptoSelect: defaultCrypto,
             countrySelect: defaultCountry,
             paymentMethod: defaultPaymentMethod,
+            provider: undefined,
             amountInCrypto: false,
             receiveAddress: undefined,
         }),

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -8,10 +8,13 @@ import { EventType } from '@suite/analytics';
 import { useTranslation } from '@suite/intl';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
+    TRADING_EXCHANGE_FORM,
+    TRADING_EXCHANGE_FORM_CEX,
     TRADING_EXCHANGE_FORM_DEX,
     TRADING_FORM_OUTPUT_ADDRESS,
     TRADING_FORM_OUTPUT_AMOUNT,
     TRADING_FORM_OUTPUT_FIAT,
+    TRADING_FORM_PROVIDER_SELECT,
     type TradingExchangeAmountLimitProps,
     type TradingExchangeFormProps,
     TradingExchangeType,
@@ -164,6 +167,7 @@ export const useTradingExchangeForm = ({
 
     const { reset, register, getValues, setValue, formState, control } = methods;
     const values = useWatch({ control }) as TradingExchangeFormProps;
+    const { provider } = values;
     const {
         rateType,
         exchangeType,
@@ -778,6 +782,26 @@ export const useTradingExchangeForm = ({
     useEffect(() => {
         dispatch(tradingThunks.loadInitialDataThunk({ activeSection: type }));
     }, [dispatch]);
+
+    useEffect(() => {
+        if (!preselectedQuote) {
+            return;
+        }
+
+        const preselectedProvider = preselectedQuote.exchange;
+        if (preselectedProvider && preselectedProvider !== provider) {
+            setValue(TRADING_FORM_PROVIDER_SELECT, preselectedProvider);
+        }
+
+        const preselectedFormType = preselectedQuote.isDex
+            ? TRADING_EXCHANGE_FORM_DEX
+            : TRADING_EXCHANGE_FORM_CEX;
+        if (preselectedFormType !== exchangeType) {
+            setValue(TRADING_EXCHANGE_FORM, preselectedFormType);
+        }
+
+        dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
+    }, [dispatch, preselectedQuote, provider, setValue, exchangeType]);
 
     // Subscribe to blocks for Solana, since they are not fetched globally
     useSolanaSubscribeBlocks(account);

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -10,6 +10,8 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
     TRADING_FORM_OUTPUT_FIAT,
+    TRADING_FORM_PAYMENT_METHOD_SELECT,
+    TRADING_FORM_PROVIDER_SELECT,
     type TradingAmountLimitProps,
     type TradingSellFormProps,
     type TradingSellType,
@@ -151,6 +153,7 @@ export const useTradingSellForm = ({
     });
     const { register, setValue, reset, control, formState } = methods;
     const values = useWatch<TradingSellFormProps>({ control });
+    const { paymentMethod, provider } = values;
 
     const formIsValid = Object.keys(formState.errors).length === 0;
     const output = values.outputs?.[0];
@@ -460,6 +463,38 @@ export const useTradingSellForm = ({
     useEffect(() => {
         dispatch(tradingThunks.loadInitialDataThunk({ activeSection: type }));
     }, [dispatch]);
+
+    useEffect(() => {
+        if (!preselectedQuote) {
+            return;
+        }
+
+        const preselectedProvider = preselectedQuote.exchange;
+        const preselectedPaymentMethod = preselectedQuote.paymentMethod;
+        const shouldUpdateProvider = !!preselectedProvider && preselectedProvider !== provider;
+        const shouldUpdatePaymentMethod =
+            !!preselectedPaymentMethod && paymentMethod?.value !== preselectedPaymentMethod;
+
+        dispatch(tradingSellActions.savePreselectedQuote(undefined));
+
+        if (shouldUpdateProvider) {
+            setValue(TRADING_FORM_PROVIDER_SELECT, preselectedProvider);
+        }
+
+        if (shouldUpdatePaymentMethod) {
+            const matchingOption = paymentMethods.find(
+                method => method.value === preselectedPaymentMethod,
+            );
+
+            setValue(
+                TRADING_FORM_PAYMENT_METHOD_SELECT,
+                matchingOption ?? {
+                    value: preselectedPaymentMethod,
+                    label: preselectedQuote.paymentMethodName ?? preselectedPaymentMethod,
+                },
+            );
+        }
+    }, [paymentMethod, paymentMethods, preselectedQuote, provider, setValue, dispatch]);
 
     useEffect(() => {
         if (!isChanged(defaultValues, values)) {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod.tsx
@@ -1,8 +1,9 @@
-import { Control, Controller } from 'react-hook-form';
+import { Control, Controller, UseFormSetValue } from 'react-hook-form';
 
 import { Translation } from '@suite/intl';
 import {
     TRADING_FORM_PAYMENT_METHOD_SELECT,
+    TRADING_FORM_PROVIDER_SELECT,
     type TradingPaymentMethodListProps,
 } from '@suite-common/trading';
 import { Select } from '@trezor/components';
@@ -25,8 +26,10 @@ export const TradingFormInputPaymentMethod = ({ label }: TradingFormInputDefault
             state: { isFormLoading, isFormInvalid },
         },
         getValues,
+        setValue,
         type,
     } = useTradingFormContext<TradingTradeBuySellType>();
+    const setValueTyped = setValue as UseFormSetValue<TradingBuySellFormProps>;
 
     const amountIsEmpty =
         type === 'buy'
@@ -49,7 +52,10 @@ export const TradingFormInputPaymentMethod = ({ label }: TradingFormInputDefault
             render={({ field: { onChange, value } }) => (
                 <Select
                     value={value}
-                    onChange={onChange}
+                    onChange={selected => {
+                        setValueTyped(TRADING_FORM_PROVIDER_SELECT, undefined);
+                        onChange(selected);
+                    }}
                     options={paymentMethods}
                     labelLeft={label && <Translation id={label} />}
                     formatOptionLabel={(option: TradingPaymentMethodListProps) =>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -1,13 +1,11 @@
 import { useEffect, useState } from 'react';
 
-import { BuyTrade, CryptoId, ExchangeTrade, SellFiatTrade } from 'invity-api';
+import type { BuyTrade, CryptoId, ExchangeTrade, SellFiatTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
 import { ExperimentId } from '@suite-common/message-system';
 import {
-    TRADING_EXCHANGE_FORM,
     TRADING_EXCHANGE_FORM_DEX,
-    type TradingTradeType,
     type TradingType,
     isSendingEvmNativeToken,
     parseCryptoId,
@@ -54,47 +52,44 @@ import { useIsContentBelowBreakpoint } from '../../../../../support/suite/Conten
 import { useReceiveAddressModalControls } from '../TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls';
 import { TradingUtilsTorWarning } from '../TradingUtils/TradingUtilsTorWarning';
 
-const getQuotesFilteredByProvider = (quotes: TradingTradeType[], provider: string | undefined) =>
-    quotes?.filter(quote => (provider ? quote.exchange === provider : true));
+const getQuotesFilteredByPaymentMethod = (
+    quotes: BuyTrade[] | SellFiatTrade[],
+    paymentMethod: string | undefined,
+) =>
+    quotes?.filter(quote =>
+        paymentMethod ? (quote as BuyTrade | SellFiatTrade).paymentMethod === paymentMethod : true,
+    ) ?? ([] as BuyTrade[] | SellFiatTrade[]);
 
 const getQuotesFilteredByProviderAndPaymentMethod = (
     quotes: BuyTrade[] | SellFiatTrade[],
     provider: string | undefined,
     paymentMethod: string | undefined,
 ) =>
-    getQuotesFilteredByProvider(quotes, provider).filter(quote =>
-        paymentMethod ? (quote as BuyTrade | SellFiatTrade).paymentMethod === paymentMethod : true,
+    getQuotesFilteredByPaymentMethod(quotes, paymentMethod).filter(quote =>
+        provider ? (quote as BuyTrade | SellFiatTrade).exchange === provider : true,
     );
 
 export const getSelectedQuote = (context: TradingFormContextValues<TradingType>) => {
     const { provider } = context.getValues();
 
-    console.warn('provider', provider);
-
     if (!isTradingExchangeContext(context)) {
-        const { paymentMethod } = context.getValues();
-        console.warn('paymentMethod', paymentMethod);
+        const { provider, paymentMethod } = context.getValues();
 
-        const q = getQuotesFilteredByProviderAndPaymentMethod(
+        return getQuotesFilteredByProviderAndPaymentMethod(
             context.quotes,
             provider,
             paymentMethod?.value,
         )?.[0];
-
-        console.warn('selected quote', q);
-        
-        return q;
     }
 
-    const isDex = context.getValues(TRADING_EXCHANGE_FORM) === TRADING_EXCHANGE_FORM_DEX;
-    const quotesFilteredByProvider = getQuotesFilteredByProvider(context.quotes, provider);
-    const bestScoredQuote = quotesFilteredByProvider?.[0];
+    const { exchangeType } = context.getValues();
+    const isDex = exchangeType === TRADING_EXCHANGE_FORM_DEX;
 
-    const selectedQuote = isDex
-        ? getQuotesFilteredByProvider(context.dexQuotes, provider)?.[0]
-        : getQuotesFilteredByProvider(context.cexQuotes, provider)?.[0];
+    const quotes = isDex ? context.dexQuotes : context.cexQuotes;
+    const selectedQuote =
+        quotes?.find(quote => !provider || quote.exchange === provider) ?? quotes?.[0];
 
-    return selectedQuote ?? bestScoredQuote;
+    return selectedQuote;
 };
 
 export const TradingFormOffer = () => {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { BuyTrade, CryptoId, ExchangeTrade } from 'invity-api';
+import { BuyTrade, CryptoId, ExchangeTrade, SellFiatTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
 import { ExperimentId } from '@suite-common/message-system';
@@ -54,17 +54,45 @@ import { useIsContentBelowBreakpoint } from '../../../../../support/suite/Conten
 import { useReceiveAddressModalControls } from '../TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls';
 import { TradingUtilsTorWarning } from '../TradingUtils/TradingUtilsTorWarning';
 
-export const getSelectedQuote = (
-    context: TradingFormContextValues<TradingType>,
-    bestScoredQuote: TradingTradeType | undefined,
-) => {
+const getQuotesFilteredByProvider = (quotes: TradingTradeType[], provider: string | undefined) =>
+    quotes?.filter(quote => (provider ? quote.exchange === provider : true));
+
+const getQuotesFilteredByProviderAndPaymentMethod = (
+    quotes: BuyTrade[] | SellFiatTrade[],
+    provider: string | undefined,
+    paymentMethod: string | undefined,
+) =>
+    getQuotesFilteredByProvider(quotes, provider).filter(quote =>
+        paymentMethod ? (quote as BuyTrade | SellFiatTrade).paymentMethod === paymentMethod : true,
+    );
+
+export const getSelectedQuote = (context: TradingFormContextValues<TradingType>) => {
+    const { provider } = context.getValues();
+
+    console.warn('provider', provider);
+
     if (!isTradingExchangeContext(context)) {
-        return bestScoredQuote;
+        const { paymentMethod } = context.getValues();
+        console.warn('paymentMethod', paymentMethod);
+
+        const q = getQuotesFilteredByProviderAndPaymentMethod(
+            context.quotes,
+            provider,
+            paymentMethod?.value,
+        )?.[0];
+
+        console.warn('selected quote', q);
+        
+        return q;
     }
 
     const isDex = context.getValues(TRADING_EXCHANGE_FORM) === TRADING_EXCHANGE_FORM_DEX;
+    const quotesFilteredByProvider = getQuotesFilteredByProvider(context.quotes, provider);
+    const bestScoredQuote = quotesFilteredByProvider?.[0];
 
-    const selectedQuote = isDex ? context.dexQuotes?.[0] : context.cexQuotes?.[0];
+    const selectedQuote = isDex
+        ? getQuotesFilteredByProvider(context.dexQuotes, provider)?.[0]
+        : getQuotesFilteredByProvider(context.cexQuotes, provider)?.[0];
 
     return selectedQuote ?? bestScoredQuote;
 };
@@ -101,7 +129,7 @@ export const TradingFormOffer = () => {
 
     const bestScoredQuote = quotes?.[0];
     const { preselectedQuote } = context;
-    const quote = preselectedQuote ?? getSelectedQuote(context, bestScoredQuote);
+    const quote = preselectedQuote ?? getSelectedQuote(context);
     const bestScoredQuoteAmounts = getCryptoQuoteAmountProps(quote, context);
     const areFeesLoading = useSelector(state => selectAreFeesLoading(state, account.symbol));
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferProvider.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferProvider.tsx
@@ -30,11 +30,10 @@ export const TradingReceiveAddressEmpty = ({ title, text }: TradingReceiveAddres
 
 export const TradingSelectedOfferProvider = () => {
     const context = useTradingFormContext();
-    const { quotes, preselectedQuote, isAmountEmpty, form, type, goToOffers } = context;
+    const { preselectedQuote, isAmountEmpty, form, type, goToOffers } = context;
 
     const providers = getProvidersInfoProps(context);
-    const bestScoredQuote = quotes?.[0];
-    const quote = preselectedQuote ?? getSelectedQuote(context, bestScoredQuote);
+    const quote = preselectedQuote ?? getSelectedQuote(context);
 
     const onGoToOffers = async () => {
         await goToOffers();

--- a/suite-common/trading/src/constants.ts
+++ b/suite-common/trading/src/constants.ts
@@ -40,6 +40,7 @@ export const TRADING_FORM_CRYPTO_INPUT = 'cryptoInput';
 export const TRADING_FORM_CRYPTO_CURRENCY_SELECT = 'cryptoSelect';
 export const TRADING_FORM_COUNTRY_SELECT = 'countrySelect';
 export const TRADING_FORM_PAYMENT_METHOD_SELECT = 'paymentMethod';
+export const TRADING_FORM_PROVIDER_SELECT = 'provider';
 export const TRADING_FORM_AMOUNT_IN_CRYPTO = 'amountInCrypto';
 
 export const TRADING_EXCHANGE_FROM_ADDRESS = 'fromAddress';

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -137,6 +137,7 @@ export type TradingBuyFormProps = {
     [constants.TRADING_FORM_CRYPTO_CURRENCY_SELECT]: TradingAssetOption;
     [constants.TRADING_FORM_COUNTRY_SELECT]: TradingCountryOption;
     [constants.TRADING_FORM_PAYMENT_METHOD_SELECT]?: TradingPaymentMethodListProps;
+    [constants.TRADING_FORM_PROVIDER_SELECT]?: string;
     [constants.TRADING_FORM_AMOUNT_IN_CRYPTO]: boolean;
     [constants.TRADING_BUY_RECEIVE_ADDRESS]?: string;
 };
@@ -201,6 +202,7 @@ export interface TradingExchangeFormProps extends FormState {
     [constants.TRADING_EXCHANGE_FROM_ADDRESS]?: string | undefined;
     [constants.TRADING_EXCHANGE_RECEIVE_ADDRESS]?: string | undefined;
     [constants.TRADING_EXCHANGE_EXTRA_FIELD]?: string | undefined;
+    [constants.TRADING_FORM_PROVIDER_SELECT]?: string;
 }
 
 export type MinimalExchangeFormProps = {
@@ -243,6 +245,7 @@ export interface TradingSellFormProps extends FormState {
     [constants.TRADING_FORM_PAYMENT_METHOD_SELECT]?: TradingPaymentMethodListProps;
     [constants.TRADING_FORM_COUNTRY_SELECT]: TradingCountryOption;
     [constants.TRADING_FORM_AMOUNT_IN_CRYPTO]: boolean;
+    [constants.TRADING_FORM_PROVIDER_SELECT]?: string;
 }
 
 export type MinimalSellFormProps = {


### PR DESCRIPTION
When user selects trade via list of trades, it is saved into `preselectedQuote`, but this one is not cleared when user changes payment method. This PR changes the way how preselectedQuote is treated on going back to form. Provider and payment method (buy and sell) are set to the form and used to identify selected quote. For exchange, it is provider and isDex parameter. After this, `preselectedQuote` is cleared. These parameters (if present) are then used to identify selected trade in the form.

Note: This is just an attempt to fix issue with stalled preselected trade. The flow would use complete rework on how trades are selected. This will be part of an initiative (probably) later this year.

## Notes for QA

After this, user should be able to change quote after it is selected via list of trades by changing the payment method.

## Related Issue

Resolve #24383



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading/form-updating&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading/form-updating&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading/form-updating&lookback=7)