### PR TITLE
fix(ci): exclude lib & libESM from depcheck

### DIFF
--- a/.depcheckrc.json
+++ b/.depcheckrc.json
@@ -1,5 +1,5 @@
 {
-    "ignore-patterns": ["libDev"],
+    "ignore-patterns": ["libDev", "lib", "libESM"],
     "ignores": [
         "babel*",
         "karma*",


### PR DESCRIPTION
## Description

Small fix for depcheck running locally.
This does not happen in CI, but locally, if you have run `build:libs`, connect `lib` folders may be checked and fail

I have not checked the code that triggers failure, but generally it makes total sense – built code may contain imports for subdeps (not listed in package.json). 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/local-depcheck&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/local-depcheck&lookback=7)