### PR TITLE
fix: skip PIN onboarding step when it is not needed

### DIFF
--- a/packages/suite/src/actions/onboarding/__fixtures__/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/__fixtures__/onboardingActions.ts
@@ -8,9 +8,7 @@ export default [
     {
         description: 'goToNextStep (without param)',
         initialState: {
-            suite: {
-                device: mockSuiteDevice(),
-            },
+            device: mockSuiteDevice(),
         },
         action: () => onboardingActions.goToNextStep(),
         expect: {
@@ -20,13 +18,28 @@ export default [
     {
         description: 'goToNextStep (with param)',
         initialState: {
-            suite: {
-                device: mockSuiteDevice(),
-            },
+            device: mockSuiteDevice(),
         },
         action: () => onboardingActions.goToNextStep('firmware'),
         expect: {
             toMatchObject: { activeStepId: STEP.ID_FIRMWARE_STEP },
+        },
+    },
+    {
+        description: 'goToNextStep: from backup step skip set-pin when pin is already set',
+        initialState: {
+            onboarding: {
+                activeStepId: STEP.ID_BACKUP_STEP,
+            },
+            device: {
+                selectedDevice: mockSuiteDevice(undefined, {
+                    pin_protection: true,
+                }),
+            },
+        },
+        action: () => onboardingActions.goToNextStep(),
+        expect: {
+            toMatchObject: { activeStepId: STEP.ID_COINS_STEP },
         },
     },
     {
@@ -47,9 +60,7 @@ export default [
             onboarding: {
                 path: ['new'],
             },
-            suite: {
-                device: mockSuiteDevice(),
-            },
+            device: mockSuiteDevice(),
         },
         action: () => onboardingActions.addPath('create'),
         expect: {
@@ -62,9 +73,7 @@ export default [
             onboarding: {
                 path: ['create'],
             },
-            suite: {
-                device: mockSuiteDevice(),
-            },
+            device: mockSuiteDevice(),
         },
         action: () => onboardingActions.addPath('create'),
         expect: {
@@ -89,9 +98,7 @@ export default [
             onboarding: {
                 path: ['create', 'recovery'],
             },
-            suite: {
-                device: mockSuiteDevice(),
-            },
+            device: mockSuiteDevice(),
         },
         action: () => onboardingActions.removePath(['recovery']),
         expect: {
@@ -105,9 +112,7 @@ export default [
                 path: ['create'],
                 activeStepId: STEP.ID_RECOVERY_STEP,
             },
-            suite: {
-                device: mockSuiteDevice(),
-            },
+            device: mockSuiteDevice(),
         },
         action: () => onboardingActions.resetOnboarding(),
         expect: {

--- a/packages/suite/src/actions/onboarding/__tests__/onboardingActions.test.ts
+++ b/packages/suite/src/actions/onboarding/__tests__/onboardingActions.test.ts
@@ -20,6 +20,7 @@ import fixtures from '../__fixtures__/onboardingActions';
 const getInitialState = (custom?: any) => {
     const suite = custom ? custom.suite : undefined;
     const onboarding = custom ? custom.onboarding : undefined;
+    const device = custom ? custom.device : undefined;
 
     return {
         onboarding: {
@@ -34,7 +35,7 @@ const getInitialState = (custom?: any) => {
             ...suiteReducer(undefined, {} as Action),
             ...suite,
         },
-        device: {},
+        device: device ?? {},
     };
 };
 

--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -9,7 +9,12 @@ import { stepCategories } from 'src/config/onboarding/steps';
 import * as STEP from 'src/constants/onboarding/steps';
 import { AnyPath, AnyStepId } from 'src/types/onboarding';
 import { Dispatch, GetState } from 'src/types/suite';
-import { findNextStep, findPrevStep, isStepUsed } from 'src/utils/onboarding/steps';
+import {
+    findNextStep,
+    findPrevStep,
+    isStepUsed,
+    resolveNextAvailableStep,
+} from 'src/utils/onboarding/steps';
 
 import { selectOnboardingAnalytics } from '../../reducers/onboarding/onboardingReducer';
 import * as modalActions from '../suite/modalActions';
@@ -62,6 +67,7 @@ const removePath = (payload: AnyPath[]): OnboardingAction => ({
 
 const getAllStepsInPath = (getState: GetState) => {
     const allSteps = stepCategories.flatMap(({ steps }) => steps);
+
     const isStepUsedProps = {
         device: selectSelectedDevice(getState()),
         onboardingPath: getState().onboarding.path,
@@ -133,12 +139,13 @@ const goToSuite = () => (dispatch: Dispatch, getState: GetState, extra: ExtraDep
     reportAnalytics();
 };
 
-const goToNextStep = (stepId?: AnyStepId) => (dispatch: Dispatch, getState: GetState) => {
-    if (stepId) {
-        return dispatch(goToStep(stepId));
+const goToNextStep = (nextStepId?: AnyStepId) => (dispatch: Dispatch, getState: GetState) => {
+    if (nextStepId) {
+        return dispatch(goToStep(nextStepId));
     }
+    const device = selectSelectedDevice(getState());
     const stepsInPath = getAllStepsInPath(getState);
-    const nextStep = findNextStep(getState().onboarding.activeStepId, stepsInPath);
+    const nextStep = findNextStep(getState().onboarding.activeStepId, stepsInPath, device ?? null);
     // we are at last step, so go to Suite
     if (nextStep === null) {
         dispatch(goToSuite());
@@ -176,6 +183,19 @@ const beginOnboardingTutorial = () => async (dispatch: Dispatch, getState: GetSt
     dispatch(goToNextStep());
 };
 
+const resolveNextAfterSkipped =
+    (skippedToStepId: AnyStepId) => (_dispatch: Dispatch, getState: GetState) => {
+        const device = selectSelectedDevice(getState());
+        const stepsInPath = getAllStepsInPath(getState);
+        const resolvedNextStep = resolveNextAvailableStep(
+            skippedToStepId,
+            stepsInPath,
+            device ?? null,
+        );
+
+        return resolvedNextStep?.id;
+    };
+
 export {
     enableOnboardingReducer,
     goToNextStep,
@@ -188,4 +208,5 @@ export {
     updateAnalytics,
     beginOnboardingTutorial,
     updateBackupType,
+    resolveNextAfterSkipped,
 };

--- a/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
+++ b/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
@@ -18,7 +18,10 @@ type SkipModalContent = {
     nextStep?: AnyStepId;
 };
 
-const getModalContent = (activeStepId: AnyStepId): SkipModalContent => {
+const getModalContent = (
+    activeStepId: AnyStepId,
+    resolveNextAfterSkipped: (stepId: AnyStepId) => AnyStepId | undefined,
+): SkipModalContent => {
     switch (activeStepId) {
         case STEP.ID_FIRMWARE_STEP:
             return {
@@ -32,7 +35,7 @@ const getModalContent = (activeStepId: AnyStepId): SkipModalContent => {
                 heading: <Translation id="TR_SKIP_BACKUP" />,
                 secondaryButtonText: <Translation id="TR_SKIP_BACKUP" />,
                 body: <Translation id="TR_SKIP_BACKUP_DESCRIPTION" />,
-                nextStep: STEP.ID_SET_PIN_STEP,
+                nextStep: resolveNextAfterSkipped(STEP.ID_SET_PIN_STEP),
             };
         case STEP.ID_SET_PIN_STEP:
             return {
@@ -46,8 +49,11 @@ const getModalContent = (activeStepId: AnyStepId): SkipModalContent => {
 };
 
 export const SkipStepConfirmation = ({ onCancel }: SkipStepConfirmationProps) => {
-    const { activeStepId, goToNextStep } = useOnboarding();
-    const { heading, secondaryButtonText, body, nextStep } = getModalContent(activeStepId);
+    const { activeStepId, goToNextStep, resolveNextAfterSkipped } = useOnboarding();
+    const { heading, secondaryButtonText, body, nextStep } = getModalContent(
+        activeStepId,
+        resolveNextAfterSkipped,
+    );
 
     if (!heading) return;
 

--- a/packages/suite/src/hooks/suite/useOnboarding.ts
+++ b/packages/suite/src/hooks/suite/useOnboarding.ts
@@ -35,6 +35,8 @@ export const useOnboarding = () => {
             updateBackupType: (payload: BackupType) =>
                 dispatch(onboardingActions.updateBackupType(payload)),
             goToSuite: () => dispatch(onboardingActions.goToSuite()),
+            resolveNextAfterSkipped: (requestedStepId: AnyStepId) =>
+                dispatch(onboardingActions.resolveNextAfterSkipped(requestedStepId)),
         }),
         [dispatch],
     );

--- a/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
+++ b/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
@@ -10,6 +10,7 @@ import {
     findPrevStep,
     isStepCategoryUsed,
     isStepUsed,
+    resolveNextAvailableStep,
 } from '../steps';
 
 const firmwareStep: Step = {
@@ -54,11 +55,19 @@ const stepsMock = [firmwareStep, backupStep];
 describe('steps', () => {
     describe(findNextStep.name, () => {
         it('should find next step', () => {
-            expect(findNextStep(firmwareStep.id, stepsMock)).toEqual(backupStep);
+            const device = {
+                ...defaultDevice,
+                features: {
+                    internal_model: DeviceModelInternal.T2T1,
+                    backup_availability: 'Required',
+                },
+            } as AcquiredDevice;
+
+            expect(findNextStep(firmwareStep.id, stepsMock, device)).toEqual(backupStep);
         });
 
         it('should return null in no next step exists', () => {
-            expect(findNextStep(backupStep.id, stepsMock)).toBe(null);
+            expect(findNextStep(backupStep.id, stepsMock, defaultDevice)).toBe(null);
         });
     });
 
@@ -91,7 +100,10 @@ describe('steps', () => {
 
         it('should exclude steps not supported by device', () => {
             const deviceT3B1 = {
-                features: { internal_model: DeviceModelInternal.T3B1 },
+                features: {
+                    internal_model: DeviceModelInternal.T3B1,
+                    backup_availability: 'Required',
+                },
             } as AcquiredDevice;
             const propsWithT3B1 = { ...propsMock, device: deviceT3B1 };
             expect(isStepUsed(backupStep, propsWithT3B1)).toEqual(true);
@@ -110,6 +122,7 @@ describe('steps', () => {
                     major_version: 2,
                     minor_version: 8,
                     patch_version: 0,
+                    backup_availability: 'Required',
                 },
             } as AcquiredDevice;
             const propsNewerT3T1 = { ...propsMock, device: deviceT3T1newer };
@@ -169,6 +182,82 @@ describe('steps', () => {
                 steps: [backupStep, coinsStep],
             };
             expect(isStepCategoryUsed(modifiedStepCategory, propsWithBtcOnlyT1B1)).toEqual(false);
+        });
+    });
+
+    describe(resolveNextAvailableStep.name, () => {
+        const setPinStep: Step = { id: STEP.ID_SET_PIN_STEP, path: [] };
+        const backupStepInSteps: Step = { id: STEP.ID_BACKUP_STEP, path: [] };
+        const coinsStepInSteps: Step = { id: STEP.ID_COINS_STEP, path: [] };
+
+        const steps: Step[] = [backupStepInSteps, setPinStep, coinsStepInSteps];
+
+        it('should return requested step if it is accessible', () => {
+            const device = {
+                ...defaultDevice,
+                features: {
+                    internal_model: DeviceModelInternal.T2T1,
+                    pin_protection: false,
+                    backup_availability: 'Required',
+                },
+            } as AcquiredDevice;
+
+            expect(resolveNextAvailableStep(STEP.ID_SET_PIN_STEP, steps, device)).toEqual(
+                setPinStep,
+            );
+        });
+
+        it('should skip PIN step when pin protection is already set', () => {
+            const device = {
+                ...defaultDevice,
+                features: {
+                    internal_model: DeviceModelInternal.T2T1,
+                    pin_protection: true,
+                    backup_availability: 'Required',
+                },
+            } as AcquiredDevice;
+
+            expect(resolveNextAvailableStep(STEP.ID_SET_PIN_STEP, steps, device)).toEqual(
+                coinsStepInSteps,
+            );
+        });
+
+        it('should NOT skip Backup step when device does not require backup - you cant do backup on the device', () => {
+            const device = {
+                ...defaultDevice,
+                features: {
+                    internal_model: DeviceModelInternal.T2T1,
+                    pin_protection: false,
+                    backup_availability: 'Available',
+                },
+            } as AcquiredDevice;
+
+            expect(resolveNextAvailableStep(STEP.ID_BACKUP_STEP, steps, device)).toEqual(
+                backupStepInSteps,
+            );
+        });
+
+        it('should return null when requested step is not in steps list', () => {
+            expect(resolveNextAvailableStep(STEP.ID_FIRMWARE_STEP, steps, defaultDevice)).toEqual(
+                null,
+            );
+        });
+    });
+
+    describe(findNextStep.name, () => {
+        it('should return null when current step is not present in the steps list', () => {
+            // This may happen when a step becomes unused right after it is completed (e.g. backup step is removed
+            // from available steps once the device no longer requires backup). In that case returning the first step
+            // (firmware) would incorrectly restart onboarding.
+            const steps: Step[] = [
+                { id: STEP.ID_FIRMWARE_STEP, path: [] },
+                { id: STEP.ID_SECURITY_STEP, path: [] },
+                { id: STEP.ID_SET_PIN_STEP, path: [] },
+            ];
+
+            // Without the `currentIndex === -1` guard this would incorrectly return `steps[0]` (firmware).
+            expect(findNextStep(STEP.ID_BACKUP_STEP, steps, defaultDevice)).toEqual(null);
+            expect(findNextStep(STEP.ID_BACKUP_STEP, steps, defaultDevice)).not.toEqual(steps[0]);
         });
     });
 });

--- a/packages/suite/src/utils/onboarding/steps.ts
+++ b/packages/suite/src/utils/onboarding/steps.ts
@@ -1,7 +1,7 @@
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
 
-import { ID_AUTHENTICATE_DEVICE_STEP } from 'src/constants/onboarding/steps';
+import { ID_AUTHENTICATE_DEVICE_STEP, ID_SET_PIN_STEP } from 'src/constants/onboarding/steps';
 import { AnyPath, AnyStepId, Step, StepCategory } from 'src/types/onboarding';
 import { TrezorDevice } from 'src/types/suite';
 
@@ -87,13 +87,50 @@ export const isStepUsed = (step: Step, props: IsStepUsedProps): boolean => {
 export const isStepCategoryUsed = (stepCategory: StepCategory, props: IsStepUsedProps): boolean =>
     stepCategory.steps.some(step => isStepUsed(step, props));
 
-export const findNextStep = (currentStepId: AnyStepId, steps: Step[]): Step | null => {
-    const currentIndex = steps.findIndex((step: Step) => step.id === currentStepId);
-    if (!steps[currentIndex + 1]) {
+// Validates if Id of the next step is available, or returns the earliest next available step
+export const resolveNextAvailableStep = (
+    requestedStepId: AnyStepId | null,
+    steps: Step[],
+    device: TrezorDevice | null,
+): Step | null => {
+    const currentIndex = steps.findIndex((step: Step) => step.id === requestedStepId);
+
+    // NOTE: the next step may not be in available steps at all
+    // in that case, we would go to the first step which is incorrect, the onboarding is complete
+    if (currentIndex === -1) {
         return null;
     }
 
-    return steps[currentIndex + 1];
+    const nextStep = steps[currentIndex] ?? null;
+    if (!nextStep) {
+        return null;
+    }
+
+    if (nextStep.id === ID_SET_PIN_STEP && device) {
+        // Skip PIN setup step only if device has PIN protection explicitly enabled
+        if (device?.features?.pin_protection === true) {
+            return resolveNextAvailableStep(steps[currentIndex + 1]?.id, steps, device);
+        }
+    }
+
+    return nextStep;
+};
+
+// Calculates the next step given the current step Id
+export const findNextStep = (
+    currentStepId: AnyStepId,
+    steps: Step[],
+    device: TrezorDevice | null,
+) => {
+    const currentIndex = steps.findIndex((step: Step) => step.id === currentStepId);
+
+    if (currentIndex === -1) {
+        return null;
+    }
+
+    const nextStepOfCurrentIndex = steps[currentIndex + 1]?.id ?? null;
+
+    return resolveNextAvailableStep(nextStepOfCurrentIndex, steps, device);
 };
 
 export const findPrevStep = (currentStepId: AnyStepId, steps: Step[]) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For THP devices, it makes sure that onboarding skips the PIN step when the PIN is alreyd set on the device.

For **cable USB** connection, it doesnt skip the PIN, because at that moment, there isn't such update event comming.

## Notes for QA

When you create a wallet in onboarding and then you set the PIN on the device, after going through / skipping backup, you should go right to the COIN selection

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24468#issuecomment-3835035713

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=24468-skip-pin-onboarding-when-not-needed&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=24468-skip-pin-onboarding-when-not-needed&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24468-skip-pin-onboarding-when-not-needed&lookback=7)