### PR TITLE
fix(suite): show token logo in transaction notifications

### DIFF
--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/ExchangeInfoRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/ExchangeInfoRenderer.tsx
@@ -72,7 +72,7 @@ export const ExchangeInfoRenderer = ({ render: View, ...props }: ExchangeInfoRen
                         <Row gap={8} alignItems="center">
                             <AssetLogo
                                 size={20}
-                                coingeckoId={sendNetwork.coingeckoId!}
+                                coingeckoId={sendNetwork.coingeckoId ?? ''}
                                 contractAddress={send.contractAddress}
                                 symbol={send.symbol}
                                 placeholder={getDisplaySymbol(sendSymbol || send.symbol)}
@@ -84,7 +84,7 @@ export const ExchangeInfoRenderer = ({ render: View, ...props }: ExchangeInfoRen
                             <Icon name="arrowRight" variant="tertiary" size="mediumLarge" />
                             <AssetLogo
                                 size={20}
-                                coingeckoId={receiveNetwork.coingeckoId!}
+                                coingeckoId={receiveNetwork.coingeckoId ?? ''}
                                 contractAddress={receive.contractAddress}
                                 symbol={receive.symbol}
                                 placeholder={getDisplaySymbol(receiveSymbol || receive.symbol)}

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -1,5 +1,5 @@
 import { Translation } from '@suite/intl';
-import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { getCoingeckoId, getDisplaySymbol } from '@suite-common/wallet-config';
 import {
     selectAccounts,
     selectBlockchainState,
@@ -55,12 +55,13 @@ const TransactionRendererContent = ({ notification, account }: TransactionRender
         case 'tx-approved':
         case 'tx-revoked': {
             const { token, symbol } = notification;
+            const coingeckoId = getCoingeckoId(account.symbol);
 
             return (
                 <Row gap={8} alignItems="center">
                     <AssetLogo
                         symbol={symbol}
-                        coingeckoId={account.symbol}
+                        coingeckoId={coingeckoId ?? ''}
                         contractAddress={token.contract}
                         placeholder={token.name ?? symbol}
                         size={20}
@@ -80,11 +81,35 @@ const TransactionRendererContent = ({ notification, account }: TransactionRender
                 </Row>
             );
         }
-        case 'tx-claimed':
-        case 'tx-unstaked':
-        case 'tx-staked':
         case 'tx-sent':
-        case 'tx-received':
+        case 'tx-received': {
+            const { token, symbol } = notification;
+            const coingeckoId = getCoingeckoId(account.symbol);
+
+            return (
+                <Row gap={8} alignItems="center">
+                    {token ? (
+                        <AssetLogo
+                            symbol={symbol}
+                            coingeckoId={coingeckoId ?? ''}
+                            contractAddress={token.contract}
+                            placeholder={token.name ?? symbol}
+                            size={20}
+                            shouldTryToFetch
+                        />
+                    ) : (
+                        <CoinLogo symbol={symbol} size={20} />
+                    )}
+
+                    <HiddenPlaceholder data-testid={amountTestId}>
+                        {notification.formattedAmount}
+                    </HiddenPlaceholder>
+                </Row>
+            );
+        }
+        case 'tx-staked':
+        case 'tx-unstaked':
+        case 'tx-claimed':
         case 'tx-confirmed':
         default: {
             const { symbol } = notification;

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -25,6 +25,7 @@ type TransactionNotificationPayload = {
 };
 type SentTransactionNotification = {
     type: 'tx-sent';
+    token?: TokenInfo;
 } & TransactionNotificationPayload;
 
 type RevokeTransactionNotification = {
@@ -45,6 +46,7 @@ type ExchangeTransactionNotification = {
 
 type ReceivedTransactionNotification = {
     type: 'tx-received' | 'tx-confirmed';
+    token?: Pick<TokenInfo, 'contract' | 'name' | 'symbol'>;
 } & TransactionNotificationPayload;
 
 type StakedTransactionNotification = {

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -339,6 +339,7 @@ export const onBlockchainNotificationThunk = createThunk(
                     type: 'tx-received',
                     formattedAmount,
                     device: accountDevice,
+                    token,
                     descriptor: account.descriptor,
                     symbol: account.symbol,
                     txid: tx.txid,

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -414,6 +414,7 @@ export const pushSendFormTransactionThunk = createThunk<
                         type: 'tx-sent',
                         formattedAmount,
                         device,
+                        token,
                         descriptor: selectedAccount.descriptor,
                         symbol: selectedAccount.symbol,
                         txid,


### PR DESCRIPTION
## Description

Transaction notifications now show the correct token logo.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22595

## Screenshots:

<img width="416" height="105" alt="image" src="https://github.com/user-attachments/assets/d77b6045-f641-49ac-8ffd-9999a2ef522d" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/transaction-notifications-logo&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/transaction-notifications-logo&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/transaction-notifications-logo&lookback=7)