### PR TITLE
Migrate mobile AppReady event from legacy to new analytics structure

### DIFF
--- a/suite-native/analytics/src/events/appReadyEvent.ts
+++ b/suite-native/analytics/src/events/appReadyEvent.ts
@@ -1,0 +1,112 @@
+import type { AttributeDef, EventDef } from '@suite-common/analytics';
+import type { UNIT_ABBREVIATION } from '@suite-common/suite-constants';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import type { AppColorScheme } from '@suite-native/theme';
+import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+
+import { EventType } from '../constants';
+
+type Attributes = {
+    appLanguage: AttributeDef<'en'>;
+    deviceLanguage: AttributeDef<string | undefined>;
+    localCurrency: AttributeDef<BaseCurrencyCode>;
+    bitcoinUnit: AttributeDef<UNIT_ABBREVIATION>;
+    screenWidth: AttributeDef<number>;
+    screenHeight: AttributeDef<number>;
+    pixelDensity: AttributeDef<number>;
+    fontScale: AttributeDef<number>;
+    osName: AttributeDef<'ios' | 'android' | 'windows' | 'macos' | 'web'>;
+    osVersion: AttributeDef<string | number>;
+    discreetMode: AttributeDef<boolean>;
+    theme: AttributeDef<AppColorScheme>;
+    loadDuration: AttributeDef<number>;
+    isBiometricsEnabled: AttributeDef<boolean>;
+    rememberedStandardWallets: AttributeDef<number>;
+    rememberedHiddenWallets: AttributeDef<number>;
+    enabledNetworks: AttributeDef<NetworkSymbol[]>;
+};
+
+export const appReadyEvent: EventDef<Attributes, EventType.AppReady> = {
+    name: EventType.AppReady,
+    descriptionTrigger:
+        'On the application start but only if the app onboarding (Welcome flow) is done. Otherwise when leaving the app onboarding.',
+    changelog: [
+        { version: '23.4.1', notes: 'added' },
+        {
+            version: '24.5.1',
+            notes: 'added rememberedStandardWallets, rememberedHiddenWallets',
+        },
+        { version: '24.7.2', notes: 'added fontScale, pixelDensity' },
+        { version: '24.9.1', notes: 'added enabledNetworks' },
+    ],
+    attributes: {
+        appLanguage: {
+            changelog: [{ version: '23.4.1', notes: 'added' }],
+            description: 'Application language setting but so far only en is hardcoded.',
+        },
+        deviceLanguage: {
+            changelog: [{ version: '23.4.1', notes: 'added' }],
+            description: 'Firmware language but so far only undefined is hardcoded.',
+        },
+        localCurrency: {
+            changelog: [{ version: '23.4.1', notes: 'added' }],
+            description: 'User preferred currency',
+        },
+        bitcoinUnit: {
+            changelog: [{ version: '23.4.1', notes: 'added' }],
+            description: 'Bitcoin display unit (BTC, mBTC, sat)',
+        },
+        screenWidth: {
+            changelog: [{ version: '23.4.1', notes: 'added' }],
+            description: 'Device screen width in pixels',
+        },
+        screenHeight: {
+            changelog: [{ version: '23.4.1', notes: 'added' }],
+            description: 'Device screen height in pixels',
+        },
+        pixelDensity: {
+            changelog: [{ version: '24.7.2', notes: 'added' }],
+            description: 'Device pixel density ratio',
+        },
+        fontScale: {
+            changelog: [{ version: '24.7.2', notes: 'added' }],
+            description: 'System font scale setting',
+        },
+        osName: {
+            changelog: [{ version: '23.4.1', notes: 'added' }],
+            description: 'Operating system name (ios or android)',
+        },
+        osVersion: {
+            changelog: [{ version: '23.4.1', notes: 'added' }],
+            description: 'OS version number',
+        },
+        discreetMode: {
+            changelog: [{ version: '23.4.1', notes: 'added' }],
+            description: 'Whether discreet mode is enabled',
+        },
+        theme: {
+            changelog: [{ version: '23.4.1', notes: 'added' }],
+            description: 'Current color scheme (debug/standard/dark/system)',
+        },
+        loadDuration: {
+            changelog: [{ version: '23.4.1', notes: 'added' }],
+            description: 'Milliseconds from app start to ready state',
+        },
+        isBiometricsEnabled: {
+            changelog: [{ version: '23.4.1', notes: 'added' }],
+            description: 'Whether biometrics authentication is enabled',
+        },
+        rememberedStandardWallets: {
+            changelog: [{ version: '24.5.1', notes: 'added' }],
+            description: 'Count of saved standard wallets',
+        },
+        rememberedHiddenWallets: {
+            changelog: [{ version: '24.5.1', notes: 'added' }],
+            description: 'Count of saved hidden wallets',
+        },
+        enabledNetworks: {
+            changelog: [{ version: '24.9.1', notes: 'added' }],
+            description: 'List of enabled networks (btc, eth, etc.)',
+        },
+    },
+};

--- a/suite-native/analytics/src/events/index.ts
+++ b/suite-native/analytics/src/events/index.ts
@@ -1,3 +1,4 @@
+export { appReadyEvent } from './appReadyEvent';
 export { assetDetailEvent } from './assetDetailEvent';
 export { earnNavigateEvent } from './earnNavigateEvent';
 export { earnStakeTilePressedEvent } from './earnStakeTilePressedEvent';

--- a/suite-native/analytics/src/types.ts
+++ b/suite-native/analytics/src/types.ts
@@ -30,28 +30,6 @@ export type CountryChangeAction = 'submitDefault' | 'submitCustom' | 'cancel';
 /** @deprecated use `AnalyticsNativeEvents` */
 export type SuiteNativeLegacyAnalyticsEvents =
     | {
-          type: EventType.AppReady;
-          payload: {
-              appLanguage: string;
-              deviceLanguage?: string;
-              localCurrency: BaseCurrencyCode;
-              bitcoinUnit: UNIT_ABBREVIATION;
-              screenWidth: number;
-              screenHeight: number;
-              pixelDensity: number;
-              fontScale: number;
-              osName: string;
-              osVersion: string | number;
-              discreetMode: boolean;
-              theme: string;
-              loadDuration: number;
-              isBiometricsEnabled: boolean;
-              rememberedStandardWallets: number;
-              rememberedHiddenWallets: number;
-              enabledNetworks: NetworkSymbol[];
-          };
-      }
-    | {
           type: EventType.OnboardingCompleted;
           payload: {
               analyticsPermission: boolean;

--- a/suite-native/app/src/hooks/useReportAppInitToAnalytics.ts
+++ b/suite-native/app/src/hooks/useReportAppInitToAnalytics.ts
@@ -10,10 +10,10 @@ import {
     selectRememberedHiddenWalletsCount,
     selectRememberedStandardWalletsCount,
 } from '@suite-common/wallet-core';
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { useDiscreetMode } from '@suite-native/atoms';
 import { useIsBiometricsEnabled } from '@suite-native/biometrics';
-import { useLegacyAnalytics } from '@suite-native/services';
+import { useAnalytics } from '@suite-native/services';
 import { selectIsOnboardingFinished } from '@suite-native/settings';
 import { selectIsAppReady } from '@suite-native/state';
 import { useUserColorScheme } from '@suite-native/theme';
@@ -21,7 +21,7 @@ import { useUserColorScheme } from '@suite-native/theme';
 export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
     const [loadDuration, setLoadDuration] = useState<number | null>(null);
     const [initWasReported, setInitWasReported] = useState(false);
-    const legacyAnalytics = useLegacyAnalytics();
+    const analytics = useAnalytics();
     const isAppReady = useSelector(selectIsAppReady);
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const { userColorScheme } = useUserColorScheme();
@@ -40,8 +40,8 @@ export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
     useEffect(() => {
         if (isAppReady && isOnboardingFinished && loadDuration && !initWasReported) {
             setInitWasReported(true);
-            legacyAnalytics.report({
-                type: EventType.AppReady,
+            analytics.report({
+                type: events.appReadyEvent.name,
                 payload: {
                     appLanguage: 'en',
                     deviceLanguage: undefined,
@@ -76,6 +76,6 @@ export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
         rememberedStandardWallets,
         rememberedHiddenWallets,
         enabledNetworks,
-        legacyAnalytics,
+        analytics,
     ]);
 };


### PR DESCRIPTION
## Description

Migration of app_ready event https://www.notion.so/satoshilabs/app_ready-a4488687b9494668b3ade1582d646979?source=copy_link

TODO:
- [ ] fix appLanguage 
- [ ] fix deviceLanguage 
- [ ] add experimental features
## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/analytics-migrate-app-ready&lookback=7)