### PR TITLE
fix(suite-native): fix formatter for empty amount transactions

### DIFF
--- a/suite-native/formatters/src/components/TokenAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/TokenAmountFormatter.tsx
@@ -26,7 +26,9 @@ export const TokenAmountFormatter = ({
 }: TokenAmountFormatterProps) => {
     // Phishing transactions values may be equal to empty string, so we replace it with 0.
     // These values are hidden by discreet mode , so the exact value does not matter anyway.
-    const decimalValue = isPhishingTransaction ? 0 : convertTokenValueToDecimal(value, decimals);
+
+    const decimalValue =
+        isPhishingTransaction || !value ? 0 : convertTokenValueToDecimal(value, decimals);
 
     const { CryptoAmountFormatter: formatter } = useFormatters();
     const formattedValue = formatter.format(decimalValue.toString(), {

--- a/suite-native/transactions/src/components/TokenTransferListItem.tsx
+++ b/suite-native/transactions/src/components/TokenTransferListItem.tsx
@@ -59,6 +59,8 @@ export const TokenTransferListItemValues = ({
 
     const isFailedTx = transaction.type === 'failed';
 
+    if (!tokenTransfer?.amount) return;
+
     return (
         <>
             <TokenToFiatAmountFormatter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

prevent app from crash when the transaction's amount value is ''

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18465

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/amount-is-not-number&lookback=7)