### PR TITLE
chore(suite-native): Trading: Improve country list

### DIFF
--- a/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
@@ -23,7 +23,7 @@ describe('Trade Buy [@noDevice]', () => {
         await tradingBuyActions.selectReceiveAsset('BTC');
         await tradingBuyActions.selectBtcReceiveAccount('BTC SegWit', "m/84'/0'/0'/0/0");
         await tradingBuyActions.selectFiatCurrency('PLN');
-        await tradingBuyActions.selectCountry('Polan', '🇵🇱 Poland', '🇵🇱 POL');
+        await tradingBuyActions.selectCountry('Polan', 'Poland', '🇵🇱 POL');
         await tradingBuyActions.setFiatAmount('100');
 
         await tradingBuyActions.scrollToLearnMoreLink();

--- a/suite-native/app/e2e/tests/tradingSellFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingSellFlow.test.ts
@@ -63,7 +63,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Trade Sell', () => {
         });
 
         it('should request trezor connect before preview', async () => {
-            await tradingSellActions.selectCountry('Czechi', '🇨🇿 Czechia', '🇨🇿 CZE');
+            await tradingSellActions.selectCountry('Czechi', 'Czechia', '🇨🇿 CZE');
             await tradingSellActions.selectFiatCurrency('EUR');
             await tradingSellActions.selectSendAsset('USDC');
             await tradingSellActions.setSendCryptoAmount('55');
@@ -101,7 +101,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Trade Sell', () => {
         });
 
         it('Basic sell USDC for EUR', async () => {
-            await tradingSellActions.selectCountry('Czechi', '🇨🇿 Czechia', '🇨🇿 CZE');
+            await tradingSellActions.selectCountry('Czechi', 'Czechia', '🇨🇿 CZE');
             await tradingSellActions.selectFiatCurrency('EUR');
             await tradingSellActions.selectSendAsset('USDC');
             await tradingSellActions.setSendCryptoAmount('55');

--- a/suite-native/trading-residence/src/components/CountrySheet/CountryListItem.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountryListItem.tsx
@@ -1,22 +1,31 @@
-import { ReactNode } from 'react';
 import { Platform, Pressable } from 'react-native';
 import { FadeIn, FadeOut } from 'react-native-reanimated';
 
+import { TradingCountryOption } from '@suite-common/trading';
 import { AnimatedBox, Box, Card, HStack, Radio, Text } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 export type CountryListItemProps = {
-    value: string;
-    label: ReactNode;
     isSelected: boolean;
     onPress: () => void;
-};
+} & TradingCountryOption;
 
 const wrapperStyle = prepareNativeStyle(({ spacings }) => ({
     marginVertical: spacings.sp4,
 }));
 
-export const CountryListItem = ({ label, onPress, value, isSelected }: CountryListItemProps) => {
+const flagStyle = prepareNativeStyle(() => ({
+    fontSize: 20,
+    lineHeight: 24,
+}));
+
+export const CountryListItem = ({
+    name,
+    flag,
+    onPress,
+    value,
+    isSelected,
+}: CountryListItemProps) => {
     const { applyStyle } = useNativeStyles();
     // on android fade animation looks ugly on view with shadows, but without animation it looks even worse
     // do not display shadow on android and keep animating
@@ -27,9 +36,14 @@ export const CountryListItem = ({ label, onPress, value, isSelected }: CountryLi
             <Pressable onPress={onPress} style={applyStyle(wrapperStyle)}>
                 <Card noShadow={noShadow}>
                     <HStack alignItems="center" justifyContent="space-between">
+                        <Box flex={0}>
+                            <Text variant="body" color="textDefault" style={applyStyle(flagStyle)}>
+                                {flag}
+                            </Text>
+                        </Box>
                         <Box flex={1}>
                             <Text variant="body" color="textDefault">
-                                {label}
+                                {name}
                             </Text>
                         </Box>
                         <Box flex={0}>

--- a/suite-native/trading-residence/src/components/CountrySheet/__tests__/CountryListItem.comp.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/__tests__/CountryListItem.comp.test.tsx
@@ -1,29 +1,27 @@
+import { nonSanctionedRegional } from '@suite-common/trading';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { CountryListItem, CountryListItemProps } from '../CountryListItem';
 
 describe('CountryListItem', () => {
+    const usData = nonSanctionedRegional.countriesOptionsMap.get('US')!;
+
     const renderCountryListItem = (props: Partial<CountryListItemProps>) =>
         renderWithBasicProvider(
-            <CountryListItem
-                value="US"
-                isSelected={false}
-                label="🇺🇸 United States of America"
-                onPress={jest.fn()}
-                {...props}
-            />,
+            <CountryListItem isSelected={false} onPress={jest.fn()} {...usData} {...props} />,
         );
-    it('should render given name', () => {
-        const { getByText } = renderCountryListItem({ label: '🇺🇸 United States of America' });
+    it('should render flag and name', () => {
+        const { getByText } = renderCountryListItem({});
 
-        expect(getByText('🇺🇸 United States of America')).toBeTruthy();
+        expect(getByText('🇺🇸')).toBeOnTheScreen();
+        expect(getByText('United States of America')).toBeOnTheScreen();
     });
 
     it('should call onPress callback on item press', () => {
         const onPress = jest.fn();
         const { getByText } = renderCountryListItem({ onPress });
 
-        fireEvent.press(getByText('🇺🇸 United States of America'));
+        fireEvent.press(getByText('🇺🇸'));
 
         expect(onPress).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/trading-residence/src/screens/__tests__/SettingsTradingLocationScreen.comp.test.tsx
+++ b/suite-native/trading-residence/src/screens/__tests__/SettingsTradingLocationScreen.comp.test.tsx
@@ -69,7 +69,7 @@ describe('TradingLocationSettingsScreen', () => {
         const { getByText } = renderTradingLocationSettingsScreen();
 
         await userEvent.press(getByText('Country of residence'));
-        await userEvent.press(getByText('🇦🇷 Argentina'));
+        await userEvent.press(getByText('Argentina'));
 
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({

--- a/suite-native/trading-residence/src/screens/__tests__/TradingLocationModalScreen.comp.test.tsx
+++ b/suite-native/trading-residence/src/screens/__tests__/TradingLocationModalScreen.comp.test.tsx
@@ -82,7 +82,7 @@ describe('TradingLocationModalScreen', () => {
         const { getByText } = renderTradingLocationModalScreen();
 
         await userEvent.press(getByText('Country of residence'));
-        await userEvent.press(getByText('🇦🇷 Argentina'));
+        await userEvent.press(getByText('Argentina'));
 
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
WIP

## Description

Improve country list UI by displaying country flag and name as two separate texts.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #24894


## Screenshots:
### Before and after
<img width="300" alt="before" src="https://github.com/user-attachments/assets/a3c09f23-f2d9-488a-a14d-6681917ca460" />

<img width="300" alt="after" src="https://github.com/user-attachments/assets/13ffab6c-082a-4334-9f75-c31dfd640178" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mobile-trade-emoji-flags&lookback=7)