### PR TITLE
test(e2e-suite): rework test suite-sync read from server

### DIFF
--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -38,6 +38,7 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-constants": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
+        "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@suite/analytics": "workspace:*",
         "@suite/intl": "workspace:^",

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { AnalyticsFixture } from './analytics';
+import { EvoluClient } from './helpers/evoluClient';
 import { IndexedDbFixture } from './indexedDb';
 import { BlockbookMock } from './mocks/blockBookMock';
 import { MetadataMock } from './mocks/metadataMock';
@@ -46,6 +47,7 @@ type Fixtures = {
     connectPermissionsModal: ConnectPermissionsModal;
     stakingSection: StakingSection;
     paginationControl: PaginationControl;
+    evoluClient: EvoluClient;
 };
 
 const test = suiteBaseTest.extend<Fixtures>({
@@ -118,6 +120,9 @@ const test = suiteBaseTest.extend<Fixtures>({
     },
     paginationControl: async ({ page }, use) => {
         await use(new PaginationControl(page));
+    },
+    evoluClient: async ({}, use) => {
+        await use(new EvoluClient());
     },
 });
 

--- a/suite/e2e/support/helpers/evoluClient.ts
+++ b/suite/e2e/support/helpers/evoluClient.ts
@@ -1,16 +1,19 @@
-/* eslint-disable no-console */
-import { Evolu, SimpleName, createIdFromString, getOrThrow, id } from '@evolu/common';
-import { createEvolu, createOwnerWebSocketTransport } from '@evolu/common/local-first';
+import { Evolu, SimpleName, getOrThrow } from '@evolu/common';
+import { Upsertable, createEvolu, createOwnerWebSocketTransport } from '@evolu/common/local-first';
+import { expect } from '@playwright/test';
 
 import { Schema, createEvoluAppOwnerFromTrezorData } from '@suite-common/suite-sync-evolu';
 import { SuiteSyncOwnerSecretHex } from '@suite-common/suite-types';
 
 import { createNodeEvoluDeps } from './createEvoluNodeDeps';
-import { expect } from '../../support/fixtures';
+import { step } from '../common';
+
+type TableName = keyof typeof Schema;
 
 export class EvoluClient {
     private _evolu?: Evolu<typeof Schema>;
 
+    @step()
     async init({
         ownerSecret,
         //TODO: replace with one source definition
@@ -57,56 +60,52 @@ export class EvoluClient {
         return this._evolu;
     }
 
-    //TMP
-    async getAccountData() {
-        const accountData = await this.evolu.loadQuery(
-            this.evolu.createQuery(db => db.selectFrom('account').selectAll()),
-        );
-        const error = this.evolu.getError();
-        if (error) {
-            console.error('Evolu Error detected during wait:', error);
-        }
-
-        return accountData;
-    }
-
-    //TMP
-    async testWriteAndRead() {
-        this.writeTestData();
-        await this.readTestData();
-    }
-
-    //TMP
-    writeTestData() {
-        // Insert a wallet label
-        const WalletLabelId = id('WalletLabelId');
-        const walletDescriptor = 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zTXPD';
-        const walletIdResult = WalletLabelId.from(createIdFromString(walletDescriptor));
-        if (!walletIdResult.ok) {
-            throw walletIdResult.error;
-        }
-        const upsertResult = this.evolu.upsert('wallet', {
-            id: walletIdResult.value,
-            walletDescriptor,
-            label: 'My Test Wallet',
-        });
+    @step()
+    writeTo<T extends TableName>(table: T, object: Upsertable<(typeof Schema)[T]>) {
+        const upsertResult = this.evolu.upsert(table, object as any);
         if (!upsertResult.ok) {
-            console.error('Upsert failed:', upsertResult.error);
-            throw upsertResult.error;
+            throw new Error(
+                `Upsert to Evolu relay failed: ${JSON.stringify(upsertResult.error, null, 2)}`,
+            );
         }
     }
 
-    //TMP
-    async readTestData() {
-        // Get and log the wallet data to verify
-        await expect(async () => {
-            const walletData = await this.evolu.loadQuery(
-                this.evolu.createQuery(db => db.selectFrom('wallet').selectAll()),
-            );
-            console.log('Wallet data:', walletData);
+    @step()
+    async readFrom(table: TableName) {
+        return await this.evolu.loadQuery(
+            this.evolu.createQuery(db => db.selectFrom(table).selectAll()),
+        );
+    }
 
-            expect(walletData).not.toEqual([]);
-            console.error('Wallet data from Evolu:', JSON.stringify(walletData));
-        }).toPass({ timeout: 30_000 });
+    // Suite sync by design will first return data from local storage
+    // and then update it with data from the server.
+    // Because of that we need to retry reads until we get expected data
+    @step()
+    async readWithRetryFrom(table: TableName) {
+        const result = await expect(async () => {
+            const data = await this.readFrom(table);
+            expect(data).not.toEqual([]);
+
+            return data;
+        }).toPass({ timeout: 5_000 });
+
+        return result;
+    }
+
+    @step()
+    async debugReadAllTablesAndThrow() {
+        const allTables = Object.keys(Schema) as TableName[];
+        const allDataPromise = allTables.map(async table => await this.readFrom(table));
+        await expect(async () => {
+            const allData = await Promise.all(allDataPromise);
+            // test if any tables are empty
+            if (allData.some(item => item.length === 0)) {
+                // we want to throw even partial results so we can debug
+                throw new Error(`Evolu Data: ${JSON.stringify(allData, null, 2)}`);
+            }
+
+            // we have collected all data, throw it for debugging purposes
+            throw new Error(`Evolu Data: ${JSON.stringify(allData, null, 2)}`);
+        }).toPass({ timeout: 3_000, intervals: [1000, 2000, 2500] });
     }
 }

--- a/suite/e2e/tests/metadata/suite-sync.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync.test.ts
@@ -1,14 +1,12 @@
-import { getOrThrow } from '@evolu/common';
-import { OwnerId } from '@evolu/common/local-first';
 import { generateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
 
 import { asSuiteSyncOwnerSecretHex } from '@suite-common/suite-types';
+import { asAccountDescriptor, asWalletDescriptor } from '@suite-common/wallet-types';
 
 import { isWebProject, skipFixture } from '../../support/common';
 import { AccountLabelId } from '../../support/enums/accountLabelId';
 import { expect, test } from '../../support/fixtures';
-import { EvoluClient } from '../../support/helpers/evoluClient';
 
 test.use({ exceptionLogger: skipFixture });
 test.describe(
@@ -74,124 +72,125 @@ test.describe(
     },
 );
 
-const MNEMONIC = 'ugly rally dial movie exhibit annual bean slender illegal frown giraffe scare';
-const ownerId = getOrThrow(OwnerId.from('yg0UgROParTpm60ltI3hDw'));
+// const ownerId = getOrThrow(OwnerId.from('0Fco3XDgKR59zX5VBvyyGQ'));
 const ownerSecret = asSuiteSyncOwnerSecretHex(
-    'e17818d7c458f171885280eeef2d70078c6842b51e18ec6f2f8c9f44d3d171fd0f49a3aeff32a560d7f823321fcd24f8d8773ffa59855c6447b11af88a2fd7b5',
+    'd5cafbfc837fcdba7fd54025ce352fac369db9383d41d73dbd4f3353b63bc4644585f41195021419707ccdf76bbdf0b1cb0e11f07ff19a41b5f22602dfee3b63',
 );
 
-// These labels were set manually on this seed
-const ACCOUNT_LABEL = 'Evolu synced BTC account';
-const WALLET_INDEX = 0;
-const WALLET_LABEL = 'Evolu synced wallet';
-const ADDRESS = 'bc1q8aekqmmpxujx8xpgxp9mcwe6kdjpcnpzpehsmm';
-const ADDRESS_LABEL = 'Evolu synced BTC address';
+const WALLET_SEED_INDEX = 0;
+const accountDescriptor = asAccountDescriptor(
+    'zpub6qSSRL9wLd6LNee7qjDEuULWccP5Vbm5nuX4geBu8zMCQBWsF5Jo5UswLVxFzcbCMr2yQPG27ZhDs1cUGKVH1RmqkG1PFHkEXyHG7EV3ogY',
+);
+const walletSeed = {
+    id: 'ya1CCDTCVPyRa6egTac7yg',
+    walletDescriptor: asWalletDescriptor('mkqRFzxmkCGX9jxgpqqFHcxRUmLJcLDBer'),
+    label: 'Evolu synced wallet',
+};
 
-test.describe('Suite Sync - Labelling', { tag: ['@specificFirmware', '@T3W1', '@T3T1'] }, () => {
-    test.use({
-        firmwareVersion: '2-main',
-        deviceSetup: { mnemonic: MNEMONIC, passphrase_protection: true },
-    });
+const accountSeed = {
+    id: 'RSZ0aKqUcO_e0WoQO32x4w',
+    accountDescriptor,
+    networkSymbol: 'btc',
+    label: 'Evolu synced BTC account',
+};
 
-    //TMP Test just for local demonstration purposes
-    test.skip('Set label in suite and verify it on server', async ({
-        page,
-        onboardingPage,
-        metadataPage,
-        walletPage,
-    }) => {
-        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
-        await metadataPage.setupQuotaManager();
-        await metadataPage.enableSuiteSync();
+const addressSeed = {
+    id: 'DmBRN-GwcRyC-cuTPczSXg',
+    label: 'Evolu synced BTC address',
+    address: 'bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa',
+    accountDescriptor,
+    networkSymbol: 'btc',
+};
 
-        await walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }).click();
-        await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
-        await metadataPage.account.metadataInput.fill(ACCOUNT_LABEL);
-        await page.keyboard.press('Enter');
-        await expect(
-            walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
-        ).toHaveText(ACCOUNT_LABEL);
+test.describe(
+    'Suite Sync - Labelling',
+    { tag: ['@webOnly', '@specificFirmware', '@T3W1', '@T3T1'] },
+    () => {
+        test.use({
+            firmwareVersion: '2-main',
+            deviceSetup: { passphrase_protection: true },
+        });
 
-        const evoluClient = new EvoluClient();
-        await evoluClient.init({ ownerSecret });
-
-        await expect(async () => {
-            const accountData = await evoluClient.getAccountData();
-            expect(accountData).not.toEqual([]);
-            expect(accountData[0].ownerId).toBe(ownerId);
-            expect(accountData[0].label).toBe(ACCOUNT_LABEL);
-        }).toPass({ timeout: 30_000 });
-    });
-
-    // TODO: Temporarily skipping the test due to work in progress
-    test.skip('Sync labels from server', async ({
-        page,
-        target,
-        device,
-        devicePrompt,
-        onboardingPage,
-        dashboardPage,
-        walletPage,
-        metadataPage,
-    }) => {
-        await test.step('Enable Suite Sync', async () => {
+        test.beforeEach(async ({ evoluClient, onboardingPage }) => {
             await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
-            await metadataPage.setupQuotaManager();
-            await metadataPage.initiateSuiteSyncSetup();
-            if (isWebProject(target)) {
-                // eslint-disable-next-line playwright/no-conditional-expect
-                await expect(device).toShowOnDisplay({
-                    T3W1: {
-                        header: { title: 'Suite Sync' },
-                        body: [
-                            [
-                                'Allow Trezor Suite',
-                                '\n',
-                                'on Chrome to use',
-                                '\n',
-                                'Suite Sync with this',
-                                '\n',
-                                'Trezor?',
-                            ],
-                        ],
-                        actions: { right_button: 'Confirm' },
-                    },
-                    T3T1: {
-                        body: [
-                            [
-                                'Allow Trezor Suite to use',
-                                '\n',
-                                'Suite Sync with this',
-                                '\n',
-                                'Trezor?',
-                            ],
-                        ],
-                    },
+            await test.step('Seed Evolu relay server', async () => {
+                await evoluClient.init({
+                    ownerSecret,
                 });
-            }
-            await metadataPage.confirmSuiteSyncSetup();
+                evoluClient.writeTo('wallet', walletSeed);
+                evoluClient.writeTo('account', accountSeed);
+                evoluClient.writeTo('address', addressSeed);
+            });
         });
 
-        await test.step('Verify BTC account label is synced', async () => {
-            await walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }).click();
-            await expect(
-                walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
-            ).toHaveText(ACCOUNT_LABEL, { timeout: 30_000 });
-        });
+        test('Sync labels from server', async ({
+            target,
+            device,
+            dashboardPage,
+            walletPage,
+            metadataPage,
+        }) => {
+            await test.step('Enable Suite Sync', async () => {
+                await metadataPage.setupQuotaManager();
+                await metadataPage.initiateSuiteSyncSetup();
+                if (isWebProject(target)) {
+                    // eslint-disable-next-line playwright/no-conditional-expect
+                    await expect(device).toShowOnDisplay({
+                        T3W1: {
+                            header: { title: 'Suite Sync' },
+                            body: [
+                                [
+                                    'Allow Trezor Suite',
+                                    '\n',
+                                    'on Chrome to use',
+                                    '\n',
+                                    'Suite Sync with this',
+                                    '\n',
+                                    'Trezor?',
+                                ],
+                            ],
+                            actions: { right_button: 'Confirm' },
+                        },
+                        T3T1: {
+                            body: [
+                                [
+                                    'Allow Trezor Suite to use',
+                                    '\n',
+                                    'Suite Sync with this',
+                                    '\n',
+                                    'Trezor?',
+                                ],
+                            ],
+                        },
+                    });
+                }
+                await metadataPage.confirmSuiteSyncSetup();
+            });
 
-        await test.step('Verify wallet label is synced', async () => {
-            await dashboardPage.openDeviceSwitcher();
-            await expect(metadataPage.wallet.walletLabel(WALLET_INDEX)).toHaveText(WALLET_LABEL);
-            await dashboardPage.deviceSwitchingCloseButton.click();
-        });
+            await test.step('Verify BTC account label is synced', async () => {
+                await walletPage
+                    .accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 })
+                    .click();
+                await expect
+                    .soft(walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }))
+                    .toHaveText(accountSeed.label, { timeout: 30_000 });
+            });
 
-        await test.step('Verify address label is synced', async () => {
-            await walletPage.openAccount();
-            await walletPage.receiveButton.click();
-            await walletPage.revealAddressButton.click();
-            await devicePrompt.waitForPromptAndConfirm();
-            await page.modalCloseButton.click();
-            await expect(metadataPage.address.label(ADDRESS)).toHaveText(ADDRESS_LABEL);
+            await test.step('Verify wallet label is synced', async () => {
+                await dashboardPage.openDeviceSwitcher();
+                await expect
+                    .soft(metadataPage.wallet.walletLabel(WALLET_SEED_INDEX))
+                    .toHaveText(walletSeed.label);
+                await dashboardPage.deviceSwitchingCloseButton.click();
+            });
+
+            await test.step('Verify address label is synced', async () => {
+                await walletPage.openAccount();
+                await walletPage.receiveButton.click();
+                await expect
+                    .soft(metadataPage.address.label(addressSeed.address))
+                    .toHaveText(addressSeed.label);
+            });
         });
-    });
-});
+    },
+);

--- a/suite/e2e/tsconfig.json
+++ b/suite/e2e/tsconfig.json
@@ -32,6 +32,9 @@
             "path": "../../suite-common/wallet-core"
         },
         {
+            "path": "../../suite-common/wallet-types"
+        },
+        {
             "path": "../../suite-common/wallet-utils"
         },
         { "path": "../analytics" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15214,6 +15214,7 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-constants": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@suite/analytics": "workspace:*"
     "@suite/intl": "workspace:^"


### PR DESCRIPTION
Original test was disabled because of current work on our evolu support methods. 
Test was reworked from relying on manually preseeded data on staging evolu to work with locally spawned relay. 
As part of beforeEach setup, the relay is seeded.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-suite-sync-framework&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-suite-sync-framework&lookback=7)