### PR TITLE
 filter icons in explorer

### DIFF
--- a/packages/connect-explorer/.depcheckrc.json
+++ b/packages/connect-explorer/.depcheckrc.json
@@ -8,6 +8,7 @@
         "nextra-theme-docs",
         "// yarn depcheck does not support *.mdx files by default. It may solvable by custom-parser. But it is probably not worth the hassle",
         "remark-gfm",
-        "swr"
+        "swr",
+        "@suite-common/icons"
     ]
 }

--- a/packages/connect-explorer/next.config.mjs
+++ b/packages/connect-explorer/next.config.mjs
@@ -57,6 +57,12 @@ export default withNextra({
                     /@trezor\/connect-web$/,
                     '@trezor/connect-webextension/src/proxy',
                 ),
+                // Replace the full icons bundle with a minimal version containing only used icons
+                // This prevents bundling 2,677 unused SVG files (11MB) into build
+                new webpack.NormalModuleReplacementPlugin(
+                    /@suite-common\/icons\/src\/icons$/,
+                    path.resolve('./src/icons/minimalIcons.ts'),
+                ),
             );
         }
         config.resolve.alias = {

--- a/packages/connect-explorer/src/icons/minimalIcons.ts
+++ b/packages/connect-explorer/src/icons/minimalIcons.ts
@@ -1,0 +1,42 @@
+// Minimal icon set for connect-explorer build
+// This file is type-checked against the full icon set to avoid typos.
+
+import type { IconName as FullIconName } from '@suite-common/icons/src/icons-types';
+
+export const requiredIconNames = [
+    'plus',
+    'x',
+    'check',
+    'xCircle',
+    'question',
+    'caretDown',
+    'bookOpenText',
+    'book',
+    'lightning',
+    'newspaper',
+    'arrowLineUpRight',
+    'githubLogoAlt',
+    'arrowRight',
+    'caretCircleDown',
+] as const satisfies readonly FullIconName[];
+
+export type IconName = (typeof requiredIconNames)[number];
+
+// you might be tempted to build this dynamically based on requiredIconNames but this is not possible
+// webpack won't be able to statically analyze it and it would end up in importing everything again.
+export const icons = {
+    plus: require('../../../../suite-common/icons/assets/plus.svg'),
+    x: require('../../../../suite-common/icons/assets/x.svg'),
+    check: require('../../../../suite-common/icons/assets/check.svg'),
+    xCircle: require('../../../../suite-common/icons/assets/xCircle.svg'),
+    question: require('../../../../suite-common/icons/assets/question.svg'),
+    caretDown: require('../../../../suite-common/icons/assets/caretDown.svg'),
+    bookOpenText: require('../../../../suite-common/icons/assets/bookOpenText.svg'),
+    book: require('../../../../suite-common/icons/assets/book.svg'),
+    lightning: require('../../../../suite-common/icons/assets/lightning.svg'),
+    newspaper: require('../../../../suite-common/icons/assets/newspaper.svg'),
+    arrowLineUpRight: require('../../../../suite-common/icons/assets/arrowLineUpRight.svg'),
+    githubLogoAlt: require('../../../../suite-common/icons/assets/githubLogoAlt.svg'),
+    arrowRight: require('../../../../suite-common/icons/assets/arrowRight.svg'),
+    caretCircleDown: require('../../../../suite-common/icons/assets/caretCircleDown.svg'),
+} satisfies Record<IconName, string>;

--- a/packages/connect-explorer/tsconfig.json
+++ b/packages/connect-explorer/tsconfig.json
@@ -5,6 +5,12 @@
         "lib": ["dom", "dom.iterable", "esnext"],
         "emitDeclarationOnly": false,
         "noEmit": true,
+        "baseUrl": ".",
+        "paths": {
+            "@suite-common/icons/src/icons": [
+                "src/icons/minimalIcons.ts"
+            ]
+        },
         "plugins": [
             { "name": "typescript-styled-plugin" }
         ]

--- a/suite-common/icons/src/icons-types.ts
+++ b/suite-common/icons/src/icons-types.ts
@@ -1,0 +1,3 @@
+// Type-only export to avoid bundling assets in consumers.
+// This file intentionally re-exports the IconName type from the full icon set.
+export type IconName = import('./icons').IconName;


### PR DESCRIPTION
with every build, every CI run, every deploy, we are uploading thousands of never used svg icons. Here my goal is to mitigate it at least for connect explorer. Maybe not the most elegant way but a working one. Or maybe somebody got a better idea? 🤔 

Before 

<img width="462" height="522" alt="image" src="https://github.com/user-attachments/assets/83b644fa-4c31-46f3-865d-f626630cef5d" />

After 
 It still contains some unused coins svgs but you can see that apparantly unused icons are not part of the list
<img width="390" height="473" alt="image" src="https://github.com/user-attachments/assets/64085150-e0e1-4ef6-bf88-2f9dbfa6bc35" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=filter-icons&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=filter-icons&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=filter-icons&lookback=7)