### PR TITLE
refactor(e2e-suite): improves recovery and logging of device setup

### DIFF
--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -183,29 +183,27 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
             use,
             testInfo,
         ) => {
-            await TrezorUserEnvLink.logTestDetails(
-                ` - - - EXECUTING TENV CLEANUP FOR TEST ${testInfo.titlePath.join(' - ')}`,
-            );
             const setupPromise = (async () => {
+                await TrezorUserEnvLink.logTestDetails(
+                    ` - - - EXECUTING TENV CLEANUP FOR TEST ${testInfo.titlePath.join(' - ')}`,
+                );
                 await TrezorUserEnvLink.stopBridge();
                 await TrezorUserEnvLink.stopEmu();
                 await TrezorUserEnvLink.connect();
+                await TrezorUserEnvLink.logTestDetails(
+                    ` - - - TENV CLEANUP COMPLETED FOR TEST ${testInfo.titlePath.join(' - ')}`,
+                );
             })();
 
-            await trezorUserEnvStuckProtection(setupPromise);
-
-            await TrezorUserEnvLink.logTestDetails(
-                ` - - - TENV CLEANUP COMPLETED FOR TEST ${testInfo.titlePath.join(' - ')}`,
-            );
+            await base.step('Device environment cleanup', async () => {
+                await trezorUserEnvStuckProtection(setupPromise);
+            });
 
             if (!model || !firmwareVersion) {
                 await use(undefined as unknown as DeviceFixture);
 
                 return;
             }
-            await TrezorUserEnvLink.logTestDetails(
-                ` - - - STARTING TEST ${testInfo.titlePath.join(' - ')}`,
-            );
             testInfo.annotations.push({
                 type: TestAnnotationType.DeviceModel,
                 description: model,
@@ -214,6 +212,9 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
             const device = new DeviceFixture(model, firmwareVersion);
 
             const startDevicePromise = (async () => {
+                await TrezorUserEnvLink.logTestDetails(
+                    ` - - - STARTING TEST ${testInfo.titlePath.join(' - ')}`,
+                );
                 if (startEmulator) {
                     await device.powerOn({ wipe: true });
                 }
@@ -223,13 +224,20 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
                 }
             })();
 
-            await trezorUserEnvStuckProtection(startDevicePromise);
-
+            await base.step('Device startup', async () => {
+                await trezorUserEnvStuckProtection(startDevicePromise);
+            });
             await use(device);
 
-            await TrezorUserEnvLink.logTestDetails(
-                ` - - - FINISHING TEST ${testInfo.titlePath.join(' - ')}`,
-            );
+            await base.step('Logging test-end to Device logs', async () => {
+                await trezorUserEnvStuckProtection(
+                    (async () => {
+                        await TrezorUserEnvLink.logTestDetails(
+                            ` - - - FINISHING TEST ${testInfo.titlePath.join(' - ')}`,
+                        );
+                    })(),
+                );
+            });
         },
         { auto: true },
     ],


### PR DESCRIPTION
Trezor User Env have some kind of race condition that causes whole instance to be irrevertable stuck. we have mechanism that on timeout does restart tenv docker. Yet we are encountering lately tests failing on tenv being stuck

I have improved logging and moved all tenv action to be handled with said protection. I have hunch that even tenv.log can get stuck. 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-e2e-safer-tenv-handling&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-e2e-safer-tenv-handling&lookback=7)