### PR TITLE
Fix encryption of local evolu DB on mobile

### DIFF
--- a/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
+++ b/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
@@ -8,7 +8,7 @@ import { Schema } from './schema';
 // This is a way how to force change of the SQL files. It was useful for development
 // so not everybody had to delete SQLite file manually:
 // See: https://www.evolu.dev/docs/faq#how-to-delete-opfs-sqlite-in-browser
-const VERSION = 6;
+const VERSION = 7;
 
 type CreateEvoluInstanceFactoryDeps = EvoluDeps;
 

--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -165,6 +165,12 @@ const getPlugins = (): ExpoPlugins => {
             },
         ],
         ['expo-localization'],
+        [
+            'expo-sqlite',
+            {
+                useSQLCipher: true,
+            },
+        ],
     ];
 
     return [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There was a missing expo-sqlite config to use SQLCipher.

## Steps to verify encryption of DB

1. Run the app, initiate Suite Sync
2. Locate DB file: 
	- android:
	```bash
	adb exec-out run-as io.trezor.suite.debug tar -C /data/data/io.trezor.suite.debug -cf - . > suite_debug_data.tar
    tar -xf suite_debug_data.tar
    # go to files/SQLite folder
    ```
    - ios (simulator):
     ```bash
     APP_DATA="$(xcrun simctl get_app_container booted io.trezor.suite.debug data)"
     find "$APP_DATA" -type f \( -name "*.db" \) -maxdepth 6 -print
     ```
3. Verify DB content: `hexdump -c {path to .db file} | head` (if you can read " S   Q   L   i   t   e       f   o   r   m   a   t       3" on the first line, it's not encrypted)
4. To double check you can run `sqlite3 {path to .db file} "SELECT appOwnerMnemonic FROM evolu_config;"`

## Screenshots:
before:
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/dab6636a-e136-4a54-ac7d-27a95c42292b" />

after:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b237a88b-8a0b-4a50-8226-99eae1ca7942" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/fix-encryption-of-evolu-db&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/fix-encryption-of-evolu-db&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/fix-encryption-of-evolu-db&lookback=7)