### PR TITLE
chore(connect): rename IFRAME.CALL to CORE_CALL

### DIFF
--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -2,9 +2,9 @@ import EventEmitter from 'events';
 
 // NOTE: @trezor/connect part is intentionally not imported from the index so we do include the whole library.
 import {
+    CORE_CALL,
     CallMethodAnyResponse,
     CallMethodPayload,
-    IFRAME,
     POPUP,
     UiResponseEvent,
 } from '@trezor/connect/src/events';
@@ -155,7 +155,7 @@ export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSet
 
             const response = await this.ws.sendMessage(
                 {
-                    type: IFRAME.CALL,
+                    type: CORE_CALL,
                     payload: params,
                 },
                 {

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -2,10 +2,10 @@ import EventEmitter from 'events';
 
 // NOTE: @trezor/connect part is intentionally not imported from the index so we do include the whole library.
 import {
+    CORE_CALL,
     CallMethodAnyResponse,
     CallMethodPayload,
     DEVICE_EVENT,
-    IFRAME,
     POPUP,
     UiResponseEvent,
     createErrorMessage,
@@ -110,7 +110,7 @@ export class CoreInSuiteWeb implements ConnectFactoryDependencies<ConnectSetting
         try {
             // post message to core in popup
             const response = await this._popupManager.channel.postMessage({
-                type: IFRAME.CALL,
+                type: CORE_CALL,
                 payload: params,
             });
             this.logger.debug('call: response: ', response);

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -2,9 +2,9 @@ import EventEmitter from 'events';
 
 // NOTE: @trezor/connect part is intentionally not imported from the index
 import {
+    CORE_CALL,
     CallMethod,
     ConnectSettings,
-    IFRAME,
     Manifest,
     POPUP,
     createErrorMessage,
@@ -87,7 +87,7 @@ const setTransports = () => {
 const call: CallMethod = async (params: any) => {
     try {
         const response = await _channel.postMessage({
-            type: IFRAME.CALL,
+            type: CORE_CALL,
             payload: params,
         });
         if (response) {

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -15,12 +15,12 @@ import type { Device, DeviceEvents } from '../device/Device';
 import { DeviceList, IDeviceList, assertDeviceListConnected } from '../device/DeviceList';
 import * as workflows from '../device/workflow';
 import {
+    CORE_CALL,
     CORE_EVENT,
+    CoreCallMessage,
     CoreEventMessage,
     CoreRequestMessage,
     DEVICE,
-    IFRAME,
-    IFrameCallMessage,
     POPUP,
     RESPONSE_EVENT,
     TransportInfo,
@@ -146,8 +146,8 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
  * @returns {Promise<void>}
  * @memberof Core
  */
-const onCall = async (context: CoreContext, message: IFrameCallMessage) => {
-    if (!message.id || !message.payload || message.type !== IFRAME.CALL) {
+const onCall = async (context: CoreContext, message: CoreCallMessage) => {
+    if (!message.id || !message.payload || message.type !== CORE_CALL) {
         throw ERRORS.TypedError(
             'Method_InvalidParameter',
             'onCall: message.id or message.payload is missing',
@@ -215,7 +215,7 @@ const onCall = async (context: CoreContext, message: IFrameCallMessage) => {
 
 const onCallDevice = async (
     context: CoreContext,
-    message: IFrameCallMessage,
+    message: CoreCallMessage,
     method: AbstractMethod<any>,
 ): Promise<void> => {
     const { deviceList, callMethods, sendCoreMessage } = context;
@@ -775,7 +775,7 @@ export class Core extends EventEmitter {
             }
 
             // message from index
-            case IFRAME.CALL:
+            case CORE_CALL:
                 // firmwareUpdate is the only procedure that expects device disconnecting
                 // and reconnecting during the process. Due to this it can't be handled just
                 // like regular methods using onCall function. In onCall, disconnecting device

--- a/packages/connect/src/core/method.native.ts
+++ b/packages/connect/src/core/method.native.ts
@@ -2,7 +2,7 @@ import { TypedError } from '@trezor/connect-common/src/constants/errors';
 
 import * as Methods from '../api';
 import { MODULES, ModuleName } from '../constants/network';
-import type { IFrameCallMessage } from '../events';
+import type { CoreCallMessage } from '../events';
 
 const moduleMethods = {
     cardano: require('../api/cardano/api'),
@@ -15,11 +15,11 @@ const moduleMethods = {
     tron: require('../api/tron/api'),
 } as const satisfies Record<ModuleName, any>;
 
-const getMethodModule = (method: IFrameCallMessage['payload']['method']) =>
+const getMethodModule = (method: CoreCallMessage['payload']['method']) =>
     MODULES.find(module => method.startsWith(module));
 
 // eslint-disable-next-line require-await
-export const getMethod = async (message: IFrameCallMessage) => {
+export const getMethod = async (message: CoreCallMessage) => {
     const { method } = message.payload;
     if (typeof method !== 'string') {
         throw TypedError('Method_InvalidParameter', 'Message method is not set');

--- a/packages/connect/src/core/method.ts
+++ b/packages/connect/src/core/method.ts
@@ -2,13 +2,13 @@ import { TypedError } from '@trezor/connect-common/src/constants/errors';
 
 import * as Methods from '../api';
 import { MODULES } from '../constants/network';
-import type { IFrameCallMessage } from '../events';
+import type { CoreCallMessage } from '../events';
 import type { AbstractMethod } from './AbstractMethod';
 
-const getMethodModule = (method: IFrameCallMessage['payload']['method']) =>
+const getMethodModule = (method: CoreCallMessage['payload']['method']) =>
     MODULES.find(module => method.startsWith(module));
 
-export const getMethod = async (message: IFrameCallMessage): Promise<AbstractMethod<any>> => {
+export const getMethod = async (message: CoreCallMessage): Promise<AbstractMethod<any>> => {
     const { method } = message.payload;
     if (typeof method !== 'string') {
         throw TypedError('Method_InvalidParameter', 'Message method is not set');

--- a/packages/connect/src/events/call.ts
+++ b/packages/connect/src/events/call.ts
@@ -1,6 +1,6 @@
 import { serializeError } from '@trezor/connect-common/src/constants/errors';
 
-import type { IFRAME } from './iframe';
+import type { CORE_CALL } from './core-call';
 import type { Device } from '../device/Device';
 import type { TrezorConnect } from '../types/api';
 import type { CommonParams, DeviceIdentity } from '../types/params';
@@ -66,9 +66,9 @@ export type CallMethodAnyResponse = ReturnType<CallMethodUnion>;
 
 export type CallMethod = (params: CallMethodPayload) => Promise<any>;
 
-export interface IFrameCallMessage {
+export interface CoreCallMessage {
     id: number;
-    type: typeof IFRAME.CALL;
+    type: typeof CORE_CALL;
     payload: CallMethodPayload;
 }
 

--- a/packages/connect/src/events/core-call.ts
+++ b/packages/connect/src/events/core-call.ts
@@ -1,0 +1,2 @@
+// Request to execute a Connect method in Core
+export const CORE_CALL = 'iframe-call' as const; // Keep old name for backward compatibility.

--- a/packages/connect/src/events/core.ts
+++ b/packages/connect/src/events/core.ts
@@ -1,7 +1,7 @@
 import { ErrorCode, TrezorError } from '@trezor/connect-common/src/constants/errors';
 
 import type { BlockchainEventMessage } from './blockchain';
-import type { IFrameCallMessage, MethodResponseMessage } from './call';
+import type { CoreCallMessage, MethodResponseMessage } from './call';
 import type { DeviceEventMessage } from './device';
 import type { PopupClosedMessage, PopupEventMessage } from './popup';
 import type {
@@ -24,7 +24,7 @@ export type CoreRequestMessage =
     | TransportRequestWebUSBDevice
     | TransportGetInfo
     | UiResponseEvent
-    | IFrameCallMessage;
+    | CoreCallMessage;
 
 export type CoreEventMessage = {
     success?: boolean; // response status in ResponseMessage

--- a/packages/connect/src/events/iframe.ts
+++ b/packages/connect/src/events/iframe.ts
@@ -1,4 +1,0 @@
-export const IFRAME = {
-    // Message from window.opener to core. Call method
-    CALL: 'iframe-call',
-} as const;

--- a/packages/connect/src/events/index.ts
+++ b/packages/connect/src/events/index.ts
@@ -5,7 +5,7 @@ export * from './blockchain';
 export * from './call';
 export * from './core';
 export * from './device';
-export * from './iframe';
+export * from './core-call';
 export * from './popup';
 export * from './transport';
 export * from './ui-promise';

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -6,11 +6,11 @@ import { DeferredManager, cloneObject, createDeferredManager } from '@trezor/uti
 import { parseConnectSettings } from '../data/connectSettings';
 import {
     BLOCKCHAIN_EVENT,
+    CORE_CALL,
     CallMethodPayload,
     CoreEventMessage,
     CoreRequestMessage,
     DEVICE_EVENT,
-    IFRAME,
     POPUP,
     RESPONSE_EVENT,
     TRANSPORT,
@@ -198,7 +198,7 @@ export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsP
             const { promiseId, promise } = this._messagePromises.create();
             const payload = cloneObject<any>(params);
             this.handleCoreMessage({
-                type: IFRAME.CALL,
+                type: CORE_CALL,
                 id: promiseId,
                 payload,
             });

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -5,10 +5,10 @@ import { initCoreState } from './core';
 import { parseConnectSettings } from './data/connectSettings';
 import {
     BLOCKCHAIN_EVENT,
+    CORE_CALL,
     CallMethod,
     CoreEventMessage,
     DEVICE_EVENT,
-    IFRAME,
     POPUP,
     RESPONSE_EVENT,
     TRANSPORT,
@@ -123,7 +123,7 @@ const call: CallMethod = async params => {
     try {
         const { promiseId, promise } = messagePromises.create();
         core.handleMessage({
-            type: IFRAME.CALL,
+            type: CORE_CALL,
             payload: params,
             id: promiseId,
         });

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -2,9 +2,9 @@ import { ipcMain, nativeImage } from 'electron';
 import { WebSocketServer } from 'ws';
 
 import {
+    CORE_CALL,
     ConnectSettings,
-    IFRAME,
-    IFrameCallMessage,
+    CoreCallMessage,
     POPUP,
     PopupClosedMessage,
     PopupHandshake,
@@ -25,7 +25,7 @@ const LOG_PREFIX = 'connect-ws';
  * allowed message from connect-in-suite-desktop implementation
  */
 type IncomingMessage =
-    | (IFrameCallMessage & { id: string })
+    | (CoreCallMessage & { id: string })
     | (PopupHandshake & { id: string })
     | (PopupClosedMessage & { id: string })
     | { type: 'ping'; id: string };
@@ -53,7 +53,7 @@ const validateIncomingMessage = (message: any): message is IncomingMessage => {
     }
 
     // todo: this is incomplete validation
-    if (message.type === IFRAME.CALL && message.payload?.method) {
+    if (message.type === CORE_CALL && message.payload?.method) {
         return true;
     }
 
@@ -166,7 +166,7 @@ export const exposeConnectWs = ({
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
                     error: message.payload?.error,
                 });
-            } else if (message.type === IFRAME.CALL) {
+            } else if (message.type === CORE_CALL) {
                 if (!processOnPort) {
                     // ts check, should be set
                     logger.error(LOG_PREFIX, 'processOnPort result not found');

--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -9,7 +9,13 @@ import {
     queuePopupCall,
     selectConnectPopupCall,
 } from '@suite-common/connect-popup';
-import { CallMethodKeys, IFRAME, POPUP, RESPONSE_EVENT, createPopupMessage } from '@trezor/connect';
+import {
+    CORE_CALL,
+    CallMethodKeys,
+    POPUP,
+    RESPONSE_EVENT,
+    createPopupMessage,
+} from '@trezor/connect';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
@@ -46,10 +52,10 @@ export const useConnectPopupWeb = () => {
                     npmVersion: event.data.payload.settings.version,
                 };
                 setPendingHandshake(event.data.id);
-            } else if (event.data?.type === IFRAME.CALL) {
+            } else if (event.data?.type === CORE_CALL) {
                 if (!manifest.current) {
                     console.warn(
-                        'Connect Popup Web: manifest is not set yet, cannot process IFRAME.CALL',
+                        'Connect Popup Web: manifest is not set yet, cannot process CORE_CALL',
                     );
 
                     return;


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
We already have removed all the iframe but we still have this core event with it's name. This changes the name of the event from `IFRAME` to CORE_CALL and `CoreCallMessage`.

There might be different ideas or opinion to name this event. I am open to any suggestions :) 

## Notes for QA

Nothing to test.

## Related Issue

Resolve <!--- link the issue here -->


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/change-iframe-event-name&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/change-iframe-event-name&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/change-iframe-event-name&lookback=7)