### PR TITLE
feat(common): fetch owner quota on demand

### DIFF
--- a/packages/suite/src/components/suite/labeling/TurnOnSuiteSync/SuiteSyncTurnOnModal.tsx
+++ b/packages/suite/src/components/suite/labeling/TurnOnSuiteSync/SuiteSyncTurnOnModal.tsx
@@ -42,6 +42,10 @@ export const SuiteSyncTurnOnModal = ({
 
                     return;
 
+                case 'WriteModeRequiredForAllocation':
+                    // Do nothing, this is expected control flow error when we want allocate on-demand.
+                    return;
+
                 case 'SuiteSyncUnavailableOnDeviceError':
                 case 'DeviceCancelled':
                 case 'DeviceError':

--- a/packages/suite/src/components/suite/labeling/suiteSyncErrorHandler.ts
+++ b/packages/suite/src/components/suite/labeling/suiteSyncErrorHandler.ts
@@ -33,6 +33,11 @@ export const suiteSyncErrorHandler = ({
             dispatch(notificationsActions.addToast({ type: 'error', error: type }));
 
             return;
+
+        case 'WriteModeRequiredForAllocation':
+            // Do nothing, this is expected control flow error when we want allocate on-demand.
+            return;
+
         default:
             return exhaustive(type);
     }

--- a/suite-common/suite-sync-quota-manager/package.json
+++ b/suite-common/suite-sync-quota-manager/package.json
@@ -15,6 +15,7 @@
         "@reduxjs/toolkit": "2.10.1",
         "@suite-common/delegated-identity-key": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/suite-sync-types": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",

--- a/suite-common/suite-sync-quota-manager/src/ensureOwnerHasAllocatedQuotaThunk.ts
+++ b/suite-common/suite-sync-quota-manager/src/ensureOwnerHasAllocatedQuotaThunk.ts
@@ -4,32 +4,54 @@ import {
     getProofOfDelegatedIdentity,
     getPublicIdentityKeyFromDelegatedKey,
 } from '@suite-common/delegated-identity-key';
-import { DelegatedIdentityKey, SuiteSyncOwnerId } from '@suite-common/suite-types';
-import { WalletDescriptor } from '@suite-common/wallet-types';
+import {
+    ChallengeFailedErrType,
+    EnsureOwnerHasAllocatedQuota,
+    EnsureOwnerHasAllocatedQuotaParams,
+    HttpErrType,
+    ProofOfDelegatedIdentityFailedErrType,
+    WriteModeRequiredForAllocationErrType,
+} from '@suite-common/suite-sync-types';
+import { err, ok } from '@trezor/type-utils';
 
 import { prepareChallengeSession } from './challenge/prepareChallengeSession';
 import {
     DEFAULT_ACCOUNT_SIZE_QUOTA,
     EVOLU_SIGN_ADD_SPACE_TO_OWNER_REQUEST_HEADER,
 } from './constants';
-import { quotaManagerFetchError, quotaManagerOwnerFetched } from './quotaManagerActions';
+import { quotaManagerOwnerFetched } from './quotaManagerActions';
 import { selectIsQuotaManagerEnabled, selectQuotaManagerBaseUrl } from './quotaManagerSelectors';
 import { checkStorageByOwnerId } from './storage/checkStorage';
 import { transferStorageThunk } from './storage/transferStorageThunk';
 import { prepareMessageBufferEvoluAddSpaceToOwner } from './util/prepareMessageBufferEvoluAddSpaceToOwner';
 
-type EnsureOwnerHasAllocatedQuotaParams = {
-    ownerId: SuiteSyncOwnerId;
-    walletDescriptor: WalletDescriptor;
-    delegatedKey: DelegatedIdentityKey;
-};
+export const WriteModeRequiredForAllocation = (): WriteModeRequiredForAllocationErrType => ({
+    type: 'WriteModeRequiredForAllocation',
+});
+
+export const ChallengeFailed = (): ChallengeFailedErrType => ({
+    type: 'ChallengeFailed',
+});
+
+export const HttpError = (): HttpErrType => ({
+    type: 'HttpError',
+});
+
+export const ProofOfDelegatedIdentityFailed = (): ProofOfDelegatedIdentityFailedErrType => ({
+    type: 'ProofOfDelegatedIdentityFailed',
+});
 
 export const ensureOwnerHasAllocatedQuotaThunk =
-    ({ ownerId, walletDescriptor, delegatedKey }: EnsureOwnerHasAllocatedQuotaParams) =>
-    async (dispatch: Dispatch, getState: () => any) => {
+    ({
+        ownerId,
+        walletDescriptor,
+        delegatedKey,
+        isWriteMode,
+    }: EnsureOwnerHasAllocatedQuotaParams) =>
+    async (dispatch: Dispatch, getState: () => any): ReturnType<EnsureOwnerHasAllocatedQuota> => {
         const isQuotaManagerEnabled = selectIsQuotaManagerEnabled(getState());
 
-        if (!isQuotaManagerEnabled) return;
+        if (!isQuotaManagerEnabled) return ok();
 
         const quotaManagerBaseUrl = selectQuotaManagerBaseUrl(getState());
 
@@ -46,16 +68,19 @@ export const ensureOwnerHasAllocatedQuotaThunk =
                 }),
             );
 
-            return;
+            return ok();
         }
 
         const isHttp404 =
             hasOwnerStorage.error.type === 'HttpError' && hasOwnerStorage.error.code === 404;
 
         if (!isHttp404) {
-            dispatch(quotaManagerFetchError({ error: hasOwnerStorage.error.message }));
+            return err(HttpError());
+        }
 
-            return;
+        if (isWriteMode === false) {
+            // we want to allocate on-demand
+            return err(WriteModeRequiredForAllocation());
         }
 
         const sessionChallenge = await prepareChallengeSession({
@@ -63,9 +88,7 @@ export const ensureOwnerHasAllocatedQuotaThunk =
         });
 
         if (!sessionChallenge.success) {
-            dispatch(quotaManagerFetchError({ error: sessionChallenge.error.message }));
-
-            return;
+            return err(HttpError());
         }
 
         const proofOfDelegatedIdentity = getProofOfDelegatedIdentity({
@@ -80,7 +103,7 @@ export const ensureOwnerHasAllocatedQuotaThunk =
         });
 
         if (!proofOfDelegatedIdentity.success) {
-            return;
+            return err(ProofOfDelegatedIdentityFailed());
         }
 
         await dispatch(
@@ -96,4 +119,6 @@ export const ensureOwnerHasAllocatedQuotaThunk =
                 walletDescriptor,
             }),
         );
+
+        return ok();
     };

--- a/suite-common/suite-sync-quota-manager/src/index.ts
+++ b/suite-common/suite-sync-quota-manager/src/index.ts
@@ -6,7 +6,10 @@ export { registerStorageThunk } from './storage/registerStorageThunk';
 export { transferStorageThunk } from './storage/transferStorageThunk';
 export { prepareChallengeSession } from './challenge/prepareChallengeSession';
 export { ensureDeviceHasQuotaThunk } from './ensureDeviceHasQuotaThunk';
-export { ensureOwnerHasAllocatedQuotaThunk } from './ensureOwnerHasAllocatedQuotaThunk';
+export {
+    ensureOwnerHasAllocatedQuotaThunk,
+    WriteModeRequiredForAllocation,
+} from './ensureOwnerHasAllocatedQuotaThunk';
 export { increaseOwnerQuotaThunk } from './increaseOwnerQuotaThunk';
 
 /**

--- a/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
@@ -51,10 +51,12 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
         const getState = createGetState({ enabled: false });
         const dispatch = jest.fn();
 
-        await ensureOwnerHasAllocatedQuotaThunk({ ownerId, delegatedKey, walletDescriptor })(
-            dispatch,
-            getState,
-        );
+        await ensureOwnerHasAllocatedQuotaThunk({
+            ownerId,
+            delegatedKey,
+            walletDescriptor,
+            isWriteMode: false,
+        })(dispatch, getState);
 
         expect(checkStorageByOwnerIdMock).not.toHaveBeenCalled();
         expect(dispatch).not.toHaveBeenCalled();
@@ -66,10 +68,12 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
 
         checkStorageByOwnerIdMock.mockResolvedValue(ok({ totalSpace: 2048 }));
 
-        await ensureOwnerHasAllocatedQuotaThunk({ ownerId, delegatedKey, walletDescriptor })(
-            dispatch,
-            getState,
-        );
+        await ensureOwnerHasAllocatedQuotaThunk({
+            ownerId,
+            delegatedKey,
+            walletDescriptor,
+            isWriteMode: false,
+        })(dispatch, getState);
 
         expect(checkStorageByOwnerIdMock).toHaveBeenCalledWith({
             baseUrl: 'https://quota-manager.test',
@@ -96,17 +100,13 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
             err({ type: 'HttpError', code: 500, message: 'Internal error' }),
         );
 
-        await ensureOwnerHasAllocatedQuotaThunk({ ownerId, delegatedKey, walletDescriptor })(
-            dispatch,
-            getState,
-        );
+        await ensureOwnerHasAllocatedQuotaThunk({
+            ownerId,
+            delegatedKey,
+            walletDescriptor,
+            isWriteMode: false,
+        })(dispatch, getState);
 
-        expect(dispatch).toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: '@suite/quota-manager/fetchError',
-                payload: { error: 'Internal error' },
-            }),
-        );
         expect(prepareChallengeSessionMock).not.toHaveBeenCalled();
     });
 
@@ -129,10 +129,12 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
         const transferThunkInner = jest.fn();
         transferStorageThunkMock.mockReturnValue(transferThunkInner);
 
-        await ensureOwnerHasAllocatedQuotaThunk({ ownerId, delegatedKey, walletDescriptor })(
-            dispatch,
-            getState,
-        );
+        await ensureOwnerHasAllocatedQuotaThunk({
+            ownerId,
+            delegatedKey,
+            walletDescriptor,
+            isWriteMode: true,
+        })(dispatch, getState);
 
         expect(prepareChallengeSessionMock).toHaveBeenCalledWith({
             baseUrl: 'https://quota-manager.test',

--- a/suite-common/suite-sync-quota-manager/tsconfig.json
+++ b/suite-common/suite-sync-quota-manager/tsconfig.json
@@ -7,6 +7,7 @@
     "references": [
         { "path": "../delegated-identity-key" },
         { "path": "../redux-utils" },
+        { "path": "../suite-sync-types" },
         { "path": "../suite-types" },
         { "path": "../suite-utils" },
         { "path": "../wallet-core" },

--- a/suite-common/suite-sync-types/src/data/subscribeSuiteSyncData.ts
+++ b/suite-common/suite-sync-types/src/data/subscribeSuiteSyncData.ts
@@ -7,10 +7,14 @@ import {
 import { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
-import { SuiteSyncUnavailableOnDeviceErrorType } from '../refreshSuiteSyncKeys';
+import {
+    SuiteSyncUnavailableOnDeviceErrorType,
+    WriteModeRequiredForAllocationErrType,
+} from '../refreshSuiteSyncKeys';
 
 type SubscribeSuiteSyncDataParams = {
     deviceStaticSessionId: StaticSessionId;
+    isWriteMode: boolean;
 };
 
 export type Subscriptions = {
@@ -34,7 +38,10 @@ export type SubscribeSuiteSyncData = (
 ) => Promise<
     Result<
         SuiteSyncStorage,
-        SuiteSyncUnavailableOnDeviceErrorType | DeviceErrorType | DeviceCancelledErrType
+        | SuiteSyncUnavailableOnDeviceErrorType
+        | DeviceErrorType
+        | DeviceCancelledErrType
+        | WriteModeRequiredForAllocationErrType
     >
 >;
 

--- a/suite-common/suite-sync-types/src/index.ts
+++ b/suite-common/suite-sync-types/src/index.ts
@@ -6,7 +6,11 @@ export type {
     StorageId,
 } from './storage/suiteSyncStorageRepository';
 
-export type { RefreshSuiteSyncKeys, RefreshSuiteSyncKeysDep } from './refreshSuiteSyncKeys';
+export type {
+    RefreshSuiteSyncKeys,
+    RefreshSuiteSyncKeysDep,
+    WriteModeRequiredForAllocationErrType,
+} from './refreshSuiteSyncKeys';
 export type { TurnOffSuiteSyncDep, TurnOffSuiteSync } from './turnOffSuiteSync';
 export type { TurnOnSuiteSyncDep, TurnOnSuiteSync } from './turnOnSuiteSync';
 export type { SuiteSyncUnavailableOnDeviceErrorType } from './refreshSuiteSyncKeys';
@@ -71,3 +75,11 @@ export type {
     Errors,
     CreateSuiteSyncErrorHandlerDep,
 } from './SuiteSyncErrorHandler';
+
+export type {
+    EnsureOwnerHasAllocatedQuotaParams,
+    EnsureOwnerHasAllocatedQuota,
+    ChallengeFailedErrType,
+    HttpErrType,
+    ProofOfDelegatedIdentityFailedErrType,
+} from './quotaManager/ensureOwnerHasAllocatedQuotaThunk';

--- a/suite-common/suite-sync-types/src/quotaManager/ensureOwnerHasAllocatedQuotaThunk.ts
+++ b/suite-common/suite-sync-types/src/quotaManager/ensureOwnerHasAllocatedQuotaThunk.ts
@@ -1,0 +1,30 @@
+import { DelegatedIdentityKey, SuiteSyncOwnerId } from '@suite-common/suite-types';
+import { WalletDescriptor } from '@suite-common/wallet-types';
+import { Result } from '@trezor/type-utils';
+
+import { WriteModeRequiredForAllocationErrType } from '../refreshSuiteSyncKeys';
+
+export type HttpErrType = { type: 'HttpError' };
+
+export type ChallengeFailedErrType = { type: 'ChallengeFailed' };
+
+export type ProofOfDelegatedIdentityFailedErrType = { type: 'ProofOfDelegatedIdentityFailed' };
+
+export type EnsureOwnerHasAllocatedQuotaParams = {
+    ownerId: SuiteSyncOwnerId;
+    walletDescriptor: WalletDescriptor;
+    delegatedKey: DelegatedIdentityKey;
+    isWriteMode: boolean;
+};
+
+export type EnsureOwnerHasAllocatedQuota = (
+    params: EnsureOwnerHasAllocatedQuotaParams,
+) => Promise<
+    Result<
+        void,
+        | WriteModeRequiredForAllocationErrType
+        | HttpErrType
+        | ChallengeFailedErrType
+        | ProofOfDelegatedIdentityFailedErrType
+    >
+>;

--- a/suite-common/suite-sync-types/src/refreshSuiteSyncKeys.ts
+++ b/suite-common/suite-sync-types/src/refreshSuiteSyncKeys.ts
@@ -4,6 +4,7 @@ import { Result } from '@trezor/type-utils';
 
 type RefreshSuiteSyncKeysParams = {
     device: TrezorDevice;
+    isWriteMode: boolean;
 };
 
 /**
@@ -16,12 +17,19 @@ export type SuiteSyncUnavailableOnDeviceErrorType = {
     type: 'SuiteSyncUnavailableOnDeviceError';
 };
 
+export type WriteModeRequiredForAllocationErrType = {
+    type: 'WriteModeRequiredForAllocation';
+};
+
 export type RefreshSuiteSyncKeys = (
     params: RefreshSuiteSyncKeysParams,
 ) => Promise<
     Result<
         SuiteSyncOwner,
-        SuiteSyncUnavailableOnDeviceErrorType | DeviceErrorType | DeviceCancelledErrType
+        | SuiteSyncUnavailableOnDeviceErrorType
+        | DeviceErrorType
+        | DeviceCancelledErrType
+        | WriteModeRequiredForAllocationErrType
     >
 >;
 

--- a/suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn.ts
+++ b/suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn.ts
@@ -3,13 +3,19 @@ import { DeviceCancelledErrType, DeviceErrorType } from '@suite-common/wallet-ty
 import { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
-import { SuiteSyncUnavailableOnDeviceErrorType } from '../refreshSuiteSyncKeys';
+import {
+    SuiteSyncUnavailableOnDeviceErrorType,
+    WriteModeRequiredForAllocationErrType,
+} from '../refreshSuiteSyncKeys';
 
 export type SuiteSyncFirmwareUpgradeNeededDeviceErrorType = {
     type: 'SuiteSyncFirmwareUpgradeNeededDeviceErrorType';
 };
 
-export type EnsureWalletSuiteSyncOnParams = { deviceStaticSessionId: StaticSessionId };
+export type EnsureWalletSuiteSyncOnParams = {
+    deviceStaticSessionId: StaticSessionId;
+    isWriteMode: boolean;
+};
 
 /**
  * Those are all errors that may happen during ensuring that SuiteSync is in on.
@@ -20,7 +26,8 @@ export type EnsureWalletSuiteSyncOnErrors =
     | SuiteSyncUnavailableOnDeviceErrorType
     | SuiteSyncFirmwareUpgradeNeededDeviceErrorType
     | DeviceErrorType
-    | DeviceCancelledErrType;
+    | DeviceCancelledErrType
+    | WriteModeRequiredForAllocationErrType;
 
 export type EnsureWalletSuiteSyncOn = (
     params: EnsureWalletSuiteSyncOnParams,

--- a/suite-common/suite-sync/src/createRefreshSuiteSyncKeys.ts
+++ b/suite-common/suite-sync/src/createRefreshSuiteSyncKeys.ts
@@ -2,6 +2,7 @@ import { Dispatch } from '@reduxjs/toolkit';
 
 import { EnsureDelegatedIdentityKeyDep } from '@suite-common/delegated-identity-key-types';
 import {
+    WriteModeRequiredForAllocation,
     ensureDeviceHasQuotaThunk,
     ensureOwnerHasAllocatedQuotaThunk,
 } from '@suite-common/suite-sync-quota-manager';
@@ -36,7 +37,7 @@ export type RefreshSuiteSyncKeysDeps = {
 
 export const createRefreshSuiteSync =
     (deps: RefreshSuiteSyncKeysDeps): RefreshSuiteSyncKeys =>
-    async ({ device }): ReturnType<RefreshSuiteSyncKeys> => {
+    async ({ device, isWriteMode }): ReturnType<RefreshSuiteSyncKeys> => {
         if (!device || !isTrezorDeviceWithState(device)) {
             return err(SuiteSyncUnavailableOnDeviceError());
         }
@@ -90,13 +91,21 @@ export const createRefreshSuiteSync =
                 return ownerResult;
             }
 
-            await deps.dispatch(
+            const allocatedQuota = await deps.dispatch(
                 ensureOwnerHasAllocatedQuotaThunk({
                     walletDescriptor,
                     ownerId: ownerResult.payload.ownerId,
                     delegatedKey: delegatedKeyResult.payload,
+                    isWriteMode,
                 }),
             );
+
+            if (
+                allocatedQuota.success === false &&
+                allocatedQuota.error.type === 'WriteModeRequiredForAllocation'
+            ) {
+                return err(WriteModeRequiredForAllocation());
+            }
 
             return ok(ownerResult.payload);
         };
@@ -109,6 +118,7 @@ export const createRefreshSuiteSync =
             switch (errType) {
                 case 'DeviceError':
                 case 'DeviceCancelled':
+                case 'WriteModeRequiredForAllocation':
                     return err(result.error);
 
                 // Those errors are most likely due to Bug in the code or data corruption

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -21,7 +21,7 @@ import { createRefreshSuiteSync } from './createRefreshSuiteSyncKeys';
 import { createSuiteSyncErrorHandler } from './createSuiteSyncErrorHandler';
 import { createTurnOffSuiteSync } from './createTurnOffSuiteSync';
 import { createTurnOnSuiteSync } from './createTurnOnSuiteSync';
-import { createEnsureSubscribeSuiteSyncData } from './data/createEnsureSuiteSyncData';
+import { createEnsureSubscribeSuiteSyncData } from './data/createEnsureSubscribeSuiteSyncData';
 import { createSuiteSyncListener } from './data/createSuiteSyncListener';
 import { createUpdateAccountLabel } from './data/labeling/createUpdateAccountLabel';
 import { createUpdateAddressLabel } from './data/labeling/createUpdateAddressLabel';

--- a/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
@@ -24,6 +24,7 @@ export const createTurnOnSuiteSync =
         if (deviceStaticSessionId !== undefined) {
             const result = await deps.ensureWalletSuiteSyncOn({
                 deviceStaticSessionId,
+                isWriteMode: false,
             });
 
             if (!result.success) {

--- a/suite-common/suite-sync/src/data/createEnsureSubscribeSuiteSyncData.ts
+++ b/suite-common/suite-sync/src/data/createEnsureSubscribeSuiteSyncData.ts
@@ -17,8 +17,11 @@ export type CreateSubscribeSuiteSyncDataDeps = EnsureStorageDep &
 
 export const createEnsureSubscribeSuiteSyncData =
     (deps: CreateSubscribeSuiteSyncDataDeps): SubscribeSuiteSyncData =>
-    async ({ deviceStaticSessionId }): ReturnType<SubscribeSuiteSyncData> => {
-        const storageResult = await deps.ensureStorage({ deviceStaticSessionId });
+    async ({ deviceStaticSessionId, isWriteMode }): ReturnType<SubscribeSuiteSyncData> => {
+        const storageResult = await deps.ensureStorage({
+            deviceStaticSessionId,
+            isWriteMode,
+        });
 
         if (!storageResult.success) {
             return storageResult;

--- a/suite-common/suite-sync/src/data/labeling/createUpdateAccountLabel.ts
+++ b/suite-common/suite-sync/src/data/labeling/createUpdateAccountLabel.ts
@@ -8,6 +8,7 @@ export const createUpdateAccountLabel =
     async ({ deviceStaticSessionId, accountKey, label }) => {
         const ensureWalletOnResult = await deps.ensureWalletSuiteSyncOn({
             deviceStaticSessionId,
+            isWriteMode: true,
         });
 
         if (!ensureWalletOnResult.success) {

--- a/suite-common/suite-sync/src/data/labeling/createUpdateAddressLabel.ts
+++ b/suite-common/suite-sync/src/data/labeling/createUpdateAddressLabel.ts
@@ -8,6 +8,7 @@ export const createUpdateAddressLabel =
     async ({ deviceStaticSessionId, address, label, accountDescriptor, networkSymbol }) => {
         const ensureWalletOnResult = await deps.ensureWalletSuiteSyncOn({
             deviceStaticSessionId,
+            isWriteMode: true,
         });
 
         if (!ensureWalletOnResult.success) {

--- a/suite-common/suite-sync/src/data/labeling/createUpdateOutputLabel.ts
+++ b/suite-common/suite-sync/src/data/labeling/createUpdateOutputLabel.ts
@@ -15,6 +15,7 @@ export const createUpdateOutputLabel =
     }) => {
         const ensureWalletOnResult = await deps.ensureWalletSuiteSyncOn({
             deviceStaticSessionId,
+            isWriteMode: true,
         });
 
         if (!ensureWalletOnResult.success) {

--- a/suite-common/suite-sync/src/data/labeling/createUpdateWalletLabel.ts
+++ b/suite-common/suite-sync/src/data/labeling/createUpdateWalletLabel.ts
@@ -9,6 +9,7 @@ export const createUpdateWalletLabel =
     async ({ deviceStaticSessionId, label }) => {
         const ensureWalletOnResult = await deps.ensureWalletSuiteSyncOn({
             deviceStaticSessionId,
+            isWriteMode: true,
         });
 
         if (!ensureWalletOnResult.success) {

--- a/suite-common/suite-sync/src/data/labeling/tests/createUpdateAccountLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/tests/createUpdateAccountLabel.test.ts
@@ -29,7 +29,10 @@ describe(createUpdateAccountLabel.name, () => {
             label: 'New Account Label',
         });
 
-        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            isWriteMode: true,
+        });
 
         expect(storage.data.accounts.update).toHaveBeenCalledWith({
             accountDescriptor: asAccountDescriptor('accountDescriptor'),
@@ -54,7 +57,10 @@ describe(createUpdateAccountLabel.name, () => {
             label: 'New Account Label',
         });
 
-        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            isWriteMode: true,
+        });
         expect(result).toBe(ensureWalletSuiteSyncOnResult);
     });
 });

--- a/suite-common/suite-sync/src/data/labeling/tests/createUpdateAddressLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/tests/createUpdateAddressLabel.test.ts
@@ -35,7 +35,10 @@ describe(createUpdateAddressLabel.name, () => {
             networkSymbol,
         });
 
-        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            isWriteMode: true,
+        });
 
         expect(storage.data.addresses.update).toHaveBeenCalledWith({
             address: 'bc1address',
@@ -63,7 +66,10 @@ describe(createUpdateAddressLabel.name, () => {
             networkSymbol,
         });
 
-        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            isWriteMode: true,
+        });
         expect(result).toBe(ensureWalletSuiteSyncOnResult);
     });
 });

--- a/suite-common/suite-sync/src/data/labeling/tests/createUpdateOutputLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/tests/createUpdateOutputLabel.test.ts
@@ -36,7 +36,10 @@ describe(createUpdateOutputLabel.name, () => {
             networkSymbol,
         });
 
-        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            isWriteMode: true,
+        });
 
         expect(storage.data.outputs.update).toHaveBeenCalledWith({
             txId: 'txid',
@@ -66,7 +69,10 @@ describe(createUpdateOutputLabel.name, () => {
             networkSymbol,
         });
 
-        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            isWriteMode: true,
+        });
         expect(result).toBe(ensureWalletSuiteSyncOnResult);
     });
 });

--- a/suite-common/suite-sync/src/data/labeling/tests/createUpdateWalletLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/tests/createUpdateWalletLabel.test.ts
@@ -23,9 +23,15 @@ describe(createUpdateWalletLabel.name, () => {
         });
 
         const updateWalletLabel = createUpdateWalletLabel(deps);
-        const result = await updateWalletLabel({ deviceStaticSessionId, label: 'New Label' });
+        const result = await updateWalletLabel({
+            deviceStaticSessionId,
+            label: 'New Label',
+        });
 
-        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            isWriteMode: true,
+        });
 
         expect(storage.data.wallets.update).toHaveBeenCalledWith({
             walletDescriptor: asWalletDescriptor('1'),
@@ -43,9 +49,15 @@ describe(createUpdateWalletLabel.name, () => {
         });
 
         const updateWalletLabel = createUpdateWalletLabel(deps);
-        const result = await updateWalletLabel({ deviceStaticSessionId, label: 'New Label' });
+        const result = await updateWalletLabel({
+            deviceStaticSessionId,
+            label: 'New Label',
+        });
 
-        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            isWriteMode: true,
+        });
         expect(result).toBe(ensureWalletSuiteSyncOnResult);
     });
 });

--- a/suite-common/suite-sync/src/data/tests/createEnsureSuiteSyncData.test.ts
+++ b/suite-common/suite-sync/src/data/tests/createEnsureSuiteSyncData.test.ts
@@ -21,7 +21,7 @@ import { createSubscriptionStorage } from '../../storage/createSubscriptionStora
 import {
     CreateSubscribeSuiteSyncDataDeps,
     createEnsureSubscribeSuiteSyncData,
-} from '../createEnsureSuiteSyncData';
+} from '../createEnsureSubscribeSuiteSyncData';
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3';
 
@@ -86,9 +86,12 @@ describe(createEnsureSubscribeSuiteSyncData.name, () => {
         });
 
         const subscribeLabeling = createEnsureSubscribeSuiteSyncData(deps);
-        const result = await subscribeLabeling({ deviceStaticSessionId });
+        const result = await subscribeLabeling({ deviceStaticSessionId, isWriteMode: false });
 
-        expect(deps.ensureStorage).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(deps.ensureStorage).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            isWriteMode: false,
+        });
         expect(result).toBe(storageResult);
     });
 
@@ -116,9 +119,12 @@ describe(createEnsureSubscribeSuiteSyncData.name, () => {
         });
 
         const subscribeLabeling = createEnsureSubscribeSuiteSyncData(deps);
-        const result = await subscribeLabeling({ deviceStaticSessionId });
+        const result = await subscribeLabeling({ deviceStaticSessionId, isWriteMode: false });
 
-        expect(deps.ensureStorage).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(deps.ensureStorage).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            isWriteMode: false,
+        });
         expect(result.success && result.payload).toBe(storage);
     });
 
@@ -138,9 +144,12 @@ describe(createEnsureSubscribeSuiteSyncData.name, () => {
         });
 
         const subscribeLabeling = createEnsureSubscribeSuiteSyncData(deps);
-        const result = await subscribeLabeling({ deviceStaticSessionId });
+        const result = await subscribeLabeling({ deviceStaticSessionId, isWriteMode: false });
 
-        expect(deps.ensureStorage).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(deps.ensureStorage).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            isWriteMode: false,
+        });
         expect(result.success).toBe(true);
 
         expect(storage.data.wallets.subscribe).toHaveBeenCalledTimes(1);
@@ -169,7 +178,7 @@ describe(createEnsureSubscribeSuiteSyncData.name, () => {
 
         const subscribeLabeling = createEnsureSubscribeSuiteSyncData(deps);
 
-        const result = await subscribeLabeling({ deviceStaticSessionId });
+        const result = await subscribeLabeling({ deviceStaticSessionId, isWriteMode: false });
 
         expect(result.success).toBe(true);
 

--- a/suite-common/suite-sync/src/storage/createEnsureStorage.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureStorage.ts
@@ -4,6 +4,7 @@ import {
     SuiteSyncStorageRepositoryDep,
     SuiteSyncUnavailableOnDeviceErrorType,
 } from '@suite-common/suite-sync-types';
+import type { WriteModeRequiredForAllocationErrType } from '@suite-common/suite-sync-types';
 import { DeviceCancelledErrType, DeviceErrorType } from '@suite-common/wallet-types';
 import { StaticSessionId } from '@trezor/connect';
 import { Result, err, ok } from '@trezor/type-utils';
@@ -22,6 +23,7 @@ export type EnsureStorageDeps = {
 
 export type EnsureStorageParams = {
     deviceStaticSessionId: StaticSessionId;
+    isWriteMode: boolean;
 };
 
 export type CreateEnsureStorage = (
@@ -29,7 +31,10 @@ export type CreateEnsureStorage = (
 ) => Promise<
     Result<
         SuiteSyncStorage,
-        SuiteSyncUnavailableOnDeviceErrorType | DeviceErrorType | DeviceCancelledErrType
+        | SuiteSyncUnavailableOnDeviceErrorType
+        | DeviceErrorType
+        | DeviceCancelledErrType
+        | WriteModeRequiredForAllocationErrType
     >
 >;
 
@@ -39,7 +44,7 @@ export type EnsureStorageDep = {
 
 export const createEnsureStorage =
     (deps: EnsureStorageDeps): CreateEnsureStorage =>
-    async ({ deviceStaticSessionId }): ReturnType<CreateEnsureStorage> => {
+    async ({ deviceStaticSessionId, isWriteMode }): ReturnType<CreateEnsureStorage> => {
         const storageId = createStorageIdFromDeviceStaticSessionId(deviceStaticSessionId);
 
         const storage = deps.suiteSyncStorageRepository.get(storageId);
@@ -54,7 +59,7 @@ export const createEnsureStorage =
             return err(SuiteSyncUnavailableOnDeviceError());
         }
 
-        const ownerResult = await deps.refreshSuiteSyncKeys({ device });
+        const ownerResult = await deps.refreshSuiteSyncKeys({ device, isWriteMode });
 
         if (!ownerResult.success) {
             return ownerResult;

--- a/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOn.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOn.ts
@@ -22,7 +22,7 @@ export type EnsureWalletSuiteSyncOnDeps = {
 
 export const createEnsureWalletSuiteSyncOn =
     (deps: EnsureWalletSuiteSyncOnDeps): EnsureWalletSuiteSyncOn =>
-    async ({ deviceStaticSessionId }) => {
+    async ({ deviceStaticSessionId, isWriteMode }) => {
         const device = selectDeviceByStaticSessionId(deps.getState(), deviceStaticSessionId);
 
         if (isFwUpgradeNeededForSuiteSync(device)) {
@@ -36,7 +36,10 @@ export const createEnsureWalletSuiteSyncOn =
             return err({ type: 'SuiteSyncUnavailableOnDeviceError' });
         }
 
-        const result = await deps.ensureSuiteSyncData({ deviceStaticSessionId });
+        const result = await deps.ensureSuiteSyncData({
+            deviceStaticSessionId,
+            isWriteMode,
+        });
 
         if (!result.success) {
             const { type } = result.error;
@@ -50,6 +53,10 @@ export const createEnsureWalletSuiteSyncOn =
                 case 'SuiteSyncUnavailableOnDeviceError':
                     // This error is now not handled in the UI, so we don't need to set the error. It will probably be added as a follow up.
                     deps.dispatch(setSuiteSyncError({ error: null }));
+                    break;
+
+                case 'WriteModeRequiredForAllocation':
+                    // Do nothing, this is expected control flow error when we want allocate on-demand.
                     break;
 
                 default:

--- a/suite-common/suite-sync/src/storage/tests/createEnsureStorage.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createEnsureStorage.test.ts
@@ -37,7 +37,10 @@ describe(createEnsureStorage.name, () => {
             getDeviceForStaticSessionId: null,
         });
 
-        const result = await createEnsureStorage(deps)({ deviceStaticSessionId });
+        const result = await createEnsureStorage(deps)({
+            deviceStaticSessionId,
+            isWriteMode: false,
+        });
 
         expect(result).toEqual(ok(existingStorage));
         expect(deps.suiteSyncStorageRepository.get).toHaveBeenCalled();
@@ -60,7 +63,10 @@ describe(createEnsureStorage.name, () => {
             getDeviceForStaticSessionId: () => null,
         });
 
-        const result = await createEnsureStorage(deps)({ deviceStaticSessionId });
+        const result = await createEnsureStorage(deps)({
+            deviceStaticSessionId,
+            isWriteMode: false,
+        });
 
         expect(result.success).toBe(false);
         expect(!result.success && result.error.type).toBe('SuiteSyncUnavailableOnDeviceError');
@@ -86,11 +92,14 @@ describe(createEnsureStorage.name, () => {
             getDeviceForStaticSessionId: () => device,
         });
 
-        const result = await createEnsureStorage(deps)({ deviceStaticSessionId });
+        const result = await createEnsureStorage(deps)({
+            deviceStaticSessionId,
+            isWriteMode: false,
+        });
 
         expect(result).toBe(refreshError);
         expect(deps.getDeviceForStaticSessionId).toHaveBeenCalledWith(deviceStaticSessionId);
-        expect(deps.refreshSuiteSyncKeys).toHaveBeenCalledWith({ device });
+        expect(deps.refreshSuiteSyncKeys).toHaveBeenCalledWith({ device, isWriteMode: false });
         expect(deps.createSuiteStorage).not.toHaveBeenCalled();
     });
 
@@ -111,11 +120,14 @@ describe(createEnsureStorage.name, () => {
             getDeviceForStaticSessionId: () => device,
         });
 
-        const result = await createEnsureStorage(deps)({ deviceStaticSessionId });
+        const result = await createEnsureStorage(deps)({
+            deviceStaticSessionId,
+            isWriteMode: false,
+        });
 
         expect(result).toEqual(ok(newStorage));
         expect(deps.getDeviceForStaticSessionId).toHaveBeenCalledWith(deviceStaticSessionId);
-        expect(deps.refreshSuiteSyncKeys).toHaveBeenCalledWith({ device });
+        expect(deps.refreshSuiteSyncKeys).toHaveBeenCalledWith({ device, isWriteMode: false });
         expect(deps.createSuiteStorage).toHaveBeenCalledWith({
             suiteSyncOwner: OWNER_ABCD,
             relayUrl: 'wss://default-relay.example.com',
@@ -143,7 +155,7 @@ describe(createEnsureStorage.name, () => {
         });
 
         const ensureStorage = createEnsureStorage(deps);
-        const result = await ensureStorage({ deviceStaticSessionId });
+        const result = await ensureStorage({ deviceStaticSessionId, isWriteMode: false });
 
         expect(result).toEqual(ok(newStorage));
         expect(deps.createSuiteStorage).toHaveBeenCalledWith({
@@ -170,7 +182,10 @@ describe(createEnsureStorage.name, () => {
             getDeviceForStaticSessionId: () => device,
         });
 
-        const result = await createEnsureStorage(deps)({ deviceStaticSessionId });
+        const result = await createEnsureStorage(deps)({
+            deviceStaticSessionId,
+            isWriteMode: false,
+        });
 
         expect(result).toEqual(ok(newStorage));
         expect(deps.createSuiteStorage).toHaveBeenCalledWith({
@@ -197,7 +212,10 @@ describe(createEnsureStorage.name, () => {
             getDeviceForStaticSessionId: () => device,
         });
 
-        const result = await createEnsureStorage(deps)({ deviceStaticSessionId });
+        const result = await createEnsureStorage(deps)({
+            deviceStaticSessionId,
+            isWriteMode: false,
+        });
 
         expect(result).toEqual(ok(newStorage));
         expect(deps.createSuiteStorage).toHaveBeenCalledWith({

--- a/suite-common/suite-sync/src/storage/tests/createEnsureWalletSuiteSyncOn.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createEnsureWalletSuiteSyncOn.test.ts
@@ -37,6 +37,7 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
 
         const result = await createEnsureWalletSuiteSyncOn(deps)({
             deviceStaticSessionId: DEVICE_STATIC_SESSION_ID_123,
+            isWriteMode: false,
         });
 
         expect(result.success).toBe(false);
@@ -59,6 +60,7 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
 
         const result = await createEnsureWalletSuiteSyncOn(deps)({
             deviceStaticSessionId: DEVICE_STATIC_SESSION_ID_123,
+            isWriteMode: false,
         });
 
         expect(result.success).toBe(false);
@@ -89,6 +91,7 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
 
         const result = await createEnsureWalletSuiteSyncOn(deps)({
             deviceStaticSessionId: DEVICE_STATIC_SESSION_ID_123,
+            isWriteMode: false,
         });
 
         expect(!result.success && result.error.type).toBe(
@@ -110,10 +113,12 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
 
         const result = await createEnsureWalletSuiteSyncOn(deps)({
             deviceStaticSessionId: DEVICE_STATIC_SESSION_ID_123,
+            isWriteMode: false,
         });
 
         expect(deps.ensureSuiteSyncData).toHaveBeenCalledWith({
             deviceStaticSessionId: DEVICE_STATIC_SESSION_ID_123,
+            isWriteMode: false,
         });
         expect(result).toBe(ensureResult);
     });
@@ -131,10 +136,12 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
 
         const result = await createEnsureWalletSuiteSyncOn(deps)({
             deviceStaticSessionId: DEVICE_STATIC_SESSION_ID_123,
+            isWriteMode: false,
         });
 
         expect(deps.ensureSuiteSyncData).toHaveBeenCalledWith({
             deviceStaticSessionId: DEVICE_STATIC_SESSION_ID_123,
+            isWriteMode: false,
         });
         expect(result).toBe(ensureResult);
     });

--- a/suite-common/suite-sync/src/suiteSyncMiddleware.ts
+++ b/suite-common/suite-sync/src/suiteSyncMiddleware.ts
@@ -18,6 +18,7 @@ export const prepareSuiteSyncMiddleware = createMiddlewareWithExtraDeps(
             if (action.payload.success) {
                 extra.services.suiteSync.ensureWalletSuiteSyncOn({
                     deviceStaticSessionId: action.payload.staticSessionId,
+                    isWriteMode: false,
                 });
             }
         }
@@ -28,6 +29,7 @@ export const prepareSuiteSyncMiddleware = createMiddlewareWithExtraDeps(
             if (isTrezorDeviceWithState(payload.device)) {
                 extra.services.suiteSync.ensureWalletSuiteSyncOn({
                     deviceStaticSessionId: payload.device.state.staticSessionId,
+                    isWriteMode: false,
                 });
             }
         }

--- a/suite-common/suite-sync/src/tests/createRefreshSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/tests/createRefreshSuiteSync.test.ts
@@ -65,6 +65,7 @@ describe(createRefreshSuiteSync.name, () => {
         const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
         const result = await refreshSuiteSyncKeys({
             device: createDevice({}, null),
+            isWriteMode: false,
         });
 
         expect(result.success).toEqual(false);
@@ -79,6 +80,7 @@ describe(createRefreshSuiteSync.name, () => {
         const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
         const result = await refreshSuiteSyncKeys({
             device: createDevice(),
+            isWriteMode: false,
         });
 
         expect(result.success).toEqual(true);
@@ -92,6 +94,7 @@ describe(createRefreshSuiteSync.name, () => {
         const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
         const result = await refreshSuiteSyncKeys({
             device: createDevice({ connected: false }),
+            isWriteMode: false,
         });
 
         expect(result.success).toEqual(false);
@@ -100,7 +103,7 @@ describe(createRefreshSuiteSync.name, () => {
 
     it('ensures that the delegated identity key is available when owner is not in state', async () => {
         const deps = createMockDeps();
-        deps.dispatch.mockImplementation(() => Promise.resolve(undefined));
+        deps.dispatch.mockImplementation(() => Promise.resolve(ok()));
         deps.loadSuiteSyncOwnerFromState.mockResolvedValue(null);
         deps.ensureSuiteSyncOwner.mockResolvedValue(ok(OWNER_1));
         deps.ensureDelegatedIdentityKey.mockResolvedValue(
@@ -113,6 +116,7 @@ describe(createRefreshSuiteSync.name, () => {
         const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
         await refreshSuiteSyncKeys({
             device: mockDevice,
+            isWriteMode: false,
         });
 
         expect(deps.ensureDelegatedIdentityKey).toHaveBeenCalledWith({
@@ -122,7 +126,12 @@ describe(createRefreshSuiteSync.name, () => {
 
     it('requests ensureSuiteSyncOwner when owner is not in state', async () => {
         const deps = createMockDeps();
-        deps.dispatch.mockImplementation(() => Promise.resolve(undefined));
+        deps.dispatch.mockImplementation(() =>
+            Promise.resolve({
+                success: false,
+                error: { type: 'WriteModeRequiredForAllocation' },
+            }),
+        );
         deps.loadSuiteSyncOwnerFromState.mockResolvedValue(null);
         deps.ensureSuiteSyncOwner.mockResolvedValue(ok(OWNER_1));
         deps.ensureDelegatedIdentityKey.mockResolvedValue(
@@ -135,6 +144,7 @@ describe(createRefreshSuiteSync.name, () => {
         const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
         await refreshSuiteSyncKeys({
             device: mockDevice,
+            isWriteMode: false,
         });
 
         expect(deps.ensureSuiteSyncOwner).toHaveBeenCalledWith({
@@ -145,7 +155,7 @@ describe(createRefreshSuiteSync.name, () => {
 
     it('finally returns the new refreshed owner', async () => {
         const deps = createMockDeps();
-        deps.dispatch.mockImplementation(() => Promise.resolve(undefined));
+        deps.dispatch.mockImplementation(() => Promise.resolve(ok()));
         deps.loadSuiteSyncOwnerFromState.mockResolvedValue(null);
         deps.ensureDelegatedIdentityKey.mockResolvedValue(
             ok(asDelegatedIdentityKey('delegated-key-value')),
@@ -163,6 +173,7 @@ describe(createRefreshSuiteSync.name, () => {
         const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
         const result = await refreshSuiteSyncKeys({
             device: mockDevice,
+            isWriteMode: false,
         });
 
         expect(result.success).toBe(true);

--- a/suite-common/suite-sync/src/tests/createTurnOnSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/tests/createTurnOnSuiteSync.test.ts
@@ -40,7 +40,10 @@ describe(createTurnOnSuiteSync.name, () => {
         const result = await turnOnSuiteSync({ deviceStaticSessionId });
 
         expect(deps.dispatch).toHaveBeenCalledWith(updateSuiteSyncEnabled({ isEnabled: true }));
-        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            isWriteMode: false,
+        });
         expect(result).toEqual(ok());
     });
 
@@ -72,7 +75,10 @@ describe(createTurnOnSuiteSync.name, () => {
         const result = await turnOnSuiteSync({ deviceStaticSessionId });
 
         expect(deps.dispatch).toHaveBeenCalledWith(updateSuiteSyncEnabled({ isEnabled: true }));
-        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({ deviceStaticSessionId });
+        expect(deps.ensureWalletSuiteSyncOn).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            isWriteMode: false,
+        });
         expect(result).toBe(ensureWalletSuiteSyncOnResult);
     });
 });

--- a/suite-native/labeling/src/components/EditableLabelLayout.tsx
+++ b/suite-native/labeling/src/components/EditableLabelLayout.tsx
@@ -50,6 +50,11 @@ export const EditableLabelLayout = ({ children, label, testID }: EditableLabelLa
                             showToast({ variant: 'error', icon: 'warning', message: type });
 
                             return;
+
+                        case 'WriteModeRequiredForAllocation':
+                            // Do nothing, this is expected control flow error when we want allocate on-demand.
+                            return;
+
                         default:
                             return exhaustive(type);
                     }

--- a/suite-native/module-home/src/screens/HomeScreen/components/SuiteSyncKeysAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/SuiteSyncKeysAlert.tsx
@@ -62,6 +62,7 @@ export const SuiteSyncKeysAlert = () => {
         } else {
             await suiteSync.ensureWalletSuiteSyncOn({
                 deviceStaticSessionId,
+                isWriteMode: false,
             });
         }
     }, [deviceStaticSessionId, isDeviceConnected, navigation, suiteSync]);

--- a/suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx
@@ -65,6 +65,10 @@ export const ToggleSuiteSyncCard = () => {
                         showToast({ variant: 'error', icon: 'warning', message: type });
 
                         return;
+
+                    case 'WriteModeRequiredForAllocation':
+                        // Do nothing, this is expected control flow error when we want allocate on-demand.
+                        return;
                     default:
                         return exhaustive(type);
                 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11063,6 +11063,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:2.10.1"
     "@suite-common/delegated-identity-key": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/suite-sync-types": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"


### PR DESCRIPTION
Prop drilling practise! Kidding.

We've just changed the way we allocate Owner quota. Usually we allocated some initial value when user opened the wallet, but this approach could burn users quota if they are searching for forgotten passphrase for example.

To fix this, we are allocating on-demand which means we do the following:
- when user submits edited label - we try to allocate quota
- we drill `isWriteMode` over to many FNs to see if this is the case or not


## Description

Changed the way we allocate Owner data
- now it should be done when user submits the edited label

## Known issues / things to be solved
https://github.com/trezor/trezor-suite/issues/24881

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23231

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fet/qm/allocate-owner-quota-on-demand&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fet/qm/allocate-owner-quota-on-demand&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fet/qm/allocate-owner-quota-on-demand&lookback=7)