### PR TITLE
fix(suite): invert everstake logo in dark mode

### DIFF
--- a/packages/suite/src/components/wallet/PoweredByBadge.tsx
+++ b/packages/suite/src/components/wallet/PoweredByBadge.tsx
@@ -1,3 +1,5 @@
+import styled from 'styled-components';
+
 import { Translation } from '@suite/intl';
 import { Image, ImageType, Row, Text } from '@trezor/components';
 
@@ -6,6 +8,10 @@ const PROVIDERS = {
         logo: 'EVERSTAKE_LOGO',
     },
 } as const satisfies Record<string, { logo: ImageType }>;
+
+const ImageWrapper = styled.div`
+    filter: ${({ theme }) => (theme.variant === 'dark' ? 'invert(1)' : 'none')};
+`;
 
 interface PoweredByBadgeProps {
     provider: keyof typeof PROVIDERS;
@@ -17,7 +23,9 @@ export function PoweredByBadge({ provider }: PoweredByBadgeProps) {
             <Text variant="tertiary">
                 <Translation id="TR_STAKE_PROVIDED_BY" />
             </Text>
-            <Image image={PROVIDERS[provider].logo} width={100} height={40} />
+            <ImageWrapper>
+                <Image image={PROVIDERS[provider].logo} width={100} height={40} />
+            </ImageWrapper>
         </Row>
     );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes visibility of Everstake provider logo in dark mode

## Notes for QA

Everstake logo should be visible both for dark and light mode.

## Related Issue

Resolve [#24296](https://github.com/trezor/trezor-suite/issues/24296)

## Screenshots:
<img width="1006" height="235" alt="image" src="https://github.com/user-attachments/assets/cf2defaf-7f9d-49f1-902f-a81fbc066cb6" />
<img width="995" height="216" alt="Screenshot 2026-01-20 at 13 52 41" src="https://github.com/user-attachments/assets/8c00eab8-1675-4839-b81e-977933092a45" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/everstake-dark-mode-logo&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/everstake-dark-mode-logo&lookback=7)