### PR TITLE
Show warning on experimental features only if turned on

### DIFF
--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -1042,7 +1042,7 @@
   "TR_EXCHANGE_USE_NON_SUITE_ACCOUNT": "Use an account ({symbol}) that isn't in Trezor Suite.",
   "TR_EXPERIMENTAL_FEATURES": "Experimental",
   "TR_EXPERIMENTAL_FEATURES_ALLOW": "Experimental features",
-  "TR_EXPERIMENTAL_FEATURES_WARNING": "For experienced users only. Use at your own risk. These features are in testing, may be unstable, and might not have long-term support.",
+  "TR_EXPERIMENTAL_FEATURES_WARNING": "For experienced users only. Use at your own risk.",
   "TR_EXPERIMENTAL_NETWORKS": "{networkNames} {count, plural, one {network} other {networks}}",
   "TR_EXPERIMENTAL_NETWORKS_DESCRIPTION": "Send and receive transactions on the {networkNames} {count, plural, one {network} other {networks}}.",
   "TR_EXPERIMENTAL_NFT_SECTION": "NFTs (non-fungible tokens)",

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -154,7 +154,7 @@ export const Experimental = () => {
                                             icon="warning"
                                             intent="warning"
                                             description={
-                                                <Translation id="TR_EXPERIMENTAL_FEATURES_WARNING" />
+                                                <Translation id="TR_EXPERIMENTAL_FEATURES_WARNING_IF_ENABLED" />
                                             }
                                         />
                                     </motion.div>

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -91,8 +91,25 @@ const motionDivProps = {
     exit: 'initial',
 } as const;
 
+const bannerMotionDivProps = {
+    variants: {
+        initial: { overflow: 'hidden', height: 0, marginBottom: 0, opacity: 0 },
+        visible: {
+            height: 'auto',
+            marginBottom: '12px',
+            opacity: 1,
+            transitionEnd: { overflow: 'unset' },
+        },
+    },
+    transition: { duration: 0.24, ease: 'easeInOut' },
+    initial: 'initial',
+    animate: 'visible',
+    exit: 'initial',
+} as const;
+
 export const Experimental = () => {
     const enabledFeatures = useSelector(state => state.suite.settings.experimental);
+    const isExperimentalEnabled = enabledFeatures !== undefined;
     const isDebug = useSelector(selectIsDebugModeActive);
 
     const dispatch = useDispatch();
@@ -128,17 +145,28 @@ export const Experimental = () => {
                 <TextColumn
                     title={<Translation id="TR_EXPERIMENTAL_FEATURES_ALLOW" />}
                     description={
-                        <Banner
-                            icon="warning"
-                            intent="warning"
-                            description={<Translation id="TR_EXPERIMENTAL_FEATURES_WARNING" />}
-                        />
+                        <>
+                            <Translation id="TR_EXPERIMENTAL_FEATURES_DESCRIPTION" />
+                            <AnimatePresence>
+                                {isExperimentalEnabled && (
+                                    <motion.div {...bannerMotionDivProps}>
+                                        <Banner
+                                            icon="warning"
+                                            intent="warning"
+                                            description={
+                                                <Translation id="TR_EXPERIMENTAL_FEATURES_WARNING" />
+                                            }
+                                        />
+                                    </motion.div>
+                                )}
+                            </AnimatePresence>
+                        </>
                     }
                     buttonLink={EXPERIMENTAL_FEATURES_KB_URL}
                 />
                 <ActionColumn>
                     <Switch
-                        isChecked={enabledFeatures !== undefined}
+                        isChecked={isExperimentalEnabled}
                         onChange={onSwitchExperimental}
                         data-testid="@settings/experimental-features/toggle-switch"
                     />

--- a/suite-native/experimental-features/src/ExperimentalFeaturesSettingsCard.tsx
+++ b/suite-native/experimental-features/src/ExperimentalFeaturesSettingsCard.tsx
@@ -56,6 +56,16 @@ export const ExperimentalFeaturesSettingsCard = () => {
         overflow: 'hidden',
     }));
 
+    const animatedAlertStyle = useAnimatedStyle(() => ({
+        opacity: withTiming(areExperimentalFeaturesAllowed ? 1 : 0, {
+            duration: ANIMATION_DURATION,
+        }),
+        maxHeight: withTiming(areExperimentalFeaturesAllowed ? 200 : 0, {
+            duration: ANIMATION_DURATION,
+        }),
+        overflow: 'hidden',
+    }));
+
     const handleContentLayout = ({ nativeEvent }: LayoutChangeEvent) => {
         contentHeight.value = nativeEvent.layout.height;
     };
@@ -100,13 +110,20 @@ export const ExperimentalFeaturesSettingsCard = () => {
                                     testID="@settings/experimental-features/toggle-switch"
                                 />
                             </HStack>
-                            <InlineAlertBox
-                                variant="warning"
-                                title={
-                                    <Translation id="moduleSettings.advanced.experimentalFeatures.warning" />
-                                }
-                            />
-                            <VStack marginTop="sp8">
+                            <Text variant="hint" color="textSubdued">
+                                <Translation id="moduleSettings.advanced.experimentalFeatures.subtitle" />
+                            </Text>
+                            <AnimatedBox style={animatedAlertStyle}>
+                                <Box marginBottom="sp8">
+                                    <InlineAlertBox
+                                        variant="warning"
+                                        title={
+                                            <Translation id="moduleSettings.advanced.experimentalFeatures.warning" />
+                                        }
+                                    />
+                                </Box>
+                            </AnimatedBox>
+                            <VStack>
                                 <Button
                                     size="small"
                                     viewLeft="arrowSquareOut"

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1408,8 +1408,9 @@ export const messages = {
             },
             experimentalFeatures: {
                 title: 'Experimental features',
-                warning:
-                    'For experienced users only. Use at your own risk. These features are in testing, may be unstable, and might not have long-term support.',
+                subtitle:
+                    'These features are in testing, may be unstable, and might not have long-term support.',
+                warning: 'For experienced users only.\nUse at your own risk.',
                 suiteSync: {
                     title: 'Suite Sync',
                     description:

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5148,8 +5148,8 @@ export const messages = defineMessages({
         defaultMessage:
             'These features are in testing, may be unstable, and might not have long-term support.',
     },
-    TR_EXPERIMENTAL_FEATURES_WARNING: {
-        id: 'TR_EXPERIMENTAL_FEATURES_WARNING',
+    TR_EXPERIMENTAL_FEATURES_WARNING_IF_ENABLED: {
+        id: 'TR_EXPERIMENTAL_FEATURES_WARNING_IF_ENABLED',
         defaultMessage: 'For experienced users only. Use at your own risk.',
     },
     TR_GO_TO_EXP_FEATURE: {

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5143,10 +5143,14 @@ export const messages = defineMessages({
         id: 'TR_EXPERIMENTAL_FEATURES_ALLOW',
         defaultMessage: 'Experimental features',
     },
+    TR_EXPERIMENTAL_FEATURES_DESCRIPTION: {
+        id: 'TR_EXPERIMENTAL_FEATURES_DESCRIPTION',
+        defaultMessage:
+            'These features are in testing, may be unstable, and might not have long-term support.',
+    },
     TR_EXPERIMENTAL_FEATURES_WARNING: {
         id: 'TR_EXPERIMENTAL_FEATURES_WARNING',
-        defaultMessage:
-            'For experienced users only. Use at your own risk. These features are in testing, may be unstable, and might not have long-term support.',
+        defaultMessage: 'For experienced users only. Use at your own risk.',
     },
     TR_GO_TO_EXP_FEATURE: {
         id: 'TR_GO_TO_EXP_FEATURE',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Simply hiding the warning when the feature is disabled felt suboptimal because it removed the context/description present in other settings. I’ve implemented a hybrid approach to improve UI consistency while maintaining the necessary warnings.

**The Proposal:**
- Moved the primary explanation into the field description (always visible).
- The high-risk warning ("For experienced users only. Use at your own risk.") now triggers as a conditional warning only when the toggle is enabled.

**UI/UX Inconsistencies:** I noticed a few discrepancies that we might want to address for a more polished experience:
- Desktop: Early Access uses a confirmation modal instead of an inline yellow warning. To be consistent, Experimental Features should probably follow this pattern.
- Mobile: Most Advanced Settings use an On/Off button, but Experimental Features currently uses a toggle. Switching to a button is a "low-hanging fruit" fix. But not sure if it makes sense, because the Experimental Features toggle does not actually turn anything on. It just shows the options.

I will not address those inconsistencies now; priority is too low.
    
## Notes for QA

Check the UI; there are no changes in the logic or behavior.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24324

## Screenshots:

https://github.com/user-attachments/assets/2bc85dc6-6b5d-4b32-9396-aec50fd5bc3e

https://github.com/user-attachments/assets/ecc068a3-34b8-44b8-9408-4f3c6dbb3215






🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/experimental-features-hide-warning&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/experimental-features-hide-warning&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/experimental-features-hide-warning&lookback=7)