### PR TITLE
Extract allowance modals from trading

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
         "native:prebuild:clean": "yarn workspace @suite-native/app prebuild:clean",
         "native:adhoc": "yarn workspace @suite-native/app build:adhoc",
         "native:reverse-ports": "yarn workspace @suite-native/app reverse-ports",
+        "ws": "./scripts/workspace-run.sh",
         "_______ Aliases _______": "Aliases for longer commands which we often have to run manually. Names don't have to be pretty or make total sense.",
         "refs": "yarn update-project-references",
         "types": "yarn type-check",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -74,6 +74,7 @@
         "@suite/platform-encryption-webauthn": "workspace:*",
         "@suite/suite-sync": "workspace:*",
         "@suite/tx-simulation": "workspace:^",
+        "@tanstack/react-query": "5.90.16",
         "@testing-library/jest-dom": "6.9.1",
         "@trezor/address-validator": "workspace:*",
         "@trezor/analytics-uploader": "workspace:*",

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx
@@ -1,0 +1,42 @@
+import { ProviderMetadata } from 'invity-api';
+import styled from 'styled-components';
+
+import { Translation } from '@suite/intl';
+import { invityAPI } from '@suite-common/trading';
+import { Box, Column, Row, Text } from '@trezor/components';
+import { borders } from '@trezor/theme';
+
+interface AllowanceModalProviderInfoProps {
+    provider: ProviderMetadata;
+    spender: string;
+}
+
+const ProviderLogo = styled.img`
+    flex: none;
+    width: 24px;
+    height: 24px;
+`;
+
+export const AllowanceModalProviderInfo = ({
+    provider,
+    spender,
+}: AllowanceModalProviderInfoProps) => (
+    <Box padding={12} borderWidth={borders.widths.large} borderRadius={borders.radii.sm}>
+        <Column gap={12}>
+            <Text>
+                <Translation id="TR_EXCHANGE_APPROVAL_PROVIDER" />
+            </Text>
+            <Row gap={8}>
+                {provider.logo && (
+                    <ProviderLogo src={invityAPI.getProviderLogoUrl(provider.logo)} alt="" />
+                )}
+                <Column>
+                    {provider.companyName && <Text>{provider.companyName}</Text>}
+                    <Text typographyStyle="hint" variant="tertiary">
+                        {spender}
+                    </Text>
+                </Column>
+            </Row>
+        </Column>
+    </Box>
+);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
@@ -1,0 +1,123 @@
+import { FormProvider } from 'react-hook-form';
+
+import { CryptoId, DexApprovalType, ProviderMetadata } from 'invity-api';
+
+import { Translation } from '@suite/intl';
+import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { Account } from '@suite-common/wallet-types';
+import { Box, Column, Modal, Row } from '@trezor/components';
+import { CoinLogo } from '@trezor/product-components';
+import { borders } from '@trezor/theme';
+
+import { AccountLabeling } from 'src/components/suite/labeling';
+import { Fees } from 'src/components/wallet/Fees/Fees';
+import { useDevice } from 'src/hooks/suite';
+import { useAllowanceModal } from 'src/hooks/wallet/allowance';
+
+import { AllowanceModalProviderInfo } from './AllowanceModalProviderInfo';
+import { ApproveModalTypeSelector } from './ApproveModalTypeSelector';
+
+interface ApproveModalProps {
+    amount: string;
+    cryptoId: CryptoId;
+    account: Account;
+    provider: ProviderMetadata;
+    spender: string;
+    onSelectApprovalType?: (type: DexApprovalType) => void;
+    onConfirm?: () => void;
+    onCancel?: () => void;
+}
+
+export const ApproveModal = (props: ApproveModalProps) => {
+    const { account, provider, spender, cryptoId } = props;
+    const { device } = useDevice();
+    const context = useAllowanceModal({ ...props, type: 'APPROVE' });
+
+    const {
+        inputAmount,
+        feeInfo,
+        token,
+        approvalType,
+        isLoading,
+        composedLevels,
+        data,
+        methods,
+        selectApprovalType,
+        handleClose,
+        handleFeeChange,
+        confirmAndSend,
+    } = context;
+
+    if (!token?.symbol) return null;
+
+    return (
+        <FormProvider {...methods}>
+            <Modal
+                onCancel={handleClose}
+                variant="primary"
+                width={600}
+                heading={
+                    <Translation
+                        id="TR_EXCHANGE_APPROVAL_APPROVE_TOKEN_SPENDING"
+                        values={{ displaySymbol: getDisplaySymbol(token.symbol, token.contract) }}
+                    />
+                }
+                bottomContent={
+                    <>
+                        <Modal.Button
+                            isLoading={isLoading}
+                            isDisabled={!device?.connected}
+                            onClick={confirmAndSend}
+                        >
+                            <Translation id="TR_CONTINUE" />
+                        </Modal.Button>
+
+                        <Modal.Button intent="neutral" priority="secondary" onClick={handleClose}>
+                            <Translation id="TR_CANCEL" />
+                        </Modal.Button>
+                    </>
+                }
+                description={
+                    <Row margin={{ top: 8 }} gap={4}>
+                        <CoinLogo size={20} symbol={account.symbol} />
+                        <AccountLabeling
+                            account={account}
+                            showAccountTypeBadge
+                            accountTypeBadgeSize="small"
+                        />
+                    </Row>
+                }
+                // Disable shadow bottom to make `Fees` component fully visible
+                shadowBottom={false}
+            >
+                <Column gap={12}>
+                    <AllowanceModalProviderInfo spender={spender} provider={provider} />
+                    <ApproveModalTypeSelector
+                        approvalType={approvalType}
+                        isLoading={isLoading}
+                        data={data}
+                        cryptoId={cryptoId}
+                        onSelect={selectApprovalType}
+                        provider={provider}
+                        token={token}
+                        displayAmount={inputAmount}
+                    />
+
+                    <Box
+                        padding={12}
+                        borderWidth={borders.widths.large}
+                        borderRadius={borders.radii.sm}
+                    >
+                        <Fees
+                            label="TR_TX_FEE"
+                            feeInfo={feeInfo}
+                            account={account}
+                            composedLevels={composedLevels}
+                            changeFeeLevel={handleFeeChange}
+                        />
+                    </Box>
+                </Column>
+            </Modal>
+        </FormProvider>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModalTypeSelector.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModalTypeSelector.tsx
@@ -1,0 +1,108 @@
+import { CryptoId, DexApprovalType, ProviderMetadata } from 'invity-api';
+import styled from 'styled-components';
+
+import { Translation } from '@suite/intl';
+import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { AmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
+import { TokenInfo } from '@trezor/blockchain-link-types';
+import { Box, CollapsibleBox, Column, Paragraph, RadioCard, Row, Text } from '@trezor/components';
+import { borders } from '@trezor/theme';
+
+import { DebugOnlyBadge } from 'src/components/suite/DebugOnlyBadge';
+import { useSelector } from 'src/hooks/suite';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
+import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';
+
+interface ApproveModalTypeSelectorProps {
+    approvalType: DexApprovalType;
+    isLoading: boolean;
+    data: string;
+    cryptoId: CryptoId;
+    onSelect: (type: DexApprovalType) => void;
+    provider: ProviderMetadata;
+    token: TokenInfo;
+    displayAmount: AmountSubunit;
+}
+
+const BreakableValue = styled.span`
+    word-break: break-all;
+`;
+
+export const ApproveModalTypeSelector = ({
+    approvalType,
+    isLoading,
+    data,
+    cryptoId,
+    onSelect,
+    provider,
+    token,
+    displayAmount,
+}: ApproveModalTypeSelectorProps) => {
+    const isDebug = useSelector(selectIsDebugModeActive);
+
+    const translationValues = {
+        value: subunitsToUnits({ value: displayAmount, decimals: token.decimals }).toString(),
+        send: token.symbol ? getDisplaySymbol(token.symbol) : '',
+        provider: provider.name,
+    };
+
+    return (
+        <Box borderWidth={borders.widths.large} padding={12} borderRadius={borders.radii.sm}>
+            <Column gap={12}>
+                <Text>
+                    <Translation id="TR_EXCHANGE_APPROVAL_SET_LIMIT" />
+                </Text>
+                <RadioCard
+                    isActive={approvalType === 'INFINITE'}
+                    isDisabled={isLoading}
+                    onClick={() => onSelect('INFINITE')}
+                >
+                    <Row>
+                        <TradingCoinLogo cryptoId={cryptoId} size={20} margin={{ right: 4 }} />
+                        <Text>
+                            <Translation id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE" />
+                        </Text>
+                    </Row>
+                    <Paragraph margin={{ top: 4 }} typographyStyle="hint" variant="tertiary">
+                        <Translation
+                            id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO"
+                            values={translationValues}
+                        />
+                    </Paragraph>
+                </RadioCard>
+                <RadioCard
+                    isActive={approvalType === 'MINIMAL'}
+                    isDisabled={isLoading}
+                    onClick={() => onSelect('MINIMAL')}
+                >
+                    <Row>
+                        <TradingCoinLogo cryptoId={cryptoId} size={20} margin={{ right: 4 }} />
+                        <Text>
+                            <Translation
+                                id="TR_EXCHANGE_APPROVAL_VALUE_MINIMAL"
+                                values={translationValues}
+                            />
+                        </Text>
+                    </Row>
+                    <Paragraph margin={{ top: 4 }} typographyStyle="hint" variant="tertiary">
+                        <Translation
+                            id="TR_EXCHANGE_APPROVAL_VALUE_MINIMAL_INFO"
+                            values={translationValues}
+                        />
+                    </Paragraph>
+                </RadioCard>
+                {isDebug ? (
+                    <CollapsibleBox
+                        heading={
+                            <DebugOnlyBadge>
+                                <Translation id="TR_EXCHANGE_APPROVAL_DATA" />
+                            </DebugOnlyBadge>
+                        }
+                    >
+                        <BreakableValue>{data}</BreakableValue>
+                    </CollapsibleBox>
+                ) : null}
+            </Column>
+        </Box>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx
@@ -1,0 +1,150 @@
+import { FormProvider } from 'react-hook-form';
+
+import { CryptoId, ProviderMetadata } from 'invity-api';
+
+import { Translation } from '@suite/intl';
+import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { Account } from '@suite-common/wallet-types';
+import { Box, Column, Icon, Modal, Row, Text } from '@trezor/components';
+import { CoinLogo } from '@trezor/product-components';
+import { borders } from '@trezor/theme';
+
+import { AccountLabeling } from 'src/components/suite/labeling';
+import { Fees } from 'src/components/wallet/Fees/Fees';
+import { useDevice } from 'src/hooks/suite';
+import { useAllowanceModal } from 'src/hooks/wallet/allowance';
+import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';
+
+import { AllowanceModalProviderInfo } from './AllowanceModalProviderInfo';
+
+interface RevokeModalProps {
+    cryptoId: CryptoId;
+    account: Account;
+    provider: ProviderMetadata;
+    spender: string;
+    preapprovedAmount?: string;
+    onConfirm?: () => void;
+    onCancel?: () => void;
+}
+
+export const RevokeModal = (props: RevokeModalProps) => {
+    const { account, provider, spender, cryptoId, preapprovedAmount } = props;
+    const { device } = useDevice();
+
+    const context = useAllowanceModal({
+        ...props,
+        type: 'REVOKE',
+        amount: '0',
+    });
+
+    const {
+        feeInfo,
+        token,
+        isLoading,
+        composedLevels,
+        methods,
+        handleClose,
+        handleFeeChange,
+        confirmAndSend,
+    } = context;
+
+    if (!token?.symbol) return null;
+
+    const displaySymbol = getDisplaySymbol(token.symbol, token.contract);
+
+    return (
+        <FormProvider {...methods}>
+            <Modal
+                onCancel={handleClose}
+                variant="primary"
+                width={600}
+                heading={
+                    <Translation
+                        id="TR_EXCHANGE_APPROVAL_REVOKE_TOKEN_SPENDING"
+                        values={{ displaySymbol }}
+                    />
+                }
+                bottomContent={
+                    <>
+                        <Modal.Button
+                            isLoading={isLoading}
+                            isDisabled={!device?.connected}
+                            onClick={confirmAndSend}
+                        >
+                            <Translation id="TR_CONTINUE" />
+                        </Modal.Button>
+
+                        <Modal.Button intent="neutral" priority="secondary" onClick={handleClose}>
+                            <Translation id="TR_CANCEL" />
+                        </Modal.Button>
+                    </>
+                }
+                description={
+                    <Row margin={{ top: 8 }} gap={4}>
+                        <CoinLogo size={20} symbol={account.symbol} />
+                        <AccountLabeling
+                            account={account}
+                            showAccountTypeBadge
+                            accountTypeBadgeSize="small"
+                        />
+                    </Row>
+                }
+                shadowBottom={false}
+            >
+                <Column gap={12}>
+                    <AllowanceModalProviderInfo spender={spender} provider={provider} />
+
+                    <Box
+                        borderWidth={borders.widths.large}
+                        padding={12}
+                        borderRadius={borders.radii.sm}
+                    >
+                        <Column gap={12}>
+                            <Row alignItems="flex-start" gap={48}>
+                                <Column gap={12} flex="1" overflow="hidden">
+                                    <Text>
+                                        <Translation id="TR_EXCHANGE_APPROVAL_CURRENT_LIMIT" />
+                                    </Text>
+                                    <Row gap={12}>
+                                        <TradingCoinLogo cryptoId={cryptoId} size={24} />
+                                        <Text>
+                                            {preapprovedAmount ?? '∞'} {displaySymbol}
+                                        </Text>
+                                    </Row>
+                                </Column>
+
+                                <Column alignSelf="center">
+                                    <Icon name="arrowRight" />
+                                </Column>
+
+                                <Column gap={12} flex="1">
+                                    <Text>
+                                        <Translation id="TR_EXCHANGE_APPROVAL_NEW_LIMIT" />
+                                    </Text>
+                                    <Row gap={12}>
+                                        <TradingCoinLogo cryptoId={cryptoId} size={24} />
+                                        <Text>0 {displaySymbol}</Text>
+                                    </Row>
+                                </Column>
+                            </Row>
+                        </Column>
+                    </Box>
+
+                    <Box
+                        padding={12}
+                        borderWidth={borders.widths.large}
+                        borderRadius={borders.radii.sm}
+                    >
+                        <Fees
+                            label="TR_TX_FEE"
+                            feeInfo={feeInfo}
+                            account={account}
+                            composedLevels={composedLevels}
+                            changeFeeLevel={handleFeeChange}
+                        />
+                    </Box>
+                </Column>
+            </Modal>
+        </FormProvider>
+    );
+};

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/EthereumFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/EthereumFeeCards.tsx
@@ -45,8 +45,7 @@ export const EthereumFeeCards = ({ feeOptions }: EthereumFeeCardsProps) => {
     useEffect(() => {
         if (transactionInfo && transactionInfo.type !== 'error' && transactionInfo.feeLimit) {
             setCachedGasLimit(transactionInfo.feeLimit);
-        }
-        if (!isDirty) {
+        } else if (!isDirty) {
             setCachedGasLimit(undefined);
         }
     }, [transactionInfo, isDirty]);

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -1,5 +1,4 @@
 import { Column } from '@trezor/components';
-import { spacings } from '@trezor/theme';
 
 import { Account } from 'src/types/wallet';
 
@@ -33,7 +32,7 @@ export const Fees = ({
     useFetchFees({ networkSymbol });
 
     return (
-        <Column gap={spacings.md} overflow="unset">
+        <Column gap={16} overflow="unset">
             <CollapsibleFees
                 networkType={networkType}
                 networkSymbol={networkSymbol}

--- a/packages/suite/src/hooks/wallet/allowance/index.ts
+++ b/packages/suite/src/hooks/wallet/allowance/index.ts
@@ -1,0 +1,5 @@
+export { AllowanceContext, useAllowanceContext } from './useAllowanceContext';
+export { useAllowance } from './useAllowance';
+export { useAllowanceModal } from './useAllowanceModal';
+
+export type { AllowanceContextValue } from './useAllowanceContext';

--- a/packages/suite/src/hooks/wallet/allowance/useAllowance.ts
+++ b/packages/suite/src/hooks/wallet/allowance/useAllowance.ts
@@ -1,0 +1,19 @@
+import { Account } from '@suite-common/wallet-types';
+
+import { AllowanceContextValue } from './useAllowanceContext';
+import { useAllowanceState } from './useAllowanceState';
+import { useAllowanceTxTracking } from './useAllowanceTxTracking';
+
+interface UseAllowanceParams {
+    account: Account;
+}
+
+export const useAllowance = ({ account }: UseAllowanceParams): AllowanceContextValue => {
+    const tx = useAllowanceTxTracking({ accountKey: account.key });
+    const state = useAllowanceState();
+
+    return {
+        tx,
+        state,
+    };
+};

--- a/packages/suite/src/hooks/wallet/allowance/useAllowanceCompose.ts
+++ b/packages/suite/src/hooks/wallet/allowance/useAllowanceCompose.ts
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { isFulfilled } from '@reduxjs/toolkit';
+import { useMutation } from '@tanstack/react-query';
+
+import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
+import {
+    ComposeAllowanceTransactionThunkParams,
+    composeAllowanceTransactionThunk,
+    selectRawNetworkFeeInfo,
+} from '@suite-common/wallet-core';
+import { Account, FeeLevelLabel, FormState, PrecomposedLevels } from '@suite-common/wallet-types';
+import {
+    buildApprovalTransactionData,
+    getConvertedOrDefaultFeeInfo,
+} from '@suite-common/wallet-utils';
+import { TokenInfo } from '@trezor/blockchain-link-types';
+import { useCurrentRef, useDebounce } from '@trezor/react-utils';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useFees } from 'src/hooks/wallet/form/useFees';
+
+interface UseAllowanceComposeParams {
+    account: Account;
+    contract: string;
+    spender: string;
+    amount: string;
+    token?: TokenInfo;
+}
+
+export const useAllowanceCompose = ({
+    account,
+    contract,
+    spender,
+    amount,
+    token,
+}: UseAllowanceComposeParams) => {
+    const dispatch = useDispatch();
+    const debounce = useDebounce();
+
+    const { networkType, symbol } = account;
+
+    const rawFeeInfo = useSelector(state => selectRawNetworkFeeInfo(state, symbol));
+    const feeInfo = useMemo(
+        () => getConvertedOrDefaultFeeInfo({ networkType, feeInfo: rawFeeInfo }),
+        [networkType, rawFeeInfo],
+    );
+
+    const methods = useForm<FormState>({
+        mode: 'onChange',
+        defaultValues: {
+            ...DEFAULT_VALUES,
+            outputs: [],
+            options: ['broadcast'],
+        },
+    });
+
+    const [composedLevels, setComposedLevels] = useState<PrecomposedLevels | undefined>(undefined);
+    const composeRequestIdRef = useRef(0);
+    const prevFeeInfoBlockHeightRef = useRef<number | null>(null);
+    const methodsRef = useCurrentRef(methods);
+
+    const data = useMemo(
+        () => buildApprovalTransactionData({ amount, spender }),
+        [amount, spender],
+    );
+
+    const { mutate, isPending: isComposing } = useMutation({
+        mutationFn: async () => {
+            composeRequestIdRef.current += 1;
+            const currentRequestId = composeRequestIdRef.current;
+
+            const formValues = methods.getValues();
+            const feeLevel = (formValues.selectedFee ?? 'normal') satisfies FeeLevelLabel;
+
+            const customFee =
+                feeLevel === 'custom'
+                    ? {
+                          feePerUnit: formValues.feePerUnit ?? '',
+                          feeLimit: formValues.feeLimit ?? '',
+                          maxFeePerGas: formValues.maxFeePerGas,
+                          maxPriorityFeePerGas: formValues.maxPriorityFeePerGas,
+                      }
+                    : undefined;
+
+            const thunkParams: ComposeAllowanceTransactionThunkParams = {
+                feeInfo,
+                account,
+                contract,
+                data,
+                selectedFee: feeLevel,
+                customFee,
+            };
+
+            const result = await debounce(() =>
+                dispatch(composeAllowanceTransactionThunk(thunkParams)).then(res =>
+                    isFulfilled(res) ? res.payload : undefined,
+                ),
+            );
+
+            if (currentRequestId !== composeRequestIdRef.current) {
+                return null;
+            }
+
+            return result ? { levels: result as PrecomposedLevels, feeLevel } : null;
+        },
+        onMutate: () => {
+            setComposedLevels(undefined);
+        },
+        onSuccess: result => {
+            if (!result) return;
+
+            const { levels, feeLevel } = result;
+            setComposedLevels(levels);
+
+            const selected = levels[feeLevel];
+            if (selected?.type === 'final' && selected.estimatedFeeLimit) {
+                methods.setValue('estimatedFeeLimit', selected.estimatedFeeLimit, {
+                    shouldDirty: true,
+                });
+            }
+        },
+    });
+
+    const composeRequest = useCallback(
+        (_field?: string) => {
+            mutate();
+        },
+        [mutate],
+    );
+    const composeRequestRef = useCurrentRef(composeRequest);
+
+    const onFeeLevelChange = useCallback(
+        (prev?: string, current?: string) => {
+            if (!current || !composedLevels) return;
+
+            if (current === 'custom') {
+                const prevLevel = composedLevels[prev || 'normal'];
+                setComposedLevels({
+                    ...composedLevels,
+                    custom: prevLevel,
+                });
+            }
+        },
+        [composedLevels],
+    );
+
+    const { changeFeeLevel, selectedFee: formSelectedFee } = useFees({
+        ...methods,
+        defaultValue: 'normal',
+        feeInfo,
+        onChange: onFeeLevelChange,
+        composeRequest,
+        composedLevels,
+    });
+    const selectedFee = formSelectedFee ?? ('normal' satisfies FeeLevelLabel);
+
+    const composedTransaction = useMemo(() => {
+        if (!composedLevels) return undefined;
+
+        const selected = composedLevels[selectedFee];
+
+        return selected?.type === 'final' ? selected : undefined;
+    }, [composedLevels, selectedFee]);
+
+    useEffect(() => {
+        methodsRef.current.setValue('transactionData', data, { shouldDirty: true });
+    }, [data, methodsRef]);
+
+    useEffect(() => {
+        methodsRef.current.setValue(
+            'outputs',
+            [
+                {
+                    ...DEFAULT_PAYMENT,
+                    address: contract,
+                    amount: '0',
+                    token: token?.contract ?? null,
+                },
+            ],
+            { shouldDirty: true },
+        );
+    }, [contract, token?.contract, methodsRef]);
+
+    useEffect(() => {
+        if (prevFeeInfoBlockHeightRef.current === null) {
+            prevFeeInfoBlockHeightRef.current = feeInfo.blockHeight;
+
+            return;
+        }
+
+        if (feeInfo.blockHeight > prevFeeInfoBlockHeightRef.current && composedLevels) {
+            prevFeeInfoBlockHeightRef.current = feeInfo.blockHeight;
+
+            composeRequestRef.current();
+        }
+    }, [composedLevels, feeInfo.blockHeight, composeRequestRef]);
+
+    return {
+        data,
+        feeInfo,
+        isComposing,
+        composedLevels,
+        composedTransaction,
+        selectedFee,
+        composeRequest,
+        methods,
+        changeFeeLevel,
+    };
+};

--- a/packages/suite/src/hooks/wallet/allowance/useAllowanceContext.ts
+++ b/packages/suite/src/hooks/wallet/allowance/useAllowanceContext.ts
@@ -1,0 +1,21 @@
+import { createContext, useContext } from 'react';
+
+import { useAllowanceState } from './useAllowanceState';
+import { useAllowanceTxTracking } from './useAllowanceTxTracking';
+
+export interface AllowanceContextValue {
+    tx: ReturnType<typeof useAllowanceTxTracking>;
+    state: ReturnType<typeof useAllowanceState>;
+}
+
+export const AllowanceContext = createContext<AllowanceContextValue | null>(null);
+AllowanceContext.displayName = 'AllowanceContext';
+
+export const useAllowanceContext = () => {
+    const context = useContext(AllowanceContext);
+    if (context === null) {
+        throw new Error('useAllowanceContext must be used within AllowanceContext.Provider');
+    }
+
+    return context;
+};

--- a/packages/suite/src/hooks/wallet/allowance/useAllowanceModal.ts
+++ b/packages/suite/src/hooks/wallet/allowance/useAllowanceModal.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { CryptoId, DexApprovalType } from 'invity-api';
+
+import { parseCryptoId } from '@suite-common/trading';
+import { Account, AllowanceType } from '@suite-common/wallet-types';
+import { asAmountSubunit, findToken, getAllowanceAmount } from '@suite-common/wallet-utils';
+import { useCurrentRef } from '@trezor/react-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { useAllowanceCompose } from './useAllowanceCompose';
+import { useAllowanceContext } from './useAllowanceContext';
+import { useAllowanceSend } from './useAllowanceSend';
+
+interface UseAllowanceModalProps {
+    type: AllowanceType;
+    amount: string;
+    cryptoId: CryptoId;
+    account: Account;
+    spender: string;
+    onSelectApprovalType?: (type: DexApprovalType) => void;
+    onConfirm?: () => void;
+    onCancel?: () => void;
+}
+
+export const useAllowanceModal = ({
+    type,
+    amount: rawAmount,
+    cryptoId,
+    account,
+    spender,
+    onSelectApprovalType,
+    onConfirm,
+    onCancel,
+}: UseAllowanceModalProps) => {
+    const { state, tx } = useAllowanceContext();
+    const closeModal = type === 'REVOKE' ? state.closeRevokeModal : state.closeApproveModal;
+    const [approvalType, setApprovalType] = useState<DexApprovalType>(
+        type === 'REVOKE' ? 'ZERO' : 'MINIMAL',
+    );
+
+    const { contractAddress: contract = '' } = parseCryptoId(cryptoId);
+    const token = findToken(account.tokens, contract);
+
+    const { inputAmount = asAmountSubunit(new BigNumber(0)), allowanceAmount = '0' } = token
+        ? getAllowanceAmount({ rawAmount, approvalType, token })
+        : {};
+
+    const {
+        data,
+        feeInfo,
+        isComposing,
+        composedLevels,
+        composedTransaction,
+        selectedFee,
+        composeRequest,
+        methods,
+        changeFeeLevel,
+    } = useAllowanceCompose({
+        account,
+        amount: allowanceAmount,
+        contract,
+        spender,
+        token,
+    });
+
+    const { send } = useAllowanceSend({
+        account,
+        methods,
+    });
+
+    const composeRequestRef = useCurrentRef(composeRequest);
+    const onSelectApprovalTypeRef = useCurrentRef(onSelectApprovalType);
+    const onConfirmRef = useCurrentRef(onConfirm);
+    const onCancelRef = useCurrentRef(onCancel);
+
+    useEffect(() => {
+        composeRequestRef.current();
+    }, [allowanceAmount, composeRequestRef]);
+
+    const selectApprovalType = useCallback(
+        (type: DexApprovalType) => {
+            setApprovalType(type);
+            onSelectApprovalTypeRef.current?.(type);
+        },
+        [onSelectApprovalTypeRef],
+    );
+
+    const confirmAndSend = useCallback(async () => {
+        if (!composedTransaction) return;
+
+        onConfirmRef.current?.();
+        closeModal();
+        state.setIsWaitingForDevice(true);
+
+        try {
+            const result = await send({ composedTransaction });
+
+            if (result?.txid) {
+                tx.setApprovalTxid(result.txid);
+            }
+        } finally {
+            state.setIsWaitingForDevice(false);
+        }
+    }, [composedTransaction, send, state, tx, closeModal, onConfirmRef]);
+
+    const handleClose = useCallback(() => {
+        closeModal();
+        onCancelRef.current?.();
+    }, [closeModal, onCancelRef]);
+
+    return {
+        approvalType,
+        isLoading: isComposing,
+        allowanceAmount,
+        inputAmount,
+        token,
+        feeInfo,
+        composedLevels,
+        composedTransaction,
+        selectedFee,
+        data,
+        methods,
+        selectApprovalType,
+        confirmAndSend,
+        handleClose,
+        handleFeeChange: changeFeeLevel,
+    };
+};

--- a/packages/suite/src/hooks/wallet/allowance/useAllowanceSend.ts
+++ b/packages/suite/src/hooks/wallet/allowance/useAllowanceSend.ts
@@ -1,0 +1,56 @@
+import { useCallback } from 'react';
+import { UseFormReturn } from 'react-hook-form';
+
+import { Account, FormState, PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { useCurrentRef } from '@trezor/react-utils';
+
+import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sendFormThunks';
+import { useDispatch } from 'src/hooks/suite';
+
+interface UseAllowanceSendParams {
+    account: Account;
+    methods: UseFormReturn<FormState>;
+}
+
+interface SendParams {
+    composedTransaction: PrecomposedTransactionFinal;
+}
+
+export const useAllowanceSend = ({ account, methods }: UseAllowanceSendParams) => {
+    const dispatch = useDispatch();
+    const methodsRef = useCurrentRef(methods);
+    const accountRef = useCurrentRef(account);
+
+    const send = useCallback(
+        async ({ composedTransaction }: SendParams): Promise<{ txid: string } | null> => {
+            const formState: FormState = methodsRef.current.getValues();
+
+            const result = await dispatch(
+                signAndPushSendFormTransactionThunk({
+                    formState,
+                    precomposedTransaction: composedTransaction,
+                    selectedAccount: accountRef.current,
+                }),
+            ).unwrap();
+
+            if (!result) {
+                return null;
+            }
+
+            const { payload } = result;
+
+            if ('txid' in payload) {
+                return { txid: payload.txid };
+            }
+
+            if ('error' in payload) {
+                throw new Error(payload.error);
+            }
+
+            return null;
+        },
+        [dispatch, methodsRef, accountRef],
+    );
+
+    return { send };
+};

--- a/packages/suite/src/hooks/wallet/allowance/useAllowanceState.ts
+++ b/packages/suite/src/hooks/wallet/allowance/useAllowanceState.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from 'react';
+
+import { AllowanceType } from '@suite-common/wallet-types';
+
+export const useAllowanceState = () => {
+    const [approvalType, setApprovalType] = useState<AllowanceType>('APPROVE');
+    const [isWaitingForDevice, setIsWaitingForDevice] = useState(false);
+
+    const [isApproveModalOpen, setIsApproveModalOpen] = useState(false);
+    const [isRevokeModalOpen, setIsRevokeModalOpen] = useState(false);
+
+    const openApproveModal = useCallback(() => setIsApproveModalOpen(true), []);
+    const closeApproveModal = useCallback(() => setIsApproveModalOpen(false), []);
+    const openRevokeModal = useCallback(() => setIsRevokeModalOpen(true), []);
+    const closeRevokeModal = useCallback(() => setIsRevokeModalOpen(false), []);
+
+    return {
+        approvalType,
+        isWaitingForDevice,
+        setApprovalType,
+        setIsWaitingForDevice,
+        isApproveModalOpen,
+        isRevokeModalOpen,
+        openApproveModal,
+        closeApproveModal,
+        openRevokeModal,
+        closeRevokeModal,
+    };
+};

--- a/packages/suite/src/hooks/wallet/allowance/useAllowanceTxTracking.ts
+++ b/packages/suite/src/hooks/wallet/allowance/useAllowanceTxTracking.ts
@@ -1,0 +1,51 @@
+import { useMemo, useState } from 'react';
+
+import { selectTransactionByAccountKeyAndTxid } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
+import { isPending } from '@suite-common/wallet-utils';
+
+import { useSelector } from 'src/hooks/suite';
+
+interface UseAllowanceTxTrackingParams {
+    accountKey: AccountKey;
+}
+
+interface TransactionStatus {
+    isPending: boolean;
+    isConfirmed: boolean;
+    isFailed: boolean;
+}
+
+export const useAllowanceTxTracking = ({ accountKey }: UseAllowanceTxTrackingParams) => {
+    const [approvalTxid, setApprovalTxid] = useState<string | null>(null);
+
+    const transaction = useSelector(state =>
+        approvalTxid ? selectTransactionByAccountKeyAndTxid(state, accountKey, approvalTxid) : null,
+    );
+
+    const status = useMemo<TransactionStatus>(() => {
+        if (!transaction) {
+            return {
+                isPending: false,
+                isConfirmed: false,
+                isFailed: false,
+            };
+        }
+
+        const pending = isPending(transaction);
+        const failed = !pending && transaction.type === 'failed';
+        const confirmed = !pending && !failed;
+
+        return {
+            isPending: pending,
+            isConfirmed: confirmed,
+            isFailed: failed,
+        };
+    }, [transaction]);
+
+    return {
+        approvalTxid,
+        status,
+        setApprovalTxid,
+    };
+};

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeCryptoAndProviderInfo.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeCryptoAndProviderInfo.ts
@@ -24,7 +24,7 @@ export const useTradingExchangeCryptoAndProviderInfo = () => {
             receiveCryptoNetworkSymbol: receiveCryptoSelect?.networkSymbol,
             receiveCryptoContractAddress: receiveCryptoSelect?.contractAddress ?? undefined,
 
-            providerName: quoteProviderName,
+            exchangeName: quoteProviderName,
             selectedFee,
         };
     }, [

--- a/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
+++ b/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
@@ -1,6 +1,11 @@
 import { ConnectPopupState } from '@suite-common/connect-popup';
 import { TradingState } from '@suite-common/trading';
-import { AccountsRootState, accountsActions, selectAccountByKey } from '@suite-common/wallet-core';
+import {
+    AccountsRootState,
+    SendRootState,
+    accountsActions,
+    selectAccountByKey,
+} from '@suite-common/wallet-core';
 import type { SelectedAccountStatus } from '@suite-common/wallet-types';
 
 import type { Action } from 'src/types/suite';
@@ -13,12 +18,13 @@ export type SelectedAccountRootState = {
     };
 } & AccountsRootState;
 
-export type SelectedAccountRootStateWithTrading = SelectedAccountRootState & {
-    wallet: {
-        trading: TradingState;
+export type SelectedAccountRootStateWithTrading = SelectedAccountRootState &
+    SendRootState & {
+        wallet: {
+            trading: TradingState;
+        };
+        connectPopup: ConnectPopupState;
     };
-    connectPopup: ConnectPopupState;
-};
 
 export const initialState: State = {
     status: 'none',
@@ -48,13 +54,17 @@ export const selectIsSelectedAccountLoaded = (state: SelectedAccountRootState) =
 
 /**
  * Mainly used for common modals, also used in the Trading section.
- * @returns account from trading if it's set, otherwise account from the store
+ * @returns account from send state if set, then trading if set, otherwise account from the store
  */
 export const selectAccountIncludingChosenInTrading = (
     state: SelectedAccountRootStateWithTrading,
 ) => {
-    const { modalAccountKey } = state.wallet.trading;
+    const sendAccountKey = state.wallet.send.accountKey;
+    if (sendAccountKey) {
+        return selectAccountByKey(state, sendAccountKey) ?? undefined;
+    }
 
+    const { modalAccountKey } = state.wallet.trading;
     if (modalAccountKey) {
         return selectAccountByKey(state, modalAccountKey) ?? undefined;
     }

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx
@@ -1,0 +1,120 @@
+import { useCallback, useMemo } from 'react';
+
+import { CryptoId, DexApprovalType } from 'invity-api';
+
+import { events } from '@suite/analytics';
+import { getEvmApprovalTxData } from '@suite-common/wallet-utils';
+import { useCurrentRef } from '@trezor/react-utils';
+
+import { ApproveModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal';
+import { useAllowanceContext } from 'src/hooks/wallet/allowance';
+import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { useTradingExchangeCryptoAndProviderInfo } from 'src/hooks/wallet/trading/form/useTradingExchangeCryptoAndProviderInfo';
+import { useAnalytics } from 'src/support/useAnalytics';
+import {
+    getProvidersInfoProps,
+    isTradingExchangeContext,
+} from 'src/utils/wallet/trading/tradingTypingUtils';
+
+interface TradingApproveModalProps {
+    amount: string;
+    cryptoId: CryptoId;
+}
+
+export const TradingApproveModal = ({ amount, cryptoId }: TradingApproveModalProps) => {
+    const { state } = useAllowanceContext();
+    const context = useTradingFormContext();
+    const analytics = useAnalytics();
+    const getCryptoInfo = useTradingExchangeCryptoAndProviderInfo();
+
+    const contextRef = useCurrentRef(context);
+    const getCryptoInfoRef = useCurrentRef(getCryptoInfo);
+
+    const handleCancel = useCallback(async () => {
+        analytics.report({
+            type: events.tradeApprovalEvent.name,
+            payload: {
+                type: 'approve-modal',
+                action: 'cancel',
+                ...getCryptoInfoRef.current(),
+            },
+        });
+
+        const ctx = contextRef.current;
+        if (isTradingExchangeContext(ctx)) {
+            ctx.setIsApproval(false);
+
+            if (ctx.selectedQuote?.receiveAddress) {
+                await ctx.confirmApproval({
+                    trade: { ...ctx.selectedQuote, approvalType: undefined },
+                    receiveAddress: ctx.selectedQuote.receiveAddress,
+                });
+            }
+        }
+    }, [analytics, getCryptoInfoRef, contextRef]);
+
+    const onConfirm = useCallback(() => {
+        analytics.report({
+            type: events.tradeApprovalEvent.name,
+            payload: {
+                type: 'approve-modal',
+                action: 'continue',
+                ...getCryptoInfoRef.current(),
+            },
+        });
+    }, [analytics, getCryptoInfoRef]);
+
+    const onSelectApprovalType = useCallback(
+        (approvalType: DexApprovalType) => {
+            if (approvalType !== 'MINIMAL' && approvalType !== 'INFINITE') return;
+
+            analytics.report({
+                type: events.tradeApprovalEvent.name,
+                payload: {
+                    type: 'approve-modal',
+                    action: approvalType === 'MINIMAL' ? 'limit-exact' : 'limit-unlimited',
+                    ...getCryptoInfoRef.current(),
+                },
+            });
+        },
+        [analytics, getCryptoInfoRef],
+    );
+
+    const selectedQuote = isTradingExchangeContext(context) ? context.selectedQuote : undefined;
+
+    const approveParams = useMemo(() => {
+        const ctx = contextRef.current;
+        if (!isTradingExchangeContext(ctx)) {
+            return null;
+        }
+
+        const providersInfo = getProvidersInfoProps(ctx);
+        const exchange = selectedQuote?.exchange;
+        const provider = exchange ? providersInfo?.[exchange] : null;
+
+        const approvalData = getEvmApprovalTxData(selectedQuote?.dexTx?.data);
+        const spender = approvalData?.spender ?? null;
+
+        return {
+            provider,
+            spender,
+        };
+    }, [selectedQuote, contextRef]);
+
+    const { provider, spender } = approveParams ?? {};
+
+    if (!state.isApproveModalOpen || !provider || !spender) return null;
+
+    return (
+        <ApproveModal
+            amount={amount}
+            cryptoId={cryptoId}
+            account={context.account}
+            provider={provider}
+            spender={spender}
+            onSelectApprovalType={onSelectApprovalType}
+            onConfirm={onConfirm}
+            onCancel={handleCancel}
+        />
+    );
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { usePrevious } from 'react-use';
 
 import styled, { DefaultTheme, keyframes } from 'styled-components';
 
@@ -11,17 +10,17 @@ import {
     useTradingUtils,
 } from '@suite-common/trading';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { AllowanceType } from '@suite-common/wallet-types';
 import { Banner, Button, Column, Icon, Link, Paragraph, Row } from '@trezor/components';
-import { spacings } from '@trezor/theme';
+import { useCurrentRef } from '@trezor/react-utils';
 
 import { openModal } from 'src/actions/suite/modalActions';
 import { Address } from 'src/components/suite/Address';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useAllowanceContext } from 'src/hooks/wallet/allowance';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingExchangeCryptoAndProviderInfo } from 'src/hooks/wallet/trading/form/useTradingExchangeCryptoAndProviderInfo';
-import { useTradingExchangeWatchApproval } from 'src/hooks/wallet/trading/form/useTradingExchangeWatchApproval';
 import { useAnalytics } from 'src/support/useAnalytics';
-import { TradingExchangeApprovalType } from 'src/types/trading/tradingForm';
 
 const TextButton = styled.div<{ $disabled: boolean }>`
     color: ${({ theme, $disabled }) =>
@@ -56,33 +55,17 @@ const IconWrapper = styled.div`
 
 type ApprovalStep = 'REQUIRED' | 'APPROVED' | 'LOADING' | 'ERROR';
 
-interface TradingFormApprovalProps {
-    openApproveModal: () => void;
-    openRevokeModal: () => void;
-    isWaitingForDevice: boolean;
-    approvalType: TradingExchangeApprovalType;
-    setApprovalType: (approvalType: TradingExchangeApprovalType) => void;
-    isManuallyApproved: boolean;
-    setIsManuallyApproved: (value: boolean) => void;
-}
-
-export const TradingFormApproval = ({
-    openApproveModal,
-    openRevokeModal,
-    isWaitingForDevice,
-    approvalType,
-    setApprovalType,
-    setIsManuallyApproved,
-}: TradingFormApprovalProps) => {
+export const TradingFormApproval = () => {
     const context = useTradingFormContext<TradingExchangeType>();
     const dispatch = useDispatch();
     const analytics = useAnalytics();
+
+    const { tx, state: allowanceState } = useAllowanceContext();
 
     const {
         selectQuote,
         approveTransaction,
         revokeApproval,
-        watchApproval,
         refreshQuotes,
         confirmApproval,
         resetSelectedOffer,
@@ -97,8 +80,9 @@ export const TradingFormApproval = ({
 
     const getCryptoInfo = useTradingExchangeCryptoAndProviderInfo();
 
+    const refreshQuotesRef = useCurrentRef(refreshQuotes);
+
     const currentQuoteStatus = selectedQuote?.status;
-    const previousQuoteStatus = usePrevious(currentQuoteStatus);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const [isApproveButtonLoading, setIsApproveButtonLoading] = useState(false);
@@ -106,89 +90,58 @@ export const TradingFormApproval = ({
     const [isSwapButtonLoading, setIsSwapButtonLoading] = useState(false);
     const [isRefreshButtonLoading, setIsRefreshButtonLoading] = useState(false);
 
-    const [approvalStep, setApprovalStep] = useState<ApprovalStep>();
-
-    useTradingExchangeWatchApproval({
-        selectedQuote,
-        watchApproval,
-    });
+    const [approvalStep, setApprovalStep] = useState<ApprovalStep | undefined>();
 
     const { cryptoIdToSymbolAndContractAddress } = useTradingUtils();
 
+    const [txApprovalType, setTxApprovalType] = useState<AllowanceType | null>(null);
+
     useEffect(() => {
+        if (tx.approvalTxid && tx.status.isPending && !txApprovalType) {
+            setTxApprovalType(allowanceState.approvalType);
+        }
+    }, [tx.approvalTxid, tx.status.isPending, allowanceState.approvalType, txApprovalType]);
+
+    useEffect(() => {
+        if (!tx.approvalTxid) return;
+
+        if (tx.status.isPending) {
+            setApprovalStep('LOADING');
+
+            return;
+        }
+
+        if (tx.status.isFailed) {
+            setApprovalStep('REQUIRED');
+
+            return;
+        }
+
+        if (tx.status.isConfirmed && txApprovalType) {
+            setApprovalStep(txApprovalType === 'APPROVE' ? 'APPROVED' : 'REQUIRED');
+
+            refreshQuotesRef.current().finally(() => {
+                tx.setApprovalTxid(null);
+                setTxApprovalType(null);
+            });
+        }
+    }, [tx, txApprovalType, refreshQuotesRef]);
+
+    useEffect(() => {
+        if (tx.approvalTxid) return;
+
         if (currentQuoteStatus === 'ERROR') {
             return setApprovalStep('ERROR');
         }
 
-        if (previousQuoteStatus === undefined || previousQuoteStatus === 'ERROR') {
-            if (currentQuoteStatus === 'APPROVAL_REQ') {
-                return setApprovalStep('REQUIRED');
-            }
-
-            if (currentQuoteStatus === 'CONFIRM') {
-                return setApprovalStep('APPROVED');
-            }
-
-            if (currentQuoteStatus === 'SIGN_DATA') {
-                return setApprovalStep('APPROVED');
-            }
-
-            if (currentQuoteStatus === 'APPROVAL_PENDING') {
-                return setApprovalStep('LOADING');
-            }
-        }
-
-        if (previousQuoteStatus === 'APPROVAL_REQ' && currentQuoteStatus === 'CONFIRM') {
-            return setApprovalStep('APPROVED');
-        }
-
-        if (previousQuoteStatus === 'CONFIRM' && currentQuoteStatus === 'APPROVAL_REQ') {
+        if (currentQuoteStatus === 'APPROVAL_REQ') {
             return setApprovalStep('REQUIRED');
         }
 
-        if (previousQuoteStatus === 'APPROVAL_REQ' && currentQuoteStatus === 'APPROVAL_PENDING') {
-            return setApprovalStep('LOADING');
+        if (currentQuoteStatus === 'CONFIRM' || currentQuoteStatus === 'SIGN_DATA') {
+            return setApprovalStep('APPROVED');
         }
-
-        if (previousQuoteStatus === 'CONFIRM' && currentQuoteStatus === 'APPROVAL_PENDING') {
-            return setApprovalStep('LOADING');
-        }
-
-        if (
-            previousQuoteStatus === 'APPROVAL_PENDING' &&
-            currentQuoteStatus !== 'APPROVAL_PENDING'
-        ) {
-            refreshQuotes();
-        }
-
-        if (previousQuoteStatus === 'APPROVAL_PENDING' && currentQuoteStatus === 'CONFIRM') {
-            setIsManuallyApproved(true);
-
-            if (approvalType === 'REVOKE') {
-                return setApprovalStep('REQUIRED');
-            }
-
-            if (approvalType === 'APPROVE') {
-                return setApprovalStep('APPROVED');
-            }
-        }
-
-        if (previousQuoteStatus === 'APPROVAL_PENDING' && currentQuoteStatus === 'SIGN_DATA') {
-            if (approvalType === 'REVOKE') {
-                return setApprovalStep('REQUIRED');
-            }
-
-            if (approvalType === 'APPROVE') {
-                return setApprovalStep('APPROVED');
-            }
-        }
-    }, [
-        currentQuoteStatus,
-        previousQuoteStatus,
-        approvalType,
-        refreshQuotes,
-        setIsManuallyApproved,
-    ]);
+    }, [currentQuoteStatus, tx.approvalTxid]);
 
     const onApproveTransactionClick = async () => {
         if (!selectedQuote || !selectedQuote.isDex) {
@@ -204,13 +157,14 @@ export const TradingFormApproval = ({
             },
         });
 
-        setApprovalType('APPROVE');
+        allowanceState.setApprovalType('APPROVE');
         setIsApproveButtonLoading(true);
 
         await approveTransaction(selectedQuote);
 
         setIsApproveButtonLoading(false);
-        openApproveModal();
+        context.setIsApproval(true);
+        allowanceState.openApproveModal();
     };
 
     const onRevokeApprovalClick = async () => {
@@ -227,13 +181,14 @@ export const TradingFormApproval = ({
             },
         });
 
-        setApprovalType('REVOKE');
+        allowanceState.setApprovalType('REVOKE');
         setIsRevokeButtonLoading(true);
 
         await revokeApproval(selectedQuote);
 
         setIsRevokeButtonLoading(false);
-        openRevokeModal();
+        context.setIsApproval(true);
+        allowanceState.openRevokeModal();
     };
 
     const onProceedToSwapClick = async () => {
@@ -286,27 +241,27 @@ export const TradingFormApproval = ({
 
     const isApproveButtonDisabled =
         isApproveButtonLoading ||
-        (approvalStep === 'LOADING' && approvalType === 'REVOKE') ||
+        (approvalStep === 'LOADING' && allowanceState.approvalType === 'REVOKE') ||
         isFormLoading ||
         isScheduledQuotesRefresh ||
         isDiscoveryRunning ||
-        isWaitingForDevice;
+        allowanceState.isWaitingForDevice;
 
     const isSwapButtonDisabled =
         isSwapButtonLoading ||
-        (approvalStep === 'LOADING' && approvalType === 'APPROVE') ||
+        (approvalStep === 'LOADING' && allowanceState.approvalType === 'APPROVE') ||
         isFormLoading ||
         isScheduledQuotesRefresh ||
         isDiscoveryRunning ||
-        isWaitingForDevice;
+        allowanceState.isWaitingForDevice;
 
     const isRevokeButtonDisabled =
         isRevokeButtonLoading ||
-        (approvalStep === 'LOADING' && approvalType === 'APPROVE') ||
+        (approvalStep === 'LOADING' && allowanceState.approvalType === 'APPROVE') ||
         isFormLoading ||
         isScheduledQuotesRefresh ||
         isDiscoveryRunning ||
-        isWaitingForDevice;
+        allowanceState.isWaitingForDevice;
 
     const isRefreshButtonDisabled =
         isRefreshButtonLoading || isFormLoading || isScheduledQuotesRefresh || isDiscoveryRunning;
@@ -318,7 +273,7 @@ export const TradingFormApproval = ({
     const isIncreasingAllowanceSupported = tokenSupportsIncreasingAllowance(contractAddress);
 
     return (
-        <Column gap={spacings.md} alignItems="center">
+        <Column gap={16} alignItems="center">
             {approvalStep === 'REQUIRED' && (
                 <>
                     {isApprovalTxPreApproved ? (
@@ -445,7 +400,7 @@ export const TradingFormApproval = ({
 
             {approvalStep === 'LOADING' && (
                 <Column width="100%" alignItems="flex-start">
-                    <Row alignItems="flex-start" gap={spacings.sm}>
+                    <Row alignItems="flex-start" gap={12}>
                         <IconWrapper>
                             <Icon name="spinnerGap" size="mediumLarge" />
                         </IconWrapper>
@@ -454,7 +409,7 @@ export const TradingFormApproval = ({
                             <Paragraph typographyStyle="body" variant="tertiary" align="start">
                                 <Translation
                                     id={
-                                        approvalType === 'APPROVE'
+                                        allowanceState.approvalType === 'APPROVE'
                                             ? 'TR_EXCHANGE_APPROVAL_FORM_CONFIRMING_APPROVAL'
                                             : 'TR_EXCHANGE_APPROVAL_FORM_REVOKING_APPROVAL'
                                     }
@@ -465,24 +420,27 @@ export const TradingFormApproval = ({
                                 <Translation id="TR_EXCHANGE_APPROVAL_FORM_TRANSACTION_ID" />
                             </Paragraph>
 
-                            {selectedQuote?.approvalSendTxHash && (
+                            {tx.approvalTxid && (
                                 <Link
-                                    onClick={() =>
-                                        dispatch(
-                                            openModal({
-                                                type: 'transaction-detail',
-                                                txid: selectedQuote.approvalSendTxHash ?? '',
-                                                descriptor: account.descriptor,
-                                                symbol: account.symbol,
-                                                deviceState: account.deviceState,
-                                                flow: 'detail',
-                                            }),
-                                        )
-                                    }
+                                    onClick={() => {
+                                        const txid = tx.approvalTxid;
+                                        if (txid) {
+                                            dispatch(
+                                                openModal({
+                                                    type: 'transaction-detail',
+                                                    txid,
+                                                    descriptor: account.descriptor,
+                                                    symbol: account.symbol,
+                                                    deviceState: account.deviceState,
+                                                    flow: 'detail',
+                                                }),
+                                            );
+                                        }
+                                    }}
                                 >
                                     <Address
                                         isTruncated
-                                        value={selectedQuote.approvalSendTxHash}
+                                        value={tx.approvalTxid}
                                         variant="primary"
                                         typographyStyle="body"
                                     />

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
-import type { BuyTrade, ExchangeTrade, SellFiatTrade } from 'invity-api';
+import type { BuyTrade, CryptoId, ExchangeTrade, SellFiatTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
 import {
@@ -14,18 +14,13 @@ import { selectAreFeesLoading, selectHasRunningDiscovery } from '@suite-common/w
 import { TokenAddress } from '@suite-common/wallet-types';
 import { isAmountTooHigh } from '@suite-common/wallet-utils';
 import { Button, Card, Column, Paragraph } from '@trezor/components';
-import { breakpoints, spacings } from '@trezor/theme';
+import { breakpoints } from '@trezor/theme';
 
-import { ApproveModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal';
-import { RevokeModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingDeviceDisconnected } from 'src/hooks/wallet/trading/form/common/useTradingDeviceDisconnected';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { selectTorState } from 'src/selectors/suite/suiteSelectors';
-import {
-    TradingExchangeApprovalType,
-    TradingFormContextValues,
-} from 'src/types/trading/tradingForm';
+import { TradingFormContextValues } from 'src/types/trading/tradingForm';
 import {
     getCryptoQuoteAmountProps,
     getSelectQuoteTyped,
@@ -44,6 +39,8 @@ import { TradingFormOfferCryptoAmount } from 'src/views/wallet/trading/common/Tr
 import { TradingFormOfferFiatAmount } from 'src/views/wallet/trading/common/TradingForm/TradingFormOfferFiatAmount';
 import { TradingFormOfferOTC } from 'src/views/wallet/trading/common/TradingForm/TradingFormOfferOTC';
 
+import { TradingApproveModal } from './TradingApproveModal';
+import { TradingRevokeModal } from './TradingRevokeModal';
 import { useIsContentBelowBreakpoint } from '../../../../../support/suite/ContentFlex';
 import { useReceiveAddressModalControls } from '../TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls';
 import { TradingUtilsTorWarning } from '../TradingUtils/TradingUtilsTorWarning';
@@ -92,10 +89,6 @@ export const TradingFormOffer = () => {
     const dispatch = useDispatch();
     const { isTorEnabled } = useSelector(selectTorState);
 
-    const [isApproveModalOpen, setIsApproveModalOpen] = useState(false);
-    const [isRevokeModalOpen, setIsRevokeModalOpen] = useState(false);
-    const [isManuallyApproved, setIsManuallyApproved] = useState(false);
-
     const context = useTradingFormContext();
     const {
         account,
@@ -136,9 +129,6 @@ export const TradingFormOffer = () => {
     const shouldDisplayFiatAmount = isTradingExchangeContext(context) ? false : amountInCrypto;
 
     const { tradingDeviceDisconnected } = useTradingDeviceDisconnected();
-
-    const [approvalType, setApprovalType] = useState<TradingExchangeApprovalType>('APPROVE');
-    const [isWaitingForDevice, setIsWaitingForDevice] = useState(false);
 
     const requiresTokenApproval =
         isTradingExchangeContext(context) &&
@@ -216,7 +206,7 @@ export const TradingFormOffer = () => {
     };
 
     let amount: string = '0';
-    let tokenAddress: TokenAddress | undefined;
+    let tokenAddress: TokenAddress | null = null;
     let areSatsUsed = false;
 
     if (isTradingSellContext(context) || isTradingExchangeContext(context)) {
@@ -225,59 +215,9 @@ export const TradingFormOffer = () => {
 
         const output = outputs[0];
         amount = output.amount;
-        tokenAddress = (output.token ?? undefined) as TokenAddress | undefined;
+        tokenAddress = output.token as TokenAddress | null;
         areSatsUsed = !!shouldSendInSats;
     }
-
-    const onOpenApproveModal = () => {
-        if (isTradingExchangeContext(context)) {
-            context.setIsApproval(true);
-        }
-
-        setIsApproveModalOpen(true);
-    };
-
-    const onCloseApproveModal = async (isSubmitting = false) => {
-        setIsApproveModalOpen(false);
-
-        if (isTradingExchangeContext(context)) {
-            context.setIsApproval(false);
-
-            if (isSubmitting) return;
-
-            if (context.selectedQuote?.receiveAddress) {
-                await context.confirmApproval({
-                    trade: { ...context.selectedQuote, approvalType: undefined },
-                    receiveAddress: context.selectedQuote.receiveAddress,
-                });
-            }
-        }
-    };
-
-    const onOpenRevokeModal = () => {
-        if (isTradingExchangeContext(context)) {
-            context.setIsApproval(true);
-        }
-
-        setIsRevokeModalOpen(true);
-    };
-
-    const onCloseRevokeModal = async (isSubmitting = false) => {
-        setIsRevokeModalOpen(false);
-
-        if (isTradingExchangeContext(context)) {
-            context.setIsApproval(false);
-
-            if (isSubmitting) return;
-
-            if (context.selectedQuote?.receiveAddress) {
-                await context.confirmApproval({
-                    trade: { ...context.selectedQuote, approvalType: undefined },
-                    receiveAddress: context.selectedQuote?.receiveAddress,
-                });
-            }
-        }
-    };
 
     const amountTooHigh = isAmountTooHigh({
         amount,
@@ -311,12 +251,8 @@ export const TradingFormOffer = () => {
     const noOffersWithTor = isTorEnabled && !quote && !isLoading;
 
     return (
-        <Column gap={spacings.lg}>
-            <Column
-                gap={spacings.xs}
-                data-testid="@trading/best-offer"
-                margin={{ bottom: spacings.md }}
-            >
+        <Column gap={20}>
+            <Column gap={8} data-testid="@trading/best-offer" margin={{ bottom: 16 }}>
                 {selectedAssetCryptoId && <Translation id={amountLabels.offerLabel} />}
                 {shouldDisplayFiatAmount ? (
                     <TradingFormOfferFiatAmount amount={tradingGetRoundedFiatAmount(sendAmount)} />
@@ -341,7 +277,7 @@ export const TradingFormOffer = () => {
                         typographyStyle="hint"
                         variant="tertiary"
                         align="center"
-                        margin={{ vertical: spacings.xs }}
+                        margin={{ vertical: 8 }}
                         data-testid="trading-offer-found-none"
                     >
                         <Translation
@@ -364,7 +300,7 @@ export const TradingFormOffer = () => {
                     onClick={onContinueClick}
                     intent="brand"
                     margin={{
-                        top: spacings.md,
+                        top: 16,
                     }}
                     isDisabled={isButtonDisabled || isLoading}
                     isLoading={areFeesLoading || (preselectedQuote && state.isFormLoading)}
@@ -376,22 +312,17 @@ export const TradingFormOffer = () => {
                 </Button>
             ) : (
                 <>
-                    {requiresTokenApproval && bestScoredQuote && !isLoading ? (
-                        <TradingFormApproval
-                            openApproveModal={onOpenApproveModal}
-                            openRevokeModal={onOpenRevokeModal}
-                            isWaitingForDevice={isWaitingForDevice}
-                            approvalType={approvalType}
-                            setApprovalType={setApprovalType}
-                            isManuallyApproved={isManuallyApproved}
-                            setIsManuallyApproved={setIsManuallyApproved}
-                        />
+                    {isTradingExchangeContext(context) &&
+                    requiresTokenApproval &&
+                    bestScoredQuote &&
+                    !isLoading ? (
+                        <TradingFormApproval />
                     ) : (
                         <Button
                             onClick={onSelectQuote}
                             intent="brand"
                             margin={{
-                                top: spacings.md,
+                                top: 16,
                             }}
                             size="large"
                             isDisabled={isButtonDisabled || isLoading}
@@ -420,18 +351,14 @@ export const TradingFormOffer = () => {
                 </>
             )}
             {(type === 'buy' || type === 'sell') && <TradingFormOfferOTC />}
-            {isApproveModalOpen && (
-                <ApproveModal
-                    onCancel={onCloseApproveModal}
-                    setApprovalType={setApprovalType}
-                    setIsWaitingForDevice={setIsWaitingForDevice}
+            {isTradingExchangeContext(context) && bestScoredQuoteAmounts?.sendCurrency && (
+                <TradingApproveModal
+                    amount={amount}
+                    cryptoId={bestScoredQuoteAmounts.sendCurrency as CryptoId}
                 />
             )}
-            {isRevokeModalOpen && (
-                <RevokeModal
-                    onCancel={onCloseRevokeModal}
-                    setIsWaitingForDevice={setIsWaitingForDevice}
-                />
+            {isTradingExchangeContext(context) && bestScoredQuoteAmounts?.sendCurrency && (
+                <TradingRevokeModal cryptoId={bestScoredQuoteAmounts.sendCurrency as CryptoId} />
             )}
         </Column>
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingRevokeModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingRevokeModal.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useMemo } from 'react';
+
+import { CryptoId } from 'invity-api';
+
+import { events } from '@suite/analytics';
+import { getEvmApprovalTxData } from '@suite-common/wallet-utils';
+
+import { RevokeModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal';
+import { useAllowanceContext } from 'src/hooks/wallet/allowance';
+import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { useTradingExchangeCryptoAndProviderInfo } from 'src/hooks/wallet/trading/form/useTradingExchangeCryptoAndProviderInfo';
+import { useAnalytics } from 'src/support/useAnalytics';
+import {
+    getProvidersInfoProps,
+    isTradingExchangeContext,
+} from 'src/utils/wallet/trading/tradingTypingUtils';
+
+interface TradingRevokeModalProps {
+    cryptoId: CryptoId;
+}
+
+export const TradingRevokeModal = ({ cryptoId }: TradingRevokeModalProps) => {
+    const { state } = useAllowanceContext();
+    const context = useTradingFormContext();
+    const analytics = useAnalytics();
+    const getCryptoInfo = useTradingExchangeCryptoAndProviderInfo();
+
+    const handleCancel = useCallback(async () => {
+        analytics.report({
+            type: events.tradeApprovalEvent.name,
+            payload: {
+                type: 'revoke-modal',
+                action: 'cancel',
+                ...getCryptoInfo(),
+            },
+        });
+
+        if (isTradingExchangeContext(context)) {
+            context.setIsApproval(false);
+
+            if (context.selectedQuote?.receiveAddress) {
+                await context.confirmApproval({
+                    trade: { ...context.selectedQuote, approvalType: undefined },
+                    receiveAddress: context.selectedQuote.receiveAddress,
+                });
+            }
+        }
+    }, [analytics, getCryptoInfo, context]);
+
+    const onConfirm = useCallback(() => {
+        analytics.report({
+            type: events.tradeApprovalEvent.name,
+            payload: {
+                type: 'revoke-modal',
+                action: 'continue',
+                ...getCryptoInfo(),
+            },
+        });
+    }, [analytics, getCryptoInfo]);
+
+    const revokeParams = useMemo(() => {
+        if (!isTradingExchangeContext(context)) return null;
+
+        const providersInfo = getProvidersInfoProps(context);
+        const exchange = context.selectedQuote?.exchange;
+        const provider = exchange ? providersInfo?.[exchange] : null;
+
+        const dexTxData = context.selectedQuote?.dexTx?.data;
+        const approvalData = getEvmApprovalTxData(dexTxData);
+        const spender = approvalData?.spender ?? null;
+
+        const preapprovedAmount = context.selectedQuote?.preapprovedStringAmount;
+
+        return {
+            provider,
+            spender,
+            preapprovedAmount,
+        };
+    }, [context]);
+
+    const { provider, spender, preapprovedAmount } = revokeParams || {};
+
+    if (!state.isRevokeModalOpen || !provider || !spender) return null;
+
+    return (
+        <RevokeModal
+            cryptoId={cryptoId}
+            account={context.account}
+            provider={provider}
+            spender={spender}
+            preapprovedAmount={preapprovedAmount}
+            onConfirm={onConfirm}
+            onCancel={handleCancel}
+        />
+    );
+};

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx
@@ -6,6 +6,7 @@ import { TradingType } from '@suite-common/trading';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useSelector } from 'src/hooks/suite';
 import { useMessageSystemTrading } from 'src/hooks/suite/useMessageSystemTrading';
+import { AllowanceContext, useAllowance } from 'src/hooks/wallet/allowance';
 import { TradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingExchangeForm } from 'src/hooks/wallet/trading/form/useTradingExchangeForm';
 import { selectIsDeviceCompromised } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
@@ -24,12 +25,15 @@ const TradingExchangeFormContent = () => (
 
 const TradingExchangeFormWrapper = () => {
     const tradingExchangeContextValue = useTradingExchangeForm({});
+    const allowanceContextValue = useAllowance({ account: tradingExchangeContextValue.account });
 
     return (
         <TradingFormContext.Provider value={tradingExchangeContextValue}>
-            <FormProvider {...tradingExchangeContextValue.methods}>
-                <TradingContainer SectionComponent={TradingExchangeFormContent} />
-            </FormProvider>
+            <AllowanceContext.Provider value={allowanceContextValue}>
+                <FormProvider {...tradingExchangeContextValue.methods}>
+                    <TradingContainer SectionComponent={TradingExchangeFormContent} />
+                </FormProvider>
+            </AllowanceContext.Provider>
         </TradingFormContext.Provider>
     );
 };

--- a/scripts/workspace-run.sh
+++ b/scripts/workspace-run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+#
+# Interactively select a yarn workspace and run one of its scripts.
+#
+set -eu
+
+command -v fzf >/dev/null || { echo "fzf is required"; exit 1; }
+command -v yarn >/dev/null || { echo "yarn is required"; exit 1; }
+command -v jq   >/dev/null || { echo "jq is required"; exit 1; }
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+WS_NAME="$(
+  yarn workspaces list --json \
+  | jq -r '.name' \
+  | fzf --prompt='workspace> '
+)"
+
+[ -n "$WS_NAME" ] || exit 0
+
+WS_LOCATION="$(
+  yarn workspaces list --json \
+  | jq -r "select(.name == \"$WS_NAME\") | .location"
+)"
+
+SCRIPT="$(
+  jq -r '.scripts // {} | keys[]' "$WS_LOCATION/package.json" \
+  | sort \
+  | fzf --prompt="$WS_NAME script> "
+)"
+
+[ -n "$SCRIPT" ] || exit 0
+
+echo
+echo "→ yarn workspace $WS_NAME $SCRIPT $*"
+echo
+
+exec yarn workspace "$WS_NAME" "$SCRIPT" "$@"
+

--- a/suite-common/wallet-core/src/allowance/allowanceConstants.ts
+++ b/suite-common/wallet-core/src/allowance/allowanceConstants.ts
@@ -1,0 +1,1 @@
+export const ALLOWANCE_MODULE_PREFIX = '@common/wallet-core/approval';

--- a/suite-common/wallet-core/src/allowance/buildAllowanceTransaction.ts
+++ b/suite-common/wallet-core/src/allowance/buildAllowanceTransaction.ts
@@ -1,0 +1,53 @@
+import { fromWei, toWei } from 'web3-utils';
+
+import { PrecomposedTransaction } from '@suite-common/wallet-types';
+import { calculateTotalGasCost } from '@suite-common/wallet-utils';
+import { FeeLevel, TokenInfo } from '@trezor/connect';
+import { BigNumber } from '@trezor/utils';
+
+export const buildAllowanceTransaction = (
+    balance: string,
+    contract: string,
+    feeLevel: FeeLevel,
+    token?: TokenInfo,
+    estimatedFeeLimit?: string,
+): PrecomposedTransaction => {
+    const gasPrice = feeLevel.maxFeePerGas || feeLevel.feePerUnit;
+
+    const fee = calculateTotalGasCost(toWei(gasPrice, 'gwei'), feeLevel.feeLimit);
+
+    if (new BigNumber(fee).gt(balance)) {
+        return {
+            type: 'error',
+            error: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
+            errorMessage: {
+                id: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
+                values: {
+                    feeAmount: fromWei(fee, 'ether'),
+                },
+            },
+        };
+    }
+
+    return {
+        type: 'final',
+        totalSpent: '0',
+        fee,
+        feePerByte: feeLevel.feePerUnit,
+        feeLimit: feeLevel.feeLimit,
+        maxFeePerGas: feeLevel.maxFeePerGas,
+        maxPriorityFeePerGas: feeLevel.maxPriorityFeePerGas,
+        estimatedFeeLimit,
+        token,
+        bytes: 0,
+        inputs: [],
+        outputsPermutation: [0],
+        outputs: [
+            {
+                address: contract,
+                amount: '0',
+                script_type: 'PAYTOADDRESS',
+            },
+        ],
+    };
+};

--- a/suite-common/wallet-core/src/allowance/composeAllowanceTransactionThunk.ts
+++ b/suite-common/wallet-core/src/allowance/composeAllowanceTransactionThunk.ts
@@ -1,0 +1,97 @@
+import { createThunk } from '@suite-common/redux-utils';
+import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
+import { Account, FeeInfo, FeeLevelLabel, PrecomposedLevels } from '@suite-common/wallet-types';
+import { findToken, getAccountIdentity } from '@suite-common/wallet-utils';
+import TrezorConnect from '@trezor/connect';
+import { BigNumber, typedObjectFromEntries } from '@trezor/utils';
+
+import { ALLOWANCE_MODULE_PREFIX } from './allowanceConstants';
+import { buildAllowanceTransaction } from './buildAllowanceTransaction';
+import { ETHEREUM_ADJUST_GAS_LIMIT } from '../fees/feesUtils';
+import { ComposeFeeLevelsError } from '../send/sendFormTypes';
+
+export interface ComposeAllowanceTransactionThunkParams {
+    feeInfo: FeeInfo;
+    account: Account;
+    contract: string;
+    data: string;
+    selectedFee?: FeeLevelLabel;
+    customFee?: {
+        feeLimit: string;
+        feePerUnit: string;
+        maxFeePerGas?: string;
+        maxPriorityFeePerGas?: string;
+    };
+}
+
+export const composeAllowanceTransactionThunk = createThunk<
+    PrecomposedLevels,
+    ComposeAllowanceTransactionThunkParams,
+    { rejectValue: ComposeFeeLevelsError }
+>(
+    `${ALLOWANCE_MODULE_PREFIX}/composeAllowanceTransactionThunk`,
+    async ({ feeInfo, account, contract, selectedFee, customFee, data }, { rejectWithValue }) => {
+        const token = findToken(account.tokens, contract);
+
+        if (!token) {
+            return rejectWithValue({
+                error: 'fee-levels-compose-failed',
+                message: 'Token not found in account tokens.',
+            });
+        }
+
+        const estimatedFee = await TrezorConnect.blockchainEstimateFee({
+            coin: account.symbol,
+            identity: getAccountIdentity(account),
+            request: {
+                blocks: [2],
+                specific: {
+                    from: account.descriptor,
+                    to: contract,
+                    value: '0x0',
+                    data,
+                },
+            },
+        });
+
+        const estimatedGasLimit = estimatedFee.success
+            ? new BigNumber(
+                  estimatedFee.payload.levels[0].feeLimit || ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT,
+              )
+            : new BigNumber(ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT);
+
+        const adjustedGasLimit = estimatedGasLimit
+            .multipliedBy(ETHEREUM_ADJUST_GAS_LIMIT)
+            .integerValue(BigNumber.ROUND_UP);
+
+        const predefinedLevels = feeInfo.levels
+            .filter(l => l.label !== 'custom')
+            .map(l => ({ ...l, feeLimit: adjustedGasLimit.toFixed(0) }));
+
+        if (selectedFee === 'custom' && customFee) {
+            predefinedLevels.push({
+                label: 'custom',
+                feePerUnit: customFee.feePerUnit,
+                feeLimit: customFee.feeLimit,
+                maxFeePerGas: customFee.maxFeePerGas,
+                maxPriorityFeePerGas: customFee.maxPriorityFeePerGas,
+                blocks: -1,
+            });
+        }
+
+        const levels = typedObjectFromEntries(
+            predefinedLevels.map(level => [
+                level.label,
+                buildAllowanceTransaction(
+                    account.availableBalance,
+                    contract,
+                    level,
+                    token,
+                    adjustedGasLimit.toFixed(0),
+                ),
+            ]),
+        );
+
+        return levels;
+    },
+);

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -5,6 +5,7 @@ export * from './accounts/accountsMiddleware';
 export * from './accounts/accountsReducer';
 export * from './accounts/accountsSelectors';
 export * from './accounts/accountsThunks';
+export * from './allowance/composeAllowanceTransactionThunk';
 export { useSelector as useAccoutsSelector } from './accounts/hooks/useSelector';
 export * from './blockchain/blockchainActions';
 export * from './blockchain/blockchainMiddleware';

--- a/suite-common/wallet-core/src/send/sendFormActions.ts
+++ b/suite-common/wallet-core/src/send/sendFormActions.ts
@@ -30,6 +30,7 @@ const storePrecomposedTransaction = createAction(
     (payload: {
         formState: FormState;
         precomposedTransaction: GeneralPrecomposedTransactionFinal;
+        accountKey?: AccountKey;
     }) => ({
         payload,
     }),

--- a/suite-common/wallet-core/src/send/sendFormReducer.ts
+++ b/suite-common/wallet-core/src/send/sendFormReducer.ts
@@ -1,5 +1,6 @@
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import {
+    AccountKey,
     FormState,
     GeneralPrecomposedTransactionFinal,
     SendFormDraftKey,
@@ -22,6 +23,7 @@ export type SendState = {
     precomposedForm?: FormState; // Used to pass the form state to the review modal. Holds similar data as drafts, but drafts are not used in RBF form.
     signedTx?: BlockbookTransaction;
     serializedTx?: SerializedTx; // Hexadecimal representation of signed transaction (payload for TrezorConnect.pushTransaction).
+    accountKey?: AccountKey; // Account key for the transaction being processed.
 };
 
 export const initialState: SendState = {
@@ -29,6 +31,7 @@ export const initialState: SendState = {
     precomposedTx: undefined,
     serializedTx: undefined,
     signedTx: undefined,
+    accountKey: undefined,
 };
 
 export type SendRootState = {
@@ -61,13 +64,14 @@ export const prepareSendFormReducer = createReducerWithExtraDeps(initialState, (
         )
         .addCase(
             sendFormActions.storePrecomposedTransaction,
-            (state, { payload: { precomposedTransaction, formState } }) => {
+            (state, { payload: { precomposedTransaction, formState, accountKey } }) => {
                 state.precomposedTx = precomposedTransaction;
                 // Deep-cloning to prevent buggy interaction between react-hook-form and immer, see https://github.com/orgs/react-hook-form/discussions/3715#discussioncomment-2151458
                 // Otherwise, whenever the outputs fieldArray is updated after the form draft or precomposedForm is saved, there is na error:
                 // TypeError: Cannot assign to read only property of object '#<Object>'
                 // This might not be necessary in the future when the dependencies are upgraded.
                 state.precomposedForm = cloneObject(formState);
+                state.accountKey = accountKey;
             },
         )
         .addCase(
@@ -82,6 +86,7 @@ export const prepareSendFormReducer = createReducerWithExtraDeps(initialState, (
             delete state.precomposedForm;
             delete state.serializedTx;
             delete state.signedTx;
+            delete state.accountKey;
         })
         .addCase(sendFormActions.sendRaw, (state, { payload: sendRaw }) => {
             state.sendRaw = sendRaw;
@@ -92,6 +97,7 @@ export const prepareSendFormReducer = createReducerWithExtraDeps(initialState, (
             delete state.precomposedForm;
             delete state.serializedTx;
             delete state.signedTx;
+            delete state.accountKey;
         })
         .addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadFormDrafts)
         .addCase(accountsActions.removeAccount, (state, { payload }) => {

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -719,6 +719,7 @@ export const enhancePrecomposedTransactionThunk = createThunk<
                     createdTimestamp: new Date().getTime(),
                     isTokenKnown,
                 },
+                accountKey: selectedAccount.key,
             }),
         );
 

--- a/suite-common/wallet-core/tests/allowance/buildAllowanceTransaction.fixtures.ts
+++ b/suite-common/wallet-core/tests/allowance/buildAllowanceTransaction.fixtures.ts
@@ -1,0 +1,74 @@
+import { PrecomposedTransaction } from '@suite-common/wallet-types';
+import { FeeLevel, TokenInfo } from '@trezor/connect';
+
+interface BuildAllowanceTransactionFixture {
+    description: string;
+    input: {
+        balance: string;
+        contract: string;
+        feeLevel: FeeLevel;
+        token?: TokenInfo;
+        estimatedFeeLimit?: string;
+    };
+    result: PrecomposedTransaction;
+}
+
+export const buildAllowanceTransaction: BuildAllowanceTransactionFixture[] = [
+    {
+        description: 'Balance sufficient, returns final transaction',
+        input: {
+            balance: '1000000000000000000',
+            contract: '0x1234567890abcdef1234567890abcdef12345678',
+            feeLevel: {
+                label: 'normal',
+                feePerUnit: '10',
+                feeLimit: '50000',
+                blocks: -1,
+            },
+        },
+        result: {
+            type: 'final',
+            totalSpent: '0',
+            fee: '500000000000000',
+            feePerByte: '10',
+            feeLimit: '50000',
+            maxFeePerGas: undefined,
+            maxPriorityFeePerGas: undefined,
+            estimatedFeeLimit: undefined,
+            token: undefined,
+            bytes: 0,
+            inputs: [],
+            outputsPermutation: [0],
+            outputs: [
+                {
+                    address: '0x1234567890abcdef1234567890abcdef12345678',
+                    amount: '0',
+                    script_type: 'PAYTOADDRESS',
+                },
+            ],
+        },
+    },
+    {
+        description: 'Insufficient balance, returns error',
+        input: {
+            balance: '100000000000000',
+            contract: '0x1234567890abcdef1234567890abcdef12345678',
+            feeLevel: {
+                label: 'normal',
+                feePerUnit: '10',
+                feeLimit: '50000',
+                blocks: -1,
+            },
+        },
+        result: {
+            type: 'error',
+            error: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
+            errorMessage: {
+                id: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
+                values: {
+                    feeAmount: '0.0005',
+                },
+            },
+        },
+    },
+];

--- a/suite-common/wallet-core/tests/allowance/buildAllowanceTransaction.test.ts
+++ b/suite-common/wallet-core/tests/allowance/buildAllowanceTransaction.test.ts
@@ -1,0 +1,18 @@
+import * as fixtures from './buildAllowanceTransaction.fixtures';
+import { buildAllowanceTransaction } from '../../src/allowance/buildAllowanceTransaction';
+
+describe(buildAllowanceTransaction.name, () => {
+    fixtures.buildAllowanceTransaction.forEach(f => {
+        it(f.description, () => {
+            const result = buildAllowanceTransaction(
+                f.input.balance,
+                f.input.contract,
+                f.input.feeLevel,
+                f.input.token,
+                f.input.estimatedFeeLimit,
+            );
+
+            expect(result).toEqual(f.result);
+        });
+    });
+});

--- a/suite-common/wallet-types/src/allowance.ts
+++ b/suite-common/wallet-types/src/allowance.ts
@@ -1,0 +1,1 @@
+export type AllowanceType = 'APPROVE' | 'REVOKE';

--- a/suite-common/wallet-types/src/index.ts
+++ b/suite-common/wallet-types/src/index.ts
@@ -1,4 +1,5 @@
 export * from './account';
+export * from './allowance';
 export * from './backend';
 export * from './cardanoStaking';
 export * from './discovery';

--- a/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
@@ -1,30 +1,17 @@
+import { UINT256_MAX } from '@suite-common/suite-constants';
+import { BigNumber } from '@trezor/utils';
+
 import {
-    decimalToHex,
+    buildApprovalTransactionData,
     getEvmApprovalTxData,
     getEvmTransactionTextSignature,
     getEvmTransferTxData,
-    hexToDecimal,
     padLeftEven,
     sanitizeHex,
     strip,
 } from '../ethUtils';
 
 describe('eth utils', () => {
-    it('decimalToHex', () => {
-        expect(decimalToHex(0)).toBe('0');
-        expect(decimalToHex(1)).toBe('1');
-        expect(decimalToHex(2)).toBe('2');
-        expect(decimalToHex(100)).toBe('64');
-        expect(decimalToHex(9999999999)).toBe('2540be3ff');
-    });
-
-    it('hexToDecimal', () => {
-        expect(hexToDecimal(64)).toBe('100');
-        expect(hexToDecimal(2)).toBe('2');
-        expect(hexToDecimal(1)).toBe('1');
-        expect(hexToDecimal(0)).toBe('0');
-    });
-
     it('padLeftEven', () => {
         // TODO: add more tests
         expect(padLeftEven('2540be3ff')).toBe('02540be3ff');
@@ -245,6 +232,86 @@ describe('eth utils', () => {
                 '000000000000000000000000742D35CC6634C0532925A3B8D40E592E43A73654' +
                 '00000000000000000000000000000000000000000000000000000000000003E8';
             expect(getEvmTransactionTextSignature(upperNoPrefix)).toBe('transfer');
+        });
+    });
+
+    describe('buildApprovalTransactionData', () => {
+        const VALID_SPENDER = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+
+        it('builds correct calldata for a valid approval', () => {
+            const result = buildApprovalTransactionData({
+                amount: '1000000000000000000',
+                spender: VALID_SPENDER,
+            });
+
+            expect(result).toBe(
+                '0x095ea7b3' +
+                    '000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e' +
+                    '0000000000000000000000000000000000000000000000000de0b6b3a7640000',
+            );
+        });
+
+        it('builds correct calldata for zero amount (revoke)', () => {
+            const result = buildApprovalTransactionData({
+                amount: '0',
+                spender: VALID_SPENDER,
+            });
+
+            expect(result).toBe(
+                '0x095ea7b3' +
+                    '000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e' +
+                    '0000000000000000000000000000000000000000000000000000000000000000',
+            );
+        });
+
+        it('builds correct calldata for max uint256 (infinite approval)', () => {
+            const maxUint256Decimal = new BigNumber(UINT256_MAX).toString(10);
+            const result = buildApprovalTransactionData({
+                amount: maxUint256Decimal,
+                spender: VALID_SPENDER,
+            });
+
+            expect(result).toBe(
+                '0x095ea7b3' +
+                    '000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e' +
+                    'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            );
+        });
+
+        it.each([
+            ['wrong length', '0x742d35cc6634c0532925a3b844bc454e4438f44'],
+            ['non-hex characters', '0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ'],
+            ['empty string', ''],
+        ])('throws for invalid spender address (%s)', (_, spender) => {
+            expect(() => buildApprovalTransactionData({ amount: '1000', spender })).toThrow(
+                'Invalid spender address',
+            );
+        });
+
+        it.each([
+            ['negative', '-1'],
+            ['non-numeric', 'abc'],
+            ['decimal', '1.5'],
+            ['exceeds uint256 max', new BigNumber(UINT256_MAX).plus(1).toString(10)],
+        ])('throws for invalid amount (%s)', (_, amount) => {
+            expect(() => buildApprovalTransactionData({ amount, spender: VALID_SPENDER })).toThrow(
+                'Invalid amount',
+            );
+        });
+
+        it('produces calldata that getEvmApprovalTxData can decode', () => {
+            const amount = '1000000000000000000';
+            const calldata = buildApprovalTransactionData({
+                amount,
+                spender: VALID_SPENDER,
+            });
+
+            const decoded = getEvmApprovalTxData(calldata);
+
+            expect(decoded).not.toBeNull();
+            expect(decoded?.spender).toBe(VALID_SPENDER.toLowerCase());
+            expect(decoded?.amount).toBe(amount);
+            expect(decoded?.type).toBe('approve');
         });
     });
 

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -1,8 +1,15 @@
 import { decodeParameters } from 'web3-eth-abi';
 import { sha3 } from 'web3-utils';
 
+import { UINT256_MAX } from '@suite-common/suite-constants';
 import { EvmTransactionPurpose } from '@suite-common/wallet-types';
-import { BigNumber } from '@trezor/utils/src/bigNumber';
+import { TokenInfo } from '@trezor/blockchain-link-types';
+import { exhaustive } from '@trezor/type-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { asAmountSubunit, asAmountUnit } from './AmountTypes';
+import { unitsToSubunits } from './amountUtils';
+import { isAddressValid } from './validationUtils';
 
 export const isEip1559 = (
     tx: Record<string, any> | null | undefined,
@@ -12,8 +19,6 @@ export const hasEip1559MaxPriorityFee = (
     tx: Record<string, any> | null | undefined,
 ): tx is { maxPriorityFeePerGas: string } => !!tx && !!tx.maxPriorityFeePerGas;
 
-export const decimalToHex = (dec: number): string => new BigNumber(dec).toString(16);
-
 export const padLeftEven = (hex: string): string => (hex.length % 2 !== 0 ? `0${hex}` : hex);
 
 export const sanitizeHex = ($hex: string): string => {
@@ -21,12 +26,6 @@ export const sanitizeHex = ($hex: string): string => {
     if (hex === '') return '';
 
     return `0x${padLeftEven(hex)}`;
-};
-
-export const hexToDecimal = (hex: number): string => {
-    const sanitized: string = sanitizeHex(hex.toString());
-
-    return !sanitized ? 'null' : new BigNumber(sanitized).toString();
 };
 
 export const strip = (str: string): string => {
@@ -53,14 +52,16 @@ interface EvmTxTransferData extends EvmTxData {
 const normalizeHex = (data: string) =>
     data.toLowerCase().startsWith('0x') ? data.toLowerCase() : `0x${data.toLowerCase()}`;
 
+const ERC20_APPROVE_SELECTOR = sha3('approve(address,uint256)')!.slice(0, 10);
+const ERC20_TRANSFER_SELECTOR = sha3('transfer(address,uint256)')!.slice(0, 10);
+
 export const getEvmApprovalTxData = (data?: string): EvmTxApprovalData | null => {
     if (!data) return null;
 
     const dataWithPrefix = normalizeHex(data);
     const dataLowercase = dataWithPrefix.toLowerCase();
     try {
-        const approvalPrefix = sha3('approve(address,uint256)')?.slice(0, 10);
-        const hasApprovalPrefix = !!approvalPrefix && dataLowercase.startsWith(approvalPrefix);
+        const hasApprovalPrefix = dataLowercase.startsWith(ERC20_APPROVE_SELECTOR);
 
         if (!hasApprovalPrefix) return null;
 
@@ -84,8 +85,7 @@ export const getEvmTransferTxData = (data?: string): EvmTxTransferData | null =>
     const d = normalizeHex(data);
 
     try {
-        const transferPrefix = sha3('transfer(address,uint256)')?.slice(0, 10); // '0xa9059cbb'
-        if (!transferPrefix || !d.startsWith(transferPrefix)) return null;
+        if (!d.startsWith(ERC20_TRANSFER_SELECTOR)) return null;
 
         const decoded = decodeParameters(['address', 'uint256'], d.slice(10)); // [to, amount]
 
@@ -136,4 +136,64 @@ export const ensureHexPrefix = (hex?: string): string => {
     if (!hex) return '';
 
     return hex.startsWith('0x') ? hex : `0x${hex}`;
+};
+
+interface BuildTransactionDataParams {
+    amount: string;
+    spender: string;
+}
+
+export const buildApprovalTransactionData = ({
+    amount: rawAmount,
+    spender: rawSpender,
+}: BuildTransactionDataParams): string => {
+    if (!isAddressValid(rawSpender, 'base')) {
+        throw new Error('Invalid spender address');
+    }
+
+    const amount = new BigNumber(rawAmount);
+    const spender = rawSpender.toLowerCase().replace(/^0x/, '').padStart(64, '0');
+
+    if (amount.isNaN() || !amount.isInteger() || amount.isNegative() || amount.gt(UINT256_MAX)) {
+        throw new Error('Invalid amount');
+    }
+
+    const amountHex = amount.toString(16).padStart(64, '0');
+
+    return `${ERC20_APPROVE_SELECTOR}${spender}${amountHex}`;
+};
+
+interface GetAllowanceAmountParams {
+    rawAmount: string;
+    approvalType: 'MINIMAL' | 'INFINITE' | 'ZERO' | 'PRESET';
+    token: TokenInfo;
+}
+
+export const getAllowanceAmount = ({
+    rawAmount,
+    approvalType,
+    token,
+}: GetAllowanceAmountParams) => {
+    const inputAmount = unitsToSubunits({
+        value: asAmountUnit(new BigNumber(rawAmount)),
+        decimals: token.decimals,
+    });
+
+    const getAmount = () => {
+        switch (approvalType) {
+            case 'INFINITE':
+                return asAmountSubunit(new BigNumber(UINT256_MAX)).toString();
+            case 'ZERO':
+                return '0';
+            case 'MINIMAL':
+            case 'PRESET':
+                return inputAmount.toString();
+            default:
+                exhaustive(approvalType);
+        }
+    };
+
+    const allowanceAmount = getAmount();
+
+    return { inputAmount, allowanceAmount };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -15369,6 +15369,7 @@ __metadata:
     "@suite/platform-encryption-webauthn": "workspace:*"
     "@suite/suite-sync": "workspace:*"
     "@suite/tx-simulation": "workspace:^"
+    "@tanstack/react-query": "npm:5.90.16"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:^16.3.0"
     "@testing-library/user-event": "npm:^14.6.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Extracts the ERC-20 token approve/revoke flow from the trading module into a standalone, reusable allowance module. 

#### Allowance modals

`ApproveModal` and `RevokeModal` are no longer dependent on trading context. They now use its own `AllowanceContext` handling everything allowance related.

Usage:

```tsx
// Modal
<ApproveModal
  amount={amount}
  cryptoId={cryptoId}
  account={account}
  provider={provider}
  spender={spender}
  onSelectApprovalType={onSelectApprovalType}
  onConfirm={onConfirm}
  onCancel={onCancel}
/>

// Provider
const allowanceContextValue = useAllowance({ account });
<AllowanceContext.Provider value={allowanceContextValue}>
  ...
</AllowanceContext.Provider>

// Consumer
const { state, tx } = useAllowanceContext();
state.openApproveModal();
tx.status.isPending; // true while approval tx is confirming
```

#### AccountKey

Added optional `accountKey` to `storePrecomposedTransaction`, checked by `selectAccountIncludingChosenInTrading` before the trading `modalAccountKey` fallback. This allows the allowance flow to resolve the correct account for transaction review modal without depending on trading actions.


 #### Workspace script (unrelated to Allowance)

Added `scripts/ws.sh` — an interactive script runner that uses `fzf` to fuzzy-search workspaces and their scripts, then executes via `yarn workspace`. Useful for quickly running any package script across the monorepo without remembering exact workspace names.

![pr-demo](https://github.com/user-attachments/assets/83d1febb-7f7a-428b-bf9e-33d716fc0c6c)


## Notes for QA

Nothing should change really, approve/revoke modals should work as before, but please go through all the trading flows - swap, buy and sell to see if everything works correctly.


## Related Issue

Resolve [#24335](https://github.com/trezor/trezor-suite/issues/24335)

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/extract-approval-modal-from-trading&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/extract-approval-modal-from-trading&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/extract-approval-modal-from-trading&lookback=7)