### PR TITLE
refactor(transport): rename ThpStateMissing > ThpStateError

### DIFF
--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -10,6 +10,7 @@ import {
 import { AbstractApi } from '@trezor/transport/src/api/abstract';
 import { UdpApi } from '@trezor/transport/src/api/udp';
 import { UsbApi } from '@trezor/transport/src/api/usb';
+import { THP_STATE_ERROR } from '@trezor/transport/src/errors';
 import { SessionsBackground } from '@trezor/transport/src/sessions/background';
 import { SessionsClient } from '@trezor/transport/src/sessions/client';
 import { callThpMessage, receiveThpMessage, sendThpMessage } from '@trezor/transport/src/thp';
@@ -247,7 +248,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
 
             if (protocol.name === 'v2') {
                 if (!thpState) {
-                    return error({ error: 'ThpStateMissing' });
+                    return error({ error: THP_STATE_ERROR, message: 'ThpStateMissing' });
                 }
 
                 const state = new protocolThp.ThpState();
@@ -318,7 +319,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         const { path } = sessionsResult.payload;
         if (protocol.name === 'v2') {
             if (!thpState) {
-                return error({ error: 'ThpStateMissing' });
+                return error({ error: THP_STATE_ERROR, message: 'ThpStateMissing' });
             }
 
             const state = new protocolThp.ThpState();
@@ -372,7 +373,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         return api.runInIsolation({ lock: { read: true, write: false }, path }, async () => {
             if (protocol.name === 'v2') {
                 if (!thpState) {
-                    return error({ error: 'ThpStateMissing' });
+                    return error({ error: THP_STATE_ERROR, message: 'ThpStateMissing' });
                 }
 
                 const state = new protocolThp.ThpState();

--- a/packages/transport/src/errors.ts
+++ b/packages/transport/src/errors.ts
@@ -97,4 +97,4 @@ export const LIBUSB_ERROR_ACCESS = 'LIBUSB_ERROR_ACCESS' as const;
 /**
  * missing THP state
  */
-export const THP_STATE_MISSING = 'ThpStateMissing' as const;
+export const THP_STATE_ERROR = 'ThpStateError' as const;

--- a/packages/transport/src/thp/receive.ts
+++ b/packages/transport/src/thp/receive.ts
@@ -4,6 +4,7 @@ import { decodeMessage } from '@trezor/protobuf';
 import { thp as protocolThp, v2 as protocolV2 } from '@trezor/protocol';
 
 import type { AbstractApi } from '../api/abstract';
+import { THP_STATE_ERROR } from '../errors';
 import { Logger } from '../types';
 import { readWithExpectedHeaders } from '../utils/readWithExpectedHeaders';
 import { receive } from '../utils/receive';
@@ -29,7 +30,7 @@ export const receiveThpMessage = async ({
     logger,
 }: ReceiveThpMessageProps) => {
     if (!thpState) {
-        return error({ error: 'ThpStateMissing' });
+        return error({ error: THP_STATE_ERROR, message: 'ThpStateMissing' });
     }
 
     logger?.debug(`receiveThpMessage start ${thpState.expectedResponses}`);

--- a/packages/transport/src/thp/send.ts
+++ b/packages/transport/src/thp/send.ts
@@ -1,6 +1,7 @@
 import { thp as protocolThp, v2 as protocolV2 } from '@trezor/protocol';
 import { scheduleAction } from '@trezor/utils';
 
+import { THP_STATE_ERROR } from '../errors';
 import type { ReceiveThpMessageProps } from './receive';
 import { readWithExpectedHeaders } from '../utils/readWithExpectedHeaders';
 import { error, success } from '../utils/result';
@@ -24,7 +25,7 @@ export const sendThpMessage = async ({
     logger,
 }: SendThpMessageProps) => {
     if (!thpState) {
-        return error({ error: 'ThpStateMissing' });
+        return error({ error: THP_STATE_ERROR, message: 'ThpStateMissing' });
     }
 
     const expectedResponses = protocolThp.getExpectedResponses(chunks[0]);

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -72,7 +72,7 @@ export type ReadWriteError =
     | typeof ERRORS.DEVICE_NOT_FOUND
     | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
     | typeof ERRORS.INTERFACE_DATA_TRANSFER
-    | typeof ERRORS.THP_STATE_MISSING;
+    | typeof ERRORS.THP_STATE_ERROR;
 
 type TransportEvents = {
     [TRANSPORT.DEVICE_CONNECTED]: Descriptor;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

cherry picked from https://github.com/trezor/trezor-suite/pull/24599

rename AbstractApi read/write error `ThpStateMissing` to `ThpStateError`

ThpStateError mayhave differen reasons `ThpStateMissing` or `Retransmission limit reached' 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/transport-thp-error&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/transport-thp-error&lookback=7)