### PR TITLE
chore(ci): reenable Nx tsc cache

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -55,8 +55,7 @@ jobs:
       - name: "Minimal yarn install"
         uses: ./.github/actions/minimal-yarn-install
       - name: Type Check
-        # Temporarily disabling the cache (false positives because of cache mismatch after NX update)
-        run: yarn nx:type-check --output-style=stream --skip-nx-cache
+        run: yarn nx:type-check --output-style=stream
 
   lint:
     name: Linting and formatting


### PR DESCRIPTION
## Description

Reverts e28738f1

I hope sufficient time has passed, old PRs with old cache are closed now, and we can reenable the cache to save some CI time.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/reenable-nx-tsc-cache&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/reenable-nx-tsc-cache&lookback=7)