### PR TITLE
fix(suite): go to correct account in staking dashboard

### DIFF
--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardAccountRow.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardAccountRow.tsx
@@ -99,7 +99,6 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
 
         dispatch(
             goto('wallet-trading-buy', {
-                preserveParams: true,
                 params: {
                     symbol: account.symbol,
                     accountIndex: account.index,
@@ -122,7 +121,6 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
     const navigateToStaking = () => {
         dispatch(
             goto('wallet-staking', {
-                preserveParams: true,
                 params: {
                     symbol: account.symbol,
                     accountIndex: account.index,


### PR DESCRIPTION
## Description

After click on an account (or buttons) in the staking dashboard (in Dashboard and Earn sections), navigate to correct account.

## Related Issue

Resolve #25034 

## Screenshots:

https://github.com/user-attachments/assets/cf7087be-c353-4514-a57c-b0e5e1d566b4



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/staking-dashboard&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/staking-dashboard&lookback=7)