### PR TITLE
fix: test fixutres for the parsing of the version and device id when …

### DIFF
--- a/packages/connect/src/device/__tests__/DeviceList.test.ts
+++ b/packages/connect/src/device/__tests__/DeviceList.test.ts
@@ -270,10 +270,18 @@ describe('DeviceList', () => {
                     res = '3f2323000300000000000000000000000000000000';
                 } else if (readCount === 1) {
                     // features
-                    res = '3f232300110000000c1002180020006000aa010154'; // 2.0.0;
+                    res =
+                        // headers
+                        `3f2323001100000017` +
+                        // { major_version: 2, minor_version: 0, patch_version: 0, model: 'T', initialized: false, device_id: 'device-id' }
+                        `10021800200${0}32096465766963652d69646000aa010154`;
                 } else {
                     // features
-                    res = `3f232300110000000c10021800200${1}6000aa010154`; // 2.0.1
+                    res =
+                        // headers
+                        `3f2323001100000017` +
+                        // { major_version: 2, minor_version: 0, patch_version: 1, model: 'T', initialized: false, device_id: 'device-id' }
+                        `10021800200${1}32096465766963652d69646000aa010154`;
                 }
                 readCount++;
 

--- a/packages/utils/src/isSafeObjectKey.ts
+++ b/packages/utils/src/isSafeObjectKey.ts
@@ -1,2 +1,2 @@
 export const isSafeObjectKey = (key: string) =>
-    !['__proto__', 'constructor', 'prototype'].includes(key);
+    !['__proto__', 'prototype', 'constructor'].includes(key);


### PR DESCRIPTION
…identifying a newer fw version

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes failing tests in `deviceList`

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-crashing-device-list-tests&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-crashing-device-list-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-crashing-device-list-tests&lookback=7)