### PR TITLE
feat(suite): improve error message for device locked state

### DIFF
--- a/packages/suite/src/components/suite/getMessageId.tsx
+++ b/packages/suite/src/components/suite/getMessageId.tsx
@@ -97,10 +97,10 @@ export const getMessageId = ({
             heading: 'TR_FIRMWARE_CORRUPTED_CONNECT_TITLE',
             description: 'TR_FIRMWARE_CORRUPTED_CONNECT_DESCRIPTION',
         },
-        'device-busy': defaultKey, // TODO: device returned Busy error - we don't know exactly why it depends on the workflow
-        'device-rebooting': defaultKey, // TODO: device is booting to normal mode
-        'device-bootloader-locked': defaultKey, // TODO: device is  a) rebooting or b) its was rebooted to bootloader
-        'device-hard-locked': defaultKey, // TODO: device is hard locked and will not respond to messages, unlock it
+        'device-busy': { heading: 'TR_NEEDS_ATTENTION_DEVICE_BUSY' }, // device returned Busy error - we don't know exactly why it depends on the workflow
+        'device-rebooting': { heading: 'TR_RESTARTING_TREZOR' }, // device is booting to normal mode
+        'device-bootloader-locked': { heading: 'TR_NEEDS_ATTENTION_DEVICE_LOCKED' }, // device is  a) rebooting or b) its was rebooted to bootloader
+        'device-hard-locked': { heading: 'TR_NEEDS_ATTENTION_DEVICE_LOCKED' }, // device is hard locked and will not respond to messages, unlock it
         'device-disconnect-required': {
             heading: 'TR_INITIAL_RECONNECT_DEVICE_TITLE',
             description: 'TR_INITIAL_RECONNECT_DEVICE_DESCRIPTION',

--- a/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
@@ -39,13 +39,13 @@ const getDeviceNeedsAttentionMessage = (
         case 'device-busy':
             return 'TR_NEEDS_ATTENTION_DEVICE_BUSY';
         case 'device-bootloader-locked':
-            return 'TR_NEEDS_ATTENTION_DEVICE_BUSY'; // TODO
+            return 'TR_NEEDS_ATTENTION_DEVICE_LOCKED';
         case 'device-hard-locked':
-            return 'TR_NEEDS_ATTENTION_DEVICE_BUSY'; // TODO
+            return 'TR_NEEDS_ATTENTION_DEVICE_LOCKED';
         case 'device-pin-locked':
-            return 'TR_NEEDS_ATTENTION_DEVICE_BUSY'; // TODO
+            return 'TR_NEEDS_ATTENTION_DEVICE_LOCKED';
         case 'device-rebooting':
-            return 'TR_NEEDS_ATTENTION_DEVICE_BUSY'; // TODO
+            return 'TR_RESTARTING_TREZOR';
 
         case 'connected':
         case 'disconnected':

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1911,6 +1911,10 @@ export const messages = defineMessages({
         defaultMessage: 'Trezor detected in incorrect state. Restart it to reconnect.',
         id: 'TR_NEEDS_ATTENTION_DEVICE_BUSY',
     },
+    TR_NEEDS_ATTENTION_DEVICE_LOCKED: {
+        defaultMessage: 'Trezor is locked. Please unlock it to continue.',
+        id: 'TR_NEEDS_ATTENTION_DEVICE_LOCKED',
+    },
     TR_DEVICE_CONNECTED_BUSY_BOOTLOADER: {
         defaultMessage: 'Trezor is already in use',
         id: 'TR_DEVICE_CONNECTED_BUSY_BOOTLOADER',


### PR DESCRIPTION
## Description

Finish correct error messages for device busy-locked states

Resolve #25040

### Screenshots

<img width="384" height="198" alt="Screenshot 2026-02-09 at 14 28 09" src="https://github.com/user-attachments/assets/cae05468-cf68-4f91-862f-be893ea3107d" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=device-busy-translate-messages&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=device-busy-translate-messages&lookback=7)