### PR TITLE
chore(ci): use artifacts instead of github cache for android e2e builds

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -112,11 +112,11 @@ jobs:
           docker compose pull trezor-user-env-unix trezor-user-env-regtest
           docker compose up --detach trezor-user-env-unix trezor-user-env-regtest
 
-      - name: Read test .apk from cache
-        uses: actions/cache/restore@v4
+      - name: Download Android build artifact
+        uses: actions/download-artifact@v4
         with:
+          name: android-test-build-${{ github.run_id }}
           path: suite-native/app/android/app/build/
-          key: android_test_build/${{ github.ref }}/${{github.run_id}}
 
       - name: Enable Android emulator KVM optimalization
         run: |

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -153,9 +153,9 @@ jobs:
         working-directory: ./suite-native/app/android/app/build/outputs
         run: aws s3 cp . s3://dev.suite.sldev.cz/suite-mobile/${{ steps.expo-fingerprint.outputs.HASH }}/ --recursive
 
-      - name: Save build to cache
-        uses: actions/cache/save@v4
+      - name: Upload Android build artifact
+        uses: actions/upload-artifact@v4
         with:
-          path: |
-            suite-native/app/android/app/build/
-          key: android_test_build/${{ github.ref }}/${{github.run_id}}
+          name: android-test-build-${{ github.run_id }}
+          path: suite-native/app/android/app/build/
+          retention-days: 1


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Our github cache is always full and it start failing even for two subsequent jobs.




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/android-e2e-build-in-artifacts&lookback=7)