### PR TITLE
fix(suite-native): use unique key for transaction inputs/outputs

### DIFF
--- a/suite-native/module-transactions/src/components/TransactionDetailInputsSheetSection.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailInputsSheetSection.tsx
@@ -85,9 +85,9 @@ export const TransactionDetailInputsSheetSection = ({
                     {transfers.map(({ inputs, outputs, symbol, decimals }) => (
                         <Fragment key={symbol}>
                             <Box style={applyStyle(addressAmountColumnStyle)}>
-                                {inputs.map(({ address, amount }) => (
+                                {inputs.map(({ address, amount }, index) => (
                                     <TransactionAddressAmount
-                                        key={address}
+                                        key={`${address}:${index}`}
                                         address={address}
                                         amount={amount}
                                         symbol={symbol}
@@ -97,9 +97,9 @@ export const TransactionDetailInputsSheetSection = ({
                             </Box>
                             <Icon name="caretCircleRight" color="iconDisabled" size="medium" />
                             <Box style={applyStyle(addressAmountColumnStyle)}>
-                                {outputs.map(({ address, amount }) => (
+                                {outputs.map(({ address, amount }, index) => (
                                     <TransactionAddressAmount
-                                        key={address}
+                                        key={`${address}:${index}`}
                                         address={address}
                                         amount={amount}
                                         symbol={symbol}


### PR DESCRIPTION
Fixes the _Encountered two children with the same key_ error on the _Inputs & Outputs_ bottom sheet.
Happens whenever you spend multiple UTXOs from a single address.

## Notes for QA

Testable on the all seed BTC account, transaction from 28th January 2026 at 16:13.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/transaction-inputs-outputs&lookback=7)