### PR TITLE
chore(sentry): reorganize app-specific config from common

### DIFF
--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -18,6 +18,7 @@
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-constants": "workspace:^",
         "@suite-common/suite-utils": "workspace:*",
+        "@suite/sentry": "workspace:*",
         "@trezor/coinjoin": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/env-utils": "workspace:*",

--- a/packages/suite-desktop-core/src/libs/sentry.ts
+++ b/packages/suite-desktop-core/src/libs/sentry.ts
@@ -6,7 +6,7 @@ import {
 } from '@sentry/electron/main';
 import { session } from 'electron';
 
-import { SENTRY_CONFIG } from '@suite-common/sentry';
+import { SENTRY_CONFIG } from '@suite/sentry';
 import { TorStatus } from '@trezor/suite-desktop-api';
 
 import type { Store } from './store';

--- a/packages/suite-desktop-core/tsconfig.json
+++ b/packages/suite-desktop-core/tsconfig.json
@@ -13,6 +13,7 @@
         {
             "path": "../../suite-common/suite-utils"
         },
+        { "path": "../../suite/sentry" },
         { "path": "../coinjoin" },
         { "path": "../connect" },
         { "path": "../env-utils" },

--- a/packages/suite-desktop-ui/package.json
+++ b/packages/suite-desktop-ui/package.json
@@ -13,10 +13,10 @@
     },
     "dependencies": {
         "@sentry/electron": "^7.5.0",
-        "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite/analytics": "workspace:*",
         "@suite/intl": "workspace:*",
+        "@suite/sentry": "workspace:*",
         "@trezor/components": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/ipc-proxy": "workspace:*",

--- a/packages/suite-desktop-ui/src/sentry.ts
+++ b/packages/suite-desktop-ui/src/sentry.ts
@@ -1,6 +1,6 @@
 import { BrowserOptions, captureConsoleIntegration, init } from '@sentry/electron/renderer';
 
-import { SENTRY_CONFIG } from '@suite-common/sentry';
+import { SENTRY_CONFIG } from '@suite/sentry';
 
 const ELECTRON_RENDERER_SENTRY_CONFIG = {
     ...SENTRY_CONFIG,

--- a/packages/suite-desktop-ui/tsconfig.json
+++ b/packages/suite-desktop-ui/tsconfig.json
@@ -9,12 +9,12 @@
         "../suite/src/components/suite/BioAuthGuard"
     ],
     "references": [
-        { "path": "../../suite-common/sentry" },
         {
             "path": "../../suite-common/suite-types"
         },
         { "path": "../../suite/analytics" },
         { "path": "../../suite/intl" },
+        { "path": "../../suite/sentry" },
         { "path": "../components" },
         { "path": "../connect" },
         { "path": "../ipc-proxy" },

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -16,7 +16,6 @@
     },
     "dependencies": {
         "@sentry/browser": "10.32.1",
-        "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/suite": "workspace:*",
@@ -27,6 +26,7 @@
         "react-redux": "9.2.0"
     },
     "devDependencies": {
+        "@suite/sentry": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/eslint": "workspace:*",
         "@types/react": "19.1.6",

--- a/packages/suite-web/src/sentry.ts
+++ b/packages/suite-web/src/sentry.ts
@@ -1,6 +1,6 @@
 import { BrowserOptions, captureConsoleIntegration, init } from '@sentry/browser';
 
-import { SENTRY_CONFIG } from '@suite-common/sentry';
+import { SENTRY_CONFIG } from '@suite/sentry';
 
 const BROWSER_SENTRY_CONFIG: BrowserOptions = {
     ...SENTRY_CONFIG,

--- a/packages/suite-web/tsconfig.json
+++ b/packages/suite-web/tsconfig.json
@@ -6,12 +6,12 @@
     },
     "include": ["."],
     "references": [
-        { "path": "../../suite-common/sentry" },
         {
             "path": "../../suite-common/suite-types"
         },
         { "path": "../connect" },
         { "path": "../suite" },
+        { "path": "../../suite/sentry" },
         { "path": "../eslint" }
     ]
 }

--- a/suite-common/sentry/README.md
+++ b/suite-common/sentry/README.md
@@ -1,13 +1,13 @@
 # @suite-common/sentry
 
-This is a package for code that's common for Sentry integration in Suite applications.
+This is a package for code that's common for all Sentry integration in Suite applications.
 
-Also contains static config for individual Suite applications, but there mustn't be any runtime setup of Sentry.
-That must be kept in the individual applications or their respective packages.
+Sentry in Trezor Suite is split into two projects (which have their own config),<br />
+and four separate runtimes (each has its own SDK initialization):
 
-Sentry is then initialized in 4 separate runtimes:
-
-- browser (Suite Web, in `@packages/suite-web`)
-- electron-renderer (Suite Desktop, in `@packages/suite-desktop-ui`)
-- electron-main (Suite Desktop, in `@packages/suite-desktop-core`)
-- react-native (Suite Mobile, in `@suite-native/sentry`)
+- project `trezor-suite`, with common config in `@suite/sentry`
+    - browser runtime (Suite Web, in `@packages/suite-web`)
+    - electron-renderer runtime (Suite Desktop, in `@packages/suite-desktop-ui`)
+    - electron-main runtime (Suite Desktop, in `@packages/suite-desktop-core`)
+- project `suite-native`
+    - react-native runtime (Suite Mobile, in `@suite-native/sentry`)

--- a/suite-common/sentry/package.json
+++ b/suite-common/sentry/package.json
@@ -10,9 +10,6 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@sentry/core": "10.32.1",
-        "@suite-common/suite-utils": "workspace:*",
-        "@trezor/env-utils": "workspace:*",
-        "@trezor/utils": "workspace:*"
+        "@sentry/core": "10.32.1"
     }
 }

--- a/suite-common/sentry/src/ignoreErrors.ts
+++ b/suite-common/sentry/src/ignoreErrors.ts
@@ -7,7 +7,7 @@ import type { Options } from '@sentry/core';
  * This is a good place to add commonly occurring lifecycle errors that may happen during normal use (not preventable).
  * Do not add here errors that are now definitively fixed (those belong in Sentry ingest inbound filters).
  */
-const ignoreErrorsCommon = [
+export const ignoreErrorsCommon = [
     /.*Sequence of config.*is older than the current one.*/,
 
     // Various kinds of network connectivity problems
@@ -37,24 +37,4 @@ const ignoreErrorsCommon = [
     /.*session not found.*/,
     /.*Action canceled by user.*/,
     /.*device disconnected during action.*/, // the same as with 'other call in progress'
-] satisfies Options['ignoreErrors'];
-
-export const ignoreErrorsSuite = [
-    ...ignoreErrorsCommon,
-    /.*ResizeObserver loop limit exceeded.*/,
-    /.*Timeout waiting for TOR control port.*/,
-    /.*write EPIPE.*/,
-
-    // Common IDB lifecycle errors
-    /.*The database connection is closing.*/,
-    /.*Error: InvalidStateError: Failed to execute 'transaction' on 'IDBDatabase'.*/,
-
-    // Common Electron lifecycle errors
-    /.*Frame property was accessed after it navigated or was destroyed.*/, // Renderer process already closed while main is still responding to its IPC
-] satisfies Options['ignoreErrors'];
-
-export const ignoreErrorsSuiteMobile = [
-    ...ignoreErrorsCommon,
-    /.*Websocket closed.*/,
-    /.*Network request failed.*/,
 ] satisfies Options['ignoreErrors'];

--- a/suite-common/sentry/src/index.ts
+++ b/suite-common/sentry/src/index.ts
@@ -1,4 +1,3 @@
 export * from './constants';
-export { ignoreErrorsSuite, ignoreErrorsSuiteMobile } from './ignoreErrors';
-export { SENTRY_CONFIG } from './suiteConfig';
+export { ignoreErrorsCommon } from './ignoreErrors';
 export { redactSentryEvent } from './redactSentryEvent';

--- a/suite-common/sentry/tsconfig.json
+++ b/suite-common/sentry/tsconfig.json
@@ -1,9 +1,5 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": [
-        { "path": "../suite-utils" },
-        { "path": "../../packages/env-utils" },
-        { "path": "../../packages/utils" }
-    ]
+    "references": []
 }

--- a/suite-native/sentry/README.md
+++ b/suite-native/sentry/README.md
@@ -1,0 +1,3 @@
+# @suite-native/sentry
+
+Static Sentry config and Sentry SDK initialization for the `suite-native` project, used by Suite Mobile.

--- a/suite-native/sentry/src/ignoreErrors.ts
+++ b/suite-native/sentry/src/ignoreErrors.ts
@@ -1,0 +1,9 @@
+import type { Options } from '@sentry/core';
+
+import { ignoreErrorsCommon } from '@suite-common/sentry';
+
+export const ignoreErrors = [
+    ...ignoreErrorsCommon,
+    /.*Websocket closed.*/,
+    /.*Network request failed.*/,
+] satisfies Options['ignoreErrors'];

--- a/suite-native/sentry/src/sentry.ts
+++ b/suite-native/sentry/src/sentry.ts
@@ -1,7 +1,9 @@
 import * as Sentry from '@sentry/react-native';
 
-import { ALLOW_REPORT_TAG, ignoreErrorsSuiteMobile, redactSentryEvent } from '@suite-common/sentry';
+import { ALLOW_REPORT_TAG, redactSentryEvent } from '@suite-common/sentry';
 import { getEnv, isDebugEnv, isDetoxTestBuild } from '@suite-native/config';
+
+import { ignoreErrors } from './ignoreErrors';
 
 export const setSentryContext = Sentry.setContext;
 
@@ -31,7 +33,7 @@ export const initSentry = () => {
         integrations: [Sentry.consoleLoggingIntegration({ levels: ['error'] })],
         enableLogs: true,
         beforeSend: redactSentryEvent,
-        ignoreErrors: ignoreErrorsSuiteMobile,
+        ignoreErrors,
 
         // You can put EXPO_PUBLIC_IS_SENTRY_ON_DEBUG_BUILD_ENABLED=true to `.env.development.local` to debug Sentry locally.
         enabled:

--- a/suite/sentry/README.md
+++ b/suite/sentry/README.md
@@ -1,0 +1,7 @@
+# @suite/sentry
+
+Common static config of Sentry for `trezor-suite` project, used by these three runtimes:
+
+- browser runtime (Suite Web, in `@packages/suite-web`)
+- electron-renderer runtime (Suite Desktop, in `@packages/suite-desktop-ui`)
+- electron-main runtime (Suite Desktop, in `@packages/suite-desktop-core`)

--- a/suite/sentry/package.json
+++ b/suite/sentry/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@suite-native/sentry",
+    "name": "@suite/sentry",
     "version": "1.0.0",
     "private": true,
     "license": "See LICENSE.md in repo root",
@@ -12,9 +12,9 @@
     },
     "dependencies": {
         "@sentry/core": "10.32.1",
-        "@sentry/react-native": "7.8.0",
         "@suite-common/sentry": "workspace:*",
-        "@suite-common/suite-types": "workspace:*",
-        "@suite-native/config": "workspace:*"
+        "@suite-common/suite-utils": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
+        "@trezor/utils": "workspace:*"
     }
 }

--- a/suite/sentry/src/config.ts
+++ b/suite/sentry/src/config.ts
@@ -1,12 +1,11 @@
 import type { ErrorEvent, Options } from '@sentry/core';
 
+import { COINJOIN_NETWORK_TAG, COINJOIN_REPORT_TAG, redactSentryEvent } from '@suite-common/sentry';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { isCodesignBuild } from '@trezor/env-utils';
 import { redactUserPathFromString } from '@trezor/utils';
 
-import { COINJOIN_NETWORK_TAG, COINJOIN_REPORT_TAG } from './constants';
-import { ignoreErrorsSuite } from './ignoreErrors';
-import { redactSentryEvent } from './redactSentryEvent';
+import { ignoreErrors } from './ignoreErrors';
 
 /**
  * Full user path could be part of reported error in some cases and we want to actively filter username out.
@@ -84,7 +83,7 @@ export const SENTRY_CONFIG = {
     normalizeDepth: 4,
     maxBreadcrumbs: 40,
     beforeBreadcrumb,
-    ignoreErrors: ignoreErrorsSuite,
+    ignoreErrors,
     initialScope: {
         tags: {
             version: process.env.VERSION || 'undefined',

--- a/suite/sentry/src/ignoreErrors.ts
+++ b/suite/sentry/src/ignoreErrors.ts
@@ -1,0 +1,17 @@
+import type { Options } from '@sentry/core';
+
+import { ignoreErrorsCommon } from '@suite-common/sentry';
+
+export const ignoreErrors = [
+    ...ignoreErrorsCommon,
+    /.*ResizeObserver loop limit exceeded.*/,
+    /.*Timeout waiting for TOR control port.*/,
+    /.*write EPIPE.*/,
+
+    // Common IDB lifecycle errors
+    /.*The database connection is closing.*/,
+    /.*Error: InvalidStateError: Failed to execute 'transaction' on 'IDBDatabase'.*/,
+
+    // Common Electron lifecycle errors
+    /.*Frame property was accessed after it navigated or was destroyed.*/, // Renderer process already closed while main is still responding to its IPC
+] satisfies Options['ignoreErrors'];

--- a/suite/sentry/src/index.ts
+++ b/suite/sentry/src/index.ts
@@ -1,0 +1,1 @@
+export { SENTRY_CONFIG } from './config';

--- a/suite/sentry/tsconfig.json
+++ b/suite/sentry/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../../suite-common/sentry" },
+        {
+            "path": "../../suite-common/suite-utils"
+        },
+        { "path": "../../packages/env-utils" },
+        { "path": "../../packages/utils" }
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10954,9 +10954,6 @@ __metadata:
   resolution: "@suite-common/sentry@workspace:suite-common/sentry"
   dependencies:
     "@sentry/core": "npm:10.32.1"
-    "@suite-common/suite-utils": "workspace:*"
-    "@trezor/env-utils": "workspace:*"
-    "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -13408,6 +13405,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/sentry@workspace:suite-native/sentry"
   dependencies:
+    "@sentry/core": "npm:10.32.1"
     "@sentry/react-native": "npm:7.8.0"
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
@@ -13999,6 +13997,18 @@ __metadata:
   dependencies:
     "@suite-common/platform-encryption": "workspace:*"
     "@trezor/type-utils": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@suite/sentry@workspace:*, @suite/sentry@workspace:suite/sentry":
+  version: 0.0.0-use.local
+  resolution: "@suite/sentry@workspace:suite/sentry"
+  dependencies:
+    "@sentry/core": "npm:10.32.1"
+    "@suite-common/sentry": "workspace:*"
+    "@suite-common/suite-utils": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -15088,6 +15098,7 @@ __metadata:
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-constants": "workspace:^"
     "@suite-common/suite-utils": "workspace:*"
+    "@suite/sentry": "workspace:*"
     "@trezor/coinjoin": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/env-utils": "workspace:*"
@@ -15135,10 +15146,10 @@ __metadata:
   resolution: "@trezor/suite-desktop-ui@workspace:packages/suite-desktop-ui"
   dependencies:
     "@sentry/electron": "npm:^7.5.0"
-    "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite/analytics": "workspace:*"
     "@suite/intl": "workspace:*"
+    "@suite/sentry": "workspace:*"
     "@trezor/components": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/ipc-proxy": "workspace:*"
@@ -15236,8 +15247,8 @@ __metadata:
   resolution: "@trezor/suite-web@workspace:packages/suite-web"
   dependencies:
     "@sentry/browser": "npm:10.32.1"
-    "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
+    "@suite/sentry": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/eslint": "workspace:*"
     "@trezor/suite": "workspace:*"


### PR DESCRIPTION
## Description

Small reorganization after #24778

This PR creates a new `@suite/sentry` workspace, and makes sure that the `suite-common` package only contains common config and utils. Project-specific config is either:
- `@suite/sentry` for `trezor-suite` project
- `@suite-native/sentry` for `suite-native` project

## Notes for QA

Just smoke test that Sentry testing event from Web, Desktop, Mobile still works.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/organize-sentry-config&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/organize-sentry-config&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/organize-sentry-config&lookback=7)