### PR TITLE
Feat/solana outside staking info message

### DIFF
--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -286,7 +286,8 @@ export interface AccountInfo {
         // SOL
         owner?: string; // The Solana program owning the account
         rent?: number; // The rent required for the account to opened
-        solStakingAccounts?: SolanaStakingAccount[]; // Solana staking accounts
+        solStakingAccounts?: SolanaStakingAccount[]; // Solana staking accounts (Everstake)
+        solExternalStakingAccounts?: SolanaStakingAccount[]; // Solana staking accounts (non-Everstake)
         solEpoch?: number; // Solana current epoch
     };
     page?: {

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -436,7 +436,12 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
     // Not necessary for basic and tokens details
     if (!['basic', 'tokens'].includes(details)) {
         const solEpoch = await getEpoch();
-        const solStakingAccounts = await getSolanaStakingData(api?.rpc, publicKey, solEpoch);
+        const solStakingAccounts = await getSolanaStakingData(
+            api?.rpc,
+            publicKey,
+            solEpoch,
+            'only',
+        );
 
         misc = {
             solStakingAccounts,

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -436,15 +436,14 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
     // Not necessary for basic and tokens details
     if (!['basic', 'tokens'].includes(details)) {
         const solEpoch = await getEpoch();
-        const solStakingAccounts = await getSolanaStakingData(
-            api?.rpc,
-            publicKey,
-            solEpoch,
-            'only',
-        );
+        const [solStakingAccounts, solExternalStakingAccounts] = await Promise.all([
+            getSolanaStakingData(api?.rpc, publicKey, solEpoch, 'everstake'),
+            getSolanaStakingData(api?.rpc, publicKey, solEpoch, 'non-everstake'),
+        ]);
 
         misc = {
             solStakingAccounts,
+            solExternalStakingAccounts,
             solEpoch,
         };
 

--- a/packages/blockchain-link/src/workers/solana/utils/stakingAccounts.ts
+++ b/packages/blockchain-link/src/workers/solana/utils/stakingAccounts.ts
@@ -83,9 +83,10 @@ export const getDelegations = async (
 };
 
 export const getSolanaStakingData = async (
-    rpc: RpcMainnet<SolanaRpcApiMainnet>,
+    rpc: RpcMainnet<SolanaRpcApiMainnet> | Rpc<SolanaRpcApiMainnet>,
     descriptor: string,
     epoch: number,
+    everstakeAccountsFilter: 'all' | 'only' | 'exclude' = 'all',
 ): Promise<SolanaStakingAccount[]> => {
     const stakingAccounts = await getDelegations(rpc, descriptor);
 
@@ -103,12 +104,15 @@ export const getSolanaStakingData = async (
                 const { fields } = state;
 
                 const voterPubkey = fields[1]?.delegation?.voterPubkey;
-                if (!EVERSTAKE_VOTER_PUBKEYS.includes(voterPubkey)) return; // filter out non-everstake accounts
+                const isEverStake = EVERSTAKE_VOTER_PUBKEYS.includes(voterPubkey);
+                if (everstakeAccountsFilter === 'only' && !isEverStake) return; // filter out non-everstake accounts
+                if (everstakeAccountsFilter === 'exclude' && isEverStake) return; // filter out everstake accounts
 
                 return {
                     rentExemptReserve: fields[0]?.rentExemptReserve.toString(),
                     stake: fields[1]?.delegation?.stake.toString(),
                     status: stakeState,
+                    isEverStake,
                 };
             }
         })

--- a/packages/blockchain-link/src/workers/solana/utils/stakingAccounts.ts
+++ b/packages/blockchain-link/src/workers/solana/utils/stakingAccounts.ts
@@ -86,7 +86,7 @@ export const getSolanaStakingData = async (
     rpc: RpcMainnet<SolanaRpcApiMainnet> | Rpc<SolanaRpcApiMainnet>,
     descriptor: string,
     epoch: number,
-    everstakeAccountsFilter: 'all' | 'only' | 'exclude' = 'all',
+    stakingProvider: 'all' | 'everstake' | 'non-everstake' = 'all',
 ): Promise<SolanaStakingAccount[]> => {
     const stakingAccounts = await getDelegations(rpc, descriptor);
 
@@ -105,8 +105,8 @@ export const getSolanaStakingData = async (
 
                 const voterPubkey = fields[1]?.delegation?.voterPubkey;
                 const isEverStake = EVERSTAKE_VOTER_PUBKEYS.includes(voterPubkey);
-                if (everstakeAccountsFilter === 'only' && !isEverStake) return; // filter out non-everstake accounts
-                if (everstakeAccountsFilter === 'exclude' && isEverStake) return; // filter out everstake accounts
+                if (stakingProvider === 'everstake' && !isEverStake) return;
+                if (stakingProvider === 'non-everstake' && isEverStake) return;
 
                 return {
                     rentExemptReserve: fields[0]?.rentExemptReserve.toString(),

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
@@ -2,7 +2,9 @@ import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
 import {
     selectAccountIsStakingActive,
     selectHasRunningDiscovery,
+    selectHasSolExternalStakingAccounts,
     selectPoolStatsApyData,
+    selectSolExternalStakingAccountsTotalStaked,
 } from '@suite-common/wallet-core';
 import { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
@@ -21,9 +23,9 @@ import { ApyCard } from '../StakingDashboard/components/ApyCard';
 import { ClaimCard } from '../StakingDashboard/components/ClaimCard';
 import { DiscoveryWarning } from '../StakingDashboard/components/DiscoveryWarning';
 import { EmptyStakingCard } from '../StakingDashboard/components/EmptyStakingCard';
+import { ExternalStakingProviderCard } from '../StakingDashboard/components/ExternalStakingProviderCard';
 import { PayoutCardFrequencyRewards } from '../StakingDashboard/components/PayoutCardFrequencyRewards';
 import { StakingCard } from '../StakingDashboard/components/StakingCard';
-
 interface SolStakingDashboardProps {
     selectedAccount: SelectedAccountLoaded;
 }
@@ -46,11 +48,24 @@ export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProp
         rewards.selectedAccountRewards?.[0],
     );
 
+    const hasExternalStakingAccounts = useSelector(state =>
+        selectHasSolExternalStakingAccounts(state, account.key),
+    );
+    const externalStakingTotalStaked = useSelector(state =>
+        selectSolExternalStakingAccountsTotalStaked(state, account.key),
+    );
+
     return (
         <StakingDashboard
             selectedAccount={selectedAccount}
             dashboard={
                 <Column alignItems="normal" gap={spacings.xxxxl}>
+                    {hasExternalStakingAccounts && (
+                        <ExternalStakingProviderCard
+                            symbol={account.symbol}
+                            totalStaked={externalStakingTotalStaked}
+                        />
+                    )}
                     {isStakingActive ? (
                         <>
                             <DashboardSection>
@@ -84,7 +99,9 @@ export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProp
                             <RewardsList account={account} rewards={rewards} />
                         </>
                     ) : (
-                        <EmptyStakingCard />
+                        <>
+                            <EmptyStakingCard />
+                        </>
                     )}
                 </Column>
             }

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ExternalStakingProviderCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ExternalStakingProviderCard.tsx
@@ -1,0 +1,54 @@
+import { Translation } from '@suite/intl';
+import { NetworkSymbol, getDisplaySymbol } from '@suite-common/wallet-config';
+import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
+import { Card, Column, H3, IconCircle, Paragraph, Row } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { DashboardSection } from 'src/components/dashboard';
+import { BaseCurrencyValue } from 'src/components/suite';
+
+type ExternalStakingProviderCardProps = {
+    symbol: NetworkSymbol;
+    totalStaked: string;
+};
+
+export const ExternalStakingProviderCard = ({
+    symbol,
+    totalStaked,
+}: ExternalStakingProviderCardProps) => {
+    const displaySymbol = getDisplaySymbol(symbol);
+    const totalStakedInUnits = subunitsToUnits({
+        value: asAmountSubunit(new BigNumber(totalStaked || '0')),
+        symbol,
+    }).toString();
+
+    return (
+        <DashboardSection data-testid="@wallet/staking/outside-staking-card">
+            <Card paddingType="large">
+                <Row alignItems="start" gap={16}>
+                    <IconCircle name="puzzlePiece" variant="primary" size={44} />
+                    <Column gap={4}>
+                        <H3>
+                            <Translation id="TR_OUTSIDE_STAKING_CARD_TITLE" />
+                        </H3>
+                        <Paragraph intent="neutral" priority="secondary" maxWidth={700}>
+                            <Translation
+                                id="TR_OUTSIDE_STAKING_CARD_TEXT"
+                                values={{
+                                    amount: totalStakedInUnits,
+                                    displaySymbol,
+                                    fiat: (
+                                        <BaseCurrencyValue
+                                            amount={totalStakedInUnits}
+                                            symbol={symbol}
+                                        />
+                                    ),
+                                }}
+                            />
+                        </Paragraph>
+                    </Column>
+                </Row>
+            </Card>
+        </DashboardSection>
+    );
+};

--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -292,6 +292,38 @@ export const selectSolAccountHasStaked = createMemoizedSelector([selectAccountBy
     return !!account.misc.solStakingAccounts?.length;
 });
 
+export const selectSolExternalStakingAccounts = createMemoizedSelector(
+    [selectAccountByKey],
+    account => {
+        if (!account?.misc || account.networkType !== 'solana') return [];
+
+        return account.misc.solExternalStakingAccounts ?? [];
+    },
+);
+
+export const selectHasSolExternalStakingAccounts = createMemoizedSelector(
+    [selectAccountByKey],
+    account => {
+        if (!account?.misc || account.networkType !== 'solana') return false;
+
+        return (account.misc.solExternalStakingAccounts?.length ?? 0) > 0;
+    },
+);
+
+export const selectSolExternalStakingAccountsTotalStaked = createMemoizedSelector(
+    [selectAccountByKey],
+    account => {
+        if (!account?.misc || account.networkType !== 'solana') return '0';
+
+        const totalLamports = (account.misc.solExternalStakingAccounts ?? []).reduce(
+            (sum, { stake }) => sum + BigInt(stake ?? '0'),
+            0n,
+        );
+
+        return totalLamports.toString();
+    },
+);
+
 export const selectAdaAccountHasStaked = createMemoizedSelector([selectAccountByKey], account =>
     isCardanoStakingActive(account),
 );

--- a/suite-common/wallet-types/mocks/mockWalletAccount.ts
+++ b/suite-common/wallet-types/mocks/mockWalletAccount.ts
@@ -5,50 +5,43 @@ import {
     Account,
     AccountBase,
     AccountFailureSpecific,
-    AccountNetworkSpecific,
-    AccountNetworkSpecificBitcoin,
-    AccountNetworkSpecificCardano,
-    AccountNetworkSpecificEthereum,
-    AccountNetworkSpecificRipple,
-    AccountNetworkSpecificSolana,
-    AccountNetworkSpecificStellar,
     asAccountDescriptor,
     createAccountKey,
 } from '../src/account';
 
-const networkSpecificDefaultBitcoin: AccountNetworkSpecificBitcoin = {
-    networkType: 'bitcoin',
+const networkSpecificDefaultBitcoin = {
+    networkType: 'bitcoin' as const,
     misc: undefined,
     marker: undefined,
     stellarCursor: undefined,
     page: { index: 1, size: 25, total: 1 },
 };
 
-export const networkSpecificDefaultEthereum: AccountNetworkSpecificEthereum = {
-    networkType: 'ethereum',
+export const networkSpecificDefaultEthereum = {
+    networkType: 'ethereum' as const,
     misc: { nonce: '6' },
     marker: undefined,
     stellarCursor: undefined,
     page: { index: 1, size: 25, total: 1 },
 };
 
-export const networkSpecificDefaultSolana: AccountNetworkSpecificSolana = {
-    networkType: 'solana',
+export const networkSpecificDefaultSolana = {
+    networkType: 'solana' as const,
     marker: undefined,
     stellarCursor: undefined,
     page: { index: 1, size: 25, total: 1 },
 };
 
-export const networkSpecificDefaultRipple: AccountNetworkSpecificRipple = {
-    networkType: 'ripple',
+export const networkSpecificDefaultRipple = {
+    networkType: 'ripple' as const,
     marker: undefined,
     stellarCursor: undefined,
     misc: { sequence: 0, reserve: '21' },
     page: undefined,
 };
 
-export const networkSpecificDefaultCardano: AccountNetworkSpecificCardano = {
-    networkType: 'cardano',
+export const networkSpecificDefaultCardano = {
+    networkType: 'cardano' as const,
     marker: undefined,
     stellarCursor: undefined,
     misc: {
@@ -63,15 +56,23 @@ export const networkSpecificDefaultCardano: AccountNetworkSpecificCardano = {
     page: undefined,
 };
 
-export const networkSpecificDefaultStellar: AccountNetworkSpecificStellar = {
+export const networkSpecificDefaultStellar = {
     marker: undefined,
     misc: { reserve: '100', stellarSequence: '0' },
     page: undefined,
     stellarCursor: undefined,
-    networkType: 'stellar',
+    networkType: 'stellar' as const,
 };
 
-const networkTypeMap: Record<NetworkSymbol, AccountNetworkSpecific> = {
+type NetworkSpecificDefault =
+    | typeof networkSpecificDefaultBitcoin
+    | typeof networkSpecificDefaultEthereum
+    | typeof networkSpecificDefaultSolana
+    | typeof networkSpecificDefaultRipple
+    | typeof networkSpecificDefaultCardano
+    | typeof networkSpecificDefaultStellar;
+
+const networkTypeMap: Record<NetworkSymbol, NetworkSpecificDefault> = {
     // Bitcoin-like
     btc: networkSpecificDefaultBitcoin,
     regtest: networkSpecificDefaultBitcoin,
@@ -121,7 +122,7 @@ export const mockWalletAccount = (
         | 'symbol'
     > &
         MandatoryAccountData,
-    networkSpecific?: AccountNetworkSpecific,
+    networkSpecific?: NetworkSpecificDefault,
 ): Account => {
     const descriptor = account.descriptor ?? asAccountDescriptor(account.symbol);
 

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -25,97 +25,84 @@ export type TokenInfoBranded = TokenInfo & {
     contract: TokenAddress;
 };
 
-export type AccountNetworkSpecificBitcoin = {
-    networkType: 'bitcoin';
-    misc: undefined;
-    marker: undefined;
-    stellarCursor: undefined;
-    page: AccountInfo['page'];
-};
-
-export type AccountNetworkSpecificRipple = {
-    networkType: 'ripple';
-    misc: { sequence: number; reserve: string };
-    marker: AccountInfo['marker'];
-    stellarCursor: undefined;
-    page: undefined;
-};
-
-export type AccountNetworkSpecificCardano = {
-    networkType: 'cardano';
-    marker: undefined;
-    stellarCursor: undefined;
-    misc: {
-        staking: {
-            address: string;
-            isActive: boolean;
-            rewards: string;
-            poolId: string | null;
-            drep: {
-                drep_id: string;
-                hex: string;
-                amount: string;
-                active: boolean;
-                active_epoch: number | null;
-                has_script: boolean;
-            } | null;
-        };
-    };
-    page: AccountInfo['page'];
-};
-
-export type AccountNetworkSpecificEthereum = {
-    networkType: 'ethereum';
-    misc: {
-        nonce: string;
-        contractInfo?: ContractInfo;
-        stakingPools?: StakingPool[];
-        addressAliases?: { [key: string]: AddressAlias };
-    };
-    marker: undefined;
-    stellarCursor: undefined;
-    page: AccountInfo['page'];
-};
-
-export type AccountNetworkSpecificTron = {
-    networkType: 'tron';
-    misc: {
-        contractInfo?: ContractInfo;
-    };
-    marker: undefined;
-    stellarCursor: undefined;
-    page: AccountInfo['page'];
-};
-
-export type AccountNetworkSpecificSolana = {
-    networkType: 'solana';
-    misc?: {
-        rent?: number;
-        solStakingAccounts?: SolanaStakingAccount[];
-        solEpoch?: number;
-        owner?: string;
-    };
-    marker: undefined;
-    stellarCursor: undefined;
-    page: AccountInfo['page'];
-};
-
-export type AccountNetworkSpecificStellar = {
-    networkType: 'stellar';
-    misc: { stellarSequence: string; reserve: string };
-    marker: undefined;
-    stellarCursor: AccountInfo['stellarCursor'];
-    page: undefined;
-};
-
-export type AccountNetworkSpecific =
-    | AccountNetworkSpecificBitcoin
-    | AccountNetworkSpecificRipple
-    | AccountNetworkSpecificCardano
-    | AccountNetworkSpecificEthereum
-    | AccountNetworkSpecificTron
-    | AccountNetworkSpecificSolana
-    | AccountNetworkSpecificStellar;
+type AccountNetworkSpecific =
+    | {
+          networkType: 'bitcoin';
+          misc: undefined;
+          marker: undefined;
+          stellarCursor: undefined;
+          page: AccountInfo['page'];
+      }
+    | {
+          networkType: 'ripple';
+          misc: { sequence: number; reserve: string };
+          marker: AccountInfo['marker'];
+          stellarCursor: undefined;
+          page: undefined;
+      }
+    | {
+          networkType: 'cardano';
+          marker: undefined;
+          stellarCursor: undefined;
+          misc: {
+              staking: {
+                  address: string;
+                  isActive: boolean;
+                  rewards: string;
+                  poolId: string | null;
+                  drep: {
+                      drep_id: string;
+                      hex: string;
+                      amount: string;
+                      active: boolean;
+                      active_epoch: number | null;
+                      has_script: boolean;
+                  } | null;
+              };
+          };
+          page: AccountInfo['page'];
+      }
+    | {
+          networkType: 'ethereum';
+          misc: {
+              nonce: string;
+              contractInfo?: ContractInfo;
+              stakingPools?: StakingPool[];
+              addressAliases?: { [key: string]: AddressAlias };
+          };
+          marker: undefined;
+          stellarCursor: undefined;
+          page: AccountInfo['page'];
+      }
+    | {
+          networkType: 'tron';
+          misc: {
+              contractInfo?: ContractInfo;
+          };
+          marker: undefined;
+          stellarCursor: undefined;
+          page: AccountInfo['page'];
+      }
+    | {
+          networkType: 'solana';
+          misc?: {
+              rent?: number;
+              solStakingAccounts?: SolanaStakingAccount[];
+              solExternalStakingAccounts?: SolanaStakingAccount[];
+              solEpoch?: number;
+              owner?: string;
+          };
+          marker: undefined;
+          stellarCursor: undefined;
+          page: AccountInfo['page'];
+      }
+    | {
+          networkType: 'stellar';
+          misc: { stellarSequence: string; reserve: string };
+          marker: undefined;
+          stellarCursor: AccountInfo['stellarCursor'];
+          page: undefined;
+      };
 
 // decides if account is using TrezorConnect/blockchain-link or other non-standard api
 export type AccountBackendSpecific =

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -763,6 +763,7 @@ export const getAccountSpecific = (accountInfo: Partial<AccountInfo>, networkTyp
             misc: {
                 rent: misc?.rent,
                 solStakingAccounts: misc?.solStakingAccounts,
+                solExternalStakingAccounts: misc?.solExternalStakingAccounts,
                 solEpoch: misc?.solEpoch,
                 owner: misc?.owner,
             },

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10829,6 +10829,14 @@ export const messages = defineMessages({
     },
     TR_EXPERIMENTAL_FEEDBACK_CARD_RATE_BUTTON: {
         id: 'TR_EXPERIMENTAL_FEEDBACK_CARD_RATE_BUTTON',
-        defaultMessage: 'Share feedback',
+        defaultMessage: 'Sure thing',
+    },
+    TR_OUTSIDE_STAKING_CARD_TITLE: {
+        id: 'TR_OUTSIDE_STAKING_CARD_TITLE',
+        defaultMessage: "You're staking outside of Trezor Suite",
+    },
+    TR_OUTSIDE_STAKING_CARD_TEXT: {
+        id: 'TR_OUTSIDE_STAKING_CARD_TEXT',
+        defaultMessage: '{amount} {displaySymbol} (= {fiat}) is currently staked elsewhere.',
     },
 } as const);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implemented support for detecting and displaying Solana staking accounts created outside of Trezor Suite (non-Everstake).

## Notes for QA

You should test 4 cases:

Stake outside of Trezor
Stake via Trezor
Mix - outside Trezor and via it
Without any stake

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19075

## Screenshots:
<img width="1428" height="906" alt="Screenshot 2026-01-30 at 09 36 51" src="https://github.com/user-attachments/assets/ccf6256f-22f4-4e2d-9838-9a95a4c683e7" />
<img width="1425" height="914" alt="Screenshot 2026-01-30 at 09 41 26" src="https://github.com/user-attachments/assets/ac56a15d-2ce0-4abd-be68-64f3a861789e" />
<img width="1429" height="910" alt="Screenshot 2026-01-30 at 09 45 17" src="https://github.com/user-attachments/assets/4e33de6e-b152-48c9-ab28-59a185db575d" />
<img width="1436" height="915" alt="Screenshot 2026-01-30 at 09 48 38" src="https://github.com/user-attachments/assets/ee7adbea-89ef-4087-a43b-c045afe69d26" />