### PR TITLE
Typing Connect EventEmitter

### DIFF
--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,7 +1,5 @@
-import EventEmitter from 'events';
-
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import { createDeferredManager } from '@trezor/utils';
+import { TypedEmitter, createDeferredManager } from '@trezor/utils';
 
 import { initCoreState } from './core';
 import { parseConnectSettings } from './data/connectSettings';
@@ -21,9 +19,10 @@ import {
 } from './events';
 import { factory } from './factory';
 import type { ConnectSettings, Manifest } from './types';
+import { ConnectEvents } from './types/emitter';
 import { initLog } from './utils/debug';
 
-export const eventEmitter = new EventEmitter();
+export const eventEmitter = new TypedEmitter<ConnectEvents>();
 const _log = initLog('@trezor/connect');
 
 let _settings = parseConnectSettings();
@@ -46,41 +45,39 @@ const dispose = () => {
 
 // handle message received from Core
 const onCoreEvent = (message: CoreEventMessage) => {
-    const { event, type, payload } = message;
-
     _log.debug('handleMessage', message.type);
 
-    switch (event) {
+    switch (message.event) {
         case RESPONSE_EVENT: {
-            const { id = 0, success, device } = message;
+            const { id = 0, success, payload, device } = message;
             const resolved = messagePromises.resolve(id, { id, success, payload, device });
             if (!resolved) _log.warn(`Unknown message id ${id}`);
             break;
         }
         case DEVICE_EVENT:
             // pass DEVICE event up to html
-            eventEmitter.emit(event, message);
-            eventEmitter.emit(type, payload); // DEVICE_EVENT also emit single events (connect/disconnect...)
+            eventEmitter.emit(message.event, message);
+            eventEmitter.emit(message.type, message.payload); // DEVICE_EVENT also emit single events (connect/disconnect...)
             break;
 
         case TRANSPORT_EVENT:
-            eventEmitter.emit(event, message);
-            eventEmitter.emit(type, payload);
+            eventEmitter.emit(message.event, message);
+            eventEmitter.emit(message.type, message.payload);
             break;
 
         case BLOCKCHAIN_EVENT:
-            eventEmitter.emit(event, message);
-            eventEmitter.emit(type, payload);
+            eventEmitter.emit(message.event, message);
+            eventEmitter.emit(message.type, message.payload);
             break;
 
         case UI_EVENT:
             // pass UI event up
-            eventEmitter.emit(event, message);
-            eventEmitter.emit(type, payload);
+            eventEmitter.emit(message.event, message);
+            eventEmitter.emit(message.type, message.payload);
             break;
 
         default:
-            _log.warn('Undefined message', event, message);
+            _log.warn('Undefined message', message);
     }
 };
 

--- a/packages/connect/src/types/emitter.ts
+++ b/packages/connect/src/types/emitter.ts
@@ -1,0 +1,31 @@
+import {
+    BLOCKCHAIN_EVENT,
+    BlockchainEvent,
+    BlockchainEventMessage,
+    DEVICE_EVENT,
+    DeviceEvent,
+    DeviceEventMessage,
+    PopupEvent,
+    PopupEventMessage,
+    TRANSPORT_EVENT,
+    TransportEvent,
+    TransportEventMessage,
+    UI_EVENT,
+    UiEvent,
+    UiEventMessage,
+} from '../events';
+
+type EventPayloadMap<T extends { type: string; payload?: any }> = {
+    [E in T as E['type']]: E extends { payload: infer P } ? P : undefined;
+};
+
+export type ConnectEvents = {
+    [DEVICE_EVENT]: DeviceEventMessage;
+    [TRANSPORT_EVENT]: TransportEventMessage;
+    [BLOCKCHAIN_EVENT]: BlockchainEventMessage;
+    [UI_EVENT]: UiEventMessage | PopupEventMessage;
+} & EventPayloadMap<DeviceEvent> &
+    EventPayloadMap<TransportEvent> &
+    EventPayloadMap<BlockchainEvent> &
+    EventPayloadMap<UiEvent> &
+    EventPayloadMap<PopupEvent>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Event Emitter in Connect is now typed using TypedEmitter from
@trezor/utils.

## Notes for QA

Nothing to test

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/24021

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/connect-event-emmiter-type&lookback=7)