### PR TITLE
fix(suite-native): Trading: Fix preview screen footer

### DIFF
--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useProviderMetadataChangeEffect.hook.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useProviderMetadataChangeEffect.hook.test.ts
@@ -7,6 +7,17 @@ import {
     useProviderMetadataChangeEffect,
 } from '../useProviderMetadataChangeEffect';
 
+let mockIsFocused = true;
+
+jest.mock('@react-navigation/native', () => {
+    const actualNav = jest.requireActual('@react-navigation/native');
+
+    return {
+        ...actualNav,
+        useIsFocused: () => mockIsFocused,
+    };
+});
+
 describe('useProviderMetadataChangeEffect', () => {
     let store: TestStore;
 
@@ -17,6 +28,7 @@ describe('useProviderMetadataChangeEffect', () => {
 
     beforeEach(() => {
         ({ store } = initStore({ wallet: getWalletState({ tradeType: 'buy' }) }));
+        mockIsFocused = true;
     });
 
     it('should set currentProviderMetadata when quote is set', () => {
@@ -30,6 +42,13 @@ describe('useProviderMetadataChangeEffect', () => {
         const { unmount } = renderUseProviderMetadataChangeEffect(_ => 'mercuryo');
 
         unmount();
+
+        expect(selectTradingProviderMetadata(store.getState())).toBeUndefined();
+    });
+
+    it('should not change provider metadata when screen is not focused', () => {
+        mockIsFocused = false;
+        renderUseProviderMetadataChangeEffect(_ => 'mercuryo');
 
         expect(selectTradingProviderMetadata(store.getState())).toBeUndefined();
     });

--- a/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.ts
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { useIsFocused } from '@react-navigation/native';
+
 import {
     type TradingRootState,
     TradingType,
@@ -16,6 +18,7 @@ export const useProviderMetadataChangeEffect = (
 ) => {
     const dispatch = useDispatch();
     const exchange = watch('quote.exchange');
+    const isFocused = useIsFocused();
 
     const providerMetadata = useSelector((state: TradingRootState) =>
         selectTradingProviderByNameAndTradeType(state, exchange, tradingType),
@@ -23,10 +26,19 @@ export const useProviderMetadataChangeEffect = (
     const currentProviderMetadata = useSelector(selectTradingProviderMetadata);
 
     useEffect(() => {
-        if (providerMetadata !== currentProviderMetadata) {
-            dispatch(tradingActions.setCurrentProviderMetadata(providerMetadata));
+        // On navigation to preview screen the form is cleared, but we want to keep this value, therefore
+        // we skip updates to currentProviderMetadata.
+        // The effect will clear the provider metadata as soon as user goes back to form screen.
+        if (!isFocused) {
+            return;
         }
-    }, [providerMetadata, currentProviderMetadata, dispatch]);
+
+        if (providerMetadata === currentProviderMetadata) {
+            return;
+        }
+
+        dispatch(tradingActions.setCurrentProviderMetadata(providerMetadata));
+    }, [providerMetadata, currentProviderMetadata, dispatch, isFocused]);
 
     useEffect(
         () => () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the footer on preview screen. Instead of general one, footer with selected provider is displayed.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #24759 
## Screenshots:

### Before
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-01-28 at 11 48 04" src="https://github.com/user-attachments/assets/cfbe46e8-7023-4b80-b1c0-01a781ba8f8e" />


### After
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-01-28 at 14 12 39" src="https://github.com/user-attachments/assets/1b8e8372-6d5f-4531-aa5d-50880a35543c" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24759-trading-mobile-wrong-trading-footer-on-preview-step&lookback=7)