### PR TITLE
24632 trading thunks should log errors

### DIFF
--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -61,6 +61,24 @@ type ClaimedTransactionNotification = {
     type: 'tx-claimed';
 } & TransactionNotificationPayload;
 
+export type ErrorToastPayload = {
+    type:
+        | 'error'
+        | 'discovery-error'
+        | 'verify-address-error'
+        | 'verify-xpub-error'
+        | 'sign-message-error'
+        | 'verify-message-error'
+        | 'sign-tx-error'
+        | 'metadata-auth-error'
+        | 'metadata-not-found-error'
+        | 'metadata-unexpected-error'
+        | 'device-authenticity-error'
+        | 'cardano-delegate-error'
+        | 'cardano-withdrawal-error';
+    error: string;
+};
+
 export type ToastPayload = (
     | {
           type: 'acquire-error';
@@ -110,23 +128,7 @@ export type ToastPayload = (
           type: 'raw-tx-sent';
           txid: string;
       }
-    | {
-          type:
-              | 'error'
-              | 'discovery-error'
-              | 'verify-address-error'
-              | 'verify-xpub-error'
-              | 'sign-message-error'
-              | 'verify-message-error'
-              | 'sign-tx-error'
-              | 'metadata-auth-error'
-              | 'metadata-not-found-error'
-              | 'metadata-unexpected-error'
-              | 'device-authenticity-error'
-              | 'cardano-delegate-error'
-              | 'cardano-withdrawal-error';
-          error: string;
-      }
+    | ErrorToastPayload
     | {
           type: 'auto-updater-error';
           state: DesktopAppUpdateState;

--- a/suite-common/trading/src/reducers/__tests__/buyReducer.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/buyReducer.test.ts
@@ -3,7 +3,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { configureMockStore } from '@suite-common/test-utils';
 
 import { buyTradingFixtures } from '../__fixtures__/buyTradingReducer';
-import { tradingBuyReducer } from '../buyReducer';
+import { tradingBuyActions, tradingBuyReducer } from '../buyReducer';
 
 describe('tradingBuyReducer', () => {
     buyTradingFixtures.forEach(f => {
@@ -29,6 +29,23 @@ describe('tradingBuyReducer', () => {
                 store.dispatch(action);
             });
             expect(store.getState().wallet.trading.buy).toEqual(f.result);
+        });
+    });
+
+    describe('lastErrorMessage', () => {
+        it('should be undefined initially', () => {
+            const state = tradingBuyReducer(undefined, { type: 'unknown' });
+
+            expect(state.lastErrorMessage).toBeUndefined();
+        });
+
+        it('setLastErrorMessage should set lastErrorMessage', () => {
+            const state = tradingBuyReducer(
+                undefined,
+                tradingBuyActions.setLastErrorMessage('Some error'),
+            );
+
+            expect(state.lastErrorMessage).toBe('Some error');
         });
     });
 });

--- a/suite-common/trading/src/reducers/__tests__/exchangeReducer.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/exchangeReducer.test.ts
@@ -3,7 +3,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { configureMockStore } from '@suite-common/test-utils';
 
 import { exchangeTradingFixtures } from '../__fixtures__/exchangeTradingReducer';
-import { tradingExchangeReducer } from '../exchangeReducer';
+import { tradingExchangeActions, tradingExchangeReducer } from '../exchangeReducer';
 
 describe('tradingExchangeReducer', () => {
     exchangeTradingFixtures.forEach(fixture => {
@@ -29,6 +29,23 @@ describe('tradingExchangeReducer', () => {
                 store.dispatch(action);
             });
             expect(store.getState().wallet.trading.exchange).toEqual(fixture.result);
+        });
+    });
+
+    describe('lastErrorMessage', () => {
+        it('should be undefined initially', () => {
+            const state = tradingExchangeReducer(undefined, { type: 'unknown' });
+
+            expect(state.lastErrorMessage).toBeUndefined();
+        });
+
+        it('setLastErrorMessage should set lastErrorMessage', () => {
+            const state = tradingExchangeReducer(
+                undefined,
+                tradingExchangeActions.setLastErrorMessage('Some error'),
+            );
+
+            expect(state.lastErrorMessage).toBe('Some error');
         });
     });
 });

--- a/suite-common/trading/src/reducers/__tests__/sellReducer.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/sellReducer.test.ts
@@ -3,7 +3,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { configureMockStore } from '@suite-common/test-utils';
 
 import { sellTradingFixtures } from '../__fixtures__/sellTradingReducer';
-import { tradingSellReducer } from '../sellReducer';
+import { tradingSellActions, tradingSellReducer } from '../sellReducer';
 
 describe('tradingSellReducer', () => {
     sellTradingFixtures.forEach(fixture => {
@@ -29,6 +29,23 @@ describe('tradingSellReducer', () => {
                 store.dispatch(action);
             });
             expect(store.getState().wallet.trading.sell).toEqual(fixture.result);
+        });
+    });
+
+    describe('lastErrorMessage', () => {
+        it('should be undefined initially', () => {
+            const state = tradingSellReducer(undefined, { type: 'unknown' });
+
+            expect(state.lastErrorMessage).toBeUndefined();
+        });
+
+        it('setLastErrorMessage should set lastErrorMessage', () => {
+            const state = tradingSellReducer(
+                undefined,
+                tradingSellActions.setLastErrorMessage('Some error'),
+            );
+
+            expect(state.lastErrorMessage).toBe('Some error');
         });
     });
 });

--- a/suite-common/trading/src/reducers/buyReducer.ts
+++ b/suite-common/trading/src/reducers/buyReducer.ts
@@ -31,8 +31,8 @@ export interface TradingBuyState {
     receiveAddress?: string;
     isLoading: boolean;
     amountLimits: TradingAmountLimitProps | undefined;
-
     transactionId?: string;
+    lastErrorMessage?: string;
 }
 
 export const buyInitialState: TradingBuyState = {
@@ -88,6 +88,9 @@ const tradingBuySlice = createSlice({
         },
         setReceiveAddress(state, action: PayloadAction<string | undefined>) {
             state.receiveAddress = action.payload;
+        },
+        setLastErrorMessage(state, action: PayloadAction<string | undefined>) {
+            state.lastErrorMessage = action.payload;
         },
     },
 });

--- a/suite-common/trading/src/reducers/exchangeReducer.ts
+++ b/suite-common/trading/src/reducers/exchangeReducer.ts
@@ -32,8 +32,8 @@ export interface TradingExchangeState {
     isLoading: boolean;
     amountLimits: TradingExchangeAmountLimitProps | undefined;
     formStep: TradingExchangeStepType;
-
     transactionId?: string;
+    lastErrorMessage?: string;
 }
 
 export const exchangeInitialState: TradingExchangeState = {
@@ -101,6 +101,9 @@ const tradingExchangeSlice = createSlice({
         },
         setFormStep(state, action: PayloadAction<TradingExchangeStepType>) {
             state.formStep = action.payload;
+        },
+        setLastErrorMessage(state, action: PayloadAction<string | undefined>) {
+            state.lastErrorMessage = action.payload;
         },
     },
 });

--- a/suite-common/trading/src/reducers/sellReducer.ts
+++ b/suite-common/trading/src/reducers/sellReducer.ts
@@ -25,8 +25,8 @@ export type TradingSellState = {
     isLoading: boolean;
     amountLimits: TradingAmountLimitProps | undefined;
     formStep: TradingSellStepType;
-
     transactionId?: string;
+    lastErrorMessage?: string;
 };
 
 export const sellInitialState: TradingSellState = {
@@ -79,6 +79,9 @@ const tradingSellSlice = createSlice({
         },
         setFormStep(state, action: PayloadAction<TradingSellStepType>) {
             state.formStep = action.payload;
+        },
+        setLastErrorMessage(state, action: PayloadAction<string | undefined>) {
+            state.lastErrorMessage = action.payload;
         },
     },
 });

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -30,6 +30,7 @@ import {
     selectTradingBuy,
     selectTradingBuyInfo,
     selectTradingBuyIsLoading,
+    selectTradingBuyLastErrorMessage,
     selectTradingBuyLoadingTimestampAndStatus,
     selectTradingBuyProviders,
     selectTradingBuyQuoteByOrderId,
@@ -45,6 +46,7 @@ import {
     selectTradingExchangeFormStep,
     selectTradingExchangeInfo,
     selectTradingExchangeIsLoading,
+    selectTradingExchangeLastErrorMessage,
     selectTradingExchangeLoadingTimestampAndStatus,
     selectTradingExchangeProviders,
     selectTradingExchangeQuotesRequest,
@@ -59,6 +61,7 @@ import {
     selectTradingSellAccountKey,
     selectTradingSellFormStep,
     selectTradingSellInfo,
+    selectTradingSellLastErrorMessage,
     selectTradingSellLoadingTimestampAndStatus,
     selectTradingSellProviders,
     selectTradingSellQuotes,
@@ -1439,6 +1442,27 @@ describe('tradingSelectors', () => {
             const second = selectTradingAccountKeyByTradeType(state, 'exchange');
 
             expect(first).toBe(second);
+        });
+    });
+
+    describe('selectTradingBuyLastErrorMessage', () => {
+        it('should return lastErrorMessage from buy state', () => {
+            state.wallet.trading.buy.lastErrorMessage = 'Buy error message';
+            expect(selectTradingBuyLastErrorMessage(state)).toBe('Buy error message');
+        });
+    });
+
+    describe('selectTradingSellLastErrorMessage', () => {
+        it('should return lastErrorMessage from sell state', () => {
+            state.wallet.trading.sell.lastErrorMessage = 'Sell error message';
+            expect(selectTradingSellLastErrorMessage(state)).toBe('Sell error message');
+        });
+    });
+
+    describe('selectTradingExchangeLastErrorMessage', () => {
+        it('should return lastErrorMessage from exchange state', () => {
+            state.wallet.trading.exchange.lastErrorMessage = 'Exchange error message';
+            expect(selectTradingExchangeLastErrorMessage(state)).toBe('Exchange error message');
         });
     });
 });

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -18,7 +18,7 @@ import { BuyInfo, TradingBuyState } from '../../reducers/buyReducer';
 import { ExchangeInfo, exchangeInitialState } from '../../reducers/exchangeReducer';
 import { SellInfo, sellInitialState } from '../../reducers/sellReducer';
 import { type TradingRootState, initialState } from '../../reducers/tradingCommonReducer';
-import type { TradingPaymentMethodListProps } from '../../types';
+import type { TradingPaymentMethodListProps, TradingType } from '../../types';
 import {
     TradingRootStateWithDeviceAndAccounts,
     selectDeviceHasTradingTrades,
@@ -52,6 +52,7 @@ import {
     selectTradingExchangeQuotesRequest,
     selectTradingExchangeSelectedQuote,
     selectTradingExchangeSellCryptoIds,
+    selectTradingLastErrorMessageByTradeType,
     selectTradingModalAccountKey,
     selectTradingNativeCoinSymbolByCryptoId,
     selectTradingPaymentMethods,
@@ -1463,6 +1464,24 @@ describe('tradingSelectors', () => {
         it('should return lastErrorMessage from exchange state', () => {
             state.wallet.trading.exchange.lastErrorMessage = 'Exchange error message';
             expect(selectTradingExchangeLastErrorMessage(state)).toBe('Exchange error message');
+        });
+    });
+
+    describe('selectTradingLastErrorMessageByTradeType', () => {
+        beforeEach(() => {
+            state.wallet.trading.buy.lastErrorMessage = 'Buy error message';
+            state.wallet.trading.sell.lastErrorMessage = 'Sell error message';
+            state.wallet.trading.exchange.lastErrorMessage = 'Exchange error message';
+        });
+
+        it.each<[TradingType, string]>([
+            ['buy', 'Buy error message'],
+            ['sell', 'Sell error message'],
+            ['exchange', 'Exchange error message'],
+        ])('should return lastErrorMessage for %s', (tradeType, expectedMessage) => {
+            const result = selectTradingLastErrorMessageByTradeType(state, tradeType);
+
+            expect(result).toBe(expectedMessage);
         });
     });
 });

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -710,3 +710,12 @@ export const selectTradingDetailData = createMemoizedSelector(
         };
     },
 );
+
+export const selectTradingBuyLastErrorMessage = (state: TradingRootState) =>
+    selectTradingBuy(state).lastErrorMessage;
+
+export const selectTradingExchangeLastErrorMessage = (state: TradingRootState) =>
+    selectTradingExchange(state).lastErrorMessage;
+
+export const selectTradingSellLastErrorMessage = (state: TradingRootState) =>
+    selectTradingSell(state).lastErrorMessage;

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -719,3 +719,22 @@ export const selectTradingExchangeLastErrorMessage = (state: TradingRootState) =
 
 export const selectTradingSellLastErrorMessage = (state: TradingRootState) =>
     selectTradingSell(state).lastErrorMessage;
+
+export const selectTradingLastErrorMessageByTradeType = (
+    state: TradingRootState,
+    tradingType: TradingType,
+) => {
+    switch (tradingType) {
+        case 'buy':
+            return selectTradingBuyLastErrorMessage(state);
+
+        case 'exchange':
+            return selectTradingExchangeLastErrorMessage(state);
+
+        case 'sell':
+            return selectTradingSellLastErrorMessage(state);
+
+        default:
+            exhaustive(tradingType, 'Unexpected trade type');
+    }
+};

--- a/suite-common/trading/src/thunks/buy/__tests__/confirmBuyTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/confirmBuyTradeThunk.test.ts
@@ -9,9 +9,17 @@ import { invityAPI } from '../../../invityAPI';
 import { TradingBuyState } from '../../../reducers/buyReducer';
 import { initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
+import type { LogErrorThunkProps } from '../../common/logErrorThunk';
 import { buyThunks } from '../index';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
+
+jest.mock('../../common/logErrorThunk', () => ({
+    logErrorThunk: (props: LogErrorThunkProps) => ({
+        type: 'mockedLogErrorThunk',
+        payload: props,
+    }),
+}));
 
 describe('confirmBuyTradeThunk', () => {
     afterEach(() => {
@@ -118,11 +126,13 @@ describe('confirmBuyTradeThunk', () => {
 
             const toastAction = store
                 .getActions()
-                .find(action => action.type === '@common/in-app-notifications/addToast');
+                .find(action => action.type === 'mockedLogErrorThunk');
 
             expect(mocktriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
-            expect(toastAction?.payload.type).toEqual('error');
-            expect(toastAction?.payload.error).toEqual('No response from the server');
+            expect(toastAction?.payload).toEqual({
+                tradingType: 'buy',
+                errorMessage: 'No response from the server',
+            });
             expect(mockProcessResponseData).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.buy.isLoading).toBeFalsy();
         });
@@ -150,11 +160,13 @@ describe('confirmBuyTradeThunk', () => {
 
             const toastAction = store
                 .getActions()
-                .find(action => action.type === '@common/in-app-notifications/addToast');
+                .find(action => action.type === 'mockedLogErrorThunk');
 
             expect(mocktriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
-            expect(toastAction?.payload.type).toEqual('error');
-            expect(toastAction?.payload.error).toEqual('No response from the server');
+            expect(toastAction?.payload).toEqual({
+                tradingType: 'buy',
+                errorMessage: 'No response from the server',
+            });
             expect(mockProcessResponseData).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.buy.isLoading).toBeFalsy();
         });
@@ -188,11 +200,13 @@ describe('confirmBuyTradeThunk', () => {
 
             const toastAction = store
                 .getActions()
-                .find(action => action.type === '@common/in-app-notifications/addToast');
+                .find(action => action.type === 'mockedLogErrorThunk');
 
             expect(mocktriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
-            expect(toastAction?.payload.type).toEqual('error');
-            expect(toastAction?.payload.error).toEqual('No response from the server');
+            expect(toastAction?.payload).toEqual({
+                tradingType: 'buy',
+                errorMessage: 'No response from the server',
+            });
             expect(mockProcessResponseData).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.buy.isLoading).toBeFalsy();
         });
@@ -227,10 +241,12 @@ describe('confirmBuyTradeThunk', () => {
 
             const toastAction = store
                 .getActions()
-                .find(action => action.type === '@common/in-app-notifications/addToast');
+                .find(action => action.type === 'mockedLogErrorThunk');
             expect(mocktriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
-            expect(toastAction?.payload.type).toEqual('error');
-            expect(toastAction?.payload.error).toEqual(error);
+            expect(toastAction?.payload).toEqual({
+                tradingType: 'buy',
+                errorMessage: error,
+            });
             expect(mockProcessResponseData).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.buy.isLoading).toBeFalsy();
         });

--- a/suite-common/trading/src/thunks/buy/__tests__/selectBuyQuoteThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/selectBuyQuoteThunk.test.ts
@@ -16,10 +16,18 @@ import { BuyInfo, TradingBuyState } from '../../../reducers/buyReducer';
 import { initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
 import { TradingCountryCode } from '../../../types';
+import type { LogErrorThunkProps } from '../../common/logErrorThunk';
 import { buyThunks } from '../index';
 import { SelectBuyQuoteThunkProps } from '../selectBuyQuoteThunk';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
+
+jest.mock('../../common/logErrorThunk', () => ({
+    logErrorThunk: (props: LogErrorThunkProps) => ({
+        type: 'mockedLogErrorThunk',
+        payload: props,
+    }),
+}));
 
 describe('selectBuyQuoteThunk', () => {
     afterEach(() => {
@@ -379,12 +387,14 @@ describe('selectBuyQuoteThunk', () => {
 
             const actionToast = store
                 .getActions()
-                .find(action => action.type === '@common/in-app-notifications/addToast');
+                .find(action => action.type === 'mockedLogErrorThunk');
 
             expect(mockLoginRequest).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
-            expect(actionToast?.payload?.type).toEqual('error');
-            expect(actionToast?.payload?.error).toEqual('No response from the server');
+            expect(actionToast?.payload).toEqual({
+                errorMessage: 'No response from the server',
+                tradingType: 'buy',
+            });
         });
     });
 });

--- a/suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts
+++ b/suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts
@@ -1,7 +1,6 @@
 import { BuyTrade, BuyTradeResponse } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { notificationsActions } from '@suite-common/toast-notifications';
 import { Account } from '@suite-common/wallet-types';
 
 import { TRADING_BUY_THUNK_PREFIX } from '../../constants';
@@ -12,6 +11,7 @@ import {
     selectTradingBuyReceiveAccountKey,
     selectTradingBuySelectedQuote,
 } from '../../selectors/tradingSelectors';
+import { logErrorThunk } from '../common/logErrorThunk';
 
 export type ConfirmTradeThunkProps = {
     quote?: BuyTrade;
@@ -61,9 +61,9 @@ export const confirmBuyTradeThunk = createThunk(
 
         if (!response || !response.trade || !response.trade.paymentId) {
             dispatch(
-                notificationsActions.addToast({
-                    type: 'error',
-                    error: 'No response from the server',
+                logErrorThunk({
+                    errorMessage: 'No response from the server',
+                    tradingType: 'buy',
                 }),
             );
 
@@ -74,9 +74,9 @@ export const confirmBuyTradeThunk = createThunk(
 
         if (response.trade.error) {
             dispatch(
-                notificationsActions.addToast({
-                    type: 'error',
-                    error: response.trade.error,
+                logErrorThunk({
+                    errorMessage: response.trade.error,
+                    tradingType: 'buy',
                 }),
             );
 

--- a/suite-common/trading/src/thunks/buy/selectBuyQuoteThunk.ts
+++ b/suite-common/trading/src/thunks/buy/selectBuyQuoteThunk.ts
@@ -1,7 +1,6 @@
 import { BuyTrade, FormResponse } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { notificationsActions } from '@suite-common/toast-notifications';
 import { Timer } from '@trezor/react-utils';
 
 import { TRADING_BUY_THUNK_PREFIX } from '../../constants';
@@ -11,6 +10,7 @@ import {
     selectTradingBuyInfo,
     selectTradingBuyQuotesRequest,
 } from '../../selectors/tradingSelectors';
+import { logErrorThunk } from '../common/logErrorThunk';
 
 export type SelectBuyQuoteThunkProps = {
     quote: BuyTrade;
@@ -40,9 +40,9 @@ export const selectBuyQuoteThunk = createThunk(
 
             if (!response) {
                 dispatch(
-                    notificationsActions.addToast({
-                        type: 'error',
-                        error: 'No response from the server',
+                    logErrorThunk({
+                        errorMessage: 'No response from the server',
+                        tradingType: 'buy',
                     }),
                 );
 

--- a/suite-common/trading/src/thunks/common/__tests__/logErrorThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/logErrorThunk.test.ts
@@ -1,0 +1,97 @@
+import { TradingType } from '../../../types';
+import { logErrorThunk } from '../logErrorThunk';
+
+jest.mock('@suite-common/toast-notifications', () => {
+    const originalModule = jest.requireActual('@suite-common/toast-notifications');
+
+    return {
+        ...originalModule,
+        notificationsActions: {
+            ...originalModule.notificationsActions,
+            addToast: jest.fn().mockImplementation(toast => ({
+                type: 'mockedAddToastAction',
+                payload: toast,
+            })),
+        },
+    };
+});
+
+jest.mock('../setLastErrorMessageByTradingType', () => {
+    const originalModule = jest.requireActual('../setLastErrorMessageByTradingType');
+
+    return {
+        ...originalModule,
+        setLastErrorMessageByTradingType: jest
+            .fn()
+            .mockImplementation(({ tradingType, errorMessage }) => ({
+                type: 'mockedSetLastErrorMessageByTradingTypeAction',
+                payload: { tradingType, errorMessage },
+            })),
+    };
+});
+
+describe('logErrorThunk', () => {
+    const dispatch = jest.fn();
+    const getState = () => {};
+    const extra = {} as any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should call addToast', async () => {
+        const errorMessage = 'Test error message';
+        const tradingType = 'buy';
+
+        const thunk = logErrorThunk({
+            errorMessage,
+            tradingType,
+        });
+        await thunk(dispatch, getState, extra);
+
+        expect(dispatch).toHaveBeenCalledWith({
+            type: 'mockedAddToastAction',
+            payload: {
+                type: 'error',
+                error: errorMessage,
+            },
+        });
+    });
+
+    it('should call addToast with specified type', async () => {
+        const errorMessage = 'Test error message';
+        const tradingType = 'buy';
+        const toastType = 'discovery-error';
+
+        const thunk = logErrorThunk({
+            errorMessage,
+            tradingType,
+            toastType,
+        });
+        await thunk(dispatch, getState, extra);
+
+        expect(dispatch).toHaveBeenCalledWith({
+            type: 'mockedAddToastAction',
+            payload: {
+                type: toastType,
+                error: errorMessage,
+            },
+        });
+    });
+
+    it('should set last error message', async () => {
+        const errorMessage = 'Test error message';
+        const tradingType: TradingType = 'buy';
+
+        const thunk = logErrorThunk({
+            errorMessage,
+            tradingType,
+        });
+        await thunk(dispatch, getState, extra);
+
+        expect(dispatch).toHaveBeenCalledWith({
+            type: 'mockedSetLastErrorMessageByTradingTypeAction',
+            payload: { errorMessage: 'Test error message', tradingType: 'buy' },
+        });
+    });
+});

--- a/suite-common/trading/src/thunks/common/__tests__/setLastErrorMessageByTradingType.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/setLastErrorMessageByTradingType.test.ts
@@ -1,0 +1,33 @@
+import { ActionCreator } from '@reduxjs/toolkit';
+
+import { tradingBuyActions } from '../../../reducers/buyReducer';
+import { tradingExchangeActions } from '../../../reducers/exchangeReducer';
+import { tradingSellActions } from '../../../reducers/sellReducer';
+import { TradingType } from '../../../types';
+import { setLastErrorMessageByTradingType } from '../setLastErrorMessageByTradingType';
+
+describe('setLastErrorMessageByTradingType', () => {
+    const dispatch = jest.fn();
+    const getState = () => {};
+    const extra = {} as any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it.each<[TradingType, ActionCreator<any>]>([
+        ['buy', tradingBuyActions.setLastErrorMessage],
+        ['sell', tradingSellActions.setLastErrorMessage],
+        ['exchange', tradingExchangeActions.setLastErrorMessage],
+    ])('should set last error message for %s', async (tradingType, expectedAction) => {
+        const errorMessage = 'Test error message';
+
+        const thunk = setLastErrorMessageByTradingType({
+            errorMessage,
+            tradingType,
+        });
+        await thunk(dispatch, getState, extra);
+
+        expect(dispatch).toHaveBeenCalledWith(expectedAction(errorMessage));
+    });
+});

--- a/suite-common/trading/src/thunks/common/__tests__/verifyAddressThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/verifyAddressThunk.test.ts
@@ -9,6 +9,7 @@ import { tradingThunks } from '../';
 import { accounts } from '../../../reducers/__fixtures__/account';
 import { initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
+import type { LogErrorThunkProps } from '../logErrorThunk';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 const mockedSuiteReducer = createReducerWithExtraDeps(
@@ -24,6 +25,13 @@ jest.mock('@suite-common/wallet-core', () => ({
     confirmAddressOnDeviceThunk: jest.fn(),
     selectSelectedDevice: jest.fn(),
     selectAccounts: jest.fn(),
+}));
+
+jest.mock('../../common/logErrorThunk', () => ({
+    logErrorThunk: (props: LogErrorThunkProps) => ({
+        type: 'mockedLogErrorThunk',
+        payload: props,
+    }),
 }));
 
 describe('verifyAddressThunk', () => {
@@ -340,11 +348,13 @@ describe('verifyAddressThunk', () => {
 
         const actionToast = store
             .getActions()
-            .find(action => action.type === '@common/in-app-notifications/addToast');
+            .find(action => action.type === 'mockedLogErrorThunk');
 
-        expect(actionToast?.type).toEqual('@common/in-app-notifications/addToast');
-        expect(actionToast?.payload?.type).toEqual('verify-address-error');
-        expect(actionToast?.payload?.error).toEqual(error);
+        expect(actionToast?.payload).toEqual({
+            tradingType: 'buy',
+            toastType: 'verify-address-error',
+            errorMessage: error,
+        });
 
         expect(store.getState().wallet.trading.verifiedAddress).toEqual(undefined);
     });

--- a/suite-common/trading/src/thunks/common/index.ts
+++ b/suite-common/trading/src/thunks/common/index.ts
@@ -1,6 +1,7 @@
 import { createPaymentRequestsThunk } from './createPaymentRequestsThunk';
 import { loadInitialDataThunk } from './loadInitialDataThunk';
 import { recomposeAndSignTxThunk } from './recomposeAndSignTxThunk';
+import { setLastErrorMessageByTradingType } from './setLastErrorMessageByTradingType';
 import { verifyAddressThunk } from './verifyAddressThunk';
 import { watchTradeThunk } from './watchTradeThunk';
 
@@ -10,4 +11,5 @@ export const tradingThunks = {
     recomposeAndSignTxThunk,
     watchTradeThunk,
     createPaymentRequestsThunk,
+    setLastErrorMessageByTradingType,
 };

--- a/suite-common/trading/src/thunks/common/logErrorThunk.ts
+++ b/suite-common/trading/src/thunks/common/logErrorThunk.ts
@@ -1,0 +1,31 @@
+import { createThunk } from '@suite-common/redux-utils';
+import { ErrorToastPayload, notificationsActions } from '@suite-common/toast-notifications';
+
+import { TRADING_THUNK_PREFIX } from '../../constants';
+import { TradingType } from '../../types';
+import { setLastErrorMessageByTradingType } from '../common/setLastErrorMessageByTradingType';
+
+export type LogErrorThunkProps = {
+    errorMessage: ErrorToastPayload['error'];
+    toastType?: ErrorToastPayload['type'];
+    tradingType: TradingType;
+};
+
+export const logErrorThunk = createThunk(
+    `${TRADING_THUNK_PREFIX}/logError`,
+    ({ errorMessage, tradingType, toastType = 'error' }: LogErrorThunkProps, { dispatch }) => {
+        dispatch(
+            notificationsActions.addToast({
+                type: toastType,
+                error: errorMessage,
+            }),
+        );
+
+        dispatch(
+            setLastErrorMessageByTradingType({
+                tradingType,
+                errorMessage,
+            }),
+        );
+    },
+);

--- a/suite-common/trading/src/thunks/common/setLastErrorMessageByTradingType.ts
+++ b/suite-common/trading/src/thunks/common/setLastErrorMessageByTradingType.ts
@@ -1,0 +1,35 @@
+import { createThunk } from '@suite-common/redux-utils';
+import { exhaustive } from '@trezor/type-utils';
+
+import { TRADING_THUNK_PREFIX } from '../../constants';
+import { tradingBuyActions } from '../../reducers/buyReducer';
+import { tradingExchangeActions } from '../../reducers/exchangeReducer';
+import { tradingSellActions } from '../../reducers/sellReducer';
+import { TradingType } from '../../types';
+
+export type SetLastErrorMessageByTradingTypeProps = {
+    tradingType: TradingType;
+    errorMessage: string | undefined;
+};
+
+export const setLastErrorMessageByTradingType = createThunk(
+    `${TRADING_THUNK_PREFIX}/setLastErrorMessageByTradingType`,
+    ({ tradingType, errorMessage }: SetLastErrorMessageByTradingTypeProps, { dispatch }) => {
+        switch (tradingType) {
+            case 'buy':
+                dispatch(tradingBuyActions.setLastErrorMessage(errorMessage));
+                break;
+
+            case 'sell':
+                dispatch(tradingSellActions.setLastErrorMessage(errorMessage));
+                break;
+
+            case 'exchange':
+                dispatch(tradingExchangeActions.setLastErrorMessage(errorMessage));
+                break;
+
+            default:
+                return exhaustive(tradingType);
+        }
+    },
+);

--- a/suite-common/trading/src/thunks/common/verifyAddressThunk.ts
+++ b/suite-common/trading/src/thunks/common/verifyAddressThunk.ts
@@ -1,8 +1,8 @@
 import { createThunk } from '@suite-common/redux-utils';
-import { notificationsActions } from '@suite-common/toast-notifications';
 import { confirmAddressOnDeviceThunk, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account, AddressDisplayOptions } from '@suite-common/wallet-types';
 
+import { logErrorThunk } from './logErrorThunk';
 import { TRADING_THUNK_PREFIX } from '../../constants';
 import { tradingBuyActions } from '../../reducers/buyReducer';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
@@ -74,9 +74,10 @@ export const verifyAddressThunk = createThunk(
             if (response.payload.code === 'Method_PermissionsNotGranted') return;
 
             dispatch(
-                notificationsActions.addToast({
-                    type: 'verify-address-error',
-                    error: response.payload.error,
+                logErrorThunk({
+                    errorMessage: response.payload.error,
+                    tradingType: activeSection,
+                    toastType: 'verify-address-error',
                 }),
             );
         }

--- a/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
@@ -12,8 +12,16 @@ import { TradingExchangeState } from '../../../reducers/exchangeReducer';
 import { initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
 import { getUnusedAddressFromAccount } from '../../../utils';
+import type { LogErrorThunkProps } from '../../common/logErrorThunk';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
+
+jest.mock('../../common/logErrorThunk', () => ({
+    logErrorThunk: (props: LogErrorThunkProps) => ({
+        type: 'mockedLogErrorThunk',
+        payload: props,
+    }),
+}));
 
 describe('confirmExchangeTradeThunk', () => {
     afterEach(() => {
@@ -247,10 +255,12 @@ describe('confirmExchangeTradeThunk', () => {
         const { exchange } = store.getState().wallet.trading;
         const actionToast = store
             .getActions()
-            .find(action => action.type === '@common/in-app-notifications/addToast');
+            .find(action => action.type === 'mockedLogErrorThunk');
 
-        expect(actionToast?.payload?.type).toEqual('error');
-        expect(actionToast?.payload?.error).toEqual('No response from the server');
+        expect(actionToast?.payload).toEqual({
+            errorMessage: 'No response from the server',
+            tradingType: 'exchange',
+        });
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
         expect(store.getActions().length).toEqual(4);
@@ -317,12 +327,15 @@ describe('confirmExchangeTradeThunk', () => {
             const { exchange } = store.getState().wallet.trading;
             const actionToast = store
                 .getActions()
-                .find(action => action.type === '@common/in-app-notifications/addToast');
+                .find(action => action.type === 'mockedLogErrorThunk');
 
-            expect(actionToast?.payload?.type).toEqual('error');
-            expect(actionToast?.payload?.error).toEqual(
-                'error' in mockResponse ? mockResponse?.error : 'Error response from the server',
-            );
+            expect(actionToast?.payload).toEqual({
+                tradingType: 'exchange',
+                errorMessage:
+                    'error' in mockResponse
+                        ? mockResponse?.error
+                        : 'Error response from the server',
+            });
 
             expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
             expect(store.getActions().length).toEqual(5);

--- a/suite-common/trading/src/thunks/exchange/__tests__/signDataAndConfirmThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/signDataAndConfirmThunk.test.ts
@@ -13,6 +13,7 @@ import { invityAPI } from '../../../invityAPI';
 import { TradingExchangeState } from '../../../reducers/exchangeReducer';
 import { initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
+import type { LogErrorThunkProps } from '../../common/logErrorThunk';
 import { exchangeThunks } from '../index';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
@@ -20,6 +21,13 @@ const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 jest.mock('@trezor/connect-plugin-ethereum', () => ({
     ...jest.requireActual('@trezor/connect-plugin-ethereum'),
     transformTypedData: jest.fn().mockReturnValue({ domain_separator_hash: '', message_hash: '' }),
+}));
+
+jest.mock('../../common/logErrorThunk', () => ({
+    logErrorThunk: (props: LogErrorThunkProps) => ({
+        type: 'mockedLogErrorThunk',
+        payload: props,
+    }),
 }));
 
 describe('signDataAndConfirmThunk', () => {
@@ -107,11 +115,13 @@ describe('signDataAndConfirmThunk', () => {
 
         const actionToast = store
             .getActions()
-            .find(action => action.type === '@common/in-app-notifications/addToast');
+            .find(action => action.type === 'mockedLogErrorThunk');
 
         expect(store.getActions().length).toEqual(3);
-        expect(actionToast?.payload?.type).toEqual('error');
-        expect(actionToast?.payload?.error).toEqual('Cannot sign, missing data');
+        expect(actionToast?.payload).toEqual({
+            tradingType: 'exchange',
+            errorMessage: 'Cannot sign, missing data',
+        });
     });
 
     it('should return error notification when signData type is not eip712-typed-data', async () => {
@@ -145,11 +155,13 @@ describe('signDataAndConfirmThunk', () => {
 
         const actionToast = store
             .getActions()
-            .find(action => action.type === '@common/in-app-notifications/addToast');
+            .find(action => action.type === 'mockedLogErrorThunk');
 
         expect(store.getActions().length).toEqual(3);
-        expect(actionToast?.payload?.type).toEqual('error');
-        expect(actionToast?.payload?.error).toEqual('Cannot sign data, unsupported network');
+        expect(actionToast?.payload).toEqual({
+            tradingType: 'exchange',
+            errorMessage: 'Cannot sign data, unsupported network',
+        });
     });
 
     it('should return error notification when account networkType is not ethereum', async () => {
@@ -186,11 +198,13 @@ describe('signDataAndConfirmThunk', () => {
 
         const actionToast = store
             .getActions()
-            .find(action => action.type === '@common/in-app-notifications/addToast');
+            .find(action => action.type === 'mockedLogErrorThunk');
 
         expect(store.getActions().length).toEqual(3);
-        expect(actionToast?.payload?.type).toEqual('error');
-        expect(actionToast?.payload?.error).toEqual('Cannot sign data, unsupported network');
+        expect(actionToast?.payload).toEqual({
+            tradingType: 'exchange',
+            errorMessage: 'Cannot sign data, unsupported network',
+        });
     });
 
     it('should return error notification when ethereum signing is not successful', async () => {
@@ -232,12 +246,15 @@ describe('signDataAndConfirmThunk', () => {
         const { trading } = store.getState().wallet;
         const actionToast = store
             .getActions()
-            .find(action => action.type === '@common/in-app-notifications/addToast');
+            .find(action => action.type === 'mockedLogErrorThunk');
 
         expect(store.getActions().length).toEqual(4);
         expect(trading.modalAccountKey).toEqual(account.key);
-        expect(actionToast?.payload?.type).toEqual('sign-message-error');
-        expect(actionToast?.payload?.error).toEqual('Data is not correct');
+        expect(actionToast?.payload).toEqual({
+            tradingType: 'exchange',
+            errorMessage: 'Data is not correct',
+            toastType: 'sign-message-error',
+        });
     });
 
     it('should not continue to confirmation and saving trade when there is not receive address in selected quote', async () => {

--- a/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
@@ -1,7 +1,6 @@
 import { ExchangeTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { notificationsActions } from '@suite-common/toast-notifications';
 import { Account } from '@suite-common/wallet-types';
 
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
@@ -14,6 +13,7 @@ import {
     selectTradingExchangeSelectedQuote,
 } from '../../selectors/tradingSelectors';
 import { getUnusedAddressFromAccount } from '../../utils';
+import { logErrorThunk } from '../common/logErrorThunk';
 
 export type ConfirmExchangeTradeThunkProps = {
     returnUrl: string;
@@ -80,9 +80,9 @@ export const confirmExchangeTradeThunk = createThunk(
 
         if (!response) {
             dispatch(
-                notificationsActions.addToast({
-                    type: 'error',
-                    error: 'No response from the server',
+                logErrorThunk({
+                    errorMessage: 'No response from the server',
+                    tradingType: 'exchange',
                 }),
             );
 
@@ -96,9 +96,9 @@ export const confirmExchangeTradeThunk = createThunk(
             response.status === 'ERROR'
         ) {
             dispatch(
-                notificationsActions.addToast({
-                    type: 'error',
-                    error: response.error || 'Error response from the server',
+                logErrorThunk({
+                    errorMessage: response.error || 'Error response from the server',
+                    tradingType: 'exchange',
                 }),
             );
             dispatch(tradingExchangeActions.saveSelectedQuote(response));

--- a/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
@@ -1,6 +1,5 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { TrezorDevice } from '@suite-common/suite-types';
-import { notificationsActions } from '@suite-common/toast-notifications';
 import { Account } from '@suite-common/wallet-types';
 import TrezorConnect, {
     EthereumSignTypedDataMessage,
@@ -16,6 +15,7 @@ import {
     selectTradingExchangeReceiveAccountKey,
     selectTradingExchangeSelectedQuote,
 } from '../../selectors/tradingSelectors';
+import { logErrorThunk } from '../common/logErrorThunk';
 
 export type SignDataAndConfirmThunkProps = {
     account: Account;
@@ -46,9 +46,9 @@ export const signDataAndConfirmThunk = createThunk(
 
         if (!selectedQuote?.signData) {
             dispatch(
-                notificationsActions.addToast({
-                    type: 'error',
-                    error: 'Cannot sign, missing data',
+                logErrorThunk({
+                    errorMessage: 'Cannot sign, missing data',
+                    tradingType: 'exchange',
                 }),
             );
 
@@ -60,9 +60,9 @@ export const signDataAndConfirmThunk = createThunk(
             selectedQuote.signData.type !== 'eip712-typed-data'
         ) {
             dispatch(
-                notificationsActions.addToast({
-                    type: 'error',
-                    error: 'Cannot sign data, unsupported network',
+                logErrorThunk({
+                    errorMessage: 'Cannot sign data, unsupported network',
+                    tradingType: 'exchange',
                 }),
             );
 
@@ -77,9 +77,10 @@ export const signDataAndConfirmThunk = createThunk(
             hashes = transformTypedData(typedData as any, true);
         } catch (error) {
             dispatch(
-                notificationsActions.addToast({
-                    type: 'sign-message-error',
-                    error: error.message,
+                logErrorThunk({
+                    errorMessage: error.message,
+                    tradingType: 'exchange',
+                    toastType: 'sign-message-error',
                 }),
             );
 
@@ -103,9 +104,10 @@ export const signDataAndConfirmThunk = createThunk(
 
         if (!result.success) {
             dispatch(
-                notificationsActions.addToast({
-                    type: 'sign-message-error',
-                    error: result.payload.error,
+                logErrorThunk({
+                    errorMessage: result.payload.error,
+                    tradingType: 'exchange',
+                    toastType: 'sign-message-error',
                 }),
             );
 

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellTradeThunk.test.ts
@@ -9,9 +9,17 @@ import { invityAPI } from '../../../invityAPI';
 import { TradingSellState } from '../../../reducers/sellReducer';
 import { initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
+import type { LogErrorThunkProps } from '../../common/logErrorThunk';
 import { handleSellTradeThunk } from '../handleSellTradeThunk';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
+
+jest.mock('../../common/logErrorThunk', () => ({
+    logErrorThunk: (props: LogErrorThunkProps) => ({
+        type: 'mockedLogErrorThunk',
+        payload: props,
+    }),
+}));
 
 describe('handleSellTradeThunk', () => {
     const date = new Date('2025-04-09');
@@ -146,11 +154,13 @@ describe('handleSellTradeThunk', () => {
 
         const actionToast = store
             .getActions()
-            .find(action => action.type === '@common/in-app-notifications/addToast');
+            .find(action => action.type === 'mockedLogErrorThunk');
         const tradingState = store.getState().wallet.trading;
 
-        expect(actionToast?.payload?.type).toEqual('error');
-        expect(actionToast?.payload?.error).toEqual('No response from the server');
+        expect(actionToast?.payload).toEqual({
+            tradingType: 'sell',
+            errorMessage: 'No response from the server',
+        });
         expect(result).toBeUndefined();
         expect(tradingState.sell.transactionId).toBeUndefined();
         expect(tradingState.sell.selectedQuote).toBeUndefined();
@@ -179,11 +189,13 @@ describe('handleSellTradeThunk', () => {
 
         const actionToast = store
             .getActions()
-            .find(action => action.type === '@common/in-app-notifications/addToast');
+            .find(action => action.type === 'mockedLogErrorThunk');
         const tradingState = store.getState().wallet.trading;
 
-        expect(actionToast?.payload?.type).toEqual('error');
-        expect(actionToast?.payload?.error).toEqual('Trade error');
+        expect(actionToast?.payload).toEqual({
+            tradingType: 'sell',
+            errorMessage: 'Trade error',
+        });
         expect(result).toBeUndefined();
         expect(tradingState.sell.transactionId).toBeUndefined();
         expect(tradingState.sell.selectedQuote).toBeUndefined();

--- a/suite-common/trading/src/thunks/sell/handleSellTradeThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellTradeThunk.ts
@@ -1,7 +1,6 @@
 import { SellFiatTrade, SellFiatTradeResponse } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { notificationsActions } from '@suite-common/toast-notifications';
 import { Account } from '@suite-common/wallet-types';
 
 import { TRADING_SELL_THUNK_PREFIX } from '../../constants';
@@ -10,6 +9,7 @@ import { tradingSellActions } from '../../reducers/sellReducer';
 import { tradingActions } from '../../reducers/tradingCommonReducer';
 import { selectTradingSellInfo } from '../../selectors/tradingSelectors';
 import { getUnusedAddressFromAccount } from '../../utils';
+import { logErrorThunk } from '../common/logErrorThunk';
 
 export type HandleSellTradeThunkProps = {
     account: Account;
@@ -45,9 +45,9 @@ export const handleSellTradeThunk = createThunk(
 
         if (!response.trade) {
             dispatch(
-                notificationsActions.addToast({
-                    type: 'error',
-                    error: 'No response from the server',
+                logErrorThunk({
+                    errorMessage: 'No response from the server',
+                    tradingType: 'sell',
                 }),
             );
 
@@ -56,9 +56,9 @@ export const handleSellTradeThunk = createThunk(
 
         if (response.trade.error && response.trade.status !== 'LOGIN_REQUEST') {
             dispatch(
-                notificationsActions.addToast({
-                    type: 'error',
-                    error: response.trade.error,
+                logErrorThunk({
+                    errorMessage: response.trade.error,
+                    tradingType: 'sell',
                 }),
             );
 

--- a/suite-native/module-trading/src/__tests__/thunks.test.ts
+++ b/suite-native/module-trading/src/__tests__/thunks.test.ts
@@ -1,0 +1,32 @@
+import {
+    tradingBuyActions,
+    tradingExchangeActions,
+    tradingSellActions,
+} from '@suite-common/trading';
+
+import { clearTradingStateThunk } from '../thunks';
+
+describe('thunks', () => {
+    const dispatch = jest.fn();
+    const getState = jest.fn();
+    const extra = {} as any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('clearTradingStateThunk', () => {
+        it('should clear last error message for all trade types', async () => {
+            const thunk = clearTradingStateThunk();
+            await thunk(dispatch, getState, extra);
+
+            expect(dispatch).toHaveBeenCalledWith(
+                tradingSellActions.setLastErrorMessage(undefined),
+            );
+            expect(dispatch).toHaveBeenCalledWith(
+                tradingExchangeActions.setLastErrorMessage(undefined),
+            );
+            expect(dispatch).toHaveBeenCalledWith(tradingBuyActions.setLastErrorMessage(undefined));
+        });
+    });
+});

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
@@ -11,6 +11,7 @@ import { ExchangeFromAccountTradePreviewCard } from './ExchangeFromAccountTradeP
 import { ExchangeFusionPlusInfo } from './ExchangeFusionPlusInfo';
 import { ExchangeToAccountTradePreviewCard } from './ExchangeToAccountTradePreviewCard';
 import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
+import { LastErrorMessage } from '../../general/Error/LastErrorMessage';
 
 export type ExchangePreviewViewProps = {
     quote: ExchangeTrade | undefined;
@@ -26,6 +27,7 @@ export const ExchangePreviewView = memo(
 
         return (
             <VStack spacing="sp20" paddingVertical="sp20">
+                <LastErrorMessage tradingType="exchange" />
                 {!!isApproved && (
                     <InlineAlertBox
                         variant="success"

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewView.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewView.comp.test.tsx
@@ -11,6 +11,7 @@ describe('ExchangePreviewView', () => {
         preloadedState.wallet!.trading!.composedTransactionInfo = { composed: { fee: '1000' } };
         preloadedState.wallet!.trading!.exchange!.tradingAccountKey = 'btc-account-1';
         preloadedState.wallet!.trading!.exchange!.receiveAccountKey = 'eth-account-1';
+        preloadedState.wallet!.trading!.exchange!.lastErrorMessage = 'ERROR_MESSAGE';
 
         return renderWithStoreProviderAsync(
             <ExchangePreviewView quote={exchangeQuotes[0]} txnErrorString={null} {...props} />,
@@ -25,6 +26,7 @@ describe('ExchangePreviewView', () => {
         expect(getByText('BTC Account #1')).toBeOnTheScreen();
         expect(getByText('Ethereum #1')).toBeOnTheScreen();
         expect(getByText('Fee')).toBeOnTheScreen();
+        expect(getByText('ERROR_MESSAGE')).toBeOnTheScreen();
     });
 
     // Todo: https://github.com/trezor/trezor-suite/issues/24906

--- a/suite-native/module-trading/src/components/general/Error/LastErrorMessage.tsx
+++ b/suite-native/module-trading/src/components/general/Error/LastErrorMessage.tsx
@@ -1,0 +1,21 @@
+import { useSelector } from 'react-redux';
+
+import {
+    TradingRootState,
+    TradingType,
+    selectTradingLastErrorMessageByTradeType,
+} from '@suite-common/trading';
+
+import { GeneralAlert } from '../GeneralAlert';
+
+export type LastErrorMessageProps = {
+    tradingType: TradingType;
+};
+
+export const LastErrorMessage = ({ tradingType }: LastErrorMessageProps) => {
+    const lastErrorMessage = useSelector((state: TradingRootState) =>
+        selectTradingLastErrorMessageByTradeType(state, tradingType),
+    );
+
+    return <GeneralAlert text={lastErrorMessage} />;
+};

--- a/suite-native/module-trading/src/components/general/Error/__tests__/LastErrorMessage.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/Error/__tests__/LastErrorMessage.comp.test.tsx
@@ -1,0 +1,30 @@
+import { tradingBuyActions } from '@suite-common/trading';
+import { TestStore, initStore, renderWithStoreProvider } from '@suite-native/test-utils';
+
+import { LastErrorMessage, LastErrorMessageProps } from '../LastErrorMessage';
+
+describe('LastErrorMessage', () => {
+    let store: TestStore;
+
+    const renderLastErrorMessage = (props: LastErrorMessageProps) =>
+        renderWithStoreProvider(<LastErrorMessage {...props} />, { store });
+
+    beforeEach(() => {
+        ({ store } = initStore());
+    });
+
+    it('should render nothing when no error is specified', () => {
+        const { toJSON } = renderLastErrorMessage({ tradingType: 'buy' });
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render the last error message for the specified trading type', () => {
+        const errorMessage = 'An error occurred during the buy process';
+        store.dispatch(tradingBuyActions.setLastErrorMessage(errorMessage));
+
+        const { getByText } = renderLastErrorMessage({ tradingType: 'buy' });
+
+        expect(getByText(errorMessage)).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
@@ -9,6 +9,7 @@ import {
 } from '@suite-common/trading';
 import { Screen } from '@suite-native/navigation';
 
+import { LastErrorMessage } from '../components/general/Error/LastErrorMessage';
 import { Footer } from '../components/general/Footer';
 import { TradingDeviceConnectionGuard } from '../components/general/TradingDeviceConnectionGuard';
 import { ProviderConfirmationStatusInfo } from '../components/sell/ProviderConfirmation/ProviderConfirmationStatusInfo';
@@ -81,6 +82,7 @@ const TradingSellPreviewScreenContent = () => {
     return (
         <Screen header={<SellPreviewScreenHeader />}>
             <ProviderStatusDevButtons />
+            <LastErrorMessage tradingType="sell" />
             <ProviderConfirmationStatusInfo />
             <SellPreviewView quote={currentQuote} txnErrorString={errorString} />
             {!isFinalized && (

--- a/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.comp.test.tsx
@@ -229,4 +229,15 @@ describe('TradingSellPreviewScreen', () => {
         // Should be called exactly once for this orderId
         expect(mockFetchFeesAndCompose).toHaveBeenCalledTimes(1);
     });
+
+    it('should render last error message', async () => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'sell' }),
+        };
+        preloadedState.wallet!.trading!.sell!.lastErrorMessage = 'last error message';
+
+        const { getByText } = await renderTradingSellPreviewScreen(preloadedState);
+
+        expect(getByText('last error message')).toBeOnTheScreen();
+    });
 });

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -11,6 +11,7 @@ import {
     selectTradingExchangeSelectedQuote,
     selectTradingSellProviders,
     selectTradingSellSelectedQuote,
+    tradingBuyActions,
     tradingActions as tradingCommonActions,
     tradingExchangeActions,
     tradingSellActions,
@@ -67,6 +68,11 @@ export const clearTradingStateThunk = createThunk(
         // Clear form draft with selected fees
         dispatch(formDraftActions.removeDraft({ key: getFormDraftKeyByTradeType('sell') }));
         dispatch(formDraftActions.removeDraft({ key: getFormDraftKeyByTradeType('exchange') }));
+
+        // Clear last error messages
+        dispatch(tradingSellActions.setLastErrorMessage(undefined));
+        dispatch(tradingExchangeActions.setLastErrorMessage(undefined));
+        dispatch(tradingBuyActions.setLastErrorMessage(undefined));
     },
 );
 

--- a/suite-native/state/src/store.ts
+++ b/suite-native/state/src/store.ts
@@ -18,7 +18,10 @@ import { messageSystemMiddleware } from '@suite-native/message-system';
 import { sendFormMiddleware } from '@suite-native/send';
 import { createEnsureEncryptionKey, createMMKVStorage } from '@suite-native/storage';
 import { thpMiddleware } from '@suite-native/thp';
-import { prepareTradingMiddleware } from '@suite-native/trading-state';
+import {
+    prepareTradingLastErrorSentryMiddleware,
+    prepareTradingMiddleware,
+} from '@suite-native/trading-state';
 import { DeepPartial } from '@trezor/type-utils';
 
 import { createNativeCompositionRoot, extraDependencies } from './extraDependencies';
@@ -41,6 +44,7 @@ const getMiddlewares = (getExtra: () => ExtraDependencies | null) => {
         sendFormMiddleware,
         thpMiddleware(getExtra),
         prepareTradingMiddleware(getExtra),
+        prepareTradingLastErrorSentryMiddleware(getExtra),
         preparePushNotificationMiddleware(getExtra),
         prepareSuiteSyncMiddleware(getExtra),
         logsMiddleware,

--- a/suite-native/trading-state/package.json
+++ b/suite-native/trading-state/package.json
@@ -27,6 +27,7 @@
         "@suite-native/accounts": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/labeling": "workspace:*",
+        "@suite-native/sentry": "workspace:*",
         "@suite-native/settings": "workspace:*",
         "@suite-native/tokens": "workspace:*",
         "@suite-native/trading-atoms": "workspace:*",

--- a/suite-native/trading-state/src/index.ts
+++ b/suite-native/trading-state/src/index.ts
@@ -1,6 +1,7 @@
 export * from './reducers';
 
-export * from './middlewares/tradingMiddleware';
+export { prepareTradingMiddleware } from './middlewares/tradingMiddleware';
+export { prepareTradingLastErrorSentryMiddleware } from './middlewares/tradingLastErrorSentryMiddleware';
 
 export * from './selectors/buySelectors';
 export * from './selectors/commonSelectors';

--- a/suite-native/trading-state/src/middlewares/__tests__/tradingLastErrorSentryMiddleware.test.ts
+++ b/suite-native/trading-state/src/middlewares/__tests__/tradingLastErrorSentryMiddleware.test.ts
@@ -1,0 +1,69 @@
+import type { ExtraDependencies } from '@suite-common/redux-utils';
+import {
+    tradingBuyActions,
+    tradingExchangeActions,
+    tradingSellActions,
+} from '@suite-common/trading';
+
+import { prepareTradingLastErrorSentryMiddleware } from '../tradingLastErrorSentryMiddleware';
+
+const mockCaptureSentryException = jest.fn();
+
+jest.mock('@suite-native/sentry', () => ({
+    captureSentryException: (...args: unknown[]) => mockCaptureSentryException(...args),
+}));
+
+describe('tradingLastErrorSentryMiddleware', () => {
+    const tradingLastErrorSentryMiddleware = prepareTradingLastErrorSentryMiddleware(
+        () => ({}) as ExtraDependencies,
+    );
+    const next = jest.fn(a => a);
+    const dispatch = jest.fn();
+    const getState = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should do nothing on general action', () => {
+        const action = { type: 'GENERAL_ACTION' };
+        const ret = tradingLastErrorSentryMiddleware({ dispatch, getState })(next)(action);
+
+        expect(ret).toBe(action);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(next).toHaveBeenCalledWith(action);
+        expect(mockCaptureSentryException).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['buy', tradingBuyActions.setLastErrorMessage('Error message')],
+        ['exchange', tradingExchangeActions.setLastErrorMessage('Error message')],
+        ['sell', tradingSellActions.setLastErrorMessage('Error message')],
+    ])('should capture last error message for %s trading type', (_, action) => {
+        const ret = tradingLastErrorSentryMiddleware({ dispatch, getState })(next)(action);
+
+        expect(ret).toBe(action);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(next).toHaveBeenCalledWith(action);
+        expect(mockCaptureSentryException).toHaveBeenCalledTimes(1);
+        expect(mockCaptureSentryException).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Error message',
+                name: 'TradingError',
+            }),
+        );
+    });
+
+    it.each([
+        ['buy', tradingBuyActions.setLastErrorMessage(undefined)],
+        ['exchange', tradingExchangeActions.setLastErrorMessage(undefined)],
+        ['sell', tradingSellActions.setLastErrorMessage(undefined)],
+    ])('should ignore empty last error message for %s trading type', (_, action) => {
+        const ret = tradingLastErrorSentryMiddleware({ dispatch, getState })(next)(action);
+
+        expect(ret).toBe(action);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(next).toHaveBeenCalledWith(action);
+        expect(mockCaptureSentryException).not.toHaveBeenCalled();
+    });
+});

--- a/suite-native/trading-state/src/middlewares/tradingLastErrorSentryMiddleware.ts
+++ b/suite-native/trading-state/src/middlewares/tradingLastErrorSentryMiddleware.ts
@@ -1,0 +1,33 @@
+import { isAnyOf } from '@reduxjs/toolkit';
+
+import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    tradingBuyActions,
+    tradingExchangeActions,
+    tradingSellActions,
+} from '@suite-common/trading';
+import { captureSentryException } from '@suite-native/sentry';
+
+class TradingError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'TradingError';
+    }
+}
+
+export const prepareTradingLastErrorSentryMiddleware = createMiddlewareWithExtraDeps(
+    (action, { next }) => {
+        const isLastErrorMessageAction = isAnyOf(
+            tradingBuyActions.setLastErrorMessage,
+            tradingExchangeActions.setLastErrorMessage,
+            tradingSellActions.setLastErrorMessage,
+        )(action);
+
+        if (isLastErrorMessageAction && !!action.payload) {
+            console.warn(new TradingError(action.payload));
+            captureSentryException(new TradingError(action.payload));
+        }
+
+        return next(action);
+    },
+);

--- a/suite-native/trading-state/src/reducers/__tests__/buySlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/buySlice.test.ts
@@ -25,6 +25,7 @@ describe('buySlice', () => {
                     currency: 'CZK',
                     minFiat: '100',
                 },
+                lastErrorMessage: 'Some error',
             };
 
             const state = buyReducer(prevState, buyActions.clearState());

--- a/suite-native/trading-state/src/reducers/__tests__/exchangeSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/exchangeSlice.test.ts
@@ -36,6 +36,7 @@ describe('exchangeSlice', () => {
                     minCrypto: '0.001',
                     maxCrypto: '10',
                 },
+                lastErrorMessage: 'Some error',
             };
 
             const state = exchangeReducer(prevState, exchangeActions.clearState());

--- a/suite-native/trading-state/src/reducers/__tests__/sellSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/sellSlice.test.ts
@@ -24,6 +24,7 @@ describe('sellSlice', () => {
                     currency: 'CZK',
                     minFiat: '100',
                 },
+                lastErrorMessage: 'Some error',
             };
 
             const state = sellReducer(prevState, sellActions.clearState());

--- a/suite-native/trading-state/src/reducers/buySlice.ts
+++ b/suite-native/trading-state/src/reducers/buySlice.ts
@@ -15,6 +15,7 @@ const buySlice = createSlice({
             state.quotes = [];
             state.selectedQuote = undefined;
             state.amountLimits = undefined;
+            state.lastErrorMessage = undefined;
         },
         clearQuotesAndQuotesRequest: state => {
             state.quotesRequest = undefined;

--- a/suite-native/trading-state/src/reducers/exchangeSlice.ts
+++ b/suite-native/trading-state/src/reducers/exchangeSlice.ts
@@ -16,6 +16,7 @@ const exchangeSlice = createSlice({
             state.quotes = [];
             state.selectedQuote = undefined;
             state.amountLimits = undefined;
+            state.lastErrorMessage = undefined;
         },
         clearQuotesAndQuotesRequest: state => {
             state.quotesRequest = undefined;

--- a/suite-native/trading-state/src/reducers/sellSlice.ts
+++ b/suite-native/trading-state/src/reducers/sellSlice.ts
@@ -14,6 +14,7 @@ const sellSlice = createSlice({
             state.quotes = [];
             state.selectedQuote = undefined;
             state.amountLimits = undefined;
+            state.lastErrorMessage = undefined;
         },
         clearQuotesAndQuotesRequest: state => {
             state.quotesRequest = undefined;

--- a/suite-native/trading-state/tsconfig.json
+++ b/suite-native/trading-state/tsconfig.json
@@ -36,6 +36,7 @@
         { "path": "../accounts" },
         { "path": "../feature-flags" },
         { "path": "../labeling" },
+        { "path": "../sentry" },
         { "path": "../settings" },
         { "path": "../tokens" },
         { "path": "../trading-atoms" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13831,6 +13831,7 @@ __metadata:
     "@suite-native/accounts": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/labeling": "workspace:*"
+    "@suite-native/sentry": "workspace:*"
     "@suite-native/settings": "workspace:*"
     "@suite-native/tokens": "workspace:*"
     "@suite-native/trading-atoms": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- trading thunks now try to populate `trading.XXX.lastErrorMessage` state field as well as `notificationActions.addToast`
- for native `lastErrorMessage` fields are observed by `LastErrorMessage` component and displayed as warnings on trading preview screens.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #24632


## Screenshots:

<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-01-28 at 10 11 44" src="https://github.com/user-attachments/assets/642f8e8d-f64b-4871-b364-cad4263563d1" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-01-28 at 11 48 04" src="https://github.com/user-attachments/assets/6280482f-b3e4-4007-b394-f9bea51efb70" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=24632-trading-thunks-should-log-errors&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=24632-trading-thunks-should-log-errors&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24632-trading-thunks-should-log-errors&lookback=7)