### PR TITLE
Tron updates

### DIFF
--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -70,12 +70,14 @@ export interface ServerInfo {
 
 export type TokenStandard =
     | 'TRC10'
-    | 'TRC20'
     | 'ERC20'
+    | 'TRC20'
     | 'BEP20'
-    | 'BEP721'
     | 'ERC721'
+    | 'TRC721'
+    | 'BEP721'
     | 'ERC1155'
+    | 'TRC1155'
     | 'BEP1155'
     | 'SPL'
     | 'SPL-2022'

--- a/packages/blockchain-link/src/ui/config.ts
+++ b/packages/blockchain-link/src/ui/config.ts
@@ -158,7 +158,7 @@ export default [
         blockchain: {
             name: 'Tron',
             worker: 'js/blockbook-worker.js',
-            server: ['https://backend14.sldev.cz:9312/'],
+            server: ['https://tron.trezor.io'],
             debug: true,
         },
         data: {

--- a/packages/connect-data/files/coins.json
+++ b/packages/connect-data/files/coins.json
@@ -2804,7 +2804,7 @@
         {
             "blockchain_link": {
                 "type": "blockbook",
-                "url": ["https://backend14.sldev.cz:9312"]
+                "url": ["https://tron.trezor.io"]
             },
             "curve": "secp256k1",
             "decimals": 6,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOItem.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOItem.tsx
@@ -45,14 +45,16 @@ export const IOItem = ({
             <Column alignItems="flex-start" overflow="hidden">
                 {!isOpReturn ? (
                     <>
-                        <Link href={explorerLink}>
-                            <Address
-                                value={value ?? ''}
-                                isTruncated
-                                data-testid="@tx-detail/txid-value"
-                                isCopyAllowed={!isPhishingTransaction}
-                            />
-                        </Link>
+                        {value && (
+                            <Link href={explorerLink}>
+                                <Address
+                                    value={value}
+                                    isTruncated
+                                    data-testid="@tx-detail/txid-value"
+                                    isCopyAllowed={!isPhishingTransaction}
+                                />
+                            </Link>
+                        )}
                         <Row gap={8}>
                             {anonymity && <UtxoAnonymity anonymity={anonymity} />}
                             {amount &&

--- a/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
+++ b/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
@@ -10,7 +10,12 @@ import {
 import { Explorer, Network } from '@suite-common/wallet-config';
 import { selectExplorer } from '@suite-common/wallet-core';
 import { SelectedAccountStatus } from '@suite-common/wallet-types';
-import { getNftContractExplorerUrl, getNftExplorerUrl } from '@suite-common/wallet-utils';
+import {
+    NFT_MULTITOKEN_STANDARDS,
+    NFT_SINGLETOKEN_STANDARDS,
+    getNftContractExplorerUrl,
+    getNftExplorerUrl,
+} from '@suite-common/wallet-utils';
 import {
     Badge,
     Button,
@@ -194,7 +199,7 @@ const NftsRow = ({
                     </Row>
                 </Table.Cell>
             </Table.Row>
-            {['ERC721', 'BEP721'].includes(nft.standard) &&
+            {NFT_SINGLETOKEN_STANDARDS.has(nft.standard) &&
                 nft.ids?.map((id, index) => (
                     <Table.Row
                         key={`${id}-${index}`}
@@ -226,7 +231,7 @@ const NftsRow = ({
                         </Table.Cell>
                     </Table.Row>
                 ))}
-            {['ERC1155', 'BEP1155'].includes(nft.standard) &&
+            {NFT_MULTITOKEN_STANDARDS.has(nft.standard) &&
                 nft.multiTokenValues?.map((value, index) => (
                     <Table.Row
                         key={`${nft.contract}-${index}`}

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -331,7 +331,7 @@ export const networks = {
         bip43Path: "m/44'/195'/0'/0/i",
         decimals: 6,
         testnet: false,
-        features: ['tokens', 'coin-definitions', 'graph'],
+        features: ['tokens', 'coin-definitions', 'graph', 'nfts'],
         explorer: getExplorerUrls('https://tronscan.org/#', 'tron'),
         support: {
             [DeviceModelInternal.T2T1]: '2.10.1',

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -512,11 +512,21 @@ export const getTxOperation = (
     return null;
 };
 
-const NFT_TOKEN_STANDARDS: ReadonlySet<TokenStandard> = new Set([
-    'ERC1155',
+export const NFT_SINGLETOKEN_STANDARDS: ReadonlySet<TokenStandard> = new Set([
     'ERC721',
-    'BEP1155',
+    'TRC721',
     'BEP721',
+]);
+
+export const NFT_MULTITOKEN_STANDARDS: ReadonlySet<TokenStandard> = new Set([
+    'ERC1155',
+    'TRC1155',
+    'BEP1155',
+]);
+
+const NFT_TOKEN_STANDARDS: ReadonlySet<TokenStandard> = new Set([
+    ...NFT_SINGLETOKEN_STANDARDS,
+    ...NFT_MULTITOKEN_STANDARDS,
 ]);
 
 export const isNftToken = <T extends Pick<TokenInfo, 'standard'>>(token: T) =>
@@ -531,7 +541,7 @@ export const isNftMultitokenTransfer = (transfer: TokenTransfer) =>
 export const getNftTokenId = (transfer: TokenTransfer) =>
     // use 0 index, haven't found an example where multiTokenValues.length > 1
     transfer.standard &&
-    ['ERC1155', 'BEP1155'].includes(transfer.standard) &&
+    NFT_MULTITOKEN_STANDARDS.has(transfer.standard) &&
     transfer.multiTokenValues?.length
         ? transfer.multiTokenValues[0].id
         : transfer.amount;

--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -16,7 +16,7 @@ import { CombinedLabelingState, selectAccountLabel } from '@suite-native/labelin
 import { NativeStakingRootState, selectAccountHasStaking } from '@suite-native/staking';
 import {
     TokensRootState,
-    isCoinWithTokens,
+    isNetworkWithTokens,
     selectAccountHasAnyKnownToken,
     selectNumberOfAccountTokensWithFiatRates,
 } from '@suite-native/tokens';
@@ -104,8 +104,8 @@ export const AccountsListItem = ({
         ),
     );
 
-    const doesCoinSupportTokens = isCoinWithTokens(account.symbol);
-    const shouldShowAccountLabel = !doesCoinSupportTokens || !isNativeCoinOnly;
+    const isNetworkSupportingTokens = isNetworkWithTokens(account.symbol);
+    const shouldShowAccountLabel = !isNetworkSupportingTokens || !isNativeCoinOnly;
     const shouldShowTokenBadge = accountHasAnyTokens && !isNativeCoinOnly;
     const shouldShowStakingBadge = accountHasStaking && !isNativeCoinOnly;
 

--- a/suite-native/accounts/src/components/SelectableNetworkItem.tsx
+++ b/suite-native/accounts/src/components/SelectableNetworkItem.tsx
@@ -3,7 +3,7 @@ import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { Badge, Box, HStack, PressableOpacity, RoundedIcon, Text } from '@suite-native/atoms';
 import { Icon, IconName } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { isCoinWithTokens } from '@suite-native/tokens';
+import { isNetworkWithTokens } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 export type SelectableAssetItemProps = {
@@ -35,7 +35,7 @@ export const SelectableNetworkItem = ({ symbol, onPress, rightIcon }: Selectable
 
     const networkName = getNetwork(symbol).name;
 
-    const hasTokens = isCoinWithTokens(symbol);
+    const isNetworkSupportingTokens = isNetworkWithTokens(symbol);
 
     return (
         <PressableOpacity
@@ -55,7 +55,7 @@ export const SelectableNetworkItem = ({ symbol, onPress, rightIcon }: Selectable
                                     areAmountUnitsEnabled={false}
                                 />
                             </Text>
-                            {hasTokens && (
+                            {isNetworkSupportingTokens && (
                                 <Box style={applyStyle(tokensBadgeStyle)}>
                                     <Badge
                                         label={<Translation id="generic.tokens" />}

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -33,7 +33,7 @@ import {
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
 import { doesCoinSupportStaking } from '@suite-native/staking';
-import { isCoinWithTokens, selectAccountTokenInfo } from '@suite-native/tokens';
+import { isNetworkWithTokens, selectAccountTokenInfo } from '@suite-native/tokens';
 
 import { AccountSelectBottomSheetSection, GroupedByTypeAccounts } from './types';
 import {
@@ -128,17 +128,17 @@ export const getAccountListSections = (
     tokenDefinitions: SimpleTokenStructure | undefined,
 ) => {
     const sections: AccountSelectBottomSheetSection[] = [];
-    const canHasTokens = isCoinWithTokens(account.symbol);
+    const isNetworkSupportingTokens = isNetworkWithTokens(account.symbol);
 
     const tokens = filterKnownTokens(tokenDefinitions, account.symbol, account.tokens ?? []);
-    const hasAnyKnownTokens = canHasTokens && !!tokens.length;
+    const hasAnyKnownTokens = isNetworkSupportingTokens && !!tokens.length;
 
     const stakingBalance = getAccountTotalStakingBalance(account) ?? '0';
 
     const hasStakingBalance = stakingBalance !== '0' || isCardanoStakingActive(account);
     const hasStaking = doesCoinSupportStaking(account.symbol) && hasStakingBalance;
 
-    if (canHasTokens) {
+    if (isNetworkSupportingTokens) {
         sections.push({
             type: 'sectionTitle',
             account,

--- a/suite-native/coin-enabling/src/components/NetworkSymbolSwitchItem.tsx
+++ b/suite-native/coin-enabling/src/components/NetworkSymbolSwitchItem.tsx
@@ -4,7 +4,7 @@ import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { Card, HStack, PressableOpacity, Switch, Text, VStack } from '@suite-native/atoms';
 import { CryptoIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { isCoinWithTokens } from '@suite-native/tokens';
+import { isNetworkWithTokens } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type NetworkSymbolSwitchItemProps = {
@@ -66,7 +66,7 @@ export const NetworkSymbolSwitchItem = ({
                     >
                         <VStack spacing={0}>
                             <Text variant="callout">{name}</Text>
-                            {isCoinWithTokens(symbol) && (
+                            {isNetworkWithTokens(symbol) && (
                                 <Text variant="hint" color="textSubdued">
                                     <Translation id="generic.tokens" />
                                 </Text>

--- a/suite-native/discovery/src/discoverySelectors.ts
+++ b/suite-native/discovery/src/discoverySelectors.ts
@@ -23,7 +23,7 @@ import {
 } from '@suite-native/feature-flags';
 import { SettingsSliceRootState, selectAreTestnetsEnabled } from '@suite-native/settings';
 import {
-    isCoinWithTokens,
+    isNetworkWithTokens,
     selectNetworkSymbolsOfAccountsWithTokensAllowed,
 } from '@suite-native/tokens';
 import { getFirmwareVersion } from '@trezor/device-utils';
@@ -121,7 +121,7 @@ export const selectTokenDefinitionsEnabledNetworks = createMemoizedSelector(
         returnStableArrayIfEmpty(
             pipe(
                 [...enabledNetworkSymbols, ...accountNetworkSymbols],
-                A.filter(s => isCoinWithTokens(s)),
+                A.filter(s => isNetworkWithTokens(s)),
                 A.uniq,
             ),
         ),

--- a/suite-native/formatters/src/components/TransactionIdFormatter.tsx
+++ b/suite-native/formatters/src/components/TransactionIdFormatter.tsx
@@ -7,6 +7,6 @@ type TransactionIdFormatterProps = FormatterProps<WalletAccountTransaction['txid
 
 export const TransactionIdFormatter = ({ value, ...rest }: TransactionIdFormatterProps) => (
     <Text variant="hint" numberOfLines={1} ellipsizeMode="tail" {...rest}>
-        #{value}
+        {value}
     </Text>
 );

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -15,7 +15,7 @@ import {
 } from '@suite-common/wallet-core';
 import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
 import { getAccountIdentity, shouldUseIdentities } from '@suite-common/wallet-utils';
-import { isCoinWithTokens } from '@suite-native/tokens';
+import { isNetworkWithTokens } from '@suite-native/tokens';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import TrezorConnect, { AccountInfo } from '@trezor/connect';
 import { convertTaprootXpub } from '@trezor/utils';
@@ -120,7 +120,7 @@ export const getAccountInfoThunk = createThunk<
                 const tokenDefinitions = selectNetworkTokenDefinitions(getState(), symbol);
 
                 // fetch token definitions for this network in case they are needed
-                if (!tokenDefinitions && isCoinWithTokens(symbol)) {
+                if (!tokenDefinitions && isNetworkWithTokens(symbol)) {
                     const definitionTypes = getSupportedDefinitionTypes(symbol);
 
                     const promises = definitionTypes.map(async type => {

--- a/suite-native/module-send/src/components/CorrectNetworkMessageCard.tsx
+++ b/suite-native/module-send/src/components/CorrectNetworkMessageCard.tsx
@@ -3,7 +3,6 @@ import { Card, HStack, Text } from '@suite-native/atoms';
 import { NetworkIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { Link } from '@suite-native/link';
-import { isCoinWithTokens } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { HOW_TO_CHOOSE_RIGHT_NETWORK_URL } from '@trezor/urls';
 
@@ -23,9 +22,9 @@ type CorrectNetworkMessageCardProps = {
 export const CorrectNetworkMessageCard = ({ symbol }: CorrectNetworkMessageCardProps) => {
     const { applyStyle } = useNativeStyles();
 
-    if (!isCoinWithTokens(symbol)) return null;
+    const network = getNetwork(symbol);
 
-    const networkName = getNetwork(symbol).name;
+    if (network.networkType !== 'ethereum') return null;
 
     return (
         <Card style={applyStyle(cardStyle)}>
@@ -35,7 +34,7 @@ export const CorrectNetworkMessageCard = ({ symbol }: CorrectNetworkMessageCardP
                     <Translation
                         id="moduleSend.outputs.correctNetworkMessage"
                         values={{
-                            networkName,
+                            networkName: network.name,
                             link: linkChunk => {
                                 const label = (linkChunk[0] as string) ?? '';
 

--- a/suite-native/module-transactions/src/components/NetworkTransactionDetailSummary.tsx
+++ b/suite-native/module-transactions/src/components/NetworkTransactionDetailSummary.tsx
@@ -71,9 +71,12 @@ export const NetworkTransactionDetailSummary = ({
             selectTransactionAddresses(state, accountKey, transaction.txid, 'outputs'),
     );
 
+    const isNonEmptyInput = A.isNotEmpty(transactionInputAddresses);
+    const isNonEmptyOutput = A.isNotEmpty(transactionOutputAddresses);
+
     return (
         <VStack spacing="sp24">
-            {A.isNotEmpty(transactionInputAddresses) && (
+            {isNonEmptyInput && (
                 <TransactionDetailAddressesSection
                     addressesType="inputs"
                     addresses={transactionInputAddresses}
@@ -81,7 +84,7 @@ export const NetworkTransactionDetailSummary = ({
                     transaction={transaction}
                 />
             )}
-            {A.isNotEmpty(transactionOutputAddresses) && (
+            {isNonEmptyOutput && (
                 <TransactionDetailAddressesSection
                     addressesType="outputs"
                     addresses={transactionOutputAddresses}
@@ -89,7 +92,9 @@ export const NetworkTransactionDetailSummary = ({
                     transaction={transaction}
                 />
             )}
-            <VerticalSeparator inputsCount={transactionInputAddresses.length} />
+            {isNonEmptyInput && isNonEmptyOutput && (
+                <VerticalSeparator inputsCount={transactionInputAddresses.length} />
+            )}
         </VStack>
     );
 };

--- a/suite-native/tokens/src/tokensSelectors.ts
+++ b/suite-native/tokens/src/tokensSelectors.ts
@@ -28,7 +28,7 @@ import { shouldUppercaseTokenSymbol } from '@suite-common/wallet-utils';
 import { TokenInfo, TokenTransfer } from '@trezor/blockchain-link';
 
 import { TypedTokenTransfer, WalletAccountTransaction } from './types';
-import { isCoinWithTokens } from './utils';
+import { isNetworkWithTokens } from './utils';
 
 export type TokensRootState = AccountsRootState &
     DeviceRootState &
@@ -152,7 +152,7 @@ export const selectAccountTransactionsWithTokenTransfers = createMemoizedSelecto
 export const selectAccountsKnownTokens = createMemoizedSelector(
     [selectAccountByKey, selectTokenDefinitions],
     (account, tokenDefinitions): TokenInfoBranded[] => {
-        if (!account || !isCoinWithTokens(account.symbol)) {
+        if (!account || !isNetworkWithTokens(account.symbol)) {
             return returnStableArrayIfEmpty<TokenInfoBranded>([]);
         }
 
@@ -177,7 +177,7 @@ export const selectNumberOfAccountTokensWithFiatRates = (
 ): number => {
     const account = selectAccountByKey(state, accountKey);
 
-    if (!account || !isCoinWithTokens(account.symbol)) {
+    if (!account || !isNetworkWithTokens(account.symbol)) {
         return 0;
     }
 
@@ -190,7 +190,7 @@ export const selectHasDeviceAnyTokensForNetwork = (
     state: TokensRootState,
     symbol: NetworkSymbol,
 ) => {
-    if (!isCoinWithTokens(symbol)) {
+    if (!isNetworkWithTokens(symbol)) {
         return false;
     }
 
@@ -206,7 +206,7 @@ export const selectHasDeviceAnyTokensForNetwork = (
 export const selectAccountHasAnyKnownToken = (state: TokensRootState, accountKey: string) => {
     const account = selectAccountByKey(state, accountKey);
 
-    if (!account || !isCoinWithTokens(account.symbol)) {
+    if (!account || !isNetworkWithTokens(account.symbol)) {
         return false;
     }
 
@@ -219,7 +219,7 @@ export const selectNetworkSymbolsOfAccountsWithTokensAllowed = createMemoizedSel
     [selectAccounts],
     accounts =>
         accounts
-            .filter(a => isCoinWithTokens(a.symbol))
+            .filter(a => isNetworkWithTokens(a.symbol))
             .reduce((acc, account) => {
                 if (!acc.includes(account.symbol)) {
                     acc.push(account.symbol);

--- a/suite-native/tokens/src/utils.ts
+++ b/suite-native/tokens/src/utils.ts
@@ -9,21 +9,7 @@ export const getTokenName = (tokenName?: string) => {
     return tokenName;
 };
 
-export const NETWORK_SYMBOLS_WITH_TOKENS = [
-    'eth',
-    'pol',
-    'bsc',
-    'sol',
-    'op',
-    'base',
-    'arb',
-    'avax',
-    'xlm',
-    'ada',
-] satisfies Array<NetworkSymbol>;
-export type NetworkSymbolWithTokens = (typeof NETWORK_SYMBOLS_WITH_TOKENS)[number];
-
-export const isCoinWithTokens = (symbol: NetworkSymbol): symbol is NetworkSymbolWithTokens => {
+export const isNetworkWithTokens = (symbol: NetworkSymbol) => {
     if (symbol === 'xlm' && !isDevelopOrDebugEnv()) {
         return false;
     }

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.tsx
@@ -4,7 +4,7 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenAddress } from '@suite-common/wallet-types';
 import { VStack } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
-import { isCoinWithTokens } from '@suite-native/tokens';
+import { isNetworkWithTokens } from '@suite-native/tokens';
 import { BigNumber } from '@trezor/utils';
 
 import { ReviewOutputCard } from './ReviewOutputCard';
@@ -82,7 +82,7 @@ export const ReviewOutputSummaryItem = ({
 
     const { state, totalSpent, fee } = summaryOutput;
 
-    const canHaveTokens = isCoinWithTokens(symbol);
+    const isNetworkSupportingTokens = isNetworkWithTokens(symbol);
 
     return (
         <View onLayout={onLayout}>
@@ -91,7 +91,7 @@ export const ReviewOutputSummaryItem = ({
                 outputState={state}
             >
                 <VStack spacing="sp16">
-                    {canHaveTokens ? (
+                    {isNetworkSupportingTokens ? (
                         <TokenEnabledValues
                             accountKey={accountKey}
                             totalSpent={totalSpent}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- tron updated to the production one to have valid certificate
- mobile: nit: # does not make sense in tx id, removed
- mobile: show warning about address in send form only for EVM
- desktop: fix undefined ... undefined address in inputs outputs
- rename method from isCoinWithTokens to isNetworkWithTokens
- no to Separator when there is no to
- nfts should be displayed same as on EVM, not tested, no nft on account

## Notes for QA

## Related Issue

resolve #24648
resolve  #24711
resolve #24651
resolve [#24653](https://github.com/trezor/trezor-suite/issues/24653)

## Screenshots:

<img width="801" height="549" alt="Screenshot 2026-01-28 at 15 52 24" src="https://github.com/user-attachments/assets/16483c89-818e-41bf-96d0-aef9144cb122" />

Now removed for non-EVMs

<img width="447" height="564" alt="Screenshot 2026-01-28 at 9 30 44" src="https://github.com/user-attachments/assets/1cf9f5bf-1d18-4258-937a-2ccef730aaf8" />

Now does not have `#`

<img width="424" height="401" alt="Screenshot 2026-01-28 at 9 27 03" src="https://github.com/user-attachments/assets/71455bca-8b3a-461d-811b-5a81c2f77f4c" />
<img width="416" height="299" alt="Screenshot 2026-01-28 at 9 26 22" src="https://github.com/user-attachments/assets/765f8fcd-981e-49a5-8e00-1ad7538fc277" />

No To separator
<img width="408" height="354" alt="Screenshot 2026-01-28 at 16 18 57" src="https://github.com/user-attachments/assets/06105af4-d3b7-4151-a6a1-3a7b69476d44" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/tron-url&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/tron-url&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/tron-url&lookback=7)