### PR TITLE
feat(suite-native): remove copy button from TX detail overivew

### DIFF
--- a/suite-native/module-transactions/src/screens/TransactionDetailOverviewScreen.tsx
+++ b/suite-native/module-transactions/src/screens/TransactionDetailOverviewScreen.tsx
@@ -1,5 +1,4 @@
 import { ReactNode, useMemo } from 'react';
-import { TouchableOpacity } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { A } from '@mobily/ts-belt';
@@ -8,10 +7,9 @@ import { RouteProp, useRoute } from '@react-navigation/native';
 import { TokenDefinitionsRootState } from '@suite-common/token-definitions';
 import { TransactionsRootState } from '@suite-common/wallet-core';
 import { Box, HStack, Text, VStack } from '@suite-native/atoms';
-import { useCopyToClipboard } from '@suite-native/clipboard';
 import { AccountAddressFormatter } from '@suite-native/formatters';
 import { Icon, IconName } from '@suite-native/icons';
-import { Translation, useTranslate } from '@suite-native/intl';
+import { Translation } from '@suite-native/intl';
 import {
     DynamicScreenHeader,
     Screen,
@@ -30,20 +28,8 @@ const addressCardStyle = prepareNativeStyle(utils => ({
     borderRadius: utils.borders.radii.r12,
 }));
 
-const addressStyle = prepareNativeStyle(_ => ({ maxWidth: '90%' }));
-
 const AddressRow = ({ address }: { address: string }) => {
     const { applyStyle } = useNativeStyles();
-
-    const { translate } = useTranslate();
-
-    const copyToClipboard = useCopyToClipboard();
-
-    const handleCopy = () =>
-        copyToClipboard(
-            address,
-            translate('transactions.TransactionDetailScreen.addressesSheet.copied'),
-        );
 
     return (
         <HStack
@@ -52,10 +38,7 @@ const AddressRow = ({ address }: { address: string }) => {
             alignItems="center"
             style={applyStyle(addressCardStyle)}
         >
-            <AccountAddressFormatter value={address} style={applyStyle(addressStyle)} />
-            <TouchableOpacity onPress={handleCopy}>
-                <Icon name="copy" color="iconPrimaryDefault" size="medium" />
-            </TouchableOpacity>
+            <AccountAddressFormatter value={address} />
         </HStack>
     );
 };


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- There will be an edit label button in the future, for now just removing redundant copy button as requested.

## Notes for QA
Nothing to test, it's just a removal of a feature.

## Related Issue

Part of https://github.com/trezor/trezor-suite/issues/24444

## Screenshots:
| BEFORE | AFTER |
|---|---|
| ![Screenshot_2026-02-03-13-01-37-353_io trezor suite debug](https://github.com/user-attachments/assets/dbb45138-7289-4758-ae22-1523221d9a9b) | ![Screenshot_2026-02-03-13-03-53-530_io trezor suite debug](https://github.com/user-attachments/assets/6d4fba40-a629-47a1-ba04-06389383cd07) |


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/remove-copy-button-from-tx-detail-overview&lookback=7)