### PR TITLE
fix(suite): move FW install progress check conditions to Connect

### DIFF
--- a/packages/connect/src/api/firmware/uploadFirmware.ts
+++ b/packages/connect/src/api/firmware/uploadFirmware.ts
@@ -1,7 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/uploadFirmware.js
 
 import { ERRORS } from '@trezor/connect-common/src/constants';
+import { getFirmwareVersionArray } from '@trezor/device-utils';
 import { TRANSPORT } from '@trezor/transport';
+import { isWithinRange } from '@trezor/utils/src/versionUtils';
 
 import { PROTO } from '../../constants';
 import type { Device } from '../../device/Device';
@@ -34,6 +36,8 @@ const postProgressMessage = (
 };
 
 const FIRMWARE_ERASE_TIMEOUT_MILLISECONDS = 15_000;
+const TIMEOUT_MIN_FW_VERSION = '1.12.1';
+const TIMEOUT_MAX_FW_VERSION = '1.13.0';
 
 type UploadFirmwareProps = {
     typedCall: TypedCall;
@@ -57,7 +61,11 @@ export const uploadFirmware = async ({
         // but it may also indicate that something is wrong with the device, so inform Suite which can then display warning.
         // this may be removed in future if we confirm that the issue was resolved
         const timeoutId = setTimeout(() => {
-            postMessage(createUiMessage(UI.FIRMWARE_PROGRESS_UNEXPECTED_DELAY, {}));
+            const version = getFirmwareVersionArray(device.toMessageObject());
+            if (version === null) return;
+            if (isWithinRange(version, TIMEOUT_MIN_FW_VERSION, TIMEOUT_MAX_FW_VERSION)) {
+                postMessage(createUiMessage(UI.FIRMWARE_PROGRESS_UNEXPECTED_DELAY, {}));
+            }
         }, FIRMWARE_ERASE_TIMEOUT_MILLISECONDS);
         await typedCall('FirmwareErase', 'Success', {});
         clearTimeout(timeoutId);

--- a/packages/suite/src/hooks/suite/useFirmwareInstallationProgressCheck.ts
+++ b/packages/suite/src/hooks/suite/useFirmwareInstallationProgressCheck.ts
@@ -1,41 +1,20 @@
 import { useState } from 'react';
 
-import * as semver from 'semver';
-
-import { TrezorDevice } from '@suite-common/suite-types';
 import { UI } from '@trezor/connect';
-import { DeviceModelInternal, getFirmwareVersion } from '@trezor/device-utils';
+import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { useFirmwareDesktopUpdate } from './useFirmwareDesktopUpdate';
 
-// because the UI is targeted to a specific bootloader screen, we can only reliably target FW versions that share the same bootloader (the 1.12.1)
-const MIN_T1B1_FW_VERSION = '1.12.1';
-const MAX_T1B1_FW_VERSION = '1.13.1';
-
-/**
- * This check is currently targeted only for T1B1 devices, and only for specific versions
- */
-const getCheckSupport = (device?: TrezorDevice): boolean => {
-    const isT1B1 = device?.features?.internal_model === DeviceModelInternal.T1B1;
-    const deviceFWVersion = getFirmwareVersion(device);
-    if (semver.valid(deviceFWVersion) === null) return false;
-
-    return (
-        isT1B1 &&
-        semver.gte(deviceFWVersion, MIN_T1B1_FW_VERSION) &&
-        semver.lt(deviceFWVersion, MAX_T1B1_FW_VERSION)
-    );
-};
-
 export const useFirmwareInstallationProgressCheck = () => {
     const { originalDevice, uiEvent } = useFirmwareDesktopUpdate();
-    const isCheckSupported = getCheckSupport(originalDevice);
+    const isT1B1 = originalDevice?.features?.internal_model === DeviceModelInternal.T1B1;
+
     const isUnexpectedDelay = uiEvent?.type === UI.FIRMWARE_PROGRESS_UNEXPECTED_DELAY;
 
     const [isDismissed, setIsDismissed] = useState(false);
     const handleDismissProgressCheck = () => setIsDismissed(true);
 
-    const isProgressCheckDisplayed = isCheckSupported && isUnexpectedDelay && !isDismissed;
+    const isProgressCheckDisplayed = isT1B1 && isUnexpectedDelay && !isDismissed;
 
     return {
         isProgressCheckDisplayed,

--- a/packages/utils/src/versionUtils.ts
+++ b/packages/utils/src/versionUtils.ts
@@ -53,3 +53,12 @@ export const isNewerOrEqual = (versionX: VersionInput, versionY: VersionInput) =
 export const normalizeVersion = (version: string) =>
     // remove any zeros that are not preceded by Latin letters, decimal digits, underscores
     version.replace(/\b0+(\d)/g, '$1');
+
+/**
+ * Is version within the range of minVersion and maxVersion (inclusive on both ends)
+ */
+export const isWithinRange = (
+    version: VersionInput,
+    minVersion: VersionInput,
+    maxVersion: VersionInput,
+) => isNewerOrEqual(version, minVersion) && isNewerOrEqual(maxVersion, version);

--- a/packages/utils/tests/versionUtils.test.ts
+++ b/packages/utils/tests/versionUtils.test.ts
@@ -3,6 +3,7 @@ import {
     isNewer,
     isNewerOrEqual,
     isVersionArray,
+    isWithinRange,
     normalizeVersion,
 } from '../src/versionUtils';
 
@@ -34,19 +35,19 @@ const testMatrix = (
 };
 
 describe('versionUtils', () => {
-    describe('isNewer', () => {
+    describe(isNewer.name, () => {
         testMatrix(isNewer, (a, b) => a > b);
     });
 
-    describe('isNewerOrEqual', () => {
+    describe(isNewerOrEqual.name, () => {
         testMatrix(isNewerOrEqual, (a, b) => a >= b);
     });
 
-    describe('isEqual', () => {
+    describe(isEqual.name, () => {
         testMatrix(isEqual, (a, b) => a === b);
     });
 
-    describe('normalizeVersion', () => {
+    describe(normalizeVersion.name, () => {
         it('removes preceding zeros from versions to normalize it', () => {
             expect(normalizeVersion('2020.05.13-beta')).toEqual('2020.5.13-beta');
             expect(normalizeVersion('2022.12.01-beta')).toEqual('2022.12.1-beta');
@@ -61,7 +62,7 @@ describe('versionUtils', () => {
         });
     });
 
-    describe('isVersionArray', () => {
+    describe(isVersionArray.name, () => {
         it('invalid cases', () => {
             expect(isVersionArray(null)).toEqual(false);
             expect(isVersionArray([null])).toEqual(false);
@@ -77,6 +78,18 @@ describe('versionUtils', () => {
         it('valid cases', () => {
             expect(isVersionArray([0, 1, 2])).toEqual(true);
             expect(isVersionArray([1, 2, 3])).toEqual(true);
+        });
+    });
+
+    describe(isWithinRange.name, () => {
+        it('returns true if version is within range (inclusive)', () => {
+            expect(isWithinRange([1, 0, 0], '1.0.0', '2.0.0')).toBe(true);
+            expect(isWithinRange('1.5.0', [1, 0, 0], '2.0.0')).toBe(true);
+            expect(isWithinRange('2.0.0', '1.0.0', [2, 0, 0])).toBe(true);
+        });
+        it('returns false if version is outside of range', () => {
+            expect(isWithinRange('0.9.9', '1.0.0', [2, 0, 0])).toBe(false);
+            expect(isWithinRange([2, 0, 1], '1.0.0', '2.0.0')).toBe(false);
         });
     });
 });


### PR DESCRIPTION
## Description

Fix for T1B1 outside the version range 1.12.1–1.13.0 (incl.)

Previously, Connect would emit the UI event always for T1B1, but Suite would show modal only within version range.
But the Suite redux can only hold one UI event, meaning it would drop the "Confirm on device" and instead show nothing.
:arrow_right: Move that condition to Connect, i.e. emit the timeout UI event only for T1B1 within the version range. Suite then shows the modal for all T1B1s, so outside of this range the timeout UI event never arrives, and it keeps showing Confirm on device.  

## Related Issue

Follow up to https://github.com/trezor/trezor-suite/pull/24861
Resolves https://github.com/trezor/trezor-suite-private/issues/184

`no-project` because QA will be done as part of that 

## Screenshots:

1) Install T1B1 1.12.1 → 1.14.0, after confirming bootloader, device should show this screen
<img width="128" height="65" alt="image" src="https://github.com/user-attachments/assets/12268e55-8dc0-4c02-82b2-c4b90511c5e3" />
And Suite should show this for first 15 s
<img width="511" height="629" alt="Screenshot from 2026-02-03 10-34-54" src="https://github.com/user-attachments/assets/7871ae13-21b7-4c3c-a215-16d8962f7928" />

After the 15 s it should swich to this screen
<img width="1000" height="485" alt="Screenshot from 2026-02-03 10-55-34" src="https://github.com/user-attachments/assets/7bebb742-4440-410a-b768-904426f58a44" />


2) Install T1B1 1.13.1 and above → 1.14.0, wait 15 s during the same screen, and you should still see only the Confirm on device and it shall not vanish


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/T1B1-FW-install-missing-confim-on-device&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/T1B1-FW-install-missing-confim-on-device&lookback=7)