### PR TITLE
fix(connect): handle device disconnection in FW update + THP flow

### DIFF
--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -44,6 +44,53 @@ type ReconnectContext = {
     uiPromises: { create: UiPromiseCreator; rejectAll: (e: Error) => void };
 };
 
+// create UI promise and wait for:
+// - pairing confirmation
+// - device disconnection
+// - abort signal
+const waitForThpPairingConfirmation = async ({
+    uiPromises,
+    postMessage,
+    device,
+    deviceList,
+    abortSignal,
+    thpPairingError,
+}: Pick<
+    ReconnectContext,
+    'uiPromises' | 'postMessage' | 'device' | 'deviceList' | 'abortSignal'
+> & {
+    thpPairingError: boolean;
+}) => {
+    const uiPromise = uiPromises.create(UI.RECEIVE_CONFIRMATION, device);
+    postMessage(
+        createUiMessage(UI.REQUEST_CONFIRMATION, {
+            view: thpPairingError ? 'thp-pairing-failed' : 'thp-pairing-start',
+        }),
+    );
+
+    const devicePath = device.getUniquePath();
+    const disconnectListener = (event: Device) => {
+        if (event.getUniquePath() === devicePath) {
+            uiPromise.reject(ERRORS.TypedError('Device_Disconnected'));
+        }
+    };
+    const abortListener = () => {
+        uiPromise.reject(ERRORS.TypedError('Method_Interrupted'));
+    };
+
+    try {
+        abortSignal.addEventListener('abort', abortListener);
+        deviceList.on('device-disconnect', disconnectListener);
+        const uiResp = await uiPromise.promise;
+        if (!uiResp.payload) {
+            throw ERRORS.TypedError('Method_PermissionsNotGranted');
+        }
+    } finally {
+        abortSignal.removeEventListener('abort', abortListener);
+        deviceList.off('device-disconnect', disconnectListener);
+    }
+};
+
 const waitForReconnectedDevice = async (
     { bootloader, method, intermediary }: ReconnectParams,
     {
@@ -119,15 +166,20 @@ const waitForReconnectedDevice = async (
             let runFn;
             if (reconnectedDevice.getThpState()?.properties) {
                 // stop and wait for UI decision
-                const uiPromise = uiPromises.create(UI.RECEIVE_CONFIRMATION, reconnectedDevice);
-                postMessage(
-                    createUiMessage(UI.REQUEST_CONFIRMATION, {
-                        view: thpPairingError ? 'thp-pairing-failed' : 'thp-pairing-start',
-                    }),
-                );
-                const uiResp = await uiPromise.promise;
-                if (!uiResp.payload) {
-                    throw ERRORS.TypedError('Method_PermissionsNotGranted');
+                try {
+                    await waitForThpPairingConfirmation({
+                        uiPromises,
+                        postMessage,
+                        device: reconnectedDevice,
+                        deviceList,
+                        thpPairingError,
+                        abortSignal,
+                    });
+                } catch (e) {
+                    if (e.code === 'Device_Disconnected') {
+                        continue; // loop again, wait for FIRMWARE_RECONNECT
+                    }
+                    throw e;
                 }
 
                 runFn = () => Promise.resolve(); // enforce pairing UI interaction

--- a/packages/connect/src/utils/uiPromiseManager.ts
+++ b/packages/connect/src/utils/uiPromiseManager.ts
@@ -21,6 +21,13 @@ export const createUiPromiseManager = () => {
             _uiPromises.splice(existing, 1);
         }
 
+        // enhance Deferred reject fn
+        const { reject } = uiPromise;
+        uiPromise.reject = (error: Error) => {
+            reject(error);
+            _uiPromises = _uiPromises.filter(p => p.id !== promiseEvent);
+        };
+
         _uiPromises.push(uiPromise as unknown as AnyUiPromise);
 
         return uiPromise;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

firmware update workflow **expects device disconnection** therefore it doesn't reject as other workflows/methods.

with this fix awaited `UI.REQUEST_CONFIRMATION` promise will also reject on disconnection and/or method abort signal.

additionally fixing/enhancing `uiPromise.reject` method to clear itself from the list after rejection

## Notes for QA

follow the steps in both issues

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21957 
Resolve https://github.com/trezor/trezor-suite/issues/24600


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/t3w1-disconnect-fw-update&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/t3w1-disconnect-fw-update&lookback=7)