### PR TITLE
feat(connect): add lockDevice method

### DIFF
--- a/packages/connect-explorer/src/pages/methods/device/lockDevice.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/lockDevice.mdx
@@ -1,0 +1,54 @@
+import { Callout } from 'nextra/components';
+
+import { PROTO } from '@trezor/connect/src/constants';
+
+import { ApiPlayground } from '../../../components/ApiPlayground';
+import { CommonParamsLink } from '../../../components/CommonParamsLink';
+import { ParamsTable } from '../../../components/ParamsTable';
+
+<ApiPlayground
+    options={[{ title: 'Advanced schema', method: 'lockDevice', schema: PROTO.LockDevice }]}
+/>
+
+export const paramDescriptions = {};
+
+## Lock device
+
+<Callout type="error">
+    **Management command** - this method is restricted to Trezor.io and can't be used in 3rd party
+    applications.
+</Callout>
+
+Lock the device (remove the ability execute any other calls) until device is unlocked. Prerequisite for this feature is that PIN must be set.
+
+```javascript
+const result = await TrezorConnect.lockDevice(params);
+```
+
+### Params
+
+<CommonParamsLink />
+
+No other parameters.
+
+### Result
+
+```javascript
+{
+    success: true,
+    payload: {
+        message: 'Success',
+    }
+}
+```
+
+Error
+
+```javascript
+{
+    success: false,
+    payload: {
+        error: string, // error message
+    }
+}
+```

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -46,6 +46,7 @@ export { default as recoveryDevice } from './recoveryDevice';
 export { default as requestLogin } from './requestLogin';
 export { default as resetDevice } from './resetDevice';
 export { default as loadDevice } from './loadDevice';
+export { default as lockDevice } from './lockDevice';
 export { default as setBrightness } from './setBrightness';
 export { default as setBusy } from './setBusy';
 export { default as signMessage } from './signMessage';

--- a/packages/connect/src/api/lockDevice.ts
+++ b/packages/connect/src/api/lockDevice.ts
@@ -1,0 +1,28 @@
+import { MessagesSchema as PROTO } from '@trezor/protobuf';
+import { Assert } from '@trezor/schema-utils';
+
+import { AbstractMethod } from '../core/AbstractMethod';
+import { getFirmwareRange } from './common/paramsValidator';
+
+export default class LockDevice extends AbstractMethod<'lockDevice', PROTO.LockDevice> {
+    init() {
+        this.useDeviceState = false;
+        this.requiredPermissions = ['management'];
+        this.skipFinalReload = true;
+
+        const { payload } = this;
+
+        Assert(PROTO.LockDevice, payload);
+
+        this.firmwareRange = getFirmwareRange(this.name, undefined, this.firmwareRange);
+
+        this.params = {};
+    }
+
+    async run() {
+        const cmd = this.device.getCommands();
+        const { message } = await cmd.typedCall('LockDevice', 'Success', this.params);
+
+        return message;
+    }
+}

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -72,6 +72,7 @@ export const connectCallableMethods = [
     'getPublicKey',
     'getSettings',
     'loadDevice',
+    'lockDevice',
     'moneroGetAddress',
     'moneroGetWatchKey',
     'moneroKeyImageSync',

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -57,6 +57,7 @@ import { getPublicKey } from './getPublicKey';
 import { getSettings } from './getSettings';
 import { init } from './init';
 import { loadDevice } from './loadDevice';
+import { lockDevice } from './lockDevice';
 import { moneroGetAddress } from './moneroGetAddress';
 import { moneroGetWatchKey } from './moneroGetWatchKey';
 import { moneroKeyImageSync } from './moneroKeyImageSync';
@@ -321,6 +322,9 @@ export interface TrezorConnect {
 
     // https://connect.trezor.io/9/methods/device/setBusy/
     setBusy: typeof setBusy;
+
+    // https://connect.trezor.io/9/methods/device/lockDevice/
+    lockDevice: typeof lockDevice;
 
     // https://connect.trezor.io/9/methods/bitcoin/signMessage/
     signMessage: typeof signMessage;

--- a/packages/connect/src/types/api/lockDevice.ts
+++ b/packages/connect/src/types/api/lockDevice.ts
@@ -1,0 +1,5 @@
+import { MessagesSchema as PROTO } from '@trezor/protobuf';
+
+import type { Params, Response } from '../params';
+
+export declare function lockDevice(params: Params<PROTO.LockDevice>): Response<PROTO.Success>;


### PR DESCRIPTION
Inspired by @juriczech who asked how to lock device. To my suprise  we did not have this implemented in connect. 


Product thoughts:
- maybe we should sometimes actively lock device (instead of waiting for autolock)
- maybe when desktop goes to sleep? 
- maybe when bioauth lock is triggered?


https://dev.suite.sldev.cz/connect/connect-lock-device-method/methods/device/lockDevice/


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-lock-device-method&lookback=7)