### PR TITLE
refactor(suite): separate thpState (pairing) from autoconnectStep (after pairing)

### DIFF
--- a/packages/suite/src/components/connection/thp/ThpGlobalModalManager.tsx
+++ b/packages/suite/src/components/connection/thp/ThpGlobalModalManager.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { selectThpStep } from '@suite-common/thp';
+import { selectThpAutoconnectStep, selectThpStep } from '@suite-common/thp';
 import { selectSelectedFirstThpDevice } from '@suite-common/wallet-core';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -14,8 +14,13 @@ import { ThpPairingFailedModal } from './ThpPairingFailedModal';
 export const ThpGlobalModalManager = () => {
     const device = useSelector(selectSelectedFirstThpDevice);
     const thpStep = useSelector(selectThpStep);
+    const thpAutoconnectStep = useSelector(selectThpAutoconnectStep);
 
-    if (device !== undefined && thpStep !== null) {
+    if (!device) {
+        return null;
+    }
+
+    if (thpStep !== null) {
         switch (thpStep) {
             // handled in FirmwareModal and onboarding FirmwareStep
             case 'BeforeConnectionInfo':
@@ -28,12 +33,18 @@ export const ThpGlobalModalManager = () => {
                 return <ThpPairingPinEntryModal />;
             case 'CodeInvalid':
                 return <ThpPairingFailedModal />;
-            case 'AutoconnectInfo':
-                return <ThpAutoconnectInfoModal device={device} />;
-            case 'Autoconnect':
-                return <ThpAutoconnectionModal device={device} />;
             default:
                 return exhaustive(thpStep);
         }
     }
+
+    if (thpAutoconnectStep === 'AutoconnectInfo') {
+        return <ThpAutoconnectInfoModal device={device} />;
+    }
+
+    if (thpAutoconnectStep === 'Autoconnect') {
+        return <ThpAutoconnectionModal device={device} />;
+    }
+
+    return null;
 };

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -1,7 +1,7 @@
 import { connectPopupCallThunkInner } from '@suite-common/connect-popup';
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
-import { selectThpStep } from '@suite-common/thp';
+import { selectThpAutoconnectStep } from '@suite-common/thp';
 import {
     accountsActions,
     changeNetworks,
@@ -56,7 +56,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
 
         // delay discovery if THP Autoconnect modal is open (discovery executed by the modal), as it is the only
         // THP step that takes place *after* device acquisition, and also needs device interaction to complete.
-        const isTHPAutoconnectModal = selectThpStep(getState()) === 'AutoconnectInfo';
+        const isTHPAutoconnectModal = selectThpAutoconnectStep(getState()) === 'AutoconnectInfo';
         const isUIReady = !isTHPAutoconnectModal;
 
         if (

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -23,6 +23,7 @@ export const initialAppState: AppState = {
     bluetooth: initialDesktopBluetoothState,
     thp: {
         step: null,
+        autoconnectStep: null,
         lastThpCode: undefined,
         credentials: [],
     },

--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -71,13 +71,6 @@ export const FirmwareModal = ({
                 case 'CodeEntry':
                     return device !== undefined ? <StepThpPairing modalHeading={heading} /> : null;
 
-                // Auto-connect not relevant for Firmware Installation.
-                // We don't want to ask the user for autoconnect during FW installation, instead we
-                // postpone it for the next connection.
-                case 'AutoconnectInfo':
-                case 'Autoconnect':
-                    return null;
-
                 case 'CodeInvalid':
                     return <StepThpFailed modalHeading={heading} />;
 

--- a/packages/suite/src/views/onboarding/steps/FirmwareStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep/index.tsx
@@ -155,14 +155,6 @@ export const FirmwareStep = () => {
                 return <ThpPairingConfirmStep device={device} />;
             case 'CodeEntry':
                 return <ThpPairingStep />;
-
-            // Auto-connect not relevant for Onboarding Firmware Installation.
-            // 1) We don't want to ask user for autoconnect during FW installation.
-            // 2) It shall never happen anyway, onboarding is the 1st connection.
-            case 'AutoconnectInfo':
-            case 'Autoconnect':
-                return null;
-
             case 'CodeInvalid':
                 return <ThpPairingFailedStep />;
 

--- a/suite-common/thp/src/finishThpAutoconnectThunk.ts
+++ b/suite-common/thp/src/finishThpAutoconnectThunk.ts
@@ -11,7 +11,7 @@ import { THP_PREFIX, thpActions } from './thpActions';
 export const finishThpAutoconnectThunk = createThunk<void, void, void>(
     `${THP_PREFIX}/finishThpAutoconnectThunk`,
     (_, { dispatch }) => {
-        dispatch(thpActions.finishThpFlow());
+        dispatch(thpActions.finishAutoconnectFlow());
         dispatch(startOrRestartDiscoveryThunk());
     },
 );

--- a/suite-common/thp/src/index.ts
+++ b/suite-common/thp/src/index.ts
@@ -5,6 +5,7 @@ export {
     selectThp,
     selectIsThpInProgress,
     selectThpStep,
+    selectThpAutoconnectStep,
     selectThpLastResult,
     selectThpCredentials,
 } from './thpSelectors';

--- a/suite-common/thp/src/thpActions.ts
+++ b/suite-common/thp/src/thpActions.ts
@@ -11,6 +11,8 @@ const finishThpFlow = createAction(`${THP_PREFIX}/finish-thp-flow`);
 
 const cancelThpFlow = createAction(`${THP_PREFIX}/cancel-thp-flow`);
 
+const finishAutoconnectFlow = createAction(`${THP_PREFIX}/finish-autoconnect-flow`);
+
 export const showAutoconnectInfo = createAction(`${THP_PREFIX}/showAutoconnectInfo`);
 
 export const setLastThpCode = createAction(
@@ -46,6 +48,7 @@ export const removeAllCredentials = createAction(`${THP_PREFIX}/removeAllCredent
 export const thpActions = {
     invalidCode,
     finishThpFlow,
+    finishAutoconnectFlow,
     addCredential,
     cancelThpFlow,
     removeCredentials,

--- a/suite-common/thp/src/thpReducer.ts
+++ b/suite-common/thp/src/thpReducer.ts
@@ -29,14 +29,15 @@ export type ThpStep =
     | 'ConfirmOnlyConnection'
     | 'CodeEntry'
     | 'CodeInvalid'
-    | 'AutoconnectInfo'
-    | 'Autoconnect'
     // Currently relevant only for Firmware Update / Custom Firmware & Onboarding Firmware
     | 'BeforeConnectionInfo'
     | null;
 
+export type ThpAutoconnectStep = 'AutoconnectInfo' | 'Autoconnect';
+
 export type ThpState = {
     step: ThpStep;
+    autoconnectStep: ThpAutoconnectStep | null;
     lastThpCode?: string;
     lastResult?: 'finished' | 'canceled';
     credentials: ThpSuiteCredentials[];
@@ -44,6 +45,7 @@ export type ThpState = {
 
 export const initialThpState: ThpState = {
     step: null,
+    autoconnectStep: null,
     lastThpCode: undefined,
     lastResult: undefined,
     credentials: [] as ThpSuiteCredentials[],
@@ -65,7 +67,7 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
                 state.lastThpCode = payload.code;
             })
             .addCase(thpActions.showAutoconnectInfo, state => {
-                state.step = 'AutoconnectInfo';
+                state.autoconnectStep = 'AutoconnectInfo';
             })
             .addCase(thpActions.incrementCredentialConnectionCounter, (state, { payload }) => {
                 const credentialToUpdate = state.credentials.find(
@@ -103,6 +105,9 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
                 state.step = null;
                 state.lastResult = 'canceled';
             })
+            .addCase(thpActions.finishAutoconnectFlow, state => {
+                state.autoconnectStep = null;
+            })
             .addMatcher(
                 action => action.type === UI.REQUEST_THP_PAIRING,
                 state => {
@@ -129,7 +134,7 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
                             state.step = 'ConfirmOnlyConnection';
                             break;
                         case 'thp_autoconnect_credential_request':
-                            state.step = 'Autoconnect';
+                            state.autoconnectStep = 'Autoconnect';
                             break;
                     }
                 },
@@ -157,7 +162,7 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
                             state.step = 'ConfirmOnlyConnection';
                         }
                         if (action.payload.name === 'thp_autoconnect_credential_request') {
-                            state.step = 'Autoconnect';
+                            state.autoconnectStep = 'Autoconnect';
                         }
                     }
                 },

--- a/suite-common/thp/src/thpSelectors.ts
+++ b/suite-common/thp/src/thpSelectors.ts
@@ -10,6 +10,8 @@ export const selectIsThpInProgress = (state: ThpRootState) => state.thp.step !==
 
 export const selectThpStep = (state: ThpRootState) => state.thp.step;
 
+export const selectThpAutoconnectStep = (state: ThpRootState) => state.thp.autoconnectStep;
+
 export const selectThpLastResult = (state: ThpRootState) => state.thp.lastResult;
 
 export const selectThpCredentials = (state: ThpRootState) => state.thp.credentials;

--- a/suite-common/thp/tests/autoInitThpAfterDeviceConnectionThunk.test.ts
+++ b/suite-common/thp/tests/autoInitThpAfterDeviceConnectionThunk.test.ts
@@ -17,7 +17,12 @@ const deviceReduce = prepareDeviceReducer(extraDependenciesCommonMock);
 const device = mockConnectDevice({
     thp: createDeviceThp(),
 });
-const initialThpState: ThpState = { step: null, lastThpCode: undefined, credentials: [] };
+const initialThpState: ThpState = {
+    step: null,
+    autoconnectStep: null,
+    lastThpCode: undefined,
+    credentials: [],
+};
 const initialFirmwareState: FirmwareUpdateState = {
     error: '',
     cachedDevice: undefined,

--- a/suite-common/thp/tests/connectThpDeviceThunk.test.ts
+++ b/suite-common/thp/tests/connectThpDeviceThunk.test.ts
@@ -16,6 +16,7 @@ const thpCredential2 = createCredential({ credential: 'credential-2' });
 
 const initialThpState: ThpState = {
     step: null,
+    autoconnectStep: null,
     lastThpCode: undefined,
     credentials: [thpCredential1, thpCredential2],
 };
@@ -62,7 +63,7 @@ describe(connectThpDeviceThunk.name, () => {
             store.dispatch(connectThpDeviceThunk({ device }));
             expect(store.getState().thp.credentials[0].connectionCounter).toEqual(expectedCounter);
             expect(store.getState().thp.credentials[1].connectionCounter).toEqual(0);
-            expect(store.getState().thp.step).toEqual(expectedStep);
+            expect(store.getState().thp.autoconnectStep).toEqual(expectedStep);
         },
     );
 

--- a/suite-common/thp/tests/thpReducer.test.ts
+++ b/suite-common/thp/tests/thpReducer.test.ts
@@ -11,6 +11,7 @@ const thpReduce = prepareThpReducer(extraDependenciesCommonMock);
 
 const initialState: ThpState = {
     step: null,
+    autoconnectStep: null,
     lastThpCode: undefined,
     lastResult: undefined,
     credentials: [],

--- a/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
+++ b/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
@@ -316,7 +316,7 @@ export const deviceConnectBlockedFixtures: NoNavigationFixture[] = [
     {
         description: 'blocks navigation when auto-connect offered',
         initialState: buildInitialState({
-            thp: { step: 'AutoconnectInfo' },
+            thp: { autoconnectStep: 'AutoconnectInfo' },
         }),
         action: {
             type: deviceActions.connectDevice.type,

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -10,7 +10,7 @@ import {
     getIsDeviceDescriptorApiTypeBluetooth,
     getIsDeviceInitialized,
 } from '@suite-common/suite-utils';
-import { isThpPairingUIRequestButtonAction, selectThpStep } from '@suite-common/thp';
+import { isThpPairingUIRequestButtonAction, selectThpAutoconnectStep } from '@suite-common/thp';
 import {
     deviceActions,
     selectDevices,
@@ -158,7 +158,7 @@ deviceConnectionMiddleware.startListening({
         }
 
         // In case auto-connect is offered, we don't want to interfere with the flow.
-        if (selectThpStep(getState()) === 'AutoconnectInfo') return;
+        if (selectThpAutoconnectStep(getState()) === 'AutoconnectInfo') return;
 
         // If device is authorized already (usually in case of remembered device which has already been authorized)
         // We need to use the state before we add connected device to the array so we find out whether it was previously remembered

--- a/suite-native/module-authorize-device/src/screens/thp/ThpConfirmationScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/thp/ThpConfirmationScreen.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import { selectThpStep } from '@suite-common/thp';
+import { selectThpAutoconnectStep, selectThpStep } from '@suite-common/thp';
 import { useAlert } from '@suite-native/alerts';
 import { ContinueOnTrezorScreenContent } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
@@ -31,6 +31,7 @@ export const ThpConfirmationScreen = ({
     const { startThpAutoconnect, ignoreThpAutoconnect } = useThpAutoconnectActions();
 
     const thpStep = useSelector(selectThpStep);
+    const thpAutoconnectStep = useSelector(selectThpAutoconnectStep);
     const isThpScreenDismissable = useSelector(selectIsThpScreenDismissable);
 
     const { showAlert } = useAlert();
@@ -50,13 +51,14 @@ export const ThpConfirmationScreen = ({
         useCallback(() => {
             if (thpStep === 'CodeEntry') {
                 navigation.replace(AuthorizeDeviceStackRoutes.ThpCodeEntry);
-            } else if (thpStep === 'AutoconnectInfo') {
+            } else if (thpAutoconnectStep === 'AutoconnectInfo') {
                 showThpAutoconnectEnableAlert();
             } else if (isThpScreenDismissable) {
                 navigateToInitialScreen();
             }
         }, [
             thpStep,
+            thpAutoconnectStep,
             isThpScreenDismissable,
             navigateToInitialScreen,
             navigation,

--- a/suite-native/module-authorize-device/src/selectors.ts
+++ b/suite-native/module-authorize-device/src/selectors.ts
@@ -1,11 +1,18 @@
 import { createWeakMapSelector } from '@suite-common/redux-utils';
-import { ThpRootState, selectThpLastResult, selectThpStep } from '@suite-common/thp';
+import {
+    ThpRootState,
+    selectThpAutoconnectStep,
+    selectThpLastResult,
+    selectThpStep,
+} from '@suite-common/thp';
 import { DeviceRootState, selectIsDeviceThpLocked } from '@suite-common/wallet-core';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<ThpRootState & DeviceRootState>();
 
 export const selectIsThpScreenDismissable = createMemoizedSelector(
-    [selectThpStep, selectThpLastResult, selectIsDeviceThpLocked],
-    (thpStep, thpLastResult, isDeviceThpLocked) =>
-        thpStep === null && (thpLastResult === 'canceled' || !isDeviceThpLocked),
+    [selectThpStep, selectThpAutoconnectStep, selectThpLastResult, selectIsDeviceThpLocked],
+    (thpStep, thpAutoconnectStep, thpLastResult, isDeviceThpLocked) =>
+        thpStep === null &&
+        thpAutoconnectStep === null &&
+        (thpLastResult === 'canceled' || !isDeviceThpLocked),
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Cherrypicked from https://github.com/trezor/trezor-suite/pull/24952 for easier review

separate thpReducer.state and thpReducer.autoconnectState,those are two different workflows:
- if pairing workflow fails then device is unacquired and thp-locked
- if autoconnect workflow fails then it is just an error (for example Canceled)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/suite-thp-reducer-step&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/suite-thp-reducer-step&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/suite-thp-reducer-step&lookback=7)