### PR TITLE
refactor(suite-native): simplify usage of requestPrioritizedDeviceAccess

### DIFF
--- a/suite-native/bluetooth/src/hooks/useBluetoothDevice.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothDevice.ts
@@ -39,9 +39,7 @@ export const useBluetoothDevice = () => {
                 return;
             }
 
-            const result = await requestPrioritizedDeviceAccess({
-                deviceCallback: () => TrezorConnect.bleUnpair({}),
-            });
+            const result = await requestPrioritizedDeviceAccess(() => TrezorConnect.bleUnpair({}));
 
             if (!result.success) {
                 return;

--- a/suite-native/device-mutex/jest.config.js
+++ b/suite-native/device-mutex/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('../../jest.config.native');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-native/device-mutex/src/requestDeviceAccess.ts
+++ b/suite-native/device-mutex/src/requestDeviceAccess.ts
@@ -8,15 +8,10 @@ import { DeviceAccessResponse } from './types';
 /**
  * Puts the callback to the end of the queue and waits for its turn to execute.
  */
-export const requestDeviceAccess = async <TParams extends unknown[], TReturnType>({
-    deviceCallback,
-    isPrioritized = false,
-    callbackParams = [] as unknown as TParams,
-}: {
-    deviceCallback: (...args: TParams) => TReturnType;
-    isPrioritized?: boolean;
-    callbackParams?: TParams;
-}): DeviceAccessResponse<TReturnType> => {
+export const requestDeviceAccess = async <TReturnType>(
+    deviceCallback: () => TReturnType,
+    isPrioritized?: boolean,
+): DeviceAccessResponse<TReturnType> => {
     const wasLockSuccessful = await (isPrioritized
         ? deviceAccessMutex.prioritizedLock()
         : deviceAccessMutex.lock());
@@ -26,7 +21,7 @@ export const requestDeviceAccess = async <TParams extends unknown[], TReturnType
 
     try {
         activateKeepAwakeAsync(keepAwakeTag); // Prevents screen from sleeping while app interacts with device.
-        const response = await deviceCallback(...callbackParams);
+        const response = await deviceCallback();
         deviceAccessMutex.unlock();
 
         return { success: true, payload: response };
@@ -42,13 +37,9 @@ export const requestDeviceAccess = async <TParams extends unknown[], TReturnType
 /**
  * Puts the callback to the beginning of the queue to execute the callback with priority.
  */
-export const requestPrioritizedDeviceAccess = <TParams extends unknown[], TReturnType>({
-    deviceCallback,
-    callbackParams = [] as unknown as TParams,
-}: {
-    deviceCallback: (...args: TParams) => TReturnType;
-    callbackParams?: TParams;
-}) => requestDeviceAccess({ deviceCallback, isPrioritized: true, callbackParams });
+export const requestPrioritizedDeviceAccess = <TReturnType>(
+    deviceCallback: () => TReturnType,
+): DeviceAccessResponse<TReturnType> => requestDeviceAccess(deviceCallback, true);
 
 export const clearAndUnlockDeviceAccessQueue = () => {
     deviceAccessMutex.clearQueue();

--- a/suite-native/device-mutex/src/tests/DeviceAccessMutex.test.ts
+++ b/suite-native/device-mutex/src/tests/DeviceAccessMutex.test.ts
@@ -63,9 +63,7 @@ describe('RequestDeviceAccess', () => {
 
         // Put multiple tasks in the queue.
         const queuedTasks = A.makeWithIndex(numberOfTasks, () =>
-            requestDeviceAccess({
-                deviceCallback: deviceAccessCallbackMock,
-            }),
+            requestDeviceAccess(deviceAccessCallbackMock),
         );
 
         let expectedQueueLength = 4;
@@ -90,11 +88,7 @@ describe('RequestDeviceAccess', () => {
         const callbackError = 'Callback failed';
         const mockCallback = jest.fn().mockRejectedValue(callbackError);
 
-        const result = await requestDeviceAccess({
-            deviceCallback: mockCallback,
-            isPrioritized: false,
-            callbackParams: [],
-        });
+        const result = await requestDeviceAccess(mockCallback, false);
 
         expect(result).toEqual({ success: false, error: callbackError });
         expect(deviceAccessMutex.isLocked).toBe(false);
@@ -104,18 +98,12 @@ describe('RequestDeviceAccess', () => {
 describe('RequestPrioritizedDeviceAccess', () => {
     test('prioritized task execution', async () => {
         // Put multiple tasks in the queue.
-        A.makeWithIndex(5, () =>
-            requestDeviceAccess({
-                deviceCallback: deviceAccessCallbackMock,
-            }),
-        );
+        A.makeWithIndex(5, () => requestDeviceAccess(deviceAccessCallbackMock));
 
         expect(deviceAccessMutex.isLocked).toBe(true);
 
         // Execute prioritized task.
-        await requestPrioritizedDeviceAccess({
-            deviceCallback: deviceAccessCallbackMock,
-        });
+        await requestPrioritizedDeviceAccess(deviceAccessCallbackMock);
 
         // The prioritized task should be put at the beginning of the queue, so after its execution,
         // so there should be still the rest of the tasks in the queue.
@@ -130,9 +118,7 @@ describe('clearAndUnlockDeviceAccessQueue', () => {
 
         // Put multiple tasks in the queue.
         const queuedTasks = A.makeWithIndex(numberOfTasks, () =>
-            requestDeviceAccess({
-                deviceCallback: deviceAccessCallbackMock,
-            }),
+            requestDeviceAccess(deviceAccessCallbackMock),
         );
         expect(deviceAccessMutex.isLocked).toBe(true);
 

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -97,13 +97,12 @@ export const createAndBackupWalletThunk = createThunk<
                       }
                     : {};
 
-            const deviceResponse = await requestPrioritizedDeviceAccess({
-                deviceCallback: () =>
-                    TrezorConnect.backupDevice({
-                        ...backupParams,
-                        device: { path: device.path },
-                    }),
-            });
+            const deviceResponse = await requestPrioritizedDeviceAccess(() =>
+                TrezorConnect.backupDevice({
+                    ...backupParams,
+                    device: { path: device.path },
+                }),
+            );
             // error from device-mutex
             if (!deviceResponse.success) return rejectWithValue(deviceResponse.error);
 
@@ -111,16 +110,15 @@ export const createAndBackupWalletThunk = createThunk<
             return fulfillWithValue(deviceResponse.payload);
         }
 
-        const deviceResponse = await requestPrioritizedDeviceAccess({
-            deviceCallback: () =>
-                TrezorConnect.resetDevice({
-                    device: { path: devicePath },
-                    skip_backup: false,
-                    ...getResetDeviceConfig(walletBackupType),
-                    //Entropy check can be toggled via message system config so it should be always last to avoid unintentional disabling.
-                    entropy_check: isEntropyCheckEnabled,
-                }),
-        });
+        const deviceResponse = await requestPrioritizedDeviceAccess(() =>
+            TrezorConnect.resetDevice({
+                device: { path: devicePath },
+                skip_backup: false,
+                ...getResetDeviceConfig(walletBackupType),
+                //Entropy check can be toggled via message system config so it should be always last to avoid unintentional disabling.
+                entropy_check: isEntropyCheckEnabled,
+            }),
+        );
         // error from device-mutex
         if (!deviceResponse.success) return rejectWithValue(deviceResponse.error);
 
@@ -144,9 +142,9 @@ export const recoverWalletThunk = createThunk(
     async (_, { getState }) => {
         const devicePath = selectDevicePath(getState());
 
-        const deviceResponse = await requestPrioritizedDeviceAccess({
-            deviceCallback: () => TrezorConnect.recoveryDevice({ device: { path: devicePath } }),
-        });
+        const deviceResponse = await requestPrioritizedDeviceAccess(() =>
+            TrezorConnect.recoveryDevice({ device: { path: devicePath } }),
+        );
 
         if (!deviceResponse.success) {
             throw new Error(deviceResponse.error);

--- a/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
+++ b/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
@@ -152,15 +152,14 @@ export const useDeviceAuthenticityCheck = () => {
             // Clear previous result
             dispatch(deviceActions.setDeviceAuthenticityResult({ device, result: undefined }));
 
-            const deviceAccessResponse = await requestPrioritizedDeviceAccess({
-                deviceCallback: () =>
-                    TrezorConnect.authenticateDevice({
-                        device: {
-                            path: device.path,
-                        },
-                        allowDebugKeys,
-                    }),
-            });
+            const deviceAccessResponse = await requestPrioritizedDeviceAccess(() =>
+                TrezorConnect.authenticateDevice({
+                    device: {
+                        path: device.path,
+                    },
+                    allowDebugKeys,
+                }),
+            );
 
             if (!deviceAccessResponse.success) {
                 handleDeviceAccessError(deviceAccessResponse.error);

--- a/suite-native/device/src/hooks/usePinAction.tsx
+++ b/suite-native/device/src/hooks/usePinAction.tsx
@@ -88,15 +88,14 @@ export const usePinAction = ({ type, onSuccess, onError }: PinActionProps) => {
 
         const { remove, successMessageKey, canceledMessageKey } = actionConfigMap[type];
 
-        const result = await requestPrioritizedDeviceAccess({
-            deviceCallback: () =>
-                TrezorConnect.changePin({
-                    device: {
-                        path: device?.path,
-                    },
-                    remove,
-                }),
-        });
+        const result = await requestPrioritizedDeviceAccess(() =>
+            TrezorConnect.changePin({
+                device: {
+                    path: device?.path,
+                },
+                remove,
+            }),
+        );
 
         if (!result.success) {
             return;

--- a/suite-native/device/src/hooks/useRetryFwAuthenticityChecks.ts
+++ b/suite-native/device/src/hooks/useRetryFwAuthenticityChecks.ts
@@ -26,9 +26,7 @@ export const useRetryFwAuthenticityChecks = () => {
                 if (deviceAccessMutex.taskQueue.length === 0) {
                     // any device call will cause the tests to be rerun, so getFeatures is used as the most basic one
                     // it'd be useless to await the result; what interests us is the Device state that updates, and gets propagated into redux
-                    requestDeviceAccess({
-                        deviceCallback: () => TrezorConnect.getFeatures(),
-                    });
+                    requestDeviceAccess(() => TrezorConnect.getFeatures());
                 }
                 timeoutHandle = setTimeout(recheckFwRevision, REFRESH_INTERVAL);
             }

--- a/suite-native/device/src/hooks/useWipeDevice.tsx
+++ b/suite-native/device/src/hooks/useWipeDevice.tsx
@@ -36,9 +36,9 @@ export const useWipeDevice = () => {
 
         navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack);
 
-        const response = await requestPrioritizedDeviceAccess({
-            deviceCallback: async () => await dispatch(wipeDeviceThunk()),
-        });
+        const response = await requestPrioritizedDeviceAccess(
+            async () => await dispatch(wipeDeviceThunk()),
+        );
 
         if (response.success && isFulfilled(response.payload)) {
             analytics.report({

--- a/suite-native/firmware/src/hooks/useFirmwareLanguage.ts
+++ b/suite-native/firmware/src/hooks/useFirmwareLanguage.ts
@@ -32,9 +32,9 @@ export const useFirmwareLanguage = () => {
         async (language: Locale) => {
             navigation.navigate(DeviceSettingsStackRoutes.FirmwareLanguageStack);
 
-            const result = await requestPrioritizedDeviceAccess({
-                deviceCallback: () => TrezorConnect.changeLanguage({ language }),
-            });
+            const result = await requestPrioritizedDeviceAccess(() =>
+                TrezorConnect.changeLanguage({ language }),
+            );
 
             if (!result.success) {
                 return;

--- a/suite-native/module-check-backup/src/checkBackupThunks.ts
+++ b/suite-native/module-check-backup/src/checkBackupThunks.ts
@@ -12,15 +12,14 @@ export const checkBackupThunk = createThunk(
 
         if (!device?.features) throw new Error('Device is not ready for check backup.');
 
-        const mutexResponse = await requestPrioritizedDeviceAccess({
-            deviceCallback: () =>
-                TrezorConnect.recoveryDevice({
-                    type: 'DryRun',
-                    device: {
-                        path: device.path,
-                    },
-                }),
-        });
+        const mutexResponse = await requestPrioritizedDeviceAccess(() =>
+            TrezorConnect.recoveryDevice({
+                type: 'DryRun',
+                device: {
+                    path: device.path,
+                },
+            }),
+        );
 
         if (!mutexResponse.success) throw new Error(mutexResponse.error);
 

--- a/suite-native/module-device-onboarding/src/screens/DeviceTutorialScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/DeviceTutorialScreen.tsx
@@ -25,9 +25,9 @@ export const DeviceTutorialScreen = ({
     useFocusEffect(
         useCallback(() => {
             const showTutorial = async () => {
-                await requestPrioritizedDeviceAccess({
-                    deviceCallback: () => TrezorConnect.showDeviceTutorial({ device }),
-                });
+                await requestPrioritizedDeviceAccess(() =>
+                    TrezorConnect.showDeviceTutorial({ device }),
+                );
                 navigation.replace(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
             };
             showTutorial();

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -250,17 +250,16 @@ export const signTradingTransactionThunk = createThunk(
         }: TradingSignAndPushSendFormTransactionProps,
         { dispatch, rejectWithValue, fulfillWithValue },
     ) => {
-        const deviceAccessResponse = await requestPrioritizedDeviceAccess({
-            deviceCallback: () =>
-                dispatch(
-                    signTransactionThunk({
-                        formState,
-                        precomposedTransaction,
-                        selectedAccount,
-                        paymentRequests,
-                    }),
-                ),
-        });
+        const deviceAccessResponse = await requestPrioritizedDeviceAccess(() =>
+            dispatch(
+                signTransactionThunk({
+                    formState,
+                    precomposedTransaction,
+                    selectedAccount,
+                    paymentRequests,
+                }),
+            ),
+        );
 
         if (!deviceAccessResponse.success) {
             return rejectWithValue({

--- a/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
+++ b/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
@@ -47,16 +47,15 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
 
     const verifyAddressOnDevice = useCallback(async (): Promise<boolean> => {
         if (accountKey && freshAddress) {
-            const response = await requestPrioritizedDeviceAccess({
-                deviceCallback: () =>
-                    dispatch(
-                        confirmAddressOnDeviceThunk({
-                            accountKey,
-                            addressPath: freshAddress.path,
-                            chunkify: true,
-                        }),
-                    ).unwrap(),
-            });
+            const response = await requestPrioritizedDeviceAccess(() =>
+                dispatch(
+                    confirmAddressOnDeviceThunk({
+                        accountKey,
+                        addressPath: freshAddress.path,
+                        chunkify: true,
+                    }),
+                ).unwrap(),
+            );
 
             if (!response.success) {
                 // Wasn't able to get access to device

--- a/suite-native/send/src/sendFormThunks.ts
+++ b/suite-native/send/src/sendFormThunks.ts
@@ -74,16 +74,15 @@ export const signTransactionNativeThunk = createThunk<
                 error: 'sign-transaction-failed',
                 message: 'Unable to precompose transaction for signing.',
             });
-        const deviceAccessResponse = await requestPrioritizedDeviceAccess({
-            deviceCallback: () =>
-                dispatch(
-                    signTransactionThunk({
-                        formState,
-                        precomposedTransaction,
-                        selectedAccount: account,
-                    }),
-                ),
-        });
+        const deviceAccessResponse = await requestPrioritizedDeviceAccess(() =>
+            dispatch(
+                signTransactionThunk({
+                    formState,
+                    precomposedTransaction,
+                    selectedAccount: account,
+                }),
+            ),
+        );
 
         if (!deviceAccessResponse.success) {
             return rejectWithValue({


### PR DESCRIPTION
* Unused `callbackParams` argument removed.
* Callback passed directly without a wrapper.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/request-device-access&lookback=7)