### PR TITLE
refactor(suite-common): rename selectIsDeviceThpRequired to selectIsDeviceThpLocked

### DIFF
--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -323,7 +323,7 @@ export const selectDeviceStatus = createMemoizedSelector(
     device => device && getStatus(device),
 );
 
-export const selectIsDeviceThpRequired = createMemoizedSelector(
+export const selectIsDeviceThpLocked = createMemoizedSelector(
     [selectDeviceStatus],
     deviceStatus => deviceStatus === 'device-thp-locked',
 );

--- a/suite-native/device/src/hooks/useConnectDeviceHandler.tsx
+++ b/suite-native/device/src/hooks/useConnectDeviceHandler.tsx
@@ -8,7 +8,7 @@ import { bluetoothActions } from '@suite-common/bluetooth';
 import {
     acquireDevice,
     selectIsAnyPhysicalDeviceConnectedViaUsb,
-    selectIsDeviceThpRequired,
+    selectIsDeviceThpLocked,
 } from '@suite-common/wallet-core';
 import {
     AuthorizeDeviceStackRoutes,
@@ -29,13 +29,13 @@ export const useConnectDeviceHandler = () => {
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
 
-    const isDeviceThpRequired = useSelector(selectIsDeviceThpRequired);
+    const isDeviceThpLocked = useSelector(selectIsDeviceThpLocked);
     const isAnyPhysicalDeviceConnectedViaUsb = useSelector(
         selectIsAnyPhysicalDeviceConnectedViaUsb,
     );
 
     const onConnectDevicePress = useCallback(() => {
-        if (isDeviceThpRequired) {
+        if (isDeviceThpLocked) {
             dispatch(acquireDevice({}));
         } else if (isAnyPhysicalDeviceConnectedViaUsb || Platform.OS === 'ios') {
             // Make sure auto-connect is enabled in case some device was manually disconnected.
@@ -48,7 +48,7 @@ export const useConnectDeviceHandler = () => {
                 screen: AuthorizeDeviceStackRoutes.ConnectDeviceCrossroads,
             });
         }
-    }, [dispatch, isDeviceThpRequired, isAnyPhysicalDeviceConnectedViaUsb, navigation]);
+    }, [dispatch, isDeviceThpLocked, isAnyPhysicalDeviceConnectedViaUsb, navigation]);
 
     return { onConnectDevicePress };
 };

--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -9,7 +9,7 @@ import {
     selectHasDeviceFirmwareInstalled,
     selectIsConnectedDeviceUninitialized,
     selectIsDevicePinLocked,
-    selectIsDeviceThpRequired,
+    selectIsDeviceThpLocked,
     selectIsNoPhysicalDeviceConnected,
     selectIsPortfolioTrackerDevice,
     selectIsUnacquiredDevice,
@@ -60,7 +60,7 @@ export const useDetectDeviceError = () => {
 
     const selectedDevice = useSelector(selectSelectedDevice);
     const isUnacquiredDevice = useSelector(selectIsUnacquiredDevice);
-    const isDeviceThpRequired = useSelector(selectIsDeviceThpRequired);
+    const isDeviceThpLocked = useSelector(selectIsDeviceThpLocked);
     const isConnectedDeviceUninitialized = useSelector(selectIsConnectedDeviceUninitialized);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isNoPhysicalDeviceConnected = useSelector(selectIsNoPhysicalDeviceConnected);
@@ -97,7 +97,7 @@ export const useDetectDeviceError = () => {
             isOnboardingFinished &&
             isUnacquiredDevice &&
             !isDevicePinLocked &&
-            !isDeviceThpRequired &&
+            !isDeviceThpLocked &&
             !isFirmwareInstallationRunning
         ) {
             showAlert({
@@ -123,7 +123,7 @@ export const useDetectDeviceError = () => {
         isDevicePinLocked,
         isOnboardingFinished,
         isUnacquiredDevice,
-        isDeviceThpRequired,
+        isDeviceThpLocked,
         isFirmwareInstallationRunning,
         dispatch,
         hideAlert,

--- a/suite-native/module-authorize-device/src/selectors.ts
+++ b/suite-native/module-authorize-device/src/selectors.ts
@@ -1,11 +1,11 @@
 import { createWeakMapSelector } from '@suite-common/redux-utils';
 import { ThpRootState, selectThpLastResult, selectThpStep } from '@suite-common/thp';
-import { DeviceRootState, selectIsDeviceThpRequired } from '@suite-common/wallet-core';
+import { DeviceRootState, selectIsDeviceThpLocked } from '@suite-common/wallet-core';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<ThpRootState & DeviceRootState>();
 
 export const selectIsThpScreenDismissable = createMemoizedSelector(
-    [selectThpStep, selectThpLastResult, selectIsDeviceThpRequired],
-    (thpStep, thpLastResult, isDeviceThpRequired) =>
-        thpStep === null && (thpLastResult === 'canceled' || !isDeviceThpRequired),
+    [selectThpStep, selectThpLastResult, selectIsDeviceThpLocked],
+    (thpStep, thpLastResult, isDeviceThpLocked) =>
+        thpStep === null && (thpLastResult === 'canceled' || !isDeviceThpLocked),
 );

--- a/suite-native/module-home/src/screens/HomeScreen/components/EmptyHomeRenderer.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EmptyHomeRenderer.tsx
@@ -5,7 +5,7 @@ import {
     selectIsDeviceAuthorized,
     selectIsDeviceConnected,
     selectIsDeviceInitialized,
-    selectIsDeviceThpRequired,
+    selectIsDeviceThpLocked,
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
 import { Box } from '@suite-native/atoms';
@@ -24,7 +24,7 @@ export const EmptyHomeRenderer = () => {
     const isDeviceReadyToUse = useSelector(selectIsDeviceReadyToUse);
     const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
-    const isDeviceThpRequired = useSelector(selectIsDeviceThpRequired);
+    const isDeviceThpLocked = useSelector(selectIsDeviceThpLocked);
     const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
 
     // This state is present only for a fraction of second while redirecting to the Connecting screen is already happening.
@@ -35,12 +35,7 @@ export const EmptyHomeRenderer = () => {
 
     let ScreenContent = EmptyPortfolioTrackerState;
 
-    if (
-        isDeviceSetupSupported &&
-        isDeviceConnected &&
-        !isDeviceInitialized &&
-        !isDeviceThpRequired
-    ) {
+    if (isDeviceSetupSupported && isDeviceConnected && !isDeviceInitialized && !isDeviceThpLocked) {
         ScreenContent = UninitializedConnectedDeviceState;
     }
     // Crossroads should be displayed if there is no real device connected and portfolio tracker has no accounts


### PR DESCRIPTION


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/common/select-is-device-thp-locked&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/common/select-is-device-thp-locked&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/common/select-is-device-thp-locked&lookback=7)