### PR TITLE
feat(native, common): added analytics to native, renamed secure sync …

### DIFF
--- a/packages/suite/src/constants/suite/labeling.ts
+++ b/packages/suite/src/constants/suite/labeling.ts
@@ -1,7 +1,7 @@
 import { TranslationKey } from '@suite/intl';
 import { typedObjectValues } from '@trezor/utils';
 
-export type LabelingSelectValue = 'off' | 'secure-sync' | 'legacy';
+export type LabelingSelectValue = 'off' | 'suite-sync' | 'legacy';
 
 export type LabelingOption<T> = { label: T; value: LabelingSelectValue };
 export type LabelingOptionTranslated = LabelingOption<TranslationKey>;
@@ -11,7 +11,7 @@ export const LABELING_SELECT_OPTIONS_MAP: Record<
     LabelingOption<TranslationKey>
 > = {
     off: { label: 'TR_LABELING_OFF', value: 'off' },
-    'secure-sync': { label: 'TR_LABELING_SECURE_SYNC', value: 'secure-sync' },
+    'suite-sync': { label: 'TR_LABELING_SECURE_SYNC', value: 'suite-sync' },
     legacy: { label: 'TR_LABELING_LEGACY', value: 'legacy' },
 };
 

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -79,7 +79,7 @@ export const Labeling = () => {
                 suiteSync.turnOffSuiteSync();
                 break;
 
-            case 'secure-sync': {
+            case 'suite-sync': {
                 const result = await suiteSync.turnOnSuiteSync({ deviceStaticSessionId });
                 if (!result.success) {
                     const { type } = result.error;
@@ -114,7 +114,7 @@ export const Labeling = () => {
         analytics.report({
             type: EventType.SettingsGeneralLabeling,
             payload: {
-                value: value === 'secure-sync' ? 'suite-sync' : value,
+                value,
             },
         });
     };
@@ -130,7 +130,7 @@ export const Labeling = () => {
         );
 
         if (showSuiteSync) {
-            if (isSuiteSyncEnabled) return LABELING_SELECT_TRANSLATED_OPTIONS_MAP['secure-sync'];
+            if (isSuiteSyncEnabled) return LABELING_SELECT_TRANSLATED_OPTIONS_MAP['suite-sync'];
             if (legacyMetadataState.enabled) return LABELING_SELECT_TRANSLATED_OPTIONS_MAP.legacy;
 
             return LABELING_SELECT_TRANSLATED_OPTIONS_MAP.off;

--- a/suite-native/app/e2e/pageObjects/settingsActions.ts
+++ b/suite-native/app/e2e/pageObjects/settingsActions.ts
@@ -119,7 +119,7 @@ class SettingsActions {
         await onTabBar.tapBackButton();
 
         await this.openSection('suite-sync');
-        await element(by.id('settings/secure-sync-touchable-row')).tap();
+        await element(by.id('settings/suite-sync-touchable-row')).tap();
         await TrezorUserEnvLink.pressYes();
     }
 }

--- a/suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx
@@ -5,11 +5,12 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { TouchableSwitchRow } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
-import { useNativeServices } from '@suite-native/services';
+import { useLegacyAnalytics, useNativeServices } from '@suite-native/services';
 import { useToast } from '@suite-native/toasts';
 import { exhaustive } from '@trezor/type-utils';
 
 export const ToggleSuiteSyncCard = () => {
+    const analytics = useLegacyAnalytics();
     const { showAlert } = useAlert();
     const { showToast } = useToast();
     const { suiteSync } = useNativeServices();
@@ -21,7 +22,15 @@ export const ToggleSuiteSyncCard = () => {
             title: <Translation id="suiteSync.disableAlert.title" />,
             description: <Translation id="suiteSync.disableAlert.description" />,
             primaryButtonTitle: <Translation id="suiteSync.disableAlert.cta" />,
-            onPressPrimaryButton: suiteSync.turnOffSuiteSync,
+            onPressPrimaryButton: () => {
+                suiteSync.turnOffSuiteSync();
+                analytics.report({
+                    type: 'settings/general/labeling',
+                    payload: {
+                        value: 'off',
+                    },
+                });
+            },
             secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
         });
     };
@@ -32,6 +41,13 @@ export const ToggleSuiteSyncCard = () => {
         } else {
             const result = await suiteSync.turnOnSuiteSync({
                 deviceStaticSessionId: selectedDevice?.state?.staticSessionId,
+            });
+
+            analytics.report({
+                type: 'settings/general/labeling',
+                payload: {
+                    value: 'suite-sync',
+                },
             });
 
             if (!result.success) {
@@ -62,7 +78,7 @@ export const ToggleSuiteSyncCard = () => {
                     <Translation id="moduleSettings.items.features.suiteSync.toggleDescription" />
                 }
                 accessibilityLabel="Secure sync toggle"
-                testID="settings/secure-sync-touchable-row"
+                testID="settings/suite-sync-touchable-row"
             />
         </>
     );

--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -64,7 +64,7 @@ export class MetadataPage {
         await this.settingsPage.navigateTo('application');
         await this.page.selectDropdownOptionWithRetry(
             this.settingsPage.metadataSelectInput,
-            this.settingsPage.metadataSelectInputOption('secure-sync'),
+            this.settingsPage.metadataSelectInputOption('suite-sync'),
         );
     }
 


### PR DESCRIPTION
Add analytics event when turning on and off the suite sync.


## Notes for QA

- should send analytics event from native app when user turns on / off the suite sync

## Related Issue

partially https://github.com/trezor/trezor-suite/issues/24036

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=native/suite-sync/analytics&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=native/suite-sync/analytics&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=native/suite-sync/analytics&lookback=7)