### PR TITLE
fix(trade): fix selecting fixed-rate quotes

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeQuotesFilter.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeQuotesFilter.ts
@@ -9,8 +9,8 @@ import {
     TRADING_EXCHANGE_FORM_DEX,
     TradingExchangeFormProps,
     TradingExchangeFormType,
-    exchangeUtils,
 } from '@suite-common/trading';
+import { arrayPartition } from '@trezor/utils';
 
 interface TradingExchangeQuotesFilterProps {
     quotes: ExchangeTrade[];
@@ -22,13 +22,11 @@ interface TradingExchangeQuotesFilterProps {
 export const useTradingExchangeQuotesFilter = ({
     exchangeType,
     quotes,
-    exchangeInfo,
     setValue,
 }: TradingExchangeQuotesFilterProps) => {
-    const dexQuotes = useMemo(() => quotes.filter(quote => quote.isDex), [quotes]);
-    const cexQuotes = useMemo(
-        () => exchangeUtils.getPreferredCexQuotes(quotes, exchangeInfo),
-        [quotes, exchangeInfo],
+    const [dexQuotes, cexQuotes] = useMemo(
+        () => arrayPartition(quotes, quote => quote?.isDex ?? false),
+        [quotes],
     );
 
     // handle edge case when there are no longer quotes of selected exchange type

--- a/suite-common/trading/src/utils/exchange/exchangeUtils.ts
+++ b/suite-common/trading/src/utils/exchange/exchangeUtils.ts
@@ -81,20 +81,6 @@ const fixedRateCexQuotes = (quotes: ExchangeTrade[], exchangeInfo: ExchangeInfo 
             !isQuoteError(q),
     );
 
-const floatRateCexQuotes = (quotes: ExchangeTrade[], exchangeInfo: ExchangeInfo | undefined) =>
-    quotes.filter(q => {
-        const provider = exchangeInfo?.providerInfos[q.exchange || ''];
-
-        return provider && !provider.isFixedRate && !q.isDex && !isQuoteError(q);
-    });
-
-// Prefer floating-rate quotes, fallback to fixed-rate if none available
-const getPreferredCexQuotes = (quotes: ExchangeTrade[], exchangeInfo: ExchangeInfo | undefined) => {
-    const floatQuotes = floatRateCexQuotes(quotes, exchangeInfo);
-
-    return floatQuotes.length > 0 ? floatQuotes : fixedRateCexQuotes(quotes, exchangeInfo);
-};
-
 const getSuccessQuotesOrdered = (quotes: ExchangeTrade[]): ExchangeTrade[] =>
     quotes.filter(q => !isQuoteError(q));
 
@@ -127,8 +113,6 @@ export const exchangeUtils = {
     getAmountLimits,
     isQuoteError,
     fixedRateCexQuotes,
-    floatRateCexQuotes,
-    getPreferredCexQuotes,
     getSuccessQuotesOrdered,
     getStatusMessage,
     tokenSupportsIncreasingAllowance,

--- a/suite/e2e/fixtures/invity/swap/quotes-solana-tokens.json
+++ b/suite/e2e/fixtures/invity/swap/quotes-solana-tokens.json
@@ -1,5 +1,17 @@
 [
     {
+        "exchange": "sideshift",
+        "send": "solana--Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+        "receive": "solana--EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "exp": "N3F1XsERV+McG2zVZXSbaLRkxjv7pkSk5oqTjxFToQw=",
+        "sendStringAmount": "9",
+        "receiveStringAmount": "8.68630294",
+        "fee": "UNKNOWN",
+        "min": 1.0,
+        "max": 50000,
+        "rate": 0.965144771716
+    },
+    {
         "exchange": "changeherofr",
         "send": "solana--Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
         "receive": "solana--EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
@@ -12,18 +24,7 @@
         "rate": 0.9706117549014007,
         "rateIdentificator": "e270b1fd-8358-4dde-ad78-6d816c9f0c33"
     },
-    {
-        "exchange": "sideshift",
-        "send": "solana--Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
-        "receive": "solana--EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-        "exp": "N3F1XsERV+McG2zVZXSbaLRkxjv7pkSk5oqTjxFToQw=",
-        "sendStringAmount": "9",
-        "receiveStringAmount": "8.68630294",
-        "fee": "UNKNOWN",
-        "min": 1.0,
-        "max": 50000,
-        "rate": 0.965144771716
-    },
+
     {
         "exchange": "changenow",
         "send": "solana--Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",

--- a/suite/e2e/fixtures/invity/swap/quotes-solana-usdc.json
+++ b/suite/e2e/fixtures/invity/swap/quotes-solana-usdc.json
@@ -1,5 +1,17 @@
 [
     {
+        "exchange": "sideshift",
+        "send": "solana",
+        "receive": "ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "exp": "N3F1XsERV+McG2zVZXSbaLRkxjv7pkSk5oqTjxFToQw=",
+        "sendStringAmount": "0.05",
+        "receiveStringAmount": "8.3318799699925",
+        "fee": "UNKNOWN",
+        "min": 0.01,
+        "max": 350.71311666,
+        "rate": 166.63759939985
+    },
+    {
         "exchange": "changeherofr",
         "send": "solana",
         "receive": "ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11,18 +23,6 @@
         "max": 551.4413810596296,
         "rate": 160.96471164572347,
         "rateIdentificator": "58c25a03-fced-4a52-abac-191cd28a2be9"
-    },
-    {
-        "exchange": "sideshift",
-        "send": "solana",
-        "receive": "ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-        "exp": "N3F1XsERV+McG2zVZXSbaLRkxjv7pkSk5oqTjxFToQw=",
-        "sendStringAmount": "0.05",
-        "receiveStringAmount": "8.3318799699925",
-        "fee": "UNKNOWN",
-        "min": 0.01,
-        "max": 350.71311666,
-        "rate": 166.63759939985
     },
     {
         "exchange": "changelly",

--- a/suite/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/suite/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -13,9 +13,9 @@ import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
-const sendAmount = swapQuotesSolanaUSDC[1].sendStringAmount;
-const receiveAmount = localizeNumber(swapQuotesSolanaUSDC[1].receiveStringAmount);
-const provider = getCompanyNameFromList(swapQuotesSolanaUSDC[1].exchange, 'swapList');
+const sendAmount = swapQuotesSolanaUSDC[0].sendStringAmount;
+const receiveAmount = localizeNumber(swapQuotesSolanaUSDC[0].receiveStringAmount);
+const provider = getCompanyNameFromList(swapQuotesSolanaUSDC[0].exchange, 'swapList');
 const formattedSendAmount = `${localizeNumber(sendAmount)} SOL`;
 const formattedReceiveAmount = `${receiveAmount} USDC`;
 const { sendAddress, receive: usdcMint, receiveAddress } = swapTradeSolanaUSDC;

--- a/suite/e2e/tests/trading/swap-tokens.test.ts
+++ b/suite/e2e/tests/trading/swap-tokens.test.ts
@@ -12,9 +12,9 @@ import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
-const sendAmount = swapQuotesSolanaTokens[1].sendStringAmount!;
-const receiveAmount = localizeNumber(swapQuotesSolanaTokens[1].receiveStringAmount!);
-const provider = getCompanyNameFromList(swapQuotesSolanaTokens[1].exchange, 'swapList');
+const sendAmount = swapQuotesSolanaTokens[0].sendStringAmount!;
+const receiveAmount = localizeNumber(swapQuotesSolanaTokens[0].receiveStringAmount!);
+const provider = getCompanyNameFromList(swapQuotesSolanaTokens[0].exchange, 'swapList');
 const formattedSendAmount = `${localizeNumber(sendAmount)} USDT`;
 const formattedReceiveAmount = `${receiveAmount} USDC`;
 const { sendAddress, send: tetherMint, receive: usdcMint, receiveAddress } = swapTradeSolanaTokens;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously implemented getPreferredCexQuotes filter caused TradingForm to stop receiving fixed-rate quotes, so it always picked the first floating-rate quote.

## Notes for QA

Please verify that best offer is preselected in the TradingForm

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/24755

## Screenshots:
<img width="992" height="648" alt="image" src="https://github.com/user-attachments/assets/c044f74f-590b-43c1-bbc7-d8a41e525b2c" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/fixed-rate-quote&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/fixed-rate-quote&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/fixed-rate-quote&lookback=7)