### PR TITLE
fix: removed delegated's public key from redux & improved initial data fetching

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
@@ -89,10 +89,8 @@ export const QuotaManagerSettings = () => {
                             <div>No devices registered.</div>
                         ) : (
                             registeredDevices.map(device => (
-                                <div key={device.publicKey} style={{ marginBottom: 8 }}>
+                                <div key={device.deviceId} style={{ marginBottom: 8 }}>
                                     <strong>Device ID:</strong> {device.deviceId}
-                                    <br />
-                                    <strong>Public Key:</strong> {device.publicKey}
                                     <br />
                                     <strong>Total Storage Size:</strong> {device.totalStorageSize}
                                     <br />

--- a/suite-common/suite-sync-quota-manager/src/ensureDeviceHasQuotaThunk.ts
+++ b/suite-common/suite-sync-quota-manager/src/ensureDeviceHasQuotaThunk.ts
@@ -42,7 +42,6 @@ export const ensureDeviceHasQuotaThunk =
             dispatch(
                 quotaManagerDeviceFetched({
                     deviceId: device.id,
-                    publicKey: delegatedKeyPublic,
                     totalStorageSize: hasPublicKeyStorage.payload.totalSpace,
                     unspentStorageSize: hasPublicKeyStorage.payload.unspentSpace,
                 }),

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerActions.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerActions.ts
@@ -23,12 +23,18 @@ export const quotaManagerEnabledUpdated = createAction(
 
 export const quotaManagerDeviceFetched = createAction(
     `${QUOTA_MANAGER_PREFIX}/deviceFetched`,
-    (payload: {
-        deviceId: string;
-        publicKey: string;
-        totalStorageSize: number;
-        unspentStorageSize: number;
-    }) => ({
+    (payload: { deviceId: string; totalStorageSize: number; unspentStorageSize: number }) => ({
+        payload,
+    }),
+);
+
+/**
+ * When we call for transferStorageThunk with deviceId, we want to update device quota info
+ * after successful storage transfer.
+ */
+export const quotaManagerDeviceUnspentStorageFetched = createAction(
+    `${QUOTA_MANAGER_PREFIX}/deviceQuotaUpdate`,
+    (payload: { deviceId: string; unspentStorageSize: number }) => ({
         payload,
     }),
 );

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerReducer.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerReducer.ts
@@ -3,6 +3,7 @@ import { createReducer } from '@reduxjs/toolkit';
 import {
     eraseFetchedDataDebug,
     quotaManagerDeviceFetched,
+    quotaManagerDeviceUnspentStorageFetched,
     quotaManagerEnabledUpdated,
     quotaManagerOwnerFetched,
     updateQuotaManagerBaseUrl,
@@ -40,7 +41,7 @@ export const suiteSyncQuotaManagerReducer = createReducer<SuiteSyncQuotaManagerS
             })
             .addCase(quotaManagerDeviceFetched, (state, { payload }) => {
                 const existingDevice = state.registeredDevices.find(
-                    device => device.publicKey === payload.publicKey,
+                    device => device.deviceId === payload.deviceId,
                 );
                 if (existingDevice) {
                     existingDevice.deviceId = payload.deviceId;
@@ -49,10 +50,17 @@ export const suiteSyncQuotaManagerReducer = createReducer<SuiteSyncQuotaManagerS
                 } else {
                     state.registeredDevices.push({
                         deviceId: payload.deviceId,
-                        publicKey: payload.publicKey,
                         totalStorageSize: payload.totalStorageSize,
                         unspentStorageSize: payload.unspentStorageSize,
                     });
+                }
+            })
+            .addCase(quotaManagerDeviceUnspentStorageFetched, (state, { payload }) => {
+                const existingDevice = state.registeredDevices.find(
+                    device => device.deviceId === payload.deviceId,
+                );
+                if (existingDevice) {
+                    existingDevice.unspentStorageSize = payload.unspentStorageSize;
                 }
             })
             .addCase(quotaManagerOwnerFetched, (state, { payload }) => {

--- a/suite-common/suite-sync-quota-manager/src/storage/registerStorageThunk.ts
+++ b/suite-common/suite-sync-quota-manager/src/storage/registerStorageThunk.ts
@@ -54,7 +54,6 @@ export const registerStorageThunk =
             dispatch(
                 quotaManagerDeviceFetched({
                     deviceId: device.id,
-                    publicKey: params.publicKey,
                     totalStorageSize: response.totalStorageSize,
                     unspentStorageSize: response.unspentStorageSize,
                 }),

--- a/suite-common/suite-sync-quota-manager/src/storage/tests/registerStorageThunk.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/storage/tests/registerStorageThunk.test.ts
@@ -58,7 +58,6 @@ describe(registerStorageThunk.name, () => {
         expect(mockDispatch).toHaveBeenCalledWith(
             quotaManagerDeviceFetched({
                 deviceId: 'device-id',
-                publicKey: 'pubkey',
                 totalStorageSize: 1000,
                 unspentStorageSize: 800,
             }),

--- a/suite-common/suite-sync-quota-manager/src/storage/transferStorageThunk.ts
+++ b/suite-common/suite-sync-quota-manager/src/storage/transferStorageThunk.ts
@@ -4,7 +4,11 @@ import { SuiteSyncOwnerId } from '@suite-common/suite-types';
 import { WalletDescriptor } from '@suite-common/wallet-types';
 import { err, ok } from '@trezor/type-utils';
 
-import { quotaManagerFetchError, quotaManagerOwnerFetched } from '../quotaManagerActions';
+import {
+    quotaManagerDeviceUnspentStorageFetched,
+    quotaManagerFetchError,
+    quotaManagerOwnerFetched,
+} from '../quotaManagerActions';
 import { quotaManagerFetch } from '../quotaManagerFetch';
 import { selectQuotaManagerBaseUrl } from '../quotaManagerSelectors';
 
@@ -18,16 +22,18 @@ type TransferStorageBody = {
 };
 
 type TransferStorageResponse = {
-    storageLimit: number | null;
+    publicKeyUnspentSpace: number | null;
+    ownerTotalSpace: number | null;
 };
 
 type TransferStorageThunkParams = {
     params: TransferStorageBody;
     walletDescriptor: WalletDescriptor;
+    deviceId?: string;
 };
 
 export const transferStorageThunk =
-    ({ params, walletDescriptor }: TransferStorageThunkParams) =>
+    ({ params, walletDescriptor, deviceId }: TransferStorageThunkParams) =>
     async (dispatch: Dispatch, getState: () => any) => {
         const baseUrl = selectQuotaManagerBaseUrl(getState());
 
@@ -49,9 +55,18 @@ export const transferStorageThunk =
         dispatch(
             quotaManagerOwnerFetched({
                 walletDescriptor,
-                totalSpace: response.storageLimit ?? 0,
+                totalSpace: response.ownerTotalSpace ?? 0,
             }),
         );
+
+        if (deviceId !== undefined && response.publicKeyUnspentSpace !== null) {
+            dispatch(
+                quotaManagerDeviceUnspentStorageFetched({
+                    deviceId,
+                    unspentStorageSize: response.publicKeyUnspentSpace,
+                }),
+            );
+        }
 
         return ok(response);
     };

--- a/suite-common/suite-sync-quota-manager/src/tests/ensureDeviceHasQuotaThunk.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/tests/ensureDeviceHasQuotaThunk.test.ts
@@ -101,8 +101,6 @@ describe(ensureDeviceHasQuotaThunk.name, () => {
                 type: '@suite/quota-manager/deviceFetched',
                 payload: {
                     deviceId: 'device-id',
-                    publicKey:
-                        '0428a3cefc19b41ff56795e371aab72d6d85a3ca2200bd46c54e611a36222295a88b44d6f23ce94025b6010f9eb0f9168ad35d8396dc865fa0a16f2f5471816a45',
                     totalStorageSize: 5000,
                     unspentStorageSize: 1200,
                 },

--- a/suite-common/suite-sync-quota-manager/src/types.ts
+++ b/suite-common/suite-sync-quota-manager/src/types.ts
@@ -8,7 +8,6 @@ export const asSuiteSyncOwnerIdHashed = (value: string): SuiteSyncOwnerIdHashed 
 
 export type RegisteredDevice = {
     deviceId: string;
-    publicKey: string;
     totalStorageSize: number;
     unspentStorageSize: number;
 };

--- a/suite-native/module-dev-utils/src/components/SuiteSyncQuotaManager.tsx
+++ b/suite-native/module-dev-utils/src/components/SuiteSyncQuotaManager.tsx
@@ -79,11 +79,9 @@ export const SuiteSyncQuotaManager = () => {
                         <Text>No devices registered.</Text>
                     ) : (
                         registeredDevices.map(device => (
-                            <VStack key={device.publicKey} spacing="sp2">
+                            <VStack key={device.deviceId} spacing="sp2">
                                 <Text variant="label">Device ID</Text>
                                 <Text>{device.deviceId}</Text>
-                                <Text variant="label">Public Key</Text>
-                                <Text>{device.publicKey}</Text>
                                 <Text variant="label">Total Storage Size</Text>
                                 <Text>{device.totalStorageSize}</Text>
                                 <Text variant="label">Unspent Storage Size</Text>


### PR DESCRIPTION
merge along with https://github.com/trezor/trezor-suite-sync/pull/88

**changes**:
- removed public key from redux
 - its harder to call QM API outside a few functions, but public key indentifies device, so we should not store that
  
## Notes for QA
- initial fetch of debug data should fetch correctly
- removed public key from debug QM

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24578


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/qm/fetch-initial-values&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/qm/fetch-initial-values&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/qm/fetch-initial-values&lookback=7)