### PR TITLE
fix(connect): propagate currencies param to getAccountBalanceHistory

### DIFF
--- a/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
+++ b/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
@@ -31,6 +31,7 @@ export default class BlockchainGetAccountBalanceHistory extends AbstractMethod<
             { name: 'from', type: 'number' },
             { name: 'to', type: 'number' },
             { name: 'groupBy', type: 'number' },
+            { name: 'currencies', type: 'array' },
         ]);
 
         const coinInfo = getCoinInfo(payload.coin);
@@ -48,6 +49,7 @@ export default class BlockchainGetAccountBalanceHistory extends AbstractMethod<
                 from: payload.from,
                 to: payload.to,
                 groupBy: payload.groupBy,
+                currencies: payload.currencies,
             },
         };
     }

--- a/suite-common/graph/src/graphBalanceEvents.ts
+++ b/suite-common/graph/src/graphBalanceEvents.ts
@@ -169,8 +169,6 @@ export const getAccountMovementEvents = async ({
             to: getUnixTime(endOfTimeFrameDate),
             groupBy: 1,
             // we don't need currencies at all here, this will just reduce transferred data size
-            // TODO: doesn't work at all, fix it in connect or blockchain-link?
-            // issue: https://github.com/trezor/trezor-suite/issues/8888
             currencies: ['usd'],
         });
 

--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -197,8 +197,6 @@ const getAccountBalanceHistory = async ({
             to: endTimeFrameTimestamp,
             groupBy: 1,
             // we don't need currencies at all here, this will just reduce transferred data size
-            // TODO: doesn't work at all, fix it in connect or blockchain-link?
-            // issue: https://github.com/trezor/trezor-suite/issues/8888
             currencies: ['usd'],
         });
 


### PR DESCRIPTION
The `currencies` param provided to `TrezorConnect.blockchainGetAccountBalanceHistory` is ignored.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect/account-balance-history&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect/account-balance-history&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect/account-balance-history&lookback=7)