### PR TITLE
fix(connect): handle device disconnection in FW update + THP flow

### DIFF
--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -44,6 +44,53 @@ type ReconnectContext = {
     uiPromises: { create: UiPromiseCreator; rejectAll: (e: Error) => void };
 };
 
+// create UI promise and wait for:
+// - pairing confirmation
+// - device disconnection
+// - abort signal
+const waitForThpPairingConfirmation = async ({
+    uiPromises,
+    postMessage,
+    device,
+    deviceList,
+    abortSignal,
+    thpPairingError,
+}: Pick<
+    ReconnectContext,
+    'uiPromises' | 'postMessage' | 'device' | 'deviceList' | 'abortSignal'
+> & {
+    thpPairingError: boolean;
+}) => {
+    const uiPromise = uiPromises.create(UI.RECEIVE_CONFIRMATION, device);
+    postMessage(
+        createUiMessage(UI.REQUEST_CONFIRMATION, {
+            view: thpPairingError ? 'thp-pairing-failed' : 'thp-pairing-start',
+        }),
+    );
+
+    const devicePath = device.getUniquePath();
+    const disconnectListener = (event: Device) => {
+        if (event.getUniquePath() === devicePath) {
+            uiPromise.reject(ERRORS.TypedError('Device_Disconnected'));
+        }
+    };
+    const abortListener = () => {
+        uiPromise.reject(ERRORS.TypedError('Method_Interrupted'));
+    };
+
+    try {
+        abortSignal.addEventListener('abort', abortListener);
+        deviceList.on('device-disconnect', disconnectListener);
+        const uiResp = await uiPromise.promise;
+        if (!uiResp.payload) {
+            throw ERRORS.TypedError('Method_PermissionsNotGranted');
+        }
+    } finally {
+        abortSignal.removeEventListener('abort', abortListener);
+        deviceList.off('device-disconnect', disconnectListener);
+    }
+};
+
 const waitForReconnectedDevice = async (
     { bootloader, method, intermediary }: ReconnectParams,
     {
@@ -119,15 +166,20 @@ const waitForReconnectedDevice = async (
             let runFn;
             if (reconnectedDevice.getThpState()?.properties) {
                 // stop and wait for UI decision
-                const uiPromise = uiPromises.create(UI.RECEIVE_CONFIRMATION, reconnectedDevice);
-                postMessage(
-                    createUiMessage(UI.REQUEST_CONFIRMATION, {
-                        view: thpPairingError ? 'thp-pairing-failed' : 'thp-pairing-start',
-                    }),
-                );
-                const uiResp = await uiPromise.promise;
-                if (!uiResp.payload) {
-                    throw ERRORS.TypedError('Method_PermissionsNotGranted');
+                try {
+                    await waitForThpPairingConfirmation({
+                        uiPromises,
+                        postMessage,
+                        device: reconnectedDevice,
+                        deviceList,
+                        thpPairingError,
+                        abortSignal,
+                    });
+                } catch (e) {
+                    if (e.code === 'Device_Disconnected') {
+                        continue; // loop again, wait for FIRMWARE_RECONNECT
+                    }
+                    throw e;
                 }
 
                 runFn = () => Promise.resolve(); // enforce pairing UI interaction

--- a/packages/connect/src/utils/uiPromiseManager.ts
+++ b/packages/connect/src/utils/uiPromiseManager.ts
@@ -21,6 +21,13 @@ export const createUiPromiseManager = () => {
             _uiPromises.splice(existing, 1);
         }
 
+        // enhance Deferred reject fn
+        const { reject } = uiPromise;
+        uiPromise.reject = (error: Error) => {
+            reject(error);
+            _uiPromises = _uiPromises.filter(p => p.id !== promiseEvent);
+        };
+
         _uiPromises.push(uiPromise as unknown as AnyUiPromise);
 
         return uiPromise;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Steps to completely lock you remembered device:

1. connect and pair THP device
2. wait for accounts discovery
3. restart trezor (from device menu Power > Restart)
4. wait for THP pairing (connection confirmation) and cancel it
5. you remembered wallet is completely inaccessible, even if you disconnect the device or restart suite

If device is remembered then this state shouldnt be considered as blocking prerequisite

Note sure if this issue was reported somewhere, please link it if so


## Screenshots:
<img width="1447" height="959" alt="Screenshot from 2026-01-28 16-46-12" src="https://github.com/user-attachments/assets/beb89170-361c-4561-a7c5-1338044c1a0a" />
<img width="1447" height="959" alt="Screenshot from 2026-01-28 16-45-53" src="https://github.com/user-attachments/assets/11f7da85-88a1-4375-a6e9-c0a5a2013448" />


## New proposed view:
<img width="1447" height="959" alt="Screenshot from 2026-01-28 16-17-54" src="https://github.com/user-attachments/assets/64187613-b27d-44ba-a18b-da2407883c49" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-thp-device-needs-atention&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-thp-device-needs-atention&lookback=7)