### PR TITLE
fix(suite): amounts in send form modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -129,7 +129,7 @@ const Value = ({ value, type, symbol, token, isFiatVisible, state }: ValueProps)
                 : formatNetworkAmount(value, symbol);
 
             return (
-                <>
+                <Column alignItems="flex-end">
                     <FormattedCryptoAmount
                         data-testid="@modal/crypto-amount"
                         disableHiddenPlaceholder
@@ -148,7 +148,7 @@ const Value = ({ value, type, symbol, token, isFiatVisible, state }: ValueProps)
                             />
                         </Text>
                     )}
-                </>
+                </Column>
             );
         }
         case 'default':


### PR DESCRIPTION
## Notes for QA

Fixed amounts in send form modal

<img width="6014" height="3252" alt="image" src="https://github.com/user-attachments/assets/f8406895-52da-4349-919d-c2e630546b4f" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/send-form-amounts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/send-form-amounts&lookback=7)