### PR TITLE
chore(suite-native): remove app logs feature flag

### DIFF
--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react';
-import { PressableProps } from 'react-native';
+import { View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
 import { Icon, IconName } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -8,11 +10,10 @@ import { Color } from '@trezor/theme';
 import { Box } from '../Box';
 import { InlineAlertBox, InlineAlertBoxProps } from '../InlineAlertBox/InlineAlertBox';
 import { Loader } from '../Loader';
-import { PressableOpacity } from '../Pressable';
 import { RoundedIcon } from '../RoundedIcon';
 import { HStack, VStack } from '../Stack';
 import { Text } from '../Text';
-import { Card } from './Card';
+import { AnimatedCard, CardProps } from './Card';
 
 export const COMPACT_CARD_VARIANTS = ['normal', 'danger', 'primary'] as const;
 type CompactCardVariant = (typeof COMPACT_CARD_VARIANTS)[number];
@@ -25,9 +26,8 @@ export type CompactCardWithIconLayoutProps = {
     alertBoxProps?: Omit<InlineAlertBoxProps, 'borderRadius'>;
     onPress?: () => void;
     variant?: CompactCardVariant;
-    noShadow?: boolean;
     borderColor?: Color | null;
-} & PressableProps;
+} & Omit<CardProps, 'children' | 'borderColor'>;
 
 type CardColorScheme = {
     iconWrapperBackgroundColor: Color;
@@ -66,12 +66,6 @@ const contentStyle = prepareNativeStyle(() => ({
     flexShrink: 1,
 }));
 
-const touchableOpacityStyle = prepareNativeStyle<Pick<CompactCardWithIconLayoutProps, 'noShadow'>>(
-    (utils, { noShadow }) => ({
-        ...(noShadow ? {} : utils.boxShadows.small),
-    }),
-);
-
 export const CompactCardWithIconLayout = ({
     icon,
     title,
@@ -80,54 +74,72 @@ export const CompactCardWithIconLayout = ({
     onPress,
     isDisabled = false,
     variant = 'normal',
-    noShadow = false,
     borderColor = 'borderElevation1',
-    ...pressableProps
+    ...cardProps
 }: CompactCardWithIconLayoutProps) => {
     const { applyStyle } = useNativeStyles();
-
+    const isPressed = useSharedValue(false);
     const { caretColor, iconColor, titleColor, subtitleColor, iconWrapperBackgroundColor } =
         cardVariantToColorsMap[variant];
 
+    const tap = Gesture.Tap()
+        .onBegin(() => {
+            isPressed.value = true;
+        })
+        .onEnd(() => {
+            if (onPress) {
+                runOnJS(onPress)();
+            }
+        })
+        .onFinalize(() => {
+            isPressed.value = false;
+        });
+
+    const animatedStyle = useAnimatedStyle(() => ({
+        opacity: withTiming(isPressed.value ? 0.5 : 1, { duration: 100 }),
+    }));
+
     return (
-        <PressableOpacity
-            style={applyStyle(touchableOpacityStyle, { noShadow })}
-            disabled={isDisabled}
-            onPress={onPress}
-            {...pressableProps}
-        >
-            <Card noPadding noShadow borderColor={borderColor ?? undefined}>
-                <HStack
-                    paddingHorizontal="sp16"
-                    paddingVertical="sp12"
-                    spacing="sp12"
-                    alignItems="center"
+        <GestureDetector gesture={tap}>
+            <View collapsable={false}>
+                <AnimatedCard
+                    noPadding
+                    borderColor={borderColor ?? undefined}
+                    style={animatedStyle}
+                    {...cardProps}
                 >
-                    <RoundedIcon
-                        backgroundColor={iconWrapperBackgroundColor}
-                        color={iconColor}
-                        name={icon}
-                    />
-                    <VStack spacing="sp2" style={applyStyle(contentStyle)}>
-                        <Text color={titleColor}>{title}</Text>
-                        {subtitle && (
-                            <Text color={subtitleColor} variant="hint">
-                                {subtitle}
-                            </Text>
+                    <HStack
+                        paddingHorizontal="sp16"
+                        paddingVertical="sp12"
+                        spacing="sp12"
+                        alignItems="center"
+                    >
+                        <RoundedIcon
+                            backgroundColor={iconWrapperBackgroundColor}
+                            color={iconColor}
+                            name={icon}
+                        />
+                        <VStack spacing="sp2" style={applyStyle(contentStyle)}>
+                            <Text color={titleColor}>{title}</Text>
+                            {subtitle && (
+                                <Text color={subtitleColor} variant="hint">
+                                    {subtitle}
+                                </Text>
+                            )}
+                        </VStack>
+                        {isDisabled ? (
+                            <Loader />
+                        ) : (
+                            <Icon name="caretRight" size="mediumLarge" color={caretColor} />
                         )}
-                    </VStack>
-                    {isDisabled ? (
-                        <Loader />
-                    ) : (
-                        <Icon name="caretRight" size="mediumLarge" color={caretColor} />
+                    </HStack>
+                    {alertBoxProps && (
+                        <Box margin="sp4">
+                            <InlineAlertBox {...alertBoxProps} />
+                        </Box>
                     )}
-                </HStack>
-                {alertBoxProps && (
-                    <Box margin="sp4">
-                        <InlineAlertBox {...alertBoxProps} />
-                    </Box>
-                )}
-            </Card>
-        </PressableOpacity>
+                </AnimatedCard>
+            </View>
+        </GestureDetector>
     );
 };

--- a/suite-native/config/src/types.ts
+++ b/suite-native/config/src/types.ts
@@ -14,5 +14,4 @@ export type LaunchArguments = {
     isTradingResidenceCheckEnabled?: boolean;
     isTradingDebugEnabled?: boolean;
     isEarnEnabled?: boolean;
-    areAppLogsEnabled?: boolean;
 };

--- a/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
@@ -26,7 +26,6 @@ describe('featureFlagsSlice', () => {
                 isTradingSellEnabled: false,
                 isTradingDebugEnabled: false,
                 isEarnEnabled: false,
-                areAppLogsEnabled: false,
             });
         });
 
@@ -48,7 +47,6 @@ describe('featureFlagsSlice', () => {
                 isTradingResidenceCheckEnabled: false,
                 isTradingDebugEnabled: false,
                 isEarnEnabled: false,
-                areAppLogsEnabled: false,
             });
         });
     });

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -14,7 +14,6 @@ export const FeatureFlag = {
     IsTradingResidenceCheckEnabled: 'isTradingResidenceCheckEnabled',
     IsTradingDebugEnabled: 'isTradingDebugEnabled',
     IsEarnEnabled: 'isEarnEnabled',
-    AreAppLogsEnabled: 'areAppLogsEnabled',
 } as const;
 
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
@@ -46,7 +45,6 @@ export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsTradingDebugEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_TRADING_DEBUG_ENABLED === 'true',
     [FeatureFlag.IsEarnEnabled]: process.env.EXPO_PUBLIC_FF_IS_EARN_ENABLED === 'true',
-    [FeatureFlag.AreAppLogsEnabled]: process.env.EXPO_PUBLIC_FF_ARE_APP_LOGS_ENABLED === 'true',
 };
 
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
@@ -60,7 +58,6 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsTradingResidenceCheckEnabled,
     FeatureFlag.IsTradingDebugEnabled,
     FeatureFlag.IsEarnEnabled,
-    FeatureFlag.AreAppLogsEnabled,
 ];
 
 export const featureFlagsSlice = createSlice({

--- a/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
@@ -18,7 +18,6 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsTradingResidenceCheckEnabled]: '💰 Trading Residence Check',
     [FeatureFlagEnum.IsTradingDebugEnabled]: '💰 Trading Debug Mode',
     [FeatureFlagEnum.IsEarnEnabled]: 'Earn',
-    [FeatureFlagEnum.AreAppLogsEnabled]: '📝 App Logs',
 } as const satisfies Record<FeatureFlagEnum, string>;
 
 const FeatureFlag = ({ featureFlag }: { featureFlag: FeatureFlagEnum }) => {

--- a/suite-native/module-settings/package.json
+++ b/suite-native/module-settings/package.json
@@ -37,7 +37,6 @@
         "@suite-native/device-manager": "workspace:*",
         "@suite-native/discovery": "workspace:*",
         "@suite-native/experimental-features": "workspace:*",
-        "@suite-native/feature-flags": "workspace:*",
         "@suite-native/forms": "workspace:*",
         "@suite-native/helpers": "workspace:*",
         "@suite-native/icons": "workspace:*",

--- a/suite-native/module-settings/src/components/NeedHelpSection.tsx
+++ b/suite-native/module-settings/src/components/NeedHelpSection.tsx
@@ -1,7 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 
 import { CompactCardWithIconLayout, TitledSection } from '@suite-native/atoms';
-import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import { Translation } from '@suite-native/intl';
 import { SUITE_MOBILE_SUPPORT_URL, useOpenLink } from '@suite-native/link';
 import {
@@ -17,7 +16,6 @@ type NavigationProps = StackNavigationProps<
 
 export const NeedHelpSection = () => {
     const navigation = useNavigation<NavigationProps>();
-    const areAppLogsEnabled = useFeatureFlag(FeatureFlag.AreAppLogsEnabled);
 
     const openLink = useOpenLink();
 
@@ -36,13 +34,11 @@ export const NeedHelpSection = () => {
                 icon="lifebuoy"
                 onPress={openContactSupport}
             />
-            {areAppLogsEnabled && (
-                <CompactCardWithIconLayout
-                    title={<Translation id="moduleSettings.faq.needHelp.appLog" />}
-                    icon="fileTxt"
-                    onPress={navigateToAppLogs}
-                />
-            )}
+            <CompactCardWithIconLayout
+                title={<Translation id="moduleSettings.faq.needHelp.appLog" />}
+                icon="fileTxt"
+                onPress={navigateToAppLogs}
+            />
         </TitledSection>
     );
 };

--- a/suite-native/module-settings/src/components/__tests__/GeneralSettings.comp.test.tsx
+++ b/suite-native/module-settings/src/components/__tests__/GeneralSettings.comp.test.tsx
@@ -1,20 +1,11 @@
-import { act, renderWithStoreProviderAsync, userEvent } from '@suite-native/test-utils';
+import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import { GeneralSettings } from '../GeneralSettings';
-
-const mockNavigate = jest.fn();
 
 jest.mock('@suite-native/trading-state', () => ({
     ...jest.requireActual('@suite-native/trading-state'),
     selectIsTradingCountrySet: () => true,
     selectIsTradingResidenceCheckEnabled: () => true,
-}));
-
-jest.mock('@react-navigation/native', () => ({
-    ...jest.requireActual('@react-navigation/native'),
-    useNavigation: () => ({
-        navigate: mockNavigate,
-    }),
 }));
 
 describe('GeneralSettings', () => {
@@ -28,14 +19,5 @@ describe('GeneralSettings', () => {
         const { getByTestId } = await renderGeneralSettings();
 
         expect(getByTestId('@settings/trading')).toBeOnTheScreen();
-
-        await act(async () => {
-            await userEvent.press(getByTestId('@settings/trading'));
-        });
-
-        expect(mockNavigate).toHaveBeenCalledTimes(1);
-        expect(mockNavigate).toHaveBeenCalledWith('SettingsScreenStack', {
-            screen: 'SettingsTradingLocation',
-        });
     });
 });

--- a/suite-native/module-settings/src/components/__tests__/TradingSettingsCard.comp.test.tsx
+++ b/suite-native/module-settings/src/components/__tests__/TradingSettingsCard.comp.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderWithStoreProviderAsync, userEvent } from '@suite-native/test-utils';
+import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import { TradingSettingsCard, TradingSettingsCardProps } from '../TradingSettingsCard';
 
@@ -50,20 +50,6 @@ describe('TradingSettingsCard', () => {
             expect(getByTestId('@settings/trading')).toBeOnTheScreen();
             expect(getByText('Trading')).toBeOnTheScreen();
             expect(getByText('Country of residence')).toBeOnTheScreen();
-        });
-
-        it('should call onPress callback when button is pressed', async () => {
-            const onPressMock = jest.fn();
-            const { getByTestId } = await renderTradingSettingsCard({
-                testID: '@settings/trading',
-                onPress: onPressMock,
-            });
-
-            await act(async () => {
-                await userEvent.press(getByTestId('@settings/trading'));
-            });
-
-            expect(onPressMock).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/suite-native/module-settings/tsconfig.json
+++ b/suite-native/module-settings/tsconfig.json
@@ -44,7 +44,6 @@
         { "path": "../device-manager" },
         { "path": "../discovery" },
         { "path": "../experimental-features" },
-        { "path": "../feature-flags" },
         { "path": "../forms" },
         { "path": "../helpers" },
         { "path": "../icons" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13109,7 +13109,6 @@ __metadata:
     "@suite-native/device-manager": "workspace:*"
     "@suite-native/discovery": "workspace:*"
     "@suite-native/experimental-features": "workspace:*"
-    "@suite-native/feature-flags": "workspace:*"
     "@suite-native/forms": "workspace:*"
     "@suite-native/helpers": "workspace:*"
     "@suite-native/icons": "workspace:*"


### PR DESCRIPTION
## Description
- removes `app log` feature feature flag so it is accesible in the produciton build 
- fix shadow of `CompactCardWithIconLayout` atom component

## Notes for QA
- test that the FF is gone and the feature is accessible in RC


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/remove-app-log-ff&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/remove-app-log-ff&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/remove-app-log-ff&lookback=7)