### PR TITLE
Suite Sync feature flag moved from Debug to Experimental Features on desktop

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -475,7 +475,6 @@ export const saveSuiteSyncSettings = () => (_dispatch: Dispatch, getState: GetSt
     return db.addItem(
         'suiteSyncSettings',
         {
-            isFeatureSuiteSyncAvailable: suiteSync.settings.isFeatureSuiteSyncAvailable,
             isSuiteSyncEnabled: suiteSync.settings.isSuiteSyncEnabled,
             isSuiteSyncDebugEnabled: suiteSync.settings.isSuiteSyncDebugEnabled,
             suiteSyncRelayUrl: suiteSync.settings.suiteSyncRelayUrl,

--- a/packages/suite/src/actions/suiteSync/suiteSyncSlice.ts
+++ b/packages/suite/src/actions/suiteSync/suiteSyncSlice.ts
@@ -1,5 +1,3 @@
-import { PayloadAction } from '@reduxjs/toolkit';
-
 import { AnyAction, createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import {
     SuiteSyncInteraction,
@@ -11,31 +9,19 @@ import {
 } from '@suite-common/suite-sync';
 import { StaticSessionId } from '@trezor/connect';
 
+import { SuiteRootState } from 'src/reducers/suite/suiteReducer';
+import { selectHasExperimentalFeature } from 'src/selectors/suite/suiteSelectors';
 import { Action } from 'src/types/suite';
 
 import { STORAGE } from '../suite/constants';
 
 export type DesktopSuiteSyncState = SuiteSyncState & {
     showEnableSuiteSyncModal: StaticSessionId | null;
-    settings: {
-        /**
-         * This is flag, that enables the Suite Sync Feature.
-         * On mobile, it is managed by Experimental Features.
-         * On desktop, it is managed by Debug Settings.
-         *
-         * It shall be removed once we release the Suite Sync feature.
-         */
-        isFeatureSuiteSyncAvailable: boolean;
-    };
 };
 
 export const initialSuiteSyncState: DesktopSuiteSyncState = {
     ...commonInitialState,
     showEnableSuiteSyncModal: null,
-    settings: {
-        ...commonInitialState.settings,
-        isFeatureSuiteSyncAvailable: false,
-    },
 };
 
 export type DesktopSuiteSyncRootState = {
@@ -48,12 +34,6 @@ export const suiteSyncSlice = createSliceWithExtraDeps({
     reducers: {
         updateShowEnableSuiteSyncModal: (state, action) => {
             state.showEnableSuiteSyncModal = action.payload.deviceStaticSessionId;
-        },
-        updateIsFeatureSuiteSyncAvailable: (
-            state,
-            { payload }: PayloadAction<{ isShownInSettings: boolean }>,
-        ) => {
-            state.settings.isFeatureSuiteSyncAvailable = payload.isShownInSettings;
         },
     },
     extraReducers: builder => {
@@ -80,21 +60,18 @@ export const suiteSyncSlice = createSliceWithExtraDeps({
     },
 });
 
-export const selectIsFeatureSuiteSyncAvailable = (state: DesktopSuiteSyncRootState): boolean =>
-    state.suiteSync.settings.isFeatureSuiteSyncAvailable;
-
 export const selectShowEnableSuiteSyncModal = (
     state: DesktopSuiteSyncRootState,
 ): StaticSessionId | null => state.suiteSync.showEnableSuiteSyncModal;
 
 export const selectDesktopSuiteSyncInteraction = (
-    state: DesktopSuiteSyncRootState & WithSuiteSyncAndDeviceState,
+    state: DesktopSuiteSyncRootState & WithSuiteSyncAndDeviceState & SuiteRootState,
     deviceStaticSessionId: StaticSessionId | null,
 ): SuiteSyncInteraction | null => {
-    if (!selectIsFeatureSuiteSyncAvailable(state)) return null;
+    const isSuiteSyncFeatureEnabled = selectHasExperimentalFeature('suite-sync')(state);
+    if (!isSuiteSyncFeatureEnabled) return null;
 
     return selectSuiteSyncInteraction(state, deviceStaticSessionId);
 };
 
-export const { updateShowEnableSuiteSyncModal, updateIsFeatureSuiteSyncAvailable } =
-    suiteSyncSlice.actions;
+export const { updateShowEnableSuiteSyncModal } = suiteSyncSlice.actions;

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/selectIsLabelActionEnabled.test.ts
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/selectIsLabelActionEnabled.test.ts
@@ -10,13 +10,13 @@ import { deviceReducerInitialState } from '@suite-common/wallet-core';
 import { StaticSessionId, UnavailableCapabilities } from '@trezor/connect';
 
 import { selectIsLabelActionEnabled } from './selectIsLabelActionEnabled';
-import { DesktopSuiteSyncState } from '../../../../actions/suiteSync/suiteSyncSlice';
 import {
     MetadataRootState,
     initialMetadataState,
     selectIsLabelingAvailableForEntity,
     selectIsLabelingInitPossible,
 } from '../../../../reducers/suite/metadataReducer';
+import { SuiteRootState, suiteInitialState } from '../../../../reducers/suite/suiteReducer';
 
 /**
  * It was really hard to mock the state for metadata. So I statically mocked
@@ -33,6 +33,7 @@ const DEVICE_STATIC_SESSION_ID_123: StaticSessionId = '1@2:3';
 const createMockState = (
     deviceOverrides: Parameters<typeof getSuiteDevice>[0] = {},
     suiteSyncOverrides: Partial<SuiteSyncState> = {},
+    isSuiteSyncFeatureEnabled = false,
 ) =>
     ({
         device: {
@@ -43,6 +44,13 @@ const createMockState = (
             ...initialSuiteSyncState,
             ...suiteSyncOverrides,
         },
+        suite: {
+            ...suiteInitialState,
+            settings: {
+                ...suiteInitialState.settings,
+                experimental: isSuiteSyncFeatureEnabled ? ['suite-sync'] : undefined,
+            },
+        },
         wallet: {
             accounts: [] as any[],
         },
@@ -51,39 +59,39 @@ const createMockState = (
         },
         // This HARD CAST is here because MetadataRootState is HUGE,
         // and I do not want to refactor Legacy Labeling
-    }) as WithSuiteSyncAndDeviceState & MetadataRootState;
+    }) as WithSuiteSyncAndDeviceState & MetadataRootState & SuiteRootState;
 
 describe(selectIsLabelActionEnabled.name, () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    const testLabelActionEnabled = (
-        unavailableCapabilities: UnavailableCapabilities,
-        suiteSyncSettings: Partial<DesktopSuiteSyncState['settings']>,
-    ) => {
-        const state = createMockState(
-            { unavailableCapabilities },
-            { settings: { ...initialSuiteSyncState.settings, ...suiteSyncSettings } },
-        );
+    const testLabelActionEnabled = ({
+        unavailableCapabilities,
+        isSuiteSyncFeatureEnabled,
+    }: {
+        unavailableCapabilities: UnavailableCapabilities;
+        isSuiteSyncFeatureEnabled: boolean;
+    }) => {
+        const state = createMockState({ unavailableCapabilities }, {}, isSuiteSyncFeatureEnabled);
 
         return selectIsLabelActionEnabled(state, DEVICE_STATIC_SESSION_ID_123, 'address-123');
     };
 
     it('allows labeling despite update-needed for Suite Sync', () => {
-        const result = testLabelActionEnabled(
-            { evolu: 'update-required' },
-            { isFeatureSuiteSyncAvailable: true },
-        );
+        const result = testLabelActionEnabled({
+            unavailableCapabilities: { evolu: 'update-required' },
+            isSuiteSyncFeatureEnabled: true,
+        });
 
         expect(result).toBe(true);
     });
 
     it('disables labeling for unsupported device', () => {
-        const result = testLabelActionEnabled(
-            { evolu: 'no-capability' },
-            { isFeatureSuiteSyncAvailable: true },
-        );
+        const result = testLabelActionEnabled({
+            unavailableCapabilities: { evolu: 'no-capability' },
+            isSuiteSyncFeatureEnabled: true,
+        });
 
         expect(result).toBe(false);
     });
@@ -92,7 +100,10 @@ describe(selectIsLabelActionEnabled.name, () => {
         mocked(selectIsLabelingAvailableForEntity).mockReturnValue(false);
         mocked(selectIsLabelingInitPossible).mockReturnValue(false);
 
-        const result = testLabelActionEnabled({}, { isFeatureSuiteSyncAvailable: false });
+        const result = testLabelActionEnabled({
+            unavailableCapabilities: {},
+            isSuiteSyncFeatureEnabled: false,
+        });
 
         expect(result).toBe(false);
     });
@@ -101,7 +112,10 @@ describe(selectIsLabelActionEnabled.name, () => {
         mocked(selectIsLabelingAvailableForEntity).mockReturnValue(true);
         mocked(selectIsLabelingInitPossible).mockReturnValue(false);
 
-        const result = testLabelActionEnabled({}, { isFeatureSuiteSyncAvailable: false });
+        const result = testLabelActionEnabled({
+            unavailableCapabilities: {},
+            isSuiteSyncFeatureEnabled: false,
+        });
 
         expect(result).toBe(true);
     });
@@ -110,7 +124,10 @@ describe(selectIsLabelActionEnabled.name, () => {
         mocked(selectIsLabelingAvailableForEntity).mockReturnValue(true);
         mocked(selectIsLabelingInitPossible).mockReturnValue(true);
 
-        const result = testLabelActionEnabled({}, { isFeatureSuiteSyncAvailable: false });
+        const result = testLabelActionEnabled({
+            unavailableCapabilities: {},
+            isSuiteSyncFeatureEnabled: false,
+        });
 
         expect(result).toBe(true);
     });

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/selectIsLabelActionEnabled.ts
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/selectIsLabelActionEnabled.ts
@@ -2,18 +2,16 @@ import { WithSuiteSyncAndDeviceState } from '@suite-common/suite-sync';
 import { StaticSessionId } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
-import {
-    selectDesktopSuiteSyncInteraction,
-    selectIsFeatureSuiteSyncAvailable,
-} from '../../../../actions/suiteSync/suiteSyncSlice';
+import { selectDesktopSuiteSyncInteraction } from '../../../../actions/suiteSync/suiteSyncSlice';
 import {
     MetadataRootState,
     selectIsLabelingAvailableForEntity,
     selectIsLabelingInitPossible,
 } from '../../../../reducers/suite/metadataReducer';
+import { SuiteRootState } from '../../../../reducers/suite/suiteReducer';
 
 export const selectIsLabelActionEnabled = (
-    state: WithSuiteSyncAndDeviceState & MetadataRootState,
+    state: WithSuiteSyncAndDeviceState & MetadataRootState & SuiteRootState,
     deviceStaticSessionId: StaticSessionId,
     legacyEntityKey: string,
 ): boolean => {
@@ -24,10 +22,11 @@ export const selectIsLabelActionEnabled = (
         deviceStaticSessionId,
     );
 
-    const isSuiteSyncFeatureAvailable = selectIsFeatureSuiteSyncAvailable(state);
+    const isSuiteSyncFeatureEnabled =
+        state.suite.settings.experimental?.includes('suite-sync') ?? false;
 
-    // Turn ON in Debug/Experimental Features
-    if (isSuiteSyncFeatureAvailable) {
+    // Turn ON in Experimental Features
+    if (isSuiteSyncFeatureEnabled) {
         const suiteSyncInteraction = selectDesktopSuiteSyncInteraction(
             state,
             deviceStaticSessionId,

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -5,7 +5,7 @@ import { isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { EXPERIMENTAL_PASSWORD_MANAGER_KB_URL, HELP_CENTER_TOR_URL, Url } from '@trezor/urls';
 
-import { Dispatch } from '../../types/suite';
+import { SuiteServices } from '../../support/extraDependencies';
 
 const experimentalNetworks = networksCollection.filter(
     network => network.isExperimentalOnlyNetwork,
@@ -17,8 +17,8 @@ export type ExperimentalFeature =
     | 'tor-external'
     | 'testnet-networks'
     | 'nft-section'
-    | 'experimental-networks';
-// | 'suite-sync';
+    | 'experimental-networks'
+    | 'suite-sync';
 
 export type ExperimentalFeatureConfig = {
     title: ExtendedMessageDescriptor;
@@ -26,7 +26,7 @@ export type ExperimentalFeatureConfig = {
     knowledgeBaseUrl?: Url;
     routeName?: Route['name'];
     isDisabled?: (context: { isDebug: boolean }) => boolean;
-    onToggle?: ({ newValue, dispatch }: { newValue: boolean; dispatch: Dispatch }) => void;
+    onToggle?: ({ newValue, services }: { newValue: boolean; services: SuiteServices }) => void;
 };
 
 export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeatureConfig> = {
@@ -76,16 +76,14 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
         },
         isDisabled: () => experimentalNetworks.length === 0,
     },
-    // temporarily disabled, moved to debug
-    /*     'suite-sync': {
+    'suite-sync': {
         title: { id: 'TR_EXPERIMENTAL_SUITE_SYNC_TITLE' },
         description: { id: 'TR_EXPERIMENTAL_SUITE_SYNC_DESCRIPTION' },
-        onToggle: ({ newValue, dispatch }) => {
-            dispatch(
-                suiteSyncActions.updateIsFeatureSuiteSyncAvailable({
-                    isShownInSettings: newValue,
-                }),
-            );
+        onToggle: ({ newValue, services }) => {
+            if (!newValue) {
+                // Turn off Suite Sync
+                services.suiteSync.turnOffSuiteSync();
+            }
         },
-    }, */
+    },
 };

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -49,8 +49,6 @@ import { db } from 'src/storage';
 import type { AppState, Dispatch, Action as SuiteAction } from 'src/types/suite';
 import type { WalletAction } from 'src/types/wallet';
 
-import { updateIsFeatureSuiteSyncAvailable } from '../../actions/suiteSync/suiteSyncSlice';
-
 const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
     db.onBlocking = () => api.dispatch({ type: STORAGE.ERROR, payload: 'blocking' });
     db.onBlocked = () => api.dispatch({ type: STORAGE.ERROR, payload: 'blocked' });
@@ -187,7 +185,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 isAnyOf(
                     updateSuiteSyncDebugEnabled,
                     updateSuiteSyncEnabled,
-                    updateIsFeatureSuiteSyncAvailable,
                     setSuiteSyncRelayUrl,
                 )(action)
             ) {

--- a/packages/suite/src/storage/migrations/versions/25.12.0.ts
+++ b/packages/suite/src/storage/migrations/versions/25.12.0.ts
@@ -14,7 +14,6 @@ export default createMigration<SuiteDBSchema>('25.12.0', (db, tx) => {
 
         tx.objectStore('suiteSyncSettings').put(
             {
-                isFeatureSuiteSyncAvailable: false,
                 isSuiteSyncEnabled: false,
                 isSuiteSyncDebugEnabled: false,
                 suiteSyncRelayUrl: null,

--- a/packages/suite/src/views/settings/SettingsDebug/SuiteSyncSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SuiteSyncSettings.tsx
@@ -9,14 +9,10 @@ import {
 import { Button, Checkbox, Code, Column, Input, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import * as storageActions from 'src/actions/suite/storageActions';
-import {
-    selectIsFeatureSuiteSyncAvailable,
-    updateIsFeatureSuiteSyncAvailable,
-} from 'src/actions/suiteSync/suiteSyncSlice';
 import { SettingsSection } from 'src/components/settings/SettingsSection';
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectHasExperimentalFeature } from 'src/selectors/suite/suiteSelectors';
 import { useSuiteServices } from 'src/support/SuiteServicesProvider';
 
 export const SuiteSyncSettings = () => {
@@ -25,22 +21,8 @@ export const SuiteSyncSettings = () => {
     const dispatch = useDispatch();
     const { suiteSync } = useSuiteServices();
 
-    const isFeatureSuiteSyncAvailable = useSelector(selectIsFeatureSuiteSyncAvailable);
+    const isSuiteSyncFeatureEnabled = useSelector(selectHasExperimentalFeature('suite-sync'));
     const isSuiteSyncDebugEnabled = useSelector(selectIsSuiteSyncDebugEnabled);
-
-    const toggleIsFeatureSuiteSyncAvailable = () => {
-        dispatch(
-            updateIsFeatureSuiteSyncAvailable({
-                isShownInSettings: !isFeatureSuiteSyncAvailable,
-            }),
-        );
-
-        if (isFeatureSuiteSyncAvailable) {
-            suiteSync.turnOffSuiteSync({
-                ensureSettingsPersisted: () => dispatch(storageActions.saveSuiteSettings()),
-            });
-        }
-    };
 
     const suiteSyncRelayUrl = useSelector(selectSuiteSyncRelayUrl);
 
@@ -65,63 +47,51 @@ export const SuiteSyncSettings = () => {
         }, 300);
     };
 
+    if (!isSuiteSyncFeatureEnabled) {
+        return (
+            <SettingsSection title="Suite Sync">
+                <p>Suite Sync is disabled. Enable it in the Experimental Features settings.</p>
+            </SettingsSection>
+        );
+    }
+
     return (
         <SettingsSection title="Suite Sync">
             <SectionItem>
-                <TextColumn
-                    title="Suite Sync (Evolu)"
-                    description="This enables Suite Sync (Evolu) for labeling in the application settings. This is an experimental feature."
-                />
+                <TextColumn title="Relay URL" />
+                <ActionColumn>
+                    <Column gap={spacings.xxs}>
+                        <Input
+                            data-testid="@settings/debug/suite-sync/relay-url-input"
+                            isDisabled={isLoading}
+                            value={relayUrl}
+                            onChange={e => setRelayUrl(e.target.value)}
+                            rightContent={
+                                <Button
+                                    data-testid="@settings/debug/suite-sync/save-button"
+                                    isLoading={isLoading}
+                                    onClick={onRelayUrlSave}
+                                    size="small"
+                                >
+                                    Save
+                                </Button>
+                            }
+                        />
+                        <Text typographyStyle="hint" variant="tertiary">
+                            Default is: <Code>{DEFAULT_SUITE_SYNC_RELAY_URL}</Code>
+                        </Text>
+                    </Column>
+                </ActionColumn>
+            </SectionItem>
+            <SectionItem>
+                <TextColumn title="Suite Sync (Evolu) Debug" />
                 <ActionColumn>
                     <Checkbox
-                        data-testid="@settings/debug/suite-sync/checkbox"
-                        isChecked={isFeatureSuiteSyncAvailable}
-                        onClick={toggleIsFeatureSuiteSyncAvailable}
+                        isChecked={isSuiteSyncDebugEnabled}
+                        onClick={handleToggleSuiteSyncDebug}
                     />
                 </ActionColumn>
             </SectionItem>
-            {!isFeatureSuiteSyncAvailable && (
-                <p>Suite Sync is disabled. Enable it in the Experimental Features settings.</p>
-            )}
-            {isFeatureSuiteSyncAvailable && (
-                <>
-                    <SectionItem>
-                        <TextColumn title="Relay URL" />
-                        <ActionColumn>
-                            <Column gap={spacings.xxs}>
-                                <Input
-                                    data-testid="@settings/debug/suite-sync/relay-url-input"
-                                    isDisabled={isLoading}
-                                    value={relayUrl}
-                                    onChange={e => setRelayUrl(e.target.value)}
-                                    rightContent={
-                                        <Button
-                                            data-testid="@settings/debug/suite-sync/save-button"
-                                            isLoading={isLoading}
-                                            onClick={onRelayUrlSave}
-                                            size="small"
-                                        >
-                                            Save
-                                        </Button>
-                                    }
-                                />
-                                <Text typographyStyle="hint" variant="tertiary">
-                                    Default is: <Code>{DEFAULT_SUITE_SYNC_RELAY_URL}</Code>
-                                </Text>
-                            </Column>
-                        </ActionColumn>
-                    </SectionItem>
-                    <SectionItem>
-                        <TextColumn title="Suite Sync (Evolu) Debug" />
-                        <ActionColumn>
-                            <Checkbox
-                                isChecked={isSuiteSyncDebugEnabled}
-                                onClick={handleToggleSuiteSyncDebug}
-                            />
-                        </ActionColumn>
-                    </SectionItem>
-                </>
-            )}
         </SettingsSection>
     );
 };

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -14,6 +14,7 @@ import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { EXPERIMENTAL_FEATURES, ExperimentalFeature } from 'src/constants/suite/experimental';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
+import { useSuiteServices } from 'src/support/SuiteServicesProvider';
 
 type FeatureLineProps = {
     feature: ExperimentalFeature;
@@ -22,6 +23,7 @@ type FeatureLineProps = {
 
 const FeatureLine = ({ feature, enabledFeatures }: FeatureLineProps) => {
     const dispatch = useDispatch();
+    const services = useSuiteServices();
     const checked = enabledFeatures.includes(feature);
 
     const config = EXPERIMENTAL_FEATURES[feature];
@@ -32,7 +34,7 @@ const FeatureLine = ({ feature, enabledFeatures }: FeatureLineProps) => {
         const newValue = !checked;
 
         try {
-            await config?.onToggle?.({ dispatch, newValue });
+            await config?.onToggle?.({ services, newValue });
             dispatch({
                 type: SUITE.SET_EXPERIMENTAL_FEATURES,
                 payload: {
@@ -113,12 +115,13 @@ export const Experimental = () => {
     const isDebug = useSelector(selectIsDebugModeActive);
 
     const dispatch = useDispatch();
+    const services = useSuiteServices();
 
     const onSwitchExperimental = () => {
         enabledFeatures?.forEach(feature =>
             EXPERIMENTAL_FEATURES[feature]?.onToggle?.({
-                dispatch,
-                newValue: false,
+                services,
+                newValue: !isExperimentalEnabled,
             }),
         );
 

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -8,7 +8,6 @@ import { exhaustive } from '@trezor/type-utils';
 import { HELP_CENTER_LABELING } from '@trezor/urls';
 
 import * as metadataLabelingActions from 'src/actions/suite/metadata/metadataLabelingActions';
-import { selectIsFeatureSuiteSyncAvailable } from 'src/actions/suiteSync/suiteSyncSlice';
 import { SettingsSectionItem } from 'src/components/settings/SettingsSectionItem';
 import { ActionColumn, ActionSelect, TextColumn } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
@@ -21,6 +20,7 @@ import {
 } from 'src/constants/suite/labeling';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { useLabelingDeviceState } from 'src/hooks/suite/useLabelingDeviceState';
+import { selectHasExperimentalFeature } from 'src/selectors/suite/suiteSelectors';
 import { useSuiteServices } from 'src/support/SuiteServicesProvider';
 import { useAnalytics } from 'src/support/useAnalytics';
 
@@ -37,7 +37,7 @@ export const Labeling = () => {
     const deviceStaticSessionId = device?.state?.staticSessionId;
     const { isDeviceLabelingDisabled } = useLabelingDeviceState();
 
-    const showSuiteSync = useSelector(selectIsFeatureSuiteSyncAvailable);
+    const showSuiteSync = useSelector(selectHasExperimentalFeature('suite-sync'));
     const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
 
     const legacyMetadataState = useSelector(state => state.metadata);

--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -56,11 +56,17 @@ export class MetadataPage {
 
     @step()
     async initiateSuiteSyncSetup() {
+        // Enable Suite Sync in Experimental Features
+        await this.settingsPage.navigateTo('application');
+        await this.settingsPage.experimentalFeaturesSwitch.click();
+        await this.settingsPage.suiteSyncCheckbox.click();
+
+        // Configure Suite Sync relay URL in Debug settings
         await this.settingsPage.navigateTo('debug');
-        await this.settingsPage.debugTab.suiteSyncCheckbox.click();
         await this.settingsPage.debugTab.suiteSyncUrlInput.fill('http://127.0.0.1:4000');
         await this.settingsPage.debugTab.suiteSyncUrlSaveButton.click();
 
+        // Select Suite Sync as the labeling method
         await this.settingsPage.navigateTo('application');
         await this.page.selectDropdownOptionWithRetry(
             this.settingsPage.metadataSelectInput,

--- a/suite/e2e/support/pageObjects/settings/debugTab.ts
+++ b/suite/e2e/support/pageObjects/settings/debugTab.ts
@@ -5,7 +5,6 @@ import { step } from '../../common';
 import { PromoBannerType } from '../dashboardPage';
 
 export class DebugTab {
-    readonly suiteSyncCheckbox: Locator;
     readonly suiteSyncUrlInput: Locator;
     readonly suiteSyncUrlSaveButton: Locator;
     readonly modal: Locator;
@@ -19,7 +18,6 @@ export class DebugTab {
     readonly quotaManagerUrlSaveButton: Locator;
 
     constructor(private readonly page: Page) {
-        this.suiteSyncCheckbox = page.getByTestId('@settings/debug/suite-sync/checkbox');
         this.suiteSyncUrlInput = page.getByTestId('@settings/debug/suite-sync/relay-url-input');
         this.suiteSyncUrlSaveButton = page.getByTestId('@settings/debug/suite-sync/save-button');
         this.modal = page.getByTestId('@modal');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moved the Suite Sync toggle from Debug settings to Experimental Features settings.

Users can show the Suite Sync feature in Settings > General > Experimental features.
It still does exactly the same as the original debug settings, so  It does NOT initiate the Suite Sync, it only makes it available so effectively by turning on the Suite Sync experimental feature, you get to the state as if Suite Sync is released for all users.

Debug settings now only show relay URL configuration (when Suite Sync is enabled in Experimental Features)
Shows a message in Debug settings when Suite Sync is disabled: "Suite Sync is disabled. Enable it in the Experimental Features settings."

There is no migration so even if you had Suite Sync enabled in debug utils, you will need to enable it in experimental features after update to this version.


## Notes for QA

- Turning off Suite Sync experimental feature or whole Experimental features should turn off Suite Sync completely.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24776

## Screenshots:
Newly added (uncomennted, it was there before but commented out):
<img width="600" alt="image" src="https://github.com/user-attachments/assets/2f01a0d9-c7c6-46b6-8957-5cc1d12f6a97" />

Debug settings if not enabled in Experimental:
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/5ea15613-ac31-4a2f-8d13-c6899da26931" />
Debug settings if enabled:
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/d8168cc6-8d6e-4f07-a415-b0ffc57917dc" />







🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-sync-ff-move-to-experimental&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-sync-ff-move-to-experimental&lookback=7)