### PR TITLE
fix(suite-sync): don't retrigger suite sync key retrieval

### DIFF
--- a/suite-common/suite-sync/src/suiteSyncMiddleware.ts
+++ b/suite-common/suite-sync/src/suiteSyncMiddleware.ts
@@ -4,18 +4,20 @@ import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { deviceActions, selectDeviceThunk } from '@suite-common/wallet-core';
 import { isTrezorDeviceWithState } from '@suite-common/wallet-utils';
 
-import { selectIsSuiteSyncEnabled } from './suiteSyncSelectors';
-
-// Thunk triggers for which we want to turn on Suite Sync for the currently selected wallet
-const suiteSyncTurnOnTriggers = [
-    // Wallet selected
-    selectDeviceThunk.fulfilled,
-] as const;
+import { selectHasDeviceSuiteSyncError, selectIsSuiteSyncEnabled } from './suiteSyncSelectors';
 
 export const prepareSuiteSyncMiddleware = createMiddlewareWithExtraDeps(
     (action, { next, getState, extra }) => {
-        if (selectIsSuiteSyncEnabled(getState()) && deviceActions.setDiscovered.match(action)) {
-            if (action.payload.success) {
+        if (
+            selectIsSuiteSyncEnabled(getState()) &&
+            deviceActions.setDiscovered.match(action) &&
+            action.payload.success
+        ) {
+            const suiteSyncErrors = selectHasDeviceSuiteSyncError(
+                getState(),
+                action.payload.staticSessionId,
+            );
+            if (!suiteSyncErrors) {
                 extra.services.suiteSync.ensureWalletSuiteSyncOn({
                     deviceStaticSessionId: action.payload.staticSessionId,
                     isWriteMode: false,
@@ -23,14 +25,22 @@ export const prepareSuiteSyncMiddleware = createMiddlewareWithExtraDeps(
             }
         }
 
-        if (selectIsSuiteSyncEnabled(getState()) && isAnyOf(...suiteSyncTurnOnTriggers)(action)) {
-            const { payload } = action as ReturnType<(typeof suiteSyncTurnOnTriggers)[number]>;
+        if (selectIsSuiteSyncEnabled(getState()) && isAnyOf(selectDeviceThunk.fulfilled)(action)) {
+            const { payload } = action as ReturnType<typeof selectDeviceThunk.fulfilled>;
 
-            if (isTrezorDeviceWithState(payload.device)) {
-                extra.services.suiteSync.ensureWalletSuiteSyncOn({
-                    deviceStaticSessionId: payload.device.state.staticSessionId,
-                    isWriteMode: false,
-                });
+            if (isTrezorDeviceWithState(payload.device) && payload.device.discovered) {
+                const suiteSyncErrors = selectHasDeviceSuiteSyncError(
+                    getState(),
+                    payload.device?.state.staticSessionId,
+                );
+
+                // If the device is reselected with already existing error within the session, don't trigger it again.
+                if (!suiteSyncErrors) {
+                    extra.services.suiteSync.ensureWalletSuiteSyncOn({
+                        deviceStaticSessionId: payload.device.state.staticSessionId,
+                        isWriteMode: false,
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- only call suite sync key retrieval if the wallet doesn't already have and error in the app memory
- if `selectDeviceThunk` was called but the wallet wasn't fully discovered yet, we don't ensure the keys (this happens when creating new passphrase wallet)

## Notes for QA
Described in attached issue.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25046

## Screenshots:


https://github.com/user-attachments/assets/de83a41a-23ba-45fa-848f-0f33d996a162


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-sync/duplicate-suite-sync-retrieval&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-sync/duplicate-suite-sync-retrieval&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-sync/duplicate-suite-sync-retrieval&lookback=7)