### PR TITLE
refactor(analytics): Update SuiteReady event handling and types

### DIFF
--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -108,7 +108,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
 
             case SUITE.READY:
                 getSuiteReadyPayload(state).then(payload => {
-                    getTypedDesktopLegacyAnalytics(legacyAnalytics).report({
+                    getTypedDesktopAnalytics(analytics).report({
                         type: EventType.SuiteReady,
                         payload,
                     });

--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -1,4 +1,4 @@
-import { AppUpdateEvent, SuiteAnalyticsEventSuiteReady } from '@suite/analytics';
+import type { AppUpdateEvent, SuiteReadyPayload } from '@suite/analytics';
 import {
     formatExperimentVariantsForAnalytics,
     selectActiveExperimentsWithVariants,
@@ -55,9 +55,7 @@ export const redactTransactionIdFromAnchor = (anchor?: string) => {
 // 1. replace coinjoin by taproot
 export const redactRouterUrl = (url: string) => url.replace(/coinjoin/g, 'taproot');
 
-export const getSuiteReadyPayload = async (
-    state: AppState,
-): Promise<SuiteAnalyticsEventSuiteReady['payload']> => {
+export const getSuiteReadyPayload = async (state: AppState): Promise<SuiteReadyPayload> => {
     const experimentVariants = selectActiveExperimentsWithVariants(state);
     const [osVersion, osCpuArch] = await Promise.all([getOsVersion(), getCpuArch()]);
 

--- a/suite/analytics/src/analyticsEvents.ts
+++ b/suite/analytics/src/analyticsEvents.ts
@@ -1,7 +1,13 @@
 import type { AnalyticsSharedEvents, EventInstance } from '@suite-common/analytics';
 
+import { EventType } from './constants';
 import * as desktopEventsData from './events';
 
 export const desktopEvents = desktopEventsData;
 export type AnyDesktopEventsDef = (typeof desktopEvents)[keyof typeof desktopEvents];
 export type AnalyticsDesktopEvents = EventInstance<AnyDesktopEventsDef> | AnalyticsSharedEvents;
+
+export type SuiteReadyPayload = Extract<
+    AnalyticsDesktopEvents,
+    { type: EventType.SuiteReady }
+>['payload'];

--- a/suite/analytics/src/events/index.ts
+++ b/suite/analytics/src/events/index.ts
@@ -48,6 +48,7 @@ export { stakingNavigateEvent } from './stakingNavigateEvent';
 export { stakingStakeEvent } from './stakingStakeEvent';
 export { stakingUnstakeEvent } from './stakingUnstakeEvent';
 export { stakingUpdateProviderEvent } from './stakingUpdateProviderEvent';
+export { suiteReadyEvent } from './suiteReadyEvent';
 export { switchDeviceEjectEvent } from './switchDeviceEjectEvent';
 export { switchDeviceForgetEvent } from './switchDeviceForgetEvent';
 export { switchDeviceRememberEvent } from './switchDeviceRememberEvent';

--- a/suite/analytics/src/events/suiteReadyEvent.ts
+++ b/suite/analytics/src/events/suiteReadyEvent.ts
@@ -1,0 +1,121 @@
+import type { AttributeDef, EventDef } from '@suite-common/analytics';
+import type { MetadataProviderType } from '@suite-common/metadata-types';
+
+import { EventType } from '../constants';
+
+type Attributes = {
+    language: AttributeDef<string>;
+    enabledNetworks: AttributeDef<string[]>;
+    customBackends: AttributeDef<string[]>;
+    localCurrency: AttributeDef<string>;
+    bitcoinUnit: AttributeDef<string>;
+    discreetMode: AttributeDef<boolean>;
+    screenWidth: AttributeDef<number>;
+    screenHeight: AttributeDef<number>;
+    platformLanguages: AttributeDef<string>;
+    tor: AttributeDef<boolean>;
+    rememberedStandardWallets: AttributeDef<number>;
+    rememberedHiddenWallets: AttributeDef<number>;
+    theme: AttributeDef<string>;
+    suiteVersion: AttributeDef<string>;
+    windowWidth: AttributeDef<number>;
+    windowHeight: AttributeDef<number>;
+    osVersion: AttributeDef<string>;
+    osName: AttributeDef<string>;
+    osCpuArch: AttributeDef<string>;
+    browserVersion: AttributeDef<string>;
+    browserName: AttributeDef<string>;
+    earlyAccessProgram: AttributeDef<boolean>;
+    autodetectLanguage: AttributeDef<boolean>;
+    autodetectTheme: AttributeDef<boolean>;
+    labeling: AttributeDef<MetadataProviderType | 'missing-provider' | 'suite-sync' | 'off'>;
+    experimentalFeatures?: AttributeDef<string[]>;
+    isAutomaticUpdateEnabled: AttributeDef<boolean>;
+    experimentVariants: AttributeDef<string[]>;
+    mevProtection: AttributeDef<boolean>;
+    networkReserve: AttributeDef<boolean>;
+};
+
+export const suiteReadyEvent: EventDef<Attributes, EventType.SuiteReady> = {
+    name: EventType.SuiteReady,
+    descriptionTrigger: 'Triggers on the application start or when the onboarding is done.',
+    changelog: [
+        { version: '1.0.0', notes: 'added' },
+        { version: '25.9.0', notes: 'updated' },
+    ],
+
+    attributes: {
+        language: {
+            changelog: [{ version: '1.0.0', notes: 'added' }],
+            description: 'Available Suite languages e.g. "en"',
+        },
+        enabledNetworks: {
+            changelog: [{ version: '1.0.0', notes: 'added' }],
+            description: 'Available suite coins e.g. "btc,ltc,doge"',
+        },
+        localCurrency: {
+            changelog: [{ version: '1.0.0', notes: 'added' }],
+            description: 'Available suite currencies e.g. "usd"',
+        },
+        discreetMode: { changelog: [{ version: '1.0.0', notes: 'added' }] },
+        screenWidth: { changelog: [{ version: '1.0.0', notes: 'added' }] },
+        screenHeight: { changelog: [{ version: '1.0.0', notes: 'added' }] },
+        platformLanguages: {
+            changelog: [{ version: '1.9.0', notes: 'added' }],
+            description: "Array of user's languages in browser/os",
+        },
+        tor: { changelog: [{ version: '1.2.0', notes: 'added' }] },
+        rememberedStandardWallets: { changelog: [{ version: '1.4.0', notes: 'added' }] },
+        rememberedHiddenWallets: { changelog: [{ version: '1.4.0', notes: 'added' }] },
+        theme: {
+            changelog: [{ version: '1.5.0', notes: 'added' }],
+            description: 'dark, light, custom',
+        },
+        suiteVersion: { changelog: [{ version: '1.6.0', notes: 'added' }] },
+        windowWidth: { changelog: [{ version: '1.8.0', notes: 'added' }] },
+        windowHeight: { changelog: [{ version: '1.8.0', notes: 'added' }] },
+        osVersion: { changelog: [{ version: '1.8.0', notes: 'added' }] },
+        osName: {
+            changelog: [{ version: '1.8.0', notes: 'added' }],
+            description: 'windows, macos, linux, android, chromeos',
+        },
+        osCpuArch: {
+            changelog: [{ version: '25.4.0', notes: 'added' }],
+            description: 'amd64, arm64',
+        },
+        browserVersion: {
+            changelog: [{ version: '1.8.0', notes: 'added' }],
+            description: 'Version of browser in semver format',
+        },
+        browserName: {
+            changelog: [{ version: '1.8.0', notes: 'added' }],
+            description: 'chrome, firefox, electron',
+        },
+        earlyAccessProgram: {
+            changelog: [{ version: '1.15.0', notes: 'added' }],
+            description: 'boolean - true only on Desktop app with Early Access Program active',
+        },
+        customBackends: {
+            changelog: [{ version: '1.17.0', notes: 'added' }],
+            description: 'Available suite coins e.g. "btc,ltc,doge"',
+        },
+        autodetectLanguage: { changelog: [{ version: '1.17.0', notes: 'added' }] },
+        autodetectTheme: { changelog: [{ version: '1.17.0', notes: 'added' }] },
+        labeling: {
+            changelog: [{ version: '1.21.0', notes: 'added' }],
+            description: "'dropbox' | 'google' | 'fileSystem' | 'sdCard' | ''",
+        },
+        bitcoinUnit: {
+            changelog: [{ version: '1.21.0', notes: 'added' }],
+            description: "'BTC' | 'μBTC' | 'mBTC' | 'sat'",
+        },
+        experimentalFeatures: {
+            changelog: [{ version: '24.8.0', notes: 'added' }],
+            description: 'list of active experimental features as strings',
+        },
+        isAutomaticUpdateEnabled: { changelog: [{ version: '25.1.0', notes: 'added' }] },
+        experimentVariants: { changelog: [{ version: '25.9.0', notes: 'added' }] },
+        mevProtection: { changelog: [{ version: '25.10.0', notes: 'added' }] },
+        networkReserve: { changelog: [{ version: '25.10.0', notes: 'added' }] },
+    },
+};

--- a/suite/analytics/src/index.ts
+++ b/suite/analytics/src/index.ts
@@ -1,11 +1,11 @@
 export { createLegacyAnalytics, type DesktopLegacyAnalyticsDep } from './createLegacyAnalytics';
 export { createAnalytics, type DesktopAnalyticsDep } from './createAnalytics';
-export type { SuiteAnalyticsEventSuiteReady, SuiteDesktopLegacyAnalyticsEvents } from './types';
+export type { SuiteDesktopLegacyAnalyticsEvents } from './types';
 export type { OnboardingAnalytics, AppUpdateEvent, FirmwareSource } from './definitions';
 export { EventType, AppUpdateEventStatus } from './constants';
 export { getTypedDesktopLegacyAnalytics } from './getTypedDesktopLegacyAnalytics';
 export { getTypedDesktopAnalytics } from './getTypedDesktopAnalytics';
-export type { AnalyticsDesktopEvents } from './analyticsEvents';
+export type { AnalyticsDesktopEvents, SuiteReadyPayload } from './analyticsEvents';
 
 export * from './events';
 export * as events from './events';

--- a/suite/analytics/src/types.ts
+++ b/suite/analytics/src/types.ts
@@ -1,51 +1,8 @@
-import { MetadataProviderType } from '@suite-common/metadata-types';
-
 import { EventType } from './constants';
 import type { AppUpdateEvent, FirmwareSource, OnboardingAnalytics } from './definitions';
 
-/** @deprecated */
-export type SuiteAnalyticsEventSuiteReady = {
-    type: EventType.SuiteReady;
-    payload: {
-        language: string;
-        enabledNetworks: string[];
-        customBackends: string[];
-        localCurrency: string;
-        bitcoinUnit: string;
-        discreetMode: boolean;
-        screenWidth: number;
-        screenHeight: number;
-        tor: boolean;
-        labeling: MetadataProviderType | 'missing-provider' | 'suite-sync' | 'off';
-        rememberedStandardWallets: number;
-        rememberedHiddenWallets: number;
-        theme: string;
-        suiteVersion: string;
-        earlyAccessProgram: boolean;
-        experimentalFeatures?: string[];
-        browserName: string;
-        browserVersion: string;
-        osName: string;
-        osVersion: string;
-        osCpuArch: string;
-        windowWidth: number;
-        windowHeight: number;
-        platformLanguages: string;
-        autodetectLanguage: boolean;
-        autodetectTheme: boolean;
-        desktopOsVersion?: string;
-        desktopOsName?: string;
-        desktopOsArchitecture?: string;
-        isAutomaticUpdateEnabled: boolean;
-        experimentVariants: string[];
-        mevProtection: boolean;
-        networkReserve: boolean;
-    };
-};
-
 /** @deprecated use `AnalyticsDesktopEvents` */
 export type SuiteDesktopLegacyAnalyticsEvents =
-    | SuiteAnalyticsEventSuiteReady
     | { type: EventType.TransportType; payload: { type: string; version: string } }
     | {
           type: EventType.AppUpdate;


### PR DESCRIPTION
- Replaced legacy analytics reporting with updated typed analytics in analyticsMiddleware.
- Refactored getSuiteReadyPayload to return the new SuiteReadyPayload type.
- Introduced a new suiteReadyEvent definition with detailed attributes for analytics.
- Removed deprecated SuiteAnalyticsEventSuiteReady type from types.ts.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=analytics-migration21&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=analytics-migration21&lookback=7)