### PR TITLE
fix(ci): move @trezor/urls unit tests to nightly

### DIFF
--- a/packages/urls/package.json
+++ b/packages/urls/package.json
@@ -8,7 +8,6 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
-        "test:e2e": "yarn g:jest -c ../../jest.config.base.js",
-        "test:unit": "yarn g:jest"
+        "test:e2e": "yarn g:jest -c ../../jest.config.base.js"
     }
 }

--- a/packages/urls/tests/urls.test.ts
+++ b/packages/urls/tests/urls.test.ts
@@ -60,8 +60,6 @@ describe('Test that all external links are alive', () => {
     Object.values(URLS)
         .filter(url => !excluded.includes(url))
         .forEach(url => {
-            // Todo: temp fix. this shall run in the Nightly not on every PR
-            //       there shall be probably a test group to run some tests only nightly
             it(`HTTP GET request to ${url} should respond with an acceptable http code`, async () => {
                 const { status } = await fetch(url);
                 expect(isAcceptableHttpCode(status)).toBe(true);


### PR DESCRIPTION
## Description

Remove `@trezor/urls` unit tests from unit tests jobs run on each PR.
It's a quick fix, because required checks are now failing because of an external page :see_no_evil: 
Disadvantage: tests will no longer be run when you modify this package.

It is still run for nightlies, [see here](https://github.com/trezor/trezor-suite/blob/902ef4b22975a0b065cc8c6af7e860121818aa60/.github/workflows/test-misc.yml#L17-L30).
:thought_balloon: we could make a separate `.yml` to run the url "e2e" tests when you modify `packages/urls` :thinking: 

BTW media duplicates have failed, but [that's a preexisting issue](https://github.com/trezor/trezor-suite/actions/workflows/test-misc.yml) :facepalm:

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/move-urls-unit-tests-2-nightly&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/move-urls-unit-tests-2-nightly&lookback=7)