### PR TITLE
Mobile Trade: Show country code instead of name

### DIFF
--- a/suite-common/trading/src/__tests__/regional.test.ts
+++ b/suite-common/trading/src/__tests__/regional.test.ts
@@ -38,14 +38,22 @@ describe('Regional', () => {
     describe('getCountryOptionWithWorldwideFallback', () => {
         it('should return country option for existing country', () => {
             expect(regional.getCountryOptionWithWorldwideFallback('DE')).toEqual({
+                codeAlpha3: 'DEU',
+                flag: '🇩🇪',
                 label: '🇩🇪 Germany',
+                name: 'Germany',
+                shortLabel: '🇩🇪 DEU',
                 value: 'DE',
             });
         });
 
         it('should fallback to worldwide for non-existing country', () => {
             expect(regional.getCountryOptionWithWorldwideFallback('test')).toEqual({
+                codeAlpha3: 'unknown',
+                flag: '🌍',
                 label: '🌍 Worldwide',
+                name: 'Worldwide',
+                shortLabel: '🌍 Worldwide',
                 value: 'unknown',
             });
         });

--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -251,18 +251,36 @@ describe('toTokenCryptoId', () => {
 
 describe('getDefaultCountry', () => {
     it('should return default country for unknown country', () => {
-        expect(getDefaultCountry()).toEqual({ label: '🌍 Worldwide', value: 'unknown' });
+        expect(getDefaultCountry()).toEqual({
+            codeAlpha3: 'unknown',
+            flag: '🌍',
+            label: '🌍 Worldwide',
+            name: 'Worldwide',
+            shortLabel: '🌍 Worldwide',
+            value: 'unknown',
+        });
     });
 
     it('should return correct value', () => {
         expect(getDefaultCountry('US')).toEqual({
+            codeAlpha3: 'USA',
+            flag: '🇺🇸',
             label: '🇺🇸 United States of America',
+            name: 'United States of America',
+            shortLabel: '🇺🇸 USA',
             value: 'US',
         });
     });
 
     it('should return default country for non existing code', () => {
-        expect(getDefaultCountry('XX')).toEqual({ label: '🌍 Worldwide', value: 'unknown' });
+        expect(getDefaultCountry('XX')).toEqual({
+            codeAlpha3: 'unknown',
+            flag: '🌍',
+            label: '🌍 Worldwide',
+            name: 'Worldwide',
+            shortLabel: '🌍 Worldwide',
+            value: 'unknown',
+        });
     });
 });
 

--- a/suite-common/trading/src/regional.ts
+++ b/suite-common/trading/src/regional.ts
@@ -23,16 +23,25 @@ class Regional {
 
     constructor(countriesFilter: (country: CountryItem) => boolean) {
         this.countriesOptions = [
-            { value: this.UNKNOWN_COUNTRY, label: '🌍 Worldwide' },
+            {
+                value: this.UNKNOWN_COUNTRY,
+                label: '🌍 Worldwide',
+                shortLabel: '🌍 Worldwide',
+                codeAlpha3: this.UNKNOWN_COUNTRY,
+                flag: '🌍',
+                name: 'Worldwide',
+            },
             ...typedObjectValues(countriesRecord)
                 .filter(countriesFilter)
-                .map(({ code, flag, name }) => ({ value: code, label: `${flag} ${name}` })),
-        ].sort((c1, c2) => {
-            const l1 = c1.label.split(' ')[1];
-            const l2 = c2.label.split(' ')[1];
-
-            return l1.localeCompare(l2);
-        });
+                .map(({ code, codeAlpha3, flag, name }) => ({
+                    value: code,
+                    label: `${flag} ${name}`,
+                    shortLabel: `${flag} ${codeAlpha3}`,
+                    codeAlpha3,
+                    flag,
+                    name,
+                })),
+        ].sort((c1, c2) => c1.name.localeCompare(c2.name));
 
         this.countriesOptionsMap = new Map(
             this.countriesOptions.map(option => [option.value, option]),

--- a/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
@@ -86,7 +86,11 @@ describe('handleBuyRequestThunk', () => {
             } satisfies TradingAssetOption,
             countrySelect: {
                 value: 'CZ',
-                label: 'Czech Republic',
+                codeAlpha3: 'CZE',
+                flag: '🇨🇿',
+                name: 'Czechia',
+                label: '🇨🇿 Czechia',
+                shortLabel: '🇨🇿 CZE',
             },
             paymentMethod: {
                 value: 'creditCard',

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
@@ -84,7 +84,14 @@ describe('handleSellRequestThunk', () => {
                     label: '',
                 },
             ],
-            countrySelect: { value: 'US', label: 'United States' },
+            countrySelect: {
+                codeAlpha3: 'USA',
+                flag: '🇺🇸',
+                name: 'United States of America',
+                value: 'US',
+                label: '🇺🇸 United States',
+                shortLabel: '🇺🇸 USA',
+            },
             sendCryptoSelect: {
                 id: 'bitcoin' as CryptoId,
                 isNativeToken: true,

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -128,6 +128,10 @@ export type TradingCountryCode = CountryCode | 'unknown';
 export type TradingCountryOption = {
     value: TradingCountryCode;
     label: string;
+    shortLabel: string;
+    codeAlpha3: string;
+    flag: string;
+    name: string;
 };
 
 export type TradingBuyFormProps = {

--- a/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
@@ -51,7 +51,7 @@ export abstract class TradingFormActions extends TradingActions {
             .withTimeout(this.SHORT_TIMEOUT);
     }
 
-    async selectCountry(countrySearch: string, country: string) {
+    async selectCountry(countrySearch: string, country: string, shortLabel: string) {
         const countryPicker = this.getElementById('country');
         await waitForVisible(countryPicker, { timeout: this.SHORT_TIMEOUT });
         await countryPicker.tap();
@@ -62,7 +62,7 @@ export abstract class TradingFormActions extends TradingActions {
         await element(by.text(country)).tap();
 
         await waitFor(this.getElementById('country/value'))
-            .toHaveText(country)
+            .toHaveText(shortLabel)
             .withTimeout(this.SHORT_TIMEOUT);
     }
 

--- a/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
@@ -24,7 +24,7 @@ describe('Trade Buy [@noDevice]', () => {
         await tradingBuyActions.selectReceiveAsset('BTC');
         await tradingBuyActions.selectBtcReceiveAccount('BTC SegWit', "m/84'/0'/0'/0/0");
         await tradingBuyActions.selectFiatCurrency('PLN');
-        await tradingBuyActions.selectCountry('Polan', '🇵🇱 Poland');
+        await tradingBuyActions.selectCountry('Polan', '🇵🇱 Poland', '🇵🇱 POL');
         await tradingBuyActions.setFiatAmount('100');
 
         // Scroll to bottom of the page.

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyForm.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyForm.comp.test.tsx
@@ -78,7 +78,7 @@ describe('BuyForm', () => {
             expect(queryByText('Receive account')).toBeNull();
 
             expect(getByText('Country of residence')).toBeTruthy();
-            expect(getByText('🇨🇿 Czechia')).toBeTruthy();
+            expect(getByText('🇨🇿 CZE')).toBeTruthy();
 
             expect(queryByText('Provider')).toBeNull();
             expect(queryByText('Continue')).toBeNull();

--- a/suite-native/module-trading/src/components/general/__tests__/TradingCountryOfResidencePicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingCountryOfResidencePicker.comp.test.tsx
@@ -65,12 +65,19 @@ describe('TradingCountryOfResidencePicker', () => {
 
     it('should use country from form', async () => {
         act(() => {
-            form.setValue('country', { value: 'US', label: 'United States' });
+            form.setValue('country', {
+                value: 'US',
+                label: '🇺🇸 United States',
+                shortLabel: '🇺🇸 USA',
+                codeAlpha3: 'USA',
+                flag: '🇺🇸',
+                name: 'United States',
+            });
         });
 
         const { getByTestId } = await renderCountryOfResidencePicker(residenceCheckDisabledState);
 
-        expect(getByTestId('testID/value')).toHaveTextContent('United States');
+        expect(getByTestId('testID/value')).toHaveTextContent('🇺🇸 USA');
     });
 
     it('should call analytics on country change', async () => {

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
@@ -673,7 +673,14 @@ describe('useBuyForm', () => {
             const { result } = await renderUseTradingBuyForm(store);
 
             act(() => {
-                result.current.setValue('country', { value: 'CA', label: 'Canada' });
+                result.current.setValue('country', {
+                    value: 'CA',
+                    label: '🇨🇦 Canada',
+                    shortLabel: '🇨🇦 CAN',
+                    codeAlpha3: 'CAN',
+                    flag: '🇨🇦',
+                    name: 'Canada',
+                });
             });
 
             expect(selectTradingResidenceCountry(store.getState())).toBe('CA');

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useCountryChangeEffect.comp.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useCountryChangeEffect.comp.test.tsx
@@ -15,14 +15,28 @@ describe('useCountryChangeEffect', () => {
     });
 
     it('should do nothing on mount', async () => {
-        await renderUseCountryChangeEffect(() => ({ value: 'US', label: 'United States' }));
+        await renderUseCountryChangeEffect(() => ({
+            codeAlpha3: 'USA',
+            flag: '🇺🇸',
+            name: 'United States of America',
+            value: 'US',
+            label: '🇺🇸 United States',
+            shortLabel: '🇺🇸 USA',
+        }));
 
         expect(selectTradingResidenceCountry(store.getState())).toBeUndefined();
     });
 
     it('should update trading residence country on country change', async () => {
         let countryValue: TradingCountryCode = 'US';
-        const watch: CountryFormWatch = () => ({ value: countryValue, label: 'Country' });
+        const watch: CountryFormWatch = () => ({
+            value: countryValue,
+            codeAlpha3: 'USA',
+            flag: 'Flag',
+            name: 'Country long name',
+            label: 'Country label',
+            shortLabel: 'Short label',
+        });
 
         const { rerender } = await renderUseCountryChangeEffect(watch);
 
@@ -33,7 +47,14 @@ describe('useCountryChangeEffect', () => {
     });
 
     it('should not update when country becomes undefined', async () => {
-        let countryOption: TradingCountryOption | undefined = { value: 'US', label: 'Country' };
+        let countryOption: TradingCountryOption | undefined = {
+            codeAlpha3: 'USA',
+            flag: '🇺🇸',
+            name: 'United States of America',
+            value: 'US',
+            label: '🇺🇸 United States',
+            shortLabel: '🇺🇸 USA',
+        };
         const watch: CountryFormWatch = () => countryOption;
         const { rerender } = await renderUseCountryChangeEffect(watch);
 

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
@@ -667,7 +667,14 @@ describe('useSellForm', () => {
             const { result } = await renderUseSellForm();
 
             act(() => {
-                result.current.setValue('country', { value: 'CA', label: 'Canada' });
+                result.current.setValue('country', {
+                    value: 'CA',
+                    label: '🇨🇦 Canada',
+                    shortLabel: '🇨🇦 CAN',
+                    codeAlpha3: 'CAN',
+                    flag: '🇨🇦',
+                    name: 'Canada',
+                });
             });
 
             expect(selectTradingResidenceCountry(store.getState())).toBe('CA');

--- a/suite-native/module-trading/src/utils/buy/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/buy/__tests__/quotesUtils.test.ts
@@ -56,8 +56,12 @@ describe('quotesUtils', () => {
                     form.setValue('fiatValue', '100');
                     form.setValue('asset', btcAsset);
                     form.setValue('country', {
+                        codeAlpha3: 'USA',
+                        flag: '🇺🇸',
+                        name: 'United States of America',
                         value: 'US',
-                        label: 'United States of America',
+                        label: '🇺🇸 United States',
+                        shortLabel: '🇺🇸 USA',
                     });
                     form.setValue('quote', buyQuotes[0]);
                 });
@@ -90,8 +94,12 @@ describe('quotesUtils', () => {
                         networkSymbol: 'btc',
                     } satisfies TradingAssetOption,
                     countrySelect: {
+                        label: '🇺🇸 United States',
+                        codeAlpha3: 'USA',
+                        flag: '🇺🇸',
+                        name: 'United States of America',
+                        shortLabel: '🇺🇸 USA',
                         value: 'US',
-                        label: 'United States of America',
                     },
                     paymentMethod: {
                         value: 'applePay',

--- a/suite-native/module-trading/src/utils/sell/__tests__/quoteUtils.test.ts
+++ b/suite-native/module-trading/src/utils/sell/__tests__/quoteUtils.test.ts
@@ -68,7 +68,11 @@ describe('quoteUtils', () => {
                 ],
                 countrySelect: {
                     label: '🇨🇿 Czechia',
+                    shortLabel: '🇨🇿 CZE',
                     value: 'CZ',
+                    codeAlpha3: 'CZE',
+                    flag: '🇨🇿',
+                    name: 'Czechia',
                 },
                 sendCryptoSelect: {
                     id: 'bitcoin' as CryptoId,
@@ -94,7 +98,11 @@ describe('quoteUtils', () => {
                 ],
                 countrySelect: {
                     label: '🇨🇿 Czechia',
+                    shortLabel: '🇨🇿 CZE',
                     value: 'CZ',
+                    codeAlpha3: 'CZE',
+                    flag: '🇨🇿',
+                    name: 'Czechia',
                 },
                 sendCryptoSelect: {
                     id: 'bitcoin' as CryptoId,

--- a/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.tsx
@@ -77,7 +77,7 @@ export const CountryOfResidencePicker = ({ testID, context }: CountryOfResidence
                             )}
                             testID={valueTestID}
                         >
-                            {selectedValue.label}
+                            {selectedValue.shortLabel}
                         </Text>
                     </HStack>
                 ) : (

--- a/suite-native/trading-residence/src/components/CountrySheet/__tests__/CountryOfResidencePicker.comp.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/__tests__/CountryOfResidencePicker.comp.test.tsx
@@ -66,7 +66,7 @@ describe('CountryOfResidencePicker', () => {
     it('should display value from expo-localization (Poland) when in default state', () => {
         const { getByLabelText } = renderCountryOfResidencePicker();
 
-        expect(getByLabelText('Selected country of residence')).toHaveTextContent('🇵🇱 Poland');
+        expect(getByLabelText('Selected country of residence')).toHaveTextContent('🇵🇱 POL');
     });
 
     it('should allow to select country', async () => {
@@ -75,7 +75,7 @@ describe('CountryOfResidencePicker', () => {
         await userEvent.press(getByText('Country of residence'));
         await userEvent.press(getByText(/Algeria/));
 
-        expect(getByLabelText('Selected country of residence')).toHaveTextContent('🇩🇿 Algeria');
+        expect(getByLabelText('Selected country of residence')).toHaveTextContent('🇩🇿 DZA');
     });
 
     it('should display empty component when filtered data is empty', async () => {
@@ -104,14 +104,14 @@ describe('CountryOfResidencePicker', () => {
     });
 
     it('should not report to analytics when user selects already selected country', async () => {
-        const { getByText, getAllByText } = renderCountryOfResidencePicker();
+        const { getByText } = renderCountryOfResidencePicker();
 
         await userEvent.press(getByText('Country of residence'));
         await userEvent.press(getByText(/Algeria/));
         reportMock.mockClear();
 
-        await userEvent.press(getAllByText(/Algeria/)[0]);
-        await userEvent.press(getAllByText(/Algeria/)[1]);
+        await userEvent.press(getByText('Country of residence'));
+        await userEvent.press(getByText(/Algeria/));
 
         expect(reportMock).not.toHaveBeenCalled();
     });

--- a/suite-native/trading-residence/src/components/__tests__/ConfirmLocationButton.comp.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/ConfirmLocationButton.comp.test.tsx
@@ -18,7 +18,14 @@ const ConfirmLocationButtonWithChangedCountry = () => {
     const { setValue } = useFormContext<TradingLocationFormValues>();
 
     useEffect(() => {
-        setValue('country', { value: 'SK', label: 'SHOULD NOT MATTER' });
+        setValue('country', {
+            value: 'SK',
+            label: '🇸🇰 Slovakia',
+            shortLabel: '🇸🇰 SVK',
+            codeAlpha3: 'SVK',
+            flag: '🇸🇰',
+            name: 'Slovakia',
+        });
     }, [setValue]);
 
     return <ConfirmLocationButton afterConfirm={jest.fn} />;

--- a/suite-native/trading-residence/src/components/__tests__/TradingLocationSettings.comp.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/TradingLocationSettings.comp.test.tsx
@@ -27,6 +27,6 @@ describe('TradingLocationSettings', () => {
         expect(getByText('Test Children')).toBeOnTheScreen();
         expect(getByText('Trading is available')).toBeOnTheScreen();
         expect(getByText('Country of residence')).toBeOnTheScreen();
-        expect(getByText('🇵🇱 Poland')).toBeOnTheScreen();
+        expect(getByText('🇵🇱 POL')).toBeOnTheScreen();
     });
 });

--- a/suite-native/trading-residence/src/hooks/__tests__/useCountryFilteredData.test.ts
+++ b/suite-native/trading-residence/src/hooks/__tests__/useCountryFilteredData.test.ts
@@ -10,10 +10,9 @@ describe('useCountryFilteredData', () => {
 
         expect(result.current.filteredData).toEqual(
             expect.arrayContaining([
-                {
-                    label: '🇨🇿 Czechia',
+                expect.objectContaining({
                     value: 'CZ',
-                },
+                }),
             ]),
         );
     });

--- a/suite-native/trading-residence/src/hooks/__tests__/useFormCountryCode.hook.test.tsx
+++ b/suite-native/trading-residence/src/hooks/__tests__/useFormCountryCode.hook.test.tsx
@@ -24,7 +24,11 @@ describe('useFormCountryCode', () => {
         act(() => {
             formResult.current.setValue('country', {
                 value: country,
-                label: 'does not matter',
+                codeAlpha3: 'USA',
+                flag: 'Flag',
+                name: 'Country long name',
+                label: 'Country label',
+                shortLabel: 'Short label',
             });
         });
         const { result } = renderUseFormCountryCode(formResult.current);

--- a/suite-native/trading-residence/src/hooks/__tests__/useLocationForm.hook.test.ts
+++ b/suite-native/trading-residence/src/hooks/__tests__/useLocationForm.hook.test.ts
@@ -22,19 +22,21 @@ describe('useLocationForm', () => {
 
         const { result } = renderUseLocationForm();
 
-        expect(result.current.getValues('country')).toEqual({
-            label: '🇨🇿 Czechia',
-            value: 'CZ',
-        });
+        expect(result.current.getValues('country')).toEqual(
+            expect.objectContaining({
+                value: 'CZ',
+            }),
+        );
     });
 
     it('should use value from expo-localization when country is not set in store', () => {
         const { result } = renderUseLocationForm();
 
-        expect(result.current.getValues('country')).toEqual({
-            label: '🇵🇱 Poland',
-            value: 'PL',
-        });
+        expect(result.current.getValues('country')).toEqual(
+            expect.objectContaining({
+                value: 'PL',
+            }),
+        );
     });
 
     it('should fallback to worldwide when country is not set in store and expo-localization country is not supported', () => {
@@ -55,9 +57,10 @@ describe('useLocationForm', () => {
 
         const { result } = renderUseLocationForm();
 
-        expect(result.current.getValues('country')).toEqual({
-            label: '🌍 Worldwide',
-            value: 'unknown',
-        });
+        expect(result.current.getValues('country')).toEqual(
+            expect.objectContaining({
+                value: 'unknown',
+            }),
+        );
     });
 });

--- a/suite-native/trading-residence/src/utils/__tests__/getPreferredCountryOption.test.ts
+++ b/suite-native/trading-residence/src/utils/__tests__/getPreferredCountryOption.test.ts
@@ -4,10 +4,11 @@ import { getPreferredCountryOption } from '../getPreferredCountryOption';
 
 describe('getPreferredCountryOption()', () => {
     it('should use value from expo-localization when country is not set in store', () => {
-        expect(getPreferredCountryOption()).toEqual({
-            label: '🇵🇱 Poland',
-            value: 'PL',
-        });
+        expect(getPreferredCountryOption()).toEqual(
+            expect.objectContaining({
+                value: 'PL',
+            }),
+        );
     });
 
     it('should fallback to worldwide when country is not set in store and expo-localization country is not supported', () => {
@@ -26,9 +27,10 @@ describe('getPreferredCountryOption()', () => {
             } as unknown as Locale,
         ]);
 
-        expect(getPreferredCountryOption()).toEqual({
-            label: '🌍 Worldwide',
-            value: 'unknown',
-        });
+        expect(getPreferredCountryOption()).toEqual(
+            expect.objectContaining({
+                value: 'unknown',
+            }),
+        );
     });
 });

--- a/suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts
@@ -110,10 +110,9 @@ describe('buySelectors', () => {
         it('should return object with computed default values', () => {
             expect(selectBuyFormDefaultValues(state)).toEqual({
                 fiatCurrency: 'czk',
-                country: {
-                    label: '🇨🇿 Czechia',
+                country: expect.objectContaining({
                     value: 'CZ',
-                },
+                }),
                 amountInCrypto: false,
             });
         });
@@ -123,10 +122,9 @@ describe('buySelectors', () => {
 
             expect(selectBuyFormDefaultValues(state)).toEqual(
                 expect.objectContaining({
-                    country: {
-                        label: '🇩🇪 Germany',
+                    country: expect.objectContaining({
                         value: 'DE',
-                    },
+                    }),
                 }),
             );
         });
@@ -146,10 +144,9 @@ describe('buySelectors', () => {
 
             expect(selectBuyFormDefaultValues(state)).toEqual(
                 expect.objectContaining({
-                    country: {
-                        label: '🌍 Worldwide',
+                    country: expect.objectContaining({
                         value: 'unknown',
-                    },
+                    }),
                 }),
             );
         });
@@ -159,10 +156,9 @@ describe('buySelectors', () => {
 
             expect(selectBuyFormDefaultValues(state)).toEqual(
                 expect.objectContaining({
-                    country: {
-                        label: '🌍 Worldwide',
+                    country: expect.objectContaining({
                         value: 'unknown',
-                    },
+                    }),
                 }),
             );
         });

--- a/suite-native/trading-state/src/selectors/__tests__/sellSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/sellSelectors.test.ts
@@ -161,10 +161,9 @@ describe('sellSelectors', () => {
         it('should return object with computed default values', () => {
             expect(selectSellFormDefaultValues(state)).toEqual({
                 fiatCurrency: 'usd',
-                country: {
-                    label: '🇨🇿 Czechia',
+                country: expect.objectContaining({
                     value: 'CZ',
-                },
+                }),
                 amountInCrypto: false,
             });
         });
@@ -174,10 +173,9 @@ describe('sellSelectors', () => {
 
             expect(selectSellFormDefaultValues(state)).toEqual(
                 expect.objectContaining({
-                    country: {
-                        label: '🇩🇪 Germany',
+                    country: expect.objectContaining({
                         value: 'DE',
-                    },
+                    }),
                 }),
             );
         });
@@ -199,10 +197,9 @@ describe('sellSelectors', () => {
 
             expect(selectSellFormDefaultValues(state)).toEqual(
                 expect.objectContaining({
-                    country: {
-                        label: '🌍 Worldwide',
+                    country: expect.objectContaining({
                         value: 'unknown',
-                    },
+                    }),
                 }),
             );
         });
@@ -212,10 +209,9 @@ describe('sellSelectors', () => {
 
             expect(selectSellFormDefaultValues(state)).toEqual(
                 expect.objectContaining({
-                    country: {
-                        label: '🌍 Worldwide',
+                    country: expect.objectContaining({
                         value: 'unknown',
-                    },
+                    }),
                 }),
             );
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Updated regional structure to contain also other information about country (codeAlpha3, flag, name).
- Country of residence is now displayed as "flag codeAlpha3" (e.g. "🇨🇿 CZE")
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #24521


## Screenshots:

<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-01-21 at 09 21 08" src="https://github.com/user-attachments/assets/721d19b9-4297-4a52-935f-ecd774ec9783" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-01-21 at 09 21 24" src="https://github.com/user-attachments/assets/97fecf26-1f55-4a6b-abb5-7d57e3cf2fdf" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-01-21 at 09 21 27" src="https://github.com/user-attachments/assets/32af1df1-14cc-44bc-a880-23adf0d703d5" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=24521-show-country-code-instead-of-name-mobile&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=24521-show-country-code-instead-of-name-mobile&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24521-show-country-code-instead-of-name-mobile&lookback=7)