### PR TITLE
fix(common): change ask storage ep get to post

### DIFF
--- a/suite-common/suite-sync-quota-manager/src/storage/checkStorage.ts
+++ b/suite-common/suite-sync-quota-manager/src/storage/checkStorage.ts
@@ -31,8 +31,8 @@ export const checkStorageByPublicKey = async ({
     const result = await quotaManagerFetch({
         baseUrl,
         path: '/storage/ask',
-        method: 'GET',
-        queryParams: { publicKey },
+        method: 'POST',
+        body: { publicKey },
     });
 
     if (!result.success) {
@@ -49,8 +49,8 @@ export const checkStorageByOwnerId = async ({ baseUrl, ownerId }: CheckStorageBy
     const result = await quotaManagerFetch({
         baseUrl,
         path: '/storage/ask',
-        method: 'GET',
-        queryParams: { ownerId },
+        method: 'POST',
+        body: { ownerId },
     });
 
     if (!result.success) {


### PR DESCRIPTION
Updated `storage/ask` POST endpoint to match the spec.

Needs to be merged along with https://github.com/trezor/trezor-suite-sync/pull/73

## Notes for QA

- Suite still registers device & allocates data via QuotaManager
- or properly loads the data from QM

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24509



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/qm/ownerid-to-post&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/qm/ownerid-to-post&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/qm/ownerid-to-post&lookback=7)