### PR TITLE
chore: ignore static files from vite watcher

### DIFF
--- a/packages/suite-build/vite.config.mts
+++ b/packages/suite-build/vite.config.mts
@@ -491,5 +491,8 @@ export default defineConfig({
         port: 8000,
         open: false,
         host: true,
+        watch: {
+            ignored: ['**/node_modules/**', '**/dist/**', '**/.nx/**', '**/.git/**'],
+        },
     },
 });


### PR DESCRIPTION
## Description
- Vite watcher is ignoring static files now`['**/node_modules/**', '**/dist/**', '**/.nx/**', '**/.git/**'],`


## Notes for QA
- dev thing no need qa



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/vite-config&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/vite-config&lookback=7)