### PR TITLE
Feat/app log analytics

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
+import { events } from '@suite-common/analytics';
 import {
     Card,
     Column,
@@ -17,6 +18,7 @@ import {
 } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
 
+import { useAnalytics } from 'src/support/useAnalytics';
 import { useApplicationLogs } from 'src/utils/suite/logsUtils';
 
 const ScrollContainer = styled.div`
@@ -42,6 +44,7 @@ const LogWrapper = styled.pre`
 type ApplicationLogModalProps = { onCancel: () => void };
 
 export const ApplicationLogModal = ({ onCancel }: ApplicationLogModalProps) => {
+    const analytics = useAnalytics();
     const [hideSensitiveInfo, setHideSensitiveInfo] = useState(false);
     const applicationLogs = useApplicationLogs({ hideSensitiveInfo });
     const { ShadowTop, ShadowBottom, ShadowContainer, onScroll, scrollElementRef } =
@@ -49,6 +52,14 @@ export const ApplicationLogModal = ({ onCancel }: ApplicationLogModalProps) => {
 
     const download = () => {
         if (applicationLogs === null) return;
+
+        analytics.report({
+            type: events.settingsAppLogExportedEvent.name,
+            payload: {
+                isRedacted: hideSensitiveInfo,
+            },
+        });
+
         const element = document.createElement('a');
         element.setAttribute(
             'href',

--- a/suite-common/analytics/src/constants.ts
+++ b/suite-common/analytics/src/constants.ts
@@ -6,6 +6,7 @@ export enum EventType {
     DeviceConnectionDeviceConfirmation = 'device-connection/device-confirmation',
     DeviceConnectionDeviceFound = 'device-connection/device-found',
     DeviceConnectionDevicePaired = 'device-connection/device-paired',
+    SettingsAppLogExported = 'settings/app-log/exported',
     SettingsDeviceChangeLabel = 'settings/device/change-label',
     SettingsDeviceWipe = 'settings/device/wipe',
     SettingsGeneralLabeling = 'settings/general/labeling',

--- a/suite-common/analytics/src/events/appLogExportedEvent.ts
+++ b/suite-common/analytics/src/events/appLogExportedEvent.ts
@@ -1,0 +1,22 @@
+import { EventType } from '../constants';
+import type { AttributeDef, EventDef } from '../eventDefinition';
+
+type Attributes = {
+    isRedacted: AttributeDef<boolean>;
+};
+
+export const appLogExportedEvent: EventDef<
+    Attributes,
+    EventType.AppLogExported
+> = {
+    name: EventType.AppLogExported,
+    descriptionTrigger: 'App logs exported by user action.',
+    changelog: [{ version: '26.2.1', notes: 'added' }],
+
+    attributes: {
+        isRedacted: {
+            changelog: [{ version: '26.2.1', notes: 'added' }],
+            description: 'Whether the sensitive data is excluded.',
+        },
+    },
+};

--- a/suite-common/analytics/src/events/index.ts
+++ b/suite-common/analytics/src/events/index.ts
@@ -5,6 +5,7 @@ export { connectPopupPermissionsEvent } from './connectPopupPermissionsEvent';
 export { deviceConnectionDeviceConfirmationEvent } from './deviceConnectionDeviceConfirmationEvent';
 export { deviceConnectionDeviceFoundEvent } from './deviceConnectionDeviceFoundEvent';
 export { deviceConnectionDevicePairedEvent } from './deviceConnectionDevicePairedEvent';
+export { settingsAppLogExportedEvent } from './settingsAppLogExportedEvent';
 export { settingsDeviceChangeLabelEvent } from './settingsDeviceChangeLabelEvent';
 export { settingsDeviceWipeEvent } from './settingsDeviceWipeEvent';
 export { settingsGeneralLabelingEvent } from './settingsGeneralLabelingEvent';

--- a/suite-common/analytics/src/events/settingsAppLogExportedEvent.ts
+++ b/suite-common/analytics/src/events/settingsAppLogExportedEvent.ts
@@ -5,11 +5,8 @@ type Attributes = {
     isRedacted: AttributeDef<boolean>;
 };
 
-export const appLogExportedEvent: EventDef<
-    Attributes,
-    EventType.AppLogExported
-> = {
-    name: EventType.AppLogExported,
+export const settingsAppLogExportedEvent: EventDef<Attributes, EventType.SettingsAppLogExported> = {
+    name: EventType.SettingsAppLogExported,
     descriptionTrigger: 'App logs exported by user action.',
     changelog: [{ version: '26.2.1', notes: 'added' }],
 

--- a/suite-native/module-settings/src/screens/SettingsAppLogScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsAppLogScreen.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { EventType } from '@suite-common/analytics';
+import { events } from '@suite-common/analytics';
 import { prettifyLog, useCommonApplicationLogs as useApplicationLogs } from '@suite-common/logger';
 import {
     Button,
@@ -28,7 +28,7 @@ export const SettingsAppLogScreen = () => {
         setIsLoading(true);
 
         analytics.report({
-            type: EventType.AppLogExported,
+            type: events.settingsAppLogExportedEvent.name,
             payload: {
                 isRedacted: !includeSensitiveInfo,
             },

--- a/suite-native/module-settings/src/screens/SettingsAppLogScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsAppLogScreen.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { EventType } from '@suite-common/analytics';
 import { prettifyLog, useCommonApplicationLogs as useApplicationLogs } from '@suite-common/logger';
 import {
     Button,
@@ -13,16 +14,25 @@ import {
 import { shareAsTextFile } from '@suite-native/helpers';
 import { Translation } from '@suite-native/intl';
 import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
+import { useAnalytics } from '@suite-native/services';
 
 export const SettingsAppLogScreen = () => {
     const [includeSensitiveInfo, setIncludeSensitiveInfo] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
+    const analytics = useAnalytics();
 
     const applicationLogs = useApplicationLogs(!includeSensitiveInfo);
     const stringifiedApplicationLogs = applicationLogs ? prettifyLog(applicationLogs) : '';
 
     const shareLogsAsFile = async () => {
         setIsLoading(true);
+
+        analytics.report({
+            type: EventType.AppLogExported,
+            payload: {
+                isRedacted: !includeSensitiveInfo,
+            },
+        });
 
         const formattedTimestamp = new Date().toISOString().substring(0, 10); // YYYY-MM-DD
         const filename = `trezor-suite-mobile-log-${formattedTimestamp}.txt`;


### PR DESCRIPTION
## Description
- adds app log analytics event
-  report it from both mobile and desktop Suite

## Notes for QA
- test that an analytics event is emitted when the user exports the app log file. Test it for both mobile and desktop. 

## Related Issue

Resolve #24934 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/app-log-analytics&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/app-log-analytics&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/app-log-analytics&lookback=7)