### PR TITLE
fix: label token-contract transactions

### DIFF
--- a/packages/suite/src/actions/wallet/processLegacyMetadataIntoSuiteSyncThunk.ts
+++ b/packages/suite/src/actions/wallet/processLegacyMetadataIntoSuiteSyncThunk.ts
@@ -55,7 +55,7 @@ export const processLegacyMetadataIntoSuiteSyncThunk = createThunk<
                 return await services.suiteSync.labeling.updateOutputLabel({
                     deviceStaticSessionId,
                     txId: payload.txid,
-                    outputIndex: Number(payload.outputIndex),
+                    outputIndex: `${payload.outputIndex}`,
                     label: value ?? null,
                     accountDescriptor: asAccountDescriptor(payload.accountDescriptor),
                     networkSymbol: payload.networkSymbol as NetworkSymbol,

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -393,6 +393,10 @@ export const Labeling = ({
     );
 
     const handleEdit = useCallback(async () => {
+        if (isSuiteSyncEnabled && suiteSyncInteraction === null) {
+            return;
+        }
+
         // When clicking on inline input edit, ensure that everything needed is already ready.
         if (
             // Isn't initiation in progress?
@@ -435,9 +439,10 @@ export const Labeling = ({
             }
         }
     }, [
+        isSuiteSyncEnabled,
+        suiteSyncInteraction,
         legacyMetadataState.initiating,
         isLegacyLabelingEnabled,
-        suiteSyncInteraction,
         suiteSync,
         deviceStaticSessionId,
         dispatch,
@@ -546,6 +551,10 @@ export const MetadataLabeling = ({
     const editActive = legacyMetadataState.editing === payload.defaultValue;
 
     const activateEdit = () => {
+        if (isSuiteSyncEnabled && suiteSyncInteraction === null) {
+            return;
+        }
+
         // When clicking on inline input edit, ensure that everything needed is already ready.
         if (
             !isSuiteSyncEnabled &&

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -125,7 +125,7 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
         addressLabels[utxo.address];
 
     const outputLabel =
-        suiteSyncOutputLabels.find(it => it.txId === utxo.txid && it.outputIndex == utxo.vout)
+        suiteSyncOutputLabels.find(it => it.txId === utxo.txid && it.outputIndex === `${utxo.vout}`)
             ?.label ?? outputLabels?.[utxo.txid]?.[utxo.vout];
 
     return (

--- a/suite-common/suite-rbf-labels-migrations/src/createMigrateSuiteSyncLabelsForRbfTransaction.ts
+++ b/suite-common/suite-rbf-labels-migrations/src/createMigrateSuiteSyncLabelsForRbfTransaction.ts
@@ -20,7 +20,7 @@ export const createSetLabelsForSuiteSync =
                 deps.updateOutputLabel({
                     deviceStaticSessionId,
                     txId: newTxId,
-                    outputIndex: Number(outputLabel.suiteSyncOutputLabelsToBeUpdated.outputIndex),
+                    outputIndex: outputLabel.suiteSyncOutputLabelsToBeUpdated.outputIndex,
                     label: outputLabel.suiteSyncOutputLabelsToBeUpdated.label,
                     accountDescriptor: outputLabel.data.toBeMoved.descriptor,
                     networkSymbol: outputLabel.data.toBeMoved.symbol,
@@ -37,9 +37,7 @@ export const createDeleteLabelsForSuiteSync =
                     deps.updateOutputLabel({
                         deviceStaticSessionId,
                         txId: toBeDeleted.txid,
-                        outputIndex: Number(
-                            deleteOutput.suiteSyncOutputLabelsToBeDeleted.outputIndex,
-                        ),
+                        outputIndex: deleteOutput.suiteSyncOutputLabelsToBeDeleted.outputIndex,
                         label: null,
                         accountDescriptor: deleteOutput.data.toBeMoved.descriptor,
                         networkSymbol: deleteOutput.data.toBeMoved.symbol,

--- a/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
+++ b/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
@@ -12,7 +12,7 @@ import { Schema } from './schema';
 // This is a way how to force change of the SQL files. It was useful for development
 // so not everybody had to delete SQLite file manually:
 // See: https://www.evolu.dev/docs/faq#how-to-delete-opfs-sqlite-in-browser
-const VERSION = 7;
+const VERSION = 8;
 
 type CreateEvoluInstanceFactoryDeps = {
     suiteSyncErrorHandler: SuiteSyncErrorHandler;

--- a/suite-common/suite-sync-evolu/src/data/accountTable.ts
+++ b/suite-common/suite-sync-evolu/src/data/accountTable.ts
@@ -25,6 +25,10 @@ import { normalizeLabel } from './normalizeLabel';
 export const AccountEvoluId = id('AccountEvoluId');
 export type AccountEvoluId = typeof AccountEvoluId.Type;
 
+/**
+ * IMPORTANT: Only additive changes allowed. Schema MUST BE always backwards
+ *            compatible!
+ */
 export const AccountSchema = {
     account: {
         id: AccountEvoluId,

--- a/suite-common/suite-sync-evolu/src/data/addressTable.ts
+++ b/suite-common/suite-sync-evolu/src/data/addressTable.ts
@@ -27,6 +27,10 @@ export type AddressEvoluId = typeof AddressEvoluId.Type;
 export const createAddressEvoluId = (address: string, networkSymbol: NetworkSymbol) =>
     AddressEvoluId.from(createIdFromString(createSuiteSyncAddressId(address, networkSymbol)));
 
+/**
+ * IMPORTANT: Only additive changes allowed. Schema MUST BE always backwards
+ *            compatible!
+ */
 export const AddressLabelSchema = {
     address: {
         id: AddressEvoluId,

--- a/suite-common/suite-sync-evolu/src/data/outputTable.ts
+++ b/suite-common/suite-sync-evolu/src/data/outputTable.ts
@@ -1,7 +1,6 @@
 import {
     Evolu,
     NonEmptyString1000,
-    NonNegativeNumber,
     QueryRows,
     createIdFromString,
     id,
@@ -25,12 +24,16 @@ import { normalizeLabel } from './normalizeLabel';
 export const OutputEvoluId = id('OutputLabelId');
 export type OutputEvoluId = typeof OutputEvoluId.Type;
 
+/**
+ * IMPORTANT: Only additive changes allowed. Schema MUST BE always backwards
+ *            compatible!
+ */
 export const OutputLabelSchema = {
     output: {
         id: OutputEvoluId,
         label: nullOr(NonEmptyString1000),
         txId: NonEmptyString1000,
-        outputIndex: NonNegativeNumber,
+        outputIndex: NonEmptyString1000,
         accountDescriptor: NonEmptyString1000,
         networkSymbol: NonEmptyString1000,
     },

--- a/suite-common/suite-sync-evolu/src/data/walletTable.ts
+++ b/suite-common/suite-sync-evolu/src/data/walletTable.ts
@@ -22,6 +22,10 @@ import { normalizeLabel } from './normalizeLabel';
 export const WalletLabelId = id('WalletLabelId');
 export type WalletLabelId = typeof WalletLabelId.Type;
 
+/**
+ * IMPORTANT: Only additive changes allowed. Schema MUST BE always backwards
+ *            compatible!
+ */
 export const WalletLabelSchema = {
     wallet: {
         // This table will have only 1 record. As every wallet has its own secret, and therefore

--- a/suite-common/suite-sync-storage/src/data/OutputTable.ts
+++ b/suite-common/suite-sync-storage/src/data/OutputTable.ts
@@ -6,13 +6,19 @@ import { SuiteSyncTable } from '../SuiteSyncTable';
 
 export type SuiteSyncOutputId = string & Branded<'SuiteSyncOutputId'>;
 
-export const createSuiteSyncOutputId = (txId: string, outputIndex: number) =>
+export const createSuiteSyncOutputId = (txId: string, outputIndex: string) =>
     `${txId}-${outputIndex}` as SuiteSyncOutputId;
 
 export type SuiteSyncOutput = {
     id: SuiteSyncOutputId;
     txId: string;
-    outputIndex: number;
+
+    /**
+     * This is not just index, for tokens, it may be Contract Address, etc...
+     * It is a number index only for bitcoin-like networks
+     */
+    outputIndex: string;
+
     label: string | null;
     accountDescriptor: AccountDescriptor;
     networkSymbol: NetworkSymbol;

--- a/suite-common/suite-sync-types/src/data/updateOutputLabel.ts
+++ b/suite-common/suite-sync-types/src/data/updateOutputLabel.ts
@@ -6,10 +6,10 @@ import { Result } from '@trezor/type-utils';
 
 import { EnsureWalletSuiteSyncOnErrors } from '../storage/ensureWalletSuiteSyncOn';
 
-type UpdateOutputLabelParams = {
+export type UpdateOutputLabelParams = {
     deviceStaticSessionId: StaticSessionId;
     txId: string;
-    outputIndex: number;
+    outputIndex: string;
     label: string | null;
     accountDescriptor: AccountDescriptor;
     networkSymbol: NetworkSymbol;

--- a/suite-common/suite-sync-types/src/index.ts
+++ b/suite-common/suite-sync-types/src/index.ts
@@ -59,7 +59,11 @@ export type {
     UpdateAddressLabelDep,
     UpdateAddressLabelParams,
 } from './data/updateAddressLabel';
-export type { UpdateOutputLabelDep, UpdateOutputLabel } from './data/updateOutputLabel';
+export type {
+    UpdateOutputLabelDep,
+    UpdateOutputLabel,
+    UpdateOutputLabelParams,
+} from './data/updateOutputLabel';
 export type {
     UpdateWalletLabel,
     UpdateWalletLabelDep,

--- a/suite-common/suite-sync/src/data/labeling/tests/createUpdateOutputLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/tests/createUpdateOutputLabel.test.ts
@@ -1,5 +1,5 @@
 import { createMockDeps, mock } from '@suite-common/dependency-injection';
-import type { OutputTable } from '@suite-common/suite-sync-storage';
+import { OutputTable, SuiteSyncOutput } from '@suite-common/suite-sync-storage';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import type { StaticSessionId } from '@trezor/connect';
@@ -30,7 +30,7 @@ describe(createUpdateOutputLabel.name, () => {
         const result = await updateOutputLabel({
             deviceStaticSessionId,
             txId: 'txid',
-            outputIndex: 1,
+            outputIndex: '1',
             label: 'New Output Label',
             accountDescriptor,
             networkSymbol,
@@ -43,11 +43,11 @@ describe(createUpdateOutputLabel.name, () => {
 
         expect(storage.data.outputs.update).toHaveBeenCalledWith({
             txId: 'txid',
-            outputIndex: 1,
+            outputIndex: '1',
             label: 'New Output Label',
             accountDescriptor,
             networkSymbol,
-        });
+        } satisfies Partial<SuiteSyncOutput>);
 
         expect(result).toBe(updateResult);
     });
@@ -63,7 +63,7 @@ describe(createUpdateOutputLabel.name, () => {
         const result = await updateOutputLabel({
             deviceStaticSessionId,
             txId: 'txid',
-            outputIndex: 1,
+            outputIndex: '1',
             label: 'New Output Label',
             accountDescriptor,
             networkSymbol,

--- a/suite-common/suite-sync/src/data/labeling/tests/suiteSyncToBip329.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/tests/suiteSyncToBip329.test.ts
@@ -14,10 +14,10 @@ describe(suiteSyncToBip329.name, () => {
             {
                 id: createSuiteSyncOutputId(
                     '50e4fa9ebfca7d510feae7226a7d5d046114f54a7918cdd83e40c98d70d17e4d',
-                    0,
+                    '0',
                 ),
                 txId: '50e4fa9ebfca7d510feae7226a7d5d046114f54a7918cdd83e40c98d70d17e4d',
-                outputIndex: 0,
+                outputIndex: '0',
                 label: 'this is expending transaction output or just tx',
                 accountDescriptor: asAccountDescriptor('xpub...'),
                 networkSymbol: 'btc',
@@ -25,10 +25,10 @@ describe(suiteSyncToBip329.name, () => {
             {
                 id: createSuiteSyncOutputId(
                     '519e17d6f3eb87cc8c4bf450d0dc2bad83a1387713680bec609bcb5d8e53335e',
-                    0,
+                    '0',
                 ),
                 txId: '519e17d6f3eb87cc8c4bf450d0dc2bad83a1387713680bec609bcb5d8e53335e',
-                outputIndex: 0,
+                outputIndex: '0',
                 label: 'this is receive tx label',
                 accountDescriptor: asAccountDescriptor('xpub...'),
                 networkSymbol: 'btc',

--- a/suite-common/suite-sync/src/data/suiteSyncDataSelectors.ts
+++ b/suite-common/suite-sync/src/data/suiteSyncDataSelectors.ts
@@ -91,7 +91,7 @@ export const selectSuiteSyncOutputLabel = createMemoizedSelector(
         (
             state: SuiteSyncDataRootState,
             _txId: string,
-            _outputIndex: number,
+            _outputIndex: string,
             deviceStaticSessionId: StaticSessionId,
         ) => {
             const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
@@ -99,10 +99,10 @@ export const selectSuiteSyncOutputLabel = createMemoizedSelector(
             return selectAllOutputsForWallet(state, walletDescriptor);
         },
         (_state: SuiteSyncDataRootState, txId: string) => txId,
-        (_state: SuiteSyncDataRootState, _txId: string, outputIndex: number) => outputIndex,
+        (_state: SuiteSyncDataRootState, _txId: string, outputIndex: string) => outputIndex,
     ],
     (outputs, txId, outputIndex) => {
-        const id = createSuiteSyncOutputId(txId, outputIndex);
+        const id = createSuiteSyncOutputId(txId, `${outputIndex}`);
 
         return outputs.find(output => output.id === id)?.label ?? null;
     },

--- a/suite-common/suite-sync/src/data/tests/createEnsureSuiteSyncData.test.ts
+++ b/suite-common/suite-sync/src/data/tests/createEnsureSuiteSyncData.test.ts
@@ -239,11 +239,11 @@ describe(createEnsureSubscribeSuiteSyncData.name, () => {
         storageEmitters.outputs.forEach(it =>
             it.onChange([
                 {
-                    id: createSuiteSyncOutputId('transaction-id', 0),
+                    id: createSuiteSyncOutputId('transaction-id', '0'),
                     networkSymbol: 'btc',
                     accountDescriptor: asAccountDescriptor('account-1'),
                     txId: 'transaction-id',
-                    outputIndex: 0,
+                    outputIndex: '0',
                     label: 'Output spend for buying drugs',
                 },
             ]),

--- a/suite-native/labeling/src/components/TransactionOutputLabel.tsx
+++ b/suite-native/labeling/src/components/TransactionOutputLabel.tsx
@@ -8,7 +8,7 @@ import { selectIsLabellingAllowed } from '../selectors';
 
 type TransactionOutputLabelProps = {
     txId: string;
-    outputIndex: number;
+    outputIndex: string;
     deviceStaticSessionId: StaticSessionId;
 };
 

--- a/suite-native/labeling/src/components/TransactionOutputLabelEditable.tsx
+++ b/suite-native/labeling/src/components/TransactionOutputLabelEditable.tsx
@@ -14,7 +14,7 @@ import { selectIsLabellingAllowed } from '../selectors';
 
 type TransactionOutputLabelEditableProps = {
     txId: string;
-    outputIndex: number;
+    outputIndex: string;
     deviceStaticSessionId: StaticSessionId;
     accountDescriptor: AccountDescriptor;
     networkSymbol: NetworkSymbol;

--- a/suite-native/module-send/src/components/CoinControl/UtxoCard.tsx
+++ b/suite-native/module-send/src/components/CoinControl/UtxoCard.tsx
@@ -158,7 +158,7 @@ export const UtxoCard = ({
                                 />
                                 <TransactionOutputLabel
                                     txId={utxo.txid}
-                                    outputIndex={utxo.vout}
+                                    outputIndex={`${utxo.vout}`}
                                     deviceStaticSessionId={deviceStaticSessionId}
                                 />
                             </HStack>

--- a/suite-native/module-transactions/src/components/TransactionUtxoAddress.tsx
+++ b/suite-native/module-transactions/src/components/TransactionUtxoAddress.tsx
@@ -60,7 +60,7 @@ export const TransactionUtxoAddress = ({
             {showLabels && (
                 <TransactionOutputLabelEditable
                     txId={txId}
-                    outputIndex={outputIndex}
+                    outputIndex={`${outputIndex}`}
                     deviceStaticSessionId={deviceStaticSessionId}
                     accountDescriptor={accountDescriptor}
                     networkSymbol={networkSymbol}

--- a/suite-native/transaction-management/src/addTransactionLabelingThunk.ts
+++ b/suite-native/transaction-management/src/addTransactionLabelingThunk.ts
@@ -60,7 +60,11 @@ export const addTransactionLabelingThunk = createThunk<
                 extra.services.suiteSync.labeling.updateOutputLabel({
                     deviceStaticSessionId: selectedAccount.deviceState,
                     txId,
-                    outputIndex: label.outputIndex,
+
+                    // This is probably not working for non-bitcoin networks
+                    // Todo: see `TransactionTarget:metadataId` and unify
+                    outputIndex: `${label.outputIndex}`,
+
                     label: label.value,
                     accountDescriptor: selectedAccount.descriptor,
                     networkSymbol: selectedAccount.symbol,


### PR DESCRIPTION
Fixies the issue of outputIndex is not number for non-bitcoin networks.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-other-coins&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-other-coins&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-other-coins&lookback=7)