### PR TITLE
chore: remove all selectors fom useLabelingCombined

### DIFF
--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -4,7 +4,12 @@ import { isFulfilled } from '@reduxjs/toolkit';
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
-import { selectShouldOfferSecureSync } from '@suite-common/suite-sync';
+import {
+    isSuiteSyncSupportedByDevice,
+    selectIsSuiteSyncEnabled,
+    selectShouldOfferSecureSync,
+} from '@suite-common/suite-sync';
+import { selectDeviceByStaticSessionId } from '@suite-common/wallet-core';
 import { Button, DropdownMenuItemProps, Row, Text, Tooltip } from '@trezor/components';
 import { StaticSessionId } from '@trezor/connect';
 import { EditableText, EditableTextProps } from '@trezor/product-components';
@@ -24,7 +29,6 @@ import { LabelContentProps, LabelingVariant, MetadataProps, PrimitiveProps } fro
 import { withDropdown } from './withDropdown';
 import { withEditable } from './withEditable';
 import { processLegacyMetadataIntoSuiteSyncThunk } from '../../../../actions/wallet/processLegacyMetadataIntoSuiteSyncThunk';
-import { useLabelingCombined } from '../../../../hooks/suite/useLabelingCombined';
 import { AccountTypeBadge } from '../../AccountTypeBadge';
 import { NO_HIGHLIGHT_ATTRIBUTE } from '../../FindBar/consts';
 
@@ -353,16 +357,18 @@ export const Labeling = ({
 }: LabelingProps) => {
     const dispatch = useDispatch();
     const { isDiscoveryRunning } = useDiscovery();
-    const {
-        isSuiteSyncEnabled,
-        isEvoluSupportedByDevice,
-        legacyMetadataState,
-        hasDeviceSuiteSyncOwner,
-    } = useLabelingCombined({ deviceStaticSessionId });
+    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
+    const legacyMetadataState = useSelector(state => state.metadata);
     const isLegacyLabelingInitPossible = useSelector(selectIsLabelingInitPossible);
     const shouldOfferSecureSync = useSelector(selectShouldOfferSecureSync);
+    const device = useSelector(state =>
+        selectDeviceByStaticSessionId(state, deviceStaticSessionId),
+    );
+
+    const hasDeviceSuiteSyncOwner = device?.suiteSyncOwner !== undefined;
     const isEvoluLabeling =
-        isSuiteSyncEnabled && isEvoluSupportedByDevice && hasDeviceSuiteSyncOwner;
+        isSuiteSyncEnabled && isSuiteSyncSupportedByDevice(device) && hasDeviceSuiteSyncOwner;
+
     const deviceState =
         payload.type === 'walletLabel' ? (payload.entityKey as StaticSessionId) : undefined;
     const isLegacyLabelingEnabled = useSelector(state =>
@@ -473,17 +479,18 @@ export const MetadataLabeling = ({
     const [showSuccess, setShowSuccess] = useState(false);
     const [pending, setPending] = useState(false);
 
+    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
+    const legacyMetadataState = useSelector(state => state.metadata);
+    const device = useSelector(state =>
+        selectDeviceByStaticSessionId(state, deviceStaticSessionId),
+    );
+
     const l10nLabelling = getLocalizedActions(payload.type);
     const dataTestBase = `@metadata/${payload.type}/${payload.defaultValue}`;
     const actionButtonsDisabled = isDiscoveryRunning || pending;
     const isSubscribedToSubmitResult = useRef(payload.defaultValue);
 
-    const {
-        isSuiteSyncEnabled,
-        isEvoluSupportedByDevice,
-        legacyMetadataState,
-        hasDeviceSuiteSyncOwner,
-    } = useLabelingCombined({ deviceStaticSessionId });
+    const hasDeviceSuiteSyncOwner = device?.suiteSyncOwner !== undefined;
 
     let timeout: TimerId | undefined;
     useEffect(() => {
@@ -606,7 +613,7 @@ export const MetadataLabeling = ({
     const labelContainerDataTest = `${dataTestBase}/hover-container`;
 
     const isEvoluLabeling =
-        isSuiteSyncEnabled && isEvoluSupportedByDevice && hasDeviceSuiteSyncOwner;
+        isSuiteSyncEnabled && isSuiteSyncSupportedByDevice(device) && hasDeviceSuiteSyncOwner;
 
     // Should "add label"/"edit label" button be visible?
     const showActionButton =
@@ -634,7 +641,7 @@ export const MetadataLabeling = ({
         <Tooltip
             content={
                 isSuiteSyncEnabled &&
-                !isEvoluSupportedByDevice && (
+                !isSuiteSyncSupportedByDevice(device) && (
                     <Text variant="warning">
                         <Translation id="FIRMWARE_NEEDS_UPGRADE_FOR_SUITE_SYNC" />
                     </Text>

--- a/packages/suite/src/components/suite/labeling/TurnOnSecureSyncModal.tsx
+++ b/packages/suite/src/components/suite/labeling/TurnOnSecureSyncModal.tsx
@@ -8,9 +8,7 @@ type TurnOnSecureSyncModalProps = {
 };
 
 export const TurnOnSecureSyncModal = ({ onClose }: TurnOnSecureSyncModalProps) => {
-    const { enableSuiteSyncIfNeeded } = useLabelingCombined({
-        deviceStaticSessionId: undefined,
-    });
+    const { enableSuiteSyncIfNeeded } = useLabelingCombined();
 
     const onSwitch = () => {
         enableSuiteSyncIfNeeded();

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useEffect, useState } from 'react';
 
 import { EventType } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
-import { selectSuiteSyncAddressLabels } from '@suite-common/suite-sync';
+import { selectIsSuiteSyncEnabled, selectSuiteSyncAddressLabels } from '@suite-common/suite-sync';
 import { getDeviceInternalModel } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
@@ -37,7 +37,6 @@ import { QrCode } from 'src/components/suite/QrCode';
 import { Labeling } from 'src/components/suite/labeling';
 import { useGuideOpenNode } from 'src/hooks/guide';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
-import { useLabelingCombined } from 'src/hooks/suite/useLabelingCombined';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 import { useLegacyAnalytics } from 'src/support/useAnalytics';
 import { ThunkAction } from 'src/types/suite';
@@ -76,9 +75,9 @@ export const ConfirmValueModal = ({
     const { openNodeById } = useGuideOpenNode();
     const { translationString } = useTranslation();
     const legacyAnalytics = useLegacyAnalytics();
-    const { isSuiteSyncEnabled, legacyMetadataState } = useLabelingCombined({
-        deviceStaticSessionId: account?.deviceState,
-    });
+    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
+    const legacyMetadataState = useSelector(state => state.metadata);
+
     // block labeling if metadata needs to be enabled on device until receive address is confirmed (device locked)
     const isMetadataBlockedByDeviceCall =
         isDeviceLocked &&

--- a/packages/suite/src/hooks/suite/useLabelingCombined.ts
+++ b/packages/suite/src/hooks/suite/useLabelingCombined.ts
@@ -1,13 +1,6 @@
 import { EventType } from '@suite/analytics';
-import {
-    selectIsFeatureSuiteSyncAvailable,
-    selectIsSuiteSyncDebugEnabled,
-    selectIsSuiteSyncEnabled,
-    suiteSyncActions,
-} from '@suite-common/suite-sync';
+import { selectIsFeatureSuiteSyncAvailable, suiteSyncActions } from '@suite-common/suite-sync';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { selectDeviceByStaticSessionId } from '@suite-common/wallet-core';
-import type { StaticSessionId } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
 import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
@@ -18,30 +11,16 @@ import { useLegacyAnalytics } from 'src/support/useAnalytics';
 import { useDispatch } from './useDispatch';
 import { useSelector } from './useSelector';
 
-type UseLabelingCombinedParams = {
-    // This needs to be passed, as labeling can be attached to remembered wallets
-    // and different devices can have different states (FW versions)
-    deviceStaticSessionId: StaticSessionId | undefined;
-};
-
 /**
  * @deprecated This hook is obsolete. Once legacy metadata labeling is removed -> use only the hook
  * `useSuiteSync` from `@suite-common/suite-sync`.
  */
-export const useLabelingCombined = ({ deviceStaticSessionId }: UseLabelingCombinedParams) => {
+export const useLabelingCombined = () => {
     const legacyAnalytics = useLegacyAnalytics();
     const dispatch = useDispatch();
     const { suiteSync } = useSuiteServices();
 
-    const device = useSelector(state =>
-        deviceStaticSessionId !== undefined
-            ? selectDeviceByStaticSessionId(state, deviceStaticSessionId)
-            : undefined,
-    );
-
-    const isSuiteSyncDebugEnabled = useSelector(selectIsSuiteSyncDebugEnabled);
     const isFeatureSuiteSyncAvailable = useSelector(selectIsFeatureSuiteSyncAvailable);
-    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
 
     const legacyMetadataState = useSelector(state => state.metadata);
 
@@ -96,23 +75,12 @@ export const useLabelingCombined = ({ deviceStaticSessionId }: UseLabelingCombin
         }
     };
 
-    const isEvoluSupportedByDevice = device?.unavailableCapabilities?.evolu === undefined;
-
-    const hasDeviceSuiteSyncOwner = device?.suiteSyncOwner !== undefined;
-
     return {
         /** New Labeling: SuiteSync (Evolu) */
-        isFeatureSuiteSyncAvailable,
         toggleIsFeatureSuiteSyncAvailable,
-        isSuiteSyncEnabled,
-        isEvoluSupportedByDevice,
-        isSuiteSyncDebugEnabled,
-        hasDeviceSuiteSyncOwner,
         enableSuiteSyncIfNeeded,
 
         /** Legacy Labeling */
-        isMetadataEnabled: legacyMetadataState.enabled,
-        legacyMetadataState,
         legacyEnableIfNeeded,
         legacyDisableIfNeeded,
     };

--- a/packages/suite/src/views/settings/SettingsDebug/SuiteSyncSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SuiteSyncSettings.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 
 import {
     DEFAULT_SUITE_SYNC_RELAY_URL,
+    selectIsFeatureSuiteSyncAvailable,
+    selectIsSuiteSyncDebugEnabled,
     selectSuiteSyncRelayUrl,
     suiteSyncActions,
 } from '@suite-common/suite-sync';
@@ -21,14 +23,10 @@ export const SuiteSyncSettings = () => {
     const dispatch = useDispatch();
     const { suiteSync } = useSuiteServices();
 
-    const {
-        isSuiteSyncDebugEnabled,
-        isFeatureSuiteSyncAvailable,
-        toggleIsFeatureSuiteSyncAvailable,
-    } = useLabelingCombined({
-        // In debug, there may not be any device selected and it is in fact irrelevant
-        deviceStaticSessionId: undefined,
-    });
+    const isFeatureSuiteSyncAvailable = useSelector(selectIsFeatureSuiteSyncAvailable);
+    const isSuiteSyncDebugEnabled = useSelector(selectIsSuiteSyncDebugEnabled);
+
+    const { toggleIsFeatureSuiteSyncAvailable } = useLabelingCombined();
 
     const suiteSyncRelayUrl = useSelector(selectSuiteSyncRelayUrl);
 

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -2,7 +2,11 @@ import { useState } from 'react';
 
 import { EventType } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
-import { selectIsFeatureSuiteSyncAvailable } from '@suite-common/suite-sync';
+import {
+    isSuiteSyncSupportedByDevice,
+    selectIsFeatureSuiteSyncAvailable,
+    selectIsSuiteSyncEnabled,
+} from '@suite-common/suite-sync';
 import { LoadingContent } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 import { HELP_CENTER_LABELING } from '@trezor/urls';
@@ -34,17 +38,11 @@ export const Labeling = () => {
     const { isDeviceLabelingDisabled } = useLabelingDeviceState();
 
     const showSuiteSync = useSelector(selectIsFeatureSuiteSyncAvailable);
+    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
+    const legacyMetadataState = useSelector(state => state.metadata);
 
-    const {
-        legacyMetadataState,
-        legacyEnableIfNeeded,
-        legacyDisableIfNeeded,
-        enableSuiteSyncIfNeeded,
-        isEvoluSupportedByDevice,
-        isSuiteSyncEnabled,
-    } = useLabelingCombined({
-        deviceStaticSessionId: device?.state?.staticSessionId,
-    });
+    const { legacyEnableIfNeeded, legacyDisableIfNeeded, enableSuiteSyncIfNeeded } =
+        useLabelingCombined();
 
     const translatedOptions: LabelingOption<string>[] = LABELING_SELECT_OPTIONS.map(option => ({
         ...option,
@@ -147,7 +145,7 @@ export const Labeling = () => {
                         options={translatedOptions.filter(
                             option =>
                                 option.value !== 'secure-sync' ||
-                                (showSuiteSync && isEvoluSupportedByDevice),
+                                (showSuiteSync && isSuiteSyncSupportedByDevice(device)),
                         )}
                         value={getSelectedOption()}
                         onChange={handleOnChange}

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/SuiteSyncWalletDebug.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/SuiteSyncWalletDebug.tsx
@@ -1,24 +1,30 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
+import {
+    isSuiteSyncSupportedByDevice,
+    selectIsSuiteSyncDebugEnabled,
+    selectIsSuiteSyncEnabled,
+} from '@suite-common/suite-sync';
 import { AcquiredDevice } from '@suite-common/suite-types';
 import { deviceActions } from '@suite-common/wallet-core';
 import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { Code, Row, Text, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { useDispatch } from 'src/hooks/suite';
-
-import { useLabelingCombined } from '../../../../hooks/suite/useLabelingCombined';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const SuiteSyncWalletDebug = ({ device }: { device: AcquiredDevice }) => {
     const dispatch = useDispatch();
-    const {
-        legacyMetadataState,
-        isSuiteSyncEnabled,
-        isSuiteSyncDebugEnabled,
-        isEvoluSupportedByDevice,
-    } = useLabelingCombined({ deviceStaticSessionId: device.state?.staticSessionId });
 
-    if (!isSuiteSyncDebugEnabled || !isEvoluSupportedByDevice || !device.state?.staticSessionId) {
+    const isSuiteSyncDebugEnabled = useSelector(selectIsSuiteSyncDebugEnabled);
+    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
+
+    const legacyMetadataState = useSelector(state => state.metadata);
+
+    if (
+        !isSuiteSyncDebugEnabled ||
+        !isSuiteSyncSupportedByDevice(device) ||
+        !device.state?.staticSessionId
+    ) {
         return;
     }
 

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { Translation, useTranslation } from '@suite/intl';
-import { selectSuiteSyncWalletLabel } from '@suite-common/suite-sync';
+import { selectIsSuiteSyncEnabled, selectSuiteSyncWalletLabel } from '@suite-common/suite-sync';
 import {
     getAccountsByDeviceState,
     selectAllAccountsToList,
@@ -39,7 +39,6 @@ import { AcquiredDevice, AppState, ForegroundAppProps } from 'src/types/suite';
 import { EjectConfirmation } from './EjectConfirmation';
 import { SuiteSyncWalletDebug } from './SuiteSyncWalletDebug';
 import { METADATA_LABELING } from '../../../../actions/suite/constants';
-import { useLabelingCombined } from '../../../../hooks/suite/useLabelingCombined';
 
 type WalletInstanceProps = {
     instance: AcquiredDevice;
@@ -82,9 +81,7 @@ export const WalletInstance = ({
     const dispatch = useDispatch();
     const store = useStore();
     const { translationString } = useTranslation();
-    const { isSuiteSyncEnabled } = useLabelingCombined({
-        deviceStaticSessionId: instance?.state?.staticSessionId,
-    });
+    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
 
     const { defaultAccountLabelString } = useWalletLabeling();
 

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -22,7 +22,6 @@ import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
 import { AccountTypeDescription } from 'src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription';
 import { WalletLayout } from 'src/components/wallet';
 import { useDefaultAccountLabel, useDevice, useDispatch, useSelector } from 'src/hooks/suite';
-import { useLabelingCombined } from 'src/hooks/suite/useLabelingCombined';
 import { useReceiveDisabled } from 'src/hooks/suite/useReceiveDisabled';
 
 import { CoinjoinLogs } from './CoinjoinLogs';
@@ -86,9 +85,7 @@ const Details = () => {
     const isLocalFirstStorageEnabled = useSelector(selectIsSuiteSyncEnabled);
 
     const { isReceiveDisabled, ReceiveDisabledWrapper } = useReceiveDisabled();
-    const { isMetadataEnabled } = useLabelingCombined({
-        deviceStaticSessionId: device?.state?.staticSessionId,
-    });
+    const isMetadataEnabled = useSelector(state => state.metadata).enabled;
 
     const dispatch = useDispatch();
 

--- a/suite-common/suite-sync/src/index.ts
+++ b/suite-common/suite-sync/src/index.ts
@@ -34,3 +34,4 @@ export {
     findSuiteSyncAccountLabel,
 } from './data/suiteSyncDataSelectors';
 export { suiteSyncToBip329 } from './data/labeling/suiteSyncToBip329';
+export { isSuiteSyncSupportedByDevice } from './suiteSyncUtils';


### PR DESCRIPTION
This PR refactors the useLabelingCombined hook. It removes all selectors logic from it as there is no reason to combine it here. 

There is no benefit, those selectors can be used directly without the hook. No added value there.

## Test
- This may break both Legacy Labeling & Suite Sync (turning on/of, edit labels for both)
- This shall only affect desktop.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=use-labeling-combined-selectors&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=use-labeling-combined-selectors&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=use-labeling-combined-selectors&lookback=7)