### PR TITLE
Fix lib dependency checks

### DIFF
--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -33,13 +33,13 @@
                 "types": "./lib/index.d.ts"
             },
             "./lib/*": "./lib/*.js",
+            "./lib/data": "./lib/data/index.js",
             "./lib/data/*": "./lib/data/*.js",
+            "./lib/constants": "./lib/constants/index.js",
             "./lib/constants/*": "./lib/constants/*.js",
-            "./lib/types/*": "./lib/types/*.js",
-            "./libESM/*": "./libESM/*.js",
-            "./libESM/constants/*": "./libESM/constants/*.js",
-            "./libESM/data/*": "./libESM/data/*.js",
-            "./libESM/types/*": "./libESM/types/*.js"
+            "./libESM/*": "./libESM/*",
+            "./libESM/constants/*": "./libESM/constants/*",
+            "./libESM/data/*": "./libESM/data/*"
         }
     },
     "scripts": {

--- a/scripts/ci/pack-packages.ts
+++ b/scripts/ci/pack-packages.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import util from 'node:util';
 
-import { exec, getTrezorDependencies } from './helpers';
+import { exec, getPackageDependencies } from './helpers';
 
 const mkdir = util.promisify(fs.mkdir);
 const existsDirectory = util.promisify(fs.exists);
@@ -15,12 +15,12 @@ const __dirname = import.meta.dirname;
 const ROOT_DIR = path.resolve(__dirname, '..', '..');
 const OUTPUT_DIR = path.join(ROOT_DIR, 'tmp/packed-packages');
 
-// Get dependencies for connect.
-const connectDeps = await getTrezorDependencies(ROOT_DIR, 'connect');
-
-const PACKAGES = [...new Set([...connectDeps, 'connect'])];
-
 const buildAllPackages = async () => {
+    // Get dependencies for connect.
+    const connectDeps = (await getPackageDependencies('connect')).update;
+
+    const PACKAGES = [...new Set([...connectDeps, 'connect'])];
+
     if (await existsDirectory(OUTPUT_DIR)) {
         await removeDir(OUTPUT_DIR, { recursive: true });
     }

--- a/scripts/publish/babel-plugin-add-js-extension.js
+++ b/scripts/publish/babel-plugin-add-js-extension.js
@@ -32,7 +32,11 @@ const addJSExtensionPlugin = ({ types }) => {
             const match = src.match(/^@trezor\/([^/]+)\/libESM\/(.+)$/);
             const [, packageName, subpath] = match;
 
-            const packagesRoot = path.resolve(state.filename, '..', '..', '..', '..');
+            // Find packages/ root from the current file's absolute path by locating the libESM/ segment.
+            // e.g., /packages/connect/libESM/device/thp/pairing.js → /packages/
+            const libESMIndex = state.filename.indexOf(`${path.sep}libESM${path.sep}`);
+            const packageDir = state.filename.substring(0, libESMIndex);
+            const packagesRoot = path.dirname(packageDir);
             const resolvedPath = path.join(packagesRoot, packageName, 'libESM', subpath);
 
             const isDirectory =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

5a6aaaa187b4dc4c48f2117277cba1e8f715e631 - With these changes the script for js extension for libESM can now change
when from deeper levels.
34649c638a167b6159b58bd371c121f9eef62c57 - The script was not properly using the method to get dependencies
recursively so it was not getting @trezor dependencies of the 2nd level
dependencies.
97e5a6e09f7858531e09296e7f741472f0828d03 - update exports for new directories in connect-common

## Notes for QA

Nothing to test.

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/23779

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/lib-dependency-checks&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/lib-dependency-checks&lookback=7)