### PR TITLE
feat(connect-web): remove webusb helpers

### DIFF
--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -173,17 +173,4 @@ export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSet
     uiResponse(_response: UiResponseEvent) {
         throw ERRORS.TypedError('Method_InvalidPackage');
     }
-
-    // not needed, only because of types
-    disableWebUSB() {
-        throw ERRORS.TypedError('Method_InvalidPackage');
-    }
-
-    // not needed, only because of types
-    requestWebUSBDevice() {
-        throw ERRORS.TypedError('Method_InvalidPackage');
-    }
-
-    // not needed, only because of types
-    renderWebUSBButton() {}
 }

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -142,17 +142,4 @@ export class CoreInSuiteWeb implements ConnectFactoryDependencies<ConnectSetting
     uiResponse(_response: UiResponseEvent) {
         throw ERRORS.TypedError('Method_InvalidPackage');
     }
-
-    // not needed, only because of types
-    disableWebUSB() {
-        throw ERRORS.TypedError('Method_InvalidPackage');
-    }
-
-    // not needed, only because of types
-    requestWebUSBDevice() {
-        throw ERRORS.TypedError('Method_InvalidPackage');
-    }
-
-    // not needed, only because of types
-    renderWebUSBButton() {}
 }

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -5,16 +5,10 @@ import { TrezorConnectDynamic } from '@trezor/connect/src/impl/dynamic';
 import { CoreInSuiteDesktop } from './impl/core-in-suite-desktop';
 import { CoreInSuiteWeb } from './impl/core-in-suite-web';
 
-type ConnectWebExtraMethods = {
-    renderWebUSBButton: (className?: string) => void;
-    disableWebUSB: () => void;
-    requestWebUSBDevice: () => void;
-};
-
 const impl = new TrezorConnectDynamic<
     'core-in-suite-desktop' | 'core-in-suite-web',
     ConnectSettingsWeb,
-    ConnectFactoryDependencies<ConnectSettingsWeb> & ConnectWebExtraMethods
+    ConnectFactoryDependencies<ConnectSettingsWeb>
 >({
     implementations: [
         {
@@ -63,7 +57,7 @@ const impl = new TrezorConnectDynamic<
     },
 });
 
-const TrezorConnect = factory<ConnectSettingsWeb, ConnectWebExtraMethods>(
+const TrezorConnect = factory<ConnectSettingsWeb, {}>(
     {
         eventEmitter: impl.eventEmitter,
         init: impl.init.bind(impl),
@@ -73,11 +67,7 @@ const TrezorConnect = factory<ConnectSettingsWeb, ConnectWebExtraMethods>(
         cancel: impl.cancel.bind(impl),
         dispose: impl.dispose.bind(impl),
     },
-    {
-        renderWebUSBButton: impl.getTarget().renderWebUSBButton.bind(impl),
-        disableWebUSB: impl.getTarget().disableWebUSB.bind(impl),
-        requestWebUSBDevice: impl.getTarget().requestWebUSBDevice.bind(impl),
-    },
+    {},
 );
 
 export default TrezorConnect;

--- a/packages/connect/e2e/tests/device/info.test.ts
+++ b/packages/connect/e2e/tests/device/info.test.ts
@@ -75,7 +75,6 @@ describe('__info common param', () => {
                     'dispose',
                     'cancel',
                     'requestWebUSBDevice',
-                    'renderWebUSBButton',
                     'disableWebUSB',
                     'bleUnpair',
                     'firmwareUpdate', // todo: this should probably work with __info param as well

--- a/packages/connect/src/types/api/disableWebUSB.ts
+++ b/packages/connect/src/types/api/disableWebUSB.ts
@@ -1,1 +1,0 @@
-export declare function disableWebUSB(): void;

--- a/packages/connect/src/types/api/renderWebUSBButton.ts
+++ b/packages/connect/src/types/api/renderWebUSBButton.ts
@@ -1,1 +1,0 @@
-export declare function renderWebUSBButton(className?: string): void;

--- a/packages/connect/src/types/api/requestWebUSBDevice.ts
+++ b/packages/connect/src/types/api/requestWebUSBDevice.ts
@@ -1,1 +1,0 @@
-export declare function requestWebUSBDevice(): void;

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -84,7 +84,6 @@
         "@trezor/components": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/connect-common": "workspace:^",
-        "@trezor/connect-web": "workspace:*",
         "@trezor/crypto-utils": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/dom-utils": "workspace:*",

--- a/packages/suite/src/components/firmware/FirmwareInstallation.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallation.tsx
@@ -1,7 +1,7 @@
 import { Translation } from '@suite/intl';
 import { Banner, Card, Column } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
-import type TrezorConnectWeb from '@trezor/connect-web';
+import type TrezorConnectBrowser from '@trezor/connect/src/index-browser';
 
 import {
     FirmwareOffer,
@@ -58,7 +58,7 @@ export const FirmwareInstallation = ({
                             <Banner.Button
                                 onClick={() => {
                                     (
-                                        TrezorConnect as typeof TrezorConnectWeb
+                                        TrezorConnect as typeof TrezorConnectBrowser
                                     ).requestWebUSBDevice();
                                 }}
                             >

--- a/packages/suite/src/components/suite/WebUsbButton.tsx
+++ b/packages/suite/src/components/suite/WebUsbButton.tsx
@@ -1,11 +1,11 @@
 import { Translation } from '@suite/intl';
 import { Button, ButtonProps } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
-import type TrezorConnectWeb from '@trezor/connect-web';
+import type TrezorConnectBrowser from '@trezor/connect/src/index-browser';
 
 const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();
-    (TrezorConnect as typeof TrezorConnectWeb).requestWebUSBDevice();
+    (TrezorConnect as typeof TrezorConnectBrowser).requestWebUSBDevice();
 };
 
 type WebUsbButtonProps = Omit<ButtonProps, 'onClick' | 'data-testid' | 'children' | 'iconRight'> & {

--- a/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
+++ b/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
@@ -1,5 +1,5 @@
 import TrezorConnect from '@trezor/connect';
-import type TrezorConnectWeb from '@trezor/connect-web';
+import type TrezorConnectBrowser from '@trezor/connect/src/index-browser';
 import { useWindowFocus } from '@trezor/react-utils';
 import { SUITE_BRIDGE_DEEPLINK, SUITE_URL } from '@trezor/urls';
 
@@ -20,7 +20,7 @@ export const useOpenSuiteDesktop = () => {
         window.setTimeout(() => {
             document.body.removeChild(iframe);
             if (isWebUsbTransport) {
-                (TrezorConnect as typeof TrezorConnectWeb).disableWebUSB();
+                (TrezorConnect as typeof TrezorConnectBrowser).disableWebUSB();
             }
             if (!windowFocused.current) return;
 

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -157,7 +157,6 @@
         { "path": "../components" },
         { "path": "../connect" },
         { "path": "../connect-common" },
-        { "path": "../connect-web" },
         { "path": "../crypto-utils" },
         { "path": "../device-utils" },
         { "path": "../dom-utils" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15375,7 +15375,6 @@ __metadata:
     "@trezor/components": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/connect-common": "workspace:^"
-    "@trezor/connect-web": "workspace:*"
     "@trezor/crypto-utils": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/dom-utils": "workspace:*"


### PR DESCRIPTION
## Description

Remove unimplemented webUSB helper methods from Connect-web. Keep them only in browser impl. of main Connect. 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/remove-webusb-helpers&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/remove-webusb-helpers&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/remove-webusb-helpers&lookback=7)