### PR TITLE
fix: display the current background route behind a 'foregound app'

### DIFF
--- a/packages/suite/src/components/suite/AppRouter.tsx
+++ b/packages/suite/src/components/suite/AppRouter.tsx
@@ -5,6 +5,8 @@ import { PageName } from '@suite-common/suite-types';
 import routes from 'src/constants/suite/routes';
 import { useSelector } from 'src/hooks/suite';
 import { selectRouteName } from 'src/reducers/suite/routerReducer';
+import { useSuiteServices } from 'src/support/SuiteServicesProvider';
+import { resolveEffectiveBackgroundRouteName } from 'src/utils/suite/router';
 
 type AppRouterProps = {
     components: Record<PageName, ComponentType>;
@@ -12,12 +14,17 @@ type AppRouterProps = {
 
 export const AppRouter = memo(({ components }: AppRouterProps) => {
     const routeName = useSelector(selectRouteName);
+    const route = useSelector(state => state.router.route);
+    const { suiteRouterHistory } = useSuiteServices();
+
+    const resolvedRouteName =
+        resolveEffectiveBackgroundRouteName(route, suiteRouterHistory.getLocation()) ?? routeName;
 
     // Resolve component by route name, with nested routes falling back to parent component
-    let componentName = routeName;
+    let componentName = resolvedRouteName;
     // NOTE: This throws a TS error becuase routeNames also contain foreground app names
-    if (routeName && !Object.prototype.hasOwnProperty.call(components, routeName)) {
-        const current = routes.find(r => r.name === routeName);
+    if (resolvedRouteName && !Object.prototype.hasOwnProperty.call(components, resolvedRouteName)) {
+        const current = routes.find(r => r.name === resolvedRouteName);
         if (current?.isNestedRoute) {
             const parent = routes.find(
                 r => r.hasNestedRoutes && current.pattern.startsWith(`${r.pattern}/`),

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
@@ -4,6 +4,8 @@ import { selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex } from '@sui
 import { useSelector } from 'src/hooks/suite';
 import { selectIsAccountTabPage } from 'src/reducers/suite/routerReducer';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { useSuiteServices } from 'src/support/SuiteServicesProvider';
+import { resolveEffectiveBackgroundRouteName } from 'src/utils/suite/router';
 
 import { AccountName } from './AccountName/AccountName';
 import { AccountSubpageName } from './AccountName/AccountSubpageName';
@@ -11,7 +13,12 @@ import { BasicName } from './BasicName';
 import { SettingsName } from './SettingsName';
 
 export const PageName = () => {
-    const currentRoute = useSelector(state => state.router.route?.name);
+    const route = useSelector(state => state.router.route);
+    const { suiteRouterHistory } = useSuiteServices();
+    const currentRoute = resolveEffectiveBackgroundRouteName(
+        route,
+        suiteRouterHistory.getLocation(),
+    );
     const selectedAccount = useSelector(selectSelectedAccount);
     const isAccountTabPage = useSelector(selectIsAccountTabPage);
     const { params } = useSelector(state => state.wallet.selectedAccount);

--- a/packages/suite/src/utils/suite/router.ts
+++ b/packages/suite/src/utils/suite/router.ts
@@ -188,6 +188,17 @@ export const getAppWithParams = (path: { pathname: PathString; hash?: HashString
     return { app, params, route } as RouterAppWithParams;
 };
 
+export const resolveEffectiveBackgroundRouteName = (
+    route: Route | undefined,
+    location: { pathname: PathString; hash?: HashString },
+) => {
+    if (route?.isForegroundApp) {
+        return getAppWithParams(location).route?.name ?? route?.name;
+    }
+
+    return route?.name;
+};
+
 export type WalletParams = CommonWalletParams;
 export type RouteParams = {
     [K in keyof (WalletParams & ModalAppParams & DashboardParams)]?: (WalletParams &


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fix UI/UX issue for the "foreground app routes" that causes that opened popover of foreground app (typically `suite-switch-device` - device switcher, or `firmware-update`) caused that their background changed to dashboard.

The reason being that these aren't popovers but rather routes. But these routes doesnt change the url in the browser history. So we could use this route history to display the "true route in the background". And all should work normally as the foreground app, on its close, just takes the current history url and applies it as a route.

## Notes for QA

Stuff should work normally. Only UI/UX should be better when opening foreground apps - device switcher, firmware update modal.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24777

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=24777-keep-the-background-route-on-foreground-route&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=24777-keep-the-background-route-on-foreground-route&lookback=7)