### PR TITLE
fix: URL for defalt production URL relay

### DIFF
--- a/suite-common/suite-sync/src/relay/relayUrl.ts
+++ b/suite-common/suite-sync/src/relay/relayUrl.ts
@@ -4,4 +4,4 @@ import { isDevEnv } from '@suite-common/suite-utils';
 
 export const DEFAULT_SUITE_SYNC_RELAY_URL = isDevEnv
     ? 'https://suite-sync.suite.sldev.cz/evolu/'
-    : 'https://suite-sync.trezor.io/';
+    : 'https://suite-sync.trezor.io/evolu/';


### PR DESCRIPTION
Nothing to test. => Production URL for Suite Sync was wrong.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-production-url&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-production-url&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-production-url&lookback=7)