### PR TITLE
fix(suite-sync): ignore allowance if quota manager is disabled

### DIFF
--- a/suite-common/suite-sync-quota-manager/src/quotaManagerSelectors.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerSelectors.ts
@@ -21,14 +21,6 @@ export const selectHasOwnerAllowance = (
         owner => owner.walletDescriptor === walletDescriptor,
     ) !== undefined;
 
-// If device has an owner, is registered in quota manager and the owner
-// already has an allowance, there's nothing to refresh — return success.
-export const selectHasDeviceAllowance = (
-    state: WithSuiteSyncQuotaManagerState,
-    deviceId: string,
-    walletDescriptor: WalletDescriptor,
-) => selectIsDeviceRegistered(state, deviceId) && selectHasOwnerAllowance(state, walletDescriptor);
-
 export const selectRegisteredDevices = (state: WithSuiteSyncQuotaManagerState) =>
     state.suiteSyncQuotaManager.registeredDevices;
 
@@ -37,3 +29,17 @@ export const selectOwnersAllowance = (state: WithSuiteSyncQuotaManagerState) =>
 
 export const selectIsQuotaManagerEnabled = (state: WithSuiteSyncQuotaManagerState) =>
     state.suiteSyncQuotaManager.enabled;
+
+export const selectHasDeviceAllowance = (
+    state: WithSuiteSyncQuotaManagerState,
+    deviceId: string,
+    walletDescriptor: WalletDescriptor,
+) => {
+    // Return success - ignore allowance if case quota manager is disabled.
+    if (!selectIsQuotaManagerEnabled(state)) return true;
+
+    return (
+        selectIsDeviceRegistered(state, deviceId) &&
+        selectHasOwnerAllowance(state, walletDescriptor)
+    );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is a hotfix for cases when quota manager is disabled. If it's disabled, the allowance is checked when retrieving suite sync keys and it breaks suite sync. This is a temporary workaround that will be removed after we separate the concerns of quota manager and suite sync key retrieval. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24360



https://github.com/user-attachments/assets/22710e2c-0985-4c5e-a204-e5d5abb65794



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/disconnected-device-with-quota-manager-disabled&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/disconnected-device-with-quota-manager-disabled&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/disconnected-device-with-quota-manager-disabled&lookback=7)