### PR TITLE
fix(e2e-suite): limit send-base test to run once per night

### DIFF
--- a/suite/e2e/tests/metadata/suite-sync.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync.test.ts
@@ -111,6 +111,17 @@ test.describe('Suite Sync - Labelling', { tag: ['@specificFirmware', '@T3W1', '@
                         ],
                         actions: { right_button: 'Confirm' },
                     },
+                    T3T1: {
+                        body: [
+                            [
+                                'Allow Trezor Suite to use',
+                                '\n',
+                                'Suite Sync with this',
+                                '\n',
+                                'Trezor?',
+                            ],
+                        ],
+                    },
                 });
             }
             await metadataPage.confirmSuiteSyncSetup();

--- a/suite/e2e/tests/wallet/send-base.test.ts
+++ b/suite/e2e/tests/wallet/send-base.test.ts
@@ -12,240 +12,261 @@ const formattedSendAddress = formatAddressWithNewlines(sendAddress);
 const sendAmount = '0.000008';
 const formattedSendAmount = `${localizeNumber(sendAmount)} ETH`;
 
-test.describe('Send Base', { tag: ['@nightlyOnly', '@T3W1', '@T3T1'] }, () => {
-    test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
-
-    test.beforeEach(async ({ onboardingPage, dashboardPage, walletPage, settingsPage, page }) => {
-        await page.clock.install();
-        await onboardingPage.completeOnboarding();
-        await settingsPage.changeNetworks({
-            enableNetworks: ['base'], //add more EVMs
-            disableNetworks: ['btc'],
+// This test is vulnerable to being run twice simultaneously
+// in such case nonce will collide and second transaction will fail
+// To avoid this, we tag this way to unsure it runs only once per night
+test.describe(
+    'Send Base',
+    { tag: ['@desktopOnly', '@nightlyOnly', '@T3W1', '@specificFirmware'] },
+    () => {
+        test.use({
+            emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true },
         });
-        await dashboardPage.deviceSwitchingOpenButton.click();
-        await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
-        await walletPage.openAccount({ symbol: 'base', type: 'normal', atIndex: 0 });
-    });
 
-    test('User can set custom fees', async ({ devicePrompt, walletPage, tradingPage }) => {
-        const gasLimit = '26000';
-        const maxFeePerGas = '0.67674454';
-        const maxFeePerGasRounded = new BigNumber(maxFeePerGas).decimalPlaces(
-            4,
-            BigNumber.ROUND_UP,
-        ); // beware of decimal places rounding
-        const maxPriorityFeePerGas = '0.375641927';
-        const maxPriorityFeePerGasRounded = new BigNumber(maxPriorityFeePerGas).decimalPlaces(
-            4, // beware of decimal places rounding
-            BigNumber.ROUND_UP,
+        test.beforeEach(
+            async ({ onboardingPage, dashboardPage, walletPage, settingsPage, page }) => {
+                await page.clock.install();
+                await onboardingPage.completeOnboarding();
+                await settingsPage.changeNetworks({
+                    enableNetworks: ['base'], //add more EVMs
+                    disableNetworks: ['btc'],
+                });
+                await dashboardPage.deviceSwitchingOpenButton.click();
+                await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+                await walletPage.openAccount({ symbol: 'base', type: 'normal', atIndex: 0 });
+            },
         );
-        await test.step('Fill in a Send form', async () => {
-            await walletPage.openSendFormButton.click();
-            // Race condition 1:5, if input is filled before form completely loads then
-            // input will be cleared and test will fail. As a workaround we wait for fees to be loaded.
-            await tradingPage.fees.expectEthereumFeeCalculated();
-            await tradingPage.sendAddressInput.fill(sendAddress);
-            await tradingPage.sendAmountInput.fill(sendAmount);
-            await tradingPage.fees.setEthereumCustomFees({
+
+        test('User can set custom fees', async ({ devicePrompt, walletPage, tradingPage }) => {
+            const gasLimit = '26000';
+            const maxFeePerGas = '0.67674454';
+            const maxFeePerGasRounded = new BigNumber(maxFeePerGas).decimalPlaces(
+                4,
+                BigNumber.ROUND_UP,
+            ); // beware of decimal places rounding
+            const maxPriorityFeePerGas = '0.375641927';
+            const maxPriorityFeePerGasRounded = new BigNumber(maxPriorityFeePerGas).decimalPlaces(
+                4, // beware of decimal places rounding
+                BigNumber.ROUND_UP,
+            );
+            await test.step('Fill in a Send form', async () => {
+                await walletPage.openSendFormButton.click();
+                // Race condition 1:5, if input is filled before form completely loads then
+                // input will be cleared and test will fail. As a workaround we wait for fees to be loaded.
+                await tradingPage.fees.expectEthereumFeeCalculated();
+                await tradingPage.sendAddressInput.fill(sendAddress);
+                await tradingPage.sendAmountInput.fill(sendAmount);
+                await tradingPage.fees.setEthereumCustomFees({
+                    gasLimit,
+                    maxFeePerGas,
+                    maxPriorityFeePerGas,
+                });
+            });
+
+            const { ethereumMaximumFee, errorMessageMaxCalculation } =
+                tradingPage.fees.calculateEthereumMaxFee({
+                    gasLimit,
+                    maxFeePerGas,
+                });
+
+            await test.step('Verify Recipient address', async () => {
+                await tradingPage.sendButton.click();
+                await expect(devicePrompt.headerParagraph).toContainText(networkName);
+                await expect(devicePrompt.outputValueOf('address')).toHaveText(
+                    formattedSendAddress,
+                );
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    T3W1: {
+                        header: { title: 'Send' },
+                        body: [transformAddress(sendAddress)],
+                        actions: { right_button: 'Continue' },
+                    },
+                    T3T1: {
+                        header: { title: 'Address', subtitle: 'Recipient' },
+                        body: [transformAddress(sendAddress)],
+                    },
+                });
+            });
+
+            await test.step('Verify Total including fee', async () => {
+                await devicePrompt.waitForPromptAndClick();
+                const gasLimitTranslation = `${messages['TR_GAS_LIMIT'].defaultMessage}: ${gasLimit}`;
+                await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitTranslation);
+                await expect(devicePrompt.ethereumFeeRate).toHaveText(
+                    `${maxFeePerGasRounded} Gwei`,
+                );
+                await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(
+                    `${maxPriorityFeePerGasRounded} Gwei`,
+                );
+                await expect(devicePrompt.cryptoAmountOf('amount')).toHaveText(sendAmount);
+                await expect(
+                    devicePrompt.cryptoAmountOf('fee'),
+                    errorMessageMaxCalculation,
+                ).toHaveText(ethereumMaximumFee);
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    T3W1: {
+                        header: { title: 'Send' },
+                        body: [
+                            ['Amount'],
+                            [formattedSendAmount],
+                            ['Maximum fee'],
+                            devicePrompt.wrapText(`${ethereumMaximumFee} ETH`, { isAmount: true }),
+                        ],
+                        actions: { right_button: 'Hold to sign' },
+                    },
+                    T3T1: {
+                        header: { title: 'Summary' },
+                    },
+                });
+            });
+
+            await test.step('Verify Fee Info on emulator', async () => {
+                await devicePrompt.openFeeInfoOnEmulator();
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    T3W1: {
+                        header: { title: 'Fee info' },
+                        body: [
+                            ['Gas limit'],
+                            [`${gasLimit} units`],
+                            ['Max fee per gas'],
+                            [maxFeePerGas, '\n', 'Gwei'],
+                            ['Max priority fee'],
+                            [maxPriorityFeePerGas, '\n', 'Gwei'],
+                        ],
+                    },
+                    T3T1: {
+                        header: { title: 'Fee info' },
+                        body: [
+                            ['Gas limit'],
+                            [`${gasLimit} units`],
+                            ['Max fee per gas'],
+                            [`${maxFeePerGas} Gwei`],
+                            ['Max priority fee'],
+                            [`${maxPriorityFeePerGas} Gwei`],
+                        ],
+                        footer: undefined,
+                    },
+                });
+            });
+        });
+
+        test('User can perform ethereum sending on base network', async ({
+            devicePrompt,
+            walletPage,
+            tradingPage,
+            page,
+        }) => {
+            await test.step('Fill in a Send form', async () => {
+                await walletPage.openSendFormButton.click();
+                // Race condition 1:5, if input is filled before form completely loads then
+                // input will be cleared and test will fail. As a workaround we wait for fees to be loaded.
+                await tradingPage.fees.expectEthereumFeeCalculated();
+                await tradingPage.sendAddressInput.fill(sendAddress);
+                await tradingPage.sendAmountInput.fill(sendAmount);
+            });
+            const {
                 gasLimit,
                 maxFeePerGas,
                 maxPriorityFeePerGas,
-            });
-        });
+                maxFeePerGasRounded,
+                maxPriorityFeePerGasRounded,
+            } = await tradingPage.fees.getStandardFeeWorkaround();
+            const { ethereumMaximumFee, errorMessageMaxCalculation } =
+                tradingPage.fees.calculateEthereumMaxFee({
+                    gasLimit,
+                    maxFeePerGas,
+                    numberOfDecimals: 15,
+                });
 
-        const { ethereumMaximumFee, errorMessageMaxCalculation } =
-            tradingPage.fees.calculateEthereumMaxFee({
-                gasLimit,
-                maxFeePerGas,
-            });
-
-        await test.step('Verify Recipient address', async () => {
-            await tradingPage.sendButton.click();
-            await expect(devicePrompt.headerParagraph).toContainText(networkName);
-            await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedSendAddress);
-            await expect(devicePrompt).toDisplayOnEmulator({
-                T3W1: {
-                    header: { title: 'Send' },
-                    body: [transformAddress(sendAddress)],
-                    actions: { right_button: 'Continue' },
-                },
-                T3T1: {
-                    header: { title: 'Address', subtitle: 'Recipient' },
-                    body: [transformAddress(sendAddress)],
-                },
-            });
-        });
-
-        await test.step('Verify Total including fee', async () => {
-            await devicePrompt.waitForPromptAndClick();
-            const gasLimitTranslation = `${messages['TR_GAS_LIMIT'].defaultMessage}: ${gasLimit}`;
-            await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitTranslation);
-            await expect(devicePrompt.ethereumFeeRate).toHaveText(`${maxFeePerGasRounded} Gwei`);
-            await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(
-                `${maxPriorityFeePerGasRounded} Gwei`,
-            );
-            await expect(devicePrompt.cryptoAmountOf('amount')).toHaveText(sendAmount);
-            await expect(devicePrompt.cryptoAmountOf('fee'), errorMessageMaxCalculation).toHaveText(
-                ethereumMaximumFee,
-            );
-            await expect(devicePrompt).toDisplayOnEmulator({
-                T3W1: {
-                    header: { title: 'Send' },
-                    body: [
-                        ['Amount'],
-                        [formattedSendAmount],
-                        ['Maximum fee'],
-                        devicePrompt.wrapText(`${ethereumMaximumFee} ETH`, { isAmount: true }),
-                    ],
-                    actions: { right_button: 'Hold to sign' },
-                },
-                T3T1: {
-                    header: { title: 'Summary' },
-                },
-            });
-        });
-
-        await test.step('Verify Fee Info on emulator', async () => {
-            await devicePrompt.openFeeInfoOnEmulator();
-            await expect(devicePrompt).toDisplayOnEmulator({
-                T3W1: {
-                    header: { title: 'Fee info' },
-                    body: [
-                        ['Gas limit'],
-                        [`${gasLimit} units`],
-                        ['Max fee per gas'],
-                        [maxFeePerGas, '\n', 'Gwei'],
-                        ['Max priority fee'],
-                        [maxPriorityFeePerGas, '\n', 'Gwei'],
-                    ],
-                },
-                T3T1: {
-                    header: { title: 'Fee info' },
-                    body: [
-                        ['Gas limit'],
-                        [`${gasLimit} units`],
-                        ['Max fee per gas'],
-                        [`${maxFeePerGas} Gwei`],
-                        ['Max priority fee'],
-                        [`${maxPriorityFeePerGas} Gwei`],
-                    ],
-                    footer: undefined,
-                },
-            });
-        });
-    });
-
-    test('User can perform ethereum sending on base network', async ({
-        devicePrompt,
-        walletPage,
-        tradingPage,
-        page,
-    }) => {
-        await test.step('Fill in a Send form', async () => {
-            await walletPage.openSendFormButton.click();
-            // Race condition 1:5, if input is filled before form completely loads then
-            // input will be cleared and test will fail. As a workaround we wait for fees to be loaded.
-            await tradingPage.fees.expectEthereumFeeCalculated();
-            await tradingPage.sendAddressInput.fill(sendAddress);
-            await tradingPage.sendAmountInput.fill(sendAmount);
-        });
-        const {
-            gasLimit,
-            maxFeePerGas,
-            maxPriorityFeePerGas,
-            maxFeePerGasRounded,
-            maxPriorityFeePerGasRounded,
-        } = await tradingPage.fees.getStandardFeeWorkaround();
-        const { ethereumMaximumFee, errorMessageMaxCalculation } =
-            tradingPage.fees.calculateEthereumMaxFee({
-                gasLimit,
-                maxFeePerGas,
-                numberOfDecimals: 15,
-            });
-
-        await test.step('Verify Recipient address', async () => {
-            await tradingPage.sendButton.click();
-            await expect(devicePrompt.headerParagraph).toContainText(networkName);
-            await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedSendAddress);
-            await expect(devicePrompt).toDisplayOnEmulator({
-                T3W1: {
-                    header: { title: 'Send' },
-                    body: [transformAddress(sendAddress)],
-                    actions: { right_button: 'Continue' },
-                },
-                T3T1: {
-                    header: { title: 'Address', subtitle: 'Recipient' },
-                    body: [transformAddress(sendAddress)],
-                },
-            });
-        });
-
-        await test.step('Verify Total including fee', async () => {
-            await devicePrompt.waitForPromptAndClick();
-            const gasLimitTranslation = `${messages['TR_GAS_LIMIT'].defaultMessage}: ${gasLimit}`;
-            await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitTranslation);
-            await expect(devicePrompt.ethereumFeeRate).toHaveText(`${maxFeePerGasRounded} Gwei`);
-            await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(
-                `${maxPriorityFeePerGasRounded} Gwei`,
-            );
-            await expect(devicePrompt.cryptoAmountOf('amount')).toHaveText(sendAmount);
-            await expect(devicePrompt.cryptoAmountOf('fee'), errorMessageMaxCalculation).toHaveText(
-                ethereumMaximumFee,
-            );
-            const maxFeeWrapped = devicePrompt.wrapText(`${ethereumMaximumFee} ETH`, {
-                isAmount: true,
-            });
-            await expect(devicePrompt).toDisplayOnEmulator({
-                T3W1: {
-                    header: { title: 'Send' },
-                    body: [['Amount'], [formattedSendAmount], ['Maximum fee'], maxFeeWrapped],
-                    actions: { right_button: 'Hold to sign' },
-                },
-                T3T1: {
-                    header: { title: 'Summary' },
-                },
-            });
-        });
-
-        await test.step('Verify Fee Info on emulator', async () => {
-            await devicePrompt.openFeeInfoOnEmulator();
-            await expect(devicePrompt).toDisplayOnEmulator({
-                T3W1: {
-                    header: { title: 'Fee info' },
-                    body: [
-                        ['Gas limit'],
-                        [`${gasLimit} units`],
-                        ['Max fee per gas'],
-                        devicePrompt.wrapText(`${maxFeePerGas} Gwei`, { wrapByWords: true }),
-                        ['Max priority fee'],
-                        devicePrompt.wrapText(`${maxPriorityFeePerGas} Gwei`, {
-                            wrapByWords: true,
-                        }),
-                    ],
-                },
-                T3T1: { footer: undefined },
-            });
-        });
-        await test.step('Confirm transaction', async () => {
-            await devicePrompt.waitForPromptAndConfirm();
-            // wait for transaction to be prepared
-            await page.expectReduxObjectToEqual('wallet.send.serializedTx.symbol', 'base');
-            await devicePrompt.sendButton.click();
-            await page.getByTestId('@toast/tx-sent').click();
-            await page.getByRole('button', { name: 'View details' }).hover();
-            // wait for transaction to be processed in Suite before navigating to its detail
-            await page.expectReduxObjectToEqual('wallet.send.drafts', {});
-            await page.getByRole('button', { name: 'View details' }).click();
-
-            // Transaction takes ~5s to confirm on the network, but we need to pull
-            // for updated data and check status repeatedly until confirmed
-            await expect(async () => {
-                await page.clock.fastForward(30_000);
-
-                await expect(page.getByTestId('@modal/tx-details/confirmed')).toHaveText(
-                    'Confirmed',
+            await test.step('Verify Recipient address', async () => {
+                await tradingPage.sendButton.click();
+                await expect(devicePrompt.headerParagraph).toContainText(networkName);
+                await expect(devicePrompt.outputValueOf('address')).toHaveText(
+                    formattedSendAddress,
                 );
-            }, 'expect Transaction to be confirmed').toPass({ timeout: 30_000 });
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    T3W1: {
+                        header: { title: 'Send' },
+                        body: [transformAddress(sendAddress)],
+                        actions: { right_button: 'Continue' },
+                    },
+                    T3T1: {
+                        header: { title: 'Address', subtitle: 'Recipient' },
+                        body: [transformAddress(sendAddress)],
+                    },
+                });
+            });
+
+            await test.step('Verify Total including fee', async () => {
+                await devicePrompt.waitForPromptAndClick();
+                const gasLimitTranslation = `${messages['TR_GAS_LIMIT'].defaultMessage}: ${gasLimit}`;
+                await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitTranslation);
+                await expect(devicePrompt.ethereumFeeRate).toHaveText(
+                    `${maxFeePerGasRounded} Gwei`,
+                );
+                await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(
+                    `${maxPriorityFeePerGasRounded} Gwei`,
+                );
+                await expect(devicePrompt.cryptoAmountOf('amount')).toHaveText(sendAmount);
+                await expect(
+                    devicePrompt.cryptoAmountOf('fee'),
+                    errorMessageMaxCalculation,
+                ).toHaveText(ethereumMaximumFee);
+                const maxFeeWrapped = devicePrompt.wrapText(`${ethereumMaximumFee} ETH`, {
+                    isAmount: true,
+                });
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    T3W1: {
+                        header: { title: 'Send' },
+                        body: [['Amount'], [formattedSendAmount], ['Maximum fee'], maxFeeWrapped],
+                        actions: { right_button: 'Hold to sign' },
+                    },
+                    T3T1: {
+                        header: { title: 'Summary' },
+                    },
+                });
+            });
+
+            await test.step('Verify Fee Info on emulator', async () => {
+                await devicePrompt.openFeeInfoOnEmulator();
+                await expect(devicePrompt).toDisplayOnEmulator({
+                    T3W1: {
+                        header: { title: 'Fee info' },
+                        body: [
+                            ['Gas limit'],
+                            [`${gasLimit} units`],
+                            ['Max fee per gas'],
+                            devicePrompt.wrapText(`${maxFeePerGas} Gwei`, { wrapByWords: true }),
+                            ['Max priority fee'],
+                            devicePrompt.wrapText(`${maxPriorityFeePerGas} Gwei`, {
+                                wrapByWords: true,
+                            }),
+                        ],
+                    },
+                    T3T1: { footer: undefined },
+                });
+            });
+            await test.step('Confirm transaction', async () => {
+                await devicePrompt.waitForPromptAndConfirm();
+                // wait for transaction to be prepared
+                await page.expectReduxObjectToEqual('wallet.send.serializedTx.symbol', 'base');
+                await devicePrompt.sendButton.click();
+                await page.getByTestId('@toast/tx-sent').click();
+                await page.getByRole('button', { name: 'View details' }).hover();
+                // wait for transaction to be processed in Suite before navigating to its detail
+                await page.expectReduxObjectToEqual('wallet.send.drafts', {});
+                await page.getByRole('button', { name: 'View details' }).click();
+
+                // Transaction takes ~5s to confirm on the network, but we need to pull
+                // for updated data and check status repeatedly until confirmed
+                await expect(async () => {
+                    await page.clock.fastForward(30_000);
+
+                    await expect(page.getByTestId('@modal/tx-details/confirmed')).toHaveText(
+                        'Confirmed',
+                    );
+                }, 'expect Transaction to be confirmed').toPass({ timeout: 30_000 });
+            });
         });
-    });
-});
+    },
+);


### PR DESCRIPTION
This test is vulnerable to being run twice simultaneously in such case nonce will collide and second transaction will fail. To avoid this, we tag this way to unsure it runs only once per night - nightlyOnly, one device, specificFirmware

We could think of more elegant solution but this one will at least tell if we are going right direction and fixes it now.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-limit-e2e-test-send-base&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-limit-e2e-test-send-base&lookback=7)