### PR TITLE
fix(common): turn on QM by default

### DIFF
--- a/suite-common/suite-sync-quota-manager/src/quotaManagerReducer.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerReducer.ts
@@ -19,7 +19,7 @@ export type SuiteSyncQuotaManagerState = {
 };
 
 export const quotaManagerInitialState: SuiteSyncQuotaManagerState = {
-    enabled: false,
+    enabled: true,
     baseUrl: null,
     registeredDevices: [],
     ownersAllowance: [],

--- a/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
@@ -1,5 +1,6 @@
 import { Dispatch } from '@reduxjs/toolkit';
 
+import { quotaManagerEnabledUpdated } from '@suite-common/suite-sync-quota-manager';
 import { EnsureWalletSuiteSyncOnDep, TurnOnSuiteSync } from '@suite-common/suite-sync-types';
 import { ok } from '@trezor/type-utils';
 
@@ -20,6 +21,12 @@ export const createTurnOnSuiteSync =
         }
 
         deps.dispatch(updateSuiteSyncEnabled({ isEnabled: true }));
+
+        deps.dispatch(
+            quotaManagerEnabledUpdated({
+                isEnabled: true,
+            }),
+        );
 
         if (deviceStaticSessionId !== undefined) {
             const result = await deps.ensureWalletSuiteSyncOn({


### PR DESCRIPTION
Changes:
- added enable QM by default when user selects suite sync option from labeling

## Notes for QA

- have QM turned off
- turn on suite sync
- check that QM is turned on

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24996

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/qm/turn-on-by-default&lookback=7)