### PR TITLE
Test for suite sync

### DIFF
--- a/packages/type-utils/src/object.ts
+++ b/packages/type-utils/src/object.ts
@@ -34,5 +34,5 @@ export type NullablePropsRecursive<T extends Record<string, any>> = {
         ? T[K] | null
         : T[K] extends Record<string, any>
           ? NullablePropsRecursive<T[K]> | null
-          : never;
+          : T[K];
 };

--- a/packages/type-utils/src/object.ts
+++ b/packages/type-utils/src/object.ts
@@ -34,5 +34,5 @@ export type NullablePropsRecursive<T extends Record<string, any>> = {
         ? T[K] | null
         : T[K] extends Record<string, any>
           ? NullablePropsRecursive<T[K]> | null
-          : T[K];
+          : T[K] | null;
 };

--- a/packages/type-utils/test/object.type-test.ts
+++ b/packages/type-utils/test/object.type-test.ts
@@ -1,0 +1,22 @@
+import { NullablePropsRecursive } from '../src';
+
+type X = {
+    a: 'A';
+    b: {
+        c: 'C';
+        d: {
+            e: 'E';
+        };
+    };
+};
+
+type Y = NullablePropsRecursive<X>;
+
+export const y1ok: Y = { a: 'A', b: null };
+export const y2ok: Y = { a: 'A', b: { c: 'C', d: { e: null } } };
+
+// @ts-expect-error This expects and error as a, b is missing
+export const y4fail: Y = {};
+
+// @ts-expect-error This expects and error as b is missing
+export const y3fail: Y = { a: null };

--- a/suite-common/redux-utils/src/index.ts
+++ b/suite-common/redux-utils/src/index.ts
@@ -10,4 +10,4 @@ export * from './hooks/useSelectorDeepComparison';
 export * from './selectorsUtils';
 export * from './extraWithStoreThunkMiddleware';
 export * from './notImplemented';
-export { toGetter, type ToGetter } from './toGetter';
+export { toGetter } from './toGetter';

--- a/suite-common/redux-utils/src/index.ts
+++ b/suite-common/redux-utils/src/index.ts
@@ -10,3 +10,4 @@ export * from './hooks/useSelectorDeepComparison';
 export * from './selectorsUtils';
 export * from './extraWithStoreThunkMiddleware';
 export * from './notImplemented';
+export { toGetter, type ToGetter } from './toGetter';

--- a/suite-common/redux-utils/src/toGetter.ts
+++ b/suite-common/redux-utils/src/toGetter.ts
@@ -1,0 +1,13 @@
+/**
+ * The utils that provides a conversion from selector to a getter-service.
+ *
+ * Simply wrap any Redux selector with this + provide getState callback,
+ * and you get a service, ready to be used in Dependency Injection.
+ */
+export const toGetter =
+    <TReturn, TParams extends any[], TState = any>(
+        getState: () => TState,
+        selector: (state: TState, ...params: TParams) => TReturn,
+    ) =>
+    (...params: TParams): TReturn =>
+        selector(getState(), ...params);

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -2,6 +2,7 @@ import { Dispatch } from '@reduxjs/toolkit';
 
 import { EnsureDelegatedIdentityKeyDep } from '@suite-common/delegated-identity-key-types';
 import { PlatformEncryptionDep } from '@suite-common/platform-encryption';
+import { toGetter } from '@suite-common/redux-utils';
 import { selectHasDeviceAllowance } from '@suite-common/suite-sync-quota-manager';
 import { CreateSuiteStorageDep, CreateSuiteSyncOwnerDep } from '@suite-common/suite-sync-storage';
 import { SuiteSync, SuiteSyncAppReloaderDep } from '@suite-common/suite-sync-types';
@@ -36,7 +37,7 @@ import { createEnsureWalletSuiteSyncOn } from './storage/createEnsureWalletSuite
 import { createSubscriptionStorage } from './storage/createSubscriptionStorage';
 import { createSuiteSyncStorageRepository } from './storage/createSuiteSyncStorageRepository';
 import { createTurnOffSuiteSyncForWallet } from './storage/createTurnOffSuiteSyncForWallet';
-import { selectSuiteSyncRelayUrl } from './suiteSyncSelectors';
+import { selectIsSuiteSyncEnabled, selectSuiteSyncRelayUrl } from './suiteSyncSelectors';
 
 type CreateSuiteSyncCompositionRootDeps = {
     getState: () => any;
@@ -94,7 +95,7 @@ export const createSuiteSyncCompositionRoot = (
         suiteSyncStorageRepository,
         createSuiteStorage: deps.createSuiteStorage,
         defaultRelayUrl: DEFAULT_SUITE_SYNC_RELAY_URL,
-        getRelayUrl: () => selectSuiteSyncRelayUrl(deps.getState()),
+        getRelayUrl: toGetter(deps.getState, selectSuiteSyncRelayUrl),
         getDeviceForStaticSessionId,
     });
 
@@ -121,7 +122,7 @@ export const createSuiteSyncCompositionRoot = (
         subscriptionStorage,
     });
 
-    const getAllDeviceSessionIds = () => selectAllDeviceStaticIds(deps.getState());
+    const getAllDeviceSessionIds = toGetter(deps.getState, selectAllDeviceStaticIds);
 
     return {
         changeRelayUrl: createChangeRelayUrl({
@@ -139,7 +140,7 @@ export const createSuiteSyncCompositionRoot = (
             reloadApp: deps.reloadApp,
         }),
         turnOnSuiteSync: createTurnOnSuiteSync({
-            getState: deps.getState,
+            getIsSuiteSyncEnabled: toGetter(deps.getState, selectIsSuiteSyncEnabled),
             dispatch: deps.dispatch,
             ensureWalletSuiteSyncOn,
         }),

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -123,6 +123,7 @@ export const createSuiteSyncCompositionRoot = (
     });
 
     const getAllDeviceSessionIds = toGetter(deps.getState, selectAllDeviceStaticIds);
+    const getIsSuiteSyncEnabled = toGetter(deps.getState, selectIsSuiteSyncEnabled);
 
     return {
         changeRelayUrl: createChangeRelayUrl({
@@ -133,14 +134,14 @@ export const createSuiteSyncCompositionRoot = (
         ensureWalletSuiteSyncOn,
         turnOffSuiteSyncForWallet,
         turnOffSuiteSync: createTurnOffSuiteSync({
+            getIsSuiteSyncEnabled,
             getAllDeviceSessionIds,
             dispatch: deps.dispatch,
-            getState: deps.getState,
             turnOffSuiteSyncForWallet,
             reloadApp: deps.reloadApp,
         }),
         turnOnSuiteSync: createTurnOnSuiteSync({
-            getIsSuiteSyncEnabled: toGetter(deps.getState, selectIsSuiteSyncEnabled),
+            getIsSuiteSyncEnabled,
             dispatch: deps.dispatch,
             ensureWalletSuiteSyncOn,
         }),

--- a/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
@@ -9,11 +9,10 @@ import { StaticSessionId } from '@trezor/connect';
 
 import { clearAll } from './data/suiteSyncDataReducer';
 import { suiteSyncActions } from './suiteSyncActions';
-import { selectIsSuiteSyncEnabled } from './suiteSyncSelectors';
 
 export type CreateTurnOffSuiteSyncDeps = {
+    getIsSuiteSyncEnabled: () => boolean;
     dispatch: Dispatch;
-    getState: () => any;
     getAllDeviceSessionIds: () => StaticSessionId[];
 } & TurnOffSuiteSyncForWalletDep &
     SuiteSyncAppReloaderDep;
@@ -21,7 +20,7 @@ export type CreateTurnOffSuiteSyncDeps = {
 export const createTurnOffSuiteSync =
     (deps: CreateTurnOffSuiteSyncDeps): TurnOffSuiteSync =>
     async () => {
-        const isSuiteSyncEnabled = selectIsSuiteSyncEnabled(deps.getState());
+        const isSuiteSyncEnabled = deps.getIsSuiteSyncEnabled();
 
         if (!isSuiteSyncEnabled) {
             return;

--- a/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
@@ -1,21 +1,19 @@
 import { Dispatch } from '@reduxjs/toolkit';
 
-import { TurnOnSuiteSync } from '@suite-common/suite-sync-types';
-import { EnsureWalletSuiteSyncOnDep } from '@suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn';
+import { EnsureWalletSuiteSyncOnDep, TurnOnSuiteSync } from '@suite-common/suite-sync-types';
 import { ok } from '@trezor/type-utils';
 
 import { suiteSyncActions } from './suiteSyncActions';
-import { selectIsSuiteSyncEnabled } from './suiteSyncSelectors';
 
 export type CreateTurnOnSuiteSyncDeps = {
-    getState: () => any;
+    getIsSuiteSyncEnabled: () => boolean;
     dispatch: Dispatch;
 } & EnsureWalletSuiteSyncOnDep;
 
 export const createTurnOnSuiteSync =
     (deps: CreateTurnOnSuiteSyncDeps): TurnOnSuiteSync =>
     async ({ deviceStaticSessionId }) => {
-        const isSuiteSyncEnabled = selectIsSuiteSyncEnabled(deps.getState());
+        const isSuiteSyncEnabled = deps.getIsSuiteSyncEnabled();
 
         if (isSuiteSyncEnabled) {
             return ok();

--- a/suite-common/suite-sync/src/data/labeling/createUpdateAccountLabel.ts
+++ b/suite-common/suite-sync/src/data/labeling/createUpdateAccountLabel.ts
@@ -1,5 +1,4 @@
-import { UpdateAccountLabel } from '@suite-common/suite-sync-types';
-import { EnsureWalletSuiteSyncOnDep } from '@suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn';
+import { EnsureWalletSuiteSyncOnDep, UpdateAccountLabel } from '@suite-common/suite-sync-types';
 import { parseAccountKey } from '@suite-common/wallet-utils';
 
 export type UpdateAccountLabelDeps = EnsureWalletSuiteSyncOnDep;

--- a/suite-common/suite-sync/src/relay/tests/createChangeRelayUrl.test.ts
+++ b/suite-common/suite-sync/src/relay/tests/createChangeRelayUrl.test.ts
@@ -39,7 +39,7 @@ describe(createChangeRelayUrl.name, () => {
         expect(actions).toStrictEqual([
             {
                 payload: { url: 'http://localhost:4000' },
-                type: '@suite/suite-sync/set-local-first-storage-relay-url',
+                type: '@suite/suite-sync/set-suite-sync-relay-url',
             },
         ]);
 

--- a/suite-common/suite-sync/src/storage/tests/createEnsureStorage.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createEnsureStorage.test.ts
@@ -1,0 +1,224 @@
+import {
+    SuiteSyncOwner,
+    TrezorDevice,
+    asSuiteSyncOwnerId,
+    asSuiteSyncOwnerSecretHex,
+} from '@suite-common/suite-types';
+import type { StaticSessionId } from '@trezor/connect';
+import { err, ok } from '@trezor/type-utils';
+
+import { createSuiteSyncStorageMock } from '../../../tests/createSuiteSyncStorageMock.mock';
+import { createMockDeps, mock } from '../../../tests/utils';
+import { SuiteSyncUnavailableOnDeviceError } from '../../createRefreshSuiteSyncKeys';
+import type { EnsureStorageDeps } from '../createEnsureStorage';
+import { createEnsureStorage } from '../createEnsureStorage';
+
+const OWNER_ABCD: SuiteSyncOwner = {
+    ownerId: asSuiteSyncOwnerId('owner-id-abcd'),
+    ownerSecret: asSuiteSyncOwnerSecretHex('owner-secret-abcd'),
+};
+
+const deviceStaticSessionId: StaticSessionId = '1@2:3';
+
+const createDevice = (overrides: Partial<TrezorDevice> = {}): TrezorDevice =>
+    ({
+        id: 'device-id',
+        state: {
+            staticSessionId: deviceStaticSessionId,
+        },
+        unavailableCapabilities: {},
+        ...overrides,
+    }) as unknown as TrezorDevice;
+
+describe(createEnsureStorage.name, () => {
+    it('returns existing storage when it is already in repository', async () => {
+        const existingStorage = createSuiteSyncStorageMock();
+
+        const deps = createMockDeps<EnsureStorageDeps>({
+            defaultRelayUrl: 'wss://default-relay.example.com',
+            getRelayUrl: () => null,
+            suiteSyncStorageRepository: {
+                get: () => existingStorage,
+                set: null,
+                delete: null,
+            },
+            createSuiteStorage: null,
+            refreshSuiteSyncKeys: null,
+            getDeviceForStaticSessionId: null,
+        });
+
+        const ensureStorage = createEnsureStorage(deps);
+        const result = await ensureStorage({ deviceStaticSessionId });
+
+        expect(result).toEqual(ok(existingStorage));
+        expect(deps.suiteSyncStorageRepository.get).toHaveBeenCalled();
+        expect(deps.createSuiteStorage).not.toHaveBeenCalled();
+        expect(deps.refreshSuiteSyncKeys).not.toHaveBeenCalled();
+        expect(deps.getDeviceForStaticSessionId).not.toHaveBeenCalled();
+    });
+
+    it('returns error when device is not found', async () => {
+        const deps = createMockDeps<EnsureStorageDeps>({
+            defaultRelayUrl: 'wss://default-relay.example.com',
+            getRelayUrl: () => null,
+            suiteSyncStorageRepository: {
+                get: () => null,
+                set: null,
+                delete: null,
+            },
+            createSuiteStorage: null,
+            refreshSuiteSyncKeys: null,
+            getDeviceForStaticSessionId: () => null,
+        });
+
+        const ensureStorage = createEnsureStorage(deps);
+        const result = await ensureStorage({ deviceStaticSessionId });
+
+        expect(result.success).toBe(false);
+        expect(!result.success && result.error.type).toBe('SuiteSyncUnavailableOnDeviceError');
+        expect(deps.getDeviceForStaticSessionId).toHaveBeenCalledWith(deviceStaticSessionId);
+        expect(deps.refreshSuiteSyncKeys).not.toHaveBeenCalled();
+        expect(deps.createSuiteStorage).not.toHaveBeenCalled();
+    });
+
+    it('returns error when refreshSuiteSyncKeys fails', async () => {
+        const device = createDevice();
+        const refreshError = err(SuiteSyncUnavailableOnDeviceError());
+
+        const deps = createMockDeps<EnsureStorageDeps>({
+            defaultRelayUrl: 'wss://default-relay.example.com',
+            getRelayUrl: () => null,
+            suiteSyncStorageRepository: {
+                get: () => null,
+                set: null,
+                delete: null,
+            },
+            createSuiteStorage: null,
+            refreshSuiteSyncKeys: () => Promise.resolve(refreshError),
+            getDeviceForStaticSessionId: () => device,
+        });
+
+        const ensureStorage = createEnsureStorage(deps);
+        const result = await ensureStorage({ deviceStaticSessionId });
+
+        expect(result).toBe(refreshError);
+        expect(deps.getDeviceForStaticSessionId).toHaveBeenCalledWith(deviceStaticSessionId);
+        expect(deps.refreshSuiteSyncKeys).toHaveBeenCalledWith({ device });
+        expect(deps.createSuiteStorage).not.toHaveBeenCalled();
+    });
+
+    it('creates and stores new storage when all dependencies succeed', async () => {
+        const device = createDevice();
+        const newStorage = createSuiteSyncStorageMock();
+
+        const deps = createMockDeps<EnsureStorageDeps>({
+            defaultRelayUrl: 'wss://default-relay.example.com',
+            getRelayUrl: () => null,
+            suiteSyncStorageRepository: {
+                get: () => null,
+                set: mock(() => {}),
+                delete: null,
+            },
+            createSuiteStorage: () => newStorage,
+            refreshSuiteSyncKeys: () => Promise.resolve(ok(OWNER_ABCD)),
+            getDeviceForStaticSessionId: () => device,
+        });
+
+        const ensureStorage = createEnsureStorage(deps);
+        const result = await ensureStorage({ deviceStaticSessionId });
+
+        expect(result).toEqual(ok(newStorage));
+        expect(deps.getDeviceForStaticSessionId).toHaveBeenCalledWith(deviceStaticSessionId);
+        expect(deps.refreshSuiteSyncKeys).toHaveBeenCalledWith({ device });
+        expect(deps.createSuiteStorage).toHaveBeenCalledWith({
+            suiteSyncOwner: OWNER_ABCD,
+            relayUrl: 'wss://default-relay.example.com',
+        });
+        expect(deps.suiteSyncStorageRepository.set).toHaveBeenCalled();
+    });
+
+    it('uses custom relay URL when provided and not empty', async () => {
+        const device = createDevice();
+
+        const newStorage = createSuiteSyncStorageMock();
+        const customRelayUrl = 'wss://custom-relay.example.com';
+
+        const deps = createMockDeps<EnsureStorageDeps>({
+            defaultRelayUrl: 'wss://default-relay.example.com',
+            getRelayUrl: () => customRelayUrl,
+            suiteSyncStorageRepository: {
+                get: () => null,
+                set: mock(() => {}),
+                delete: null,
+            },
+            createSuiteStorage: () => newStorage,
+            refreshSuiteSyncKeys: () => Promise.resolve(ok(OWNER_ABCD)),
+            getDeviceForStaticSessionId: () => device,
+        });
+
+        const ensureStorage = createEnsureStorage(deps);
+        const result = await ensureStorage({ deviceStaticSessionId });
+
+        expect(result).toEqual(ok(newStorage));
+        expect(deps.createSuiteStorage).toHaveBeenCalledWith({
+            suiteSyncOwner: OWNER_ABCD,
+            relayUrl: customRelayUrl,
+        });
+    });
+
+    it('uses default relay URL when custom relay URL is empty string', async () => {
+        const device = createDevice();
+
+        const newStorage = createSuiteSyncStorageMock();
+
+        const deps = createMockDeps<EnsureStorageDeps>({
+            defaultRelayUrl: 'wss://default-relay.example.com',
+            getRelayUrl: () => '',
+            suiteSyncStorageRepository: {
+                get: () => null,
+                set: mock(() => {}),
+                delete: null,
+            },
+            createSuiteStorage: () => newStorage,
+            refreshSuiteSyncKeys: () => Promise.resolve(ok(OWNER_ABCD)),
+            getDeviceForStaticSessionId: () => device,
+        });
+
+        const ensureStorage = createEnsureStorage(deps);
+        const result = await ensureStorage({ deviceStaticSessionId });
+
+        expect(result).toEqual(ok(newStorage));
+        expect(deps.createSuiteStorage).toHaveBeenCalledWith({
+            suiteSyncOwner: OWNER_ABCD,
+            relayUrl: 'wss://default-relay.example.com',
+        });
+    });
+
+    it('uses default relay URL when custom relay URL is whitespace only', async () => {
+        const device = createDevice();
+
+        const newStorage = createSuiteSyncStorageMock();
+
+        const deps = createMockDeps<EnsureStorageDeps>({
+            defaultRelayUrl: 'wss://default-relay.example.com',
+            getRelayUrl: () => '   ',
+            suiteSyncStorageRepository: {
+                get: () => null,
+                set: mock(() => {}),
+                delete: null,
+            },
+            createSuiteStorage: () => newStorage,
+            refreshSuiteSyncKeys: () => Promise.resolve(ok(OWNER_ABCD)),
+            getDeviceForStaticSessionId: () => device,
+        });
+
+        const ensureStorage = createEnsureStorage(deps);
+        const result = await ensureStorage({ deviceStaticSessionId });
+
+        expect(result).toEqual(ok(newStorage));
+        expect(deps.createSuiteStorage).toHaveBeenCalledWith({
+            suiteSyncOwner: OWNER_ABCD,
+            relayUrl: 'wss://default-relay.example.com',
+        });
+    });
+});

--- a/suite-common/suite-sync/src/suiteSyncActions.ts
+++ b/suite-common/suite-sync/src/suiteSyncActions.ts
@@ -2,23 +2,23 @@ import { createAction } from '@reduxjs/toolkit';
 export const SUITE_SYNC_PREFIX = '@suite/suite-sync';
 
 export const updateSuiteSyncEnabled = createAction(
-    `${SUITE_SYNC_PREFIX}/update-locale-first-storage-enabled`,
+    `${SUITE_SYNC_PREFIX}/update-suite-sync-enabled`,
     (payload: { isEnabled: boolean }) => ({ payload }),
 );
 
 export const updateSuiteSyncDebugEnabled = createAction(
-    `${SUITE_SYNC_PREFIX}/update-locale-first-storage-debug-enabled`,
+    `${SUITE_SYNC_PREFIX}/update-suite-sync-debug-enabled`,
     (payload: { isEnabled: boolean }) => ({ payload }),
 );
 
 export const updateIsFeatureSuiteSyncAvailable = createAction(
-    `${SUITE_SYNC_PREFIX}/update-show-locale-first-storage`,
+    `${SUITE_SYNC_PREFIX}/update-is-feature-suite-sync-available`,
     (payload: { isShownInSettings: boolean }) => ({ payload }),
 );
 
 /** @deprecated this shall be called only from `changeRelayUrlThunk`, use the thunk only */
 export const setSuiteSyncRelayUrl = createAction(
-    `${SUITE_SYNC_PREFIX}/set-local-first-storage-relay-url`,
+    `${SUITE_SYNC_PREFIX}/set-suite-sync-relay-url`,
     (payload: { url: string | null }) => ({ payload }),
 );
 

--- a/suite-common/suite-sync/src/tests/createTurnOffSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/tests/createTurnOffSuiteSync.test.ts
@@ -17,7 +17,7 @@ describe(createTurnOffSuiteSync.name, () => {
             dispatch: mock<Dispatch>(() => {}),
             getAllDeviceSessionIds: () => [],
             turnOffSuiteSyncForWallet: () => Promise.resolve(),
-            flushSuiteSyncStorage: () => {},
+            reloadApp: () => {},
         });
 
         const turnOffSuiteSync = createTurnOffSuiteSync(deps);
@@ -26,7 +26,7 @@ describe(createTurnOffSuiteSync.name, () => {
         expect(deps.dispatch).not.toHaveBeenCalled();
         expect(deps.getAllDeviceSessionIds).not.toHaveBeenCalled();
         expect(deps.turnOffSuiteSyncForWallet).not.toHaveBeenCalled();
-        expect(deps.flushSuiteSyncStorage).not.toHaveBeenCalled();
+        expect(deps.reloadApp).not.toHaveBeenCalled();
     });
 
     it('disables suite sync and turns off sync for all devices', async () => {
@@ -35,7 +35,7 @@ describe(createTurnOffSuiteSync.name, () => {
             dispatch: mock<Dispatch>(() => {}),
             getAllDeviceSessionIds: () => [deviceStaticSessionId1, deviceStaticSessionId2],
             turnOffSuiteSyncForWallet: () => Promise.resolve(),
-            flushSuiteSyncStorage: () => {},
+            reloadApp: () => {},
         });
 
         const turnOffSuiteSync = createTurnOffSuiteSync(deps);
@@ -51,7 +51,7 @@ describe(createTurnOffSuiteSync.name, () => {
             deviceStaticSessionId: deviceStaticSessionId2,
         });
         expect(deps.dispatch).toHaveBeenCalledWith(clearAll());
-        expect(deps.flushSuiteSyncStorage).toHaveBeenCalled();
+        expect(deps.reloadApp).toHaveBeenCalled();
     });
 
     it('clears data and flushes storage even when no devices exist', async () => {
@@ -60,7 +60,7 @@ describe(createTurnOffSuiteSync.name, () => {
             dispatch: mock<Dispatch>(() => {}),
             getAllDeviceSessionIds: () => [],
             turnOffSuiteSyncForWallet: () => Promise.resolve(),
-            flushSuiteSyncStorage: () => {},
+            reloadApp: () => {},
         });
 
         const turnOffSuiteSync = createTurnOffSuiteSync(deps);
@@ -71,6 +71,6 @@ describe(createTurnOffSuiteSync.name, () => {
         );
         expect(deps.turnOffSuiteSyncForWallet).not.toHaveBeenCalled();
         expect(deps.dispatch).toHaveBeenCalledWith(clearAll());
-        expect(deps.flushSuiteSyncStorage).toHaveBeenCalled();
+        expect(deps.reloadApp).toHaveBeenCalled();
     });
 });

--- a/suite-common/suite-sync/src/tests/createTurnOffSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/tests/createTurnOffSuiteSync.test.ts
@@ -1,0 +1,76 @@
+import type { Dispatch } from '@reduxjs/toolkit';
+
+import type { StaticSessionId } from '@trezor/connect';
+
+import { createMockDeps, mock } from '../../tests/utils';
+import { CreateTurnOffSuiteSyncDeps, createTurnOffSuiteSync } from '../createTurnOffSuiteSync';
+import { clearAll } from '../data/suiteSyncDataReducer';
+import { suiteSyncActions } from '../suiteSyncActions';
+
+const deviceStaticSessionId1: StaticSessionId = '1@2:3';
+const deviceStaticSessionId2: StaticSessionId = '4@5:6';
+
+describe(createTurnOffSuiteSync.name, () => {
+    it('returns early when suite sync is already disabled', async () => {
+        const deps = createMockDeps<CreateTurnOffSuiteSyncDeps>({
+            getIsSuiteSyncEnabled: () => false,
+            dispatch: mock<Dispatch>(() => {}),
+            getAllDeviceSessionIds: () => [],
+            turnOffSuiteSyncForWallet: () => Promise.resolve(),
+            flushSuiteSyncStorage: () => {},
+        });
+
+        const turnOffSuiteSync = createTurnOffSuiteSync(deps);
+        await turnOffSuiteSync();
+
+        expect(deps.dispatch).not.toHaveBeenCalled();
+        expect(deps.getAllDeviceSessionIds).not.toHaveBeenCalled();
+        expect(deps.turnOffSuiteSyncForWallet).not.toHaveBeenCalled();
+        expect(deps.flushSuiteSyncStorage).not.toHaveBeenCalled();
+    });
+
+    it('disables suite sync and turns off sync for all devices', async () => {
+        const deps = createMockDeps<CreateTurnOffSuiteSyncDeps>({
+            getIsSuiteSyncEnabled: () => true,
+            dispatch: mock<Dispatch>(() => {}),
+            getAllDeviceSessionIds: () => [deviceStaticSessionId1, deviceStaticSessionId2],
+            turnOffSuiteSyncForWallet: () => Promise.resolve(),
+            flushSuiteSyncStorage: () => {},
+        });
+
+        const turnOffSuiteSync = createTurnOffSuiteSync(deps);
+        await turnOffSuiteSync();
+
+        expect(deps.dispatch).toHaveBeenCalledWith(
+            suiteSyncActions.updateSuiteSyncEnabled({ isEnabled: false }),
+        );
+        expect(deps.turnOffSuiteSyncForWallet).toHaveBeenCalledWith({
+            deviceStaticSessionId: deviceStaticSessionId1,
+        });
+        expect(deps.turnOffSuiteSyncForWallet).toHaveBeenCalledWith({
+            deviceStaticSessionId: deviceStaticSessionId2,
+        });
+        expect(deps.dispatch).toHaveBeenCalledWith(clearAll());
+        expect(deps.flushSuiteSyncStorage).toHaveBeenCalled();
+    });
+
+    it('clears data and flushes storage even when no devices exist', async () => {
+        const deps = createMockDeps<CreateTurnOffSuiteSyncDeps>({
+            getIsSuiteSyncEnabled: () => true,
+            dispatch: mock<Dispatch>(() => {}),
+            getAllDeviceSessionIds: () => [],
+            turnOffSuiteSyncForWallet: () => Promise.resolve(),
+            flushSuiteSyncStorage: () => {},
+        });
+
+        const turnOffSuiteSync = createTurnOffSuiteSync(deps);
+        await turnOffSuiteSync();
+
+        expect(deps.dispatch).toHaveBeenCalledWith(
+            suiteSyncActions.updateSuiteSyncEnabled({ isEnabled: false }),
+        );
+        expect(deps.turnOffSuiteSyncForWallet).not.toHaveBeenCalled();
+        expect(deps.dispatch).toHaveBeenCalledWith(clearAll());
+        expect(deps.flushSuiteSyncStorage).toHaveBeenCalled();
+    });
+});

--- a/suite-common/suite-sync/src/tests/createTurnOnSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/tests/createTurnOnSuiteSync.test.ts
@@ -1,0 +1,84 @@
+import type { Dispatch } from '@reduxjs/toolkit';
+
+import type { StaticSessionId } from '@trezor/connect';
+import { err, ok } from '@trezor/type-utils';
+
+import { createSuiteSyncStorageMock } from '../../tests/createSuiteSyncStorageMock.mock';
+import { createMockDeps, mock } from '../../tests/utils';
+import { SuiteSyncUnavailableOnDeviceError } from '../createRefreshSuiteSyncKeys';
+import { CreateTurnOnSuiteSyncDeps, createTurnOnSuiteSync } from '../createTurnOnSuiteSync';
+import { suiteSyncActions } from '../suiteSyncActions';
+
+const deviceStaticSessionId: StaticSessionId = '1@2:3';
+
+describe(createTurnOnSuiteSync.name, () => {
+    it('returns ok early when suite sync is already enabled', async () => {
+        const deps = createMockDeps<CreateTurnOnSuiteSyncDeps>({
+            getIsSuiteSyncEnabled: () => true,
+            dispatch: mock<Dispatch>(() => {}),
+            ensureWalletSuiteSyncOn: () => Promise.resolve(ok(createSuiteSyncStorageMock())),
+        });
+
+        const turnOnSuiteSync = createTurnOnSuiteSync(deps);
+        const result = await turnOnSuiteSync({ deviceStaticSessionId });
+
+        expect(result).toEqual(ok());
+        expect(deps.dispatch).not.toHaveBeenCalled();
+        expect(deps.ensureWalletSuiteSyncOn).not.toHaveBeenCalled();
+    });
+
+    it('enables suite sync and ensures wallet sync when deviceStaticSessionId is provided', async () => {
+        const storage = createSuiteSyncStorageMock();
+
+        const deps = createMockDeps<CreateTurnOnSuiteSyncDeps>({
+            getIsSuiteSyncEnabled: () => false,
+            dispatch: mock<Dispatch>(() => {}),
+            ensureWalletSuiteSyncOn: () => Promise.resolve(ok(storage)),
+        });
+
+        const turnOnSuiteSync = createTurnOnSuiteSync(deps);
+        const result = await turnOnSuiteSync({ deviceStaticSessionId });
+
+        expect(deps.dispatch).toHaveBeenCalledWith(
+            suiteSyncActions.updateSuiteSyncEnabled({ isEnabled: true }),
+        );
+        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(result).toEqual(ok());
+    });
+
+    it('enables suite sync without calling ensureWalletSuiteSyncOn when deviceStaticSessionId is undefined', async () => {
+        const deps = createMockDeps<CreateTurnOnSuiteSyncDeps>({
+            getIsSuiteSyncEnabled: () => false,
+            dispatch: mock<Dispatch>(() => {}),
+            ensureWalletSuiteSyncOn: () => Promise.resolve(ok(createSuiteSyncStorageMock())),
+        });
+
+        const turnOnSuiteSync = createTurnOnSuiteSync(deps);
+        const result = await turnOnSuiteSync({ deviceStaticSessionId: undefined });
+
+        expect(deps.dispatch).toHaveBeenCalledWith(
+            suiteSyncActions.updateSuiteSyncEnabled({ isEnabled: true }),
+        );
+        expect(deps.ensureWalletSuiteSyncOn).not.toHaveBeenCalled();
+        expect(result).toEqual(ok());
+    });
+
+    it('returns ensureWalletSuiteSyncOn error when it fails', async () => {
+        const ensureWalletSuiteSyncOnResult = err(SuiteSyncUnavailableOnDeviceError());
+
+        const deps = createMockDeps<CreateTurnOnSuiteSyncDeps>({
+            getIsSuiteSyncEnabled: () => false,
+            dispatch: mock<Dispatch>(() => {}),
+            ensureWalletSuiteSyncOn: () => Promise.resolve(ensureWalletSuiteSyncOnResult),
+        });
+
+        const turnOnSuiteSync = createTurnOnSuiteSync(deps);
+        const result = await turnOnSuiteSync({ deviceStaticSessionId });
+
+        expect(deps.dispatch).toHaveBeenCalledWith(
+            suiteSyncActions.updateSuiteSyncEnabled({ isEnabled: true }),
+        );
+        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(result).toBe(ensureWalletSuiteSyncOnResult);
+    });
+});

--- a/suite-common/suite-sync/tests/utils.ts
+++ b/suite-common/suite-sync/tests/utils.ts
@@ -9,7 +9,10 @@ export const mockNotExpected = <T extends (...args: any[]) => any>(key: string) 
     });
 
 type RecursiveDeps = {
-    [key: string]: ((...args: any[]) => any) | RecursiveDeps;
+    [key: string]:
+        | ((...args: any[]) => any) // service can be a function
+        | RecursiveDeps // or object, where properties can be other services => recursive
+        | (string | number | boolean); // or a static configuration
 };
 
 export type MockDeps<T extends RecursiveDeps> = {
@@ -17,7 +20,7 @@ export type MockDeps<T extends RecursiveDeps> = {
         ? jest.Mock<ReturnType<T[K]>, Parameters<T[K]>>
         : T[K] extends RecursiveDeps
           ? MockDeps<T[K]>
-          : never;
+          : T[K];
 };
 
 /**
@@ -42,10 +45,17 @@ export const createMockDeps = <T extends RecursiveDeps>(
 
     for (const key in deps) {
         const value = deps[key];
+
         if (typeof value === 'function' || value === null) {
+            // Service is a function, so we create jest.fn mock (or provide default throwing impl.)
+            // It must be failing to fail the test, if it's not mocked we assume it SHALL NOT be called
             result[key] = jest.fn(value ?? mockNotExpected(key)) as MockDeps<T>[typeof key];
+        } else if (typeof value === 'object') {
+            // Recursive case, dependency is an object containing other dependencies/function
+            result[key] = createMockDeps(value as RecursiveDeps) as MockDeps<T>[typeof key];
         } else {
-            result[key] = createMockDeps(value) as MockDeps<T>[typeof key];
+            // Dependency is just a value, and we pass it
+            result[key] = value as MockDeps<T>[typeof key];
         }
     }
 


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/23296

- Adds a test for `createTurnOnSuiteSync`
- Adds a test for `createTurnOffSuiteSync`
- intruces `toGetter` to convert selectors to services

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-for-suite-sync&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-for-suite-sync&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test-for-suite-sync&lookback=7)