### PR TITLE
fix(suite): handle missing metadata provider (legacy labeling)

### DIFF
--- a/packages/suite/src/actions/suite/metadata/metadataLabelingActions.ts
+++ b/packages/suite/src/actions/suite/metadata/metadataLabelingActions.ts
@@ -19,6 +19,7 @@ import {
     MetadataAddPayload,
     MetadataEncryptionVersion,
     MetadataProvider,
+    Error as MetadataProviderError,
     ProviderErrorAction,
     WalletLabels,
 } from 'src/types/suite/metadata';
@@ -328,7 +329,7 @@ export const addDeviceMetadata =
 
         const providerInstance = dispatch(
             metadataProviderActions.getProviderInstance({
-                clientId: selectSelectedProviderForLabels(getState())!.clientId,
+                clientId: provider.clientId,
                 dataType: 'labels',
             }),
         );
@@ -437,7 +438,7 @@ export const addAccountMetadata =
 
         const providerInstance = dispatch(
             metadataProviderActions.getProviderInstance({
-                clientId: selectSelectedProviderForLabels(getState())!.clientId,
+                clientId: provider.clientId,
                 dataType: 'labels',
             }),
         );
@@ -510,7 +511,8 @@ export const setDeviceMetadataKey =
     };
 
 export const addMetadata =
-    (payload: MetadataAddPayload) => async (dispatch: Dispatch, getState: GetState) => {
+    (payload: MetadataAddPayload) =>
+    async (dispatch: Dispatch, getState: GetState): Promise<boolean> => {
         const result = await dispatch(
             payload.type === 'walletLabel'
                 ? addDeviceMetadata(payload)
@@ -518,35 +520,38 @@ export const addMetadata =
         );
 
         if (!result.success) {
-            if ('code' in result) {
-                console.log(result.code);
-                dispatch(
-                    metadataProviderActions.handleProviderError({
-                        error: result,
-                        action: ProviderErrorAction.SAVE,
-                        clientId: selectSelectedProviderForLabels(getState())!.clientId,
-                    }),
-                );
-            } else {
-                const providerInstance = dispatch(
-                    metadataProviderActions.getProviderInstance({
-                        clientId: selectSelectedProviderForLabels(getState())!.clientId,
-                        dataType: 'labels',
-                    }),
-                );
-                if (providerInstance) {
-                    dispatch(
-                        metadataProviderActions.handleProviderError({
-                            error: providerInstance.error(
-                                'OTHER_ERROR',
-                                'error' in result ? result.error : '',
-                            ),
-                            action: ProviderErrorAction.SAVE,
-                            clientId: selectSelectedProviderForLabels(getState())!.clientId,
+            const provider = selectSelectedProviderForLabels(getState());
+
+            const getErrorFromUnsuccessfulResult = (): MetadataProviderError => {
+                // error from provider
+                if ('code' in result) return result;
+
+                // unknown error, need to generate a custom one from the provider instance
+                if (provider !== undefined) {
+                    const providerInstance = dispatch(
+                        metadataProviderActions.getProviderInstance({
+                            clientId: provider.clientId,
+                            dataType: 'labels',
                         }),
                     );
+                    if (providerInstance) {
+                        const reason = 'error' in result ? result.error : '';
+
+                        return providerInstance.error('OTHER_ERROR', reason);
+                    }
                 }
-            }
+
+                // no provider, or not possible to get its instance
+                return { ...result, code: 'OTHER_ERROR' };
+            };
+
+            dispatch(
+                metadataProviderActions.handleProviderError({
+                    error: getErrorFromUnsuccessfulResult(),
+                    action: ProviderErrorAction.SAVE,
+                    clientId: provider?.clientId,
+                }),
+            );
         }
 
         return result.success;

--- a/packages/suite/src/actions/suite/metadata/metadataProviderThunks.ts
+++ b/packages/suite/src/actions/suite/metadata/metadataProviderThunks.ts
@@ -291,9 +291,11 @@ export const connectProvider =
     };
 
 export const exportMetadataToLocalFile = () => async (dispatch: Dispatch, getState: GetState) => {
+    const provider = selectSelectedProviderForLabels(getState());
+    if (!provider) return;
     const providerInstance = dispatch(
         getProviderInstance({
-            clientId: selectSelectedProviderForLabels(getState())!.clientId,
+            clientId: provider.clientId,
             dataType: 'labels',
         }),
     );


### PR DESCRIPTION
## Description

:warning:  I have not tested this. It's just defensive programming to fix Sentry error, which I don't know how to reproduce.
Likely there is case where you add a label with Labeling on but no provider, and currently it crashes.
Now it will probably do nothing in that situation.

## Notes for QA

As I write above, I'm not sure how this will behave, but I am confident it's not going to make any worse what is currently an unhandled exception.
:point_right:  Please just verify the old labeling still works with any provider – click through various places where you can add label, and then try the same with labeling **on** but **no provider**.
Please make an issue if there's any undefined behavior (add label action doing nothing), though legacy labeling is not highest prio RN.

## Related Issue

[Sentry error in Notion](https://www.notion.so/satoshilabs/TypeError-Cannot-read-properties-of-undefined-reading-clientId-2fbdc526060680e285c0e2886c3ca98f)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/missing-provider-sentry&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/missing-provider-sentry&lookback=7)