### PR TITLE
fix(ci): put `default` in proper category in Nx config

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -24,13 +24,16 @@
         },
         "type-check": {
             "dependsOn": [
-                "default",
                 "^type-check",
                 "^guide-pull-content",
                 "guide-pull-content",
                 "@suite-common/message-system:build:lib"
             ],
-            "inputs": ["{workspaceRoot}/tsconfig.base.json", "{workspaceRoot}/tsconfig.lib.json"],
+            "inputs": [
+                "default",
+                "{workspaceRoot}/tsconfig.base.json",
+                "{workspaceRoot}/tsconfig.lib.json"
+            ],
             "outputs": ["{projectRoot}/libDev"],
             "cache": true
         },


### PR DESCRIPTION
## Description

Fix a typo from #24605 – put `defaults` in the proper category of `inputs`, not `dependsOn`, [as mentioned here](https://github.com/trezor/trezor-suite/pull/24605#discussion_r2720220768)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/nx-default-proper-category&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/nx-default-proper-category&lookback=7)