### PR TITLE
AccountKey is now proper brnaded type.

### DIFF
--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -12,7 +12,7 @@ import {
     transactionsActions,
 } from '@suite-common/wallet-core';
 import * as discoveryActions from '@suite-common/wallet-core';
-import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { AccountKey, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { getAccountIdentifier, getAccountTransactions } from '@suite-common/wallet-utils';
 
@@ -227,7 +227,7 @@ describe('Storage actions', () => {
         store.dispatch(await preloadStore());
         expect(store.getState().wallet.send.drafts).toEqual({ 'account-key': { address: 'b' } });
 
-        await storageActions.removeDraft('account-key');
+        await storageActions.removeDraft('account-key' as AccountKey); // Todo: create properly via `createAccountKey()`
         store = mockStore(getInitialState());
         updateStore(store);
         store.dispatch(await preloadStore());

--- a/packages/suite/src/actions/suite/metadata/__fixtures__/moveLabelsForRbfAccounts.fixture.ts
+++ b/packages/suite/src/actions/suite/metadata/__fixtures__/moveLabelsForRbfAccounts.fixture.ts
@@ -1,5 +1,5 @@
 import { AccountsRootState } from '@suite-common/wallet-core';
-import { Account, asAccountDescriptor } from '@suite-common/wallet-types';
+import { Account, AccountKey, asAccountDescriptor } from '@suite-common/wallet-types';
 
 export const accountSpendingCoins: Account = {
     deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@AC94BB9C1B08FE73BE1E3322:0',
@@ -8,7 +8,7 @@ export const accountSpendingCoins: Account = {
     descriptor: asAccountDescriptor(
         '(accountSpendingCoins:descriptor)vpub5YX1yJFY8E236pH3iNvCpThsXLxoQoC4nwraaS5h4TZwaSp1Gg9SQoxCsrumxjh7nZRQQkNfH29TEDeMvAZVmD3rpmsDnFc5Sj4JgJG6m4b',
     ),
-    key: '(accountSpendingCoins:key)vpub5YX1yJFY8E236pH3iNvCpThsXLxoQoC4nwraaS5h4TZwaSp1Gg9SQoxCsrumxjh7nZRQQkNfH29TEDeMvAZVmD3rpmsDnFc5Sj4JgJG6m4b-regtest-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@AC94BB9C1B08FE73BE1E3322:0',
+    key: '(accountSpendingCoins:key)vpub5YX1yJFY8E236pH3iNvCpThsXLxoQoC4nwraaS5h4TZwaSp1Gg9SQoxCsrumxjh7nZRQQkNfH29TEDeMvAZVmD3rpmsDnFc5Sj4JgJG6m4b-regtest-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@AC94BB9C1B08FE73BE1E3322:0' as AccountKey, // Todo: create properly via `createAccountKey()`
     accountType: 'normal',
     symbol: 'regtest',
     empty: false,
@@ -403,7 +403,7 @@ export const accountReceivingCoins: Account = {
     descriptor: asAccountDescriptor(
         '(accountReceivingCoins:descriptor)vpub5YX1yJFY8E238aESifzcpXQHLzNDYJC22yLWqCwJ5pN85E27ku5wUXdhnh3HSMs3HibDQzeWmVeH52bAAa9LvkK4L1V9XfZbmHxGDuZSJks',
     ),
-    key: '(accountReceivingCoins:key)vpub5YX1yJFY8E238aESifzcpXQHLzNDYJC22yLWqCwJ5pN85E27ku5wUXdhnh3HSMs3HibDQzeWmVeH52bAAa9LvkK4L1V9XfZbmHxGDuZSJks-regtest-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@AC94BB9C1B08FE73BE1E3322:0',
+    key: '(accountReceivingCoins:key)vpub5YX1yJFY8E238aESifzcpXQHLzNDYJC22yLWqCwJ5pN85E27ku5wUXdhnh3HSMs3HibDQzeWmVeH52bAAa9LvkK4L1V9XfZbmHxGDuZSJks-regtest-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@AC94BB9C1B08FE73BE1E3322:0' as AccountKey, // Todo: create properly via `createAccountKey()`
     accountType: 'normal',
     symbol: 'regtest',
     empty: false,

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -13,7 +13,12 @@ import {
     selectDevices,
     selectPersistentDeviceData,
 } from '@suite-common/wallet-core';
-import type { FormState, RatesByTimestamps, SuccessfulAccount } from '@suite-common/wallet-types';
+import type {
+    AccountKey,
+    FormState,
+    RatesByTimestamps,
+    SuccessfulAccount,
+} from '@suite-common/wallet-types';
 import { FormDraftKeyPrefix } from '@suite-common/wallet-types';
 import {
     getFormDraftKey,
@@ -53,13 +58,13 @@ export const saveExplorer = ({
     }
 };
 
-export const saveDraft = (formState: FormState, accountKey: string) => {
+export const saveDraft = (formState: FormState, accountKey: AccountKey) => {
     if (!db.isAccessible()) return;
 
     return db.addItem('sendFormDrafts', formState, accountKey, true);
 };
 
-export const removeDraft = (accountKey: string) => {
+export const removeDraft = (accountKey: AccountKey) => {
     if (!db.isAccessible()) return;
 
     return db.removeItemByPK('sendFormDrafts', accountKey);
@@ -80,13 +85,14 @@ const removeAccountDraft = (account: Account) => {
     return db.removeItemByPK('sendFormDrafts', account.key);
 };
 
-export const saveCoinjoinAccount = (accountKey: string) => (_: Dispatch, getState: GetState) => {
-    const coinjoinAccount = selectCoinjoinAccountByKey(getState(), accountKey);
-    if (!coinjoinAccount || !db.isAccessible()) return;
-    const serializedAccount = serializeCoinjoinAccount(coinjoinAccount);
+export const saveCoinjoinAccount =
+    (accountKey: AccountKey) => (_: Dispatch, getState: GetState) => {
+        const coinjoinAccount = selectCoinjoinAccountByKey(getState(), accountKey);
+        if (!coinjoinAccount || !db.isAccessible()) return;
+        const serializedAccount = serializeCoinjoinAccount(coinjoinAccount);
 
-    return db.addItem('coinjoinAccounts', serializedAccount, accountKey, true);
-};
+        return db.addItem('coinjoinAccounts', serializedAccount, accountKey, true);
+    };
 
 const removeCoinjoinRelatedSetting = (state: AppState) => {
     const settings = { ...state.suite.settings };
@@ -277,7 +283,7 @@ export const saveGraph = (graphData: GraphData[]) => {
 };
 
 export const saveAccountHistoricRates =
-    (accountKey: string, historicRates: RatesByTimestamps) =>
+    (accountKey: AccountKey, historicRates: RatesByTimestamps) =>
     (_dispatch: Dispatch, getState: GetState) => {
         if (!db.isAccessible()) return Promise.resolve();
         const allTxs = getState().wallet.transactions.transactions;

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -1,5 +1,6 @@
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { accountsActions } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 
 import * as COINJOIN from 'src/actions/wallet/constants/coinjoinConstants';
 import { Account } from 'src/types/wallet';
@@ -9,7 +10,7 @@ const ACCOUNT: Partial<Account> = {
     backendType: 'coinjoin',
     symbol: 'btc',
     deviceState: '1stTestnetAddress@device_id:0',
-    key: '12345',
+    key: '12345' as AccountKey, // Todo: create properly via `createAccountKey()`
 };
 
 const CJ_ACCOUNT = {
@@ -217,7 +218,7 @@ export const stopCoinjoinSession = [
                 accounts: [{ key: ACCOUNT.key }],
             },
         },
-        param: '000',
+        param: '000' as AccountKey,
         result: {
             actions: [],
         },
@@ -231,7 +232,7 @@ export const stopCoinjoinSession = [
                 accounts: [{ key: ACCOUNT.key }],
             },
         },
-        param: '12345',
+        param: '12345' as AccountKey, // Todo: create properly via `createAccountKey()`
         result: {
             actions: ['@coinjoin/account-unregister'],
         },
@@ -280,7 +281,7 @@ export const restoreCoinjoinSession = [
                 accounts: [{ ...CJ_ACCOUNT, session: { ...SESSION, paused: true } }],
             },
         },
-        param: '12345',
+        param: '12345' as AccountKey, // Todo: create properly via `createAccountKey()`
         result: {
             actions: [
                 COINJOIN.SESSION_STARTING,

--- a/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
@@ -15,6 +15,7 @@ import {
 } from '@suite-common/wallet-core';
 import { FeesState } from '@suite-common/wallet-types';
 import { PROTO } from '@trezor/connect';
+import { typedObjectKeys } from '@trezor/utils';
 
 import { accountsReducer, blockchainReducer, transactionsReducer } from 'src/reducers/wallet';
 import { configureStore, filterThunkActionTypes } from 'src/support/tests/configureStore';
@@ -180,9 +181,8 @@ describe('Blockchain Actions', () => {
                 });
                 if (f.resultTxs) {
                     const txs = store.getState().wallet.transactions.transactions;
-                    Object.keys(txs).forEach(key => {
-                        // @ts-expect-error
-                        const resTxs = f.resultTxs[key];
+                    typedObjectKeys(txs).forEach(key => {
+                        const resTxs = f.resultTxs[key as unknown as keyof typeof f.resultTxs]; // Todo: type fixtures
                         expect(txs[key].length).toEqual(resTxs.length);
                         txs[key].forEach((t, i) => expect(t).toMatchObject(resTxs[i]));
                     });

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
@@ -3,7 +3,7 @@ import { combineReducers, createReducer } from '@reduxjs/toolkit';
 import { prepareMessageSystemReducer } from '@suite-common/message-system';
 import { configureMockStore, initPreloadedState, testMocks } from '@suite-common/test-utils';
 import '@suite-common/test-utils/src/globalOverrides';
-import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { AccountKey, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { promiseAllSequence } from '@trezor/utils';
 
@@ -384,7 +384,7 @@ describe('coinjoinClientActions', () => {
     // for coverage: edge cases, missing data etc...
     it('pauseCoinjoinSession without related account', () => {
         const store = initStore();
-        store.dispatch(pauseCoinjoinSession('account-Z'));
+        store.dispatch(pauseCoinjoinSession('account-Z' as AccountKey));
     });
 
     it('stopCoinjoinSession without connected device', async () => {
@@ -396,7 +396,7 @@ describe('coinjoinClientActions', () => {
 
         await store.dispatch(initCoinjoinService('btc'));
 
-        store.dispatch(stopCoinjoinSession('account-A'));
+        store.dispatch(stopCoinjoinSession('account-A' as AccountKey));
     });
 
     it('stopCoinjoinSession with error from Trezor', async () => {
@@ -416,7 +416,7 @@ describe('coinjoinClientActions', () => {
 
         await store.dispatch(initCoinjoinService('btc'));
 
-        store.dispatch(stopCoinjoinSession('account-A'));
+        store.dispatch(stopCoinjoinSession('account-A' as AccountKey));
 
         expect(TrezorConnect.cancelCoinjoinAuthorization).toHaveBeenCalledTimes(1);
     });
@@ -453,7 +453,7 @@ describe('coinjoinClientActions', () => {
 
         await store.dispatch(initCoinjoinService('btc'));
 
-        store.dispatch(stopCoinjoinSession('account-A'));
+        store.dispatch(stopCoinjoinSession('account-A' as AccountKey));
 
         expect(TrezorConnect.cancelCoinjoinAuthorization).toHaveBeenCalledTimes(0);
     });

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -8,7 +8,7 @@ import {
     selectSelectedDevice,
     transactionsActions,
 } from '@suite-common/wallet-core';
-import { Account } from '@suite-common/wallet-types';
+import { Account, AccountKey } from '@suite-common/wallet-types';
 import {
     getAccountTransactions,
     sortByBIP44AddressIndex,
@@ -348,7 +348,7 @@ const coinjoinAccountAddTransactions =
  In case of adding a coinjoin transaction, log anonymity gain.
  */
 export const updatePendingAccountInfo =
-    (accountKey: string) => async (dispatch: Dispatch, getState: GetState) => {
+    (accountKey: AccountKey) => async (dispatch: Dispatch, getState: GetState) => {
         const state = getState();
         const account = selectAccountByKey(state, accountKey);
         const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
@@ -393,7 +393,7 @@ export const updatePendingAccountInfo =
     };
 
 export const createPendingTransaction =
-    (accountKey: string, payload: BroadcastedTransactionDetails) =>
+    (accountKey: AccountKey, payload: BroadcastedTransactionDetails) =>
     async (dispatch: Dispatch, getState: GetState) => {
         const state = getState();
         const account = selectAccountByKey(state, accountKey);
@@ -652,7 +652,7 @@ export const createCoinjoinAccount =
     };
 
 export const rescanCoinjoinAccount =
-    (accountKey: string, fullRescan = false) =>
+    (accountKey: AccountKey, fullRescan = false) =>
     async (dispatch: Dispatch, getState: GetState) => {
         const state = getState();
         const account = selectAccountByKey(state, accountKey);
@@ -762,7 +762,7 @@ export const startCoinjoinSession =
 // use same parameters as in startCoinjoinSession but recalculate maxRounds value
 // if Trezor is already preauthorized it will not ask for confirmation
 export const restoreCoinjoinSession =
-    (accountKey: string) => async (dispatch: Dispatch, getState: GetState) => {
+    (accountKey: AccountKey) => async (dispatch: Dispatch, getState: GetState) => {
         // TODO: check if device is connected, passphrase is authorized...
         const isDeviceLocked = selectIsDeviceLocked(getState());
         const device = selectSelectedDevice(getState());
@@ -936,7 +936,7 @@ export const restoreCoinjoinAccounts = () => (dispatch: Dispatch, getState: GetS
 };
 
 export const toggleAutostopCoinjoin =
-    (accountKey: string) => (dispatch: Dispatch, getState: GetState) => {
+    (accountKey: AccountKey) => (dispatch: Dispatch, getState: GetState) => {
         const currentAccountState = selectSessionByAccountKey(getState(), accountKey);
 
         if (!currentAccountState) {

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -2,7 +2,7 @@ import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import { getDeviceInstances } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { selectAccountByKey, selectDevices } from '@suite-common/wallet-core';
-import { Account, AddressDisplayOptions } from '@suite-common/wallet-types';
+import { Account, AccountKey, AddressDisplayOptions } from '@suite-common/wallet-types';
 import { getUtxoOutpoint } from '@suite-common/wallet-utils';
 import {
     CoinjoinClientEvents,
@@ -277,7 +277,7 @@ export const closeCriticalPhaseModal = () => (dispatch: Dispatch) => {
 
 // called from coinjoin account UI or exceptions like device disconnection, forget wallet/account etc.
 export const pauseCoinjoinSession =
-    (accountKey: string) => (dispatch: Dispatch, getState: GetState) => {
+    (accountKey: AccountKey) => (dispatch: Dispatch, getState: GetState) => {
         const account = selectAccountByKey(getState(), accountKey);
 
         if (!account || !isCoinjoinSupportedSymbol(account.symbol)) {
@@ -295,7 +295,7 @@ export const pauseCoinjoinSession =
 
 // called from coinjoin account UI or exceptions like device disconnection, forget wallet/account etc.
 export const stopCoinjoinSession =
-    (accountKey: string) => async (dispatch: Dispatch, getState: GetState) => {
+    (accountKey: AccountKey) => async (dispatch: Dispatch, getState: GetState) => {
         const state = getState();
         const account = selectAccountByKey(state, accountKey);
 
@@ -366,7 +366,7 @@ export const onCoinjoinRoundChanged =
         // collect all account.keys from the round including failed one
         const accountKeys = round.inputs
             .concat(round.failed)
-            .map(input => input.accountKey)
+            .map(input => input.accountKey as AccountKey)
             .filter(arrayDistinct);
 
         const currentTimestamp = Date.now();

--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -1,11 +1,7 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { selectBaseCurrency, selectIsElectrumBackendSelected } from '@suite-common/wallet-core';
-import { AccountKey } from '@suite-common/wallet-types';
-import {
-    getAccountKey,
-    isTrezorConnectBackendType,
-    tryGetAccountIdentity,
-} from '@suite-common/wallet-utils';
+import { AccountKey, createAccountKey } from '@suite-common/wallet-types';
+import { isTrezorConnectBackendType, tryGetAccountIdentity } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
 
 import { type Dispatch, type GetState } from 'src/types/suite';
@@ -176,7 +172,11 @@ export const updateGraphData = createThunk<
 
         const graphDataPointsByAccount = new Map<AccountKey, AccountHistoryWithBalance[]>(
             graph.data.map(({ account, data }) => [
-                getAccountKey(account.descriptor, account.symbol, account.deviceState),
+                createAccountKey({
+                    accountDescriptor: account.descriptor,
+                    networkSymbol: account.symbol,
+                    deviceStaticSessionId: account.deviceState,
+                }),
                 data,
             ]),
         );

--- a/packages/suite/src/actions/wallet/processLegacyMetadataIntoSuiteSyncThunk.ts
+++ b/packages/suite/src/actions/wallet/processLegacyMetadataIntoSuiteSyncThunk.ts
@@ -3,7 +3,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { SuiteSyncUpdateError } from '@suite-common/suite-sync-storage';
 import { EnsureWalletSuiteSyncOnErrors } from '@suite-common/suite-sync-types';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { AccountKey, asAccountDescriptor } from '@suite-common/wallet-types';
 import type { StaticSessionId } from '@trezor/connect';
 import { Result, exhaustive } from '@trezor/type-utils';
 
@@ -37,7 +37,7 @@ export const processLegacyMetadataIntoSuiteSyncThunk = createThunk<
             case 'accountLabel':
                 return await services.suiteSync.labeling.updateAccountLabel({
                     deviceStaticSessionId,
-                    accountKey: payload.entityKey,
+                    accountKey: payload.entityKey as AccountKey,
                     label: value ?? null,
                 });
 

--- a/packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/accounts.ts
+++ b/packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/accounts.ts
@@ -1,4 +1,4 @@
-import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { AccountKey, asAccountDescriptor } from '@suite-common/wallet-types';
 
 import { Account } from 'src/types/wallet';
 
@@ -9,7 +9,7 @@ export const BTC_ACCOUNT: Account = {
     deviceState: '1stTestnetAddress@device_id:0',
     index: 0,
     path: "m/84'/0'/0'",
-    key: 'descriptor-btc-1stTestnetAddress@device_id:0',
+    key: 'descriptor-btc-1stTestnetAddress@device_id:0' as AccountKey, // Todo: create properly via `createAccountKey()`,
     accountType: 'normal',
     empty: true,
     visible: true,
@@ -55,7 +55,7 @@ export const ETH_ACCOUNT: Account = {
     networkType: 'ethereum',
     descriptor: asAccountDescriptor('0xdB09b793984B862C430b64B9ed53AcF867cC041F'),
     deviceState: '1stTestnetAddress@device_id:0',
-    key: '0xdB09b793984B862C430b64B9ed53AcF867cC041F-eth-deviceState',
+    key: '0xdB09b793984B862C430b64B9ed53AcF867cC041F-eth-deviceState' as AccountKey, // Todo: create properly via `createAccountKey()`
     accountType: 'normal',
     index: 0,
     path: "m/44'/60'/0'/0/0",
@@ -94,7 +94,7 @@ export const XRP_ACCOUNT: Account = {
     networkType: 'ripple',
     descriptor: asAccountDescriptor('rAPERVgXZavGgiGv6xBgtiZurirW2yAmY'),
     deviceState: '1stTestnetAddress@device_id:0',
-    key: 'rAPERVgXZavGgiGv6xBgtiZurirW2yAmY-xrp-deviceState',
+    key: 'rAPERVgXZavGgiGv6xBgtiZurirW2yAmY-xrp-deviceState' as AccountKey, // Todo: create properly via `createAccountKey()`
     availableBalance: '100000000000',
     accountType: 'normal',
     index: 0,

--- a/packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/store.ts
+++ b/packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/store.ts
@@ -1,4 +1,4 @@
-import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { AccountKey, asAccountDescriptor } from '@suite-common/wallet-types';
 
 import { Account } from 'src/types/wallet';
 
@@ -9,7 +9,7 @@ export const ACCOUNT: Account = {
     deviceState: '1stTestnetAddress@device_id:0',
     index: 0,
     path: "m/84'/0'/0'",
-    key: 'descriptor-btc-1stTestnetAddress@device_id:0',
+    key: 'descriptor-btc-1stTestnetAddress@device_id:0' as AccountKey, // Todo: create properly via `createAccountKey()`
     accountType: 'normal',
     empty: true,
     visible: true,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
@@ -7,7 +7,7 @@ import {
     selectDevices,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
-import { WalletParams } from '@suite-common/wallet-types';
+import { AccountKey, WalletParams } from '@suite-common/wallet-types';
 import { ProgressPie } from '@trezor/components';
 import { typography } from '@trezor/theme';
 
@@ -70,7 +70,7 @@ const Separator = styled.span`
 `;
 
 interface CoinjoinStatusBarProps {
-    accountKey: string;
+    accountKey: AccountKey;
     session: CoinjoinSession;
     isSingle: boolean;
 }

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -3,7 +3,12 @@ import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { formatDurationStrict } from '@suite-common/suite-utils';
 import { NetworkType, networks } from '@suite-common/wallet-config';
 import { selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
-import { FeeInfo, GeneralPrecomposedTransactionFinal, StakeType } from '@suite-common/wallet-types';
+import {
+    FeeInfo,
+    GeneralPrecomposedTransactionFinal,
+    SendFormDraftKey,
+    StakeType,
+} from '@suite-common/wallet-types';
 import {
     asAmountUnit,
     getFee,
@@ -69,8 +74,8 @@ export const TransactionReviewSummary = ({
     const connectPopupCall = useSelector(selectConnectPopupCall);
     const isDebug = useSelector(selectIsDebugModeActive);
 
-    const formFeeRate = drafts[currentAccountKey]?.feePerUnit;
-    const isFeeCustom = drafts[currentAccountKey]?.selectedFee === 'custom';
+    const formFeeRate = drafts[currentAccountKey as SendFormDraftKey]?.feePerUnit; // Todo: is this cast correct? https://github.com/trezor/trezor-suite/issues/24918
+    const isFeeCustom = drafts[currentAccountKey as SendFormDraftKey]?.selectedFee === 'custom'; // Todo: is this cast correct? https://github.com/trezor/trezor-suite/issues/24918
     const isComposedFeeRateDifferent = isFeeCustom && formFeeRate !== fee;
 
     const isEthereumNetworkType = networkType === 'ethereum';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CoinjoinSuccessModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CoinjoinSuccessModal.tsx
@@ -1,6 +1,6 @@
 import { Translation } from '@suite/intl';
 import { selectAccountByKey } from '@suite-common/wallet-core';
-import { WalletParams } from '@suite-common/wallet-types';
+import { AccountKey, WalletParams } from '@suite-common/wallet-types';
 import { Column, H3, Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -11,7 +11,7 @@ import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectRouterParams } from 'src/reducers/suite/routerReducer';
 
 type CoinjoinSuccessModalProps = {
-    relatedAccountKey: string;
+    relatedAccountKey: AccountKey;
 };
 
 export const CoinjoinSuccessModal = ({ relatedAccountKey }: CoinjoinSuccessModalProps) => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/AutoStopButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/AutoStopButton.tsx
@@ -1,4 +1,5 @@
 import { Translation } from '@suite/intl';
+import { AccountKey } from '@suite-common/wallet-types';
 import { Checkbox, Text } from '@trezor/components';
 
 import { toggleAutostopCoinjoin } from 'src/actions/wallet/coinjoinAccountActions';
@@ -7,7 +8,7 @@ import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectIsSessionAutostopped } from 'src/reducers/wallet/coinjoinReducer';
 
 type AutoStopButtonProps = {
-    relatedAccountKey: string;
+    relatedAccountKey: AccountKey;
 };
 
 export const AutoStopButton = ({ relatedAccountKey }: AutoStopButtonProps) => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/CriticalCoinjoinPhaseModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/CriticalCoinjoinPhaseModal.tsx
@@ -1,4 +1,5 @@
 import { Translation } from '@suite/intl';
+import { AccountKey } from '@suite-common/wallet-types';
 import { Banner, Card, Column, Divider, LoadingContent, Modal } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -11,7 +12,7 @@ import { AutoStopButton } from './AutoStopButton';
 import { CoinjoinPhaseProgress } from './CoinjoinPhaseProgress';
 
 type CriticalCoinjoinPhaseModalProps = {
-    relatedAccountKey: string;
+    relatedAccountKey: AccountKey;
 };
 
 export const CriticalCoinjoinPhaseModal = ({

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChainedTxs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChainedTxs.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
 import { AccountType, Network } from '@suite-common/wallet-config';
-import { ChainedTransactions } from '@suite-common/wallet-types';
+import { ChainedTransactions, createAccountKey } from '@suite-common/wallet-types';
 import { typography } from '@trezor/theme';
 
 import { TrezorLink } from 'src/components/suite/TrezorLink';
@@ -74,7 +74,11 @@ export const ChainedTxs = ({ txs, network, accountType, explorerUrl }: ChainedTx
                     accountType={accountType}
                     isPending
                     isActionDisabled
-                    accountKey={`${tx.descriptor}-${tx.symbol}-${tx.deviceState}`}
+                    accountKey={createAccountKey({
+                        accountDescriptor: tx.descriptor,
+                        networkSymbol: tx.symbol,
+                        deviceStaticSessionId: tx.deviceState,
+                    })}
                     index={index}
                 />
             </TrezorLink>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -1,7 +1,6 @@
 import { Translation } from '@suite/intl';
 import { selectIsPhishingTransaction } from '@suite-common/wallet-core';
-import { WalletAccountTransaction } from '@suite-common/wallet-types';
-import { getAccountKey } from '@suite-common/wallet-utils';
+import { WalletAccountTransaction, createAccountKey } from '@suite-common/wallet-types';
 import { Column, Divider } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -21,7 +20,11 @@ type IODetailsProps = {
 // Not ready for Cardano tokens because they are utxo based
 export const IODetails = ({ tx }: IODetailsProps) => {
     const network = useSelector(state => state.wallet.selectedAccount.network);
-    const accountKey = getAccountKey(tx.descriptor, tx.symbol, tx.deviceState);
+    const accountKey = createAccountKey({
+        accountDescriptor: tx.descriptor,
+        networkSymbol: tx.symbol,
+        deviceStaticSessionId: tx.deviceState,
+    });
     const isPhishingTransaction = useSelector(state =>
         selectIsPhishingTransaction(state, tx.txid, accountKey),
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/DetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/DetailModal.tsx
@@ -2,8 +2,12 @@ import { Translation } from '@suite/intl';
 import { Explorer, getNetwork } from '@suite-common/wallet-config';
 import { getExplorerUrl } from '@suite-common/wallet-config/src/getExplorerUrls';
 import { selectAccountByKey, selectExplorer } from '@suite-common/wallet-core';
-import { Account, ChainedTransactions, WalletAccountTransaction } from '@suite-common/wallet-types';
-import { getAccountKey } from '@suite-common/wallet-utils';
+import {
+    Account,
+    ChainedTransactions,
+    WalletAccountTransaction,
+    createAccountKey,
+} from '@suite-common/wallet-types';
 import { Modal } from '@trezor/components';
 
 import { AdvancedTxDetails, TabID } from './AdvancedTxDetails/AdvancedTxDetails';
@@ -31,7 +35,11 @@ export const DetailModal = ({
     canReplaceTransaction,
     canCancelTransaction,
 }: DetailModalProps) => {
-    const accountKey = getAccountKey(tx.descriptor, tx.symbol, tx.deviceState);
+    const accountKey = createAccountKey({
+        accountDescriptor: tx.descriptor,
+        networkSymbol: tx.symbol,
+        deviceStaticSessionId: tx.deviceState,
+    });
     const account = useSelector(state => selectAccountByKey(state, accountKey)) as Account;
     const network = getNetwork(account.symbol);
     const explorer = useSelector(state => selectExplorer(state, network.symbol)) as Explorer;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
@@ -8,8 +8,11 @@ import {
     selectAllPendingTransactions,
     selectTransactionByAccountKeyAndTxid,
 } from '@suite-common/wallet-core';
-import { WalletAccountTransactionWithRequiredRbfParams } from '@suite-common/wallet-types';
-import { findChainedTransactions, getAccountKey, isPending } from '@suite-common/wallet-utils';
+import {
+    WalletAccountTransactionWithRequiredRbfParams,
+    createAccountKey,
+} from '@suite-common/wallet-types';
+import { findChainedTransactions, isPending } from '@suite-common/wallet-utils';
 import { Modal } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
@@ -44,7 +47,11 @@ export const TxDetailModal = ({
     const [section, setSection] = useState<TxDetailModalProps['flow']>(flow);
     const [tab, setTab] = useState<TabID | undefined>(undefined);
 
-    const accountKey = getAccountKey(descriptor, symbol, deviceState);
+    const accountKey = createAccountKey({
+        accountDescriptor: descriptor,
+        networkSymbol: symbol,
+        deviceStaticSessionId: deviceState,
+    });
     const originalTx = useSelector(state =>
         selectTransactionByAccountKeyAndTxid(state, accountKey, txid),
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModalBase.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModalBase.tsx
@@ -9,7 +9,7 @@ import {
     selectIsPhishingTransaction,
     selectTransactionConfirmations,
 } from '@suite-common/wallet-core';
-import { getAccountKey } from '@suite-common/wallet-utils';
+import { createAccountKey } from '@suite-common/wallet-types';
 import { Banner, Column, Modal } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { HELP_CENTER_ZERO_VALUE_ATTACKS } from '@trezor/urls';
@@ -37,7 +37,11 @@ export const TxDetailModalBase = ({
     bottomContent,
     children,
 }: TxDetailModalProps) => {
-    const accountKey = getAccountKey(tx.descriptor, tx.symbol, tx.deviceState);
+    const accountKey = createAccountKey({
+        accountDescriptor: tx.descriptor,
+        networkSymbol: tx.symbol,
+        deviceStaticSessionId: tx.deviceState,
+    });
     const confirmations = useSelector(state =>
         selectTransactionConfirmations(state, tx.txid, accountKey),
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -1,3 +1,4 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import { UI } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -128,9 +129,15 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL.CONTE
         case 'cancel-coinjoin':
             return <CancelCoinjoinModal onClose={onCancel} />;
         case 'critical-coinjoin-phase':
-            return <CriticalCoinjoinPhaseModal relatedAccountKey={payload.relatedAccountKey} />;
+            return (
+                <CriticalCoinjoinPhaseModal
+                    relatedAccountKey={payload.relatedAccountKey as AccountKey}
+                />
+            );
         case 'coinjoin-success':
-            return <CoinjoinSuccessModal relatedAccountKey={payload.relatedAccountKey} />;
+            return (
+                <CoinjoinSuccessModal relatedAccountKey={payload.relatedAccountKey as AccountKey} />
+            );
         case 'more-rounds-needed':
             return <MoreRoundsNeededModal />;
         case 'uneco-coinjoin-warning':

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -6,6 +6,7 @@ import { Translation } from '@suite/intl';
 import { getInstantStakeType } from '@suite-common/staking';
 import { AccountType, Network } from '@suite-common/wallet-config';
 import { selectIsPhishingTransaction, useDisplayBaseCurrency } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import { formatNetworkAmount, isTxFeePaid } from '@suite-common/wallet-utils';
 import { Button, Link, Row, Tooltip } from '@trezor/components';
 import { HELP_CENTER_REPLACE_BY_FEE_ETHEREUM } from '@trezor/urls';
@@ -41,7 +42,7 @@ type TransactionItemProps = {
     transaction: WalletAccountTransaction;
     isPending: boolean;
     isActionDisabled?: boolean; // Used in "chained transactions" transaction detail modal
-    accountKey: string;
+    accountKey: AccountKey;
     network: Network;
     accountType: AccountType;
     disableBumpFee?: boolean;

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -7,7 +7,7 @@ import {
     selectHistoricFiatRatesByTimestamp,
     useDisplayBaseCurrency,
 } from '@suite-common/wallet-core';
-import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, Timestamp, TokenAddress } from '@suite-common/wallet-types';
 import {
     convertAmountSubunitsToUnits,
     formatNetworkAmount,
@@ -41,7 +41,7 @@ import { TransactionTargetLayout } from '../TransactionTargetLayout';
 
 type TransactionTargetProps = CombinedTarget & {
     transaction: WalletAccountTransaction;
-    accountKey: string;
+    accountKey: AccountKey;
     isActionDisabled?: boolean;
     isPhishingTransaction?: boolean;
 };

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTargetsList.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTargetsList.tsx
@@ -1,3 +1,4 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     InternalTransfer as InternalTransferType,
     TokenTransfer as TokenTransferType,
@@ -26,7 +27,7 @@ type TransactionTargetsListProps = {
     allOutputs: CombinedTarget[];
     limit: number;
     defaultLimit: number;
-    accountKey: string;
+    accountKey: AccountKey;
     isActionDisabled?: boolean;
     isPhishingTransaction?: boolean;
 };

--- a/packages/suite/src/hooks/coinjoin/useCoinjoinSessionBlockers.ts
+++ b/packages/suite/src/hooks/coinjoin/useCoinjoinSessionBlockers.ts
@@ -1,12 +1,13 @@
 import { useTranslation } from '@suite/intl';
 import { Feature, selectFeatureMessageContent } from '@suite-common/message-system';
+import { AccountKey } from '@suite-common/wallet-types';
 
 import { useSelector } from 'src/hooks/suite';
 import { selectCoinjoinSessionBlockerByAccountKey } from 'src/reducers/wallet/coinjoinReducer';
 import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 export const useCoinjoinSessionBlockers = (
-    accountKey: string,
+    accountKey: AccountKey,
 ): {
     coinjoinSessionBlocker: ReturnType<typeof selectCoinjoinSessionBlockerByAccountKey>;
     coinjoinSessionBlockedMessage?: string;

--- a/packages/suite/src/hooks/coinjoin/useCoinjoinSessionPhase.ts
+++ b/packages/suite/src/hooks/coinjoin/useCoinjoinSessionPhase.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { AccountKey } from '@suite-common/wallet-types';
+
 import { SESSION_PHASE_TRANSITION_DELAY } from 'src/constants/suite/coinjoin';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectSessionByAccountKey } from 'src/reducers/wallet/coinjoinReducer';
@@ -17,7 +19,7 @@ const checkExpiration = (lastChangeTimestamp: number) => {
     };
 };
 
-export const useCoinjoinSessionPhase = (accountKey: string) => {
+export const useCoinjoinSessionPhase = (accountKey: AccountKey) => {
     const { sessionPhaseQueue, roundPhase, paused } =
         useSelector(state => selectSessionByAccountKey(state, accountKey)) || {};
     const [phaseIndex, setPhaseIndex] = useState(0);

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -6,8 +6,14 @@ import { testMocks } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { Network, getNetwork } from '@suite-common/wallet-config';
 import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
-import { SendState, accountsActions, prepareSendFormReducer } from '@suite-common/wallet-core';
-import { FeesState, SelectedAccountStatus, asAccountDescriptor } from '@suite-common/wallet-types';
+import { accountsActions, prepareSendFormReducer } from '@suite-common/wallet-core';
+import {
+    FeesState,
+    FormState,
+    SelectedAccountStatus,
+    SendFormDraftKey,
+    asAccountDescriptor,
+} from '@suite-common/wallet-types';
 import {
     mockWalletAccount,
     networkSpecificDefaultEthereum,
@@ -259,7 +265,8 @@ const DEFAULT_FEES: FeesState = {
 
 // - default selectedAccount needs to be explicitly passed from test. merging default with custom will override custom
 // - default fees needs to be explicitly passed from test. merge Arrays will add items, not replace them
-export const getRootReducer = (selectedAccount = BTC_ACCOUNT, fees = DEFAULT_FEES) =>
+// Todo: Type properly as the Error: "The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed."
+export const getRootReducer: any = (selectedAccount = BTC_ACCOUNT, fees = DEFAULT_FEES) =>
     combineReducers({
         suite: createReducer(
             {
@@ -441,8 +448,8 @@ const DEFAULT_DRAFT = {
     selectedUtxos: [],
 };
 
-const getDraft = (draft?: any): SendState['drafts'] => ({
-    'xpub-btc-1stTestnetAddress@device_id:0': {
+const getDraft = (draft?: any): Record<SendFormDraftKey, FormState> => ({
+    ['xpub-btc-1stTestnetAddress@device_id:0' as SendFormDraftKey]: {
         ...DEFAULT_DRAFT,
         outputs: [
             {
@@ -453,18 +460,19 @@ const getDraft = (draft?: any): SendState['drafts'] => ({
         ],
         ...draft,
     },
-    '0xdB09b793984B862C430b64B9ed53AcF867cC041F-eth-1stTestnetAddress@device_id:0': {
-        ...DEFAULT_DRAFT,
-        outputs: [
-            {
-                ...DEFAULT_PAYMENT,
-                address: '0xdB09b793984B862C430b64B9ed53AcF867cC041F',
-                amount: '1',
-            },
-        ],
-        ...draft,
-    },
-    'rAPERVgXZavGgiGv6xBgtiZurirW2yAmY-xrp-1stTestnetAddress@device_id:0': {
+    ['0xdB09b793984B862C430b64B9ed53AcF867cC041F-eth-1stTestnetAddress@device_id:0' as SendFormDraftKey]:
+        {
+            ...DEFAULT_DRAFT,
+            outputs: [
+                {
+                    ...DEFAULT_PAYMENT,
+                    address: '0xdB09b793984B862C430b64B9ed53AcF867cC041F',
+                    amount: '1',
+                },
+            ],
+            ...draft,
+        },
+    ['rAPERVgXZavGgiGv6xBgtiZurirW2yAmY-xrp-1stTestnetAddress@device_id:0' as SendFormDraftKey]: {
         ...DEFAULT_DRAFT,
         outputs: [
             {
@@ -475,17 +483,18 @@ const getDraft = (draft?: any): SendState['drafts'] => ({
         ],
         ...draft,
     },
-    'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF-sol-1stTestnetAddress@device_id:0': {
-        ...DEFAULT_DRAFT,
-        outputs: [
-            {
-                ...DEFAULT_PAYMENT,
-                address: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
-                amount: '1',
-            },
-        ],
-        ...draft,
-    },
+    ['ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF-sol-1stTestnetAddress@device_id:0' as SendFormDraftKey]:
+        {
+            ...DEFAULT_DRAFT,
+            outputs: [
+                {
+                    ...DEFAULT_PAYMENT,
+                    address: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                    amount: '1',
+                },
+            ],
+            ...draft,
+        },
 });
 
 export const addingOutputs = [
@@ -1417,7 +1426,14 @@ const getComposeResponse = (resp?: any) => ({
     ...resp,
 });
 
-export const signAndPush = [
+type SignAndPush = {
+    description: string;
+    store: any;
+    connect?: any;
+    result: any;
+};
+
+export const signAndPush: SignAndPush[] = [
     {
         description: 'ETH',
         store: {

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -32,6 +32,7 @@ import {
 } from '@suite-common/trading';
 import { networks } from '@suite-common/wallet-config';
 import { selectAccountByKey, selectBaseCurrency, useFormDraft } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import { isChanged } from '@trezor/utils';
 
 import * as routerActions from 'src/actions/suite/routerActions';
@@ -181,7 +182,7 @@ export const useTradingSellForm = ({
     const decimals = useMemo(
         () =>
             getAssetDecimals({
-                accountKey: values.sendCryptoSelect?.accountKey,
+                accountKey: values.sendCryptoSelect?.accountKey as AccountKey,
                 cryptoId: values.sendCryptoSelect?.id as CryptoId,
             }),
         [getAssetDecimals, values.sendCryptoSelect?.accountKey, values.sendCryptoSelect?.id],

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -17,6 +17,7 @@ import {
     selectDevices,
     selectDevicesCount,
 } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     accumulateAccountCountBySymbolAndType,
     getAccountTotalStakingBalance,
@@ -270,11 +271,11 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
             case COINJOIN.ACCOUNT_UNREGISTER: {
                 const coinjoinAccount = selectCoinjoinAccountByKey(
                     state,
-                    action.payload.accountKey,
+                    action.payload.accountKey as AccountKey,
                 );
                 const anonymityGainToReport = selectAnonymityGainToReportByAccountKey(
                     state,
-                    action.payload.accountKey,
+                    action.payload.accountKey as AccountKey,
                 );
 
                 if (coinjoinAccount && anonymityGainToReport !== null) {

--- a/packages/suite/src/middlewares/wallet/__fixtures__/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/__fixtures__/coinjoinMiddleware.ts
@@ -1,5 +1,5 @@
 import { accountsActions } from '@suite-common/wallet-core';
-import { SelectedAccountLoaded } from '@suite-common/wallet-types';
+import { AccountKey, SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { AnonymitySet } from '@trezor/blockchain-link';
 import { DEVICE, StaticSessionId } from '@trezor/connect';
 
@@ -30,7 +30,7 @@ const ACCOUNT_A = {
     backendType: 'coinjoin',
     deviceState: '1stTestnet@device_A_id:0' as StaticSessionId,
     history: {},
-    key: 'account-A-key',
+    key: 'account-A-key' as AccountKey, // Todo: create properly via `createAccountKey()`
     status: 'ready',
     symbol: 'btc',
     utxo: [{ address: 'address', amount: '10000', vout: 1 }],
@@ -43,11 +43,11 @@ const ACCOUNT_A = {
 const ACCOUNT_B = {
     ...ACCOUNT_A,
     deviceState: '1stTestnet@device_B_id:0' as StaticSessionId,
-    key: 'account-B-key',
+    key: 'account-B-key' as AccountKey, // Todo: create properly via `createAccountKey()`
 };
 
 const COINJOIN_ACCOUNT_A = {
-    key: 'account-A-key',
+    key: 'account-A-key' as AccountKey, // Todo: create properly via `createAccountKey()`
     session: { signedRounds: [] as string[] },
     setup: {
         targetAnonymity: 2,
@@ -55,7 +55,7 @@ const COINJOIN_ACCOUNT_A = {
 } as CoinjoinAccount;
 const COINJOIN_ACCOUNT_B = {
     ...COINJOIN_ACCOUNT_A,
-    key: 'account-B-key',
+    key: 'account-B-key' as AccountKey, // Todo: create properly via `createAccountKey()`
 };
 
 const DEFAULT_STATE = {

--- a/packages/suite/src/middlewares/wallet/__fixtures__/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/__fixtures__/walletMiddleware.ts
@@ -8,6 +8,7 @@ import {
 import {
     Account,
     AccountBase,
+    AccountKey,
     Output,
     FormState as SendFormState,
     asAccountDescriptor,
@@ -141,13 +142,13 @@ export const draftsFixtures = [
             settings: { bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN },
             accounts: [
                 {
-                    key: 'one',
+                    key: 'one' as AccountKey, // Todo: create properly via `createAccountKey()`
                     networkType: 'bitcoin',
                     symbol: 'btc',
                     accountType: 'normal',
                 } as Account,
                 {
-                    key: 'two',
+                    key: 'two' as AccountKey, // Todo: create properly via `createAccountKey()`
                     networkType: 'bitcoin',
                     symbol: 'regtest',
                     accountType: 'normal',
@@ -156,7 +157,7 @@ export const draftsFixtures = [
             selectedAccount: {
                 status: 'loaded',
                 account: {
-                    key: 'one',
+                    key: 'one' as AccountKey, // Todo: create properly via `createAccountKey()`
                     networkType: 'bitcoin',
                     symbol: 'btc',
                     accountType: 'normal',

--- a/packages/suite/src/middlewares/wallet/__tests__/tradingMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/tradingMiddleware.test.ts
@@ -11,7 +11,7 @@ import {
     tradingSellActions,
 } from '@suite-common/trading';
 import { prepareAccountsReducer } from '@suite-common/wallet-core';
-import { SelectedAccountStatus } from '@suite-common/wallet-types';
+import { AccountKey, SelectedAccountStatus } from '@suite-common/wallet-types';
 
 import { MODAL, ROUTER } from 'src/actions/suite/constants';
 import { ACCOUNT } from 'src/actions/wallet/trading/__fixtures__/tradingCommonActions/store';
@@ -140,7 +140,7 @@ describe('tradingMiddleware', () => {
             getInitialState({
                 trading: {
                     ...initialState,
-                    modalAccountKey: 'mocked-key',
+                    modalAccountKey: 'mocked-key' as AccountKey, // Todo: create properly via `createAccountKey()`
                     modalCryptoId: 'mocked-key' as CryptoId,
                 },
                 router: routerReducer(tradingMiddlewareFixtures.TRADING_SELL_ROUTE, {} as Action),
@@ -203,7 +203,7 @@ describe('tradingMiddleware', () => {
                     ...initialState,
                     prefilledFromAccount: {
                         cryptoId: 'bitcoin' as CryptoId,
-                        key: 'descriptor',
+                        key: 'descriptor' as AccountKey, // Todo: create properly via `createAccountKey()`
                     },
                 },
                 router: routerReducer(routeDefault, {} as Action),

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -15,6 +15,7 @@ import {
     selectAccountByKey,
     transactionsActions,
 } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import { RoundPhase, SessionPhase } from '@trezor/coinjoin';
 import { DEVICE, UI } from '@trezor/connect';
 import { arrayDistinct } from '@trezor/utils';
@@ -96,7 +97,7 @@ export const coinjoinMiddleware =
             accountKeys.forEach(accountKey => {
                 api.dispatch(
                     coinjoinAccountActions.createPendingTransaction(
-                        accountKey,
+                        accountKey as AccountKey,
                         broadcastedTxDetails,
                     ),
                 );
@@ -294,7 +295,7 @@ export const coinjoinMiddleware =
 
             if (action.payload.phase === SessionPhase.CriticalError && !isAlreadyPaused) {
                 action.payload.accountKeys.forEach(key =>
-                    api.dispatch(coinjoinClientActions.pauseCoinjoinSession(key)),
+                    api.dispatch(coinjoinClientActions.pauseCoinjoinSession(key as AccountKey)),
                 );
                 api.dispatch(addToast({ type: 'coinjoin-interrupted' }));
             }

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -36,6 +36,7 @@ import {
     transactionsActions,
     updateTxsFiatRatesThunk,
 } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import { findAccountDevice, isAccountSuccessful } from '@suite-common/wallet-utils';
 import { walletConnectActions } from '@suite-common/walletconnect';
 
@@ -389,11 +390,18 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case COINJOIN.ACCOUNT_UPDATE_TARGET_ANONYMITY:
                 case COINJOIN.ACCOUNT_UPDATE_MAX_MING_FEE:
                 case COINJOIN.ACCOUNT_TOGGLE_SKIP_ROUNDS: {
-                    const account = selectAccountByKey(api.getState(), action.payload.accountKey);
+                    const account = selectAccountByKey(
+                        api.getState(),
+                        action.payload.accountKey as AccountKey,
+                    );
                     const device =
                         account && findAccountDevice(account, selectDevices(api.getState()));
                     if (device && isDeviceRemembered(device)) {
-                        api.dispatch(storageActions.saveCoinjoinAccount(action.payload.accountKey));
+                        api.dispatch(
+                            storageActions.saveCoinjoinAccount(
+                                action.payload.accountKey as AccountKey,
+                            ),
+                        );
                     }
                     break;
                 }
@@ -402,10 +410,10 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     const state = api.getState();
                     const devices = selectDevices(state);
                     affectedAccounts.forEach(key => {
-                        const account = selectAccountByKey(state, key);
+                        const account = selectAccountByKey(state, key as AccountKey);
                         const device = account && findAccountDevice(account, devices);
                         if (device && isDeviceRemembered(device)) {
-                            api.dispatch(storageActions.saveCoinjoinAccount(key));
+                            api.dispatch(storageActions.saveCoinjoinAccount(key as AccountKey));
                         }
                     });
                     break;

--- a/packages/suite/src/reducers/wallet/__fixtures__/transactionConstants.ts
+++ b/packages/suite/src/reducers/wallet/__fixtures__/transactionConstants.ts
@@ -1,4 +1,5 @@
 import {
+    AccountKey,
     Account as CommonAccount,
     WalletAccountTransaction,
     asAccountDescriptor,
@@ -12,7 +13,7 @@ export const accounts: CommonAccount[] = [
         descriptor: asAccountDescriptor(
             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
         ),
-        key: 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
+        key: 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0' as AccountKey,
         accountType: 'normal',
         symbol: 'btc',
         empty: false,
@@ -107,7 +108,7 @@ export const accounts: CommonAccount[] = [
         descriptor: asAccountDescriptor(
             "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)",
         ),
-        key: "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0",
+        key: "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0" as AccountKey,
         accountType: 'taproot',
         symbol: 'btc',
         empty: false,

--- a/packages/suite/src/reducers/wallet/__tests__/sendFormReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/sendFormReducer.test.ts
@@ -5,7 +5,12 @@ import {
     prepareSendFormReducer,
     sendFormActions,
 } from '@suite-common/wallet-core';
-import { Account, FormState, PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import {
+    Account,
+    AccountKey,
+    FormState,
+    PrecomposedTransactionFinal,
+} from '@suite-common/wallet-types';
 
 import { STORAGE } from 'src/actions/suite/constants';
 import { extraDependencies } from 'src/support/extraDependencies';
@@ -24,7 +29,12 @@ describe('sendFormReducer', () => {
         const action: Action = {
             type: STORAGE.LOAD,
             payload: {
-                sendFormDrafts: [{ key: 'draft1', value: formStateMock }],
+                sendFormDrafts: [
+                    {
+                        key: 'draft1' as AccountKey, // Todo: create properly via `createAccountKey()`
+                        value: formStateMock,
+                    },
+                ],
             },
         } as Extract<PreloadStoreAction, { type: typeof STORAGE.LOAD }>;
 
@@ -36,7 +46,7 @@ describe('sendFormReducer', () => {
 
     it('SEND.STORE_DRAFT', () => {
         const action: Action = sendFormActions.storeDraft({
-            accountKey: 'key1',
+            accountKey: 'key1' as AccountKey, // Todo: create properly via `createAccountKey()`
             formState: formStateMock,
         });
 
@@ -47,20 +57,24 @@ describe('sendFormReducer', () => {
     });
 
     it('SEND.REMOVE_DRAFT', () => {
-        const action: Action = sendFormActions.removeDraft({ accountKey: 'key1' });
+        const action: Action = sendFormActions.removeDraft({
+            accountKey: 'key1' as AccountKey, // Todo: create properly via `createAccountKey()`
+        });
 
         const state = prepareSendFormReducer(extraDependencies)(
-            { ...initialState, drafts: { key1: formStateMock } },
+            { ...initialState, drafts: { ['key1' as AccountKey]: formStateMock } },
             action,
         );
         expect(state.drafts).toEqual({});
     });
 
     it('accountsActions.removeAccount', () => {
-        const action = accountsActions.removeAccount([{ key: 'deletedAccountKey' } as Account]);
+        const action = accountsActions.removeAccount([
+            { key: 'deletedAccountKey' as AccountKey } as Account, // Todo: create properly via `createAccountKey()`
+        ]);
 
         const state = prepareSendFormReducer(extraDependencies)(
-            { ...initialState, drafts: { deletedAccountKey: formStateMock } },
+            { ...initialState, drafts: { ['deletedAccountKey' as AccountKey]: formStateMock } },
             action,
         );
         expect(state.drafts).toEqual({});

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -625,13 +625,16 @@ export const selectMaxMiningFeeModifier = (state: CoinjoinRootState) =>
 export const selectMaxMiningFeeConfig = (state: CoinjoinRootState) =>
     state.wallet.coinjoin.config.maxFeePerVbyte;
 
-export const selectCoinjoinAccountByKey = (state: CoinjoinRootState, accountKey: AccountKey) => {
+export const selectCoinjoinAccountByKey = (
+    state: CoinjoinRootState,
+    accountKey: AccountKey | null,
+) => {
     const coinjoinAccounts = selectCoinjoinAccounts(state);
 
     return coinjoinAccounts.find(account => account.key === accountKey);
 };
 
-export const selectCoinjoinClient = (state: CoinjoinRootState, accountKey: AccountKey) => {
+export const selectCoinjoinClient = (state: CoinjoinRootState, accountKey: AccountKey | null) => {
     const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
     const clients = selectCoinjoinClients(state);
 
@@ -646,7 +649,7 @@ export const selectSessionByAccountKey = (state: CoinjoinRootState, accountKey: 
 
 export const selectTargetAnonymityByAccountKey = (
     state: CoinjoinRootState,
-    accountKey: AccountKey,
+    accountKey: AccountKey | null,
 ) => {
     const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
     if (!coinjoinAccount) return;
@@ -694,7 +697,7 @@ export const selectRegisteredUtxosByAccountKey = createMemoizedSelector(
 
 export const selectSessionProgressByAccountKey = (
     state: CoinjoinRootState,
-    accountKey: AccountKey,
+    accountKey: AccountKey | null,
 ) => {
     const relatedAccount = selectAccountByKey(state, accountKey);
     const targetAnonymity = selectTargetAnonymityByAccountKey(state, accountKey);
@@ -913,8 +916,12 @@ export const selectHasAnonymitySetError = (state: CoinjoinRootState) => {
 
 export const selectCoinjoinSessionBlockerByAccountKey = (
     state: CoinjoinRootState & DeviceRootState,
-    accountKey: AccountKey,
+    accountKey: AccountKey | null,
 ) => {
+    if (accountKey === null) {
+        return;
+    }
+
     if (selectSessionByAccountKey(state, accountKey)?.starting) {
         return 'SESSION_STARTING';
     }
@@ -951,11 +958,11 @@ export const selectCoinjoinSessionBlockerByAccountKey = (
 export const selectCurrentCoinjoinWheelStates = (state: CoinjoinRootState & DeviceRootState) => {
     const { notAnonymized } = selectCurrentCoinjoinBalanceBreakdown(state);
     const { key, balance } = selectSelectedAccount(state) || {};
-    const coinjoinAccount = selectCoinjoinAccountByKey(state, key || '');
-    const coinjoinClient = selectCoinjoinClient(state, key || '');
-    const sessionProgress = selectSessionProgressByAccountKey(state, key || '');
+    const coinjoinAccount = selectCoinjoinAccountByKey(state, key || null);
+    const coinjoinClient = selectCoinjoinClient(state, key || null);
+    const sessionProgress = selectSessionProgressByAccountKey(state, key || null);
 
-    const coinjoinSessionBlocker = selectCoinjoinSessionBlockerByAccountKey(state, key || '');
+    const coinjoinSessionBlocker = selectCoinjoinSessionBlockerByAccountKey(state, key || null);
 
     const { paused } = coinjoinAccount?.session || {};
 
@@ -1052,7 +1059,7 @@ export const selectCurrentSessionDeadlineInfo = (state: CoinjoinRootState) => {
 export const selectIsPublic = (state: CoinjoinRootState) =>
     selectFeatureConfig(state, Feature.coinjoin)?.isPublic !== false;
 
-export const selectIsSessionAutostopped = (state: CoinjoinRootState, accountKey: string) => {
+export const selectIsSessionAutostopped = (state: CoinjoinRootState, accountKey: AccountKey) => {
     const currentState = selectSessionByAccountKey(state, accountKey);
 
     return !!currentState?.isAutoStopEnabled;

--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -16,6 +16,7 @@ import { SimpleTokenStructure } from '@suite-common/token-definitions';
 import type { TradingTransaction } from '@suite-common/trading';
 import { Explorer, NetworkSymbol } from '@suite-common/wallet-config';
 import type {
+    AccountKey,
     BackendSettings,
     FormState,
     RatesByTimestamps,
@@ -59,7 +60,7 @@ export interface SuiteDBSchema extends DBSchema {
         value: { symbol: NetworkSymbol; explorer: Explorer };
     };
     sendFormDrafts: {
-        key: string; // accountKey
+        key: AccountKey;
         value: FormState;
     };
     suiteSettings: {

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -6,7 +6,12 @@ import {
     isNetworkSymbol,
     networkSymbolCollection,
 } from '@suite-common/wallet-config';
-import type { BackendSettings, WalletSettings } from '@suite-common/wallet-types';
+import {
+    AccountKey,
+    BackendSettings,
+    WalletSettings,
+    createAccountKey,
+} from '@suite-common/wallet-types';
 import {
     convertAmountUnitsToSubunits,
     formatNetworkAmount,
@@ -94,14 +99,18 @@ export const runLegacyMigrations: OnUpgradeFunc<SuiteDBSchema> = async (
 
         await updateAll(transaction, 'accounts', account => {
             account.metadata = {
-                key: '',
+                key: '' as AccountKey,
                 // @ts-expect-error
                 fileName: '',
                 aesKey: '',
                 outputLabels: {},
                 addressLabels: {},
             };
-            account.key = `${account.descriptor}-${account.symbol}-${account.deviceState}`;
+            account.key = createAccountKey({
+                accountDescriptor: account.descriptor,
+                networkSymbol: account.symbol,
+                deviceStaticSessionId: account.deviceState,
+            });
 
             return account;
         });
@@ -312,7 +321,7 @@ export const runLegacyMigrations: OnUpgradeFunc<SuiteDBSchema> = async (
         accounts.forEach(account => {
             // @ts-expect-error
             account.deviceState = account.deviceState.replace('undefined', '0');
-            account.key = account.key.replace('undefined', '0');
+            account.key = account.key.replace('undefined', '0') as AccountKey;
             accountsStoreNew.add(account);
         });
 
@@ -917,7 +926,7 @@ export const runLegacyMigrations: OnUpgradeFunc<SuiteDBSchema> = async (
                 const newAccount = {
                     ...account,
                     symbol: 'pol' as const,
-                    key: account.key.replace('matic', 'pol'),
+                    key: account.key.replace('matic', 'pol') as AccountKey,
                 };
                 await accountsCursor.delete();
                 await accounts.add(newAccount);
@@ -1001,7 +1010,7 @@ export const runLegacyMigrations: OnUpgradeFunc<SuiteDBSchema> = async (
         sendFormDraftsKeysWithMatic.forEach(async key => {
             const draft = await sendFormDrafts.get(key);
             if (draft) {
-                sendFormDrafts.add(draft, key.replace('matic', 'pol'));
+                sendFormDrafts.add(draft, key.replace('matic', 'pol') as AccountKey);
             }
             sendFormDrafts.delete(key);
         });

--- a/packages/suite/src/storage/migrations/networks/bnb.ts
+++ b/packages/suite/src/storage/migrations/networks/bnb.ts
@@ -1,3 +1,4 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import type { OnUpgradeFunc } from '@trezor/suite-storage';
 
 import type { SuiteDBSchema } from '../../definitions';
@@ -78,7 +79,7 @@ export const migrationOfBnbNetwork: OnUpgradeFunc<SuiteDBSchema> = async (
             const newAccount = {
                 ...account,
                 symbol: 'bsc' as const,
-                key: account.key.replace('bnb', 'bsc'),
+                key: account.key.replace('bnb', 'bsc') as AccountKey,
             };
             await accountsCursor.delete();
             await accounts.add(newAccount);
@@ -162,7 +163,7 @@ export const migrationOfBnbNetwork: OnUpgradeFunc<SuiteDBSchema> = async (
     sendFormDraftsKeysWithBnb.forEach(async key => {
         const draft = await sendFormDrafts.get(key);
         if (draft) {
-            sendFormDrafts.add(draft, key.replace('bnb', 'bsc'));
+            sendFormDrafts.add(draft, key.replace('bnb', 'bsc') as AccountKey);
         }
         sendFormDrafts.delete(key);
     });

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -31,7 +31,8 @@ import {
     TransactionsState,
     WalletSettingsState,
 } from '@suite-common/wallet-core';
-import { buildHistoricRatesFromStorage, getAccountKey } from '@suite-common/wallet-utils';
+import { createAccountKey } from '@suite-common/wallet-types';
+import { buildHistoricRatesFromStorage } from '@suite-common/wallet-utils';
 import TrezorConnect, { StaticSessionId } from '@trezor/connect';
 import { isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
@@ -222,7 +223,11 @@ export const extraDependencies: ExtraDependenciesStatic = {
         storageLoadTransactions: (state: TransactionsState, { payload }: StorageLoadAction) => {
             const { txs } = payload;
             txs.forEach(item => {
-                const k = getAccountKey(item.tx.descriptor, item.tx.symbol, item.tx.deviceState);
+                const k = createAccountKey({
+                    accountDescriptor: item.tx.descriptor,
+                    networkSymbol: item.tx.symbol,
+                    deviceStaticSessionId: item.tx.deviceState,
+                });
                 if (!state.transactions[k]) {
                     state.transactions[k] = [];
                 }

--- a/packages/suite/src/types/wallet/coinjoin.ts
+++ b/packages/suite/src/types/wallet/coinjoin.ts
@@ -1,6 +1,7 @@
 import { NetworkSymbol } from '@suite-common/wallet-config';
 // @trezor/coinjoin package is meant to be imported dynamically
 // importing types is safe, but importing an enum thru index will bundle whole lib
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     CoinjoinClientVersion,
     CoinjoinPrisonInmate,
@@ -83,7 +84,7 @@ export interface CoinjoinLegalDocuments {
 }
 
 export interface CoinjoinAccount {
-    key: string; // reference to wallet Account.key
+    key: AccountKey; // reference to wallet Account.key
     symbol: NetworkSymbol;
     setup?: CoinjoinSetup; // unless enabled, account uses default (recommended) values
     rawLiquidityClue: RegisterAccountParams['rawLiquidityClue'];

--- a/packages/suite/src/views/wallet/details/CoinjoinSetup/CoinjoinSetup.tsx
+++ b/packages/suite/src/views/wallet/details/CoinjoinSetup/CoinjoinSetup.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     Banner,
     Card,
@@ -42,7 +43,7 @@ const CustomSetup = styled.div<{ $elevation: Elevation }>`
 `;
 
 interface CoinjoinSetupProps {
-    accountKey: string;
+    accountKey: AccountKey;
 }
 
 export const CoinjoinSetup = ({ accountKey }: CoinjoinSetupProps) => {

--- a/packages/suite/src/views/wallet/details/CoinjoinSetup/MaxMiningFeeSetup.tsx
+++ b/packages/suite/src/views/wallet/details/CoinjoinSetup/MaxMiningFeeSetup.tsx
@@ -1,4 +1,5 @@
 import { Translation } from '@suite/intl';
+import { AccountKey } from '@suite-common/wallet-types';
 
 import { coinjoinAccountUpdateMaxMiningFee } from 'src/actions/wallet/coinjoinAccountActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -27,7 +28,7 @@ const labels = [min, max / 2, max].map(number => ({
 const getPercentage = (value: number) => ((value - min) / (max - min)) * 100;
 
 interface MaxMiningFeeSetupProps {
-    accountKey: string;
+    accountKey: AccountKey;
     maxMiningFee: number;
 }
 

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -84,7 +84,7 @@ export const FreshAddress = ({
     isDeviceConnected,
 }: FreshAddressProps) => {
     const isAccountUtxoBased = useSelector((state: AccountsRootState) =>
-        selectIsAccountUtxoBased(state, account?.key ?? ''),
+        selectIsAccountUtxoBased(state, account?.key ?? null),
     );
     const { isReceiveDisabled, receiveDisabledTooltipContent } = useReceiveDisabled();
     const dispatch = useDispatch();

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx
@@ -19,7 +19,7 @@ export const ClaimCard = () => {
     const analytics = useAnalytics();
     const selectedAccount = useSelector(selectSelectedAccount);
     const claimTxs = useSelector(state =>
-        selectAccountClaimTransactions(state, selectedAccount?.key || ''),
+        selectAccountClaimTransactions(state, selectedAccount?.key || null),
     );
     const { isClaimingDisabled, claimingMessageContent } = useMessageSystemStaking(
         selectedAccount?.symbol,

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/Transactions.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/Transactions.tsx
@@ -9,7 +9,7 @@ import { TransactionList } from 'src/views/wallet/transactions/TransactionList/T
 
 export const Transactions = () => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
-    const accountKey = selectedAccount.account?.key ?? '';
+    const accountKey = selectedAccount.account?.key ?? null;
 
     const areAllTransactionsLoaded = useSelector(state =>
         Boolean(selectAreAllTransactionsLoaded(state, accountKey)),

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinBalanceSection.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinBalanceSection.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import { selectHasAccountTransactionHistory } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import { Card, Column } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
@@ -27,7 +28,7 @@ export const Container = styled.div`
 `;
 
 interface CoinjoinBalanceSectionProps {
-    accountKey: string;
+    accountKey: AccountKey;
 }
 
 export const CoinjoinBalanceSection = ({ accountKey }: CoinjoinBalanceSectionProps) => {

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinProgressContent.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinProgressContent.tsx
@@ -3,6 +3,7 @@ import { FormattedNumber } from 'react-intl';
 import styled, { useTheme } from 'styled-components';
 
 import { Translation } from '@suite/intl';
+import { AccountKey } from '@suite-common/wallet-types';
 import { Icon, Spinner, Tooltip } from '@trezor/components';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
 
@@ -60,7 +61,7 @@ const TimeLeft = styled.p`
 `;
 
 interface CoinjoinProgressContentProps {
-    accountKey: string;
+    accountKey: AccountKey;
     isWheelHovered: boolean;
 }
 

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinProgressWheel.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinProgressWheel.tsx
@@ -4,6 +4,7 @@ import { lighten, rgba } from 'polished';
 import styled, { DefaultTheme, css, keyframes } from 'styled-components';
 
 import { Translation } from '@suite/intl';
+import { AccountKey } from '@suite-common/wallet-types';
 import { Tooltip, useElevation } from '@trezor/components';
 import { Elevation, mapElevationToBorder } from '@trezor/theme';
 
@@ -164,7 +165,7 @@ const Wheel = styled.div<{
 `;
 
 interface CoinjoinProgressWheelProps {
-    accountKey: string;
+    accountKey: AccountKey;
 }
 
 export const CoinjoinProgressWheel = ({ accountKey }: CoinjoinProgressWheelProps) => {

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinStatusMessage.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinStatusMessage.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
+import { AccountKey } from '@suite-common/wallet-types';
 import { spacingsPx, typography } from '@trezor/theme';
 
 import { CountdownTimer } from 'src/components/suite';
@@ -23,7 +24,7 @@ const CountdownWrapper = styled.p`
 `;
 
 interface CoinjoinStatusMessageProps {
-    accountKey: string;
+    accountKey: AccountKey;
 }
 
 export const CoinjoinStatusMessage = ({ accountKey }: CoinjoinStatusMessageProps) => {

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinStatusWheel.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinStatusWheel.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
+import { AccountKey } from '@suite-common/wallet-types';
 import { Button, Card } from '@trezor/components';
 import { spacings, typography } from '@trezor/theme';
 
@@ -32,7 +33,7 @@ const Container = styled(Card)<{ $isWide?: boolean }>`
 `;
 
 interface CoinjoinStatusWheelProps {
-    accountKey: string;
+    accountKey: AccountKey;
 }
 
 export const CoinjoinStatusWheel = ({ accountKey }: CoinjoinStatusWheelProps) => {

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinSummary.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
+import { AccountKey } from '@suite-common/wallet-types';
 import { H3 } from '@trezor/components';
 
 import { CoinjoinBalanceSection } from './CoinjoinBalanceSection';
@@ -11,7 +12,7 @@ const Container = styled.div`
 `;
 
 interface CoinjoinSummaryProps {
-    accountKey: string;
+    accountKey: AccountKey;
 }
 
 export const CoinjoinSummary = ({ accountKey }: CoinjoinSummaryProps) => (

--- a/packages/suite/src/views/wallet/transactions/Transactions.tsx
+++ b/packages/suite/src/views/wallet/transactions/Transactions.tsx
@@ -36,7 +36,7 @@ export const Transactions = () => {
         selectIsLoadingAccountTransactions(state, selectedAccount.account?.key || null),
     );
     const accountTransactions = useSelector(state =>
-        selectAccountTransactionsWithNulls(state, selectedAccount.account?.key || ''),
+        selectAccountTransactionsWithNulls(state, selectedAccount.account?.key || null),
     );
 
     if (selectedAccount.status !== 'loaded') {

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -1,4 +1,4 @@
-import { TxSimulationAction } from '@suite-common/wallet-types';
+import { AccountKey, TxSimulationAction } from '@suite-common/wallet-types';
 import { CallMethodKeys } from '@trezor/connect';
 import { MethodPermission } from '@trezor/connect/src/core/AbstractMethod';
 import { ErrorCode } from '@trezor/connect-common/src/constants/errors';
@@ -64,7 +64,7 @@ type SelectedFee =
 
 type TxSimulationConnectPopupCallLoaded = {
     state: 'tx-simulation';
-    selectedAccountKey?: string;
+    selectedAccountKey?: AccountKey;
 } & Omit<TxSimulationAction, 'sourceOrigin'>;
 
 export type ConnectPopupCallLoaded = {
@@ -81,7 +81,7 @@ export type ConnectPopupCallLoaded = {
     | {
           method: CallMethodKeys;
           state: 'ongoing';
-          selectedAccountKey?: string;
+          selectedAccountKey?: AccountKey;
           payload: any;
       }
     | {

--- a/suite-common/graph/src/tests/graphBalanceEvents.test.ts
+++ b/suite-common/graph/src/tests/graphBalanceEvents.test.ts
@@ -1,3 +1,4 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import { AccountBalanceHistory } from '@trezor/blockchain-link';
 
 import {
@@ -231,7 +232,7 @@ describe('mergeGroups', () => {
                     sentTransactionsCount: 2,
                     receivedTransactionsCount: 2,
                     symbol,
-                    accountKey: 'accountKey',
+                    accountKey: 'accountKey' as AccountKey, // Todo: create properly via `createAccountKey()`
                 },
             },
             {
@@ -242,12 +243,16 @@ describe('mergeGroups', () => {
                     sentTransactionsCount: 1,
                     receivedTransactionsCount: 1,
                     symbol,
-                    accountKey: 'accountKey',
+                    accountKey: 'accountKey' as AccountKey, // Todo: create properly via `createAccountKey()`
                 },
             },
         ];
 
-        const result = mergeGroups({ groups, symbol, accountKey: 'accountKey' });
+        const result = mergeGroups({
+            groups,
+            symbol,
+            accountKey: 'accountKey' as AccountKey, // Todo: create properly via `createAccountKey()`
+        });
         expect(result).toEqual(expectedMergedGroups);
     });
 
@@ -257,7 +262,11 @@ describe('mergeGroups', () => {
 
         const expectedMergedGroups: GroupedBalanceMovementEvent[] = [];
 
-        const result = mergeGroups({ groups, symbol, accountKey: 'accountKey' });
+        const result = mergeGroups({
+            groups,
+            symbol,
+            accountKey: 'accountKey' as AccountKey, // Todo: create properly via `createAccountKey()`
+        });
         expect(result).toEqual(expectedMergedGroups);
     });
 });

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -188,10 +188,13 @@ export abstract class AbstractMetadataProvider {
 
 export type AccountOutputLabels = { [index: string]: MetadataItem };
 
+/**
+ * @deprecated Legacy Labeling
+ */
 export interface AccountLabels {
     accountLabel?: MetadataItem;
-    outputLabels: { [txid: string]: AccountOutputLabels };
-    addressLabels: { [address: string]: MetadataItem };
+    outputLabels: Record<string, AccountOutputLabels>;
+    addressLabels: Record<string, MetadataItem>;
 }
 
 export interface WalletLabels {

--- a/suite-common/suite-rbf-labels-migrations/src/findLabelsToBeMovedOrDeleted.ts
+++ b/suite-common/suite-rbf-labels-migrations/src/findLabelsToBeMovedOrDeleted.ts
@@ -4,7 +4,7 @@ import { findChainedTransactions, findTransactions } from '@suite-common/wallet-
 
 type FindLabelsToBeMovedOrDeletedThunkParams = {
     prevTxId: string;
-    walletTransactions: { [key: AccountKey]: WalletAccountTransaction[] };
+    walletTransactions: Record<AccountKey, WalletAccountTransaction[]>;
 };
 
 export const findLabelsToBeMovedOrDeleted = ({

--- a/suite-common/suite-sync-types/src/data/updateAccountLabel.ts
+++ b/suite-common/suite-sync-types/src/data/updateAccountLabel.ts
@@ -1,4 +1,5 @@
 import { SuiteSyncUpdateError } from '@suite-common/suite-sync-storage';
+import { AccountKey } from '@suite-common/wallet-types';
 import type { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
@@ -6,7 +7,7 @@ import { EnsureWalletSuiteSyncOnErrors } from '../storage/ensureWalletSuiteSyncO
 
 export type UpdateAccountLabelParams = {
     deviceStaticSessionId: StaticSessionId;
-    accountKey: string;
+    accountKey: AccountKey;
     label: string | null;
 };
 

--- a/suite-common/suite-sync/src/data/labeling/tests/createUpdateAccountLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/tests/createUpdateAccountLabel.test.ts
@@ -1,6 +1,6 @@
 import { createMockDeps, mock } from '@suite-common/dependency-injection';
 import type { AccountTable } from '@suite-common/suite-sync-storage';
-import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { asAccountDescriptor, createAccountKey } from '@suite-common/wallet-types';
 import { StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
@@ -25,7 +25,11 @@ describe(createUpdateAccountLabel.name, () => {
         const updateAccountLabel = createUpdateAccountLabel(deps);
         const result = await updateAccountLabel({
             deviceStaticSessionId,
-            accountKey: 'accountDescriptor-btc-1@2:3',
+            accountKey: createAccountKey({
+                accountDescriptor: asAccountDescriptor('accountDescriptor'),
+                networkSymbol: 'btc',
+                deviceStaticSessionId: '1@2:3',
+            }),
             label: 'New Account Label',
         });
 
@@ -53,7 +57,11 @@ describe(createUpdateAccountLabel.name, () => {
         const updateAccountLabel = createUpdateAccountLabel(deps);
         const result = await updateAccountLabel({
             deviceStaticSessionId,
-            accountKey: 'accountDescriptor-btc-1@2:3',
+            accountKey: createAccountKey({
+                accountDescriptor: asAccountDescriptor('accountDescriptor'),
+                networkSymbol: 'btc',
+                deviceStaticSessionId: '1@2:3',
+            }),
             label: 'New Account Label',
         });
 

--- a/suite-common/trading/src/__fixtures__/utils.ts
+++ b/suite-common/trading/src/__fixtures__/utils.ts
@@ -1,9 +1,11 @@
+import { AccountKey } from '@suite-common/wallet-types';
+
 export const accountBtc = {
     index: 1,
     accountType: 'segwit',
     networkType: 'bitcoin',
     descriptor: 'btc-descriptor',
-    key: 'btc-descriptor-btc',
+    key: 'btc-descriptor-btc' as AccountKey, // Todo: create properly via `createAccountKey()`,
     symbol: 'btc',
     addresses: {
         unused: [
@@ -23,7 +25,7 @@ export const accountEth = {
     networkType: 'ethereum',
     symbol: 'eth',
     descriptor: 'eth-descriptor',
-    key: 'eth-descriptor-eth',
+    key: 'eth-descriptor-eth' as AccountKey, // Todo: create properly via `createAccountKey()`,
     path: "m/44'/60'/0'/0/1",
     deviceState: 'staticSessionId',
     tokens: [

--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
 import { CryptoId, ExchangeProviderInfo, ExchangeTrade, SellFiatTrade } from 'invity-api';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import type { Account } from '@suite-common/wallet-types';
+import type { Account, AccountKey } from '@suite-common/wallet-types';
 
 import * as BUY_FIXTURE from '../__fixtures__/buyUtils';
 import * as EXCHANGE_FIXTURE from '../__fixtures__/exchangeUtils';
@@ -27,6 +27,9 @@ import {
     testnetToProdCryptoId,
     toTokenCryptoId,
 } from '../utils';
+
+const sendAccountKey = 'send-account-key' as AccountKey;
+const receiveAccountKey = 'receive-account-key' as AccountKey;
 
 describe('getUnusedAddressFromAccount', () => {
     it('should return unused value from the passed account', () => {
@@ -374,7 +377,7 @@ describe('getTradingFormState', () => {
                 activeSection,
                 trade: incompleteTrade,
                 providers,
-                sendAccountKey: '',
+                sendAccountKey,
             });
 
             expect(result).toEqual({
@@ -396,7 +399,7 @@ describe('getTradingFormState', () => {
                 activeSection,
                 trade,
                 providers: {},
-                sendAccountKey: '',
+                sendAccountKey,
             });
 
             expect(result).toEqual({
@@ -422,7 +425,7 @@ describe('getTradingFormState', () => {
                 activeSection,
                 trade,
                 providers,
-                sendAccountKey: '',
+                sendAccountKey,
                 isSlip24Active: false,
             });
 
@@ -450,8 +453,8 @@ describe('getTradingFormState', () => {
                 trade,
                 providers,
                 isSlip24Active: true,
-                sendAccountKey: '',
-                receiveAccountKey: 'receive-account-key',
+                sendAccountKey,
+                receiveAccountKey,
             });
 
             expect(result).toEqual({
@@ -459,7 +462,7 @@ describe('getTradingFormState', () => {
                 isSlip24Active: true,
                 recipientName: 'Test Exchange',
                 send: {
-                    accountKey: '',
+                    accountKey: sendAccountKey,
                     cryptoId: 'bitcoin',
                     symbol: 'btc',
                     contractAddress: undefined,
@@ -490,8 +493,8 @@ describe('getTradingFormState', () => {
                 trade,
                 providers,
                 isSlip24Active: true,
-                sendAccountKey: '',
-                receiveAccountKey: 'receive-account-key',
+                sendAccountKey,
+                receiveAccountKey,
             });
 
             expect(result).toEqual({
@@ -499,7 +502,7 @@ describe('getTradingFormState', () => {
                 recipientName: 'Test Exchange',
                 isSlip24Active: true,
                 send: {
-                    accountKey: '',
+                    accountKey: sendAccountKey,
                     symbol: 'eth',
                     contractAddress: '0x123456789',
                     amount: '100',
@@ -531,7 +534,7 @@ describe('getTradingFormState', () => {
                 trade: incompleteTrade,
                 providers,
                 isSlip24Active: true,
-                sendAccountKey: '',
+                sendAccountKey,
             });
 
             expect(result).toEqual({
@@ -554,7 +557,7 @@ describe('getTradingFormState', () => {
                 trade,
                 providers: {},
                 isSlip24Active: true,
-                sendAccountKey: '',
+                sendAccountKey,
             });
 
             expect(result).toEqual({
@@ -581,7 +584,7 @@ describe('getTradingFormState', () => {
                 trade,
                 providers,
                 isSlip24Active: true,
-                sendAccountKey: '',
+                sendAccountKey,
             });
 
             expect(result).toEqual({
@@ -608,7 +611,7 @@ describe('getTradingFormState', () => {
                 trade,
                 providers,
                 isSlip24Active: true,
-                sendAccountKey: '',
+                sendAccountKey,
             });
 
             expect(result).toEqual({
@@ -635,8 +638,8 @@ describe('getTradingFormState', () => {
                 trade,
                 providers,
                 isSlip24Active: true,
-                sendAccountKey: '',
-                receiveAccountKey: 'receive-account-key',
+                sendAccountKey,
+                receiveAccountKey,
             });
 
             expect(result).toEqual({
@@ -644,14 +647,14 @@ describe('getTradingFormState', () => {
                 recipientName: 'Test Exchange',
                 isSlip24Active: true,
                 send: {
-                    accountKey: '',
+                    accountKey: sendAccountKey,
                     cryptoId: 'bitcoin',
                     symbol: 'btc',
                     contractAddress: undefined,
                     amount: '0.025',
                 },
                 receive: {
-                    accountKey: 'receive-account-key',
+                    accountKey: receiveAccountKey,
                     cryptoId: 'ethereum',
                     symbol: 'eth',
                     contractAddress: undefined,
@@ -678,8 +681,8 @@ describe('getTradingFormState', () => {
                 trade,
                 providers,
                 isSlip24Active: true,
-                sendAccountKey: '',
-                receiveAccountKey: 'receive-account-key',
+                sendAccountKey,
+                receiveAccountKey,
             });
 
             expect(result).toEqual({
@@ -687,14 +690,14 @@ describe('getTradingFormState', () => {
                 recipientName: 'Test Exchange',
                 isSlip24Active: true,
                 send: {
-                    accountKey: '',
+                    accountKey: sendAccountKey,
                     cryptoId: 'ethereum--0xsend456',
                     symbol: 'eth',
                     contractAddress: '0xsend456',
                     amount: '50',
                 },
                 receive: {
-                    accountKey: 'receive-account-key',
+                    accountKey: receiveAccountKey,
                     cryptoId: 'ethereum--0xreceive123',
                     symbol: 'eth',
                     contractAddress: '0xreceive123',
@@ -719,7 +722,7 @@ describe('getTradingFormState', () => {
                 trade,
                 providers: undefined,
                 isSlip24Active: true,
-                sendAccountKey: '',
+                sendAccountKey,
             });
 
             expect(result).toEqual({
@@ -742,7 +745,7 @@ describe('getTradingFormState', () => {
                 trade,
                 providers: { 'test-exchange': mockProvider },
                 isSlip24Active: true,
-                sendAccountKey: '',
+                sendAccountKey,
             });
 
             expect(result).toEqual({
@@ -769,7 +772,7 @@ describe('getTradingFormState', () => {
                 trade,
                 providers,
                 isSlip24Active: true,
-                sendAccountKey: '',
+                sendAccountKey,
             });
 
             expect(result).toEqual({

--- a/suite-common/trading/src/reducers/__fixtures__/account.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/account.ts
@@ -1,4 +1,9 @@
-import { Account, WalletAccountTransaction, asAccountDescriptor } from '@suite-common/wallet-types';
+import {
+    Account,
+    AccountKey,
+    WalletAccountTransaction,
+    asAccountDescriptor,
+} from '@suite-common/wallet-types';
 
 export const accounts: Account[] = [
     {
@@ -8,7 +13,7 @@ export const accounts: Account[] = [
         descriptor: asAccountDescriptor(
             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
         ),
-        key: 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
+        key: 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0' as AccountKey, // Todo: create properly via `createAccountKey()`
         accountType: 'normal',
         symbol: 'btc',
         empty: false,
@@ -103,7 +108,7 @@ export const accounts: Account[] = [
         descriptor: asAccountDescriptor(
             "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)",
         ),
-        key: "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0",
+        key: "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0" as AccountKey, // Todo: create properly via `createAccountKey()`
         accountType: 'taproot',
         symbol: 'btc',
         empty: false,

--- a/suite-common/trading/src/reducers/__fixtures__/buyTradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/buyTradingReducer.ts
@@ -1,5 +1,7 @@
 import { BuyTrade, BuyTradeQuoteRequest, CryptoId, FiatCurrenciesProps } from 'invity-api';
 
+import { AccountKey } from '@suite-common/wallet-types';
+
 import { TradingAmountLimitProps } from '../../types';
 import { BuyInfo, buyInitialState, tradingBuyActions } from '../buyReducer';
 
@@ -203,7 +205,7 @@ export const buyTradingFixtures = [
         ],
         result: {
             ...buyInitialState,
-            tradingAccountKey: '123456',
+            tradingAccountKey: '123456' as AccountKey, // Todo: create properly via `createAccountKey()`
         },
     },
 ];

--- a/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
@@ -1,6 +1,7 @@
 import { CryptoId, InfoResponse } from 'invity-api';
 
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { AccountKey } from '@suite-common/wallet-types';
 
 import { buyThunks } from '../../thunks/buy';
 import { exchangeThunks } from '../../thunks/exchange';
@@ -34,8 +35,8 @@ const tradeBuy: TradingTransactionBuy = {
         maxCrypto: 0.19952,
         paymentMethod: 'creditCard',
     },
-    selectedAccountKey: 'xxx',
-    receiveAccountKey: 'yyy',
+    selectedAccountKey: 'xxx' as AccountKey, // Todo: create properly via `createAccountKey()`
+    receiveAccountKey: 'yyy' as AccountKey, // Todo: create properly via `createAccountKey()`
 };
 
 const tradeExchange: TradingTransactionExchange = {
@@ -51,8 +52,8 @@ const tradeExchange: TradingTransactionExchange = {
         exchange: 'changelly',
         status: 'CONFIRMING',
     },
-    sendAccountKey: 'xxx',
-    receiveAccountKey: 'yyy',
+    sendAccountKey: 'xxx' as AccountKey, // Todo: create properly via `createAccountKey()`
+    receiveAccountKey: 'yyy' as AccountKey, // Todo: create properly via `createAccountKey()`
 };
 
 const symbolsInfo: InfoResponse = {

--- a/suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { AccountKey } from '@suite-common/wallet-types';
 
 import { selectTradingMaxSlippagePercentage } from '../../selectors/settingsSelectors';
 import { buyThunks } from '../../thunks/buy';
@@ -133,7 +134,7 @@ describe('Testing trading reducer', () => {
             });
 
             it('should delegate common actions to common slice', () => {
-                store.dispatch(tradingActions.setModalAccountKey('MY_KEY'));
+                store.dispatch(tradingActions.setModalAccountKey('MY_KEY' as AccountKey)); // Todo: create properly via `createAccountKey()`
 
                 expect(store.getState().wallet.trading.modalAccountKey).toEqual('MY_KEY');
             });
@@ -157,8 +158,9 @@ describe('Testing trading reducer', () => {
             });
 
             it('should delegate buy actions to buy slice', () => {
-                store.dispatch(tradingBuyActions.setTradingAccountKey('TRADING_KEY'));
-
+                store.dispatch(
+                    tradingBuyActions.setTradingAccountKey('TRADING_KEY' as AccountKey), // Todo: create properly via `createAccountKey()`
+                );
                 expect(store.getState().wallet.trading.buy.tradingAccountKey).toEqual(
                     'TRADING_KEY',
                 );
@@ -171,7 +173,9 @@ describe('Testing trading reducer', () => {
             });
 
             it('should delegate exchange actions to exchange slice', () => {
-                store.dispatch(tradingExchangeActions.setTradingAccountKey('TRADING_KEY'));
+                store.dispatch(
+                    tradingExchangeActions.setTradingAccountKey('TRADING_KEY' as AccountKey), // Todo: create properly via `createAccountKey()`
+                );
 
                 expect(store.getState().wallet.trading.exchange.tradingAccountKey).toEqual(
                     'TRADING_KEY',
@@ -185,7 +189,9 @@ describe('Testing trading reducer', () => {
             });
 
             it('should delegate sell actions to sell slice', () => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('TRADING_KEY'));
+                store.dispatch(
+                    tradingSellActions.setTradingAccountKey('TRADING_KEY' as AccountKey), // Todo: create properly via `createAccountKey()`
+                );
 
                 expect(store.getState().wallet.trading.sell.tradingAccountKey).toEqual(
                     'TRADING_KEY',

--- a/suite-common/trading/src/reducers/tradingCommonReducer.ts
+++ b/suite-common/trading/src/reducers/tradingCommonReducer.ts
@@ -118,7 +118,7 @@ const tradingCommonSlice = createSlice({
         setModalCryptoCurrency(state, action: PayloadAction<CryptoId | undefined>) {
             state.modalCryptoId = action.payload;
         },
-        setModalAccountKey(state, action: PayloadAction<string | undefined>) {
+        setModalAccountKey(state, action: PayloadAction<AccountKey | undefined>) {
             state.modalAccountKey = action.payload;
         },
         setLoading(
@@ -135,7 +135,7 @@ const tradingCommonSlice = createSlice({
             state,
             action: PayloadAction<{
                 cryptoId: CryptoId | undefined;
-                key: string | undefined;
+                key: AccountKey | undefined;
             }>,
         ) {
             state.prefilledFromAccount.cryptoId = action.payload.cryptoId;

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -8,6 +8,7 @@ import {
     SellFiatTrade,
 } from 'invity-api';
 
+import { AccountKey } from '@suite-common/wallet-types';
 import { StaticSessionId } from '@trezor/connect';
 
 import coins from '../../__fixtures__/coins.json';
@@ -953,8 +954,9 @@ describe('tradingSelectors', () => {
     });
 
     it('selectTradingSellAccountKey should return the correct account key when set', () => {
-        const testAccountKey = 'test-account-key-123';
-        state.wallet.trading.sell.tradingAccountKey = testAccountKey;
+        const testAccountKey: AccountKey = 'test-account-key-123' as AccountKey; // Todo: create properly via `createAccountKey()`
+
+        (state as TradingRootState).wallet.trading.sell.tradingAccountKey = testAccountKey;
 
         expect(selectTradingSellAccountKey(state)).toBe(testAccountKey);
     });

--- a/suite-common/trading/src/thunks/buy/__tests__/confirmBuyTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/confirmBuyTradeThunk.test.ts
@@ -2,7 +2,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { BuyTradeResponse } from 'invity-api';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
-import { Account } from '@suite-common/wallet-types';
+import { Account, AccountKey } from '@suite-common/wallet-types';
 
 import { MIN_MAX_QUOTES_OK } from '../../../__fixtures__/buyUtils';
 import { invityAPI } from '../../../invityAPI';
@@ -271,7 +271,7 @@ describe('confirmBuyTradeThunk', () => {
                 returnUrl: 'returnUrl',
                 address: 'address',
                 account: {
-                    key: 'yyy',
+                    key: 'yyy' as AccountKey, // Todo: create properly via `createAccountKey()`
                 } as Account,
                 triggerAnalyticsTradeConfirmation: mocktriggerAnalyticsTradeConfirmation,
                 processResponseData: mockProcessResponseData,

--- a/suite-common/trading/src/thunks/common/__tests__/watchTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/watchTradeThunk.test.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
-import { Account } from '@suite-common/wallet-types';
+import { Account, AccountKey } from '@suite-common/wallet-types';
 
 import { accountBtc } from '../../../__fixtures__/utils';
 import { invityAPI } from '../../../invityAPI';
@@ -190,7 +190,7 @@ describe('watchTradeThunk', () => {
                     status: 'LOGIN_REQUEST',
                     orderId: 'tradeKey',
                 },
-                sendAccountKey: 'sendAccountKey',
+                sendAccountKey: 'sendAccountKey' as AccountKey, // Todo: create properly via `createAccountKey()`,
             } as TradingTransactionSell;
 
             const store = getStore({

--- a/suite-common/trading/src/thunks/exchange/__tests__/handleExchangeRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/handleExchangeRequestThunk.test.ts
@@ -3,6 +3,7 @@ import { CryptoId, ExchangeTrade } from 'invity-api';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { getNetwork } from '@suite-common/wallet-config';
+import { AccountKey } from '@suite-common/wallet-types';
 
 import { exchangeThunks } from '../';
 import { MIN_MAX_QUOTES_OK } from '../../../__fixtures__/exchangeUtils';
@@ -107,7 +108,7 @@ describe('handleExchangeRequestThunk', () => {
                 displaySymbol: 'BTC',
                 networkName: 'Bitcoin',
                 networkSymbol: 'btc',
-                accountKey: 'descriptor-btc-123',
+                accountKey: 'descriptor-btc-123' as AccountKey, // Todo: create properly via `createAccountKey()`,
             } satisfies TradingAssetSellOption,
             receiveCryptoSelect: {
                 id: 'ethereum' as CryptoId,

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
@@ -4,7 +4,7 @@ import { CryptoId, ExchangeTrade } from 'invity-api';
 import { createThunk } from '@suite-common/redux-utils';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { getNetwork } from '@suite-common/wallet-config';
-import { Account } from '@suite-common/wallet-types';
+import { Account, AccountKey } from '@suite-common/wallet-types';
 
 import { MIN_MAX_QUOTES_OK } from '../../../__fixtures__/exchangeUtils';
 import { accountBtc } from '../../../__fixtures__/utils';
@@ -92,8 +92,8 @@ describe('sendTransactionThunk', () => {
                 ...getQuote(),
                 sendAddress: '1',
             },
-            sendAccountKey: 'xxx',
-            receiveAccountKey: 'yyy',
+            sendAccountKey: 'xxx' as AccountKey, // Todo: create properly via `createAccountKey()`
+            receiveAccountKey: 'yyy' as AccountKey, // Todo: create properly via `createAccountKey()`
         };
 
         return {

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
@@ -3,6 +3,7 @@ import { CryptoId, SellFiatTrade } from 'invity-api';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { getNetwork } from '@suite-common/wallet-config';
+import { AccountKey } from '@suite-common/wallet-types';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 
 import { sellThunks } from '../';
@@ -102,7 +103,7 @@ describe('handleSellRequestThunk', () => {
                 displaySymbol: 'BTC',
                 networkName: 'Bitcoin',
                 networkSymbol: 'btc',
-                accountKey: 'descriptor-btc-123',
+                accountKey: 'descriptor-btc-123' as AccountKey, // Todo: create properly via `createAccountKey()`
             } satisfies TradingAssetSellOption,
             amountInCrypto: true,
             feePerUnit: '',

--- a/suite-common/trading/src/thunks/sell/__tests__/sendSellTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/sendSellTransactionThunk.test.ts
@@ -4,7 +4,7 @@ import { SellFiatTrade } from 'invity-api';
 import { createThunk } from '@suite-common/redux-utils';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { getNetwork } from '@suite-common/wallet-config';
-import { Account } from '@suite-common/wallet-types';
+import { Account, AccountKey } from '@suite-common/wallet-types';
 
 import { accountBtc } from '../../../__fixtures__/utils';
 import { invityAPI } from '../../../invityAPI';
@@ -81,7 +81,7 @@ describe('sendSellTransactionThunk', () => {
             date: new Date().toISOString(),
             key: getQuote().orderId,
             data: getQuote(),
-            sendAccountKey: 'xxx',
+            sendAccountKey: 'xxx' as AccountKey, // Todo: create properly via `createAccountKey()`
         };
         const mockNextStep = jest.fn();
         const formValues = {

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -20,7 +20,7 @@ import {
     getNetworkByTradeCryptoId,
     networksCollection,
 } from '@suite-common/wallet-config';
-import type { Account, FormStateTrading } from '@suite-common/wallet-types';
+import type { Account, AccountKey, FormStateTrading } from '@suite-common/wallet-types';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { TokenInfo } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
@@ -328,8 +328,8 @@ type TradingGetFormStateExchangeProps = {
 type TradingGetFormStateProps = {
     providers: Record<string, ExchangeProviderInfo | SellProviderInfo> | undefined;
     isSlip24Active?: boolean;
-    sendAccountKey: string | undefined;
-    receiveAccountKey?: string | undefined;
+    sendAccountKey: AccountKey | undefined;
+    receiveAccountKey?: AccountKey | undefined;
 } & (TradingGetFormStateSellProps | TradingGetFormStateExchangeProps);
 
 export const getTradingFormState = ({

--- a/suite-common/wallet-config/package.json
+++ b/suite-common/wallet-config/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@trezor/device-utils": "workspace:*",
-        "@trezor/type-utils": "workspace:*"
+        "@trezor/type-utils": "workspace:*",
+        "@trezor/utils": "workspace:*"
     }
 }

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -1,4 +1,5 @@
 import { DeviceModelInternal } from '@trezor/device-utils';
+import { typedObjectEntries } from '@trezor/utils';
 
 import { getExplorerUrls } from './getExplorerUrls';
 import { NetworkFeature, Networks } from './types';
@@ -686,8 +687,8 @@ export type StakingNetworkSymbol = NetworkWithFeature<'staking'>['symbol'];
 
 export type StakingNetworkType = NetworksConfigs[StakingNetworkSymbol]['networkType'];
 
-export const [STAKING_SYMBOLS, STAKING_TYPES, PROD_STAKING_SYMBOLS] = (
-    Object.entries(networks) as Array<[keyof NetworksConfigs, NetworkConfig]>
+export const [STAKING_SYMBOLS, STAKING_TYPES, PROD_STAKING_SYMBOLS] = typedObjectEntries(
+    networks,
 ).reduce<[StakingNetworkSymbol[], StakingNetworkType[], StakingNetworkSymbol[]]>(
     (acc, [symbol, { features, networkType, testnet }]) => {
         if ((features as readonly string[]).includes('staking')) {

--- a/suite-common/wallet-config/tsconfig.json
+++ b/suite-common/wallet-config/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../../packages/device-utils" },
-        { "path": "../../packages/type-utils" }
+        { "path": "../../packages/type-utils" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -7,13 +7,13 @@ import {
     AccountFailureSpecific,
     SelectedAccountStatus,
     asAccountDescriptor,
+    createAccountKey,
 } from '@suite-common/wallet-types';
 import {
     enhanceAddresses,
     enhanceTokens,
     enhanceUtxo,
     formatNetworkAmount,
-    getAccountKey,
     getAccountSpecific,
 } from '@suite-common/wallet-utils';
 import { AccountInfo, StaticSessionId } from '@trezor/connect';
@@ -74,7 +74,11 @@ const createAccount = createAction(
                 balance,
                 availableBalance,
                 history,
-                key: getAccountKey(asAccountDescriptor(descriptor), symbol, deviceState),
+                key: createAccountKey({
+                    accountDescriptor: asAccountDescriptor(descriptor),
+                    networkSymbol: symbol,
+                    deviceStaticSessionId: deviceState,
+                }),
                 formattedBalance: formatNetworkAmount(
                     // Ripple and Stellar `availableBalance` is reduced by reserve, use regular balance
                     isArrayMember(networkType, ['ripple', 'stellar']) ? balance : availableBalance,

--- a/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
@@ -1,7 +1,7 @@
 import { TrezorDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { networks } from '@suite-common/wallet-config';
-import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { AccountKey, asAccountDescriptor } from '@suite-common/wallet-types';
 
 import { DeviceRootState } from '../../device/deviceReducer';
 import { AccountsRootState } from '../accountsReducer';
@@ -27,7 +27,7 @@ const mockState: AccountsRootState & DeviceRootState = {
                 misc: undefined,
                 marker: undefined,
                 stellarCursor: undefined,
-                key: 'key',
+                key: 'key' as AccountKey, // Todo: unify key, use `createAccountKey`,
                 accountType: 'normal',
                 empty: false,
                 visible: true,
@@ -84,7 +84,7 @@ const mockState: AccountsRootState & DeviceRootState = {
                 networkType: 'ethereum',
                 descriptor: asAccountDescriptor('0xEthereumAddress'),
                 deviceState: ETH_DEVICE_SSID,
-                key: '0xEthereumAddress-eth-deviceState',
+                key: '0xEthereumAddress-eth-deviceState' as AccountKey, // Todo: unify key, use `createAccountKey`
                 accountType: 'normal',
                 index: 0,
                 path: "m/44'/60'/0'/0",

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -38,7 +38,7 @@ import TrezorConnect, { PROTO, Success, SuccessWithDevice, Unsuccessful } from '
 import { getSolanaTokenDefinition } from '@trezor/connect/src/api/solana/solanaDefinitions';
 import { PushedTransaction } from '@trezor/connect/src/types/api/pushTransaction';
 import { exhaustive } from '@trezor/type-utils';
-import { cloneObject } from '@trezor/utils';
+import { cloneObject, typedObjectEntries } from '@trezor/utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { sendFormActions } from './sendFormActions';
@@ -103,7 +103,7 @@ export const convertSendFormDraftsBtcAmountUnitsThunk = createThunk(
         const sendFormDrafts = selectSendFormDrafts(getState());
         const areSatsAmountUnit = selectAreSatsAmountUnit(getState());
 
-        const draftEntries = Object.entries(sendFormDrafts);
+        const draftEntries = typedObjectEntries(sendFormDrafts);
 
         if (G.isNullable(selectedAccountKey)) {
             return rejectWithValue('Account not found.');
@@ -113,7 +113,8 @@ export const convertSendFormDraftsBtcAmountUnitsThunk = createThunk(
         const isOnDesktopSendPage = suiteRoute?.name === 'wallet-send';
 
         draftEntries.forEach(([accountKey, draft]) => {
-            const relatedAccount = selectAccountByKey(getState(), accountKey);
+            // Todo: is this cast correct? https://github.com/trezor/trezor-suite/issues/24918
+            const relatedAccount = selectAccountByKey(getState(), accountKey as AccountKey);
 
             const isSelectedAccount = selectedAccountKey === accountKey;
 
@@ -139,7 +140,8 @@ export const convertSendFormDraftsBtcAmountUnitsThunk = createThunk(
 
             dispatch(
                 sendFormActions.storeDraft({
-                    accountKey,
+                    // Todo: is this cast correct? https://github.com/trezor/trezor-suite/issues/24918
+                    accountKey: accountKey as AccountKey,
                     formState: updatedDraft,
                 }),
             );

--- a/suite-common/wallet-core/src/transactions/transactionsActions.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsActions.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@reduxjs/toolkit';
 
-import { Account, WalletAccountTransaction } from '@suite-common/wallet-types';
+import { Account, AccountKey, WalletAccountTransaction } from '@suite-common/wallet-types';
 import { enhanceTransaction } from '@suite-common/wallet-utils';
 import { AccountTransaction } from '@trezor/connect';
 
@@ -13,7 +13,7 @@ const resetTransaction = createAction(
 
 const replaceTransaction = createAction(
     `${TRANSACTIONS_MODULE_PREFIX}/replaceTransaction`,
-    (payload: { key: string; txid: string; tx: WalletAccountTransaction }) => ({ payload }),
+    (payload: { key: AccountKey; txid: string; tx: WalletAccountTransaction }) => ({ payload }),
 );
 
 const removeTransaction = createAction(

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -14,6 +14,7 @@ import {
     isStakeTypeTx,
     isUnstakeTx,
 } from '@suite-common/wallet-utils';
+import { typedObjectKeys } from '@trezor/utils';
 
 import { TransactionsRootState } from './transactionsReducer';
 import { AccountsRootState } from '../accounts/accountsReducer';
@@ -31,7 +32,9 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<
 export const selectIsLoadingAccountTransactions = (
     state: TransactionsRootState,
     accountKey: AccountKey | null,
-) => state.wallet.transactions.fetchStatusDetail?.[accountKey ?? '']?.status === 'loading';
+) =>
+    accountKey !== null &&
+    state.wallet.transactions.fetchStatusDetail?.[accountKey]?.status === 'loading';
 
 export const selectTransactions = (state: TransactionsRootState) =>
     state.wallet.transactions.transactions;
@@ -39,7 +42,9 @@ export const selectTransactions = (state: TransactionsRootState) =>
 export const selectAreAllTransactionsLoaded = (
     state: TransactionsRootState,
     accountKey: AccountKey | null,
-) => state.wallet.transactions.fetchStatusDetail?.[accountKey ?? '']?.areAllTransactionsLoaded;
+) =>
+    accountKey !== null &&
+    state.wallet.transactions.fetchStatusDetail?.[accountKey]?.areAllTransactionsLoaded;
 
 const EMPTY_STABLE_TRANSACTIONS: WalletAccountTransaction[] = [];
 /**
@@ -50,7 +55,10 @@ const EMPTY_STABLE_TRANSACTIONS: WalletAccountTransaction[] = [];
 export const selectAccountTransactionsWithNulls = (
     state: TransactionsRootState,
     accountKey: AccountKey | null,
-) => state.wallet.transactions.transactions[accountKey ?? ''] ?? EMPTY_STABLE_TRANSACTIONS;
+) =>
+    accountKey !== null && state.wallet.transactions.transactions[accountKey]
+        ? state.wallet.transactions.transactions[accountKey]
+        : EMPTY_STABLE_TRANSACTIONS;
 
 export const selectAccountTransactions = createMemoizedSelector(
     [selectAccountTransactionsWithNulls],
@@ -75,7 +83,7 @@ export const selectPendingAccountAddresses = createMemoizedSelector(
 export const selectAllPendingTransactions = createMemoizedSelector(
     [selectTransactions],
     transactions =>
-        Object.keys(transactions).reduce(
+        typedObjectKeys(transactions).reduce(
             (response, accountKey) => {
                 response[accountKey] = (transactions[accountKey] ?? []).filter(isPending);
 
@@ -218,7 +226,10 @@ export const selectAccountTotalTransactions = createMemoizedSelector(
     account => account?.history.total ?? 0,
 );
 
-export const selectAreAllAccountTransactionsLoaded = createMemoizedSelector(
+export const selectAreAllAccountTransactionsLoaded: (
+    state: TransactionsRootState & AccountsRootState,
+    accountKey: AccountKey,
+) => boolean = createMemoizedSelector(
     [
         selectAccountTransactions,
         selectAccountTotalTransactions,

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -136,7 +136,8 @@ export type AccountFailureSpecific =
  * @deprecated For domain structures (entities, storage & API of components/functions)
  *             prefer the separate `AccountDescriptor`, `NetworkSymbol` and `DeviceStaticSessionId`
  */
-export type AccountKey = string; // <AccountDescriptor>-<NetworkSymbol>-<DeviceStaticSessionId>
+export type AccountKey = `${AccountDescriptor}-${NetworkSymbol}-${StaticSessionId}` &
+    Branded<'AccountKey'>;
 
 export type CreateAccountKeyParams = {
     accountDescriptor: AccountDescriptor;
@@ -149,7 +150,7 @@ export const createAccountKey = ({
     networkSymbol,
     deviceStaticSessionId,
 }: CreateAccountKeyParams): AccountKey =>
-    `${accountDescriptor}-${networkSymbol}-${deviceStaticSessionId}`;
+    `${accountDescriptor}-${networkSymbol}-${deviceStaticSessionId}` as AccountKey;
 
 /**
  * Descriptor or xpub/zpub/..

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -3,6 +3,7 @@ import { CryptoId } from 'invity-api';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountUtxo, FeeLevel } from '@trezor/connect';
 
+import { AccountKey } from './account';
 import { Output, RbfTransactionParams } from './transaction';
 
 export type FormOptions =
@@ -17,7 +18,7 @@ export type UtxoSorting = 'newestFirst' | 'oldestFirst' | 'smallestFirst' | 'lar
 
 export type FormStateTradingCryptoCurrency = {
     cryptoId: CryptoId | undefined;
-    accountKey: string | undefined;
+    accountKey: AccountKey | undefined;
     symbol: NetworkSymbol;
     contractAddress?: string;
     amount: string;

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -1,6 +1,6 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { NetworkFeature } from '@suite-common/wallet-config';
-import { Account, asAccountDescriptor } from '@suite-common/wallet-types';
+import { Account, asAccountDescriptor, createAccountKey } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import * as fixtures from '../__fixtures__/accountUtils';
@@ -9,7 +9,6 @@ import {
     enhanceAddresses,
     findAccountDevice,
     getAccountIdentifier,
-    getAccountKey,
     getBip43Type,
     getFirstFreshAddress,
     getNetworkAccountFeatures,
@@ -138,11 +137,11 @@ describe('account utils', () => {
 
     it('getAccountKey', () => {
         expect(
-            getAccountKey(
-                asAccountDescriptor('descriptor'),
-                'btc',
-                '1stTestnetAddress@device_id:0',
-            ),
+            createAccountKey({
+                accountDescriptor: asAccountDescriptor('descriptor'),
+                networkSymbol: 'btc',
+                deviceStaticSessionId: '1stTestnetAddress@device_id:0',
+            }),
         ).toEqual('descriptor-btc-1stTestnetAddress@device_id:0');
     });
 

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -26,6 +26,7 @@ import {
     SuccessfulAccount,
     TokenAddress,
     asBaseCurrencyAmount,
+    createAccountKey,
 } from '@suite-common/wallet-types';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { solanaUtils } from '@trezor/blockchain-link-utils';
@@ -365,15 +366,6 @@ export const getAllAccounts = (
                 : a.deviceState === deviceState.staticSessionId) && a.visible,
     );
 };
-
-/**
- * Returns a string used as an index to separate txs for given account inside a transactions reducer
- */
-export const getAccountKey = (
-    descriptor: AccountDescriptor,
-    symbol: NetworkSymbol,
-    deviceStaticSessionId: StaticSessionId,
-): AccountKey => `${descriptor}-${symbol}-${deviceStaticSessionId}`;
 
 /**
  * Clear invalid tokens and formats amounts
@@ -1138,15 +1130,12 @@ export const parseAccountKey = (accountKey: AccountKey) => {
     };
 };
 
-export const createAccountKey = ({
-    accountDescriptor,
-    networkSymbol,
-    deviceStaticSessionId,
-}: {
-    accountDescriptor: AccountDescriptor;
-    networkSymbol: NetworkSymbol;
-    deviceStaticSessionId: StaticSessionId;
-}) => `${accountDescriptor}-${networkSymbol}-${deviceStaticSessionId}`;
+/**
+ * Returns a string used as an index to separate txs for given account inside a transactions reducer
+ *
+ * @deprecated use createAccountKey directly
+ */
+export const getAccountKey = createAccountKey;
 
 export const prepareNewAccountPayload = async ({
     accountType,

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -634,7 +634,8 @@ export const getExcludedUtxos = ({
 export const getSendFormDraftKey = (
     accountKey: AccountKey,
     tokenAddress?: TokenAddress,
-): SendFormDraftKey => (tokenAddress ? `${accountKey}-${tokenAddress}` : accountKey);
+): SendFormDraftKey =>
+    tokenAddress ? (`${accountKey}-${tokenAddress}` as SendFormDraftKey) : accountKey;
 
 type AmountValidationResult =
     | { type: 'ok' }

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -29,7 +29,7 @@ import {
     TokenTransfer,
 } from '@trezor/connect';
 import { Branded } from '@trezor/type-utils';
-import { arrayPartition } from '@trezor/utils';
+import { arrayPartition, typedObjectKeys } from '@trezor/utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { convertAmountSubunitsToUnits, formatNetworkAmount } from './amountUtils';
@@ -59,8 +59,8 @@ export const sortByBlockHeight = (a: { blockHeight?: number }, b: { blockHeight?
  * for transactions that have not been fetched yet. (This affects pagination.)
  */
 export const getAccountTransactions = (
-    accountKey: string,
-    transactions: Record<string, WalletAccountTransaction[]>,
+    accountKey: AccountKey,
+    transactions: Record<AccountKey, WalletAccountTransaction[]>,
 ) => transactions[accountKey] || [];
 
 export const isPending = (tx: WalletAccountTransaction | AccountTransaction) => {
@@ -343,9 +343,9 @@ export const findTransaction = (txid: string, transactions: WalletAccountTransac
 
 export const findTransactions = (
     txid: string,
-    transactions: { [key: string]: WalletAccountTransaction[] },
+    transactions: { [key: AccountKey]: WalletAccountTransaction[] },
 ) =>
-    Object.keys(transactions).flatMap(key => {
+    typedObjectKeys(transactions).flatMap(key => {
         const tx = findTransaction(txid, transactions[key]);
         if (!tx) return [];
 
@@ -359,7 +359,7 @@ export const findChainedTransactions = (
     transactions: Record<AccountKey, WalletAccountTransaction[]>,
     result: ChainedTransactions = { own: [], others: [] },
 ) => {
-    Object.keys(transactions).forEach(accountKey => {
+    typedObjectKeys(transactions).forEach(accountKey => {
         const ownTxs = result.own.map(tx => tx.txid);
         const othersTxs = result.others.map(tx => tx.txid);
         // check if any pending transaction is using the utxo/vin with requested txid
@@ -885,7 +885,7 @@ export const enhanceTransaction = (
 });
 
 const groupTransactionIdsByAddress = (transactions: WalletAccountTransaction[]) => {
-    const addresses: { [address: string]: string[] } = {};
+    const addresses: Record<string, string[]> = {};
     const addAddress = (txid: string, addrs: string[] | undefined) => {
         if (!addrs) {
             return;
@@ -915,10 +915,10 @@ const groupTransactionIdsByAddress = (transactions: WalletAccountTransaction[]) 
 };
 
 const groupTransactionsByLabel = (accountMetadata: AccountLabels) => {
-    const labels: { [label: string]: string[] } = {};
+    const labels: Record<string, string[]> = {};
     const { outputLabels } = accountMetadata;
 
-    Object.keys(outputLabels).forEach(txid => {
+    typedObjectKeys(outputLabels).forEach(txid => {
         Object.values(outputLabels[txid]).forEach(label => {
             if (!labels[label]) {
                 labels[label] = [];
@@ -932,10 +932,10 @@ const groupTransactionsByLabel = (accountMetadata: AccountLabels) => {
 };
 
 const groupAddressesByLabel = (accountMetadata: AccountLabels) => {
-    const labels: { [label: string]: string[] } = {};
+    const labels: Record<string, string[]> = {};
     const { addressLabels } = accountMetadata;
 
-    Object.keys(addressLabels).forEach(address => {
+    typedObjectKeys(addressLabels).forEach(address => {
         const label = addressLabels[address];
 
         if (!labels[label]) {
@@ -1068,7 +1068,7 @@ export const simpleSearchTransactions = (
 
     // Find by output label
     const txsForOutputLabels = groupTransactionsByLabel(accountMetadata);
-    const foundTxsForOutputLabel = Object.keys(txsForOutputLabels).flatMap(label => {
+    const foundTxsForOutputLabel = typedObjectKeys(txsForOutputLabels).flatMap(label => {
         if (label.toLowerCase().includes(search.toLowerCase())) {
             return txsForOutputLabels[label];
         }
@@ -1079,7 +1079,7 @@ export const simpleSearchTransactions = (
 
     // Find by address label
     const addressesForLabel = groupAddressesByLabel(accountMetadata);
-    const foundAddressesForLabel = Object.keys(addressesForLabel).flatMap(label => {
+    const foundAddressesForLabel = typedObjectKeys(addressesForLabel).flatMap(label => {
         if (label.toLowerCase().includes(search.toLowerCase())) {
             return addressesForLabel[label];
         }
@@ -1089,7 +1089,7 @@ export const simpleSearchTransactions = (
 
     // Find by address
     const txsForAddresses = groupTransactionIdsByAddress(transactions);
-    const foundTxsForAddress = Object.keys(txsForAddresses).flatMap(address => {
+    const foundTxsForAddress = typedObjectKeys(txsForAddresses).flatMap(address => {
         if (
             address.toLowerCase().includes(search.toLowerCase()) ||
             foundAddressesForLabel.includes(address)

--- a/suite-native/accounts/src/tests/selectors.test.ts
+++ b/suite-native/accounts/src/tests/selectors.test.ts
@@ -1,4 +1,9 @@
-import { Account, TokenInfoBranded, asAccountDescriptor } from '@suite-common/wallet-types';
+import {
+    Account,
+    AccountKey,
+    TokenInfoBranded,
+    asAccountDescriptor,
+} from '@suite-common/wallet-types';
 
 import { getAccountListSections, selectFreshAccountAddress } from '../selectors';
 import {
@@ -124,7 +129,7 @@ describe('sortAccountsByNetworksAndAccountTypes', () => {
 describe('selectFreshAccountAddress', () => {
     const mockAccount = {
         symbol: 'btc',
-        key: 'btc-1',
+        key: 'btc-1' as AccountKey, // Todo: create properly via `createAccountKey()`,
         addresses: {
             unused: [
                 {
@@ -203,7 +208,10 @@ describe('selectFreshAccountAddress', () => {
     };
 
     it('should return null when account is not provided', () => {
-        const result = selectFreshAccountAddress(mockState, 'non-existent-key');
+        const result = selectFreshAccountAddress(
+            mockState,
+            'non-existent-key' as AccountKey, // Todo: create properly via `createAccountKey()`
+        );
         expect(result).toBeNull();
     });
 

--- a/suite-native/blockchain/package.json
+++ b/suite-native/blockchain/package.json
@@ -14,6 +14,7 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
-        "@trezor/connect": "workspace:*"
+        "@trezor/connect": "workspace:*",
+        "@trezor/utils": "workspace:*"
     }
 }

--- a/suite-native/blockchain/src/blockchainMiddleware.ts
+++ b/suite-native/blockchain/src/blockchainMiddleware.ts
@@ -8,6 +8,7 @@ import {
     setCustomBackendThunk,
 } from '@suite-common/wallet-core';
 import { BLOCKCHAIN as TREZOR_CONNECT_BLOCKCHAIN_ACTIONS } from '@trezor/connect';
+import { typedObjectKeys } from '@trezor/utils';
 
 import {
     onBlockchainConnectThunk,
@@ -18,7 +19,7 @@ import {
 export const selectNetworksWithPendingTransactions = (state: TransactionsRootState) => {
     const pendingTransactions = selectAllPendingTransactions(state);
 
-    return Object.keys(pendingTransactions)
+    return typedObjectKeys(pendingTransactions)
         .filter(accountKey => pendingTransactions[accountKey].length > 0)
         .map(accountKey => pendingTransactions[accountKey][0].symbol);
 };

--- a/suite-native/blockchain/tsconfig.json
+++ b/suite-native/blockchain/tsconfig.json
@@ -14,6 +14,7 @@
         {
             "path": "../../suite-common/wallet-types"
         },
-        { "path": "../../packages/connect" }
+        { "path": "../../packages/connect" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite-native/graph/src/selectors.ts
+++ b/suite-native/graph/src/selectors.ts
@@ -14,7 +14,7 @@ import {
     selectAccountByKey,
     selectDeviceMainnetAccounts,
 } from '@suite-common/wallet-core';
-import { TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { tryGetAccountIdentity } from '@suite-common/wallet-utils';
 
 type GraphCommonRootState = DeviceRootState & AccountsRootState & TokenDefinitionsRootState;
@@ -54,7 +54,7 @@ export const selectDeviceHistoryIgnoredNetworkSymbols = createMemoizedSelector(
 
 export const selectIsHistoryEnabledAccountByAccountKey = (
     state: AccountsRootState,
-    accountKey: string | undefined,
+    accountKey: AccountKey | undefined,
 ): boolean => {
     const account = selectAccountByKey(state, accountKey);
 

--- a/suite-native/labeling/src/selectors.ts
+++ b/suite-native/labeling/src/selectors.ts
@@ -11,8 +11,8 @@ import {
     selectAccountByKey,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
-import { AccountDescriptor } from '@suite-common/wallet-types';
-import { createAccountKey, parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
+import { AccountDescriptor, createAccountKey } from '@suite-common/wallet-types';
+import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { SettingsSliceRootState, selectIsExperimentalFeatureEnabled } from '@suite-native/settings';
 import { StaticSessionId } from '@trezor/connect';
 

--- a/suite-native/module-accounts-management/src/components/AccountRenameButton.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountRenameButton.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux';
 
+import { AccountKey } from '@suite-common/wallet-types';
 import { BottomSheetModal, Box, IconButton, useBottomSheetModal } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { selectIsLabellingAllowed, useTurnOnSuiteSyncGuard } from '@suite-native/labeling';
@@ -7,7 +8,7 @@ import { selectIsLabellingAllowed, useTurnOnSuiteSyncGuard } from '@suite-native
 import { AccountRenameForm } from './AccountRenameForm';
 
 type AccountRenameModalProps = {
-    accountKey: string;
+    accountKey: AccountKey;
 };
 
 export const AccountRenameButton = ({ accountKey }: AccountRenameModalProps) => {

--- a/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { AccountsRootState, accountsActions, selectAccountByKey } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     AccountFormValues,
     AccountLabelFieldHint,
@@ -21,7 +22,7 @@ import { useToast } from '@suite-native/toasts';
 import { exhaustive } from '@trezor/type-utils';
 
 type AccountRenameFormProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     onSubmit: () => void;
 };
 

--- a/suite-native/module-accounts-management/src/components/AccountSettingsShowXpubButton.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountSettingsShowXpubButton.tsx
@@ -8,6 +8,7 @@ import {
     selectSelectedDevice,
     showXpubOnDevice,
 } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import { isAddressBasedNetwork } from '@suite-common/wallet-utils';
 import { useAlert } from '@suite-native/alerts';
 import { Button, useBottomSheetModal } from '@suite-native/atoms';
@@ -18,7 +19,7 @@ import { WalletBackupNotSetWarningBottomSheet } from '@suite-native/module-devic
 import { XpubQRCodeBottomSheet } from '@suite-native/qr-code';
 import { convertTaprootXpub } from '@trezor/utils';
 
-export const AccountSettingsShowXpubButton = ({ accountKey }: { accountKey: string }) => {
+export const AccountSettingsShowXpubButton = ({ accountKey }: { accountKey: AccountKey }) => {
     const openLink = useOpenLink();
     const { showAlert } = useAlert();
     const { translate } = useTranslate();

--- a/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenHeader.tsx
@@ -4,7 +4,7 @@ import { RouteProp, useRoute } from '@react-navigation/native';
 
 import { SuiteSyncDataRootState, selectSuiteSyncAccountLabel } from '@suite-common/suite-sync';
 import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
-import { TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { parseAccountKey, parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { Box, HStack, Text, VStack } from '@suite-native/atoms';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
@@ -13,7 +13,7 @@ import { RootStackParamList, RootStackRoutes, ScreenHeader } from '@suite-native
 import { TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
 
 type TokenAccountDetailScreenHeaderProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     tokenContract: TokenAddress;
 };
 

--- a/suite-native/module-earn/src/components/AutoStakedBalancesCard.tsx
+++ b/suite-native/module-earn/src/components/AutoStakedBalancesCard.tsx
@@ -1,4 +1,5 @@
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountKey } from '@suite-common/wallet-types';
 import { Box, Card, PressableOpacity, Text } from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Icon } from '@suite-native/icons';
@@ -34,7 +35,7 @@ const separatorStyle = prepareNativeStyle(utils => ({
 }));
 
 type AutoStakedBalancesCardProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     symbol: NetworkSymbol | null;
     rewardsBalance: string | null;
     apy: number | null;

--- a/suite-native/module-earn/src/components/CardanoStakingInfoBanner.tsx
+++ b/suite-native/module-earn/src/components/CardanoStakingInfoBanner.tsx
@@ -1,4 +1,5 @@
 import { useAccoutsSelector } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import { InlineAlertBox } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -11,7 +12,7 @@ import {
 } from '@suite-native/staking/src/cardanoStakingSelectors';
 
 type CardanoStakingInfoBannerProps = {
-    accountKey: string;
+    accountKey: AccountKey;
 };
 
 export const CardanoStakingInfoBanner = ({ accountKey }: CardanoStakingInfoBannerProps) => {

--- a/suite-native/module-earn/src/components/EarnItemOverviewSection.tsx
+++ b/suite-native/module-earn/src/components/EarnItemOverviewSection.tsx
@@ -1,4 +1,5 @@
 import { selectFormattedAccountType, useAccoutsSelector } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import { Badge, Box, HStack, Text } from '@suite-native/atoms';
 import { CryptoAmountFormatter, NetworkDisplaySymbolNameFormatter } from '@suite-native/formatters';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
@@ -29,7 +30,7 @@ type EarnItemOverviewSectionProps = {
 } & EarnItem;
 
 export const EarnItemOverviewSection = ({
-    accountKey = '',
+    accountKey = '' as AccountKey, // Todo: this is wrong, use null or something
     symbol,
     stakedBalance,
     accountLabel,

--- a/suite-native/module-earn/src/components/ManualStakedBalancesCard.tsx
+++ b/suite-native/module-earn/src/components/ManualStakedBalancesCard.tsx
@@ -1,4 +1,5 @@
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountKey } from '@suite-common/wallet-types';
 import { Box, Card, PressableOpacity, Text } from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Icon } from '@suite-native/icons';
@@ -26,7 +27,7 @@ const separatorStyle = prepareNativeStyle(utils => ({
 }));
 
 type ManualStakedBalancesCardProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     symbol: NetworkSymbol | null;
     rewardsBalance: string | null;
     apy: number | null;

--- a/suite-native/module-earn/src/components/StakeClaimableCard.tsx
+++ b/suite-native/module-earn/src/components/StakeClaimableCard.tsx
@@ -1,5 +1,6 @@
 import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from '@suite-common/formatters';
 import { selectAccountNetworkSymbol, useAccoutsSelector } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import { Box, Card, PressableOpacity, Text } from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
@@ -10,7 +11,7 @@ import {
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type StakeClaimableCardProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     handleToggleBottomSheet: (value: boolean) => void;
 };
 

--- a/suite-native/module-earn/src/components/StakePendingCard.tsx
+++ b/suite-native/module-earn/src/components/StakePendingCard.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from '@suite-common/formatters';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectAccountNetworkSymbol, useAccoutsSelector } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import { Box, Card, InlineAlertBoxProps, PressableOpacity, Text } from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
@@ -16,7 +17,7 @@ import { NativeStakingRootState } from '@suite-native/staking/src/types';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type StakePendingCardProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     handleToggleBottomSheet: (value: boolean) => void;
 };
 const stakingItemStyle = prepareNativeStyle(utils => ({

--- a/suite-native/module-earn/src/components/StakingBalancesOverviewCard.tsx
+++ b/suite-native/module-earn/src/components/StakingBalancesOverviewCard.tsx
@@ -1,4 +1,5 @@
 import { selectAccountNetworkSymbol, useAccoutsSelector } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     AUTO_STAKED_SYMBOLS,
     selectAPYByAccountKey,
@@ -10,7 +11,7 @@ import { AutoStakedBalancesCard } from './AutoStakedBalancesCard';
 import { ManualStakedBalancesCard } from './ManualStakedBalancesCard';
 
 type StakingBalancesCardProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     handleToggleBottomSheet: (value: boolean) => void;
 };
 

--- a/suite-native/module-earn/src/components/StakingInfo.tsx
+++ b/suite-native/module-earn/src/components/StakingInfo.tsx
@@ -1,3 +1,4 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import { Box, PressableOpacity, Text, useBottomSheetModal } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
@@ -22,7 +23,7 @@ const linkStyle = prepareNativeStyle(() => ({
 }));
 
 type StakingInfoProps = {
-    accountKey: string;
+    accountKey: AccountKey;
 };
 
 export const StakingInfo = ({ accountKey }: StakingInfoProps) => {

--- a/suite-native/module-earn/src/hooks/useStakingListData.ts
+++ b/suite-native/module-earn/src/hooks/useStakingListData.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { PROD_STAKING_SYMBOLS } from '@suite-common/wallet-config';
 import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     getAccountTotalStakingBalance,
     isCardanoStakedWithFiveBinaries,
@@ -40,7 +41,11 @@ export const useStakingListData = () => {
 
             // if not return fallback value
             if (accountsStakingActive.length === 0) {
-                return { symbol, accountKey: '', accountLabel: '' };
+                return {
+                    symbol,
+                    accountKey: '' as AccountKey, // Todo: this is bad, use null or something
+                    accountLabel: '',
+                };
             }
 
             return accountsStakingActive;

--- a/suite-native/module-earn/src/types.ts
+++ b/suite-native/module-earn/src/types.ts
@@ -1,8 +1,8 @@
 import { StakingNetworkSymbol } from '@suite-common/wallet-config';
-import { Account } from '@suite-common/wallet-types';
+import { Account, AccountKey } from '@suite-common/wallet-types';
 
 export type EarnItem = {
     symbol: StakingNetworkSymbol;
-    accountKey: Account['key'];
+    accountKey: AccountKey;
     accountLabel?: Account['accountLabel'];
 };

--- a/suite-native/module-send/src/__tests__/selectors.test.ts
+++ b/suite-native/module-send/src/__tests__/selectors.test.ts
@@ -1,4 +1,4 @@
-import { FormState, TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, FormState, TokenAddress } from '@suite-common/wallet-types';
 import { NativeSendRootState } from '@suite-native/transaction-management';
 
 import { selectDestinationTagFromDraft } from '../selectors';
@@ -34,14 +34,20 @@ describe('send selectors', () => {
             >;
 
             const state = createMockState({ drafts: mockDraftsTyped });
-            const result = selectDestinationTagFromDraft(state, 'btc-0');
+            const result = selectDestinationTagFromDraft(
+                state,
+                'btc-0' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('12345');
         });
 
         it('should return undefined when draft does not exist', () => {
             const state = createMockState();
-            const result = selectDestinationTagFromDraft(state, 'btc-0');
+            const result = selectDestinationTagFromDraft(
+                state,
+                'btc-0' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBeUndefined();
         });
@@ -63,7 +69,7 @@ describe('send selectors', () => {
             const state = createMockState({ drafts: mockDraftsTyped });
             const result = selectDestinationTagFromDraft(
                 state,
-                'eth-0',
+                'eth-0' as AccountKey, // Todo: create properly via `createAccountKey()`
                 '0x1234567890123456789012345678901234567890' as TokenAddress,
             );
 

--- a/suite-native/module-send/src/components/CoinControl/SendUtxoScreenHeader.tsx
+++ b/suite-native/module-send/src/components/CoinControl/SendUtxoScreenHeader.tsx
@@ -1,3 +1,4 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import { useAlert } from '@suite-native/alerts';
 import { IconButton } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
@@ -6,7 +7,7 @@ import { ScreenHeader } from '@suite-native/navigation';
 import { useUtxoSelection } from '../../hooks/useUtxoSelection';
 
 type SendUtxoScreenHeaderProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     onDelete?: () => void;
 };
 

--- a/suite-native/module-send/src/components/CoinControl/UtxoList.tsx
+++ b/suite-native/module-send/src/components/CoinControl/UtxoList.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { FlashList } from '@shopify/flash-list';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountKey } from '@suite-common/wallet-types';
 import { isSameUtxo } from '@suite-common/wallet-utils';
 import { Box } from '@suite-native/atoms';
 import { Utxo } from '@trezor/blockchain-link-types';
@@ -19,7 +20,7 @@ const spacerStyle = prepareNativeStyle(utils => ({
 
 type UtxoListProps = {
     deviceStaticSessionId: StaticSessionId;
-    accountKey: string;
+    accountKey: AccountKey;
     utxos: Utxo[];
     selectedUtxos: Utxo[];
     onUtxoToggle: (utxo: Utxo) => void;

--- a/suite-native/module-send/src/components/CoinControl/__tests__/SendUtxosScreenHeader.comp.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/__tests__/SendUtxosScreenHeader.comp.test.tsx
@@ -1,3 +1,4 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { useUtxoSelection } from '../../../hooks/useUtxoSelection';
@@ -25,7 +26,11 @@ describe('SendUtxosScreenHeader', () => {
         });
 
         const { getByTestId } = renderWithBasicProvider(
-            <SendUtxoScreenHeader accountKey="testAccKey" />,
+            <SendUtxoScreenHeader
+                accountKey={
+                    'testAccKey' as AccountKey // Todo: create properly via `createAccountKey()`
+                }
+            />,
         );
 
         expect(getByTestId('coin-control-delete-button')).toBeTruthy();
@@ -38,7 +43,11 @@ describe('SendUtxosScreenHeader', () => {
         });
 
         const { queryByTestId } = renderWithBasicProvider(
-            <SendUtxoScreenHeader accountKey="testAccKey" />,
+            <SendUtxoScreenHeader
+                accountKey={
+                    'testAccKey' as AccountKey // Todo: create properly via `createAccountKey()`
+                }
+            />,
         );
 
         expect(queryByTestId('coin-control-delete-button')).toBeNull();

--- a/suite-native/module-send/src/components/CoinControl/__tests__/SwitchCoinControlButton.comp.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/__tests__/SwitchCoinControlButton.comp.test.tsx
@@ -1,3 +1,4 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     BasicProviderForTests,
     renderHook,
@@ -12,6 +13,8 @@ import { SwitchCoinControlButton } from '../SwitchCoinControlButton';
 jest.mock('../../../hooks/useUtxoSelection', () => ({
     useUtxoSelection: jest.fn(),
 }));
+
+const accountKey = 'account-key' as AccountKey; // Todo: create properly via `createAccountKey()`
 
 describe('renders button with correct color scheme', () => {
     let colors: NativeStyleUtils['colors'];
@@ -39,7 +42,7 @@ describe('renders button with correct color scheme', () => {
         });
 
         const { getByTestId } = renderWithBasicProvider(
-            <SwitchCoinControlButton accountKey="account-key" amount="1000" />,
+            <SwitchCoinControlButton accountKey={accountKey} amount="1000" />,
         );
 
         const button = getByTestId('switch-coin-control-button');
@@ -63,7 +66,7 @@ describe('renders button with correct color scheme', () => {
             totalSelectedAmount: BigNumber(1000),
         });
         const { getByTestId } = renderWithBasicProvider(
-            <SwitchCoinControlButton accountKey="account-key" amount="1000" />,
+            <SwitchCoinControlButton accountKey={accountKey} amount="1000" />,
         );
 
         const button = getByTestId('switch-coin-control-button');
@@ -78,7 +81,7 @@ describe('renders button with correct color scheme', () => {
         });
 
         const { getByTestId } = renderWithBasicProvider(
-            <SwitchCoinControlButton accountKey="account-key" />,
+            <SwitchCoinControlButton accountKey={accountKey} />,
         );
 
         const button = getByTestId('switch-coin-control-button');

--- a/suite-native/module-send/src/hooks/__tests__/useUtxoSelection.hook.test.ts
+++ b/suite-native/module-send/src/hooks/__tests__/useUtxoSelection.hook.test.ts
@@ -1,11 +1,12 @@
 import { useAtom } from 'jotai';
 
+import { AccountKey } from '@suite-common/wallet-types';
 import { renderHook } from '@suite-native/test-utils';
 
 import { SelectedUtxos } from '../../types';
 import { useUtxoSelection } from '../useUtxoSelection';
 
-const accountKey = 'testAccKey';
+const accountKey = 'testAccKey' as AccountKey; // Todo: create properly via `createAccountKey()`
 
 jest.mock('jotai', () => ({
     useAtom: jest.fn(() => [[], jest.fn()]),

--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/alertBuilders.tsx
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/alertBuilders.tsx
@@ -1,3 +1,4 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import { Translation } from '@suite-native/intl';
 import { Link } from '@suite-native/link';
 import { HELP_CENTER_EVM_ADDRESS_CHECKSUM } from '@trezor/urls';
@@ -37,7 +38,7 @@ export const createContractAlert = (onPressPrimaryButton: () => void) => ({
 });
 
 export const createTokenAlert = (
-    accountKey: string,
+    accountKey: AccountKey,
     tokenContract: string,
     onPressPrimaryButton: () => void,
 ) => ({

--- a/suite-native/module-send/src/hooks/useHandleOnDeviceTransactionReview.tsx
+++ b/suite-native/module-send/src/hooks/useHandleOnDeviceTransactionReview.tsx
@@ -5,7 +5,11 @@ import { useNavigation } from '@react-navigation/native';
 import { isRejected } from '@reduxjs/toolkit';
 
 import { selectIsDeviceRemembered, sendFormActions } from '@suite-common/wallet-core';
-import { GeneralPrecomposedTransactionFinal, TokenAddress } from '@suite-common/wallet-types';
+import {
+    AccountKey,
+    GeneralPrecomposedTransactionFinal,
+    TokenAddress,
+} from '@suite-common/wallet-types';
 import { useAlert } from '@suite-native/alerts';
 import { Translation } from '@suite-native/intl';
 import {
@@ -32,7 +36,7 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 >;
 
 type HandleOnDeviceTransactionReviewProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     tokenContract?: TokenAddress;
     transaction: GeneralPrecomposedTransactionFinal | null;
 };

--- a/suite-native/module-send/src/hooks/useSendForm.ts
+++ b/suite-native/module-send/src/hooks/useSendForm.ts
@@ -22,7 +22,7 @@ import {
     sendFormActions,
     updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
-import { TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { convertAmountUnitsToSubunits, getExcludedUtxos } from '@suite-common/wallet-utils';
 import { useForm } from '@suite-native/forms';
 import {
@@ -62,7 +62,7 @@ const getDefaultValues = ({
         ],
     }) as const;
 
-export const useSendForm = (accountKey: string, tokenContract?: TokenAddress) => {
+export const useSendForm = (accountKey: AccountKey, tokenContract?: TokenAddress) => {
     const dispatch = useDispatch();
     const debounce = useDebounce();
     const navigation =

--- a/suite-native/module-send/src/hooks/useUtxoSelection.ts
+++ b/suite-native/module-send/src/hooks/useUtxoSelection.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { useAtom } from 'jotai';
 
+import { AccountKey } from '@suite-common/wallet-types';
 import { isSameUtxo } from '@suite-common/wallet-utils';
 import { Utxo } from '@trezor/blockchain-link-types';
 import { BigNumber } from '@trezor/utils';
@@ -16,7 +17,7 @@ type UseUtxoSelectionReturn = {
     setSelectedUtxos: (utxos: Utxo[]) => void;
 };
 
-export const useUtxoSelection = (accountKey: string): UseUtxoSelectionReturn => {
+export const useUtxoSelection = (accountKey: AccountKey): UseUtxoSelectionReturn => {
     const [selectedUtxosMap, setSelectedUtxosMap] = useAtom(selectedUtxosAtom);
 
     const selectedUtxos = useMemo(

--- a/suite-native/module-stellar-token-management/src/hooks/__tests__/useStellarFeeScreen.test.ts
+++ b/suite-native/module-stellar-token-management/src/hooks/__tests__/useStellarFeeScreen.test.ts
@@ -1,4 +1,4 @@
-import { TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import {
     AuthorizeDeviceStackRoutes,
     RootStackRoutes,
@@ -32,8 +32,10 @@ const triggerFocusEffect = () => {
     focusEffectCallback?.();
 };
 
+const accountKey = 'stellar-1' as AccountKey;
+
 const mockAccount = {
-    key: 'stellar-1',
+    key: accountKey,
     symbol: 'xlm',
     networkType: 'stellar',
     descriptor: 'GAXSFOOGF4ELO5HT5PTN23T5XE6D5QWL3YBHSVQ2HWOFEJNYYMRJENBV',
@@ -126,8 +128,8 @@ jest.mock('../useStellarTokenInfo', () => ({
 }));
 
 jest.mock('../../thunks', () => ({
-    getStellarTokenFormDraftKey: (accountKey: string, tokenContract: string) =>
-        `stellar-token/${accountKey}/${tokenContract}`,
+    getStellarTokenFormDraftKey: (accountKeyParam: AccountKey, tokenContract: string) =>
+        `stellar-token/${accountKeyParam}/${tokenContract}`,
     updateStellarTokenSelectedFeeLevelThunk: jest.fn(),
 }));
 
@@ -184,7 +186,7 @@ describe('useStellarFeeScreen', () => {
         'UNKNOWN-GC2QJHYZSO5UV5DZYAQIQMSSGXERQPJC54PLA7NPLWTC7Y2TQFUT4QA7' as TokenAddress;
 
     const defaultProps: UseStellarFeeScreenParams = {
-        accountKey: 'stellar-1',
+        accountKey,
         tokenContract: KNOWN_USDC_CONTRACT,
         mode: 'activation',
         thunkAction: mockThunkAction,
@@ -353,7 +355,7 @@ describe('useStellarFeeScreen', () => {
             customFeePerUnit: undefined,
         });
         expect(mockFetchAndUpdateAccountThunk).toHaveBeenCalledWith({
-            accountKey: 'stellar-1',
+            accountKey,
         });
         expect(mockOnSuccess).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/module-stellar-token-management/src/hooks/useStellarFeeScreen.ts
+++ b/suite-native/module-stellar-token-management/src/hooks/useStellarFeeScreen.ts
@@ -16,6 +16,7 @@ import {
     useThunkDispatch,
 } from '@suite-common/wallet-core';
 import {
+    AccountKey,
     FeeLevelLabel,
     FormState,
     PrecomposedTransactionFinal,
@@ -55,7 +56,7 @@ type StellarFeeNavigationProps = StackToStackCompositeNavigationProps<
 >;
 
 type UseStellarFeeScreenParams = {
-    accountKey: string;
+    accountKey: AccountKey;
     tokenContract: TokenAddress;
     mode: StellarFeeScreenMode;
     thunkAction: (params: {

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeApprovalForCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeApprovalForCard.comp.test.tsx
@@ -1,3 +1,4 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
@@ -9,7 +10,7 @@ describe('ExchangeApprovalForCard', () => {
 
     it('should render text based on redux state', async () => {
         const preloadedState = { wallet: getWalletState({ tradeType: 'exchange' }) };
-        preloadedState.wallet.trading.exchange.tradingAccountKey = 'eth-account-1';
+        preloadedState.wallet.trading.exchange.tradingAccountKey = 'eth-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
 
         const { getByText } = await renderExchangeApprovalForCard(preloadedState);
 

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewContinueButton.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewContinueButton.comp.test.tsx
@@ -1,4 +1,4 @@
-import { GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { AccountKey, GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { PreloadedState, renderWithStoreProviderAsync, userEvent } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
@@ -37,8 +37,8 @@ describe('ExchangePreviewContinueButton', () => {
 
     const getPreloadedState = (): PreloadedState => {
         const preloadedState = { wallet: getWalletState({ tradeType: 'exchange' }) };
-        preloadedState.wallet!.trading!.exchange!.tradingAccountKey = 'btc-account-1';
-        preloadedState.wallet!.trading!.exchange!.receiveAccountKey = 'eth-account-1';
+        preloadedState.wallet!.trading!.exchange!.tradingAccountKey = 'btc-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
+        preloadedState.wallet!.trading!.exchange!.receiveAccountKey = 'eth-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
         preloadedState.wallet!.send!.precomposedTx = {
             type: 'final',
             totalSpent: '1100',

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountInput.comp.test.tsx
@@ -1,4 +1,4 @@
-import { Account, TokenAddress } from '@suite-common/wallet-types';
+import { Account, AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { Form } from '@suite-native/forms';
 import {
     PreloadedState,
@@ -141,7 +141,7 @@ describe('ExchangeSendAmountInput', () => {
         act(() => {
             form.setValue('sendAsset', usdcAsset);
             form.setValue('sendAccount', {
-                key: 'account-key',
+                key: 'account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
                 symbol: 'eth',
             } as Account);
         });

--- a/suite-native/module-trading/src/components/fees/__tests__/TradingFeesForm.comp.test.tsx
+++ b/suite-native/module-trading/src/components/fees/__tests__/TradingFeesForm.comp.test.tsx
@@ -31,9 +31,11 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 describe('TradingFeesForm', () => {
-    const mockAccountKey: AccountKey = 'btc1';
+    const mockAccountKey: AccountKey = 'btc1' as AccountKey; // Todo: create properly via `createAccountKey()`
     const mockAccount = getBtcAccount(mockAccountKey);
-    const mockEthAccount = getEthAccount('eth1');
+    const mockEthAccount = getEthAccount(
+        'eth1' as AccountKey, // Todo: create properly via `createAccountKey()`
+    );
 
     const defaultState = {
         wallet: {
@@ -94,7 +96,7 @@ describe('TradingFeesForm', () => {
 
     it('should work with token contract for Ethereum accounts', async () => {
         const { getByText } = await renderTradingFeesForm({
-            accountKey: 'eth1',
+            accountKey: 'eth1' as AccountKey, // Todo: create properly via `createAccountKey()`
             tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
         });
 

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx
@@ -1,4 +1,4 @@
-import { Account, asAccountDescriptor } from '@suite-common/wallet-types';
+import { Account, AccountKey, asAccountDescriptor } from '@suite-common/wallet-types';
 import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 import { ReceiveAccount } from '@suite-native/trading-types';
 
@@ -61,7 +61,7 @@ describe(AccountListAddressItem.name, () => {
     it('should call onPress callback when pressed', async () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
-                key: 'btc1',
+                key: 'btc1' as AccountKey, // Todo: create properly via `createAccountKey()`
                 symbol: 'btc',
                 accountLabel: 'My BTC account',
                 availableBalance: '10000000',
@@ -85,7 +85,7 @@ describe(AccountListAddressItem.name, () => {
     it('should not display caret for address addresses', async () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
-                key: 'btc1',
+                key: 'btc1' as AccountKey, // Todo: create properly via `createAccountKey()`
                 symbol: 'btc',
                 accountLabel: 'My BTC account',
                 availableBalance: '10000000',
@@ -109,7 +109,7 @@ describe(AccountListAddressItem.name, () => {
     it('should display address', async () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
-                key: 'btc1',
+                key: 'btc1' as AccountKey, // Todo: create properly via `createAccountKey()`
                 symbol: 'btc',
                 accountLabel: 'My BTC account',
                 availableBalance: '10000000',
@@ -136,7 +136,7 @@ describe(AccountListAddressItem.name, () => {
     it('should display zero balance', async () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
-                key: 'btc1',
+                key: 'btc1' as AccountKey, // Todo: create properly via `createAccountKey()`
                 symbol: 'btc',
                 accountLabel: 'My BTC account',
                 availableBalance: '10000000',
@@ -159,7 +159,7 @@ describe(AccountListAddressItem.name, () => {
     it('should render nothing when no address is specified', async () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
-                key: 'btc1',
+                key: 'btc1' as AccountKey, // Todo: create properly via `createAccountKey()`
                 symbol: 'btc',
                 accountLabel: 'My BTC account',
                 availableBalance: '10000000',

--- a/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.comp.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import type { ExchangeTrade, SellFiatTrade } from 'invity-api';
 
+import { AccountKey } from '@suite-common/wallet-types';
 import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
 import {
     exchangeMercuryo,
@@ -28,7 +29,7 @@ describe('ProviderReceiveAddress', () => {
     const renderProviderReceiveAddress = async (
         trade: ExchangeTrade | SellFiatTrade,
         tradeType: 'exchange' | 'sell' = 'exchange',
-        accountKey: string = 'btc-account-1',
+        accountKey: AccountKey = 'btc-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
     ) => {
         const walletState = getWalletState({ tradeType });
 
@@ -124,7 +125,7 @@ describe('ProviderReceiveAddress', () => {
         const { getByText } = await renderProviderReceiveAddress(
             mockExchangeTrade,
             'exchange',
-            'sol-account-1',
+            'sol-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
         );
 
         // For Solana addresses, the address should be displayed without splitting
@@ -135,7 +136,7 @@ describe('ProviderReceiveAddress', () => {
         const { getByText } = await renderProviderReceiveAddress(
             mockExchangeTrade,
             'exchange',
-            'eth-account-1',
+            'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
         );
 
         // For non-Solana addresses, the address should be displayed with chunking
@@ -146,7 +147,7 @@ describe('ProviderReceiveAddress', () => {
         const { getByText } = await renderProviderReceiveAddress(
             mockExchangeTrade,
             'exchange',
-            'btc-account-1',
+            'btc-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
         );
 
         // For non-Solana addresses, the address should be displayed with chunking
@@ -162,7 +163,7 @@ describe('ProviderReceiveAddress', () => {
         const { getByText } = await renderProviderReceiveAddress(
             solanaTrade,
             'exchange',
-            'sol-account-1',
+            'sol-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
         );
 
         // For Solana addresses, the address should be displayed without splitting
@@ -173,7 +174,7 @@ describe('ProviderReceiveAddress', () => {
         const { queryByText } = await renderProviderReceiveAddress(
             mockExchangeTrade,
             'exchange',
-            'unknown-account-1',
+            'unknown-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
         );
 
         // Should not render anything when network symbol is undefined

--- a/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsContent.comp.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsContent.comp.test.tsx
@@ -1,4 +1,4 @@
-import type { TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import { ReviewOutputsContent, ReviewOutputsContentProps } from '../ReviewOutputsContent';
@@ -30,7 +30,9 @@ describe('ReviewOutputsContent', () => {
         renderWithStoreProviderAsync(
             <ReviewOutputsContent
                 orderId="ORDER_ID"
-                accountKey="ACCOUNT_KEY"
+                accountKey={
+                    'ACCOUNT_KEY' as AccountKey // Todo: create properly via `createAccountKey()`
+                }
                 reportToAnalytics={jest.fn()}
                 tradingType="exchange"
                 isTransactionSendConsentRequested={true}

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewContinueButton.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewContinueButton.comp.test.tsx
@@ -1,4 +1,4 @@
-import { GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { AccountKey, GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { PreloadedState, renderWithStoreProviderAsync, userEvent } from '@suite-native/test-utils';
 import { getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 
@@ -37,7 +37,7 @@ describe('SellPreviewContinueButton', () => {
 
     const getPreloadedState = (): PreloadedState => {
         const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
-        preloadedState.wallet!.trading!.sell!.tradingAccountKey = 'eth-account-1';
+        preloadedState.wallet!.trading!.sell!.tradingAccountKey = 'eth-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
         preloadedState.wallet!.send!.precomposedTx = {
             type: 'final',
             totalSpent: '1100',

--- a/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAmountInput.test.tsx
@@ -1,4 +1,4 @@
-import { Account, TokenAddress } from '@suite-common/wallet-types';
+import { Account, AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { Form } from '@suite-native/forms';
 import {
     PreloadedState,
@@ -141,7 +141,7 @@ describe('SellSendAmountInput', () => {
         act(() => {
             form.setValue('sendAsset', usdcAsset);
             form.setValue('sendAccount', {
-                key: 'account-key',
+                key: 'account-key' as AccountKey, // Todo: create properly via `createAccountKey()`,
                 symbol: 'eth',
             } as Account);
         });

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyData.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyData.test.tsx
@@ -1,4 +1,5 @@
 import { tradingBuyActions, tradingThunks } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     PreloadedState,
     TestStore,
@@ -15,15 +16,19 @@ jest.mock('../../../utils/general/utils', () => ({
     getRandomAccountDescriptor: () => 'random_string',
 }));
 
+const btc1AccountKey = 'btc-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
+const btc2AccountKey = 'btc-account-2' as AccountKey; // Todo: create properly via `createAccountKey()`
+const btc3AccountKey = 'btc-account-3' as AccountKey; // Todo: create properly via `createAccountKey()`
+
 describe('useBuyData', () => {
-    const getInitializedStore = (tradingAccountKey: string | undefined) => {
+    const getInitializedStore = (tradingAccountKey: AccountKey | undefined) => {
         const preloadedState: PreloadedState = {
             wallet: {
                 trading: getInitializedTradingState(),
                 accounts: [
-                    getBtcAccount('btc-account-1'),
-                    getBtcAccount('btc-account-2'),
-                    { ...getBtcAccount('btc-account-3'), descriptor: '' },
+                    getBtcAccount(btc1AccountKey),
+                    getBtcAccount(btc2AccountKey),
+                    { ...getBtcAccount(btc3AccountKey), descriptor: '' },
                 ],
             },
         };
@@ -119,7 +124,7 @@ describe('useBuyData', () => {
             initialThunkLoadActionSpy.mockClear();
 
             act(() => {
-                store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-2'));
+                store.dispatch(tradingBuyActions.setTradingAccountKey(btc2AccountKey));
             });
 
             // Wait for the effect to run
@@ -134,14 +139,14 @@ describe('useBuyData', () => {
         });
 
         it('should not dispatch loadInitialDataThunk when descriptor is not changed', async () => {
-            const store = await getInitializedStore('btc-account-2');
+            const store = await getInitializedStore(btc2AccountKey);
             await renderUseBuyData(0, store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
             act(() => {
-                store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-2'));
+                store.dispatch(tradingBuyActions.setTradingAccountKey(btc2AccountKey));
             });
 
             // Wait for effects to run
@@ -153,14 +158,14 @@ describe('useBuyData', () => {
         });
 
         it('should dispatch loadInitialDataThunk with random string when descriptor is empty string', async () => {
-            const store = await getInitializedStore('btc-account-1');
+            const store = await getInitializedStore(btc1AccountKey);
             await renderUseBuyData(0, store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
             act(() => {
-                store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-3'));
+                store.dispatch(tradingBuyActions.setTradingAccountKey(btc3AccountKey));
             });
 
             // Wait for the effect to run
@@ -176,7 +181,7 @@ describe('useBuyData', () => {
         });
 
         it('should dispatch loadInitialDataThunk with random string when descriptor is undefined', async () => {
-            const store = await getInitializedStore('btc-account-1');
+            const store = await getInitializedStore(btc1AccountKey);
             await renderUseBuyData(0, store);
 
             // Clear the initial call

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
@@ -4,6 +4,7 @@ import { EnhancedStore } from '@reduxjs/toolkit';
 import type { BuyTrade, CryptoId } from 'invity-api';
 
 import { tradingBuyActions } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import { Form, useField } from '@suite-native/forms';
 import {
     PreloadedState,
@@ -40,6 +41,10 @@ jest.mock('@trezor/react-utils', () => {
     };
 });
 
+const btc1AccountKey = 'btc-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
+const btc2AccountKey = 'btc-account-2' as AccountKey; // Todo: create properly via `createAccountKey()`
+const btc3AccountKey = 'btc-account-3' as AccountKey; // Todo: create properly via `createAccountKey()`
+
 describe('useBuyForm', () => {
     const renderUseTradingBuyForm = (store: TestStore) =>
         renderHookWithStoreProvider(() => useBuyForm(), { store });
@@ -54,13 +59,13 @@ describe('useBuyForm', () => {
                         : PROTO.AmountUnit.BITCOIN,
                 },
                 accounts: [
-                    getBtcAccount('btc-account-1'),
-                    getBtcAccount('btc-account-2'),
-                    { ...getBtcAccount('btc-account-3'), descriptor: '' },
+                    getBtcAccount(btc1AccountKey),
+                    getBtcAccount(btc2AccountKey),
+                    { ...getBtcAccount(btc3AccountKey), descriptor: '' },
                 ],
             },
         };
-        preloadedState.wallet!.trading!.buy!.tradingAccountKey = 'btc-account-1';
+        preloadedState.wallet!.trading!.buy!.tradingAccountKey = btc1AccountKey;
 
         return initStore(preloadedState).store;
     };
@@ -91,11 +96,11 @@ describe('useBuyForm', () => {
         const { result } = renderUseTradingBuyForm(store);
 
         act(() => {
-            store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-2'));
+            store.dispatch(tradingBuyActions.setTradingAccountKey(btc2AccountKey));
         });
 
         expect(result.current.getValues('receiveAccount')).toEqual({
-            account: expect.objectContaining({ key: 'btc-account-2' }),
+            account: expect.objectContaining({ key: btc2AccountKey }),
         });
     });
 
@@ -117,12 +122,12 @@ describe('useBuyForm', () => {
         const { result } = renderUseTradingBuyForm(store);
 
         act(() => {
-            store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-1'));
+            store.dispatch(tradingBuyActions.setTradingAccountKey(btc1AccountKey));
             result.current.setValue('asset', undefined as unknown as TradeableAsset);
         });
 
         expect(result.current.getValues('receiveAccount')).toEqual({
-            account: expect.objectContaining({ key: 'btc-account-1' }),
+            account: expect.objectContaining({ key: btc1AccountKey }),
         });
     });
 

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
@@ -1,5 +1,5 @@
 import { INVITY_API_RELOAD_QUOTES_AFTER_SECONDS, tradingBuyActions } from '@suite-common/trading';
-import { Account } from '@suite-common/wallet-types';
+import { Account, AccountKey } from '@suite-common/wallet-types';
 import {
     PreloadedState,
     TestStore,
@@ -51,7 +51,7 @@ describe('useBuyQuotes', () => {
         const preloadedState: PreloadedState = {
             wallet: { trading: getInitializedTradingState(), accounts: [getBtcAccount()] },
         };
-        preloadedState.wallet!.trading!.buy!.tradingAccountKey = 'btc-account-1';
+        preloadedState.wallet!.trading!.buy!.tradingAccountKey = 'btc-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
 
         return initStore(preloadedState).store;
     };
@@ -169,7 +169,15 @@ describe('useBuyQuotes', () => {
     it.each([
         ['fiatValue', '1000'],
         ['country', 'CZ'],
-        ['receiveAccount', { account: { key: 'btc1', descriptor: 'descriptor_btc1' } as Account }],
+        [
+            'receiveAccount',
+            {
+                account: {
+                    key: 'btc1' as AccountKey, // Todo: create properly via `createAccountKey()`
+                    descriptor: 'descriptor_btc1',
+                } as Account,
+            },
+        ],
     ] as [keyof BuyFormValues, BuyFormValues[keyof BuyFormValues]][])(
         'should re-fetch quotes on %s value change',
         (field, value) => {

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeData.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeData.test.ts
@@ -1,4 +1,5 @@
 import { tradingExchangeActions, tradingThunks } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     PreloadedState,
     TestStore,
@@ -15,15 +16,19 @@ jest.mock('../../../utils/general/utils', () => ({
     getRandomAccountDescriptor: () => 'random_string',
 }));
 
+const btc1AccountKey = 'btc-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
+const btc2AccountKey = 'btc-account-2' as AccountKey; // Todo: create properly via `createAccountKey()`
+const btc3AccountKey = 'btc-account-3' as AccountKey; // Todo: create properly via `createAccountKey()`
+
 describe('useExchangeData', () => {
     const getInitializedStore = (tradingAccountKey: string | undefined) => {
         const preloadedState: PreloadedState = {
             wallet: {
                 trading: getInitializedTradingState('exchange'),
                 accounts: [
-                    getBtcAccount('btc-account-1'),
-                    getBtcAccount('btc-account-2'),
-                    { ...getBtcAccount('btc-account-3'), descriptor: '' },
+                    getBtcAccount(btc1AccountKey),
+                    getBtcAccount(btc2AccountKey),
+                    { ...getBtcAccount(btc3AccountKey), descriptor: '' },
                 ],
             },
         };
@@ -118,7 +123,7 @@ describe('useExchangeData', () => {
             initialThunkLoadActionSpy.mockClear();
 
             act(() => {
-                store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-2'));
+                store.dispatch(tradingExchangeActions.setTradingAccountKey(btc2AccountKey));
             });
 
             // Wait for the effect to run
@@ -133,14 +138,14 @@ describe('useExchangeData', () => {
         });
 
         it('should not dispatch loadInitialDataThunk when descriptor is not changed', async () => {
-            const store = await getInitializedStore('btc-account-2');
+            const store = await getInitializedStore(btc2AccountKey);
             await renderUseExchangeData(0, store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
             act(() => {
-                store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-2'));
+                store.dispatch(tradingExchangeActions.setTradingAccountKey(btc2AccountKey));
             });
 
             // Wait for effects to run
@@ -159,7 +164,7 @@ describe('useExchangeData', () => {
             initialThunkLoadActionSpy.mockClear();
 
             act(() => {
-                store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-3'));
+                store.dispatch(tradingExchangeActions.setTradingAccountKey(btc3AccountKey));
             });
 
             // Wait for the effect to run

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
@@ -1,3 +1,4 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import { EventType } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
 import {
@@ -41,13 +42,16 @@ jest.mock('@suite-common/trading', () => ({
     },
 }));
 
+const btc1AccountKey = 'btc1' as AccountKey; // Todo: create properly via `createAccountKey()`
+const btc2AccountKey = 'btc2' as AccountKey; // Todo: create properly via `createAccountKey()`
+
 describe('useExchangeFlow', () => {
-    const getMockAccounts = () => [getBtcAccount('btc1'), getBtcAccount('btc2')];
+    const getMockAccounts = () => [getBtcAccount(btc1AccountKey), getBtcAccount(btc2AccountKey)];
 
     const getInitializedStore = () => {
         const tradingState = getInitializedTradingStateWithQuotes();
-        tradingState.exchange.tradingAccountKey = 'btc1';
-        tradingState.exchange.receiveAccountKey = 'btc2';
+        tradingState.exchange.tradingAccountKey = btc1AccountKey;
+        tradingState.exchange.receiveAccountKey = btc2AccountKey;
         tradingState.exchange.selectedQuote = tradingState.exchange.quotes[0];
 
         const preloadedState: PreloadedState = {
@@ -177,8 +181,8 @@ describe('useExchangeFlow', () => {
             const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
 
             const tradingState = getInitializedTradingStateWithQuotes();
-            tradingState.exchange.tradingAccountKey = 'invalid-account-key';
-            tradingState.exchange.receiveAccountKey = 'btc2';
+            tradingState.exchange.tradingAccountKey = 'invalid-account-key' as AccountKey; // Todo: create properly via `createAccountKey()`
+            tradingState.exchange.receiveAccountKey = btc2AccountKey;
             tradingState.exchange.selectedQuote = tradingState.exchange.quotes[0];
 
             const preloadedState: PreloadedState = {

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -1,6 +1,7 @@
 import type { ExchangeTrade } from 'invity-api';
 
 import { tradingExchangeActions } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import { EventType } from '@suite-native/analytics';
 import { FeatureFlag, FeatureFlagsRootState } from '@suite-native/feature-flags';
 import {
@@ -36,6 +37,8 @@ jest.mock('@suite-native/services', () => {
         }),
     };
 });
+
+const btc1AccountKey = 'btc-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
 
 describe('useExchangeForm', () => {
     let store: TestStore;
@@ -263,10 +266,10 @@ describe('useExchangeForm', () => {
             const { result } = renderUseExchangeForm();
 
             act(() => {
-                store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
             });
 
-            expect(result.current.getValues('sendAccount')).toEqual(getBtcAccount('btc-account-1'));
+            expect(result.current.getValues('sendAccount')).toEqual(getBtcAccount(btc1AccountKey));
         });
     });
 
@@ -324,12 +327,12 @@ describe('useExchangeForm', () => {
             const { result } = renderUseExchangeForm();
 
             act(() => {
-                store.dispatch(tradingExchangeActions.setReceiveAccountKey('btc-account-1'));
+                store.dispatch(tradingExchangeActions.setReceiveAccountKey(btc1AccountKey));
             });
 
             expect(result.current.getValues('receiveAccount')).toEqual(
                 expect.objectContaining({
-                    account: getBtcAccount('btc-account-1'),
+                    account: getBtcAccount(btc1AccountKey),
                 }),
             );
         });
@@ -374,7 +377,7 @@ describe('useExchangeForm', () => {
 
             act(() => {
                 result.current.setValue('sendAsset', btcAsset);
-                store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(
                     tradingExchangeActions.setAmountLimits({
                         minCrypto: '0.0001',
@@ -403,7 +406,7 @@ describe('useExchangeForm', () => {
 
             act(() => {
                 result.current.setValue('sendAsset', btcAsset);
-                store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(
                     tradingExchangeActions.setAmountLimits({
                         minCrypto: '0.0001',
@@ -427,7 +430,7 @@ describe('useExchangeForm', () => {
             const { result } = renderUseExchangeForm();
 
             act(() => {
-                store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
                 result.current.setValue('sendAsset', btcAsset);
                 result.current.setValue('sendCryptoAmount', '10000');
             });
@@ -446,7 +449,11 @@ describe('useExchangeForm', () => {
             const { result } = renderUseExchangeForm();
 
             act(() => {
-                store.dispatch(tradingExchangeActions.setTradingAccountKey('eth-account-1'));
+                store.dispatch(
+                    tradingExchangeActions.setTradingAccountKey(
+                        'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
+                    ),
+                );
                 result.current.setValue('sendAsset', usdcAsset);
                 result.current.setValue('sendCryptoAmount', amount);
             });
@@ -461,7 +468,7 @@ describe('useExchangeForm', () => {
         it('should trigger validation once limits are loaded', async () => {
             act(() => {
                 store.dispatch(tradingExchangeActions.setAmountLimits(undefined));
-                store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
             });
 
             const { result } = renderUseExchangeForm();

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
@@ -5,6 +5,7 @@ import {
     MinimalExchangeFormProps,
     tradingExchangeActions,
 } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import { EventType } from '@suite-native/analytics';
 import {
     PreloadedState,
@@ -259,7 +260,12 @@ describe('useExchangeQuotes', () => {
     it.each<[keyof ExchangeFormValues, ExchangeFormValues[keyof ExchangeFormValues]]>([
         ['receiveAsset', usdtAsset],
         ['sendCryptoAmount', '0.2'],
-        ['sendAccount', getBtcAccount('btc-account-2')],
+        [
+            'sendAccount',
+            getBtcAccount(
+                'btc-account-2' as AccountKey, // Todo: create properly via `createAccountKey()`
+            ),
+        ],
     ])('should refetch quotes on %s value change', async (field, value) => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { tradingExchangeActions, tradingSettingsActions } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import { EventType } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
 import {
@@ -66,8 +67,12 @@ describe('useExchangeSelectQuote', () => {
     let store: TestStore;
 
     const getInitializedStore = ({ isLoading }: { isLoading?: boolean }) => {
-        const btcAccount = getBtcAccount('btc-account-key');
-        const ethAccount = getEthAccount('eth-account-key');
+        const btcAccount = getBtcAccount(
+            'btc-account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
+        );
+        const ethAccount = getEthAccount(
+            'eth-account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
+        );
 
         const preloadedState: PreloadedState = {
             wallet: {
@@ -184,8 +189,12 @@ describe('useExchangeSelectQuote', () => {
         it('should not call selectQuoteThunk when account is not fully selected', async () => {
             act(() => {
                 [
-                    tradingExchangeActions.setReceiveAccountKey('btc-account-key'),
-                    tradingExchangeActions.setTradingAccountKey('eth-account-key'),
+                    tradingExchangeActions.setReceiveAccountKey(
+                        'btc-account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
+                    ),
+                    tradingExchangeActions.setTradingAccountKey(
+                        'eth-account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
+                    ),
                 ].forEach(store.dispatch);
                 exchangeForm.setValue('receiveAsset', btcAsset);
             });

--- a/suite-native/module-trading/src/hooks/general/__tests__/useAmountInputDecimals.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useAmountInputDecimals.test.ts
@@ -38,7 +38,7 @@ describe('useAmountInputDecimals', () => {
 
     it('should limit value to decimals based on network.decimals value for networks', async () => {
         const account = {
-            key: 'account_key',
+            key: 'account_key' as AccountKey, // Todo: create properly via `createAccountKey()`
             symbol: 'eth',
         } as Account;
         const { result } = await renderUseAmountInputDecimals(account, undefined);
@@ -48,7 +48,7 @@ describe('useAmountInputDecimals', () => {
 
     it('should limit value to decimals based on selectAccountTokenDecimals return value', async () => {
         const account = {
-            key: 'account_key',
+            key: 'account_key' as AccountKey, // Todo: create properly via `createAccountKey()`
             symbol: 'eth',
         } as Account;
         const contractAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress;
@@ -60,7 +60,7 @@ describe('useAmountInputDecimals', () => {
     it('should return undefined when selectAccountTokenDecimals returns nullish value', async () => {
         mockSelectAccountTokenDecimals.mockReturnValue(null);
         const account = {
-            key: 'account_key',
+            key: 'account_key' as AccountKey, // Todo: create properly via `createAccountKey()`
             symbol: 'eth',
         } as Account;
         const contractAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress;

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
@@ -1,3 +1,4 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     PreloadedState,
     TestStore,
@@ -62,14 +63,21 @@ jest.mock('@suite-common/wallet-core', () => ({
 }));
 
 describe('useTradingTransaction', () => {
-    const getMockAccounts = () => [getBtcAccount('btc1'), getBtcAccount('btc2')];
+    const getMockAccounts = () => [
+        getBtcAccount(
+            'btc1' as AccountKey, // Todo: create properly via `createAccountKey()`
+        ),
+        getBtcAccount(
+            'btc2' as AccountKey, // Todo: create properly via `createAccountKey()`
+        ),
+    ];
 
     const getInitializedStore = () => {
         const tradingState = getInitializedTradingStateWithQuotes();
 
         // Add the required account keys to the exchange state
-        tradingState.exchange.tradingAccountKey = 'btc1';
-        tradingState.exchange.receiveAccountKey = 'btc2';
+        tradingState.exchange.tradingAccountKey = 'btc1' as AccountKey; // Todo: create properly via `createAccountKey()`
+        tradingState.exchange.receiveAccountKey = 'btc2' as AccountKey; // Todo: create properly via `createAccountKey()`
         // Set a selected quote so the hook can access selectedQuote.send
         tradingState.exchange.selectedQuote = tradingState.exchange.quotes[0];
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useWatchTrade.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useWatchTrade.test.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { AccountKey } from '@suite-common/wallet-types';
 import { useAnalytics } from '@suite-native/services';
 import {
     PreloadedState,
@@ -28,7 +29,7 @@ const mockUseReloadTimer = require('../useReloadTimer').useReloadTimer;
 type ReportSpy = jest.SpyInstance;
 
 const useWatchTradeWithReportSpy = (props: {
-    accountKey?: string;
+    accountKey?: AccountKey;
     orderId?: string;
     isInProgress?: boolean;
 }) => {
@@ -47,6 +48,8 @@ const useWatchTradeWithReportSpy = (props: {
 
     return spyRef.current!;
 };
+
+const btc1AccountKey = 'btc1' as AccountKey; // Todo: create properly via `createAccountKey()`
 
 describe('useWatchTrade', () => {
     beforeEach(() => {
@@ -97,7 +100,7 @@ describe('useWatchTrade', () => {
 
     const renderUseWatchTrade = async (
         store: any,
-        props: { accountKey?: string; orderId?: string; isInProgress?: boolean },
+        props: { accountKey?: AccountKey; orderId?: string; isInProgress?: boolean },
     ) => {
         const hook = await renderHookWithStoreProviderAsync(
             () => useWatchTradeWithReportSpy(props),
@@ -111,7 +114,7 @@ describe('useWatchTrade', () => {
         it('should not dispatch watch trade thunk when no trade is found', async () => {
             const store = await getInitializedStore();
             await renderUseWatchTrade(store, {
-                accountKey: 'btc1',
+                accountKey: btc1AccountKey,
                 orderId: 'non-existent-order',
             });
 
@@ -125,7 +128,7 @@ describe('useWatchTrade', () => {
             });
 
             await renderUseWatchTrade(store, {
-                accountKey: 'non-existent-account',
+                accountKey: 'non-existent-account' as AccountKey, // Todo: create properly via `createAccountKey()`
                 orderId: buyTrade.data.orderId,
             });
 
@@ -139,7 +142,7 @@ describe('useWatchTrade', () => {
             });
 
             await renderUseWatchTrade(store, {
-                accountKey: 'btc1',
+                accountKey: btc1AccountKey as AccountKey, // Todo: create properly via `createAccountKey()`
                 orderId: buyTrade.data.orderId,
             });
 
@@ -165,7 +168,7 @@ describe('useWatchTrade', () => {
             });
 
             await renderUseWatchTrade(store, {
-                accountKey: 'btc1',
+                accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
             });
 
@@ -183,7 +186,7 @@ describe('useWatchTrade', () => {
             });
 
             await renderUseWatchTrade(store, {
-                accountKey: 'btc1',
+                accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
             });
 
@@ -199,7 +202,7 @@ describe('useWatchTrade', () => {
             });
 
             await renderUseWatchTrade(store, {
-                accountKey: 'btc1',
+                accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
                 isInProgress: true,
             });
@@ -217,7 +220,7 @@ describe('useWatchTrade', () => {
             });
 
             await renderUseWatchTrade(store, {
-                accountKey: 'btc1',
+                accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
                 isInProgress: false,
             });
@@ -235,7 +238,7 @@ describe('useWatchTrade', () => {
             });
 
             await renderUseWatchTrade(store, {
-                accountKey: 'btc1',
+                accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
             });
 

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useReceiveAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useReceiveAccountChangeEffect.test.ts
@@ -1,4 +1,5 @@
 import { tradingExchangeActions } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     TestStore,
     act,
@@ -38,12 +39,18 @@ describe('useReceiveAccountChangeEffect', () => {
 
         setValue.mockClear();
         act(() => {
-            store.dispatch(tradingExchangeActions.setReceiveAccountKey('btc-account-1'));
+            store.dispatch(
+                tradingExchangeActions.setReceiveAccountKey(
+                    'btc-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
+                ),
+            );
         });
 
         expect(setValue).toHaveBeenCalledTimes(1);
         expect(setValue).toHaveBeenCalledWith('receiveAccount', {
-            account: getBtcAccount('btc-account-1'),
+            account: getBtcAccount(
+                'btc-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            ),
             address: undefined,
         });
     });

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountChangeEffect.test.ts
@@ -1,4 +1,5 @@
 import { tradingExchangeActions } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     TestStore,
     act,
@@ -9,6 +10,9 @@ import { getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
 import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
 
 import { useSendAccountChangeEffect } from '../useSendAccountChangeEffect';
+
+const btc1AccountKey = 'btc-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
+const btc2AccountKey = 'btc-account-2' as AccountKey; // Todo: create properly via `createAccountKey()`
 
 describe('useSendAccountChangeEffect', () => {
     let store: TestStore;
@@ -41,17 +45,17 @@ describe('useSendAccountChangeEffect', () => {
 
         setValue.mockClear();
         act(() => {
-            store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
+            store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
         });
 
         expect(setValue).toHaveBeenCalledTimes(1);
-        expect(setValue).toHaveBeenCalledWith('sendAccount', getBtcAccount('btc-account-1'));
+        expect(setValue).toHaveBeenCalledWith('sendAccount', getBtcAccount(btc1AccountKey));
     });
 
     it('should set sendAsset to undefined when no trading account is selected', async () => {
         await renderUseSendAccountChangeEffect();
         act(() => {
-            store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
+            store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
         });
 
         setValue.mockClear();
@@ -67,15 +71,15 @@ describe('useSendAccountChangeEffect', () => {
     it('should not change sendAsset when trading account key changed', async () => {
         await renderUseSendAccountChangeEffect();
         act(() => {
-            store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
+            store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
         });
 
         setValue.mockClear();
         act(() => {
-            store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-2'));
+            store.dispatch(tradingExchangeActions.setTradingAccountKey(btc2AccountKey));
         });
 
         expect(setValue).toHaveBeenCalledTimes(1);
-        expect(setValue).toHaveBeenCalledWith('sendAccount', getBtcAccount('btc-account-2'));
+        expect(setValue).toHaveBeenCalledWith('sendAccount', getBtcAccount(btc2AccountKey));
     });
 });

--- a/suite-native/module-trading/src/hooks/general/useWatchTrade.ts
+++ b/suite-native/module-trading/src/hooks/general/useWatchTrade.ts
@@ -11,6 +11,7 @@ import {
     tradingThunks,
 } from '@suite-common/trading';
 import { AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import { events } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
 import { TradingRootState } from '@suite-native/trading-state';
@@ -25,7 +26,7 @@ export type TradingTradeMapProps = {
 };
 
 export interface TradingUseWatchTradeProps {
-    accountKey: string | undefined;
+    accountKey: AccountKey | undefined;
     orderId: string | undefined;
     isInProgress: boolean;
 }

--- a/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewErrorAlert.hook.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewErrorAlert.hook.test.ts
@@ -33,7 +33,9 @@ describe('useTradingOutputsReviewErrorAlert', () => {
     it('should show alert', async () => {
         const mockOnRetry = jest.fn();
         const mockOnCancel = jest.fn();
-        const { result } = await renderUseTradingOutputsReviewErrorAlert('btc-account-1');
+        const { result } = await renderUseTradingOutputsReviewErrorAlert(
+            'btc-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
+        );
 
         act(() => {
             result.current(mockOnRetry, mockOnCancel);
@@ -57,7 +59,9 @@ describe('useTradingOutputsReviewErrorAlert', () => {
     it('should show special text fort solana', async () => {
         const mockOnRetry = jest.fn();
         const mockOnCancel = jest.fn();
-        const { result } = await renderUseTradingOutputsReviewErrorAlert('sol-account-1');
+        const { result } = await renderUseTradingOutputsReviewErrorAlert(
+            'sol-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
+        );
 
         act(() => {
             result.current(mockOnRetry, mockOnCancel);

--- a/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewScreenControls.hook.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewScreenControls.hook.test.ts
@@ -1,4 +1,5 @@
 import { sendFormActions } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     TestStore,
     act,
@@ -58,7 +59,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
             () =>
                 useTradingOutputsReviewScreenControls({
                     orderId: 'orderId',
-                    accountKey: 'btc-account-1',
+                    accountKey: 'btc-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
                     signAndSendTransaction: mockSignAndSendTransaction,
                     reportToAnalytics: mockReportToAnalytics,
                 }),

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellData.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellData.test.tsx
@@ -1,4 +1,5 @@
 import { tradingSellActions, tradingThunks } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     PreloadedState,
     TestStore,
@@ -15,15 +16,19 @@ jest.mock('../../../utils/general/utils', () => ({
     getRandomAccountDescriptor: () => 'random_string',
 }));
 
+const btc1AccountKey = 'btc-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
+const btc2AccountKey = 'btc-account-2' as AccountKey; // Todo: create properly via `createAccountKey()`
+const btc3AccountKey = 'btc-account-3' as AccountKey; // Todo: create properly via `createAccountKey()`
+
 describe('useSellData', () => {
-    const getInitializedStore = (tradingAccountKey: string | undefined) => {
+    const getInitializedStore = (tradingAccountKey: AccountKey | undefined) => {
         const preloadedState: PreloadedState = {
             wallet: {
                 trading: getInitializedTradingState('sell'),
                 accounts: [
-                    getBtcAccount('btc-account-1'),
-                    getBtcAccount('btc-account-2'),
-                    { ...getBtcAccount('btc-account-3'), descriptor: '' },
+                    getBtcAccount(btc1AccountKey),
+                    getBtcAccount(btc2AccountKey),
+                    { ...getBtcAccount(btc3AccountKey), descriptor: '' },
                 ],
             },
         };
@@ -115,7 +120,7 @@ describe('useSellData', () => {
             initialThunkLoadActionSpy.mockClear();
 
             act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-2'));
+                store.dispatch(tradingSellActions.setTradingAccountKey(btc2AccountKey));
             });
 
             // Wait for the effect to run
@@ -130,14 +135,14 @@ describe('useSellData', () => {
         });
 
         it('should not dispatch loadInitialDataThunk when descriptor is not changed', async () => {
-            const store = await getInitializedStore('btc-account-2');
+            const store = await getInitializedStore(btc2AccountKey);
             await renderUseSellData(0, store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
             act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-2'));
+                store.dispatch(tradingSellActions.setTradingAccountKey(btc2AccountKey));
             });
 
             // Wait for effects to run
@@ -149,14 +154,14 @@ describe('useSellData', () => {
         });
 
         it('should dispatch loadInitialDataThunk with random string when descriptor is empty string', async () => {
-            const store = await getInitializedStore('btc-account-1');
+            const store = await getInitializedStore(btc1AccountKey);
             await renderUseSellData(0, store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
             act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-3'));
+                store.dispatch(tradingSellActions.setTradingAccountKey(btc3AccountKey));
             });
 
             // Wait for the effect to run
@@ -172,7 +177,7 @@ describe('useSellData', () => {
         });
 
         it('should dispatch loadInitialDataThunk with random string when descriptor is undefined', async () => {
-            const store = await getInitializedStore('btc-account-1');
+            const store = await getInitializedStore(btc1AccountKey);
             await renderUseSellData(0, store);
 
             // Clear the initial call

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
@@ -1,6 +1,7 @@
 import type { SellFiatTrade, SellFiatTradeResponse } from 'invity-api';
 
 import { tradingSellActions } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     TestStore,
     act,
@@ -62,6 +63,8 @@ jest.mock('../../general/useTradingTransaction', () => ({
     }),
 }));
 
+const btc1AccountKey = 'btc-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
+
 describe('useSellFlow', () => {
     let store: TestStore;
 
@@ -85,7 +88,7 @@ describe('useSellFlow', () => {
 
             // Set up required state
             act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
@@ -101,7 +104,7 @@ describe('useSellFlow', () => {
                 payload: expect.objectContaining({
                     trade,
                     account: expect.objectContaining({
-                        key: 'btc-account-1',
+                        key: btc1AccountKey,
                     }),
                     returnUrl: expect.stringContaining('trezorsuite://trading'),
                     processResponseData: expect.any(Function),
@@ -140,7 +143,7 @@ describe('useSellFlow', () => {
 
             // Set up account but not selectedQuote
             act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(undefined));
             });
 
@@ -168,7 +171,7 @@ describe('useSellFlow', () => {
 
             // Set up required state
             act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
@@ -184,7 +187,7 @@ describe('useSellFlow', () => {
                 payload: expect.objectContaining({
                     bankAccount,
                     account: expect.objectContaining({
-                        key: 'btc-account-1',
+                        key: btc1AccountKey,
                     }),
                     returnUrl: expect.stringContaining('trezorsuite://trading'),
                     triggerAnalyticsTradeConfirmation: expect.any(Function),
@@ -199,7 +202,7 @@ describe('useSellFlow', () => {
 
             // Set up account but not quote
             act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(undefined));
             });
 
@@ -247,7 +250,7 @@ describe('useSellFlow', () => {
             const trade = { ...sellQuotes[0], exchange: 'banxa-sell', quoteId: undefined };
 
             act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
@@ -270,7 +273,7 @@ describe('useSellFlow', () => {
             const trade = { ...sellQuotes[0], quoteId: '' };
 
             act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
@@ -294,7 +297,7 @@ describe('useSellFlow', () => {
             const trade = { ...sellQuotes[0], quoteId: 'test-quote-id' };
 
             act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
@@ -315,7 +318,7 @@ describe('useSellFlow', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
 
             act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(undefined));
             });
 
@@ -338,7 +341,7 @@ describe('useSellFlow', () => {
             const trade = sellQuotes[0];
 
             act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
@@ -1,6 +1,7 @@
 import type { SellFiatTrade } from 'invity-api';
 
 import { tradingSellActions } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import { EventType } from '@suite-native/analytics';
 import { Form, useField } from '@suite-native/forms';
 import {
@@ -44,6 +45,8 @@ jest.mock('@suite-native/services', () => {
     };
 });
 
+const btc1account = 'btc-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
+
 describe('useSellForm', () => {
     let store: TestStore;
 
@@ -76,10 +79,10 @@ describe('useSellForm', () => {
             const { result } = renderUseSellForm();
 
             act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.setTradingAccountKey(btc1account));
             });
 
-            expect(result.current.getValues('sendAccount')).toEqual(getBtcAccount('btc-account-1'));
+            expect(result.current.getValues('sendAccount')).toEqual(getBtcAccount(btc1account));
         });
     });
 
@@ -266,7 +269,7 @@ describe('useSellForm', () => {
             ])('should display error for crypto amount %s BTC', async (amount, expectedValue) => {
                 const { result } = renderUseSellForm();
                 act(() => {
-                    store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                    store.dispatch(tradingSellActions.setTradingAccountKey(btc1account));
                     result.current.setValue('amountInCrypto', true);
                     result.current.setValue('sendAsset', btcAsset);
                     result.current.setValue('cryptoStringAmount', amount);
@@ -294,7 +297,7 @@ describe('useSellForm', () => {
                 store = getInitializedStore(PROTO.AmountUnit.SATOSHI);
                 const { result } = renderUseSellForm();
                 act(() => {
-                    store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                    store.dispatch(tradingSellActions.setTradingAccountKey(btc1account));
                     result.current.setValue('amountInCrypto', true);
                     result.current.setValue('sendAsset', btcAsset);
                     result.current.setValue('cryptoStringAmount', amount);
@@ -322,7 +325,11 @@ describe('useSellForm', () => {
                 async (amount, expectedInvalid) => {
                     const { result } = renderUseSellForm();
                     act(() => {
-                        store.dispatch(tradingSellActions.setTradingAccountKey('eth-account-1'));
+                        store.dispatch(
+                            tradingSellActions.setTradingAccountKey(
+                                'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
+                            ),
+                        );
                         result.current.setValue('amountInCrypto', true);
                         result.current.setValue('sendAsset', usdcAsset);
                         result.current.setValue('cryptoStringAmount', amount);
@@ -338,7 +345,11 @@ describe('useSellForm', () => {
             it("should be validated once the quote is selected and it changes it's value", async () => {
                 const { result } = renderUseSellForm();
                 act(() => {
-                    store.dispatch(tradingSellActions.setTradingAccountKey('eth-account-1'));
+                    store.dispatch(
+                        tradingSellActions.setTradingAccountKey(
+                            'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
+                        ),
+                    );
                     result.current.setValue('amountInCrypto', false);
                     result.current.setValue('sendAsset', usdcAsset);
                     result.current.setValue('fiatStringAmount', '100');
@@ -371,7 +382,7 @@ describe('useSellForm', () => {
             ])('should display fiat error for amount %s', async (amount, expectedValue) => {
                 const { result } = renderUseSellForm();
                 act(() => {
-                    store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                    store.dispatch(tradingSellActions.setTradingAccountKey(btc1account));
                     result.current.setValue('amountInCrypto', false);
                     result.current.setValue('sendAsset', btcAsset);
                     result.current.setValue('fiatStringAmount', amount);
@@ -395,7 +406,7 @@ describe('useSellForm', () => {
         it('should trigger validation once limits are loaded', async () => {
             act(() => {
                 store.dispatch(tradingSellActions.setAmountLimits(undefined));
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(tradingSellActions.setTradingAccountKey(btc1account));
             });
             const { result } = renderUseSellForm();
             act(() => {
@@ -517,7 +528,7 @@ describe('useSellForm', () => {
         const initFormAndQuoteRequest = (form: SellFormType) => {
             act(() => {
                 form.setValue('sendAsset', btcAsset);
-                form.setValue('sendAccount', getBtcAccount('btc-account-1'));
+                form.setValue('sendAccount', getBtcAccount(btc1account));
                 form.setValue('amountInCrypto', false);
                 form.setValue('fiatStringAmount', '10');
             });

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellQuotes.test.ts
@@ -1,4 +1,5 @@
 import { INVITY_API_RELOAD_QUOTES_AFTER_SECONDS, tradingSellActions } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     PreloadedState,
     TestStore,
@@ -160,7 +161,12 @@ describe('useSellQuotes', () => {
     it.each([
         ['fiatStringAmount', '1000'],
         ['country', 'CZ'],
-        ['sendAccount', getBtcAccount('btc-account-2')],
+        [
+            'sendAccount',
+            getBtcAccount(
+                'btc-account-2' as AccountKey, // Todo: create properly via `createAccountKey()`
+            ),
+        ],
     ] as [keyof SellFormValues, SellFormValues[keyof SellFormValues]][])(
         'should re-fetch quotes on %s value change',
         async (field, value) => {
@@ -281,7 +287,11 @@ describe('useSellQuotes', () => {
         const { result } = renderUseSellQuotes(store);
 
         act(() => {
-            store.dispatch(tradingSellActions.setTradingAccountKey('eth-account-1'));
+            store.dispatch(
+                tradingSellActions.setTradingAccountKey(
+                    'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
+                ),
+            );
             result.current.setValue('sendAsset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
             result.current.setValue('amountInCrypto', false);

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellSelectQuote.test.ts
@@ -1,4 +1,5 @@
 import { tradingSellActions } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     TestStore,
     act,
@@ -54,7 +55,11 @@ describe('useSellSelectQuote', () => {
 
         it('should be false when form contains error', async () => {
             act(() => {
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(
+                    tradingSellActions.setTradingAccountKey(
+                        'btc-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
+                    ),
+                );
                 sellForm.setValue('quote', sellQuotes[0]);
                 sellForm.setError('cryptoStringAmount', {
                     type: 'manual',
@@ -70,7 +75,11 @@ describe('useSellSelectQuote', () => {
         it('should be true when quote is selected', async () => {
             act(() => {
                 sellForm.setValue('quote', sellQuotes[0]);
-                store.dispatch(tradingSellActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(
+                    tradingSellActions.setTradingAccountKey(
+                        'btc-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
+                    ),
+                );
             });
 
             const { result } = await renderUseSellSelectQuote();

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.comp.test.tsx
@@ -4,6 +4,7 @@ import {
     selectTradingExchangePreselectedQuote,
     tradingExchangeActions,
 } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import { TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
 import {
     TestStore,
@@ -70,7 +71,11 @@ describe('TradingExchangeApprovalScreen', () => {
 
         store = initStore(preloadedState).store;
         store.dispatch(tradingExchangeActions.savePreselectedQuote(testQuote));
-        store.dispatch(tradingExchangeActions.setTradingAccountKey('eth-account-1'));
+        store.dispatch(
+            tradingExchangeActions.setTradingAccountKey(
+                'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            ),
+        );
     });
 
     afterEach(() => {

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
@@ -1,7 +1,7 @@
 import { RouteProp } from '@react-navigation/native';
 import type { ExchangeTrade } from 'invity-api';
 
-import { GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { AccountKey, GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { EventType } from '@suite-native/analytics';
 import { TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
 import { useAnalytics } from '@suite-native/services';
@@ -83,8 +83,8 @@ const createPreloadedState = (quote?: ExchangeTrade): PreloadedState => {
     preloadedState.wallet.trading.exchange = {
         ...preloadedState.wallet.trading.exchange,
         quotes: exchangeQuotes,
-        tradingAccountKey: 'eth-account-1',
-        receiveAccountKey: 'btc-account-1',
+        tradingAccountKey: 'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
+        receiveAccountKey: 'btc-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
         receiveAddress: getBtcAccount().addresses?.used[0].address,
         selectedQuote: quote ?? exchangeQuotes[0],
     };

--- a/suite-native/module-trading/src/utils/__tests__/tradingFormUtils.test.ts
+++ b/suite-native/module-trading/src/utils/__tests__/tradingFormUtils.test.ts
@@ -1,12 +1,13 @@
 import type { ExchangeTrade, SellFiatTrade } from 'invity-api';
 
+import { AccountKey } from '@suite-common/wallet-types';
 import { exchangeInvity, sellInvity } from '@suite-native/trading-fixtures';
 
 import { createFormStateForSendForm } from '../tradingFormUtils';
 
 describe('createFormStateForSendForm', () => {
     describe('createTradingFormState', () => {
-        const sendAccountKey = '';
+        const sendAccountKey = 'send-account-key' as AccountKey;
         it('should create FormState for exchange quote (swap)', () => {
             const exchangeQuote: ExchangeTrade = {
                 exchange: 'sideshiftfr',

--- a/suite-native/module-trading/src/utils/tradingFormUtils.ts
+++ b/suite-native/module-trading/src/utils/tradingFormUtils.ts
@@ -11,7 +11,7 @@ import {
     isExchangeTrade,
     isSellFiatTrade,
 } from '@suite-common/trading';
-import { FormState, FormStateTrading } from '@suite-common/wallet-types';
+import { AccountKey, FormState, FormStateTrading } from '@suite-common/wallet-types';
 import { FeeLevel } from '@trezor/connect';
 
 interface CreateFormStateForSendFormParams {
@@ -23,8 +23,8 @@ interface CreateFormStateForSendFormParams {
     >;
     extraField?: string;
     isSlip24Active?: boolean;
-    sendAccountKey: string | undefined;
-    receiveAccountKey?: string | undefined;
+    sendAccountKey: AccountKey | undefined;
+    receiveAccountKey?: AccountKey | undefined;
 }
 
 /**

--- a/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
@@ -11,6 +11,7 @@ import {
     selectIsTransactionPending,
     selectTransactionByAccountKeyAndTxid,
 } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import { events } from '@suite-native/analytics';
 import { Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
@@ -46,7 +47,11 @@ export const TransactionDetailScreen = ({
         selectExplorer(state, transaction?.symbol),
     );
     const isPending = useSelector((state: TransactionsRootState) =>
-        selectIsTransactionPending(state, txid, accountKey),
+        selectIsTransactionPending(
+            state,
+            txid as AccountKey, // Todo: I think this is a bug
+            accountKey,
+        ),
     );
 
     const tokenTransfer = transaction?.tokens.find(token => token.contract === tokenContract);

--- a/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
@@ -11,7 +11,6 @@ import {
     selectIsTransactionPending,
     selectTransactionByAccountKeyAndTxid,
 } from '@suite-common/wallet-core';
-import { AccountKey } from '@suite-common/wallet-types';
 import { events } from '@suite-native/analytics';
 import { Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
@@ -47,11 +46,7 @@ export const TransactionDetailScreen = ({
         selectExplorer(state, transaction?.symbol),
     );
     const isPending = useSelector((state: TransactionsRootState) =>
-        selectIsTransactionPending(
-            state,
-            txid as AccountKey, // Todo: I think this is a bug
-            accountKey,
-        ),
+        selectIsTransactionPending(state, accountKey, txid),
     );
 
     const tokenTransfer = transaction?.tokens.find(token => token.contract === tokenContract);

--- a/suite-native/send/package.json
+++ b/suite-native/send/package.json
@@ -23,6 +23,7 @@
         "@suite-native/tokens": "workspace:*",
         "@suite-native/transaction-management": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
-        "@trezor/connect": "workspace:*"
+        "@trezor/connect": "workspace:*",
+        "@trezor/utils": "workspace:*"
     }
 }

--- a/suite-native/send/src/sendFormThunks.ts
+++ b/suite-native/send/src/sendFormThunks.ts
@@ -34,6 +34,7 @@ import {
 } from '@suite-native/transaction-management';
 import { BlockbookTransaction } from '@trezor/blockchain-link-types';
 import { Success } from '@trezor/connect';
+import { typedObjectKeys } from '@trezor/utils';
 
 import { SEND_MODULE_PREFIX } from './constants';
 
@@ -127,12 +128,12 @@ export const removeSendFormDraftsSupportingAmountUnitThunk = createThunk(
     (_, { dispatch, getState }) => {
         const sendFormDrafts = selectSendFormDrafts(getState());
         // Draft keys may include tokenContract, but no token networks use amount-unit, so it's fine (for now).
-        const accountKeys = Object.keys(sendFormDrafts);
+        const accountKeys = typedObjectKeys(sendFormDrafts);
 
         accountKeys.forEach(accountKey => {
-            const account = selectAccountByKey(getState(), accountKey);
+            const account = selectAccountByKey(getState(), accountKey as AccountKey); // Todo: is this cast correct? https://github.com/trezor/trezor-suite/issues/24918
             if (account && hasNetworkFeatures(account, 'amount-unit')) {
-                dispatch(sendFormActions.removeDraft({ accountKey }));
+                dispatch(sendFormActions.removeDraft({ accountKey: accountKey as AccountKey })); // Todo: is this cast correct? https://github.com/trezor/trezor-suite/issues/24918
             }
         });
     },

--- a/suite-native/send/tsconfig.json
+++ b/suite-native/send/tsconfig.json
@@ -22,6 +22,7 @@
         {
             "path": "../../packages/blockchain-link-types"
         },
-        { "path": "../../packages/connect" }
+        { "path": "../../packages/connect" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite-native/staking/src/__tests__/ethereumStakingSelectors.test.ts
+++ b/suite-native/staking/src/__tests__/ethereumStakingSelectors.test.ts
@@ -1,5 +1,5 @@
 import { TrezorDevice } from '@suite-common/suite-types';
-import { Account } from '@suite-common/wallet-types';
+import { Account, AccountKey } from '@suite-common/wallet-types';
 
 import {
     selectEthereumAccountHasStaking,
@@ -99,7 +99,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return staking pool for account with staking', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumStakingPoolByAccountKey(testState as any, 'eth1');
+            const result = selectEthereumStakingPoolByAccountKey(
+                testState as any,
+                'eth1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toEqual({
                 name: 'Everstake',
@@ -119,7 +122,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return undefined for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumStakingPoolByAccountKey(testState as any, 'eth2');
+            const result = selectEthereumStakingPoolByAccountKey(
+                testState as any,
+                'eth2' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBeUndefined();
         });
@@ -127,7 +133,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return null for non-existent account', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumStakingPoolByAccountKey(testState as any, 'non-existent');
+            const result = selectEthereumStakingPoolByAccountKey(
+                testState as any,
+                'non-existent' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBeNull();
         });
@@ -137,7 +146,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return true for account with staking', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumAccountHasStaking(testState as any, 'eth1');
+            const result = selectEthereumAccountHasStaking(
+                testState as any,
+                'eth1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(true);
         });
@@ -145,7 +157,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return false for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumAccountHasStaking(testState as any, 'eth2');
+            const result = selectEthereumAccountHasStaking(
+                testState as any,
+                'eth2' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(false);
         });
@@ -155,7 +170,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return true for account with pending stake', () => {
             const testState = getTestState([ethAccountWithPendingStake]);
 
-            const result = selectEthereumIsStakePendingByAccountKey(testState as any, 'eth3');
+            const result = selectEthereumIsStakePendingByAccountKey(
+                testState as any,
+                'eth3' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(true);
         });
@@ -163,7 +181,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return false for account without pending stake', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumIsStakePendingByAccountKey(testState as any, 'eth1');
+            const result = selectEthereumIsStakePendingByAccountKey(
+                testState as any,
+                'eth1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(true);
         });
@@ -171,7 +192,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return false for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumIsStakePendingByAccountKey(testState as any, 'eth2');
+            const result = selectEthereumIsStakePendingByAccountKey(
+                testState as any,
+                'eth2' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(false);
         });
@@ -181,7 +205,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return staked balance for account with staking', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumStakedBalanceByAccountKey(testState as any, 'eth1');
+            const result = selectEthereumStakedBalanceByAccountKey(
+                testState as any,
+                'eth1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('2');
         });
@@ -189,7 +216,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return "0" for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumStakedBalanceByAccountKey(testState as any, 'eth2');
+            const result = selectEthereumStakedBalanceByAccountKey(
+                testState as any,
+                'eth2' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('0');
         });
@@ -199,7 +229,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return rewards balance for account with staking', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumRewardsBalanceByAccountKey(testState as any, 'eth1');
+            const result = selectEthereumRewardsBalanceByAccountKey(
+                testState as any,
+                'eth1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('0.05');
         });
@@ -207,7 +240,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return "0" for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumRewardsBalanceByAccountKey(testState as any, 'eth2');
+            const result = selectEthereumRewardsBalanceByAccountKey(
+                testState as any,
+                'eth2' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('0');
         });
@@ -217,7 +253,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return pending stake balance for account with pending stake', () => {
             const testState = getTestState([ethAccountWithPendingStake]);
 
-            const result = selectEthereumTotalStakePendingByAccountKey(testState as any, 'eth3');
+            const result = selectEthereumTotalStakePendingByAccountKey(
+                testState as any,
+                'eth3' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('1');
         });
@@ -225,7 +264,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return "0" for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumTotalStakePendingByAccountKey(testState as any, 'eth2');
+            const result = selectEthereumTotalStakePendingByAccountKey(
+                testState as any,
+                'eth2' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('0');
         });
@@ -235,7 +277,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return claimable amount for account with claimable stake', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumClaimableAmountByAccountKey(testState as any, 'eth1');
+            const result = selectEthereumClaimableAmountByAccountKey(
+                testState as any,
+                'eth1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('0.5');
         });
@@ -243,7 +288,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return "0" for account without claimable stake', () => {
             const testState = getTestState([ethAccountWithPendingStake]);
 
-            const result = selectEthereumClaimableAmountByAccountKey(testState as any, 'eth3');
+            const result = selectEthereumClaimableAmountByAccountKey(
+                testState as any,
+                'eth3' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('0');
         });
@@ -251,7 +299,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return "0" for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumClaimableAmountByAccountKey(testState as any, 'eth2');
+            const result = selectEthereumClaimableAmountByAccountKey(
+                testState as any,
+                'eth2' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('0');
         });
@@ -261,7 +312,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return true for account with claimable stake', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumCanClaimByAccountKey(testState as any, 'eth1');
+            const result = selectEthereumCanClaimByAccountKey(
+                testState as any,
+                'eth1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(true);
         });
@@ -269,7 +323,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return false for account without claimable stake', () => {
             const testState = getTestState([ethAccountWithPendingStake]);
 
-            const result = selectEthereumCanClaimByAccountKey(testState as any, 'eth3');
+            const result = selectEthereumCanClaimByAccountKey(
+                testState as any,
+                'eth3' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(false);
         });
@@ -277,7 +334,10 @@ describe('ethereumStakingSelectors', () => {
         it('should return false for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumCanClaimByAccountKey(testState as any, 'eth2');
+            const result = selectEthereumCanClaimByAccountKey(
+                testState as any,
+                'eth2' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(false);
         });

--- a/suite-native/staking/src/__tests__/selectors.test.ts
+++ b/suite-native/staking/src/__tests__/selectors.test.ts
@@ -1,4 +1,4 @@
-import { Account } from '@suite-common/wallet-types';
+import { Account, AccountKey } from '@suite-common/wallet-types';
 
 import {
     selectAPYBySymbol,
@@ -53,7 +53,7 @@ const etcAccount: Account = {
     symbol: 'etc',
     accountLabel: 'ETC Account #1',
     deviceState: 'device@state:1',
-    key: 'etc1',
+    key: 'etc1' as AccountKey, // Todo: create properly via `createAccountKey()`
     visible: true,
     networkType: 'ethereum',
 } as unknown as Account;
@@ -122,7 +122,10 @@ describe('main staking selectors', () => {
         it('should return claimable amount for ETH account with claimable stake', () => {
             const testState = getTestState([ethAccountWithClaimableStake]);
 
-            const result = selectClaimableAmountByAccountKey(testState as any, 'eth1');
+            const result = selectClaimableAmountByAccountKey(
+                testState as any,
+                'eth1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('0.5');
         });
@@ -130,7 +133,10 @@ describe('main staking selectors', () => {
         it('should return "0" for SOL account without claimable stake', () => {
             const testState = getTestState([solAccountWithStaking]);
 
-            const result = selectClaimableAmountByAccountKey(testState as any, 'sol1');
+            const result = selectClaimableAmountByAccountKey(
+                testState as any,
+                'sol1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('0');
         });
@@ -138,7 +144,10 @@ describe('main staking selectors', () => {
         it('should return "0" for unsupported network', () => {
             const testState = getTestState([etcAccount]);
 
-            const result = selectClaimableAmountByAccountKey(testState as any, 'etc1');
+            const result = selectClaimableAmountByAccountKey(
+                testState as any,
+                'etc1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('0');
         });
@@ -146,7 +155,10 @@ describe('main staking selectors', () => {
         it('should return "0" for non-existent account', () => {
             const testState = getTestState([ethAccountWithClaimableStake]);
 
-            const result = selectClaimableAmountByAccountKey(testState as any, 'non-existent');
+            const result = selectClaimableAmountByAccountKey(
+                testState as any,
+                'non-existent' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('0');
         });
@@ -156,7 +168,10 @@ describe('main staking selectors', () => {
         it('should return true for ETH account with claimable stake', () => {
             const testState = getTestState([ethAccountWithClaimableStake]);
 
-            const result = selectCanClaimByAccountKey(testState as any, 'eth1');
+            const result = selectCanClaimByAccountKey(
+                testState as any,
+                'eth1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(true);
         });
@@ -164,7 +179,10 @@ describe('main staking selectors', () => {
         it('should return false for SOL account without claimable stake', () => {
             const testState = getTestState([solAccountWithStaking]);
 
-            const result = selectCanClaimByAccountKey(testState as any, 'sol1');
+            const result = selectCanClaimByAccountKey(
+                testState as any,
+                'sol1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(false);
         });
@@ -172,7 +190,10 @@ describe('main staking selectors', () => {
         it('should return false for unsupported network', () => {
             const testState = getTestState([etcAccount]);
 
-            const result = selectCanClaimByAccountKey(testState as any, 'etc1');
+            const result = selectCanClaimByAccountKey(
+                testState as any,
+                'etc1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(false);
         });
@@ -180,7 +201,10 @@ describe('main staking selectors', () => {
         it('should return false for non-existent account', () => {
             const testState = getTestState([ethAccountWithClaimableStake]);
 
-            const result = selectCanClaimByAccountKey(testState as any, 'non-existent');
+            const result = selectCanClaimByAccountKey(
+                testState as any,
+                'non-existent' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(false);
         });

--- a/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
+++ b/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
@@ -1,7 +1,7 @@
 import { initialSuiteSyncDataState, initialSuiteSyncState } from '@suite-common/suite-sync';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { StakeState, stakeInitialState } from '@suite-common/wallet-core';
-import { Account, Timestamp } from '@suite-common/wallet-types';
+import { Account, AccountKey, Timestamp } from '@suite-common/wallet-types';
 
 import {
     selectExpectedRewardsForEpoch,
@@ -198,7 +198,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'sol1',
+                    'sol1' as AccountKey, // Todo: create properly via `createAccountKey()`,
                 )?.solStakedBalance,
             ).toEqual('1');
         });
@@ -213,7 +213,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'sol1',
+                    'sol1' as AccountKey, // Todo: create properly via `createAccountKey()`F
                 ),
             ).toBeNull();
         });
@@ -228,7 +228,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'sol3',
+                    'sol3' as AccountKey, // Todo: create properly via `createAccountKey()`
                 )?.solPendingStakeBalance,
             ).toEqual('2');
         });
@@ -245,7 +245,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'sol3',
+                    'sol3' as AccountKey, // Todo: create properly via `createAccountKey()`
                 ),
             ).toEqual(true);
         });
@@ -260,7 +260,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'sol3',
+                    'sol3' as AccountKey, // Todo: create properly via `createAccountKey()`
                 ),
             ).toEqual(false);
         });
@@ -278,7 +278,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'sol3',
+                    'sol3' as AccountKey, // Todo: create properly via `createAccountKey()`
                 ),
             ).toEqual(6.21);
         });
@@ -293,7 +293,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'sol3',
+                    'sol3' as AccountKey, // Todo: create properly via `createAccountKey()`
                 ),
             ).toEqual(0);
         });
@@ -310,7 +310,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'sol1',
+                    'sol1' as AccountKey, // Todo: create properly via `createAccountKey()`
                 ),
             ).toEqual('1');
         });
@@ -325,7 +325,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'non-existent-key',
+                    'non-existent-key' as AccountKey, // Todo: create properly via `createAccountKey()`
                 ),
             ).toEqual('0');
         });
@@ -343,7 +343,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'sol1',
+                    'sol1' as AccountKey, // Todo: create properly via `createAccountKey()`
                 ),
             ).toEqual('0.000340274');
         });
@@ -359,7 +359,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'sol3',
+                    'sol3' as AccountKey, // Todo: create properly via `createAccountKey()`
                 ),
             ).toEqual('0.000000000');
         });
@@ -374,7 +374,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'non-existent-key',
+                    'non-existent-key' as AccountKey, // Todo: create properly via `createAccountKey()`
                 ),
             ).toEqual('0');
         });
@@ -391,7 +391,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'sol3',
+                    'sol3' as AccountKey, // Todo: create properly via `createAccountKey()`
                 ),
             ).toEqual('2');
         });
@@ -406,7 +406,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'non-existent-key',
+                    'non-existent-key' as AccountKey, // Todo: create properly via `createAccountKey()`
                 ),
             ).toEqual('0');
         });
@@ -421,7 +421,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'sol1',
+                    'sol1' as AccountKey, // Todo: create properly via `createAccountKey()`
                 ),
             ).toEqual('0');
         });
@@ -433,7 +433,10 @@ describe('selectors', () => {
                 accounts: [solAccountWithStaking],
             });
 
-            const result = selectSolanaClaimableAmountByAccountKey(testState as any, 'sol1');
+            const result = selectSolanaClaimableAmountByAccountKey(
+                testState as any,
+                'sol1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('0');
         });
@@ -443,7 +446,10 @@ describe('selectors', () => {
                 accounts: [solAccountWithDeactivatedStaking],
             });
 
-            const result = selectSolanaClaimableAmountByAccountKey(testState as any, 'sol4');
+            const result = selectSolanaClaimableAmountByAccountKey(
+                testState as any,
+                'sol4' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('3');
         });
@@ -453,7 +459,10 @@ describe('selectors', () => {
                 accounts: [solAccountNoStaking],
             });
 
-            const result = selectSolanaClaimableAmountByAccountKey(testState as any, 'sol2');
+            const result = selectSolanaClaimableAmountByAccountKey(
+                testState as any,
+                'sol2' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('0');
         });
@@ -463,7 +472,10 @@ describe('selectors', () => {
                 accounts: [solAccountWithStaking],
             });
 
-            const result = selectSolanaClaimableAmountByAccountKey(testState, 'non-existent');
+            const result = selectSolanaClaimableAmountByAccountKey(
+                testState,
+                'non-existent' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe('0');
         });
@@ -475,7 +487,10 @@ describe('selectors', () => {
                 accounts: [solAccountWithStaking],
             });
 
-            const result = selectSolanaCanClaimByAccountKey(testState as any, 'sol1');
+            const result = selectSolanaCanClaimByAccountKey(
+                testState as any,
+                'sol1' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(false);
         });
@@ -485,7 +500,10 @@ describe('selectors', () => {
                 accounts: [solAccountWithDeactivatedStaking],
             });
 
-            const result = selectSolanaCanClaimByAccountKey(testState as any, 'sol4');
+            const result = selectSolanaCanClaimByAccountKey(
+                testState as any,
+                'sol4' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(true);
         });
@@ -495,7 +513,10 @@ describe('selectors', () => {
                 accounts: [solAccountNoStaking],
             });
 
-            const result = selectSolanaCanClaimByAccountKey(testState as any, 'sol2');
+            const result = selectSolanaCanClaimByAccountKey(
+                testState as any,
+                'sol2' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(false);
         });
@@ -505,7 +526,10 @@ describe('selectors', () => {
                 accounts: [solAccountWithStaking],
             });
 
-            const result = selectSolanaCanClaimByAccountKey(testState as any, 'non-existent');
+            const result = selectSolanaCanClaimByAccountKey(
+                testState as any,
+                'non-existent' as AccountKey, // Todo: create properly via `createAccountKey()`
+            );
 
             expect(result).toBe(false);
         });

--- a/suite-native/staking/src/cardanoStakingSelectors.ts
+++ b/suite-native/staking/src/cardanoStakingSelectors.ts
@@ -6,6 +6,7 @@ import {
     selectCardanoPoolsInfo,
     selectDeviceAccounts,
 } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     getStakingDataForNetwork,
     isCardanoStakedOutsideEverstake,
@@ -30,7 +31,7 @@ export const selectVisibleDeviceCardanoAccountsWithStakingByNetworkSymbol = crea
 
 export const selectCardanoStakedBalanceByAccountKey = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const account = selectAccountByKey(state, accountKey);
     if (!account || account.networkType !== 'cardano') return null;
@@ -42,7 +43,7 @@ export const selectCardanoStakedBalanceByAccountKey = (
 
 export const selectCardanoRewardsBalanceByAccountKey = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const account = selectAccountByKey(state, accountKey);
     if (!account || account.networkType !== 'cardano') return null;
@@ -54,7 +55,7 @@ export const selectCardanoRewardsBalanceByAccountKey = (
 
 export const selectCardanoTotalStakePendingByAccountKey = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const account = selectAccountByKey(state, accountKey);
     if (!account || account.networkType !== 'cardano') return null;
@@ -66,7 +67,7 @@ export const selectCardanoTotalStakePendingByAccountKey = (
 
 export const selectIsCardanoStakedWithFiveBinaries = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const account = selectAccountByKey(state, accountKey);
     if (!account || account.networkType !== 'cardano') return false;
@@ -76,7 +77,7 @@ export const selectIsCardanoStakedWithFiveBinaries = (
 
 export const selectIsCardanoStakedOutsideEverstake = (
     state: NativeStakingRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const account = selectAccountByKey(state, accountKey);
     if (!account || account.networkType !== 'cardano') return false;

--- a/suite-native/staking/src/ethereumStakingSelectors.ts
+++ b/suite-native/staking/src/ethereumStakingSelectors.ts
@@ -26,7 +26,7 @@ export const selectVisibleDeviceEthereumAccountsWithStakingByNetworkSymbol = (
 
 export const selectEthereumStakingPoolByAccountKey = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const account = selectAccountByKey(state, accountKey);
     if (!account) return null;
@@ -41,7 +41,7 @@ export const selectEthereumAccountHasStaking = (
 
 export const selectEthereumIsStakePendingByAccountKey = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const stakingPool = selectEthereumStakingPoolByAccountKey(state, accountKey);
     const isStakePending = Number(stakingPool?.totalPendingStakeBalance ?? 0) > 0;
@@ -51,7 +51,7 @@ export const selectEthereumIsStakePendingByAccountKey = (
 
 export const selectEthereumIsStakeConfirmingByAccountKey = (
     state: NativeStakingRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const stakeTxs = selectAccountStakeTransactions(state, accountKey);
     const isStakeConfirming = stakeTxs.some(tx => isPending(tx));
@@ -61,7 +61,7 @@ export const selectEthereumIsStakeConfirmingByAccountKey = (
 
 export const selectEthereumStakedBalanceByAccountKey = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const stakingPool = selectEthereumStakingPoolByAccountKey(state, accountKey);
 
@@ -70,7 +70,7 @@ export const selectEthereumStakedBalanceByAccountKey = (
 
 export const selectEthereumRewardsBalanceByAccountKey = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const stakingPool = selectEthereumStakingPoolByAccountKey(state, accountKey);
 
@@ -79,7 +79,7 @@ export const selectEthereumRewardsBalanceByAccountKey = (
 
 export const selectEthereumTotalStakePendingByAccountKey = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const stakingPool = selectEthereumStakingPoolByAccountKey(state, accountKey);
 
@@ -88,7 +88,7 @@ export const selectEthereumTotalStakePendingByAccountKey = (
 
 export const selectEthereumClaimableAmountByAccountKey = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const stakingPool = selectEthereumStakingPoolByAccountKey(state, accountKey);
 
@@ -97,7 +97,7 @@ export const selectEthereumClaimableAmountByAccountKey = (
 
 export const selectEthereumCanClaimByAccountKey = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const stakingPool = selectEthereumStakingPoolByAccountKey(state, accountKey);
 

--- a/suite-native/staking/src/solanaStakingSelectors.ts
+++ b/suite-native/staking/src/solanaStakingSelectors.ts
@@ -7,6 +7,7 @@ import {
     selectDeviceAccounts,
     selectPoolStatsApyData,
 } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     calculateSolanaStakingReward,
     getSolStakingAccountsInfo,
@@ -42,7 +43,7 @@ export const selectSolStakingAccountsInfoByAccountKey = createMemoizedSelector(
 
 export const selectSolanaIsStakePendingByAccountKey = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const stakingInfo = selectSolStakingAccountsInfoByAccountKey(state, accountKey);
 
@@ -55,7 +56,7 @@ export const selectSolanaIsStakePendingByAccountKey = (
 
 export const selectSolanaAPYByAccountKey = (
     state: StakeRootState & AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const account = selectAccountByKey(state, accountKey);
     if (!account) return 0;
@@ -65,7 +66,7 @@ export const selectSolanaAPYByAccountKey = (
 
 export const selectSolanaStakedBalanceByAccountKey = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const stakingInfo = selectSolStakingAccountsInfoByAccountKey(state, accountKey);
     if (!stakingInfo) {
@@ -79,7 +80,7 @@ export const selectSolanaStakedBalanceByAccountKey = (
 
 export const selectExpectedRewardsForEpoch = (
     state: StakeRootState & AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const stakingInfo = selectSolStakingAccountsInfoByAccountKey(state, accountKey);
     const apy = selectSolanaAPYByAccountKey(state, accountKey)?.toString();
@@ -97,7 +98,7 @@ export const selectExpectedRewardsForEpoch = (
 
 export const selectSolanaTotalStakePendingByAccountKey = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const stakingInfo = selectSolStakingAccountsInfoByAccountKey(state, accountKey);
     if (!stakingInfo) {
@@ -109,7 +110,7 @@ export const selectSolanaTotalStakePendingByAccountKey = (
 
 export const selectSolanaClaimableAmountByAccountKey = (
     state: AccountsRootState,
-    accountKey: string,
+    accountKey: AccountKey,
 ) => {
     const stakingInfo = selectSolStakingAccountsInfoByAccountKey(state, accountKey);
     if (!stakingInfo) {
@@ -119,7 +120,10 @@ export const selectSolanaClaimableAmountByAccountKey = (
     return stakingInfo.solClaimableBalance;
 };
 
-export const selectSolanaCanClaimByAccountKey = (state: AccountsRootState, accountKey: string) => {
+export const selectSolanaCanClaimByAccountKey = (
+    state: AccountsRootState,
+    accountKey: AccountKey,
+) => {
     const stakingInfo = selectSolStakingAccountsInfoByAccountKey(state, accountKey);
     if (!stakingInfo) {
         return false;

--- a/suite-native/tokens/src/__tests__/tokensSelectors.test.ts
+++ b/suite-native/tokens/src/__tests__/tokensSelectors.test.ts
@@ -1,4 +1,4 @@
-import { TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 
 import { btcAccount, ethAccount } from '../__fixtures__/accounts';
 import { TokensRootState, selectAccountTokenInfo } from '../tokensSelectors';
@@ -48,7 +48,7 @@ describe('tokensSelectors', () => {
             expect(
                 selectAccountTokenInfo(
                     getState(),
-                    'UNKNOWN_ACCOUNT_KEY',
+                    'UNKNOWN_ACCOUNT_KEY' as AccountKey, // Todo: create properly via `createAccountKey()`
                     '0x4d224452801ACEd8B2F0aebE155379bb5D594381' as TokenAddress,
                 ),
             ).toBeNull();

--- a/suite-native/tokens/src/tokensSelectors.ts
+++ b/suite-native/tokens/src/tokensSelectors.ts
@@ -214,7 +214,7 @@ export const selectHasDeviceAnyTokensForNetwork = (
     });
 };
 
-export const selectAccountHasAnyKnownToken = (state: TokensRootState, accountKey: string) => {
+export const selectAccountHasAnyKnownToken = (state: TokensRootState, accountKey: AccountKey) => {
     const account = selectAccountByKey(state, accountKey);
 
     if (!account || !isNetworkWithTokens(account.symbol)) {

--- a/suite-native/trading-atoms/src/utils/general/__tests__/receiveAccountUtils.test.ts
+++ b/suite-native/trading-atoms/src/utils/general/__tests__/receiveAccountUtils.test.ts
@@ -1,4 +1,4 @@
-import type { Account } from '@suite-common/wallet-types';
+import type { Account, AccountKey } from '@suite-common/wallet-types';
 import { getBtcAccount, getEthAccount } from '@suite-native/trading-fixtures';
 
 import { getReceiveAccountFromAccountAndAddressString } from '../receiveAccountUtils';
@@ -8,48 +8,51 @@ describe('receiveAccountUtils', () => {
         let account: Account;
 
         beforeEach(() => {
-            account = getBtcAccount('btc-account-2', {
-                addresses: {
-                    used: [
-                        {
-                            address: 'USED1',
-                            path: 'm/84/0/0',
-                            transfers: 0,
-                            balance: '0',
-                            sent: '0',
-                            received: '0',
-                        },
-                    ],
-                    change: [
-                        {
-                            address: 'CHANGE',
-                            path: 'm/84/0/3',
-                            transfers: 0,
-                            balance: '0',
-                            sent: '0',
-                            received: '0',
-                        },
-                    ],
-                    unused: [
-                        {
-                            address: 'UNUSED1',
-                            path: 'm/84/0/1',
-                            transfers: 0,
-                            balance: '0',
-                            sent: '0',
-                            received: '0',
-                        },
-                        {
-                            address: 'UNUSED2',
-                            path: 'm/84/0/2',
-                            transfers: 0,
-                            balance: '0',
-                            sent: '0',
-                            received: '0',
-                        },
-                    ],
+            account = getBtcAccount(
+                'btc-account-2' as AccountKey, // Todo: create properly via `createAccountKey()`
+                {
+                    addresses: {
+                        used: [
+                            {
+                                address: 'USED1',
+                                path: 'm/84/0/0',
+                                transfers: 0,
+                                balance: '0',
+                                sent: '0',
+                                received: '0',
+                            },
+                        ],
+                        change: [
+                            {
+                                address: 'CHANGE',
+                                path: 'm/84/0/3',
+                                transfers: 0,
+                                balance: '0',
+                                sent: '0',
+                                received: '0',
+                            },
+                        ],
+                        unused: [
+                            {
+                                address: 'UNUSED1',
+                                path: 'm/84/0/1',
+                                transfers: 0,
+                                balance: '0',
+                                sent: '0',
+                                received: '0',
+                            },
+                            {
+                                address: 'UNUSED2',
+                                path: 'm/84/0/2',
+                                transfers: 0,
+                                balance: '0',
+                                sent: '0',
+                                received: '0',
+                            },
+                        ],
+                    },
                 },
-            });
+            );
         });
 
         it('should return account when no address is specified', () => {

--- a/suite-native/trading-fixtures/src/__fixtures__/account.ts
+++ b/suite-native/trading-fixtures/src/__fixtures__/account.ts
@@ -4,7 +4,7 @@ import { Account, AccountKey } from '@suite-common/wallet-types';
  * @deprecated use `mockWalletAccount`, to keep AccountKey in sync with Descriptor, etc...
  */
 export const getBtcAccount = (
-    key: AccountKey = 'btc-account-1',
+    key: AccountKey = 'btc-account-1' as AccountKey,
     overrides: Partial<Account> = {},
 ) =>
     ({
@@ -40,7 +40,7 @@ export const getBtcAccount = (
  * @deprecated use `mockWalletAccount`, to keep AccountKey in sync with Descriptor, etc...
  */
 export const getEthAccount = (
-    key: AccountKey = 'eth-account-1',
+    key: AccountKey = 'eth-account-1' as AccountKey,
     overrides: Partial<Account> = {},
 ) =>
     ({
@@ -116,7 +116,7 @@ export const getEthAccount = (
  * @deprecated use `mockWalletAccount`, to keep AccountKey in sync with Descriptor, etc...
  */
 export const getBaseAccount = (
-    key: AccountKey = 'base-account-1',
+    key: AccountKey = 'base-account-1' as AccountKey,
     overrides: Partial<Account> = {},
 ) =>
     ({
@@ -161,7 +161,7 @@ export const getBaseAccount = (
  * @deprecated use `mockWalletAccount`, to keep AccountKey in sync with Descriptor, etc...
  */
 export const getCardanoAccount = (
-    key: AccountKey = 'ada-account-1',
+    key: AccountKey = 'ada-account-1' as AccountKey,
     overrides: Partial<Account> = {},
 ) =>
     ({
@@ -183,7 +183,7 @@ export const getCardanoAccount = (
  * @deprecated use `mockWalletAccount`, to keep AccountKey in sync with Descriptor, etc...
  */
 export const getSolAccount = (
-    key: AccountKey = 'sol-account-1',
+    key: AccountKey = 'sol-account-1' as AccountKey,
     overrides: Partial<Account> = {},
 ) =>
     ({

--- a/suite-native/trading-fixtures/src/__fixtures__/walletState.ts
+++ b/suite-native/trading-fixtures/src/__fixtures__/walletState.ts
@@ -2,6 +2,7 @@ import { TradingType } from '@suite-common/trading';
 import { FiatRatesState, SendState } from '@suite-common/wallet-core';
 import {
     Account,
+    AccountKey,
     GeneralPrecomposedLevels,
     RatesByKey,
     type WalletSettings,
@@ -55,8 +56,8 @@ export const getWalletState = ({
             lastWeek: {},
         } as FiatRatesState,
         accounts: [
-            getBtcAccount('btc-account-1', accountOverrides),
-            getBtcAccount('btc-account-2', accountOverrides),
+            getBtcAccount('btc-account-1' as AccountKey, accountOverrides),
+            getBtcAccount('btc-account-2' as AccountKey, accountOverrides),
             getEthAccount(undefined, accountOverrides),
             getBaseAccount(undefined, accountOverrides),
             getSolAccount(undefined, accountOverrides),

--- a/suite-native/trading-state/src/reducers/__tests__/buySlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/buySlice.test.ts
@@ -1,5 +1,6 @@
 import type { CryptoId } from 'invity-api';
 
+import { AccountKey } from '@suite-common/wallet-types';
 import { tradingInitialState } from '@suite-native/trading-consts';
 import { buyQuotes } from '@suite-native/trading-fixtures';
 import { TradingBuyState } from '@suite-native/trading-types';
@@ -11,7 +12,7 @@ describe('buySlice', () => {
         it('should clear buy state', () => {
             const prevState: TradingBuyState = {
                 ...tradingInitialState.buy,
-                tradingAccountKey: 'account-key',
+                tradingAccountKey: 'account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
                 receiveAddress: 'bc1qxyz',
                 quotesRequest: {
                     wantCrypto: true,
@@ -62,7 +63,7 @@ describe('buySlice', () => {
         it('should clear tradingAccountKey and receiveAddress', () => {
             const prevState: TradingBuyState = {
                 ...tradingInitialState.buy,
-                tradingAccountKey: 'account-key',
+                tradingAccountKey: 'account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
                 receiveAddress: 'bc1qxyz',
             };
 

--- a/suite-native/trading-state/src/reducers/__tests__/exchangeSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/exchangeSlice.test.ts
@@ -1,5 +1,6 @@
 import type { CryptoId } from 'invity-api';
 
+import { AccountKey } from '@suite-common/wallet-types';
 import { tradingInitialState } from '@suite-native/trading-consts';
 import { exchangeQuotes } from '@suite-native/trading-fixtures';
 import { TradingExchangeState } from '@suite-native/trading-types';
@@ -23,8 +24,8 @@ describe('exchangeSlice', () => {
             const prevState: TradingExchangeState = {
                 ...tradingInitialState.exchange,
                 receiveAddress: 'bc1qxyz',
-                tradingAccountKey: 'account-key1',
-                receiveAccountKey: 'account-key2',
+                tradingAccountKey: 'account-key1' as AccountKey, // Todo: create properly via `createAccountKey()`
+                receiveAccountKey: 'account-key2' as AccountKey, // Todo: create properly via `createAccountKey()`
                 quotesRequest: {
                     send: 'bitcoin' as CryptoId,
                     receive: 'ethereum' as CryptoId,
@@ -103,7 +104,7 @@ describe('exchangeSlice', () => {
                     send: 'bitcoin' as CryptoId,
                     receive: 'ethereum' as CryptoId,
                 },
-                receiveAccountKey: 'account-key1',
+                receiveAccountKey: 'account-key1' as AccountKey, // Todo: create properly via `createAccountKey()`
                 receiveAddress: 'bc1qxyz',
             };
 

--- a/suite-native/trading-state/src/reducers/__tests__/sellSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/sellSlice.test.ts
@@ -1,5 +1,6 @@
 import type { CryptoId } from 'invity-api';
 
+import { AccountKey } from '@suite-common/wallet-types';
 import { tradingInitialState } from '@suite-native/trading-consts';
 import { sellQuotes } from '@suite-native/trading-fixtures';
 import { TradingSellState } from '@suite-native/trading-types';
@@ -11,7 +12,7 @@ describe('sellSlice', () => {
         it('should clear the state', () => {
             const prevState: TradingSellState = {
                 ...tradingInitialState.sell,
-                tradingAccountKey: 'account-key',
+                tradingAccountKey: 'account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
                 quotesRequest: {
                     fiatCurrency: 'czk',
                     country: 'CZ',

--- a/suite-native/trading-state/src/reducers/__tests__/tradingSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/tradingSlice.test.ts
@@ -7,6 +7,7 @@ import {
     tradingExchangeActions,
     tradingSellActions,
 } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import { tradingInitialState } from '@suite-native/trading-consts/';
 import {
     adaAsset,
@@ -124,7 +125,7 @@ describe('tradingSlice', () => {
                 ...tradingInitialState,
                 buy: {
                     ...tradingInitialState.buy,
-                    tradingAccountKey: 'account-key',
+                    tradingAccountKey: 'account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
                     receiveAddress: 'bc1qxyz',
                     quotesRequest: {
                         wantCrypto: true,
@@ -156,7 +157,7 @@ describe('tradingSlice', () => {
                 sell: {
                     ...tradingInitialState.sell,
                     quotes: sellQuotes,
-                    tradingAccountKey: 'account-key',
+                    tradingAccountKey: 'account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
                     quotesRequest: {
                         amountInCrypto: true,
                         cryptoCurrency: 'bitcoin' as CryptoId,
@@ -345,7 +346,9 @@ describe('tradingSlice', () => {
 
         it('should clear buy.tradingAccountKey', () => {
             const actions = [
-                tradingBuyActions.setTradingAccountKey('account-key'),
+                tradingBuyActions.setTradingAccountKey(
+                    'account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
+                ),
                 tradingActions.clearSelectedAccounts(),
             ];
 
@@ -355,8 +358,12 @@ describe('tradingSlice', () => {
 
         it('should clear exchange.receiveAccountKey and exchange.tradingAccountKey', () => {
             const actions = [
-                tradingExchangeActions.setReceiveAccountKey('account-key'),
-                tradingExchangeActions.setTradingAccountKey('account-key'),
+                tradingExchangeActions.setReceiveAccountKey(
+                    'account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
+                ),
+                tradingExchangeActions.setTradingAccountKey(
+                    'account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
+                ),
                 tradingActions.clearSelectedAccounts(),
             ];
 
@@ -367,7 +374,9 @@ describe('tradingSlice', () => {
 
         it('should clear sell.tradingAccountKey', () => {
             const actions = [
-                tradingSellActions.setTradingAccountKey('account-key'),
+                tradingSellActions.setTradingAccountKey(
+                    'account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
+                ),
                 tradingActions.clearSelectedAccounts(),
             ];
 

--- a/suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts
@@ -3,7 +3,7 @@ import { Platform } from 'react-native';
 import type { BuyTrade } from 'invity-api';
 
 import { AccountsRootState } from '@suite-common/wallet-core';
-import { Account } from '@suite-common/wallet-types';
+import { Account, AccountKey } from '@suite-common/wallet-types';
 import { buyQuotes, getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
 
 import { TradingRootState } from '../../reducers';
@@ -64,7 +64,7 @@ describe('buySelectors', () => {
         });
 
         it('should throw when no account with given key exists', () => {
-            state.wallet.trading.buy.tradingAccountKey = 'unknown_account_key';
+            state.wallet.trading.buy.tradingAccountKey = 'unknown_account_key' as AccountKey; // Todo: create properly via `createAccountKey()`
 
             expect(() => selectBuySelectedReceiveAccount(state)).toThrow(
                 'Unknown tradingAccountKey: [unknown_account_key]',

--- a/suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts
@@ -12,7 +12,7 @@ import {
     DeviceReducerState,
     deviceInitialState,
 } from '@suite-common/wallet-core';
-import { Account } from '@suite-common/wallet-types';
+import { Account, AccountKey } from '@suite-common/wallet-types';
 import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
 import { appSettingsInitialState } from '@suite-native/settings';
 import {
@@ -1192,11 +1192,25 @@ describe('commonSelectors', () => {
             wallet: {
                 ...getWalletState({ tradeType: 'exchange' }),
                 accounts: [
-                    getEthAccount('eth1'),
-                    getBtcAccount('btc0', { deviceState: 'other-device@test:123' }),
-                    getBtcAccount('btc1', { accountType: 'ledger' }),
-                    getBtcAccount('btc2', { accountType: 'normal' }),
-                    getBtcAccount('btc3', { accountType: 'segwit' }),
+                    getEthAccount(
+                        'eth1' as AccountKey, // Todo: create properly via `createAccountKey()`
+                    ),
+                    getBtcAccount(
+                        'btc0' as AccountKey, // Todo: create properly via `createAccountKey()`
+                        { deviceState: 'other-device@test:123' },
+                    ),
+                    getBtcAccount(
+                        'btc1' as AccountKey, // Todo: create properly via `createAccountKey()`
+                        { accountType: 'ledger' },
+                    ),
+                    getBtcAccount(
+                        'btc2' as AccountKey, // Todo: create properly via `createAccountKey()`
+                        { accountType: 'normal' },
+                    ),
+                    getBtcAccount(
+                        'btc3' as AccountKey, // Todo: create properly via `createAccountKey()`
+                        { accountType: 'segwit' },
+                    ),
                 ],
             },
             device: {
@@ -1252,7 +1266,7 @@ describe('commonSelectors', () => {
                         device: deviceInitialState,
                         appSettings: appSettingsInitialState,
                     },
-                    'eth-account-1',
+                    'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
                     'eth' as CryptoId,
                 ),
             ).toBe('Ethereum #1');
@@ -1274,7 +1288,7 @@ describe('commonSelectors', () => {
                             device: deviceInitialState,
                             appSettings: appSettingsInitialState,
                         },
-                        'eth-account-2',
+                        'eth-account-2' as AccountKey, // Todo: create properly via `createAccountKey()`
                         asset as CryptoId,
                     ),
                 ).toBe(expectedLabel);

--- a/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
@@ -1,5 +1,5 @@
 import { AccountsRootState } from '@suite-common/wallet-core';
-import { Account } from '@suite-common/wallet-types';
+import { Account, AccountKey } from '@suite-common/wallet-types';
 import { FeatureFlag, FeatureFlagsRootState } from '@suite-native/feature-flags';
 import { exchangeQuotes, getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
 
@@ -55,7 +55,7 @@ describe('exchangeSelectors', () => {
         });
 
         it('should return undefined when no account with given key exists', () => {
-            state.wallet.trading.exchange.tradingAccountKey = 'unknown_account_key';
+            state.wallet.trading.exchange.tradingAccountKey = 'unknown_account_key' as AccountKey; // Todo: create properly via `createAccountKey()`
 
             expect(selectExchangeSelectedSendAccount(state)).toBeUndefined();
         });
@@ -90,7 +90,7 @@ describe('exchangeSelectors', () => {
         });
 
         it('should return undefined no account with given key exists', () => {
-            state.wallet.trading.exchange.receiveAccountKey = 'unknown_account_key';
+            state.wallet.trading.exchange.receiveAccountKey = 'unknown_account_key' as AccountKey; // Todo: create properly via `createAccountKey()`
 
             expect(selectExchangeSelectedReceiveAccount(state)).toBeUndefined();
         });

--- a/suite-native/trading-state/src/selectors/__tests__/sellSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/sellSelectors.test.ts
@@ -1,7 +1,7 @@
 import type { SellFiatTrade } from 'invity-api';
 
 import { AccountsRootState } from '@suite-common/wallet-core';
-import { Account } from '@suite-common/wallet-types';
+import { Account, AccountKey } from '@suite-common/wallet-types';
 import { getBtcAccount, getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 
 import { TradingRootState } from '../../reducers';
@@ -260,7 +260,7 @@ describe('sellSelectors', () => {
         });
 
         it('should return undefined when no account with given key exists', () => {
-            state.wallet.trading.sell.tradingAccountKey = 'unknown_account_key';
+            state.wallet.trading.sell.tradingAccountKey = 'unknown_account_key' as AccountKey; // Todo: create properly via `createAccountKey()`
 
             expect(selectSellSelectedSendAccount(state)).toBeUndefined();
         });

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx
@@ -1,6 +1,6 @@
 import { LayoutChangeEvent, View } from 'react-native';
 
-import { ReviewOutputType, TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, ReviewOutputType, TokenAddress } from '@suite-common/wallet-types';
 import { TxKeyPath, useTranslate } from '@suite-native/intl';
 
 import { ReviewOutputCard } from './ReviewOutputCard';
@@ -8,7 +8,7 @@ import { ReviewOutputItemContent } from './ReviewOutputItemContent';
 import { StatefulReviewOutput } from '../../types';
 
 export type ReviewOutputItemProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     reviewOutput: StatefulReviewOutput;
     onLayout: (event: LayoutChangeEvent) => void;
     tokenContract?: TokenAddress;

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx
@@ -1,4 +1,4 @@
-import { ReviewOutputType, TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, ReviewOutputType, TokenAddress } from '@suite-common/wallet-types';
 import { Text } from '@suite-native/atoms';
 import { splitAddressToChunks } from '@suite-native/helpers';
 import { Translation } from '@suite-native/intl';
@@ -6,7 +6,7 @@ import { Translation } from '@suite-native/intl';
 import { ReviewOutputItemValues } from './ReviewOutputItemValues';
 
 export type ReviewOutputItemContentProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     outputType: ReviewOutputType;
     value: string;
     tokenContract?: TokenAddress;

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemList.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemList.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
-import { FormDraftWithSendKeyPrefix, TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, FormDraftWithSendKeyPrefix, TokenAddress } from '@suite-common/wallet-types';
 import { ErrorMessage, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
@@ -19,7 +19,7 @@ import { SlidingFooterOverlay } from '../SlidingFooterOverlay';
 
 export type ReviewOutputItemListProps = {
     prefix: FormDraftWithSendKeyPrefix;
-    accountKey: string;
+    accountKey: AccountKey;
     tokenContract?: TokenAddress;
 };
 

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemValues.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemValues.tsx
@@ -1,10 +1,10 @@
-import { TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { Box, HStack, Text, VStack } from '@suite-native/atoms';
 import { CoinAmountFormatter, CoinToFiatAmountFormatter } from '@suite-native/formatters';
 import { Translation, TxKeyPath } from '@suite-native/intl';
 
 export type ReviewOutputItemValuesProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     value: string;
     translationKey: TxKeyPath;
     tokenContract?: TokenAddress;

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.tsx
@@ -1,7 +1,7 @@
 import { LayoutChangeEvent, View } from 'react-native';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { VStack } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import { isNetworkWithTokens } from '@suite-native/tokens';
@@ -12,7 +12,7 @@ import { ReviewOutputItemValues } from './ReviewOutputItemValues';
 import { ReviewSummaryOutput } from '../../types';
 
 export type ReviewOutputSummaryItemProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     symbol: NetworkSymbol;
     onLayout: (event: LayoutChangeEvent) => void;
     tokenContract?: TokenAddress;
@@ -20,7 +20,7 @@ export type ReviewOutputSummaryItemProps = {
 };
 
 type BitcoinValuesProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     totalSpent: string;
     fee: string;
 };

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItem.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItem.comp.test.tsx
@@ -1,3 +1,4 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import { Text as MockText } from '@suite-native/atoms';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
@@ -22,7 +23,9 @@ describe('ReviewOutputItem', () => {
     const renderReviewOutputItem = (props: Partial<ReviewOutputItemProps>) =>
         renderWithBasicProvider(
             <ReviewOutputItem
-                accountKey="eth-account-1"
+                accountKey={
+                    'eth-account-1' as AccountKey // Todo: create properly via `createAccountKey()`
+                }
                 onLayout={jest.fn()}
                 reviewOutput={{
                     type: 'address',

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemList.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemList.comp.test.tsx
@@ -1,3 +1,4 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import { renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { getWalletState } from '../../../__fixtures__/walletState';
@@ -26,7 +27,13 @@ jest.mock('../../../selectors', () => {
 describe('ReviewOutputItemList', () => {
     const renderReviewOutputItemList = (props: Partial<ReviewOutputItemListProps> = {}) =>
         renderWithStoreProvider(
-            <ReviewOutputItemList prefix="send" accountKey="eth-account-1" {...props} />,
+            <ReviewOutputItemList
+                prefix="send"
+                accountKey={
+                    'eth-account-1' as AccountKey // Todo: create properly via `createAccountKey()`
+                }
+                {...props}
+            />,
             { preloadedState: { wallet: getWalletState() } },
         );
 
@@ -48,7 +55,9 @@ describe('ReviewOutputItemList', () => {
     });
 
     it('should render Error when account is not found', () => {
-        const { getByText } = renderReviewOutputItemList({ accountKey: 'btc-account-3' });
+        const { getByText } = renderReviewOutputItemList({
+            accountKey: 'btc-account-3' as AccountKey, // Todo: create properly via `createAccountKey()`
+        });
 
         expect(getByText('Error: Account not found.')).toBeOnTheScreen();
     });

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemValues.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemValues.comp.test.tsx
@@ -1,4 +1,4 @@
-import { TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { getWalletState } from '../../../__fixtures__/walletState';
@@ -13,7 +13,9 @@ describe('ReviewOutputItemValues', () => {
     ) =>
         renderWithStoreProvider(
             <ReviewOutputItemValues
-                accountKey="eth-account-1"
+                accountKey={
+                    'eth-account-1' as AccountKey // Todo: create properly via `createAccountKey()`
+                }
                 value={oneUsdc}
                 translationKey="transactionManagement.review.outputs.summary.totalAmount"
                 {...props}

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputSummaryItem.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputSummaryItem.comp.test.tsx
@@ -1,4 +1,4 @@
-import { TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { Text as MockText } from '@suite-native/atoms';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
@@ -22,7 +22,9 @@ describe('ReviewOutputSummaryItem', () => {
     const renderReviewOutputSummaryItem = (props: Partial<ReviewOutputSummaryItemProps>) =>
         renderWithBasicProvider(
             <ReviewOutputSummaryItem
-                accountKey="eth-account-1"
+                accountKey={
+                    'eth-account-1' as AccountKey // Todo: create properly via `createAccountKey()`
+                }
                 symbol="btc"
                 onLayout={jest.fn()}
                 {...props}

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFee.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFee.comp.test.tsx
@@ -42,7 +42,7 @@ describe('CustomFee', () => {
     };
 
     const renderUseFeesForm = (
-        accountKey: AccountKey = 'eth-account-1',
+        accountKey: AccountKey = 'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
         preloadedState?: PreloadedState,
         defaultFeePerUnit?: string,
     ) => {
@@ -225,7 +225,9 @@ describe('CustomFee', () => {
     });
 
     it('should handle different account keys', () => {
-        const form = renderUseFeesForm('btc-account-1');
+        const form = renderUseFeesForm(
+            'btc-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
+        );
         const { getByTestId } = renderCustomFee({
             form,
             props: {

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeCard.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeCard.comp.test.tsx
@@ -24,7 +24,7 @@ describe('CustomFeeCard', () => {
     };
 
     const renderUseFeesForm = (
-        accountKey: AccountKey = 'eth-account-1',
+        accountKey: AccountKey = 'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`,
         preloadedState?: PreloadedState,
         defaultFeePerUnit?: string,
     ) => {

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeInputs.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeInputs.comp.test.tsx
@@ -35,7 +35,7 @@ describe('CustomFeeInputs', () => {
     };
 
     const renderUseFeesForm = (
-        accountKey: AccountKey = 'eth-account-1',
+        accountKey: AccountKey = 'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`,
         preloadedState?: PreloadedState,
         defaultFeePerUnit?: string,
     ) => {

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeLabel.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeLabel.comp.test.tsx
@@ -1,4 +1,5 @@
 import { NetworkType as NetworkTypeConfig } from '@suite-common/wallet-config';
+import { AccountKey } from '@suite-common/wallet-types';
 import { Form } from '@suite-native/forms';
 import {
     PreloadedState,
@@ -21,7 +22,7 @@ describe('CustomFeeLabel', () => {
         const { result } = renderHookWithStoreProvider(
             () =>
                 useFeesForm({
-                    accountKey: 'test-account-key',
+                    accountKey: 'test-account-key' as AccountKey, // Todo: create properly via `createAccountKey()`,
                     defaultFeePerUnit: defaultFeePerUnit || '1',
                 }),
             {

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOptionsList.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOptionsList.comp.test.tsx
@@ -59,7 +59,7 @@ describe('FeeOptionsList', () => {
     };
 
     const renderUseFeesForm = (
-        accountKey: AccountKey = 'eth-account-1',
+        accountKey: AccountKey = 'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`,
         preloadedState?: PreloadedState,
         defaultFeePerUnit?: string,
     ) => {

--- a/suite-native/transaction-management/src/components/fees/__tests__/FeesContent.comp.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/__tests__/FeesContent.comp.test.tsx
@@ -28,7 +28,7 @@ const TestFormWrapper = ({ children }: { children: React.ReactNode }) => {
 };
 
 describe('FeesContent', () => {
-    const mockAccountKey: AccountKey = 'btc1';
+    const mockAccountKey: AccountKey = 'btc1' as AccountKey; // Todo: create properly via `createAccountKey()`
     const mockOnSelectedFeeLevel = jest.fn();
     const mockOnCustomFeeSet = jest.fn();
 

--- a/suite-native/transaction-management/src/hooks/fees/__tests__/useFeesForm.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/__tests__/useFeesForm.test.ts
@@ -1,10 +1,11 @@
+import { AccountKey } from '@suite-common/wallet-types';
 import { act, renderHookWithStoreProvider } from '@suite-native/test-utils';
 
 import { UseFeesFormProps, useFeesForm } from '../useFeesForm';
 
 describe('useFeesForm', () => {
     const mockProps: UseFeesFormProps = {
-        accountKey: 'eth-1',
+        accountKey: 'eth-1' as AccountKey, // Todo: create properly via `createAccountKey()`
         defaultFeeLevel: 'normal',
         defaultFeePerUnit: '20000000000', // 20 gwei
     };
@@ -107,7 +108,7 @@ describe('useFeesForm', () => {
 
     it('should initialize with custom default values', () => {
         const customProps: UseFeesFormProps = {
-            accountKey: 'eth-1',
+            accountKey: 'eth-1' as AccountKey, // Todo: create properly via `createAccountKey()`
             defaultFeeLevel: 'high',
             defaultFeePerUnit: '15000000000',
         };

--- a/suite-native/transactions/src/components/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionList.tsx
@@ -37,7 +37,7 @@ import { TransactionsListFooter } from './TransactionsListFooter';
 
 type AccountTransactionProps = {
     listHeaderComponent: JSX.Element;
-    accountKey: string;
+    accountKey: AccountKey;
     tokenContract?: TokenAddress;
 };
 

--- a/suite-native/transactions/src/components/TransactionsEmptyState.tsx
+++ b/suite-native/transactions/src/components/TransactionsEmptyState.tsx
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
+import { AccountKey } from '@suite-common/wallet-types';
 import { Box, Button, Text, VStack } from '@suite-native/atoms';
 import { selectHasFirmwareAuthenticityCheckHardFailed } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
@@ -16,7 +17,7 @@ import { NoTransactionsSvg } from './NoTransactionsSvg';
 
 type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes.AccountDetail>;
 
-export const TransactionsEmptyState = ({ accountKey }: { accountKey: string }) => {
+export const TransactionsEmptyState = ({ accountKey }: { accountKey: AccountKey }) => {
     const navigation = useNavigation<NavigationProp>();
     const hasFirmwareAuthenticityCheckHardFailed = useSelector(
         selectHasFirmwareAuthenticityCheckHardFailed,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11329,6 +11329,7 @@ __metadata:
   dependencies:
     "@trezor/device-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -11852,6 +11853,7 @@ __metadata:
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -13476,6 +13478,7 @@ __metadata:
     "@suite-native/transaction-management": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The goal is not to fix all test fixtures. But to make sure we have a correct branded type in all the component API and data structures.

## Testing

Potentially dangerous places:
- There is some change in everstake (`""` => `null`)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=make-account-key-branded&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=make-account-key-branded&lookback=7)