### PR TITLE
fix(suite-native): prevent UI glitches when new THP code is requested

### DIFF
--- a/suite-native/module-authorize-device/src/hooks/useInitiateThpConnection.ts
+++ b/suite-native/module-authorize-device/src/hooks/useInitiateThpConnection.ts
@@ -1,13 +1,27 @@
 import { useDispatch, useSelector } from 'react-redux';
 
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
 import { acquireDevice, selectSelectedDevice } from '@suite-common/wallet-core';
+import {
+    AuthorizeDeviceStackParamList,
+    AuthorizeDeviceStackRoutes,
+} from '@suite-native/navigation';
+
+type NavigationProp = NativeStackNavigationProp<AuthorizeDeviceStackParamList>;
 
 export const useInitiateThpConnection = () => {
+    const navigation = useNavigation<NavigationProp>();
     const dispatch = useDispatch();
 
     const device = useSelector(selectSelectedDevice);
 
     const initiateThpConnection = () => {
+        // Navigate as soon as the action is called, do not wait for deviceConnectionMiddleware to
+        // do that. In addition to better UX, this also prevents the current screen from multiplying
+        // in the navigation stack and the invalidCode alert from reappearing once dismissed.
+        navigation.replace(AuthorizeDeviceStackRoutes.ThpConfirmation);
         dispatch(acquireDevice({ requestedDevice: device }));
     };
 


### PR DESCRIPTION
Navigate to `AuthorizeDeviceStackRoutes.ThpConfirmation` as soon as `initiateThpConnection` is called, do not wait for `deviceConnectionMiddleware` to do that. In addition to better UX, this also prevents the current screen from multiplying in the navigation stack and the invalidCode alert from reappearing once dismissed.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/thp-invalid-code-entry&lookback=7)