### PR TITLE
Fixing uncleared sync data

### DIFF
--- a/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
@@ -7,6 +7,7 @@ import {
 } from '@suite-common/suite-sync-types';
 import { StaticSessionId } from '@trezor/connect';
 
+import { clearAll } from './data/suiteSyncDataReducer';
 import { suiteSyncActions } from './suiteSyncActions';
 import { selectIsSuiteSyncEnabled } from './suiteSyncSelectors';
 
@@ -34,6 +35,8 @@ export const createTurnOffSuiteSync =
             await deps.turnOffSuiteSyncForWallet({ deviceStaticSessionId });
         }
 
+        // NOTE: enforce clearing all data from the suite sync
+        deps.dispatch(clearAll());
         // NOTE: this is TEMPORARY solution until https://github.com/trezor/trezor-suite/issues/23641 is resolved
         deps.flushSuiteSyncStorage();
     };

--- a/suite-native/device-manager/src/components/WalletItemBase.tsx
+++ b/suite-native/device-manager/src/components/WalletItemBase.tsx
@@ -9,7 +9,7 @@ import { HStack, Radio, Text } from '@suite-native/atoms';
 import { BaseCurrencyAmountFormatter } from '@suite-native/formatters';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { WalletLabel, selectIsLabelingEnabled } from '@suite-native/labeling';
+import { WalletLabel, selectSuiteSyncLabelingEnabled } from '@suite-native/labeling';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type WalletItemBaseVariant = 'standard' | 'passphrase';
@@ -59,7 +59,7 @@ const labelStyle = prepareNativeStyle(() => ({
 }));
 
 const SuiteSyncWalletDebug = ({ device }: { device?: TrezorDevice }) => {
-    const isLabelingEnabled = useSelector(selectIsLabelingEnabled);
+    const isLabelingEnabled = useSelector(selectSuiteSyncLabelingEnabled);
     const isSuiteSyncDebugEnabled = useSelector(selectIsSuiteSyncDebugEnabled);
 
     if (!isLabelingEnabled || !device || !isSuiteSyncDebugEnabled) {

--- a/suite-native/labeling/src/components/AddressLabel.tsx
+++ b/suite-native/labeling/src/components/AddressLabel.tsx
@@ -5,7 +5,7 @@ import { SuiteSyncDataRootState, selectSuiteSyncAddressLabel } from '@suite-comm
 import { Text } from '@suite-native/atoms';
 import type { StaticSessionId } from '@trezor/connect';
 
-import { selectIsLabelingEnabled } from '../selectors';
+import { selectSuiteSyncLabelingEnabled } from '../selectors';
 
 type AddressLabelEProps = {
     address: string;
@@ -14,7 +14,7 @@ type AddressLabelEProps = {
 };
 
 export const AddressLabel = ({ address, deviceStaticSessionId, fallback }: AddressLabelEProps) => {
-    const isLabelingEnabled = useSelector(selectIsLabelingEnabled);
+    const isLabelingEnabled = useSelector(selectSuiteSyncLabelingEnabled);
 
     const label = useSelector((state: SuiteSyncDataRootState) =>
         selectSuiteSyncAddressLabel(state, deviceStaticSessionId, address),

--- a/suite-native/labeling/src/components/AddressLabelEditable.tsx
+++ b/suite-native/labeling/src/components/AddressLabelEditable.tsx
@@ -8,7 +8,7 @@ import type { StaticSessionId } from '@trezor/connect';
 
 import { EditableLabelLayout } from './EditableLabelLayout';
 import { LabelEditForm } from './LabelEditForm';
-import { selectIsLabelingEnabled } from '../selectors';
+import { selectSuiteSyncLabelingEnabled } from '../selectors';
 
 type AddressLabelEditableProps = {
     address: string;
@@ -25,7 +25,7 @@ export const AddressLabelEditable = ({
     networkSymbol,
     testID,
 }: AddressLabelEditableProps) => {
-    const isLabelingEnabled = useSelector(selectIsLabelingEnabled);
+    const isLabelingEnabled = useSelector(selectSuiteSyncLabelingEnabled);
     const { suiteSync } = useNativeServices();
 
     const label = useSelector((state: SuiteSyncDataRootState) =>

--- a/suite-native/labeling/src/components/EditableLabelLayout.tsx
+++ b/suite-native/labeling/src/components/EditableLabelLayout.tsx
@@ -12,7 +12,7 @@ import { useNativeServices } from '@suite-native/services';
 import { useToast } from '@suite-native/toasts';
 import { exhaustive } from '@trezor/type-utils';
 
-import { selectIsLabelingEnabled } from '../selectors';
+import { selectSuiteSyncLabelingEnabled } from '../selectors';
 
 type EditableLabelLayoutParams = {
     children: (params: { onClose: () => void; ref: Ref<BottomSheetModalMethods> }) => ReactNode;
@@ -27,8 +27,8 @@ export const EditableLabelLayout = ({ children, label, testID }: EditableLabelLa
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
 
     const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
-    const isLabelingEnabled = useSelector(selectIsLabelingEnabled);
     const selectedDevice = useSelector(selectSelectedDevice);
+    const isLabelingEnabled = useSelector(selectSuiteSyncLabelingEnabled);
 
     const showSuiteSyncEnableConfirmationAlert = (onSuccess: () => void) => {
         showAlert({

--- a/suite-native/labeling/src/components/SendFormLabelEditable.tsx
+++ b/suite-native/labeling/src/components/SendFormLabelEditable.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { EditableLabelLayout } from './EditableLabelLayout';
 import { LabelEditForm } from './LabelEditForm';
-import { selectIsLabelingEnabled } from '../selectors';
+import { selectSuiteSyncLabelingEnabled } from '../selectors';
 
 type SendFormLabelEditableProps = {
     label: string | null;
@@ -10,7 +10,7 @@ type SendFormLabelEditableProps = {
 };
 
 export const SendFormLabelEditable = ({ onLabelChange, label }: SendFormLabelEditableProps) => {
-    const isLabelingEnabled = useSelector(selectIsLabelingEnabled);
+    const isLabelingEnabled = useSelector(selectSuiteSyncLabelingEnabled);
 
     if (!isLabelingEnabled) {
         return null;

--- a/suite-native/labeling/src/components/TransactionOutputLabel.tsx
+++ b/suite-native/labeling/src/components/TransactionOutputLabel.tsx
@@ -4,7 +4,7 @@ import { SuiteSyncDataRootState, selectSuiteSyncOutputLabel } from '@suite-commo
 import { Text } from '@suite-native/atoms';
 import type { StaticSessionId } from '@trezor/connect';
 
-import { selectIsLabelingEnabled } from '../selectors';
+import { selectSuiteSyncLabelingEnabled } from '../selectors';
 
 type TransactionOutputLabelProps = {
     txId: string;
@@ -17,7 +17,7 @@ export const TransactionOutputLabel = ({
     outputIndex,
     deviceStaticSessionId,
 }: TransactionOutputLabelProps) => {
-    const isLabelingEnabled = useSelector(selectIsLabelingEnabled);
+    const isLabelingEnabled = useSelector(selectSuiteSyncLabelingEnabled);
 
     const label = useSelector((state: SuiteSyncDataRootState) =>
         selectSuiteSyncOutputLabel(state, txId, outputIndex, deviceStaticSessionId),

--- a/suite-native/labeling/src/components/TransactionOutputLabelEditable.tsx
+++ b/suite-native/labeling/src/components/TransactionOutputLabelEditable.tsx
@@ -8,7 +8,7 @@ import type { StaticSessionId } from '@trezor/connect';
 
 import { EditableLabelLayout } from './EditableLabelLayout';
 import { LabelEditForm } from './LabelEditForm';
-import { selectIsLabelingEnabled } from '../selectors';
+import { selectSuiteSyncLabelingEnabled } from '../selectors';
 
 type TransactionOutputLabelEditableProps = {
     txId: string;
@@ -25,7 +25,7 @@ export const TransactionOutputLabelEditable = ({
     accountDescriptor,
     networkSymbol,
 }: TransactionOutputLabelEditableProps) => {
-    const isLabelingEnabled = useSelector(selectIsLabelingEnabled);
+    const isLabelingEnabled = useSelector(selectSuiteSyncLabelingEnabled);
     const { suiteSync } = useNativeServices();
 
     const label = useSelector((state: SuiteSyncDataRootState) =>

--- a/suite-native/labeling/src/components/WalletLabel.tsx
+++ b/suite-native/labeling/src/components/WalletLabel.tsx
@@ -5,7 +5,7 @@ import { SuiteSyncDataRootState, selectSuiteSyncWalletLabel } from '@suite-commo
 import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import type { StaticSessionId } from '@trezor/connect';
 
-import { selectIsLabelingEnabled } from '../selectors';
+import { selectSuiteSyncLabelingEnabled } from '../selectors';
 
 type WalletLabelProps = {
     deviceStaticSessionId: StaticSessionId | undefined;
@@ -13,7 +13,7 @@ type WalletLabelProps = {
 };
 
 export const WalletLabel = ({ deviceStaticSessionId, fallbackLabel }: WalletLabelProps) => {
-    const isLabelingEnabled = useSelector(selectIsLabelingEnabled);
+    const isLabelingEnabled = useSelector(selectSuiteSyncLabelingEnabled);
 
     const label = useSelector((state: SuiteSyncDataRootState) => {
         if (!deviceStaticSessionId) return null;

--- a/suite-native/labeling/src/selectors.ts
+++ b/suite-native/labeling/src/selectors.ts
@@ -18,11 +18,11 @@ export type CombinedLabelingState = SuiteSyncDataRootState &
     WithSuiteSyncAndDeviceState &
     AccountsRootState;
 
-export const selectIsLabelingEnabled = (state: WithSuiteSyncAndDeviceState) => {
-    const isSuiteSyncAvailable = selectIsSuiteSyncEnabled(state);
+export const selectSuiteSyncLabelingEnabled = (state: WithSuiteSyncAndDeviceState) => {
+    const isSuiteSyncEnabled = selectIsSuiteSyncEnabled(state);
     const isPortfolioTracker = selectIsPortfolioTrackerDevice(state);
 
-    return isSuiteSyncAvailable && !isPortfolioTracker;
+    return isSuiteSyncEnabled && !isPortfolioTracker;
 };
 
 export const selectAccountLabel = (
@@ -32,7 +32,7 @@ export const selectAccountLabel = (
     networkSymbol: NetworkSymbol,
     accountKey: string,
 ) => {
-    const isLabelingEnabled = selectIsLabelingEnabled(state);
+    const suiteSyncLabelingEnabled = selectSuiteSyncLabelingEnabled(state);
 
     const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
 
@@ -43,7 +43,7 @@ export const selectAccountLabel = (
         networkSymbol,
     );
 
-    if (isLabelingEnabled && syncedLabel) {
+    if (suiteSyncLabelingEnabled && syncedLabel) {
         return syncedLabel;
     }
 

--- a/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
@@ -14,7 +14,7 @@ import { Translation, useTranslate } from '@suite-native/intl';
 import {
     CombinedLabelingState,
     selectAccountLabel,
-    selectIsLabelingEnabled,
+    selectSuiteSyncLabelingEnabled,
 } from '@suite-native/labeling';
 import { useNativeServices } from '@suite-native/services';
 
@@ -30,7 +30,7 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
-    const isLabelingEnabled = useSelector(selectIsLabelingEnabled);
+    const suiteSyncLabelingEnabled = useSelector(selectSuiteSyncLabelingEnabled);
     const inputRef = useRef<InputType>(null);
 
     const accountLabel = useSelector((state: CombinedLabelingState) => {
@@ -66,13 +66,15 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
     if (!account) return null;
 
     const handleRenameAccount = handleSubmit((formValues: AccountFormValues) => {
-        dispatch(accountsActions.renameAccount(accountKey, formValues.accountLabel));
-        if (isLabelingEnabled && account.deviceState) {
+        if (suiteSyncLabelingEnabled) {
+            if (!account.deviceState) return;
             suiteSync.labeling.updateAccountLabel({
                 deviceStaticSessionId: account.deviceState,
                 accountKey,
                 label: formValues.accountLabel,
             });
+        } else {
+            dispatch(accountsActions.renameAccount(accountKey, formValues.accountLabel));
         }
         onSubmit();
     });

--- a/suite-native/module-transactions/src/components/TransactionUtxoAddress.tsx
+++ b/suite-native/module-transactions/src/components/TransactionUtxoAddress.tsx
@@ -8,7 +8,7 @@ import { AccountAddressFormatter } from '@suite-native/formatters';
 import {
     AddressLabel,
     TransactionOutputLabelEditable,
-    selectIsLabelingEnabled,
+    selectSuiteSyncLabelingEnabled,
 } from '@suite-native/labeling';
 import type { StaticSessionId } from '@trezor/connect';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -37,7 +37,7 @@ export const TransactionUtxoAddress = ({
     showLabels,
 }: TransactionUtxoAddressProps) => {
     const { applyStyle } = useNativeStyles();
-    const isLabelingEnabled = useSelector(selectIsLabelingEnabled);
+    const isLabelingEnabled = useSelector(selectSuiteSyncLabelingEnabled);
 
     return (
         <VStack>

--- a/suite-native/suite-sync/package.json
+++ b/suite-native/suite-sync/package.json
@@ -21,7 +21,6 @@
         "@trezor/connect": "workspace:*",
         "expo": "~54.0.30",
         "expo-sqlite": "^16.0.8",
-        "react-native-restart": "0.0.27",
         "react-redux": "9.2.0"
     }
 }

--- a/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
+++ b/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
@@ -1,7 +1,6 @@
-import RNRestart from 'react-native-restart';
-
 import { evoluReactNativeDeps } from '@evolu/react-native/expo-sqlite';
 import { Dispatch } from '@reduxjs/toolkit';
+import { reloadAppAsync } from 'expo';
 
 import { EnsureDelegatedIdentityKeyDep } from '@suite-common/delegated-identity-key-types';
 import { PlatformEncryptionDep } from '@suite-common/platform-encryption';
@@ -32,7 +31,7 @@ export const createSuiteSyncNativeCompositionRoot = (
         createSuiteStorage: createEvoluStorage,
         createSuiteSyncOwner: evoluCreateSuiteSyncOwner,
         flushSuiteSyncStorage: () => {
-            RNRestart.restart();
+            reloadAppAsync();
         },
     });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -13491,7 +13491,6 @@ __metadata:
     "@trezor/connect": "workspace:*"
     expo: "npm:~54.0.30"
     expo-sqlite: "npm:^16.0.8"
-    react-native-restart: "npm:0.0.27"
     react-redux: "npm:9.2.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the issues we found in testgin:
- labels werent cleared after suite sync was turned off
- the problem was that we updated both local labels and suite sync labels at once
- now, when suite sync is on, I update only suite sync label (for account)

## Resolves
Resolve https://github.com/trezor/trezor-suite/issues/24611

## Notes for QA

Account suite sync labels should disapear and old "local labels" should appear when you turn off suite sync on native

## Related Issue

Resolve: issue from mass testing

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fixing-uncleared-sync-data&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fixing-uncleared-sync-data&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fixing-uncleared-sync-data&lookback=7)