### PR TITLE
fix(suite-native): hide device switcher before navigation

### DIFF
--- a/suite-native/device-manager/src/components/DeviceSwitch.tsx
+++ b/suite-native/device-manager/src/components/DeviceSwitch.tsx
@@ -1,4 +1,7 @@
+import { useEffect } from 'react';
 import { Pressable } from 'react-native';
+
+import { useNavigation } from '@react-navigation/native';
 
 import { Box, HStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
@@ -36,6 +39,7 @@ const switchWrapperStyle = prepareNativeStyle(_ => ({
 }));
 
 export const DeviceSwitch = () => {
+    const navigation = useNavigation();
     const { applyStyle } = useNativeStyles();
 
     const { setIsDeviceManagerVisible, isDeviceManagerVisible } = useDeviceManager();
@@ -43,6 +47,11 @@ export const DeviceSwitch = () => {
     const toggleDeviceManager = () => {
         setIsDeviceManagerVisible(!isDeviceManagerVisible);
     };
+
+    useEffect(
+        () => navigation.addListener('blur', () => setIsDeviceManagerVisible(false)),
+        [navigation, setIsDeviceManagerVisible],
+    );
 
     return (
         <Pressable


### PR DESCRIPTION
## Related Issue

Resolve #23041

## Screenshots:

https://github.com/user-attachments/assets/ee600a0b-00f6-4f02-9d3a-7a2666bfec73


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/wallet-switcher&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/wallet-switcher&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/wallet-switcher&lookback=7)