### PR TITLE
test(e2e-suite): Switch suite sync tests to local relay

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -13,7 +13,8 @@ inputs:
     required: false
   containers:
     description: "Docker containers to pull"
-    required: true
+    default: "trezor-user-env-unix bitcoin-regtest electrum-regtest quota-db suite-sync"
+    required: false
   workspace-dependencies:
     description: "Additional workspaces to install"
     required: false

--- a/.github/actions/upload-test-logs/action.yml
+++ b/.github/actions/upload-test-logs/action.yml
@@ -15,6 +15,8 @@ runs:
         docker cp docker-trezor-user-env-unix-1:/trezor-user-env/logs/emulator_bridge.log tenv-emulator-bridge-debugging.log || true
         docker cp docker-trezor-user-env-unix-1:/trezor-user-env/docker/version.txt trezor-user-env-version.txt || true
         docker logs docker-electrum-regtest-1 > electrum-regtest.txt || true
+        docker logs docker-quota-db-1 > quota-db.txt || true
+        docker logs docker-suite-sync-1 > suite-sync.txt || true
 
     - name: Upload Trezor-user-env and Regtest logs
       uses: actions/upload-artifact@v4
@@ -25,4 +27,6 @@ runs:
           tenv-emulator-bridge-debugging.log
           trezor-user-env-version.txt
           electrum-regtest.txt
+          quota-db.txt
+          suite-sync.txt
         retention-days: 30

--- a/.github/workflows/test-suite-desktop-e2e-nightly.yml
+++ b/.github/workflows/test-suite-desktop-e2e-nightly.yml
@@ -62,7 +62,6 @@ jobs:
         with:
           target: "desktop"
           pw-config: "./playwright-config/playwright-desktop-nightly.config.ts"
-          containers: "trezor-user-env-unix bitcoin-regtest electrum-regtest"
           workspace-dependencies: "@trezor/suite-desktop"
           test-group: ${{ matrix.TEST_GROUP }}
           fail-fast: false

--- a/.github/workflows/test-suite-desktop-e2e-pr.yml
+++ b/.github/workflows/test-suite-desktop-e2e-pr.yml
@@ -124,7 +124,6 @@ jobs:
         with:
           target: "desktop"
           pw-config: "./playwright-config/playwright-desktop-pr.config.ts"
-          containers: "trezor-user-env-unix bitcoin-regtest electrum-regtest"
           workspace-dependencies: "@trezor/suite-desktop"
           test-group: ${{ matrix.TEST_GROUP }}
           fail-fast: 7

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -88,7 +88,6 @@ jobs:
         with:
           target: "desktop"
           pw-config: "./playwright-config/playwright-desktop.config.ts"
-          containers: "trezor-user-env-unix bitcoin-regtest electrum-regtest"
           workspace-dependencies: "@trezor/suite-desktop"
           test-group: ${{ matrix.TEST_GROUP }}
           fail-fast: false

--- a/.github/workflows/test-suite-web-e2e-nightly.yml
+++ b/.github/workflows/test-suite-web-e2e-nightly.yml
@@ -58,7 +58,6 @@ jobs:
         with:
           target: "web"
           pw-config: "./playwright-config/playwright-web-nightly.config.ts"
-          containers: "trezor-user-env-unix bitcoin-regtest electrum-regtest"
           test-group: ${{ matrix.TEST_GROUP }}
           fail-fast: false
           currents-project-id: "Og0NOQ"

--- a/.github/workflows/test-suite-web-e2e-pr.yml
+++ b/.github/workflows/test-suite-web-e2e-pr.yml
@@ -124,7 +124,6 @@ jobs:
         with:
           target: "web"
           pw-config: "./playwright-config/playwright-web-pr.config.ts"
-          containers: "trezor-user-env-unix bitcoin-regtest electrum-regtest"
           test-group: ${{ matrix.TEST_GROUP }}
           fail-fast: 7
           currents-project-id: "Og0NOQ"

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -81,7 +81,6 @@ jobs:
         with:
           target: "web"
           pw-config: "./playwright-config/playwright-web.config.ts"
-          containers: "trezor-user-env-unix bitcoin-regtest electrum-regtest"
           test-group: ${{ matrix.TEST_GROUP }}
           fail-fast: false
           currents-project-id: "Og0NOQ"

--- a/docker/docker-compose.suite-ci-e2e.yml
+++ b/docker/docker-compose.suite-ci-e2e.yml
@@ -7,12 +7,45 @@ services:
     network_mode: host
     volumes:
       - ./trezor-user-env-logs:/trezor-user-env/logs
+
   bitcoin-regtest:
     image: ghcr.io/trezor/trezor-user-env-regtest # this is a special image that runs regtest and blockbook
     depends_on:
       - trezor-user-env-unix
     network_mode: service:trezor-user-env-unix
+
   electrum-regtest:
     image: ghcr.io/trezor/electrs:latest
     ports:
       - "50001:50001"
+
+  quota-db:
+    image: postgres
+    environment:
+      POSTGRES_USER: suite-sync
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: suite-sync-gate
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U suite-sync -d suite-sync-gate"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  suite-sync:
+    image: ghcr.io/trezor/suite-sync:main
+    environment:
+      POSTGRES_GATE_USER: suite-sync
+      POSTGRES_GATE_PASSWORD: password
+      POSTGRES_GATE_HOST: quota-db
+      POSTGRES_GATE_PORT: 5432
+      POSTGRES_GATE_DB: suite-sync-gate
+      SERVER_ENV: dev
+    ports:
+      - "4000:4000"
+      - "4001:4001"
+      - "4002:4002"
+    depends_on:
+      quota-db:
+        condition: service_healthy

--- a/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
@@ -55,6 +55,7 @@ export const QuotaManagerSettings = () => {
                 />
                 <ActionColumn>
                     <Checkbox
+                        data-testid="@settings/debug/enable-quota-manager-checkbox"
                         isChecked={isQuotaManagerEnabled}
                         onClick={toggleIsQuotaManagerEnabled}
                     />
@@ -65,11 +66,13 @@ export const QuotaManagerSettings = () => {
                 <ActionColumn>
                     <Column gap={spacings.xxs}>
                         <Input
+                            data-testid="@settings/debug/quota-manager-url-input"
                             disabled={isUpdateUrlLoading}
                             value={quotaManagerUrl}
                             onChange={e => setQuotaManagerUrl(e.target.value)}
                             rightContent={
                                 <Button
+                                    data-testid="@settings/debug/quota-manager-url-save-button"
                                     onClick={onQuotaManagerBaseUrlSave}
                                     size="small"
                                     isLoading={isUpdateUrlLoading}

--- a/suite/e2e/docs/e2e-playwright-suite.md
+++ b/suite/e2e/docs/e2e-playwright-suite.md
@@ -66,7 +66,7 @@ _(in case of Linux with X11 support, skip to step 6.)_
 
 1. **To check for flakiness** you can specify test/suite and how many time it should run: `--repeat-each=10`
 
-1. **To check for flakiness on CI** you can edit in `packages/suite/package.json` script `"test:orchestrated:e2e:desktop": "NODE_OPTIONS='--no-warnings=DEP0040' yarn xvfb-maybe -- pwc-p --config=./playwright-desktop.config.ts --project=desktop --repeat-each=30 <test-file-name>",`, commit, push and run this CI against your branch. This will run this one test 30 times. Please, always specify limited number of tests, never run full suite 30 times.
+1. **To check for flakiness on CI** you can edit in `packages/suite/package.json` script `"test:orchestrated:e2e:desktop": "NODE_OPTIONS='--no-warnings=DEP0040' yarn xvfb-maybe -- pwc-p --config=./playwright-config/playwright-desktop-nightly.config.ts --repeat-each=30 --grep=<test-file-name>",`, commit, push and run this CI against your branch. This will run this one test 30 times. Please, always specify limited number of tests, never run full suite 30 times.
 
 1. **To debug test** add `await page.pause();` to place where you want test to stop. Debugger window will open. This works only in `--headed` run.
 

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -15,7 +15,8 @@
         "github:report:manual": "NODE_OPTIONS='--no-warnings=DEP0040' yarn xvfb-maybe -- playwright test --config=./playwright-manual.config.ts --reporter=./support/reporters/gitHubReporter.ts",
         "github:create:project": "tsx ./support/reporters/scriptCreateProject.ts",
         "git:bisect": "./scripts/bisect-commits.sh",
-        "decode:sol:stake": "tsx ./scripts/decode-sol-staking-account.ts"
+        "decode:sol:stake": "tsx ./scripts/decode-sol-staking-account.ts",
+        "docker:suite-sync": "docker compose -f ../../docker/docker-compose.suite-ci-e2e.yml up --force-recreate quota-db suite-sync"
     },
     "devDependencies": {
         "@currents/playwright": "^1.19.0",

--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -58,9 +58,7 @@ export class MetadataPage {
     async initiateSuiteSyncSetup() {
         await this.settingsPage.navigateTo('debug');
         await this.settingsPage.debugTab.suiteSyncCheckbox.click();
-        await this.settingsPage.debugTab.suiteSyncUrlInput.fill(
-            'https://suite-sync.suite.sldev.cz/evolu/',
-        );
+        await this.settingsPage.debugTab.suiteSyncUrlInput.fill('http://127.0.0.1:4000');
         await this.settingsPage.debugTab.suiteSyncUrlSaveButton.click();
 
         await this.settingsPage.navigateTo('application');
@@ -74,12 +72,21 @@ export class MetadataPage {
     async confirmSuiteSyncSetup() {
         await this.devicePrompt.confirmOnDevicePromptIsShown();
         await this.device.pressYes();
-        await this.page.waitForTimeout(2000); // wait before closing the modal to prevent "Trezor Sync key retrieval failed" error
+        // wait before closing the modal to prevent "Trezor Sync key retrieval failed" error
+        await this.page.waitForTimeout(2000);
     }
 
     @step()
     async enableSuiteSync() {
         await this.initiateSuiteSyncSetup();
         await this.confirmSuiteSyncSetup();
+    }
+
+    @step()
+    async setupQuotaManager() {
+        await this.settingsPage.navigateTo('debug');
+        await this.settingsPage.debugTab.quotaManagerCheckbox.click();
+        await this.settingsPage.debugTab.quotaManagerUrlInput.fill('http://127.0.0.1:4001');
+        await this.settingsPage.debugTab.quotaManagerUrlSaveButton.click();
     }
 }

--- a/suite/e2e/support/pageObjects/settings/debugTab.ts
+++ b/suite/e2e/support/pageObjects/settings/debugTab.ts
@@ -14,6 +14,9 @@ export class DebugTab {
     readonly addNewMessageButton: Locator;
     readonly jsonEditor: Locator;
     readonly addMessageButton: Locator;
+    readonly quotaManagerCheckbox: Locator;
+    readonly quotaManagerUrlInput: Locator;
+    readonly quotaManagerUrlSaveButton: Locator;
 
     constructor(private readonly page: Page) {
         this.suiteSyncCheckbox = page.getByTestId('@settings/debug/suite-sync/checkbox');
@@ -30,6 +33,13 @@ export class DebugTab {
         this.jsonEditor = page.getByTestId('@settings/debug/message-system/json-editor-textarea');
         this.addMessageButton = page.getByTestId(
             '@settings/debug/message-system/json-editor-add-message-button',
+        );
+        this.quotaManagerCheckbox = page.getByTestId(
+            '@settings/debug/enable-quota-manager-checkbox',
+        );
+        this.quotaManagerUrlInput = page.getByTestId('@settings/debug/quota-manager-url-input');
+        this.quotaManagerUrlSaveButton = page.getByTestId(
+            '@settings/debug/quota-manager-url-save-button',
         );
     }
 

--- a/suite/e2e/tests/metadata/suite-sync.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync.test.ts
@@ -27,6 +27,7 @@ test.describe(
         }) => {
             await test.step('Onboarding and enable Suite Sync', async () => {
                 await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+                await metadataPage.setupQuotaManager();
                 await metadataPage.enableSuiteSync();
             });
 
@@ -52,6 +53,7 @@ test.describe(
 
             await test.step('Onboarding and enable Suite Sync', async () => {
                 await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+                await metadataPage.setupQuotaManager();
                 await metadataPage.enableSuiteSync();
             });
 
@@ -81,7 +83,8 @@ test.describe('Suite Sync - Labelling', { tag: ['@specificFirmware', '@T3W1', '@
         deviceSetup: { mnemonic: MNEMONIC, passphrase_protection: true },
     });
 
-    test('Sync labels from server', async ({
+    // TODO: Temporarily skipping the test due to work in progress
+    test.skip('Sync labels from server', async ({
         page,
         target,
         device,
@@ -93,6 +96,7 @@ test.describe('Suite Sync - Labelling', { tag: ['@specificFirmware', '@T3W1', '@
     }) => {
         await test.step('Enable Suite Sync', async () => {
             await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+            await metadataPage.setupQuotaManager();
             await metadataPage.initiateSuiteSyncSetup();
             if (isWebProject(target)) {
                 // eslint-disable-next-line playwright/no-conditional-expect


### PR DESCRIPTION
-new docker services in docker compose for e2e tests (quota-db, suite-sync) 
-new method and locators for configuring quota manager 
-minor refactor of docker param in wf
-tmp disables incompatible suite-sync test until test implementation is done

Goal: We want more complex suite sync tests and for that we need a better control of the env. That will be achieved by a local server spawn by tests and set of extra control methods for seed and verification. This PR brings the dockerized server.



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-suite-sync-server-local&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-suite-sync-server-local&lookback=7)