### PR TITLE
Reorder advanced settings to have less dangerous settings on top

### DIFF
--- a/suite-native/module-settings/src/screens/SettingsAdvancedScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsAdvancedScreen.tsx
@@ -23,11 +23,11 @@ export const SettingsAdvancedScreen = () => {
             }
         >
             <VStack spacing="sp16">
-                <TurnOffFirmwareAuthenticityCheckCard />
-                <TurnOffDeviceAuthenticityCheckCard />
-                {isMevProtectionSettingsVisible && <TurnOffMevProtectionCard />}
                 {isBitcoinBackendsConfigVisible && <BitcoinBackendsCard />}
                 <ExperimentalFeaturesSettingsCard />
+                {isMevProtectionSettingsVisible && <TurnOffMevProtectionCard />}
+                <TurnOffFirmwareAuthenticityCheckCard />
+                <TurnOffDeviceAuthenticityCheckCard />
             </VStack>
         </Screen>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reorganize Advanced settings based on riskiness and usefulness. 

Until now, we've just been adding new features at the bottom, but that didn't make any sense... This is based on a subjective view without any research, and I may change it again, but I believe it's better than the current situation.

BEFORE:
1. Firmware Check
1. Device Check
1. MEW protection
1. BTC custom backend
1. Experimental Features

NOW:
1. BTC custom backend
1. Experimental Features
1. MEW protection
1. Firmware Check
1. Device Check


## Notes for QA

Nothing really changed, just the order of elements.

## Related Issue

Followup for https://github.com/trezor/trezor-suite/pull/24322

## Screenshots:


https://github.com/user-attachments/assets/74c8755d-5ca5-44e5-aee7-bd04bd9e6d9d




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/advanced-settings-reorder&lookback=7)