### PR TITLE
fix: move the routerServices to services: and rename to SuiteRouterHi…

### DIFF
--- a/packages/connect-plugin-ethereum/tsconfig.lib.json
+++ b/packages/connect-plugin-ethereum/tsconfig.lib.json
@@ -3,5 +3,6 @@
     "compilerOptions": {
         "outDir": "lib"
     },
-    "include": ["./src"]
+    "include": ["./src"],
+    "references": []
 }

--- a/packages/crypto-utils/tsconfig.lib.json
+++ b/packages/crypto-utils/tsconfig.lib.json
@@ -3,5 +3,6 @@
     "compilerOptions": {
         "outDir": "./lib"
     },
-    "include": ["./src"]
+    "include": ["./src"],
+    "references": []
 }

--- a/packages/protobuf/tsconfig.lib.json
+++ b/packages/protobuf/tsconfig.lib.json
@@ -3,5 +3,6 @@
     "compilerOptions": {
         "outDir": "lib"
     },
-    "include": ["./src"]
+    "include": ["./src"],
+    "references": []
 }

--- a/packages/protocol/tsconfig.lib.json
+++ b/packages/protocol/tsconfig.lib.json
@@ -5,5 +5,6 @@
         "target": "es2022",
         "lib": ["es2022", "esnext"]
     },
-    "include": ["./src"]
+    "include": ["./src"],
+    "references": []
 }

--- a/packages/suite-desktop-ui/package.json
+++ b/packages/suite-desktop-ui/package.json
@@ -13,7 +13,6 @@
     },
     "dependencies": {
         "@sentry/electron": "^7.5.0",
-        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite/analytics": "workspace:*",

--- a/packages/suite-desktop-ui/src/MainDesktop.tsx
+++ b/packages/suite-desktop-ui/src/MainDesktop.tsx
@@ -3,7 +3,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { createMemoryHistory } from 'history';
 import { createRoot } from 'react-dom/client';
 
-import { RouterServices } from '@suite-common/redux-utils';
+import { SuiteRouterHistoryDep } from '@suite-common/redux-utils';
 import TrezorConnect from '@trezor/connect';
 import { createIpcProxy } from '@trezor/ipc-proxy';
 import { desktopApi } from '@trezor/suite-desktop-api';
@@ -23,7 +23,6 @@ import { Metadata } from 'src/components/suite/Metadata';
 import { useDebugLanguageShortcut } from 'src/hooks/suite';
 import { initStore } from 'src/reducers/store';
 import { SuiteServicesProvider } from 'src/support/SuiteServicesProvider';
-import { createRouterServices } from 'src/support/extraDependencies';
 import { ConnectedIntlProvider } from 'src/support/suite/ConnectedIntlProvider';
 import { Main } from 'src/support/suite/Main';
 import { preloadStore } from 'src/support/suite/preloadStore';
@@ -38,14 +37,14 @@ import { DesktopUpdater } from './support/DesktopUpdater';
 import { desktopComponents } from './support/desktopComponents';
 import { TorLoadingScreen } from './support/screens/TorLoadingScreen';
 
-const MainDesktop = ({ routerServices }: { routerServices: RouterServices }) => {
+const MainDesktop = ({ suiteRouterHistory }: SuiteRouterHistoryDep) => {
     useTor();
     useDebugLanguageShortcut();
     useConnectPopupDesktop();
 
     return (
         <Main
-            routerServices={routerServices}
+            suiteRouterHistory={suiteRouterHistory}
             trafficLightOffset={<TrafficLightDraggableWindowHeader />}
         >
             <GlobalStyle />
@@ -71,14 +70,17 @@ export const init = async (container: HTMLElement) => {
     const root = createRoot(container);
     root.render(<LoadingScreen />);
 
-    const memoryHistory = createMemoryHistory();
     const preloadAction = await preloadStore();
     const { statePatch } = await desktopApi.handshake();
-    const routerServices = createRouterServices(memoryHistory);
-    const { store, services } = initStore(preloadAction, {
-        statePatch,
-        additionalExtraDeps: { routerServices },
-    });
+    const { store, services } = initStore(
+        {
+            history: createMemoryHistory(),
+        },
+        preloadAction,
+        {
+            statePatch,
+        },
+    );
 
     // Expose Redux store for Playwright/e2e tests
     if (typeof window !== 'undefined' && window.desktopFlags?.exposeStore) {
@@ -146,7 +148,7 @@ export const init = async (container: HTMLElement) => {
     root.render(
         <SuiteServicesProvider services={services}>
             <ReduxProvider store={store}>
-                <MainDesktop routerServices={routerServices} />
+                <MainDesktop suiteRouterHistory={services.suiteRouterHistory} />
             </ReduxProvider>
         </SuiteServicesProvider>,
     );

--- a/packages/suite-desktop-ui/src/MainDesktop.tsx
+++ b/packages/suite-desktop-ui/src/MainDesktop.tsx
@@ -3,7 +3,6 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { createMemoryHistory } from 'history';
 import { createRoot } from 'react-dom/client';
 
-import { SuiteRouterHistoryDep } from '@suite-common/redux-utils';
 import TrezorConnect from '@trezor/connect';
 import { createIpcProxy } from '@trezor/ipc-proxy';
 import { desktopApi } from '@trezor/suite-desktop-api';
@@ -37,16 +36,13 @@ import { DesktopUpdater } from './support/DesktopUpdater';
 import { desktopComponents } from './support/desktopComponents';
 import { TorLoadingScreen } from './support/screens/TorLoadingScreen';
 
-const MainDesktop = ({ suiteRouterHistory }: SuiteRouterHistoryDep) => {
+const MainDesktop = () => {
     useTor();
     useDebugLanguageShortcut();
     useConnectPopupDesktop();
 
     return (
-        <Main
-            suiteRouterHistory={suiteRouterHistory}
-            trafficLightOffset={<TrafficLightDraggableWindowHeader />}
-        >
+        <Main trafficLightOffset={<TrafficLightDraggableWindowHeader />}>
             <GlobalStyle />
             <DesktopUpdater />
             <Metadata />
@@ -148,7 +144,7 @@ export const init = async (container: HTMLElement) => {
     root.render(
         <SuiteServicesProvider services={services}>
             <ReduxProvider store={store}>
-                <MainDesktop suiteRouterHistory={services.suiteRouterHistory} />
+                <MainDesktop />
             </ReduxProvider>
         </SuiteServicesProvider>,
     );

--- a/packages/suite-desktop-ui/tsconfig.json
+++ b/packages/suite-desktop-ui/tsconfig.json
@@ -9,9 +9,6 @@
         "../suite/src/components/suite/BioAuthGuard"
     ],
     "references": [
-        {
-            "path": "../../suite-common/redux-utils"
-        },
         { "path": "../../suite-common/sentry" },
         {
             "path": "../../suite-common/suite-types"

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -14,7 +14,6 @@
     },
     "dependencies": {
         "@sentry/browser": "10.32.1",
-        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/packages/suite-web/src/MainWeb.tsx
+++ b/packages/suite-web/src/MainWeb.tsx
@@ -6,8 +6,6 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { createBrowserHistory } from 'history';
 import { createRoot } from 'react-dom/client';
 
-import { SuiteRouterHistoryDep } from '@suite-common/redux-utils/src/extraDependenciesType';
-
 import {
     AppRouter,
     BundleLoader,
@@ -28,14 +26,14 @@ import { initSentry } from './sentry';
 import { usePlaywright } from './support/usePlaywright';
 import { webComponents } from './support/webComponents';
 
-const MainWeb = ({ suiteRouterHistory }: SuiteRouterHistoryDep) => {
+const MainWeb = () => {
     usePlaywright();
     useTor();
     useDebugLanguageShortcut();
     useConnectPopupWeb();
 
     return (
-        <Main suiteRouterHistory={suiteRouterHistory}>
+        <Main>
             <Metadata />
             <ToasterProvider />
             <Preloader>
@@ -62,7 +60,7 @@ export const init = async (container: HTMLElement) => {
     root.render(
         <SuiteServicesProvider services={services}>
             <ReduxProvider store={store}>
-                <MainWeb suiteRouterHistory={services.suiteRouterHistory} />
+                <MainWeb />
             </ReduxProvider>
         </SuiteServicesProvider>,
     );

--- a/packages/suite-web/src/MainWeb.tsx
+++ b/packages/suite-web/src/MainWeb.tsx
@@ -6,7 +6,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { createBrowserHistory } from 'history';
 import { createRoot } from 'react-dom/client';
 
-import { RouterServices } from '@suite-common/redux-utils';
+import { SuiteRouterHistoryDep } from '@suite-common/redux-utils/src/extraDependenciesType';
 
 import {
     AppRouter,
@@ -18,7 +18,6 @@ import {
 import { useDebugLanguageShortcut } from 'src/hooks/suite';
 import { initStore } from 'src/reducers/store';
 import { SuiteServicesProvider } from 'src/support/SuiteServicesProvider';
-import { createRouterServices } from 'src/support/extraDependencies';
 import { Main } from 'src/support/suite/Main';
 import { preloadStore } from 'src/support/suite/preloadStore';
 import { LoadingScreen } from 'src/support/suite/screens/LoadingScreen';
@@ -29,14 +28,14 @@ import { initSentry } from './sentry';
 import { usePlaywright } from './support/usePlaywright';
 import { webComponents } from './support/webComponents';
 
-const MainWeb = ({ routerServices }: { routerServices: RouterServices }) => {
+const MainWeb = ({ suiteRouterHistory }: SuiteRouterHistoryDep) => {
     usePlaywright();
     useTor();
     useDebugLanguageShortcut();
     useConnectPopupWeb();
 
     return (
-        <Main routerServices={routerServices}>
+        <Main suiteRouterHistory={suiteRouterHistory}>
             <Metadata />
             <ToasterProvider />
             <Preloader>
@@ -53,22 +52,17 @@ export const init = async (container: HTMLElement) => {
         initSentry();
     }
 
-    const browserHistory = createBrowserHistory();
-
     // render simple loader with theme provider without redux, wait for indexedDB
     const root = createRoot(container);
     root.render(<LoadingScreen />);
 
     const preloadAction = await preloadStore();
-    const routerServices = createRouterServices(browserHistory);
-    const { store, services } = initStore(preloadAction, {
-        additionalExtraDeps: { routerServices },
-    });
+    const { store, services } = initStore({ history: createBrowserHistory() }, preloadAction);
 
     root.render(
         <SuiteServicesProvider services={services}>
             <ReduxProvider store={store}>
-                <MainWeb routerServices={routerServices} />
+                <MainWeb suiteRouterHistory={services.suiteRouterHistory} />
             </ReduxProvider>
         </SuiteServicesProvider>,
     );

--- a/packages/suite-web/tsconfig.json
+++ b/packages/suite-web/tsconfig.json
@@ -6,9 +6,6 @@
     },
     "include": ["."],
     "references": [
-        {
-            "path": "../../suite-common/redux-utils"
-        },
         { "path": "../../suite-common/sentry" },
         {
             "path": "../../suite-common/suite-types"

--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -40,7 +40,7 @@ import routerReducer from 'src/reducers/suite/routerReducer';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
 import windowReducer from 'src/reducers/suite/windowReducer';
 import walletReducers from 'src/reducers/wallet';
-import { createRouterServices, extraDependencies } from 'src/support/extraDependencies';
+import { createSuiteRouterHistory, extraDependencies } from 'src/support/extraDependencies';
 import { configureStore } from 'src/support/tests/configureStore';
 import type { AppState } from 'src/types/suite';
 
@@ -263,11 +263,13 @@ type State = ReturnType<typeof getInitialState>;
 
 const initStore = (state: State) => {
     const memoryHistory = createMemoryHistory();
-    const routerServices = createRouterServices(memoryHistory);
+    const suiteRouterHistory = createSuiteRouterHistory({ history: memoryHistory });
     const mockStore = configureStore<State, any>(
         [prepareSuiteMiddleware(() => extraDependenciesMock)],
         {
-            routerServices,
+            services: {
+                suiteRouterHistory,
+            },
         },
     );
     const store = mockStore(state);
@@ -280,17 +282,17 @@ const initStore = (state: State) => {
 
     return {
         store,
-        routerServices,
+        suiteRouterHistory,
     };
 };
 
 describe('Suite init action', () => {
     fixtures.forEach(({ description, options, actions }) => {
         it(description, async () => {
-            const { store, routerServices } = initStore(getInitialState(options.initialRun));
+            const { store, suiteRouterHistory } = initStore(getInitialState(options.initialRun));
 
             if (options?.initialPath) {
-                routerServices.navigate({ pathname: options.initialPath as PathString });
+                suiteRouterHistory.navigate({ pathname: options.initialPath as PathString });
             }
 
             if (options?.trezorConnectError) {

--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -9,7 +9,6 @@ import {
     prepareMessageSystemReducer,
 } from '@suite-common/message-system';
 import { validJws } from '@suite-common/message-system/src/__fixtures__/messageSystemActions';
-import type { PathString } from '@suite-common/redux-utils';
 import { extraDependenciesMock } from '@suite-common/test-utils';
 import {
     initTokenDefinitionsThunk,
@@ -43,6 +42,7 @@ import walletReducers from 'src/reducers/wallet';
 import { createSuiteRouterHistory, extraDependencies } from 'src/support/extraDependencies';
 import { configureStore } from 'src/support/tests/configureStore';
 import type { AppState } from 'src/types/suite';
+import { PathString } from 'src/utils/suite/router';
 
 import { initialRedirection } from '../routerActions';
 import { appChanged } from '../suiteActions';

--- a/packages/suite/src/actions/suite/__tests__/routerActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/routerActions.test.ts
@@ -4,7 +4,7 @@ import { AppState } from 'src/reducers/store';
 import modalReducer from 'src/reducers/suite/modalReducer';
 import routerReducer from 'src/reducers/suite/routerReducer';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
-import { createRouterServices } from 'src/support/extraDependencies';
+import { createSuiteRouterHistory } from 'src/support/extraDependencies';
 import { configureStore } from 'src/support/tests/configureStore';
 
 import * as fixtures from '../__fixtures__/routerActions';
@@ -52,9 +52,9 @@ const getInitialState = (
 type State = ReturnType<typeof getInitialState>;
 
 const initStore = (state: State) => {
-    const routerServices = createRouterServices(createMemoryHistory());
+    const suiteRouterHistory = createSuiteRouterHistory({ history: createMemoryHistory() });
     const store = configureStore<State, any>([], {
-        routerServices,
+        services: { suiteRouterHistory },
     })(state);
     store.subscribe(() => {
         const action = store.getActions().pop();
@@ -65,15 +65,15 @@ const initStore = (state: State) => {
         store.getActions().push(action);
     });
 
-    return { store, routerServices };
+    return { store, suiteRouterHistory };
 };
 
 describe('Suite Actions', () => {
     fixtures.init.forEach(f => {
         it(`init: ${f.description}`, () => {
             const state = getInitialState(f.state as InitialState | undefined);
-            const { store, routerServices } = initStore(state);
-            routerServices.navigate(defaultLocation);
+            const { store, suiteRouterHistory } = initStore(state);
+            suiteRouterHistory.navigate(defaultLocation);
             store.dispatch(routerActions.init());
             if (f.result) {
                 expect(store.getState().router).toEqual(f.result);
@@ -94,9 +94,9 @@ describe('Suite Actions', () => {
     fixtures.initialRedirection.forEach(f => {
         it(`initialRedirection: ${f.description}`, () => {
             const state = getInitialState(f.state as InitialState);
-            const { store, routerServices } = initStore(state);
+            const { store, suiteRouterHistory } = initStore(state);
 
-            routerServices.navigate({
+            suiteRouterHistory.navigate({
                 ...defaultLocation,
                 pathname: f.pathname || '/',
             });
@@ -109,14 +109,15 @@ describe('Suite Actions', () => {
     fixtures.goto.forEach(f => {
         it(`goto: ${f.description}`, () => {
             const state = getInitialState(f.state as InitialState);
-            const { store, routerServices } = initStore(state);
-            routerServices.navigate({ ...defaultLocation, hash: `#${f.hash}` });
-            store.dispatch(routerActions.onLocationChange(routerServices.getLocation()));
+            const { store, suiteRouterHistory } = initStore(state);
+            suiteRouterHistory.navigate({ ...defaultLocation, hash: `#${f.hash}` });
+            store.dispatch(routerActions.onLocationChange(suiteRouterHistory.getLocation()));
 
             store.dispatch(routerActions.goto(f.url as any, { preserveParams: f.preserveHash }));
             if (f.result) {
                 expect(
-                    routerServices.getLocation().pathname + routerServices.getLocation().hash,
+                    suiteRouterHistory.getLocation().pathname +
+                        suiteRouterHistory.getLocation().hash,
                 ).toEqual(f.result);
             }
         });
@@ -135,8 +136,8 @@ describe('Suite Actions', () => {
     it('closeModalApp', () => {
         // @ts-expect-error this test is interested only in router.pathname, for better maintainability ignore other properties
         const state = getInitialState({ router: { pathname: '/firmware' } });
-        const { store, routerServices } = initStore(state);
-        routerServices.navigate({
+        const { store, suiteRouterHistory } = initStore(state);
+        suiteRouterHistory.navigate({
             ...defaultLocation,
             pathname: '/accounts/send',
         });

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -15,6 +15,7 @@ import { isArrayMember } from '@trezor/utils';
 import * as routerActions from 'src/actions/suite/routerActions';
 import { goto } from 'src/actions/suite/routerActions';
 import type { SendFormState } from 'src/reducers/suite/protocolReducer';
+import { asSuiteServices } from 'src/support/extraDependencies';
 import { Dispatch, GetState } from 'src/types/suite';
 import { parseUri } from 'src/utils/suite/parseUri';
 import { CoinProtocolInfo, getProtocolInfo } from 'src/utils/suite/protocol';
@@ -112,7 +113,7 @@ export const handleProtocolRequest =
                 const [, hash] = decodedPath.split('/coinmarket-redirect/');
                 if (hash) {
                     const path = { pathname: '/coinmarket-redirect', hash: `#${hash}` } as const;
-                    extra.routerServices.navigate(path);
+                    asSuiteServices(extra.services).suiteRouterHistory.navigate(path);
                     dispatch(routerActions.onLocationChange(path));
                 }
             }

--- a/packages/suite/src/actions/suite/routerActions.ts
+++ b/packages/suite/src/actions/suite/routerActions.ts
@@ -10,6 +10,7 @@ import * as suiteActions from 'src/actions/suite/suiteActions';
 import type { AnchorType } from 'src/constants/suite/anchors';
 import { RouterAppWithParams, SettingsBackRoute } from 'src/constants/suite/routes';
 import { selectIsRouterLocked, selectIsRouterOrUiLocked } from 'src/selectors/suite/suiteSelectors';
+import { asSuiteServices } from 'src/support/extraDependencies';
 import { Dispatch, GetState } from 'src/types/suite';
 import {
     RouteParams,
@@ -80,7 +81,7 @@ export const onAnchorChange = (anchor?: AnchorType) => (dispatch: Dispatch, _get
 export const init = () => (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
     // check if location was not already changed by initialRedirection
     if (getState().router.app === 'unknown') {
-        const location = extra.routerServices.getLocation();
+        const location = asSuiteServices(extra.services).suiteRouterHistory.getLocation();
         dispatch(onLocationChange(location));
     }
 };
@@ -131,13 +132,13 @@ export const goto =
             // where we want to have suite-start router clearing the URL to ensure
             // that there isn't a state stuck
             if (route.clearUrl) {
-                extra.routerServices.navigate({ pathname });
+                asSuiteServices(extra.services).suiteRouterHistory.navigate({ pathname });
             }
 
             return;
         }
 
-        extra.routerServices.navigate({ pathname, hash });
+        asSuiteServices(extra.services).suiteRouterHistory.navigate({ pathname, hash });
     };
 
 /**
@@ -150,7 +151,7 @@ export const closeModalApp =
     (dispatch: Dispatch, _: GetState, extra: ExtraDependencies) => {
         dispatch(suiteActions.lockRouter(false));
 
-        const location = extra.routerServices.getLocation();
+        const location = asSuiteServices(extra.services).suiteRouterHistory.getLocation();
         const route = findRoute(location.pathname);
 
         // if user enters route of modal app manually, back would redirect him again to the same route and he would remain stuck
@@ -160,7 +161,9 @@ export const closeModalApp =
         }
 
         if (!preserveParams && location.hash.length > 0) {
-            extra.routerServices.navigate({ pathname: location.pathname });
+            asSuiteServices(extra.services).suiteRouterHistory.navigate({
+                pathname: location.pathname,
+            });
         } else {
             // + history.location.hash is here to preserve params (e.g. nth account)
             dispatch(onLocationChange(location));
@@ -174,7 +177,7 @@ export const closeModalApp =
 export const initialRedirection = createThunk(
     '@suite/initial-redirection',
     (_, { dispatch, getState, extra }) => {
-        const location = extra.routerServices.getLocation();
+        const location = asSuiteServices(extra.services).suiteRouterHistory.getLocation();
         const route = findRoute(location.pathname);
 
         const { initialRun } = getState().suite.flags;

--- a/packages/suite/src/actions/wallet/addWalletThunk.ts
+++ b/packages/suite/src/actions/wallet/addWalletThunk.ts
@@ -1,6 +1,7 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { DEVICE_MODULE_PREFIX } from '@suite-common/wallet-core';
 
+import { asSuiteServices } from 'src/support/extraDependencies';
 import { findRoute } from 'src/utils/suite/router';
 
 import { goto } from '../suite/routerActions';
@@ -12,7 +13,7 @@ export const redirectAfterWalletSelectedThunk = createThunk<
 >(
     `${DEVICE_MODULE_PREFIX}/redirectAfterWalletSelectedThunk`,
     async (options, { dispatch, extra }) => {
-        const location = extra.routerServices.getLocation();
+        const location = asSuiteServices(extra.services).suiteRouterHistory.getLocation();
         const backgroundRoute = findRoute(location.pathname);
 
         // NOTE: the URL is being static when you switch device like /btc/4/norma

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -41,15 +41,12 @@ import suiteReducers from 'src/reducers/suite';
 import walletReducers from 'src/reducers/wallet';
 import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
 import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
+import { HistoryDep } from 'src/support/suite/suiteRouterHistory';
 
 import { prepareBioAuthReducer } from './bioAuth';
 import { desktopReducer } from './desktop';
 import { bluetoothSlice } from '../actions/bluetooth/desktopBluetoothReducer';
-import {
-    HistoryDep,
-    createSuiteCompositionRoot,
-    extraDependencies,
-} from '../support/extraDependencies';
+import { createSuiteCompositionRoot, extraDependencies } from '../support/extraDependencies';
 
 const firmwareReducer = prepareFirmwareReducer(extraDependencies);
 const tokenDefinitionsReducer = prepareTokenDefinitionsReducer(extraDependencies);
@@ -128,8 +125,10 @@ type RootReducerShape = typeof rootReducer;
 type PreloadedState = Partial<AppState>;
 type InferredAction = Parameters<RootReducerShape>[1];
 
+type SuiteStoreDeps = HistoryDep;
+
 export const initStore = (
-    deps: HistoryDep,
+    deps: SuiteStoreDeps,
     preloadStoreAction?: PreloadStoreAction,
     options: { statePatch?: Record<string, any> } = {},
 ) => {

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -46,7 +46,10 @@ import { HistoryDep } from 'src/support/suite/suiteRouterHistory';
 import { prepareBioAuthReducer } from './bioAuth';
 import { desktopReducer } from './desktop';
 import { bluetoothSlice } from '../actions/bluetooth/desktopBluetoothReducer';
-import { createSuiteCompositionRoot, extraDependencies } from '../support/extraDependencies';
+import {
+    createSuiteServicesCompositionRoot,
+    extraDependencies,
+} from '../support/extraDependencies';
 
 const firmwareReducer = prepareFirmwareReducer(extraDependencies);
 const tokenDefinitionsReducer = prepareTokenDefinitionsReducer(extraDependencies);
@@ -149,7 +152,7 @@ export const initStore = (
 
     const extraFactory = (api: MiddlewareAPI) => ({
         ...extraDependencies,
-        services: createSuiteCompositionRoot({
+        services: createSuiteServicesCompositionRoot({
             history: deps.history,
             getState: api.getState,
             dispatch: api.dispatch,

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -45,7 +45,11 @@ import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
 import { prepareBioAuthReducer } from './bioAuth';
 import { desktopReducer } from './desktop';
 import { bluetoothSlice } from '../actions/bluetooth/desktopBluetoothReducer';
-import { createSuiteCompositionRoot, extraDependencies } from '../support/extraDependencies';
+import {
+    HistoryDep,
+    createSuiteCompositionRoot,
+    extraDependencies,
+} from '../support/extraDependencies';
 
 const firmwareReducer = prepareFirmwareReducer(extraDependencies);
 const tokenDefinitionsReducer = prepareTokenDefinitionsReducer(extraDependencies);
@@ -124,9 +128,10 @@ type RootReducerShape = typeof rootReducer;
 type PreloadedState = Partial<AppState>;
 type InferredAction = Parameters<RootReducerShape>[1];
 
-export const initStore = <E extends Partial<ExtraDependencies>>(
+export const initStore = (
+    deps: HistoryDep,
     preloadStoreAction?: PreloadStoreAction,
-    options: { statePatch?: Record<string, any>; additionalExtraDeps?: E } = {},
+    options: { statePatch?: Record<string, any> } = {},
 ) => {
     // get initial state by calling STORAGE.LOAD action with optional payload
     // payload will be processed in each reducer explicitly
@@ -145,8 +150,11 @@ export const initStore = <E extends Partial<ExtraDependencies>>(
 
     const extraFactory = (api: MiddlewareAPI) => ({
         ...extraDependencies,
-        ...(options.additionalExtraDeps || {}),
-        services: createSuiteCompositionRoot(api),
+        services: createSuiteCompositionRoot({
+            history: deps.history,
+            getState: api.getState,
+            dispatch: api.dispatch,
+        }),
     });
 
     let extra: ReturnType<typeof extraFactory> | null = null as ReturnType<

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -1,6 +1,6 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 import { saveAs } from 'file-saver';
-import { type History, createMemoryHistory } from 'history';
+import { type History } from 'history';
 
 import {
     DesktopAnalyticsDep,
@@ -16,7 +16,15 @@ import {
 } from '@suite/suite-sync';
 import { delegatedIdentityKeyCompositionRoot } from '@suite-common/delegated-identity-key';
 import { FW_HASH_CHECK_DEFAULT_TIMEOUTS } from '@suite-common/firmware-authenticity';
-import { CommonServices, ExtraDependenciesStatic, RouterServices } from '@suite-common/redux-utils';
+import {
+    CommonServices,
+    ExtraDependenciesStatic,
+    SuiteRouterHistory,
+} from '@suite-common/redux-utils';
+import {
+    SuiteRouterHistoryDep,
+    SuiteRouterHistoryDeps,
+} from '@suite-common/redux-utils/src/extraDependenciesType';
 import {
     TokenDefinitionsState,
     buildTokenDefinitionsFromStorage,
@@ -70,7 +78,9 @@ const connectInitSettings = {
     firmwareHashCheckTimeouts: FW_HASH_CHECK_DEFAULT_TIMEOUTS,
 };
 
-export const createRouterServices = (history: History): RouterServices => ({
+export const createSuiteRouterHistory = ({
+    history,
+}: SuiteRouterHistoryDeps): SuiteRouterHistory => ({
     getLocation: () => {
         const { location } = history;
 
@@ -87,15 +97,20 @@ export const createRouterServices = (history: History): RouterServices => ({
         ),
 });
 
+export type HistoryDep = {
+    history: History;
+};
+
 type SuiteAppDeps = {
     getState: () => any;
     dispatch: any;
-};
+} & HistoryDep;
 
 export type SuiteServices = CommonServices &
     DesktopAnalyticsDep &
     DesktopLegacyAnalyticsDep &
-    DisableLegacyMetadataIfNeededDep;
+    DisableLegacyMetadataIfNeededDep &
+    SuiteRouterHistoryDep;
 
 export const createSuiteCompositionRoot = (deps: SuiteAppDeps): SuiteServices => {
     const platformEncryption = isDesktop()
@@ -131,6 +146,9 @@ export const createSuiteCompositionRoot = (deps: SuiteAppDeps): SuiteServices =>
         legacyAnalytics,
         analytics: createAnalytics(),
         disableLegacyMetadataIfNeeded,
+        suiteRouterHistory: createSuiteRouterHistory({
+            history: deps.history,
+        }),
     };
 };
 
@@ -307,5 +325,10 @@ export const extraDependencies: ExtraDependenciesStatic = {
         connectInitSettings,
         reportSecurityCheck,
     },
-    routerServices: createRouterServices(createMemoryHistory()),
 };
+
+// NOTE: We need to typecast the common services in extra argument in thunks to this proper type
+// extra.services do contain all the needed services, but in order to make the typing work properly,
+// we'd need to define dispatch() for each platform separately
+export const asSuiteServices = (services: CommonServices): SuiteServices =>
+    services as SuiteServices;

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -1,6 +1,5 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 import { saveAs } from 'file-saver';
-import { type History } from 'history';
 
 import {
     DesktopAnalyticsDep,
@@ -16,15 +15,7 @@ import {
 } from '@suite/suite-sync';
 import { delegatedIdentityKeyCompositionRoot } from '@suite-common/delegated-identity-key';
 import { FW_HASH_CHECK_DEFAULT_TIMEOUTS } from '@suite-common/firmware-authenticity';
-import {
-    CommonServices,
-    ExtraDependenciesStatic,
-    SuiteRouterHistory,
-} from '@suite-common/redux-utils';
-import {
-    SuiteRouterHistoryDep,
-    SuiteRouterHistoryDeps,
-} from '@suite-common/redux-utils/src/extraDependenciesType';
+import { CommonServices, ExtraDependenciesStatic } from '@suite-common/redux-utils';
 import {
     TokenDefinitionsState,
     buildTokenDefinitionsFromStorage,
@@ -59,6 +50,12 @@ import { createDisableLegacyMetadataIfNeeded } from '../actions/suite/metadata/d
 import * as suiteActions from '../actions/suite/suiteActions';
 import type { BioAuthState } from '../reducers/bioAuth';
 import { AppState, TrezorDevice } from '../types/suite';
+import {
+    HistoryDep,
+    SuiteRouterHistory,
+    SuiteRouterHistoryDep,
+    SuiteRouterHistoryDeps,
+} from './suite/suiteRouterHistory';
 
 const connectSrc = '../';
 // 'https://localhost:8088/';
@@ -96,10 +93,6 @@ export const createSuiteRouterHistory = ({
             listener({ location: ensureRouterPath(location), action }),
         ),
 });
-
-export type HistoryDep = {
-    history: History;
-};
 
 type SuiteAppDeps = {
     getState: () => any;

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -105,7 +105,7 @@ export type SuiteServices = CommonServices &
     DisableLegacyMetadataIfNeededDep &
     SuiteRouterHistoryDep;
 
-export const createSuiteCompositionRoot = (deps: SuiteAppDeps): SuiteServices => {
+export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteServices => {
     const platformEncryption = isDesktop()
         ? createElectronPlatformEncryption({ desktopApi })
         : createWebauthnPlatformEncryption();

--- a/packages/suite/src/support/suite/Main.tsx
+++ b/packages/suite/src/support/suite/Main.tsx
@@ -1,7 +1,7 @@
 import { HelmetProvider } from 'react-helmet-async';
 
 import { FormatterProvider } from '@suite-common/formatters';
-import { RouterServices } from '@suite-common/redux-utils';
+import { SuiteRouterHistoryDep } from '@suite-common/redux-utils';
 import { SelectCacheProvider } from '@trezor/components';
 
 import { useFormattersConfig } from 'src/hooks/suite';
@@ -18,14 +18,13 @@ import { RouterHandler } from './RouterHandler';
 import { useConnectPopupModals } from './useConnectPopupModals';
 
 export const Main = ({
-    routerServices,
+    suiteRouterHistory,
     trafficLightOffset,
     children,
 }: {
-    routerServices: RouterServices;
     trafficLightOffset?: React.ReactNode;
     children: React.ReactNode;
-}) => {
+} & SuiteRouterHistoryDep) => {
     useConnectPopupModals();
     const formattersConfig = useFormattersConfig();
 
@@ -41,7 +40,7 @@ export const Main = ({
                         <Resize />
                         <Protocol />
                         <OnlineStatus />
-                        <RouterHandler routerServices={routerServices} />
+                        <RouterHandler suiteRouterHistory={suiteRouterHistory} />
                         <ConnectedIntlProvider>
                             <SelectCacheProvider>
                                 <FormatterProvider config={formattersConfig}>

--- a/packages/suite/src/support/suite/Main.tsx
+++ b/packages/suite/src/support/suite/Main.tsx
@@ -1,7 +1,6 @@
 import { HelmetProvider } from 'react-helmet-async';
 
 import { FormatterProvider } from '@suite-common/formatters';
-import { SuiteRouterHistoryDep } from '@suite-common/redux-utils';
 import { SelectCacheProvider } from '@trezor/components';
 
 import { useFormattersConfig } from 'src/hooks/suite';
@@ -18,13 +17,12 @@ import { RouterHandler } from './RouterHandler';
 import { useConnectPopupModals } from './useConnectPopupModals';
 
 export const Main = ({
-    suiteRouterHistory,
     trafficLightOffset,
     children,
 }: {
     trafficLightOffset?: React.ReactNode;
     children: React.ReactNode;
-} & SuiteRouterHistoryDep) => {
+}) => {
     useConnectPopupModals();
     const formattersConfig = useFormattersConfig();
 
@@ -40,7 +38,7 @@ export const Main = ({
                         <Resize />
                         <Protocol />
                         <OnlineStatus />
-                        <RouterHandler suiteRouterHistory={suiteRouterHistory} />
+                        <RouterHandler />
                         <ConnectedIntlProvider>
                             <SelectCacheProvider>
                                 <FormatterProvider config={formattersConfig}>

--- a/packages/suite/src/support/suite/RouterHandler.tsx
+++ b/packages/suite/src/support/suite/RouterHandler.tsx
@@ -2,19 +2,19 @@ import { useEffect } from 'react';
 
 import { Action } from 'history';
 
-import type { RouterServices } from '@suite-common/redux-utils';
+import type { SuiteRouterHistoryDep } from '@suite-common/redux-utils';
 
 import { onBeforePopState, onLocationChange } from 'src/actions/suite/routerActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-export const RouterHandler = ({ routerServices }: { routerServices: RouterServices }) => {
+export const RouterHandler = ({ suiteRouterHistory }: SuiteRouterHistoryDep) => {
     const dispatch = useDispatch();
     const routerLoaded = useSelector(state => state.router.loaded);
 
     useEffect(() => {
         const emitLocation = () => {
             if (routerLoaded) {
-                const location = routerServices.getLocation();
+                const location = suiteRouterHistory.getLocation();
                 dispatch(onLocationChange(location));
             }
         };
@@ -22,7 +22,7 @@ export const RouterHandler = ({ routerServices }: { routerServices: RouterServic
         // initial sync
         emitLocation();
 
-        const unlisten = routerServices.listen(update => {
+        const unlisten = suiteRouterHistory.listen(update => {
             // If back navigation is blocked, re-go forward by 1 to cancel it
             if (update.action === Action.Pop) {
                 const canGoBack = dispatch(onBeforePopState());
@@ -36,7 +36,7 @@ export const RouterHandler = ({ routerServices }: { routerServices: RouterServic
         });
 
         return unlisten;
-    }, [dispatch, routerLoaded, routerServices]);
+    }, [dispatch, routerLoaded, suiteRouterHistory]);
 
     return null;
 };

--- a/packages/suite/src/support/suite/RouterHandler.tsx
+++ b/packages/suite/src/support/suite/RouterHandler.tsx
@@ -2,14 +2,15 @@ import { useEffect } from 'react';
 
 import { Action } from 'history';
 
-import type { SuiteRouterHistoryDep } from '@suite-common/redux-utils';
-
 import { onBeforePopState, onLocationChange } from 'src/actions/suite/routerActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-export const RouterHandler = ({ suiteRouterHistory }: SuiteRouterHistoryDep) => {
+import { useSuiteServices } from '../SuiteServicesProvider';
+
+export const RouterHandler = () => {
     const dispatch = useDispatch();
     const routerLoaded = useSelector(state => state.router.loaded);
+    const { suiteRouterHistory } = useSuiteServices();
 
     useEffect(() => {
         const emitLocation = () => {

--- a/packages/suite/src/support/suite/suiteRouterHistory.ts
+++ b/packages/suite/src/support/suite/suiteRouterHistory.ts
@@ -1,0 +1,27 @@
+import { type History } from 'history';
+
+import type { RouterPath } from 'src/utils/suite/router';
+
+export type LocationPushState = Record<string, unknown>;
+
+// This is a Listener from history package
+type Listener = (_: { location: RouterPath; action: 'PUSH' | 'POP' | 'REPLACE' }) => void;
+
+export type SuiteRouterHistory = {
+    getLocation: () => RouterPath;
+    navigate: (to: Partial<RouterPath>, state?: LocationPushState) => void;
+    // calling .listen(listener) returns a cleanup function
+    listen: (listener: Listener) => () => void;
+};
+
+export type SuiteRouterHistoryDep = {
+    suiteRouterHistory: SuiteRouterHistory;
+};
+
+export type SuiteRouterHistoryDeps = {
+    history: History;
+};
+
+export type HistoryDep = {
+    history: History;
+};

--- a/packages/suite/src/support/tests/configureStore.tsx
+++ b/packages/suite/src/support/tests/configureStore.tsx
@@ -4,9 +4,9 @@ import reduxMockStore, { MockStoreCreator } from 'redux-mock-store';
 import { withExtraArgument } from 'redux-thunk';
 
 import type { ExtraDependencies } from '@suite-common/redux-utils';
-import { extraDependenciesMock } from '@suite-common/test-utils';
 
-import { extraDependencies } from '../extraDependencies';
+import { SuiteServices, extraDependencies } from '../extraDependencies';
+import { extraDependenciesDesktopMock } from './extraDependenciesDesktop.mock';
 
 interface MiddlewareAPI<D extends Dispatch = Dispatch<AnyAction>, S = any> {
     dispatch: D;
@@ -22,11 +22,12 @@ interface Middleware<_DispatchExt = {}, S = any, D extends Dispatch = Dispatch<a
  */
 export const configureStore = <S, DispatchExts = {}>(
     middlewares?: Middleware[],
-    additionalExtraDeps?: Partial<ExtraDependencies>,
+    additionalExtraDeps?: Partial<Omit<ExtraDependencies, 'services'>> &
+        Partial<{ services: Partial<SuiteServices> }>,
 ): MockStoreCreator<S, DispatchExts> =>
     reduxMockStore([
         withExtraArgument({
-            ...extraDependenciesMock,
+            ...extraDependenciesDesktopMock,
             ...extraDependencies,
             ...additionalExtraDeps,
         }),

--- a/packages/suite/src/support/tests/extraDependenciesDesktop.mock.ts
+++ b/packages/suite/src/support/tests/extraDependenciesDesktop.mock.ts
@@ -9,6 +9,16 @@ export const extraDependenciesDesktopMock: ExtraDependenciesSuiteMock = {
     ...extraDependenciesMock,
     services: {
         ...extraDependenciesMock.services,
+        suiteRouterHistory: {
+            getLocation: () => ({
+                pathname: '/mocked_path',
+                hash: '#mocked_hash',
+                search: '?mocked_search',
+            }),
+            navigate: (to, state) => console.warn(`Mock navigating to ${to} with state`, state),
+            listen: (_: {}) => () => {},
+        },
+
         disableLegacyMetadataIfNeeded: () => {},
     },
 };

--- a/packages/suite/src/utils/suite/router.ts
+++ b/packages/suite/src/utils/suite/router.ts
@@ -1,4 +1,3 @@
-import { HashString, PathString, RouterPath, SearchString } from '@suite-common/redux-utils';
 import { modalAppParams } from '@suite-common/suite-config';
 import { Route } from '@suite-common/suite-types';
 import { yup } from '@suite-common/validators';
@@ -10,7 +9,17 @@ import {
 
 import routes, { type RouterAppWithParams } from 'src/constants/suite/routes';
 
-export type { RouterPath } from '@suite-common/redux-utils';
+export type PathString = `/${string}`; // in format `/alpha/beta/gamma`
+export type SearchString = '' | `?${string}`; // in format `?alpha=beta&gamma=delta`
+export type HashString = '' | `#${string}`; // in format `#/alpha/beta/gamma`
+
+// NOTE: this is basically a bit stricter Path from history package (file://./../../../node_modules/history/index.d.ts),
+// but it is satisfied by window.location as well
+export type RouterPath = {
+    pathname: PathString;
+    search: SearchString;
+    hash: HashString;
+};
 
 // Prefix a url with ASSET_PREFIX (eg. name of the branch in CI)
 // Useful with next.js Router.push() that accepts `as` prop as second arg

--- a/packages/type-utils/tsconfig.lib.json
+++ b/packages/type-utils/tsconfig.lib.json
@@ -3,5 +3,6 @@
     "compilerOptions": {
         "outDir": "lib"
     },
-    "include": ["./src"]
+    "include": ["./src"],
+    "references": []
 }

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -3,6 +3,7 @@ import {
     ActionCreatorWithPreparedPayload,
     ActionCreatorWithoutPayload,
 } from '@reduxjs/toolkit';
+import { type History } from 'history';
 
 import type {
     AnalyticsSharedEvents,
@@ -53,11 +54,19 @@ export type RouterPath = {
 // This is a Listener from history package
 type Listener = (_: { location: RouterPath; action: 'PUSH' | 'POP' | 'REPLACE' }) => void;
 
-export type RouterServices = {
+export type SuiteRouterHistory = {
     getLocation: () => RouterPath;
     navigate: (to: Partial<RouterPath>, state?: LocationPushState) => void;
     // calling .listen(listener) returns a cleanup function
     listen: (listener: Listener) => () => void;
+};
+
+export type SuiteRouterHistoryDep = {
+    suiteRouterHistory: SuiteRouterHistory;
+};
+
+export type SuiteRouterHistoryDeps = {
+    history: History;
 };
 
 export type LocationPushState = Record<string, unknown>;
@@ -143,7 +152,6 @@ export type ExtraDependenciesStatic = {
         connectInitSettings: ConnectInitSettings;
         reportSecurityCheck: (props: ReportSecurityCheckProps) => void;
     };
-    routerServices: RouterServices;
 };
 
 export type ExtraDependencies = ExtraDependenciesStatic & { services: CommonServices };

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -3,7 +3,6 @@ import {
     ActionCreatorWithPreparedPayload,
     ActionCreatorWithoutPayload,
 } from '@reduxjs/toolkit';
-import { type History } from 'history';
 
 import type {
     AnalyticsSharedEvents,
@@ -38,38 +37,6 @@ type StorageLoadTransactionsReducer = (state: any, action: { type: any; payload:
 type ConnectInitSettings = {
     manifest: Manifest;
 } & Partial<ConnectSettings>;
-
-export type PathString = `/${string}`; // in format `/alpha/beta/gamma`
-export type SearchString = '' | `?${string}`; // in format `?alpha=beta&gamma=delta`
-export type HashString = '' | `#${string}`; // in format `#/alpha/beta/gamma`
-
-// NOTE: this is basically a bit stricter Path from history package (file://./../../../node_modules/history/index.d.ts),
-// but it is satisfied by window.location as well
-export type RouterPath = {
-    pathname: PathString;
-    search: SearchString;
-    hash: HashString;
-};
-
-// This is a Listener from history package
-type Listener = (_: { location: RouterPath; action: 'PUSH' | 'POP' | 'REPLACE' }) => void;
-
-export type SuiteRouterHistory = {
-    getLocation: () => RouterPath;
-    navigate: (to: Partial<RouterPath>, state?: LocationPushState) => void;
-    // calling .listen(listener) returns a cleanup function
-    listen: (listener: Listener) => () => void;
-};
-
-export type SuiteRouterHistoryDep = {
-    suiteRouterHistory: SuiteRouterHistory;
-};
-
-export type SuiteRouterHistoryDeps = {
-    history: History;
-};
-
-export type LocationPushState = Record<string, unknown>;
 
 export type CommonServices = SuiteSyncDep &
     PlatformEncryptionDep & {

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -200,13 +200,4 @@ export const extraDependenciesMock = {
         reportSecurityCheck: ({ level, checkType }: ReportSecurityCheckProps) =>
             console.warn(`Mock reporting ${checkType} check ${level} to Sentry.`),
     },
-    routerServices: {
-        getLocation: () => ({
-            pathname: '/mocked_path',
-            hash: '#mocked_hash',
-            search: '?mocked_search',
-        }),
-        navigate: (to, state) => console.warn(`Mock navigating to ${to} with state`, state),
-        listen: (_: {}) => () => {},
-    },
 } satisfies ExtraDependencies;

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -8,12 +8,7 @@ import { ExtraDependencies, ExtraDependenciesStatic } from '@suite-common/redux-
 import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
 import { extraDependenciesMock } from '@suite-common/test-utils/src/extraDependenciesMock'; // precise import path to avoid circular dependencies
 import { selectSelectedDevice } from '@suite-common/wallet-core';
-import {
-    type NativeAnalyticsDep,
-    type NativeLegacyAnalyticsDep,
-    createAnalytics,
-    createLegacyAnalytics,
-} from '@suite-native/analytics';
+import { createAnalytics, createLegacyAnalytics } from '@suite-native/analytics';
 import { forgetBluetoothDeviceThunk } from '@suite-native/bluetooth';
 import { selectTokenDefinitionsEnabledNetworks } from '@suite-native/discovery';
 import { reportSecurityCheck } from '@suite-native/sentry';
@@ -48,9 +43,7 @@ type NativeAppDeps = {
 } & EnsureEncryptionKeyDep &
     MMKVStorageDep;
 
-export const createNativeCompositionRoot = (
-    deps: NativeAppDeps,
-): NativeServices & NativeAnalyticsDep & NativeLegacyAnalyticsDep => {
+export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices => {
     const platformEncryption = createNativePlatformEncryption({
         ensureEncryptionKey: deps.ensureEncryptionKey,
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -14878,7 +14878,6 @@ __metadata:
   resolution: "@trezor/suite-desktop-ui@workspace:packages/suite-desktop-ui"
   dependencies:
     "@sentry/electron": "npm:^7.5.0"
-    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite/analytics": "workspace:*"
@@ -14979,7 +14978,6 @@ __metadata:
   resolution: "@trezor/suite-web@workspace:packages/suite-web"
   dependencies:
     "@sentry/browser": "npm:10.32.1"
-    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@trezor/connect": "workspace:*"


### PR DESCRIPTION
…story

## Description

Moves the `routerServices` to `services` key in `extra`. And renames it to the more correct `suiteRouterHistory`


## Notes for QA

The app itself should run without any issues (e2e tests should be enough). Changing routes should be okay, redirects should be okay.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=router-services-service&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=router-services-service&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=router-services-service&lookback=7)