### PR TITLE
docs(connect-explorer): tutorial for handling passphrases

### DIFF
--- a/packages/connect-explorer/.gitignore
+++ b/packages/connect-explorer/.gitignore
@@ -2,3 +2,4 @@
 .next/
 out/
 !public/
+next-env.d.ts

--- a/packages/connect-explorer/.gitignore
+++ b/packages/connect-explorer/.gitignore
@@ -1,3 +1,4 @@
 # NextJS ignore file
 .next/
 !public/
+next-env.d.ts

--- a/packages/connect-explorer/next-env.d.ts
+++ b/packages/connect-explorer/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/connect-explorer/next-env.d.ts
+++ b/packages/connect-explorer/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/connect-explorer/src/pages/guides/handling-passphrases.mdx
+++ b/packages/connect-explorer/src/pages/guides/handling-passphrases.mdx
@@ -1,0 +1,92 @@
+---
+description: Automatically remember which passphrase belongs to each account based on a unique identifier
+---
+
+# Handling Passphrases in Trezor Connect
+
+Passphrases are a critical security feature of Trezor.
+
+Each passphrase creates a separate wallet (and therefore separate accounts and addresses).
+
+However in real usage:
+
+- Users often have multiple passphrase wallets.
+- They may use the same account index in different passphrase wallets.
+- Current integrations require users to:
+    - Manually re-enter the passphrase for every operation.
+    - Manually verify that the correct passphrase wallet is active.
+
+This leads to:
+
+- Risk of signing with the wrong wallet.
+- Poor UX.
+- Extra confirmation steps.
+
+Trezor Connect provides a solution using a unique identifier for each passphrase wallet:
+
+**`device.state.staticSessionId`**
+
+## Step 1: Initial Account Import
+
+When importing an account from Trezor, we can request the public key as usual:
+
+```tsx
+const response = await TrezorConnect.getPublicKey({
+    path: "m/49'/0'/0'",
+    coin: 'btc',
+    showOnTrezor: true,
+});
+```
+
+## Step 2: Read and Store `staticSessionId`
+
+Along with the usual `payload`, the response also contains a `device` object describing the currently unlocked wallet (including the active passphrase).
+
+Example response:
+
+```json
+{
+    "success": true,
+    "payload": {
+        "xpub": "..."
+    },
+    "device": {
+        "state": {
+            "staticSessionId": "k9F3sLqT2P8mZxA7QwR5E4nC1D6H0B@A1B2C3D4E5F60718293A4B5C6D7E8F90:1"
+            //...
+        }
+        //...
+    }
+}
+```
+
+Store the `device.state.staticSessionId` together with the other details about the imported account to bind it to a specific passphrase wallet.
+
+## Step 3: Use `staticSessionId` for Future Operations
+
+For all future operations (for example signing), pass back the stored `staticSessionId` together with the account path:
+
+```tsx
+await TrezorConnect.signTransaction({
+  device: {
+    state: {
+      staticSessionId: storedAccount.staticSessionId,
+    },
+  },
+  path: storedAccount.path,
+  inputs: [...],
+  outputs: [...],
+});
+
+```
+
+Trezor Connect will automatically restore the correct passphrase wallet and sign using the intended account.
+
+## Summary
+
+- Each passphrase wallet has a unique `staticSessionId`.
+- Read it from the response’s `device.state.staticSessionId` when importing an account.
+- Store it with the account.
+- Provide it in `device.state.staticSessionId` payload for future operations.
+
+This removes the need for manual wallet switching and ensures actions always use the correct passphrase wallet.

--- a/packages/connect-explorer/src/pages/guides/handling-passphrases.mdx
+++ b/packages/connect-explorer/src/pages/guides/handling-passphrases.mdx
@@ -1,0 +1,94 @@
+---
+description: Automatically remember which passphrase belongs to each account based on a unique identifier
+---
+
+# Handling Passphrases in Trezor Connect
+
+Passphrases are a critical security feature of Trezor.
+
+Each passphrase creates a separate wallet (and therefore separate accounts and addresses).
+
+However in real usage:
+
+- Users often have multiple passphrase wallets.
+- They may use the same account index in different passphrase wallets.
+- Current integrations require users to:
+    - Manually re-enter the passphrase for every operation.
+    - Manually verify that the correct passphrase wallet is active.
+
+This leads to:
+
+- Risk of signing with the wrong wallet.
+- Poor UX.
+- Extra confirmation steps.
+
+Trezor Connect provides a solution using a unique identifier for each passphrase wallet:
+
+**`device.state.staticSessionId`**
+
+## Step 1: Initial Account Import
+
+When importing an account from Trezor, we can request the public key as usual:
+
+```tsx
+const response = await TrezorConnect.getPublicKey({
+    path: "m/49'/0'/0'",
+    coin: 'btc',
+    showOnTrezor: true,
+});
+```
+
+## Step 2: Read and Store `staticSessionId`
+
+Along with the usual `payload`, the response also contains a `device` object describing the currently unlocked wallet (including the active passphrase).
+
+Example response:
+
+```json
+{
+    "success": true,
+    "payload": {
+        "xpub": "..."
+    },
+    "device": {
+        "path": "2ea8a457",
+        "state": {
+            "staticSessionId": "k9F3sLqT2P8mZxA7QwR5E4nC1D6H0B@A1B2C3D4E5F60718293A4B5C6D7E8F90:1",
+            "deriveCardano": false,
+            "sessionId": "01"
+        },
+        "instance": 2
+    }
+}
+```
+
+Store the `device.state.staticSessionId` together with the other details about the imported account to bind it to a specific passphrase wallet.
+
+## Step 3: Use `staticSessionId` for Future Operations
+
+For all future operations (for example signing), pass back the stored `staticSessionId` together with the account path:
+
+```tsx
+await TrezorConnect.signTransaction({
+  device: {
+    state: {
+      staticSessionId: storedAccount.staticSessionId,
+    },
+  },
+  path: storedAccount.path,
+  inputs: [...],
+  outputs: [...],
+});
+
+```
+
+Trezor Connect will automatically restore the correct passphrase wallet and sign using the intended account.
+
+## Summary
+
+- Each passphrase wallet has a unique `staticSessionId`.
+- Read it from the response’s `device.state.staticSessionId` when importing an account.
+- Store it with the account.
+- Provide it in `device.state.staticSessionId` payload for future operations.
+
+This removes the need for manual wallet switching and ensures actions always use the correct passphrase wallet.


### PR DESCRIPTION
## Description

Add a tutorial for 3rd parties explaining handling passphrases using `staticSessionId`: https://dev.suite.sldev.cz/connect/docs/connect-passphrase-handling/guides/handling-passphrases/

But now that I look at the process... maybe this is a bit clunky and we should improve this for Connect 10 - see #23786

Resolves #23800

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect-explorer/next-env.d.ts`

</details>

_No test recommendations found._

_Updated: 2026-07-27T08:41:17.017Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=docs/connect-passphrase-handling&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=docs/connect-passphrase-handling&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T08:45:20.029Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T08:44:55.010Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/docs/connect-passphrase-handling/web/](https://dev.suite.sldev.cz/suite-web/docs/connect-passphrase-handling/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->