### PR TITLE
fix(suite): update cardano unstake tx view in history

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -10,6 +10,7 @@ import {
     formatCardanoDeposit,
     formatCardanoWithdrawal,
     formatNetworkAmount,
+    getCardanoStakingSignValue,
     getFiatRateKey,
     getTxOperation,
     isStakeTypeTx,
@@ -52,19 +53,6 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
     const txSignature = tx.ethereumSpecific?.parsedData?.methodId;
     const isStakeType = isStakeTypeTx(txSignature) || tx?.solanaSpecific?.stakeOperation?.type; // ethereum or solana staking tx
     const isStakeTypeTxNoAmount = isStakeType && amount.eq(0);
-
-    const getCardanoStakingSignValue = () => {
-        const subtype = tx.cardanoSpecific?.subtype;
-
-        switch (subtype) {
-            case 'stake_registration':
-                return 'negative';
-            case 'stake_deregistration':
-                return 'positive';
-        }
-
-        return 'positive';
-    };
 
     const getAmountSignValue = () => {
         const txOp = getTxOperation(tx.type, true);
@@ -270,7 +258,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 <FormattedCryptoAmount
                                     value={cardanoWithdrawal}
                                     symbol={tx.symbol}
-                                    signValue="negative"
+                                    signValue={getCardanoStakingSignValue(tx)}
                                 />
                             </Text>
                         </Table.Cell>
@@ -303,7 +291,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 <FormattedCryptoAmount
                                     value={cardanoDeposit}
                                     symbol={tx.symbol}
-                                    signValue={getCardanoStakingSignValue()}
+                                    signValue={getCardanoStakingSignValue(tx)}
                                 />
                             </Text>
                         </Table.Cell>

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionRow.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionRow.tsx
@@ -6,6 +6,7 @@ import {
     formatCardanoDeposit,
     formatCardanoWithdrawal,
     formatNetworkAmount,
+    getCardanoStakingSignValue,
     getFiatRateKey,
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -114,11 +115,7 @@ export const DepositRow = ({
     <CustomRow
         {...baseLayoutProps}
         title="TR_TX_DEPOSIT"
-        sign={
-            transaction.cardanoSpecific?.subtype === 'stake_deregistration'
-                ? 'positive'
-                : 'negative'
-        }
+        sign={getCardanoStakingSignValue(transaction)}
         amount={formatCardanoDeposit(transaction) ?? '0'}
         transaction={transaction}
         useFiatValues={useFiatValues}

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -167,6 +167,21 @@ export const formatCardanoDeposit = (tx: WalletAccountTransaction) =>
         ? formatNetworkAmount(tx.cardanoSpecific.deposit, tx.symbol)
         : undefined;
 
+export const getCardanoStakingSignValue = (transaction: WalletAccountTransaction) => {
+    if (!transaction?.cardanoSpecific) return 'negative';
+    const subtype = transaction.cardanoSpecific?.subtype;
+
+    switch (subtype) {
+        case 'stake_registration':
+            return 'negative';
+        case 'stake_deregistration':
+        case 'withdrawal':
+            return 'positive';
+    }
+
+    return 'positive';
+};
+
 export const isTxFeePaid = (tx: WalletAccountTransaction) => {
     const showFeeRowForSolClaim = tx?.solanaSpecific?.stakeOperation?.type === 'claim';
     const showFeeRowForStellar = tx?.stellarSpecific?.feeSource === tx.descriptor;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes Cardano unstake transaction display in history.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24527

## Screenshots:
<img width="2398" height="410" alt="image" src="https://github.com/user-attachments/assets/dfafd3d9-6140-4d5b-903a-4e5d40292855" />
<img width="1534" height="1012" alt="image" src="https://github.com/user-attachments/assets/8569c684-7a81-432b-bacd-f24ae7c46b7d" />
