### PR TITLE
chore(wallet-constants): cardano eve8 default pool

### DIFF
--- a/suite-common/wallet-constants/src/cardanoConstants.ts
+++ b/suite-common/wallet-constants/src/cardanoConstants.ts
@@ -15,8 +15,8 @@ export const MIN_CARDANO_BALANCE_FOR_STAKING = MIN_CARDANO_AMOUNT_FOR_STAKING.pl
 );
 
 export const CARDANO_EVERSTAKE_STAKING_POOL = {
-    hex: '9bf86442804da9329bfe0300592ce2e71eac4d6384a72e925f02f322',
-    bech32: 'pool1n0uxgs5qfk5n9xl7qvq9jt8zuu02cntrsjnjayjlqtejyffnemj',
+    hex: '88d719a2d9b57e7f68a77e70b3e8b8e17c76c74dc12ea52e159bb89f',
+    bech32: 'pool13rt3ngkek4l876980ect869cu978d36dcyh22ts4nwuf7ncq02u',
 };
 
 export const CARDANO_EVERSTAKE_DREP = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

EVE8 as default for this version. EVE7 is almost full

https://cardanoscan.io/pool/pool13rt3ngkek4l876980ect869cu978d36dcyh22ts4nwuf7ncq02u

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/eve8-default&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/eve8-default&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/eve8-default&lookback=7)