### PR TITLE
chore(suite-sync): make error device dependant

### DIFF
--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -3,7 +3,10 @@ import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { selectBannerMessage } from '@suite-common/message-system';
-import { selectSuiteSyncError, selectSuiteSyncInteraction } from '@suite-common/suite-sync';
+import {
+    selectHasDeviceSuiteSyncError,
+    selectSuiteSyncInteraction,
+} from '@suite-common/suite-sync';
 import {
     selectDeviceStaticSessionId,
     selectIsDeviceBackupRequired,
@@ -69,7 +72,9 @@ export const SuiteBanners = ({ isOnboarding, fill }: SuiteBannersProps) => {
     const suiteSyncInteraction = useSelector(state =>
         selectSuiteSyncInteraction(state, deviceStaticSessionId),
     );
-    const suiteSyncError = useSelector(selectSuiteSyncError);
+    const hasSuiteSyncError = useSelector(state =>
+        selectHasDeviceSuiteSyncError(state, deviceStaticSessionId),
+    );
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
 
     // The dismissal doesn't need to outlive the session. Use local state.
@@ -131,7 +136,7 @@ export const SuiteBanners = ({ isOnboarding, fill }: SuiteBannersProps) => {
         suiteSyncInteraction === 'keys-needed' &&
         deviceStaticSessionId &&
         isDeviceConnected &&
-        suiteSyncError
+        hasSuiteSyncError
     ) {
         banner = <SuiteSyncKeysBanner deviceStaticSessionId={deviceStaticSessionId} />;
         priority = 10;

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -427,7 +427,7 @@ export const getRootReducer = (selectedAccount = BTC_ACCOUNT, fees = DEFAULT_FEE
                     isSuiteSyncDebugEnabled: false,
                     suiteSyncRelayUrl: null,
                 },
-                suiteSyncError: null,
+                suiteSyncErrors: {},
             } satisfies SuiteSyncState,
             state => state,
         ),

--- a/suite-common/suite-sync/src/index.ts
+++ b/suite-common/suite-sync/src/index.ts
@@ -3,7 +3,7 @@ export {
     selectSuiteSyncRelayUrl,
     selectSuiteSyncInteraction,
     selectIsSuiteSyncDebugEnabled,
-    selectSuiteSyncError,
+    selectHasDeviceSuiteSyncError,
     type WithSuiteSyncState,
 } from './suiteSyncSelectors';
 export type { WithSuiteSyncAndDeviceState } from './suiteSyncSelectors';

--- a/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOn.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOn.ts
@@ -47,12 +47,14 @@ export const createEnsureWalletSuiteSyncOn =
             switch (type) {
                 case 'DeviceCancelled':
                 case 'DeviceError':
-                    deps.dispatch(setSuiteSyncError({ error: result.error }));
+                    deps.dispatch(
+                        setSuiteSyncError({ deviceStaticSessionId, error: result.error }),
+                    );
                     break;
 
                 case 'SuiteSyncUnavailableOnDeviceError':
                     // This error is now not handled in the UI, so we don't need to set the error. It will probably be added as a follow up.
-                    deps.dispatch(setSuiteSyncError({ error: null }));
+                    deps.dispatch(setSuiteSyncError({ deviceStaticSessionId, error: null }));
                     break;
 
                 case 'WriteModeRequiredForAllocation':
@@ -63,7 +65,7 @@ export const createEnsureWalletSuiteSyncOn =
                     exhaustive(type);
             }
         } else {
-            deps.dispatch(setSuiteSyncError({ error: null }));
+            deps.dispatch(setSuiteSyncError({ deviceStaticSessionId, error: null }));
         }
 
         return result;

--- a/suite-common/suite-sync/src/suiteSyncSelectors.ts
+++ b/suite-common/suite-sync/src/suiteSyncSelectors.ts
@@ -55,5 +55,13 @@ export const selectSuiteSyncInteraction = (
     return null;
 };
 
-export const selectSuiteSyncError = (state: WithSuiteSyncAndDeviceState) =>
-    !!state.suiteSync.suiteSyncError;
+export const selectHasDeviceSuiteSyncError = (
+    state: WithSuiteSyncAndDeviceState,
+    deviceStaticSessionId: StaticSessionId | null,
+): boolean => {
+    if (deviceStaticSessionId === null) {
+        return false;
+    }
+
+    return state.suiteSync.suiteSyncErrors[deviceStaticSessionId] !== undefined;
+};

--- a/suite-common/suite-sync/src/suiteSyncSlice.ts
+++ b/suite-common/suite-sync/src/suiteSyncSlice.ts
@@ -1,6 +1,9 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { DeviceCancelledErrType, DeviceErrorType } from '@suite-common/wallet-types';
+import { StaticSessionId } from '@trezor/connect';
+
+export type SuiteSyncErrorType = DeviceErrorType | DeviceCancelledErrType;
 
 export type SuiteSyncSettings = {
     /**
@@ -27,7 +30,7 @@ export type SuiteSyncSettings = {
 
 export type SuiteSyncState = {
     settings: SuiteSyncSettings;
-    suiteSyncError: DeviceErrorType | DeviceCancelledErrType | null;
+    suiteSyncErrors: Record<StaticSessionId, SuiteSyncErrorType>;
 };
 
 export const initialSuiteSyncState: SuiteSyncState = {
@@ -36,7 +39,7 @@ export const initialSuiteSyncState: SuiteSyncState = {
         isSuiteSyncDebugEnabled: false,
         suiteSyncRelayUrl: null,
     },
-    suiteSyncError: null,
+    suiteSyncErrors: {},
 };
 
 export const suiteSyncSlice = createSlice({
@@ -57,9 +60,18 @@ export const suiteSyncSlice = createSlice({
         },
         setSuiteSyncError: (
             state,
-            { payload }: PayloadAction<{ error: DeviceErrorType | DeviceCancelledErrType | null }>,
+            {
+                payload,
+            }: PayloadAction<{
+                deviceStaticSessionId: StaticSessionId;
+                error: SuiteSyncErrorType | null;
+            }>,
         ) => {
-            state.suiteSyncError = payload.error;
+            if (payload.error === null) {
+                delete state.suiteSyncErrors[payload.deviceStaticSessionId];
+            } else {
+                state.suiteSyncErrors[payload.deviceStaticSessionId] = payload.error;
+            }
         },
     },
 });

--- a/suite-native/module-home/src/screens/HomeScreen/homescreenSelectors.ts
+++ b/suite-native/module-home/src/screens/HomeScreen/homescreenSelectors.ts
@@ -2,7 +2,7 @@ import { MessageSystemRootState } from '@suite-common/message-system';
 import { createWeakMapSelector } from '@suite-common/redux-utils';
 import {
     WithSuiteSyncState,
-    selectSuiteSyncError,
+    selectHasDeviceSuiteSyncError,
     selectSuiteSyncInteraction,
 } from '@suite-common/suite-sync';
 import {
@@ -52,11 +52,12 @@ export const selectShouldDisplayUpgradeFirmwareAlert = createMemoizedSelector(
 
 export const selectShouldDisplaySuiteSyncAlert = createMemoizedSelector(
     [
-        selectSuiteSyncError,
+        (state: WithSuiteSyncState & DeviceRootState) =>
+            selectHasDeviceSuiteSyncError(state, selectDeviceStaticSessionId(state)),
         selectIsDeviceConnected,
         (state: WithSuiteSyncState & DeviceRootState) =>
             selectSuiteSyncInteraction(state, selectDeviceStaticSessionId(state)),
     ],
-    (suiteSyncError, isDeviceConnected, interactionNeeded) =>
-        interactionNeeded === 'keys-needed' && (!!suiteSyncError || !isDeviceConnected),
+    (hasSuiteSyncError, isDeviceConnected, interactionNeeded) =>
+        interactionNeeded === 'keys-needed' && (hasSuiteSyncError || !isDeviceConnected),
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Small code improvement so we can attach errors to specific `staticSessionId`'s in case user selects another device after cancelling the suite sync keys windows. On its own, this PR doesn't solve anything and behaves same way as before, but I'll use this in a follow up so we can treat banners per device rather than per app session. 

## For QA
There's nothing to test, just code improvement.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-sync/make-suite-sync-error-device-dependent&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-sync/make-suite-sync-error-device-dependent&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-sync/make-suite-sync-error-device-dependent&lookback=7)