### PR TITLE
fix(connect): useEmptyPassphrase on EvoluSignRegistrationRequest

### DIFF
--- a/packages/connect/src/api/evoluSignRegistrationRequest.ts
+++ b/packages/connect/src/api/evoluSignRegistrationRequest.ts
@@ -13,6 +13,7 @@ export default class EvoluSignRegistrationRequest extends AbstractMethod<
     init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
+        this.useEmptyPassphrase = true;
 
         const { payload } = this;
 


### PR DESCRIPTION
Fix the passphrase require while signing Evolu registration request.

**changes**:
- added `useEmptyPassphrase` set to true for `packages/connect/src/api/evoluSignRegistrationRequest.ts`


## Notes for QA

- registering device in QM should not prompt for passphrase

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24554



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/qm-requires-passphrase&lookback=7)