### PR TITLE
fix(suite): send missing-provider instead of closed event

### DIFF
--- a/packages/suite/src/actions/suite/metadata/metadataLabelingActions.ts
+++ b/packages/suite/src/actions/suite/metadata/metadataLabelingActions.ts
@@ -635,7 +635,7 @@ export const init =
                 getTypedDesktopAnalytics(extra.services.analytics).report({
                     type: EventType.SettingsGeneralLabelingProvider,
                     payload: {
-                        provider: 'closed',
+                        provider: 'missing-provider',
                     },
                 });
 

--- a/suite/analytics/src/events/settingsGeneralLabelingProviderEvent.ts
+++ b/suite/analytics/src/events/settingsGeneralLabelingProviderEvent.ts
@@ -9,7 +9,6 @@ type Attributes = {
         | 'fileSystem'
         | 'missing-provider'
         | 'inMemoryTest'
-        | 'closed'
         | 'evolu'
         | 'legacy'
         | ''


### PR DESCRIPTION
**changes**:
- when user closes the provider modal, we don't send `closed` analytics val anymore

## Notes for QA

- choose legacy labeling
- dont select the provider and hit `x` at top right corner
- analytics event should send `missing-provider` instead of `closed`

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24864



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/analytics/closed-missing-privider&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/analytics/closed-missing-privider&lookback=7)