### PR TITLE
refactor(suite-sync): flusher renamed to reloader

### DIFF
--- a/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
+++ b/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
@@ -10,9 +10,11 @@ export const createSuiteDesktopCompositionRoot = (
     statePatch?: Record<string, any>,
 ) => {
     const history = createMemoryHistory();
-    const flushSuiteSyncStorage = () => {
+    const reloadApp = () => {
         desktopApi.reloadBrowserWindow();
     };
 
-    return initStore({ history, flushSuiteSyncStorage }, preloadStoreAction, { statePatch });
+    return initStore({ history, reloadApp }, preloadStoreAction, {
+        statePatch,
+    });
 };

--- a/packages/suite-web/src/createSuiteWebCompositionRoot.ts
+++ b/packages/suite-web/src/createSuiteWebCompositionRoot.ts
@@ -5,9 +5,9 @@ import { PreloadStoreAction } from 'src/support/suite/preloadStore';
 
 export const createSuiteWebCompositionRoot = (preloadStoreAction?: PreloadStoreAction) => {
     const history = createBrowserHistory();
-    const flushSuiteSyncStorage = () => {
+    const reloadApp = () => {
         window.location.reload();
     };
 
-    return initStore({ history, flushSuiteSyncStorage }, preloadStoreAction);
+    return initStore({ history, reloadApp }, preloadStoreAction);
 };

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -19,7 +19,7 @@ import {
     createStoreWithExtraStoreMiddleware,
 } from '@suite-common/redux-utils';
 import { suiteSyncDataReducer } from '@suite-common/suite-sync';
-import { SuiteSyncStorageFlusherDep } from '@suite-common/suite-sync-types';
+import { SuiteSyncAppReloaderDep } from '@suite-common/suite-sync-types';
 import { prepareThpReducer } from '@suite-common/thp';
 import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions';
 import { accountsActions } from '@suite-common/wallet-core';
@@ -129,7 +129,7 @@ type RootReducerShape = typeof rootReducer;
 type PreloadedState = Partial<AppState>;
 type InferredAction = Parameters<RootReducerShape>[1];
 
-export type SuiteStoreDeps = HistoryDep & SuiteSyncStorageFlusherDep;
+export type SuiteStoreDeps = HistoryDep & SuiteSyncAppReloaderDep;
 
 export const initStore = (
     deps: SuiteStoreDeps,
@@ -156,7 +156,7 @@ export const initStore = (
         services: createSuiteServicesCompositionRoot({
             getState: api.getState,
             dispatch: api.dispatch,
-            flushSuiteSyncStorage: deps.flushSuiteSyncStorage,
+            reloadApp: deps.reloadApp,
             history: deps.history,
         }),
     });

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -16,7 +16,7 @@ import {
 import { delegatedIdentityKeyCompositionRoot } from '@suite-common/delegated-identity-key';
 import { FW_HASH_CHECK_DEFAULT_TIMEOUTS } from '@suite-common/firmware-authenticity';
 import { CommonServices, ExtraDependenciesStatic } from '@suite-common/redux-utils';
-import { SuiteSyncStorageFlusherDep } from '@suite-common/suite-sync-types';
+import { SuiteSyncAppReloaderDep } from '@suite-common/suite-sync-types';
 import {
     TokenDefinitionsState,
     buildTokenDefinitionsFromStorage,
@@ -100,7 +100,7 @@ export type StoreAPIDep = {
     dispatch: (_: any) => any;
 };
 
-export type SuiteAppDeps = StoreAPIDep & HistoryDep & SuiteSyncStorageFlusherDep;
+export type SuiteAppDeps = StoreAPIDep & HistoryDep & SuiteSyncAppReloaderDep;
 
 export type SuiteServices = CommonServices &
     DesktopAnalyticsDep &
@@ -132,7 +132,7 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
         suiteSync: createSuiteSyncDesktopCompositionRoot({
             dispatch: deps.dispatch,
             getState: deps.getState,
-            flushSuiteSyncStorage: deps.flushSuiteSyncStorage,
+            reloadApp: deps.reloadApp,
             platformEncryption,
             trezorConnect: TrezorConnect,
             ensureDelegatedIdentityKey,

--- a/suite-common/suite-sync-types/src/index.ts
+++ b/suite-common/suite-sync-types/src/index.ts
@@ -61,7 +61,4 @@ export type {
     UpdateWalletLabelParams,
 } from './data/updateWalletLabel';
 
-export type {
-    SuiteSyncStorageFlusher,
-    SuiteSyncStorageFlusherDep,
-} from './suiteSyncStorageFlusher';
+export type { SuiteSyncAppReloader, SuiteSyncAppReloaderDep } from './suiteSyncAppReloader';

--- a/suite-common/suite-sync-types/src/suiteSyncAppReloader.ts
+++ b/suite-common/suite-sync-types/src/suiteSyncAppReloader.ts
@@ -1,0 +1,5 @@
+export type SuiteSyncAppReloader = () => void;
+
+export type SuiteSyncAppReloaderDep = {
+    reloadApp: SuiteSyncAppReloader;
+};

--- a/suite-common/suite-sync-types/src/suiteSyncStorageFlusher.ts
+++ b/suite-common/suite-sync-types/src/suiteSyncStorageFlusher.ts
@@ -1,5 +1,0 @@
-export type SuiteSyncStorageFlusher = () => void;
-
-export type SuiteSyncStorageFlusherDep = {
-    flushSuiteSyncStorage: SuiteSyncStorageFlusher;
-};

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -4,7 +4,7 @@ import { EnsureDelegatedIdentityKeyDep } from '@suite-common/delegated-identity-
 import { PlatformEncryptionDep } from '@suite-common/platform-encryption';
 import { selectHasDeviceAllowance } from '@suite-common/suite-sync-quota-manager';
 import { CreateSuiteStorageDep, CreateSuiteSyncOwnerDep } from '@suite-common/suite-sync-storage';
-import { SuiteSync, SuiteSyncStorageFlusherDep } from '@suite-common/suite-sync-types';
+import { SuiteSync, SuiteSyncAppReloaderDep } from '@suite-common/suite-sync-types';
 import {
     selectAllDeviceStaticIds,
     selectDeviceByStaticSessionId,
@@ -46,7 +46,7 @@ type CreateSuiteSyncCompositionRootDeps = {
     CreateSuiteStorageDep &
     CreateSuiteSyncOwnerDep &
     PlatformEncryptionDep &
-    SuiteSyncStorageFlusherDep;
+    SuiteSyncAppReloaderDep;
 
 export const createSuiteSyncCompositionRoot = (
     deps: CreateSuiteSyncCompositionRootDeps,
@@ -136,7 +136,7 @@ export const createSuiteSyncCompositionRoot = (
             dispatch: deps.dispatch,
             getState: deps.getState,
             turnOffSuiteSyncForWallet,
-            flushSuiteSyncStorage: deps.flushSuiteSyncStorage,
+            reloadApp: deps.reloadApp,
         }),
         turnOnSuiteSync: createTurnOnSuiteSync({
             getState: deps.getState,

--- a/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
@@ -1,7 +1,7 @@
 import { Dispatch } from '@reduxjs/toolkit';
 
 import {
-    SuiteSyncStorageFlusherDep,
+    SuiteSyncAppReloaderDep,
     TurnOffSuiteSync,
     TurnOffSuiteSyncForWalletDep,
 } from '@suite-common/suite-sync-types';
@@ -16,7 +16,7 @@ export type CreateTurnOffSuiteSyncDeps = {
     getState: () => any;
     getAllDeviceSessionIds: () => StaticSessionId[];
 } & TurnOffSuiteSyncForWalletDep &
-    SuiteSyncStorageFlusherDep;
+    SuiteSyncAppReloaderDep;
 
 export const createTurnOffSuiteSync =
     (deps: CreateTurnOffSuiteSyncDeps): TurnOffSuiteSync =>
@@ -38,5 +38,5 @@ export const createTurnOffSuiteSync =
         // NOTE: enforce clearing all data from the suite sync
         deps.dispatch(clearAll());
         // NOTE: this is TEMPORARY solution until https://github.com/trezor/trezor-suite/issues/23641 is resolved
-        deps.flushSuiteSyncStorage();
+        deps.reloadApp();
     };

--- a/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
+++ b/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
@@ -30,6 +30,6 @@ export const createSuiteSyncNativeCompositionRoot = (
         ...deps,
         createSuiteStorage: createEvoluStorage,
         createSuiteSyncOwner: evoluCreateSuiteSyncOwner,
-        flushSuiteSyncStorage: reloadAppAsync,
+        reloadApp: reloadAppAsync,
     });
 };

--- a/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
+++ b/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
@@ -10,7 +10,7 @@ import {
     createEvoluStorageFactory,
     evoluCreateSuiteSyncOwner,
 } from '@suite-common/suite-sync-evolu';
-import { SuiteSync, SuiteSyncStorageFlusherDep } from '@suite-common/suite-sync-types';
+import { SuiteSync, SuiteSyncAppReloaderDep } from '@suite-common/suite-sync-types';
 import { TrezorConnect } from '@trezor/connect';
 
 import {
@@ -26,7 +26,7 @@ type SuiteSyncDesktopCompositionRootDeps = {
     EnsureDelegatedIdentityKeyDep &
     DesktopLegacyAnalyticsDep &
     DisableLegacyMetadataIfNeededDep &
-    SuiteSyncStorageFlusherDep;
+    SuiteSyncAppReloaderDep;
 
 export const createSuiteSyncDesktopCompositionRoot = (
     deps: SuiteSyncDesktopCompositionRootDeps,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The flusher name is quite confusing. It's a nit, but we only reload the app so I renamed the method to appReloader. No functionality changes in this PR.

## Notes for QA

Nothing to test, just renaming a method.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/suite-sync/rename-flusher&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/suite-sync/rename-flusher&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/suite-sync/rename-flusher&lookback=7)