### PR TITLE
delete no longer used labeling messages

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3066,20 +3066,4 @@ export const messages = {
     moduleClipboard: {
         copiedToClipboard: 'Copied to clipboard',
     },
-    labeling: {
-        label: 'Label',
-        addLabel: 'Add label',
-        disableAlert: {
-            title: 'Are you sure you want to turn off Suite Sync?',
-            description:
-                'Turning off Suite Sync disables labeling. Your labels will stay safely encrypted, but they won’t be visible until you turn Suite Sync back on.',
-            cta: 'Turn off',
-        },
-        enableAlert: {
-            title: 'Turn on Suite Sync to use labels',
-            description:
-                'Suite Sync keeps your data up to date on all your devices. Your data stays local and syncs only with devices you approve.',
-            cta: 'Turn on',
-        },
-    },
 };


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- The key has been renamed to suiteSync, but old messages remained there. Let's clean them.

## Notes for QA

No need to test, it was dead code.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/delete-unused-labeling-messages&lookback=7)