### PR TITLE
fix(suite-native): bootloader mode navigation

### DIFF
--- a/suite-native/device-bootloader-mode/src/screens/BootloaderModeScreen.tsx
+++ b/suite-native/device-bootloader-mode/src/screens/BootloaderModeScreen.tsx
@@ -10,8 +10,10 @@ import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
     DeviceSettingsStackRoutes,
+    RootStackParamList,
+    RootStackRoutes,
     Screen,
-    StackNavigationProps,
+    StackToStackCompositeNavigationProps,
     WipeDeviceStackRoutes,
     useInterceptNativeNavigation,
     useNavigateToInitialScreen,
@@ -29,9 +31,10 @@ const contentWrapperStyle = prepareNativeStyle(() => ({
     justifyContent: 'center',
 }));
 
-type NavigationProps = StackNavigationProps<
+type NavigationProps = StackToStackCompositeNavigationProps<
     DeviceSettingsStackParamList,
-    DeviceSettingsStackRoutes.WipeDeviceStack
+    DeviceSettingsStackRoutes.WipeDeviceStack,
+    RootStackParamList
 >;
 
 export const BootloaderModeScreen = () => {
@@ -43,8 +46,11 @@ export const BootloaderModeScreen = () => {
     useInterceptNativeNavigation();
 
     const handleRedirectToFactoryReset = () => {
-        navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack, {
-            screen: WipeDeviceStackRoutes.FactoryReset,
+        navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
+            screen: DeviceSettingsStackRoutes.WipeDeviceStack,
+            params: {
+                screen: WipeDeviceStackRoutes.FactoryReset,
+            },
         });
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bootloader mode navigation was broken, as shown in screen recording. This PR fixes it. 

## Notes for QA
Test navigation to factory reset by connecting device in bootloader mode and navigating to factory reset.

## Screenshots:
After:
https://github.com/user-attachments/assets/0e008160-49d9-47a0-9bb2-3a424bb2993a

Before:
https://github.com/user-attachments/assets/7507c066-64ca-4a8c-bdfd-70cb9ce2ecbe



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/bootloader-navigation&lookback=7)