### PR TITLE
fix(suite-native): services provider (analytics) in graph

### DIFF
--- a/suite-native/analytics/src/createAnalytics.ts
+++ b/suite-native/analytics/src/createAnalytics.ts
@@ -8,7 +8,7 @@ export type NativeAnalyticsDep = {
     analytics: Analytics<AnalyticsNativeEvents>;
 };
 
-export const createAnalytics = (): Analytics<AnalyticsNativeEvents> => {
+const createAnalytics = (): Analytics<AnalyticsNativeEvents> => {
     const newAnalytics = new QueuedAnalytics<AnalyticsNativeEvents>({
         version: getSuiteVersion(),
         app: 'suite',
@@ -26,3 +26,5 @@ export const createAnalytics = (): Analytics<AnalyticsNativeEvents> => {
 
     return newAnalytics;
 };
+
+export const analytics = createAnalytics();

--- a/suite-native/analytics/src/index.ts
+++ b/suite-native/analytics/src/index.ts
@@ -23,7 +23,7 @@ export { type DeviceSetupInfoLocation } from './events/deviceSetupInfoEvent';
 
 export type { AutoEjectModalValue } from './events/autoEjectModalEvent';
 export type { DemoAccountQuestionnaireLinkKey } from './events/demoAccountQuestionnaireLinksEvent';
-export { createAnalytics, type NativeAnalyticsDep } from './createAnalytics';
+export { analytics, type NativeAnalyticsDep } from './createAnalytics';
 export { asTypedNativeAnalytics } from './asTypedNativeAnalytics';
 export type { AnalyticsNativeEvents } from './analyticsEvents';
 

--- a/suite-native/graph/src/components/GraphContextProvider.tsx
+++ b/suite-native/graph/src/components/GraphContextProvider.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react';
 
+import { analytics } from '@suite-native/analytics';
+import { NativeServices, NativeServicesProvider } from '@suite-native/services';
 import { useActiveColorScheme } from '@suite-native/theme';
 import { StylesProvider, createRenderer } from '@trezor/styles';
 import { prepareNativeTheme } from '@trezor/theme';
@@ -10,10 +12,16 @@ type ProviderProps = {
 
 const renderer = createRenderer();
 
-// Since react native skia `Canvas` is using its own renderer, the  React Native context
-// is not available directly. This component re-injects the needed context providers.
-// read more: https://shopify.github.io/react-native-skia/docs/canvas/contexts
-export const GraphContextProvider = ({ children }: ProviderProps) => {
+// So far only analytics are needed in th graph context. Might be extended later.
+const services = {
+    analytics,
+} as NativeServices;
+
+const GraphServicesProvider = ({ children }: ProviderProps) => (
+    <NativeServicesProvider services={services}>{children}</NativeServicesProvider>
+);
+
+const GraphStylesProvider = ({ children }: ProviderProps) => {
     const colorVariant = useActiveColorScheme();
     const theme = prepareNativeTheme({ colorVariant });
 
@@ -23,3 +31,13 @@ export const GraphContextProvider = ({ children }: ProviderProps) => {
         </StylesProvider>
     );
 };
+
+// Since react native skia `Canvas` is using its own renderer, the  React Native context
+// is not available directly. This component re-injects the needed context providers.
+// read more: https://shopify.github.io/react-native-skia/docs/canvas/contexts
+export const GraphContextProvider = ({ children }: ProviderProps) => (
+    <GraphServicesProvider>
+        {/* StylesProvider needs access to the ServicesProvider */}
+        <GraphStylesProvider>{children}</GraphStylesProvider>
+    </GraphServicesProvider>
+);

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -17,7 +17,7 @@ import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
 import { Route } from '@suite-common/suite-types';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
-import { createAnalytics } from '@suite-native/analytics';
+import { analytics } from '@suite-native/analytics';
 import { forgetBluetoothDeviceThunk } from '@suite-native/bluetooth';
 import { selectTokenDefinitionsEnabledNetworks } from '@suite-native/discovery';
 import { reportSecurityCheck } from '@suite-native/sentry';
@@ -73,8 +73,8 @@ export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices
     return {
         suiteSync,
         platformEncryption,
+        analytics,
         getMMKVStorage: () => deps.mmkvStorage.getMMKV(),
-        analytics: createAnalytics(),
         reportSecurityCheck,
         saveAs: (data, fileName) =>
             console.warn(


### PR DESCRIPTION
## Description
- adds a missing services provider to the graph context (error message bellow)
	- --> That fixes the graph that relies on the services

> GraphContextProvider (suite-native/graph/src/components/GraphContextProvider.tsx:23:48)
>  ERROR  [Error: useNativeServices must be used within a NativeServicesProvider] 
> 
> Code: GraphContextProvider.tsx
>   21 | // is not available directly. This component re-injects the needed context providers.
>   22 | // read more: https://shopify.github.io/react-native-skia/docs/canvas/contexts
>   23 | export const GraphContextProvider = ({ children }: ProviderProps) => {
>      |                                                ^
>   24 |     const colorVariant = useActiveColorScheme();
>   25 |     const theme = prepareNativeTheme({ colorVariant });
>   26 |



## Notes for QA
- Check if the graph works (check multiple accounts: BTC, ETH, etc.)

## Related Issue

Resolve #24716 

## Screenshots:
<img width="436" height="885" alt="Screenshot 2026-02-09 at 9 59 15 PM" src="https://github.com/user-attachments/assets/81ffccb6-f25b-43f1-aff6-e225a284b84b" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/services-provider-in-graph-context&lookback=7)