### PR TITLE
fix: make sure that scnaned device list covers the BT hints when tehy…

### DIFF
--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -247,22 +247,6 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
         return <BluetoothManualPairingModal onCancel={onCancel} />;
     }
 
-    if (showHints) {
-        return (
-            <CantSeeTrezorModal
-                onClose={() => {
-                    legacyAnalytics.report({
-                        type: EventType.DeviceConnectionHintModal,
-                        payload: {
-                            option: 'close',
-                        },
-                    });
-                    onCancel();
-                }}
-            />
-        );
-    }
-
     // handle Bluetooth adapter non ideal status cases
     if (
         isBluetoothMode &&
@@ -301,6 +285,22 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
         manuallyPairedConnectedDevices.length > 0;
     if (isBluetoothMode && areConnectableDevices) {
         return <BluetoothConnectionModal onClose={onCancel} />;
+    }
+
+    if (showHints) {
+        return (
+            <CantSeeTrezorModal
+                onClose={() => {
+                    legacyAnalytics.report({
+                        type: EventType.DeviceConnectionHintModal,
+                        payload: {
+                            option: 'close',
+                        },
+                    });
+                    onCancel();
+                }}
+            />
+        );
     }
 
     // scanning for nearby devices


### PR DESCRIPTION
… are displayed

<!--- Provide a general summary of your changes in the Title above -->

## Description

Puts the hints modal under the scanned devices list in the order. Which means that scanned devices are always first returned if some are found.

## Notes for QA

When you connecting a BT device and you displayed the connection hints, the modal with scanned device should displayed when some device is found instead of these hints.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24567

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=24567-fix-the-show-hints-covering-bl-device-list&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=24567-fix-the-show-hints-covering-bl-device-list&lookback=7)