### PR TITLE
fix(suite-native): improve UX of Bluetooth device connection

### DIFF
--- a/suite-native/bluetooth/src/__tests__/selectors.test.ts
+++ b/suite-native/bluetooth/src/__tests__/selectors.test.ts
@@ -157,6 +157,17 @@ describe('selectNearbyPairableBluetoothDevices', () => {
                 },
             }),
         ).toStrictEqual(expectedDevices);
+        expect(
+            selectNearbyPairableBluetoothDevices(
+                {
+                    bluetooth: {
+                        ...initialState,
+                        nearbyDevices,
+                    },
+                },
+                knownDevices,
+            ),
+        ).toStrictEqual(expectedDevices);
     });
 });
 

--- a/suite-native/bluetooth/src/selectors.ts
+++ b/suite-native/bluetooth/src/selectors.ts
@@ -8,6 +8,7 @@ import {
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 
 import { NativeBluetoothRootState } from './bluetoothSlice';
+import { BluetoothDevice } from './types';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<NativeBluetoothRootState>();
 
@@ -32,7 +33,11 @@ export const selectNearbyBluetoothDevices = (state: NativeBluetoothRootState) =>
     selectNearbyDevices(state);
 
 export const selectNearbyPairableBluetoothDevices = createMemoizedSelector(
-    [selectNearbyBluetoothDevices, selectKnownBluetoothDevices],
+    [
+        selectNearbyBluetoothDevices,
+        (state: NativeBluetoothRootState, knownBluetoothDevices?: BluetoothDevice[]) =>
+            knownBluetoothDevices ?? selectKnownBluetoothDevices(state),
+    ],
     (nearbyBluetoothDevices, knownBluetoothDevices) =>
         returnStableArrayIfEmpty(
             nearbyBluetoothDevices.filter(

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectBluetoothDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectBluetoothDeviceScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
@@ -7,7 +7,8 @@ import { EventType } from '@suite-common/analytics-types';
 import {
     BluetoothDevice,
     BluetoothDeviceList,
-    selectNearbyBluetoothDevices,
+    NativeBluetoothRootState,
+    selectKnownBluetoothDevices,
     selectNearbyPairableBluetoothDevices,
     useBluetoothDevice,
 } from '@suite-native/bluetooth';
@@ -31,8 +32,12 @@ export const ConnectBluetoothDeviceScreen = () => {
     const navigation = useNavigation<NavigationProps>();
     const analytics = useAnalytics();
 
-    const nearbyBluetoothDevices = useSelector(selectNearbyBluetoothDevices);
-    const nearbyPairableBluetoothDevices = useSelector(selectNearbyPairableBluetoothDevices);
+    // Once a device is connected, it's added to known devices and thus disappears from the list
+    // before the transition to the next screen finishes. This ensures it doesn't feel glitchy.
+    const [knownBluetoothDevices] = useState(useSelector(selectKnownBluetoothDevices));
+    const nearbyPairableBluetoothDevices = useSelector((state: NativeBluetoothRootState) =>
+        selectNearbyPairableBluetoothDevices(state, knownBluetoothDevices),
+    );
 
     const handleDeviceButtonPress = useCallback(
         (device: BluetoothDevice) => {
@@ -48,10 +53,10 @@ export const ConnectBluetoothDeviceScreen = () => {
     );
 
     useEffect(() => {
-        if (nearbyBluetoothDevices.length === 0) {
+        if (nearbyPairableBluetoothDevices.length === 0) {
             navigation.goBack();
         }
-    }, [nearbyBluetoothDevices, navigation]);
+    }, [nearbyPairableBluetoothDevices, navigation]);
 
     return (
         <Screen header={<BluetoothDeviceScreenHeader />}>


### PR DESCRIPTION
Once a device is connected, it's added to known devices and thus disappears from the list before the transition to the next screen finishes. This ensures it doesn't feel glitchy.

## Screenshots:

### Before
https://github.com/user-attachments/assets/9641e218-9b60-41eb-b7a3-acf7bc689279
### After
https://github.com/user-attachments/assets/f4f479e3-c8f7-4843-b96d-3e1189bf65f3



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/connect-bluetooth-device&lookback=7)