### PR TITLE
feat(suite-native): use app scheme callback for all partners

### DIFF
--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAlert.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAlert.tsx
@@ -147,7 +147,6 @@ export const TradeDetailAlert = ({
                     actionType: 'trade',
                     tradeType: trade.tradeType,
                     orderId,
-                    exchange: trade.data.partnerData,
                 }),
                 tradingType: trade.tradeType,
                 source: { uri: trade.data.partnerData },

--- a/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
@@ -119,7 +119,6 @@ export const useBuyFlow = (form: BuyFormType) => {
             actionType: 'trade',
             tradeType: 'buy',
             orderId: quote.orderId,
-            exchange: quote.exchange,
         });
 
         await dispatch(
@@ -169,7 +168,6 @@ export const useBuyFlow = (form: BuyFormType) => {
             actionType: 'quote',
             tradeType: 'buy',
             orderId: candidateQuote.orderId,
-            exchange: candidateQuote.exchange,
         });
 
         await dispatch(

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
@@ -79,7 +79,6 @@ export const useExchangeFlow = () => {
                 actionType: 'trade',
                 tradeType: 'exchange',
                 orderId: tradeToUse.orderId,
-                exchange: tradeToUse.exchange,
             });
 
             const triggerAnalyticsTradeConfirmation = () => {

--- a/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
@@ -62,7 +62,6 @@ export const useSellFlow = () => {
                 actionType: 'trade',
                 tradeType: 'sell',
                 orderId: tradeToUse.orderId,
-                exchange: tradeToUse.exchange,
             });
 
             const triggerAnalyticsTradeConfirmation = () => {

--- a/suite-native/module-trading/src/utils/general/__tests__/formUtils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/formUtils.test.ts
@@ -184,27 +184,13 @@ describe('getRequestFormSource', () => {
 });
 
 describe('buildTradingUrl', () => {
-    it('should return correct url format without https', () => {
+    it('should return correct url format', () => {
         expect(
             buildTradingUrl({
                 actionType: 'quote',
                 tradeType: 'buy',
                 orderId: '1234',
-                exchange: 'paybis',
             }),
         ).toBe('trezorsuite://trading?action=quote&tradeType=buy&orderId=1234');
-    });
-
-    it('should return correct url format with https', () => {
-        expect(
-            buildTradingUrl({
-                actionType: 'quote',
-                tradeType: 'buy',
-                orderId: '1234',
-                exchange: 'invity',
-            }),
-        ).toBe(
-            'https://suite.trezor.io/web/accounts/coinmarket/buy?action=quote&tradeType=buy&orderId=1234',
-        );
     });
 });

--- a/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
@@ -6,7 +6,7 @@ import { useTranslate } from '@suite-native/intl';
 import { renderHookWithBasicProvider } from '@suite-native/test-utils';
 import { getBuyTrade, getExchangeTrade, getSellTrade } from '@suite-native/trading-fixtures';
 
-import { INVITY_CALLBACK_TREZOR_BUY_URL, TRADING_URL_DEFAULT_BACK } from '../formUtils';
+import { TRADING_URL_DEFAULT_BACK } from '../formUtils';
 import {
     doesUrlContainCloseCallbackUrl,
     getErrorStrFromThunkRejectedValue,
@@ -126,11 +126,6 @@ describe('utils', () => {
 
         it('should return true when URL contains TRADING_URL_DEFAULT_BACK', () => {
             const url = `${TRADING_URL_DEFAULT_BACK}?action=trade&tradeType=buy&orderId=123`;
-            expect(doesUrlContainCloseCallbackUrl(url, closeCallbackUrl)).toBe(true);
-        });
-
-        it('should return true when URL contains INVITY_CALLBACK_TREZOR_BUY_URL', () => {
-            const url = `${INVITY_CALLBACK_TREZOR_BUY_URL}?action=trade&tradeType=buy&orderId=123`;
             expect(doesUrlContainCloseCallbackUrl(url, closeCallbackUrl)).toBe(true);
         });
 

--- a/suite-native/module-trading/src/utils/general/formUtils.ts
+++ b/suite-native/module-trading/src/utils/general/formUtils.ts
@@ -19,14 +19,10 @@ export type BuildTradingUrlProps = {
     actionType: 'quote' | 'trade';
     tradeType: TradingType;
     orderId: string | undefined;
-    exchange: string | undefined;
 };
 
 export const TRADING_URL_BASE = 'trezorsuite://trading';
 export const TRADING_URL_DEFAULT_BACK = `${TRADING_URL_BASE}/back`;
-export const INVITY_CALLBACK_TREZOR_BUY_URL = 'https://suite.trezor.io/web/accounts/coinmarket/buy';
-
-const exchangesWithHttps = ['invity', 'btcdirect-sandbox', 'btcdirect'];
 
 export const applyHtmlTemplate = (
     content = 'You may now close this window.',
@@ -122,14 +118,8 @@ export const getSourceForForm = (form: FormResponse['form'] | undefined, backUrl
     return null;
 };
 
-export const buildTradingUrl = ({
-    actionType,
-    tradeType,
-    orderId,
-    exchange,
-}: BuildTradingUrlProps) => {
-    const useHttpsVersion = exchangesWithHttps.includes(exchange ?? '');
-    const url = new URL(useHttpsVersion ? INVITY_CALLBACK_TREZOR_BUY_URL : TRADING_URL_BASE);
+export const buildTradingUrl = ({ actionType, tradeType, orderId }: BuildTradingUrlProps) => {
+    const url = new URL(TRADING_URL_BASE);
     const { searchParams } = url;
     searchParams.set('action', actionType);
     searchParams.set('tradeType', tradeType);

--- a/suite-native/module-trading/src/utils/general/utils.ts
+++ b/suite-native/module-trading/src/utils/general/utils.ts
@@ -14,7 +14,7 @@ import type { Translate } from '@suite-native/intl';
 import { exhaustive } from '@trezor/type-utils';
 import { getWeakRandomId } from '@trezor/utils';
 
-import { INVITY_CALLBACK_TREZOR_BUY_URL, TRADING_URL_DEFAULT_BACK } from './formUtils';
+import { TRADING_URL_DEFAULT_BACK } from './formUtils';
 
 type UndefinedTradeOperation = {
     fromValue: undefined;
@@ -185,9 +185,7 @@ export const getTradeStatusStep = (trade: TradingTransaction | undefined) => {
 export type TradeStatusStep = ReturnType<typeof getTradeStatusStep>;
 
 export const doesUrlContainCloseCallbackUrl = (url: string, closeCallbackUrl: string) =>
-    url.includes(closeCallbackUrl) ||
-    url.includes(TRADING_URL_DEFAULT_BACK) ||
-    url.includes(INVITY_CALLBACK_TREZOR_BUY_URL);
+    url.includes(closeCallbackUrl) || url.includes(TRADING_URL_DEFAULT_BACK);
 
 export const getRandomAccountDescriptor = () => getWeakRandomId(20);
 


### PR DESCRIPTION
After Invity and BTCDirect enabled app scheme `trezorsuite://` we dont have to use https callbacks anymore

## Notes for QA
Callbacks should work correctly for Invity and BtcDirect




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/use-app-scheme-for-invity&lookback=7)