### PR TITLE
fix(suite-common): return stable array from selectFilterKnownTokens

### DIFF
--- a/suite-common/token-definitions/src/tokenDefinitionsSelectors.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsSelectors.ts
@@ -1,3 +1,4 @@
+import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { type TokenInfo } from '@trezor/connect';
@@ -44,4 +45,7 @@ export const selectFilterKnownTokens = (
     state: TokenDefinitionsRootState,
     symbol: NetworkSymbol,
     tokens: TokenInfo[],
-) => tokens.filter(token => selectCoinDefinition(state, symbol, token.contract as TokenAddress));
+) =>
+    returnStableArrayIfEmpty(
+        tokens.filter(token => selectCoinDefinition(state, symbol, token.contract as TokenAddress)),
+    );


### PR DESCRIPTION
Fixes the _Selector unknown returned a different result when called with the same parameters_ warning originating from `AccountImportConfirmFormScreen.tsx`.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/common/select-filter-known-tokens&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/common/select-filter-known-tokens&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/common/select-filter-known-tokens&lookback=7)