### PR TITLE
Feat: Sentry tweaks, ignores & event hard limit

### DIFF
--- a/packages/suite-desktop-core/src/modules/coinjoin.ts
+++ b/packages/suite-desktop-core/src/modules/coinjoin.ts
@@ -5,7 +5,7 @@
 import { captureMessage, withScope } from '@sentry/electron/main';
 import { ipcMain } from 'electron';
 
-import { coinjoinNetworkTag, coinjoinReportTag } from '@suite-common/sentry';
+import { COINJOIN_NETWORK_TAG, COINJOIN_REPORT_TAG } from '@suite-common/sentry';
 import { CoinjoinBackend, CoinjoinBackendSettings, CoinjoinClient } from '@trezor/coinjoin';
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { getFreePort } from '@trezor/node-utils';
@@ -51,8 +51,8 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
     const sentryError = (network: string, payload: string) => {
         withScope(scope => {
             scope.clear(); // scope is also cleared in beforeSend sentry handler, this is just to be safe.
-            scope.setTag(coinjoinReportTag, true);
-            scope.setTag(coinjoinNetworkTag, network);
+            scope.setTag(COINJOIN_REPORT_TAG, true);
+            scope.setTag(COINJOIN_NETWORK_TAG, network);
             captureMessage(payload, scope);
         });
     };

--- a/packages/suite/src/utils/suite/sentry.ts
+++ b/packages/suite/src/utils/suite/sentry.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/core';
 
 import { selectAnalyticsInstanceId } from '@suite-common/analytics-redux';
 import { redactDevice, selectRedactedActionsLog } from '@suite-common/logger';
-import { allowReportTag } from '@suite-common/sentry';
+import { ALLOW_REPORT_TAG } from '@suite-common/sentry';
 import { ReportSecurityCheckParams } from '@suite-common/suite-types';
 import {
     selectDiscoveryForSelectedDevice,
@@ -23,7 +23,7 @@ export const withSentryScope = Sentry.withScope;
 export const captureSentryMessage = Sentry.captureMessage;
 
 export const allowSentryReport = (value: boolean) => {
-    Sentry.setTag(allowReportTag, value);
+    Sentry.setTag(ALLOW_REPORT_TAG, value);
 };
 
 export const setSentryUser = (instanceId: string) => {

--- a/suite-common/sentry/src/constants.ts
+++ b/suite-common/sentry/src/constants.ts
@@ -1,3 +1,3 @@
-export const allowReportTag = 'allowReport';
-export const coinjoinReportTag = 'coinjoinReport';
-export const coinjoinNetworkTag = 'coinjoinNetwork';
+export const ALLOW_REPORT_TAG = 'allowReport';
+export const COINJOIN_REPORT_TAG = 'coinjoinReport';
+export const COINJOIN_NETWORK_TAG = 'coinjoinNetwork';

--- a/suite-common/sentry/src/constants.ts
+++ b/suite-common/sentry/src/constants.ts
@@ -1,3 +1,5 @@
 export const ALLOW_REPORT_TAG = 'allowReport';
 export const COINJOIN_REPORT_TAG = 'coinjoinReport';
 export const COINJOIN_NETWORK_TAG = 'coinjoinNetwork';
+export const MAX_EVENTS_PER_INTERVAL = 100;
+export const MAX_EVENTS_INTERVAL_LENGTH = 3_600_000; // [ms]

--- a/suite-common/sentry/src/ignoreErrors.ts
+++ b/suite-common/sentry/src/ignoreErrors.ts
@@ -3,15 +3,58 @@ import type { Options } from '@sentry/core';
 /**
  * List of Sentry error messages to be filtered client-side, which are either irrelevant or out of our control.
  * Note that when you add it here, inbound filters in Sentry ingest are still needed for older Suite versions.
+ *
+ * This is a good place to add commonly occurring lifecycle errors that may happen during normal use (not preventable).
+ * Do not add here errors that are now definitively fixed (those belong in Sentry ingest inbound filters).
  */
-export const ignoreErrors = [
-    'ERR_INTERNET_DISCONNECTED',
-    'ERR_NETWORK_IO_SUSPENDED',
-    'ERR_NETWORK_CHANGED',
-    'Error: HTTP Error',
-    'ResizeObserver loop limit exceeded',
+const ignoreErrorsCommon = [
+    /.*Sequence of config.*is older than the current one.*/,
+
+    // Various kinds of network connectivity problems
+    /.*ERR_INTERNET_DISCONNECTED.*/,
+    /.*ERR_NETWORK_IO_SUSPENDED.*/,
+    /.*ERR_NETWORK_CHANGED.*/,
+    /.*ERR_CONNECTION_TIMED_OUT.*/,
+    /.*HTTP Error.*/,
+    /.*ERR_NAME_NOT_RESOLVED.*/,
+    /.*Websocket timeout.*/,
+    /.*Socket is closed.*/,
+    /.*websocket was closed.*/,
+    /.*Timeout for request.*/,
+    /.*Websocket closed unexpectedly.*/,
+    /.*Failed to fetch.*/,
+    /.*Aborted by timeout.*/,
+    /.*Client network socket disconnected before secure TLS connection was established.*/,
+    /.*Failed to open URL.*/,
+    /.*Fetching of remote JWS config failed: Error: Aborted by timeout.*/,
+    /.*failed to get recent blockhash: TypeError: fetch failed.*/,
+
+    // Common transport or Connect lifecycle errors
+    /.*Transport stopped.*/,
+    /.*Response of unexpected type.*/,
     // comes from bridge originally, we allowed user to init another connect call. should now be wrapped however and not thrown on transport layer
-    'other call in progress',
-    'Action canceled by user',
-    'device disconnected during action', // the same as with 'other call in progress'
+    /.*other call in progress.*/,
+    /.*session not found.*/,
+    /.*Action canceled by user.*/,
+    /.*device disconnected during action.*/, // the same as with 'other call in progress'
+] satisfies Options['ignoreErrors'];
+
+export const ignoreErrorsSuite = [
+    ...ignoreErrorsCommon,
+    /.*ResizeObserver loop limit exceeded.*/,
+    /.*Timeout waiting for TOR control port.*/,
+    /.*write EPIPE.*/,
+
+    // Common IDB lifecycle errors
+    /.*The database connection is closing.*/,
+    /.*Error: InvalidStateError: Failed to execute 'transaction' on 'IDBDatabase'.*/,
+
+    // Common Electron lifecycle errors
+    /.*Frame property was accessed after it navigated or was destroyed.*/, // Renderer process already closed while main is still responding to its IPC
+] satisfies Options['ignoreErrors'];
+
+export const ignoreErrorsSuiteMobile = [
+    ...ignoreErrorsCommon,
+    /.*Websocket closed.*/,
+    /.*Network request failed.*/,
 ] satisfies Options['ignoreErrors'];

--- a/suite-common/sentry/src/index.ts
+++ b/suite-common/sentry/src/index.ts
@@ -1,4 +1,4 @@
 export * from './constants';
-export { ignoreErrors } from './ignoreErrors';
+export { ignoreErrorsSuite, ignoreErrorsSuiteMobile } from './ignoreErrors';
 export { SENTRY_CONFIG } from './suiteConfig';
 export { redactSentryEvent } from './redactSentryEvent';

--- a/suite-common/sentry/src/redactSentryEvent.ts
+++ b/suite-common/sentry/src/redactSentryEvent.ts
@@ -1,13 +1,13 @@
 import type { ErrorEvent } from '@sentry/core';
 
-import { allowReportTag } from './constants';
+import { ALLOW_REPORT_TAG } from './constants';
 
 /**
  * Common function in all Sentry application to redact a Sentry event or filter it out completely (then returns null).
  */
 export const redactSentryEvent = (event: ErrorEvent): ErrorEvent | null => {
     // sentry events are skipped until user confirm analytics reporting
-    const allowReport = event.tags?.[allowReportTag];
+    const allowReport = event.tags?.[ALLOW_REPORT_TAG];
 
     if (allowReport === false) {
         return null;

--- a/suite-common/sentry/src/redactSentryEvent.ts
+++ b/suite-common/sentry/src/redactSentryEvent.ts
@@ -1,11 +1,27 @@
 import type { ErrorEvent } from '@sentry/core';
 
-import { ALLOW_REPORT_TAG } from './constants';
+import { ALLOW_REPORT_TAG, MAX_EVENTS_INTERVAL_LENGTH, MAX_EVENTS_PER_INTERVAL } from './constants';
+
+let eventCountThisSession = 0;
+let countingStartTimestamp = Date.now();
+const incrementOrResetCounter = () => {
+    if (Date.now() - countingStartTimestamp > MAX_EVENTS_INTERVAL_LENGTH) {
+        eventCountThisSession = 0;
+        countingStartTimestamp = Date.now();
+    }
+    eventCountThisSession++;
+};
 
 /**
  * Common function in all Sentry application to redact a Sentry event or filter it out completely (then returns null).
  */
 export const redactSentryEvent = (event: ErrorEvent): ErrorEvent | null => {
+    incrementOrResetCounter();
+    // hard limit the number of events sent this session (app instance), to prevent a flurry of events sent in a loop
+    if (eventCountThisSession > MAX_EVENTS_PER_INTERVAL) {
+        return null;
+    }
+
     // sentry events are skipped until user confirm analytics reporting
     const allowReport = event.tags?.[ALLOW_REPORT_TAG];
 

--- a/suite-common/sentry/src/suiteConfig.ts
+++ b/suite-common/sentry/src/suiteConfig.ts
@@ -5,7 +5,7 @@ import { isCodesignBuild } from '@trezor/env-utils';
 import { redactUserPathFromString } from '@trezor/utils';
 
 import { COINJOIN_NETWORK_TAG, COINJOIN_REPORT_TAG } from './constants';
-import { ignoreErrors } from './ignoreErrors';
+import { ignoreErrorsSuite } from './ignoreErrors';
 import { redactSentryEvent } from './redactSentryEvent';
 
 /**
@@ -84,7 +84,7 @@ export const SENTRY_CONFIG = {
     normalizeDepth: 4,
     maxBreadcrumbs: 40,
     beforeBreadcrumb,
-    ignoreErrors,
+    ignoreErrors: ignoreErrorsSuite,
     initialScope: {
         tags: {
             version: process.env.VERSION || 'undefined',

--- a/suite-common/sentry/src/suiteConfig.ts
+++ b/suite-common/sentry/src/suiteConfig.ts
@@ -4,7 +4,7 @@ import { isDevEnv } from '@suite-common/suite-utils';
 import { isCodesignBuild } from '@trezor/env-utils';
 import { redactUserPathFromString } from '@trezor/utils';
 
-import { coinjoinNetworkTag, coinjoinReportTag } from './constants';
+import { COINJOIN_NETWORK_TAG, COINJOIN_REPORT_TAG } from './constants';
 import { ignoreErrors } from './ignoreErrors';
 import { redactSentryEvent } from './redactSentryEvent';
 
@@ -38,7 +38,7 @@ const redactUserPath = (event: ErrorEvent): ErrorEvent => {
 
 // Leaves only what is really necessary on a coinjoin error event
 const redactCoinjoinData = (event: ErrorEvent): ErrorEvent => {
-    if (event.tags?.[coinjoinReportTag]) {
+    if (event.tags?.[COINJOIN_REPORT_TAG]) {
         return {
             type: event.type,
             message: event.message,
@@ -46,7 +46,7 @@ const redactCoinjoinData = (event: ErrorEvent): ErrorEvent => {
             level: event.level,
             tags: {
                 coinjoinReport: true,
-                coinjoinNetworkTag: event.tags?.[coinjoinNetworkTag],
+                coinjoinNetworkTag: event.tags?.[COINJOIN_NETWORK_TAG],
             },
         };
     }

--- a/suite-native/sentry/src/sentry.ts
+++ b/suite-native/sentry/src/sentry.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react-native';
 
-import { ALLOW_REPORT_TAG, redactSentryEvent } from '@suite-common/sentry';
+import { ALLOW_REPORT_TAG, ignoreErrorsSuiteMobile, redactSentryEvent } from '@suite-common/sentry';
 import { getEnv, isDebugEnv, isDetoxTestBuild } from '@suite-native/config';
 
 export const setSentryContext = Sentry.setContext;
@@ -31,6 +31,7 @@ export const initSentry = () => {
         integrations: [Sentry.consoleLoggingIntegration({ levels: ['error'] })],
         enableLogs: true,
         beforeSend: redactSentryEvent,
+        ignoreErrors: ignoreErrorsSuiteMobile,
 
         // You can put EXPO_PUBLIC_IS_SENTRY_ON_DEBUG_BUILD_ENABLED=true to `.env.development.local` to debug Sentry locally.
         enabled:

--- a/suite-native/sentry/src/sentry.ts
+++ b/suite-native/sentry/src/sentry.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react-native';
 
-import { allowReportTag, redactSentryEvent } from '@suite-common/sentry';
+import { ALLOW_REPORT_TAG, redactSentryEvent } from '@suite-common/sentry';
 import { getEnv, isDebugEnv, isDetoxTestBuild } from '@suite-native/config';
 
 export const setSentryContext = Sentry.setContext;
@@ -16,7 +16,7 @@ export const captureSentryException = Sentry.captureException;
 export const captureSentryMessage = Sentry.captureMessage;
 
 export const allowSentryReport = (value: boolean) => {
-    Sentry.setTag(allowReportTag, value);
+    Sentry.setTag(ALLOW_REPORT_TAG, value);
 };
 
 export const setSentryUser = (instanceId: string) => {


### PR DESCRIPTION
## Description

New features to stabilize our Sentry ingest and small code tweaks:

Commits:
- rename Sentry constants to uppercase
- :point_right: **Most important:** introduce a simple hard limit for 100 events per hour
  - there is no config parameter for it; this is the recommended way as per [here](https://sentry.zendesk.com/hc/en-us/articles/32757664867227-Is-it-possible-to-cap-the-number-of-events-per-distinct-error) & [here](https://sentry.zendesk.com/hc/en-us/articles/23704082966811-I-ve-exhausted-my-quota-what-now) on Sentry Zendesk
  - [locally in a testing branch](https://github.com/trezor/trezor-suite/compare/feat/sentry-tweaks-ignores-and-hard-limit...feat/sentry-tweaks-ignores-and-hard-limit-TESTING) I decreased limit to 10, interval to 30 s
  - and I have run a [testing loop for Web](https://satoshilabs.sentry.io/issues/7225059554/events/?project=5193825) & [testing loop for Mobile](https://satoshilabs.sentry.io/issues/7225070939/events/?project=4504214699245568&statsPeriod=1h).
  You can see for both platforms that there is alway period of 10 events, then pause, then 10 events :heavy_check_mark: 
- expand `ignoreErrors` (Sentry outbound filters):
  - use also on mobile, categorizing into common list, suite-only and mobile-only
  - for both mobile & desktop respectively, copy some errors from our Sentry ingest inbound filters to these lists 
  - I tested that the Desktop | Mobile debug setting testing error does not get filtered, and does when I introduce a new regex for them, confirming it now works properly on both platforms

Note: I am not implementing [sampleRate setting](https://docs.sentry.io/concepts/key-terms/sample-rates/) after all. It only makes sense when we truly need it, because it will make it more difficult to see interlinked issues per single session. Note that we don't use transactions at all at Web/Desktop, and minimal traffic on Mobile, so `traceSampleRate` would have no effect

## Notes for QA

Test testing error both on Desktop, Web and Mobile

**After release:** we must watch prod Sentry that traffic does not decrease suspiciously

## Related Issue

Resolve #24726
Resolve #24727

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/sentry-tweaks-ignores-and-hard-limit&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/sentry-tweaks-ignores-and-hard-limit&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/sentry-tweaks-ignores-and-hard-limit&lookback=7)