### PR TITLE
feat(trade): fees header style

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
@@ -4,7 +4,7 @@ import { useWatch } from 'react-hook-form';
 import { Translation, TranslationKey } from '@suite/intl';
 import { NetworkSymbol, NetworkType } from '@suite-common/wallet-config';
 import { FormState } from '@suite-common/wallet-types';
-import { Button, Collapsible, Column, Row, TextButton } from '@trezor/components';
+import { Box, Button, Collapsible, Column, Row, TextButton } from '@trezor/components';
 import { TypographyStyle, spacings } from '@trezor/theme';
 
 import { CollapsibleFeesHeader } from './CollapsibleFeesHeader';
@@ -21,6 +21,7 @@ export type CollapsibleFeesProps = {
     label?: TranslationKey;
     rbfForm?: boolean;
     headerTypographyStyle?: TypographyStyle;
+    isHeaderRowLayout?: boolean;
 } & Pick<FeesContextType, 'feeInfo' | 'composedLevels' | 'changeFeeLevel'>;
 
 export function CollapsibleFees({
@@ -32,6 +33,7 @@ export function CollapsibleFees({
     changeFeeLevel,
     rbfForm,
     headerTypographyStyle = 'body',
+    isHeaderRowLayout,
 }: CollapsibleFeesProps) {
     const selectedFee = useWatch<FormState, 'selectedFee'>({
         name: 'selectedFee',
@@ -57,6 +59,20 @@ export function CollapsibleFees({
         selectedFeeLevel,
     });
 
+    const headerContent = (
+        <Collapsible.Toggle data-testid="@wallet/fees/collapsible-fees-toggle">
+            <ContentFlex justifyContent="space-between" gap={12}>
+                <CollapsibleFeesHeader label={label} typographyStyle={headerTypographyStyle} />
+                <Row gap={10}>
+                    <MaximumFee typographyStyle={headerTypographyStyle} txMaxFee={txMaxFee} />
+                    {supportsAdjustableFees && (
+                        <Collapsible.ToggleIcon iconName="caretDown" size="mediumLarge" />
+                    )}
+                </Row>
+            </ContentFlex>
+        </Collapsible.Toggle>
+    );
+
     return (
         <FeesContext.Provider
             value={{
@@ -68,24 +84,17 @@ export function CollapsibleFees({
                 composedLevels,
             }}
         >
-            <Collapsible gap={20}>
-                <ContentFlex justifyContent="space-between" gap={12}>
-                    <CollapsibleFeesHeader label={label} typographyStyle={headerTypographyStyle} />
-                    <Collapsible.Toggle
-                        data-testid="@wallet/fees/collapsible-fees-toggle"
-                        disabled={!supportsAdjustableFees}
+            <Collapsible>
+                {isHeaderRowLayout && (
+                    <Box
+                        backgroundColorOnInteraction="backgroundSurfaceElevation2"
+                        padding={{ vertical: spacings.sm, horizontal: spacings.lg }}
                     >
-                        <Row gap={10}>
-                            <MaximumFee
-                                typographyStyle={headerTypographyStyle}
-                                txMaxFee={txMaxFee}
-                            />
-                            {supportsAdjustableFees && (
-                                <Collapsible.ToggleIcon iconName="caretDown" size="mediumLarge" />
-                            )}
-                        </Row>
-                    </Collapsible.Toggle>
-                </ContentFlex>
+                        {headerContent}
+                    </Box>
+                )}
+                {!isHeaderRowLayout && headerContent}
+
                 {supportsAdjustableFees && (
                     <Collapsible.Content overflow="unset">
                         <Column gap={16}>

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
@@ -1,28 +1,26 @@
 import { useMemo } from 'react';
 import { useWatch } from 'react-hook-form';
 
-import { Translation, TranslationKey } from '@suite/intl';
+import { Translation } from '@suite/intl';
 import { NetworkSymbol, NetworkType } from '@suite-common/wallet-config';
 import { FormState } from '@suite-common/wallet-types';
-import { Box, Button, Collapsible, Column, Row, TextButton } from '@trezor/components';
-import { TypographyStyle, spacings } from '@trezor/theme';
+import { Button, Collapsible, Column, Row, TextButton } from '@trezor/components';
 
-import { CollapsibleFeesHeader } from './CollapsibleFeesHeader';
+import {
+    CollapsibleFeesHeaderContent,
+    CollapsibleFeesHeaderContentProps,
+} from './CollapsibleFeesHeaderContent';
 import { CustomFee } from './CustomFee/CustomFee';
-import { MaximumFee } from './MaximumFee';
 import { StandardFee } from './StandardFee/StandardFee';
 import { FeesContext, FeesContextType } from '../context/FeesContext';
 import { useTransactionMaxFee } from './hooks/useTransactionMaxFee';
-import { ContentFlex } from '../../../../support/suite/ContentFlex';
 
 export type CollapsibleFeesProps = {
-    networkType: NetworkType;
     networkSymbol: NetworkSymbol;
-    label?: TranslationKey;
+    networkType: NetworkType;
     rbfForm?: boolean;
-    headerTypographyStyle?: TypographyStyle;
-    isHeaderRowLayout?: boolean;
-} & Pick<FeesContextType, 'feeInfo' | 'composedLevels' | 'changeFeeLevel'>;
+} & Pick<FeesContextType, 'feeInfo' | 'composedLevels' | 'changeFeeLevel'> &
+    Omit<CollapsibleFeesHeaderContentProps, 'supportsAdjustableFees' | 'txMaxFee'>;
 
 export function CollapsibleFees({
     label,
@@ -59,20 +57,6 @@ export function CollapsibleFees({
         selectedFeeLevel,
     });
 
-    const headerContent = (
-        <Collapsible.Toggle data-testid="@wallet/fees/collapsible-fees-toggle">
-            <ContentFlex justifyContent="space-between" gap={12}>
-                <CollapsibleFeesHeader label={label} typographyStyle={headerTypographyStyle} />
-                <Row gap={10}>
-                    <MaximumFee typographyStyle={headerTypographyStyle} txMaxFee={txMaxFee} />
-                    {supportsAdjustableFees && (
-                        <Collapsible.ToggleIcon iconName="caretDown" size="mediumLarge" />
-                    )}
-                </Row>
-            </ContentFlex>
-        </Collapsible.Toggle>
-    );
-
     return (
         <FeesContext.Provider
             value={{
@@ -85,15 +69,13 @@ export function CollapsibleFees({
             }}
         >
             <Collapsible>
-                {isHeaderRowLayout && (
-                    <Box
-                        backgroundColorOnInteraction="backgroundSurfaceElevation2"
-                        padding={{ vertical: spacings.sm, horizontal: spacings.lg }}
-                    >
-                        {headerContent}
-                    </Box>
-                )}
-                {!isHeaderRowLayout && headerContent}
+                <CollapsibleFeesHeaderContent
+                    label={label}
+                    headerTypographyStyle={headerTypographyStyle}
+                    supportsAdjustableFees={supportsAdjustableFees}
+                    isHeaderRowLayout={isHeaderRowLayout}
+                    txMaxFee={txMaxFee}
+                />
 
                 {supportsAdjustableFees && (
                     <Collapsible.Content overflow="unset">
@@ -103,7 +85,7 @@ export function CollapsibleFees({
                                 {isCustomFee && <CustomFee showCurrentFee={!rbfForm} />}
                             </Column>
 
-                            <Row justifyContent="center" margin={{ bottom: spacings.xs }}>
+                            <Row justifyContent="center" margin={{ bottom: 8 }}>
                                 {isCustomFee && (
                                     <Button
                                         intent="neutral"

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeaderContent.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeaderContent.tsx
@@ -24,29 +24,31 @@ export const CollapsibleFeesHeaderContent = ({
     txMaxFee,
 }: CollapsibleFeesHeaderContentProps) => {
     const content = (
-        <Collapsible.Toggle data-testid="@wallet/fees/collapsible-fees-toggle">
-            <ContentFlex justifyContent="space-between" gap={12}>
-                <CollapsibleFeesHeader label={label} typographyStyle={headerTypographyStyle} />
-                <Row gap={8}>
-                    <MaximumFee typographyStyle={headerTypographyStyle} txMaxFee={txMaxFee} />
-                    {supportsAdjustableFees && (
-                        <Collapsible.ToggleIcon iconName="caretDown" size="mediumLarge" />
-                    )}
-                </Row>
-            </ContentFlex>
-        </Collapsible.Toggle>
+        <ContentFlex justifyContent="space-between" gap={12}>
+            <CollapsibleFeesHeader label={label} typographyStyle={headerTypographyStyle} />
+            <Row gap={8}>
+                <MaximumFee typographyStyle={headerTypographyStyle} txMaxFee={txMaxFee} />
+                {supportsAdjustableFees && (
+                    <Collapsible.ToggleIcon iconName="caretDown" size="mediumLarge" />
+                )}
+            </Row>
+        </ContentFlex>
     );
 
-    return isHeaderRowLayout ? (
-        <Box
-            backgroundColorOnInteraction={
-                supportsAdjustableFees ? 'backgroundSurfaceElevation2' : undefined
-            }
-            padding={{ vertical: 12, horizontal: 16 }}
-        >
-            {content}
-        </Box>
-    ) : (
-        content
+    return (
+        <Collapsible.Toggle data-testid="@wallet/fees/collapsible-fees-toggle">
+            {isHeaderRowLayout ? (
+                <Box
+                    backgroundColorOnInteraction={
+                        supportsAdjustableFees ? 'backgroundSurfaceElevation2' : undefined
+                    }
+                    padding={{ vertical: 12, horizontal: 16 }}
+                >
+                    {content}
+                </Box>
+            ) : (
+                content
+            )}
+        </Collapsible.Toggle>
     );
 };

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeaderContent.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeaderContent.tsx
@@ -1,0 +1,50 @@
+import { TranslationKey } from '@suite/intl';
+import { Box, Collapsible, Row } from '@trezor/components';
+import { TypographyStyle } from '@trezor/theme';
+
+import { ContentFlex } from 'src/support/suite/ContentFlex';
+
+import { CollapsibleFeesHeader } from './CollapsibleFeesHeader';
+import { MaximumFee } from './MaximumFee';
+import { useTransactionMaxFee } from './hooks/useTransactionMaxFee';
+
+export type CollapsibleFeesHeaderContentProps = {
+    label?: TranslationKey;
+    headerTypographyStyle?: TypographyStyle;
+    isHeaderRowLayout?: boolean;
+    supportsAdjustableFees: boolean;
+    txMaxFee: ReturnType<typeof useTransactionMaxFee>;
+};
+
+export const CollapsibleFeesHeaderContent = ({
+    label,
+    headerTypographyStyle = 'body',
+    supportsAdjustableFees,
+    isHeaderRowLayout,
+    txMaxFee,
+}: CollapsibleFeesHeaderContentProps) => {
+    const content = (
+        <Collapsible.Toggle data-testid="@wallet/fees/collapsible-fees-toggle">
+            <ContentFlex justifyContent="space-between" gap={12}>
+                <CollapsibleFeesHeader label={label} typographyStyle={headerTypographyStyle} />
+                <Row gap={10}>
+                    <MaximumFee typographyStyle={headerTypographyStyle} txMaxFee={txMaxFee} />
+                    {supportsAdjustableFees && (
+                        <Collapsible.ToggleIcon iconName="caretDown" size="mediumLarge" />
+                    )}
+                </Row>
+            </ContentFlex>
+        </Collapsible.Toggle>
+    );
+
+    return isHeaderRowLayout ? (
+        <Box
+            backgroundColorOnInteraction="backgroundSurfaceElevation2"
+            padding={{ vertical: 12, horizontal: 16 }}
+        >
+            {content}
+        </Box>
+    ) : (
+        content
+    );
+};

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeaderContent.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeaderContent.tsx
@@ -39,7 +39,9 @@ export const CollapsibleFeesHeaderContent = ({
 
     return isHeaderRowLayout ? (
         <Box
-            backgroundColorOnInteraction="backgroundSurfaceElevation2"
+            backgroundColorOnInteraction={
+                supportsAdjustableFees ? 'backgroundSurfaceElevation2' : undefined
+            }
             padding={{ vertical: 12, horizontal: 16 }}
         >
             {content}

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeaderContent.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeaderContent.tsx
@@ -27,7 +27,7 @@ export const CollapsibleFeesHeaderContent = ({
         <Collapsible.Toggle data-testid="@wallet/fees/collapsible-fees-toggle">
             <ContentFlex justifyContent="space-between" gap={12}>
                 <CollapsibleFeesHeader label={label} typographyStyle={headerTypographyStyle} />
-                <Row gap={10}>
+                <Row gap={8}>
                     <MaximumFee typographyStyle={headerTypographyStyle} txMaxFee={txMaxFee} />
                     {supportsAdjustableFees && (
                         <Collapsible.ToggleIcon iconName="caretDown" size="mediumLarge" />

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -1,4 +1,4 @@
-import { Column, FlexProps } from '@trezor/components';
+import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { Account } from 'src/types/wallet';
@@ -9,7 +9,7 @@ import { FieldErrorBanner } from './FieldErrorBanner';
 
 export type FeesProps = {
     account: Pick<Account, 'symbol' | 'networkType'>;
-    padding?: FlexProps['padding'];
+    isHeaderRowLayout?: boolean;
 } & Pick<
     CollapsibleFeesProps,
     'label' | 'rbfForm' | 'feeInfo' | 'changeFeeLevel' | 'composedLevels' | 'headerTypographyStyle'
@@ -23,12 +23,12 @@ export const Fees = ({
     label,
     rbfForm,
     headerTypographyStyle,
-    padding,
+    isHeaderRowLayout,
 }: FeesProps) => {
     useFetchFees({ networkSymbol });
 
     return (
-        <Column gap={spacings.md} padding={padding} overflow="unset">
+        <Column gap={spacings.md} overflow="unset">
             <CollapsibleFees
                 networkType={networkType}
                 networkSymbol={networkSymbol}
@@ -38,6 +38,7 @@ export const Fees = ({
                 changeFeeLevel={changeFeeLevel}
                 rbfForm={rbfForm}
                 headerTypographyStyle={headerTypographyStyle}
+                isHeaderRowLayout={isHeaderRowLayout}
             />
 
             <FieldErrorBanner fieldName="selectedFee" />

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -205,7 +205,7 @@ export const TradingExchangeFormInputs = () => {
                 account={account}
                 composedLevels={composedLevels}
                 changeFeeLevel={changeFeeLevel}
-                padding={{ vertical: spacings.sm, horizontal: spacings.lg }}
+                isHeaderRowLayout
             />
             <TradingSelectedOfferProvider />
             <Divider margin={0} />

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -131,7 +131,7 @@ export const TradingSellFormInputs = () => {
                 account={account}
                 composedLevels={composedLevels}
                 changeFeeLevel={changeFeeLevel}
-                padding={{ vertical: spacings.sm, horizontal: spacings.lg }}
+                isHeaderRowLayout
             />
             <Divider margin={0} />
             <Column gap={spacings.lg} padding={{ vertical: spacings.md, horizontal: spacings.lg }}>

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 
 import { Translation } from '@suite/intl';
-import { Column, Divider, Icon, Row, Text } from '@trezor/components';
+import { Box, Column, Divider, Icon, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { AccountLabeling, Address } from 'src/components/suite';
@@ -34,7 +34,7 @@ export const TradingReceiveAddress = () => {
     };
 
     return (
-        <Column cursor="pointer">
+        <Box cursor="pointer" backgroundColorOnInteraction="backgroundSurfaceElevation2">
             <Divider margin={0} />
 
             <Row
@@ -94,6 +94,6 @@ export const TradingReceiveAddress = () => {
                     <Icon name="caretRight" size={20} variant="tertiary" />
                 </Row>
             </Row>
-        </Column>
+        </Box>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Changed Fees header layout
- https://www.figma.com/design/nsDtvR2N5TmuK1QCefRdvP/Trading--Final-?node-id=6940-12252&m=dev
- Solved with adding property `isHeaderRowLayout`
- TradingReceiveAddress has same hover styles as Fees header
- 

## Notes for QA
New layout is defined as property and component has this style is defined in Swap and Sell only, please check all other places where Fees are used. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23233

## Screenshots:
<img width="662" height="225" alt="image" src="https://github.com/user-attachments/assets/322e159b-4be2-4ad8-8f10-4adc798222b0" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/swap-trade-collapse&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/swap-trade-collapse&lookback=7)