### PR TITLE
feat(transport-bridge): add `/abort` endpoint

### DIFF
--- a/packages/transport-bridge/CHANGELOG.md
+++ b/packages/transport-bridge/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 3.2.0
 
+- added: `/abort` endpoint
+- fixed: http route matching
+
+# 3.2.0
+
 - breaking: return processed `ThpState` 8e9501f5c9cfd6c6751ec2318c43398b47a814bc
 
 # 3.1.0

--- a/packages/transport-bridge/package.json
+++ b/packages/transport-bridge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/transport-bridge",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "main": "src/index",
     "license": "See LICENSE.md in repo root",
     "private": true,

--- a/packages/transport-bridge/pkg.config.json
+++ b/packages/transport-bridge/pkg.config.json
@@ -1,7 +1,7 @@
 {
     "__reason_for_this_file__": "pkg packs all the 'dependencies' but we wan't only some of them to be packed.",
     "name": "@trezor/transport-bridge",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "license": "See LICENSE.md in repo root",
     "dependencies": {
         "@trezor/transport": "workspace:*",

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -13,7 +13,7 @@ import {
 } from '@trezor/node-utils';
 import { checkOrigin } from '@trezor/node-utils/src/http';
 import { AbstractApi } from '@trezor/transport/src/api/abstract';
-import { UNEXPECTED_ERROR } from '@trezor/transport/src/errors';
+import { SESSION_NOT_FOUND, UNEXPECTED_ERROR } from '@trezor/transport/src/errors';
 import { Descriptor, PathPublic, Session } from '@trezor/transport/src/types';
 import { validateProtocolMessage } from '@trezor/transport/src/utils/bridgeProtocolMessage';
 import { Log, Throttler, arrayPartition } from '@trezor/utils';
@@ -94,6 +94,8 @@ export class TrezordNode {
         req: Parameters<RequestHandler<unknown, unknown>>[0];
         res: Response;
     }[];
+    /** pending /call /read and /post sessions. can be aborted via /abort endpoint */
+    private abortableSignals: { session: string; abort: () => void }[] = [];
     private readonly requestedPort: number;
     private port?: number;
     server: HttpServer<never>[] = [];
@@ -185,7 +187,7 @@ export class TrezordNode {
         this.checkAffectedSubscriptions();
     }
 
-    private createAbortSignal(res: Response) {
+    private createAbortSignal(res: Response, session?: string) {
         const abortController = new AbortController();
         const listener = () => {
             abortController.abort();
@@ -193,7 +195,18 @@ export class TrezordNode {
         };
         res.addListener('close', listener);
 
+        if (session) {
+            this.abortableSignals.push({
+                session,
+                abort: () => abortController.abort(),
+            });
+        }
+
         return abortController.signal;
+    }
+
+    private removeAbortableSignal(session: string) {
+        this.abortableSignals = this.abortableSignals.filter(s => s.session !== session);
     }
 
     private handleResponse(res: Response, data: string) {
@@ -390,19 +403,43 @@ export class TrezordNode {
                 },
             ]);
 
+            app.post('/abort/:session', [
+                validateSessionParams,
+                parseBodyText,
+                (req, res) => {
+                    let statusCode = 400;
+                    this.abortableSignals.forEach(s => {
+                        if (s.session === req.params.session) {
+                            statusCode = 200;
+                            s.abort();
+                        }
+                    });
+                    this.removeAbortableSignal(req.params.session);
+
+                    res.statusCode = statusCode;
+
+                    return this.handleResponse(
+                        res,
+                        str(statusCode === 200 ? { success: true } : { error: SESSION_NOT_FOUND }),
+                    );
+                },
+            ]);
+
             app.post('/call/:session', [
                 validateSessionParams,
                 parseBodyText,
                 validateProtocolMessageBody(true, this.protocolMessages),
                 (req, res) => {
-                    const signal = this.createAbortSignal(res);
+                    const { session } = req.params;
+                    const signal = this.createAbortSignal(res, session);
                     this.core
                         .call({
                             ...req.body,
-                            session: req.params.session,
+                            session,
                             signal,
                         })
                         .then(result => {
+                            this.removeAbortableSignal(session);
                             if (!result.success) {
                                 res.statusCode = 400;
 
@@ -423,14 +460,16 @@ export class TrezordNode {
                 parseBodyText,
                 validateProtocolMessageBody(false, this.protocolMessages),
                 (req, res) => {
-                    const signal = this.createAbortSignal(res);
+                    const { session } = req.params;
+                    const signal = this.createAbortSignal(res, session);
                     this.core
                         .receive({
                             ...req.body,
-                            session: req.params.session,
+                            session,
                             signal,
                         })
                         .then(result => {
+                            this.removeAbortableSignal(session);
                             if (!result.success) {
                                 res.statusCode = 400;
 
@@ -451,14 +490,16 @@ export class TrezordNode {
                 parseBodyText,
                 validateProtocolMessageBody(true, this.protocolMessages),
                 (req, res) => {
-                    const signal = this.createAbortSignal(res);
+                    const { session } = req.params;
+                    const signal = this.createAbortSignal(res, session);
                     this.core
                         .send({
                             ...req.body,
-                            session: req.params.session,
+                            session,
                             signal,
                         })
                         .then(result => {
+                            this.removeAbortableSignal(session);
                             if (!result.success) {
                                 res.statusCode = 400;
 

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -83,7 +83,7 @@ const COMPATIBILITY_PORT = 21325;
 const ADDRESS = new URL('http://127.0.0.1');
 
 export class TrezordNode {
-    version = '3.2.0';
+    version = '3.2.1';
     bundledVersion?: string;
     serviceName = 'trezord-node';
     /** last known descriptors state */

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -5,6 +5,7 @@ import {
     bridge as protocolBridge,
     v1 as protocolV1,
 } from '@trezor/protocol';
+import { versionUtils } from '@trezor/utils';
 
 import {
     AbstractTransport,
@@ -36,6 +37,7 @@ type BridgeEndpoint =
     | '/listen'
     | '/acquire'
     | '/post'
+    | '/abort'
     | '/call'
     | '/enumerate'
     | '/release'
@@ -68,6 +70,7 @@ type BridgeConstructorParameters = AbstractTransportParams & { port?: number };
 
 export class BridgeTransport extends AbstractTransport {
     private useProtocolMessages: boolean = false;
+    private useAbortEndpoint: boolean = false;
     /**
      * url of trezord server.
      */
@@ -102,6 +105,7 @@ export class BridgeTransport extends AbstractTransport {
                     this.isOutdated = true;
                 }
                 this.useProtocolMessages = !!response.payload.protocolMessages;
+                this.useAbortEndpoint = versionUtils.isNewerOrEqual(this.version, '3.2.1');
 
                 this.stopped = false;
 
@@ -206,6 +210,26 @@ export class BridgeTransport extends AbstractTransport {
         );
     }
 
+    // in some setups abort signal is resolved on the client-side but never resolves on the server-size (like android OkHttp request)
+    // abort signal is also meant to resolve immediately but it could take a while to process it on the server
+    // try to abort pending process through the server and fallback to local signal only if that fails
+    private createAbortSignal = (session: Session, signal?: AbortSignal) => {
+        if (!this.useAbortEndpoint) {
+            return signal;
+        }
+
+        const abortController = new AbortController();
+        signal?.addEventListener('abort', async () => {
+            const result = await this.post('/abort', { params: session });
+            if (!result.success) {
+                this.logger?.warn(`/abort/${session} error: ${result.error}`);
+                abortController.abort();
+            }
+        });
+
+        return abortController.signal;
+    };
+
     // https://github.com/trezor/trezord-go/blob/f559ee5079679aeb5f897c65318d3310f78223ca/core/core.go#L534
     public call({
         session,
@@ -231,7 +255,7 @@ export class BridgeTransport extends AbstractTransport {
                 const response = await this.post(`/call`, {
                     params: session,
                     body: this.getRequestBody(bytes, protocol, thpState),
-                    signal,
+                    signal: this.createAbortSignal(session, signal),
                 });
 
                 if (!response.success) {
@@ -294,7 +318,7 @@ export class BridgeTransport extends AbstractTransport {
                 const response = await this.post('/post', {
                     params: session,
                     body: this.getRequestBody(bytes, protocol, thpState),
-                    signal,
+                    signal: this.createAbortSignal(session, signal),
                 });
                 if (!response.success) {
                     return response;
@@ -322,7 +346,7 @@ export class BridgeTransport extends AbstractTransport {
                 const response = await this.post('/read', {
                     params: session,
                     body: this.getRequestBody(Buffer.alloc(0), protocol, thpState),
-                    signal,
+                    signal: this.createAbortSignal(session, signal),
                 });
 
                 if (!response.success) {
@@ -388,6 +412,10 @@ export class BridgeTransport extends AbstractTransport {
         options: IncompleteRequestOptions,
     ): AsyncResultWithTypedError<undefined, BridgeCommonErrors | typeof ERRORS.SESSION_NOT_FOUND>;
     private async post(
+        endpoint: '/abort',
+        options: IncompleteRequestOptions,
+    ): AsyncResultWithTypedError<undefined, BridgeCommonErrors | typeof ERRORS.SESSION_NOT_FOUND>;
+    private async post(
         endpoint: '/listen',
         options?: IncompleteRequestOptions,
     ): AsyncResultWithTypedError<Descriptor[], BridgeCommonErrors>;
@@ -435,6 +463,8 @@ export class BridgeTransport extends AbstractTransport {
                         ERRORS.INTERFACE_DATA_TRANSFER,
                         PROTOCOL_MALFORMED,
                     ]);
+                case '/abort':
+                    return this.unknownError(response.error, [ERRORS.SESSION_NOT_FOUND]);
                 case '/enumerate':
                 case '/listen':
                     return this.unknownError(response.error);
@@ -466,6 +496,8 @@ export class BridgeTransport extends AbstractTransport {
             case '/listen':
                 return bridgeApiResult.devices(response.payload);
             case '/release':
+                return bridgeApiResult.empty(response.payload);
+            case '/abort':
                 return bridgeApiResult.empty(response.payload);
             default:
                 return this.error({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Problem:
abort signal in native `fetch` rejects faster on the host side than actually is processed by the server.
in suite-native (e2e tests) it doesnt work at all (hosts rejects but doesnt close the request - well known issue of react-native)

Solution:
create `/abort` endpoint to abort any pending calls for given session

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bridge-abort&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bridge-abort&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/bridge-abort&lookback=7)