### PR TITLE
test(e2e): offline-shamir

### DIFF
--- a/docs/packages/suite-desktop/runtime-flags.md
+++ b/docs/packages/suite-desktop/runtime-flags.md
@@ -26,3 +26,4 @@ Available flags:
 | `--log-no-print`              | Suppress console logs                                                                                                                                                                  |
 | `--remove-user-data-on-start` | Removes user data directory on start (used for E2E testing)                                                                                                                            |
 | `--expose-connect-ws`         | Expose Connect websocket even on production build                                                                                                                                      |
+| `--offline-mode`              | Experimental flag to disable all network connection both in Renderer and Main process. Note that it does **not** directly control subprocesses (e.g. tor, coinjoin)                    |

--- a/packages/suite-desktop-core/src/config.ts
+++ b/packages/suite-desktop-core/src/config.ts
@@ -16,9 +16,10 @@ const allowedDomainsDev = [
     'googleusercontent.com',
 ];
 
+export const localhostDomains = ['localhost', '127.0.0.1'];
+
 export const allowedDomains = [
-    'localhost',
-    '127.0.0.1',
+    ...localhostDomains,
     'trezor.io',
     'sldev.cz', // Test environment, available only with VPN
     'invity.io',

--- a/packages/suite-desktop-core/src/libs/process-switches.ts
+++ b/packages/suite-desktop-core/src/libs/process-switches.ts
@@ -18,6 +18,7 @@ export type SuiteSwitch =
     | 'remove-user-data-on-start'
     | 'expose-connect-ws'
     | 'expose-store'
+    | 'offline-mode'
     | 'state'; // very special handling, see `./app-utils.ts`
 
 /**

--- a/packages/suite-desktop-core/src/libs/request-interceptor.ts
+++ b/packages/suite-desktop-core/src/libs/request-interceptor.ts
@@ -1,5 +1,7 @@
 import { session } from 'electron';
 
+import { hasSwitch } from './process-switches';
+
 /**
  * Should be used for all webRequest.on* events as there can be only
  * one listener for each of them, but sometimes we need to bind more
@@ -9,10 +11,32 @@ export const createInterceptor = (): RequestInterceptor => {
     let beforeRequestListeners: BeforeRequestListener[] = [];
     const filter = { urls: ['*://*/*'] };
 
+    // URLs that should work even in offline mode (e.g., localhost, test servers)
+    const offlineModeAllowedUrls = [
+        'http://localhost:8000', // Development server (app itself)
+        'file://', // App's own local resources
+        'devtools://', // Chrome DevTools
+        'chrome-extension://', // Browser extensions
+        'data:', // Inline data URLs
+        'blob:', // Blob URLs
+        // Note: Intentionally NOT allowing other localhost ports or ws:// to force blockchain/discovery to fail
+    ];
+
+    const isUrlAllowedInOfflineMode = (url: string): boolean =>
+        offlineModeAllowedUrls.some(allowedUrl => url.startsWith(allowedUrl));
+
     const handleRequest = (
         details: Electron.OnBeforeRequestListenerDetails,
         callback: (response: Electron.CallbackResponse) => void,
     ) => {
+        // In offline mode, block all requests from Electron Renderer process (except localhost).
+        // This immediately cancels requests, preventing hangs during app initialization.
+        if (hasSwitch('offline-mode') && !isUrlAllowedInOfflineMode(details.url)) {
+            callback({ cancel: true });
+
+            return;
+        }
+
         for (let i = 0; i < beforeRequestListeners.length; ++i) {
             const res = beforeRequestListeners[i](details);
             if (res) {

--- a/packages/suite-desktop-core/src/modules/request-interceptor.ts
+++ b/packages/suite-desktop-core/src/modules/request-interceptor.ts
@@ -12,8 +12,9 @@ import { InterceptedEvent, createInterceptor } from '@trezor/request-manager';
 import { TorStatus } from '@trezor/suite-desktop-api';
 import { exhaustive } from '@trezor/type-utils';
 
-import { allowedDomains } from '../config';
+import { allowedDomains, localhostDomains } from '../config';
 import type { ModuleInit } from './module';
+import { hasSwitch } from '../libs/process-switches';
 
 export const SERVICE_NAME = 'request-interceptor';
 
@@ -83,14 +84,22 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
     // handle event sent from modules/coinjoin (background thread)
     mainThreadEmitter.on('module/request-interceptor', requestInterceptorEventHandler);
 
+    // Allow only the configured list of domains (static config), plus custom backends (variable config by user).
+    // In offline mode, block all requests from Electron Main process (except localhost).
+    const getWhitelistedDomains = () => {
+        if (hasSwitch('offline-mode')) return localhostDomains;
+
+        return [
+            ...mainThreadAllowedDomain.general,
+            ...Object.values(mainThreadAllowedDomain.customBackends).flat(),
+        ];
+    };
+
     createInterceptor({
         handler: requestInterceptorEventHandler,
         getTorSettings: () => store.getTorSettings(),
         allowTorBypass: isDevEnv,
         notRequiredTorDomainsList: ['127.0.0.1', 'localhost', '.sldev.cz'],
-        getWhitelistedDomains: () => [
-            ...mainThreadAllowedDomain.general,
-            ...Object.values(mainThreadAllowedDomain.customBackends).flat(),
-        ],
+        getWhitelistedDomains,
     });
 };

--- a/packages/suite/src/components/suite/banners/SuiteBanners/NoConnectionBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/NoConnectionBanner.tsx
@@ -6,5 +6,6 @@ export const NoConnectionBanner = () => (
         icon
         intent="critical"
         description={<Translation id="TR_YOU_WERE_DISCONNECTED_DOT" />}
+        data-testid="@suite/no-connection-banner"
     />
 );

--- a/packages/suite/src/views/onboarding/steps/CoinsStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/CoinsStep/index.tsx
@@ -21,7 +21,7 @@ export const CoinsStep = () => {
             description={<Translation id="TR_ONBOARDING_COINS_STEP_DESCRIPTION" />}
             innerActions={
                 <OnboardingCard.Button
-                    data-testid="@onboarding/exit-app-button"
+                    data-testid="@onboarding/complete-onboarding"
                     onClick={goToSuite}
                     isLoading={isTorLoading}
                     isDisabled={noNetworkEnabled}

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -264,7 +264,7 @@ const SecurityCheckContent = ({
                 </Button>
                 {initialized ? (
                     <Button
-                        data-testid="@onboarding/exit-app-button"
+                        data-testid="@onboarding/complete-onboarding"
                         onClick={handleContinueButtonClick}
                         size="large"
                         intent="brand"

--- a/suite/e2e/support/electron.ts
+++ b/suite/e2e/support/electron.ts
@@ -19,6 +19,7 @@ export type LaunchSuiteParams = {
     keepUserData?: boolean;
     bridgeDaemon?: boolean;
     exposeConnectWs?: boolean;
+    offlineMode?: boolean;
     locale?: string;
     colorScheme?: 'light' | 'dark' | 'no-preference' | null | undefined;
     artefactFolder: string;
@@ -62,6 +63,10 @@ const buildArgs = (params: LaunchSuiteParams) => {
 
     if (params.exposeConnectWs) {
         args.push('--expose-connect-ws');
+    }
+
+    if (params.offlineMode) {
+        args.push('--offline-mode');
     }
 
     const deleteUserData = !params.keepUserData;

--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -21,7 +21,7 @@ export class OnboardingPage {
     readonly tutorial: TutorialSection;
 
     readonly welcomeBody: Locator;
-    readonly onboardingExitButton: Locator;
+    readonly completeOnboardingButton: Locator;
     readonly connectDevicePrompt: Locator;
     readonly authenticityStartButton: Locator;
     readonly authenticityContinueButton: Locator;
@@ -54,7 +54,7 @@ export class OnboardingPage {
         this.pin = new PinSection(page);
 
         this.welcomeBody = this.page.getByTestId('@welcome-layout/body');
-        this.onboardingExitButton = this.page.getByTestId('@onboarding/exit-app-button');
+        this.completeOnboardingButton = this.page.getByTestId('@onboarding/complete-onboarding');
         this.connectDevicePrompt = this.page.getByTestId('@connect-device-prompt');
         this.authenticityStartButton = this.page.getByTestId('@authenticity-check/start-button');
         this.authenticityContinueButton = this.page.getByTestId(
@@ -118,7 +118,7 @@ export class OnboardingPage {
             await this.enableAutoconnect();
         }
 
-        await this.onboardingExitButton.click();
+        await this.completeOnboardingButton.click();
         if (this.device.hasSecureElement && this.device.model !== Model.T3W1) {
             await this.passThroughAuthenticityCheck();
         }

--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -14,7 +14,10 @@ import { BRIDGE_VERSION } from '../bridge';
 import { PlaywrightTarget, SuiteTestOptions } from './suiteTestOptions';
 import { DeviceFixture } from '../device';
 
-type ElectronConf = Pick<LaunchSuiteParams, 'keepUserData' | 'bridgeDaemon' | 'exposeConnectWs'>;
+type ElectronConf = Pick<
+    LaunchSuiteParams,
+    'keepUserData' | 'bridgeDaemon' | 'exposeConnectWs' | 'offlineMode'
+>;
 type TrezorUserEnv = Pick<
     TrezorUserEnvLinkClass,
     | 'logTestDetails'
@@ -66,6 +69,8 @@ const electronSetup = async (
     await suite.window
         .context()
         .tracing.start({ screenshots: true, snapshots: true, sources: true });
+    // this setting only takes effect for the renderer process. To emulate offline mode also in the main process, a custom runtime flag is used.
+    await suite.electronApp.context().setOffline(electronConf.offlineMode ?? false);
 
     await mockRemoteMessageSystem(suite.window);
 

--- a/suite/e2e/tests/analytics/events.test.ts
+++ b/suite/e2e/tests/analytics/events.test.ts
@@ -161,7 +161,7 @@ test.describe('Analytics Events', { tag: ['@webOnly', '@T3W1', '@T3T1', '@smoke'
             await settingsPage.analyticsSwitch.click();
             await settingsPage.closeSettings();
             await page.reload();
-            await onboardingPage.onboardingExitButton.click();
+            await onboardingPage.completeOnboardingButton.click();
         });
 
         await test.step('Wait for analytics events and validate event types', async () => {

--- a/suite/e2e/tests/analytics/toggle.test.ts
+++ b/suite/e2e/tests/analytics/toggle.test.ts
@@ -53,7 +53,7 @@ test.describe(
                     await onboardingPage.enableAutoconnect();
                 }
 
-                await onboardingPage.onboardingExitButton.click();
+                await onboardingPage.completeOnboardingButton.click();
             });
 
             await test.step('Reload app and check analytics state', async () => {
@@ -145,7 +145,7 @@ test.describe(
                     await devicePrompt.allowConnectToTrezor();
                     await onboardingPage.enterTHPPairingCode();
                 }
-                await onboardingPage.onboardingExitButton.click();
+                await onboardingPage.completeOnboardingButton.click();
             });
 
             await test.step('Go to settings and disable analytics', async () => {

--- a/suite/e2e/tests/onboarding/analytics-consent.test.ts
+++ b/suite/e2e/tests/onboarding/analytics-consent.test.ts
@@ -24,7 +24,7 @@ test.describe('Onboarding - analytics consent', { tag: ['@webOnly', '@T3W1', '@T
             await onboardingPage.enterTHPPairingCode();
         }
 
-        await onboardingPage.onboardingExitButton.click();
+        await onboardingPage.completeOnboardingButton.click();
 
         await expect(dashboardPage.suiteLayout).toBeVisible();
         await walletPage.openAccount();

--- a/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -87,7 +87,7 @@ test.describe('Onboarding - create wallet', { tag: ['@firmware-ready', '@T1B1'] 
             });
 
             await test.step('Finish wallet creation', async () => {
-                await onboardingPage.onboardingExitButton.click();
+                await onboardingPage.completeOnboardingButton.click();
                 await expect(onboardingPage.suiteLoadedIndicator).toBeVisible();
                 await expect(dashboardPage.walletReady).toBeVisible();
             });

--- a/suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts
@@ -51,7 +51,7 @@ test.describe('Onboarding - recover wallet T1B1', { tag: ['@firmware-ready', '@T
             // Finalize recovery, skip pin, and verify success
             await onboardingPage.continueRecoveryButton.click();
             await onboardingPage.pin.skip();
-            await expect(onboardingPage.onboardingExitButton).toBeVisible();
+            await expect(onboardingPage.completeOnboardingButton).toBeVisible();
         },
     );
 });

--- a/suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
@@ -37,6 +37,6 @@ test.describe('Onboarding - create wallet', { tag: ['@T2T1'] }, () => {
         await device.type('12');
         await devicePrompt.confirmOnDevicePromptIsShown();
         await device.pressYes();
-        await expect(onboardingPage.onboardingExitButton).toBeVisible();
+        await expect(onboardingPage.completeOnboardingButton).toBeVisible();
     });
 });

--- a/suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts
+++ b/suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts
@@ -48,7 +48,7 @@ test.describe('Onboarding - recover wallet T2T1', { tag: ['@T2T1'] }, () => {
             // Finalize recovery, skip pin, and check success
             await onboardingPage.continueRecoveryButton.click();
             await onboardingPage.pin.skip();
-            await expect(onboardingPage.onboardingExitButton).toBeVisible();
+            await expect(onboardingPage.completeOnboardingButton).toBeVisible();
         },
     );
 });

--- a/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts
+++ b/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts
@@ -1,0 +1,88 @@
+import { TestCategory, TestPriority } from '@trezor/e2e-utils';
+
+import { expect, test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe('Onboarding - create wallet', { tag: ['@T3T1', '@smoke'] }, () => {
+    test.use({
+        setupEmulator: false,
+        electronConf: { offlineMode: true },
+    });
+
+    test.beforeEach(async ({ onboardingPage }) => {
+        await onboardingPage.disableNecessaryFirmwareChecks();
+    });
+
+    test(
+        'Success (Shamir backup) offline',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that a user can successfully create a wallet during the offline onboarding process.',
+                category: TestCategory.Onboarding,
+                priority: TestPriority.Critical,
+            }),
+        },
+        async ({ page, onboardingPage, devicePrompt, analyticsSection, device }) => {
+            await expect(page.getByTestId('@suite/no-connection-banner')).toHaveTranslation(
+                'TR_YOU_WERE_DISCONNECTED_DOT',
+            );
+
+            await analyticsSection.continueButton.click();
+            await expect(page.getByTestId('@suite/no-connection-banner')).toHaveTranslation(
+                'TR_YOU_WERE_DISCONNECTED_DOT',
+            );
+            await analyticsSection.continueButton.click();
+
+            await test.step('Device onboarding steps', async () => {
+                await onboardingPage.firmware.continueThroughFirmware();
+                await onboardingPage.passThroughAuthenticityCheck();
+                await page.waitForTimeout(500);
+                await onboardingPage.tutorial.skip();
+            });
+
+            await test.step('Create wallet with Shamir backup', async () => {
+                await onboardingPage.createWalletButton.click();
+                await onboardingPage.selectSeedType('shamir-advanced');
+            });
+
+            await test.step('Accept ToS and confirm wallet creation', async () => {
+                // Accept ToS
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await device.pressYes();
+
+                // Confirm wallet created
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await device.pressYes();
+                await onboardingPage.createBackupButton.click();
+            });
+
+            await test.step('Create backup with Shamir shares and threshold', async () => {
+                const shares = 3;
+                const threshold = 2;
+                await onboardingPage.backup.passThroughShamirBackup(shares, threshold);
+            });
+
+            await test.step('Set PIN', async () => {
+                await onboardingPage.pin.setPinButton.click();
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await device.pressYes();
+                await device.selectNumberOfWords(12);
+                await device.selectNumberOfWords(12);
+
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await device.pressYes();
+            });
+
+            await test.step('Complete onboarding and verify offline state', async () => {
+                await onboardingPage.completeOnboardingButton.click();
+                await expect(page.getByTestId('@suite/no-connection-banner')).toHaveTranslation(
+                    'TR_YOU_WERE_DISCONNECTED_DOT',
+                );
+                await expect(
+                    page.getByTestId('@exception/discovery-failed/description'),
+                ).toBeVisible({ timeout: 30_000 });
+            });
+        },
+    );
+});

--- a/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
@@ -43,7 +43,7 @@ test.describe('Onboarding - create wallet', { tag: ['@T3T1', '@smoke'] }, () => 
             await devicePrompt.confirmOnDevicePromptIsShown();
             await device.pressYes();
 
-            onboardingPage.createBackupButton.click();
+            await onboardingPage.createBackupButton.click();
 
             // Create backup with Shamir shares and threshold
             const shares = 3;
@@ -54,8 +54,8 @@ test.describe('Onboarding - create wallet', { tag: ['@T3T1', '@smoke'] }, () => 
             await onboardingPage.pin.setPinButton.click();
             await devicePrompt.confirmOnDevicePromptIsShown();
             await device.pressYes();
-            await device.type('12');
-            await device.type('12');
+            await device.selectNumberOfWords(12);
+            await device.selectNumberOfWords(12);
 
             await devicePrompt.confirmOnDevicePromptIsShown();
             await device.pressYes();

--- a/suite/e2e/tests/suite/db-locale-migration.test.ts
+++ b/suite/e2e/tests/suite/db-locale-migration.test.ts
@@ -34,7 +34,7 @@ test.describe(
                     await onboardingPage.disableNecessaryFirmwareChecks();
                     await page.locator('[data-testid="@analytics/toggle-switch"]').click();
                     await page.locator('[data-testid="@analytics/continue-button"]').click();
-                    await page.locator('[data-testid="@onboarding/exit-app-button"]').click();
+                    await page.locator('[data-testid="@onboarding/complete-onboarding"]').click();
 
                     await expect(page.locator('[data-testid="@suite/loading"]')).toBeHidden();
                 });

--- a/suite/e2e/tests/suite/db-migration.test.ts
+++ b/suite/e2e/tests/suite/db-migration.test.ts
@@ -54,7 +54,7 @@ test.describe(
                 await test.step(`Load suite in old version ${migrateFromVersion}`, async () => {
                     await page.goto(`${suiteDevInstance}/${migrateFromVersion}`);
                     await page.locator('[data-test="@onboarding/continue-button"]').click();
-                    await page.locator('[data-test="@onboarding/exit-app-button"]').click();
+                    await page.locator('[data-test="@onboarding/complete-onboarding"]').click();
                     await expect(page.locator('[data-test="@suite/loading"]')).toBeHidden();
                     await page.locator('[data-test="@passphrase-type/standard"]').click();
                     await discoveryBar.waitFor({ state: 'visible', timeout: 45000 });

--- a/suite/e2e/tests/suite/initial-run.test.ts
+++ b/suite/e2e/tests/suite/initial-run.test.ts
@@ -38,14 +38,14 @@ test.describe('Suite initial run', { tag: ['@T3W1', '@T3T1'] }, () => {
             await onboardingPage.enterTHPPairingCode();
         }
 
-        await expect(page.getByTestId('@onboarding/exit-app-button')).toBeVisible();
+        await expect(page.getByTestId('@onboarding/complete-onboarding')).toBeVisible();
 
         await page.reload();
 
         await onboardingPage.verifySuiteIsLoaded();
         optionallyDismissFwHashCheckError(page);
         await expect(analyticsSection.toggleSwitch).toBeHidden();
-        await expect(onboardingPage.onboardingExitButton).toBeVisible();
+        await expect(onboardingPage.completeOnboardingButton).toBeVisible();
     });
 
     test('Once user passed trough, skips initial run and shows connect-device modal', async ({


### PR DESCRIPTION
## Description

Offline Shamir test - half vibe coded test, please review 🙏 
Amended by @Lemonexe 

- adds a new desktop runtime flag `--offline-mode` to cancel all outbound network traffic from Suite Desktop
  - for Renderer process it is blocked centrally in `request-interceptor`
    - contraintuitively, it also includes `electron-updater`, which creates its own session like the renderer one
  - for Main process it is blocked centrally in _a different_ `request-interceptor`
- adds a new flag to Playwright Electron setup, which also blocks renderer process traffic (superfluous, but why not) and passes the runtime flag `--offline-mode` to electron process
- a new Playwright E2E test

**TODO:** in next PR: cleanup the naming here and add comments. It's confusing AF that we have two files named `request-interceptor`, and two functions named `createInterceptor`, which do the analogical thing for electron Main & for Renderer, but work very differently :see_no_evil: 

## Notes for QA

:point_right:  Please test Suite Desktop run normally without the flag. All network services should work, i.e. no missing:
- coin discovery
- fiat rates
- fees
- desktop & FW update
- trading
- analytics
- sentry
- using Tor

:ice_cube: low prio: test that none of the above works when you start Suite Desktop with `--offline-mode`

Note that CJ is not covered by this, because it's its own process.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/offline-shamir-onboarding&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/offline-shamir-onboarding&lookback=7)