### PR TITLE
feat(ci): tweaks and fixes for nightly tests

### DIFF
--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -63,6 +63,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -71,7 +71,10 @@ jobs:
 
       - run: yarn install --immutable
       - run: yarn message-system-sign-config
-      - run: yarn test:unit
+      - name: Unit Tests - Suite, Connect, Common
+        run: yarn test:unit --exclude='@suite-native/*'
+      - name: Unit Tests - Native
+        run: yarn test:unit --exclude='@trezor/*,@suite/*,@suite-common/*'
 
   test-unit-windows:
     runs-on: windows-latest

--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -14,21 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  urls-health:
-    runs-on: ubuntu-latest
-    if: github.repository == 'trezor/trezor-suite'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-
-      - run: yarn install --immutable
-      - run: yarn workspace @trezor/urls test:e2e
-
   translations-unused:
     runs-on: ubuntu-latest
     if: github.repository == 'trezor/trezor-suite'

--- a/.github/workflows/test-urls.yml
+++ b/.github/workflows/test-urls.yml
@@ -1,0 +1,27 @@
+name: "[Test] URLs health check"
+
+on:
+  schedule:
+    # Runs at midnight UTC every day at 01:00 AM CET, same as other nightlies in test-misc.yml
+    - cron: "0 0 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/test-urls.yml"
+      - "packages/urls/**"
+  workflow_dispatch:
+
+jobs:
+  urls-health:
+    runs-on: ubuntu-latest
+    if: github.repository == 'trezor/trezor-suite'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - run: yarn install --immutable
+      - run: yarn workspace @trezor/urls test:e2e

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1090,10 +1090,6 @@ export const messages = defineMessages({
         defaultMessage: 'Swap amount',
         id: 'TR_TRADING_SWAP_AMOUNT',
     },
-    TR_TRADING_ON_NETWORK_CHAIN: {
-        defaultMessage: 'On {networkName} chain',
-        id: 'TR_TRADING_ON_NETWORK_CHAIN',
-    },
     TR_TRADING_KYC_POLICY: {
         defaultMessage: 'KYC policy',
         id: 'TR_TRADING_KYC_POLICY',


### PR DESCRIPTION
## Description

Nightly test tweaks & fixes:

- Followup to https://github.com/trezor/trezor-suite/pull/24908 – extract the URL health check job from nightlies, so that the URL health check is once again reactive on code changes in `/packages/urls/**`
  - see [that it did run](https://github.com/trezor/trezor-suite/actions/runs/21705388036/job/62595069551?pr=24915) because the `yml` file was changed (created).
- Incidental fix: split unit tests the same way as done in PR checks, because it seems that the runner is unstable on native tests when they are not separated  
- Incidental fix: checkout with submodules, because of [@trezor/connect-plugin-ethereum:test:unit](https://github.com/trezor/trezor-suite/blob/6b8e9ab6d2baee6c7600ff1c22f456c0dd55bac3/packages/connect-plugin-ethereum/__tests__/index.test.ts#L3)
- Remove unused translations

Also media duplicates are failing, but [it's been failing for quite some time](https://github.com/trezor/trezor-suite/actions/workflows/test-misc.yml) cc @trezor/suite-growth

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/new-github-action-for-urls&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/new-github-action-for-urls&lookback=7)