### PR TITLE
chore: remove core.js from connect-explorer and vite config

### DIFF
--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -30,27 +30,6 @@ const isRelativePath = (path: string) =>
     // This regex checks if the path starts with a scheme (like http://, https://, file://, etc.)
     // or an absolute path indicator (like //)
     !/^(?:[a-z]+:)?\/\//i.test(path);
-const testLoadingScript = (src: string) =>
-    new Promise((resolve, reject) => {
-        if (process.env.BUILD_TARGET === 'webextension') {
-            // Webextension does not support loading scripts in this way, we skip this check
-            resolve(null);
-
-            return;
-        }
-        const script = document.createElement('script');
-        script.src = src;
-        script.type = 'module';
-        script.onload = data => {
-            document.body.removeChild(script);
-            resolve(data);
-        };
-        script.onerror = error => {
-            document.body.removeChild(script);
-            reject(error);
-        };
-        document.body.appendChild(script);
-    });
 
 export const init =
     (options: ConnectOptions = {}) =>
@@ -103,17 +82,6 @@ export const init =
             // Check if has trailing slash
             if (options.connectSrc.slice(-1) !== '/') {
                 options.connectSrc += '/';
-            }
-            try {
-                // Verify if valid by loading core.js, if this file exists we can assume the connectSrc is valid
-                await testLoadingScript(options.connectSrc + 'js/core.js');
-            } catch {
-                dispatch({
-                    type: ON_INIT_ERROR,
-                    payload: `Invalid connectSrc: ${options.connectSrc}`,
-                });
-
-                return;
             }
 
             window.__TREZOR_CONNECT_SRC = options.connectSrc;

--- a/packages/suite-build/vite.config.mts
+++ b/packages/suite-build/vite.config.mts
@@ -257,24 +257,6 @@ const workerPlugin = (): Plugin => ({
     },
 });
 
-// Plugin to serve core.js in dev mode
-const serveCorePlugin = () => ({
-    name: 'serve-core',
-    configureServer(server: ViteDevServer) {
-        server.middlewares.use((req, res, next) => {
-            if (req.url?.includes('/js/core.js')) {
-                const coreEntryPath = resolve(__dirname, '../connect/src/core/index.ts');
-                const moduleSpecifier = `/@fs/${coreEntryPath}`;
-                res.setHeader('Content-Type', 'application/javascript');
-                res.end(`export { initCoreState } from ${JSON.stringify(moduleSpecifier)};\n`);
-
-                return;
-            }
-            next();
-        });
-    },
-});
-
 const commitId = execSync('git rev-parse HEAD').toString().trim();
 
 // Plugin to provide a no-op replacement for core-js/actual as a virtual module
@@ -456,7 +438,6 @@ export default defineConfig({
         guideMarkdownPlugin(),
         trezorLogosRequirePlugin(),
         staticAliasPlugin(),
-        serveCorePlugin(),
         sessionsSharedWorkerPlugin(),
         viteCommonjs(),
         workerPlugin(),


### PR DESCRIPTION
This removes connectSrc validation from connect-explorers hidden settings page.

- we are no longer building and [using](https://github.com/trezor/trezor-suite/pull/23829/changes#diff-8c98ba84fc78374812ebc5a974004cbaf72f6245466b70f82c6e0a53f8eadcd3L52) core.js so it will not be available when try to load in in connect-exlorer/settings
- besides that, we would like to get rid of connectSrc anyway. In progress in #24448

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-explorer-connect-src&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-explorer-connect-src&lookback=7)