### PR TITLE
fix - show suite sync labeling dropdown option in correct cases

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -42,13 +42,6 @@ export const Labeling = () => {
 
     const legacyMetadataState = useSelector(state => state.metadata);
 
-    const legacyEnableIfNeeded = () => {
-        if (!legacyMetadataState.enabled) {
-            suiteSync.turnOffSuiteSync(); // Enabling Legacy Labeling implicitly disables Evolu
-            dispatch(metadataLabelingActions.init(true));
-        }
-    };
-
     const translatedOptions: LabelingOption<string>[] = LABELING_SELECT_OPTIONS.map(option => ({
         ...option,
         label:
@@ -56,6 +49,11 @@ export const Labeling = () => {
                 ? translationString(LABELING_LEGACY_OPTION_LABEL)
                 : translationString(option.label),
     }));
+
+    const handleLegacyOptionSelect = async () => {
+        await suiteSync.turnOffSuiteSync();
+        if (legacyMetadataState.enabled === false) dispatch(metadataLabelingActions.init(true));
+    };
 
     const handleOnChange = async (selected: LabelingOptionTranslated) => {
         const { value } = selected;
@@ -83,8 +81,7 @@ export const Labeling = () => {
             }
 
             case 'legacy':
-                await suiteSync.turnOffSuiteSync();
-                legacyEnableIfNeeded();
+                await handleLegacyOptionSelect();
                 break;
 
             default:
@@ -129,9 +126,8 @@ export const Labeling = () => {
             {legacyModalWarningVisible && (
                 <LabelingSwitchToLegacyModal
                     onClose={() => setLegacyModalWarningVisible(false)}
-                    onSwitch={() => {
-                        suiteSync.turnOffSuiteSync();
-                        legacyEnableIfNeeded();
+                    onSwitch={async () => {
+                        await handleLegacyOptionSelect();
                         setLegacyModalWarningVisible(false);
                     }}
                 />

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -48,11 +48,13 @@ export const Labeling = () => {
             !showSuiteSync && option.value === 'legacy'
                 ? translationString(LABELING_LEGACY_OPTION_LABEL)
                 : translationString(option.label),
-    }));
+    })).filter(option => option.value !== 'suite-sync' || showSuiteSync);
 
     const handleLegacyOptionSelect = async () => {
         await suiteSync.turnOffSuiteSync();
-        if (legacyMetadataState.enabled === false) dispatch(metadataLabelingActions.init(true));
+        if (legacyMetadataState.enabled === false) {
+            dispatch(metadataLabelingActions.init(true));
+        }
     };
 
     const handleOnChange = async (selected: LabelingOptionTranslated) => {


### PR DESCRIPTION
✅ NOTE: this [PR](https://github.com/trezor/trezor-suite/pull/24834) needs to be merged first

changes (fixes):
- you should se SS in labeling select only if its enabled in experimental mode
- some cleaning in terms of calling turn off suite sync fn
 
## Notes for QA

- you should be able to turn on and off legacy labeling (from OFF or Suite Sync state)
- you should be able to turn on the suite sync


## Related Issue
Resolve https://github.com/trezor/trezor-suite/issues/24844



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/show-ss-correctly&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/show-ss-correctly&lookback=7)