### PR TITLE
fix(native): add labeling to suite ready native event

### DIFF
--- a/suite-native/analytics/src/events/appReadyEvent.ts
+++ b/suite-native/analytics/src/events/appReadyEvent.ts
@@ -26,6 +26,7 @@ type Attributes = {
     rememberedStandardWallets: AttributeDef<number>;
     rememberedHiddenWallets: AttributeDef<number>;
     enabledNetworks: AttributeDef<NetworkSymbol[]>;
+    labeling: AttributeDef<'suite-sync' | 'off'>;
 };
 
 export const appReadyEvent: EventDef<Attributes, EventType.AppReady> = {
@@ -43,6 +44,7 @@ export const appReadyEvent: EventDef<Attributes, EventType.AppReady> = {
             version: '26.2.1',
             notes: 'params `appLanguage` and `deviceLanguage` finally report real data.',
         },
+        { version: '26.2.1', notes: 'param `labeling` added' },
     ],
 
     attributes: {
@@ -120,6 +122,10 @@ export const appReadyEvent: EventDef<Attributes, EventType.AppReady> = {
         enabledNetworks: {
             changelog: [{ version: '24.9.1', notes: 'added' }],
             description: 'The symbols of the networks that are enabled',
+        },
+        labeling: {
+            changelog: [{ version: '26.3.1', notes: 'added' }],
+            description: "The labeling method: 'suite-sync' or 'off'",
         },
     },
 };

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -42,6 +42,7 @@
         "@suite-common/formatters": "workspace:*",
         "@suite-common/react-query": "workspace:^",
         "@suite-common/suite-constants": "workspace:*",
+        "@suite-common/suite-sync": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",

--- a/suite-native/app/src/hooks/useReportAppInitToAnalytics.ts
+++ b/suite-native/app/src/hooks/useReportAppInitToAnalytics.ts
@@ -3,6 +3,7 @@ import { Dimensions, PixelRatio, Platform } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';
+import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
 import {
     selectBaseCurrency,
     selectBitcoinAmountUnit,
@@ -36,6 +37,7 @@ export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const appLanguage = useSelector(selectLocale);
     const deviceLanguage = useSelector(selectDeviceLanguage);
+    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
 
     useEffect(() => {
         if (isAppReady && !loadDuration) setLoadDuration(Date.now() - appLaunchTimestamp);
@@ -64,6 +66,7 @@ export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
                     rememberedStandardWallets,
                     rememberedHiddenWallets,
                     enabledNetworks,
+                    labeling: isSuiteSyncEnabled ? 'suite-sync' : 'off',
                 },
             });
         }
@@ -82,6 +85,7 @@ export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
         enabledNetworks,
         appLanguage,
         deviceLanguage,
+        isSuiteSyncEnabled,
         analytics,
     ]);
 };

--- a/suite-native/app/tsconfig.json
+++ b/suite-native/app/tsconfig.json
@@ -15,6 +15,9 @@
             "path": "../../suite-common/suite-constants"
         },
         {
+            "path": "../../suite-common/suite-sync"
+        },
+        {
             "path": "../../suite-common/suite-types"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11584,6 +11584,7 @@ __metadata:
     "@suite-common/formatters": "workspace:*"
     "@suite-common/react-query": "workspace:^"
     "@suite-common/suite-constants": "workspace:*"
+    "@suite-common/suite-sync": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/test-utils": "workspace:^"
     "@suite-common/wallet-core": "workspace:*"


### PR DESCRIPTION
**changes**:
- added labeling analytics to the native 

## Notes for QA

- on suite native app start there should be app_ready event with labeling prop


## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/app-ready-labeling&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/app-ready-labeling&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/app-ready-labeling&lookback=7)