### PR TITLE
chore: add script for File Watcher to fix Webstorm libs imports

### DIFF
--- a/scripts/fix-libs.js
+++ b/scripts/fix-libs.js
@@ -1,0 +1,14 @@
+/**
+ * This is a utility that is useful for users of Webstorm. It's auto-import adds
+ * a `/libDev/src` a lot, and it's annoying to fix it manually.
+ *
+ * This may be used in as the `File Watchers` script to on-save fix the file automatically.
+ */
+import fs from 'fs';
+
+const file = process.argv[2];
+let text = fs.readFileSync(file, 'utf8');
+
+text = text.replace("/libDev/src';\n", "';\n");
+
+fs.writeFileSync(file, text);


### PR DESCRIPTION
Adds a script utils for Webstorm users to autofix the bad imports. 

File Watcher must be added manually into Webstorm Config. 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-libs-webstorm-import&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-libs-webstorm-import&lookback=7)