### PR TITLE
feat(suite): Add darkmode for storybooks

### DIFF
--- a/packages/components/.storybook/manager.js
+++ b/packages/components/.storybook/manager.js
@@ -1,8 +1,14 @@
 import { addons } from 'storybook/manager-api';
 
-import theme from './theme';
 import './theme-toggle';
+import { darkTheme, lightTheme } from './theme';
 
-addons.setConfig({
-    theme,
-});
+const mq = window.matchMedia('(prefers-color-scheme: dark)');
+
+function apply() {
+    addons.setConfig({ theme: mq.matches ? darkTheme : lightTheme });
+}
+
+apply();
+
+mq.addEventListener('change', apply);

--- a/packages/components/.storybook/theme.js
+++ b/packages/components/.storybook/theme.js
@@ -1,8 +1,16 @@
 import { create } from 'storybook/theming/create';
 
-// eslint-disable-next-line import/no-default-export
-export default create({
-    base: 'light',
+const common = {
     fontBase: 'TT Satoshi',
     brandTitle: 'Design System',
+};
+
+export const lightTheme = create({
+    ...common,
+    base: 'light',
+});
+
+export const darkTheme = create({
+    ...common,
+    base: 'dark',
 });

--- a/packages/product-components/.storybook/manager.js
+++ b/packages/product-components/.storybook/manager.js
@@ -1,7 +1,14 @@
 import { addons } from 'storybook/manager-api';
 
-import theme from './theme';
+import './theme-toggle';
+import { darkTheme, lightTheme } from './theme';
 
-addons.setConfig({
-    theme,
-});
+const mq = window.matchMedia('(prefers-color-scheme: dark)');
+
+function apply() {
+    addons.setConfig({ theme: mq.matches ? darkTheme : lightTheme });
+}
+
+apply();
+
+mq.addEventListener('change', apply);

--- a/packages/product-components/.storybook/theme.js
+++ b/packages/product-components/.storybook/theme.js
@@ -1,8 +1,16 @@
 import { create } from 'storybook/theming/create';
 
-// eslint-disable-next-line import/no-default-export
-export default create({
-    base: 'light',
+const common = {
     fontBase: 'TT Satoshi',
     brandTitle: 'Product Components',
+};
+
+export const lightTheme = create({
+    ...common,
+    base: 'light',
+});
+
+export const darkTheme = create({
+    ...common,
+    base: 'dark',
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

adds support for darkmode for the whole ui

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="1470" height="1103" alt="image" src="https://github.com/user-attachments/assets/6d5b2d5c-b75e-4844-9712-9cc0649e39a9" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=allow-darkmode-for-storybooks&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=allow-darkmode-for-storybooks&lookback=7)