### PR TITLE
fix(suite): hide trading on coinjoin account for narrow screens

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
@@ -25,7 +25,11 @@ export const HeaderActions = () => {
 
     return (
         <Row gap={12} alignItems="center">
-            <HeaderDropdown isDisabled={isAccountLoading} showSignAndVerify />
+            <HeaderDropdown
+                isDisabled={isAccountLoading}
+                isTradingDisabled={!isTradingAvailable}
+                showSignAndVerify
+            />
 
             {isTradingAvailable && <TradeActions selectedAccount={selectedAccount} />}
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
@@ -25,14 +25,19 @@ type ActionItem = {
 
 type HeaderDropdownProps = {
     isDisabled?: boolean;
+    isTradingDisabled?: boolean;
     showSignAndVerify?: boolean;
 };
-export const HeaderDropdown = ({ isDisabled, showSignAndVerify }: HeaderDropdownProps) => {
+export const HeaderDropdown = ({
+    isDisabled,
+    isTradingDisabled,
+    showSignAndVerify,
+}: HeaderDropdownProps) => {
     const analytics = useAnalytics();
     const goToWithAnalytics = useGoToWithAnalytics();
     const account = useSelector(selectSelectedAccount);
 
-    const isTradingVisible = useConditionalRender({
+    const isBuyVisible = useConditionalRender({
         container: 'content',
         minWidth: breakpoints.laptop,
     });
@@ -72,7 +77,7 @@ export const HeaderDropdown = ({ isDisabled, showSignAndVerify }: HeaderDropdown
             },
             title: <Translation id="TR_TRADING_BUY_AND_SELL" />,
             icon: 'currencyCircleDollar',
-            isHidden: isTradingVisible,
+            isHidden: isBuyVisible || isTradingDisabled,
         },
         {
             id: 'wallet-swap',
@@ -93,7 +98,7 @@ export const HeaderDropdown = ({ isDisabled, showSignAndVerify }: HeaderDropdown
             },
             title: <Translation id="TR_TRADING_SWAP" />,
             icon: 'arrowsLeftRight',
-            isHidden: isSwapVisible,
+            isHidden: isSwapVisible || isTradingDisabled,
         },
     ];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Trading is disabled on coinjoin accounts because it breaks coin anonymity. However, there was a bug causing the trade buttons to be accessible in the dropdown menu that appeared when the screen was narrower.

## Screenshots:

### before
<img width="1174" height="408" alt="image" src="https://github.com/user-attachments/assets/1144bbcf-505f-4d79-bf5f-2872142ce9f9" />


### after
<img width="683" height="99" alt="Screenshot 2026-02-02 at 18 15 35" src="https://github.com/user-attachments/assets/4eca496d-f3f9-4537-99a5-e818bc7a3b26" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/coinjoin-trade&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/coinjoin-trade&lookback=7)