### PR TITLE
feat(connect): remove manifest method in favor of init

### DIFF
--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -3,7 +3,7 @@ import EventEmitter from 'events';
 import { corsValidator, parseConnectSettings } from '@trezor/connect/src/data/connectSettings';
 import type { CallMethodPayload } from '@trezor/connect/src/events/call';
 import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
-import type { ConnectSettings, ConnectSettingsMobile, Manifest } from '@trezor/connect/src/types';
+import type { ConnectSettings, ConnectSettingsMobile } from '@trezor/connect/src/types';
 import { InitFullSettings } from '@trezor/connect/src/types/api/init';
 import * as ERRORS from '@trezor/connect-common/src/constants/errors';
 import {
@@ -24,16 +24,6 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
             deeplinkOpen: () => {
                 throw ERRORS.TypedError('Init_NotInitialized');
             },
-        };
-    }
-
-    public manifest(manifest: Manifest) {
-        this._settings = {
-            ...this._settings,
-            ...parseConnectSettings({
-                ...this._settings,
-                manifest,
-            }),
         };
     }
 
@@ -213,7 +203,6 @@ const TrezorConnect = factory<
         init: impl.init.bind(impl),
         call: impl.call.bind(impl),
         setTransports: impl.setTransports.bind(impl),
-        manifest: impl.manifest.bind(impl),
         uiResponse: impl.uiResponse.bind(impl),
         cancel: impl.cancel.bind(impl),
         dispose: impl.dispose.bind(impl),

--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -13,7 +13,6 @@ import type {
     ConnectSettings,
     ConnectSettingsPublic,
     ConnectSettingsWeb,
-    Manifest,
 } from '@trezor/connect/src/types';
 import * as ERRORS from '@trezor/connect-common/src/constants/errors';
 import { WebsocketClient } from '@trezor/websocket-client';
@@ -33,13 +32,6 @@ export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSet
     public constructor() {
         this._settings = parseConnectSettings();
         this.ws = new WebsocketClient({ url: 'ws://127.0.0.1:21335/connect-ws' });
-    }
-
-    public manifest(data: Manifest) {
-        this._settings = parseConnectSettings({
-            ...this._settings,
-            manifest: data,
-        });
     }
 
     public dispose() {

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -11,7 +11,7 @@ import {
     createErrorMessage,
 } from '@trezor/connect/src/events';
 import { ConnectFactoryDependencies } from '@trezor/connect/src/factory';
-import type { ConnectSettings, ConnectSettingsWeb, Manifest } from '@trezor/connect/src/types';
+import type { ConnectSettings, ConnectSettingsWeb } from '@trezor/connect/src/types';
 import { InitFullSettings } from '@trezor/connect/src/types/api/init';
 import { Log, initLog } from '@trezor/connect/src/utils/debug';
 import * as ERRORS from '@trezor/connect-common/src/constants/errors';
@@ -33,13 +33,6 @@ export class CoreInSuiteWeb implements ConnectFactoryDependencies<ConnectSetting
     public constructor() {
         this._settings = parseConnectSettings();
         this.logger = initLog('@trezor/connect-web');
-    }
-
-    public manifest(data: Manifest) {
-        this._settings = parseConnectSettings({
-            ...this._settings,
-            manifest: data,
-        });
     }
 
     public dispose() {

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -69,7 +69,6 @@ const TrezorConnect = factory<ConnectSettingsWeb, ConnectWebExtraMethods>(
         init: impl.init.bind(impl),
         call: impl.call.bind(impl),
         setTransports: impl.setTransports.bind(impl),
-        manifest: impl.manifest.bind(impl),
         uiResponse: impl.uiResponse.bind(impl),
         cancel: impl.cancel.bind(impl),
         dispose: impl.dispose.bind(impl),

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -79,7 +79,6 @@ const TrezorConnect = factory({
     init: impl.init.bind(impl),
     call: impl.call.bind(impl),
     setTransports: impl.setTransports.bind(impl),
-    manifest: impl.manifest.bind(impl),
     uiResponse: impl.uiResponse.bind(impl),
     cancel: impl.cancel.bind(impl),
     dispose: impl.dispose.bind(impl),

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -5,7 +5,6 @@ import {
     CORE_CALL,
     CallMethod,
     ConnectSettings,
-    Manifest,
     POPUP,
     createErrorMessage,
 } from '@trezor/connect/src/exports';
@@ -15,19 +14,6 @@ import { WindowServiceWorkerChannel } from '@trezor/connect-common/src/messageCh
 
 const eventEmitter = new EventEmitter();
 let _channel: any;
-
-const manifest = (data: Manifest) => {
-    if (_channel) {
-        _channel.postMessage({
-            type: POPUP.INIT,
-            payload: {
-                settings: { manifest: data },
-            },
-        });
-    }
-
-    return Promise.resolve(undefined);
-};
 
 const dispose = () => {
     eventEmitter.removeAllListeners();
@@ -109,7 +95,6 @@ const uiResponse = () => {
 
 const TrezorConnect = factory({
     eventEmitter,
-    manifest,
     init,
     call,
     setTransports,

--- a/packages/connect/e2e/tests/api/init.test.ts
+++ b/packages/connect/e2e/tests/api/init.test.ts
@@ -9,7 +9,7 @@ describe('TrezorConnect.init', () => {
         TrezorConnect.dispose();
     });
 
-    it('calling method before .init() and/or .manifest()', async () => {
+    it('calling method before .init()', async () => {
         const { payload } = await TrezorConnect.getCoinInfo({ coin: 'btc' });
         expect(payload).toMatchObject(INIT_ERROR);
     });
@@ -68,18 +68,6 @@ describe('TrezorConnect.init', () => {
             manifest: { appName: 'a', appUrl: 'a', email: 'b' },
         });
 
-        const resp = await TrezorConnect.getCoinInfo({ coin: 'btc' });
-        expect(resp).toMatchObject({
-            payload: { type: 'bitcoin', shortcut: 'BTC' },
-        });
-    });
-
-    it('manifest success', async () => {
-        TrezorConnect.manifest({
-            appName: 'a',
-            appUrl: 'a',
-            email: 'b',
-        });
         const resp = await TrezorConnect.getCoinInfo({ coin: 'btc' });
         expect(resp).toMatchObject({
             payload: { type: 'bitcoin', shortcut: 'BTC' },

--- a/packages/connect/e2e/tests/device/info.test.ts
+++ b/packages/connect/e2e/tests/device/info.test.ts
@@ -63,7 +63,6 @@ describe('__info common param', () => {
             if (
                 [
                     // "utility" methods
-                    'manifest',
                     'init',
                     'setTransports',
                     'getSettings',

--- a/packages/connect/src/events/call.ts
+++ b/packages/connect/src/events/call.ts
@@ -45,7 +45,6 @@ type TopLevelMethods =
     | 'cancel'
     | 'dispose'
     | 'init'
-    | 'manifest'
     | 'off'
     | 'on'
     | 'removeAllListeners'

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -9,7 +9,6 @@ export interface ConnectFactoryDependencies<SettingsType extends Record<string, 
     init: InitType<SettingsType>;
     call: CallMethod;
     eventEmitter: EventEmitter;
-    manifest: TrezorConnect['manifest'];
     setTransports: TrezorConnect['setTransports'];
     uiResponse: TrezorConnect['uiResponse'];
     cancel: TrezorConnect['cancel'];
@@ -113,7 +112,6 @@ export const factory = <
 >(
     {
         eventEmitter,
-        manifest,
         init,
         call,
         setTransports,
@@ -141,7 +139,6 @@ export const factory = <
     ) as Pick<TrezorConnect, (typeof connectCallableMethods)[number]>;
 
     return {
-        manifest,
         init,
         setTransports,
 

--- a/packages/connect/src/impl/dynamic.ts
+++ b/packages/connect/src/impl/dynamic.ts
@@ -7,7 +7,6 @@ import { CallMethodPayload, createErrorMessage } from '../events';
 import { ConnectFactoryDependencies } from '../factory';
 import { InitFullSettings } from '../types/api/init';
 import type { SetTransports } from '../types/api/setTransports';
-import type { Manifest } from '../types/settings';
 
 type TrezorConnectDynamicParams<
     ImplType,
@@ -112,12 +111,6 @@ export class TrezorConnectDynamic<
         } catch {
             this.currentTarget = oldTargetType;
         }
-    }
-
-    public manifest(manifest: Manifest) {
-        this.lastSettings = { ...this.lastSettings, manifest } as typeof this.lastSettings;
-
-        this.getTarget().manifest(manifest);
     }
 
     public async init(settings: InitFullSettings<SettingsType>) {

--- a/packages/connect/src/index-browser.ts
+++ b/packages/connect/src/index-browser.ts
@@ -22,7 +22,6 @@ const requestWebUSBDevice = async () => {
 const TrezorConnect = factory(
     {
         eventEmitter: impl.eventEmitter,
-        manifest: impl.manifest.bind(impl),
         init: impl.init.bind(impl),
         call: impl.call.bind(impl),
         setTransports: impl.setTransports.bind(impl),

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -18,7 +18,7 @@ import {
     createErrorMessage,
 } from './events';
 import { factory } from './factory';
-import type { ConnectSettings, Manifest } from './types';
+import type { ConnectSettings } from './types';
 import { ConnectEvents } from './types/emitter';
 import { initLog } from './utils/debug';
 
@@ -29,13 +29,6 @@ let _settings = parseConnectSettings();
 
 const coreManager = initCoreState();
 const messagePromises = createDeferredManager({ initialId: 1 });
-
-const manifest = (data: Manifest) => {
-    _settings = parseConnectSettings({
-        ..._settings,
-        manifest: data,
-    });
-};
 
 const dispose = () => {
     eventEmitter.removeAllListeners();
@@ -168,7 +161,6 @@ const cancel = (error?: string) => {
 const TrezorConnect = factory(
     {
         eventEmitter,
-        manifest,
         init,
         call,
         setTransports,

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -57,7 +57,6 @@ import { getPublicKey } from './getPublicKey';
 import { getSettings } from './getSettings';
 import { init } from './init';
 import { loadDevice } from './loadDevice';
-import { manifest } from './manifest';
 import { moneroGetAddress } from './moneroGetAddress';
 import { moneroGetWatchKey } from './moneroGetWatchKey';
 import { moneroKeyImageSync } from './moneroKeyImageSync';
@@ -278,9 +277,6 @@ export interface TrezorConnect {
 
     // https://connect.trezor.io/9/methods/other/init/
     init: typeof init;
-
-    // https://connect.trezor.io/9/methods/other/manifest/
-    manifest: typeof manifest;
 
     // https://connect.trezor.io/9/methods/monero/moneroGetAddress/
     moneroGetAddress: typeof moneroGetAddress;

--- a/packages/connect/src/types/api/manifest.ts
+++ b/packages/connect/src/types/api/manifest.ts
@@ -1,7 +1,0 @@
-/**
- * Set TrezorConnect manifest.
- */
-
-import type { Manifest } from '../settings';
-
-export declare function manifest(params: Manifest): void;

--- a/suite-common/connect-init/src/blacklist.ts
+++ b/suite-common/connect-init/src/blacklist.ts
@@ -2,7 +2,6 @@ import { ConnectWebKey } from './types';
 
 // List of methods that don't work with device, so they don't need to be patched
 export const blacklist: ConnectWebKey[] = [
-    'manifest',
     'init',
     'setTransports',
     'getSettings',


### PR DESCRIPTION
## Description

Remove old `TrezorConnect.manifest()` method in favor of `TrezorConnect.init()`

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-remove-manifest&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-remove-manifest&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-remove-manifest&lookback=7)