### PR TITLE
refactor(suite): Rename dashboardPromoBannerEvent to promoDashboardPromoBannerEvent

### DIFF
--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
@@ -48,7 +48,7 @@ export const DashboardPromoBanner = () => {
 
     const onCloseBanner = (currentBanner: DashboardBannerTypeWithNull) => {
         analytics.report({
-            type: EventType.DashboardBanner,
+            type: EventType.PromoDashboardBanner,
             payload: {
                 action: 'close',
                 bannerType: currentBanner,
@@ -60,7 +60,7 @@ export const DashboardPromoBanner = () => {
 
     const onCTAClick = (currentBanner: DashboardBannerTypeWithNull) => {
         analytics.report({
-            type: EventType.DashboardBanner,
+            type: EventType.PromoDashboardBanner,
             payload: {
                 action: 'cta',
                 bannerType: currentBanner,

--- a/suite-common/analytics-types/README.md
+++ b/suite-common/analytics-types/README.md
@@ -51,8 +51,8 @@ type Attributes = {
     bannerType?: AttributeDef<string | null>;
 };
 
-export const dashboardBannerEvent: EventDef<Attributes, EventType.DashboardBanner> = {
-    name: EventType.DashboardBanner,
+export const promoDashboardBannerEvent: EventDef<Attributes, EventType.PromoDashboardBanner> = {
+    name: EventType.PromoDashboardBanner,
     descriptionTrigger: 'A user clicks the dashboard promo banner',
     changelog: [{ version: '25.8.0', notes: 'added' }],
 

--- a/suite/analytics/src/constants.ts
+++ b/suite/analytics/src/constants.ts
@@ -135,7 +135,7 @@ export enum EventType {
     GetMobileApp = 'promo/mobile',
 
     ReferralButton = 'promo/referral-button',
-    DashboardBanner = 'promo/dashboard-banner',
+    PromoDashboardBanner = 'promo/dashboard-banner',
 
     AutostartModal = 'autostart-modal',
 }

--- a/suite/analytics/src/events/index.ts
+++ b/suite/analytics/src/events/index.ts
@@ -1,6 +1,6 @@
 export { appUriHandlerEvent } from './appUriHandlerEvent';
 export { stakingNavigateEvent } from './stakingNavigateEvent';
-export { dashboardBannerEvent } from './dashboardBannerEvent';
+export { promoDashboardBannerEvent } from './promoDashboardBannerEvent';
 export { routerLocationChangeEvent } from './routerLocationChangeEvent';
 export { sendQrScanEvent } from './sendQrScanEvent';
 export { stakingUpdateProviderEvent } from './stakingUpdateProviderEvent';

--- a/suite/analytics/src/events/promoDashboardBannerEvent.ts
+++ b/suite/analytics/src/events/promoDashboardBannerEvent.ts
@@ -7,8 +7,8 @@ type Attributes = {
     bannerType?: AttributeDef<string | null>;
 };
 
-export const dashboardBannerEvent: EventDef<Attributes, EventType.DashboardBanner> = {
-    name: EventType.DashboardBanner,
+export const promoDashboardBannerEvent: EventDef<Attributes, EventType.PromoDashboardBanner> = {
+    name: EventType.PromoDashboardBanner,
     descriptionTrigger: 'A user clicks the dashboard promo banner',
     changelog: [{ version: '25.8.0', notes: 'added' }],
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We need to have strictly consiste file naming according to the event name because we need to be able create links from analytics docs.

## Notes for QA

promo banner events should still work the same

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=rename-dashboard-banner-event&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=rename-dashboard-banner-event&lookback=7)