### PR TITLE
fix(blockchain-link): deduplicate transaction history by Electrum worker

### DIFF
--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
@@ -9,7 +9,6 @@ import { discovery } from '@trezor/utxo-lib';
 
 import { AddressHistory, Api, discoverAddress, getTransactions, tryGetScripthash } from '../utils';
 
-// const PAGE_DEFAULT = 0;
 const PAGE_SIZE_DEFAULT = 25;
 
 type AddressInfo = Omit<AddressHistory, 'scripthash'> & {
@@ -108,7 +107,9 @@ const getAccountInfo: Api<Req, Res> = async ({ client, addressCache }, payload) 
         ([c, u], { confirmed, unconfirmed }) => [c + confirmed, u + unconfirmed],
         [0, 0],
     );
-    const history = batch.flatMap(({ history }) => history);
+    const history = [
+        ...new Map(batch.flatMap(({ history }) => history).map(tx => [tx.tx_hash, tx])).values(),
+    ];
     const historyUnconfirmed = history.filter(r => r.height <= 0).length;
 
     const transformAddressInfo = ({ address, path, history, confirmed }: AddressInfo): Address => ({


### PR DESCRIPTION
`ElectrumWorker` fixed to return correct number of total account transactions.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/blockchain-link/electrum-account-info&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/blockchain-link/electrum-account-info&lookback=7)