### PR TITLE
fix(trading): reset preselected provider on asset selection change

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -4,6 +4,7 @@ import { useFormContext } from 'react-hook-form';
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
     TRADING_FORM_OUTPUT_FIAT,
+    TRADING_FORM_PROVIDER_SELECT,
     TRADING_FORM_RECEIVE_CRYPTO_CURRENCY_SELECT,
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
     TradingExchangeFormProps,
@@ -96,8 +97,9 @@ export const TradingExchangeFormInputs = () => {
             await onCryptoCurrencyChangeRef.current(asset);
 
             resetSelectedOfferRef.current();
+            setValueRef.current(TRADING_FORM_PROVIDER_SELECT, undefined, { shouldDirty: true });
         },
-        [onCryptoCurrencyChangeRef, resetSelectedOfferRef],
+        [onCryptoCurrencyChangeRef, resetSelectedOfferRef, setValueRef],
     );
 
     const handleReceiveAssetSelect = useCallback<TradingFormInputBuyAssetProps['onAssetSelect']>(
@@ -108,6 +110,7 @@ export const TradingExchangeFormInputs = () => {
             setAmountLimitsRef.current(undefined);
             dispatch(tradingActions.setModalCryptoCurrency(asset.id));
             resetSelectedOfferRef.current();
+            setValueRef.current(TRADING_FORM_PROVIDER_SELECT, undefined, { shouldDirty: true });
         },
         [dispatch, setAmountLimitsRef, setValueRef, resetSelectedOfferRef],
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Provider selected by the user is reseted when asset changes

## Notes for QA

Please verify it

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/24851



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/reset-preselected-provider&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/reset-preselected-provider&lookback=7)