### PR TITLE
Test suite sync server local

### DIFF
--- a/.yarn/patches/@evolu-common-npm-7.3.0-dc4f142770.patch
+++ b/.yarn/patches/@evolu-common-npm-7.3.0-dc4f142770.patch
@@ -1,0 +1,20 @@
+diff --git a/package.json b/package.json
+index 19e2455323ce634608ddc2f97d7a233eee624b12..428018bf4ab60b4844e383b2194d727a7ccfb5b5 100644
+--- a/package.json
++++ b/package.json
+@@ -23,11 +23,13 @@
+       "types": "./dist/src/index.d.ts",
+       "import": "./dist/src/index.js",
+       "browser": "./dist/src/index.js",
+-      "react-native": "./dist/src/index.js"
++      "react-native": "./dist/src/index.js",
++      "default": "./dist/src/index.js"
+     },
+     "./local-first": {
+       "types": "./dist/src/local-first/index.d.ts",
+-      "import": "./dist/src/local-first/index.js"
++      "import": "./dist/src/local-first/index.js",
++      "default": "./dist/src/local-first/index.js"
+     }
+   },
+   "typesVersions": {

--- a/scripts/list-outdated-dependencies/qa-dependencies.txt
+++ b/scripts/list-outdated-dependencies/qa-dependencies.txt
@@ -9,7 +9,9 @@
 @playwright/browser-webkit
 @playwright/test
 @types/jest
+@types/better-sqlite3
 babel-jest
+better-sqlite3
 chai
 detox
 dotenv

--- a/suite-common/suite-sync-evolu/package.json
+++ b/suite-common/suite-sync-evolu/package.json
@@ -10,7 +10,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@evolu/common": "^7.3.0",
+        "@evolu/common": "patch:@evolu/common@npm%3A7.3.0#~/.yarn/patches/@evolu-common-npm-7.3.0-dc4f142770.patch",
         "@noble/hashes": "^1.6.1",
         "@suite-common/suite-sync-storage": "workspace:*",
         "@suite-common/suite-sync-types": "workspace:*",

--- a/suite-common/suite-sync-evolu/src/index.ts
+++ b/suite-common/suite-sync-evolu/src/index.ts
@@ -6,3 +6,5 @@
 export { createEvoluStorageFactory } from './evoluStorage';
 export { createEvoluInstanceFactory } from './createEvoluInstance';
 export { evoluCreateSuiteSyncOwner } from './evoluCreateSuiteSyncOwner';
+export { createEvoluAppOwnerFromTrezorData } from './createEvoluAppOwnerFromTrezorData';
+export { Schema } from './schema';

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -53,7 +53,10 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/lodash": "^4.17.16",
+        "@types/ws": "^8",
+        "better-sqlite3": "^12.1.1",
         "dotenv": "^16.4.7",
         "fs-extra": "^11.3.1",
         "jest-diff": "^29.7.0",
@@ -61,6 +64,7 @@
         "react-intl": "^8.0.6",
         "tsx": "^4.21.0",
         "type-fest": "^5.4.1",
+        "ws": "^8.19.0",
         "xvfb-maybe": "^0.2.1"
     }
 }

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -32,6 +32,7 @@
         "@solana/rpc-types": "^2.3.0",
         "@suite-common/feedback": "workspace:*",
         "@suite-common/message-system": "workspace:*",
+        "@suite-common/suite-sync-evolu": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/trading": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -20,6 +20,7 @@
     },
     "devDependencies": {
         "@currents/playwright": "^1.19.0",
+        "@evolu/common": "patch:@evolu/common@npm%3A7.3.0#~/.yarn/patches/@evolu-common-npm-7.3.0-dc4f142770.patch",
         "@playwright/browser-chromium": "^1.57.0",
         "@playwright/browser-firefox": "^1.57.0",
         "@playwright/browser-webkit": "^1.57.0",

--- a/suite/e2e/support/helpers/createEvoluNodeDeps.ts
+++ b/suite/e2e/support/helpers/createEvoluNodeDeps.ts
@@ -1,0 +1,107 @@
+import {
+    SimpleName,
+    createConsole,
+    createRandom,
+    createRandomBytes,
+    createSqlite,
+    createTestTime,
+    createWebSocket,
+    getOrThrow,
+} from '@evolu/common';
+import {
+    type DbWorkerInput,
+    type DbWorkerOutput,
+    createDbWorkerForPlatform,
+} from '@evolu/common/local-first';
+import { WebSocket } from 'ws';
+
+let instanceCounter = 0;
+
+const createNodeWebSocketDep = () => ({
+    createWebSocket: (url: string, options?: any) =>
+        createWebSocket(url, {
+            ...options,
+            WebSocketConstructor: WebSocket as unknown as typeof globalThis.WebSocket,
+        }),
+});
+
+export const createNodeEvoluDeps = async () => {
+    const instanceName = SimpleName.orThrow(`Test${instanceCounter++}`);
+
+    const createSqliteDriver = async () => {
+        const BetterSQLite = (await import('better-sqlite3')).default;
+        type Statement = import('better-sqlite3').Statement;
+        const db = new BetterSQLite(':memory:');
+        let disposed = false;
+
+        const cache = (await import('@evolu/common')).createPreparedStatementsCache<Statement>(
+            sql => db.prepare(sql),
+            () => {},
+        );
+
+        const driver = {
+            exec: (query: any, isMutation?: boolean) => {
+                const prepared = cache.get(query, true);
+                const rows = isMutation ? [] : (prepared.all(query.parameters) as any[]);
+                const changes = isMutation ? prepared.run(query.parameters).changes : 0;
+
+                return { rows, changes };
+            },
+            export: () => db.serialize(),
+            [Symbol.dispose]: () => {
+                if (disposed) return;
+                disposed = true;
+                cache[Symbol.dispose]();
+                db.close();
+            },
+        } as const;
+
+        return driver;
+    };
+
+    // track postMessage calls (handy for tests)
+    const postMessageCalls: Array<DbWorkerInput> = [];
+    let onMessageCallback: ((message: DbWorkerOutput) => void) | undefined;
+
+    // inner worker (actual DB worker implementation)
+    const nodeWebSocketDep = createNodeWebSocketDep();
+
+    const innerDbWorker = createDbWorkerForPlatform({
+        console: createConsole(),
+        createSqliteDriver,
+        createWebSocket: nodeWebSocketDep.createWebSocket as any,
+        random: createRandom(),
+        randomBytes: createRandomBytes(),
+        time: createTestTime(),
+    });
+
+    // expose createDbWorker for the platform (in-memory bridge to innerDbWorker)
+    const deps = {
+        console: createConsole(),
+        createDbWorker: () => ({
+            onMessage: (cb: (m: DbWorkerOutput) => void) => {
+                onMessageCallback = cb;
+                innerDbWorker.onMessage(cb);
+            },
+            postMessage: (message: Parameters<typeof innerDbWorker.postMessage>[0]) => {
+                postMessageCalls.push(message);
+                innerDbWorker.postMessage(message);
+            },
+        }),
+        randomBytes: createRandomBytes(),
+        reloadApp: () => {}, // noop
+        time: createTestTime(),
+    };
+
+    // create sqlite instance (optional, useful to inspect DB)
+    const sqlite = getOrThrow(await createSqlite({ createSqliteDriver })(instanceName));
+
+    return {
+        instanceName,
+        deps,
+        postMessageCalls,
+        sqlite,
+        innerDbWorker,
+        getOnMessageCallback: () => onMessageCallback,
+    };
+};

--- a/suite/e2e/support/helpers/createEvoluNodeDeps.ts
+++ b/suite/e2e/support/helpers/createEvoluNodeDeps.ts
@@ -1,10 +1,11 @@
 import {
     SimpleName,
     createConsole,
+    createPreparedStatementsCache,
     createRandom,
     createRandomBytes,
     createSqlite,
-    createTestTime,
+    createTime,
     createWebSocket,
     getOrThrow,
 } from '@evolu/common';
@@ -13,28 +14,22 @@ import {
     type DbWorkerOutput,
     createDbWorkerForPlatform,
 } from '@evolu/common/local-first';
+import BetterSqlite3, { type Statement } from 'better-sqlite3';
 import { WebSocket } from 'ws';
 
 let instanceCounter = 0;
 
-const createNodeWebSocketDep = () => ({
-    createWebSocket: (url: string, options?: any) =>
-        createWebSocket(url, {
-            ...options,
-            WebSocketConstructor: WebSocket as unknown as typeof globalThis.WebSocket,
-        }),
-});
-
 export const createNodeEvoluDeps = async () => {
     const instanceName = SimpleName.orThrow(`Test${instanceCounter++}`);
 
+    // eslint-disable-next-line require-await
     const createSqliteDriver = async () => {
-        const BetterSQLite = (await import('better-sqlite3')).default;
-        type Statement = import('better-sqlite3').Statement;
-        const db = new BetterSQLite(':memory:');
         let disposed = false;
+        //TODO: db init here means it can be initilized multiple times
+        // Consider rework
+        const db = new BetterSqlite3(':memory:');
 
-        const cache = (await import('@evolu/common')).createPreparedStatementsCache<Statement>(
+        const cache = createPreparedStatementsCache<Statement>(
             sql => db.prepare(sql),
             () => {},
         );
@@ -63,16 +58,17 @@ export const createNodeEvoluDeps = async () => {
     const postMessageCalls: Array<DbWorkerInput> = [];
     let onMessageCallback: ((message: DbWorkerOutput) => void) | undefined;
 
-    // inner worker (actual DB worker implementation)
-    const nodeWebSocketDep = createNodeWebSocketDep();
-
     const innerDbWorker = createDbWorkerForPlatform({
         console: createConsole(),
         createSqliteDriver,
-        createWebSocket: nodeWebSocketDep.createWebSocket as any,
+        createWebSocket: (url, options) =>
+            createWebSocket(url, {
+                ...options,
+                WebSocketConstructor: WebSocket as unknown as typeof globalThis.WebSocket,
+            }),
         random: createRandom(),
         randomBytes: createRandomBytes(),
-        time: createTestTime(),
+        time: createTime(),
     });
 
     // expose createDbWorker for the platform (in-memory bridge to innerDbWorker)
@@ -89,8 +85,8 @@ export const createNodeEvoluDeps = async () => {
             },
         }),
         randomBytes: createRandomBytes(),
-        reloadApp: () => {}, // noop
-        time: createTestTime(),
+        reloadApp: () => {},
+        time: createTime(),
     };
 
     // create sqlite instance (optional, useful to inspect DB)

--- a/suite/e2e/support/helpers/evoluClient.ts
+++ b/suite/e2e/support/helpers/evoluClient.ts
@@ -1,81 +1,112 @@
 /* eslint-disable no-console */
-import { SimpleName, createIdFromString, id } from '@evolu/common';
-import { OwnerId, createEvolu } from '@evolu/common/local-first';
-// import { createEvolu, createOwnerWebSocketTransport, OwnerId } from '@evolu/common/local-first';
+import { Evolu, SimpleName, createIdFromString, getOrThrow, id } from '@evolu/common';
+import { createEvolu, createOwnerWebSocketTransport } from '@evolu/common/local-first';
 
 import { Schema, createEvoluAppOwnerFromTrezorData } from '@suite-common/suite-sync-evolu';
+import { SuiteSyncOwnerSecretHex } from '@suite-common/suite-types';
 
 import { createNodeEvoluDeps } from './createEvoluNodeDeps';
+import { expect } from '../../support/fixtures';
 
-const ownerId = 'yg0UgROParTpm60ltI3hDw';
-const ownerSecret =
-    'e17818d7c458f171885280eeef2d70078c6842b51e18ec6f2f8c9f44d3d171fd0f49a3aeff32a560d7f823321fcd24f8d8773ffa59855c6447b11af88a2fd7b5';
+export class EvoluClient {
+    private _evolu?: Evolu<typeof Schema>;
 
-export const createEvoluClient = async () => {
-    const { deps } = await createNodeEvoluDeps();
+    async init({
+        ownerSecret,
+        //TODO: replace with one source definition
+        relayUrl = 'http://localhost:4000',
+    }: {
+        ownerSecret: SuiteSyncOwnerSecretHex;
+        relayUrl?: string;
+    }) {
+        const { deps } = await createNodeEvoluDeps();
 
-    const owner = createEvoluAppOwnerFromTrezorData({ data: ownerSecret });
+        const owner = createEvoluAppOwnerFromTrezorData({ data: ownerSecret });
+        if (!owner.ok) {
+            throw new Error(`Failed to parse owner: ${JSON.stringify(owner.error)}`);
+        }
 
-    if (!owner.ok) {
-        console.error(owner.error);
+        //db name just on client side
+        //TODO: I think it is not used not at all because of how deps are created
+        const sanitizedOwnerId = owner.value.id.replaceAll('_', '-');
+        const databaseName = getOrThrow(SimpleName.from(`trezor-suite-e2e-${sanitizedOwnerId}`));
 
-        throw owner.error;
+        this._evolu = createEvolu(deps)(Schema, {
+            name: databaseName,
+            transports: [
+                createOwnerWebSocketTransport({
+                    url: relayUrl,
+                    ownerId: owner.value.id,
+                }),
+            ],
+            externalAppOwner: owner.value,
+            // This turns on the Encryption-at-rest (encryption of the SQLLite file),
+            encryptionKey: owner.value.encryptionKey,
+        });
+
+        this._evolu.subscribeError(() => {
+            console.error('Evolu Error:', this._evolu?.getError());
+        });
     }
 
-    // better var name
-    const ownerIdResult = OwnerId.fromUnknown(ownerId);
-    if (!ownerIdResult.ok) {
-        throw ownerIdResult.error;
+    get evolu() {
+        if (!this._evolu) {
+            throw new Error('EvoluClient not initialized. Call init() first.');
+        }
+
+        return this._evolu;
     }
 
-    const sanitizedOwnerId = ownerId.replaceAll('_', '-');
-    const databaseName = SimpleName.from(`trezor-suite-e2e-${sanitizedOwnerId}`);
-    if (!databaseName.ok) {
-        console.error(databaseName.error);
+    //TMP
+    async getAccountData() {
+        const accountData = await this.evolu.loadQuery(
+            this.evolu.createQuery(db => db.selectFrom('account').selectAll()),
+        );
+        const error = this.evolu.getError();
+        if (error) {
+            console.error('Evolu Error detected during wait:', error);
+        }
 
-        throw databaseName.error;
-    }
-    console.log('Database name:', databaseName);
-    console.log('Owner:', owner);
-
-    const evolu = createEvolu(deps)(Schema, {
-        name: databaseName.value,
-        transports: [
-            // createOwnerWebSocketTransport({
-            //     url: 'http://localhost:4000',
-            //     ownerId: ownerIdResult.value,
-            // }),
-        ],
-        externalAppOwner: owner.value,
-        // This turns on the Encryption-at-rest (encryption of the SQLLite file),
-        encryptionKey: owner.value.encryptionKey,
-    });
-
-    // Insert a wallet label
-    const WalletLabelId = id('WalletLabelId');
-    const walletDescriptor = 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zTXPD';
-    const walletIdResult = WalletLabelId.from(createIdFromString(walletDescriptor));
-
-    if (!walletIdResult.ok) {
-        throw walletIdResult.error;
+        return accountData;
     }
 
-    const upsertResult = evolu.upsert('wallet', {
-        id: walletIdResult.value,
-        walletDescriptor,
-        label: 'My Test Wallet',
-    });
-
-    if (!upsertResult.ok) {
-        console.error('Upsert failed:', upsertResult.error);
-        throw upsertResult.error;
+    //TMP
+    async testWriteAndRead() {
+        this.writeTestData();
+        await this.readTestData();
     }
 
-    console.log('Wallet upserted successfully');
+    //TMP
+    writeTestData() {
+        // Insert a wallet label
+        const WalletLabelId = id('WalletLabelId');
+        const walletDescriptor = 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zTXPD';
+        const walletIdResult = WalletLabelId.from(createIdFromString(walletDescriptor));
+        if (!walletIdResult.ok) {
+            throw walletIdResult.error;
+        }
+        const upsertResult = this.evolu.upsert('wallet', {
+            id: walletIdResult.value,
+            walletDescriptor,
+            label: 'My Test Wallet',
+        });
+        if (!upsertResult.ok) {
+            console.error('Upsert failed:', upsertResult.error);
+            throw upsertResult.error;
+        }
+    }
 
-    // get by using the public API:
-    const walletData = await evolu.loadQuery(
-        evolu.createQuery(db => db.selectFrom('wallet').selectAll()),
-    );
-    console.log('Wallet data', walletData);
-};
+    //TMP
+    async readTestData() {
+        // Get and log the wallet data to verify
+        await expect(async () => {
+            const walletData = await this.evolu.loadQuery(
+                this.evolu.createQuery(db => db.selectFrom('wallet').selectAll()),
+            );
+            console.log('Wallet data:', walletData);
+
+            expect(walletData).not.toEqual([]);
+            console.error('Wallet data from Evolu:', JSON.stringify(walletData));
+        }).toPass({ timeout: 30_000 });
+    }
+}

--- a/suite/e2e/support/helpers/evoluClient.ts
+++ b/suite/e2e/support/helpers/evoluClient.ts
@@ -1,0 +1,81 @@
+/* eslint-disable no-console */
+import { SimpleName, createIdFromString, id } from '@evolu/common';
+import { OwnerId, createEvolu } from '@evolu/common/local-first';
+// import { createEvolu, createOwnerWebSocketTransport, OwnerId } from '@evolu/common/local-first';
+
+import { Schema, createEvoluAppOwnerFromTrezorData } from '@suite-common/suite-sync-evolu';
+
+import { createNodeEvoluDeps } from './createEvoluNodeDeps';
+
+const ownerId = 'yg0UgROParTpm60ltI3hDw';
+const ownerSecret =
+    'e17818d7c458f171885280eeef2d70078c6842b51e18ec6f2f8c9f44d3d171fd0f49a3aeff32a560d7f823321fcd24f8d8773ffa59855c6447b11af88a2fd7b5';
+
+export const createEvoluClient = async () => {
+    const { deps } = await createNodeEvoluDeps();
+
+    const owner = createEvoluAppOwnerFromTrezorData({ data: ownerSecret });
+
+    if (!owner.ok) {
+        console.error(owner.error);
+
+        throw owner.error;
+    }
+
+    // better var name
+    const ownerIdResult = OwnerId.fromUnknown(ownerId);
+    if (!ownerIdResult.ok) {
+        throw ownerIdResult.error;
+    }
+
+    const sanitizedOwnerId = ownerId.replaceAll('_', '-');
+    const databaseName = SimpleName.from(`trezor-suite-e2e-${sanitizedOwnerId}`);
+    if (!databaseName.ok) {
+        console.error(databaseName.error);
+
+        throw databaseName.error;
+    }
+    console.log('Database name:', databaseName);
+    console.log('Owner:', owner);
+
+    const evolu = createEvolu(deps)(Schema, {
+        name: databaseName.value,
+        transports: [
+            // createOwnerWebSocketTransport({
+            //     url: 'http://localhost:4000',
+            //     ownerId: ownerIdResult.value,
+            // }),
+        ],
+        externalAppOwner: owner.value,
+        // This turns on the Encryption-at-rest (encryption of the SQLLite file),
+        encryptionKey: owner.value.encryptionKey,
+    });
+
+    // Insert a wallet label
+    const WalletLabelId = id('WalletLabelId');
+    const walletDescriptor = 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zTXPD';
+    const walletIdResult = WalletLabelId.from(createIdFromString(walletDescriptor));
+
+    if (!walletIdResult.ok) {
+        throw walletIdResult.error;
+    }
+
+    const upsertResult = evolu.upsert('wallet', {
+        id: walletIdResult.value,
+        walletDescriptor,
+        label: 'My Test Wallet',
+    });
+
+    if (!upsertResult.ok) {
+        console.error('Upsert failed:', upsertResult.error);
+        throw upsertResult.error;
+    }
+
+    console.log('Wallet upserted successfully');
+
+    // get by using the public API:
+    const walletData = await evolu.loadQuery(
+        evolu.createQuery(db => db.selectFrom('wallet').selectAll()),
+    );
+    console.log('Wallet data', walletData);
+};

--- a/suite/e2e/tests/metadata/suite-sync.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync.test.ts
@@ -4,6 +4,7 @@ import { wordlist } from '@scure/bip39/wordlists/english';
 import { isWebProject, skipFixture } from '../../support/common';
 import { AccountLabelId } from '../../support/enums/accountLabelId';
 import { expect, test } from '../../support/fixtures';
+import { createEvoluClient } from '../../support/helpers/evoluClient';
 
 test.use({ exceptionLogger: skipFixture });
 test.describe(
@@ -29,6 +30,7 @@ test.describe(
                 await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
                 await metadataPage.setupQuotaManager();
                 await metadataPage.enableSuiteSync();
+                await createEvoluClient();
             });
 
             const newLabel = 'my synced btc account label';

--- a/suite/e2e/tests/metadata/suite-sync.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync.test.ts
@@ -1,10 +1,14 @@
+import { getOrThrow } from '@evolu/common';
+import { OwnerId } from '@evolu/common/local-first';
 import { generateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
+
+import { asSuiteSyncOwnerSecretHex } from '@suite-common/suite-types';
 
 import { isWebProject, skipFixture } from '../../support/common';
 import { AccountLabelId } from '../../support/enums/accountLabelId';
 import { expect, test } from '../../support/fixtures';
-import { createEvoluClient } from '../../support/helpers/evoluClient';
+import { EvoluClient } from '../../support/helpers/evoluClient';
 
 test.use({ exceptionLogger: skipFixture });
 test.describe(
@@ -30,7 +34,6 @@ test.describe(
                 await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
                 await metadataPage.setupQuotaManager();
                 await metadataPage.enableSuiteSync();
-                await createEvoluClient();
             });
 
             const newLabel = 'my synced btc account label';
@@ -72,6 +75,11 @@ test.describe(
 );
 
 const MNEMONIC = 'ugly rally dial movie exhibit annual bean slender illegal frown giraffe scare';
+const ownerId = getOrThrow(OwnerId.from('yg0UgROParTpm60ltI3hDw'));
+const ownerSecret = asSuiteSyncOwnerSecretHex(
+    'e17818d7c458f171885280eeef2d70078c6842b51e18ec6f2f8c9f44d3d171fd0f49a3aeff32a560d7f823321fcd24f8d8773ffa59855c6447b11af88a2fd7b5',
+);
+
 // These labels were set manually on this seed
 const ACCOUNT_LABEL = 'Evolu synced BTC account';
 const WALLET_INDEX = 0;
@@ -83,6 +91,36 @@ test.describe('Suite Sync - Labelling', { tag: ['@specificFirmware', '@T3W1', '@
     test.use({
         firmwareVersion: '2-main',
         deviceSetup: { mnemonic: MNEMONIC, passphrase_protection: true },
+    });
+
+    //TMP Test just for local demonstration purposes
+    test.skip('Set label in suite and verify it on server', async ({
+        page,
+        onboardingPage,
+        metadataPage,
+        walletPage,
+    }) => {
+        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+        await metadataPage.setupQuotaManager();
+        await metadataPage.enableSuiteSync();
+
+        await walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }).click();
+        await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
+        await metadataPage.account.metadataInput.fill(ACCOUNT_LABEL);
+        await page.keyboard.press('Enter');
+        await expect(
+            walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
+        ).toHaveText(ACCOUNT_LABEL);
+
+        const evoluClient = new EvoluClient();
+        await evoluClient.init({ ownerSecret });
+
+        await expect(async () => {
+            const accountData = await evoluClient.getAccountData();
+            expect(accountData).not.toEqual([]);
+            expect(accountData[0].ownerId).toBe(ownerId);
+            expect(accountData[0].label).toBe(ACCOUNT_LABEL);
+        }).toPass({ timeout: 30_000 });
     });
 
     // TODO: Temporarily skipping the test due to work in progress

--- a/suite/e2e/tsconfig.json
+++ b/suite/e2e/tsconfig.json
@@ -16,6 +16,9 @@
             "path": "../../suite-common/message-system"
         },
         {
+            "path": "../../suite-common/suite-sync-evolu"
+        },
+        {
             "path": "../../suite-common/suite-types"
         },
         { "path": "../../suite-common/trading" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3993,7 +3993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@evolu/common@npm:^7.3.0":
+"@evolu/common@npm:7.3.0":
   version: 7.3.0
   resolution: "@evolu/common@npm:7.3.0"
   dependencies:
@@ -4004,6 +4004,20 @@ __metadata:
     msgpackr: "npm:^1.11.5"
     random: "npm:^5.4.1"
   checksum: 10/9e1b90947f28100200b5da0074698d5352369bbdd1d9e6edfa2269b25a50f52d42ec0bfa296c89ed6104801a22ceb1f4fcff91868753de3c52d8336ec445f31d
+  languageName: node
+  linkType: hard
+
+"@evolu/common@patch:@evolu/common@npm%3A7.3.0#~/.yarn/patches/@evolu-common-npm-7.3.0-dc4f142770.patch":
+  version: 7.3.0
+  resolution: "@evolu/common@patch:@evolu/common@npm%3A7.3.0#~/.yarn/patches/@evolu-common-npm-7.3.0-dc4f142770.patch::version=7.3.0&hash=f72703"
+  dependencies:
+    "@noble/ciphers": "npm:^2.0.0"
+    "@noble/hashes": "npm:^2.0.0"
+    "@scure/bip39": "npm:^2.0.0"
+    kysely: "npm:^0.28.4"
+    msgpackr: "npm:^1.11.5"
+    random: "npm:^5.4.1"
+  checksum: 10/8ca977ccc188b257a1701e7330d365c840ebe91320d5a28821cc65b922b221955b731ae2279d957c9d016a07679a105c8104f0e6802943354f9e19e5326868f3
   languageName: node
   linkType: hard
 
@@ -11045,7 +11059,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/suite-sync-evolu@workspace:suite-common/suite-sync-evolu"
   dependencies:
-    "@evolu/common": "npm:^7.3.0"
+    "@evolu/common": "patch:@evolu/common@npm%3A7.3.0#~/.yarn/patches/@evolu-common-npm-7.3.0-dc4f142770.patch"
     "@noble/hashes": "npm:^1.6.1"
     "@suite-common/suite-sync-storage": "workspace:*"
     "@suite-common/suite-sync-types": "workspace:*"
@@ -15181,6 +15195,7 @@ __metadata:
   resolution: "@trezor/suite-e2e@workspace:suite/e2e"
   dependencies:
     "@currents/playwright": "npm:^1.19.0"
+    "@evolu/common": "patch:@evolu/common@npm%3A7.3.0#~/.yarn/patches/@evolu-common-npm-7.3.0-dc4f142770.patch"
     "@playwright/browser-chromium": "npm:^1.57.0"
     "@playwright/browser-firefox": "npm:^1.57.0"
     "@playwright/browser-webkit": "npm:^1.57.0"
@@ -15213,7 +15228,10 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
+    "@types/better-sqlite3": "npm:^7.6.13"
     "@types/lodash": "npm:^4.17.16"
+    "@types/ws": "npm:^8"
+    better-sqlite3: "npm:^12.1.1"
     dotenv: "npm:^16.4.7"
     fs-extra: "npm:^11.3.1"
     jest-diff: "npm:^29.7.0"
@@ -15725,6 +15743,15 @@ __metadata:
   dependencies:
     "@babel/types": "npm:^7.28.2"
   checksum: 10/371c5e1b40399ef17570e630b2943617b84fafde2860a56f0ebc113d8edb1d0534ade0175af89eda1ae35160903c33057ed42457e165d4aa287fedab2c82abcf
+  languageName: node
+  linkType: hard
+
+"@types/better-sqlite3@npm:^7.6.13":
+  version: 7.6.13
+  resolution: "@types/better-sqlite3@npm:7.6.13"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/c74dafa3c550ac866737870016d7b1a735c7d450c16d40962eeb54510fa150e91752bfdf678f55e91894d8853771b95f909b0062122116cddac4d80491b74411
   languageName: node
   linkType: hard
 
@@ -17080,6 +17107,15 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10/08aac698ce6480b532d8311f790a8744ae489ccdd98f374cfe4b8245855439825c64b031abcbba4f30fb280da6cc2b02a4e261e16341d058ffaeecaa24ba2bd3
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/1ce05e3174dcacf28dae0e9b854ef1c9a12da44c7ed73617ab6897c5cbe4fccbb155a20be5508ae9a7dde2f83bd80f5cf3baa386b934fc4b40889ec963e94f3a
   languageName: node
   linkType: hard
 
@@ -19619,6 +19655,17 @@ __metadata:
   dependencies:
     open: "npm:^8.0.4"
   checksum: 10/24668e5a837d0d2c0edf17ad5ebcfeb00a8a5578a5eb09f7a409e1a60617cdfea40b8ebfc95e5f12d9568157930d033e6805788fcf0780413ac982c95d3745d1
+  languageName: node
+  linkType: hard
+
+"better-sqlite3@npm:^12.1.1":
+  version: 12.6.0
+  resolution: "better-sqlite3@npm:12.6.0"
+  dependencies:
+    bindings: "npm:^1.5.0"
+    node-gyp: "npm:latest"
+    prebuild-install: "npm:^7.1.1"
+  checksum: 10/4dfd6e571b91d9066826c8ff4c97eb5901b301db785286e82ec17458c22b2fdfebbb725f65f15f0edd2f3a77ba2aa7b69cd68fb22cc888c0d0e92916c89eff86
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15239,6 +15239,7 @@ __metadata:
     react-intl: "npm:^8.0.6"
     tsx: "npm:^4.21.0"
     type-fest: "npm:^5.4.1"
+    ws: "npm:^8.19.0"
     xvfb-maybe: "npm:^0.2.1"
   languageName: unknown
   linkType: soft
@@ -17110,21 +17111,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^8":
+"@types/ws@npm:^8, @types/ws@npm:^8.5.13":
   version: 8.18.1
   resolution: "@types/ws@npm:8.18.1"
   dependencies:
     "@types/node": "npm:*"
   checksum: 10/1ce05e3174dcacf28dae0e9b854ef1c9a12da44c7ed73617ab6897c5cbe4fccbb155a20be5508ae9a7dde2f83bd80f5cf3baa386b934fc4b40889ec963e94f3a
-  languageName: node
-  linkType: hard
-
-"@types/ws@npm:^8.5.13":
-  version: 8.5.13
-  resolution: "@types/ws@npm:8.5.13"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10/21369beafa75c91ae3b00d3a2671c7408fceae1d492ca2abd5ac7c8c8bf4596d513c1599ebbddeae82c27c4a2d248976d0d714c4b3d34362b2ae35b964e2e637
   languageName: node
   linkType: hard
 
@@ -46745,7 +46737,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.18.3, ws@npm:^8.11.0, ws@npm:^8.12.1, ws@npm:^8.13.0, ws@npm:^8.17.1, ws@npm:^8.18.0, ws@npm:^8.18.3":
+"ws@npm:8.18.3":
   version: 8.18.3
   resolution: "ws@npm:8.18.3"
   peerDependencies:
@@ -46781,6 +46773,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10/9c796b84ba80ffc2c2adcdfc9c8e9a219ba99caa435c9a8d45f9ac593bba325563b3f83edc5eb067cc6d21b9a6bf2c930adf76dd40af5f58a5ca6859e81858f0
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.11.0, ws@npm:^8.12.1, ws@npm:^8.13.0, ws@npm:^8.17.1, ws@npm:^8.18.0, ws@npm:^8.18.3, ws@npm:^8.19.0":
+  version: 8.19.0
+  resolution: "ws@npm:8.19.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/26e4901e93abaf73af9f26a93707c95b4845e91a7a347ec8c569e6e9be7f9df066f6c2b817b2d685544e208207898a750b78461e6e8d810c11a370771450c31b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15207,6 +15207,7 @@ __metadata:
     "@solana/rpc-types": "npm:^2.3.0"
     "@suite-common/feedback": "workspace:*"
     "@suite-common/message-system": "workspace:*"
+    "@suite-common/suite-sync-evolu": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/trading": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"


### PR DESCRIPTION
We want to vastly expand our coverage of Suite sync. For that we need to be able to control the env to have reliable and isolated tests.

Introduces minimal POC evolu client that is possible to initialized and use in Playwright tests.
Client
- parametrized by userId and UserSecret, so we can have good test isolation across test groups
- decrypts and encrypts IO
- atm provides just bare methods for proving we can write and read data to relay server
- there are lot of temporary things and unfinished work
- temporary patch to @evolu/common. We have agreement with owner that after next release he will adopt the patch to the repo.

- [x] is the patch applied correctly even to  `suite-common/suite-sync-evolu/package.json` ?
- [x] are new exports from `suite-common/suite-sync-evolu` acceptable?


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-suite-sync-server-local&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-suite-sync-server-local&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test-suite-sync-server-local&lookback=7)