### PR TITLE
Add security headers for web build preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Run a dev build:
 - `yarn suite:dev:vite` (⚠️ EXPERIMENTAL: web app with Vite bundler used for **development only**, use `yarn suite:dev` if you want fidelity to production app)
 - `yarn suite:dev:desktop` (electron app)
     - React dev tools are available with a known caveat: you need to reload the renderer process (Ctrl+R or Cmd+R) while having the dev tools open
+- `yarn suite:build:web:preview` (localhost of production web app with applied security headers)
 
 Local `.env` setup (optional):
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "build:libs": "yarn nx run-many --skip-nx-cache --target=build:lib",
         "build:essential": "yarn message-system-sign-config & yarn workspace @trezor/suite-data build:lib & yarn workspace @trezor/transport-bridge build:lib",
         "suite:build:web": "yarn workspace @trezor/suite-web build",
+        "suite:build:web:preview": "yarn workspace @trezor/suite-web build:preview",
         "_______ Start Scripts _______": "Here are standalone scripts for running individual applications for development.",
         "suite:dev": "yarn workspace @trezor/suite-web dev",
         "suite:dev:vite": "yarn workspace @trezor/suite-web dev:vite",

--- a/packages/suite-web/README.md
+++ b/packages/suite-web/README.md
@@ -15,3 +15,19 @@ Visualize size of output files with [Webpack Bundle Analyzer](https://github.com
 ```
 yarn workspace @trezor/suite-web analyze
 ```
+
+## Preview
+
+Start local server with production build and applied security headers:
+
+```
+yarn workspace @trezor/suite-web preview
+```
+
+## Build & Preview
+
+Build web app and run the preview command:
+
+```
+yarn workspace @trezor/suite-web build:preview
+```

--- a/packages/suite-web/constants/webSecurityHeaders.ts
+++ b/packages/suite-web/constants/webSecurityHeaders.ts
@@ -1,0 +1,72 @@
+import type { SecurityHeaders } from '../types/securityHeaders';
+import { formatContentSecurityPolicy } from '../utils/csp';
+import { createReportingHeaders } from '../utils/reportingHeaders';
+
+const SENTRY_REPORT_URL =
+    'https://o117836.ingest.us.sentry.io/api/5193825/security/?sentry_key=6d91ca6e6a5d4de7b47989455858b5f6';
+
+/**
+ * Response security headers applied during `yarn build:preview` / `yarn preview` command.
+ * - There's equal to the ones deployed in production (https://suite.trezor.io).
+ */
+const PRODUCTION_SECURITY_HEADERS = {
+    /**
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+     */
+    'strict-transport-security': 'max-age=31536000',
+
+    /**
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Upgrade-Insecure-Requests
+     */
+    'upgrade-insecure-requests': '1',
+
+    /**
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+     */
+    'x-content-type-options': 'nosniff',
+
+    /**
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+     * Prevent non-https://suite.trezor.io websites from embedding our website in their iframe.
+     */
+    'x-frame-options': 'SAMEORIGIN',
+
+    /**
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy
+     * This header prevents URL data leakage for foreign sites.
+     * If user clicks on a link redirecting to another (non suite.trezor.io) site, the site receives only `https://suite.trezor.io` in the referrer response header instead of whole URL
+     * It won't receive the referrer header if the target site doesn't use https.
+     */
+    'referrer-policy': 'strict-origin-when-cross-origin',
+
+    /**
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
+     * The `same-origin` header ensures the `window.opener` is `null` even without explicitly using `noopener` unless it opens website of same origin.
+     * So foreign sites can't get reference and potentially exploit the Window object.
+     */
+    'cross-origin-opener-policy': 'same-origin',
+
+    'content-security-policy': {
+        'default-src': ['self'],
+        'script-src-attr': ['none'],
+        'style-src': ['self', 'unsafe-inline'],
+        'style-src-elem': ['self', 'unsafe-inline'],
+        'img-src': ['self', 'blob:', 'data:', 'https://*.trezor.io'],
+        'connect-src': ['data:', '*'],
+        'upgrade-insecure-requests': true,
+        'script-src': ['self', 'unsafe-eval'],
+        'report-uri': SENTRY_REPORT_URL,
+        'report-to': 'csp-endpoint',
+    },
+
+    ...createReportingHeaders('csp-endpoint', SENTRY_REPORT_URL),
+} as const satisfies Partial<SecurityHeaders>;
+
+export function getSecurityHeaders() {
+    return {
+        ...PRODUCTION_SECURITY_HEADERS,
+        'content-security-policy': formatContentSecurityPolicy(
+            PRODUCTION_SECURITY_HEADERS['content-security-policy'],
+        ),
+    } as const;
+}

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -10,7 +10,9 @@
         "dev": "yarn rimraf ./build && yarn workspace @trezor/suite-build run dev:web",
         "dev:vite": "PROJECT=web yarn rimraf ./build && yarn workspace @trezor/suite-build run dev:web:vite",
         "analyze": "ANALYZE=true yarn build",
-        "build": "yarn rimraf ./build && yarn workspace @trezor/suite-build run build:web"
+        "build": "yarn rimraf ./build && yarn workspace @trezor/suite-build run build:web",
+        "preview": "vite preview -c ./preview.vite.config.mts --outDir ./build --mode production",
+        "build:preview": "yarn build && yarn preview"
     },
     "dependencies": {
         "@sentry/browser": "10.32.1",
@@ -33,6 +35,7 @@
         "rimraf": "^6.0.1",
         "stylelint": "^16.17.0",
         "stylelint-config-standard": "^38.0.0",
-        "tsx": "^4.21.0"
+        "tsx": "^4.21.0",
+        "vite": "^7.2.4"
     }
 }

--- a/packages/suite-web/preview.vite.config.mts
+++ b/packages/suite-web/preview.vite.config.mts
@@ -1,0 +1,12 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { defineConfig } from 'vite';
+
+import { getSecurityHeaders } from './constants/webSecurityHeaders';
+
+export default defineConfig({
+    preview: {
+        port: 8000,
+        open: true,
+        headers: getSecurityHeaders(),
+    },
+});

--- a/packages/suite-web/types/securityHeaders.ts
+++ b/packages/suite-web/types/securityHeaders.ts
@@ -1,0 +1,32 @@
+export type ContentSecurityPolicyRules = {
+    'default-src': string[];
+    'script-src-attr': string[];
+    'script-src': string[];
+    'style-src': string[];
+    'style-src-elem': string[];
+    'img-src': string[];
+    'connect-src': string[];
+    'upgrade-insecure-requests': true;
+    'report-uri': string;
+    'report-to': string;
+};
+
+/**
+ * Allow only stricter values from available options
+ */
+export type SecurityHeaders = {
+    'strict-transport-security': string;
+    'upgrade-insecure-requests': '1';
+    'x-content-type-options': 'nosniff';
+    'x-frame-options': 'SAMEORIGIN' | 'DENY';
+    'referrer-policy':
+        | 'strict-origin-when-cross-origin'
+        | 'no-referrer'
+        | 'no-referrer-when-downgrade'
+        | 'same-origin'
+        | 'strict-origin';
+    'cross-origin-opener-policy': 'same-origin';
+    'content-security-policy': ContentSecurityPolicyRules;
+    'report-to': string;
+    'reporting-endpoints': string;
+};

--- a/packages/suite-web/utils/csp.ts
+++ b/packages/suite-web/utils/csp.ts
@@ -1,0 +1,25 @@
+import { ContentSecurityPolicyRules } from '../types/securityHeaders';
+
+const quotedDirectivesValues = new Set(['self', 'none', 'unsafe-inline', 'unsafe-eval']);
+
+function quoteDirectiveValue(value: string) {
+    return quotedDirectivesValues.has(value) ? `'${value}'` : value;
+}
+
+export function formatContentSecurityPolicy<Rules extends Partial<ContentSecurityPolicyRules>>(
+    rules: Rules,
+) {
+    return Object.entries(rules)
+        .map(([key, value]) => {
+            if (value === true) {
+                return key;
+            }
+
+            if (Array.isArray(value)) {
+                return `${key} ${value.map(quoteDirectiveValue).join(' ')}`;
+            }
+
+            return `${key} ${value}`;
+        })
+        .join('; ');
+}

--- a/packages/suite-web/utils/reportingHeaders.ts
+++ b/packages/suite-web/utils/reportingHeaders.ts
@@ -1,0 +1,19 @@
+type UrlWithHttps = `https://${string}`;
+
+/**
+ * Headers directing CSP or other violation reporting to a given endpoint
+ */
+export function createReportingHeaders<Group extends string, ReporUrl extends UrlWithHttps>(
+    cspGroup: Group,
+    cspReportUrl: ReporUrl,
+) {
+    return {
+        'report-to': JSON.stringify({
+            group: cspGroup,
+            max_age: 10886400,
+            endpoints: [{ url: cspReportUrl }],
+            include_subdomains: true,
+        }),
+        'reporting-endpoints': `${cspGroup}=${cspReportUrl}`,
+    } as const;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15246,6 +15246,7 @@ __metadata:
     stylelint: "npm:^16.17.0"
     stylelint-config-standard: "npm:^38.0.0"
     tsx: "npm:^4.21.0"
+    vite: "npm:^7.2.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Define security headers for local testing of production web build.
- Use Vite to run the preview local server.
- As described in README, add `suite:build:web:preview` command (runs build and then serve those files with security headers on `http://localhost:8000`).

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/182

## Screenshots:

<img width="967" height="1332" alt="Snímek obrazovky 2026-01-29 v 15 36 47" src="https://github.com/user-attachments/assets/65c04fda-a0bf-4660-9612-a5e82e11809e" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/182-local-csp&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/182-local-csp&lookback=7)