### PR TITLE
fix: turning ON the SuiteSync triggers flow only for selected device

### DIFF
--- a/packages/suite/src/actions/wallet/processLegacyMetadataIntoSuiteSyncThunk.ts
+++ b/packages/suite/src/actions/wallet/processLegacyMetadataIntoSuiteSyncThunk.ts
@@ -1,7 +1,10 @@
 import { MetadataAddPayload } from '@suite-common/metadata-types';
 import { createThunk } from '@suite-common/redux-utils';
 import { SuiteSyncUpdateError } from '@suite-common/suite-sync-storage';
-import { SuiteSyncUnavailableOnDeviceErrorType } from '@suite-common/suite-sync-types';
+import {
+    SuiteSyncFirmwareUpgradeNeededDeviceErrorType,
+    SuiteSyncUnavailableOnDeviceErrorType,
+} from '@suite-common/suite-sync-types';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
     DeviceCancelledErrType,
@@ -26,6 +29,7 @@ export const processLegacyMetadataIntoSuiteSyncThunk = createThunk<
     Result<
         void,
         | SuiteSyncUnavailableOnDeviceErrorType
+        | SuiteSyncFirmwareUpgradeNeededDeviceErrorType
         | DeviceErrorType
         | DeviceCancelledErrType
         | SuiteSyncUpdateError

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -421,6 +421,7 @@ export const Labeling = ({
                 const { type } = result.payload.error;
                 switch (type) {
                     case 'SuiteSyncUnavailableOnDeviceError':
+                    case 'SuiteSyncFirmwareUpgradeNeededDeviceErrorType':
                     case 'DeviceError':
                     case 'DeviceCancelled':
                     case 'SuiteSyncUpdateError':
@@ -573,6 +574,7 @@ export const MetadataLabeling = ({
                 const { type } = result.payload.error;
                 switch (type) {
                     case 'SuiteSyncUnavailableOnDeviceError':
+                    case 'SuiteSyncFirmwareUpgradeNeededDeviceErrorType':
                     case 'DeviceError':
                     case 'DeviceCancelled':
                     case 'SuiteSyncUpdateError':

--- a/packages/suite/src/components/suite/labeling/TurnOnSecureSyncModal.tsx
+++ b/packages/suite/src/components/suite/labeling/TurnOnSecureSyncModal.tsx
@@ -3,7 +3,7 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { Card, IconCircle, List, Modal, Paragraph } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 
-import { useDispatch } from '../../../hooks/suite';
+import { useDevice, useDispatch } from '../../../hooks/suite';
 import { useSuiteServices } from '../../../support/SuiteServicesProvider';
 
 type TurnOnSecureSyncModalProps = {
@@ -14,22 +14,27 @@ export const TurnOnSecureSyncModal = ({ onClose }: TurnOnSecureSyncModalProps) =
     const { suiteSync } = useSuiteServices();
     const dispatch = useDispatch();
 
-    const onSwitch = () => {
-        suiteSync.turnOnSuiteSync({
-            onError: ({ error }) => {
-                const { type } = error;
-                switch (type) {
-                    case 'SuiteSyncUnavailableOnDeviceError':
-                    case 'DeviceCancelled':
-                    case 'DeviceError':
-                        dispatch(notificationsActions.addToast({ type: 'error', error: type }));
+    const { device } = useDevice();
 
-                        return;
-                    default:
-                        return exhaustive(type);
-                }
-            },
+    const onSwitch = async () => {
+        const result = await suiteSync.turnOnSuiteSync({
+            deviceStaticSessionId: device?.state?.staticSessionId,
         });
+
+        if (!result.success) {
+            const { type } = result.error;
+            switch (type) {
+                case 'SuiteSyncUnavailableOnDeviceError':
+                case 'SuiteSyncFirmwareUpgradeNeededDeviceErrorType':
+                case 'DeviceCancelled':
+                case 'DeviceError':
+                    dispatch(notificationsActions.addToast({ type: 'error', error: type }));
+
+                    return;
+                default:
+                    return exhaustive(type);
+            }
+        }
 
         onClose();
     };

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { EventType } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import {
-    isSuiteSyncSupportedByDevice,
     selectIsFeatureSuiteSyncAvailable,
     selectIsSuiteSyncEnabled,
 } from '@suite-common/suite-sync';
@@ -37,6 +36,7 @@ export const Labeling = () => {
     const legacyAnalytics = useLegacyAnalytics();
     const [legacyModalWarningVisible, setLegacyModalWarningVisible] = useState(false);
     const { device } = useDevice();
+    const deviceStaticSessionId = device?.state?.staticSessionId;
     const { isDeviceLabelingDisabled } = useLabelingDeviceState();
 
     const showSuiteSync = useSelector(selectIsFeatureSuiteSyncAvailable);
@@ -59,7 +59,7 @@ export const Labeling = () => {
                 : translationString(option.label),
     }));
 
-    const handleOnChange = (selected: LabelingOptionTranslated) => {
+    const handleOnChange = async (selected: LabelingOptionTranslated) => {
         const { value } = selected;
 
         // show a warning legacy modal when user selects legacy option while using Suite Sync
@@ -75,25 +75,25 @@ export const Labeling = () => {
                 suiteSync.turnOffSuiteSync();
                 break;
 
-            case 'secure-sync':
-                suiteSync.turnOnSuiteSync({
-                    onError: ({ error }) => {
-                        const { type } = error;
-                        switch (type) {
-                            case 'SuiteSyncUnavailableOnDeviceError':
-                            case 'DeviceCancelled':
-                            case 'DeviceError':
-                                dispatch(
-                                    notificationsActions.addToast({ type: 'error', error: type }),
-                                );
+            case 'secure-sync': {
+                const result = await suiteSync.turnOnSuiteSync({ deviceStaticSessionId });
+                if (!result.success) {
+                    const { type } = result.error;
+                    switch (type) {
+                        case 'SuiteSyncUnavailableOnDeviceError':
+                        case 'SuiteSyncFirmwareUpgradeNeededDeviceErrorType':
+                        case 'DeviceCancelled':
+                        case 'DeviceError':
+                            dispatch(notificationsActions.addToast({ type: 'error', error: type }));
 
-                                return;
-                            default:
-                                return exhaustive(type);
-                        }
-                    },
-                });
+                            return;
+                        default:
+                            return exhaustive(type);
+                    }
+                }
+
                 break;
+            }
 
             case 'legacy':
                 suiteSync.turnOffSuiteSync();
@@ -165,11 +165,7 @@ export const Labeling = () => {
                 />
                 <ActionColumn>
                     <ActionSelect
-                        options={translatedOptions.filter(
-                            option =>
-                                option.value !== 'secure-sync' ||
-                                (showSuiteSync && isSuiteSyncSupportedByDevice(device)),
-                        )}
+                        options={translatedOptions}
                         value={getSelectedOption()}
                         onChange={handleOnChange}
                         data-testid="@settings/labeling-select"

--- a/suite-common/suite-sync-types/src/data/updateAccountLabel.ts
+++ b/suite-common/suite-sync-types/src/data/updateAccountLabel.ts
@@ -4,6 +4,7 @@ import type { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
 import { SuiteSyncUnavailableOnDeviceErrorType } from '../refreshSuiteSyncKeys';
+import { SuiteSyncFirmwareUpgradeNeededDeviceErrorType } from '../storage/ensureWalletSuiteSyncOn';
 
 export type UpdateAccountLabelParams = {
     deviceStaticSessionId: StaticSessionId;
@@ -17,6 +18,7 @@ export type UpdateAccountLabel = (
     Result<
         void,
         | SuiteSyncUnavailableOnDeviceErrorType
+        | SuiteSyncFirmwareUpgradeNeededDeviceErrorType
         | DeviceErrorType
         | DeviceCancelledErrType
         | SuiteSyncUpdateError

--- a/suite-common/suite-sync-types/src/data/updateAddressLabel.ts
+++ b/suite-common/suite-sync-types/src/data/updateAddressLabel.ts
@@ -9,6 +9,7 @@ import type { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
 import { SuiteSyncUnavailableOnDeviceErrorType } from '../refreshSuiteSyncKeys';
+import { SuiteSyncFirmwareUpgradeNeededDeviceErrorType } from '../storage/ensureWalletSuiteSyncOn';
 
 export type UpdateAddressLabelParams = {
     deviceStaticSessionId: StaticSessionId;
@@ -24,6 +25,7 @@ export type UpdateAddressLabel = (
     Result<
         void,
         | SuiteSyncUnavailableOnDeviceErrorType
+        | SuiteSyncFirmwareUpgradeNeededDeviceErrorType
         | DeviceErrorType
         | DeviceCancelledErrType
         | SuiteSyncUpdateError

--- a/suite-common/suite-sync-types/src/data/updateOutputLabel.ts
+++ b/suite-common/suite-sync-types/src/data/updateOutputLabel.ts
@@ -9,6 +9,7 @@ import type { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
 import { SuiteSyncUnavailableOnDeviceErrorType } from '../refreshSuiteSyncKeys';
+import { SuiteSyncFirmwareUpgradeNeededDeviceErrorType } from '../storage/ensureWalletSuiteSyncOn';
 
 type UpdateOutputLabelParams = {
     deviceStaticSessionId: StaticSessionId;
@@ -25,6 +26,7 @@ export type UpdateOutputLabel = (
     Result<
         void,
         | SuiteSyncUnavailableOnDeviceErrorType
+        | SuiteSyncFirmwareUpgradeNeededDeviceErrorType
         | DeviceErrorType
         | DeviceCancelledErrType
         | SuiteSyncUpdateError

--- a/suite-common/suite-sync-types/src/data/updateWalletLabel.ts
+++ b/suite-common/suite-sync-types/src/data/updateWalletLabel.ts
@@ -4,6 +4,7 @@ import type { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
 import { SuiteSyncUnavailableOnDeviceErrorType } from '../refreshSuiteSyncKeys';
+import { SuiteSyncFirmwareUpgradeNeededDeviceErrorType } from '../storage/ensureWalletSuiteSyncOn';
 
 export type UpdateWalletLabelParams = {
     deviceStaticSessionId: StaticSessionId;
@@ -16,6 +17,7 @@ export type UpdateWalletLabel = (
     Result<
         void,
         | SuiteSyncUnavailableOnDeviceErrorType
+        | SuiteSyncFirmwareUpgradeNeededDeviceErrorType
         | DeviceErrorType
         | DeviceCancelledErrType
         | SuiteSyncUpdateError

--- a/suite-common/suite-sync-types/src/index.ts
+++ b/suite-common/suite-sync-types/src/index.ts
@@ -32,6 +32,7 @@ export type {
     EnsureWalletSuiteSyncOn,
     EnsureWalletSuiteSyncOnDep,
     EnsureWalletSuiteSyncOnParams,
+    SuiteSyncFirmwareUpgradeNeededDeviceErrorType,
 } from './storage/ensureWalletSuiteSyncOn';
 
 export type {

--- a/suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn.ts
+++ b/suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn.ts
@@ -5,6 +5,10 @@ import { Result } from '@trezor/type-utils';
 
 import { SuiteSyncUnavailableOnDeviceErrorType } from '../refreshSuiteSyncKeys';
 
+export type SuiteSyncFirmwareUpgradeNeededDeviceErrorType = {
+    type: 'SuiteSyncFirmwareUpgradeNeededDeviceErrorType';
+};
+
 export type EnsureWalletSuiteSyncOnParams = { deviceStaticSessionId: StaticSessionId };
 
 export type EnsureWalletSuiteSyncOn = (
@@ -12,7 +16,10 @@ export type EnsureWalletSuiteSyncOn = (
 ) => Promise<
     Result<
         SuiteSyncStorage,
-        SuiteSyncUnavailableOnDeviceErrorType | DeviceErrorType | DeviceCancelledErrType
+        | SuiteSyncUnavailableOnDeviceErrorType
+        | SuiteSyncFirmwareUpgradeNeededDeviceErrorType
+        | DeviceErrorType
+        | DeviceCancelledErrType
     >
 >;
 

--- a/suite-common/suite-sync-types/src/turnOnSuiteSync.ts
+++ b/suite-common/suite-sync-types/src/turnOnSuiteSync.ts
@@ -1,15 +1,30 @@
 import { DeviceCancelledErrType, DeviceErrorType } from '@suite-common/wallet-types';
 import { StaticSessionId } from '@trezor/connect';
+import { Result } from '@trezor/type-utils';
 
 import { SuiteSyncUnavailableOnDeviceErrorType } from './refreshSuiteSyncKeys';
+import { SuiteSyncFirmwareUpgradeNeededDeviceErrorType } from './storage/ensureWalletSuiteSyncOn';
 
 type TurnOnSuiteSyncParams = {
-    onError: (params: {
-        deviceStaticSessionId: StaticSessionId;
-        error: SuiteSyncUnavailableOnDeviceErrorType | DeviceErrorType | DeviceCancelledErrType;
-    }) => void;
+    /**
+     * You can optionally provide deviceStaticSessionId for which
+     * the `ensureWalletSuiteSyncOn` will be called (keys, quota-manager, ...)
+     *
+     * It is optional for context where you do not have selected device.
+     */
+    deviceStaticSessionId: StaticSessionId | undefined;
 };
 
-export type TurnOnSuiteSync = (params: TurnOnSuiteSyncParams) => void;
+export type TurnOnSuiteSync = (
+    params: TurnOnSuiteSyncParams,
+) => Promise<
+    Result<
+        void,
+        | SuiteSyncUnavailableOnDeviceErrorType
+        | SuiteSyncFirmwareUpgradeNeededDeviceErrorType
+        | DeviceErrorType
+        | DeviceCancelledErrType
+    >
+>;
 
 export type TurnOnSuiteSyncDep = { turnOnSuiteSync: TurnOnSuiteSync };

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -144,18 +144,10 @@ export const createSuiteSyncCompositionRoot = (
             ensureWalletSuiteSyncOn,
         }),
         labeling: {
-            updateWalletLabel: createUpdateWalletLabel({
-                ensureWalletSuiteSyncOn,
-            }),
-            updateAccountLabel: createUpdateAccountLabel({
-                ensureWalletSuiteSyncOn,
-            }),
-            updateOutputLabel: createUpdateOutputLabel({
-                ensureWalletSuiteSyncOn,
-            }),
-            updateAddressLabel: createUpdateAddressLabel({
-                ensureWalletSuiteSyncOn,
-            }),
+            updateWalletLabel: createUpdateWalletLabel({ ensureWalletSuiteSyncOn }),
+            updateAccountLabel: createUpdateAccountLabel({ ensureWalletSuiteSyncOn }),
+            updateOutputLabel: createUpdateOutputLabel({ ensureWalletSuiteSyncOn }),
+            updateAddressLabel: createUpdateAddressLabel({ ensureWalletSuiteSyncOn }),
         },
     };
 };

--- a/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
@@ -2,12 +2,10 @@ import { Dispatch } from '@reduxjs/toolkit';
 
 import { TurnOnSuiteSync } from '@suite-common/suite-sync-types';
 import { EnsureWalletSuiteSyncOnDep } from '@suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn';
-import { selectDevices } from '@suite-common/wallet-core';
-import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
+import { ok } from '@trezor/type-utils';
 
 import { suiteSyncActions } from './suiteSyncActions';
 import { selectIsSuiteSyncEnabled } from './suiteSyncSelectors';
-import { isSuiteSyncSupportedByDevice } from './suiteSyncUtils';
 
 export type CreateTurnOnSuiteSyncDeps = {
     getState: () => any;
@@ -16,37 +14,24 @@ export type CreateTurnOnSuiteSyncDeps = {
 
 export const createTurnOnSuiteSync =
     (deps: CreateTurnOnSuiteSyncDeps): TurnOnSuiteSync =>
-    async ({ onError }) => {
+    async ({ deviceStaticSessionId }) => {
         const isSuiteSyncEnabled = selectIsSuiteSyncEnabled(deps.getState());
 
         if (isSuiteSyncEnabled) {
-            return;
+            return ok();
         }
 
         deps.dispatch(suiteSyncActions.updateSuiteSyncEnabled({ isEnabled: true }));
 
-        // Turn on and subscribe labeling for all wallets.
-        const devices = selectDevices(deps.getState());
+        if (deviceStaticSessionId !== undefined) {
+            const result = await deps.ensureWalletSuiteSyncOn({
+                deviceStaticSessionId,
+            });
 
-        for (const device of devices) {
-            if (device?.state?.staticSessionId) {
-                const canTurnOnSuiteSync =
-                    isTrezorDeviceWithState(device) && isSuiteSyncSupportedByDevice(device);
-
-                if (!canTurnOnSuiteSync) {
-                    continue;
-                }
-
-                const result = await deps.ensureWalletSuiteSyncOn({
-                    deviceStaticSessionId: device.state.staticSessionId,
-                });
-
-                if (!result.success) {
-                    onError({
-                        deviceStaticSessionId: device.state.staticSessionId,
-                        error: result.error,
-                    });
-                }
+            if (!result.success) {
+                return result;
             }
         }
+
+        return ok();
     };

--- a/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOn.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOn.ts
@@ -10,7 +10,7 @@ import { selectDeviceByStaticSessionId } from '@suite-common/wallet-core';
 import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
 import { err } from '@trezor/type-utils';
 
-import { isSuiteSyncSupportedByDevice } from '../suiteSyncUtils';
+import { isFwUpgradeNeededForSuiteSync, isSuiteSyncSupportedByDevice } from '../suiteSyncUtils';
 
 export type EnsureWalletSuiteSyncOnDeps = {
     dispatch: Dispatch;
@@ -29,6 +29,10 @@ export const createEnsureWalletSuiteSyncOn =
 
         if (!canTurnOnSuiteSync) {
             return err({ type: 'SuiteSyncUnavailableOnDeviceError' });
+        }
+
+        if (isFwUpgradeNeededForSuiteSync(device)) {
+            return err({ type: 'SuiteSyncFirmwareUpgradeNeededDeviceErrorType' });
         }
 
         return await deps.ensureSuiteSyncData({ deviceStaticSessionId });

--- a/suite-common/suite-sync/src/suiteSyncUtils.ts
+++ b/suite-common/suite-sync/src/suiteSyncUtils.ts
@@ -1,5 +1,10 @@
 import { TrezorDevice } from '@suite-common/suite-types';
 import { Device } from '@trezor/connect';
 
-export const isSuiteSyncSupportedByDevice = (device: Device | TrezorDevice | undefined) =>
-    device?.unavailableCapabilities?.evolu === undefined;
+export const isFwUpgradeNeededForSuiteSync = (device: Device | TrezorDevice | undefined): boolean =>
+    device?.unavailableCapabilities?.evolu !== undefined &&
+    device.unavailableCapabilities.evolu === 'update-required';
+
+export const isSuiteSyncSupportedByDevice = (device: Device | TrezorDevice | undefined): boolean =>
+    device?.unavailableCapabilities?.evolu === undefined ||
+    device.unavailableCapabilities.evolu === 'update-required';

--- a/suite-common/test-utils/src/extraDependenciesCommonMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesCommonMock.ts
@@ -25,7 +25,7 @@ const suiteSyncMock: SuiteSync = {
     ensureWalletSuiteSyncOn: () =>
         Promise.resolve(err({ type: 'SuiteSyncUnavailableOnDeviceError' })),
     turnOffSuiteSyncForWallet: () => Promise.resolve(),
-    turnOnSuiteSync: () => Promise.resolve(),
+    turnOnSuiteSync: () => Promise.resolve(ok()),
     turnOffSuiteSync: () => Promise.resolve(),
     labeling: {
         updateAccountLabel: () => Promise.resolve(ok()),

--- a/suite-native/labeling/src/components/EditableLabelLayout.tsx
+++ b/suite-native/labeling/src/components/EditableLabelLayout.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import type { BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
 
 import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { BottomSheetModal, TextButton, useBottomSheetModal } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -27,28 +28,33 @@ export const EditableLabelLayout = ({ children, label, testID }: EditableLabelLa
 
     const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
     const isLabelingEnabled = useSelector(selectIsLabelingEnabled);
+    const selectedDevice = useSelector(selectSelectedDevice);
 
     const showSuiteSyncEnableConfirmationAlert = (onSuccess: () => void) => {
         showAlert({
             title: <Translation id="suiteSync.enableAlert.title" />,
             description: <Translation id="suiteSync.enableAlert.description" />,
             primaryButtonTitle: <Translation id="suiteSync.enableAlert.cta" />,
-            onPressPrimaryButton: () => {
-                suiteSync.turnOnSuiteSync({
-                    onError: ({ error }) => {
-                        const { type } = error;
-                        switch (type) {
-                            case 'SuiteSyncUnavailableOnDeviceError':
-                            case 'DeviceCancelled':
-                            case 'DeviceError':
-                                showToast({ variant: 'error', icon: 'warning', message: type });
-
-                                return;
-                            default:
-                                return exhaustive(type);
-                        }
-                    },
+            onPressPrimaryButton: async () => {
+                const result = await suiteSync.turnOnSuiteSync({
+                    deviceStaticSessionId: selectedDevice?.state?.staticSessionId,
                 });
+
+                if (!result.success) {
+                    const { type } = result.error;
+                    switch (type) {
+                        case 'SuiteSyncUnavailableOnDeviceError':
+                        case 'SuiteSyncFirmwareUpgradeNeededDeviceErrorType':
+                        case 'DeviceCancelled':
+                        case 'DeviceError':
+                            showToast({ variant: 'error', icon: 'warning', message: type });
+
+                            return;
+                        default:
+                            return exhaustive(type);
+                    }
+                }
+
                 onSuccess();
             },
             secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,

--- a/suite-native/module-settings/src/components/ToggleLabelingCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleLabelingCard.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { TouchableSwitchRow } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -13,6 +14,7 @@ export const ToggleLabelingCard = () => {
     const { showToast } = useToast();
     const { suiteSync } = useNativeServices();
     const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
+    const selectedDevice = useSelector(selectSelectedDevice);
 
     const showSuiteSyncDisableConfirmationAlert = () => {
         showAlert({
@@ -24,25 +26,28 @@ export const ToggleLabelingCard = () => {
         });
     };
 
-    const toggleSuiteSync = () => {
+    const toggleSuiteSync = async () => {
         if (isSuiteSyncEnabled) {
             showSuiteSyncDisableConfirmationAlert();
         } else {
-            suiteSync.turnOnSuiteSync({
-                onError: ({ error }) => {
-                    const { type } = error;
-                    switch (type) {
-                        case 'SuiteSyncUnavailableOnDeviceError':
-                        case 'DeviceCancelled':
-                        case 'DeviceError':
-                            showToast({ variant: 'error', icon: 'warning', message: type });
-
-                            return;
-                        default:
-                            return exhaustive(type);
-                    }
-                },
+            const result = await suiteSync.turnOnSuiteSync({
+                deviceStaticSessionId: selectedDevice?.state?.staticSessionId,
             });
+
+            if (!result.success) {
+                const { type } = result.error;
+                switch (type) {
+                    case 'SuiteSyncUnavailableOnDeviceError':
+                    case 'SuiteSyncFirmwareUpgradeNeededDeviceErrorType':
+                    case 'DeviceCancelled':
+                    case 'DeviceError':
+                        showToast({ variant: 'error', icon: 'warning', message: type });
+
+                        return;
+                    default:
+                        return exhaustive(type);
+                }
+            }
         }
     };
 


### PR DESCRIPTION
Part of: https://github.com/trezor/trezor-suite/issues/24024

Turning ON the SuiteSync for all connected devices brings a ton of edge-cases that are hard to entangle  (especially with passphrase & pin)

So we avoid this pitfall by simply turning it on only for selected device, which is like 99% case of our users.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=turn-on-suite-sync&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=turn-on-suite-sync&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=turn-on-suite-sync&lookback=7)