### PR TITLE
fix(e2e-native): skip unstable test suiteSync

### DIFF
--- a/suite-native/app/e2e/tests/suiteSync.test.ts
+++ b/suite-native/app/e2e/tests/suiteSync.test.ts
@@ -40,7 +40,8 @@ conditionalDescribe(device.getPlatform() === 'android', 'Suite Sync [@fixT3W1]',
         await onTabBar.tapBackButton();
     });
 
-    test('Sync account label across sessions', async () => {
+    // Automation is being reworked, skipping for now
+    test.skip('Sync account label across sessions', async () => {
         // Verify account label sync
         await onTabBar.navigateToMyAssets();
         await waitToHaveText(by.id('@accountList/item/title'), ACCOUNT_LABEL);


### PR DESCRIPTION
we are currently working suite sync automation with more stable support methods and approach. In meantime. Skipping this test in native


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=skip-evolu-test-native&lookback=7)