### PR TITLE
feat(suite): enhance WipeDeviceModal with new UI components and impro…

### DIFF
--- a/packages/suite/src/actions/settings/__fixtures__/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/deviceSettingsActions.ts
@@ -84,9 +84,9 @@ const fixture: Fixture[] = [
                     payload: { deviceId: 'device-id' },
                 },
                 {
-                    type: notificationsActions.addToast.type,
-                    payload: { type: 'device-wiped', context: 'toast', id: expect.any(Number) },
-                } satisfies ReturnType<typeof notificationsActions.addToast>,
+                    type: '@modal/open-user-context',
+                    payload: { type: 'wipe-device-success' },
+                },
                 {
                     type: deviceActions.requestDeviceReconnect.type,
                     payload: undefined,
@@ -220,9 +220,9 @@ const fixture: Fixture[] = [
                     payload: { deviceId: 'device-id' },
                 },
                 {
-                    type: notificationsActions.addToast.type,
-                    payload: { type: 'device-wiped', context: 'toast', id: expect.any(Number) },
-                } satisfies ReturnType<typeof notificationsActions.addToast>,
+                    type: '@modal/open-user-context',
+                    payload: { type: 'wipe-device-success' },
+                },
                 {
                     type: deviceActions.requestDeviceReconnect.type,
                     payload: undefined,

--- a/packages/suite/src/components/suite/DeviceConfirmImage.tsx
+++ b/packages/suite/src/components/suite/DeviceConfirmImage.tsx
@@ -21,7 +21,6 @@ export const DeviceConfirmImage = ({
     return (
         <DeviceWithScene
             deviceModel={deviceModelInternal}
-            scene="confirm"
             width={width}
             unitColor={device?.features?.unit_color}
             height={height}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -51,6 +51,7 @@ import { UnecoCoinjoinModal } from './UnecoCoinjoinModal';
 import { UnstakeModal } from './UnstakeModal/UnstakeModal';
 import { WalletConnectProposalModal } from './WalletConnectProposalModal';
 import { WalletConnectSwitchAccountModal } from './WalletConnectSwitchAccountModal';
+import { WipeDeviceSuccessModal } from './WipeDeviceSuccessModal';
 
 /** Modals opened as a result of user action */
 export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL.CONTEXT_USER>) => {
@@ -170,6 +171,8 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL.CONTE
             return <AutoStartBeforeQuitModal />;
         case 'tx-simulation':
             return <TxSimulationModal />;
+        case 'wipe-device-success':
+            return <WipeDeviceSuccessModal />;
         default:
             return exhaustive(payload);
     }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WipeDeviceSuccessModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WipeDeviceSuccessModal.tsx
@@ -1,0 +1,28 @@
+import { Translation } from '@suite/intl';
+import { H3, Modal } from '@trezor/components';
+
+import { onCancel as closeModal } from 'src/actions/suite/modalActions';
+import { useDispatch } from 'src/hooks/suite';
+
+export const WipeDeviceSuccessModal = () => {
+    const dispatch = useDispatch();
+
+    const close = () => dispatch(closeModal());
+
+    return (
+        <Modal
+            onCancel={close}
+            bottomContent={
+                <Modal.Button onClick={close}>
+                    <Translation id="TR_BACK_TO_DASHBOARD" />
+                </Modal.Button>
+            }
+            width={600}
+            iconName="check"
+        >
+            <H3 typographyStyle="titleMedium">
+                <Translation id="TR_WIPE_DEVICE_SUCCESS_HEADING" />
+            </H3>
+        </Modal>
+    );
+};

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
@@ -68,7 +68,7 @@ export function CollapsibleFees({
                 composedLevels,
             }}
         >
-            <Collapsible>
+            <Collapsible gap={12}>
                 <CollapsibleFeesHeaderContent
                     label={label}
                     headerTypographyStyle={headerTypographyStyle}

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeaderContent.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeaderContent.tsx
@@ -26,7 +26,7 @@ export const CollapsibleFeesHeaderContent = ({
     const content = (
         <ContentFlex justifyContent="space-between" gap={12}>
             <CollapsibleFeesHeader label={label} typographyStyle={headerTypographyStyle} />
-            <Row gap={8}>
+            <Row gap={12}>
                 <MaximumFee typographyStyle={headerTypographyStyle} txMaxFee={txMaxFee} />
                 {supportsAdjustableFees && (
                     <Collapsible.ToggleIcon iconName="caretDown" size="mediumLarge" />

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/MaximumFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/MaximumFee.tsx
@@ -44,7 +44,7 @@ export function MaximumFee({ typographyStyle, txMaxFee }: MaximumFeeProps) {
             slideContent={false}
             isLoadingPositionReversed={isContentBelowBreakpoint}
         >
-            <Column>
+            <Column alignItems="flex-end">
                 <Text variant="default" typographyStyle={typographyStyle}>
                     <FormattedCryptoAmount
                         data-testid="@trading/quote/maximum-fee-amount"

--- a/packages/suite/src/views/settings/SettingsDevice/WipeDevice/WipeDeviceModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/WipeDevice/WipeDeviceModal.tsx
@@ -1,33 +1,76 @@
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 
 import { isFulfilled } from '@reduxjs/toolkit';
 
 import { Translation } from '@suite/intl';
 import { EventType } from '@suite-common/analytics';
 import { wipeDeviceThunk } from '@suite-common/wallet-core';
-import { Card, Column, H3, Modal, Paragraph } from '@trezor/components';
+import {
+    Button,
+    Card,
+    Column,
+    Divider,
+    Icon,
+    IconName,
+    Modal,
+    Paragraph,
+    Row,
+    Text,
+} from '@trezor/components';
 import { isDeviceInBootloaderMode } from '@trezor/device-utils';
-import { spacings } from '@trezor/theme';
 
-import * as routerActions from 'src/actions/suite/routerActions';
-import { CheckItem } from 'src/components/suite';
-import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
-import { selectRouterApp } from 'src/reducers/suite/routerReducer';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
 
 type WipeDeviceModalProps = {
     onCancel: () => void;
 };
 
+type StepCardProps = {
+    heading: ReactNode;
+    description: ReactNode;
+    actions: ReactNode;
+    icon: IconName;
+    state: 'default' | 'confirmed' | 'pending';
+};
+
+const StepCard = ({ heading, description, actions, icon, state }: StepCardProps) => {
+    const variant = state === 'confirmed' ? 'primary' : 'tertiary';
+
+    return (
+        <Card paddingType="none" fillType={state === 'pending' ? 'flat' : 'default'}>
+            <Column>
+                <Row gap={8} padding={{ horizontal: 16, vertical: 12 }}>
+                    <Icon
+                        name={state === 'confirmed' ? 'check' : icon}
+                        variant={variant}
+                        size={20}
+                    />
+                    <Text typographyStyle="hint" variant={variant}>
+                        {heading}
+                    </Text>
+                </Row>
+                {state === 'default' && (
+                    <>
+                        <Divider margin={0} />
+                        <Column gap={16} padding={{ horizontal: 16, vertical: 12 }}>
+                            <Paragraph typographyStyle="highlight">{description}</Paragraph>
+                            <Row gap={12}>{actions}</Row>
+                        </Column>
+                    </>
+                )}
+            </Column>
+        </Card>
+    );
+};
+
 export const WipeDeviceModal = ({ onCancel }: WipeDeviceModalProps) => {
     const analytics = useAnalytics();
-    const [checkbox1, setCheckbox1] = useState(false);
-    const [checkbox2, setCheckbox2] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
+    const [isConfirmed, setIsConfirmed] = useState(false);
 
     const { device, isLocked } = useDevice();
     const dispatch = useDispatch();
-    const appRoute = useSelector(selectRouterApp);
 
     const isBootloaderMode = isDeviceInBootloaderMode(device);
 
@@ -39,10 +82,7 @@ export const WipeDeviceModal = ({ onCancel }: WipeDeviceModalProps) => {
             analytics.report({
                 type: EventType.SettingsDeviceWipe,
             });
-            if (appRoute === 'settings') {
-                // redirect to the index to close the settings and show initial device setup
-                dispatch(routerActions.goto('suite-index'));
-            }
+            onCancel();
         }
 
         setIsLoading(false);
@@ -60,55 +100,70 @@ export const WipeDeviceModal = ({ onCancel }: WipeDeviceModalProps) => {
     return (
         <Modal
             onCancel={handleCancel}
+            heading={<Translation id={headingTranslation} />}
+            description={<Translation id="TR_WIPE_DEVICE_MODAL_PROCEED_WITH_CAUTION" />}
             variant="destructive"
-            iconName="shieldWarning"
             width={600}
-            bottomContent={
-                <>
-                    <Modal.Button
-                        onClick={handleWipeDevice}
-                        isLoading={isLoading}
-                        isDisabled={isLocked() || !checkbox1 || !checkbox2}
-                        data-testid="@wipe/wipe-button"
-                    >
-                        <Translation id={headingTranslation} />
-                    </Modal.Button>
-                    <Modal.Button intent="neutral" priority="secondary" onClick={handleCancel}>
-                        <Translation id="TR_CANCEL" />
-                    </Modal.Button>
-                </>
-            }
         >
-            <H3>
-                <Translation id={headingTranslation} />
-            </H3>
-            <Paragraph variant="tertiary" margin={{ top: spacings.xs }}>
-                <Translation
-                    id={
-                        isBootloaderMode
-                            ? 'TR_FACTORY_RESET_MODAL_DESCRIPTION'
-                            : 'TR_WIPE_DEVICE_MODAL_DESCRIPTION'
+            <Column gap={16}>
+                <StepCard
+                    heading={<Translation id="TR_WIPE_DEVICE_ERASE_ALL_DATA" />}
+                    description={<Translation id="TR_WIPE_DEVICE_ERASE_ALL_DATA_DESCRIPTION" />}
+                    actions={
+                        <>
+                            <Button
+                                intent="critical"
+                                onClick={() => setIsConfirmed(true)}
+                                isLoading={isLoading}
+                                isDisabled={isLocked()}
+                                data-testid="@wipe/wipe-button"
+                                size="large"
+                            >
+                                <Translation id="TR_I_UNDERSTAND_THE_RISK" />
+                            </Button>
+
+                            <Button
+                                intent="neutral"
+                                priority="secondary"
+                                size="large"
+                                onClick={handleCancel}
+                            >
+                                <Translation id="TR_GO_BACK" />
+                            </Button>
+                        </>
                     }
+                    icon="trash"
+                    state={isConfirmed ? 'confirmed' : 'default'}
                 />
-            </Paragraph>
-            <Card margin={{ top: spacings.lg }}>
-                <Column gap={spacings.md} alignItems="center">
-                    <CheckItem
-                        title={<Translation id="TR_WIPE_DEVICE_CHECKBOX_1_TITLE" />}
-                        description={<Translation id="TR_WIPE_DEVICE_CHECKBOX_1_DESCRIPTION" />}
-                        isChecked={checkbox1}
-                        onClick={() => setCheckbox1(!checkbox1)}
-                        data-testid="@wipe/checkbox-1"
-                    />
-                    <CheckItem
-                        title={<Translation id="TR_WIPE_DEVICE_CHECKBOX_2_TITLE" />}
-                        description={<Translation id="TR_WIPE_DEVICE_CHECKBOX_2_DESCRIPTION" />}
-                        isChecked={checkbox2}
-                        onClick={() => setCheckbox2(!checkbox2)}
-                        data-testid="@wipe/checkbox-2"
-                    />
-                </Column>
-            </Card>
+                <StepCard
+                    heading={<Translation id="TR_WIPE_DEVICE_WALLET_BACKUP" />}
+                    description={<Translation id="TR_WIPE_DEVICE_WALLET_BACKUP_DESCRIPTION" />}
+                    actions={
+                        <>
+                            <Button
+                                intent="critical"
+                                onClick={handleWipeDevice}
+                                isLoading={isLoading}
+                                isDisabled={isLocked()}
+                                data-testid="@wipe/wipe-button"
+                                size="large"
+                            >
+                                <Translation id="TR_I_UNDERSTAND_THE_RISK" />
+                            </Button>
+                            <Button
+                                intent="neutral"
+                                priority="secondary"
+                                onClick={() => setIsConfirmed(false)}
+                                size="large"
+                            >
+                                <Translation id="TR_GO_BACK" />
+                            </Button>
+                        </>
+                    }
+                    icon="newspaper"
+                    state={isConfirmed ? 'default' : 'pending'}
+                />
+            </Column>
         </Modal>
     );
 };

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -181,4 +181,7 @@ export type UserContextPayload =
       }
     | {
           type: 'tx-simulation';
+      }
+    | {
+          type: 'wipe-device-success';
       };

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -443,7 +443,7 @@ const handlePostWipeCleanupThunk = createThunk(
             initialDevice: TrezorDevice;
             deviceInstances: AcquiredDevice[];
         },
-        { dispatch, getState },
+        { dispatch, getState, extra },
     ) => {
         // Wiping a device triggers device.id change, and this change is propagated to device reducer via @trezor/connect DEVICE.CHANGE event.
         // Accounts data are related to the old device.id; to properly clear reducers and indexed db,
@@ -463,7 +463,7 @@ const handlePostWipeCleanupThunk = createThunk(
             dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: initialDevice.id }));
         }
 
-        dispatch(notificationsActions.addToast({ type: 'device-wiped' }));
+        dispatch(extra.actions.openModal({ type: 'wipe-device-success' }));
 
         // Special case with webusb: Device after wipe changes device_id. With webusb transport, device_id is used as a path
         // and thus as a descriptor for webusb. So, after the device is wiped, in the transport layer, the device is still paired

--- a/suite/e2e/tests/settings/t2t1-device-settings.test.ts
+++ b/suite/e2e/tests/settings/t2t1-device-settings.test.ts
@@ -41,8 +41,7 @@ test.describe('T2T1 - Device settings', { tag: ['@T2T1'] }, () => {
 
     test('Device Wipe', async ({ page, device }) => {
         await page.getByTestId('@settings/device/open-wipe-modal-button').click();
-        await page.getByTestId('@wipe/checkbox-1').click();
-        await page.getByTestId('@wipe/checkbox-2').click();
+        await page.getByTestId('@wipe/wipe-button').click();
         await page.getByTestId('@wipe/wipe-button').click();
         await device.pressYes();
         //TODO: Any verification?

--- a/suite/e2e/tests/settings/t3b1-device-settings.test.ts
+++ b/suite/e2e/tests/settings/t3b1-device-settings.test.ts
@@ -43,8 +43,7 @@ test.describe('T3B1 - Device settings', { tag: ['@T3B1'] }, () => {
 
     test('Device Wipe', async ({ page, device }) => {
         await page.getByTestId('@settings/device/open-wipe-modal-button').click();
-        await page.getByTestId('@wipe/checkbox-1').click();
-        await page.getByTestId('@wipe/checkbox-2').click();
+        await page.getByTestId('@wipe/wipe-button').click();
         await page.getByTestId('@wipe/wipe-button').click();
         await device.pressYes();
         //TODO: Verification?

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1413,6 +1413,10 @@ export const messages = defineMessages({
         description: 'Back button',
         id: 'TR_BACK',
     },
+    TR_GO_BACK: {
+        id: 'TR_GO_BACK',
+        defaultMessage: 'Go back',
+    },
     TR_CONNECT: {
         defaultMessage: 'Connect',
         id: 'TR_CONNECT',
@@ -4086,29 +4090,39 @@ export const messages = defineMessages({
         defaultMessage:
             'Resetting your device will erase all its data. Make sure you have your wallet backup before resetting, so you can restore access to your funds.',
     },
-    TR_WIPE_DEVICE_MODAL_DESCRIPTION: {
-        id: 'TR_WIPE_DEVICE_MODAL_DESCRIPTION',
-        defaultMessage:
-            'Wiping your device will erase all its data. Make sure you have your wallet backup before wiping, so you can restore access to your funds.',
+    TR_WIPE_DEVICE_MODAL_PROCEED_WITH_CAUTION: {
+        id: 'TR_WIPE_DEVICE_MODAL_PROCEED_WITH_CAUTION',
+        defaultMessage: "This will erase all of your Trezor's data. Proceed with caution.",
     },
-    TR_WIPE_DEVICE_CHECKBOX_1_TITLE: {
-        id: 'TR_WIPE_DEVICE_CHECKBOX_1_TITLE',
-        defaultMessage: 'I understand this action deletes all data on the device.',
+    TR_WIPE_DEVICE_ERASE_ALL_DATA: {
+        id: 'TR_WIPE_DEVICE_ERASE_ALL_DATA',
+        defaultMessage: 'Erase all data',
     },
-    TR_WIPE_DEVICE_CHECKBOX_1_DESCRIPTION: {
-        id: 'TR_WIPE_DEVICE_CHECKBOX_1_DESCRIPTION',
-        defaultMessage:
-            "All data associated with existing accounts will be deleted. You'll need a wallet backup to recover your wallet.",
+    TR_WIPE_DEVICE_ERASE_ALL_DATA_DESCRIPTION: {
+        id: 'TR_WIPE_DEVICE_ERASE_ALL_DATA_DESCRIPTION',
+        defaultMessage: "This will erase all device data. This action can't be undone.",
     },
-    TR_WIPE_DEVICE_CHECKBOX_2_TITLE: {
-        id: 'TR_WIPE_DEVICE_CHECKBOX_2_TITLE',
-        defaultMessage:
-            'I understand I must have my wallet backup in order to regain access to my funds.',
+    TR_WIPE_DEVICE_WALLET_BACKUP: {
+        id: 'TR_WIPE_DEVICE_WALLET_BACKUP',
+        defaultMessage: 'Wallet backup',
     },
-    TR_WIPE_DEVICE_CHECKBOX_2_DESCRIPTION: {
-        id: 'TR_WIPE_DEVICE_CHECKBOX_2_DESCRIPTION',
+    TR_WIPE_DEVICE_WALLET_BACKUP_DESCRIPTION: {
+        id: 'TR_WIPE_DEVICE_WALLET_BACKUP_DESCRIPTION',
         defaultMessage:
-            'Your wallet backup is absolutely essential for regaining access to your funds in case of device loss, theft, or damage. Without it, no one—not even Trezor Support—can help you regain access. Write your wallet backup down and store it somewhere safe and secure. Just be sure to remember where it is.',
+            "Make sure you have your wallet backup. You won't be able to recover access to your assets without it.",
+    },
+    TR_WIPE_DEVICE_SUCCESS_HEADING: {
+        id: 'TR_WIPE_DEVICE_SUCCESS_HEADING',
+        defaultMessage: 'Device wiped successfully',
+    },
+    TR_WIPE_DEVICE_SUCCESS_DESCRIPTION: {
+        id: 'TR_WIPE_DEVICE_SUCCESS_DESCRIPTION',
+        defaultMessage:
+            'Your device has been wiped. You can now set it up as a new device or restore from a backup.',
+    },
+    TR_BACK_TO_DASHBOARD: {
+        id: 'TR_BACK_TO_DASHBOARD',
+        defaultMessage: 'Back to dashboard',
     },
     TR_CANCEL: {
         id: 'TR_CANCEL',


### PR DESCRIPTION
## Notes for QA

- updated the wipe device modal to step-based approach
- removed the hand illustration from confirm action on device modals
- replaced the toast notification after successful wipe with a modal

## Screenshots:
<img width="657" height="369" alt="image" src="https://github.com/user-attachments/assets/5ef78a8a-1239-41be-8842-1c748ccf7a03" />
<img width="657" height="388" alt="image" src="https://github.com/user-attachments/assets/cfc107dd-907b-4916-8533-798701e2deab" />
<img width="657" height="599" alt="image" src="https://github.com/user-attachments/assets/c67dd1a1-9aa8-4496-9256-c58e16866dd5" />
<img width="657" height="367" alt="image" src="https://github.com/user-attachments/assets/a6e3a9fd-d7f7-4148-a422-027a00f27b1b" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/update-wipe-device-modal&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/update-wipe-device-modal&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/update-wipe-device-modal&lookback=7)