### PR TITLE
refactor(e2e-suite): split metadata tests to two subfolders

### DIFF
--- a/suite/e2e/tests/metadata/legacy/account-metadata.test.ts
+++ b/suite/e2e/tests/metadata/legacy/account-metadata.test.ts
@@ -1,6 +1,6 @@
-import { AccountLabelId } from '../../support/enums/accountLabelId';
-import { expect, test } from '../../support/fixtures';
-import { MetadataProvider } from '../../support/mocks/metadataMock';
+import { AccountLabelId } from '../../../support/enums/accountLabelId';
+import { expect, test } from '../../../support/fixtures';
+import { MetadataProvider } from '../../../support/mocks/metadataMock';
 
 // Metadata is by default disabled, this means, that application does not try to generate master key and connect to cloud.
 // Hovering over fields that may be labeled shows "add label" button upon which is clicked, Suite initiates metadata flow

--- a/suite/e2e/tests/metadata/legacy/address-metadata.test.ts
+++ b/suite/e2e/tests/metadata/legacy/address-metadata.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '../../support/fixtures';
-import { MetadataProvider } from '../../support/mocks/metadataMock';
+import { expect, test } from '../../../support/fixtures';
+import { MetadataProvider } from '../../../support/mocks/metadataMock';
 
 const metadataAddress = 'bc1q7e6qu5smalrpgqrx9k2gnf0hgjyref5p36ru2m';
 

--- a/suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts
+++ b/suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts
@@ -1,7 +1,7 @@
-import { AccountLabelId } from '../../support/enums/accountLabelId';
-import { expect, test } from '../../support/fixtures';
-import { MetadataProvider } from '../../support/mocks/metadataMock';
-import { createTestAnnotation } from '../../support/reporters/annotations';
+import { AccountLabelId } from '../../../support/enums/accountLabelId';
+import { expect, test } from '../../../support/fixtures';
+import { MetadataProvider } from '../../../support/mocks/metadataMock';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe('Dropbox API errors', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     test.use({

--- a/suite/e2e/tests/metadata/legacy/google-api-errors.test.ts
+++ b/suite/e2e/tests/metadata/legacy/google-api-errors.test.ts
@@ -1,7 +1,7 @@
-import { AccountLabelId } from '../../support/enums/accountLabelId';
-import { expect, test } from '../../support/fixtures';
-import { MetadataProvider } from '../../support/mocks/metadataMock';
-import { createTestAnnotation } from '../../support/reporters/annotations';
+import { AccountLabelId } from '../../../support/enums/accountLabelId';
+import { expect, test } from '../../../support/fixtures';
+import { MetadataProvider } from '../../../support/mocks/metadataMock';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe('Google API errors', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     test.use({

--- a/suite/e2e/tests/metadata/legacy/interval-fetching.test.ts
+++ b/suite/e2e/tests/metadata/legacy/interval-fetching.test.ts
@@ -1,8 +1,8 @@
 import * as METADATA_LABELING from '@trezor/suite/src//actions/suite/metadata/metadataLabelingConstants';
 
-import { AccountLabelId } from '../../support/enums/accountLabelId';
-import { expect, test } from '../../support/fixtures';
-import { MetadataProvider } from '../../support/mocks/metadataMock';
+import { AccountLabelId } from '../../../support/enums/accountLabelId';
+import { expect, test } from '../../../support/fixtures';
+import { MetadataProvider } from '../../../support/mocks/metadataMock';
 
 const providers = [
     {

--- a/suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts
+++ b/suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts
@@ -1,6 +1,6 @@
-import { AccountLabelId } from '../../support/enums/accountLabelId';
-import { expect, test } from '../../support/fixtures';
-import { MetadataProvider } from '../../support/mocks/metadataMock';
+import { AccountLabelId } from '../../../support/enums/accountLabelId';
+import { expect, test } from '../../../support/fixtures';
+import { MetadataProvider } from '../../../support/mocks/metadataMock';
 
 test.describe('Metadata lifecycle', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     test.use({

--- a/suite/e2e/tests/metadata/legacy/output-labeling.test.ts
+++ b/suite/e2e/tests/metadata/legacy/output-labeling.test.ts
@@ -2,10 +2,10 @@ import fs from 'fs';
 
 import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 
-import { OutputLabelId } from '../../support/enums/outputLabelId';
-import { expect, test } from '../../support/fixtures';
-import { MetadataProvider } from '../../support/mocks/metadataMock';
-import { createTestAnnotation } from '../../support/reporters/annotations';
+import { OutputLabelId } from '../../../support/enums/outputLabelId';
+import { expect, test } from '../../../support/fixtures';
+import { MetadataProvider } from '../../../support/mocks/metadataMock';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe('Metadata - Output labeling', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });

--- a/suite/e2e/tests/metadata/legacy/remembered-device.test.ts
+++ b/suite/e2e/tests/metadata/legacy/remembered-device.test.ts
@@ -1,6 +1,6 @@
-import { AccountLabelId } from '../../support/enums/accountLabelId';
-import { expect, test } from '../../support/fixtures';
-import { MetadataProvider } from '../../support/mocks/metadataMock';
+import { AccountLabelId } from '../../../support/enums/accountLabelId';
+import { expect, test } from '../../../support/fixtures';
+import { MetadataProvider } from '../../../support/mocks/metadataMock';
 
 //Metadata - In settings, there is enable metadata switch.
 //On enable, it initiates metadata right away (if device already has state).

--- a/suite/e2e/tests/metadata/legacy/switching-providers.test.ts
+++ b/suite/e2e/tests/metadata/legacy/switching-providers.test.ts
@@ -1,7 +1,7 @@
-import { AccountLabelId } from '../../support/enums/accountLabelId';
-import { expect, test } from '../../support/fixtures';
-import { MetadataProvider } from '../../support/mocks/metadataMock';
-import { createTestAnnotation } from '../../support/reporters/annotations';
+import { AccountLabelId } from '../../../support/enums/accountLabelId';
+import { expect, test } from '../../../support/fixtures';
+import { MetadataProvider } from '../../../support/mocks/metadataMock';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe(
     'Metadata - switching between cloud providers',

--- a/suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts
+++ b/suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '../../support/fixtures';
-import { MetadataProvider } from '../../support/mocks/metadataMock';
+import { expect, test } from '../../../support/fixtures';
+import { MetadataProvider } from '../../../support/mocks/metadataMock';
 
 const standardWalletIndex = 0;
 const hiddenWalletIndex = 1;

--- a/suite/e2e/tests/metadata/suite-sync/suite-sync.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/suite-sync.test.ts
@@ -1,0 +1,70 @@
+import { generateMnemonic } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
+
+import { skipFixture } from '../../../support/common';
+import { AccountLabelId } from '../../../support/enums/accountLabelId';
+import { expect, test } from '../../../support/fixtures';
+
+test.describe(
+    'Suite Sync - Labelling',
+    { tag: ['@webOnly', '@specificFirmware', '@T3W1', '@T3T1'] },
+    () => {
+        test.use({
+            exceptionLogger: skipFixture,
+            firmwareVersion: '2-main',
+            deviceSetup: {
+                mnemonic: generateMnemonic(wordlist),
+                passphrase_protection: true,
+            },
+        });
+
+        test('Sync account label across sessions', async ({
+            page,
+            onboardingPage,
+            settingsPage,
+            walletPage,
+            metadataPage,
+        }) => {
+            await test.step('Onboarding and enable Suite Sync', async () => {
+                await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+                await metadataPage.setupQuotaManager();
+                await metadataPage.enableSuiteSync();
+            });
+
+            const newLabel = 'my synced btc account label';
+            await test.step('Change BTC account label in first session', async () => {
+                await walletPage
+                    .accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 })
+                    .click();
+                await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
+                await metadataPage.account.metadataInput.fill(newLabel);
+                await page.keyboard.press('Enter');
+                await expect(
+                    walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
+                ).toHaveText(newLabel);
+
+                await page.waitForTimeout(5_000); // wait for sync to complete
+            });
+
+            await test.step('Wipe Suite to simulate new session', async () => {
+                await settingsPage.navigateTo('application');
+                await settingsPage.resetAppButton.click();
+            });
+
+            await test.step('Onboarding and enable Suite Sync', async () => {
+                await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+                await metadataPage.setupQuotaManager();
+                await metadataPage.enableSuiteSync();
+            });
+
+            await test.step('Verify BTC account label is synced in second session', async () => {
+                await walletPage
+                    .accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 })
+                    .click();
+                await expect(
+                    walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
+                ).toHaveText(newLabel, { timeout: 30_000 });
+            });
+        });
+    },
+);

--- a/suite/e2e/tests/metadata/suite-sync/sync-from-server.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/sync-from-server.test.ts
@@ -1,76 +1,8 @@
-import { generateMnemonic } from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
-
 import { asSuiteSyncOwnerSecretHex } from '@suite-common/suite-types';
 import { asAccountDescriptor, asWalletDescriptor } from '@suite-common/wallet-types';
 
-import { isWebProject, skipFixture } from '../../support/common';
-import { AccountLabelId } from '../../support/enums/accountLabelId';
-import { expect, test } from '../../support/fixtures';
-
-test.use({ exceptionLogger: skipFixture });
-test.describe(
-    'Suite Sync - Labelling',
-    { tag: ['@webOnly', '@specificFirmware', '@T3W1', '@T3T1'] },
-    () => {
-        test.use({
-            firmwareVersion: '2-main',
-            deviceSetup: {
-                mnemonic: generateMnemonic(wordlist),
-                passphrase_protection: true,
-            },
-        });
-
-        test('Sync account label across sessions', async ({
-            page,
-            onboardingPage,
-            settingsPage,
-            walletPage,
-            metadataPage,
-        }) => {
-            await test.step('Onboarding and enable Suite Sync', async () => {
-                await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
-                await metadataPage.setupQuotaManager();
-                await metadataPage.enableSuiteSync();
-            });
-
-            const newLabel = 'my synced btc account label';
-            await test.step('Change BTC account label in first session', async () => {
-                await walletPage
-                    .accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 })
-                    .click();
-                await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
-                await metadataPage.account.metadataInput.fill(newLabel);
-                await page.keyboard.press('Enter');
-                await expect(
-                    walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
-                ).toHaveText(newLabel);
-
-                await page.waitForTimeout(5_000); // wait for sync to complete
-            });
-
-            await test.step('Wipe Suite to simulate new session', async () => {
-                await settingsPage.navigateTo('application');
-                await settingsPage.resetAppButton.click();
-            });
-
-            await test.step('Onboarding and enable Suite Sync', async () => {
-                await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
-                await metadataPage.setupQuotaManager();
-                await metadataPage.enableSuiteSync();
-            });
-
-            await test.step('Verify BTC account label is synced in second session', async () => {
-                await walletPage
-                    .accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 })
-                    .click();
-                await expect(
-                    walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
-                ).toHaveText(newLabel, { timeout: 30_000 });
-            });
-        });
-    },
-);
+import { isWebProject, skipFixture } from '../../../support/common';
+import { expect, test } from '../../../support/fixtures';
 
 // const ownerId = getOrThrow(OwnerId.from('0Fco3XDgKR59zX5VBvyyGQ'));
 const ownerSecret = asSuiteSyncOwnerSecretHex(
@@ -107,6 +39,7 @@ test.describe(
     { tag: ['@webOnly', '@specificFirmware', '@T3W1', '@T3T1'] },
     () => {
         test.use({
+            exceptionLogger: skipFixture,
             firmwareVersion: '2-main',
             deviceSetup: { passphrase_protection: true },
         });


### PR DESCRIPTION
just re-aranging test folder structure for new test automation.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-suite-sync-write&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-suite-sync-write&lookback=7)