### PR TITLE
fix(suite): nft id spaces and link

### DIFF
--- a/packages/suite/src/components/suite/FormattedNftAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedNftAmount.tsx
@@ -70,7 +70,7 @@ export const FormattedNftAmount = ({
                         </Row>
                         {isWithLink && network?.networkType === 'ethereum' ? (
                             <TrezorLink
-                                href={`${getExplorerUrl(explorer, 'nft')}/${transfer.contract}/${token.id}`}
+                                href={`${getExplorerUrl(explorer, 'nft')}${transfer.contract}/${token.id}`}
                                 typographyStyle={linkTypographyStyle}
                             >
                                 <Text maxWidth={145} ellipsisLineCount={1} variant="primary">
@@ -98,7 +98,7 @@ export const FormattedNftAmount = ({
                 <TrezorLink
                     href={
                         network?.networkType === 'ethereum'
-                            ? `${getExplorerUrl(explorer, 'nft')}/${transfer.contract}/${transfer.amount}`
+                            ? `${getExplorerUrl(explorer, 'nft')}${transfer.contract}/${transfer.amount}`
                             : undefined
                     }
                     typographyStyle={linkTypographyStyle}
@@ -108,17 +108,18 @@ export const FormattedNftAmount = ({
                             <HiddenPlaceholder>
                                 <RedactNumericalValue value={transfer.amount} />
                             </HiddenPlaceholder>
+                            &nbsp;
                         </Text>
-                        &nbsp;
                         {symbolComponent}
                     </Row>
                 </TrezorLink>
             ) : (
-                <Row gap={spacings.xxs}>
+                <Row padding={{ horizontal: 4 }}>
                     <Text maxWidth={145} ellipsisLineCount={1}>
                         <HiddenPlaceholder>
                             <RedactNumericalValue value={transfer.amount} />
                         </HiddenPlaceholder>
+                        &nbsp;
                     </Text>
                     {symbolComponent}
                 </Row>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- fix nft link to not contain double `//`
- spaces around nft symbol

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #18338

## Screenshots:
<img width="293" height="144" alt="Screenshot 2026-01-22 at 12 16 31" src="https://github.com/user-attachments/assets/ab6d9d72-bf07-4c61-9c6d-feb68f1e7ec7" />
<img width="393" height="221" alt="Screenshot 2026-01-22 at 12 07 09" src="https://github.com/user-attachments/assets/c65fc644-d226-4fa9-9a71-cbbd117e1580" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/nft/ui&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/nft/ui&lookback=7)