### PR TITLE
Rename firmware update source to firmware channel

### DIFF
--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -99,8 +99,8 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
         settings.localFirmwares = parseLocalFirmwares(input.localFirmwares);
     }
 
-    if (typeof input.firmwareUpdateSource === 'string') {
-        settings.firmwareUpdateSource = input.firmwareUpdateSource;
+    if (typeof input.firmwareChannel === 'string') {
+        settings.firmwareChannel = input.firmwareChannel;
     }
 
     if (Array.isArray(input.transports)) {

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -16,7 +16,7 @@ import { getIntegerInRangeFromString, removeTrailingSlashes, versionUtils } from
 
 import { DataManager } from './DataManager';
 import { Features, StrictFeatures } from '../types/device';
-import { FirmwareReleaseConfigInfo, FirmwareUpdateSource } from '../types/firmware';
+import { FirmwareChannel, FirmwareReleaseConfigInfo } from '../types/firmware';
 import { getReleaseAsset, getReleasesAssetByDeviceModelAndFirmwareType } from '../utils/assetUtils';
 import { httpRequest } from '../utils/assets';
 import {
@@ -56,7 +56,7 @@ const UNSIGNED_LOCALHOST = {
     BASE_URL: 'http://localhost:3000',
     MIDDLE_PATH: 'firmware/unsigned',
 };
-const FIRMWARE_REMOTE_BASE_URLS: Record<FirmwareUpdateSource, RemoteBaseInfo> = {
+const FIRMWARE_REMOTE_BASE_URLS: Record<FirmwareChannel, RemoteBaseInfo> = {
     production: RELEASES_URL_REMOTE_BASE,
     'test-unsigned': UNSIGNED_URL_REMOTE_BASE,
     'test-unsigned-stable': UNSIGNED_STABLE_URL_REMOTE_BASE,
@@ -65,7 +65,7 @@ const FIRMWARE_REMOTE_BASE_URLS: Record<FirmwareUpdateSource, RemoteBaseInfo> = 
     'localhost-signed': SIGNED_LOCALHOST,
 };
 
-type OnlineFirmwareBaseUrl = RemoteBaseInfo & { env: FirmwareUpdateSource };
+type OnlineFirmwareBaseUrl = RemoteBaseInfo & { env: FirmwareChannel };
 
 /**
  * Obtains the base URL and middle path where to find firmware releases, based on the current settings.
@@ -75,19 +75,19 @@ type OnlineFirmwareBaseUrl = RemoteBaseInfo & { env: FirmwareUpdateSource };
  *   { BASE_URL: 'http://localhost:3000', MIDDLE_PATH: 'firmware/unsigned', env: 'localhost-unsigned' }
  */
 export const getOnlineFirmwareBaseUrl = (): OnlineFirmwareBaseUrl => {
-    const firmwareUpdateSource = DataManager.getSettings('firmwareUpdateSource');
+    const firmwareChannel = DataManager.getSettings('firmwareChannel');
 
-    if (!firmwareUpdateSource) {
-        // If for some reason `firmwareUpdateSource` settings is not set we return production one.
+    if (!firmwareChannel) {
+        // If for some reason `firmwareChannel` settings is not set we return production one.
         return {
             ...FIRMWARE_REMOTE_BASE_URLS['production'],
-            env: 'production' as FirmwareUpdateSource,
+            env: 'production' as FirmwareChannel,
         };
     }
 
     return {
-        ...FIRMWARE_REMOTE_BASE_URLS[firmwareUpdateSource],
-        env: firmwareUpdateSource,
+        ...FIRMWARE_REMOTE_BASE_URLS[firmwareChannel],
+        env: firmwareChannel,
     };
 };
 

--- a/packages/connect/src/types/firmware.ts
+++ b/packages/connect/src/types/firmware.ts
@@ -48,7 +48,7 @@ export type FirmwareUpdateFlowType =
     | 'manual'
     | 'unknown_flow';
 
-export type FirmwareUpdateSource =
+export type FirmwareChannel =
     | 'production'
     | 'test-unsigned'
     | 'test-unsigned-stable'

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -4,7 +4,7 @@ import type { ThpCredentials, ThpPairingMethod } from '@trezor/protocol';
 import type { Transport } from '@trezor/transport';
 import { PartialRecord } from '@trezor/type-utils';
 
-import type { FirmwareUpdateSource } from '../types/firmware';
+import type { FirmwareChannel } from '../types/firmware';
 
 export type { SystemInfo } from '@trezor/connect-common';
 export interface Manifest {
@@ -68,7 +68,7 @@ export interface ConnectSettingsInternal {
     proxy?: Proxy;
     sharedLogger?: boolean;
     localFirmwares?: LocalFirmwares;
-    firmwareUpdateSource?: FirmwareUpdateSource;
+    firmwareChannel?: FirmwareChannel;
 }
 
 export interface ConnectSettingsWeb {

--- a/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
+++ b/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
@@ -5,7 +5,7 @@ import { getFirmwareReleaseJwsPublicKey } from '@trezor/env-utils';
 
 import { firmwareReleaseConfigAssets } from './assetUtils';
 import { getOnlineFirmwareBaseUrl } from '../data/firmwareInfo';
-import { FirmwareUpdateSource } from '../types/firmware';
+import { FirmwareChannel } from '../types/firmware';
 
 const JWS_CONFIG = {
     SIGN_ALGORITHM: 'ES256',
@@ -16,7 +16,7 @@ const JWS_CONFIG = {
 
 type JwsInfo = {
     jws: string;
-    env: FirmwareUpdateSource;
+    env: FirmwareChannel;
 };
 
 const fetchRemoteJws = async (): Promise<JwsInfo> => {

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -134,4 +134,4 @@ export const getFirmwareType = (features: Features) => {
 };
 
 export const isFirmwareCacheUsedForSelectedSource = () =>
-    DataManager.getSettings('firmwareUpdateSource') === 'production';
+    DataManager.getSettings('firmwareChannel') === 'production';

--- a/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
+++ b/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
@@ -35,7 +35,7 @@ const getInitialState = (override: any) => {
             },
         },
         messageSystem: messageSystemInitialState,
-        firmware: { firmwareUpdateSource: 'production' },
+        firmware: { firmwareChannel: 'production' },
     };
     if (override) {
         return mergeDeepObject(defaults, override);

--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -74,7 +74,7 @@ const getInitialState = (initialRun?: boolean) => ({
     messageSystem: messageSystemReducer(undefined, EMPTY_ACTION),
     device: deviceReducer(undefined, EMPTY_ACTION),
     metadata: metadataReducer(undefined, EMPTY_ACTION),
-    firmware: { firmwareUpdateSource: 'production' },
+    firmware: { firmwareChannel: 'production' },
     window: windowReducer({ ...initialBreakpointFlags, isVisible: true }, EMPTY_ACTION),
 });
 

--- a/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
@@ -31,7 +31,7 @@ const getInitialState = (suite?: Partial<SuiteState>, device?: Partial<DevicesSt
         },
     },
     messageSystem: messageSystemInitialState,
-    firmware: { firmwareUpdateSource: 'production' },
+    firmware: { firmwareChannel: 'production' },
 });
 
 type State = ReturnType<typeof getInitialState>;

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -569,7 +569,7 @@ export const saveFirmwareSettings = () => (_dispatch: Dispatch, getState: GetSta
     db.addItem(
         'firmware',
         {
-            firmwareUpdateSource: firmware.firmwareUpdateSource,
+            firmwareChannel: firmware.firmwareChannel,
         },
         'firmware',
         true,

--- a/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
@@ -79,7 +79,7 @@ const rootReducer = combineReducers({
         () => ({}),
     ),
     messageSystem: createReducer(messageSystemInitialState, () => ({})),
-    firmware: createReducer([{ firmwareUpdateSource: 'production' }], () => ({})),
+    firmware: createReducer([{ firmwareChannel: 'production' }], () => ({})),
 });
 
 interface StateOverrides {

--- a/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
@@ -115,7 +115,7 @@ const getInitialState = (state: Partial<InitialState> | undefined) => ({
         ...state?.device,
     },
     messageSystem: messageSystemInitialState,
-    firmware: { firmwareUpdateSource: 'production' },
+    firmware: { firmwareChannel: 'production' },
 });
 
 type State = ReturnType<typeof getInitialState>;

--- a/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
@@ -31,7 +31,7 @@ const getInitialState = () => ({
         selectedDevice: device,
     },
     messageSystem: messageSystemInitialState,
-    firmware: { firmwareUpdateSource: 'production' },
+    firmware: { firmwareChannel: 'production' },
 });
 
 type State = ReturnType<typeof getInitialState>;

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -270,7 +270,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 api.dispatch(storageActions.saveConnectSettings());
             }
 
-            if (firmwareActions.setFirmwareUpdateSource.match(action)) {
+            if (firmwareActions.setFirmwareChannel.match(action)) {
                 api.dispatch(storageActions.saveFirmwareSettings());
             }
 

--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -21,7 +21,7 @@ import type {
     RatesByTimestamps,
     WalletSettings,
 } from '@suite-common/wallet-types';
-import { FirmwareUpdateSource } from '@trezor/connect/src/types/firmware';
+import { FirmwareChannel } from '@trezor/connect/src/types/firmware';
 
 import type { BioAuthState } from 'src/reducers/bioAuth';
 import type { SuiteState } from 'src/reducers/suite/suiteReducer';
@@ -164,7 +164,7 @@ export interface SuiteDBSchema extends DBSchema {
     firmware: {
         key: 'firmware';
         value: {
-            firmwareUpdateSource: FirmwareUpdateSource;
+            firmwareChannel: FirmwareChannel;
         };
     };
     persistentDeviceData: {

--- a/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx
@@ -36,9 +36,8 @@ export const FirmwareUpdateEnvironmentSelect = () => {
                 description={
                     <Column gap={4}>
                         <Text>
-                            Set firmware channel for testing unsigned and signed. Remember you
-                            have to reload the web app or desktop in order for it to be fully
-                            applied.
+                            Set firmware channel for testing unsigned and signed. Remember you have
+                            to reload the web app or desktop in order for it to be fully applied.
                         </Text>
                         <Text variant="info">
                             If you select production, the binaries will be cached.

--- a/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
-import { firmwareActions, selectFirmwareUpdateSource } from '@suite-common/firmware';
+import { firmwareActions, selectFirmwareChannel } from '@suite-common/firmware';
 import { Column, Text } from '@trezor/components';
-import { FirmwareUpdateSource } from '@trezor/connect/src/types/firmware';
+import { FirmwareChannel } from '@trezor/connect/src/types/firmware';
 
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -12,10 +12,10 @@ const StyledActionSelect = styled(ActionSelect)`
 `;
 
 export const FirmwareUpdateEnvironmentSelect = () => {
-    const firmwareUpdateSource = useSelector(selectFirmwareUpdateSource);
+    const firmwareChannel = useSelector(selectFirmwareChannel);
     const dispatch = useDispatch();
 
-    const options: { label: string; value: FirmwareUpdateSource }[] = [
+    const options: { label: string; value: FirmwareChannel }[] = [
         { label: 'Production', value: 'production' },
         { label: 'Test Unsigned', value: 'test-unsigned' },
         { label: 'Test Unsigned Stable', value: 'test-unsigned-stable' },
@@ -23,21 +23,20 @@ export const FirmwareUpdateEnvironmentSelect = () => {
         { label: 'Localhost Signed', value: 'localhost-signed' },
         { label: 'Localhost Unsigned', value: 'localhost-unsigned' },
     ];
-    const selectedOption =
-        options.find(option => option.value === firmwareUpdateSource) || options[0];
+    const selectedOption = options.find(option => option.value === firmwareChannel) || options[0];
 
-    const handleChange = (item: { value: FirmwareUpdateSource }) => {
-        dispatch(firmwareActions.setFirmwareUpdateSource(item.value));
+    const handleChange = (item: { value: FirmwareChannel }) => {
+        dispatch(firmwareActions.setFirmwareChannel(item.value));
     };
 
     return (
         <SectionItem>
             <TextColumn
-                title="Firmware Update Source"
+                title="Firmware Channel"
                 description={
                     <Column gap={4}>
                         <Text>
-                            Set firmware update source for testing unsigned and signed. Remember you
+                            Set firmware channel for testing unsigned and signed. Remember you
                             have to reload the web app or desktop in order for it to be fully
                             applied.
                         </Text>

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -106,7 +106,7 @@ export const SettingsDebug = () => {
                 <TrezorConnectLogs />
                 {isDesktop() && <ConnectPopup />}
             </SettingsSection>
-            <SettingsSection title="Firmware update source">
+            <SettingsSection title="Firmware channel">
                 <FirmwareUpdateEnvironmentSelect />
             </SettingsSection>
             <SuiteSyncSettings />

--- a/suite-common/connect-init/src/__tests__/connectInitThunks.test.ts
+++ b/suite-common/connect-init/src/__tests__/connectInitThunks.test.ts
@@ -16,7 +16,7 @@ describe('TrezorConnect Actions', () => {
             preloadedState: {
                 wallet: { settings: { enabledNetworks: [] } },
                 device: { selectedDevice: undefined, devices: [] },
-                firmware: { firmwareUpdateSource: 'production' },
+                firmware: { firmwareChannel: 'production' },
                 messageSystem: messageSystemInitialState,
             },
         });

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -1,4 +1,4 @@
-import { selectFirmwareUpdateSource } from '@suite-common/firmware/src/firmwareReducer';
+import { selectFirmwareChannel } from '@suite-common/firmware/src/firmwareReducer';
 import {
     Feature,
     parseTimeoutThresholdsPerModel,
@@ -54,7 +54,7 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
         } = extra;
 
         const getEnabledNetworks = () => selectEnabledNetworks(getState());
-        const getFirmwareUpdateSource = () => selectFirmwareUpdateSource(getState());
+        const getFirmwareChannel = () => selectFirmwareChannel(getState());
 
         // set event listeners and dispatch as
         TrezorConnect.on(DEVICE_EVENT, ({ event: _, ...eventData }) => {
@@ -195,7 +195,7 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
                 thp,
                 debug: showConnectLogs,
                 firmwareHashCheckTimeouts,
-                firmwareUpdateSource: getFirmwareUpdateSource(),
+                firmwareChannel: getFirmwareChannel(),
             });
         } catch (error) {
             let formattedError: string;

--- a/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
+++ b/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { selectFirmwareUpdateSource } from '@suite-common/firmware';
+import { selectFirmwareChannel } from '@suite-common/firmware';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { FIRMWARE } from '@trezor/connect';
@@ -29,7 +29,7 @@ const useCommonData = ({ device }: CommonProps) => {
 const useReportRevisionCheck = ({ device }: CommonProps) => {
     const dispatch = useDispatch();
     const commonData = useCommonData({ device });
-    const firmwareSource = useSelector(selectFirmwareUpdateSource);
+    const firmwareSource = useSelector(selectFirmwareChannel);
 
     const revisionCheck = isDeviceAcquired(device)
         ? device.authenticityChecks.firmwareRevision
@@ -61,7 +61,7 @@ const useReportRevisionCheck = ({ device }: CommonProps) => {
 const useReportHashCheck = ({ device }: CommonProps) => {
     const dispatch = useDispatch();
     const commonData = useCommonData({ device });
-    const firmwareSource = useSelector(selectFirmwareUpdateSource);
+    const firmwareSource = useSelector(selectFirmwareChannel);
 
     const hashCheck = isDeviceAcquired(device) ? device.authenticityChecks.firmwareHash : null;
     const isError = hashCheck && !hashCheck.success;

--- a/suite-common/firmware/src/firmwareActions.ts
+++ b/suite-common/firmware/src/firmwareActions.ts
@@ -2,7 +2,7 @@ import { createAction } from '@reduxjs/toolkit';
 
 import { FirmwareStatus, TrezorDevice } from '@suite-common/suite-types';
 import { FirmwareType } from '@trezor/connect';
-import type { FirmwareUpdateSource } from '@trezor/connect/src/types/firmware';
+import type { FirmwareChannel } from '@trezor/connect/src/types/firmware';
 
 export const FIRMWARE_MODULE_PREFIX = '@common/wallet-core/firmware';
 
@@ -55,9 +55,9 @@ const cacheDevice = createAction(
     }),
 );
 
-const setFirmwareUpdateSource = createAction(
-    `${FIRMWARE_MODULE_PREFIX}/set-firmware-update-source`,
-    (payload: FirmwareUpdateSource) => ({
+const setFirmwareChannel = createAction(
+    `${FIRMWARE_MODULE_PREFIX}/set-firmware-channel`,
+    (payload: FirmwareChannel) => ({
         payload,
     }),
 );
@@ -71,5 +71,5 @@ export const firmwareActions = {
     resetReducer,
     toggleUseDevkit,
     cacheDevice,
-    setFirmwareUpdateSource,
+    setFirmwareChannel,
 };

--- a/suite-common/firmware/src/firmwareReducer.ts
+++ b/suite-common/firmware/src/firmwareReducer.ts
@@ -11,7 +11,7 @@ import {
     FirmwareType,
     UI,
 } from '@trezor/connect';
-import { FirmwareUpdateSource } from '@trezor/connect/src/types/firmware';
+import { FirmwareChannel } from '@trezor/connect/src/types/firmware';
 
 import { firmwareActions } from './firmwareActions';
 
@@ -28,7 +28,7 @@ type FirmwareUpdateCommon = {
     targetType?: FirmwareType;
     useDevkit: boolean;
     uiEvent?: FirmwareUpdateUiEvent;
-    firmwareUpdateSource: FirmwareUpdateSource;
+    firmwareChannel: FirmwareChannel;
     switchFirmwareType: boolean;
 };
 
@@ -49,7 +49,7 @@ const initialState: FirmwareUpdateState = {
     targetType: undefined,
     useDevkit: false,
     uiEvent: undefined,
-    firmwareUpdateSource: 'production',
+    firmwareChannel: 'production',
     switchFirmwareType: false, // NOTE: flag that indicates when the user intents to change the type of FW universal -> bitcoin-only
 };
 
@@ -59,7 +59,7 @@ type RootState = {
 
 type StorageActionPayload = {
     firmware: {
-        firmwareUpdateSource: FirmwareUpdateSource;
+        firmwareChannel: FirmwareChannel;
     };
 };
 
@@ -68,8 +68,7 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, (
         .addCase(
             extra.actionTypes.storageLoad,
             (state, { payload }: PayloadAction<StorageActionPayload>) => {
-                if (payload.firmware)
-                    state.firmwareUpdateSource = payload.firmware.firmwareUpdateSource;
+                if (payload.firmware) state.firmwareChannel = payload.firmware.firmwareChannel;
             },
         )
         .addCase(firmwareActions.setStatus, (state, { payload }) => {
@@ -90,7 +89,7 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, (
         })
         .addCase(firmwareActions.resetReducer, state => ({
             ...initialState,
-            firmwareUpdateSource: state.firmwareUpdateSource,
+            firmwareChannel: state.firmwareChannel,
             useDevkit: state.useDevkit,
         }))
         .addCase(firmwareActions.toggleUseDevkit, (state, { payload }) => {
@@ -99,8 +98,8 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, (
         .addCase(firmwareActions.cacheDevice, (state, { payload }) => {
             state.cachedDevice = payload;
         })
-        .addCase(firmwareActions.setFirmwareUpdateSource, (state, { payload }) => {
-            state.firmwareUpdateSource = payload;
+        .addCase(firmwareActions.setFirmwareChannel, (state, { payload }) => {
+            state.firmwareChannel = payload;
         })
         .addMatcher<FirmwareUpdateUiEvent>(
             (action: FirmwareUpdateUiEvent) =>
@@ -120,7 +119,7 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, (
 
 export const selectFirmware = (state: RootState) => state.firmware;
 export const selectUseDevkit = (state: RootState) => state.firmware.useDevkit;
-export const selectFirmwareUpdateSource = (state: RootState) => state.firmware.firmwareUpdateSource;
+export const selectFirmwareChannel = (state: RootState) => state.firmware.firmwareChannel;
 export const selectSwitchFirmwareType = (state: RootState) => state.firmware.switchFirmwareType;
 
 export const selectIsFirmwareInstallationRunning = (state: RootState) =>

--- a/suite-common/thp/tests/autoInitThpAfterDeviceConnectionThunk.test.ts
+++ b/suite-common/thp/tests/autoInitThpAfterDeviceConnectionThunk.test.ts
@@ -25,7 +25,7 @@ const initialFirmwareState: FirmwareUpdateState = {
     targetType: undefined,
     uiEvent: undefined,
     useDevkit: false,
-    firmwareUpdateSource: 'production',
+    firmwareChannel: 'production',
     switchFirmwareType: false,
 };
 

--- a/suite-common/thp/tests/connectThpDeviceThunk.test.ts
+++ b/suite-common/thp/tests/connectThpDeviceThunk.test.ts
@@ -27,7 +27,7 @@ const initialFirmwareState: FirmwareUpdateState = {
     targetType: undefined,
     uiEvent: undefined,
     useDevkit: false,
-    firmwareUpdateSource: 'production',
+    firmwareChannel: 'production',
     switchFirmwareType: false,
 };
 

--- a/suite-native/module-dev-utils/src/components/FirmwareSourceCard.tsx
+++ b/suite-native/module-dev-utils/src/components/FirmwareSourceCard.tsx
@@ -1,12 +1,12 @@
 import { Card, Text, VStack } from '@suite-native/atoms';
 
-import { FirmwareUpdateEnvironmentSelect } from './FirmwareUpdateEnvironmentSelect';
+import { FirmwareUpdateChannelSelect } from './FirmwareUpdateChannelSelect';
 
 export const FirmwareSourceCard = () => (
     <Card>
         <VStack spacing="sp12">
             <Text variant="titleSmall">Firmware Source</Text>
-            <FirmwareUpdateEnvironmentSelect />
+            <FirmwareUpdateChannelSelect />
         </VStack>
     </Card>
 );

--- a/suite-native/module-dev-utils/src/components/FirmwareUpdateChannelSelect.tsx
+++ b/suite-native/module-dev-utils/src/components/FirmwareUpdateChannelSelect.tsx
@@ -3,26 +3,26 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { reloadAppAsync } from 'expo';
 
-import { firmwareActions, selectFirmwareUpdateSource } from '@suite-common/firmware';
+import { firmwareActions, selectFirmwareChannel } from '@suite-common/firmware';
 import { useAlert } from '@suite-native/alerts';
 import { Select, SelectItemType } from '@suite-native/atoms';
-import { FirmwareUpdateSource } from '@trezor/connect/src/types/firmware';
+import { FirmwareChannel } from '@trezor/connect/src/types/firmware';
 
-const options: SelectItemType<FirmwareUpdateSource>[] = [
+const options: SelectItemType<FirmwareChannel>[] = [
     { label: 'Production', value: 'production' },
     { label: 'Test Unsigned', value: 'test-unsigned' },
     { label: 'Test Unsigned Stable', value: 'test-unsigned-stable' },
     { label: 'Test Signed', value: 'test-signed' },
 ];
 
-export const FirmwareUpdateEnvironmentSelect = () => {
+export const FirmwareUpdateChannelSelect = () => {
     const dispatch = useDispatch();
     const { showAlert } = useAlert();
 
-    const selectedFirmwareUpdateSource = useSelector(selectFirmwareUpdateSource);
+    const selectedFirmwareChannel = useSelector(selectFirmwareChannel);
 
-    const handleSelectEnvironment = (environment: FirmwareUpdateSource) => {
-        dispatch(firmwareActions.setFirmwareUpdateSource(environment));
+    const handleSelectEnvironment = (environment: FirmwareChannel) => {
+        dispatch(firmwareActions.setFirmwareChannel(environment));
         showAlert({
             title: 'Restart the app to apply the change?',
             primaryButtonTitle: 'Restart',
@@ -32,10 +32,10 @@ export const FirmwareUpdateEnvironmentSelect = () => {
     };
 
     return (
-        <Select<FirmwareUpdateSource>
-            title="Environment"
+        <Select<FirmwareChannel>
+            title="Channel"
             items={options}
-            value={selectedFirmwareUpdateSource}
+            value={selectedFirmwareChannel}
             onSelectItem={handleSelectEnvironment}
             isLabelShown
         />

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -285,7 +285,7 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
         reducer: firmwareReducer,
         key: 'firmware',
         version: 1,
-        persistedKeys: ['firmwareUpdateSource'],
+        persistedKeys: ['firmwareChannel'],
         storage: deps.mmkvStorage,
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changing the name from `firmwareUpdateSource` to `firmwareChannel` since
the way we are using it is like chanels for the firmware.

Also it is a preparation to add new firmware channel for Early Access
Program (EAP) in Suite.

## Notes for QA
Nothing to test

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/rename-firmwareUpdateSource-to-firmwareChannel&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/rename-firmwareUpdateSource-to-firmwareChannel&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/rename-firmwareUpdateSource-to-firmwareChannel&lookback=7)