### PR TITLE
chore(connect-core): connect errors to connect-common

### DIFF
--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -52,6 +52,8 @@
         "tslib": "^2.6.2"
     },
     "devDependencies": {
+        "@trezor/protobuf": "workspace:^",
+        "@trezor/protocol": "workspace:^",
         "@types/chrome": "^0.0.299",
         "@types/jest": "29.5.12",
         "@types/node": "22.13.10",

--- a/packages/connect-common/src/constants/errors.ts
+++ b/packages/connect-common/src/constants/errors.ts
@@ -1,5 +1,5 @@
-import { Messages } from '@trezor/protobuf';
-import { thp } from '@trezor/protocol';
+import type { Messages } from '@trezor/protobuf';
+import type { thp } from '@trezor/protocol';
 
 export const ERROR_CODES = {
     Init_NotInitialized: 'TrezorConnect not initialized', // race condition: call on not initialized Core (usually hot-reloading)

--- a/packages/connect-common/src/constants/index.ts
+++ b/packages/connect-common/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * as ERRORS from './errors';

--- a/packages/connect-common/tsconfig.json
+++ b/packages/connect-common/tsconfig.json
@@ -7,6 +7,8 @@
     "include": ["."],
     "references": [
         { "path": "../env-utils" },
-        { "path": "../utils" }
+        { "path": "../utils" },
+        { "path": "../protobuf" },
+        { "path": "../protocol" }
     ]
 }

--- a/packages/connect-common/tsconfig.lib.json
+++ b/packages/connect-common/tsconfig.lib.json
@@ -12,6 +12,12 @@
         },
         {
             "path": "../utils"
+        },
+        {
+            "path": "../protobuf"
+        },
+        {
+            "path": "../protocol"
         }
     ]
 }

--- a/packages/connect-common/tsconfig.libESM.json
+++ b/packages/connect-common/tsconfig.libESM.json
@@ -12,6 +12,12 @@
         },
         {
             "path": "../utils"
+        },
+        {
+            "path": "../protobuf"
+        },
+        {
+            "path": "../protocol"
         }
     ]
 }

--- a/packages/connect-mobile/package.json
+++ b/packages/connect-mobile/package.json
@@ -22,6 +22,7 @@
     },
     "dependencies": {
         "@trezor/connect": "workspace:^",
+        "@trezor/connect-common": "workspace:^",
         "@trezor/utils": "workspace:^"
     },
     "peerDependencies": {

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -1,12 +1,12 @@
 import EventEmitter from 'events';
 
-import * as ERRORS from '@trezor/connect/src/constants/errors';
 import { corsValidator, parseConnectSettings } from '@trezor/connect/src/data/connectSettings';
 import { DEEPLINK_VERSION, DEFAULT_DOMAIN_MAJOR_VER } from '@trezor/connect/src/data/version';
 import type { CallMethodPayload } from '@trezor/connect/src/events/call';
 import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
 import type { ConnectSettings, ConnectSettingsMobile, Manifest } from '@trezor/connect/src/types';
 import { InitFullSettings } from '@trezor/connect/src/types/api/init';
+import * as ERRORS from '@trezor/connect-common/src/constants/errors';
 import { Deferred, createDeferred, removeTrailingSlashes } from '@trezor/utils';
 
 export class TrezorConnectDeeplink implements ConnectFactoryDependencies<ConnectSettingsMobile> {

--- a/packages/connect-mobile/tsconfig.json
+++ b/packages/connect-mobile/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../connect" },
+        { "path": "../connect-common" },
         { "path": "../utils" }
     ]
 }

--- a/packages/connect-mobile/tsconfig.lib.json
+++ b/packages/connect-mobile/tsconfig.lib.json
@@ -9,6 +9,9 @@
             "path": "../connect"
         },
         {
+            "path": "../connect-common"
+        },
+        {
             "path": "../utils"
         }
     ]

--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -1,7 +1,6 @@
 import EventEmitter from 'events';
 
 // NOTE: @trezor/connect part is intentionally not imported from the index so we do include the whole library.
-import * as ERRORS from '@trezor/connect/src/constants/errors';
 import {
     CallMethodAnyResponse,
     CallMethodPayload,
@@ -16,6 +15,7 @@ import type {
     ConnectSettingsWeb,
     Manifest,
 } from '@trezor/connect/src/types';
+import * as ERRORS from '@trezor/connect-common/src/constants/errors';
 import { WebsocketClient } from '@trezor/websocket-client';
 import { WebsocketError } from '@trezor/websocket-client/src/client';
 

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -1,7 +1,6 @@
 import EventEmitter from 'events';
 
 // NOTE: @trezor/connect part is intentionally not imported from the index so we do include the whole library.
-import * as ERRORS from '@trezor/connect/src/constants/errors';
 import {
     CallMethodAnyResponse,
     CallMethodPayload,
@@ -15,6 +14,7 @@ import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory
 import type { ConnectSettings, ConnectSettingsWeb, Manifest } from '@trezor/connect/src/types';
 import { InitFullSettings } from '@trezor/connect/src/types/api/init';
 import { Log, initLog } from '@trezor/connect/src/utils/debug';
+import * as ERRORS from '@trezor/connect-common/src/constants/errors';
 
 import { parseConnectSettings } from '../connectSettings';
 import { PopupManager } from '../popup';

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -4,7 +4,6 @@ import EventEmitter from 'events';
 import {
     CallMethod,
     ConnectSettings,
-    ERRORS,
     IFRAME,
     Manifest,
     POPUP,
@@ -12,6 +11,7 @@ import {
     createErrorMessage,
 } from '@trezor/connect/src/exports';
 import { factory } from '@trezor/connect/src/factory';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { WindowServiceWorkerChannel } from '@trezor/connect-common/src/messageChannel/window-serviceworker';
 
 const eventEmitter = new EventEmitter();

--- a/packages/connect/src/api/bitcoin/outputs.ts
+++ b/packages/connect/src/api/bitcoin/outputs.ts
@@ -1,8 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/tx/outputs.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { ComposeOutput as ComposeOutputBase } from '@trezor/utxo-lib';
 
-import { ERRORS, PROTO } from '../../constants';
+import { PROTO } from '../../constants';
 import type { BitcoinNetworkInfo, ProtoWithDerivationPath } from '../../types';
 import type { ComposeOutput, ComposeResultFinal } from '../../types/api/composeTransaction';
 import { isValidAddress } from '../../utils/addressUtils';

--- a/packages/connect/src/api/bitcoin/refTx.ts
+++ b/packages/connect/src/api/bitcoin/refTx.ts
@@ -1,5 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/tx/refTx.js
 
+import { TypedError } from '@trezor/connect-common/src/constants/errors';
 import { Assert, Type } from '@trezor/schema-utils';
 import { bufferUtils } from '@trezor/utils';
 import {
@@ -14,7 +15,6 @@ import type {
 } from '@trezor/utxo-lib/src/transaction/base';
 
 import { PROTO } from '../../constants';
-import { TypedError } from '../../constants/errors';
 import type {
     AccountAddresses,
     AccountTransaction,

--- a/packages/connect/src/api/bitcoin/signtx.ts
+++ b/packages/connect/src/api/bitcoin/signtx.ts
@@ -1,6 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/signtx.js
+import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import { ERRORS, PROTO } from '../../constants';
+import { PROTO } from '../../constants';
 import type { TypedCall } from '../../device/DeviceCommands';
 import type { BitcoinNetworkInfo } from '../../types';
 import type {

--- a/packages/connect/src/api/bitcoin/signtxLegacy.ts
+++ b/packages/connect/src/api/bitcoin/signtxLegacy.ts
@@ -1,7 +1,8 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/signtx-legacy.js
+import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type { SignTxHelperParams, SignTxHelperProps } from './signtx';
-import { ERRORS, PROTO } from '../../constants';
+import { PROTO } from '../../constants';
 import type { SignedTransaction } from '../../types/api/bitcoin';
 
 const requestPrevTxInfo = ({

--- a/packages/connect/src/api/bitcoin/signtxVerify.ts
+++ b/packages/connect/src/api/bitcoin/signtxVerify.ts
@@ -1,5 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/signtxVerify.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import {
     address as BitcoinJsAddress,
     payments as BitcoinJsPayments,
@@ -7,7 +8,7 @@ import {
     bip32,
 } from '@trezor/utxo-lib';
 
-import { ERRORS, PROTO } from '../../constants';
+import { PROTO } from '../../constants';
 import type { DeviceCommands } from '../../device/DeviceCommands';
 import type { Network } from '../../types';
 

--- a/packages/connect/src/api/bleUnpair.ts
+++ b/packages/connect/src/api/bleUnpair.ts
@@ -1,7 +1,8 @@
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 import { TRANSPORT_ERROR } from '@trezor/transport';
 
-import { ERRORS, PROTO } from '../constants';
+import { PROTO } from '../constants';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI } from '../events';
 

--- a/packages/connect/src/api/blockchainDisconnect.ts
+++ b/packages/connect/src/api/blockchainDisconnect.ts
@@ -1,9 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainDisconnect.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { findBackend, isBackendSupported } from '../backend/BlockchainLink';
-import { ERRORS } from '../constants';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import { CoinInfo, CoinObj } from '../types';

--- a/packages/connect/src/api/blockchainEstimateFee.ts
+++ b/packages/connect/src/api/blockchainEstimateFee.ts
@@ -1,6 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainEstimateFee.js
 
-import { ERRORS } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { AbstractMethod, MethodReturnType, Payload } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainEvmRpcCall.ts
+++ b/packages/connect/src/api/blockchainEvmRpcCall.ts
@@ -1,5 +1,6 @@
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import { ERRORS } from '../constants';
 import { AbstractMethod, Payload } from '../core/AbstractMethod';
 import { CoinInfo } from '../types';
 import { validateParams } from './common/paramsValidator';

--- a/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
+++ b/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
@@ -1,6 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainGetAccountBalanceHistory.js
 
-import { ERRORS } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { AbstractMethod, Payload } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
+++ b/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
@@ -1,6 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainGetCurrentFiatRates.js
 
-import { ERRORS } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { AbstractMethod, Payload } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
+++ b/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
@@ -1,6 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainGetFiatRatesForTimestamps.js
 
-import { ERRORS } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { AbstractMethod, Payload } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainGetInfo.ts
+++ b/packages/connect/src/api/blockchainGetInfo.ts
@@ -1,4 +1,5 @@
-import { ERRORS } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainGetTransactions.ts
+++ b/packages/connect/src/api/blockchainGetTransactions.ts
@@ -1,6 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainGetTransactions.js
 
-import { ERRORS } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainSetCustomBackend.ts
+++ b/packages/connect/src/api/blockchainSetCustomBackend.ts
@@ -1,6 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainSetCustomBackend.js
 
-import { ERRORS } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { reconnectAllBackends, setCustomBackend } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainSubscribe.ts
+++ b/packages/connect/src/api/blockchainSubscribe.ts
@@ -1,6 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainSubscribe.js
 
-import { ERRORS } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { AbstractMethod, Payload } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainSubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainSubscribeFiatRates.ts
@@ -1,6 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainSubscribeFiatRates.js
 
-import { ERRORS } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { AbstractMethod, Payload } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainUnsubscribe.ts
+++ b/packages/connect/src/api/blockchainUnsubscribe.ts
@@ -1,6 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainUnsubscribe.js
 
-import { ERRORS } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { AbstractMethod, Payload } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
@@ -1,6 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainUnsubscribeFiatRates.js
 
-import { ERRORS } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -1,8 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/CardanoGetAddress.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../../../constants';
+import { PROTO } from '../../../constants';
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { UI, createUiMessage } from '../../../events';

--- a/packages/connect/src/api/cardano/api/cardanoSignMessage.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignMessage.ts
@@ -1,8 +1,9 @@
 import * as cbor from 'cbor';
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { CARDANO, ERRORS, PROTO } from '../../../constants';
+import { CARDANO, PROTO } from '../../../constants';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import {

--- a/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
@@ -4,9 +4,10 @@
 
 import { trezorUtils } from '@fivebinaries/coin-selection';
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { AssertWeak, Type } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../../../constants';
+import { PROTO } from '../../../constants';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import {

--- a/packages/connect/src/api/cardano/cardanoAddressParameters.ts
+++ b/packages/connect/src/api/cardano/cardanoAddressParameters.ts
@@ -1,8 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/cardanoAddressParameters.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../../constants';
+import { PROTO } from '../../constants';
 import { CardanoAddressParameters } from '../../types/api/cardano';
 import { validatePath } from '../../utils/pathUtils';
 

--- a/packages/connect/src/api/cardano/cardanoAuxiliaryData.ts
+++ b/packages/connect/src/api/cardano/cardanoAuxiliaryData.ts
@@ -1,5 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/cardanoAuxiliaryData.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import {
@@ -7,7 +8,7 @@ import {
     modifyAddressParametersForBackwardsCompatibility,
     validateAddressParameters,
 } from './cardanoAddressParameters';
-import { ERRORS, PROTO } from '../../constants';
+import { PROTO } from '../../constants';
 import {
     CardanoAuxiliaryData,
     CardanoCVoteRegistrationDelegation,

--- a/packages/connect/src/api/cardano/cardanoCertificate.ts
+++ b/packages/connect/src/api/cardano/cardanoCertificate.ts
@@ -1,8 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/cardanoCertificate.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../../constants';
+import { PROTO } from '../../constants';
 import {
     CardanoCertificate,
     CardanoDRep,

--- a/packages/connect/src/api/common/Discovery.ts
+++ b/packages/connect/src/api/common/Discovery.ts
@@ -1,9 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/Discovery.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { TypedEmitter } from '@trezor/utils';
 
 import { Blockchain } from '../../backend/BlockchainLink';
-import { ERRORS } from '../../constants';
 import type { DeviceCommands } from '../../device/DeviceCommands';
 import type { CoinInfo, DiscoveryAccount, DiscoveryAccountType } from '../../types';
 import type { GetAccountInfo } from '../../types/api/getAccountInfo';

--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -1,8 +1,8 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/paramsValidator.js
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { DeviceModelInternal } from '@trezor/device-utils';
 import { typedObjectKeys, versionUtils } from '@trezor/utils';
 
-import { ERRORS } from '../../constants';
 import { config } from '../../data/config';
 import type { CoinInfo, FirmwareRange } from '../../types';
 import { fromHardened } from '../../utils/pathUtils';

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -1,12 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ComposeTransaction.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { promiseAllSequence } from '@trezor/utils/src/promiseAllSequence';
 import { resolveAfter } from '@trezor/utils/src/resolveAfter';
 import type { ComposeOutput, TransactionInputOutputSortingStrategy } from '@trezor/utxo-lib';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import { ERRORS } from '../constants';
 import { DEFAULT_SORTING_STRATEGY } from '../constants/utxo';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI, createUiMessage } from '../events';

--- a/packages/connect/src/api/discoverAccounts.ts
+++ b/packages/connect/src/api/discoverAccounts.ts
@@ -1,9 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetAccountInfo.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { arrayPartition, getSynchronize, versionUtils } from '@trezor/utils';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import { ERRORS } from '../constants';
 import { AbstractMethod, DEFAULT_FIRMWARE_RANGE } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import { UI, createUiMessage } from '../events';

--- a/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTypedData.ts
@@ -1,7 +1,7 @@
+import { TrezorError } from '@trezor/connect-common/src/constants/errors';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { PROTO } from '../../../constants';
-import { TrezorError } from '../../../constants/errors';
 
 export const parseArrayType = [
     {

--- a/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
@@ -1,8 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/EthereumGetAddress.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../../../constants';
+import { PROTO } from '../../../constants';
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
 import { getEthereumNetwork, getUniqueNetworks } from '../../../data/coinInfo';
 import { UI, createUiMessage } from '../../../events';

--- a/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
@@ -1,10 +1,11 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/EthereumSignTypedData.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { MessagesSchema } from '@trezor/protobuf';
 import { Assert, Type } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../../../constants';
+import { PROTO } from '../../../constants';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork } from '../../../data/coinInfo';
 import { EthereumNetworkInfo } from '../../../types';

--- a/packages/connect/src/api/ethereum/ethereumSignTx.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTx.ts
@@ -3,9 +3,10 @@
 import { Common, Hardfork, Mainnet, createCustomCommon } from '@ethereumjs/common';
 import { FeeMarketEIP1559TxData, LegacyTxData, createTx } from '@ethereumjs/tx';
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { MessagesSchema } from '@trezor/protobuf';
 
-import { ERRORS, PROTO } from '../../constants';
+import { PROTO } from '../../constants';
 import type { TypedCall } from '../../device/DeviceCommands';
 import type {
     EthereumAccessList,

--- a/packages/connect/src/api/ethereum/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTypedData.ts
@@ -1,8 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/ethereumSignTypedData.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { ERRORS, PROTO } from '../../constants';
+import { PROTO } from '../../constants';
 import type { EthereumSignTypedDataTypes } from '../../types/api/ethereum';
 import { messageToHex } from '../../utils/formatUtils';
 

--- a/packages/connect/src/api/firmware/getBinary.ts
+++ b/packages/connect/src/api/firmware/getBinary.ts
@@ -1,8 +1,8 @@
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { FirmwareRelease } from '@trezor/device-utils';
 import { removeTrailingSlashes } from '@trezor/utils';
 
 import { parseFirmwareHeaders } from './parseFirmwareHeaders';
-import { ERRORS } from '../../constants';
 import { BinaryInfo } from '../../types';
 import { httpRequest } from '../../utils/assets';
 

--- a/packages/connect/src/api/firmware/uploadFirmware.ts
+++ b/packages/connect/src/api/firmware/uploadFirmware.ts
@@ -1,8 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/uploadFirmware.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { TRANSPORT } from '@trezor/transport';
 
-import { ERRORS, PROTO } from '../../constants';
+import { PROTO } from '../../constants';
 import type { Device } from '../../device/Device';
 import type { TypedCall } from '../../device/DeviceCommands';
 import { CoreEventMessage, DEVICE, UI, createUiMessage } from '../../events';

--- a/packages/connect/src/api/getAccountDescriptor.ts
+++ b/packages/connect/src/api/getAccountDescriptor.ts
@@ -1,6 +1,6 @@
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS } from '../constants';
 import { getFirmwareRange } from './common/paramsValidator';
 import { AbstractMethod, DEFAULT_FIRMWARE_RANGE, MethodReturnType } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -1,9 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetAccountInfo.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { resolveAfter } from '@trezor/utils/src/resolveAfter';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import { ERRORS } from '../constants';
 import { AbstractMethod, DEFAULT_FIRMWARE_RANGE, MethodReturnType } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import { UI, createUiMessage } from '../events';

--- a/packages/connect/src/api/getAddress.ts
+++ b/packages/connect/src/api/getAddress.ts
@@ -1,8 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetAddress.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../constants';
+import { PROTO } from '../constants';
 import { getFirmwareRange, validateCoinPath } from './common/paramsValidator';
 import { AbstractMethod, MethodReturnType } from '../core/AbstractMethod';
 import { fixCoinInfoNetwork, getBitcoinNetwork, getUniqueNetworks } from '../data/coinInfo';

--- a/packages/connect/src/api/getCoinInfo.ts
+++ b/packages/connect/src/api/getCoinInfo.ts
@@ -1,8 +1,8 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetCoinInfo.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS } from '../constants';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import { CoinInfo, CoinObj } from '../types';

--- a/packages/connect/src/api/getDeviceState.ts
+++ b/packages/connect/src/api/getDeviceState.ts
@@ -1,6 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetDeviceState.js
 
-import { ERRORS } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class GetDeviceState extends AbstractMethod<'getDeviceState'> {

--- a/packages/connect/src/api/monero/api/moneroGetAddress.ts
+++ b/packages/connect/src/api/monero/api/moneroGetAddress.ts
@@ -1,6 +1,7 @@
 // Monero GetAddress implementation
+import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import { ERRORS, PROTO } from '../../../constants';
+import { PROTO } from '../../../constants';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { Address } from '../../../types/params';

--- a/packages/connect/src/api/monero/api/moneroGetWatchKey.ts
+++ b/packages/connect/src/api/monero/api/moneroGetWatchKey.ts
@@ -1,6 +1,7 @@
 // Monero GetWatchKey implementation
+import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import { ERRORS, PROTO } from '../../../constants';
+import { PROTO } from '../../../constants';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import type { MoneroWatchKey } from '../../../types/api/monero';

--- a/packages/connect/src/api/monero/api/moneroKeyImageSync.ts
+++ b/packages/connect/src/api/monero/api/moneroKeyImageSync.ts
@@ -1,7 +1,9 @@
 import { keccak_256 } from '@noble/hashes/sha3';
 import { hexToBytes } from '@noble/hashes/utils';
 
-import { ERRORS, PROTO } from '../../../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
+import { PROTO } from '../../../constants';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import type { MoneroExportedKeyImage, MoneroKeyImageSyncResult } from '../../../types/api/monero';

--- a/packages/connect/src/api/monero/api/moneroSignTransaction.ts
+++ b/packages/connect/src/api/monero/api/moneroSignTransaction.ts
@@ -1,4 +1,6 @@
-import { ERRORS, PROTO } from '../../../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
+import { PROTO } from '../../../constants';
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { HD_HARDENED, validatePath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/pushTransaction.ts
+++ b/packages/connect/src/api/pushTransaction.ts
@@ -1,9 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/PushTransaction.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import { ERRORS } from '../constants';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import type { CoinInfo } from '../types';

--- a/packages/connect/src/api/resetDevice.ts
+++ b/packages/connect/src/api/resetDevice.ts
@@ -1,10 +1,11 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ResetDevice.js
+import { ERRORS } from '@trezor/connect-common/src/constants';
+import { TransportError } from '@trezor/connect-common/src/constants/errors';
 import { Assert } from '@trezor/schema-utils';
 import { getRandomInt } from '@trezor/utils';
 
 import { generateEntropy, verifyEntropy } from '../api/firmware/verifyEntropy';
-import { ERRORS, PROTO } from '../constants';
-import { TransportError } from '../constants/errors';
+import { PROTO } from '../constants';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';

--- a/packages/connect/src/api/ripple/api/rippleGetAddress.ts
+++ b/packages/connect/src/api/ripple/api/rippleGetAddress.ts
@@ -1,8 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/RippleGetAddress.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../../../constants';
+import { PROTO } from '../../../constants';
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { UI, createUiMessage } from '../../../events';

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -1,9 +1,10 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/SignTransaction.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { promiseAllSequence } from '@trezor/utils/src/promiseAllSequence';
 
-import { ERRORS, PROTO } from '../constants';
+import { PROTO } from '../constants';
 import {
     createPendingTransaction,
     deriveOutputScript,

--- a/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
@@ -1,8 +1,8 @@
 import { SYSTEM_PROGRAM_PUBLIC_KEY } from '@trezor/blockchain-link-utils/src/solana';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { initBlockchain, isBackendSupported } from '../../../backend/BlockchainLink';
-import { ERRORS } from '../../../constants';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getCoinInfo } from '../../../data/coinInfo';
 import { CoinInfo } from '../../../types';

--- a/packages/connect/src/api/solana/api/solanaGetAddress.ts
+++ b/packages/connect/src/api/solana/api/solanaGetAddress.ts
@@ -1,6 +1,7 @@
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../../../constants';
+import { PROTO } from '../../../constants';
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { UI, createUiMessage } from '../../../events';

--- a/packages/connect/src/api/solana/api/solanaSignTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaSignTransaction.ts
@@ -27,10 +27,11 @@ import {
 } from '@solana-program/token';
 
 import { TokenInfo } from '@trezor/blockchain-link-types';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { AssertWeak } from '@trezor/schema-utils';
 import { BigNumber } from '@trezor/utils';
 
-import { ERRORS, PROTO } from '../../../constants';
+import { PROTO } from '../../../constants';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { SolanaSignTransaction as SolanaSignTransactionSchema } from '../../../types/api/solana';

--- a/packages/connect/src/api/stellar/api/stellarGetAddress.ts
+++ b/packages/connect/src/api/stellar/api/stellarGetAddress.ts
@@ -1,8 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/StellarGetAddress.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../../../constants';
+import { PROTO } from '../../../constants';
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { UI, createUiMessage } from '../../../events';

--- a/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
+++ b/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
@@ -1,8 +1,8 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/StellarSignTransaction.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { AssertWeak } from '@trezor/schema-utils';
 
-import { ERRORS } from '../../../constants';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import {

--- a/packages/connect/src/api/stellar/stellarSignTx.ts
+++ b/packages/connect/src/api/stellar/stellarSignTx.ts
@@ -1,8 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/stellarSignTx.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../../constants';
+import { PROTO } from '../../constants';
 import type { TypedCall } from '../../device/DeviceCommands';
 import {
     StellarOperation,

--- a/packages/connect/src/api/tezos/api/tezosGetAddress.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetAddress.ts
@@ -1,8 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/TezosGetAddress.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../../../constants';
+import { PROTO } from '../../../constants';
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { UI, createUiMessage } from '../../../events';

--- a/packages/connect/src/api/tezos/tezosSignTx.ts
+++ b/packages/connect/src/api/tezos/tezosSignTx.ts
@@ -1,8 +1,9 @@
 import bs58check from 'bs58check';
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../../constants';
+import { PROTO } from '../../constants';
 import { TezosOperation } from '../../types/api/tezos';
 
 const PREFIX = {

--- a/packages/connect/src/api/thpGetCredentials.ts
+++ b/packages/connect/src/api/thpGetCredentials.ts
@@ -1,5 +1,5 @@
-// import { Assert } from '@trezor/schema-utils';
-import { ERRORS } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { AbstractMethod } from '../core/AbstractMethod';
 import { DataManager } from '../data/DataManager';
 import { getThpCredentials } from '../device/thp';

--- a/packages/connect/src/api/thpRemoveCredentials.ts
+++ b/packages/connect/src/api/thpRemoveCredentials.ts
@@ -1,4 +1,5 @@
-import { ERRORS } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { AbstractMethod } from '../core/AbstractMethod';
 import { DataManager } from '../data/DataManager';
 import { UI } from '../events';

--- a/packages/connect/src/api/tron/api/tronGetAddress.ts
+++ b/packages/connect/src/api/tron/api/tronGetAddress.ts
@@ -1,6 +1,7 @@
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../../../constants';
+import { PROTO } from '../../../constants';
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
 import { UI, createUiMessage } from '../../../events';
 import { Bundle } from '../../../types';

--- a/packages/connect/src/api/verifyMessage.ts
+++ b/packages/connect/src/api/verifyMessage.ts
@@ -1,8 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/VerifyMessage.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { ERRORS, PROTO } from '../constants';
+import { PROTO } from '../constants';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getFirmwareRange } from './common/paramsValidator';
 import { getBitcoinNetwork } from '../data/coinInfo';

--- a/packages/connect/src/backend/BackendManager.ts
+++ b/packages/connect/src/backend/BackendManager.ts
@@ -1,6 +1,6 @@
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { TimerId } from '@trezor/type-utils';
 
-import { ERRORS } from '../constants';
 import { Blockchain, BlockchainOptions } from './Blockchain';
 import { DataManager } from '../data/DataManager';
 import { BLOCKCHAIN, createBlockchainMessage } from '../events';

--- a/packages/connect/src/backend/Blockchain.ts
+++ b/packages/connect/src/backend/Blockchain.ts
@@ -3,8 +3,8 @@ import BlockchainLink, {
     ServerInfo,
     SubscriptionAccountInfo,
 } from '@trezor/blockchain-link';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import { ERRORS } from '../constants';
 import { BLOCKCHAIN, CoreEventMessage, createBlockchainMessage } from '../events';
 import type { CoinInfo, Proxy } from '../types';
 import { PushTransaction } from '../types/api/pushTransaction';

--- a/packages/connect/src/constants/index.ts
+++ b/packages/connect/src/constants/index.ts
@@ -1,4 +1,3 @@
-export * as ERRORS from './errors';
 export * as NETWORK from './network';
 export * as CARDANO from './cardano';
 export * as FIRMWARE from './firmware';

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -1,7 +1,8 @@
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Capability } from '@trezor/protobuf/src/messages';
 import { typedObjectKeys, versionUtils } from '@trezor/utils';
 
-import { ERRORS, NETWORK } from '../constants';
+import { NETWORK } from '../constants';
 import type { Device } from '../device/Device';
 import {
     CallMethodPayload,

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import EventEmitter from 'events';
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { TRANSPORT, TRANSPORT_ERROR } from '@trezor/transport';
 import { createDeferred, createLazy, getSynchronize, throwError } from '@trezor/utils';
 
-import { ERRORS } from '../constants';
 import { AbstractMethod } from './AbstractMethod';
 import { getMethod } from './method';
 import { onCallFirmwareUpdate } from './onCallFirmwareUpdate';

--- a/packages/connect/src/core/method.native.ts
+++ b/packages/connect/src/core/method.native.ts
@@ -1,5 +1,6 @@
+import { TypedError } from '@trezor/connect-common/src/constants/errors';
+
 import * as Methods from '../api';
-import { TypedError } from '../constants/errors';
 import { MODULES, ModuleName } from '../constants/network';
 import type { IFrameCallMessage } from '../events';
 

--- a/packages/connect/src/core/method.ts
+++ b/packages/connect/src/core/method.ts
@@ -1,5 +1,6 @@
+import { TypedError } from '@trezor/connect-common/src/constants/errors';
+
 import * as Methods from '../api';
-import { TypedError } from '../constants/errors';
 import { MODULES } from '../constants/network';
 import type { IFrameCallMessage } from '../events';
 import type { AbstractMethod } from './AbstractMethod';

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -1,3 +1,4 @@
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { getFirmwareOrBootloaderVersionArray } from '@trezor/device-utils';
 import { resolveAfter } from '@trezor/utils';
 import { isEqual, isNewer } from '@trezor/utils/src/versionUtils';
@@ -9,7 +10,7 @@ import {
     stripFwHeaders,
     uploadFirmware,
 } from '../api/firmware';
-import { ERRORS, PROTO } from '../constants';
+import { PROTO } from '../constants';
 import { getFirmwareLocation, getReleaseByVersion } from '../data/firmwareInfo';
 import type { Device } from '../device/Device';
 import { DeviceList } from '../device/DeviceList';

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -1,4 +1,5 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/Device.js
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import {
     DeviceModelInternal,
     FirmwareRelease,
@@ -19,7 +20,7 @@ import { TransportDeviceEvent } from '@trezor/transport/src/transports/abstract'
 import { Deferred, TypedEmitter, createDeferred, isArrayMember, versionUtils } from '@trezor/utils';
 
 import { DeviceCommands } from './DeviceCommands';
-import { ERRORS, FIRMWARE, PROTO } from '../constants';
+import { FIRMWARE, PROTO } from '../constants';
 import { DeviceCurrentSession, TypedCallProvider } from './DeviceCurrentSession';
 import { checkFirmwareRevision } from './checkFirmwareRevision';
 import { abortThpWorkflow, getThpChannel } from './thp';

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -1,8 +1,9 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/DeviceCommands.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { MessagesSchema as Messages } from '@trezor/protobuf';
 
-import { ERRORS, PROTO } from '../constants';
+import { PROTO } from '../constants';
 import { getBech32Network, getSegwitNetwork } from '../data/coinInfo';
 import type { TypedCallProvider } from '../device/DeviceCurrentSession';
 import { resolveDescriptorForTaproot } from '../device/resolveDescriptorForTaproot';

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -1,12 +1,12 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/DeviceCommands.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { MessagesSchema as Messages } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 import { MessageResponse, Session, TRANSPORT, Transport } from '@trezor/transport';
 import { isErrorWithoutDeviceInteraction } from '@trezor/transport/src/errors-groups';
 import { scheduleAction } from '@trezor/utils';
 
-import { ERRORS } from '../constants';
 import { Device } from './Device';
 import { DEVICE } from '../events';
 import { initLog } from '../utils/debug';

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -1,5 +1,6 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/DeviceList.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { TRANSPORT, Transport } from '@trezor/transport';
 import type { ApiType as TransportApiType } from '@trezor/transport/src/types';
 import { Descriptor } from '@trezor/transport/src/types';
@@ -13,7 +14,6 @@ import {
     typedObjectKeys,
 } from '@trezor/utils';
 
-import { ERRORS } from '../constants';
 import { DEVICE, DecodedTrezorPushNotification, TransportError, TransportInfo } from '../events';
 import { Device } from './Device';
 import { ConnectSettings, DeviceUniquePath, StaticSessionId, asDeviceUniquePath } from '../types';

--- a/packages/connect/src/device/TransportList.ts
+++ b/packages/connect/src/device/TransportList.ts
@@ -1,3 +1,4 @@
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import {
     BridgeTransport,
     NodeUsbTransport,
@@ -8,7 +9,6 @@ import {
 } from '@trezor/transport';
 import type { AbstractTransportParams } from '@trezor/transport/src/transports/abstract';
 
-import { ERRORS } from '../constants';
 import { ConnectSettingsTransport } from '../types';
 
 type Params = AbstractTransportParams & { sessionsBackgroundUrl?: string | null };

--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -1,10 +1,10 @@
 import { randomBytes } from 'crypto';
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { encodeMessage } from '@trezor/protobuf';
 import { ThpPairingMethod, thp as protocolThp } from '@trezor/protocol';
 
 import { thpCall } from './thpCall';
-import { ERRORS } from '../../constants';
 import { DataManager } from '../../data/DataManager';
 import type { Device } from '../Device';
 

--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -1,9 +1,9 @@
 import { createHash, randomBytes } from 'crypto';
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { ThpPairingMethod, thp as protocolThp } from '@trezor/protocol';
 import { createDeferred } from '@trezor/utils';
 
-import { ERRORS } from '../../constants';
 import { DataManager } from '../../data/DataManager';
 import { DEVICE, UiResponseThpPairingTag } from '../../events';
 import type { Device } from '../Device';

--- a/packages/connect/src/device/thp/thpCall.ts
+++ b/packages/connect/src/device/thp/thpCall.ts
@@ -1,6 +1,6 @@
+import { TypedError } from '@trezor/connect-common/src/constants/errors';
 import { thp as protocolThp } from '@trezor/protocol';
 
-import { TypedError } from '../../constants/errors';
 import { DEVICE } from '../../events';
 import type { Device } from '../Device';
 

--- a/packages/connect/src/device/validateMessageSize.ts
+++ b/packages/connect/src/device/validateMessageSize.ts
@@ -1,5 +1,6 @@
+import { TypedError } from '@trezor/connect-common/src/constants/errors';
+
 import { Device } from './Device';
-import { TypedError } from '../constants/errors';
 
 /**
  * for T1B1 maximum message size is 1024 bytes

--- a/packages/connect/src/device/workflow/handshake.ts
+++ b/packages/connect/src/device/workflow/handshake.ts
@@ -1,8 +1,8 @@
+import { TypedError } from '@trezor/connect-common/src/constants/errors';
 import { PROTOCOL_MALFORMED } from '@trezor/protocol/src/errors';
 import { TRANSPORT_ERROR } from '@trezor/transport';
 import { resolveAfter, versionUtils } from '@trezor/utils';
 
-import { TypedError } from '../../constants/errors';
 import { WorkflowContext } from '../../types/workflow';
 import { Log } from '../../utils/debug';
 

--- a/packages/connect/src/device/workflow/validateState.ts
+++ b/packages/connect/src/device/workflow/validateState.ts
@@ -1,4 +1,5 @@
-import { ERRORS } from '../../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { DEVICE, UI, createDeviceMessage, createUiMessage } from '../../events';
 import { StaticSessionId } from '../../types';
 import { WorkflowContext } from '../../types/workflow';

--- a/packages/connect/src/events/call.ts
+++ b/packages/connect/src/events/call.ts
@@ -1,5 +1,6 @@
+import { serializeError } from '@trezor/connect-common/src/constants/errors';
+
 import type { IFRAME } from './iframe';
-import { serializeError } from '../constants/errors';
 import type { Device } from '../device/Device';
 import type { TrezorConnect } from '../types/api';
 import type { CommonParams, DeviceIdentity } from '../types/params';

--- a/packages/connect/src/events/core.ts
+++ b/packages/connect/src/events/core.ts
@@ -1,3 +1,5 @@
+import { ErrorCode, TrezorError } from '@trezor/connect-common/src/constants/errors';
+
 import type { BlockchainEventMessage } from './blockchain';
 import type { IFrameCallMessage, MethodResponseMessage } from './call';
 import type { DeviceEventMessage } from './device';
@@ -11,7 +13,6 @@ import type {
 } from './transport';
 import type { UiEventMessage } from './ui-request';
 import type { UiResponseEvent } from './ui-response';
-import { ErrorCode, TrezorError } from '../constants/errors';
 import type { Unsuccessful } from '../types/params';
 
 export const CORE_EVENT = 'CORE_EVENT';

--- a/packages/connect/src/events/transport.ts
+++ b/packages/connect/src/events/transport.ts
@@ -1,7 +1,7 @@
+import { serializeError } from '@trezor/connect-common/src/constants/errors';
 import type { Transport } from '@trezor/transport';
 import { TRANSPORT } from '@trezor/transport/src/constants';
 
-import { serializeError } from '../constants/errors';
 import { ConnectSettings } from '../types/settings';
 import type { MessageFactoryFn } from '../types/utils';
 

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -1,8 +1,8 @@
 import EventEmitter from 'events';
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { DeferredManager, cloneObject, createDeferredManager } from '@trezor/utils';
 
-import * as ERRORS from '../constants/errors';
 import { parseConnectSettings } from '../data/connectSettings';
 import {
     BLOCKCHAIN_EVENT,

--- a/packages/connect/src/impl/dynamic.ts
+++ b/packages/connect/src/impl/dynamic.ts
@@ -1,8 +1,8 @@
 import EventEmitter from 'events';
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { getSynchronize } from '@trezor/utils';
 
-import { ERRORS } from '../constants';
 import { CallMethodPayload, createErrorMessage } from '../events';
 import { ConnectFactoryDependencies } from '../factory';
 import { InitFullSettings } from '../types/api/init';

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,8 +1,8 @@
 import EventEmitter from 'events';
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { createDeferredManager } from '@trezor/utils';
 
-import { ERRORS } from './constants';
 import { initCoreState } from './core';
 import { parseConnectSettings } from './data/connectSettings';
 import {

--- a/packages/connect/src/types/params.ts
+++ b/packages/connect/src/types/params.ts
@@ -1,9 +1,9 @@
 // API params
 
+import { ErrorCode } from '@trezor/connect-common/src/constants/errors';
 import { Static, TSchema, Type } from '@trezor/schema-utils';
 
 import { DeviceState, DeviceUniquePath } from './device';
-import { ErrorCode } from '../constants/errors';
 
 export interface DeviceIdentity {
     path?: DeviceUniquePath;

--- a/packages/connect/src/utils/accountUtils.ts
+++ b/packages/connect/src/utils/accountUtils.ts
@@ -1,7 +1,8 @@
 //  origin: https://github.com/trezor/connect/blob/develop/src/js/utils/accountUtils.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { fromHardened, toHardened } from './pathUtils';
-import { ERRORS } from '../constants';
 import { getCoinName } from '../data/coinInfo';
 import type { BitcoinNetworkInfo, CoinInfo } from '../types';
 

--- a/packages/connect/src/utils/hdnodeUtils.ts
+++ b/packages/connect/src/utils/hdnodeUtils.ts
@@ -1,9 +1,10 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/utils/hdnodeUtils.js
 
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { bip32 } from '@trezor/utxo-lib';
 import type { BIP32Interface, Network } from '@trezor/utxo-lib';
 
-import { ERRORS, PROTO } from '../constants';
+import { PROTO } from '../constants';
 
 const pubNode2bjsNode = (node: PROTO.HDNodeType, network?: Network) => {
     const chainCode = Buffer.from(node.chain_code, 'hex');

--- a/packages/connect/src/utils/pathUtils.ts
+++ b/packages/connect/src/utils/pathUtils.ts
@@ -1,6 +1,8 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/utils/pathUtils.js
 // TODO: There might be other issues with side-effects https://github.com/trezor/trezor-suite/issues/15559
-import { ERRORS, PROTO } from '../constants';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
+import { PROTO } from '../constants';
 import type { CoinInfo } from '../types/coinInfo';
 import type { DerivationPath, ProtoWithAddressN, ProtoWithDerivationPath } from '../types/params';
 

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -87,6 +87,7 @@
         "@trezor/coinjoin": "workspace:*",
         "@trezor/components": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-common": "workspace:^",
         "@trezor/connect-web": "workspace:*",
         "@trezor/crypto-utils": "workspace:*",
         "@trezor/device-utils": "workspace:*",

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -7,7 +7,8 @@ import {
     selectSelectedDevice,
     selectSimulatedEntropyCheckFail,
 } from '@suite-common/wallet-core';
-import TrezorConnect, { ERRORS } from '@trezor/connect';
+import TrezorConnect from '@trezor/connect';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import * as modalActions from 'src/actions/suite/modalActions';
 import {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
@@ -9,7 +9,7 @@ import {
 } from '@suite-common/connect-popup';
 import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 import { Badge, Button, Card, Column, H3, Icon, Modal, Paragraph, Row } from '@trezor/components';
-import { TypedError } from '@trezor/connect/src/constants/errors';
+import { TypedError } from '@trezor/connect-common/src/constants/errors';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { ConfirmOnDevicePill, mapTrezorModelToIcon } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
@@ -5,7 +5,7 @@ import { EventType } from '@suite-common/analytics-types';
 import { connectPopupActions, selectConnectPopupCall } from '@suite-common/connect-popup';
 import { CALL_SOURCE_WALLETCONNECT } from '@suite-common/connect-popup/src/connectPopupTypes';
 import { Card, Checkbox, Column, Icon, List, Modal, Row, Text } from '@trezor/components';
-import { ERRORS } from '@trezor/connect';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { spacings } from '@trezor/theme';
 
 import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal/hooks/useTxSimulationActions.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal/hooks/useTxSimulationActions.ts
@@ -4,7 +4,7 @@ import { numberToHex, toWei } from 'web3-utils';
 
 import { connectPopupActions } from '@suite-common/connect-popup';
 import { FeeInfo } from '@suite-common/wallet-types';
-import { ERRORS } from '@trezor/connect';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import { useDispatch } from 'src/hooks/suite';
 import { FeesFormValues } from 'src/hooks/wallet/form/useFees';

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -149,6 +149,7 @@
         { "path": "../coinjoin" },
         { "path": "../components" },
         { "path": "../connect" },
+        { "path": "../connect-common" },
         { "path": "../connect-web" },
         { "path": "../crypto-utils" },
         { "path": "../device-utils" },

--- a/suite-common/connect-popup/package.json
+++ b/suite-common/connect-popup/package.json
@@ -18,6 +18,7 @@
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-common": "workspace:^",
         "@trezor/utils": "workspace:*"
     },
     "peerDependencies": {

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -10,10 +10,10 @@ import TrezorConnect, {
     CallMethodParams,
     CallMethodPayload,
 } from '@trezor/connect';
-import { TypedError, serializeError } from '@trezor/connect/src/constants/errors';
 import { MethodInfo, MethodPermission } from '@trezor/connect/src/core/AbstractMethod';
 import { DEEPLINK_VERSION } from '@trezor/connect/src/data/version';
 import { connectCallableMethods } from '@trezor/connect/src/factory';
+import { TypedError, serializeError } from '@trezor/connect-common/src/constants/errors';
 import { resolveAfter } from '@trezor/utils';
 
 import { connectPopupActions } from './connectPopupActions';

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -1,6 +1,6 @@
 import { CallMethodKeys } from '@trezor/connect';
-import { ErrorCode } from '@trezor/connect/src/constants/errors';
 import { MethodPermission } from '@trezor/connect/src/core/AbstractMethod';
+import { ErrorCode } from '@trezor/connect-common/src/constants/errors';
 
 export type ManifestPartial = {
     appName: string;

--- a/suite-common/connect-popup/tsconfig.json
+++ b/suite-common/connect-popup/tsconfig.json
@@ -9,6 +9,9 @@
         { "path": "../wallet-core" },
         { "path": "../wallet-types" },
         { "path": "../../packages/connect" },
+        {
+            "path": "../../packages/connect-common"
+        },
         { "path": "../../packages/utils" }
     ]
 }

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -31,6 +31,7 @@
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/blockchain-link-utils": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-common": "workspace:^",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/protobuf": "workspace:*",

--- a/suite-common/wallet-core/src/send/sendFormTypes.ts
+++ b/suite-common/wallet-core/src/send/sendFormTypes.ts
@@ -8,7 +8,8 @@ import {
     PrecomposedTransactionFinal,
     WalletAccountTransaction,
 } from '@suite-common/wallet-types';
-import { ERRORS as CONNECT_ERRORS, PROTO, TokenInfo, Unsuccessful } from '@trezor/connect';
+import { PROTO, TokenInfo, Unsuccessful } from '@trezor/connect';
+import { ERRORS as CONNECT_ERRORS } from '@trezor/connect-common/src/constants';
 
 export type SerializedTx = { tx: string; symbol: NetworkSymbol };
 

--- a/suite-common/wallet-core/tsconfig.json
+++ b/suite-common/wallet-core/tsconfig.json
@@ -24,6 +24,9 @@
             "path": "../../packages/blockchain-link-utils"
         },
         { "path": "../../packages/connect" },
+        {
+            "path": "../../packages/connect-common"
+        },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },
         { "path": "../../packages/protobuf" },

--- a/suite-native/module-check-backup/package.json
+++ b/suite-native/module-check-backup/package.json
@@ -28,6 +28,7 @@
         "@suite-native/services": "workspace:*",
         "@suite-native/swipeable-walkthrough": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-common": "workspace:^",
         "@trezor/device-utils": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/urls": "workspace:*",

--- a/suite-native/module-check-backup/src/hooks/useCheckBackupOnMount.tsx
+++ b/suite-native/module-check-backup/src/hooks/useCheckBackupOnMount.tsx
@@ -10,7 +10,7 @@ import {
     StackNavigationProps,
 } from '@suite-native/navigation';
 import { useLegacyAnalytics } from '@suite-native/services';
-import { ERRORS } from '@trezor/connect';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import { checkBackupThunk } from '../checkBackupThunks';
 

--- a/suite-native/module-check-backup/tsconfig.json
+++ b/suite-native/module-check-backup/tsconfig.json
@@ -20,6 +20,9 @@
         { "path": "../services" },
         { "path": "../swipeable-walkthrough" },
         { "path": "../../packages/connect" },
+        {
+            "path": "../../packages/connect-common"
+        },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/styles" },
         { "path": "../../packages/urls" }

--- a/suite-native/module-connect-popup/package.json
+++ b/suite-native/module-connect-popup/package.json
@@ -33,6 +33,7 @@
         "@suite-native/qr-code": "workspace:^",
         "@suite-native/toasts": "workspace:^",
         "@trezor/connect": "workspace:^",
+        "@trezor/connect-common": "workspace:^",
         "@trezor/connect-mobile": "workspace:*",
         "@trezor/styles": "workspace:^",
         "@trezor/urls": "workspace:*",

--- a/suite-native/module-connect-popup/src/components/TxSimulation.tsx
+++ b/suite-native/module-connect-popup/src/components/TxSimulation.tsx
@@ -20,7 +20,7 @@ import {
 } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { ERRORS } from '@trezor/connect';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import { ConnectAppIcon } from './ConnectAppIcon';
 import { ContractInfoBottomSheet } from './TxSimulation/ContractInfoBottomSheet';

--- a/suite-native/module-connect-popup/tsconfig.json
+++ b/suite-native/module-connect-popup/tsconfig.json
@@ -42,6 +42,9 @@
         { "path": "../toasts" },
         { "path": "../../packages/connect" },
         {
+            "path": "../../packages/connect-common"
+        },
+        {
             "path": "../../packages/connect-mobile"
         },
         { "path": "../../packages/styles" },

--- a/suite-native/module-device-onboarding/package.json
+++ b/suite-native/module-device-onboarding/package.json
@@ -43,6 +43,7 @@
         "@suite-native/toasts": "workspace:*",
         "@trezor/analytics": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-common": "workspace:^",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/styles": "workspace:*",

--- a/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
@@ -19,7 +19,7 @@ import {
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 import { useToast } from '@suite-native/toasts';
-import { ERRORS } from '@trezor/connect';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
 

--- a/suite-native/module-device-onboarding/tsconfig.json
+++ b/suite-native/module-device-onboarding/tsconfig.json
@@ -36,6 +36,9 @@
         { "path": "../toasts" },
         { "path": "../../packages/analytics" },
         { "path": "../../packages/connect" },
+        {
+            "path": "../../packages/connect-common"
+        },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },
         { "path": "../../packages/styles" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10638,6 +10638,7 @@ __metadata:
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-common": "workspace:^"
     "@trezor/utils": "workspace:*"
   peerDependencies:
     "@trezor/suite-desktop-api": "workspace:*"
@@ -11303,6 +11304,7 @@ __metadata:
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/blockchain-link-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-common": "workspace:^"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/protobuf": "workspace:*"
@@ -12561,6 +12563,7 @@ __metadata:
     "@suite-native/services": "workspace:*"
     "@suite-native/swipeable-walkthrough": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-common": "workspace:^"
     "@trezor/device-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/urls": "workspace:*"
@@ -12597,6 +12600,7 @@ __metadata:
     "@suite-native/qr-code": "workspace:^"
     "@suite-native/toasts": "workspace:^"
     "@trezor/connect": "workspace:^"
+    "@trezor/connect-common": "workspace:^"
     "@trezor/connect-mobile": "workspace:*"
     "@trezor/styles": "workspace:^"
     "@trezor/urls": "workspace:*"
@@ -12712,6 +12716,7 @@ __metadata:
     "@suite-native/toasts": "workspace:*"
     "@trezor/analytics": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-common": "workspace:^"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
@@ -14334,11 +14339,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect-common@workspace:*, @trezor/connect-common@workspace:packages/connect-common":
+"@trezor/connect-common@workspace:*, @trezor/connect-common@workspace:^, @trezor/connect-common@workspace:packages/connect-common":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-common@workspace:packages/connect-common"
   dependencies:
     "@trezor/env-utils": "workspace:*"
+    "@trezor/protobuf": "workspace:^"
+    "@trezor/protocol": "workspace:^"
     "@trezor/utils": "workspace:*"
     "@types/chrome": "npm:^0.0.299"
     "@types/jest": "npm:29.5.12"
@@ -14461,6 +14468,7 @@ __metadata:
   resolution: "@trezor/connect-mobile@workspace:packages/connect-mobile"
   dependencies:
     "@trezor/connect": "workspace:^"
+    "@trezor/connect-common": "workspace:^"
     "@trezor/utils": "workspace:^"
     tsx: "npm:^4.20.3"
   peerDependencies:
@@ -14786,7 +14794,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/protocol@workspace:*, @trezor/protocol@workspace:packages/protocol":
+"@trezor/protocol@workspace:*, @trezor/protocol@workspace:^, @trezor/protocol@workspace:packages/protocol":
   version: 0.0.0-use.local
   resolution: "@trezor/protocol@workspace:packages/protocol"
   dependencies:
@@ -15216,6 +15224,7 @@ __metadata:
     "@trezor/coinjoin": "workspace:*"
     "@trezor/components": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-common": "workspace:^"
     "@trezor/connect-web": "workspace:*"
     "@trezor/crypto-utils": "workspace:*"
     "@trezor/device-utils": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Moving connect ERRORS from `connect` to `connect-common`.

## Notes for QA

Nothing to test

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/23784

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/move-errors-to-connec-common&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/move-errors-to-connec-common&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/move-errors-to-connec-common&lookback=7)