### PR TITLE
fix(ipc-proxy): Check if the senderFrame is not destroyed

### DIFF
--- a/packages/ipc-proxy/src/proxy-handler.ts
+++ b/packages/ipc-proxy/src/proxy-handler.ts
@@ -100,7 +100,8 @@ export const createIpcProxyHandler = <Api extends EventEmitterApi>(
                         // prevents 'Render frame was disposed before WebFrameMain could be accessed', occurring when renderer process is closed during responding
                         // https://github.com/electron/electron/blob/3536d49/docs/api/structures/ipc-main-event.md
                         // https://github.com/electron/electron/blob/3536d49/docs/breaking-changes.md#behavior-changed-frame-properties-may-retrieve-detached-webframemain-instances-or-none-at-all
-                        if (ipcEvent.senderFrame === null) return;
+                        if (ipcEvent.senderFrame === null || ipcEvent.senderFrame.isDestroyed())
+                            return;
 
                         reply(ipcEventName, payload);
                     });


### PR DESCRIPTION
Might help with some cases of "Render frame was disposed before WebFrameMain could be accessed". There is still a race condition, but I have no idea how to fix it.

## Notes for QA

Don't bother, the bug is almost unreproducible.

## Related Issue

Resolve #19670


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/render-frame-disposd&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/render-frame-disposd&lookback=7)