### PR TITLE
feat(suite-sync): display suite sync keys banner

### DIFF
--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -3,9 +3,12 @@ import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { selectBannerMessage } from '@suite-common/message-system';
+import { selectSuiteSyncError, selectSuiteSyncInteraction } from '@suite-common/suite-sync';
 import {
+    selectDeviceStaticSessionId,
     selectIsDeviceBackupRequired,
     selectIsDeviceBackupUnfinished,
+    selectIsDeviceConnected,
     selectSelectedDevice,
     selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
@@ -31,6 +34,7 @@ import { LocalNetworkAccessPermission } from './LocalNetworkAccessPermission';
 import { NoBackup } from './NoBackupBanner';
 import { NoConnectionBanner } from './NoConnectionBanner';
 import { SafetyChecksBanner } from './SafetyChecksBanner';
+import { SuiteSyncKeysBanner } from './SuiteSyncKeysBanner';
 
 const Container = styled.div<{ $fill?: boolean }>`
     width: 100%;
@@ -61,6 +65,12 @@ export const SuiteBanners = ({ isOnboarding, fill }: SuiteBannersProps) => {
     const transport = useSelector(state => state.suite.transport);
     const accounts = useSelector(selectVisibleDeviceAccounts);
     const { localNetworkAccessPermission } = useLocalNetworkAccessPermission();
+    const deviceStaticSessionId = useSelector(selectDeviceStaticSessionId);
+    const suiteSyncInteraction = useSelector(state =>
+        selectSuiteSyncInteraction(state, deviceStaticSessionId),
+    );
+    const suiteSyncError = useSelector(selectSuiteSyncError);
+    const isDeviceConnected = useSelector(selectIsDeviceConnected);
 
     // The dismissal doesn't need to outlive the session. Use local state.
     const [safetyChecksDismissed, setSafetyChecksDismissed] = useState(false);
@@ -117,6 +127,14 @@ export const SuiteBanners = ({ isOnboarding, fill }: SuiteBannersProps) => {
     } else if (accounts.some(account => isCardanoStakedWithFiveBinaries(account))) {
         banner = <CardanoOutdatedStakingBanner />;
         priority = 20;
+    } else if (
+        suiteSyncInteraction === 'keys-needed' &&
+        deviceStaticSessionId &&
+        isDeviceConnected &&
+        suiteSyncError
+    ) {
+        banner = <SuiteSyncKeysBanner deviceStaticSessionId={deviceStaticSessionId} />;
+        priority = 10;
     }
 
     // message system banners should always be visible in the app even if app body is blurred

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteSyncKeysBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteSyncKeysBanner.tsx
@@ -1,0 +1,48 @@
+import { Translation } from '@suite/intl';
+import { Banner } from '@trezor/components';
+import { StaticSessionId } from '@trezor/connect';
+
+import { useDispatch } from 'src/hooks/suite';
+import { useSuiteServices } from 'src/support/SuiteServicesProvider';
+
+import { suiteSyncErrorHandler } from '../../labeling/suiteSyncErrorHandler';
+
+type SuiteSyncKeysBannerProps = {
+    deviceStaticSessionId: StaticSessionId;
+};
+
+export const SuiteSyncKeysBanner = ({ deviceStaticSessionId }: SuiteSyncKeysBannerProps) => {
+    const dispatch = useDispatch();
+    const { suiteSync } = useSuiteServices();
+
+    const handleGetKeys = async () => {
+        const result = await suiteSync.ensureWalletSuiteSyncOn({
+            deviceStaticSessionId,
+            isWriteMode: false,
+        });
+
+        if (!result.success) {
+            suiteSyncErrorHandler({
+                error: result.error,
+                dispatch,
+                deviceStaticSessionId,
+            });
+        }
+    };
+
+    return (
+        <Banner
+            icon
+            intent="info"
+            rightContent={
+                <Banner.Button
+                    onClick={handleGetKeys}
+                    data-testid="@notification/suite-sync-keys/button"
+                >
+                    <Translation id="TR_SUITE_SYNC_GET_KEYS" />
+                </Banner.Button>
+            }
+            description={<Translation id="TR_SUITE_SYNC_KEYS_NEEDED_BANNER" />}
+        />
+    );
+};

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -3108,6 +3108,15 @@ export const messages = defineMessages({
         defaultMessage: 'Trezor Suite version',
         id: 'TR_SUITE_VERSION',
     },
+    TR_SUITE_SYNC_GET_KEYS: {
+        defaultMessage: 'Allow',
+        id: 'TR_SUITE_SYNC_GET_KEYS',
+    },
+    TR_SUITE_SYNC_KEYS_NEEDED_BANNER: {
+        defaultMessage:
+            'Allow Suite Sync to view and edit your labels, wallet names, and account names.',
+        id: 'TR_SUITE_SYNC_KEYS_NEEDED_BANNER',
+    },
     TR_TAKE_ME_BACK_TO_WALLET: {
         defaultMessage: 'Take me back to Suite',
         id: 'TR_TAKE_ME_BACK_TO_WALLET',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Display banner when getting suite sync keys was cancelled.


## Related Issue

Desktop follow up for https://github.com/trezor/trezor-suite/issues/24289

## Screenshots:


https://github.com/user-attachments/assets/a51108aa-f9b0-4852-8a7b-cbc9d10df041





🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-sync/desktop-keys-banner&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-sync/desktop-keys-banner&lookback=7)