### PR TITLE
fix(test): hack to fix flaky unit test

### DIFF
--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -391,7 +391,7 @@ describe('Storage actions', () => {
         // store device in db
         await store.dispatch(storageActions.rememberDevice(dev1));
 
-        // Change device label inside a reducer
+        // Change device label inside a reducer. This is a plain action, and storageMiddleware updates the db.
         await store.dispatch(
             deviceActions.updateSelectedDevice({
                 ...(dev1Connected as AcquiredDevice),
@@ -399,7 +399,8 @@ describe('Storage actions', () => {
             }),
         );
 
-        await new Promise(resolve => setTimeout(resolve));
+        // Hack - because the db operation is done in a middleware, it is not awaitable via dispatch
+        await new Promise(resolve => setTimeout(resolve, 100));
         store.dispatch(await preloadStore());
         expect(selectDevices(store.getState())[0].label).toBe('New Label');
     });


### PR DESCRIPTION
## Description

Fix a flaky unit test by timeout. It's horrible, but not fixable without rewriting whole `storageMiddleware`. Maybe that's not even desired, because IDB persistence is a side effect done on best-effort basis. Though such a thing is poorly testable :disappointed: 

Seems that 100 ms is enough – you can replicate this error by removing the `await` [on this line](https://github.com/trezor/trezor-suite/blob/61ab2d5c721ba2359c7be838b46937da264f9042/packages/suite/src/actions/suite/__tests__/storageActions.test.ts#L395), but with 100ms it passes even like that :heavy_check_mark: 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/flaky-storage-test&lookback=7)