### PR TITLE
fix(suite): THP remembered device prerequisite

### DIFF
--- a/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
@@ -270,6 +270,8 @@ const connect: Fixture<
                     type: 'acquired',
                     path: '1',
                     remember: true,
+                    connected: false,
+                    available: false,
                 }),
             ],
         },
@@ -288,10 +290,12 @@ const connect: Fixture<
         ],
         result: [
             {
-                type: 'unacquired',
+                type: 'acquired',
                 status: 'thp-locked',
                 path: '1',
                 remember: true,
+                connected: true,
+                available: true,
             },
         ],
     },

--- a/packages/suite/src/utils/suite/prerequisites.ts
+++ b/packages/suite/src/utils/suite/prerequisites.ts
@@ -65,7 +65,7 @@ export const getPrerequisiteName = ({
     // Unacquired device with Trezor Host Protocol properties means
     // that the user must perform the Trezor Host Protocol paring
     if (device.status === 'thp-locked') {
-        return 'device-thp-locked';
+        return !device.features ? 'device-thp-locked' : null;
     }
 
     // device features cannot be read, device is probably used in another window

--- a/packages/suite/src/views/suite/SwitchDevice/CardWithDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/CardWithDevice.tsx
@@ -31,7 +31,7 @@ export const CardWithDevice = ({
 }: CardWithDeviceProps) => {
     const deviceStatus = deviceUtils.getStatus(device);
 
-    const needsAttention = deviceUtils.deviceNeedsAttention(deviceStatus);
+    const needsAttention = device.connected && deviceUtils.deviceNeedsAttention(deviceStatus);
     const isUnknown = device.type !== 'acquired';
 
     return (

--- a/suite-common/suite-types/mocks/mockSuiteDevice.ts
+++ b/suite-common/suite-types/mocks/mockSuiteDevice.ts
@@ -208,5 +208,8 @@ export const mockSuiteDevice = (
         } as TrezorDevice;
     }
 
-    return device as TrezorDevice;
+    return {
+        ...device,
+        ...dev,
+    } as TrezorDevice;
 };

--- a/suite-common/suite-utils/src/__fixtures__/device.ts
+++ b/suite-common/suite-utils/src/__fixtures__/device.ts
@@ -48,12 +48,29 @@ const getStatus: Array<{ device: TrezorDevice; status: string }> = [
         status: 'connected',
     },
     {
-        device: mockSuiteDevice({ type: 'unacquired' }),
+        device: mockSuiteDevice({ connected: true, available: false, type: 'unacquired' }),
         status: 'unacquired',
     },
     {
-        device: mockSuiteDevice({ type: 'unreadable' }),
+        device: mockSuiteDevice({ connected: true, available: false, type: 'unreadable' }),
         status: 'unreadable',
+    },
+    {
+        device: mockSuiteDevice({
+            connected: true,
+            available: false,
+            type: 'unacquired',
+            status: 'thp-locked',
+        }),
+        status: 'device-thp-locked',
+    },
+    {
+        device: mockSuiteDevice({
+            connected: true,
+            available: false,
+            status: 'thp-locked',
+        }),
+        status: 'device-thp-locked',
     },
 ];
 

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -39,13 +39,29 @@ export const deviceStatuses = [
 export type DeviceStatus = (typeof deviceStatuses)[number];
 
 export const getStatus = (device: TrezorDevice): DeviceStatus => {
+    if (!device.connected) {
+        return 'disconnected';
+    }
     if (device.status === 'busy') {
         return 'device-busy';
     }
+    if (device.status === 'thp-locked') {
+        return 'device-thp-locked';
+    }
+    if (device.status === 'rebooting') {
+        return 'device-rebooting';
+    }
+    if (device.status === 'bootloader-locked') {
+        return 'device-bootloader-locked';
+    }
+    if (device.status === 'hard-locked') {
+        return 'device-hard-locked';
+    }
+    if (device.status === 'pin-locked') {
+        return 'device-pin-locked';
+    }
+
     if (device.type === 'acquired') {
-        if (!device.connected) {
-            return 'disconnected';
-        }
         if (!device.available) {
             return 'unavailable';
         }
@@ -75,26 +91,6 @@ export const getStatus = (device: TrezorDevice): DeviceStatus => {
         }
 
         return 'connected';
-    }
-
-    if (device.status === 'rebooting') {
-        return 'device-rebooting';
-    }
-
-    if (device.status === 'bootloader-locked') {
-        return 'device-bootloader-locked';
-    }
-
-    if (device.status === 'hard-locked') {
-        return 'device-hard-locked';
-    }
-
-    if (device.status === 'pin-locked') {
-        return 'device-pin-locked';
-    }
-
-    if (device.status === 'thp-locked') {
-        return 'device-thp-locked';
     }
 
     if (device.type === 'unacquired') {

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -153,14 +153,14 @@ const connectDevice = (
     if (!device.features) {
         const knownDevices = draft.devices.filter(
             ({ descriptor }) =>
-                descriptor &&
-                descriptor?.id === device.descriptor?.id &&
+                descriptor?.id &&
+                descriptor.id === device.descriptor?.id &&
                 descriptor.apiType === device.descriptor?.apiType,
         );
         if (knownDevices.length > 0) {
             knownDevices.forEach(dd => {
-                dd.type = device.type;
                 dd.connected = true;
+                dd.available = true;
                 dd.path = device.path;
                 dd.status = device.status;
                 dd.thp = device.thp;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Steps to completely lock you remembered wallets:

1. connect and pair THP device
2. wait for accounts discovery
3. restart trezor (from device menu Power > Restart)
4. wait for THP pairing (connection confirmation) and cancel it

your remembered wallet is now completely inaccessible even if you disconnect the device or restart suite, device menu doesnt even show device the name, only "Try again"

## Fixes

- `thp-locked` status shouldn't be considered as blocking prerequisite if device is remembered (has features)
-  don't display `NeedsAttentionBanner` if device is remembered and disconnected
- change the order in `getStatus` utility.  `device.connected` and `device.status` (DeviceBusyStatus from trezor-connect) applies to both device types acquired and unacquired.
- deviceReducer - do not "downgrade" device from `acquired` to `unacquired` - partial revert of https://github.com/trezor/trezor-suite/commit/b7a7ee3d904cc01c4102e36151da655f029c01e0
- deviceReducer - set device `available: true` if connected as unacquired

Note sure if this issue was reported somewhere, please link it if so


## Screenshots:
<img width="1447" height="959" alt="Screenshot from 2026-01-28 16-46-12" src="https://github.com/user-attachments/assets/beb89170-361c-4561-a7c5-1338044c1a0a" />
<img width="1447" height="959" alt="Screenshot from 2026-01-28 16-45-53" src="https://github.com/user-attachments/assets/11f7da85-88a1-4375-a6e9-c0a5a2013448" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-thp-device-needs-atention&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-thp-device-needs-atention&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-thp-device-needs-atention&lookback=7)