### PR TITLE
Mobile Trade: Improve country of residence search and sorting

### DIFF
--- a/suite-native/trading-atoms/src/hooks/__tests__/useListDataFilter.test.ts
+++ b/suite-native/trading-atoms/src/hooks/__tests__/useListDataFilter.test.ts
@@ -2,6 +2,11 @@ import { act, renderHook } from '@suite-native/test-utils';
 
 import { useListDataFilter } from '../useListDataFilter';
 
+type ItemShape = {
+    id: string;
+    name: string;
+};
+
 describe('useListDataFilter', () => {
     const rawListData = [
         { id: '1', name: 'Item 1' },
@@ -9,11 +14,16 @@ describe('useListDataFilter', () => {
         { id: '3', name: 'Item 3' },
     ];
 
-    const filterCallback = (item: (typeof rawListData)[number], filterValue: string) =>
+    const filterCallback = (item: ItemShape, filterValue: string) =>
         item.name.includes(filterValue);
+
+    const sortCallback = (a: ItemShape, b: ItemShape) => -a.name.localeCompare(b.name);
 
     const renderUseListDataFilter = () =>
         renderHook(() => useListDataFilter(rawListData, filterCallback));
+
+    const renderUseListDataFilterWithSort = () =>
+        renderHook(() => useListDataFilter(rawListData, filterCallback, sortCallback));
 
     it('should return all items by default', () => {
         const { result } = renderUseListDataFilter();
@@ -45,5 +55,21 @@ describe('useListDataFilter', () => {
         });
 
         expect(result.current.filterValue).toEqual('Item 1');
+    });
+
+    describe('with sort callback', () => {
+        it('should sort filtered items', () => {
+            const { result } = renderUseListDataFilterWithSort();
+
+            act(() => {
+                result.current.setFilterValue('Item');
+            });
+
+            expect(result.current.filteredData).toEqual([
+                { id: '3', name: 'Item 3' },
+                { id: '2', name: 'Item 2' },
+                { id: '1', name: 'Item 1' },
+            ]);
+        });
     });
 });

--- a/suite-native/trading-atoms/src/hooks/useListDataFilter.ts
+++ b/suite-native/trading-atoms/src/hooks/useListDataFilter.ts
@@ -3,6 +3,7 @@ import { useMemo, useState } from 'react';
 export const useListDataFilter = <T>(
     rawData: T[],
     filterCallback: (item: T, filterValue: string) => boolean,
+    sortCallback?: (a: T, b: T, filterValue: string) => number,
 ): {
     filteredData: T[];
     filterValue: string;
@@ -11,12 +12,18 @@ export const useListDataFilter = <T>(
     const [filterValue, setFilterValue] = useState('');
 
     const filteredData = useMemo(() => {
+        let data = [...rawData];
+
         if (filterValue?.length > 0) {
-            return rawData.filter(item => filterCallback(item, filterValue));
+            data = rawData.filter(item => filterCallback(item, filterValue));
         }
 
-        return rawData;
-    }, [rawData, filterValue, filterCallback]);
+        if (sortCallback) {
+            data.sort((a, b) => sortCallback(a, b, filterValue));
+        }
+
+        return data;
+    }, [rawData, filterValue, filterCallback, sortCallback]);
 
     return { filteredData, filterValue, setFilterValue };
 };

--- a/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.tsx
@@ -5,7 +5,7 @@ import {
     EventType,
     SuiteNativeLegacyAnalyticsEvents,
 } from '@suite-native/analytics';
-import { HStack, Text } from '@suite-native/atoms';
+import { Text } from '@suite-native/atoms';
 import { useFormContext } from '@suite-native/forms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { useLegacyAnalytics } from '@suite-native/services';
@@ -68,18 +68,17 @@ export const CountryOfResidencePicker = ({ testID, context }: CountryOfResidence
                 noBottomBorder
             >
                 {selectedValue ? (
-                    <HStack>
-                        <Text
-                            color="textSubdued"
-                            variant="body"
-                            accessibilityLabel={translate(
-                                'tradingResidence.locationSettings.selectedCountryOfResidence',
-                            )}
-                            testID={valueTestID}
-                        >
-                            {selectedValue.shortLabel}
-                        </Text>
-                    </HStack>
+                    <Text
+                        color="textSubdued"
+                        variant="body"
+                        accessibilityLabel={translate(
+                            'tradingResidence.locationSettings.selectedCountryOfResidence',
+                        )}
+                        testID={valueTestID}
+                        numberOfLines={1}
+                    >
+                        {selectedValue.shortLabel}
+                    </Text>
                 ) : (
                     <Text
                         color="textDisabled"

--- a/suite-native/trading-residence/src/hooks/__tests__/useCountryFilteredData.test.ts
+++ b/suite-native/trading-residence/src/hooks/__tests__/useCountryFilteredData.test.ts
@@ -34,7 +34,9 @@ describe('useCountryFilteredData', () => {
             result.current.setFilterValue('CZEch');
         });
 
-        expect(result.current.filteredData).toEqual([expect.objectContaining({ value: 'CZ' })]);
+        expect(result.current.filteredData).toEqual([
+            expect.objectContaining({ value: 'CZ', name: 'Czechia' }),
+        ]);
     });
 
     it('should filter by value case-insensitive', () => {
@@ -45,7 +47,101 @@ describe('useCountryFilteredData', () => {
         });
 
         expect(result.current.filteredData).toEqual(
-            expect.arrayContaining([expect.objectContaining({ value: 'US' })]),
+            expect.arrayContaining([
+                expect.objectContaining({ value: 'US', name: 'United States of America' }),
+            ]),
         );
+    });
+
+    it('should filter by codeAlpha3 case-insensitive', () => {
+        const { result } = renderUseCountryFilteredData();
+
+        act(() => {
+            result.current.setFilterValue('uSa');
+        });
+
+        expect(result.current.filteredData).toEqual([
+            expect.objectContaining({ codeAlpha3: 'USA', name: 'United States of America' }),
+        ]);
+    });
+
+    describe('sorting', () => {
+        it('should sort by name when no filter is applied', () => {
+            const { result } = renderUseCountryFilteredData();
+            expect(result.current.filteredData[0].name).toBe('Åland Islands'); // Åland Islands
+        });
+
+        it('should place exact match on name before other results', () => {
+            const { result } = renderUseCountryFilteredData();
+
+            act(() => {
+                result.current.setFilterValue('guinea');
+            });
+
+            expect(result.current.filteredData[0]).toEqual(
+                expect.objectContaining({ name: 'Guinea' }),
+            );
+        });
+
+        it('should place exact match on 2 digit code before other results', () => {
+            const { result } = renderUseCountryFilteredData();
+
+            act(() => {
+                result.current.setFilterValue('uS');
+            });
+
+            expect(result.current.filteredData[0]).toEqual(
+                expect.objectContaining({ value: 'US', name: 'United States of America' }),
+            );
+            expect(result.current.filteredData[1]).toEqual(
+                expect.objectContaining({ name: 'Australia' }),
+            );
+        });
+
+        it('should place exact match on 3 digit code before other results', () => {
+            const { result } = renderUseCountryFilteredData();
+
+            act(() => {
+                result.current.setFilterValue('pol');
+            });
+
+            expect(result.current.filteredData).toEqual([
+                expect.objectContaining({ name: 'Poland', codeAlpha3: 'POL' }),
+                expect.objectContaining({ name: 'French Polynesia' }),
+            ]);
+        });
+
+        it('should put matches on beginning before other matches - filter "sa"', () => {
+            const { result } = renderUseCountryFilteredData();
+
+            act(() => {
+                result.current.setFilterValue('sa');
+            });
+
+            expect(result.current.filteredData[0]).toEqual(
+                expect.objectContaining({ name: 'Saudi Arabia', value: 'SA' }), // exact match on value
+            );
+            expect(result.current.filteredData[1]).toEqual(
+                expect.objectContaining({ name: 'Saint Barthélemy' }), // starts with match on name
+            );
+            expect(result.current.filteredData[11]).toEqual(
+                expect.objectContaining({ name: 'American Samoa' }), // other match (that starts with a)
+            );
+        });
+
+        it('should put matches on beginning before other matches - filter "Guinea"', () => {
+            const { result } = renderUseCountryFilteredData();
+
+            act(() => {
+                result.current.setFilterValue('Guinea');
+            });
+
+            expect(result.current.filteredData).toEqual([
+                expect.objectContaining({ name: 'Guinea' }), // exact match on name
+                expect.objectContaining({ name: 'Guinea-Bissau' }), // starts with match on name
+                expect.objectContaining({ name: 'Equatorial Guinea' }), // other match
+                expect.objectContaining({ name: 'Papua New Guinea' }), // other match
+            ]);
+        });
     });
 });

--- a/suite-native/trading-residence/src/hooks/useCountryFilteredData.ts
+++ b/suite-native/trading-residence/src/hooks/useCountryFilteredData.ts
@@ -1,9 +1,65 @@
 import { TradingCountryOption, nonSanctionedRegional } from '@suite-common/trading';
 import { useListDataFilter } from '@suite-native/trading-atoms';
 
-const filterCallback = ({ label, value }: TradingCountryOption, filterValue: string): boolean =>
-    label.toLowerCase().includes(filterValue.toLowerCase()) ||
-    value.toLowerCase().includes(filterValue.toLowerCase());
+const filterCallback = (
+    { label, value, codeAlpha3 }: TradingCountryOption,
+    filterValue: string,
+): boolean => {
+    const lowerCaseFilterValue = filterValue.toLowerCase();
+
+    return (
+        label.toLowerCase().includes(lowerCaseFilterValue) ||
+        codeAlpha3.toLowerCase().includes(lowerCaseFilterValue) ||
+        value.toLowerCase().includes(lowerCaseFilterValue)
+    );
+};
+
+const sortCallback = (
+    a: TradingCountryOption,
+    b: TradingCountryOption,
+    filterValue: string,
+): number => {
+    const lowerCaseFilterValue = filterValue.toLowerCase();
+
+    if (filterValue) {
+        // exact match on name
+        if (a.name.toLowerCase() === lowerCaseFilterValue) {
+            return -1;
+        }
+        if (b.name.toLowerCase() === lowerCaseFilterValue) {
+            return 1;
+        }
+        // exact match on value
+        if (a.value.toLowerCase() === lowerCaseFilterValue) {
+            return -1;
+        }
+        if (b.value.toLowerCase() === lowerCaseFilterValue) {
+            return 1;
+        }
+        // exact match on codeAlpha3
+        if (a.codeAlpha3.toLowerCase() === lowerCaseFilterValue) {
+            return -1;
+        }
+        if (b.codeAlpha3.toLowerCase() === lowerCaseFilterValue) {
+            return 1;
+        }
+        // starts with match on name
+        if (
+            a.name.toLowerCase().startsWith(lowerCaseFilterValue) &&
+            !b.name.toLowerCase().startsWith(lowerCaseFilterValue)
+        ) {
+            return -1;
+        }
+        if (
+            b.name.toLowerCase().startsWith(lowerCaseFilterValue) &&
+            !a.name.toLowerCase().startsWith(lowerCaseFilterValue)
+        ) {
+            return 1;
+        }
+    }
+
+    return a.name.localeCompare(b.name);
+};
 
 export const useCountryFilteredData = () =>
-    useListDataFilter(nonSanctionedRegional.countriesOptions, filterCallback);
+    useListDataFilter(nonSanctionedRegional.countriesOptions, filterCallback, sortCallback);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- added filtering by codeAlpha3 value (POL, USA, CZE, ...)
- sorting improved

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #24027


## Screenshots:

<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-01-22 at 10 07 17" src="https://github.com/user-attachments/assets/fec76df7-c50f-402a-927c-813f577060dd" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-01-22 at 10 07 46" src="https://github.com/user-attachments/assets/c4e787bc-f911-401e-abd7-c2d29cab1684" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24027-improve-country-code-search-in-country-picker-mobile&lookback=7)