### PR TITLE
fix(connect): version check false positives

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -881,16 +881,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         const version = this.getVersion();
         const newVersion = getFirmwareOrBootloaderVersionArray(feat);
+        this.deviceVersionCheck(feat);
 
         // check if FW version or capabilities did change
         if (!version || !versionUtils.isEqual(version, newVersion)) {
-            if (version) {
-                this.emit(DEVICE.FIRMWARE_VERSION_CHANGED, {
-                    oldVersion: version,
-                    newVersion,
-                    device: this.toMessageObject(),
-                });
-            }
             this._unavailableCapabilities = getUnavailableCapabilities(feat, getAllNetworks());
             this._firmwareStatus = getFirmwareStatus(feat, getFirmwareType(feat));
             this._firmwareReleaseConfigInfo = getFirmwareReleaseConfigInfo(
@@ -927,6 +921,34 @@ export class Device extends TypedEmitter<DeviceEvents> {
             if (deviceUnitColor in deviceInfo.colors) {
                 this.color = (deviceInfo.colors as Record<string, string>)[deviceUnitColor];
             }
+        }
+    }
+
+    // Ensure that FW version is invariable except for firmware update
+    private deviceVersionCheck(feat: Features) {
+        const version = this.getVersion();
+        const oldId = this.features?.device_id;
+        // unacquired, bootloader, or nothing otherwise nothing compare
+        if (!oldId || !!feat.bootloader_mode || !version) return;
+
+        const newVersion = getFirmwareOrBootloaderVersionArray(feat); // guaranteed to be FW mode here
+        // This should never happen, it's indicative of a transport-level bug, so log to Sentry via console.error
+        if (feat.device_id !== oldId) {
+            // transport descriptors are useful debug info, but no need to await, the side-effect to log to Sentry can run async
+            this.transport.enumerate().then(res => {
+                const descriptors = res.success ? res.payload : undefined;
+                const oldDevice = this.toMessageObject();
+                console.error('getFeatures response mismatched', oldDevice, feat, descriptors);
+            });
+
+            return;
+        }
+        if (!versionUtils.isEqual(version, newVersion)) {
+            this.emit(DEVICE.FIRMWARE_VERSION_CHANGED, {
+                oldVersion: version,
+                newVersion,
+                device: this.toMessageObject(),
+            });
         }
     }
 


### PR DESCRIPTION
## Description

Attempt to fix and debug false positives in version check, caused by mismatch in responses from transport.

A new Sentry event should shed some more light as to why that happens (even though it's rare, it's high severity Connect bug).


## Notes for QA

N/A, there is no UI for this.

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/185

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/version-check-false-positives&lookback=7)