### PR TITLE
fix(suite-native): account list token badge count

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -18,7 +18,7 @@ import {
     TokensRootState,
     isNetworkWithTokens,
     selectAccountHasAnyKnownToken,
-    selectNumberOfAccountTokensWithFiatRates,
+    selectNumberOfAccountKnownTokensWithBalance,
 } from '@suite-native/tokens';
 
 import { AccountsListItemBase } from './AccountsListItemBase';
@@ -39,7 +39,7 @@ export type AccountListItemProps = {
 
 const TokenBadge = React.memo(({ accountKey }: { accountKey: AccountKey }) => {
     const numberOfTokens = useSelector((state: TokensRootState) =>
-        selectNumberOfAccountTokensWithFiatRates(state, accountKey),
+        selectNumberOfAccountKnownTokensWithBalance(state, accountKey),
     );
 
     return (

--- a/suite-native/tokens/src/tokensSelectors.ts
+++ b/suite-native/tokens/src/tokensSelectors.ts
@@ -149,7 +149,7 @@ export const selectAccountTransactionsWithTokenTransfers = createMemoizedSelecto
         ) as WalletAccountTransaction[],
 );
 
-export const selectAccountsKnownTokens = createMemoizedSelector(
+export const selectAccountKnownTokens = createMemoizedSelector(
     [selectAccountByKey, selectTokenDefinitions],
     (account, tokenDefinitions): TokenInfoBranded[] => {
         if (!account || !isNetworkWithTokens(account.symbol)) {
@@ -171,20 +171,15 @@ export const selectAccountsKnownTokens = createMemoizedSelector(
     },
 );
 
-export const selectNumberOfAccountTokensWithFiatRates = (
-    state: TokenDefinitionsRootState & AccountsRootState,
-    accountKey: AccountKey,
-): number => {
-    const account = selectAccountByKey(state, accountKey);
+export const selectAccountKnownTokensWithBalance = createMemoizedSelector(
+    [selectAccountKnownTokens],
+    tokens => tokens.filter(token => parseFloat(token?.balance ?? '0') > 0),
+);
 
-    if (!account || !isNetworkWithTokens(account.symbol)) {
-        return 0;
-    }
-
-    const tokens = selectAccountsKnownTokens(state, accountKey);
-
-    return tokens.length;
-};
+export const selectNumberOfAccountKnownTokensWithBalance = createMemoizedSelector(
+    [selectAccountKnownTokensWithBalance],
+    tokens => tokens.length,
+);
 
 export const selectHasDeviceAnyTokensForNetwork = (
     state: TokensRootState,


### PR DESCRIPTION
## Description
- fixes token badge of account list item, so it shows correct number of account tokens

## Related Issue

Resolve #24575 

## Screenshots:

https://github.com/user-attachments/assets/b3193099-3399-4f6c-b272-c83147ae84f4



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/account-list-token-badge-count&lookback=7)