### PR TITLE
Mobile Trade: Always hide keyboard when closing bottom sheet.

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
@@ -39,10 +39,11 @@ export const BuyTradeableAssetPicker = () => {
             setSelectedValue(asset);
             if (shouldFocusInput) {
                 setShouldFocusInput(false);
-                // CryptoAmountInput is rendered disabled allow changes to propagate.
+                // CryptoAmountInput is rendered disabled allow changes to propagate and
+                // allow bottom-sheet to hide first.
                 setTimeout(() => {
                     inputRef.current?.focus();
-                }, 0);
+                }, 300);
             }
         },
         [shouldFocusInput, setSelectedValue],

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
@@ -1,5 +1,4 @@
 import { memo, useCallback } from 'react';
-import { Keyboard } from 'react-native';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { BottomSheetSectionList, ItemRenderConfig } from '@suite-native/trading-atoms';
@@ -44,10 +43,8 @@ export const TradeableAssetSheet = memo(
         testID,
     }: TradeableAssetsSheetProps) => {
         const onAssetSelectCallback = (asset: TradeableAsset) => {
-            // has to be before onAssetSelect callback call to allow focusing another input from it
-            Keyboard.dismiss();
-            onAssetSelect(asset);
             onClose();
+            onAssetSelect(asset);
         };
 
         const listData = useFavouriteAssetsSectionList(assets);

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.comp.test.tsx
@@ -1,5 +1,3 @@
-import { Keyboard } from 'react-native';
-
 import { fireEvent, renderWithStoreProviderAsync, screen } from '@suite-native/test-utils';
 import { adaAsset, btcAsset, usdcAsset } from '@suite-native/trading-fixtures';
 import { TradeableAsset } from '@suite-native/trading-types';
@@ -27,10 +25,9 @@ describe('TradeableAssetSheet', () => {
         screen.unmount();
     });
 
-    it('should call Keyboard.dismiss, onAssetSelect and onClose when an item is pressed', async () => {
+    it('should call onAssetSelect and onClose when an item is pressed', async () => {
         const closeMock = jest.fn();
         const selectMock = jest.fn();
-        const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
         const { getByText } = await renderTradeableAssetsSheet({
             onClose: closeMock,
@@ -39,7 +36,6 @@ describe('TradeableAssetSheet', () => {
 
         fireEvent.press(getByText('BTC'));
 
-        expect(keyboardDismissSpy).toHaveBeenCalledTimes(1);
         expect(selectMock).toHaveBeenCalledTimes(1);
         expect(closeMock).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/trading-atoms/src/hooks/__tests__/useBottomSheetControls.test.ts
+++ b/suite-native/trading-atoms/src/hooks/__tests__/useBottomSheetControls.test.ts
@@ -28,7 +28,7 @@ describe('useBottomSheetControls', () => {
             expect(result.current.isSheetVisible).toBe(true);
         });
 
-        it('should be false after hideTradeableAssetsSheet call and Keyboard.dismiss should be called one time', () => {
+        it('should be false after hideTradeableAssetsSheet call and Keyboard.dismiss should be called two times', () => {
             const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
@@ -37,7 +37,7 @@ describe('useBottomSheetControls', () => {
                 result.current.hideSheet();
             });
 
-            expect(keyboardDismissSpy).toHaveBeenCalledTimes(1);
+            expect(keyboardDismissSpy).toHaveBeenCalledTimes(2);
             expect(result.current.isSheetVisible).toBe(false);
         });
     });

--- a/suite-native/trading-atoms/src/hooks/useBottomSheetControls.ts
+++ b/suite-native/trading-atoms/src/hooks/useBottomSheetControls.ts
@@ -12,6 +12,7 @@ export const useBottomSheetControls = () => {
     }, []);
 
     const hideSheet = useCallback(() => {
+        Keyboard.dismiss();
         setIsSheetVisible(false);
     }, []);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Always hide keyboard when closing any bottom sheet in mobile trading.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #24875


## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24875-stabilize-tradingbuyflow-e2e-test&lookback=7)