### PR TITLE
test(e2e-reporter): optimize reporting by skipping automated tests that passed

### DIFF
--- a/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
+++ b/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
@@ -9,6 +9,7 @@ import { LoggingFunctions, ProjectField } from './types';
 import {
     TestOsEmoticons,
     TestOsMatrix,
+    TestStatus,
     osMatrixAnnotation,
     statusAnnotation,
 } from '../enums/testAnnotations';
@@ -189,9 +190,18 @@ abstract class GitHubReporterBase implements LoggingFunctions {
             (async () => {
                 try {
                     await this.waitForOnBeginInit();
+
                     if (report.isRetryAttempt && this.createdIssuesMap.has(report.id)) {
+                        // Retry attempts update the existing issue instead of creating a new one
                         await this.updateIssue(report);
+                    } else if (!report.isManual && report.status === TestStatus.AutoPass) {
+                        this.log(
+                            `Skipping reporting because test is automated and passed: "${report.testTitle}"`,
+                        );
+
+                        return;
                     } else {
+                        // Otherwise, create a new issue(s)
                         await this.createIssuePerOs(report);
                     }
                 } catch (error) {


### PR DESCRIPTION
Optimizing how we report release test runs based on feedback from stakeholders/consumers (QEs)
Value have only manual tests and automated one that did not passed.

Here is an example from local run:
```
[GitHub Reporter] Processing test end for "Analytics captures important events when started enabled by default"
[GitHub Reporter] Skipping because it is automated passed test: "Analytics captures important events when started enabled by default"
[GitHub Reporter] Operation completed (0 remaining)
[GitHub Reporter] Processing test end for "Analytics capture suite-ready after getting enabled"
[GitHub Reporter] Creating GitHub draft issue for test "(OS Linux) Analytics capture suite-ready after getting enabled"...
[GitHub Reporter] [PVTI_lADOAD9FD84A4Mcnzgki8mo] Successfully created issue "(OS Linux) Analytics capture suite-ready after getting enabled"
[GitHub Reporter] [PVTI_lADOAD9FD84A4Mcnzgki8mo] Updating values of issue "(OS Linux) Analytics capture suite-ready after getting enabled"...
[GitHub Reporter] [PVTI_lADOAD9FD84A4Mcnzgki8mo] Successfully updated values of issue "(OS Linux) Analytics capture suite-ready after getting enabled"
[GitHub Reporter] [PVTI_lADOAD9FD84A4Mcnzgki8mo] Successfully recorded test result for "(OS Linux) Analytics capture suite-ready after getting enabled"
```

One test passed and was not reported. The other failed and was correctly reported

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-e2e-reporter-optimization&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-e2e-reporter-optimization&lookback=7)