### PR TITLE
chore(suite): remove duplicated translation

### DIFF
--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceTrezorHostProtocolPair.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceTrezorHostProtocolPair.tsx
@@ -29,7 +29,7 @@ export const DeviceTrezorHostProtocolPair = () => {
 
     return (
         <TroubleshootingTips
-            label={<Translation id="TR_NEEDS_TREZOR_HOST_PROTOCOL_PAIRING_DESCRIPTION" />}
+            label={<Translation id="TR_THP_CREATE_SECURE_CONNECTION" />}
             cta={ctaButton}
             intent="info"
             items={[]}

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1935,10 +1935,6 @@ export const messages = defineMessages({
         defaultMessage: 'Firmware installation may have failed.',
         id: 'TR_FIRMWARE_CORRUPTED_CONNECT_DESCRIPTION',
     },
-    TR_NEEDS_TREZOR_HOST_PROTOCOL_PAIRING_DESCRIPTION: {
-        defaultMessage: 'Continue to THP pairing',
-        id: 'TR_NEEDS_TREZOR_HOST_PROTOCOL_PAIRING_DESCRIPTION',
-    },
     TR_UDEV_DOWNLOAD_TITLE: {
         defaultMessage: 'Download udev rules',
         id: 'TR_UDEV_DOWNLOAD_TITLE',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We shoudn't use `THP` in description, replaced with `Create secure connection`
<img width="769" height="539" alt="Screenshot from 2026-02-03 11-19-43" src="https://github.com/user-attachments/assets/88c34fe9-e4e7-4fd7-9c7a-f815d568a5e0" />
<img width="769" height="539" alt="Screenshot from 2026-02-03 11-40-21" src="https://github.com/user-attachments/assets/fb20350c-baa7-462c-ab0f-8a2f25171412" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-dupl-translation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-dupl-translation&lookback=7)