### PR TITLE
fix(suite-native): remove problematic usage of StatusBar component

### DIFF
--- a/suite-native/swipeable-walkthrough/package.json
+++ b/suite-native/swipeable-walkthrough/package.json
@@ -13,7 +13,6 @@
     "dependencies": {
         "@suite-native/atoms": "workspace:*",
         "@suite-native/navigation": "workspace:*",
-        "@suite-native/theme": "workspace:*",
         "@trezor/styles": "workspace:*",
         "jotai": "2.15.0",
         "react": "19.1.0",

--- a/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughScreenHeader.tsx
+++ b/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughScreenHeader.tsx
@@ -1,11 +1,9 @@
 import { useCallback } from 'react';
-import { StatusBar } from 'react-native';
 import Animated, { SharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Box, IconButton } from '@suite-native/atoms';
 import { ScreenHeader, useOverrideBackNavigation } from '@suite-native/navigation';
-import { useActiveColorScheme } from '@suite-native/theme';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type SwipeableWalkthroughScreenHeaderProps = {
@@ -21,15 +19,6 @@ type SwipeableWalkthroughBackButtonProps = {
 
 const ANIMATION_DURATION = 800;
 
-const screenHeaderContainerStyle = prepareNativeStyle(utils => ({
-    // The negative top offset is necessary to fill the transparent gap between the status bar and the screen header
-    // where would be visible the swipeable walkthrough steps animated transitions.
-    marginTop: -utils.spacings.sp8,
-    paddingTop: utils.spacings.sp8,
-    backgroundColor: utils.colors.backgroundSurfaceElevation0,
-    zIndex: 2,
-}));
-
 const statusBarStyle = prepareNativeStyle<{ topSafeAreaInset: number }>(
     (utils, { topSafeAreaInset }) => ({
         zIndex: 2,
@@ -39,6 +28,10 @@ const statusBarStyle = prepareNativeStyle<{ topSafeAreaInset: number }>(
         backgroundColor: utils.colors.backgroundSurfaceElevation0,
     }),
 );
+
+const screenHeaderContainerStyle = prepareNativeStyle(() => ({
+    zIndex: 2,
+}));
 
 const SwipeableWalkthroughBackButton = ({
     onPressBack,
@@ -73,9 +66,8 @@ export const SwipeableWalkthroughScreenHeader = ({
     CustomBackButton,
     onPressBack,
 }: SwipeableWalkthroughScreenHeaderProps) => {
-    const { applyStyle, utils } = useNativeStyles();
+    const { applyStyle } = useNativeStyles();
     const { top: topSafeAreaInset } = useSafeAreaInsets();
-    const activeColorScheme = useActiveColorScheme();
 
     const BackButton = CustomBackButton || SwipeableWalkthroughBackButton;
 
@@ -92,13 +84,8 @@ export const SwipeableWalkthroughScreenHeader = ({
 
     return (
         <>
-            {/* Status bar can not be transparent same as on the other screens, because then is the animated content visible in in while transitioning. */}
-            <Box style={applyStyle(statusBarStyle, { topSafeAreaInset })}>
-                <StatusBar
-                    backgroundColor={utils.colors.backgroundSurfaceElevation0}
-                    barStyle={activeColorScheme === 'dark' ? 'light-content' : 'dark-content'}
-                />
-            </Box>
+            {/* Fill the status bar area so that the animated content is not visible while transitioning. */}
+            <Box style={applyStyle(statusBarStyle, { topSafeAreaInset })} />
             <Box style={applyStyle(screenHeaderContainerStyle)}>
                 <ScreenHeader
                     leftIcon={

--- a/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughStep.tsx
+++ b/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughStep.tsx
@@ -97,7 +97,7 @@ export const SwipeableWalkthroughStep = ({
                     title={title}
                     description={description}
                 />
-                <VStack spacing="sp24" alignItems="center" flex={1}>
+                <VStack marginBottom="sp16" spacing="sp24" alignItems="center" flex={1}>
                     {children}
                     {continueButton ?? (
                         <IconButton

--- a/suite-native/swipeable-walkthrough/tsconfig.json
+++ b/suite-native/swipeable-walkthrough/tsconfig.json
@@ -4,7 +4,6 @@
     "references": [
         { "path": "../atoms" },
         { "path": "../navigation" },
-        { "path": "../theme" },
         { "path": "../../packages/styles" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13593,7 +13593,6 @@ __metadata:
   dependencies:
     "@suite-native/atoms": "workspace:*"
     "@suite-native/navigation": "workspace:*"
-    "@suite-native/theme": "workspace:*"
     "@trezor/styles": "workspace:*"
     jotai: "npm:2.15.0"
     react: "npm:19.1.0"


### PR DESCRIPTION
As described in the [react-native-edge-to-edge](https://github.com/zoontek/react-native-edge-to-edge?tab=readme-ov-file#systembars) docs, using `StatusBar` with edge-to-edge layout enabled may cause unexpected behavior. Removing the usage fixes the layout shift during navigation transition.

## Related Issue

Resolve #19361

## Screenshots:

https://github.com/user-attachments/assets/3078a729-41f4-4f65-85e2-48a5a566423e



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/swipeable-walkthrough-header&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/swipeable-walkthrough-header&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/swipeable-walkthrough-header&lookback=7)