### PR TITLE
feat(message-system): add feature flag to disable Optiga DAC failures

### DIFF
--- a/suite-common/device-authenticity/src/checkDeviceAuthenticityThunk.ts
+++ b/suite-common/device-authenticity/src/checkDeviceAuthenticityThunk.ts
@@ -52,12 +52,17 @@ export const checkDeviceAuthenticityThunk = createThunk<
 
             return rejectWithValue(storedResult);
         }
+        const isOptigaRemotelyDisabled = selectIsFeatureDisabled(
+            getState(),
+            Feature.deviceAuthenticityCheckOptiga,
+        );
         const isTropicRemotelyDisabled = selectIsFeatureDisabled(
             getState(),
             Feature.deviceAuthenticityCheckTropic,
         );
         const isOverallValid = isDeviceAuthenticityValid({
             result: result.payload,
+            isOptigaRemotelyDisabled,
             isTropicRemotelyDisabled,
         });
         const storedResult = { valid: isOverallValid, ...result.payload };

--- a/suite-common/device-authenticity/src/utils.ts
+++ b/suite-common/device-authenticity/src/utils.ts
@@ -2,14 +2,16 @@ import { AuthenticateDeviceResult } from '@trezor/connect';
 
 type IsDeviceAuthenticityValidParams = {
     result: AuthenticateDeviceResult;
+    isOptigaRemotelyDisabled: boolean;
     isTropicRemotelyDisabled: boolean;
 };
 
 export const isDeviceAuthenticityValid = ({
     result,
+    isOptigaRemotelyDisabled,
     isTropicRemotelyDisabled,
 }: IsDeviceAuthenticityValidParams) => {
-    const isOptigaValid = result.optigaResult.valid === true;
+    const isOptigaValid = result.optigaResult.valid === true || isOptigaRemotelyDisabled;
     // Note: Tropic will be undefined for T2B1, T3B1, T3T1, but Connect takes care that it will fail for models which are expected to have it (T3W1)
     const isTropicValid = result.tropicResult?.valid !== false || isTropicRemotelyDisabled;
 

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -71,6 +71,7 @@ export const Feature = {
     entropyCheck: 'security.entropyCheck',
     entropyCheckMobile: 'security.entropyCheck.mobile',
 
+    deviceAuthenticityCheckOptiga: 'security.deviceAuthenticityCheck.optiga',
     deviceAuthenticityCheckTropic: 'security.deviceAuthenticityCheck.tropic',
 
     trading: {

--- a/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
+++ b/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
@@ -34,6 +34,9 @@ export const useDeviceAuthenticityCheck = () => {
     const { translate } = useTranslate();
     const { showToast } = useToast();
     const allowDebugKeys = useFeatureFlag(FeatureFlag.IsDebugKeysAllowed);
+    const isOptigaRemotelyDisabled = useSelector((state: MessageSystemRootState) =>
+        selectIsFeatureDisabled(state, Feature.deviceAuthenticityCheckOptiga),
+    );
     const isTropicRemotelyDisabled = useSelector((state: MessageSystemRootState) =>
         selectIsFeatureDisabled(state, Feature.deviceAuthenticityCheckTropic),
     );
@@ -82,12 +85,13 @@ export const useDeviceAuthenticityCheck = () => {
 
             const isOverallValid = isDeviceAuthenticityValid({
                 result: result.payload,
+                isOptigaRemotelyDisabled,
                 isTropicRemotelyDisabled,
             });
 
             return { valid: isOverallValid, ...result.payload };
         },
-        [isDeviceBootloaderUnlocked, isTropicRemotelyDisabled],
+        [isDeviceBootloaderUnlocked, isOptigaRemotelyDisabled, isTropicRemotelyDisabled],
     );
 
     const handleDeviceAccessError = useCallback(


### PR DESCRIPTION
## Description

Implement message system feature flag `security.deviceAuthenticityCheck.optiga` to remotely disable Optiga authenticity check (ignore its failure results and only display tropic failure results if available), in case we encounter false positives.

## Notes for QA

- Open [this branch on Web](https://dev.suite.sldev.cz/suite-web/feat/optiga-message-system/web/)
- Make sure Debug settings are **off!**
- Run any Trezor Safe on `trezor-user-env`
- Go through onboarding (skip FW check if prompted)
- Should get Device compromised, Your device authenticity check failed.
- Now go to Debug Settings > Message system manager > Add new message:
```
{"conditions": [{"environment": {"desktop": "*", "mobile": "*", "web": "*" } } ], "message": {"id": "cc5243c2-1370-4b14-999c-2e48e20a134a", "priority": 1, "dismissible": false, "variant": "info", "category": "feature", "content": {"en": "Placeholder", "es": "Placeholder", "cs": "Placeholder", "de": "Placeholder", "fr": "Placeholder", "it": "Placeholder", "pt": "Placeholder", "tr": "Placeholder", "ru": "Placeholder", "ja": "Placeholder", "uk": "Placeholder", "hu": "Placeholder" }, "feature": [{"domain": "security.deviceAuthenticityCheck.optiga", "flag": false } ] } }
```
- **Turn off Debug now!**
  - _this makes sure that DAC is set up to fail – unless the message system works to disable it_
- Connect the emulated Trezor Safe again
- Go through onboarding again
- Should succeed

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24811


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/optiga-message-system&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/optiga-message-system&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/optiga-message-system&lookback=7)