### PR TITLE
test(suite): reenable authenticity check for T3W1

### DIFF
--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -123,7 +123,7 @@ export class OnboardingPage {
         await this.pairTHP();
 
         await this.completeOnboardingButton.click();
-        if (this.device.hasSecureElement && this.device.model !== Model.T3W1) {
+        if (this.device.hasSecureElement) {
             await this.passThroughAuthenticityCheck();
         }
         // Enabled debug mode is needed for passing firmware checks but it also enables several hidden features
@@ -227,10 +227,6 @@ export class OnboardingPage {
         await this.disableFirmwareHashCheck(options);
         if (this.device.hasCanaryFirmware) {
             await this.disableFirmwareRevisionCheck();
-        }
-
-        if (this.device.model === Model.T3W1) {
-            await this.disableAuthenticityCheck();
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Device authenticity check for TS7 works in emulator so I am reenabling it in tests.

I noticed that `disableAuthenticityCheck` is used in some analytics tests independent of device model (I guess it is meant to make them simpler?) so I am keeping it there.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22765



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=revert/reenable-auth-check&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=revert/reenable-auth-check&lookback=7)