### PR TITLE
feat(trading): implement provider terms in footer

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingFooter/TradingFooter.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFooter/TradingFooter.tsx
@@ -13,13 +13,9 @@ type TradingFooterProps = {
 
 export const TradingFooter = ({ provider }: TradingFooterProps) => {
     const currentProviderMetadata = useSelector(selectTradingProviderMetadata);
-    const providerMetadata = provider ?? currentProviderMetadata;
+    const { companyName, termsUrl } = provider ?? currentProviderMetadata ?? {};
 
-    const providerName = providerMetadata?.companyName ? (
-        providerMetadata.companyName
-    ) : (
-        <Translation id="TR_TERMS_PROVIDER_PLACEHOLDER" />
-    );
+    const providerName = companyName ?? <Translation id="TR_TERMS_PROVIDER_PLACEHOLDER" />;
 
     return (
         <Column alignItems="center" margin={{ top: 48 }} gap={12}>
@@ -29,11 +25,7 @@ export const TradingFooter = ({ provider }: TradingFooterProps) => {
                     values={{
                         provider: providerName,
                         comp: chunks =>
-                            providerMetadata?.termsUrl ? (
-                                <Link href={providerMetadata.termsUrl}>{providerName}</Link>
-                            ) : (
-                                chunks
-                            ),
+                            termsUrl ? <Link href={termsUrl}>{providerName}</Link> : chunks,
                     }}
                 />
             </Text>

--- a/packages/suite/src/views/wallet/trading/common/TradingFooter/TradingFooter.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFooter/TradingFooter.tsx
@@ -1,6 +1,9 @@
+import { useSelector } from 'react-redux';
+
 import { BuyProviderInfo, ExchangeProviderInfo, SellProviderInfo } from 'invity-api';
 
 import { Translation } from '@suite/intl';
+import { selectTradingProviderMetadata } from '@suite-common/trading';
 import { Column, InfoSegments, Link, Text, Tooltip } from '@trezor/components';
 import { TREZOR_SUITE_TOS_URL, TREZOR_TRADING_LEARN_MORE_URL } from '@trezor/urls';
 
@@ -9,8 +12,11 @@ type TradingFooterProps = {
 };
 
 export const TradingFooter = ({ provider }: TradingFooterProps) => {
-    const providerName = provider?.companyName ? (
-        provider.companyName
+    const currentProviderMetadata = useSelector(selectTradingProviderMetadata);
+    const providerMetadata = provider ?? currentProviderMetadata;
+
+    const providerName = providerMetadata?.companyName ? (
+        providerMetadata.companyName
     ) : (
         <Translation id="TR_TERMS_PROVIDER_PLACEHOLDER" />
     );
@@ -23,8 +29,8 @@ export const TradingFooter = ({ provider }: TradingFooterProps) => {
                     values={{
                         provider: providerName,
                         comp: chunks =>
-                            provider?.termsUrl ? (
-                                <Link href={provider.termsUrl}>{providerName}</Link>
+                            providerMetadata?.termsUrl ? (
+                                <Link href={providerMetadata.termsUrl}>{providerName}</Link>
                             ) : (
                                 chunks
                             ),

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferProvider.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferProvider.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 
 import { Translation } from '@suite/intl';
+import { useProviderMetadataChangeEffect } from '@suite-common/trading';
 import { Column, GhostContainer, Icon, Row, SkeletonRectangle, Text } from '@trezor/components';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
@@ -33,6 +34,11 @@ export const TradingSelectedOfferProvider = () => {
 
     const providers = getProvidersInfoProps(context);
     const quote = preselectedQuote ?? getSelectedQuote(context);
+
+    useProviderMetadataChangeEffect(
+        type,
+        quote == null || isAmountEmpty ? undefined : quote?.exchange,
+    );
 
     const onGoToOffers = async () => {
         await goToOffers();

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -23,6 +23,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@suite/intl": "workspace:*",
+        "@testing-library/react": "^16.3.0",
         "@trezor/address-validator": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/connect-plugin-ethereum": "workspace:*",
@@ -36,7 +37,6 @@
     },
     "devDependencies": {
         "@suite-common/test-utils": "workspace:*",
-        "@testing-library/react": "^16.3.0",
         "@types/invity-api": "^1.1.12"
     }
 }

--- a/suite-common/trading/src/__tests__/testUtils.tsx
+++ b/suite-common/trading/src/__tests__/testUtils.tsx
@@ -3,15 +3,17 @@ import { Provider } from 'react-redux';
 
 import { combineReducers } from '@reduxjs/toolkit';
 import { RenderHookOptions, renderHook } from '@testing-library/react';
-import type { BuyProviderInfo, ExchangeProviderInfo, SellProviderInfo } from 'invity-api';
 
 import { configureMockStore } from '@suite-common/test-utils';
 
-import type { BuyInfo } from '../reducers/buyReducer';
-import type { ExchangeInfo } from '../reducers/exchangeReducer';
-import type { SellInfo } from '../reducers/sellReducer';
 import { TradingState, initialState, tradingCommonReducer } from '../reducers/tradingCommonReducer';
 import { regional } from '../regional';
+
+/**
+ * TODO This utility is a temporary solution to simplify testing of trading-related hooks and components.
+ * Is should be moved to the correct place defined in the issue below.
+ * @see https://github.com/trezor/trezor-suite/issues/25138
+ */
 
 export type TradingTestState = {
     wallet: {
@@ -51,19 +53,17 @@ export const createTradingTestState = (
 /**
  * Creates a partial BuyInfo state for testing.
  *
- * @param providerInfos - Map of provider name to BuyProviderInfo
- * @returns Partial BuyInfo with minimal required fields
+ * @param providerInfos - Map of provider name to BuyProviderInfo (or Partial for testing)
+ * @returns BuyInfo-like object for testing (with any type for flexibility)
  *
  * @example
  * ```ts
  * const buyInfo = createBuyInfoState({
- *   changenow: getProviderMetadataFixture('changenow') as BuyProviderInfo
+ *   changenow: getProviderMetadataFixture('changenow') as any
  * });
  * ```
  */
-export const createBuyInfoState = (
-    providerInfos: Record<string, BuyProviderInfo> = {},
-): Partial<BuyInfo> => ({
+export const createBuyInfoState = (providerInfos: Record<string, any> = {}): any => ({
     buyInfo: {
         country: regional.UNKNOWN_COUNTRY,
         providers: [],
@@ -77,12 +77,10 @@ export const createBuyInfoState = (
 /**
  * Creates a partial ExchangeInfo state for testing.
  *
- * @param providerInfos - Map of provider name to ExchangeProviderInfo
- * @returns Partial ExchangeInfo with minimal required fields
+ * @param providerInfos - Map of provider name to ExchangeProviderInfo (or Partial for testing)
+ * @returns ExchangeInfo-like object for testing (with any type for flexibility)
  */
-export const createExchangeInfoState = (
-    providerInfos: Record<string, ExchangeProviderInfo> = {},
-): Partial<ExchangeInfo> => ({
+export const createExchangeInfoState = (providerInfos: Record<string, any> = {}): any => ({
     providerInfos,
     buyCryptoIds: [],
     sellCryptoIds: [],
@@ -91,12 +89,10 @@ export const createExchangeInfoState = (
 /**
  * Creates a partial SellInfo state for testing.
  *
- * @param providerInfos - Map of provider name to SellProviderInfo
- * @returns Partial SellInfo with minimal required fields
+ * @param providerInfos - Map of provider name to SellProviderInfo (or Partial for testing)
+ * @returns SellInfo-like object for testing (with any type for flexibility)
  */
-export const createSellInfoState = (
-    providerInfos: Record<string, SellProviderInfo> = {},
-): Partial<SellInfo> => ({
+export const createSellInfoState = (providerInfos: Record<string, any> = {}): any => ({
     country: regional.UNKNOWN_COUNTRY,
     providerInfos,
     supportedCryptoCurrencies: [],

--- a/suite-common/trading/src/__tests__/testUtils.tsx
+++ b/suite-common/trading/src/__tests__/testUtils.tsx
@@ -1,0 +1,176 @@
+import { ReactNode } from 'react';
+import { Provider } from 'react-redux';
+
+import { combineReducers } from '@reduxjs/toolkit';
+import { RenderHookOptions, renderHook } from '@testing-library/react';
+import type { BuyProviderInfo, ExchangeProviderInfo, SellProviderInfo } from 'invity-api';
+
+import { configureMockStore } from '@suite-common/test-utils';
+
+import type { BuyInfo } from '../reducers/buyReducer';
+import type { ExchangeInfo } from '../reducers/exchangeReducer';
+import type { SellInfo } from '../reducers/sellReducer';
+import { TradingState, initialState, tradingCommonReducer } from '../reducers/tradingCommonReducer';
+import { regional } from '../regional';
+
+export type TradingTestState = {
+    wallet: {
+        trading: TradingState;
+    };
+};
+
+type RenderHookWithTradingStoreOptions<Props> = RenderHookOptions<Props> & {
+    preloadedState?: Partial<TradingTestState>;
+};
+
+/**
+ * Creates a trading test state with proper structure.
+ *
+ * @param overrides - Partial TradingState to merge with initialState
+ * @returns Complete TradingTestState ready for Redux store
+ *
+ * @example
+ * ```ts
+ * const state = createTradingTestState({
+ *   currentProviderMetadata: mockProvider,
+ *   buy: { ...initialState.buy, isLoading: true }
+ * });
+ * ```
+ */
+export const createTradingTestState = (
+    overrides: Partial<TradingState> = {},
+): TradingTestState => ({
+    wallet: {
+        trading: {
+            ...initialState,
+            ...overrides,
+        },
+    },
+});
+
+/**
+ * Creates a partial BuyInfo state for testing.
+ *
+ * @param providerInfos - Map of provider name to BuyProviderInfo
+ * @returns Partial BuyInfo with minimal required fields
+ *
+ * @example
+ * ```ts
+ * const buyInfo = createBuyInfoState({
+ *   changenow: getProviderMetadataFixture('changenow') as BuyProviderInfo
+ * });
+ * ```
+ */
+export const createBuyInfoState = (
+    providerInfos: Record<string, BuyProviderInfo> = {},
+): Partial<BuyInfo> => ({
+    buyInfo: {
+        country: regional.UNKNOWN_COUNTRY,
+        providers: [],
+        defaultAmountsOfFiatCurrencies: {} as any,
+    },
+    providerInfos,
+    supportedCryptoCurrencies: [],
+    supportedFiatCurrencies: [],
+});
+
+/**
+ * Creates a partial ExchangeInfo state for testing.
+ *
+ * @param providerInfos - Map of provider name to ExchangeProviderInfo
+ * @returns Partial ExchangeInfo with minimal required fields
+ */
+export const createExchangeInfoState = (
+    providerInfos: Record<string, ExchangeProviderInfo> = {},
+): Partial<ExchangeInfo> => ({
+    providerInfos,
+    buyCryptoIds: [],
+    sellCryptoIds: [],
+});
+
+/**
+ * Creates a partial SellInfo state for testing.
+ *
+ * @param providerInfos - Map of provider name to SellProviderInfo
+ * @returns Partial SellInfo with minimal required fields
+ */
+export const createSellInfoState = (
+    providerInfos: Record<string, SellProviderInfo> = {},
+): Partial<SellInfo> => ({
+    country: regional.UNKNOWN_COUNTRY,
+    providerInfos,
+    supportedCryptoCurrencies: [],
+    supportedFiatCurrencies: [],
+});
+
+/**
+ * Renders a hook with pre-configured trading Redux store.
+ *
+ * This utility automatically creates a Redux store with the trading reducer
+ * and wraps the hook in a Provider. It returns the standard React Testing Library
+ * hook result plus the store instance for state assertions.
+ *
+ * @template Result - Return type of the hook
+ * @template Props - Props type for the hook (for rerendering)
+ * @param callback - Hook function to test
+ * @param options - Rendering options
+ * @param options.preloadedState - Initial Redux state for the store
+ * @param options.initialProps - Initial props to pass to the hook
+ * @returns Hook result with additional `store` property
+ *
+ * @example
+ * ```ts
+ * // Simple usage
+ * const { result } = renderHookWithTradingStore(
+ *   () => useMyHook('buy')
+ * );
+ *
+ * // With preloaded state
+ * const { result, store } = renderHookWithTradingStore(
+ *   () => useProviderMetadataChangeEffect('buy', 'changenow', true),
+ *   {
+ *     preloadedState: createTradingTestState({
+ *       buy: {
+ *         ...initialState.buy,
+ *         buyInfo: createBuyInfoState({
+ *           changenow: mockProvider as BuyProviderInfo
+ *         })
+ *       }
+ *     })
+ *   }
+ * );
+ *
+ * // With props for rerendering
+ * const { result, rerender } = renderHookWithTradingStore<
+ *   ReturnType<typeof useMyHook>,
+ *   { provider: string }
+ * >(
+ *   ({ provider }) => useMyHook(provider),
+ *   { initialProps: { provider: 'changenow' } }
+ * );
+ *
+ * rerender({ provider: 'sideshift' });
+ * ```
+ */
+export const renderHookWithTradingStore = <Result, Props = unknown>(
+    callback: (props: Props) => Result,
+    { preloadedState, ...options }: RenderHookWithTradingStoreOptions<Props> = {},
+) => {
+    const store = configureMockStore({
+        reducer: combineReducers({
+            wallet: combineReducers({
+                trading: tradingCommonReducer,
+            }),
+        }),
+        preloadedState: preloadedState || createTradingTestState(),
+    });
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+        <Provider store={store}>{children}</Provider>
+    );
+
+    return {
+        ...renderHook(callback, { wrapper, ...options }),
+        store,
+    };
+};

--- a/suite-common/trading/src/hooks/__tests__/useProviderMetadataChangeEffect.test.tsx
+++ b/suite-common/trading/src/hooks/__tests__/useProviderMetadataChangeEffect.test.tsx
@@ -1,0 +1,154 @@
+import {
+    createBuyInfoState,
+    createExchangeInfoState,
+    createSellInfoState,
+    createTradingTestState,
+    renderHookWithTradingStore,
+} from '../../__tests__/testUtils';
+import { getProviderMetadataFixture } from '../../reducers/__fixtures__/providerMetadata';
+import { initialState } from '../../reducers/tradingCommonReducer';
+import { TradingType } from '../../types';
+import { useProviderMetadataChangeEffect } from '../useProviderMetadataChangeEffect';
+
+const mockProviderMetadataChangeNow = getProviderMetadataFixture();
+const mockProviderMetadataSideShift = getProviderMetadataFixture('sideshift');
+
+describe('useProviderMetadataChangeEffect', () => {
+    it('should return undefined when no provider metadata is set', () => {
+        const { result } = renderHookWithTradingStore(() =>
+            useProviderMetadataChangeEffect('buy', undefined, true),
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('should not update provider metadata when areProviderChangesAllowed is false', () => {
+        const { result, rerender } = renderHookWithTradingStore<
+            ReturnType<typeof useProviderMetadataChangeEffect>,
+            { tradingType: TradingType; quoteName?: string; areProviderChangesAllowed?: boolean }
+        >(
+            ({ tradingType, quoteName, areProviderChangesAllowed }) =>
+                useProviderMetadataChangeEffect(tradingType, quoteName, areProviderChangesAllowed),
+            {
+                preloadedState: createTradingTestState({
+                    buy: {
+                        ...initialState.buy,
+                        buyInfo: createBuyInfoState({ changenow: mockProviderMetadataChangeNow }),
+                    },
+                }),
+                initialProps: {
+                    tradingType: 'buy' as TradingType,
+                    quoteName: 'changenow',
+                    areProviderChangesAllowed: false,
+                },
+            },
+        );
+
+        expect(result.current).toBeUndefined();
+        rerender({
+            tradingType: 'buy',
+            quoteName: 'changenow',
+            areProviderChangesAllowed: true,
+        });
+        expect(result.current).toEqual(mockProviderMetadataChangeNow);
+    });
+
+    it('should update provider metadata when provider changes and areProviderChangesAllowed is true (buy)', () => {
+        const { result, rerender } = renderHookWithTradingStore<
+            ReturnType<typeof useProviderMetadataChangeEffect>,
+            { tradingType: TradingType; quoteName?: string; areProviderChangesAllowed?: boolean }
+        >(
+            ({ tradingType, quoteName, areProviderChangesAllowed }) =>
+                useProviderMetadataChangeEffect(tradingType, quoteName, areProviderChangesAllowed),
+            {
+                preloadedState: createTradingTestState({
+                    buy: {
+                        ...initialState.buy,
+                        buyInfo: createBuyInfoState({
+                            changenow: mockProviderMetadataChangeNow,
+                            sideshift: mockProviderMetadataSideShift,
+                        }),
+                    },
+                }),
+                initialProps: {
+                    tradingType: 'buy' as TradingType,
+                    quoteName: 'changenow',
+                    areProviderChangesAllowed: true,
+                },
+            },
+        );
+        expect(result.current).toEqual(mockProviderMetadataChangeNow);
+        rerender({
+            tradingType: 'buy',
+            quoteName: 'sideshift',
+            areProviderChangesAllowed: true,
+        });
+
+        expect(result.current).toEqual(mockProviderMetadataSideShift);
+    });
+
+    it('should update provider metadata for exchange type', () => {
+        const { result } = renderHookWithTradingStore(
+            () => useProviderMetadataChangeEffect('exchange', 'exchangeProvider', true),
+            {
+                preloadedState: createTradingTestState({
+                    exchange: {
+                        ...initialState.exchange,
+                        exchangeInfo: createExchangeInfoState({
+                            exchangeProvider: mockProviderMetadataChangeNow,
+                        }),
+                    },
+                }),
+            },
+        );
+        expect(result.current).toEqual(mockProviderMetadataChangeNow);
+    });
+
+    it('should update provider metadata for sell type', () => {
+        const { result } = renderHookWithTradingStore(
+            () => useProviderMetadataChangeEffect('sell', 'sellProvider', true),
+            {
+                preloadedState: createTradingTestState({
+                    sell: {
+                        ...initialState.sell,
+                        sellInfo: createSellInfoState({
+                            sellProvider: mockProviderMetadataChangeNow,
+                        }),
+                    },
+                }),
+            },
+        );
+        expect(result.current).toEqual(mockProviderMetadataChangeNow);
+    });
+
+    it('should clear provider metadata on unmount', () => {
+        const { unmount, store } = renderHookWithTradingStore(
+            () => useProviderMetadataChangeEffect('buy', 'changenow', true),
+            {
+                preloadedState: createTradingTestState({
+                    currentProviderMetadata: mockProviderMetadataChangeNow,
+                    buy: {
+                        ...initialState.buy,
+                        buyInfo: createBuyInfoState({
+                            changenow: mockProviderMetadataChangeNow,
+                        }),
+                    },
+                }),
+            },
+        );
+
+        expect(store.getState().wallet.trading.currentProviderMetadata).toEqual(
+            mockProviderMetadataChangeNow,
+        );
+        unmount();
+        expect(store.getState().wallet.trading.currentProviderMetadata).toBeUndefined();
+    });
+
+    it('should handle undefined quoteName gracefully', () => {
+        const { result } = renderHookWithTradingStore(() =>
+            useProviderMetadataChangeEffect('buy', undefined, true),
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+});

--- a/suite-common/trading/src/hooks/__tests__/useProviderMetadataChangeEffect.test.tsx
+++ b/suite-common/trading/src/hooks/__tests__/useProviderMetadataChangeEffect.test.tsx
@@ -143,12 +143,4 @@ describe('useProviderMetadataChangeEffect', () => {
         unmount();
         expect(store.getState().wallet.trading.currentProviderMetadata).toBeUndefined();
     });
-
-    it('should handle undefined quoteName gracefully', () => {
-        const { result } = renderHookWithTradingStore(() =>
-            useProviderMetadataChangeEffect('buy', undefined, true),
-        );
-
-        expect(result.current).toBeUndefined();
-    });
 });

--- a/suite-common/trading/src/hooks/useProviderMetadataChangeEffect.ts
+++ b/suite-common/trading/src/hooks/useProviderMetadataChangeEffect.ts
@@ -9,7 +9,11 @@ import {
 } from '../selectors/tradingSelectors';
 import type { TradingType } from '../types';
 
-export const useProviderMetadataChangeEffect = (tradingType: TradingType, quoteName?: string) => {
+export const useProviderMetadataChangeEffect = (
+    tradingType: TradingType,
+    quoteName?: string,
+    areProviderChangesAllowed = true,
+) => {
     const dispatch = useDispatch();
 
     const providerMetadata = useSelector((state: TradingRootState) =>
@@ -18,18 +22,16 @@ export const useProviderMetadataChangeEffect = (tradingType: TradingType, quoteN
     const currentProviderMetadata = useSelector(selectTradingProviderMetadata);
 
     useEffect(() => {
-        if (!quoteName && providerMetadata) {
-            dispatch(tradingActions.setCurrentProviderMetadata(undefined));
+        if (!areProviderChangesAllowed) {
+            return;
         }
-    }, [dispatch, quoteName, providerMetadata]);
 
-    useEffect(() => {
         if (providerMetadata === currentProviderMetadata) {
             return;
         }
 
         dispatch(tradingActions.setCurrentProviderMetadata(providerMetadata));
-    }, [providerMetadata, currentProviderMetadata, dispatch]);
+    }, [providerMetadata, currentProviderMetadata, dispatch, areProviderChangesAllowed]);
 
     useEffect(
         () => () => {

--- a/suite-common/trading/src/hooks/useProviderMetadataChangeEffect.ts
+++ b/suite-common/trading/src/hooks/useProviderMetadataChangeEffect.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import type { TradingRootState } from '../reducers/tradingCommonReducer';
+import { tradingActions } from '../reducers/tradingCommonReducer';
+import {
+    selectTradingProviderByNameAndTradeType,
+    selectTradingProviderMetadata,
+} from '../selectors/tradingSelectors';
+import type { TradingType } from '../types';
+
+export const useProviderMetadataChangeEffect = (tradingType: TradingType, quoteName?: string) => {
+    const dispatch = useDispatch();
+
+    const providerMetadata = useSelector((state: TradingRootState) =>
+        selectTradingProviderByNameAndTradeType(state, quoteName, tradingType),
+    );
+    const currentProviderMetadata = useSelector(selectTradingProviderMetadata);
+
+    useEffect(() => {
+        if (!quoteName && providerMetadata) {
+            dispatch(tradingActions.setCurrentProviderMetadata(undefined));
+        }
+    }, [dispatch, quoteName, providerMetadata]);
+
+    useEffect(() => {
+        if (providerMetadata === currentProviderMetadata) {
+            return;
+        }
+
+        dispatch(tradingActions.setCurrentProviderMetadata(providerMetadata));
+    }, [providerMetadata, currentProviderMetadata, dispatch]);
+
+    useEffect(
+        () => () => {
+            dispatch(tradingActions.setCurrentProviderMetadata(undefined));
+        },
+        [dispatch],
+    );
+
+    return currentProviderMetadata;
+};

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -6,6 +6,7 @@ export * from './hooks/useTradingAssets';
 export * from './hooks/useTradingUtils';
 export * from './hooks/useListDataFilter';
 export * from './hooks/useCountryFilteredData';
+export * from './hooks/useProviderMetadataChangeEffect';
 export * from './invityAPI';
 export * from './reducers/buyReducer';
 export * from './reducers/exchangeReducer';

--- a/suite-common/trading/src/reducers/__fixtures__/providerMetadata.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/providerMetadata.ts
@@ -1,0 +1,13 @@
+import type { ProviderMetadata } from 'invity-api';
+
+export const getProviderMetadataFixture = (
+    providerName: string = 'changenow',
+): ProviderMetadata => ({
+    name: providerName,
+    companyName: providerName,
+    logo: `${providerName}-icon.jpg`,
+    isActive: true,
+    supportUrl: `https://support.${providerName}.io`,
+    statusUrl: `https://${providerName}.io/exchange/txs/{{orderId}}`,
+    termsUrl: `https://${providerName}.io/terms-of-use`,
+});

--- a/suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts
@@ -142,41 +142,11 @@ describe('Testing trading reducer', () => {
 
             it('should set currentProviderMetadata with complete provider data', () => {
                 const providerMetadata = getProviderMetadataFixture('changenow');
-
-                expect(store.getState().wallet.trading.currentProviderMetadata).toBeUndefined();
-
                 store.dispatch(tradingActions.setCurrentProviderMetadata(providerMetadata));
 
                 expect(store.getState().wallet.trading.currentProviderMetadata).toEqual(
                     providerMetadata,
                 );
-            });
-
-            it('should update currentProviderMetadata when called multiple times', () => {
-                const firstProvider = getProviderMetadataFixture('changenow');
-                const secondProvider = getProviderMetadataFixture('sideshift');
-
-                store.dispatch(tradingActions.setCurrentProviderMetadata(firstProvider));
-                expect(store.getState().wallet.trading.currentProviderMetadata).toEqual(
-                    firstProvider,
-                );
-
-                store.dispatch(tradingActions.setCurrentProviderMetadata(secondProvider));
-                expect(store.getState().wallet.trading.currentProviderMetadata).toEqual(
-                    secondProvider,
-                );
-            });
-
-            it('should clear currentProviderMetadata when set to undefined', () => {
-                const providerMetadata = getProviderMetadataFixture('changenow');
-
-                store.dispatch(tradingActions.setCurrentProviderMetadata(providerMetadata));
-                expect(store.getState().wallet.trading.currentProviderMetadata).toEqual(
-                    providerMetadata,
-                );
-
-                store.dispatch(tradingActions.setCurrentProviderMetadata(undefined));
-                expect(store.getState().wallet.trading.currentProviderMetadata).toBeUndefined();
             });
         });
 

--- a/suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts
@@ -6,6 +6,7 @@ import { AccountKey } from '@suite-common/wallet-types';
 import { selectTradingMaxSlippagePercentage } from '../../selectors/settingsSelectors';
 import { buyThunks } from '../../thunks/buy';
 import { sellThunks } from '../../thunks/sell';
+import { getProviderMetadataFixture } from '../__fixtures__/providerMetadata';
 import { tradingFixtures } from '../__fixtures__/tradingReducer';
 import { buyInitialState, tradingBuyActions } from '../buyReducer';
 import { exchangeInitialState, tradingExchangeActions } from '../exchangeReducer';
@@ -137,6 +138,45 @@ describe('Testing trading reducer', () => {
                 store.dispatch(tradingActions.setModalAccountKey('MY_KEY' as AccountKey)); // Todo: create properly via `createAccountKey()`
 
                 expect(store.getState().wallet.trading.modalAccountKey).toEqual('MY_KEY');
+            });
+
+            it('should set currentProviderMetadata with complete provider data', () => {
+                const providerMetadata = getProviderMetadataFixture('changenow');
+
+                expect(store.getState().wallet.trading.currentProviderMetadata).toBeUndefined();
+
+                store.dispatch(tradingActions.setCurrentProviderMetadata(providerMetadata));
+
+                expect(store.getState().wallet.trading.currentProviderMetadata).toEqual(
+                    providerMetadata,
+                );
+            });
+
+            it('should update currentProviderMetadata when called multiple times', () => {
+                const firstProvider = getProviderMetadataFixture('changenow');
+                const secondProvider = getProviderMetadataFixture('sideshift');
+
+                store.dispatch(tradingActions.setCurrentProviderMetadata(firstProvider));
+                expect(store.getState().wallet.trading.currentProviderMetadata).toEqual(
+                    firstProvider,
+                );
+
+                store.dispatch(tradingActions.setCurrentProviderMetadata(secondProvider));
+                expect(store.getState().wallet.trading.currentProviderMetadata).toEqual(
+                    secondProvider,
+                );
+            });
+
+            it('should clear currentProviderMetadata when set to undefined', () => {
+                const providerMetadata = getProviderMetadataFixture('changenow');
+
+                store.dispatch(tradingActions.setCurrentProviderMetadata(providerMetadata));
+                expect(store.getState().wallet.trading.currentProviderMetadata).toEqual(
+                    providerMetadata,
+                );
+
+                store.dispatch(tradingActions.setCurrentProviderMetadata(undefined));
+                expect(store.getState().wallet.trading.currentProviderMetadata).toBeUndefined();
             });
         });
 

--- a/suite-common/trading/src/reducers/tradingCommonReducer.ts
+++ b/suite-common/trading/src/reducers/tradingCommonReducer.ts
@@ -1,5 +1,5 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
-import { Coins, CryptoId, InfoResponse, Platforms } from 'invity-api';
+import { Coins, CryptoId, InfoResponse, Platforms, type ProviderMetadata } from 'invity-api';
 
 import { AccountKey, PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { CardanoOutput, FeeLevel, PROTO } from '@trezor/connect';
@@ -61,6 +61,7 @@ export interface TradingState {
     prefilledFromAccount: TradingPrefilledFromAccount;
     verifiedAddress: TradingVerifiedAddress;
     settings: TradingSettingsState;
+    currentProviderMetadata?: ProviderMetadata;
 }
 
 export type TradingRootState = {
@@ -143,6 +144,12 @@ const tradingCommonSlice = createSlice({
         },
         setVerifiedAddress(state, action: PayloadAction<TradingVerifiedAddress>) {
             state.verifiedAddress = action.payload;
+        },
+        setCurrentProviderMetadata: (
+            state,
+            { payload }: PayloadAction<ProviderMetadata | undefined>,
+        ) => {
+            state.currentProviderMetadata = payload;
         },
     },
 });

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -60,6 +60,7 @@ import {
     selectTradingPlatformByCryptoId,
     selectTradingPrefilledFromAccount,
     selectTradingProviderByNameAndTradeType,
+    selectTradingProviderMetadata,
     selectTradingSellAccountKey,
     selectTradingSellFormStep,
     selectTradingSellInfo,
@@ -1484,6 +1485,30 @@ describe('tradingSelectors', () => {
             const result = selectTradingLastErrorMessageByTradeType(state, tradeType);
 
             expect(result).toBe(expectedMessage);
+        });
+    });
+
+    describe('selectTradingProviderMetadata', () => {
+        it('should return currentProviderMetadata from state', () => {
+            const providerMetadata = {
+                name: 'TEST_PROVIDER',
+                companyName: 'Test Company',
+                logo: 'https://example.com/logo.png',
+                isActive: true,
+            };
+            state.wallet.trading.currentProviderMetadata = providerMetadata;
+
+            const result = selectTradingProviderMetadata(state);
+
+            expect(result).toEqual(providerMetadata);
+        });
+
+        it('should return undefined when currentProviderMetadata is not set', () => {
+            state.wallet.trading.currentProviderMetadata = undefined;
+
+            const result = selectTradingProviderMetadata(state);
+
+            expect(result).toBeUndefined();
         });
     });
 });

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -15,6 +15,7 @@ import coins from '../../__fixtures__/coins.json';
 import { invityAPIFixtures } from '../../__fixtures__/invityAPI';
 import platforms from '../../__fixtures__/platforms.json';
 import { accountBtc, accountEth } from '../../__fixtures__/utils';
+import { getProviderMetadataFixture } from '../../reducers/__fixtures__/providerMetadata';
 import { BuyInfo, TradingBuyState } from '../../reducers/buyReducer';
 import { ExchangeInfo, exchangeInitialState } from '../../reducers/exchangeReducer';
 import { SellInfo, sellInitialState } from '../../reducers/sellReducer';
@@ -1490,12 +1491,7 @@ describe('tradingSelectors', () => {
 
     describe('selectTradingProviderMetadata', () => {
         it('should return currentProviderMetadata from state', () => {
-            const providerMetadata = {
-                name: 'TEST_PROVIDER',
-                companyName: 'Test Company',
-                logo: 'https://example.com/logo.png',
-                isActive: true,
-            };
+            const providerMetadata = getProviderMetadataFixture('changenow');
             state.wallet.trading.currentProviderMetadata = providerMetadata;
 
             const result = selectTradingProviderMetadata(state);

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -738,3 +738,6 @@ export const selectTradingLastErrorMessageByTradeType = (
             exhaustive(tradingType, 'Unexpected trade type');
     }
 };
+
+export const selectTradingProviderMetadata = (state: TradingRootState) =>
+    state.wallet.trading.currentProviderMetadata;

--- a/suite-native/module-trading/src/components/general/Footer.tsx
+++ b/suite-native/module-trading/src/components/general/Footer.tsx
@@ -3,13 +3,11 @@ import { useSelector } from 'react-redux';
 
 import type { ProviderMetadata } from 'invity-api';
 
+import { selectTradingProviderMetadata } from '@suite-common/trading';
 import { AnimatedBox, Divider, HStack, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { Link } from '@suite-native/link';
-import {
-    selectIsAmountInputActive,
-    selectTradingProviderMetadata,
-} from '@suite-native/trading-state';
+import { selectIsAmountInputActive } from '@suite-native/trading-state';
 import { TREZOR_SUITE_TOS_URL, TREZOR_TRADING_LEARN_MORE_URL } from '@trezor/urls';
 
 export type FooterProps = {

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
@@ -3,7 +3,7 @@ import { Platform } from 'react-native';
 import { EnhancedStore } from '@reduxjs/toolkit';
 import type { BuyTrade, CryptoId } from 'invity-api';
 
-import { tradingBuyActions } from '@suite-common/trading';
+import { selectTradingProviderMetadata, tradingBuyActions } from '@suite-common/trading';
 import { AccountKey } from '@suite-common/wallet-types';
 import { Form, useField } from '@suite-native/forms';
 import {
@@ -22,11 +22,7 @@ import {
     getInitializedTradingState,
     usdcAsset,
 } from '@suite-native/trading-fixtures';
-import {
-    buyActions,
-    selectTradingProviderMetadata,
-    selectTradingResidenceCountry,
-} from '@suite-native/trading-state';
+import { buyActions, selectTradingResidenceCountry } from '@suite-native/trading-state';
 import { BuyFormType, TradeableAsset } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -1,6 +1,6 @@
 import type { ExchangeTrade } from 'invity-api';
 
-import { tradingExchangeActions } from '@suite-common/trading';
+import { selectTradingProviderMetadata, tradingExchangeActions } from '@suite-common/trading';
 import { AccountKey } from '@suite-common/wallet-types';
 import { EventType } from '@suite-native/analytics';
 import { FeatureFlag, FeatureFlagsRootState } from '@suite-native/feature-flags';
@@ -19,7 +19,7 @@ import {
     getWalletState,
     usdcAsset,
 } from '@suite-native/trading-fixtures';
-import { exchangeActions, selectTradingProviderMetadata } from '@suite-native/trading-state';
+import { exchangeActions } from '@suite-native/trading-state';
 import { ExchangeFormType } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useProviderMetadataChangeEffect.hook.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useProviderMetadataChangeEffect.hook.test.ts
@@ -1,6 +1,6 @@
+import { selectTradingProviderMetadata } from '@suite-common/trading';
 import { TestStore, initStore, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { buyMercuryo, getWalletState } from '@suite-native/trading-fixtures';
-import { selectTradingProviderMetadata } from '@suite-native/trading-state';
 
 import {
     QuoteProviderFormWatch,

--- a/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.ts
@@ -1,14 +1,8 @@
-import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-
 import { useIsFocused } from '@react-navigation/native';
 
 import {
-    type TradingRootState,
     TradingType,
-    selectTradingProviderByNameAndTradeType,
-    selectTradingProviderMetadata,
-    tradingActions,
+    useProviderMetadataChangeEffect as useCommonProviderMetadataChangeEffect,
 } from '@suite-common/trading';
 
 export type QuoteProviderFormWatch = (key: 'quote.exchange') => string | undefined;
@@ -17,36 +11,8 @@ export const useProviderMetadataChangeEffect = (
     watch: QuoteProviderFormWatch,
     tradingType: TradingType,
 ) => {
-    const dispatch = useDispatch();
     const exchange = watch('quote.exchange');
     const isFocused = useIsFocused();
 
-    const providerMetadata = useSelector((state: TradingRootState) =>
-        selectTradingProviderByNameAndTradeType(state, exchange, tradingType),
-    );
-    const currentProviderMetadata = useSelector(selectTradingProviderMetadata);
-
-    useEffect(() => {
-        // On navigation to preview screen the form is cleared, but we want to keep this value, therefore
-        // we skip updates to currentProviderMetadata.
-        // The effect will clear the provider metadata as soon as user goes back to form screen.
-        if (!isFocused) {
-            return;
-        }
-
-        if (providerMetadata === currentProviderMetadata) {
-            return;
-        }
-
-        dispatch(tradingActions.setCurrentProviderMetadata(providerMetadata));
-    }, [providerMetadata, currentProviderMetadata, dispatch, isFocused]);
-
-    useEffect(
-        () => () => {
-            dispatch(tradingActions.setCurrentProviderMetadata(undefined));
-        },
-        [dispatch],
-    );
-
-    return currentProviderMetadata;
+    return useCommonProviderMetadataChangeEffect(tradingType, exchange, isFocused);
 };

--- a/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.ts
@@ -7,8 +7,9 @@ import {
     type TradingRootState,
     TradingType,
     selectTradingProviderByNameAndTradeType,
+    selectTradingProviderMetadata,
+    tradingActions,
 } from '@suite-common/trading';
-import { selectTradingProviderMetadata, tradingActions } from '@suite-native/trading-state';
 
 export type QuoteProviderFormWatch = (key: 'quote.exchange') => string | undefined;
 

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
@@ -18,15 +18,10 @@ import {
     btcAsset,
     getBtcAccount,
     getWalletState,
-    sellBanxa,
     sellQuotes,
     usdcAsset,
 } from '@suite-native/trading-fixtures';
-import {
-    selectTradingProviderMetadata,
-    selectTradingResidenceCountry,
-    sellActions,
-} from '@suite-native/trading-state';
+import { selectTradingResidenceCountry, sellActions } from '@suite-native/trading-state';
 import { SellFormType } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 
@@ -563,17 +558,6 @@ describe('useSellForm', () => {
             });
 
             expect(result.current.getValues('quote')).toEqual(sellQuotes[0]);
-        });
-
-        it('should persist provider metadata to redux', () => {
-            const { result } = renderUseSellForm();
-            initFormAndQuoteRequest(result.current);
-
-            act(() => {
-                store.dispatch(tradingSellActions.saveQuotes(sellQuotes));
-            });
-
-            expect(selectTradingProviderMetadata(store.getState())).toBe(sellBanxa);
         });
 
         describe('when quote is selected and new quotes are fetched', () => {

--- a/suite-native/trading-state/src/reducers/__tests__/tradingSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/tradingSlice.test.ts
@@ -1,5 +1,5 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
-import type { CryptoId, ProviderMetadata } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import {
@@ -648,27 +648,6 @@ describe('tradingSlice', () => {
 
                 expect(state.providerConfirmationStatus).toBe(newStatus);
             });
-        });
-    });
-
-    describe('currentProviderMetadata', () => {
-        const testProvider: ProviderMetadata = {
-            name: 'TEST_PROVIDER_NAME',
-            companyName: 'TEST_COMPANY_NAME',
-            logo: 'TEST_LOGO',
-            isActive: true,
-        };
-
-        it('setCurrentProviderMetadata should set currentProviderMetadata', () => {
-            const actions = [tradingActions.setCurrentProviderMetadata(testProvider)];
-
-            const state = actions.reduce(tradingReducer, undefined) as TradingState;
-
-            expect(state).toEqual(
-                expect.objectContaining({
-                    currentProviderMetadata: testProvider,
-                }),
-            );
         });
     });
 });

--- a/suite-native/trading-state/src/reducers/tradingSlice.ts
+++ b/suite-native/trading-state/src/reducers/tradingSlice.ts
@@ -1,5 +1,5 @@
 import { type PayloadAction, isAnyOf } from '@reduxjs/toolkit';
-import type { CryptoId, ProviderMetadata } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import { InvityServerEnvironment, TradingType, prepareTradingReducer } from '@suite-common/trading';
@@ -85,12 +85,6 @@ export const tradingSlice = createSliceWithExtraDeps({
             ) {
                 state.providerConfirmationStatus = newStatus;
             }
-        },
-        setCurrentProviderMetadata: (
-            state,
-            { payload }: PayloadAction<ProviderMetadata | undefined>,
-        ) => {
-            state.currentProviderMetadata = payload;
         },
         clearSelectedAccounts: state => {
             state.buy.tradingAccountKey = undefined;

--- a/suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts
@@ -6,6 +6,7 @@ import {
     InvityServerEnvironment,
     TradingCountryCode,
     TradingRootStateWithDeviceAndAccounts,
+    selectTradingProviderMetadata,
 } from '@suite-common/trading';
 import {
     AccountsRootState,
@@ -46,7 +47,6 @@ import {
     selectTradesToWatchByAccount,
     selectTradingEnvironment,
     selectTradingProviderConfirmationStatus,
-    selectTradingProviderMetadata,
     selectVisibleDeviceAccountsByNetworkSymbolSorted,
 } from '../commonSelectors';
 

--- a/suite-native/trading-state/src/selectors/commonSelectors.ts
+++ b/suite-native/trading-state/src/selectors/commonSelectors.ts
@@ -409,6 +409,3 @@ export const selectAccountLabelWithNetworkFallback = (
 
 export const selectTradingProviderConfirmationStatus = (state: TradingRootState) =>
     state.wallet.trading.providerConfirmationStatus;
-
-export const selectTradingProviderMetadata = (state: TradingRootState) =>
-    state.wallet.trading.currentProviderMetadata;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Show provider's terms in all steps of trading process

## Notes for QA

Check if provider's terms are set in footer when: 
 - provider is selected by the app (the best offer)
 - user select provider by himself
 - user is on confirm page

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/23762

## Screenshots:

<img width="1049" height="388" alt="image" src="https://github.com/user-attachments/assets/ff06a874-bf62-414a-bf51-59aa92a0fdab" />


https://github.com/user-attachments/assets/2e0834fb-01b2-44f9-8336-497911607e35




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/footer-terms&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/footer-terms&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/footer-terms&lookback=7)