### PR TITLE
fix(trade): fix missing space in translation

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingFooter/TradingFooter.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFooter/TradingFooter.tsx
@@ -8,39 +8,48 @@ type TradingFooterProps = {
     provider?: BuyProviderInfo | SellProviderInfo | ExchangeProviderInfo;
 };
 
-export const TradingFooter = ({ provider }: TradingFooterProps) => (
-    <Column alignItems="center" margin={{ top: 48 }} gap={12}>
-        <Text typographyStyle="hint" variant="tertiary">
-            <Translation id="TR_TRADING_TERMS_1" />
-            {provider ? (
-                <Link href={provider.termsUrl}>
-                    <Translation
-                        id="TR_TRADING_TERMS_PROVIDER"
-                        values={{ companyName: provider.companyName }}
-                    />
-                </Link>
-            ) : (
-                <Translation id="TR_TRADING_TERMS_2" />
-            )}
-        </Text>
+export const TradingFooter = ({ provider }: TradingFooterProps) => {
+    const providerName = provider?.companyName ? (
+        provider.companyName
+    ) : (
+        <Translation id="TR_TERMS_PROVIDER_PLACEHOLDER" />
+    );
 
-        <InfoSegments typographyStyle="hint" variant="tertiary">
-            <Link href={TREZOR_SUITE_TOS_URL}>
-                <Translation id="TR_TERMS_OF_USE_TREZOR" />
-            </Link>
-            <Tooltip
-                content={
-                    <Column gap={12}>
-                        <Translation id="TR_BUY_FOOTER_TEXT_1" />
-                        <Translation id="TR_BUY_FOOTER_TEXT_2" />
-                    </Column>
-                }
-                cursor="default"
-            >
-                <Link href={TREZOR_TRADING_LEARN_MORE_URL}>
-                    <Translation id="TR_BUY_LEARN_MORE" />
+    return (
+        <Column alignItems="center" margin={{ top: 48 }} gap={12}>
+            <Text typographyStyle="hint" variant="tertiary">
+                <Translation
+                    id="TR_TRADING_TERMS"
+                    values={{
+                        provider: providerName,
+                        comp: chunks =>
+                            provider?.termsUrl ? (
+                                <Link href={provider.termsUrl}>{providerName}</Link>
+                            ) : (
+                                chunks
+                            ),
+                    }}
+                />
+            </Text>
+
+            <InfoSegments typographyStyle="hint" variant="tertiary">
+                <Link href={TREZOR_SUITE_TOS_URL}>
+                    <Translation id="TR_TERMS_OF_USE_TREZOR" />
                 </Link>
-            </Tooltip>
-        </InfoSegments>
-    </Column>
-);
+                <Tooltip
+                    content={
+                        <Column gap={12}>
+                            <Translation id="TR_BUY_FOOTER_TEXT_1" />
+                            <Translation id="TR_BUY_FOOTER_TEXT_2" />
+                        </Column>
+                    }
+                    cursor="default"
+                >
+                    <Link href={TREZOR_TRADING_LEARN_MORE_URL}>
+                        <Translation id="TR_BUY_LEARN_MORE" />
+                    </Link>
+                </Tooltip>
+            </InfoSegments>
+        </Column>
+    );
+};

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -781,17 +781,14 @@ export const messages = defineMessages({
             "Trezor doesn't see any of your payment or KYC information. You share this only with the exchange provider if you choose to complete the transaction.",
         id: 'TR_BUY_FOOTER_TEXT_2',
     },
-    TR_TRADING_TERMS_1: {
-        id: 'TR_TRADING_TERMS_1',
-        defaultMessage: "Trezor doesn't provide this service. It's governed by ",
+    TR_TERMS_PROVIDER_PLACEHOLDER: {
+        defaultMessage: 'provider',
+        id: 'TR_TERMS_PROVIDER_PLACEHOLDER',
     },
-    TR_TRADING_TERMS_2: {
-        id: 'TR_TRADING_TERMS_2',
-        defaultMessage: "provider's Terms & Conditions.",
-    },
-    TR_TRADING_TERMS_PROVIDER: {
-        id: 'TR_TRADING_TERMS_PROVIDER',
-        defaultMessage: "{companyName}'s Terms & Conditions.",
+    TR_TRADING_TERMS: {
+        id: 'TR_TRADING_TERMS',
+        defaultMessage:
+            "Trezor doesn't provide this service. It's governed by <comp>{provider}</comp>'s Terms & Conditions.",
     },
     TR_BUY_MODAL_SECURITY_HEADER: {
         defaultMessage: 'Security first with your Trezor',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

According to missing space in the Czech translation, I've refactor whole sentence whit was previously composed from 3 translation keys. Now is one with dynamic parameters.


## Notes for QA

Please verify that provider link and name is working correctly. It should work as before but we need to re-translate in Crowdin, cause I changed translation keys

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/24223

## Screenshots:
<img width="543" height="86" alt="image" src="https://github.com/user-attachments/assets/724e1360-3457-428d-9a1b-befacb697846" />
<img width="480" height="94" alt="image" src="https://github.com/user-attachments/assets/1c3cb7f4-1308-467d-907d-d14cd104beee" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/footer-translation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/footer-translation&lookback=7)