### PR TITLE
feat(common): lowered QM owner quota split constant

### DIFF
--- a/suite-common/suite-sync-quota-manager/src/constants.ts
+++ b/suite-common/suite-sync-quota-manager/src/constants.ts
@@ -9,7 +9,7 @@ export const DEFAULT_DEVICE_SIZE_QUOTA = 1024 * 1024;
  * Default account size quota is set to 1/250th of the device size quota,
  * which is approximately enough for 10 label edits.
  */
-export const DEFAULT_ACCOUNT_SIZE_QUOTA = Math.round(DEFAULT_DEVICE_SIZE_QUOTA / 250);
+export const DEFAULT_ACCOUNT_SIZE_QUOTA = Math.round(DEFAULT_DEVICE_SIZE_QUOTA / 100);
 
 export const DEFAULT_QUOTA_MANAGER_URL = isDevEnv
     ? 'https://suite-sync.suite.sldev.cz/quota-manager/'

--- a/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
@@ -146,7 +146,7 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
                 ownerId,
                 publicKey:
                     '0428a3cefc19b41ff56795e371aab72d6d85a3ca2200bd46c54e611a36222295a88b44d6f23ce94025b6010f9eb0f9168ad35d8396dc865fa0a16f2f5471816a45',
-                proof: '106fb51f7945d6bd6fac019eb7953f43400746884f1e4f69c3cbfe13ec6539604039baa2c6b5ada1e395957908fe9777991910d4bee05c124161597cef814e3e',
+                proof: '2944ed0b226eb961750433b65639366871cf05a10dfd598a0651a39e18e5ada578f76fda26478316ac93115b1538bbad11044b83a59259efa8c2f9feaba1675b',
                 size: DEFAULT_ACCOUNT_SIZE_QUOTA,
                 challenge: 'aa55',
                 sessionId: 'session-123',


### PR DESCRIPTION
**Changes**:
- lowered split constant from 250 down to 100

## Notes for QA

- user should be able to allocate quota maximally for 100 wallets in total, instead of 250

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24793

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/qm/lower-quota-splits&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/qm/lower-quota-splits&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/qm/lower-quota-splits&lookback=7)