### PR TITLE
fix(e2e-reporter): corrects path from package script to PW config

### DIFF
--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -12,7 +12,7 @@
         "test:e2e:desktop:canary": "yarn xvfb-maybe -- playwright test --config=./playwright-config/playwright-desktop-local-canary.config.ts",
         "test:e2e:web:canary": "yarn xvfb-maybe -- playwright test --config=./playwright-config/playwright-web-local-canary.config.ts",
         "test:orchestrated:e2e": "NODE_OPTIONS='--no-warnings=DEP0040' yarn xvfb-maybe -- pwc-p",
-        "github:report:manual": "NODE_OPTIONS='--no-warnings=DEP0040' yarn xvfb-maybe -- playwright test --config=./playwright-manual.config.ts --reporter=./support/reporters/gitHubReporter.ts",
+        "github:report:manual": "NODE_OPTIONS='--no-warnings=DEP0040' yarn xvfb-maybe -- playwright test --config=./playwright-config/playwright-manual.config.ts --reporter=./support/reporters/gitHubReporter.ts",
         "github:create:project": "tsx ./support/reporters/scriptCreateProject.ts",
         "git:bisect": "./scripts/bisect-commits.sh",
         "decode:sol:stake": "tsx ./scripts/decode-sol-staking-account.ts",

--- a/suite/e2e/playwright-config/playwright-manual.config.ts
+++ b/suite/e2e/playwright-config/playwright-manual.config.ts
@@ -1,18 +1,15 @@
 import { defineConfig } from '@playwright/test';
 
 import { baseConfig } from './playwright-base.config';
-import {
-    PlaywrightProjectBuilder,
-    PlaywrightProjectDefinition,
-} from './playwright-project-builder';
-import { PlaywrightTarget } from '../support/testExtends/suiteTestOptions';
-
-const target = PlaywrightTarget.Web;
-const definition: PlaywrightProjectDefinition[] = [{ name: 'manual', grep: /@group=manual/ }];
 
 const config = defineConfig({
     ...baseConfig,
-    projects: PlaywrightProjectBuilder.buildFromDefinitions(target, definition),
+    projects: [
+        {
+            name: 'manual',
+            grep: /@group=manual/,
+        },
+    ],
 });
 
 /* eslint-disable-next-line import/no-default-export */


### PR DESCRIPTION
fixes the manual config

We havent tested our reporter after the changes to PW configs. This fixes both path issue as configs are now in theirs folder and also project builder was not supporting what we need to manual PW config. So I wrote it manually.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-reporting-paths&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-reporting-paths&lookback=7)