### PR TITLE
feat(suite): add device telemetry to logs

### DIFF
--- a/packages/connect/e2e/__fixtures__/index.ts
+++ b/packages/connect/e2e/__fixtures__/index.ts
@@ -53,6 +53,7 @@ export { default as solanaGetPublicKey } from './solanaGetPublicKey';
 export { default as solanaSignTransaction } from './solanaSignTransaction';
 export { default as stellarGetAddress } from './stellarGetAddress';
 export { default as stellarSignTransaction } from './stellarSignTransaction';
+export { default as telemetryGet } from './telemetryGet';
 export { default as tezosGetAddress } from './tezosGetAddress';
 export { default as tezosGetPublicKey } from './tezosGetPublicKey';
 export { default as tezosSignTransaction } from './tezosSignTransaction';

--- a/packages/connect/e2e/__fixtures__/telemetryGet.ts
+++ b/packages/connect/e2e/__fixtures__/telemetryGet.ts
@@ -1,0 +1,24 @@
+export default {
+    method: 'telemetryGet',
+    setup: {
+        mnemonic: 'mnemonic_12',
+    },
+    tests: [
+        {
+            description: 'Load telemetry data',
+            params: {},
+            result: {
+                battery_cycles: 30000,
+                battery_errors: 0,
+                max_temp_c: 35000,
+                min_temp_c: 20000,
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.10.1', '1'],
+                    success: false,
+                },
+            ],
+        },
+    ],
+} satisfies TestCase;

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -51,6 +51,7 @@ export { default as setBusy } from './setBusy';
 export { default as signMessage } from './signMessage';
 export { default as signTransaction } from './signTransaction';
 export { default as unlockPath } from './unlockPath';
+export { default as telemetryGet } from './telemetryGet';
 export { default as thpGetCredentials } from './thpGetCredentials';
 export { default as thpRemoveCredentials } from './thpRemoveCredentials';
 export { default as verifyMessage } from './verifyMessage';

--- a/packages/connect/src/api/telemetryGet.ts
+++ b/packages/connect/src/api/telemetryGet.ts
@@ -1,0 +1,26 @@
+import { MessagesSchema as PROTO } from '@trezor/protobuf';
+import { Assert } from '@trezor/schema-utils';
+
+import { AbstractMethod } from '../core/AbstractMethod';
+
+export default class TelemetryGet extends AbstractMethod<'telemetryGet', PROTO.TelemetryGet> {
+    init() {
+        this.requiredPermissions = ['management'];
+        this.useDeviceState = false;
+        const { payload } = this;
+
+        Assert(PROTO.TelemetryGet, payload);
+
+        this.params = {
+            ...payload,
+        };
+    }
+
+    async run() {
+        const cmd = this.device.getCommands();
+
+        const response = await cmd.typedCall('TelemetryGet', 'Telemetry', this.params);
+
+        return response.message;
+    }
+}

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -363,5 +363,11 @@ export const config: Config = {
                 T2B1: '2.5.3',
             },
         },
+        {
+            capabilities: ['telemetry'],
+            methods: ['telemetryGet'],
+            min: { T1B1: '0', T2T1: '2.10.1', T2B1: '2.10.1', T3B1: '2.10.1', T3T1: '2.10.1' },
+            comment: ['Supported since 2.10.1'],
+        },
     ],
 };

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -93,6 +93,7 @@ export const connectCallableMethods = [
     'solanaSignTransaction',
     'stellarGetAddress',
     'stellarSignTransaction',
+    'telemetryGet',
     'tezosGetAddress',
     'tezosGetPublicKey',
     'tezosSignTransaction',

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -81,6 +81,7 @@ import { solanaGetPublicKey } from './solanaGetPublicKey';
 import { solanaSignTransaction } from './solanaSignTransaction';
 import { stellarGetAddress } from './stellarGetAddress';
 import { stellarSignTransaction } from './stellarSignTransaction';
+import { telemetryGet } from './telemetryGet';
 import { tezosGetAddress } from './tezosGetAddress';
 import { tezosGetPublicKey } from './tezosGetPublicKey';
 import { tezosSignTransaction } from './tezosSignTransaction';
@@ -345,6 +346,9 @@ export interface TrezorConnect {
 
     // https://connect.trezor.io/9/methods/stellar/stellarSignTransaction/
     stellarSignTransaction: typeof stellarSignTransaction;
+
+    // https://connect.trezor.io/9/methods/device/telemetryGet/
+    telemetryGet: typeof telemetryGet;
 
     // https://connect.trezor.io/9/methods/tezos/tezosGetAddress/
     tezosGetAddress: typeof tezosGetAddress;

--- a/packages/connect/src/types/api/telemetryGet.ts
+++ b/packages/connect/src/types/api/telemetryGet.ts
@@ -1,0 +1,4 @@
+import { PROTO } from '../../constants';
+import type { Params, Response } from '../params';
+
+export declare function telemetryGet(params: Params<PROTO.TelemetryGet>): Response<PROTO.Telemetry>;

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -178,6 +178,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 evmApproval: 'no-support',
                 evolu: 'no-support',
                 slip24: 'no-support',
+                telemetry: 'no-support',
                 tutorial: 'no-support',
                 ...T1B1_UPDATE_REQUIRED,
             });
@@ -207,6 +208,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 evmApproval: 'update-required',
                 evolu: 'no-support',
                 slip24: 'update-required',
+                telemetry: 'update-required',
                 tutorial: 'no-support',
                 ...T1B1_UPDATE_REQUIRED,
             });
@@ -240,6 +242,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 evmApproval: 'update-required',
                 evolu: 'update-required',
                 slip24: 'update-required',
+                telemetry: 'update-required',
             });
         });
 
@@ -318,6 +321,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 evmApproval: 'update-required',
                 evolu: 'no-support',
                 slip24: 'update-required',
+                telemetry: 'update-required',
                 tutorial: 'no-support',
                 monero: 'update-required',
                 ...T1B1_UPDATE_REQUIRED,
@@ -347,6 +351,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 evmApproval: 'no-support',
                 evolu: 'no-support',
                 slip24: 'no-support',
+                telemetry: 'no-support',
                 tutorial: 'no-support',
                 monero: 'no-support',
                 ...T1B1_UPDATE_REQUIRED,
@@ -377,6 +382,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 evmApproval: 'no-support',
                 evolu: 'no-support',
                 slip24: 'no-support',
+                telemetry: 'no-support',
                 tutorial: 'no-support',
                 monero: 'no-support',
                 ...T1B1_UPDATE_REQUIRED,

--- a/packages/suite/src/selectors/suite/logsSelectors.ts
+++ b/packages/suite/src/selectors/suite/logsSelectors.ts
@@ -61,6 +61,5 @@ export const selectRedactedDesktopApplicationInfo = (
     transports: selectSuiteTransports(state),
     earlyAccessProgram: selectDesktopUpdateAllowPrerelease(state),
     labeling: selectSelectedLabelsProviderType(state),
-    ...selectRedactedApplicationInfo(state, shouldHideSensitiveData),
     wallets: selectRedactedWallets(state, shouldHideSensitiveData),
 });

--- a/packages/suite/src/utils/suite/logsUtils.ts
+++ b/packages/suite/src/utils/suite/logsUtils.ts
@@ -1,17 +1,30 @@
+import { useEffect } from 'react';
+
 import { prettifyLog, useCommonApplicationLogs } from '@suite-common/logger';
 
-import { useSelector } from 'src/hooks/suite';
-
+import * as modalActions from 'src/actions/suite/modalActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import {
     SuiteLogsApplicationInfoRootState,
     selectRedactedDesktopApplicationInfo,
-} from '../../selectors/suite/logsSelectors';
+} from 'src/selectors/suite/logsSelectors';
 
 export const useApplicationLogs = ({ hideSensitiveInfo }: { hideSensitiveInfo: boolean }) => {
+    const dispatch = useDispatch();
     const commonAppLogs = useCommonApplicationLogs(hideSensitiveInfo);
     const desktopApplicationInfo = useSelector((state: SuiteLogsApplicationInfoRootState) =>
         selectRedactedDesktopApplicationInfo(state, hideSensitiveInfo),
     );
+
+    useEffect(() => {
+        // Preserve modal while fetching device telemetry from Connect
+        // This is required due to CLOSE_UI_WINDOW event
+        dispatch(modalActions.preserve());
+
+        return () => {
+            dispatch(modalActions.removePreserve());
+        };
+    }, [dispatch]);
 
     if (commonAppLogs === null) return null;
 

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -27,7 +27,7 @@ const groups = {
         name: 'management',
         pattern: 'methods',
         includeFilter:
-            'applySettings,applyFlags,getFeatures,getFirmwareHash,changeLanguage,loadDevice',
+            'applySettings,applyFlags,getFeatures,getFirmwareHash,changeLanguage,loadDevice,telemetryGet',
     },
     btcSign: {
         name: 'btc-sign',

--- a/suite-common/logger/package.json
+++ b/suite-common/logger/package.json
@@ -15,6 +15,7 @@
         "@reduxjs/toolkit": "2.11.2",
         "@suite-common/analytics-redux": "workspace:*",
         "@suite-common/device": "workspace:*",
+        "@suite-common/react-query": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",

--- a/suite-common/logger/src/hooks/useCommonApplicationLogs.ts
+++ b/suite-common/logger/src/hooks/useCommonApplicationLogs.ts
@@ -1,8 +1,12 @@
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import { useQuery } from '@suite-common/react-query';
+import TrezorConnect, { PROTO } from '@trezor/connect';
+
 import {
     LogsApplicationInfoRootState,
+    RedactedDevice,
     selectRedactedActionsLog,
     selectRedactedApplicationInfo,
 } from '../logsSelectors';
@@ -22,7 +26,36 @@ export const useCommonApplicationLogs = (hideSensitiveInfo: boolean) => {
         (async () => setEnvInfo(await getEnvironmentInfo()))();
     }, []);
 
-    if (envInfo === null) return null;
+    // Enhance devices info with telemetry data (battery temp, etc.)
+    const devicePaths = new Set(redactedApplicationInfo.devices.map(d => d.path));
+    const { data: devicesWithTelemetry, isLoading } = useQuery({
+        queryKey: ['device-telemetry', ...devicePaths],
+        queryFn: async ({ signal }) => {
+            const _devicesWithTelemetry: (RedactedDevice & { telemetry?: PROTO.Telemetry })[] = [
+                ...redactedApplicationInfo.devices,
+            ];
+            for (const device of _devicesWithTelemetry) {
+                if (signal.aborted) break;
+                const telemetry = await TrezorConnect.telemetryGet({
+                    device: { path: device.path },
+                });
+                if (!telemetry.success) continue;
+                device.telemetry = telemetry.payload;
+            }
 
-    return [{ ...envInfo, startTime, ...redactedApplicationInfo }, redactedActionsLog];
+            return _devicesWithTelemetry;
+        },
+        staleTime: 60 * 1000,
+    });
+    if (envInfo === null || isLoading) return null;
+
+    return [
+        {
+            ...envInfo,
+            startTime,
+            ...redactedApplicationInfo,
+            devices: devicesWithTelemetry ?? redactedApplicationInfo.devices,
+        },
+        redactedActionsLog,
+    ];
 };

--- a/suite-common/logger/src/logsSelectors.ts
+++ b/suite-common/logger/src/logsSelectors.ts
@@ -88,6 +88,7 @@ export const selectRedactedDevices = createApplicationInfoLogsMemoizedSelector(
             A.map(device => ({
                 id: shouldHideSensitiveData ? REDACTED_REPLACEMENT : device.id,
                 label: shouldHideSensitiveData ? REDACTED_REPLACEMENT : device.label,
+                path: device.path, // needed to load telemetry
                 mode: device.mode,
                 connected: device.connected,
                 passphraseProtection: device.features?.passphrase_protection,
@@ -105,6 +106,7 @@ export const selectRedactedDevices = createApplicationInfoLogsMemoizedSelector(
         );
     },
 );
+export type RedactedDevice = ReturnType<typeof selectRedactedDevices>[number];
 
 export const selectRedactedWallets = createApplicationInfoLogsMemoizedSelector(
     [selectDevices, (_state, shouldHideSensitiveData?: boolean) => shouldHideSensitiveData],

--- a/suite-common/logger/tsconfig.json
+++ b/suite-common/logger/tsconfig.json
@@ -4,6 +4,7 @@
     "references": [
         { "path": "../analytics-redux" },
         { "path": "../device" },
+        { "path": "../react-query" },
         { "path": "../redux-utils" },
         { "path": "../suite-types" },
         { "path": "../suite-utils" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11203,6 +11203,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:2.11.2"
     "@suite-common/analytics-redux": "workspace:*"
     "@suite-common/device": "workspace:*"
+    "@suite-common/react-query": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"


### PR DESCRIPTION
## Description

Add device telemetry (used mainly for battery diagnostics) to Connect and use it to enhance data in Suite application logs modal. 

Supported on TS7 with FW 2.10.1+

<img width="746" height="730" alt="Screenshot 2026-02-24 at 14 28 54" src="https://github.com/user-attachments/assets/8c7b95e1-3426-4313-b371-a130becadbc1" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-device-telemetry&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-device-telemetry&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-device-telemetry&lookback=7)