### PR TITLE
fix(suite-sync): asynchronous app reload

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -369,9 +369,10 @@ export const saveBackend =
     };
 
 export const saveSuiteSettings = () => (_dispatch: Dispatch, getState: GetState) => {
-    if (!db.isAccessible()) return;
+    if (!db.isAccessible()) return Promise.resolve();
     const { suite } = getState();
-    db.addItem(
+
+    return db.addItem(
         'suiteSettings',
         {
             settings: {

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -368,27 +368,34 @@ export const saveBackend =
         );
     };
 
-export const saveSuiteSettings = () => (_dispatch: Dispatch, getState: GetState) => {
-    if (!db.isAccessible()) return Promise.resolve();
-    const { suite } = getState();
+export const saveSuiteSettings =
+    () =>
+    (_dispatch: Dispatch, getState: GetState): Promise<void> => {
+        if (!db.isAccessible()) return Promise.resolve();
+        const { suite } = getState();
 
-    return db.addItem(
-        'suiteSettings',
-        {
-            settings: {
-                ...suite.settings,
-                // Temporary measure to always start Suite with password manager off
-                experimental: suite.settings.experimental?.filter(e => e !== 'password-manager'),
+        const result = db.addItem(
+            'suiteSettings',
+            {
+                settings: {
+                    ...suite.settings,
+                    // Temporary measure to always start Suite with password manager off
+                    experimental: suite.settings.experimental?.filter(
+                        e => e !== 'password-manager',
+                    ),
+                },
+                flags: suite.flags,
+                evmSettings: suite.evmSettings,
+                seenDisconnectNotificationForDeviceIds:
+                    suite.seenDisconnectNotificationForDeviceIds,
+                stakingDashboardCollapsed: suite.stakingDashboardCollapsed,
             },
-            flags: suite.flags,
-            evmSettings: suite.evmSettings,
-            seenDisconnectNotificationForDeviceIds: suite.seenDisconnectNotificationForDeviceIds,
-            stakingDashboardCollapsed: suite.stakingDashboardCollapsed,
-        },
-        'suite',
-        true,
-    );
-};
+            'suite',
+            true,
+        );
+
+        return result.then(() => {});
+    };
 
 export const saveTokenManagement =
     (symbol: NetworkSymbol, type: DefinitionType, status: TokenManagementAction) =>

--- a/packages/suite/src/views/settings/SettingsDebug/SuiteSyncSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SuiteSyncSettings.tsx
@@ -10,6 +10,7 @@ import {
 import { Button, Checkbox, Code, Column, Input, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
+import * as storageActions from 'src/actions/suite/storageActions';
 import { SettingsSection } from 'src/components/settings/SettingsSection';
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -33,7 +34,9 @@ export const SuiteSyncSettings = () => {
         );
 
         if (isFeatureSuiteSyncAvailable) {
-            suiteSync.turnOffSuiteSync();
+            suiteSync.turnOffSuiteSync({
+                ensureSettingsPersisted: () => dispatch(storageActions.saveSuiteSettings()),
+            });
         }
     };
 

--- a/suite-common/suite-sync-types/src/turnOffSuiteSync.ts
+++ b/suite-common/suite-sync-types/src/turnOffSuiteSync.ts
@@ -1,4 +1,4 @@
-export type TurnOffSuiteSync = (params: {
+export type TurnOffSuiteSync = (params?: {
     // NOTE: This callback needs to be passed like this because the persistor() in native requires whole store
     ensureSettingsPersisted?: () => Promise<void>;
 }) => Promise<void>;

--- a/suite-common/suite-sync-types/src/turnOffSuiteSync.ts
+++ b/suite-common/suite-sync-types/src/turnOffSuiteSync.ts
@@ -1,3 +1,6 @@
-export type TurnOffSuiteSync = () => Promise<void>;
+export type TurnOffSuiteSync = (params: {
+    // NOTE: This callback needs to be passed like this because the persistor() in native requires whole store
+    ensureSettingsPersisted?: () => Promise<void>;
+}) => Promise<void>;
 
 export type TurnOffSuiteSyncDep = { turnOffSuiteSync: TurnOffSuiteSync };

--- a/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
@@ -37,5 +37,6 @@ export const createTurnOffSuiteSync =
         // NOTE: enforce clearing all data from the suite sync
         deps.dispatch(clearAll());
         // NOTE: this is TEMPORARY solution until https://github.com/trezor/trezor-suite/issues/23641 is resolved
-        deps.reloadApp();
+        // setTimeout as a hacky way to wait for redux state to be updated before the actual app reload. Will be removed once #23641 is implemented.
+        setTimeout(deps.reloadApp, 0);
     };

--- a/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
@@ -19,7 +19,7 @@ export type CreateTurnOffSuiteSyncDeps = {
 
 export const createTurnOffSuiteSync =
     (deps: CreateTurnOffSuiteSyncDeps): TurnOffSuiteSync =>
-    async () => {
+    async (params: { ensureSettingsPersisted?: () => Promise<void> } = {}) => {
         const isSuiteSyncEnabled = deps.getIsSuiteSyncEnabled();
 
         if (!isSuiteSyncEnabled) {
@@ -36,6 +36,7 @@ export const createTurnOffSuiteSync =
 
         // NOTE: enforce clearing all data from the suite sync
         deps.dispatch(clearAll());
+        await (params.ensureSettingsPersisted?.() ?? Promise.resolve());
         // NOTE: this is TEMPORARY solution until https://github.com/trezor/trezor-suite/issues/23641 is resolved
         // setTimeout as a hacky way to wait for redux state to be updated before the actual app reload. Will be removed once #23641 is implemented.
         setTimeout(deps.reloadApp, 0);

--- a/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
@@ -36,8 +36,10 @@ export const createTurnOffSuiteSync =
 
         // NOTE: enforce clearing all data from the suite sync
         deps.dispatch(clearAll());
-        await (params.ensureSettingsPersisted?.() ?? Promise.resolve());
+        if (params.ensureSettingsPersisted) {
+            await params.ensureSettingsPersisted();
+        }
+
         // NOTE: this is TEMPORARY solution until https://github.com/trezor/trezor-suite/issues/23641 is resolved
-        // setTimeout as a hacky way to wait for redux state to be updated before the actual app reload. Will be removed once #23641 is implemented.
-        setTimeout(deps.reloadApp, 0);
+        deps.reloadApp();
     };

--- a/suite-common/suite-sync/src/tests/createTurnOffSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/tests/createTurnOffSuiteSync.test.ts
@@ -73,4 +73,29 @@ describe(createTurnOffSuiteSync.name, () => {
         expect(deps.dispatch).toHaveBeenCalledWith(clearAll());
         expect(deps.reloadApp).toHaveBeenCalled();
     });
+
+    it('awaits ensure flushing of the storage', async () => {
+        const deps = createMockDeps<CreateTurnOffSuiteSyncDeps>({
+            getIsSuiteSyncEnabled: () => true,
+            dispatch: mock<Dispatch>(() => {}),
+            getAllDeviceSessionIds: () => [],
+            turnOffSuiteSyncForWallet: () => Promise.resolve(),
+            reloadApp: () => {},
+        });
+
+        const turnOffSuiteSync = createTurnOffSuiteSync(deps);
+        let resolveFlushPromise = null as (() => void) | null;
+        const flushPromise = new Promise<void>(resolve => {
+            resolveFlushPromise = resolve;
+        });
+        const ensureFlushMock = jest.fn().mockImplementation(() => flushPromise);
+        const turnOffPromise = turnOffSuiteSync({ ensureSettingsPersisted: ensureFlushMock });
+
+        expect(ensureFlushMock).toHaveBeenCalled();
+        expect(deps.reloadApp).not.toHaveBeenCalled();
+        resolveFlushPromise?.();
+        await flushPromise;
+        expect(deps.reloadApp).toHaveBeenCalled();
+        await turnOffPromise;
+    });
 });

--- a/suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx
@@ -1,3 +1,4 @@
+import { useContext } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
@@ -6,11 +7,13 @@ import { useAlert } from '@suite-native/alerts';
 import { TouchableSwitchRow } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useLegacyAnalytics, useNativeServices } from '@suite-native/services';
+import { StorageContext } from '@suite-native/storage';
 import { useToast } from '@suite-native/toasts';
 import { exhaustive } from '@trezor/type-utils';
 
 export const ToggleSuiteSyncCard = () => {
     const analytics = useLegacyAnalytics();
+    const persistor = useContext(StorageContext);
     const { showAlert } = useAlert();
     const { showToast } = useToast();
     const { suiteSync } = useNativeServices();
@@ -23,7 +26,9 @@ export const ToggleSuiteSyncCard = () => {
             description: <Translation id="suiteSync.disableAlert.description" />,
             primaryButtonTitle: <Translation id="suiteSync.disableAlert.cta" />,
             onPressPrimaryButton: () => {
-                suiteSync.turnOffSuiteSync();
+                suiteSync.turnOffSuiteSync({
+                    ensureSettingsPersisted: () => persistor?.flush(),
+                });
                 analytics.report({
                     type: 'settings/general/labeling',
                     payload: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The app reload doesn't wait for the redux state update. Wrapping it in `setTimeout` is not optimal solution, but since the app reload will be removed, it's a temporary fix that will enable us to disable suite sync. 

## Notes for QA
Before this PR, suite sync couldn't be turned off in mobile app. This PR should fix that. After toggling the switch, suite sync should turn off and app will reload with correct value of the switch.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-sync/flush-app-asynchronously&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-sync/flush-app-asynchronously&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-sync/flush-app-asynchronously&lookback=7)