### PR TITLE
ci: build suite-web for connect changes

### DIFF
--- a/.github/workflows/test-suite-web-e2e-pr.yml
+++ b/.github/workflows/test-suite-web-e2e-pr.yml
@@ -15,7 +15,6 @@ on:
       - develop
     paths-ignore:
       - "suite-native/**"
-      - "packages/connect*/**"
       # - "packages/suite-desktop*/**"
       - "packages/react-native-usb/**"
       # ignore unrelated github workflows config files


### PR DESCRIPTION
## Description

Due to new Connect architecture with popup in Suite, we should build&test Suite even with changes only in Connect package. 
This removes `packages/connect/` from ignored paths for the PR workflow

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/connect-build-suite-web&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/connect-build-suite-web&lookback=7)