### PR TITLE
test(e2e-suite): add analytics events 'staking/navigate' & 'dashboard/promo-banner'

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
@@ -96,9 +96,10 @@ export const MainContent = ({ children }: MainContentProps) => {
 
 interface SuiteLayoutProps {
     children: ReactNode;
+    ['data-testid']?: string;
 }
 
-export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
+export const SuiteLayout = ({ children, 'data-testid': dataTest }: SuiteLayoutProps) => {
     const theme = useTheme();
     const [{ title, layoutHeader }, setLayoutPayload] = useState<LayoutContextPayload>({});
 
@@ -138,7 +139,15 @@ export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
                                                 <ElevationUp>
                                                     {layoutHeader}
 
-                                                    <ContentContainer>{children}</ContentContainer>
+                                                    <ContentContainer
+                                                        data-testid={
+                                                            dataTest
+                                                                ? `${dataTest}/content`
+                                                                : '@app/content'
+                                                        }
+                                                    >
+                                                        {children}
+                                                    </ContentContainer>
                                                 </ElevationUp>
                                             </AppWrapper>
                                         </MainContent>

--- a/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
@@ -211,6 +211,7 @@ export const AssetCard = ({
                                 {isStakeNetwork && (
                                     <TradingButton
                                         symbol={symbol}
+                                        data-testid={`@dashboard/asset/${symbol}/stake-button`}
                                         onClick={onStakeButtonClick}
                                         routeName="wallet-staking"
                                     >

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
@@ -91,6 +91,7 @@ export const DashboardPromoBanner = () => {
                 onClose={() => onCloseBanner(visibleBanner)}
                 onCTAClick={() => onCTAClick(visibleBanner)}
                 isVisible={isVisible}
+                data-testid="@dashboard/promo-banner"
             />
         );
 

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/TS7Banner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/TS7Banner.tsx
@@ -13,6 +13,7 @@ type TS7BannerProps = {
     onClose: () => void;
     onCTAClick: () => void;
     isVisible: boolean;
+    ['data-testid']?: string;
 };
 
 export const ImageContainer = styled.div`
@@ -54,6 +55,7 @@ const CTAButton = ({ onClick, isBelowLaptop }: { onClick: () => void; isBelowLap
             onClick={onClick}
             size={isBelowLaptop ? 'medium' : 'large'}
             href={href}
+            data-testid="@dashboard/promo-banner/ts7/button"
         >
             <Translation id="TR_PROMO_BANNER_DASHBOARD_TS7_BUTTON" />
         </Button>

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/TrezorExpertBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/TrezorExpertBanner.tsx
@@ -77,7 +77,12 @@ const CTAButton = ({ onClick }: { onClick: () => void }) => {
     const href = useExternalLink(DASHBOARD_BANNER_TEX_URL);
 
     return (
-        <Button intent="brand" onClick={onClick} href={href}>
+        <Button
+            intent="brand"
+            onClick={onClick}
+            href={href}
+            data-testid="@dashboard/promo-banner/tex/button"
+        >
             <Translation id="TR_PROMO_BANNER_DASHBOARD_TEX_BUTTON" />
         </Button>
     );
@@ -87,6 +92,7 @@ type TrezorExpertBannerProps = {
     onClose: () => void;
     onCTAClick: () => void;
     isVisible: boolean;
+    ['data-testid']?: string;
 };
 
 export const TrezorExpertBanner = ({ onClose, onCTAClick, isVisible }: TrezorExpertBannerProps) => {
@@ -98,6 +104,7 @@ export const TrezorExpertBanner = ({ onClose, onCTAClick, isVisible }: TrezorExp
                 height={213}
                 padding={{ horizontal: 24 }}
                 backgroundColor="baseFillSurfaceBrandDark"
+                data-testid="@dashboard/promo-banner/trezor-expert"
             >
                 <Row
                     height="100%"

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemDebug.tsx
@@ -32,7 +32,12 @@ export const MessageSystemDebug = () => {
                 </Box>
                 <ButtonGroup size="small">
                     <Button onClick={handleCopyConfig}>Copy full config</Button>
-                    <Button onClick={() => toggleOpenMessageManager(true)}>Message Manager</Button>
+                    <Button
+                        onClick={() => toggleOpenMessageManager(true)}
+                        data-testid="@settings/debug/message-system/message-manager-button"
+                    >
+                        Message Manager
+                    </Button>
                     <Button onClick={() => toggleOpenExperiments(true)}>Experiments</Button>
                 </ButtonGroup>
             </Row>

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/MessageSystemFormMessage.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/MessageSystemFormMessage.tsx
@@ -104,7 +104,14 @@ export const MessageSystemFormMessage = () => {
     };
 
     if (!showForm) {
-        return <Modal.Button onClick={() => setShowForm(true)}>Add new message</Modal.Button>;
+        return (
+            <Modal.Button
+                onClick={() => setShowForm(true)}
+                data-testid="@settings/debug/message-system/add-new-message-button"
+            >
+                Add new message
+            </Modal.Button>
+        );
     }
 
     return (
@@ -127,7 +134,11 @@ export const MessageSystemFormMessage = () => {
             />
 
             <Row isReversed gap={spacings.xs}>
-                <Modal.Button isDisabled={!isValid} onClick={handleAddMessage}>
+                <Modal.Button
+                    isDisabled={!isValid}
+                    onClick={handleAddMessage}
+                    data-testid="@settings/debug/message-system/json-editor-add-message-button"
+                >
                     Add message
                 </Modal.Button>
                 <Modal.Button

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/MessageSystemJsonEditor.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/MessageSystemJsonEditor.tsx
@@ -17,6 +17,7 @@ type MessageSystemJsonEditorProps = {
     errors: ValidateError[];
     onChange: (next: string) => void;
     onFormat: () => void;
+    ['data-testid']?: string;
 };
 
 export const MessageSystemJsonEditor = ({
@@ -32,6 +33,7 @@ export const MessageSystemJsonEditor = ({
     return (
         <Row gap={spacings.md} alignItems="flex-start">
             <Textarea
+                data-testid="@settings/debug/message-system/json-editor-textarea"
                 innerRef={textareaRef}
                 label="Message config"
                 rows={10}

--- a/suite/e2e/fixtures/promoBannerFixture.ts
+++ b/suite/e2e/fixtures/promoBannerFixture.ts
@@ -1,0 +1,35 @@
+import { PromoBannerType } from '../support/pageObjects/dashboardPage';
+
+export function getPromoBannerJsonContent(messageId: string, bannerType: PromoBannerType): string {
+    const languages = ['en', 'es', 'cs', 'de', 'fr', 'it', 'pt', 'tr', 'ru', 'ja', 'uk', 'hu'];
+
+    const content = {
+        conditions: [
+            {
+                environment: {
+                    desktop: '>=25.10.2',
+                    mobile: '!',
+                    web: '*',
+                },
+            },
+        ],
+        message: {
+            id: messageId,
+            priority: 2,
+            dismissible: true,
+            variant: 'info',
+            category: 'feature',
+            // Dynamically create the language object
+            content: Object.fromEntries(languages.map(lang => [lang, 'Placeholder'])),
+            feature: [
+                {
+                    domain: 'dashboard.promoBanner',
+                    visibleBanner: bannerType,
+                    flag: true,
+                },
+            ],
+        },
+    };
+
+    return JSON.stringify(content, null, 2);
+}

--- a/suite/e2e/support/pageObjects/analyticsSection.ts
+++ b/suite/e2e/support/pageObjects/analyticsSection.ts
@@ -7,10 +7,24 @@ export class AnalyticsSection {
     readonly continueButton: Locator;
     readonly toggleSwitch: Locator;
 
-    constructor(page: Page) {
+    constructor(private readonly page: Page) {
         this.continueButton = page.getByTestId('@analytics/continue-button');
         this.heading = page.getByTestId('@analytics/consent/heading');
         this.toggleSwitch = page.getByTestId('@analytics/toggle-switch');
+    }
+
+    @step()
+    async waitForAnalytics(params: Record<string, string>) {
+        const request = await this.page.waitForRequest(req => {
+            const url = new URL(req.url());
+            if (url.hostname !== 'data.trezor.io') return false;
+
+            return Object.entries(params).every(
+                ([key, value]) => url.searchParams.get(key) === value,
+            );
+        });
+
+        return Object.fromEntries(new URL(request.url()).searchParams);
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/dashboardPage.ts
+++ b/suite/e2e/support/pageObjects/dashboardPage.ts
@@ -6,6 +6,7 @@ import { TrezorUserEnvLinkProxy, step } from '../common';
 import { DevicePrompt } from './devicePrompt';
 
 export type graphRangeOptions = 'day' | 'week' | 'month' | 'year' | 'all';
+export type PromoBannerType = 'tex' | 'ts7';
 
 export class DashboardPage {
     readonly suiteLayout: Locator;
@@ -43,10 +44,14 @@ export class DashboardPage {
     readonly openUnusedWalletButton2: Locator;
     readonly buyButton = (networkSymbol: NetworkSymbol): Locator =>
         this.page.getByTestId(`@dashboard/asset/${networkSymbol}/buy-button`);
+    readonly stakeButton = (networkSymbol: NetworkSymbol): Locator =>
+        this.page.getByTestId(`@dashboard/asset/${networkSymbol}/stake-button`);
     readonly walletReady: Locator;
     readonly discoveryEmptyHeader: Locator;
     readonly discoveryEmptyDesc: Locator;
     readonly discoveryEmptyPrimaryButton: Locator;
+    readonly promoBannerButton = (bannerTyp: PromoBannerType): Locator =>
+        this.page.getByTestId(`@dashboard/promo-banner/${bannerTyp}/button`);
 
     constructor(
         private readonly page: Page,

--- a/suite/e2e/support/pageObjects/settings/debugTab.ts
+++ b/suite/e2e/support/pageObjects/settings/debugTab.ts
@@ -1,13 +1,54 @@
-import { Locator, Page } from '@playwright/test';
+import { Locator, Page, expect } from '@playwright/test';
+
+import { getPromoBannerJsonContent } from '../../../fixtures/promoBannerFixture';
+import { step } from '../../common';
+import { PromoBannerType } from '../dashboardPage';
 
 export class DebugTab {
     readonly suiteSyncCheckbox: Locator;
     readonly suiteSyncUrlInput: Locator;
     readonly suiteSyncUrlSaveButton: Locator;
+    readonly modal: Locator;
+    readonly modalCloseButton: Locator;
+    readonly messageManagerButton: Locator;
+    readonly addNewMessageButton: Locator;
+    readonly jsonEditor: Locator;
+    readonly addMessageButton: Locator;
 
-    constructor(readonly page: Page) {
+    constructor(private readonly page: Page) {
         this.suiteSyncCheckbox = page.getByTestId('@settings/debug/suite-sync/checkbox');
         this.suiteSyncUrlInput = page.getByTestId('@settings/debug/suite-sync/relay-url-input');
         this.suiteSyncUrlSaveButton = page.getByTestId('@settings/debug/suite-sync/save-button');
+        this.modal = page.getByTestId('@modal');
+        this.modalCloseButton = page.getByTestId('@modal/close-button');
+        this.messageManagerButton = page.getByTestId(
+            '@settings/debug/message-system/message-manager-button',
+        );
+        this.addNewMessageButton = page.getByTestId(
+            '@settings/debug/message-system/add-new-message-button',
+        );
+        this.jsonEditor = page.getByTestId('@settings/debug/message-system/json-editor-textarea');
+        this.addMessageButton = page.getByTestId(
+            '@settings/debug/message-system/json-editor-add-message-button',
+        );
+    }
+
+    @step()
+    async addBanner(bannerType: PromoBannerType) {
+        const messageId = crypto.randomUUID();
+        const jsonContent = getPromoBannerJsonContent(messageId, bannerType);
+
+        await this.messageManagerButton.click();
+        await this.addNewMessageButton.click();
+
+        await this.jsonEditor.focus();
+        await this.jsonEditor.fill(jsonContent);
+        await this.addMessageButton.click();
+
+        await expect(this.page.getByText(messageId, { exact: true })).toBeAttached();
+
+        await this.modalCloseButton.click();
+
+        await expect(this.modal).toBeHidden();
     }
 }

--- a/suite/e2e/tests/analytics/events-new.test.ts
+++ b/suite/e2e/tests/analytics/events-new.test.ts
@@ -1,0 +1,106 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { TestCategory, TestPriority, TestStream, createTestAnnotation } from '@trezor/e2e-utils';
+
+import { expect, test } from '../../support/fixtures';
+import { PromoBannerType } from '../../support/pageObjects/dashboardPage';
+
+test.describe('New Analytics Events', { tag: ['@T3T1'] }, () => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
+        await onboardingPage.completeOnboarding();
+        await settingsPage.changeNetworks({
+            enableNetworks: ['eth', 'ada'],
+        });
+    });
+
+    // --- Staking Navigation Events ---
+    const coins: NetworkSymbol[] = ['eth', 'ada'];
+    const STAKING_EVENT = 'staking/navigate';
+
+    for (const coin of coins) {
+        test(
+            `Should log the event ${STAKING_EVENT} - ${coin.toUpperCase()} from account menu`,
+            {
+                annotation: createTestAnnotation({
+                    testCase: `Verify that the ${STAKING_EVENT} event is logged for ${coin.toUpperCase()} when navigating from the account menu`,
+                    category: TestCategory.General,
+                    priority: TestPriority.Medium,
+                    stream: TestStream.Foundation,
+                }),
+            },
+            async ({ analyticsSection, walletPage }) => {
+                await walletPage.openAccount({ symbol: coin });
+
+                const [payload] = await Promise.all([
+                    analyticsSection.waitForAnalytics({
+                        c_type: STAKING_EVENT,
+                        networkSymbol: coin,
+                    }),
+                    walletPage.stakingButton.click(),
+                ]);
+
+                expect(payload).toMatchObject({ c_type: STAKING_EVENT, networkSymbol: coin });
+            },
+        );
+
+        test(
+            `Should log ${STAKING_EVENT} - ${coin.toUpperCase()} from dashboard assets`,
+            {
+                annotation: createTestAnnotation({
+                    testCase: `Verify that the ${STAKING_EVENT} event is logged for ${coin.toUpperCase()} when navigating from the dashboard`,
+                    category: TestCategory.General,
+                    priority: TestPriority.Medium,
+                    stream: TestStream.Foundation,
+                }),
+            },
+            async ({ analyticsSection, dashboardPage }) => {
+                await dashboardPage.navigateTo();
+
+                const [payload] = await Promise.all([
+                    analyticsSection.waitForAnalytics({
+                        c_type: STAKING_EVENT,
+                        networkSymbol: coin,
+                    }),
+                    dashboardPage.stakeButton(coin).click(),
+                ]);
+
+                expect(payload).toMatchObject({ c_type: STAKING_EVENT, networkSymbol: coin });
+            },
+        );
+    }
+
+    // --- Promo Banner Events ---
+    const bannerTypes: PromoBannerType[] = ['tex', 'ts7'];
+    const PROMO_EVENT = 'promo/dashboard-banner';
+
+    for (const bannerType of bannerTypes) {
+        test(
+            `Should log ${PROMO_EVENT} - ${bannerType.toLocaleUpperCase()} from dashboard promo banner`,
+            {
+                annotation: createTestAnnotation({
+                    testCase: `Verify that the ${PROMO_EVENT} event is logged for ${bannerType.toUpperCase()} when navigating from the dashboard promo banner`,
+                    category: TestCategory.General,
+                    priority: TestPriority.Medium,
+                    stream: TestStream.Foundation,
+                }),
+            },
+            async ({ analyticsSection, dashboardPage, settingsPage }) => {
+                await test.step('Add dashboard promo banner', async () => {
+                    await settingsPage.toggleDebugModeInSettings();
+                    await settingsPage.navigateTo('debug');
+                    await settingsPage.debugTab.addBanner(bannerType);
+                });
+
+                await test.step(`Tirgger & verify ${PROMO_EVENT} - ${bannerType.toUpperCase()}`, async () => {
+                    await dashboardPage.navigateTo();
+
+                    const [payload] = await Promise.all([
+                        analyticsSection.waitForAnalytics({ c_type: PROMO_EVENT, bannerType }),
+                        dashboardPage.promoBannerButton(bannerType).click(),
+                    ]);
+
+                    expect(payload).toMatchObject({ c_type: PROMO_EVENT, bannerType });
+                });
+            },
+        );
+    }
+});


### PR DESCRIPTION
## Description

Based on [PR#24161](https://github.com/trezor/trezor-suite/pull/24161), I added a few E2E tests to verify that an event is triggered when a specific action is performed

* [staking/navigate](https://www.notion.so/satoshilabs/staking-navigate-1c4dc526060680ca9be7e62490006b3a?source=copy_link)
* [promo/dashboard-banner
](https://www.notion.so/satoshilabs/promo-dashboard-banner-23fdc52606068049974cd0120bc4ce39?source=copy_link)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/refactor-analytics&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/refactor-analytics&lookback=7)