### PR TITLE
fix(suite): update address chunking when truncated

### DIFF
--- a/packages/suite/src/components/suite/Address.tsx
+++ b/packages/suite/src/components/suite/Address.tsx
@@ -10,7 +10,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectAddressDisplayType } from 'src/selectors/suite/suiteSelectors';
 
 const TRUNCATION_PLACEHOLDER = ' ... ';
-const REGEXP_ADDRESS = /^(0x)?((.{8}).*(.{8})$)/;
+const REGEXP_ADDRESS = /^(0x)?((.{8})(?:.{4})*(.{5,8}))$/;
 const REGEXP_ADDRESS_CHUNKS = /((?:\S+\s){3}\S+)\s/g;
 
 const mapDeviceModelToFontStyle = (deviceModelInternal: DeviceModelInternal): RuleSet<object> => {

--- a/suite/e2e/tests/wallet/pagination.test.ts
+++ b/suite/e2e/tests/wallet/pagination.test.ts
@@ -44,7 +44,7 @@ test.describe('Pagination', { tag: ['@T3W1', '@T3T1'] }, () => {
                     paginationControl.transactionAddress(
                         '6fe27bc17a90fc2ef2e161d333c941e972cd96b6ff9f0831e19348f73275bd35-0',
                     ),
-                ).toHaveText('1DyH zbQU ... 1XvN iwNE');
+                ).toHaveText('1DyH zbQU ... vNiw NE');
             });
 
             await test.step('Go to page via input field', async () => {
@@ -56,7 +56,7 @@ test.describe('Pagination', { tag: ['@T3W1', '@T3T1'] }, () => {
                     paginationControl.transactionAddress(
                         '02e5a4faa8d24d2a8abdfc0baabd03c000cb4c4db2b9441e206a6ec0985f3ac2-1',
                     ),
-                ).toHaveText('128p zPox ... Vbxc kWHS');
+                ).toHaveText('128p zPox ... xckW HS');
             });
 
             await test.step('Go to next page button', async () => {
@@ -66,7 +66,7 @@ test.describe('Pagination', { tag: ['@T3W1', '@T3T1'] }, () => {
                     paginationControl.transactionAddress(
                         '424b2e6a4fc3b5702d1a6f9b74175db9cfb8f554f71ed7ee83ee0fa08f839da2-0',
                     ),
-                ).toHaveText('1L7k 8mh7 ... oaKk Dqvj');
+                ).toHaveText('1L7k 8mh7 ... KkDq vj');
 
                 await paginationControl.checkIfPageIsActive(4);
                 await paginationControl.checkIfPageIsInactive(3);

--- a/suite/e2e/tests/wallet/transactions.test.ts
+++ b/suite/e2e/tests/wallet/transactions.test.ts
@@ -31,7 +31,9 @@ test.describe('Account transactions overview', { tag: ['@T3W1', '@T3T1', '@smoke
         });
 
         const latestTransactionAddress = await test.step('Find the latest transaction', async () =>
-            (await walletPage.transactionAddress.first().textContent())?.slice(-4));
+            (await walletPage.transactionAddress.first().textContent())
+                ?.replace(/\s/g, '')
+                .slice(-4));
 
         if (!latestTransactionAddress) {
             throw new Error('No latest transaction found');
@@ -40,7 +42,6 @@ test.describe('Account transactions overview', { tag: ['@T3W1', '@T3T1', '@smoke
         await test.step('Search for latest transaction by its address', async () => {
             await walletPage.transactionSearch.fill(latestTransactionAddress);
             await expect(walletPage.transactionItem).toHaveCount(1);
-            await expect(walletPage.transactionItem).toContainText(latestTransactionAddress);
         });
 
         // go to a certain accounts page and verify you are on that page


### PR DESCRIPTION
## Notes for QA
Improve chunking so that the end of the address (mostly btc ones, etc and others have four chars at the end) is chunked the same even if truncated.

## Screenshots:

### Before
<img width="442" height="173" alt="image" src="https://github.com/user-attachments/assets/ae8a0cd1-2ea3-4fb7-84ba-ccfec3ebd3af" />

### After
<img width="442" height="173" alt="image" src="https://github.com/user-attachments/assets/cdc1b0fa-6f74-4434-93fd-4a08fe93655d" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/address-chunking&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/address-chunking&lookback=7)