### PR TITLE
fix(trading): wrap sell and exchange offers with form

### DIFF
--- a/packages/suite/src/views/wallet/trading/sell/TradingSellConfirm.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingSellConfirm.tsx
@@ -1,3 +1,5 @@
+import { FormProvider } from 'react-hook-form';
+
 import { useSelector } from 'src/hooks/suite';
 import { TradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingSellForm } from 'src/hooks/wallet/trading/form/useTradingSellForm';
@@ -20,7 +22,9 @@ const TradingSellConfirmLoaded = ({ selectedAccount }: UseTradingProps) => {
 
     return (
         <TradingFormContext.Provider value={tradingSellContextValues}>
-            <TradingContainer SectionComponent={TradingSelectedOffer} provider={provider} />
+            <FormProvider {...tradingSellContextValues.methods}>
+                <TradingContainer SectionComponent={TradingSelectedOffer} provider={provider} />
+            </FormProvider>
         </TradingFormContext.Provider>
     );
 };

--- a/packages/suite/src/views/wallet/trading/sell/TradingSellOffers.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingSellOffers.tsx
@@ -1,3 +1,5 @@
+import { FormProvider } from 'react-hook-form';
+
 import { TradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingSellForm } from 'src/hooks/wallet/trading/form/useTradingSellForm';
 import { UseTradingProps } from 'src/types/trading/trading';
@@ -12,7 +14,9 @@ const TradingSellOffersComponent = ({ selectedAccount }: UseTradingProps) => {
 
     return (
         <TradingFormContext.Provider value={tradingSellFormContextValues}>
-            <TradingOffers />
+            <FormProvider {...tradingSellFormContextValues.methods}>
+                <TradingOffers />
+            </FormProvider>
         </TradingFormContext.Provider>
     );
 };


### PR DESCRIPTION
Some pages in Sell were not wrapped in `FormProvider` causing crashes when user defined sell amount in fiat. This PR adds the provider.

## Notes for QA

When selecting how much to sell in fiat, it should not crash when clicking on provider (selecting quote from the offers list)

## Related Issue

Resolve #24590



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=24590-typeerror-cannot-destructure-property-control-of-0-ngxw-as-it-is-null&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=24590-typeerror-cannot-destructure-property-control-of-0-ngxw-as-it-is-null&lookback=7)