### PR TITLE
fix(suite-commit): remove redundant padding in THP info bottom sheet

### DIFF
--- a/suite-native/thp/src/components/ThpPairingInfoHelpButton.tsx
+++ b/suite-native/thp/src/components/ThpPairingInfoHelpButton.tsx
@@ -21,7 +21,7 @@ export const ThpPairingInfoHelpButton = () => {
                 onPress={openModal}
             />
             <BottomSheetModal ref={bottomSheetRef} isCloseDisplayed={false}>
-                <VStack spacing="sp24" paddingBottom="sp24">
+                <VStack spacing="sp24">
                     <VStack spacing="sp8">
                         <Text variant="titleSmall" color="textDefault">
                             <Translation id="thp.pairingInfo.help.title" />


### PR DESCRIPTION
| iOS | Android |
| --- | --- |
| <img width="1179" height="956" alt="image" src="https://github.com/user-attachments/assets/fa5fa009-6712-464e-8529-2d998439f652" /> | <img width="1080" height="917" alt="Screenshot_20260205_165703" src="https://github.com/user-attachments/assets/2fd290f9-0154-42af-bd78-84f46b37a492" /> |



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/thp-pairing-info-bottom-sheet&lookback=7)