### PR TITLE
fix(suite-native): improve THP and device connection flows

### DIFF
--- a/suite-common/thp/src/index.ts
+++ b/suite-common/thp/src/index.ts
@@ -1,9 +1,11 @@
 export { prepareThpReducer, initialThpState } from './thpReducer';
 export type { ThpStep, ThpState } from './thpReducer';
+export type { ThpRootState } from './thpSelectors';
 export {
     selectThp,
     selectIsThpInProgress,
     selectThpStep,
+    selectThpLastResult,
     selectThpCredentials,
 } from './thpSelectors';
 export { thpActions } from './thpActions';

--- a/suite-common/thp/src/thpReducer.ts
+++ b/suite-common/thp/src/thpReducer.ts
@@ -1,4 +1,4 @@
-import { AnyAction, isAnyOf } from '@reduxjs/toolkit';
+import { AnyAction } from '@reduxjs/toolkit';
 
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { ThpSuiteCredentials } from '@suite-common/suite-types';
@@ -38,12 +38,14 @@ export type ThpStep =
 export type ThpState = {
     step: ThpStep;
     lastThpCode?: string;
+    lastResult?: 'finished' | 'canceled';
     credentials: ThpSuiteCredentials[];
 };
 
 export const initialThpState: ThpState = {
     step: null,
     lastThpCode: undefined,
+    lastResult: undefined,
     credentials: [] as ThpSuiteCredentials[],
 };
 
@@ -93,8 +95,13 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
             .addCase(thpActions.removeAllCredentials, state => {
                 state.credentials = [];
             })
-            .addMatcher(isAnyOf(thpActions.finishThpFlow, thpActions.cancelThpFlow), state => {
+            .addCase(thpActions.finishThpFlow, state => {
                 state.step = null;
+                state.lastResult = 'finished';
+            })
+            .addCase(thpActions.cancelThpFlow, state => {
+                state.step = null;
+                state.lastResult = 'canceled';
             })
             .addMatcher(
                 action => action.type === UI.REQUEST_THP_PAIRING,

--- a/suite-common/thp/src/thpSelectors.ts
+++ b/suite-common/thp/src/thpSelectors.ts
@@ -1,13 +1,15 @@
 import { ThpState } from './thpReducer';
 
-export type WithThpState = {
+export type ThpRootState = {
     thp: ThpState;
 };
 
-export const selectThp = (state: WithThpState) => state.thp;
+export const selectThp = (state: ThpRootState) => state.thp;
 
-export const selectIsThpInProgress = (state: WithThpState) => state.thp.step !== null;
+export const selectIsThpInProgress = (state: ThpRootState) => state.thp.step !== null;
 
-export const selectThpStep = (state: WithThpState) => state.thp.step;
+export const selectThpStep = (state: ThpRootState) => state.thp.step;
 
-export const selectThpCredentials = (state: WithThpState) => state.thp.credentials;
+export const selectThpLastResult = (state: ThpRootState) => state.thp.lastResult;
+
+export const selectThpCredentials = (state: ThpRootState) => state.thp.credentials;

--- a/suite-common/thp/tests/thpReducer.test.ts
+++ b/suite-common/thp/tests/thpReducer.test.ts
@@ -2,15 +2,17 @@ import { combineReducers } from '@reduxjs/toolkit';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 
-import { prepareThpReducer, thpActions } from '../src';
+import { prepareThpReducer, selectThpStep, thpActions } from '../src';
 import { createCredential } from '../src/support/mocks';
 import { ThpState } from '../src/thpReducer';
+import { selectThpLastResult } from '../src/thpSelectors';
 
 const thpReduce = prepareThpReducer(extraDependenciesCommonMock);
 
 const initialState: ThpState = {
     step: null,
     lastThpCode: undefined,
+    lastResult: undefined,
     credentials: [],
 };
 
@@ -29,6 +31,34 @@ describe('thpReducer', () => {
         expect(store.getState().thp.lastThpCode).toEqual(undefined);
         store.dispatch(thpActions.setLastThpCode({ code: '123456' }));
         expect(store.getState().thp.lastThpCode).toEqual('123456');
+    });
+
+    test('finishThpFlow', () => {
+        const store = configureMockStore({
+            extra: {},
+            reducer: combineReducers({ thp: thpReduce }),
+            preloadedState: { thp: { ...initialState, step: 'ConfirmOnlyConnection' } },
+        });
+
+        store.dispatch(thpActions.finishThpFlow());
+
+        const state = store.getState();
+        expect(selectThpStep(state)).toEqual(null);
+        expect(selectThpLastResult(state)).toEqual('finished');
+    });
+
+    test('cancelThpFlow', () => {
+        const store = configureMockStore({
+            extra: {},
+            reducer: combineReducers({ thp: thpReduce }),
+            preloadedState: { thp: { ...initialState, step: 'ConfirmOnlyConnection' } },
+        });
+
+        store.dispatch(thpActions.cancelThpFlow());
+
+        const state = store.getState();
+        expect(selectThpStep(state)).toEqual(null);
+        expect(selectThpLastResult(state)).toEqual('canceled');
     });
 
     it('filters out the credentials to be removed', () => {

--- a/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
+++ b/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
@@ -2,6 +2,7 @@ import { UnknownAction } from '@reduxjs/toolkit';
 
 import { prepareMessageSystemReducer } from '@suite-common/message-system';
 import { extraDependenciesCommonMock, getSuiteDevice } from '@suite-common/test-utils';
+import { prepareThpReducer } from '@suite-common/thp';
 import {
     deviceActions,
     prepareDeviceReducer,
@@ -26,6 +27,7 @@ const INIT_ACTION = { type: 'foo' };
 const deviceReducer = prepareDeviceReducer(extraDependenciesCommonMock);
 const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
 const walletSettingsReducer = prepareWalletSettingsReducer(extraDependenciesCommonMock);
+const thpReducer = prepareThpReducer(extraDependenciesCommonMock);
 
 type InitialStateConfig = {
     nativeFirmware?: Partial<NativeFirmwareState>;
@@ -34,6 +36,7 @@ type InitialStateConfig = {
     walletSettings?: Partial<ReturnType<typeof walletSettingsReducer>>;
     appSettings?: Partial<typeof appSettingsSlice.reducer>;
     featureFlags?: Partial<typeof featureFlagsSlice.reducer>;
+    thp?: Partial<ReturnType<typeof thpReducer>>;
 };
 
 type RootState = {
@@ -46,6 +49,7 @@ type RootState = {
     messageSystem: ReturnType<typeof messageSystemReducer>;
     appSettings: ReturnType<typeof appSettingsSlice.reducer>;
     featureFlags: ReturnType<typeof featureFlagsSlice.reducer>;
+    thp: ReturnType<typeof thpReducer>;
 };
 
 // All routes typed directly from RootStackParamList
@@ -103,6 +107,7 @@ const buildInitialState = ({
     deviceOnboarding,
     appSettings,
     featureFlags,
+    thp,
 }: InitialStateConfig = {}): RootState => ({
     nativeFirmware: {
         ...nativeFirmwareReducer(undefined, INIT_ACTION),
@@ -130,6 +135,10 @@ const buildInitialState = ({
     featureFlags: {
         ...featureFlagsSlice.reducer(undefined, INIT_ACTION),
         ...featureFlags,
+    },
+    thp: {
+        ...thpReducer(undefined, INIT_ACTION),
+        ...thp,
     },
 });
 
@@ -297,6 +306,16 @@ export const deviceConnectBlockedFixtures: NoNavigationFixture[] = [
         description: 'blocks navigation when firmware installation is running',
         initialState: buildInitialState({
             nativeFirmware: { isFirmwareInstallationRunning: true },
+        }),
+        action: {
+            type: deviceActions.connectDevice.type,
+            payload: { device: getSuiteDevice() },
+        },
+    },
+    {
+        description: 'blocks navigation when auto-connect offered',
+        initialState: buildInitialState({
+            thp: { step: 'AutoconnectInfo' },
         }),
         action: {
             type: deviceActions.connectDevice.type,

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -10,7 +10,7 @@ import {
     getIsDeviceDescriptorApiTypeBluetooth,
     getIsDeviceInitialized,
 } from '@suite-common/suite-utils';
-import { isThpPairingUIRequestButtonAction } from '@suite-common/thp';
+import { isThpPairingUIRequestButtonAction, selectThpStep } from '@suite-common/thp';
 import {
     deviceActions,
     selectDevices,
@@ -156,6 +156,9 @@ deviceConnectionMiddleware.startListening({
 
             return;
         }
+
+        // In case auto-connect is offered, we don't want to interfere with the flow.
+        if (selectThpStep(getState()) === 'AutoconnectInfo') return;
 
         // If device is authorized already (usually in case of remembered device which has already been authorized)
         // We need to use the state before we add connected device to the array so we find out whether it was previously remembered

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -11,6 +11,7 @@ import {
     selectIsFeatureEnabled,
 } from '@suite-common/message-system';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
+import { ThpRootState } from '@suite-common/thp';
 import {
     AccountsRootState,
     DeviceRootState,
@@ -62,6 +63,7 @@ import { BigNumber } from '@trezor/utils';
 import { getIsDeviceSetupSupported, isFirmwareVersionSupported } from './utils';
 
 export type NativeDeviceRootState = DeviceRootState &
+    ThpRootState &
     AccountsRootState &
     DiscoveryRootState &
     SettingsSliceRootState &

--- a/suite-native/module-authorize-device/package.json
+++ b/suite-native/module-authorize-device/package.json
@@ -15,6 +15,7 @@
         "@reduxjs/toolkit": "2.11.0",
         "@suite-common/analytics-types": "workspace:*",
         "@suite-common/bluetooth": "workspace:*",
+        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/thp": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/alerts": "workspace:*",

--- a/suite-native/module-authorize-device/src/screens/thp/ThpCodeEntryScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/thp/ThpCodeEntryScreen.tsx
@@ -1,26 +1,28 @@
-import React, { useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import { selectThpStep } from '@suite-common/thp';
+import { useFocusEffect } from '@react-navigation/native';
+
 import { Screen, useNavigateToInitialScreen } from '@suite-native/navigation';
 import { ThpCodeEntryScreenContent } from '@suite-native/thp';
 
 import { ThpScreenHeader } from '../../components/thp/ThpScreenHeader';
 import { useInitiateThpConnection } from '../../hooks/useInitiateThpConnection';
+import { selectIsThpScreenDismissable } from '../../selectors';
 
 export const ThpCodeEntryScreen = () => {
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const { initiateThpConnection } = useInitiateThpConnection();
 
-    const thpStep = useSelector(selectThpStep);
+    const isThpScreenDismissable = useSelector(selectIsThpScreenDismissable);
 
-    useEffect(() => {
-        // This is an extreme edge case that occurs only if you disable auto-connect and later
-        // decide to enable it via device settings with your remembered device disconnected.
-        if (thpStep === 'Autoconnect') {
-            navigateToInitialScreen();
-        }
-    }, [thpStep, navigateToInitialScreen]);
+    useFocusEffect(
+        useCallback(() => {
+            if (isThpScreenDismissable) {
+                navigateToInitialScreen();
+            }
+        }, [isThpScreenDismissable, navigateToInitialScreen]),
+    );
 
     return (
         <Screen header={<ThpScreenHeader />}>

--- a/suite-native/module-authorize-device/src/screens/thp/ThpConfirmationScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/thp/ThpConfirmationScreen.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
+import { useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { selectThpStep } from '@suite-common/thp';
@@ -17,6 +18,7 @@ import {
 import { useThpAutoconnectActions } from '@suite-native/thp';
 
 import { ThpScreenHeader } from '../../components/thp/ThpScreenHeader';
+import { selectIsThpScreenDismissable } from '../../selectors';
 
 export const ThpConfirmationScreen = ({
     navigation,
@@ -29,6 +31,7 @@ export const ThpConfirmationScreen = ({
     const { startThpAutoconnect, ignoreThpAutoconnect } = useThpAutoconnectActions();
 
     const thpStep = useSelector(selectThpStep);
+    const isThpScreenDismissable = useSelector(selectIsThpScreenDismissable);
 
     const { showAlert } = useAlert();
 
@@ -43,15 +46,23 @@ export const ThpConfirmationScreen = ({
         });
     }, [showAlert, startThpAutoconnect, ignoreThpAutoconnect]);
 
-    useEffect(() => {
-        if (thpStep === 'CodeEntry') {
-            navigation.navigate(AuthorizeDeviceStackRoutes.ThpCodeEntry);
-        } else if (thpStep === 'AutoconnectInfo') {
-            showThpAutoconnectEnableAlert();
-        } else if (thpStep === null) {
-            navigateToInitialScreen();
-        }
-    }, [thpStep, navigateToInitialScreen, navigation, showThpAutoconnectEnableAlert]);
+    useFocusEffect(
+        useCallback(() => {
+            if (thpStep === 'CodeEntry') {
+                navigation.replace(AuthorizeDeviceStackRoutes.ThpCodeEntry);
+            } else if (thpStep === 'AutoconnectInfo') {
+                showThpAutoconnectEnableAlert();
+            } else if (isThpScreenDismissable) {
+                navigateToInitialScreen();
+            }
+        }, [
+            thpStep,
+            isThpScreenDismissable,
+            navigateToInitialScreen,
+            navigation,
+            showThpAutoconnectEnableAlert,
+        ]),
+    );
 
     return (
         <Screen

--- a/suite-native/module-authorize-device/src/selectors.ts
+++ b/suite-native/module-authorize-device/src/selectors.ts
@@ -1,0 +1,11 @@
+import { createWeakMapSelector } from '@suite-common/redux-utils';
+import { ThpRootState, selectThpLastResult, selectThpStep } from '@suite-common/thp';
+import { DeviceRootState, selectIsDeviceThpRequired } from '@suite-common/wallet-core';
+
+const createMemoizedSelector = createWeakMapSelector.withTypes<ThpRootState & DeviceRootState>();
+
+export const selectIsThpScreenDismissable = createMemoizedSelector(
+    [selectThpStep, selectThpLastResult, selectIsDeviceThpRequired],
+    (thpStep, thpLastResult, isDeviceThpRequired) =>
+        thpStep === null && (thpLastResult === 'canceled' || !isDeviceThpRequired),
+);

--- a/suite-native/module-authorize-device/tsconfig.json
+++ b/suite-native/module-authorize-device/tsconfig.json
@@ -8,6 +8,9 @@
         {
             "path": "../../suite-common/bluetooth"
         },
+        {
+            "path": "../../suite-common/redux-utils"
+        },
         { "path": "../../suite-common/thp" },
         {
             "path": "../../suite-common/wallet-core"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12506,6 +12506,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:2.11.0"
     "@suite-common/analytics-types": "workspace:*"
     "@suite-common/bluetooth": "workspace:*"
+    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/thp": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-native/alerts": "workspace:*"


### PR DESCRIPTION
- New state property to record the result of the last THP flow introduced.
- Device connection middleware fixed to skip navigation when auto-connect is offered.
- Navigation in THP screens moved to `useFocusEffect`.

## Notes for QA

- _Coin enabling_ and _Connecting_ screens should slide in from right (not from bottom).
- _Connecting_ screen is not shown after auto-connect is offered to be enabled.
- Would be great to also test with older devices.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/thp-navigation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/thp-navigation&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/thp-navigation&lookback=7)