### PR TITLE
fix: hash OwnerId to not leak in onto file-system

### DIFF
--- a/suite-common/suite-sync-evolu/package.json
+++ b/suite-common/suite-sync-evolu/package.json
@@ -11,6 +11,7 @@
     },
     "dependencies": {
         "@evolu/common": "^7.3.0",
+        "@noble/hashes": "^1.6.1",
         "@suite-common/suite-sync-storage": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
+++ b/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
@@ -1,4 +1,6 @@
 import { Evolu, EvoluDeps, SimpleName, createEvolu } from '@evolu/common';
+import { sha256 } from '@noble/hashes/sha2';
+import { bytesToHex } from '@noble/hashes/utils';
 
 import { SuiteSyncOwner } from '@suite-common/suite-types';
 
@@ -31,8 +33,11 @@ export const createEvoluInstanceFactory =
             throw owner.error;
         }
 
-        const sanitizedOwnerId = owner.value.id.replaceAll('_', '-');
-        const databaseName = SimpleName.from(`trezor-suite-v${VERSION}-${sanitizedOwnerId}`);
+        // The instance name is used as the SQLite database filename for persistent
+        // storage, ensuring that database files are separated and invisible to each
+        // other. Hash the ownerId to avoid leaking it into the filename.
+        const hashedOwnerId = bytesToHex(sha256(owner.value.id)).slice(0, 16);
+        const databaseName = SimpleName.from(`trezor-suite-v${VERSION}-${hashedOwnerId}`);
 
         if (!databaseName.ok) {
             console.error(databaseName.error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11009,6 +11009,7 @@ __metadata:
   resolution: "@suite-common/suite-sync-evolu@workspace:suite-common/suite-sync-evolu"
   dependencies:
     "@evolu/common": "npm:^7.3.0"
+    "@noble/hashes": "npm:^1.6.1"
     "@suite-common/suite-sync-storage": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"


### PR DESCRIPTION
This PR adds a hashing to prevent of the leak of the OwnerId into filename DB.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-owner-id-leak&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-owner-id-leak&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-owner-id-leak&lookback=7)