### PR TITLE
fix(suite-native): Fix scam transactions infinite loading state

### DIFF
--- a/suite-native/formatters/src/components/BaseCurrencyAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/BaseCurrencyAmountFormatter.tsx
@@ -26,6 +26,7 @@ export const BaseCurrencyAmountFormatter = React.memo(
         variant,
         isDiscreetText = true,
         isLoading = false,
+        isForcedDiscreetMode,
         ...otherProps
     }: FiatAmountFormatterProps) => {
         const { BaseCurrencyAmountFormatter: formatter } = useFormatters();
@@ -33,17 +34,19 @@ export const BaseCurrencyAmountFormatter = React.memo(
         if (!!symbol && isTestnet(symbol)) {
             return <EmptyAmountText variant={variant} />;
         }
-        if (isLoading || value === null) {
+        if (isLoading || (value === null && !isForcedDiscreetMode)) {
             return <EmptyAmountSkeleton variant={variant} />;
         }
 
-        const formattedValue = formatter.format(value);
+        // in case of isForceDiscreetMode the value is blurred, so the real value does not matter
+        const formattedValue = isForcedDiscreetMode ? '$0.00' : formatter.format(value!);
 
         return (
             <AmountText
                 value={formattedValue}
                 variant={variant}
                 isDiscreetText={isDiscreetText}
+                isForcedDiscreetMode={isForcedDiscreetMode}
                 {...otherProps}
             />
         );

--- a/suite-native/formatters/src/components/TokenToFiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/TokenToFiatAmountFormatter.tsx
@@ -33,6 +33,7 @@ export const TokenToFiatAmountFormatter = ({
     numberOfLines,
     historicRate,
     useHistoricRate,
+    isForcedDiscreetMode,
     ...rest
 }: TokenToFiatAmountFormatterProps) => {
     const { BaseCurrencyAmountFormatter } = useFormatters();
@@ -45,30 +46,33 @@ export const TokenToFiatAmountFormatter = ({
         useHistoricRate,
     });
 
-    if (fiatValue === null) {
+    if (fiatValue === null && !isForcedDiscreetMode) {
         return <EmptyAmountSkeleton />;
     }
 
-    const formattedFiatValue = BaseCurrencyAmountFormatter.format(fiatValue);
+    const formattedFiatValue = isForcedDiscreetMode
+        ? '$0.00' // in case of isForceDiscreetMode the value is blurred, so the real value does not matter
+        : BaseCurrencyAmountFormatter.format(fiatValue!);
 
-    return signValue ? (
-        <Box flexDirection="row">
-            <SignValueFormatter value={signValue} />
-            <AmountText
-                value={formattedFiatValue}
-                isDiscreetText={isDiscreetText}
-                ellipsizeMode={ellipsizeMode}
-                numberOfLines={numberOfLines}
-                {...rest}
-            />
-        </Box>
-    ) : (
+    const amountText = (
         <AmountText
             value={formattedFiatValue}
             isDiscreetText={isDiscreetText}
             ellipsizeMode={ellipsizeMode}
             numberOfLines={numberOfLines}
+            isForcedDiscreetMode={isForcedDiscreetMode}
             {...rest}
         />
+    );
+
+    if (!signValue) {
+        return amountText;
+    }
+
+    return (
+        <Box flexDirection="row">
+            <SignValueFormatter value={signValue} />
+            {amountText}
+        </Box>
     );
 };


### PR DESCRIPTION
## Description 
When scam/phishing transactions have tokens without fiat rates, the formatters were showing an infinite loading skeleton instead of hidden/discreet content.

This fix checks for `isForcedDiscreetMode` (set for phishing transactions) before showing the skeleton, and displays a hidden placeholder value instead.

## Notes for QA
- test that the phishing transactions are not loading infinitely

## Issue
Fixes #24717

## Demo 

https://github.com/user-attachments/assets/443753bb-c99d-4142-8ca5-714edc4b1365



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/scam-transactions-infinite-loading&lookback=7)