### PR TITLE
fix(ci): Nx caching input definitions

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -6,8 +6,7 @@
             "{workspaceRoot}/patches/*.patch",
             "{workspaceRoot}/package.json"
         ],
-        "default": ["{projectRoot}/**/*", "sharedGlobals"],
-        "prod": ["default", "!{projectRoot}/**/*.test.{ts,tsx}"]
+        "default": ["{projectRoot}/**/*", "sharedGlobals"]
     },
     "tui": {
         "autoExit": true
@@ -16,32 +15,29 @@
         "build:lib": {
             "dependsOn": [],
             "inputs": [
-                "^prod",
+                "default",
                 "{workspaceRoot}/tsconfig.base.json",
                 "{workspaceRoot}/tsconfig.lib.json"
             ],
-            "outputs": ["{projectRoot}/lib", "{projectRoot}/build"],
+            "outputs": ["{projectRoot}/lib", "{projectRoot}/libESM", "{projectRoot}/build"],
             "cache": true
         },
         "type-check": {
             "dependsOn": [
+                "default",
                 "^type-check",
                 "^guide-pull-content",
                 "guide-pull-content",
                 "@suite-common/message-system:build:lib"
             ],
-            "inputs": [
-                "^prod",
-                "{workspaceRoot}/tsconfig.base.json",
-                "{workspaceRoot}/tsconfig.lib.json"
-            ],
+            "inputs": ["{workspaceRoot}/tsconfig.base.json", "{workspaceRoot}/tsconfig.lib.json"],
             "outputs": ["{projectRoot}/libDev"],
             "cache": true
         },
         "test:unit": {
             "dependsOn": ["@suite-common/message-system:build:lib"],
             "inputs": [
-                "^prod",
+                "default",
                 "{workspaceRoot}/jest.config.base.js",
                 "{workspaceRoot}/jest.config.native.js"
             ],


### PR DESCRIPTION
## Description

Following upgrade of Nx in https://github.com/trezor/trezor-suite/pull/24271 (v18.0.3 → v22.3.3) we have suffered false negatives several times, meaning unit tests would pass in a PR, but were actually broken, and merging them broke develop :scream: 

That recently occurred in #24548 and #24494, both times the affected workspace was `Remote Cache Hit` → CI was green without running the affected test.

Turns out, our config of caching inputs was unclearly defined, which somehow worked in old version but broke in latest. Fixed. If curious, you can study [docs here](https://nx.dev/docs/reference/inputs).

### Local repro example 

I prepared a branch for local run with a commit that breaks test, but it's currently undetected.
The first unit test run creates cache, and takes a long time. If it fails it's just flaky → rerun until green.
The second run should fail at `suite-desktop-core`, but **does not** – it's a local cache hit, despite changes :scream:    
```
git fetch origin fix/nx-cache-REPRO
git checkout fix/nx-cache-REPRO
npm version major # just something to create a top-level diff against develop 
yarn nx reset # clears all local cache
yarn nx:test-unit:suite
git revert HEAD~1 --no-edit # reapplies the breaking change
yarn nx:test-unit:suite # should fail but passes!
```

With 216d1cdce340533f37ff4af9ea30bb208d381833 it's fixed, so the second run fails as it should:

```
git fetch origin fix/nx-cache-REPRO-FIX
git checkout fix/nx-cache-REPRO-FIX
npm version minor # just something to create a top-level diff against develop
yarn nx reset # clears all local cache
yarn nx:test-unit:suite
git revert HEAD~1 --no-edit # reapplies the breaking change
yarn nx:test-unit:suite # fails as it should.
```

:arrow_right: I intend to create a minimal repro gist and make an issue at nx, if possible.

## Notes for QA

N/A, it's only CI related.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/nx-cache&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/nx-cache&lookback=7)