### PR TITLE
feat: go to fw installation right from the device select when fw is r…

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
@@ -101,6 +101,12 @@ export const NeedsAttentionBanner = ({
 
     const createOnIssueClickHandler = (): (() => void) | null => {
         switch (deviceStatus) {
+            case 'firmware-required':
+                return () => {
+                    onCancel?.(false);
+                    dispatch(selectDeviceThunk({ device }));
+                    dispatch(goto('firmware-index'));
+                };
             // If onboarding is pending, then it should pass through Manual Device Check.
             case 'initialize': // Wiped device with firmware present.
             case 'bootloader': // Fresh or factory-reset device? Can also be initalized device manually put into BL,
@@ -111,7 +117,6 @@ export const NeedsAttentionBanner = ({
                 };
 
             case 'seedless':
-            case 'firmware-required':
             case 'firmware-corrupted':
             case 'unavailable':
             case 'unreadable':


### PR DESCRIPTION
…equired

This shortcuts the user to go right to the FW update , not over the start screen

## Description

<!--- Describe your changes in detail -->

## Notes for QA

I had troubles replicate a device in the `firware-required` state. I tried to flash older FWs to the older devices. But I still needed to reproduct it with code.

So If you could, put a device in the `firmware-required` state and test that it works as expected. 
Many thanks.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21463

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=21463-fw-installation-auto-jump&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=21463-fw-installation-auto-jump&lookback=7)