### PR TITLE
Trading: Set caret color to iconDefault in account list

### DIFF
--- a/suite-native/module-trading/src/components/general/AccountList/AccountListBaseItem.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListBaseItem.tsx
@@ -140,7 +140,7 @@ export const AccountListBaseItem = ({
                     <Box justifyContent="center">
                         <Icon
                             name="caretRight"
-                            color="textSecondaryHighlight"
+                            color="iconDefault"
                             accessibilityHint={translate('moduleTrading.accountScreen.step2Hint')}
                         />
                     </Box>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Caret color updated.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #25053 

## Screenshots:
### Before
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-02-09 at 14 12 43" src="https://github.com/user-attachments/assets/22d42772-82c9-4ed9-8414-dc255d377cc4" /> <img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-02-09 at 14 12 15" src="https://github.com/user-attachments/assets/8f15450d-a33c-40ed-be38-c1fb1ab9f1d9" />

### After
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-02-09 at 14 18 27" src="https://github.com/user-attachments/assets/3d0d08ea-29a2-4880-b1f2-f340e3979c30" /> <img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-02-09 at 14 18 56" src="https://github.com/user-attachments/assets/e57dfacf-172d-419d-b6e1-622dbe2e699b" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=25053-mobile-trading-caret-in-receive-account-list-has-wrong-color&lookback=7)