### PR TITLE
left align labels on TX detail in mobile

### DIFF
--- a/suite-native/module-transactions/src/components/TransactionUtxoAddress.tsx
+++ b/suite-native/module-transactions/src/components/TransactionUtxoAddress.tsx
@@ -40,7 +40,7 @@ export const TransactionUtxoAddress = ({
     const isLabelingEnabled = useSelector(selectSuiteSyncLabelingEnabled);
 
     return (
-        <VStack>
+        <VStack alignItems="flex-start">
             <HStack spacing={2}>
                 <AddressLabel
                     address={address}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It was aligned on center, now it's on the left.

## Notes for QA
Trivial change, see screenshots.

## Related Issue

Parially resolve https://github.com/trezor/trezor-suite/issues/24444

## Screenshots:
| BEFORE | AFTER |
|---|---|
|  <img width="366" height="399" alt="image" src="https://github.com/user-attachments/assets/7f29d7c3-27ba-4f93-9045-719ee85aa0f0" /> | <img width="369" height="397" alt="image" src="https://github.com/user-attachments/assets/4496d848-290b-4cc1-82ee-3f2128adb336" /> |

Suite Sync turned off:
<img width="371" height="328" alt="image" src="https://github.com/user-attachments/assets/ae2735b5-3cf1-48f3-85cb-bca3aa0ec3ed" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/label-alignment-tx-detail&lookback=7)