### PR TITLE
fix(suite-native): fix incorrect passphrase handling after adding additional coin

### DIFF
--- a/suite-native/module-add-accounts/package.json
+++ b/suite-native/module-add-accounts/package.json
@@ -25,6 +25,7 @@
         "@suite-native/intl": "workspace:*",
         "@suite-native/link": "workspace:*",
         "@suite-native/navigation": "workspace:*",
+        "@suite-native/passphrase": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/urls": "workspace:*",

--- a/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryRunningScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryRunningScreen.tsx
@@ -21,6 +21,7 @@ import {
     Screen,
     StackProps,
 } from '@suite-native/navigation';
+import { selectHasPassphraseIncorrectError } from '@suite-native/passphrase';
 
 import { AddCoinAccountNavigationProps, useAddCoinAccount } from '../hooks/useAddCoinAccount';
 
@@ -34,6 +35,7 @@ export const AddCoinDiscoveryRunningScreen = ({
         selectDeviceAccountsByNetworkSymbol(state, networkSymbol),
     );
 
+    const hasPassphraseIncorrectError = useSelector(selectHasPassphraseIncorrectError);
     const hasDiscovery = useSelector(selectHasRunningDiscovery);
     const enabledNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
     const { navigateToSuccessorScreen, clearNetworkWithTypeToBeAdded } = useAddCoinAccount();
@@ -49,6 +51,12 @@ export const AddCoinDiscoveryRunningScreen = ({
     };
 
     const handleFinish = () => {
+        if (loadingResult === 'error') {
+            navigation.goBack();
+
+            return;
+        }
+
         if (accounts.length === 0 || hasDiscovery) {
             return;
         }
@@ -94,6 +102,10 @@ export const AddCoinDiscoveryRunningScreen = ({
             return;
         }
 
+        if (!hasDiscovery && hasPassphraseIncorrectError) {
+            setLoadingResult('error');
+        }
+
         if (accounts.length > 0 && !hasDiscovery) {
             setLoadingResult('success');
         }
@@ -104,6 +116,7 @@ export const AddCoinDiscoveryRunningScreen = ({
         enabledNetworkSymbols,
         loadingResult,
         networkSymbol,
+        hasPassphraseIncorrectError,
     ]);
 
     return (

--- a/suite-native/module-add-accounts/tsconfig.json
+++ b/suite-native/module-add-accounts/tsconfig.json
@@ -21,6 +21,7 @@
         { "path": "../intl" },
         { "path": "../link" },
         { "path": "../navigation" },
+        { "path": "../passphrase" },
         { "path": "../../packages/styles" },
         { "path": "../../packages/type-utils" },
         { "path": "../../packages/urls" }

--- a/suite-native/module-authorize-device/src/hooks/useHandleNavigateToInitialScreenOnIdle.tsx
+++ b/suite-native/module-authorize-device/src/hooks/useHandleNavigateToInitialScreenOnIdle.tsx
@@ -3,21 +3,46 @@ import { useSelector } from 'react-redux';
 
 import { useFocusEffect } from '@react-navigation/native';
 
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { useAlert } from '@suite-native/alerts';
 import {
     DeviceAuthorizationStep,
     selectDeviceAuthorizationStep,
 } from '@suite-native/device-authorization';
+import { useTranslate } from '@suite-native/intl';
 import { useNavigateToInitialScreen } from '@suite-native/navigation';
+import { selectHasPassphraseIncorrectError } from '@suite-native/passphrase';
 
 export const useHandleNavigateToInitialScreenOnIdle = () => {
     const deviceAuthorizationStep = useSelector(selectDeviceAuthorizationStep);
     const navigateToInitialScreen = useNavigateToInitialScreen();
+    const hasPassphraseIncorrectError = useSelector(selectHasPassphraseIncorrectError);
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    const { showAlert } = useAlert();
+    const { translate } = useTranslate();
 
     useFocusEffect(
         useCallback(() => {
-            if (deviceAuthorizationStep === DeviceAuthorizationStep.Idle) {
-                navigateToInitialScreen();
+            if (deviceAuthorizationStep === DeviceAuthorizationStep.Idle && !isDiscoveryRunning) {
+                if (hasPassphraseIncorrectError) {
+                    showAlert({
+                        title: translate('modulePassphrase.featureAuthorizationError'),
+                        pictogramVariant: 'critical',
+                        primaryButtonTitle: translate('generic.buttons.close'),
+                        primaryButtonVariant: 'redBold',
+                        onPressPrimaryButton: navigateToInitialScreen,
+                    });
+                } else {
+                    navigateToInitialScreen();
+                }
             }
-        }, [deviceAuthorizationStep, navigateToInitialScreen]),
+        }, [
+            deviceAuthorizationStep,
+            hasPassphraseIncorrectError,
+            isDiscoveryRunning,
+            navigateToInitialScreen,
+            showAlert,
+            translate,
+        ]),
     );
 };

--- a/suite-native/passphrase/src/passphraseSelectors.ts
+++ b/suite-native/passphrase/src/passphraseSelectors.ts
@@ -10,6 +10,12 @@ export const selectHasPassphraseMismatchError = (state: DiscoveryRootState & Dev
     return discovery?.status === 'passphrase-mismatch';
 };
 
+export const selectHasPassphraseIncorrectError = (state: DiscoveryRootState & DeviceRootState) => {
+    const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);
+
+    return discovery?.status === 'failed' && discovery?.error === 'Passphrase is incorrect';
+};
+
 export const selectIsCreatingNewPassphraseWallet = (
     state: DiscoveryRootState & DeviceRootState,
 ) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12464,6 +12464,7 @@ __metadata:
     "@suite-native/intl": "workspace:*"
     "@suite-native/link": "workspace:*"
     "@suite-native/navigation": "workspace:*"
+    "@suite-native/passphrase": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

1. Open existing passphrase wallet without entering passphrase confirmation
2. go to settings and enable arbitrary coin
3. go back and wait for passphrase validation form shows up
4. enter incorrect passphrase
5. confirm on device
6. observe, the error modal should appear

Case 2
1. Open existing passphrase wallet without entering passphrase confirmation
2. Select 'My Assets' tab
3. press + button and add arbitrary coin
4. insert incorrect passphrase
5. observe, the user should see the error modal + he should NOT get stuck on the loading page

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24478

## Screenshots:


https://github.com/user-attachments/assets/7a35d889-aa74-4e33-b8b2-a9bbb1433226




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/incorrect-passhprase-fix&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/incorrect-passhprase-fix&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/incorrect-passhprase-fix&lookback=7)