### PR TITLE
fix(suite-desktop): fix BioAuthModule initialization race condition

### DIFF
--- a/packages/suite-desktop-core/src/modules/bioAuthModule.ts
+++ b/packages/suite-desktop-core/src/modules/bioAuthModule.ts
@@ -251,14 +251,8 @@ export const initBioAuthModule = ({
         ipcMain.handle('bio-auth/is-bio-auth-available', ipcEvent => {
             validateIpcMessage({ ipcEvent });
 
-            if (!bioAuth) {
-                logger.warn(
-                    'bioAuth',
-                    'is-bio-auth-available called before bioAuth is initialized',
-                );
-
-                return Promise.resolve(false);
-            }
+            // Necessary check for race condition: UI might ask for availability before await bioAuth.init()
+            if (!bioAuth) return Promise.resolve(false);
 
             return bioAuth.isAvailable();
         });
@@ -288,14 +282,20 @@ export const initBioAuthModule = ({
         ipcMain.handle('bio-auth/validate-bio-auth', (ipcEvent, params) => {
             validateIpcMessage({ ipcEvent });
 
-            if (!bioAuth?.initialized) throw new Error('BioAuth module is not initialized');
+            if (!bioAuth?.initialized) {
+                throw new Error('BioAuth module is not initialized (calling validate-bio-auth)');
+            }
 
             return bioAuth.validate(params.message ?? PROMPT_REASON);
         });
 
         ipcMain.handle('bio-auth/get-validation-status', ipcEvent => {
             validateIpcMessage({ ipcEvent });
-            if (!bioAuth?.initialized) throw new Error('BioAuth module is not initialized');
+            if (!bioAuth?.initialized) {
+                throw new Error(
+                    'BioAuth module is not initialized (calling get-validation-status)',
+                );
+            }
 
             return bioAuth.isValidated();
         });

--- a/packages/suite-desktop-core/src/modules/bioAuthModule.ts
+++ b/packages/suite-desktop-core/src/modules/bioAuthModule.ts
@@ -134,21 +134,53 @@ class BioAuthLinux extends BioAuth {
 }
 
 class BioAuthWindows extends BioAuth {
-    private winHello?: Awaited<ReturnType<typeof createWinHelloManager>>;
+    private winHello: Awaited<ReturnType<typeof createWinHelloManager>> | null;
+    private initPromise: Promise<Awaited<ReturnType<typeof createWinHelloManager>> | null>;
+
+    constructor(params: ConstructorParams) {
+        super(params);
+        this.initPromise = Promise.resolve(null);
+        this.winHello = null;
+    }
 
     async init() {
+        // Call super.init() first to set initialized flag
         await super.init();
-        this.winHello = await createWinHelloManager({
-            resourcesPath: process.resourcesPath,
-            logger,
-        });
+
+        this.initPromise = Promise.race<Awaited<ReturnType<typeof createWinHelloManager>>>([
+            createWinHelloManager({
+                resourcesPath: process.resourcesPath,
+                logger,
+            }),
+            new Promise<never>((_, reject) =>
+                setTimeout(() => reject(new Error('WinHello initialization timeout')), 40_000),
+            ),
+        ])
+            .then(winHello => {
+                this.winHello = winHello;
+                logger.info('bioAuth', 'WinHelloManager initialized successfully');
+
+                return winHello;
+            })
+            .catch(err => {
+                this.winHello = null;
+                logger.warn('bioAuth', `WinHelloManager initialization failed: ${err}`);
+
+                return null;
+            });
+
+        // Don't await initPromise - let it complete in background
+        // This ensures init() returns successfully even if WinHello setup fails
     }
 
     async isAvailable() {
-        if (!this.winHello) throw new Error('WinHelloManager is not initialized');
+        const winHello = await this.initPromise;
+        if (!winHello) {
+            return false;
+        }
 
         try {
-            return await this.winHello.isHelloAvailable();
+            return await winHello.isHelloAvailable();
         } catch (err) {
             logger.warn('bioAuth', `Error checking Windows Hello availability: ${err}`);
 
@@ -156,10 +188,13 @@ class BioAuthWindows extends BioAuth {
         }
     }
 
-    validate(message?: string) {
-        if (!this.winHello) throw new Error('WinHelloManager is not initialized');
+    async validate(message?: string) {
+        const winHello = await this.initPromise;
+        if (!winHello) {
+            throw new Error('WinHelloManager is not available');
+        }
 
-        return this.winHello
+        return winHello
             .requestHello(message ?? PROMPT_REASON)
             .then(() => {
                 this.onValidationSuccess();
@@ -197,6 +232,7 @@ export const initBioAuthModule = ({
             logger,
             enabled: store.getBioAuthSettings().enabled || false,
         };
+
         if (isMacOs()) {
             bioAuth = new BioAuthMac(constructorParams);
             logger.info('bioAuth', 'Loaded for Mac');
@@ -215,7 +251,14 @@ export const initBioAuthModule = ({
         ipcMain.handle('bio-auth/is-bio-auth-available', ipcEvent => {
             validateIpcMessage({ ipcEvent });
 
-            if (!bioAuth?.initialized) throw new Error('BioAuth module is not initialized');
+            if (!bioAuth) {
+                logger.warn(
+                    'bioAuth',
+                    'is-bio-auth-available called before bioAuth is initialized',
+                );
+
+                return Promise.resolve(false);
+            }
 
             return bioAuth.isAvailable();
         });

--- a/packages/suite/src/actions/suite/bioAuthThunks.ts
+++ b/packages/suite/src/actions/suite/bioAuthThunks.ts
@@ -24,7 +24,7 @@ const handleError = (error: string, dispatch: Dispatch, message: string) => {
 };
 
 export const init = createThunk(`${BIO_AUTH_PREFIX}/init`, (_args, { dispatch }) => {
-    // settings
+    // only fetches settings from electron-store, not dependent on BioAuthModule, see bio-auth/get-bio-auth-settings
     desktopApi.getBioAuthSettings().then(settings => {
         dispatch(bioAuthActions.setBioAuthEnabled(settings.enabled));
     });
@@ -32,20 +32,23 @@ export const init = createThunk(`${BIO_AUTH_PREFIX}/init`, (_args, { dispatch })
         dispatch(bioAuthActions.setBioAuthEnabled(settings.enabled));
     });
 
-    // api availability
-    desktopApi.isBioAuthAvailable().then(available => {
+    const onBioAuthAvailable = (available: boolean) => {
         dispatch(bioAuthActions.setIsBioAuthAvailable(available));
-    });
+        if (!available) return;
+        // ensure this api is called only when & if BioAuthModule is available = initialized
+        desktopApi.getBioAuthStatus().then(validated => {
+            dispatch(bioAuthActions.setIsBioAuthValidationRequired(!validated));
+        });
+    };
 
-    // validation status
-    desktopApi.getBioAuthStatus().then(validated => {
-        dispatch(bioAuthActions.setIsBioAuthValidationRequired(!validated));
-    });
+    // We don't know what will be faster, BioAuthModule may initialize before or after this thunk.
+    // Fetch api availability if BioAuthModule is initialized (though it may never become available, depending on the system)
+    desktopApi.isBioAuthAvailable().then(onBioAuthAvailable);
+
+    // If BioAuthModule initializes later, it will emit an event, which will be caught here
+    desktopApi.on('bio-auth/bio-auth-availability-changed', onBioAuthAvailable);
     desktopApi.on('bio-auth/validation-status-changed', validated => {
         dispatch(bioAuthActions.setIsBioAuthValidationRequired(!validated));
-    });
-    desktopApi.on('bio-auth/bio-auth-availability-changed', available => {
-        dispatch(bioAuthActions.setIsBioAuthAvailable(available));
     });
 });
 


### PR DESCRIPTION
## Description

Fixes several problems with initialization procedure of BioAuthModule and the communication between renderer process:

- rearrange `bioAuthThunks.init` so it never sends other requests until available is confirmed
- relax the condition in `'bio-auth/is-bio-auth-available'` to make it double as a status check
- on Windows specifically, store `initPromise` and ensure that other methods don't crash if Promise is still pending
  - Awaits the initilzation of the bioAuth module when calling the first method "isAvailable"
  - note that this is a side issue – a potential problem, not the cause of errors captured by Sentry

## Notes for QA

‼️ PLS TEST ALL THE PLATFORMS
Not visible, bio auth should work the same as it does now on macOS and Windows.
Smoke test Linux – does not crash, and bio auth not visible in settings. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23819

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=23819-initilaize-bioauth-not-done-validate&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=23819-initilaize-bioauth-not-done-validate&lookback=7)