### PR TITLE
feat(connect): unify result/error type

### DIFF
--- a/packages/connect-common/src/constants/errors.ts
+++ b/packages/connect-common/src/constants/errors.ts
@@ -93,12 +93,20 @@ export const TypedError = (id: ErrorCode, message?: string) =>
     new TrezorError(id, message || ERROR_CODES[id as TypedErrorCode] || id);
 
 // serialize Error/TypeError object into payload error type (Error object/class is converted to string while sent via postMessage)
-export const serializeError = (payload: any) => {
+export const serializeError = (payload: any): SerializedError => {
     const error = payload?.error instanceof Error ? payload.error : payload;
 
     return error instanceof Error
-        ? { error: error.message, code: 'code' in error ? error.code : 'Failure_UnknownCode' }
+        ? {
+              message: error.message,
+              code: 'code' in error ? (error.code as ErrorCode) : 'Failure_UnknownCode',
+          }
         : { ...payload };
+};
+
+export type SerializedError = {
+    message: string;
+    code: ErrorCode;
 };
 
 // trezord error prefix.

--- a/packages/connect-explorer/src/pages/methods/bitcoin/authorizeCoinjoin.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/authorizeCoinjoin.mdx
@@ -71,8 +71,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/bitcoin/cancelCoinjoinAuthorization.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/cancelCoinjoinAuthorization.mdx
@@ -62,8 +62,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/bitcoin/composeTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/composeTransaction.mdx
@@ -137,8 +137,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/bitcoin/getAccountInfo.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/getAccountInfo.mdx
@@ -238,8 +238,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/bitcoin/getAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/getAddress.mdx
@@ -123,8 +123,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/bitcoin/getPublicKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/getPublicKey.mdx
@@ -117,8 +117,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/bitcoin/pushTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/pushTransaction.mdx
@@ -60,8 +60,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/bitcoin/signMessage.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/signMessage.mdx
@@ -63,8 +63,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/bitcoin/signTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/signTransaction.mdx
@@ -260,8 +260,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/bitcoin/verifyMessage.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/verifyMessage.mdx
@@ -67,8 +67,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/cardano/cardanoComposeTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/cardano/cardanoComposeTransaction.mdx
@@ -117,8 +117,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/cardano/cardanoGetAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/cardano/cardanoGetAddress.mdx
@@ -389,8 +389,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/cardano/cardanoGetNativeScriptHash.mdx
+++ b/packages/connect-explorer/src/pages/methods/cardano/cardanoGetNativeScriptHash.mdx
@@ -137,8 +137,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/cardano/cardanoGetPublicKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/cardano/cardanoGetPublicKey.mdx
@@ -112,8 +112,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/cardano/cardanoSignMessage.mdx
+++ b/packages/connect-explorer/src/pages/methods/cardano/cardanoSignMessage.mdx
@@ -113,8 +113,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/cardano/cardanoSignTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/cardano/cardanoSignTransaction.mdx
@@ -643,8 +643,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/device/applyFlags.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/applyFlags.mdx
@@ -57,8 +57,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/device/applySettings.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/applySettings.mdx
@@ -64,8 +64,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/device/backupDevice.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/backupDevice.mdx
@@ -55,8 +55,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/device/changeLanguage.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/changeLanguage.mdx
@@ -61,8 +61,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/device/changePin.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/changePin.mdx
@@ -56,8 +56,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/device/changeWipeCode.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/changeWipeCode.mdx
@@ -56,8 +56,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/device/firmwareUpdate.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/firmwareUpdate.mdx
@@ -93,8 +93,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/device/getFirmwareHash.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/getFirmwareHash.mdx
@@ -66,8 +66,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/device/recoveryDevice.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/recoveryDevice.mdx
@@ -66,8 +66,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/device/resetDevice.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/resetDevice.mdx
@@ -71,8 +71,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/device/setBusy.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/setBusy.mdx
@@ -52,8 +52,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/device/showDeviceTutorial.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/showDeviceTutorial.mdx
@@ -47,8 +47,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/device/wipeDevice.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/wipeDevice.mdx
@@ -50,8 +50,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumGetAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumGetAddress.mdx
@@ -120,8 +120,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumGetPublicKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumGetPublicKey.mdx
@@ -110,8 +110,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignMessage.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignMessage.mdx
@@ -66,8 +66,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignTransaction.mdx
@@ -111,8 +111,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignTypedData.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignTypedData.mdx
@@ -131,8 +131,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumVerifyMessage.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumVerifyMessage.mdx
@@ -69,8 +69,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/monero/moneroGetAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/monero/moneroGetAddress.mdx
@@ -142,8 +142,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/monero/moneroGetWatchKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/monero/moneroGetWatchKey.mdx
@@ -81,8 +81,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/other/cipherKeyValue.mdx
+++ b/packages/connect-explorer/src/pages/methods/other/cipherKeyValue.mdx
@@ -121,8 +121,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/other/getAccountDescriptor.mdx
+++ b/packages/connect-explorer/src/pages/methods/other/getAccountDescriptor.mdx
@@ -82,8 +82,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/other/getOwnershipId.mdx
+++ b/packages/connect-explorer/src/pages/methods/other/getOwnershipId.mdx
@@ -106,8 +106,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/other/getOwnershipProof.mdx
+++ b/packages/connect-explorer/src/pages/methods/other/getOwnershipProof.mdx
@@ -111,8 +111,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/other/requestLogin.mdx
+++ b/packages/connect-explorer/src/pages/methods/other/requestLogin.mdx
@@ -82,8 +82,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/other/unlockPath.mdx
+++ b/packages/connect-explorer/src/pages/methods/other/unlockPath.mdx
@@ -54,8 +54,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/ripple/rippleGetAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/ripple/rippleGetAddress.mdx
@@ -119,8 +119,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/ripple/rippleSignTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/ripple/rippleSignTransaction.mdx
@@ -77,8 +77,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/solana/solanaComposeTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/solana/solanaComposeTransaction.mdx
@@ -88,8 +88,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/solana/solanaGetAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/solana/solanaGetAddress.mdx
@@ -101,8 +101,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/solana/solanaGetPublicKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/solana/solanaGetPublicKey.mdx
@@ -104,8 +104,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/solana/solanaSignTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/solana/solanaSignTransaction.mdx
@@ -93,8 +93,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/stellar/stellarGetAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/stellar/stellarGetAddress.mdx
@@ -119,8 +119,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/stellar/stellarSignTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/stellar/stellarSignTransaction.mdx
@@ -105,8 +105,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/tezos/tezosGetAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/tezos/tezosGetAddress.mdx
@@ -119,8 +119,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/tezos/tezosGetPublicKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/tezos/tezosGetPublicKey.mdx
@@ -106,8 +106,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/tezos/tezosSignTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/tezos/tezosSignTransaction.mdx
@@ -252,8 +252,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/tron/tronGetAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/tron/tronGetAddress.mdx
@@ -101,8 +101,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/tron/tronSignTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/tron/tronSignTransaction.mdx
@@ -115,8 +115,8 @@ Error
 ```javascript
 {
     success: false,
-    payload: {
-        error: string // error message
+    error: {
+        message: string // error message
     }
 }
 ```

--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -141,11 +141,22 @@ export class CoreInSuiteDesktop implements ConnectImpl {
                 throw ERRORS.TypedError('Desktop_ConnectionMissing', 'No response');
             }
 
-            return response;
+            if (response.success === false) {
+                return {
+                    success: false,
+                    error: response.error,
+                };
+            }
+
+            return {
+                success: true,
+                payload: response.payload,
+                device: response.device,
+            };
         } catch (err) {
             return {
                 success: false,
-                payload: ERRORS.serializeError(this.error(err)),
+                error: ERRORS.serializeError(this.error(err)),
             };
         }
     }

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -103,8 +103,8 @@ export class CoreInSuiteWeb implements ConnectImpl {
             if (!response?.payload) {
                 throw ERRORS.TypedError('Method_NoResponse');
             }
-            if (response.payload.error && response.payload.code) {
-                throw response.payload;
+            if (response.error.message && response.error.code) {
+                throw response.error;
             }
 
             return {

--- a/packages/connect/e2e/tests/api/init.test.ts
+++ b/packages/connect/e2e/tests/api/init.test.ts
@@ -10,8 +10,11 @@ describe('TrezorConnect.init', () => {
     });
 
     it('calling method before .init()', async () => {
-        const { payload } = await TrezorConnect.getCoinInfo({ coin: 'btc' });
-        expect(payload).toMatchObject(INIT_ERROR);
+        const result = await TrezorConnect.getCoinInfo({ coin: 'btc' });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error).toMatchObject(INIT_ERROR);
+        }
     });
 
     it('missing manifest in TrezorConnect.init', async () => {

--- a/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
+++ b/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
@@ -42,7 +42,7 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
             const unlockPath = await TrezorConnect.unlockPath({
                 path: "m/10025'",
             });
-            if (!unlockPath.success) throw new Error(unlockPath.payload.error);
+            if (!unlockPath.success) throw new Error(unlockPath.error.message);
 
             const auth = await TrezorConnect.authorizeCoinjoin({
                 coordinator: 'www.example.com',
@@ -55,6 +55,7 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
             });
 
             expect(auth.success).toBe(true);
+            if (!auth.success) throw new Error(auth.error.message);
             expect(auth.payload).toEqual({ message: 'Coinjoin authorized' });
 
             await new Promise(resolve => setTimeout(resolve, 11000)); // wait for auto-lock
@@ -165,6 +166,7 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
             // ButtonRequests during signing is not emitted because of preauthorization
 
             const round1 = await TrezorConnect.signTransaction(params);
+            if (!round1.success) throw new Error(round1.error.message);
             expect(round1.payload).toMatchObject({
                 signatures: [
                     undefined,
@@ -187,7 +189,8 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
             });
             const round3 = await TrezorConnect.signTransaction(params);
             expect(round3.success).toBe(false);
-            expect(round3.payload).toMatchObject({ error: 'No preauthorized operation' });
+            if (round3.success) throw new Error('Expected failure');
+            expect(round3.error).toMatchObject({ message: 'No preauthorized operation' });
         },
         40000, // extended timeout due to wait for auto-lock
     );

--- a/packages/connect/e2e/tests/device/cancel.test.ts
+++ b/packages/connect/e2e/tests/device/cancel.test.ts
@@ -87,8 +87,8 @@ describe('TrezorConnect.cancel', () => {
 
         expect(response).toMatchObject({
             success: false,
-            payload: {
-                error: 'Cancel reason',
+            error: {
+                message: 'Cancel reason',
                 code: 'Method_Cancel',
             },
         });
@@ -124,8 +124,8 @@ describe('TrezorConnect.cancel', () => {
 
         expect(response).toMatchObject({
             success: false,
-            payload: {
-                error: 'Cancel reason',
+            error: {
+                message: 'Cancel reason',
             },
         });
 
@@ -197,6 +197,7 @@ describe('TrezorConnect.cancel', () => {
 
         // assertGetAddressWorks will not work without providing pin
         const feat = await TrezorConnect.getFeatures();
+        if (!feat.success) throw new Error(feat.error.message);
         expect(feat.payload).toMatchObject({ initialized: true });
     });
 
@@ -231,6 +232,7 @@ describe('TrezorConnect.cancel', () => {
 
         // assertGetAddressWorks will not work here, device is not initialized
         const feat = await TrezorConnect.getFeatures();
+        if (!feat.success) throw new Error(feat.error.message);
         expect(feat.payload).toMatchObject({ initialized: false });
     });
 });

--- a/packages/connect/e2e/tests/device/cancelCoinjoinAuthorization.test.ts
+++ b/packages/connect/e2e/tests/device/cancelCoinjoinAuthorization.test.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect, { PROTO, Success, Unsuccessful } from '@trezor/connect';
+import TrezorConnect from '@trezor/connect';
 
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
@@ -34,7 +34,7 @@ describe('TrezorConnect.cancelCoinjoinAuthorization', () => {
             scriptType: 'SPENDTAPROOT',
         });
 
-        expect(auth.success).toBe(true);
+        if (!auth.success) throw new Error(auth.error.message);
         expect(auth.payload).toEqual({ message: 'Coinjoin authorized' });
 
         const commitmentData =
@@ -52,10 +52,8 @@ describe('TrezorConnect.cancelCoinjoinAuthorization', () => {
         expect(proof.success).toBe(true);
 
         const cancelAuthResult = await TrezorConnect.cancelCoinjoinAuthorization({});
-        expect(cancelAuthResult.success).toBe(true);
-        expect((cancelAuthResult as Success<PROTO.Success>).payload.message).toBe(
-            'Authorization cancelled',
-        );
+        if (!cancelAuthResult.success) throw new Error(cancelAuthResult.error.message);
+        expect(cancelAuthResult.payload.message).toBe('Authorization cancelled');
 
         const proof2 = await TrezorConnect.getOwnershipProof({
             coin: 'Testnet',
@@ -66,7 +64,7 @@ describe('TrezorConnect.cancelCoinjoinAuthorization', () => {
             preauthorized: true,
         });
 
-        expect(proof2.success).toBe(false);
-        expect((proof2 as Unsuccessful).payload.error).toBe('No preauthorized operation');
+        if (proof2.success) throw new Error('Expected failure but got success');
+        expect(proof2.error.message).toBe('No preauthorized operation');
     });
 });

--- a/packages/connect/e2e/tests/device/info.test.ts
+++ b/packages/connect/e2e/tests/device/info.test.ts
@@ -22,15 +22,14 @@ describe('__info common param', () => {
     [true, false].forEach(__info => {
         it(`when incorrect params are passed, __info: boolean makes no difference. case: ${__info}`, async () => {
             // @ts-expect-error
-
             const result = await TrezorConnect.getAddress({
                 __info,
             });
 
             expect(result).toBeDefined();
             expect(result.success).toBe(false);
-            // @ts-expect-error
-            expect(result.payload.error).toEqual(
+            if (result.success) throw new Error('Expected failure');
+            expect(result.error.message).toEqual(
                 'Invalid parameter "bundle/0/path" (= undefined): Expected required property',
             );
         });
@@ -45,6 +44,7 @@ describe('__info common param', () => {
             });
             expect(result).toBeDefined();
             expect(result.success).toBe(true);
+            if (!result.success) throw new Error(result.error.message);
 
             if (__info) {
                 expect(result.payload).toMatchObject({

--- a/packages/connect/e2e/tests/device/keepSession.test.ts
+++ b/packages/connect/e2e/tests/device/keepSession.test.ts
@@ -32,7 +32,7 @@ describe('keepSession common param', () => {
             keepSession: true,
         });
         if (noDerivation.success) throw new Error('noDerivation should not succeed');
-        expect(noDerivation.payload.error).toBe(
+        expect(noDerivation.error.message).toBe(
             'Cardano derivation is not enabled for this session',
         );
 
@@ -42,7 +42,7 @@ describe('keepSession common param', () => {
             useCardanoDerivation: true,
             keepSession: true,
         });
-        if (!enableDerivation.success) throw new Error(enableDerivation.payload.error);
+        if (!enableDerivation.success) throw new Error(enableDerivation.error.message);
         expect(enableDerivation.payload.descriptor).toBeDefined();
 
         const { device } = enableDerivation;
@@ -70,7 +70,7 @@ describe('keepSession common param', () => {
             },
             // useCardanoDerivation: true, // NOTE: not required, its in the state
         });
-        if (!keepCardanoDerivation.success) throw new Error(keepCardanoDerivation.payload.error);
+        if (!keepCardanoDerivation.success) throw new Error(keepCardanoDerivation.error.message);
         expect(keepCardanoDerivation.payload.descriptor).toEqual(
             enableDerivation.payload.descriptor,
         );

--- a/packages/connect/e2e/tests/device/passphrase.test.ts
+++ b/packages/connect/e2e/tests/device/passphrase.test.ts
@@ -49,14 +49,14 @@ describe('TrezorConnect passphrase', () => {
             },
         });
         if (!walletDefault.success) {
-            throw new Error(`default Wallet exception: ${walletDefault.payload.error}`);
+            throw new Error(`default Wallet exception: ${walletDefault.error.message}`);
         }
         const xpub = await TrezorConnect.getPublicKey({
             device: { instance: 0, useEmptyPassphrase: true },
             path: XPUB_PATH,
         });
         if (!xpub.success) {
-            throw new Error(`getPublicKey exception: ${xpub.payload.error}`);
+            throw new Error(`getPublicKey exception: ${xpub.error.message}`);
         }
         expect(xpub.payload).toMatchObject({
             xpub: 'xpub6DDUPHpUo4pcy43iJeZjbSVWGav1SMMmuWdMHiGtkK8rhKmfbomtkwW6GKs1GGAKehT6QRocrmda3WWxXawpjmwaUHfFRXuKrXSapdckEYF',
@@ -75,7 +75,7 @@ describe('TrezorConnect passphrase', () => {
             },
         });
         if (!walletA.success) {
-            throw new Error(`Wallet A exception: ${walletA.payload.error}`);
+            throw new Error(`Wallet A exception: ${walletA.error.message}`);
         }
         const xpubA = await TrezorConnect.getPublicKey({
             device: {
@@ -85,7 +85,7 @@ describe('TrezorConnect passphrase', () => {
             path: XPUB_PATH,
         });
         if (!xpubA.success) {
-            throw new Error(`getPublicKey A exception: ${xpubA.payload.error}`);
+            throw new Error(`getPublicKey A exception: ${xpubA.error.message}`);
         }
         expect(xpubA.payload).toMatchObject({
             xpub: 'xpub6CixwCVCacLWy2pdyzvcWATbm8cHRqLkmC3B335NzEVx3DBMG8mhoqyJzm62Qkv3UyN4haP7xnihe7ZR134vVGY8pjAHtGgiyD139Ro29N8',
@@ -103,7 +103,7 @@ describe('TrezorConnect passphrase', () => {
             },
         });
         if (!walletB.success) {
-            throw new Error(`Wallet B exception: ${walletB.payload.error}`);
+            throw new Error(`Wallet B exception: ${walletB.error.message}`);
         }
         const xpubB = await TrezorConnect.getPublicKey({
             device: {
@@ -113,7 +113,7 @@ describe('TrezorConnect passphrase', () => {
             path: XPUB_PATH,
         });
         if (!xpubB.success) {
-            throw new Error(`getPublicKey B exception: ${xpubB.payload.error}`);
+            throw new Error(`getPublicKey B exception: ${xpubB.error.message}`);
         }
         expect(xpubB.payload).toMatchObject({
             xpub: 'xpub6CUsAXLNQXX9oGjwXi2EjL1Hp8BMPSKXsgdRHv5pgPoqb9CxncThcup7YAsbYcKMgRqDbedLCNUWzD7JhPVsEc82yYz15AYR35UGiUkXtWa',
@@ -131,6 +131,7 @@ describe('TrezorConnect passphrase', () => {
             },
             path: ADDRESS_PATH,
         });
+        if (!addressA.success) throw new Error(addressA.error.message);
         expect(addressA.payload).toMatchObject({
             address: 'bc1qjgjmd5mg4acxghjcmflpvh44dfxdwnespafrd3',
         });
@@ -141,6 +142,7 @@ describe('TrezorConnect passphrase', () => {
             },
             path: ADDRESS_PATH,
         });
+        if (!addressB.success) throw new Error(addressB.error.message);
         expect(addressB.payload).toMatchObject({
             address: 'bc1qrfe6tkm77tgg03xzgvnjf9mgrr7sfez2gk2h47',
         });
@@ -152,6 +154,7 @@ describe('TrezorConnect passphrase', () => {
             path: ADDRESS_PATH,
             showOnTrezor: false,
         });
+        if (!address.success) throw new Error(address.error.message);
         expect(address.payload).toMatchObject({
             address: 'bc1qannfxke2tfd4l7vhepehpvt05y83v3qsf6nfkk',
         });
@@ -168,8 +171,12 @@ describe('TrezorConnect passphrase', () => {
             path: "m/84'/0'/0'/0/0",
             showOnTrezor: false,
         });
-        expect(invalidState.payload).toMatchObject({
-            error: 'Passphrase is incorrect',
+        if (invalidState.success) {
+            throw new Error('Expected to fail');
+        }
+        expect(invalidState.error).toMatchObject({
+            code: 'Device_InvalidState',
+            message: 'Passphrase is incorrect',
         });
         TrezorConnect.removeAllListeners('ui-request_passphrase');
     });
@@ -179,14 +186,14 @@ describe('TrezorConnect passphrase', () => {
         const standard = await TrezorConnect.getDeviceState({
             device: { instance: 0, state: undefined, useEmptyPassphrase: true },
         });
-        if (!standard.success) throw new Error(standard.payload.error);
+        if (!standard.success) throw new Error(standard.error.message);
 
         // get passphrase wallet state
         TrezorConnect.on('ui-request_passphrase', passphraseHandler('a'));
         const passphrase = await TrezorConnect.getDeviceState({
             device: { instance: 1, state: undefined },
         });
-        if (!passphrase.success) throw new Error(passphrase.payload.error);
+        if (!passphrase.success) throw new Error(passphrase.error.message);
 
         // restart the device
         await restartEmu(controller);
@@ -199,7 +206,7 @@ describe('TrezorConnect passphrase', () => {
                 state: { staticSessionId: passphrase.payload.state.staticSessionId },
             },
         });
-        if (!passphrase2.success) throw new Error(passphrase2.payload.error);
+        if (!passphrase2.success) throw new Error(passphrase2.error.message);
 
         // try to get standard wallet state, with sessionId now used for passphrase wallet
         const standard2 = await TrezorConnect.getDeviceState({
@@ -211,7 +218,7 @@ describe('TrezorConnect passphrase', () => {
                 useEmptyPassphrase: true,
             },
         });
-        if (!standard2.success) throw new Error(standard2.payload.error);
+        if (!standard2.success) throw new Error(standard2.error.message);
 
         expect(passphrase2.payload.state.staticSessionId).toEqual(
             passphrase.payload.state.staticSessionId,
@@ -233,7 +240,7 @@ describe('TrezorConnect passphrase', () => {
         });
 
         if (!xpub.success) {
-            throw new Error(`Passphrase exception: ${xpub.payload.error}`);
+            throw new Error(`Passphrase exception: ${xpub.error.message}`);
         }
         expect(xpub.payload).toMatchObject({
             xpub: 'xpub6Gw8xpZ3YUTF7ebfnT3bGLHYrZ5mRQU14SXfGsjopTx1yVcZwkXSz2TPGyS7zqvzL9McXUjBG87FugyENjxpFCCv5W3ic1SWW5oQbRKx368',
@@ -263,7 +270,7 @@ describe('TrezorConnect passphrase', () => {
             },
         });
         if (!walletA.success) {
-            throw new Error(`Wallet A exception: ${walletA.payload.error}`);
+            throw new Error(`Wallet A exception: ${walletA.error.message}`);
         }
         const xpubA = await TrezorConnect.getPublicKey({
             device: {
@@ -273,6 +280,9 @@ describe('TrezorConnect passphrase', () => {
             path: "m/84'/0'/0'",
         });
         // same xpub as walletA from previous test case enforced on instance 0
+        if (!xpubA.success) {
+            throw new Error(`getPublicKey A exception: ${xpubA.error.message}`);
+        }
         expect(xpubA.payload).toMatchObject({
             xpub: 'xpub6CixwCVCacLWy2pdyzvcWATbm8cHRqLkmC3B335NzEVx3DBMG8mhoqyJzm62Qkv3UyN4haP7xnihe7ZR134vVGY8pjAHtGgiyD139Ro29N8',
         });

--- a/packages/connect/e2e/tests/device/setBusy.test.ts
+++ b/packages/connect/e2e/tests/device/setBusy.test.ts
@@ -33,7 +33,7 @@ describe('TrezorConnect.setBusy', () => {
             expiry_ms: 3000,
             keepSession: true, // keep session
         });
-        if (!setBusy.success) throw new Error(setBusy.payload.error);
+        if (!setBusy.success) throw new Error(setBusy.error.message);
 
         expect(busy).toBe(true);
 
@@ -41,7 +41,7 @@ describe('TrezorConnect.setBusy', () => {
         await new Promise(resolve => setTimeout(resolve, 3000));
 
         const features = await TrezorConnect.getFeatures();
-        if (!features.success) throw new Error(features.payload.error);
+        if (!features.success) throw new Error(features.error.message);
         expect(features.payload.busy).toBe(false);
     });
 
@@ -49,19 +49,19 @@ describe('TrezorConnect.setBusy', () => {
         const busy = await TrezorConnect.setBusy({
             expiry_ms: 5000,
         });
-        if (!busy.success) throw new Error(busy.payload.error);
+        if (!busy.success) throw new Error(busy.error.message);
 
         let features: Awaited<ReturnType<typeof TrezorConnect.getFeatures>>;
 
         features = await TrezorConnect.getFeatures();
-        if (!features.success) throw new Error(features.payload.error);
+        if (!features.success) throw new Error(features.error.message);
         expect(features.payload.busy).toBe(true);
 
         // reset expiry
         await TrezorConnect.setBusy({});
 
         features = await TrezorConnect.getFeatures();
-        if (!features.success) throw new Error(features.payload.error);
+        if (!features.success) throw new Error(features.error.message);
         // not busy
         expect(features.payload.busy).toBe(false);
     });
@@ -80,7 +80,7 @@ describe('TrezorConnect.setBusy', () => {
             expiry_ms: 15000,
             keepSession: true, // keep session
         });
-        if (!setBusy.success) throw new Error(setBusy.payload.error);
+        if (!setBusy.success) throw new Error(setBusy.error.message);
 
         expect(busy).toBe(true);
 

--- a/packages/connect/e2e/tests/device/thpPairing.test.ts
+++ b/packages/connect/e2e/tests/device/thpPairing.test.ts
@@ -208,7 +208,7 @@ describe('THP pairing', () => {
         if (result.success) throw ERR;
 
         expect(statusChangeEvents).toEqual(['started', 'invalid-tag']);
-        expect(result.payload.code).toMatch('Device_ThpPairingTagInvalid');
+        expect(result.error.code).toMatch('Device_ThpPairingTagInvalid');
     });
 
     it('ThpPairing cancel workflow', async () => {
@@ -230,7 +230,7 @@ describe('THP pairing', () => {
         TrezorConnect.on('ui-request_thp_pairing', cancelOnHost);
         result = await TrezorConnect.getFeatures({ device });
         if (result.success) throw ERR;
-        expect(result.payload.error).toMatch(CANCEL_ERR);
+        expect(result.error.message).toMatch(CANCEL_ERR);
         expect(statusChangeEvents).toEqual(expectedStatusChangeEvents(1));
 
         // Emulate user interaction delay in order to let the device recover with ThpTransportBusy
@@ -243,7 +243,7 @@ describe('THP pairing', () => {
         });
         result = await TrezorConnect.getFeatures({ device });
         if (result.success) throw ERR;
-        expect(result.payload.error).toMatch(FW_CANCEL_ERR);
+        expect(result.error.message).toMatch(FW_CANCEL_ERR);
         expect(statusChangeEvents).toEqual(expectedStatusChangeEvents(2));
 
         // Emulate user interaction delay in order to let the device recover with ThpTransportBusy
@@ -256,7 +256,7 @@ describe('THP pairing', () => {
         });
         result = await TrezorConnect.getFeatures({ device });
         if (result.success) throw ERR;
-        expect(result.payload.error).toMatch(FW_CANCEL_ERR);
+        expect(result.error.message).toMatch(FW_CANCEL_ERR);
         expect(statusChangeEvents).toEqual(expectedStatusChangeEvents(3));
 
         // 3. reject pairing confirmation from host
@@ -264,7 +264,7 @@ describe('THP pairing', () => {
         TrezorConnect.on('ui-button', cancelOnHost);
         result = await TrezorConnect.getFeatures({ device });
         if (result.success) throw ERR;
-        expect(result.payload.error).toMatch(FW_CANCEL_ERR); // canceled gracefully on Trezor
+        expect(result.error.message).toMatch(FW_CANCEL_ERR); // canceled gracefully on Trezor
         expect(statusChangeEvents).toEqual(expectedStatusChangeEvents(4));
 
         // check if pairing is still responsive
@@ -321,7 +321,7 @@ describe('THP pairing', () => {
             showOnTrezor: true,
         });
         if (result.success) throw ERR;
-        expect(result.payload.error).toMatch(CANCEL_ERR);
+        expect(result.error.message).toMatch(CANCEL_ERR);
 
         // 4. reject ButtonRequest from Trezor
         TrezorConnect.removeAllListeners('ui-button');
@@ -334,7 +334,7 @@ describe('THP pairing', () => {
             showOnTrezor: true,
         });
         if (result.success) throw ERR;
-        expect(result.payload.error).toMatch(FW_CANCEL_ERR);
+        expect(result.error.message).toMatch(FW_CANCEL_ERR);
 
         // 5. reject passphrase from host
         TrezorConnect.removeAllListeners('ui-request_passphrase');
@@ -350,7 +350,7 @@ describe('THP pairing', () => {
             showOnTrezor: true,
         });
         if (result.success) throw ERR;
-        expect(result.payload.error).toMatch(CANCEL_ERR);
+        expect(result.error.message).toMatch(CANCEL_ERR);
 
         // 6. reject passphrase from Trezor
         TrezorConnect.removeAllListeners('ui-request_passphrase');
@@ -366,7 +366,7 @@ describe('THP pairing', () => {
             showOnTrezor: true,
         });
         if (result.success) throw ERR;
-        expect(result.payload.error).toMatch(FW_CANCEL_ERR);
+        expect(result.error.message).toMatch(FW_CANCEL_ERR);
 
         // and finally check if device is still responsive
         TrezorConnect.removeAllListeners('ui-button');

--- a/packages/connect/e2e/tests/device/unlockPath.test.ts
+++ b/packages/connect/e2e/tests/device/unlockPath.test.ts
@@ -22,7 +22,7 @@ describe('TrezorConnect.unlockPath', () => {
         const unlockPath = await TrezorConnect.unlockPath({
             path: "m/10025'",
         });
-        if (!unlockPath.success) throw new Error(unlockPath.payload.error);
+        if (!unlockPath.success) throw new Error(unlockPath.error.message);
 
         expect(unlockPath.payload).toMatchObject({
             address_n: [2147493673],
@@ -34,6 +34,7 @@ describe('TrezorConnect.unlockPath', () => {
             unlockPath: unlockPath.payload,
             coin: 'Testnet',
         });
+        if (!address.success) throw new Error(address.error.message);
 
         expect(address.payload).toMatchObject({
             address: 'tb1pl3y9gf7xk2ryvmav5ar66ra0d2hk7lhh9mmusx3qvn0n09kmaghqh32ru7',
@@ -44,6 +45,7 @@ describe('TrezorConnect.unlockPath', () => {
             unlockPath: unlockPath.payload,
             coin: 'Testnet',
         });
+        if (!address2.success) throw new Error(address2.error.message);
 
         expect(address2.payload).toMatchObject({
             address: 'tb1p64rqq64rtt7eq6p0htegalcjl2nkjz64ur8xsclc59s5845jty7skp2843',
@@ -66,6 +68,7 @@ describe('TrezorConnect.unlockPath', () => {
                 },
             ],
         });
+        if (!bundle.success) throw new Error(bundle.error.message);
 
         expect(bundle.payload).toMatchObject([
             {
@@ -82,7 +85,8 @@ describe('TrezorConnect.unlockPath', () => {
             unlockPath: unlockPath.payload,
             coin: 'Testnet',
         });
-        expect(changeAddress.payload).toMatchObject({ error: 'Forbidden key path' });
+        if (changeAddress.success) throw new Error('Expected error');
+        expect(changeAddress.error).toMatchObject({ message: 'Forbidden key path' });
 
         // Ensure that another SLIP-0025 account is inaccessible with the same MAC.
         const otherAccount = await TrezorConnect.getAddress({
@@ -90,14 +94,15 @@ describe('TrezorConnect.unlockPath', () => {
             unlockPath: unlockPath.payload,
             coin: 'Testnet',
         });
-        expect(otherAccount.payload).toMatchObject({ error: 'Forbidden key path' });
+        if (otherAccount.success) throw new Error('Expected error');
+        expect(otherAccount.error).toMatchObject({ message: 'Forbidden key path' });
     });
 
     conditionalTest(['1', '<2.5.3'], 'Unlock SLIP-25 + getPublicKey', async () => {
         const unlockPath = await TrezorConnect.unlockPath({
             path: "m/10025'",
         });
-        if (!unlockPath.success) throw new Error(unlockPath.payload.error);
+        if (!unlockPath.success) throw new Error(unlockPath.error.message);
 
         expect(unlockPath.payload).toMatchObject({
             address_n: [2147493673],
@@ -110,6 +115,7 @@ describe('TrezorConnect.unlockPath', () => {
             coin: 'Testnet',
         });
 
+        if (!unlockedPublicKey.success) throw new Error(unlockedPublicKey.error.message);
         expect(unlockedPublicKey.payload).toMatchObject({
             xpub: 'tpubDEMKm4M3S2Grx5DHTfbX9et5HQb9KhdjDCkUYdH9gvVofvPTE6yb2MH52P9uc4mx6eFohUmfN1f4hhHNK28GaZnWRXr3b8KkfFcySo1SmXU',
             xpubSegwit: `tr([5c9e228d/10025'/1'/0'/1']tpubDEMKm4M3S2Grx5DHTfbX9et5HQb9KhdjDCkUYdH9gvVofvPTE6yb2MH52P9uc4mx6eFohUmfN1f4hhHNK28GaZnWRXr3b8KkfFcySo1SmXU/<0;1>/*)`,
@@ -133,6 +139,7 @@ describe('TrezorConnect.unlockPath', () => {
             ],
         });
 
+        if (!bundle.success) throw new Error(bundle.error.message);
         expect(bundle.payload).toMatchObject([
             {
                 xpub: 'tpubDEMKm4M3S2Grx5DHTfbX9et5HQb9KhdjDCkUYdH9gvVofvPTE6yb2MH52P9uc4mx6eFohUmfN1f4hhHNK28GaZnWRXr3b8KkfFcySo1SmXU',
@@ -150,14 +157,15 @@ describe('TrezorConnect.unlockPath', () => {
             coin: 'Testnet',
         });
 
-        expect(forbiddenPublicKey.payload).toMatchObject({ error: 'Forbidden key path' });
+        if (forbiddenPublicKey.success) throw new Error('Expected error');
+        expect(forbiddenPublicKey.error).toMatchObject({ message: 'Forbidden key path' });
     });
 
     conditionalTest(['1', '<2.5.3'], 'Unlock SLIP-25 + signTransaction', async () => {
         const unlockPath = await TrezorConnect.unlockPath({
             path: "m/10025'",
         });
-        if (!unlockPath.success) throw new Error(unlockPath.payload.error);
+        if (!unlockPath.success) throw new Error(unlockPath.error.message);
 
         expect(unlockPath.payload).toMatchObject({
             address_n: [2147493673],
@@ -197,12 +205,14 @@ describe('TrezorConnect.unlockPath', () => {
             unlockPath: unlockPath.payload,
         });
 
+        if (!unlockedSignTx.success) throw new Error(unlockedSignTx.error.message);
         expect(unlockedSignTx.payload).toMatchObject({
             serializedTx:
                 '010000000001010ab6ad3ba09261cfb4fa1d3680cb19332a8fe4d9de9ea89aa565bd83a2c082f90100000000ffffffff02c8736e0000000000225120c5c7c63798b59dc16e97d916011e99da5799d1b3dd81c2f2e93392477417e71e50c30000000000001976a914a579388225827d9f2fe9014add644487808c695d88ac014006bc29900d39570fca291c038551817430965ac6aa26f286483559e692a14a82cfaf8e57610eae12a5af05ee1e9600acb31de4757349c0e3066701aa78f65d2a00000000',
         });
 
         const forbiddenSignTx = await TrezorConnect.signTransaction(params);
-        expect(forbiddenSignTx.payload).toMatchObject({ error: 'Forbidden key path' });
+        if (forbiddenSignTx.success) throw new Error('Expected error');
+        expect(forbiddenSignTx.error).toMatchObject({ message: 'Forbidden key path' });
     });
 });

--- a/packages/connect/src/events/call.ts
+++ b/packages/connect/src/events/call.ts
@@ -1,4 +1,4 @@
-import { serializeError } from '@trezor/connect-common/src/constants/errors';
+import { SerializedError, serializeError } from '@trezor/connect-common/src/constants/errors';
 
 import type { CORE_CALL } from './core-call';
 import type { Device } from '../device/Device';
@@ -73,33 +73,55 @@ export interface CoreCallMessage {
 
 export const RESPONSE_EVENT = 'RESPONSE_EVENT';
 
-export interface MethodResponseMessage {
+export type MethodResponseMessage = {
     // extends AnyResponse
     event: typeof RESPONSE_EVENT;
     type: typeof RESPONSE_EVENT;
     id: number;
-    success: boolean;
-    payload: CallMethodResponse<CallMethodKeys>;
+
     device?: DeviceIdentity;
-}
+} & (
+    | {
+          success: true;
+          payload: CallMethodResponse<CallMethodKeys>;
+          error?: undefined;
+      }
+    | {
+          success: false;
+          payload?: undefined;
+          error: SerializedError;
+      }
+);
 
 export const createResponseMessage = (
     id: number,
     success: boolean,
     payload: any,
     device?: Device,
-): MethodResponseMessage => ({
-    event: RESPONSE_EVENT,
-    type: RESPONSE_EVENT,
-    id,
-    success,
-
-    payload: success ? payload : serializeError(payload),
-    device: device
+): MethodResponseMessage => {
+    const deviceIdentity = device
         ? {
               path: device?.getUniquePath(),
               state: device?.getState(),
               instance: device?.getInstance(),
           }
-        : undefined,
-});
+        : undefined;
+    if (success)
+        return {
+            event: RESPONSE_EVENT,
+            type: RESPONSE_EVENT,
+            id,
+            success: true,
+            payload,
+            device: deviceIdentity,
+        };
+
+    return {
+        event: RESPONSE_EVENT,
+        type: RESPONSE_EVENT,
+        id,
+        success: false,
+        error: serializeError(payload),
+        device: deviceIdentity,
+    };
+};

--- a/packages/connect/src/events/core.ts
+++ b/packages/connect/src/events/core.ts
@@ -1,4 +1,9 @@
-import { ErrorCode, TrezorError } from '@trezor/connect-common/src/constants/errors';
+import {
+    ErrorCode,
+    SerializedError,
+    TrezorError,
+} from '@trezor/connect-common/src/constants/errors';
+import { Err } from '@trezor/type-utils';
 
 import type { BlockchainEventMessage } from './blockchain';
 import type { CoreCallMessage, MethodResponseMessage } from './call';
@@ -13,7 +18,6 @@ import type {
 } from './transport';
 import type { UiEventMessage } from './ui-request';
 import type { UiResponseEvent } from './ui-response';
-import type { Unsuccessful } from '../types/params';
 
 export const CORE_EVENT = 'CORE_EVENT';
 
@@ -63,10 +67,10 @@ export const parseMessage = <T extends CoreRequestMessage | CoreEventMessage = n
 // common response used straight from npm index (not from Core)
 export const createErrorMessage = (
     error: (Error & { code?: ErrorCode }) | TrezorError,
-): Unsuccessful => ({
+): Err<SerializedError> => ({
     success: false,
-    payload: {
-        error: error.message,
-        code: error.code,
+    error: {
+        message: error.message,
+        code: error.code ?? 'Failure_UnknownCode',
     },
 });

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -11,6 +11,7 @@ import {
     CoreEventMessage,
     CoreRequestMessage,
     DEVICE_EVENT,
+    MethodResponseMessage,
     POPUP,
     RESPONSE_EVENT,
     TRANSPORT,
@@ -20,7 +21,7 @@ import {
     createErrorMessage,
 } from '../events';
 import { ConnectFactoryDependencies } from '../factory';
-import type { ConnectSettings, ConnectSettingsPublic, DeviceIdentity, Manifest } from '../types';
+import type { ConnectSettings, ConnectSettingsPublic, Manifest } from '../types';
 import type { UpdateConnectSettings } from '../types/api/updateConnectSettings';
 import { Log, initLog } from '../utils/debug';
 
@@ -30,12 +31,7 @@ export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsP
 
     private _coreManager?: any;
     private _log: Log;
-    private _messagePromises: DeferredManager<{
-        id: number;
-        success: boolean;
-        payload: any;
-        device?: DeviceIdentity;
-    }>;
+    private _messagePromises: DeferredManager<Omit<MethodResponseMessage, 'event' | 'type'>>;
 
     private readonly boundOnCoreEvent = this.onCoreEvent.bind(this);
 
@@ -113,11 +109,12 @@ export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsP
 
         switch (event) {
             case RESPONSE_EVENT: {
-                const { id = 0, success, device } = message;
+                const { id = 0, success, error, device } = message;
                 const resolved = this._messagePromises.resolve(id, {
                     id,
                     success,
                     payload,
+                    error,
                     device,
                 });
                 if (!resolved) this._log.warn(`Unknown message id ${id}`);

--- a/packages/connect/src/impl/dynamic.ts
+++ b/packages/connect/src/impl/dynamic.ts
@@ -139,7 +139,7 @@ export class TrezorConnectDynamic implements ConnectFactoryDependencies<{}> {
             }
             const response = await this.getTarget().call(params);
             if (!response.success) {
-                if (await this.handleErrorFallback(response.payload.code)) {
+                if (await this.handleErrorFallback(response.error.code)) {
                     return await this.getTarget().call(params);
                 }
             }

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -45,8 +45,13 @@ const onCoreEvent = (message: CoreEventMessage) => {
 
     switch (message.event) {
         case RESPONSE_EVENT: {
-            const { id = 0, success, payload, device } = message;
-            const resolved = messagePromises.resolve(id, { id, success, payload, device });
+            const { id = 0, success, device } = message;
+            const resolved = messagePromises.resolve(
+                id,
+                success
+                    ? { id, success, payload: message.payload, device }
+                    : { id, success, error: message.error, device },
+            );
             if (!resolved) _log.warn(`Unknown message id ${id}`);
             break;
         }

--- a/packages/connect/src/types/api/__tests__/bitcoin.ts
+++ b/packages/connect/src/types/api/__tests__/bitcoin.ts
@@ -23,7 +23,7 @@ export const getAddress = async (api: TrezorConnect) => {
         // @ts-expect-error, payload is an array
         bundleAddress.payload.address.toLowerCase();
     } else {
-        bundleAddress.payload.error.toLowerCase();
+        bundleAddress.error.message.toLowerCase();
     }
 
     // with all possible params
@@ -88,7 +88,7 @@ export const getPublicKey = async (api: TrezorConnect) => {
         // @ts-expect-error, payload is an array
         bundlePK.payload.xpub.toLowerCase();
     } else {
-        bundlePK.payload.error.toLowerCase();
+        bundlePK.error.message.toLowerCase();
     }
 };
 
@@ -522,7 +522,7 @@ export const composeTransaction = async (api: TrezorConnect) => {
             tx.outputs.map((a: any) => a);
         }
     } else {
-        precompose.payload.error.toLowerCase();
+        precompose.error.message.toLowerCase();
         // @ts-expect-error
         precompose.payload.type.toLowerCase();
     }
@@ -699,7 +699,7 @@ export const getOwnershipId = async (api: TrezorConnect) => {
         // @ts-expect-error
         bundleId.payload.ownership_id.toLowerCase();
     } else {
-        bundleId.payload.error.toLowerCase();
+        bundleId.error.message.toLowerCase();
     }
 
     // @ts-expect-error missing path
@@ -737,7 +737,7 @@ export const getOwnershipProof = async (api: TrezorConnect) => {
         // @ts-expect-error
         bundleId.payload.ownership_proof.toLowerCase();
     } else {
-        bundleId.payload.error.toLowerCase();
+        bundleId.error.message.toLowerCase();
     }
 
     // @ts-expect-error missing path

--- a/packages/connect/src/types/api/__tests__/cardano.ts
+++ b/packages/connect/src/types/api/__tests__/cardano.ts
@@ -116,7 +116,7 @@ export const cardanoGetAddress = async (api: TrezorConnect) => {
         // @ts-expect-error, payload is an array
         bundleAddress.payload.address.toLowerCase();
     } else {
-        bundleAddress.payload.error.toLowerCase();
+        bundleAddress.error.message.toLowerCase();
     }
 
     // with all possible params
@@ -185,7 +185,7 @@ export const cardanoGetNativeScriptHash = async (api: TrezorConnect) => {
     if (result.success) {
         result.payload.scriptHash.toLowerCase();
     } else {
-        result.payload.error.toLowerCase();
+        result.error.message.toLowerCase();
     }
 };
 
@@ -214,7 +214,7 @@ export const cardanoGetPublicKey = async (api: TrezorConnect) => {
         // @ts-expect-error
         bundlePK.payload.path.toLowerCase();
     } else {
-        bundlePK.payload.error.toLowerCase();
+        bundlePK.error.message.toLowerCase();
     }
 };
 

--- a/packages/connect/src/types/api/__tests__/ethereum.ts
+++ b/packages/connect/src/types/api/__tests__/ethereum.ts
@@ -24,7 +24,7 @@ export const ethereumGetAddress = async (api: TrezorConnect) => {
         // @ts-expect-error, payload is an array
         bundleAddress.payload.address.toLowerCase();
     } else {
-        bundleAddress.payload.error.toLowerCase();
+        bundleAddress.error.message.toLowerCase();
     }
 
     // with all possible params
@@ -86,7 +86,7 @@ export const ethereumGetPublicKey = async (api: TrezorConnect) => {
         // @ts-expect-error, payload is an array
         bundlePK.payload.address.toLowerCase();
     } else {
-        bundlePK.payload.error.toLowerCase();
+        bundlePK.error.message.toLowerCase();
     }
 };
 

--- a/packages/connect/src/types/api/__tests__/events.ts
+++ b/packages/connect/src/types/api/__tests__/events.ts
@@ -103,7 +103,7 @@ export const events = (api: TrezorConnect) => {
     api.on(UI_EVENT, event => {
         if (event.type === UI.BUNDLE_PROGRESS) {
             // event.payload.progress;
-            // event.payload.error;
+            // event.error.message;
             // event.payload.response;
         }
         if (event.type === UI.REQUEST_BUTTON) {

--- a/packages/connect/src/types/api/__tests__/misc.ts
+++ b/packages/connect/src/types/api/__tests__/misc.ts
@@ -25,7 +25,7 @@ export const cipherKeyValue = async (api: TrezorConnect) => {
         // @ts-expect-error
         bundleKV.payload.xpub.toLowerCase();
     } else {
-        bundleKV.payload.error.toLowerCase();
+        bundleKV.error.message.toLowerCase();
     }
 };
 
@@ -35,7 +35,7 @@ export const updateConnectSettings = async (api: TrezorConnect) => {
     if (proxy.success) {
         proxy.payload.message.toLowerCase();
     } else {
-        proxy.payload.error.toLowerCase();
+        proxy.error.message.toLowerCase();
     }
     api.updateConnectSettings({
         proxy: {

--- a/packages/connect/src/types/api/__tests__/ripple.ts
+++ b/packages/connect/src/types/api/__tests__/ripple.ts
@@ -25,7 +25,7 @@ export const rippleGetAddress = async (api: TrezorConnect) => {
         // @ts-expect-error, payload is an array
         bundleAddress.payload.address.toLowerCase();
     } else {
-        bundleAddress.payload.error.toLowerCase();
+        bundleAddress.error.message.toLowerCase();
     }
 
     // with all possible params

--- a/packages/connect/src/types/api/__tests__/stellar.ts
+++ b/packages/connect/src/types/api/__tests__/stellar.ts
@@ -23,7 +23,7 @@ export const stellarGetAddress = async (api: TrezorConnect) => {
         // @ts-expect-error, payload is an array
         bundleAddress.payload.address.toLowerCase();
     } else {
-        bundleAddress.payload.error.toLowerCase();
+        bundleAddress.error.message.toLowerCase();
     }
 
     // with all possible params

--- a/packages/connect/src/types/api/__tests__/tezos.ts
+++ b/packages/connect/src/types/api/__tests__/tezos.ts
@@ -23,7 +23,7 @@ export const tezosGetAddress = async (api: TrezorConnect) => {
         // @ts-expect-error, payload is an array
         bundleAddress.payload.address.toLowerCase();
     } else {
-        bundleAddress.payload.error.toLowerCase();
+        bundleAddress.error.message.toLowerCase();
     }
 
     // with all possible params
@@ -74,7 +74,7 @@ export const tezosGetPublicKey = async (api: TrezorConnect) => {
         // @ts-expect-error, payload is an array
         bundlePK.payload.path.toLowerCase();
     } else {
-        bundlePK.payload.error.toLowerCase();
+        bundlePK.error.message.toLowerCase();
     }
 };
 

--- a/packages/connect/src/types/params.ts
+++ b/packages/connect/src/types/params.ts
@@ -1,7 +1,8 @@
 // API params
 
-import { ErrorCode } from '@trezor/connect-common/src/constants/errors';
+import { SerializedError } from '@trezor/connect-common/src/constants/errors';
 import { Static, TSchema, Type } from '@trezor/schema-utils';
+import { Err, Ok } from '@trezor/type-utils';
 
 import { DeviceState, DeviceUniquePath } from './device';
 
@@ -42,21 +43,11 @@ export interface CommonParamsWithCoin extends CommonParams {
     identity?: string; // ensures that different backend connections are opened for different identities
 }
 
-export interface Unsuccessful {
-    success: false;
-    payload: { error: string; code?: ErrorCode };
-}
-
-export interface Success<T> {
-    success: true;
-    payload: T;
-}
-
-export interface SuccessWithDevice<T> extends Success<T> {
+export interface OkWithDevice<T> extends Ok<T> {
     device?: DeviceIdentity;
 }
 
-export type Response<T> = Promise<SuccessWithDevice<T> | Unsuccessful>;
+export type Response<T> = Promise<OkWithDevice<T> | Err<SerializedError>>;
 
 export type DerivationPath = string | number[];
 export const DerivationPath = Type.Union([Type.String(), Type.Array(Type.Number())], {

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -160,6 +160,14 @@ export type ConnectPopupCancel = {
 
 export type ConnectPopupResponse = {
     id: string;
-    success: boolean;
-    payload: any;
-};
+} & (
+    | {
+          success: true;
+          payload: any;
+      }
+    | {
+          success: false;
+          payload: any; // for backward compatibility with v9
+          error: any;
+      }
+);

--- a/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
+++ b/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
@@ -93,7 +93,7 @@ describe('Backup Actions', () => {
     it('backup error', async () => {
         testMocks.setTrezorConnectFixtures({
             success: false,
-            payload: { error: 'avadakedavra' },
+            error: { message: 'avadakedavra' },
         });
 
         const state = getInitialState({});

--- a/packages/suite/src/actions/backup/backupActions.ts
+++ b/packages/suite/src/actions/backup/backupActions.ts
@@ -73,13 +73,13 @@ export const backupDevice =
             dispatch(notificationsActions.addToast({ type: 'backup-failed' }));
             dispatch({
                 type: BACKUP.SET_ERROR,
-                payload: result.payload.error,
+                payload: result.error.message,
             });
             asTypedDesktopAnalytics(extra.services.analytics).report({
                 type: events.createBackupEvent.name,
                 payload: {
                     status: 'error',
-                    error: result.payload.error,
+                    error: result.error.message,
                 },
             });
         } else {

--- a/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
@@ -44,12 +44,12 @@ const unpairCurrentBondThunk = createThunk<void, UnpairCurrentBondThunkParams, v
         const result = await TrezorConnect.bleUnpair({ device, all: false });
         if (
             result.success ||
-            result.payload.code === 'Device_Disconnected' // This is an expected success
+            result.error.code === 'Device_Disconnected' // This is an expected success
         ) {
             dispatch(bluetoothActions.removeKnownDeviceAction({ id: bluetoothId }));
             dispatch(forgetBluetoothDeviceThunk({ bluetoothId }));
         } else {
-            dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
+            dispatch(notificationsActions.addToast({ type: 'error', error: result.error.message }));
         }
     },
 );

--- a/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
@@ -176,8 +176,8 @@ export const actions = [
         mocks: {
             connect: {
                 success: false,
-                payload: {
-                    error: 'foo',
+                error: {
+                    message: 'foo',
                 },
             },
         },
@@ -213,8 +213,8 @@ export const actions = [
         mocks: {
             connect: {
                 success: false,
-                payload: {
-                    error: 'Firmware install failed',
+                error: {
+                    message: 'Firmware install failed',
                 },
             },
         },

--- a/packages/suite/src/actions/recovery/recoveryActions.ts
+++ b/packages/suite/src/actions/recovery/recoveryActions.ts
@@ -84,12 +84,12 @@ const checkSeed =
         });
 
         if (!response.success) {
-            dispatch(setError(response.payload.error));
+            dispatch(setError(response.error.message));
             asTypedDesktopAnalytics(extra.services.analytics).report({
                 type: events.settingsDeviceCheckSeedEvent.name,
                 payload: {
                     status: 'error',
-                    error: response.payload.code,
+                    error: response.error.code,
                 },
             });
         } else {
@@ -141,7 +141,7 @@ const recoverDevice = () => async (dispatch: Dispatch, getState: GetState) => {
     });
 
     if (!response.success) {
-        dispatch(setError(response.payload.error));
+        dispatch(setError(response.error.message));
     }
 
     dispatch(setStatus('finished'));

--- a/packages/suite/src/actions/settings/__fixtures__/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/deviceSettingsActions.ts
@@ -227,7 +227,7 @@ const fixture: Fixture[] = [
     {
         description: 'Wipe device errored',
         action: () => wipeDeviceThunk(),
-        mocks: { success: false, payload: { error: 'fuuu' } },
+        mocks: { success: false, error: { message: 'fuuu', code: 'Failure_UnknownCode' } },
         result: {
             actions: [
                 {
@@ -265,7 +265,7 @@ const fixture: Fixture[] = [
     {
         description: 'Apply settings - connect error',
         action: () => deviceSettingsActions.applySettings({ label: 'foo' }),
-        mocks: { success: false, payload: { error: 'eeeh' } },
+        mocks: { success: false, error: { message: 'eeeh', code: 'Failure_UnknownCode' } },
         result: {
             actions: [
                 {
@@ -298,7 +298,7 @@ const fixture: Fixture[] = [
     {
         description: 'Change pin - connect error',
         action: () => deviceSettingsActions.changePin({}),
-        mocks: { success: false, payload: { error: 'eeeh' } },
+        mocks: { success: false, error: { message: 'eeeh', code: 'Failure_UnknownCode' } },
         result: {
             actions: [
                 {
@@ -317,7 +317,7 @@ const fixture: Fixture[] = [
     {
         description: 'Reset device - Cancel - Entropy check not triggered',
         action: () => deviceSettingsActions.resetDevice(),
-        mocks: { success: false, payload: { error: 'Canceled', code: 'Method_Cancel' } },
+        mocks: { success: false, error: { message: 'Canceled', code: 'Method_Cancel' } },
         result: {
             actions: [
                 {
@@ -364,7 +364,7 @@ const fixture: Fixture[] = [
         action: () => deviceSettingsActions.resetDevice(),
         mocks: {
             success: false,
-            payload: { error: 'Entropy check failed', code: 'Failure_EntropyCheck' },
+            error: { message: 'Entropy check failed', code: 'Failure_EntropyCheck' },
         },
         result: {
             actions: [

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -30,7 +30,7 @@ export const applySettings =
         if (result.success) {
             dispatch(notificationsActions.addToast({ type: 'settings-applied' }));
         } else {
-            dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
+            dispatch(notificationsActions.addToast({ type: 'error', error: result.error.message }));
         }
 
         return result;
@@ -53,9 +53,9 @@ export const changePin =
             if (!skipSuccessToast) {
                 dispatch(notificationsActions.addToast({ type: 'pin-changed' }));
             }
-        } else if (result.payload.code === 'Failure_PinMismatch') {
+        } else if (result.error.code === 'Failure_PinMismatch') {
             dispatch(modalActions.openModal({ type: 'pin-mismatch' }));
-        } else if (result.payload.error.includes('string overflow')) {
+        } else if (result.error.message.includes('string overflow')) {
             // this is a workaround for FW < 1.10.0
             // translate generic error from the device if the entered PIN is longer than 9 digits
             dispatch(
@@ -65,7 +65,7 @@ export const changePin =
                 }),
             );
         } else {
-            dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
+            dispatch(notificationsActions.addToast({ type: 'error', error: result.error.message }));
         }
     };
 
@@ -88,10 +88,10 @@ export const changeWipeCode =
                     type: remove ? 'wipe-code-removed' : 'wipe-code-changed',
                 }),
             );
-        } else if (result.payload.code === 'Failure_WipeCodeMismatch') {
+        } else if (result.error.code === 'Failure_WipeCodeMismatch') {
             dispatch(modalActions.openModal({ type: 'pin-mismatch' }));
         } else {
-            dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
+            dispatch(notificationsActions.addToast({ type: 'error', error: result.error.message }));
         }
     };
 
@@ -194,9 +194,9 @@ export const changeLanguage = createThunk(
         } else {
             // Different errors for desktop/Chrome/Firefox
             const isFetchError =
-                result.payload.code === ('ENOTFOUND' as ERRORS.ErrorCode) ||
+                result.error.code === ('ENOTFOUND' as ERRORS.ErrorCode) ||
                 ['Failed to fetch', 'NetworkError when attempting to fetch resource.'].includes(
-                    result.payload.error,
+                    result.error.message,
                 );
             if (isFetchError) {
                 dispatch(notificationsActions.addToast({ type: 'firmware-language-fetch-error' }));
@@ -204,7 +204,7 @@ export const changeLanguage = createThunk(
                 dispatch(
                     notificationsActions.addToast({
                         type: 'error',
-                        error: result.payload.error,
+                        error: result.error.message,
                     }),
                 );
             }

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -761,8 +761,8 @@ const acquireDevice = [
         },
         getFeatures: {
             success: false,
-            payload: {
-                error: 'getFeatures error',
+            error: {
+                message: 'getFeatures error',
             },
         },
         result: notificationsActions.addToast.type,

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -38,8 +38,8 @@ export const createCoinjoinAccount = [
         description: 'path not unlocked',
         connect: {
             success: false,
-            payload: {
-                error: 'Canceled',
+            error: {
+                message: 'Canceled',
             },
         },
         params: {
@@ -70,8 +70,8 @@ export const createCoinjoinAccount = [
             },
             {
                 success: false, // getPublicKey
-                payload: {
-                    error: 'Forbidden key path',
+                error: {
+                    message: 'Forbidden key path',
                 },
             },
         ],
@@ -160,8 +160,8 @@ export const startCoinjoinSession = [
         description: 'authorizeCoinjoin cancelled',
         connect: {
             success: false,
-            payload: {
-                error: 'Canceled',
+            error: {
+                message: 'Canceled',
             },
         },
         state: {

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
@@ -408,8 +408,8 @@ export const getOwnershipProof = [
         connect: [
             {
                 success: false,
-                payload: {
-                    error: 'Firmware error',
+                error: {
+                    message: 'Firmware error',
                 },
             },
             {
@@ -761,8 +761,8 @@ export const signCoinjoinTx = [
         connect: [
             {
                 success: false,
-                payload: {
-                    error: 'Firmware error',
+                error: {
+                    message: 'Firmware error',
                 },
             },
         ],

--- a/packages/suite/src/actions/wallet/__fixtures__/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/publicKeyActions.ts
@@ -122,7 +122,7 @@ export default [
         description: 'Show public key, @trezor/connect error',
         initialState: undefined,
         mocks: {
-            getPublicKey: { success: false, payload: { error: 'Runtime error' } },
+            getPublicKey: { success: false, error: { message: 'Runtime error' } },
         },
         action: publicKeyActions.showXpub,
         result: {
@@ -148,7 +148,7 @@ export default [
         mocks: {
             getPublicKey: {
                 success: false,
-                payload: { error: 'Runtime error', code: 'Method_PermissionsNotGranted' },
+                error: { message: 'Runtime error', code: 'Method_PermissionsNotGranted' },
             },
         },
         action: publicKeyActions.showXpub,

--- a/packages/suite/src/actions/wallet/__fixtures__/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/receiveActions.ts
@@ -180,7 +180,7 @@ export default [
     {
         description: 'Show address, @trezor/connect error',
         mocks: {
-            getAddress: { success: false, payload: { error: 'Runtime error' } },
+            getAddress: { success: false, error: { message: 'Runtime error' } },
         },
         action: () => receiveActions.showAddress(PATH, ADDRESS),
         result: {
@@ -208,7 +208,7 @@ export default [
         mocks: {
             getAddress: {
                 success: false,
-                payload: { error: 'Runtime error', code: 'Method_PermissionsNotGranted' },
+                error: { message: 'Runtime error', code: 'Method_PermissionsNotGranted' },
             },
         },
         action: () => receiveActions.showAddress(PATH, ADDRESS),

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
@@ -411,7 +411,7 @@ describe('coinjoinClientActions', () => {
         } as any);
 
         testMocks.setTrezorConnectFixtures([
-            { success: false, payload: { error: 'Firmware error' } },
+            { success: false, error: { message: 'Firmware error' } },
         ]);
 
         await store.dispatch(initCoinjoinService('btc'));

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -580,7 +580,7 @@ export const createCoinjoinAccount =
         const device = selectSelectedDevice(getState());
         const unlockPath = await TrezorConnect.unlockPath({ path: "m/10025'", device });
         if (!unlockPath.success) {
-            dispatch(handleError(unlockPath.payload.error));
+            dispatch(handleError(unlockPath.error.message));
             dispatch(clearCoinjoinInstances(network.symbol));
             dispatch(coinjoinAccountPreloading(false));
 
@@ -598,7 +598,7 @@ export const createCoinjoinAccount =
             suppressBackupWarning: true,
         });
         if (!publicKey.success) {
-            dispatch(handleError(publicKey.payload.error));
+            dispatch(handleError(publicKey.error.message));
             dispatch(clearCoinjoinInstances(network.symbol));
             dispatch(coinjoinAccountPreloading(false));
 
@@ -708,12 +708,12 @@ const authorizeCoinjoin =
             return true;
         }
 
-        dispatch(coinjoinAccountAuthorizeFailed(account.key, auth.payload.error));
+        dispatch(coinjoinAccountAuthorizeFailed(account.key, auth.error.message));
 
         dispatch(
             notificationsActions.addToast({
                 type: 'error',
-                error: `Coinjoin not authorized: ${auth.payload.error}`,
+                error: `Coinjoin not authorized: ${auth.error.message}`,
             }),
         );
     };

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -343,7 +343,7 @@ export const stopCoinjoinSession =
                 dispatch(
                     notificationsActions.addToast({
                         type: 'error',
-                        error: `Cancel coinjoin authorization ${result.payload.error}`,
+                        error: `Cancel coinjoin authorization ${result.error.message}`,
                     }),
                 );
             }
@@ -533,7 +533,10 @@ const getOwnershipProof =
                     return;
                 }
                 utxos.forEach(u => {
-                    response.inputs.push({ outpoint: u.outpoint, error: proof.payload?.error });
+                    response.inputs.push({
+                        outpoint: u.outpoint,
+                        error: proof.error?.message,
+                    });
                 });
             }),
         );
@@ -678,14 +681,14 @@ const signCoinjoinTx =
                         utxos.forEach(u => {
                             response.inputs.push({
                                 outpoint: u.outpoint,
-                                error: `${fwVersion} (${getOsName()}) ${signTx.payload.error}`,
+                                error: `${fwVersion} (${getOsName()}) ${signTx.error.message}`,
                             });
                         });
 
                         dispatch(
                             notificationsActions.addToast({
                                 type: 'error',
-                                error: `Coinjoin signTransaction: ${signTx.payload.error}`,
+                                error: `Coinjoin signTransaction: ${signTx.error.message}`,
                             }),
                         );
                     },

--- a/packages/suite/src/actions/wallet/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/publicKeyActions.ts
@@ -36,11 +36,11 @@ export const showXpub = () => async (dispatch: Dispatch, getState: GetState) => 
     } else {
         dispatch(onCancel());
         // Special case: closing no-backup warning modal should not show a toast.
-        if (response.payload.code === 'Method_PermissionsNotGranted') return;
+        if (response.error.code === 'Method_PermissionsNotGranted') return;
         dispatch(
             notificationsActions.addToast({
                 type: 'verify-xpub-error',
-                error: response.payload.error,
+                error: response.error.message,
             }),
         );
     }

--- a/packages/suite/src/actions/wallet/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/receiveActions.ts
@@ -105,12 +105,12 @@ export const showAddress =
         } else {
             dispatch(modalActions.onCancel());
             // special case: device no-backup permissions not granted
-            if (response.payload.code === 'Method_PermissionsNotGranted') return;
+            if (response.error.code === 'Method_PermissionsNotGranted') return;
 
             dispatch(
                 notificationsActions.addToast({
                     type: 'verify-address-error',
-                    error: response.payload.error,
+                    error: response.error.message,
                 }),
             );
         }

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -26,7 +26,7 @@ import {
     PrecomposedTransactionFinalBumpFeeRbf,
 } from '@suite-common/wallet-types';
 import { isCardanoTx, isRbfBumpFeeTransaction } from '@suite-common/wallet-utils';
-import { PROTO, StaticSessionId, Unsuccessful } from '@trezor/connect';
+import { PROTO, StaticSessionId } from '@trezor/connect';
 import { getSynchronize } from '@trezor/utils';
 
 import * as modalActions from 'src/actions/suite/modalActions';
@@ -261,7 +261,8 @@ export const signAndPushSendFormTransactionThunk = createThunk(
 
             // Do not close the modal if the transaction signing timed out
             if (signResponse.payload?.error === 'sign-transaction-timeout') {
-                return { type: signResponse.payload.error } as unknown as Unsuccessful;
+                // TODO: this is some kinda bizarre hack
+                return { type: signResponse.error.message } as any;
             }
 
             // Close the modal manually since UI.CLOSE_UI.WINDOW was

--- a/packages/suite/src/actions/wallet/signVerifyActions.ts
+++ b/packages/suite/src/actions/wallet/signVerifyActions.ts
@@ -8,8 +8,10 @@ import {
     getProtocolMagic,
     getStakingPath,
 } from '@suite-common/wallet-utils';
-import TrezorConnect, { PROTO, Success, Unsuccessful } from '@trezor/connect';
+import TrezorConnect, { PROTO } from '@trezor/connect';
 import { getSerializedPath } from '@trezor/connect/src/utils/pathUtils';
+import { SerializedError } from '@trezor/connect-common/src/constants/errors';
+import { Result } from '@trezor/type-utils';
 
 import { selectAddressDisplayType } from 'src/selectors/suite/suiteSelectors';
 import type { Dispatch, GetState, TrezorDevice } from 'src/types/suite';
@@ -28,10 +30,10 @@ type StateParams = {
     chunkify?: boolean;
 };
 
-const throwWhenFailed = <T>(response: Unsuccessful | Success<T>) =>
+const throwWhenFailed = <T>(response: Result<T, SerializedError>) =>
     response.success
         ? Promise.resolve(response.payload)
-        : Promise.reject(new Error(response.payload.error));
+        : Promise.reject(new Error(response.error.message));
 
 const getStateParams = (getState: GetState): Promise<StateParams> => {
     const {

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -174,7 +174,7 @@ export const prepareTxPlan = async (
         testnet: isTestnet(account.symbol),
     });
 
-    if (!response.success) throw new Error(response.payload.error);
+    if (!response.success) throw new Error(response.error.message);
 
     return { txPlan: response.payload[0], certificates, withdrawals };
 };
@@ -381,15 +381,15 @@ export const signTransaction =
             });
 
             // catch manual error from TransactionReviewModal
-            if (signedTx.payload.error === 'tx-cancelled') {
+            if (signedTx.error.message === 'tx-cancelled') {
                 return;
             }
 
-            if (signedTx.payload.error !== 'tx-timeout') {
+            if (signedTx.error.message !== 'tx-timeout') {
                 dispatch(
                     notificationsActions.addToast({
                         type: 'sign-tx-error',
-                        error: signedTx.payload.error,
+                        error: signedTx.error.message,
                     }),
                 );
             }

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -227,12 +227,12 @@ export const signTransaction =
             });
 
             // catch manual error from TransactionReviewModal
-            if (signedTx.payload.error === 'tx-cancelled') return;
+            if (signedTx.error.message === 'tx-cancelled') return;
 
             dispatch(
                 notificationsActions.addToast({
                     type: 'sign-tx-error',
-                    error: signedTx.payload.error,
+                    error: signedTx.error.message,
                 }),
             );
 

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -316,15 +316,15 @@ export const signTransaction =
             });
 
             // catch manual error from TransactionReviewModal
-            if (signedTx.payload.error === 'tx-cancelled') {
+            if (signedTx.error.message === 'tx-cancelled') {
                 return;
             }
 
-            if (signedTx.payload.error !== 'tx-timeout') {
+            if (signedTx.error.message !== 'tx-timeout') {
                 dispatch(
                     notificationsActions.addToast({
                         type: 'sign-tx-error',
-                        error: signedTx.payload.error,
+                        error: signedTx.error.message,
                     }),
                 );
             }

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -25,7 +25,9 @@ import {
     isSupportedSolStakingNetworkSymbol,
     tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
-import TrezorConnect, { Unsuccessful } from '@trezor/connect';
+import TrezorConnect from '@trezor/connect';
+import { SerializedError } from '@trezor/connect-common/src/constants/errors';
+import { Err } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { Dispatch, GetState } from 'src/types/suite';
@@ -204,7 +206,7 @@ const pushTransaction =
             dispatch(
                 notificationsActions.addToast({
                     type: 'sign-tx-error',
-                    error: sentTx.payload.error,
+                    error: sentTx.error.message,
                 }),
             );
         }
@@ -241,7 +243,7 @@ export const signTransaction =
         dispatch(modalActions.preserve());
 
         // signTransaction by Trezor
-        let serializedTx: undefined | string | Unsuccessful;
+        let serializedTx: undefined | string | Err<SerializedError>;
         if (isSupportedEthStakingNetworkSymbol(account.symbol)) {
             serializedTx = await dispatch(
                 stakeFormEthereumActions.signTransaction(formValues, enhancedTxInfo),
@@ -261,7 +263,7 @@ export const signTransaction =
         }
 
         if (typeof serializedTx !== 'string') {
-            if (serializedTx?.payload?.error === 'tx-timeout') {
+            if (serializedTx?.error?.message === 'tx-timeout') {
                 return;
             }
             // close modal manually since UI.CLOSE_UI.WINDOW was blocked

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
@@ -53,7 +53,7 @@ export const AddTokenModal = ({ onCancel }: AddTokenModalProps) => {
                 setTokenInfo(undefined);
                 setError(
                     translationString('TR_ADD_TOKEN_TOAST_ERROR', {
-                        error: response.payload.error,
+                        error: response.error.message,
                     }),
                 );
             }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
@@ -122,21 +122,21 @@ export const ConnectErrorModal = () => {
         if (isCancelled) return <Translation id="TR_CONNECT_ERROR_CANCELED" />;
         if (isNoTransportError) return <Translation id="TR_BRIDGE_NEEDED_DESCRIPTION" />;
 
-        if (popupCall.error?.error === UI_REQUEST.BOOTLOADER)
+        if (popupCall.error?.message === UI_REQUEST.BOOTLOADER)
             return <Translation id="TR_DEVICE_IN_BOOTLOADER" />;
-        if (popupCall.error?.error === UI_REQUEST.NOT_IN_BOOTLOADER)
+        if (popupCall.error?.message === UI_REQUEST.NOT_IN_BOOTLOADER)
             return <Translation id="TR_RECONNECT_IN_BOOTLOADER" />;
-        if (popupCall.error?.error === UI_REQUEST.SEEDLESS)
+        if (popupCall.error?.message === UI_REQUEST.SEEDLESS)
             return <Translation id="TR_YOUR_DEVICE_IS_SEEDLESS" />;
-        if (popupCall.error?.error === UI_REQUEST.INITIALIZE)
+        if (popupCall.error?.message === UI_REQUEST.INITIALIZE)
             return <Translation id="TR_DEVICE_NOT_INITIALIZED" />;
-        if (popupCall.error?.error === UI_REQUEST.FIRMWARE_NOT_INSTALLED)
+        if (popupCall.error?.message === UI_REQUEST.FIRMWARE_NOT_INSTALLED)
             return <Translation id="TR_NO_FIRMWARE" />;
-        if (popupCall.error?.error === UI_REQUEST.FIRMWARE_NOT_SUPPORTED)
+        if (popupCall.error?.message === UI_REQUEST.FIRMWARE_NOT_SUPPORTED)
             return <Translation id="TR_UNSUPPORTED_COINS_DESCRIPTION" />;
-        if (popupCall.error?.error === UI_REQUEST.FIRMWARE_OLD)
+        if (popupCall.error?.message === UI_REQUEST.FIRMWARE_OLD)
             return <Translation id="TR_FIRMWARE_UPDATE_REQUIRED_EXPLAINED" />;
-        if (popupCall.error?.error) return popupCall.error.error;
+        if (popupCall.error?.message) return popupCall.error.message;
 
         return <Translation id="TR_UNKNOWN_ERROR_SEE_CONSOLE" />;
     };

--- a/packages/suite/src/hooks/earn/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/earn/useCardanoStaking.ts
@@ -106,7 +106,7 @@ export const useCardanoStaking = (): CardanoStaking => {
                 testnet: isTestnet(account.symbol),
             });
 
-            if (!response.success) throw new Error(response.payload.error);
+            if (!response.success) throw new Error(response.error.message);
 
             return { txPlan: response.payload[0], certificates, withdrawals };
         },

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -707,7 +707,7 @@ export const composeDebouncedTransaction = [
         description: '@trezor/connect call respond with success:false',
         connect: {
             success: false,
-            payload: { error: 'error' },
+            error: { message: 'error' },
         },
         actions: [{ type: 'input', element: 'outputs.0.amount', value: '1' }],
         finalResult: {
@@ -1694,8 +1694,8 @@ export const signAndPush: SignAndPush[] = [
             getComposeResponse(),
             {
                 success: false,
-                payload: {
-                    error: 'signTx error',
+                error: {
+                    message: 'signTx error',
                 },
             },
         ],
@@ -1723,8 +1723,8 @@ export const signAndPush: SignAndPush[] = [
             getComposeResponse(),
             {
                 success: false,
-                payload: {
-                    error: 'tx-cancelled',
+                error: {
+                    message: 'tx-cancelled',
                 },
             },
         ],
@@ -1753,8 +1753,8 @@ export const signAndPush: SignAndPush[] = [
             },
             {
                 success: false,
-                payload: {
-                    error: 'pushTx error',
+                error: {
+                    message: 'pushTx error',
                 },
             },
         ],
@@ -1812,8 +1812,8 @@ export const feeChange: FeeChangeFixture[] = [
             success: false,
             payload: {
                 success: false,
-                payload: {
-                    error: 'compose-response-is-irrelevant',
+                error: {
+                    message: 'compose-response-is-irrelevant',
                 },
             },
         },
@@ -1955,8 +1955,8 @@ export const feeChange: FeeChangeFixture[] = [
         connect: [
             {
                 success: false,
-                payload: {
-                    error: 'irrelevant',
+                error: {
+                    message: 'irrelevant',
                 },
             },
             {

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -197,7 +197,7 @@ describe('useRbfForm hook', () => {
                 .mockImplementation(() =>
                     Promise.resolve({
                         success: false,
-                        payload: { error: 'error' },
+                        error: { message: 'error', code: 'Failure_UnknownCode' },
                     }),
                 );
 

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -47,7 +47,16 @@ export const useConnectPopupDesktop = () => {
                     }),
                 );
                 const response = await deferred.promise;
-                desktopApi.connectPopupResponse({ ...response, id: params.id });
+                if (response.success) {
+                    desktopApi.connectPopupResponse({ ...response, id: params.id });
+                } else {
+                    desktopApi.connectPopupResponse({
+                        success: false,
+                        error: response.error,
+                        payload: response.error, // for backward compatibility with v9
+                        id: params.id,
+                    });
+                }
             });
             desktopApi.on('connect-popup/cancel', params => {
                 dispatch(connectPopupCancelThunk(params));

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -358,18 +358,18 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                         return translationString('TR_ADDRESS_CANT_VERIFY_HISTORY');
                     }
 
-                    const { payload, success } = await TrezorConnect.getAccountInfo({
+                    const result = await TrezorConnect.getAccountInfo({
                         descriptor: value,
                         coin: symbol,
                         details: 'basic',
                     });
 
-                    if (!success) {
+                    if (!result.success) {
                         return translationString('TR_ADDRESS_CANT_VERIFY_HISTORY');
                     }
 
                     if (!isExternalAddressCheckWarningDismissed && isExternalAddressCheckEnabled) {
-                        if (isProgramDerivedAccount(payload)) {
+                        if (isProgramDerivedAccount(result.payload)) {
                             return translationString('TR_SOL_ADDRESS_IS_ASSOCIATED_ACCOUNT');
                         }
                     }

--- a/suite-common/connect-popup/package.json
+++ b/suite-common/connect-popup/package.json
@@ -20,6 +20,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/connect-common": "workspace:^",
+        "@trezor/type-utils": "workspace:^",
         "@trezor/utils": "workspace:*",
         "react": "19.1.0",
         "react-redux": "9.2.0"

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -51,7 +51,7 @@ export const connectPopupCallThunkInner = createThunk<
                 __precomposed: true,
             } as CallMethodPayload);
             if (!methodInfo.success) {
-                throw methodInfo.payload;
+                throw methodInfo.error;
             }
             const methodInfoPayload = methodInfo.payload as MethodInfo;
             if (
@@ -145,7 +145,7 @@ export const connectPopupCallThunkInner = createThunk<
                 source,
             });
             if (!response.success) {
-                throw response.payload;
+                throw response.error;
             }
             if (!postCallOngoing) {
                 dispatch(connectPopupActions.finishCall());
@@ -210,7 +210,7 @@ export const connectPopupCallThunkInner = createThunk<
 
             getPopupCallDeferred().resolve({
                 success: false,
-                payload: serializeError(error),
+                error: serializeError(error),
             });
         } finally {
             dispatch(extra.actions.lockDevice(false));

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -1,7 +1,7 @@
 import { AccountKey, TxSimulationAction } from '@suite-common/wallet-types';
 import { CallMethodKeys } from '@trezor/connect';
 import { MethodPermission } from '@trezor/connect/src/core/AbstractMethod';
-import { ErrorCode } from '@trezor/connect-common/src/constants/errors';
+import { SerializedError } from '@trezor/connect-common/src/constants/errors';
 
 export type ManifestPartial = {
     appName: string;
@@ -16,7 +16,7 @@ export const CALL_SOURCE_WEB = 'web';
 export const CALL_SOURCE_WALLETCONNECT = 'walletconnect';
 export const CALL_SOURCE_DEEPLINK = 'deeplink';
 
-export type ConnectSerializedError = { error: string; code: ErrorCode };
+export type ConnectSerializedError = SerializedError;
 export type ConnectProcessInfo = {
     name: string;
     fullPath: string;

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -105,7 +105,7 @@ const preCallHook = async <M extends CallMethodKeys>({
                 },
                 showOnTrezor: false,
             });
-            if (!accountAddress.success) throw new Error(accountAddress.payload.error);
+            if (!accountAddress.success) throw new Error(accountAddress.error.message);
             dispatch(
                 connectPopupActions.txSimulation({
                     fromAddress: accountAddress.payload.address,
@@ -138,7 +138,7 @@ const preCallHook = async <M extends CallMethodKeys>({
                     __precomposed: true,
                 });
                 if (!methodInfo.success) {
-                    throw methodInfo.payload;
+                    throw methodInfo.error;
                 }
                 txSigningPrecomposed = (methodInfo.payload as any as MethodInfo).precomposed;
                 if (txSigningPrecomposed)

--- a/suite-common/connect-popup/src/methodHooks/types.ts
+++ b/suite-common/connect-popup/src/methodHooks/types.ts
@@ -1,13 +1,9 @@
 import { Dispatch } from '@reduxjs/toolkit/react';
 
 import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
-import {
-    CallMethodKeys,
-    CallMethodParams,
-    CallMethodResponse,
-    Success,
-    Unsuccessful,
-} from '@trezor/connect';
+import { CallMethodKeys, CallMethodParams, CallMethodResponse } from '@trezor/connect';
+import { SerializedError } from '@trezor/connect-common/src/constants/errors';
+import { Err, Ok } from '@trezor/type-utils';
 
 import { ConnectCallSource } from '../connectPopupTypes';
 
@@ -21,5 +17,5 @@ export type PreCallHookParams<M extends CallMethodKeys> = {
 };
 export type PostCallHookParams<M extends CallMethodKeys> = PreCallHookParams<M> & {
     originalPayload: Omit<CallMethodParams<M>, 'method'>;
-    response: Success<CallMethodResponse<M>> | Unsuccessful;
+    response: Ok<CallMethodResponse<M>> | Err<SerializedError>;
 };

--- a/suite-common/connect-popup/tsconfig.json
+++ b/suite-common/connect-popup/tsconfig.json
@@ -13,6 +13,7 @@
         {
             "path": "../../packages/connect-common"
         },
+        { "path": "../../packages/type-utils" },
         { "path": "../../packages/utils" }
     ]
 }

--- a/suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.ts
+++ b/suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.ts
@@ -41,9 +41,9 @@ export const createRetrieveDelegatedIdentityKeyFromDevice =
             return ok(asDelegatedIdentityKey(result.payload.private_key));
         }
 
-        if (isCanceledErrorMessage(result.payload.error)) {
+        if (isCanceledErrorMessage(result.error.message)) {
             return err(DeviceCancelledErr());
         }
 
-        return err(DeviceError(result.payload.error));
+        return err(DeviceError(result.error.message));
     };

--- a/suite-common/device-authenticity/package.json
+++ b/suite-common/device-authenticity/package.json
@@ -17,6 +17,7 @@
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
-        "@trezor/connect": "workspace:*"
+        "@trezor/connect": "workspace:*",
+        "@trezor/type-utils": "workspace:*"
     }
 }

--- a/suite-common/device-authenticity/src/checkDeviceAuthenticityThunk.ts
+++ b/suite-common/device-authenticity/src/checkDeviceAuthenticityThunk.ts
@@ -39,13 +39,13 @@ export const checkDeviceAuthenticityThunk = createThunk<
             dispatch(
                 notificationsActions.addToast({
                     type: 'error',
-                    error: `Unable to validate device: ${result.payload.error}`,
+                    error: `Unable to validate device: ${result.error.message}`,
                 }),
             );
             const isDeviceBootloaderUnlocked = device?.features?.bootloader_locked !== true;
             const storedResult = isDeviceBootloaderUnlocked
                 ? // error can be because bootloader is unlocked (definite cause of failure, should persist)
-                  { valid: false, error: result.payload.error }
+                  { valid: false, error: result.error.message }
                 : // or internal error (then skip the check by storing undefined)
                   undefined;
             dispatch(deviceActions.setDeviceAuthenticityResult({ device, result: storedResult }));

--- a/suite-common/device-authenticity/tests/deviceAuthenticityThunks.test.ts
+++ b/suite-common/device-authenticity/tests/deviceAuthenticityThunks.test.ts
@@ -4,12 +4,8 @@ import { StoredAuthenticateDeviceResult, TrezorDevice } from '@suite-common/suit
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { configureMockStore, testMocks } from '@suite-common/test-utils';
 import { ToastPayload, notificationsActions } from '@suite-common/toast-notifications';
-import type {
-    AuthenticateDeviceResult,
-    Response,
-    SuccessWithDevice,
-    Unsuccessful,
-} from '@trezor/connect';
+import type { AuthenticateDeviceResult, Response } from '@trezor/connect';
+import { Err, Ok } from '@trezor/type-utils';
 
 import { checkDeviceAuthenticityThunk } from '../src/checkDeviceAuthenticityThunk';
 
@@ -29,12 +25,12 @@ const getDevice = (isLocked: boolean) => ({
     ...mockSuiteDevice(undefined, { bootloader_locked: isLocked }),
 });
 
-const connectCallFailResponse: Unsuccessful = {
+const connectCallFailResponse: Err<any> = {
     success: false,
-    payload: { error: 'error' },
+    error: { message: 'error' },
 };
 
-const verificationSuccessResponse: SuccessWithDevice<AuthenticateDeviceResult> = {
+const verificationSuccessResponse: Ok<AuthenticateDeviceResult> = {
     success: true,
     payload: {
         optigaResult: {
@@ -46,7 +42,7 @@ const verificationSuccessResponse: SuccessWithDevice<AuthenticateDeviceResult> =
     },
 };
 
-const verifyFailureResponseNotFound: SuccessWithDevice<AuthenticateDeviceResult> = {
+const verifyFailureResponseNotFound: Ok<AuthenticateDeviceResult> = {
     success: true,
     payload: {
         optigaResult: {
@@ -58,7 +54,7 @@ const verifyFailureResponseNotFound: SuccessWithDevice<AuthenticateDeviceResult>
     },
 };
 
-const verifyFailureResponseBlacklisted: SuccessWithDevice<AuthenticateDeviceResult> = {
+const verifyFailureResponseBlacklisted: Ok<AuthenticateDeviceResult> = {
     success: true,
     payload: {
         optigaResult: {

--- a/suite-common/device-authenticity/tsconfig.json
+++ b/suite-common/device-authenticity/tsconfig.json
@@ -8,6 +8,7 @@
         { "path": "../suite-types" },
         { "path": "../test-utils" },
         { "path": "../toast-notifications" },
-        { "path": "../../packages/connect" }
+        { "path": "../../packages/connect" },
+        { "path": "../../packages/type-utils" }
     ]
 }

--- a/suite-common/device/package.json
+++ b/suite-common/device/package.json
@@ -17,6 +17,7 @@
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-common": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",

--- a/suite-common/device/src/deviceActions.ts
+++ b/suite-common/device/src/deviceActions.ts
@@ -14,8 +14,9 @@ import {
     Device,
     DeviceState,
     StaticSessionId,
-    Unsuccessful,
 } from '@trezor/connect';
+import { SerializedError } from '@trezor/connect-common/src/constants/errors';
+import { Err } from '@trezor/type-utils';
 
 export const DEVICE_MODULE_PREFIX = '@suite/device';
 
@@ -166,7 +167,7 @@ const setDeviceAuthenticityResult = createAction(
 // Use in tests only! See deviceReducer for the property definition.
 const setSimulatedEntropyCheckFail = createAction(
     `${DEVICE_MODULE_PREFIX}/setSimulatedEntropyCheckFail`,
-    (payload: Unsuccessful) => ({ payload }),
+    (payload: Err<SerializedError>) => ({ payload }),
 );
 
 export const deviceActions = {

--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -10,8 +10,10 @@ import {
 } from '@suite-common/suite-types';
 import * as deviceUtils from '@suite-common/suite-utils';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
-import { Device, DeviceState, Features, KnownDevice, Unsuccessful } from '@trezor/connect';
+import { Device, DeviceState, Features, KnownDevice } from '@trezor/connect';
+import { SerializedError } from '@trezor/connect-common/src/constants/errors';
 import { getFirmwareVersionArray } from '@trezor/device-utils';
+import { Err } from '@trezor/type-utils';
 
 import { DeviceStateActionPayload, deviceActions } from './deviceActions';
 import { PORTFOLIO_TRACKER_DEVICE_ID } from './deviceConstants';
@@ -39,7 +41,7 @@ export type DeviceReducerState = {
     };
     lastConnectedAuthenticityChecks?: KnownDevice['authenticityChecks'];
     // Setting with no UI to toggle it on, used in tests to simulate various outcomes of entropy check failure
-    simulatedEntropyCheckFail?: Unsuccessful;
+    simulatedEntropyCheckFail?: Err<SerializedError>;
 };
 
 export const deviceInitialState: DeviceReducerState = {

--- a/suite-common/device/tsconfig.json
+++ b/suite-common/device/tsconfig.json
@@ -6,6 +6,9 @@
         { "path": "../suite-types" },
         { "path": "../suite-utils" },
         { "path": "../../packages/connect" },
+        {
+            "path": "../../packages/connect-common"
+        },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },
         { "path": "../../packages/type-utils" },

--- a/suite-common/fiat-services/src/rates.ts
+++ b/suite-common/fiat-services/src/rates.ts
@@ -83,7 +83,7 @@ export const fetchCurrentFiatRates = ({
             // directly from Coingecko to ensure up-to-date values.
             if (isBlockbookBasedNetwork(ticker.symbol) && backendType !== 'evm-rpc' && !skipCache) {
                 if (backendType !== 'electrum') {
-                    const { success, payload } = await scheduleAction(
+                    const result = await scheduleAction(
                         () =>
                             TrezorConnect.blockchainGetCurrentFiatRates({
                                 coin: ticker.symbol,
@@ -93,7 +93,7 @@ export const fetchCurrentFiatRates = ({
                         { timeout: CONNECT_FETCH_TIMEOUT },
                     );
 
-                    if (!success && payload.error === 'No tickers found!') {
+                    if (!result.success && result.error.message === 'No tickers found!') {
                         const fallbackCoinGeckoResponse =
                             await coingeckoService.fetchCurrentFiatRates(ticker);
 
@@ -107,16 +107,16 @@ export const fetchCurrentFiatRates = ({
                         };
                     }
 
-                    if (!success) return null;
+                    if (!result.success) return null;
 
-                    const rate = payload.rates?.[localCurrency];
+                    const rate = result.payload.rates?.[localCurrency];
 
                     // in case blockbook does not know fiat rate, it returns -1
                     if (!rate || rate < 0) return null;
 
                     return {
                         rate,
-                        lastTickerTimestamp: payload.ts as Timestamp,
+                        lastTickerTimestamp: result.payload.ts as Timestamp,
                     };
                 }
 
@@ -161,22 +161,22 @@ export const fetchLastWeekFiatRates = ({
 
             if (isBlockbookBasedNetwork(ticker.symbol)) {
                 if (backendType !== 'electrum') {
-                    const { success, payload } = await getConnectFiatRatesForTimestamp(
+                    const result = await getConnectFiatRatesForTimestamp(
                         ticker,
                         timestamps,
                         localCurrency,
                     );
 
-                    if (!success) return null;
+                    if (!result.success) return null;
 
-                    const rate = payload.tickers?.[0]?.rates?.[localCurrency];
+                    const rate = result.payload.tickers?.[0]?.rates?.[localCurrency];
 
                     // in case blockbook does not know fiat rate, it returns -1
                     if (!rate || rate < 0) return null;
 
                     return {
                         rate,
-                        lastTickerTimestamp: payload.tickers?.[0]?.ts as Timestamp,
+                        lastTickerTimestamp: result.payload.tickers?.[0]?.ts as Timestamp,
                     };
                 }
 
@@ -225,16 +225,16 @@ export const getFiatRatesForTimestamps = (
         async () => {
             if (isBlockbookBasedNetwork(ticker.symbol)) {
                 if (!isElectrumBackend) {
-                    const { success, payload } = await getConnectFiatRatesForTimestamp(
+                    const result = await getConnectFiatRatesForTimestamp(
                         ticker,
                         timestamps,
                         baseCurrencyCode,
                     );
 
-                    if (!success) return null;
+                    if (!result.success) return null;
 
                     // in case blockbook does not know fiat rate, it returns -1
-                    const validTickers = payload.tickers.filter(
+                    const validTickers = result.payload.tickers.filter(
                         tick => tick.rates[baseCurrencyCode] && tick.rates[baseCurrencyCode] >= 0,
                     );
 

--- a/suite-common/firmware/src/firmwareThunks.ts
+++ b/suite-common/firmware/src/firmwareThunks.ts
@@ -116,12 +116,12 @@ export const firmwareUpdate = createThunk<
 
         if (!firmwareUpdateResponse.success) {
             dispatch(firmwareActions.setStatus('error'));
-            dispatch(firmwareActions.setFirmwareUpdateError(firmwareUpdateResponse.payload.error));
+            dispatch(firmwareActions.setFirmwareUpdateError(firmwareUpdateResponse.error.message));
 
             return rejectWithValue({
                 device,
                 ...targetProperties,
-                ...firmwareUpdateResponse.payload,
+                error: firmwareUpdateResponse.error.message,
                 connectResponse: firmwareUpdateResponse,
             });
         } else {

--- a/suite-common/graph/src/graphBalanceEvents.ts
+++ b/suite-common/graph/src/graphBalanceEvents.ts
@@ -174,7 +174,7 @@ export const getAccountMovementEvents = async ({
 
         if (!connectBalanceHistory?.success) {
             throw new Error(
-                `Get account balance movement error: ${connectBalanceHistory.payload.error}`,
+                `Get account balance movement error: ${connectBalanceHistory.error.message}`,
             );
         }
 

--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -89,7 +89,7 @@ const getLatestAccountInfo = async ({
     });
 
     if (!accountInfo?.success) {
-        throw new Error(`Get account balance info error: ${accountInfo.payload.error}`);
+        throw new Error(`Get account balance info error: ${accountInfo.error.message}`);
     }
 
     return accountInfo.payload;
@@ -202,7 +202,7 @@ const getAccountBalanceHistory = async ({
 
         if (!connectBalanceHistory?.success) {
             throw new Error(
-                `Get account balance movement error: ${connectBalanceHistory.payload.error}`,
+                `Get account balance movement error: ${connectBalanceHistory.error.message}`,
             );
         }
 

--- a/suite-common/staking/package.json
+++ b/suite-common/staking/package.json
@@ -18,6 +18,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-common": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "web3-utils": "^4.3.2"

--- a/suite-common/staking/src/__fixtures__/ethereumStaking.ts
+++ b/suite-common/staking/src/__fixtures__/ethereumStaking.ts
@@ -125,8 +125,8 @@ export const stakeFailedFixture = [
         },
         estimatedFee: {
             success: false,
-            payload: {
-                error: 'Estimated fee error',
+            error: {
+                message: 'Estimated fee error',
             },
         },
         result: 'Estimated fee error',
@@ -184,8 +184,8 @@ export const unstakeFailedFixture = [
         },
         accountInfo: {
             success: false,
-            payload: {
-                error: 'Account info error',
+            error: {
+                message: 'Account info error',
             },
         },
         estimatedFee: {
@@ -244,8 +244,8 @@ export const unstakeFailedFixture = [
         },
         estimatedFee: {
             success: false,
-            payload: {
-                error: 'Estimated fee error',
+            error: {
+                message: 'Estimated fee error',
             },
         },
         result: 'Estimated fee error',
@@ -322,8 +322,8 @@ export const claimFailedFixture = [
         },
         accountInfo: {
             success: false,
-            payload: {
-                error: 'Account info error',
+            error: {
+                message: 'Account info error',
             },
         },
         result: 'Account info error',
@@ -350,8 +350,8 @@ export const claimFailedFixture = [
         },
         estimatedFee: {
             success: false,
-            payload: {
-                error: 'Estimated fee error',
+            error: {
+                message: 'Estimated fee error',
             },
         },
         result: 'Estimated fee error',

--- a/suite-common/staking/src/__tests__/ethereumStaking.test.ts
+++ b/suite-common/staking/src/__tests__/ethereumStaking.test.ts
@@ -1,15 +1,11 @@
 import { ValidatorsQueue, WalletAccountTransaction } from '@suite-common/wallet-types';
-import TrezorConnect, {
-    AccountInfo,
-    InternalTransfer,
-    Success,
-    SuccessWithDevice,
-    Unsuccessful,
-} from '@trezor/connect';
+import TrezorConnect, { AccountInfo, InternalTransfer, OkWithDevice } from '@trezor/connect';
 import {
     BlockchainEstimatedFee,
     BlockchainEstimatedFeeLevel,
 } from '@trezor/connect/src/types/api/blockchainEstimateFee';
+import { SerializedError } from '@trezor/connect-common/src/constants/errors';
+import { Err, Ok, Result } from '@trezor/type-utils';
 
 import {
     claimFailedFixture,
@@ -62,7 +58,6 @@ describe('transformTx', () => {
     });
 });
 
-type Result<T> = Unsuccessful | Success<T>;
 type AccountInfoResult = Result<(AccountInfo | null)[]>;
 type EstimateFeeResult = Result<BlockchainEstimatedFeeLevel>;
 
@@ -213,7 +208,7 @@ describe('getDaysToAddToPoolInitial', () => {
     });
 });
 
-type GetAdjustedGasLimitConsumptionArgs = Success<BlockchainEstimatedFee>;
+type GetAdjustedGasLimitConsumptionArgs = Ok<BlockchainEstimatedFee>;
 
 describe('getAdjustedGasLimitConsumption', () => {
     getAdjustedGasLimitConsumptionFixture.forEach(test => {
@@ -262,7 +257,7 @@ describe('getChangedInternalTx', () => {
     });
 });
 
-type BlockchainEvmRpcCallResult = Unsuccessful | SuccessWithDevice<{ data: string }>;
+type BlockchainEvmRpcCallResult = Err<SerializedError> | OkWithDevice<{ data: string }>;
 type SimulateUnstakeArgs = StakeTxBaseArgs & { amount: string };
 
 describe('simulateUnstake', () => {

--- a/suite-common/staking/src/utils/ethereumStaking.ts
+++ b/suite-common/staking/src/utils/ethereumStaking.ts
@@ -31,10 +31,9 @@ import TrezorConnect, {
     EthereumTransaction,
     EthereumTransactionEIP1559,
     InternalTransfer,
-    Success,
 } from '@trezor/connect';
 import { BlockchainEstimatedFee } from '@trezor/connect/src/types/api/blockchainEstimateFee';
-import { PartialRecord } from '@trezor/type-utils';
+import { Ok, PartialRecord } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
 
 import {
@@ -68,7 +67,7 @@ export const getEthNetworkAddresses = (symbol: NetworkSymbol): EthNetworkAddress
     return ETH_NETWORK_ADDRESSES[ethNetwork] ?? defaultAddresses;
 };
 
-export const getAdjustedGasLimitConsumption = (estimatedFee: Success<BlockchainEstimatedFee>) =>
+export const getAdjustedGasLimitConsumption = (estimatedFee: Ok<BlockchainEstimatedFee>) =>
     new BigNumber(estimatedFee.payload.levels[0].feeLimit || '')
         .plus(STAKE_GAS_LIMIT_RESERVE)
         .integerValue(BigNumber.ROUND_DOWN)
@@ -114,7 +113,7 @@ export const stake = async ({
         });
 
         if (!estimatedFee.success) {
-            throw new Error(estimatedFee.payload.error);
+            throw new Error(estimatedFee.error.message);
         }
 
         // Create the transaction
@@ -149,7 +148,7 @@ export const unstake = async ({
             descriptor: from,
         });
         if (!accountInfo.success) {
-            throw new Error(accountInfo.payload.error);
+            throw new Error(accountInfo.error.message);
         }
 
         const { autocompoundBalance } = accountInfo.payload?.misc?.stakingPools?.[0] ?? {};
@@ -191,7 +190,7 @@ export const unstake = async ({
             },
         });
         if (!estimatedFee.success) {
-            throw new Error(estimatedFee.payload.error);
+            throw new Error(estimatedFee.error.message);
         }
 
         // Create the transaction
@@ -221,7 +220,7 @@ export const claimWithdrawRequest = async ({
             descriptor: from,
         });
         if (!accountInfo.success) {
-            throw new Error(accountInfo.payload.error);
+            throw new Error(accountInfo.error.message);
         }
 
         const { withdrawTotalAmount, claimableAmount } =
@@ -263,7 +262,7 @@ export const claimWithdrawRequest = async ({
             },
         });
         if (!estimatedFee.success) {
-            throw new Error(estimatedFee.payload.error);
+            throw new Error(estimatedFee.error.message);
         }
 
         return {
@@ -683,7 +682,7 @@ export const simulateUnstake = async ({
     });
 
     if (!transactionData.success) {
-        throw new Error(transactionData.payload.error);
+        throw new Error(transactionData.error.message);
     }
 
     const approximatedAmount = transactionData.payload.data;

--- a/suite-common/staking/tsconfig.json
+++ b/suite-common/staking/tsconfig.json
@@ -7,6 +7,9 @@
         { "path": "../wallet-types" },
         { "path": "../wallet-utils" },
         { "path": "../../packages/connect" },
+        {
+            "path": "../../packages/connect-common"
+        },
         { "path": "../../packages/type-utils" },
         { "path": "../../packages/utils" }
     ]

--- a/suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.ts
+++ b/suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.ts
@@ -67,5 +67,5 @@ export const createRetrieveSuiteSyncOwner =
             return deps.createSuiteSyncOwner({ data: result.payload.data });
         }
 
-        return err(DeviceError(result.payload.error));
+        return err(DeviceError(result.error.message));
     };

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -11,7 +11,6 @@ import {
     StaticSessionId,
     UnknownDevice as UnknownDeviceBase,
     UnreadableDevice as UnreadableDeviceBase,
-    Unsuccessful,
 } from '@trezor/connect';
 import { Branded, UnionSubset } from '@trezor/type-utils';
 import type { VersionArray } from '@trezor/utils';
@@ -109,7 +108,7 @@ export type TrezorDeviceWithState = AcquiredDevice & {
     state: NonNullable<AcquiredDevice['state']> & { staticSessionId: StaticSessionId };
 };
 
-type ConnectAuthenticateDeviceResultPayload = AuthenticateDeviceResult | Unsuccessful['payload'];
+type ConnectAuthenticateDeviceResultPayload = AuthenticateDeviceResult | { error: string };
 /**
  * Processed result of TrezorConnect.authenticateDevice call that we may store in the Redux state.
  * We want to:

--- a/suite-common/test-utils/__mocks__/@trezor/connect.ts
+++ b/suite-common/test-utils/__mocks__/@trezor/connect.ts
@@ -47,7 +47,7 @@ const result = (methodName: string, defaults: any) =>
         });
     });
 
-const ERROR_RESULT = { success: false, payload: { error: 'Default mock error' } };
+const ERROR_RESULT = { success: false, error: { message: 'Default mock error' } };
 
 // Override connect methods with mocked default response (success: true)
 const methods = connect.default;
@@ -92,7 +92,7 @@ methods.composeTransaction = jest.fn(async _params => {
         await new Promise(resolve => setTimeout(resolve, fixture.delay));
     }
 
-    return { success: false, payload: { error: 'error' }, ...fixture, _params };
+    return { success: false, error: { message: 'error' }, ...fixture, _params };
 });
 
 // Add custom methods

--- a/suite-common/thp/src/startThpAutoconnectThunk.ts
+++ b/suite-common/thp/src/startThpAutoconnectThunk.ts
@@ -21,11 +21,11 @@ export const startThpAutoconnectThunk = createThunk<void, StartThpAutoconnectThu
             return;
         } else {
             dispatch(
-                notificationsActions.addToast({ type: 'error', error: response.payload.error }),
+                notificationsActions.addToast({ type: 'error', error: response.error.message }),
             );
             dispatch(thpActions.finishAutoconnectFlow());
 
-            return rejectWithValue(response.payload.error);
+            return rejectWithValue(response.error.message);
         }
     },
 );

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -26,6 +26,7 @@
         "@suite/intl": "workspace:*",
         "@trezor/address-validator": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-common": "workspace:*",
         "@trezor/connect-plugin-ethereum": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/react-utils": "workspace:*",

--- a/suite-common/trading/src/thunks/common/__tests__/getNonce.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/getNonce.test.ts
@@ -145,7 +145,7 @@ describe('getNonce thunk', () => {
             (selectSelectedDevice as jest.Mock).mockReturnValue(mockDevice);
             (TrezorConnect.getNonce as jest.Mock).mockResolvedValue({
                 success: false,
-                payload: { error: 'Device communication failed' },
+                error: { message: 'Device communication failed' },
             });
 
             const store = createMockStore();

--- a/suite-common/trading/src/thunks/common/__tests__/getPurchaseAddress.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/getPurchaseAddress.test.ts
@@ -172,7 +172,7 @@ describe('getPurchaseAddress thunk', () => {
             (confirmAddressOnDeviceThunk as unknown as jest.Mock).mockImplementation(
                 createThunk('@suite/device/confirmAddressOnDeviceThunk', () => ({
                     success: false,
-                    payload: { error: 'Device confirmation failed' },
+                    error: { message: 'Device confirmation failed' },
                 })),
             );
 

--- a/suite-common/trading/src/thunks/common/__tests__/getRefundAddress.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/getRefundAddress.test.ts
@@ -188,7 +188,7 @@ describe('getRefundAddress thunk', () => {
             (confirmAddressOnDeviceThunk as unknown as jest.Mock).mockImplementation(
                 createThunk('@suite/device/confirmAddressOnDeviceThunk', () => ({
                     success: false,
-                    payload: { error: 'Device confirmation failed' },
+                    error: { message: 'Device confirmation failed' },
                 })),
             );
 

--- a/suite-common/trading/src/thunks/common/__tests__/verifyAddressThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/verifyAddressThunk.test.ts
@@ -290,7 +290,7 @@ describe('verifyAddressThunk', () => {
         (confirmAddressOnDeviceThunk as unknown as jest.Mock).mockImplementation(
             createThunk('@suite/device/confirmAddressOnDeviceThunk', () => ({
                 success: false,
-                payload: {
+                error: {
                     code: 'Method_PermissionsNotGranted',
                 },
             })),
@@ -336,8 +336,8 @@ describe('verifyAddressThunk', () => {
         (confirmAddressOnDeviceThunk as unknown as jest.Mock).mockImplementation(
             createThunk('@suite/device/confirmAddressOnDeviceThunk', () => ({
                 success: false,
-                payload: {
-                    error,
+                error: {
+                    message: error,
                     code: 'error-code',
                 },
             })),

--- a/suite-common/trading/src/thunks/common/verifyAddressThunk.ts
+++ b/suite-common/trading/src/thunks/common/verifyAddressThunk.ts
@@ -72,11 +72,11 @@ export const verifyAddressThunk = createThunk(
             );
         } else {
             // special case: device no-backup permissions not granted
-            if (response.payload.code === 'Method_PermissionsNotGranted') return;
+            if (response.error.code === 'Method_PermissionsNotGranted') return;
 
             dispatch(
                 logErrorThunk({
-                    errorMessage: response.payload.error,
+                    errorMessage: response.error.message,
                     tradingType: activeSection,
                     toastType: 'verify-address-error',
                 }),

--- a/suite-common/trading/src/thunks/exchange/__tests__/signDataAndConfirmThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/signDataAndConfirmThunk.test.ts
@@ -227,8 +227,8 @@ describe('signDataAndConfirmThunk', () => {
 
         TrezorConnect.ethereumSignTypedData = jest.fn().mockResolvedValue({
             success: false,
-            payload: {
-                error: 'Data is not correct',
+            error: {
+                message: 'Data is not correct',
             },
         });
 

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -119,7 +119,7 @@ export const sendDexTransactionThunk = createThunk<
             return rejectWithValue({
                 type: payload && 'type' in payload ? payload.type : 'sign-tx-error',
                 error:
-                    payload && 'error' in payload
+                    payload && 'error' in payload && 'id' in payload.error
                         ? payload.error
                         : { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
             });

--- a/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
@@ -128,7 +128,7 @@ export const sendTransactionThunk = createThunk<
             return rejectWithValue({
                 type: payload && 'type' in payload ? payload.type : 'sign-tx-error',
                 error:
-                    payload && 'error' in payload
+                    payload && 'error' in payload && 'id' in payload.error
                         ? payload.error
                         : { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
             });

--- a/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
@@ -105,7 +105,7 @@ export const signDataAndConfirmThunk = createThunk(
         if (!result.success) {
             dispatch(
                 logErrorThunk({
-                    errorMessage: result.payload.error,
+                    errorMessage: result.error.message,
                     tradingType: 'exchange',
                     toastType: 'sign-message-error',
                 }),

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -28,9 +28,10 @@ import {
     FormState,
     GeneralPrecomposedTransactionFinal,
 } from '@suite-common/wallet-types';
-import { PROTO, Success, Unsuccessful } from '@trezor/connect';
+import { PROTO } from '@trezor/connect';
+import { SerializedError } from '@trezor/connect-common/src/constants/errors';
 import { Timer } from '@trezor/react-utils';
-import { PrimitiveType } from '@trezor/type-utils';
+import { Err, Ok, PrimitiveType } from '@trezor/type-utils';
 
 import * as constants from './constants';
 
@@ -307,4 +308,4 @@ export type TradingVerifiedAddress =
       }
     | undefined;
 
-export type TradingFulfillValue = Success<{ txid: string }> | Unsuccessful | undefined;
+export type TradingFulfillValue = Ok<{ txid: string }> | Err<SerializedError> | undefined;

--- a/suite-common/trading/tsconfig.json
+++ b/suite-common/trading/tsconfig.json
@@ -18,6 +18,9 @@
         },
         { "path": "../../packages/connect" },
         {
+            "path": "../../packages/connect-common"
+        },
+        {
             "path": "../../packages/connect-plugin-ethereum"
         },
         { "path": "../../packages/env-utils" },

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -38,8 +38,8 @@ import TrezorConnect, {
     Response as ConnectResponse,
     DEVICE,
     Device,
-    Unsuccessful,
 } from '@trezor/connect';
+import { SerializedError } from '@trezor/connect-common/src/constants/errors';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { getEnvironment } from '@trezor/env-utils';
 import { exhaustive } from '@trezor/type-utils';
@@ -172,12 +172,12 @@ export const acquireDevice = createThunk(
         const response = await TrezorConnect.getFeatures({ device });
 
         if (!response.success) {
-            if (response.payload.code !== 'Device_ThpPairingTagInvalid') {
+            if (response.error.code !== 'Device_ThpPairingTagInvalid') {
                 dispatch(
                     notificationsActions.addToast({
                         type: 'acquire-error',
                         device,
-                        error: response.payload.error,
+                        error: response.error.message,
                     }),
                 );
             }
@@ -241,7 +241,10 @@ export const confirmAddressOnDeviceThunk = createThunk(
         if (!device || !account)
             return {
                 success: false,
-                payload: { error: 'Device or account does not exist.', code: undefined },
+                error: {
+                    message: 'Device or account does not exist.',
+                    code: 'Failure_UnknownCode',
+                },
             };
 
         const params = {
@@ -293,7 +296,10 @@ export const confirmAddressOnDeviceThunk = createThunk(
             default:
                 response = {
                     success: false,
-                    payload: { error: 'Method for getAddress not defined', code: undefined },
+                    error: {
+                        message: 'Method for getAddress not defined',
+                        code: 'Failure_UnknownCode',
+                    },
                 } as const;
         }
 
@@ -507,22 +513,22 @@ export const wipeDeviceThunk = createThunk(
         if (
             result.success ||
             // This is an expected success for Bluetooth-connected devices
-            (device.bluetoothProps !== undefined && result.payload.code === 'Device_Disconnected')
+            (device.bluetoothProps !== undefined && result.error.code === 'Device_Disconnected')
         ) {
             // The wipe was successful, now run the shared cleanup logic.
             // We pass the original `device` object to the cleanup thunk.
             dispatch(handlePostWipeCleanupThunk({ initialDevice: device, deviceInstances }));
         } else {
-            dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
+            dispatch(notificationsActions.addToast({ type: 'error', error: result.error.message }));
 
-            return rejectWithValue(result.payload.error);
+            return rejectWithValue(result.error.message);
         }
     },
 );
 
 type FailEntropyCheckParams = {
     device: AcquiredDevice;
-    error: Unsuccessful['payload'];
+    error: SerializedError;
 };
 
 const failEntropyCheckThunk = createThunk(
@@ -541,7 +547,7 @@ const failEntropyCheckThunk = createThunk(
             payload: error,
         });
 
-        if (!getIsIgnoredEntropyCheckError(error.error)) {
+        if (!getIsIgnoredEntropyCheckError(error.message)) {
             dispatch(deviceActions.setEntropyCheckResult({ deviceId: device.id, success: false }));
         }
     },
@@ -558,9 +564,9 @@ export const processEntropyCheckResultThunk = createThunk(
         if (result.success) {
             dispatch(deviceActions.setEntropyCheckResult({ deviceId: device.id, success: true }));
         } else {
-            dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
-            if (result.payload.code === 'Failure_EntropyCheck') {
-                dispatch(failEntropyCheckThunk({ device, error: result.payload }));
+            dispatch(notificationsActions.addToast({ type: 'error', error: result.error.message }));
+            if (result.error.code === 'Failure_EntropyCheck') {
+                dispatch(failEntropyCheckThunk({ device, error: result.error }));
             }
         }
     },

--- a/suite-common/wallet-core/src/device/publicKeyActions.ts
+++ b/suite-common/wallet-core/src/device/publicKeyActions.ts
@@ -1,7 +1,9 @@
 import { TrezorDevice } from '@suite-common/suite-types';
 import { Account } from '@suite-common/wallet-types';
 import { getDerivationType } from '@suite-common/wallet-utils';
-import TrezorConnect, { Success, Unsuccessful } from '@trezor/connect';
+import TrezorConnect from '@trezor/connect';
+import { SerializedError } from '@trezor/connect-common/src/constants/errors';
+import { Result } from '@trezor/type-utils';
 
 export const showXpubOnDevice = async (device: TrezorDevice, account: Account) => {
     const params = {
@@ -12,7 +14,7 @@ export const showXpubOnDevice = async (device: TrezorDevice, account: Account) =
         coin: account.symbol,
     };
 
-    let response: Success<unknown> | Unsuccessful;
+    let response: Result<unknown, SerializedError>;
     switch (account.networkType) {
         case 'bitcoin':
             response = await TrezorConnect.getPublicKey(params);
@@ -26,7 +28,10 @@ export const showXpubOnDevice = async (device: TrezorDevice, account: Account) =
         default:
             response = {
                 success: false,
-                payload: { error: 'Method for getPublicKey not defined', code: undefined },
+                error: {
+                    message: 'Method for getPublicKey not defined',
+                    code: 'Failure_UnknownCode',
+                },
             };
     }
 

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -399,8 +399,10 @@ export const runDiscoveryThunk = createThunk(
             }
 
             if (!deviceStateResponse.success) {
-                const { error, code } = deviceStateResponse.payload;
-                dispatch(applyDeviceStateErrorThunk({ error, code, devicePath: device.path }));
+                const { message, code } = deviceStateResponse.error;
+                dispatch(
+                    applyDeviceStateErrorThunk({ error: message, code, devicePath: device.path }),
+                );
 
                 return;
             }
@@ -536,8 +538,8 @@ export const runDiscoveryThunk = createThunk(
                     discoveryActions.updateDiscovery(
                         {
                             status: 'failed',
-                            error: result.payload.error,
-                            errorCode: result.payload.code,
+                            error: result.error.message,
+                            errorCode: result.error.code,
                         },
                         device.path,
                     ),
@@ -596,8 +598,10 @@ export const runDiscoveryThunk = createThunk(
             }
 
             if (!getDeviceState2Res.success) {
-                const { error, code } = getDeviceState2Res.payload;
-                dispatch(applyDeviceStateErrorThunk({ error, code, devicePath: device.path }));
+                const { message, code } = getDeviceState2Res.error;
+                dispatch(
+                    applyDeviceStateErrorThunk({ error: message, code, devicePath: device.path }),
+                );
                 dispatch(deviceActions.setDiscovered(deviceState.staticSessionId, false));
 
                 return;
@@ -715,8 +719,8 @@ export const runAdditionalDiscoveryThunk = createThunk(
         });
 
         if (!deviceStateResponse.success) {
-            const { error, code } = deviceStateResponse.payload;
-            dispatch(applyDeviceStateErrorThunk({ error, code, devicePath: device.path }));
+            const { message, code } = deviceStateResponse.error;
+            dispatch(applyDeviceStateErrorThunk({ error: message, code, devicePath: device.path }));
 
             return;
         }
@@ -775,8 +779,8 @@ export const runAdditionalDiscoveryThunk = createThunk(
                     ? { status: 'complete' }
                     : {
                           status: 'failed',
-                          error: result.payload.error,
-                          errorCode: result.payload.code,
+                          error: result.error.message,
+                          errorCode: result.error.code,
                       },
                 updatedDevice.path,
             ),

--- a/suite-common/wallet-core/src/send/composeCancelTransaction/composeCancelTransactionThunk.ts
+++ b/suite-common/wallet-core/src/send/composeCancelTransaction/composeCancelTransactionThunk.ts
@@ -73,7 +73,7 @@ const calculateNewTransactionSize = createThunk<
         });
 
         if (!tempCancelTxResult.success) {
-            return rejectWithValue(`Unexpected compose error: ${tempCancelTxResult.payload.error}`);
+            return rejectWithValue(`Unexpected compose error: ${tempCancelTxResult.error.message}`);
         }
 
         const tempCancelTx = tempCancelTxResult.payload[0];

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -137,13 +137,13 @@ export const composeBitcoinTransactionFeeLevelsThunk = createThunk<
             dispatch(
                 notificationsActions.addToast({
                     type: 'sign-tx-error',
-                    error: response.payload.error,
+                    error: response.error.message,
                 }),
             );
 
             return rejectWithValue({
                 error: 'fee-levels-compose-failed',
-                message: response.payload.error,
+                message: response.error.message,
             });
         }
 
@@ -353,8 +353,8 @@ export const signBitcoinSendFormTransactionThunk = createThunk<
         if (!response.success) {
             return rejectWithValue({
                 error: 'sign-transaction-failed',
-                errorCode: response.payload.code,
-                message: response.payload.error,
+                errorCode: response.error.code,
+                message: response.error.message,
             });
         }
 

--- a/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
@@ -73,13 +73,13 @@ export const composeCardanoTransactionFeeLevelsThunk = createThunk<
             dispatch(
                 notificationsActions.addToast({
                     type: 'sign-tx-error',
-                    error: response.payload.error,
+                    error: response.error.message,
                 }),
             );
 
             return rejectWithValue({
                 error: 'fee-levels-compose-failed',
-                message: response.payload.error,
+                message: response.error.message,
             });
         }
 
@@ -178,8 +178,8 @@ export const signCardanoSendFormTransactionThunk = createThunk<
         if (!response.success) {
             return rejectWithValue({
                 error: 'sign-transaction-failed',
-                errorCode: response.payload.code,
-                message: response.payload.error,
+                errorCode: response.error.code,
+                message: response.error.message,
             });
         }
 

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -431,8 +431,8 @@ export const signEthereumSendFormTransactionThunk = createThunk<
             // catch manual error from TransactionReviewModal
             return rejectWithValue({
                 error: 'sign-transaction-failed',
-                errorCode: response.payload.code,
-                message: response.payload.error,
+                errorCode: response.error.code,
+                message: response.error.message,
             });
         }
 

--- a/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
@@ -367,8 +367,8 @@ export const signRippleStellarSendFormTransactionThunk = createThunk<
         // catch manual error from TransactionReviewModal
         return rejectWithValue({
             error: 'sign-transaction-failed',
-            errorCode: response.payload.code,
-            message: response.payload.error,
+            errorCode: response.error.code,
+            message: response.error.message,
         });
     },
 );

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -234,7 +234,7 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
         if (!transaction.success) {
             return rejectWithValue({
                 error: 'fee-levels-compose-failed',
-                message: transaction.payload.error,
+                message: transaction.error.message,
             });
         }
 
@@ -259,7 +259,7 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
             fetchedFeeLimit = feeLevel.feeLimit;
         } else {
             // Error fetching fee, fall back on default values defined in `/packages/connect/src/data/defaultFeeLevels.ts`
-            console.warn('Error fetching fee, using default values.', estimatedFee.payload.error);
+            console.warn('Error fetching fee, using default values.', estimatedFee.error.message);
         }
 
         // FeeLevels are read-only, so we create a copy if need be
@@ -378,7 +378,7 @@ export const signSolanaSendFormTransactionThunk = createThunk<
         if (!transaction.success) {
             return rejectWithValue({
                 error: 'sign-transaction-failed',
-                message: transaction.payload.error,
+                message: transaction.error.message,
             });
         }
 
@@ -403,8 +403,8 @@ export const signSolanaSendFormTransactionThunk = createThunk<
             // catch manual error from TransactionReviewModal
             return rejectWithValue({
                 error: 'sign-transaction-failed',
-                errorCode: response.payload.code,
-                message: response.payload.error,
+                errorCode: response.error.code,
+                message: response.error.message,
             });
         }
 

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -35,10 +35,9 @@ import {
     tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
 import { BlockbookTransaction } from '@trezor/blockchain-link-types';
-import TrezorConnect, { PROTO, Success, SuccessWithDevice, Unsuccessful } from '@trezor/connect';
+import TrezorConnect, { PROTO } from '@trezor/connect';
 import { getSolanaTokenDefinition } from '@trezor/connect/src/api/solana/solanaDefinitions';
-import { PushedTransaction } from '@trezor/connect/src/types/api/pushTransaction';
-import { exhaustive } from '@trezor/type-utils';
+import { Ok, exhaustive } from '@trezor/type-utils';
 import { BigNumber, cloneObject, typedObjectEntries } from '@trezor/utils';
 
 import { sendFormActions } from './sendFormActions';
@@ -147,10 +146,6 @@ export const convertSendFormDraftsBtcAmountUnitsThunk = createThunk(
         });
     },
 );
-
-const isSuccessfullyPushedTransaction = (
-    results: SuccessWithDevice<PushedTransaction> | Unsuccessful,
-): results is SuccessWithDevice<PushedTransaction> => results.success;
 
 type CoinSpecificComposeResponse = ActionsFromAsyncThunk<
     | typeof composeBitcoinTransactionFeeLevelsThunk
@@ -307,7 +302,7 @@ const synchronizeSentTransactionThunk = createThunk(
 );
 
 export const pushSendFormTransactionThunk = createThunk<
-    Success<{ txid: string }>,
+    Ok<{ txid: string }>,
     { selectedAccount: Account; isMevProtectionEnabled: boolean },
     { rejectValue: PushTransactionError }
 >(
@@ -328,7 +323,10 @@ export const pushSendFormTransactionThunk = createThunk<
         if (!serializedTx || !precomposedTransaction)
             return rejectWithValue({
                 error: 'push-transaction-failed',
-                metadata: { success: false, payload: { error: 'Transaction not found.' } },
+                metadata: {
+                    success: false,
+                    error: { message: 'Transaction not found.', code: 'Failure_UnknownCode' },
+                },
             });
 
         const txData = getMevProtectedTxData(
@@ -356,7 +354,7 @@ export const pushSendFormTransactionThunk = createThunk<
         const areSatoshisUsed = getAreSatoshisUsed(bitcoinAmountUnit, selectedAccount);
         const evmApprovalData = getEvmApprovalTxData(precomposedForm?.transactionData);
 
-        if (isSuccessfullyPushedTransaction(pushTxResponse)) {
+        if (pushTxResponse.success) {
             const { txid } = pushTxResponse.payload;
 
             if (evmApprovalData && token) {
@@ -436,12 +434,12 @@ export const pushSendFormTransactionThunk = createThunk<
             dispatch(
                 notificationsActions.addToast({
                     type: 'sign-tx-error',
-                    error: pushTxResponse.payload.error,
+                    error: pushTxResponse.error.message,
                 }),
             );
         }
 
-        return isSuccessfullyPushedTransaction(pushTxResponse)
+        return pushTxResponse.success
             ? fulfillWithValue(pushTxResponse)
             : rejectWithValue({
                   error: 'push-transaction-failed',
@@ -474,7 +472,7 @@ export const pushSendFormRawTransactionThunk = createThunk(
             identity: payload.identity,
         });
 
-        if (isSuccessfullyPushedTransaction(sentTx)) {
+        if (sentTx.success) {
             dispatch(
                 notificationsActions.addToast({
                     type: 'raw-tx-sent',
@@ -484,17 +482,18 @@ export const pushSendFormRawTransactionThunk = createThunk(
             dispatch(syncAccountsWithBlockchainThunk(payload.symbol));
 
             return fulfillWithValue(true);
+        } else {
+            console.warn(sentTx.error.message);
+
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'sign-tx-error',
+                    error: sentTx.error.message,
+                }),
+            );
+
+            return rejectWithValue(sentTx.error.message);
         }
-
-        console.warn(sentTx.payload.error);
-        dispatch(
-            notificationsActions.addToast({
-                type: 'sign-tx-error',
-                error: sentTx.payload.error,
-            }),
-        );
-
-        return rejectWithValue(sentTx.payload.error);
     },
 );
 

--- a/suite-common/wallet-core/src/send/sendFormTypes.ts
+++ b/suite-common/wallet-core/src/send/sendFormTypes.ts
@@ -7,8 +7,10 @@ import {
     PrecomposedTransactionFinal,
     WalletAccountTransaction,
 } from '@suite-common/wallet-types';
-import { PROTO, TokenInfo, Unsuccessful } from '@trezor/connect';
+import { PROTO, TokenInfo } from '@trezor/connect';
 import { ERRORS as CONNECT_ERRORS } from '@trezor/connect-common/src/constants';
+import { SerializedError } from '@trezor/connect-common/src/constants/errors';
+import { Err } from '@trezor/type-utils';
 
 export type SerializedTx = { tx: string; symbol: NetworkSymbol };
 
@@ -58,7 +60,7 @@ export type SignTransactionTimeoutError = {
 
 export type PushTransactionError = {
     error: 'push-transaction-failed';
-    metadata: Unsuccessful;
+    metadata: Err<SerializedError>;
 };
 
 export type SendFormError =

--- a/suite-common/wallet-core/src/token/stellarTokenThunks.ts
+++ b/suite-common/wallet-core/src/token/stellarTokenThunks.ts
@@ -133,13 +133,13 @@ const manageTrustline = async (
         } else {
             return rejectWithValue({
                 error: 'sign-transaction-failed',
-                message: pushResponse.payload.error,
+                message: pushResponse.error.message,
             });
         }
     } else {
         return rejectWithValue({
             error: 'sign-transaction-failed',
-            message: response.payload.error,
+            message: response.error.message,
         });
     }
 };

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -504,7 +504,7 @@ export const fetchTransactionsPageThunk = createThunk(
 
             return result.payload;
         } else {
-            const error = result ? result.payload.error : 'unknown error';
+            const error = result ? result.error.message : 'unknown error';
 
             throw new Error(error);
         }
@@ -540,7 +540,7 @@ export const fetchUtxoTransactionsForAccountThunk = createSingleInstanceThunk(
         }
 
         if (!result.success) {
-            throw new Error(result.payload.error);
+            throw new Error(result.error.message);
         }
 
         dispatch(

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1175,7 +1175,7 @@ export const prepareNewAccountPayload = async ({
         details: 'txs',
     });
 
-    if (!res.success) return new Error(res.payload.error);
+    if (!res.success) return new Error(res.error.message);
 
     return {
         accountInfo: res.payload,

--- a/suite-common/walletconnect/package.json
+++ b/suite-common/walletconnect/package.json
@@ -27,6 +27,7 @@
         "@trezor/connect": "workspace:*",
         "@trezor/connect-plugin-ethereum": "workspace:*",
         "@trezor/env-utils": "workspace:*",
+        "@trezor/type-utils": "workspace:^",
         "@trezor/utils": "workspace:*",
         "@walletconnect/core": "^2.21.5",
         "@walletconnect/types": "^2.21.4",

--- a/suite-common/walletconnect/src/adapters/solana.ts
+++ b/suite-common/walletconnect/src/adapters/solana.ts
@@ -9,6 +9,7 @@ import { Network, getNetwork, networksCollection } from '@suite-common/wallet-co
 import { selectAccounts } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import TrezorConnect, { CallMethodResponse } from '@trezor/connect';
+import { Result } from '@trezor/type-utils';
 
 import { WALLETCONNECT_MODULE } from '../walletConnectConstants';
 import { selectSessionByTopic } from '../walletConnectReducer';
@@ -54,7 +55,7 @@ const solanaSignTransaction = createThunk<
             },
         });
         if (!estimatedFee.success) {
-            throw new Error('Failed to estimate fee. ' + estimatedFee.payload.error);
+            throw new Error('Failed to estimate fee. ' + estimatedFee.error.message);
         }
         // Get from argument or use decoded from estimate fee
         feePayer = feePayer || estimatedFee.payload.levels[0].feePayer;
@@ -87,16 +88,16 @@ const solanaSignTransaction = createThunk<
                 },
             }),
         );
-        const response = await trezorConnectPopupActions.getPopupCallDeferred(true).promise;
-        const typedPayload = response.payload as CallMethodResponse<'solanaSignTransaction'>;
-        if (!response.success || !typedPayload.serializedTx) {
+        const response = (await trezorConnectPopupActions.getPopupCallDeferred(true)
+            .promise) as Result<CallMethodResponse<'solanaSignTransaction'>>;
+        if (!response.success || !response.payload.serializedTx) {
             console.error('solana_signTransaction error', response);
             throw new Error('Solana signing error');
         }
 
         return {
-            signature: typedPayload.signature,
-            transaction: typedPayload.serializedTx,
+            signature: response.payload.signature,
+            transaction: response.payload.serializedTx,
         };
     },
 );

--- a/suite-common/walletconnect/tsconfig.json
+++ b/suite-common/walletconnect/tsconfig.json
@@ -20,6 +20,7 @@
             "path": "../../packages/connect-plugin-ethereum"
         },
         { "path": "../../packages/env-utils" },
+        { "path": "../../packages/type-utils" },
         { "path": "../../packages/utils" }
     ]
 }

--- a/suite-native/app/e2e/tests/entropyCheckFailT3T1.test.ts
+++ b/suite-native/app/e2e/tests/entropyCheckFailT3T1.test.ts
@@ -28,7 +28,7 @@ describe('Simulated entropy check failure on T3T1 [@androidOnly @T3T1]', () => {
                 args: {
                     preloadedState: getPreloadedState({
                         success: false,
-                        payload: { code: 'Failure_EntropyCheck', error: 'SIMULATED ERROR' },
+                        error: { code: 'Failure_EntropyCheck', message: 'SIMULATED ERROR' },
                     }),
                 },
             });
@@ -49,7 +49,7 @@ describe('Simulated entropy check failure on T3T1 [@androidOnly @T3T1]', () => {
                 args: {
                     preloadedState: getPreloadedState({
                         success: false,
-                        payload: { code: 'Failure_EntropyCheck', error: mockedError },
+                        error: { code: 'Failure_EntropyCheck', message: mockedError },
                     }),
                 },
             });

--- a/suite-native/bluetooth/src/hooks/useBluetoothDevice.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothDevice.ts
@@ -45,13 +45,13 @@ export const useBluetoothDevice = () => {
                 return;
             }
 
-            const { success, payload } = result.payload;
-            if (success || payload.code === 'Device_Disconnected') {
+            const unwrappedResult = result.payload;
+            if (unwrappedResult.success || unwrappedResult.error.code === 'Device_Disconnected') {
                 dispatch(forgetBluetoothDeviceThunk({ bluetoothId: deviceBluetoothId }));
                 onSuccess();
             } else if (
-                payload.code === 'Failure_ActionCancelled' ||
-                payload.code === 'Method_Interrupted'
+                unwrappedResult.error.code === 'Failure_ActionCancelled' ||
+                unwrappedResult.error.code === 'Method_Interrupted'
             ) {
                 onCancel();
             }

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -49,6 +49,7 @@
         "@trezor/analytics-uploader": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-common": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/styles": "workspace:*",

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -9,8 +9,9 @@ import { createThunk } from '@suite-common/redux-utils';
 import { BackupType } from '@suite-common/suite-types';
 import { processEntropyCheckResultThunk } from '@suite-common/wallet-core';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
-import TrezorConnect, { PROTO, SuccessWithDevice, Unsuccessful } from '@trezor/connect';
-import { exhaustive } from '@trezor/type-utils';
+import TrezorConnect, { OkWithDevice, PROTO } from '@trezor/connect';
+import { SerializedError } from '@trezor/connect-common/src/constants/errors';
+import { Err, exhaustive } from '@trezor/type-utils';
 
 const NATIVE_DEVICE_MODULE_PREFIX = 'nativeDevice';
 
@@ -36,7 +37,7 @@ const getResetDeviceConfig = (walletBackupType: BackupType): PROTO.ResetDevice =
 };
 
 export const createAndBackupWalletThunk = createThunk<
-    Unsuccessful | SuccessWithDevice<PROTO.Success>,
+    Err<SerializedError> | OkWithDevice<PROTO.Success>,
     { walletBackupType: BackupType },
     { rejectValue: string }
 >(

--- a/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
+++ b/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
@@ -79,7 +79,7 @@ export const useDeviceAuthenticityCheck = () => {
             // Otherwise it may be cancel on device (must not be considered device compromised), or a transport error, etc.
             if (!result.success) {
                 return isDeviceBootloaderUnlocked
-                    ? { valid: false, error: result.payload.error }
+                    ? { valid: false, error: result.error.message }
                     : undefined;
             }
 
@@ -174,8 +174,8 @@ export const useDeviceAuthenticityCheck = () => {
             const result = deviceAccessResponse.payload;
 
             if (!result.success) {
-                const { error, code } = result.payload;
-                handleError(error, code);
+                const { message, code } = result.error;
+                handleError(message, code);
             }
 
             const storedResult: StoredAuthenticateDeviceResult = createStoredResult(result);

--- a/suite-native/device/src/hooks/usePinAction.tsx
+++ b/suite-native/device/src/hooks/usePinAction.tsx
@@ -101,12 +101,12 @@ export const usePinAction = ({ type, onSuccess, onError }: PinActionProps) => {
             return;
         }
 
-        const { success, payload } = result.payload;
-        if (success) {
+        const unwrappedResult = result.payload;
+        if (unwrappedResult.success) {
             showSuccess(successMessageKey);
             onSuccess();
         } else {
-            const errorCode = payload.code;
+            const errorCode = unwrappedResult.error.code;
             if (
                 errorCode === 'Failure_ActionCancelled' ||
                 errorCode === 'Failure_PinCancelled' ||

--- a/suite-native/device/tsconfig.json
+++ b/suite-native/device/tsconfig.json
@@ -65,6 +65,9 @@
             "path": "../../packages/blockchain-link-types"
         },
         { "path": "../../packages/connect" },
+        {
+            "path": "../../packages/connect-common"
+        },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },
         { "path": "../../packages/styles" },

--- a/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
+++ b/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
@@ -145,7 +145,7 @@ export const FirmwareInstallationScreenContent = ({
         if (!result.success) {
             if (
                 // Action cancelled on device
-                result.payload?.code === 'Failure_ActionCancelled'
+                result.error?.code === 'Failure_ActionCancelled'
             ) {
                 handleAnalyticsReportCancelled();
                 onFirmwareInstallationFailure?.();
@@ -153,7 +153,7 @@ export const FirmwareInstallationScreenContent = ({
                 return;
             }
 
-            handleAnalyticsReportFinished({ error: result.payload?.error ?? 'Unknown error' });
+            handleAnalyticsReportFinished({ error: result.error?.message ?? 'Unknown error' });
 
             return;
         }

--- a/suite-native/firmware/src/hooks/useFirmwareLanguage.ts
+++ b/suite-native/firmware/src/hooks/useFirmwareLanguage.ts
@@ -40,8 +40,8 @@ export const useFirmwareLanguage = () => {
                 return;
             }
 
-            const { success, payload } = result.payload;
-            if (success) {
+            const unwrappedResult = result.payload;
+            if (unwrappedResult.success) {
                 showToast({
                     variant: 'default',
                     message: translate('firmware.changeLanguage.success', {
@@ -50,7 +50,7 @@ export const useFirmwareLanguage = () => {
                 });
                 navigation.goBack();
             } else {
-                const errorCode = payload.code;
+                const errorCode = unwrappedResult.error.code;
                 if (
                     errorCode === 'Failure_ActionCancelled' ||
                     errorCode === 'Failure_PinCancelled' ||

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -157,7 +157,7 @@ export const getAccountInfoThunk = createThunk<
 
                 return fetchedAccountInfo.payload;
             } else {
-                return rejectWithValue(fetchedAccountInfo.payload.error);
+                return rejectWithValue(fetchedAccountInfo.error.message);
             }
         } catch (error) {
             return rejectWithValue(error?.message);

--- a/suite-native/module-check-backup/src/hooks/useCheckBackupOnMount.tsx
+++ b/suite-native/module-check-backup/src/hooks/useCheckBackupOnMount.tsx
@@ -44,7 +44,7 @@ export const useCheckBackupOnMount = () => {
             if (
                 // The backup do no match.
                 response.success === false &&
-                response.payload.code === 'Failure_ProcessError'
+                response.error.code === 'Failure_ProcessError'
             ) {
                 analytics.report({
                     type: events.deviceSettingsCheckBackupFinishedEvent.name,
@@ -56,7 +56,7 @@ export const useCheckBackupOnMount = () => {
 
                 return;
             }
-            if (response.payload.code && DEFINITIVE_ERRORS.includes(response.payload.code)) return;
+            if (response.error.code && DEFINITIVE_ERRORS.includes(response.error.code)) return;
 
             startCheckBackup(); // In case any other error occurs, retry the check.
         };

--- a/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
@@ -63,11 +63,11 @@ export const WalletCreationScreen = () => {
                     flowType: 'create',
                 });
             }
-            const { code, error } = responsePayload.payload;
+            const { code, message } = responsePayload.error;
             const isDefinitiveError = code && DEFINITIVE_ERRORS.includes(code);
             // inconclusive, so repeat the attempt
-            if (!isDefinitiveError || getIsIgnoredEntropyCheckError(error)) {
-                showToast({ variant: 'error', message: error });
+            if (!isDefinitiveError || getIsIgnoredEntropyCheckError(message)) {
+                showToast({ variant: 'error', message });
                 // This code is OK, but the eslint plugin crashes on recursive calls
                 // eslint-disable-next-line react-hooks/immutability
                 handleCreateAndBackupWallet();

--- a/suite-native/module-device-onboarding/src/screens/WalletRecoveryScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletRecoveryScreen.tsx
@@ -24,7 +24,7 @@ export const WalletRecoveryScreen = ({
             });
         }
         // Do not retry if user cancelled the flow via the app UI
-        if (response.payload.code && response.payload.code === 'Method_Interrupted') return;
+        if (response.error.code && response.error.code === 'Method_Interrupted') return;
 
         // This code is OK, but the eslint plugin crashes on recursive calls
         // eslint-disable-next-line react-hooks/immutability

--- a/suite-native/module-device-settings/src/screens/BackupAndPassphrase/PassphraseCard.tsx
+++ b/suite-native/module-device-settings/src/screens/BackupAndPassphrase/PassphraseCard.tsx
@@ -36,7 +36,7 @@ export const PassphraseCard = () => {
         if (!response.success) {
             showToast({
                 variant: 'default',
-                message: response.payload.error,
+                message: response.error.message,
                 icon: 'check',
             });
         }

--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/__tests__/useAddressValidationAlerts.test.tsx
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/__tests__/useAddressValidationAlerts.test.tsx
@@ -40,7 +40,7 @@ const mockAccountInfoResponses = {
     },
     networkError: {
         success: false,
-        payload: { error: 'Network error' },
+        error: { message: 'Network error', code: 'Backend_Disconnected' },
     },
 } as const;
 

--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/useSolAssociatedTokenAddress.ts
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/useSolAssociatedTokenAddress.ts
@@ -22,13 +22,13 @@ export const useSolAssociatedTokenAddress = () => {
     }) => {
         const networkType = getNetworkType(symbol);
         if (networkType !== 'solana') return;
-        const { payload, success } = await TrezorConnect.getAccountInfo({
+        const response = await TrezorConnect.getAccountInfo({
             descriptor: value,
             coin: symbol,
             details: 'basic',
         });
 
-        if (!success) {
+        if (!response.success) {
             setError(fieldName, {
                 message: translate(
                     'moduleSend.outputs.recipients.solAssociatedAccountAddress.alert.title',
@@ -40,7 +40,7 @@ export const useSolAssociatedTokenAddress = () => {
             return;
         }
 
-        setIsSolATA(isProgramDerivedAccount(payload));
+        setIsSolATA(isProgramDerivedAccount(response.payload));
     };
 
     return { isSolATA, checkSolAssociatedTokenAddress };

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -96,7 +96,7 @@ export const pushTradingTxnThunk = createThunk(
             });
 
             if (!pushTxResponse.success) {
-                return rejectWithValue(pushTxResponse.payload ?? 'Push transaction failed');
+                return rejectWithValue(pushTxResponse.error ?? 'Push transaction failed');
             }
 
             return fulfillWithValue(pushTxResponse);

--- a/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
@@ -152,14 +152,13 @@ describe('utils', () => {
             [
                 '[error]: message',
                 {
-                    error: { message: 'Error message' },
-                    payload: { error: 'error', message: 'message' },
+                    error: { error: 'error', message: 'message' },
                 },
             ],
             ['Error message', { error: { message: 'Error message' } }],
             ['Error message', new Error('Error message')],
             ['Just a string error', 'Just a string error'],
-            ['[Unknown error]: No description', { payload: {} }],
+            ['Unknown error', { error: {} }],
             ['Unknown error', 42],
         ])('should return %s when called with %o', (expected, input) => {
             expect(getErrorStrFromThunkRejectedValue(input)).toBe(expected);

--- a/suite-native/module-trading/src/utils/general/utils.ts
+++ b/suite-native/module-trading/src/utils/general/utils.ts
@@ -204,8 +204,8 @@ export const getFormDraftKeyPrefixFromTradingType = (tradingType: TradingType) =
 
 export const getErrorStrFromThunkRejectedValue = (rejectedValue: unknown) => {
     const asAny = rejectedValue as any;
-    if (asAny?.payload) {
-        return `[${asAny.payload.error ?? 'Unknown error'}]: ${asAny.payload.message ?? 'No description'}`;
+    if (asAny?.error?.error) {
+        return `[${asAny.error.error}]: ${asAny.error.message ?? 'No description'}`;
     }
 
     if (asAny?.error?.message) {

--- a/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
+++ b/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
@@ -65,7 +65,7 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
 
             if (
                 !response.payload.success &&
-                response.payload.payload.code === 'Failure_ActionCancelled'
+                response.payload.error.code === 'Failure_ActionCancelled'
             ) {
                 showToast({
                     icon: 'warningCircle',
@@ -81,7 +81,7 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
 
             if (
                 !response.payload.success &&
-                response.payload.payload.error === 'Passphrase is incorrect'
+                response.payload.error.message === 'Passphrase is incorrect'
             ) {
                 showAlert({
                     title: <Translation id="modulePassphrase.featureAuthorizationError" />,
@@ -102,11 +102,11 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
                     'Failure_PinInvalid',
                     'Method_Cancel',
                     'Failure_PinCancelled',
-                ].includes(response.payload.payload.code ?? '')
+                ].includes(response.payload.error.code ?? '')
             ) {
                 showAlert({
-                    title: response.payload.payload.code,
-                    description: response.payload.payload.error,
+                    title: response.payload.error.code,
+                    description: response.payload.error.message,
                     pictogramVariant: 'critical',
                     primaryButtonTitle: <Translation id="generic.buttons.cancel" />,
                     onPressPrimaryButton: () => {

--- a/suite-native/send/package.json
+++ b/suite-native/send/package.json
@@ -23,7 +23,7 @@
         "@suite-native/tokens": "workspace:*",
         "@suite-native/transaction-management": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
-        "@trezor/connect": "workspace:*",
+        "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
     }
 }

--- a/suite-native/send/src/sendFormThunks.ts
+++ b/suite-native/send/src/sendFormThunks.ts
@@ -31,7 +31,7 @@ import {
     addTransactionLabelingThunk,
 } from '@suite-native/transaction-management';
 import { BlockbookTransaction } from '@trezor/blockchain-link-types';
-import { Success } from '@trezor/connect';
+import { Ok } from '@trezor/type-utils';
 import { isNotNullOrUndefined, typedObjectKeys } from '@trezor/utils';
 
 import { SEND_MODULE_PREFIX } from './constants';
@@ -173,7 +173,7 @@ type SendTransactionThunkParams = {
 };
 
 export const sendTransactionThunk = createThunk<
-    Success<{ txid: string }>,
+    Ok<{ txid: string }>,
     SendTransactionThunkParams,
     { rejectValue: PushTransactionError }
 >(
@@ -192,7 +192,10 @@ export const sendTransactionThunk = createThunk<
         if (sendResponse.payload === undefined) {
             return rejectWithValue({
                 error: 'push-transaction-failed',
-                metadata: { success: false, payload: { error: 'Payload is undefined.' } },
+                metadata: {
+                    success: false,
+                    error: { message: 'Payload is undefined.', code: 'Failure_UnknownCode' },
+                },
             });
         }
 

--- a/suite-native/send/tsconfig.json
+++ b/suite-native/send/tsconfig.json
@@ -23,7 +23,7 @@
         {
             "path": "../../packages/blockchain-link-types"
         },
-        { "path": "../../packages/connect" },
+        { "path": "../../packages/type-utils" },
         { "path": "../../packages/utils" }
     ]
 }

--- a/suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts
+++ b/suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts
@@ -30,7 +30,7 @@ test.describe('Onboarding - simulated entropy check failure', { tag: ['@T2T1'] }
                 action => window.store.dispatch(action),
                 deviceActions.setSimulatedEntropyCheckFail({
                     success: false,
-                    payload: { code: 'Failure_EntropyCheck', error: 'SIMULATED ERROR' },
+                    error: { code: 'Failure_EntropyCheck', message: 'SIMULATED ERROR' },
                 }),
             );
 
@@ -66,7 +66,7 @@ test.describe('Onboarding - simulated entropy check failure', { tag: ['@T2T1'] }
                 action => window.store.dispatch(action),
                 deviceActions.setSimulatedEntropyCheckFail({
                     success: false,
-                    payload: { code: 'Failure_EntropyCheck', error: mockedError },
+                    error: { code: 'Failure_EntropyCheck', message: mockedError },
                 }),
             );
 

--- a/suite/metadata/src/metadataPasswordsActions.ts
+++ b/suite/metadata/src/metadataPasswordsActions.ts
@@ -114,7 +114,7 @@ export const init = () => async (dispatch: Dispatch, getState: () => MetadataRoo
             askOnDecrypt: true,
         });
         if (!res.success) {
-            throw new Error(res.payload.error);
+            throw new Error(res.error.message);
         }
         const encryptionKey = res.payload.value.substring(
             res.payload.value.length / 2,

--- a/suite/metadata/src/password-manager/EntryForm.tsx
+++ b/suite/metadata/src/password-manager/EntryForm.tsx
@@ -65,7 +65,7 @@ export const EntryForm = ({ onEncrypted, entry, cancel }: Props) => {
         })
             .then(result => {
                 if (!result.success) {
-                    throw new Error(result.payload.error);
+                    throw new Error(result.error.message);
                 }
 
                 return Promise.all([

--- a/yarn.lock
+++ b/yarn.lock
@@ -10927,6 +10927,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/connect-common": "workspace:^"
+    "@trezor/type-utils": "workspace:^"
     "@trezor/utils": "workspace:*"
     "@types/react": "npm:19.1.6"
     react: "npm:19.1.0"
@@ -10983,6 +10984,7 @@ __metadata:
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/type-utils": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -10996,6 +10998,7 @@ __metadata:
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-common": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
@@ -11306,6 +11309,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-common": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     web3-utils: "npm:^4.3.2"
@@ -11596,6 +11600,7 @@ __metadata:
     "@testing-library/react": "npm:^16.3.2"
     "@trezor/address-validator": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-common": "workspace:*"
     "@trezor/connect-plugin-ethereum": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/react-utils": "workspace:*"
@@ -11774,6 +11779,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/connect-plugin-ethereum": "workspace:*"
     "@trezor/env-utils": "workspace:*"
+    "@trezor/type-utils": "workspace:^"
     "@trezor/utils": "workspace:*"
     "@walletconnect/core": "npm:^2.21.5"
     "@walletconnect/types": "npm:^2.21.4"
@@ -12452,6 +12458,7 @@ __metadata:
     "@trezor/analytics-uploader": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-common": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
@@ -13867,7 +13874,7 @@ __metadata:
     "@suite-native/tokens": "workspace:*"
     "@suite-native/transaction-management": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
-    "@trezor/connect": "workspace:*"
+    "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

Unify Connect's result type with `@trezor/type-utils`
Essentially this results in the following renaming `response.payload.error` -> `response.error.message`

## Notes for QA

This is not directly testable, but can affect a bunch of random things in Suite.

## Related Issue

Related #23789

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-unify-result-type&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-unify-result-type&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-unify-result-type&lookback=7)