### PR TITLE
chore(analytics): add event dashboard/assets-grid-mode-change

### DIFF
--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -1,5 +1,6 @@
 import styled, { useTheme } from 'styled-components';
 
+import { EventType } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { AssetFiatBalance } from '@suite-common/assets';
 import {
@@ -39,6 +40,7 @@ import { setFlag } from 'src/actions/suite/suiteActions';
 import { DashboardSection } from 'src/components/dashboard';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDiscovery, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
+import { useAnalytics } from 'src/support/useAnalytics';
 import { Account } from 'src/types/wallet';
 import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
 
@@ -93,7 +95,7 @@ const useAssetsFiatBalances = (
 export const AssetsView = () => {
     const { dashboardAssetsGridMode } = useSelector(s => s.suite.flags);
     const enabledNetworks = useSelector(selectEnabledNetworks);
-
+    const analytics = useAnalytics();
     const theme = useTheme();
     const dispatch = useDispatch();
     const { isDiscoveryRunning } = useDiscovery();
@@ -176,8 +178,24 @@ export const AssetsView = () => {
         discoveryStatus && discoveryStatus.status === 'exception' && !assetSymbols.length;
 
     const goToCoinsSettings = () => dispatch(goto('settings-coins'));
-    const setTable = () => dispatch(setFlag('dashboardAssetsGridMode', false));
-    const setGrid = () => dispatch(setFlag('dashboardAssetsGridMode', true));
+    const setTable = () => {
+        analytics.report({
+            type: EventType.DashboardAssetsGridModeChange,
+            payload: {
+                layout: 'table',
+            },
+        });
+        dispatch(setFlag('dashboardAssetsGridMode', false));
+    };
+    const setGrid = () => {
+        analytics.report({
+            type: EventType.DashboardAssetsGridModeChange,
+            payload: {
+                layout: 'grid',
+            },
+        });
+        dispatch(setFlag('dashboardAssetsGridMode', true));
+    };
 
     const showCards = isBelowTablet || dashboardAssetsGridMode;
 

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -177,7 +177,12 @@ export const AssetsView = () => {
     const isError =
         discoveryStatus && discoveryStatus.status === 'exception' && !assetSymbols.length;
 
-    const goToCoinsSettings = () => dispatch(goto('settings-coins'));
+    const goToCoinsSettings = () => {
+        analytics.report({
+            type: EventType.DashboardAssetsGoToSettingCoins,
+        });
+        dispatch(goto('settings-coins'));
+    };
     const setTable = () => {
         analytics.report({
             type: EventType.DashboardAssetsGridModeChange,

--- a/suite/analytics/src/constants.ts
+++ b/suite/analytics/src/constants.ts
@@ -10,7 +10,6 @@ export enum AppUpdateEventStatus {
 
 export enum EventType {
     SuiteReady = 'suite-ready',
-    DashboardAssetsGridModeChange = 'dashboard/assets-grid-mode-change',
     RouterLocationChange = 'router/location-change',
     TransportType = 'transport-type',
     AppUpdate = 'app-update',
@@ -18,6 +17,8 @@ export enum EventType {
     AppUriHandler = 'app/uri-handler',
 
     DashboardActions = 'dashboard/actions',
+    DashboardAssetsGridModeChange = 'dashboard/assets-grid-mode-change',
+    DashboardAssetsGoToSettingCoins = 'dashboard/assets-go-to-setting-coins',
     DashboardSendModal = 'dashboard/send-modal',
     DashboardSendModalOptions = 'dashboard/send-modal/options',
     DashboardReceiveModal = 'dashboard/receive-modal',

--- a/suite/analytics/src/constants.ts
+++ b/suite/analytics/src/constants.ts
@@ -10,6 +10,7 @@ export enum AppUpdateEventStatus {
 
 export enum EventType {
     SuiteReady = 'suite-ready',
+    DashboardAssetsGridModeChange = 'dashboard/assets-grid-mode-change',
     RouterLocationChange = 'router/location-change',
     TransportType = 'transport-type',
     AppUpdate = 'app-update',

--- a/suite/analytics/src/events/dashboardAssetsGoToSettingCoinsEvent.ts
+++ b/suite/analytics/src/events/dashboardAssetsGoToSettingCoinsEvent.ts
@@ -1,0 +1,16 @@
+import type { EventDef } from '@suite-common/analytics';
+
+import { EventType } from '../constants';
+
+type Attributes = {};
+
+export const dashboardAssetsGoToSettingCoinsEvent: EventDef<
+    Attributes,
+    EventType.DashboardAssetsGoToSettingCoins
+> = {
+    name: EventType.DashboardAssetsGoToSettingCoins,
+    descriptionTrigger: 'Fired on click on the Activate new coins on the dashboard view.',
+    changelog: [{ version: '26.1.2', notes: 'added' }],
+
+    attributes: {},
+};

--- a/suite/analytics/src/events/dashboardAssetsGridModeChangeEvent.ts
+++ b/suite/analytics/src/events/dashboardAssetsGridModeChangeEvent.ts
@@ -1,0 +1,23 @@
+import type { AttributeDef, EventDef } from '@suite-common/analytics';
+
+import { EventType } from '../constants';
+
+type Attributes = {
+    layout: AttributeDef<'grid' | 'table'>;
+};
+
+export const dashboardAssetsGridModeChangeEvent: EventDef<
+    Attributes,
+    EventType.DashboardAssetsGridModeChange
+> = {
+    name: EventType.DashboardAssetsGridModeChange,
+    descriptionTrigger:
+        'Fired on every change on the asset mode button displayed on the dashboard view.',
+    changelog: [{ version: '26.1.2', notes: 'added' }],
+
+    attributes: {
+        layout: {
+            changelog: [{ version: '26.1.2', notes: 'added' }],
+        },
+    },
+};

--- a/suite/analytics/src/events/index.ts
+++ b/suite/analytics/src/events/index.ts
@@ -16,6 +16,7 @@ export { createReceiveAddressConfirmOnTrezorEvent } from './createReceiveAddress
 export { createReceiveAddressCopyAddressEvent } from './createReceiveAddressCopyAddressEvent';
 export { createReceiveAddressShowAddressEvent } from './createReceiveAddressShowAddressEvent';
 export { dashboardActionsEvent } from './dashboardActionsEvent';
+export { dashboardAssetsGoToSettingCoinsEvent } from './dashboardAssetsGoToSettingCoinsEvent';
 export { dashboardAssetsGridModeChangeEvent } from './dashboardAssetsGridModeChangeEvent';
 export { dashboardReceiveModalEvent } from './dashboardReceiveModalEvent';
 export { dashboardReceiveModalOptionsEvent } from './dashboardReceiveModalOptionsEvent';

--- a/suite/analytics/src/events/index.ts
+++ b/suite/analytics/src/events/index.ts
@@ -16,6 +16,7 @@ export { createReceiveAddressConfirmOnTrezorEvent } from './createReceiveAddress
 export { createReceiveAddressCopyAddressEvent } from './createReceiveAddressCopyAddressEvent';
 export { createReceiveAddressShowAddressEvent } from './createReceiveAddressShowAddressEvent';
 export { dashboardActionsEvent } from './dashboardActionsEvent';
+export { dashboardAssetsGridModeChangeEvent } from './dashboardAssetsGridModeChangeEvent';
 export { dashboardReceiveModalEvent } from './dashboardReceiveModalEvent';
 export { dashboardReceiveModalOptionsEvent } from './dashboardReceiveModalOptionsEvent';
 export { dashboardSendModalEvent } from './dashboardSendModalEvent';


### PR DESCRIPTION
## Description

Adding an analytical event allowing to track clicks on buttons switching the dashboard layout (table / grid).

## Screenshots:
<img width="1192" height="718" alt="Screenshot 2026-02-02 at 14 23 33" src="https://github.com/user-attachments/assets/53c4b50c-96ee-4a91-b1c6-addc9b38d798" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/analytics-add-event-assets-grid-mode-change&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/analytics-add-event-assets-grid-mode-change&lookback=7)