### PR TITLE
chore(connect-common): config to connect-common

### DIFF
--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -52,6 +52,7 @@
         "tslib": "^2.6.2"
     },
     "devDependencies": {
+        "@trezor/device-utils": "workspace:^",
         "@trezor/protobuf": "workspace:^",
         "@trezor/protocol": "workspace:^",
         "@types/chrome": "^0.0.299",

--- a/packages/connect-common/src/constants/index.ts
+++ b/packages/connect-common/src/constants/index.ts
@@ -1,2 +1,3 @@
 export * as ERRORS from './errors';
 export * from './webextension';
+export * from './transport';

--- a/packages/connect-common/src/constants/transport.ts
+++ b/packages/connect-common/src/constants/transport.ts
@@ -1,0 +1,13 @@
+export const T1_HID_PRODUCT = 0x0001;
+const WEBUSB_FIRMWARE_PRODUCT = 0x53c1;
+export const WEBUSB_BOOTLOADER_PRODUCT = 0x53c0;
+
+export const TREZOR_USB_DESCRIPTORS = [
+    // TREZOR v1
+    // won't get opened, but we can show error at least
+    { vendorId: 0x534c, productId: T1_HID_PRODUCT },
+    // TREZOR webusb Bootloader
+    { vendorId: 0x1209, productId: WEBUSB_BOOTLOADER_PRODUCT },
+    // TREZOR webusb Firmware
+    { vendorId: 0x1209, productId: WEBUSB_FIRMWARE_PRODUCT },
+];

--- a/packages/connect-common/src/data/config.ts
+++ b/packages/connect-common/src/data/config.ts
@@ -1,31 +1,5 @@
-// origin: https://github.com/trezor/connect/blob/develop/src/data/config.json
-
-import { DeviceModelInternal } from '@trezor/device-utils';
-import { TREZOR_USB_DESCRIPTORS } from '@trezor/transport/src/constants';
-
-type Config = {
-    webusb: typeof TREZOR_USB_DESCRIPTORS;
-    whitelist: Array<{ origin: string; priority: number }>;
-    management: Array<{ origin: string }>;
-    knownHosts: Array<{ origin: string; label: string }>;
-    onionDomains: Record<string, string>;
-    supportedBrowsers: Record<
-        string,
-        {
-            version: number;
-            download: string;
-            update: string;
-        }
-    >;
-    supportedFirmware: Array<{
-        coin?: string[]; // Todo: better type?
-        capabilities?: string[]; // Todo: better type?
-        methods?: string[]; // Todo: better type?
-        min: Partial<Record<DeviceModelInternal, string>>;
-        max?: undefined; // NOTE: max field is not used anywhere at the moment, it is here for type compatibility
-        comment?: string[];
-    }>;
-};
+import { TREZOR_USB_DESCRIPTORS } from '../constants';
+import { Config } from '../types/config';
 
 export const config: Config = {
     webusb: TREZOR_USB_DESCRIPTORS,

--- a/packages/connect-common/src/types/config.ts
+++ b/packages/connect-common/src/types/config.ts
@@ -1,0 +1,27 @@
+import type { DeviceModelInternal } from '@trezor/device-utils';
+
+import { TREZOR_USB_DESCRIPTORS } from '../constants';
+
+export type Config = {
+    webusb: typeof TREZOR_USB_DESCRIPTORS;
+    whitelist: Array<{ origin: string; priority: number }>;
+    management: Array<{ origin: string }>;
+    knownHosts: Array<{ origin: string; label: string }>;
+    onionDomains: Record<string, string>;
+    supportedBrowsers: Record<
+        string,
+        {
+            version: number;
+            download: string;
+            update: string;
+        }
+    >;
+    supportedFirmware: Array<{
+        coin?: string[]; // Todo: better type?
+        capabilities?: string[]; // Todo: better type?
+        methods?: string[]; // Todo: better type?
+        min: Partial<Record<DeviceModelInternal, string>>;
+        max?: undefined; // NOTE: max field is not used anywhere at the moment, it is here for type compatibility
+        comment?: string[];
+    }>;
+};

--- a/packages/connect-common/src/types/index.ts
+++ b/packages/connect-common/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './config';

--- a/packages/connect-common/tsconfig.json
+++ b/packages/connect-common/tsconfig.json
@@ -8,6 +8,7 @@
     "references": [
         { "path": "../env-utils" },
         { "path": "../utils" },
+        { "path": "../device-utils" },
         { "path": "../protobuf" },
         { "path": "../protocol" }
     ]

--- a/packages/connect-common/tsconfig.lib.json
+++ b/packages/connect-common/tsconfig.lib.json
@@ -14,6 +14,9 @@
             "path": "../utils"
         },
         {
+            "path": "../device-utils"
+        },
+        {
             "path": "../protobuf"
         },
         {

--- a/packages/connect-common/tsconfig.libESM.json
+++ b/packages/connect-common/tsconfig.libESM.json
@@ -14,6 +14,9 @@
             "path": "../utils"
         },
         {
+            "path": "../device-utils"
+        },
+        {
             "path": "../protobuf"
         },
         {

--- a/packages/connect-explorer/src/pages/index.mdx
+++ b/packages/connect-explorer/src/pages/index.mdx
@@ -476,7 +476,7 @@ export const ExampleHeading = styled.h3`
 
                 Trezor Connect Manifest requires that you, as a Trezor Connect integrator, share your email and application URL with us. This provides us with the ability to reach you in case of any required maintenance. This subscription is mandatory.
 
-                To ensure your extension is displayed with its name rather than its ID, you need to open a Pull Request to include it in the `knownHosts` section of [our configuration file](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/data/config.ts#L17).
+                To ensure your extension is displayed with its name rather than its ID, you need to open a Pull Request to include it in the `knownHosts` section of [our configuration file](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/data/config.ts#L17).
 
                 If you need more customization, refer to [init method documentation](./methods/other/init)
 

--- a/packages/connect-web/src/webextension/extensionPermissions.ts
+++ b/packages/connect-web/src/webextension/extensionPermissions.ts
@@ -1,7 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/webusb/extensionPermissions.js
 
-import { config } from '@trezor/connect/src/data/config';
 import { WEBEXTENSION } from '@trezor/connect-common/src/constants/webextension';
+import { config } from '@trezor/connect-common/src/data/config';
 
 // This file is hosted on https://connect.trezor.io/*/extension-permissions.html
 // It's included WITHIN webextension application in trezor-usb-permissions.html to allow pairing webusb and trezor.io domain properly.

--- a/packages/connect-web/src/webusb/index.ts
+++ b/packages/connect-web/src/webusb/index.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/webusb/index.js
 
-import { config } from '@trezor/connect/src/data/config';
+import { config } from '@trezor/connect-common/src/data/config';
 
 // handle message received from connect.js
 const onload = () => {

--- a/packages/connect-webextension/README.md
+++ b/packages/connect-webextension/README.md
@@ -72,7 +72,7 @@ After completing these steps, you can use the module in your Service Worker in t
 
 ## Adding your webextension to `knownHosts`
 
-To ensure your extension is displayed with its name rather than its ID, you need to open a Pull Request to include it in the `knownHosts` section of the file located at https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/data/config.ts#L17.
+To ensure your extension is displayed with its name rather than its ID, you need to open a Pull Request to include it in the `knownHosts` section of the file located at https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/data/config.ts#L17.
 
 ## Examples
 

--- a/packages/connect/src/api/common/__tests__/paramsValidator.test.ts
+++ b/packages/connect/src/api/common/__tests__/paramsValidator.test.ts
@@ -30,8 +30,10 @@ describe('helpers/paramsValidator', () => {
                         jest.resetModules();
 
                         const mock = f.config;
-                        jest.mock('../../../data/config', () => {
-                            const actualConfig = jest.requireActual('../../../data/config').config;
+                        jest.mock('@trezor/connect-common/src/data/config', () => {
+                            const { config: actualConfig } = jest.requireActual(
+                                '@trezor/connect-common/src/data/config',
+                            );
 
                             return {
                                 __esModule: true,

--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -1,9 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/paramsValidator.js
 import { ERRORS } from '@trezor/connect-common/src/constants';
+import { config } from '@trezor/connect-common/src/data/config';
 import type { DeviceModelInternal } from '@trezor/device-utils';
 import { typedObjectKeys, versionUtils } from '@trezor/utils';
 
-import { config } from '../../data/config';
 import type { CoinInfo, FirmwareRange } from '../../types';
 import { fromHardened } from '../../utils/pathUtils';
 

--- a/packages/connect/src/index-browser.ts
+++ b/packages/connect/src/index-browser.ts
@@ -1,4 +1,5 @@
-import { config } from './data/config';
+import { config } from '@trezor/connect-common/src/data/config';
+
 import { TRANSPORT } from './events';
 import { factory } from './factory';
 import { CoreInModule } from './impl/core-in-module';

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -247,7 +247,7 @@ describe('utils/deviceFeaturesUtils', () => {
             new Promise<void>(done => {
                 jest.resetModules();
 
-                jest.mock('../../data/config', () => ({
+                jest.mock('@trezor/connect-common/src/data/config', () => ({
                     __esModule: true,
                     config: {
                         supportedFirmware: [
@@ -273,7 +273,7 @@ describe('utils/deviceFeaturesUtils', () => {
             new Promise<void>(done => {
                 jest.resetModules();
 
-                jest.mock('../../data/config', () => ({
+                jest.mock('@trezor/connect-common/src/data/config', () => ({
                     __esModule: true,
                     config: {
                         supportedFirmware: [

--- a/packages/connect/src/utils/deviceFeaturesUtils.ts
+++ b/packages/connect/src/utils/deviceFeaturesUtils.ts
@@ -1,8 +1,8 @@
+import { config } from '@trezor/connect-common/src/data/config';
 import { DeviceModelInternal, getFirmwareOrBootloaderVersionArray } from '@trezor/device-utils';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { isArrayMember, versionUtils } from '@trezor/utils';
 
-import { config } from '../data/config';
 import { CoinInfo, Features, UnavailableCapabilities } from '../types';
 
 const DEFAULT_CAPABILITIES_T1: PROTO.Capability[] = [

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -89,6 +89,7 @@
         "tsx": "^4.21.0"
     },
     "dependencies": {
+        "@trezor/connect-common": "workspace:^",
         "@trezor/protobuf": "workspace:*",
         "@trezor/protocol": "workspace:*",
         "@trezor/type-utils": "workspace:*",

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -1,3 +1,8 @@
+import {
+    T1_HID_PRODUCT,
+    TREZOR_USB_DESCRIPTORS,
+    WEBUSB_BOOTLOADER_PRODUCT,
+} from '@trezor/connect-common/src/constants';
 import { arrayPartition, createDeferred, getSynchronize, resolveAfter } from '@trezor/utils';
 
 import { AbstractApi, AbstractApiConstructorParams } from './abstract';
@@ -8,10 +13,7 @@ import {
     DEVICE_TYPE,
     ENDPOINT_ID,
     INTERFACE_ID,
-    T1_HID_PRODUCT,
     T1_HID_VENDOR,
-    TREZOR_USB_DESCRIPTORS,
-    WEBUSB_BOOTLOADER_PRODUCT,
 } from '../constants';
 import * as ERRORS from '../errors';
 import { DescriptorApiLevel, PathInternal } from '../types';

--- a/packages/transport/src/constants.ts
+++ b/packages/transport/src/constants.ts
@@ -6,20 +6,6 @@ export const DEBUGLINK_INTERFACE_ID = 1;
 export const DEBUGLINK_ENDPOINT_ID = 2;
 export const T1_HID_VENDOR = 0x534c;
 
-export const T1_HID_PRODUCT = 0x0001;
-const WEBUSB_FIRMWARE_PRODUCT = 0x53c1;
-export const WEBUSB_BOOTLOADER_PRODUCT = 0x53c0;
-
-export const TREZOR_USB_DESCRIPTORS = [
-    // TREZOR v1
-    // won't get opened, but we can show error at least
-    { vendorId: 0x534c, productId: T1_HID_PRODUCT },
-    // TREZOR webusb Bootloader
-    { vendorId: 0x1209, productId: WEBUSB_BOOTLOADER_PRODUCT },
-    // TREZOR webusb Firmware
-    { vendorId: 0x1209, productId: WEBUSB_FIRMWARE_PRODUCT },
-];
-
 /**
  * How long is single transport action (call, acquire) allowed to take
  */

--- a/packages/transport/src/index.ts
+++ b/packages/transport/src/index.ts
@@ -1,7 +1,7 @@
 export * as TRANSPORT_ERROR from './errors';
 
 export type { Descriptor, Session, MessageResponse } from './types';
-export { TREZOR_USB_DESCRIPTORS, TRANSPORT } from './constants';
+export { TRANSPORT } from './constants';
 
 export { AbstractTransport as Transport, isTransportInstance } from './transports/abstract';
 export { AbstractApiTransport } from './transports/abstractApi';

--- a/packages/transport/tsconfig.json
+++ b/packages/transport/tsconfig.json
@@ -5,6 +5,7 @@
         "types": ["w3c-web-usb", "jest", "node"]
     },
     "references": [
+        { "path": "../connect-common" },
         { "path": "../protobuf" },
         { "path": "../protocol" },
         { "path": "../type-utils" },

--- a/packages/transport/tsconfig.lib.json
+++ b/packages/transport/tsconfig.lib.json
@@ -7,6 +7,9 @@
     "include": ["./src"],
     "references": [
         {
+            "path": "../connect-common"
+        },
+        {
             "path": "../protobuf"
         },
         {

--- a/packages/transport/tsconfig.libESM.json
+++ b/packages/transport/tsconfig.libESM.json
@@ -7,6 +7,9 @@
     },
     "references": [
         {
+            "path": "../connect-common"
+        },
+        {
             "path": "../protobuf"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14427,6 +14427,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/connect-common@workspace:packages/connect-common"
   dependencies:
+    "@trezor/device-utils": "workspace:^"
     "@trezor/env-utils": "workspace:*"
     "@trezor/protobuf": "workspace:^"
     "@trezor/protocol": "workspace:^"
@@ -15477,6 +15478,7 @@ __metadata:
   dependencies:
     "@babel/preset-env": "npm:7.28.5"
     "@babel/preset-typescript": "npm:^7.28.5"
+    "@trezor/connect-common": "workspace:^"
     "@trezor/eslint": "workspace:*"
     "@trezor/protobuf": "workspace:*"
     "@trezor/protocol": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With the goal of making connect-web independent of @trezor/connect this
is one step forward moving connect[ config to connect-common](https://github.com/trezor/trezor-suite/pull/24712/changes/fc0062e715e6f18d8de4e6e6672bcc508da9f3f9).

I had to decide whether 
1. to make `connect-common` a dependency of `transport` 
2. to make `transport` a dependency of `connect-common`.

I decided the option 2 since we want to keep connect-common as free of dependencies as possible and use only `@trezor/connect-common/src/constants` in `transport.

## Notes for QA

Nothing to test

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/23784


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/move-config-from-connect-to-connect-common&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/move-config-from-connect-to-connect-common&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/move-config-from-connect-to-connect-common&lookback=7)