### PR TITLE
fix(e2e-suite): prevent Electron teardown timeouts

### DIFF
--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -54,6 +54,15 @@ const electronSetup = async (
         ...electronConf,
     });
 
+    // Mocks shell.openExternal to prevent opening real browser windows.
+    await suite.electronApp.evaluate(({ shell }) => {
+        shell.openExternal = (url: string) => {
+            console.warn(`[mock] shell.openExternal called with: ${url}`);
+
+            return Promise.resolve(); // satisfies the 'async' requirement implicitly
+        };
+    });
+
     await suite.window
         .context()
         .tracing.start({ screenshots: true, snapshots: true, sources: true });

--- a/suite/e2e/tests/analytics/events-new.test.ts
+++ b/suite/e2e/tests/analytics/events-new.test.ts
@@ -5,7 +5,7 @@ import { isDesktopProject } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 import { PromoBannerType } from '../../support/pageObjects/dashboardPage';
 
-test.describe('New Analytics Events', { tag: ['@T3T1'] }, () => {
+test.describe('New Analytics Events', { tag: ['@T3T1', '@smoke'] }, () => {
     test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({


### PR DESCRIPTION
## Description


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/test-events-new-teardown-timeout&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/test-events-new-teardown-timeout&lookback=7)