### PR TITLE
fix(suite): onboarding THP pairing/connection modal

### DIFF
--- a/packages/suite/src/views/onboarding/steps/ThpPairingConfirmStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/ThpPairingConfirmStep.tsx
@@ -1,9 +1,4 @@
-import { useCallback } from 'react';
-import { useIntl } from 'react-intl';
-
-import { messages } from '@suite/intl';
 import { TrezorDevice } from '@suite-common/suite-types';
-import TrezorConnect from '@trezor/connect';
 
 import { ConfirmActionModal } from '../../../components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal';
 
@@ -11,19 +6,10 @@ type ThpPairingConfirmStepParams = {
     device: TrezorDevice;
 };
 
-export const ThpPairingConfirmStep = ({ device }: ThpPairingConfirmStepParams) => {
-    const intl = useIntl();
-
-    const abort = useCallback(
-        () => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED)),
-        [intl],
-    );
-
-    return (
-        <ConfirmActionModal
-            device={device}
-            title="TR_THP_SECURELY_CONNECT_WITH_TREZOR"
-            onCancel={abort}
-        />
-    );
-};
+export const ThpPairingConfirmStep = ({ device }: ThpPairingConfirmStepParams) => (
+    <ConfirmActionModal
+        device={device}
+        title="TR_THP_SECURELY_CONNECT_WITH_TREZOR"
+        enableBackdropClick={false}
+    />
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Pairing modal displayed over Onboarding should be the same as [ThpConnectionModal](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/connection/thp/ThpConnectionModal.tsx) (aka ReduxModal)

Currently it have two issues:
- `abort` function is calling `TrezorConnect.cancel` but [ConfirmActionModal](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx#L35) also calls it by default so `cancel` is called twice. this is causing issue in web+webusb implementation (and probably elsewhere)
- enableBackdropClick should be false, we dont want to accidental clicks here same as  in ThpConnectionModal

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-onboarding-modal&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-onboarding-modal&lookback=7)